### PR TITLE
[fix]Remove the LLM

### DIFF
--- a/api/app/models/data_config_model.py
+++ b/api/app/models/data_config_model.py
@@ -25,7 +25,6 @@ class DataConfig(Base):
     llm_id = Column(String, nullable=True, comment="LLM模型配置ID")
     embedding_id = Column(String, nullable=True, comment="嵌入模型配置ID")
     rerank_id = Column(String, nullable=True, comment="重排序模型配置ID")
-    llm = Column(String, nullable=True, comment="LLM模型配置ID")
 
     # 记忆萃取引擎配置
     enable_llm_dedup_blockwise = Column(Boolean, default=True, comment="启用LLM决策去重")

--- a/api/app/repositories/data_config_repository.py
+++ b/api/app/repositories/data_config_repository.py
@@ -327,7 +327,7 @@ class DataConfigRepository:
             # 更新字段映射
             field_mapping = {
                 # 模型选择
-                "llm_id": "llm",
+                "llm_id": "llm_id",
                 "embedding_id": "embedding_id",
                 "rerank_id": "rerank_id",
                 # 记忆萃取引擎

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -185,7 +185,6 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,
-                "llm": config.llm,
                 "enable_llm_dedup_blockwise": config.enable_llm_dedup_blockwise,
                 "enable_llm_disambiguation": config.enable_llm_disambiguation,
                 "deep_retrieval": config.deep_retrieval,


### PR DESCRIPTION
## Summary by Sourcery

通过移除已弃用的 `llm` 字段并纠正字段映射，使数据配置模型和内存存储的输出与 `llm_id` 对齐。

Bug Fixes:
- 修复数据配置更新中 `llm_id` 字段映射错误的问题，确保其正确引用 `llm_id` 列。

Enhancements:
- 从数据配置模型和内存存储服务中移除冗余的 `llm` 列及其使用，以保持模式（schema）的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align data configuration model and memory storage output with llm_id by removing the deprecated llm field and correcting the field mapping.

Bug Fixes:
- Fix incorrect field mapping for llm_id in data configuration updates to reference the proper llm_id column.

Enhancements:
- Remove redundant llm column and its usage from data configuration model and memory storage service to keep the schema consistent.

</details>