### PR TITLE
feat(agent tool): agent tools change the parameter passing to a list

### DIFF
--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -38,8 +38,8 @@ class KnowledgeRetrievalConfig(BaseModel):
 class ToolConfig(BaseModel):
     """工具配置"""
     enabled: bool = Field(default=False, description="是否启用该工具")
-    tool_id: str = Field(default=None, description="工具ID")
-    operation: Optional[str] = Field(default_factory=dict, description="工具特定配置")
+    tool_id: Optional[str] = Field(default=None, description="工具ID")
+    operation: Optional[str] = Field(default=None, description="工具特定配置")
 
 class ToolOldConfig(BaseModel):
     """工具配置"""
@@ -164,7 +164,7 @@ class AgentConfigUpdate(BaseModel):
     variables: Optional[List[VariableDefinition]] = Field(default=None, description="变量列表")
 
     # 工具配置
-    tools: Optional[List[ToolConfig]] = Field(default=None, description="工具列表")
+    tools: Optional[List[ToolConfig]] = Field(default_factory=list, description="工具列表")
 
 
 # ---------- Output Schemas ----------

--- a/api/app/services/agent_config_converter.py
+++ b/api/app/services/agent_config_converter.py
@@ -77,7 +77,7 @@ class AgentConfigConverter:
             "knowledge_retrieval": None,
             "memory": MemoryConfig(enabled=True),
             "variables": [],
-            "tools": {},
+            "tools": [],
         }
         
         # 1. 解析模型参数配置


### PR DESCRIPTION
agent tools change the parameter passing to a list

## Summary by Sourcery

调整代理工具配置，将工具视为列表，并放宽工具字段的可选性。

Bug Fixes:
- 确保在未提供代理工具配置时，工具列表默认为空列表，而不是 `None` 或对象。

Enhancements:
- 通过在模式（schema）中将工具配置的 ID 和操作设为可选字段，允许省略这些字段。
- 更新代理配置转换的默认值，将工具表示为列表而非映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust agent tool configuration to treat tools as a list and relax tool field optionality.

Bug Fixes:
- Ensure agent tool configurations default to an empty tool list instead of None or an object when not provided.

Enhancements:
- Allow tool configuration IDs and operations to be omitted by making them optional fields in the schema.
- Update agent configuration conversion defaults to represent tools as a list rather than a mapping.

</details>