### PR TITLE
feat(agent tool)

### DIFF
--- a/api/app/schemas/tool_schema.py
+++ b/api/app/schemas/tool_schema.py
@@ -154,7 +154,7 @@ class MCPToolConfigSchema(BaseModel):
     last_health_check: Optional[datetime] = None
     health_status: str = "unknown"
     error_message: Optional[str] = None
-    available_tools: List[str] = Field(default_factory=list)
+    available_tools: List[Dict[str, Dict[str, Any]]] = Field(default_factory=list, description="工具列表，格式: [{'tool_name': str, 'arguments': dict}]")
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
mcp and custom tool repair

## Summary by Sourcery

优化 MCP 和自定义工具的处理，以支持更丰富的工具元数据、多操作工具，以及更明确的 MCP 调用参数。

新功能：
- 在 Langchain 适配器中支持多操作工具，包括从 OpenAPI 或参数枚举中派生操作的自定义工具。
- 将 MCP 工具选项作为包含描述和输入模式的结构化元数据对外暴露，而不再仅仅是名称。

错误修复：
- 确保 MCP 工具在调用时显式传入 `tool_name` 和参数负载 `arguments`，避免依赖可能选择错误工具的隐式默认值。

增强改进：
- 规范 MCP `available_tools` 的存储和展示格式，同时保持面向 UI 的表示形式向后兼容。
- 简化 MCP 工具配置，移除按实例配置的 `tool_name`/`tool_schema`，改为从所选工具或通用参数结构中派生参数。
- 改进 Langchain 封装的模式生成逻辑，在选择了特定操作时过滤掉操作参数。

文档：
- 为 MCP `available_tools` 模式补充文档，明确存储的 MCP 工具元数据所期望的结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine MCP and custom tool handling to support richer tool metadata, multi-operation tools, and more explicit MCP invocation parameters.

New Features:
- Support multi-operation tools in the Langchain adapter, including custom tools that derive operations from OpenAPI or parameter enums.
- Expose MCP tool choices as structured metadata containing descriptions and input schemas instead of plain names.

Bug Fixes:
- Ensure MCP tools are invoked with an explicit tool_name and arguments payload, avoiding reliance on implicit defaults that could select the wrong tool.

Enhancements:
- Normalize MCP available_tools storage and display formats, while keeping the UI-facing representation backward compatible.
- Simplify MCP tool configuration by removing per-instance tool_name/tool_schema and deriving parameters from the selected tool or generic arguments shape.
- Improve Langchain wrapper schema generation by filtering out the operation parameter when a specific operation is selected.

Documentation:
- Document the MCP available_tools schema to clarify expected structure for stored MCP tool metadata.

</details>