### PR TITLE
Fix/actr config

### DIFF
--- a/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
@@ -246,7 +246,7 @@ class AccessHistoryManager:
         if not node_data:
             return ConsistencyCheckResult.CONSISTENT, None
         
-        access_history = node_data.get('access_history', [])
+        access_history = node_data.get('access_history') or []
         last_access_time = node_data.get('last_access_time')
         access_count = node_data.get('access_count', 0)
         activation_value = node_data.get('activation_value')
@@ -409,7 +409,7 @@ class AccessHistoryManager:
                 logger.error(f"节点不存在，无法修复: {node_label}[{node_id}]")
                 return False
             
-            access_history = node_data.get('access_history', [])
+            access_history = node_data.get('access_history') or []
             importance_score = node_data.get('importance_score', 0.5)
             
             # 准备修复数据
@@ -530,7 +530,7 @@ class AccessHistoryManager:
         Returns:
             Dict[str, Any]: 更新数据，包含所有需要更新的字段
         """
-        access_history = node_data.get('access_history', [])
+        access_history = node_data.get('access_history') or []
         importance_score = node_data.get('importance_score', 0.5)
         
         # 追加新的访问时间

--- a/api/app/models/data_config_model.py
+++ b/api/app/models/data_config_model.py
@@ -25,7 +25,6 @@ class DataConfig(Base):
     llm_id = Column(String, nullable=True, comment="LLM模型配置ID")
     embedding_id = Column(String, nullable=True, comment="嵌入模型配置ID")
     rerank_id = Column(String, nullable=True, comment="重排序模型配置ID")
-    llm = Column(String, nullable=True, comment="LLM模型配置ID")
 
     # 记忆萃取引擎配置
     enable_llm_dedup_blockwise = Column(Boolean, default=True, comment="启用LLM决策去重")

--- a/api/app/repositories/data_config_repository.py
+++ b/api/app/repositories/data_config_repository.py
@@ -327,7 +327,7 @@ class DataConfigRepository:
             # 更新字段映射
             field_mapping = {
                 # 模型选择
-                "llm_id": "llm",
+                "llm_id": "llm_id",
                 "embedding_id": "embedding_id",
                 "rerank_id": "rerank_id",
                 # 记忆萃取引擎

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -722,7 +722,12 @@ SET m += {
     chunk_ids: summary.chunk_ids,
     content: summary.content,
     summary_embedding: summary.summary_embedding,
-    config_id: summary.config_id
+    config_id: summary.config_id,
+    importance_score: CASE WHEN summary.importance_score IS NOT NULL THEN summary.importance_score ELSE coalesce(m.importance_score, 0.5) END,
+    activation_value: CASE WHEN summary.activation_value IS NOT NULL THEN summary.activation_value ELSE m.activation_value END,
+    access_history: CASE WHEN summary.access_history IS NOT NULL THEN summary.access_history ELSE coalesce(m.access_history, []) END,
+    last_access_time: CASE WHEN summary.last_access_time IS NOT NULL THEN summary.last_access_time ELSE m.last_access_time END,
+    access_count: CASE WHEN summary.access_count IS NOT NULL THEN summary.access_count ELSE coalesce(m.access_count, 0) END
 }
 RETURN m.id AS uuid
 """

--- a/api/app/repositories/neo4j/entity_repository.py
+++ b/api/app/repositories/neo4j/entity_repository.py
@@ -58,7 +58,7 @@ class EntityRepository(BaseNeo4jRepository[ExtractedEntityNode]):
         # 处理 ACT-R 属性 - 确保字段存在且有默认值
         n['importance_score'] = n.get('importance_score', 0.5)
         n['activation_value'] = n.get('activation_value')
-        n['access_history'] = n.get('access_history', [])
+        n['access_history'] = n.get('access_history') or []
         n['last_access_time'] = n.get('last_access_time')
         n['access_count'] = n.get('access_count', 0)
         

--- a/api/app/repositories/neo4j/statement_repository.py
+++ b/api/app/repositories/neo4j/statement_repository.py
@@ -78,7 +78,7 @@ class StatementRepository(BaseNeo4jRepository[StatementNode]):
         # 处理 ACT-R 属性 - 确保字段存在且有默认值
         n['importance_score'] = n.get('importance_score', 0.5)
         n['activation_value'] = n.get('activation_value')
-        n['access_history'] = n.get('access_history', [])
+        n['access_history'] = n.get('access_history') or []
         n['last_access_time'] = n.get('last_access_time')
         n['access_count'] = n.get('access_count', 0)
         

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -185,7 +185,6 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,
-                "llm": config.llm,
                 "enable_llm_dedup_blockwise": config.enable_llm_dedup_blockwise,
                 "enable_llm_disambiguation": config.enable_llm_disambiguation,
                 "deep_retrieval": config.deep_retrieval,


### PR DESCRIPTION
## Summary by Sourcery

在各个代码仓库和服务中统一 ACT-R 内存元数据处理方式和数据配置字段。

Bug 修复：
- 在 Neo4j 中 upsert 内存总结时，确保 ACT-R 的重要性和访问相关字段被正确保留或按默认值处理。
- 对缺失或假值（falsy）的 `access_history` 进行统一处理，在与 ACT-R 相关的代码仓库和遗忘引擎逻辑中规范为一个空列表。
- 修复数据配置更新中 `llm_id` 字段映射错误的问题，并从模型和服务中移除已废弃的 `llm` 列/字段的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align ACT-R memory metadata handling and data config fields across repositories and services.

Bug Fixes:
- Ensure ACT-R importance and access-related fields are preserved or defaulted correctly when upserting memory summaries in Neo4j.
- Handle missing or falsy access_history consistently by normalizing to an empty list in ACT-R related repositories and forgetting engine logic.
- Fix incorrect field mapping for llm_id in data config updates and remove obsolete llm column/field usage from models and services.

</details>