### PR TITLE
Feature/workflow zy

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -204,8 +204,9 @@ export const getConversationMessages = (end_user: string, conversation_id: strin
 export const getConversationDetail = (end_user: string, conversation_id: string) => {
   return request.get(`/memory/work/${end_user}/detail`, { conversation_id })
 }
-
-
+export const forgetTrigger = (data: { max_merge_batch_size: number; min_days_since_access: number; end_user_id: string;}) => {
+  return request.post(`/memory/forget/trigger`, data)
+}
 /*************** end 用户记忆 相关接口 ******************************/
 
 /****************** 记忆管理 相关接口 *******************************/

--- a/web/src/assets/images/logout_hover.svg
+++ b/web/src/assets/images/logout_hover.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>退出</title>
+    <g id="V1.0版" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="应用管理-编排-默认状态" transform="translate(-1262, -24)" stroke="#155EEF">
+            <g id="返回空间" transform="translate(1262, 24)">
+                <g id="退出" transform="translate(8, 8) scale(-1, 1) translate(-8, -8)">
+                    <g id="编组-7" transform="translate(2.5, 2)">
+                        <path d="M6,12 L1,12 C0.44771525,12 0,11.5522847 0,11 L0,1 C0,0.44771525 0.44771525,1.11022302e-16 1,0 L6,0 L6,0" id="路径"></path>
+                        <line x1="11" y1="6" x2="3" y2="6" id="路径-6"></line>
+                        <polyline id="路径" points="8 3 11 6 8 9"></polyline>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2025-12-11 13:40:18
+ * @Last Modified time: 2026-01-12 20:41:27
  */
 import { type FC, useRef, useEffect } from 'react'
 import clsx from 'clsx'
@@ -55,7 +55,7 @@ const ChatContent: FC<ChatContentProps> = ({
                   </div>
                 }
                 {/* 消息气泡框 */}
-                <div className={clsx('rb:border rb:text-left rb:rounded-lg rb:mt-1.5 rb:leading-4.5 rb:p-[10px_12px_2px_12px] rb:inline-block rb:max-w-100', contentClassNames, {
+                <div className={clsx('rb:border rb:text-left rb:rounded-lg rb:mt-1.5 rb:leading-4.5 rb:p-[10px_12px_2px_12px] rb:inline-block rb:max-w-100 rb:wrap-break-word', contentClassNames, {
                   // 错误消息样式（内容为null且非助手消息）
                   'rb:border-[rgba(255,93,52,0.30)] rb:bg-[rgba(255,93,52,0.08)] rb:text-[#FF5D34]': errorDesc && item.role === 'assistant' && item.content === null,
                   // 助手消息样式

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1244,6 +1244,10 @@ export const en = {
       MemorySummary: 'Long-term Accumulation',
       Statement: 'Emotional Memory',
       ExtractedEntity: 'Episodic Memory',
+      positive: 'Positive Emotion',
+      negative: 'Negative Emotion',
+      neutral: 'Neutral Emotion',
+      interactionCountData: 'Interaction Count',
     },
     space: {
       createSpace: 'Create Space',
@@ -2203,6 +2207,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       node_type: 'Node Type',
       last_access_time: 'Last Activation Time',
       activation_value: 'Current Activation Value',
+      refreshSuccess: 'Forgetting Execution Successful',
     },
     episodicDetail: {
       title: 'Record every important scene you have truly experienced',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1324,6 +1324,10 @@ export const zh = {
       MemorySummary: '长期沉淀',
       Statement: '情绪记忆',
       ExtractedEntity: '情景记忆',
+      positive: '正向情绪',
+      negative: '负向情绪',
+      neutral: '中性情绪',
+      interactionCountData: '互动次数',
     },
     space: {
       createSpace: '创建空间',
@@ -2302,6 +2306,7 @@ export const zh = {
       node_type: '节点类型',
       last_access_time: '最后激活时间',
       activation_value: '当前激活值',
+      refreshSuccess: '遗忘执行成功',
     },
     episodicDetail: {
       title: '记录你真实经历过的每一个重要场景',

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import { cookieUtils } from './request'
 export const clearAuthData = () => {
   console.log("Clearing auth data and redirecting to login");
-  sessionStorage.clear();
-  localStorage.clear()
+  // sessionStorage.clear();
+  // localStorage.clear()
   cookieUtils.clear();
 }

--- a/web/src/utils/stream.ts
+++ b/web/src/utils/stream.ts
@@ -12,43 +12,57 @@ export function parseSSEToJSON(sseString: string) {
   const lines = sseString.trim().split('\n')
   
   let currentEvent: SSEMessage = {}
+  let dataContent = ''
   
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      if (currentEvent.event && dataContent) {
+        currentEvent.data = parseDataContent(dataContent)
+        events.push(currentEvent)
+      }
+      currentEvent = { event: line.substring(6).trim() }
+      dataContent = ''
+    } else if (line.startsWith('data:')) {
+      if (dataContent) dataContent += '\n'
+      dataContent += line.substring(5).trim()
+    }
+  }
+
+  
+  if (currentEvent.event && dataContent) {
+    currentEvent.data = parseDataContent(dataContent)
+    console.log('currentEvent', currentEvent)
+    events.push(currentEvent)
+  }
+  
+  return events
+}
+
+function parseDataContent(dataContent: string): string | object {
   try {
-    for (const line of lines) {
-      if (line.startsWith('event:')) {
-        if (Object.keys(currentEvent).length > 0) {
-          events.push(currentEvent)
-          currentEvent = {}
-        }
-        currentEvent.event = line.substring(6).trim()
-      } else if (line.startsWith('data:')) {
-        const dataStr = line.substring(5).trim()
-        if (dataStr) {
-          try {
-            // 尝试解析为 JSON
-            currentEvent.data = JSON.parse(dataStr)
-          } catch {
-            // JSON 解析失败时，检查是否是被转义的 JSON 字符串
-            try {
-              const unescaped = dataStr.replace(/&quot;/g, '"').replace(/&amp;/g, '&')
-              currentEvent.data = JSON.parse(unescaped)
-            } catch {
-              // 如果仍然失败，保存为原始字符串
-              currentEvent.data = dataStr
-            }
-          }
-        }
+    // 第一层解码：HTML实体
+    let unescaped = dataContent
+      .replace(/&quot;/g, '"')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&#39;/g, "'")
+    
+    // 解析第一层JSON
+    const firstParse = JSON.parse(unescaped)
+    
+    // 如果data字段是字符串且包含JSON，解析data层但保持chunk为字符串
+    if (firstParse.data && typeof firstParse.data === 'string' && firstParse.data.includes("{")) {
+      try {
+        firstParse.data = JSON.parse(firstParse.data)
+      } catch {
+        // 保持原字符串
       }
     }
     
-    if (Object.keys(currentEvent).length > 0) {
-      events.push(currentEvent)
-    }
-    
-    return events
-  } catch (error) {
-    console.error('Parse stream error:', error)
-    return []
+    return firstParse
+  } catch {
+    return dataContent
   }
 }
 
@@ -80,15 +94,29 @@ export const handleSSE = async (url: string, data: any, onMessage?: (data: SSEMe
         
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
+        let buffer = ''; // 添加缓冲区来处理不完整的消息
         
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
           
           const chunk = decoder.decode(value, { stream: true });
-          if (onMessage) {
-            onMessage(parseSSEToJSON(chunk) ?? {});
+          buffer += chunk;
+          
+          // 处理完整的事件
+          const events = buffer.split('\n\n');
+          buffer = events.pop() || ''; // 保留最后一个可能不完整的事件
+          
+          for (const event of events) {
+            if (event.trim() && onMessage) {
+              onMessage(parseSSEToJSON(event) ?? {});
+            }
           }
+        }
+        
+        // 处理剩余的缓冲区内容
+        if (buffer.trim() && onMessage) {
+          onMessage(parseSSEToJSON(buffer) ?? {});
         }
         break;
     }

--- a/web/src/views/UserMemoryDetail/components/EmotionLine.tsx
+++ b/web/src/views/UserMemoryDetail/components/EmotionLine.tsx
@@ -4,6 +4,7 @@ import ReactEcharts from 'echarts-for-react';
 import Empty from '@/components/Empty'
 import Loading from '@/components/Empty/Loading'
 import type { Emotion } from './GraphDetail'
+import { format } from 'echarts';
 
 interface EmotionLineProps {
   chartData: Emotion[];
@@ -26,7 +27,7 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
       const seriesData = timePoints.map(time => dataMap.get(time) || 0)
       
       return {
-        name: emotionType,
+        name: t(`userMemory.${emotionType}`),
         type: 'line',
         smooth: true,
         lineStyle: {
@@ -71,7 +72,7 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
                 formatter: function(params: any) {
                   let result = `${params[0].axisValue}<br/>`
                   params.forEach((param: any) => {
-                    result += `${param.marker}${param.seriesName}: ${param.value}<br/>`
+                    result += `${param.marker}${param.seriesName}: ${param.value}%<br/>`
                   })
                   return result
                 }
@@ -92,7 +93,7 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
               },
               grid: {
                 top: 16,
-                left: 30,
+                left: 40,
                 right: 36,
                 bottom: 48,
                 // containLabel: false
@@ -103,7 +104,7 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
                 boundaryGap: false,
                 axisLabel: {
                   color: '#A8A9AA',
-                  fontFamily: 'PingFangSC, PingFang SC'
+                  fontFamily: 'PingFangSC, PingFang SC',
                 },
                 axisLine: {
                   show: true,
@@ -130,7 +131,8 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
                 type: 'value',
                 axisLabel: {
                   color: '#A8A9AA',
-                  fontFamily: 'PingFangSC, PingFang SC'
+                  fontFamily: 'PingFangSC, PingFang SC',
+                  formatter: '{value}%'
                 },
                 axisLine: {
                   show: true,
@@ -152,7 +154,7 @@ const EmotionLine: FC<EmotionLineProps> = ({ chartData, loading }) => {
                     type: 'solid'
                   }
                 },
-                max: 1,
+                max: 100,
                 min: 0
               },
               series: getSeries()

--- a/web/src/views/UserMemoryDetail/components/ForgetRefreshModal.tsx
+++ b/web/src/views/UserMemoryDetail/components/ForgetRefreshModal.tsx
@@ -1,0 +1,113 @@
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { useParams } from 'react-router-dom'
+import { Form, Slider } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import RbModal from '@/components/RbModal'
+import { forgetTrigger } from '@/api/memory'
+import type { ForgetRefreshModalRef } from '../pages/ForgetDetail'
+
+interface ForgetRefreshModalProps {
+  refresh: (flag: boolean) => void;
+}
+
+const ForgetRefreshModal = forwardRef<ForgetRefreshModalRef, ForgetRefreshModalProps>(({
+  refresh
+}, ref) => {
+  const { t } = useTranslation();
+  const { id } = useParams()
+  const [visible, setVisible] = useState(false);
+  const [form] = Form.useForm<{ max_merge_batch_size: number; min_days_since_access: number; }>();
+  const [loading, setLoading] = useState(false)
+  const values = Form.useWatch([], form);
+
+  // 封装取消方法，添加关闭弹窗逻辑
+  const handleClose = () => {
+    setVisible(false);
+    form.resetFields();
+    setLoading(false)
+  };
+
+  const handleOpen = () => {
+    form.resetFields();
+    setVisible(true);
+  };
+  // 封装保存方法，添加提交逻辑
+  const handleSave = () => {
+    if(!id) return
+    form
+      .validateFields()
+      .then((values) => {
+        setLoading(true)
+        forgetTrigger({
+          ...values,
+          end_user_id: id
+        })
+          .then(() => {
+            refresh(true)
+            handleClose()
+          })
+          .finally(() => {
+            setLoading(false)
+          })
+      })
+      .catch((err) => {
+        console.log('err', err)
+      });
+  }
+
+  // 暴露给父组件的方法
+  useImperativeHandle(ref, () => ({
+    handleOpen,
+    handleClose
+  }));
+
+  return (
+    <RbModal
+      title={t('common.refresh')}
+      open={visible}
+      onCancel={handleClose}
+      okText={t('common.refresh')}
+      onOk={handleSave}
+      confirmLoading={loading}
+    >
+      <Form
+        form={form}
+        layout="vertical"
+      >
+        <div className="rb:pl-3">
+          <div className="rb:text-[14px] rb:font-medium rb:leading-5 rb:mb-2">
+            {t(`forgettingEngine.max_merge_batch_size`)}
+          </div>
+
+          <Form.Item
+            name="max_merge_batch_size"
+          >
+            <Slider tooltip={{ open: false }} max={1000} min={1} step={1} style={{ margin: '0' }} />
+          </Form.Item>
+          <div className="rb:flex rb:text-[12px] rb:items-center rb:justify-between rb:text-[#5B6167] rb:leading-5 rb:-mt-6.5">
+            <span>{t(`forgettingEngine.range`)}: {[1, 1000]?.join('-')}</span>
+            {t('forgettingEngine.CurrentValue')}: {values?.min_days_since_access || 0}
+          </div>
+        </div>
+        <div className="rb:pl-3 rb:mt-4">
+          <div className="rb:text-[14px] rb:font-medium rb:leading-5 rb:mb-2">
+            {t(`forgettingEngine.min_days_since_access`)}
+          </div>
+
+          <Form.Item
+            name="min_days_since_access"
+          >
+            <Slider tooltip={{ open: false }} max={365} min={1} step={1} style={{ margin: '0' }} />
+          </Form.Item>
+          <div className="rb:flex rb:text-[12px] rb:items-center rb:justify-between rb:text-[#5B6167] rb:leading-5 rb:-mt-6.5">
+            <span>{t(`forgettingEngine.range`)}: {[1, 365]?.join('-')}</span>
+            {t('forgettingEngine.CurrentValue')}: {values?.min_days_since_access || 0}
+          </div>
+        </div>
+      </Form>
+    </RbModal>
+  );
+});
+
+export default ForgetRefreshModal;

--- a/web/src/views/UserMemoryDetail/components/InteractionBar.tsx
+++ b/web/src/views/UserMemoryDetail/components/InteractionBar.tsx
@@ -1,4 +1,4 @@
-import { type FC } from 'react'
+import { type FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import ReactEcharts from 'echarts-for-react'
 import Empty from '@/components/Empty'
@@ -14,11 +14,13 @@ const Colors = ['#155EEF', '#369F21', '#FF5D34']
 const InteractionBar: FC<InteractionBarProps> = ({ chartData, loading }) => {
   const { t } = useTranslation()
 
-  const series = [{
-    name: 'Interaction Count',
-    type: 'bar',
-    data: chartData.map(item => item.count)
-  }]
+  const series = useMemo(() => {
+    return [{
+      name: t('userMemory.interactionCountData'),
+      type: 'bar',
+      data: chartData.map(item => item.count)
+    }]
+  }, [chartData, t])
 
   return (
     <>
@@ -80,6 +82,7 @@ const InteractionBar: FC<InteractionBarProps> = ({ chartData, loading }) => {
               },
               yAxis: {
                 type: 'value',
+                minInterval: 1,
                 axisLabel: {
                   color: '#A8A9AA',
                   fontFamily: 'PingFangSC, PingFang SC'
@@ -104,8 +107,6 @@ const InteractionBar: FC<InteractionBarProps> = ({ chartData, loading }) => {
                     type: 'solid'
                   }
                 },
-                max: 1,
-                min: 0
               },
               series
             }}

--- a/web/src/views/UserMemoryDetail/components/PageHeader.tsx
+++ b/web/src/views/UserMemoryDetail/components/PageHeader.tsx
@@ -1,20 +1,22 @@
 import { type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Layout } from 'antd';
+import { Layout, Space, Button } from 'antd';
 import { useTranslation } from 'react-i18next';
-import logoutIcon from '@/assets/images/logout.svg'
+import logoutIcon from '@/assets/images/logout_hover.svg'
 
 const { Header } = Layout;
 
 interface ConfigHeaderProps {
   name?: string;
   operation?: ReactNode;
-  source?: 'detail' | 'node'
+  source?: 'detail' | 'node';
+  extra?: ReactNode;
 }
 const PageHeader: FC<ConfigHeaderProps> = ({ 
   name,
   operation,
-  source = 'detail'
+  source = 'detail',
+  extra
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -33,10 +35,13 @@ const PageHeader: FC<ConfigHeaderProps> = ({
         {operation}
       </div>
 
-      <div className="rb:h-8 rb:flex rb:items-center rb:justify-end rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:cursor-pointer" onClick={goBack}>
-        <img src={logoutIcon} className="rb:mr-2 rb:w-4 rb:h-4" />
-        {t('common.return')}
-      </div>
+      <Space size={12}>
+        <Button type="primary" ghost className="rb:group rb:h-6! rb:px-2!" onClick={goBack}>
+          <img src={logoutIcon} className="rb:w-4 rb:h-4" />
+          {t('common.return')}
+        </Button>
+        {extra}
+      </Space>
     </Header>
   );
 };

--- a/web/src/views/UserMemoryDetail/components/Timeline.tsx
+++ b/web/src/views/UserMemoryDetail/components/Timeline.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/api/memory'
 import { formatDateTime } from '@/utils/format';
 import Empty from '@/components/Empty'
+import Tag from '@/components/Tag'
 
 interface TimelineItem {
   id: string;
@@ -18,6 +19,9 @@ interface TimelineItem {
   summary: string;
   storage_type: number;
   created_time: string | number;
+  domain: string;
+  topic: string;
+  keywords: string[]
 }
 
 const KEYS = {
@@ -68,9 +72,14 @@ const Timeline: FC = () => {
                   {formatDateTime(vo.created_time)}
                   {index !== data.length - 1 && <Divider type="vertical" className="rb:flex-1 rb:w-px rb:border-[#155EEF]!" />}
                 </div>
-                <div className="rb:flex rb:justify-between rb:flex-1 rb:mb-4">
-                  <div className="rb:w-150 rb:leading-5">{vo.summary}</div>
-                  <div className="rb:text-[#5B6167] rb:font-medium">{t(`perceptualDetail.${perceptual_type[vo.perceptual_type]}`)}</div>
+                <div className="rb:flex-1 rb:pb-4">
+                  <div className="rb:flex rb:justify-between">
+                    <div className="rb:w-150 rb:leading-5 rb:font-medium">{vo.summary}</div>
+                    <div className="rb:text-[#5B6167] rb:font-medium rb:flex-1 rb:text-right">{t(`perceptualDetail.${perceptual_type[vo.perceptual_type]}`)}</div>
+                  </div>
+                  <div className="rb:text-[#5B6167] rb:leading-5 rb:mt-2">{[vo.domain, vo.topic].join(' | ')}</div>
+                  
+                  <Space size={8} className="rb:mt-2">{vo.keywords.map(tag => <Tag>{tag}</Tag>)}</Space>
                 </div>
               </div>
             ))}

--- a/web/src/views/UserMemoryDetail/pages/index.tsx
+++ b/web/src/views/UserMemoryDetail/pages/index.tsx
@@ -1,7 +1,7 @@
-import { type FC, useEffect, useState, useMemo } from 'react'
+import { type FC, useEffect, useState, useMemo, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Dropdown } from 'antd'
+import { Dropdown, Space, Button } from 'antd'
 
 import PageHeader from '../components/PageHeader'
 import StatementDetail from './StatementDetail'
@@ -15,12 +15,15 @@ import WorkingDetail from './WorkingDetail'
 import {
   getEndUserProfile,
 } from '@/api/memory'
+import refreshIcon from '@/assets/images/refresh_hover.svg'
 
 const Detail: FC = () => {
   const { t } = useTranslation()
   const { id, type } = useParams()
   const navigate = useNavigate()
   const [name, setName] = useState<string>('')
+  const forgetDetailRef = useRef<{ handleRefresh: () => void }>(null)
+
   useEffect(() => {
     if (!id) return
     getData()
@@ -40,6 +43,9 @@ const Detail: FC = () => {
   const onClick = ({ key }: { key: string }) => {
     navigate(`/user-memory/detail/${id}/${key}`, { replace: true })
   }
+  const handleRefresh = () => {
+    forgetDetailRef.current?.handleRefresh()
+  }
 
   return (
     <div className="rb:h-full rb:w-full">
@@ -49,17 +55,22 @@ const Detail: FC = () => {
         operation={
           <Dropdown menu={{ items, onClick, selectedKeys: type ? [type] : [] }}>
             <div className="rb:cursor-pointer rb:group rb:flex rb:items-center rb:gap-1">
-               - {type ? t(`userMemory.${type}`) : ''}
+              - {type ? t(`userMemory.${type}`) : ''}
               <div
                 className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/userMemory/up_border.svg')]  rb:transform-[rotate(180deg)] rb:group-hover:transform-[rotate(0deg)]"
               ></div>
-              </div>
+            </div>
           </Dropdown>
         }
+        extra={type === 'FORGETTING_MANAGEMENT' &&
+          <Button type="primary" ghost className="rb:group rb:h-6! rb:px-2!" onClick={handleRefresh}>
+            <img src={refreshIcon} className="rb:w-4 rb:h-4" />
+            {t('common.refresh')}
+          </Button>}
       />
       <div className="rb:h-[calc(100vh-64px)] rb:overflow-y-auto rb:py-3 rb:px-4">
         {type === 'EMOTIONAL_MEMORY' && <StatementDetail />}
-        {type === 'FORGETTING_MANAGEMENT' && <ForgetDetail />}
+        {type === 'FORGETTING_MANAGEMENT' && <ForgetDetail ref={forgetDetailRef} />}
         {type === 'IMPLICIT_MEMORY' && <ImplicitDetail />}
         {type === 'SHORT_TERM_MEMORY' && <ShortTermDetail />}
         {type === 'PERCEPTUAL_MEMORY' && <PerceptualDetail />}

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -26,6 +26,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
   const [chatList, setChatList] = useState<ChatItem[]>([])
   const [variables, setVariables] = useState<StartVariableItem[]>([])
   const [streamLoading, setStreamLoading] = useState(false)
+  const [conversationId, setConversationId] = useState<string | null>(null)
 
   const handleOpen = () => {
     setOpen(true)
@@ -100,7 +101,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
       setStreamLoading(false)
 
       data.forEach(item => {
-        const { chunk } = item.data as { chunk: string; };
+        const { chunk, conversation_id } = item.data as { chunk: string; conversation_id: string | null; };
 
         switch(item.event) {
           case 'message':
@@ -131,6 +132,10 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
             setStreamLoading(false)
             break
         }
+
+        if (conversation_id && conversationId !== conversation_id) {
+          setConversationId(conversation_id)
+        }
       })
     }
 
@@ -138,7 +143,8 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
     draftRun(appId, {
       message: message,
       variables: params,
-      stream: true
+      stream: true,
+      conversation_id: conversationId
     }, handleStreamMessage)
       .finally(() => {
         setLoading(false)


### PR DESCRIPTION
## Summary by Sourcery

改进 SSE 流解析，并在用户记忆详情视图中引入可配置的遗忘管理刷新功能。

New Features:
- 新增通过模态框手动触发遗忘管理的功能，可调整批处理大小和可访问天数，并在成功后给予反馈。
- 支持通过跟踪和复用会话 ID，在流式请求中恢复工作流聊天会话。
- 在时间轴视图中展示更多感知记忆元数据，包括领域、主题和关键词标签。

Bug Fixes:
- 修复 SSE 处理逻辑，正确缓冲和拆分流式事件，解析多行数据负载，并健壮地解码嵌套的 JSON 和 HTML 实体。
- 确保情绪与互动图表使用本地化的序列名称、正确的百分比比例以及整数刻度的纵轴。
- 通过启用自动换行，防止聊天消息气泡内容溢出。

Enhancements:
- 更新页面标题栏以支持更多操作，并使用新的图标和按钮样式重塑返回按钮。
- 通过 refs 暴露遗忘详情刷新能力，以便父视图可以以编程方式触发更新。
- 优化情绪折线图的工具提示内容、坐标轴标签和布局，使基于百分比的展示更加清晰。

Chores:
- 新增用于触发遗忘操作的 API 客户端，并将其接入遗忘管理 UI。
- 调整认证清理逻辑，在继续清除认证 Cookie 的同时停止清空 Web 存储。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve SSE stream parsing and introduce configurable forgetting management refresh in user memory detail views.

New Features:
- Add modal-driven manual trigger for forgetting management with adjustable batch size and access days and success feedback.
- Support resuming workflow chat conversations by tracking and reusing conversation IDs across streamed requests.
- Display additional perceptual memory metadata including domain, topic, and keyword tags in the timeline view.

Bug Fixes:
- Fix SSE handling to correctly buffer and split streamed events, parse multi-line data payloads, and robustly decode nested JSON and HTML entities.
- Ensure emotion and interaction charts use localized series names, correct percentage scales, and integer y-axis steps.
- Prevent chat message bubbles from overflowing by enabling word wrapping.

Enhancements:
- Update page headers to support extra actions and restyle the back button with new iconography and button treatment.
- Expose forget detail refresh via refs so parent views can trigger updates programmatically.
- Refine emotion line chart tooltip content, axis labels, and layout for clearer percentage-based display.

Chores:
- Add API client for triggering forgetting operations and wire it into the forgetting management UI.
- Adjust auth clearing logic to stop wiping web storage while still clearing auth cookies.

</details>