### PR TITLE
Flx/develop config

### DIFF
--- a/api/app/core/memory/utils/self_reflexion_utils/self_reflexion.py
+++ b/api/app/core/memory/utils/self_reflexion_utils/self_reflexion.py
@@ -54,9 +54,9 @@ async def get_reflexion_data(host_id: uuid.UUID) -> List[Any]:
     Returns:
         符合反思范围的记忆数据列表。
     """
-    if REFLEXION_RANGE == "retrieval":
+    if REFLEXION_RANGE == "partial":
         return await get_data(host_id)
-    elif REFLEXION_RANGE == "database":
+    elif REFLEXION_RANGE == "all":
         return []
     else:
         raise ValueError(f"未知的反思范围: {REFLEXION_RANGE}")

--- a/api/app/schemas/memory_config_schema.py
+++ b/api/app/schemas/memory_config_schema.py
@@ -173,8 +173,8 @@ class MemoryConfigValidation(BaseModel):
     chunker_strategy: str = Field(default="RecursiveChunker", min_length=1, max_length=100)
     reflexion_enabled: bool = Field(default=False)
     reflexion_iteration_period: int = Field(default=3, ge=1, le=100)
-    reflexion_range: Literal["retrieval", "all"] = Field(default="retrieval")
-    reflexion_baseline: Literal["time", "fact", "time_and_fact"] = Field(default="time")
+    reflexion_range: Literal["partial", "all"] = Field(default="partial")
+    reflexion_baseline: Literal["TIME", "FACT", "HYBRID"] = Field(default="TIME")
     
     llm_params: Dict[str, Any] = Field(default_factory=dict)
     embedding_params: Dict[str, Any] = Field(default_factory=dict)

--- a/api/app/schemas/memory_config_schema.py
+++ b/api/app/schemas/memory_config_schema.py
@@ -175,7 +175,8 @@ class MemoryConfigValidation(BaseModel):
     reflexion_iteration_period: int = Field(default=3, ge=1, le=100)
     reflexion_range: Literal["partial", "all"] = Field(default="partial")
     reflexion_baseline: Literal["TIME", "FACT", "HYBRID"] = Field(default="TIME")
-    
+
+
     llm_params: Dict[str, Any] = Field(default_factory=dict)
     embedding_params: Dict[str, Any] = Field(default_factory=dict)
     config_version: str = Field(default="2.0", min_length=1, max_length=10)

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -292,8 +292,8 @@ class ConfigUpdateExtracted(BaseModel):  # 更新记忆萃取引擎配置参数�
     iteration_period: Optional[Literal["1", "3", "6", "12", "24"]] = Field(
         "3", description="反思迭代周期，单位小时"
     )
-    reflexion_range: Optional[Literal["retrieval", "database"]] = Field(
-        "retrieval", description="反思范围：部分/全部"
+    reflexion_range: Optional[Literal["partial", "all"]] = Field(
+        "partial", description="反思范围：部分/全部"
     )
     baseline: Optional[Literal["TIME", "FACT", "TIME-FACT"]] = Field(
         "TIME", description="基线：时间/事实/时间和事实"

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -529,7 +529,6 @@ class MemoryAgentService:
 
             workflow_duration = time.time() - start
             logger.info(f"Read graph workflow completed in {workflow_duration}s")
-
             # Extract final answer
             final_answer = ""
             for messages in outputs:

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -396,6 +396,7 @@ class MemoryAgentService:
         import time
         start_time = time.time()
         ori_message=message
+        end_user_id=group_id
         # Resolve config_id if None using end_user's connected config
         if config_id is None:
             try:
@@ -602,18 +603,24 @@ class MemoryAgentService:
             repo = ShortTermMemoryRepository(db)
             if str(search_switch)!="2":
                 for intermediate in intermediate_outputs:
+                    print(intermediate)
                     intermediate_type=intermediate['type']
                     if intermediate_type=="search_result":
                         query=intermediate['query']
                         raw_results=intermediate['raw_results']
                         reranked_results=raw_results.get('reranked_results',[])
-                        statements=[statement['statement'] for statement in reranked_results.get('statements', [])]
+                        try:
+                            statements=[statement['statement'] for statement in reranked_results.get('statements', [])]
+                        except Exception as e:
+                            statements=[]
                         statements=list(set(statements))
                         retrieved_content.append({query:statements})
-            if   '信息不足，无法回答' in str(final_answer) or retrieved_content!=[]:
+            if retrieved_content==[]:
+                retrieved_content=''
+            if   '信息不足，无法回答。' != str(final_answer) :#and retrieved_content!=[]
                 # 使用 upsert 方法
                 repo.upsert(
-                    end_user_id=group_id,  # 确保这个变量在作用域内
+                    end_user_id=end_user_id,  # 确保这个变量在作用域内
                     messages=ori_message,
                     aimessages=final_answer,
                     retrieved_content=retrieved_content,

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -205,8 +205,8 @@ class MemoryConfigService:
                 chunker_strategy=memory_config.chunker_strategy or "RecursiveChunker",
                 reflexion_enabled=memory_config.enable_self_reflexion or False,
                 reflexion_iteration_period=int(memory_config.iteration_period or "3"),
-                reflexion_range=memory_config.reflexion_range or "retrieval",
-                reflexion_baseline=memory_config.baseline or "time",
+                reflexion_range=memory_config.reflexion_range or "partial",
+                reflexion_baseline=memory_config.baseline or "Time",
                 loaded_at=datetime.now(),
                 # Pipeline config: Deduplication
                 enable_llm_dedup_blockwise=bool(memory_config.enable_llm_dedup_blockwise) if memory_config.enable_llm_dedup_blockwise is not None else False,


### PR DESCRIPTION
反思的默认部分检索替换为partial

## Summary by Sourcery

更新 memory reflexion 配置的默认值，使其与新的 partial/all 区间以及 TIME/FACT/HYBRID 基线保持一致，并调整 memory 写入条件。

Bug 修复：
- 在根据 reflexion 搜索结果构建语句列表时，通过安全处理缺失或格式错误的数据，避免报错。

增强功能：
- 将 reflexion 区间术语从 retrieval/database 更改为 partial/all，并在各个 schema 和工具中统一更新，同时相应调整默认值。
- 在配置 schema 和加载逻辑中，将 reflexion 基线值标准化为 TIME/FACT/HYBRID。
- 确保在 upsert 短期记忆记录时始终传入最终用户 ID，并根据最终答案内容调整记忆持久化的时机。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update memory reflexion configuration defaults and align schema values with new partial/all range and TIME/FACT/HYBRID baselines while adjusting memory write conditions.

Bug Fixes:
- Prevent errors when building statement lists from reflexion search results by safely handling missing or malformed data.

Enhancements:
- Change reflexion range terminology from retrieval/database to partial/all across schemas and utilities, updating defaults accordingly.
- Standardize reflexion baseline values to TIME/FACT/HYBRID in configuration schemas and loading logic.
- Ensure end user ID is consistently passed when upserting short-term memory records and adjust when memories are persisted based on final answer content.

</details>