### PR TITLE
Fix/main rag bug

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -510,7 +510,6 @@ async def draft_run(
             variables=payload.variables or {},
             use_llm_routing=True  # 默认启用 LLM 路由
         )
-
         # 3. 流式返回
         if payload.stream:
             logger.debug(

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -520,7 +520,6 @@ async def draft_run(
                     "has_conversation_id": bool(payload.conversation_id)
                 }
             )
-
             async def event_generator():
                 """多智能体流式事件生成器"""
                 multiservice = MultiAgentService(db)

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -506,7 +506,7 @@ async def draft_run(
         multi_agent_request = MultiAgentRunRequest(
             message=payload.message,
             conversation_id=payload.conversation_id,
-            user_id=payload.user_id,
+            user_id=payload.user_id or str(current_user.id),
             variables=payload.variables or {},
             use_llm_routing=True  # 默认启用 LLM 路由
         )

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -520,6 +520,7 @@ async def draft_run(
                     "has_conversation_id": bool(payload.conversation_id)
                 }
             )
+            
             async def event_generator():
                 """多智能体流式事件生成器"""
                 multiservice = MultiAgentService(db)

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -520,7 +520,7 @@ async def draft_run(
                     "has_conversation_id": bool(payload.conversation_id)
                 }
             )
-            
+
             async def event_generator():
                 """多智能体流式事件生成器"""
                 multiservice = MultiAgentService(db)

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -496,6 +496,7 @@ async def draft_run(
                 }
             )
             raise
+
     elif app.type == AppType.MULTI_AGENT:
         # 1. 检查多智能体配置完整性
         service._check_multi_agent_config(app_id)

--- a/api/app/core/rag/graphrag/general/leiden.py
+++ b/api/app/core/rag/graphrag/general/leiden.py
@@ -8,12 +8,10 @@ Reference:
 import logging
 import html
 from typing import Any, cast
-# from graspologic.partition import hierarchical_leiden
-# from graspologic.utils import largest_connected_component
+from graspologic.partition import hierarchical_leiden
+from graspologic.utils import largest_connected_component
 import networkx as nx
 from networkx import is_empty
-hierarchical_leiden=''
-largest_connected_component=''
 
 def _stabilize_graph(graph: nx.Graph) -> nx.Graph:
     """Ensure an undirected graph with the same relationships will always be read the same way."""

--- a/api/app/core/rag/graphrag/general/leiden.py
+++ b/api/app/core/rag/graphrag/general/leiden.py
@@ -8,11 +8,12 @@ Reference:
 import logging
 import html
 from typing import Any, cast
-from graspologic.partition import hierarchical_leiden
-from graspologic.utils import largest_connected_component
+# from graspologic.partition import hierarchical_leiden
+# from graspologic.utils import largest_connected_component
 import networkx as nx
 from networkx import is_empty
-
+hierarchical_leiden=''
+largest_connected_component=''
 
 def _stabilize_graph(graph: nx.Graph) -> nx.Graph:
     """Ensure an undirected graph with the same relationships will always be read the same way."""

--- a/api/app/core/rag/graphrag/general/leiden.py
+++ b/api/app/core/rag/graphrag/general/leiden.py
@@ -12,6 +12,8 @@ from graspologic.partition import hierarchical_leiden
 from graspologic.utils import largest_connected_component
 import networkx as nx
 from networkx import is_empty
+
+
 def _stabilize_graph(graph: nx.Graph) -> nx.Graph:
     """Ensure an undirected graph with the same relationships will always be read the same way."""
     fixed_graph = nx.DiGraph() if graph.is_directed() else nx.Graph()

--- a/api/app/core/rag/graphrag/general/leiden.py
+++ b/api/app/core/rag/graphrag/general/leiden.py
@@ -12,7 +12,6 @@ from graspologic.partition import hierarchical_leiden
 from graspologic.utils import largest_connected_component
 import networkx as nx
 from networkx import is_empty
-
 def _stabilize_graph(graph: nx.Graph) -> nx.Graph:
     """Ensure an undirected graph with the same relationships will always be read the same way."""
     fixed_graph = nx.DiGraph() if graph.is_directed() else nx.Graph()


### PR DESCRIPTION
集群报错BUG修复

## Summary by Sourcery

修复图谱 RAG 和多代理请求处理中的运行时错误。

Bug 修复：
- 在 graph RAG 模块中对 graspologic 的 Leiden 和连通分量（connected-component）依赖进行桩实现（stub out），以防止在这些库不可用时出现集群/运行时错误。
- 确保多代理运行请求始终具有有效的 `user_id`，当请求负载未提供时回退为当前用户。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix runtime errors in graph RAG and multi‑agent request handling.

Bug Fixes:
- Stub out graspologic Leiden and connected-component dependencies in the graph RAG module to prevent cluster/runtime errors when those libraries are unavailable.
- Ensure multi‑agent run requests always have a valid user_id by falling back to the current user when the payload does not provide one.

</details>