### PR TITLE
fix(workflow): fix default values in parameter extraction node and incorrect value retrieval in comparison operations

### DIFF
--- a/api/app/core/workflow/nodes/operators.py
+++ b/api/app/core/workflow/nodes/operators.py
@@ -260,8 +260,7 @@ class ConditionBase(ABC):
         raise RuntimeError("Unsupported variable type")
 
     def check(self, no_right=False):
-        left = self.pool.get(self.left_selector.variable_selector)
-        if not isinstance(left, self.type_limit):
+        if not isinstance(self.left_value, self.type_limit):
             raise TypeError(f"The variable to be compared on must be of {self.type_limit} type")
         if not no_right:
             right = self.resolve_right_literal_value()

--- a/api/app/core/workflow/nodes/parameter_extractor/config.py
+++ b/api/app/core/workflow/nodes/parameter_extractor/config.py
@@ -37,7 +37,7 @@ class ParamsConfig(BaseModel):
     )
 
     required: bool = Field(
-        ...,
+        default=False,
         description="Whether the parameter is required"
     )
 
@@ -59,6 +59,6 @@ class ParameterExtractorNodeConfig(BaseNodeConfig):
     )
 
     prompt: str = Field(
-        ...,
+        default="",
         description="User-provided supplemental prompt"
     )

--- a/api/app/core/workflow/nodes/parameter_extractor/node.py
+++ b/api/app/core/workflow/nodes/parameter_extractor/node.py
@@ -157,9 +157,17 @@ class ParameterExtractorNode(BaseNode):
 
         messages = [
             ("system", system_prompt),
-            ("user", self._render_template(self.typed_config.prompt, state)),
-            ("user", rendered_user_prompt),
+
         ]
+        if self.typed_config.prompt:
+            messages.extend([
+                ("user", self._render_template(self.typed_config.prompt, state)),
+                ("user", rendered_user_prompt),
+            ])
+        else:
+            messages.extend([
+                ("user", rendered_user_prompt),
+            ])
 
         model_resp = await llm.ainvoke(messages)
         result = json_repair.repair_json(model_resp.content, return_objects=True)


### PR DESCRIPTION
## Summary by Sourcery

调整工作流参数提取和比较逻辑，以支持可选提示、合理的默认值，以及在比较中进行正确的类型检查。

Bug 修复：
- 防止比较操作中的类型检查使用错误的左侧值引用，确保比较验证的是实际操作数的类型。
- 当未配置补充提示时，避免向参数提取器 LLM 发送空的补充提示。

增强功能：
- 在参数提取器配置中为非必需参数和补充提示设置显式默认值，使其真正成为可选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust workflow parameter extraction and comparison logic to support optional prompts, sensible defaults, and correct type checking in comparisons.

Bug Fixes:
- Prevent type checking in comparison operations from using an incorrect left-hand value reference, ensuring comparisons validate the actual operand type.
- Avoid sending an empty supplemental prompt to the parameter extractor LLM when none is configured.

Enhancements:
- Set non-required parameters and supplemental prompts to have explicit default values in the parameter extractor configuration, allowing them to be truly optional.

</details>