### PR TITLE
feat(workflow node)

### DIFF
--- a/api/app/core/tools/builtin/baidu_search_tool.py
+++ b/api/app/core/tools/builtin/baidu_search_tool.py
@@ -110,7 +110,7 @@ class BaiduSearchTool(BuiltinTool):
             
             execution_time = time.time() - start_time
             return ToolResult.success_result(
-                data=result,
+                data=result["results"],
                 execution_time=execution_time
             )
             

--- a/api/app/core/tools/builtin/datetime_tool.py
+++ b/api/app/core/tools/builtin/datetime_tool.py
@@ -95,7 +95,7 @@ class DateTimeTool(BuiltinTool):
             
             execution_time = time.time() - start_time
             return ToolResult.success_result(
-                data=result,
+                data=result["result_data"],
                 execution_time=execution_time
             )
             
@@ -123,12 +123,14 @@ class DateTimeTool(BuiltinTool):
         utc_now = datetime.now(timezone.utc)
         
         return {
-            "datetime": now.strftime(output_format),
-            "timestamp": int(now.timestamp()),
             "timezone": timezone_str,
             "iso_format": now.isoformat(),
-            "timestamp_ms": int(now.timestamp() * 1000),
-            "utc_datetime": utc_now.strftime(output_format)
+            "result_data": {
+                "datetime": now.strftime(output_format),
+                "timestamp": int(now.timestamp()),
+                "timestamp_ms": int(now.timestamp() * 1000),
+                "utc_datetime": utc_now.strftime(output_format),
+            }
         }
 
     @staticmethod
@@ -148,7 +150,8 @@ class DateTimeTool(BuiltinTool):
             "original": input_value,
             "formatted": dt.strftime(output_format),
             "timestamp": int(dt.timestamp()),
-            "iso_format": dt.isoformat()
+            "iso_format": dt.isoformat(),
+            "result_data": dt.strftime(output_format)
         }
 
     @staticmethod
@@ -189,7 +192,8 @@ class DateTimeTool(BuiltinTool):
             "original_timezone": from_timezone,
             "converted": converted_dt.strftime(output_format),
             "converted_timezone": to_timezone,
-            "timestamp": int(converted_dt.timestamp())
+            "timestamp": int(converted_dt.timestamp()),
+            "result_data": converted_dt.strftime(output_format)
         }
 
     @staticmethod
@@ -219,7 +223,8 @@ class DateTimeTool(BuiltinTool):
             "timestamp": timestamp,
             "datetime": dt.strftime(output_format),
             "timezone": timezone_str,
-            "iso_format": dt.isoformat()
+            "iso_format": dt.isoformat(),
+            "result_data": dt.strftime(output_format)
         }
 
     @staticmethod
@@ -249,7 +254,8 @@ class DateTimeTool(BuiltinTool):
             "datetime": input_value,
             "timezone": timezone_str,
             "timestamp": int(dt.timestamp()),
-            "iso_format": dt.isoformat()
+            "iso_format": dt.isoformat(),
+            "result_data": int(dt.timestamp())
         }
 
     def _calculate_datetime(self, kwargs) -> dict:
@@ -287,7 +293,8 @@ class DateTimeTool(BuiltinTool):
             "calculation": calculation,
             "result": calculated_dt.strftime(output_format),
             "timezone": timezone_str,
-            "timestamp": int(calculated_dt.timestamp())
+            "timestamp": int(calculated_dt.timestamp()),
+            "result_data": calculated_dt.strftime(output_format)
         }
 
     @staticmethod

--- a/api/app/core/tools/builtin/json_tool.py
+++ b/api/app/core/tools/builtin/json_tool.py
@@ -69,7 +69,7 @@ class JsonTool(BuiltinTool):
             ToolParameter(
                 name="json_path",
                 type=ParameterType.STRING,
-                description="JSON路径表达式（用于extract、insert、replace、delete、parse操作，如：$.user.name或users[0].name）",
+                description="JSON路径表达式（用于insert、replace、delete、parse操作，如：$.user.name或users[0].name）",
                 required=False
             ),
             ToolParameter(
@@ -136,7 +136,7 @@ class JsonTool(BuiltinTool):
             
             execution_time = time.time() - start_time
             return ToolResult.success_result(
-                data=result,
+                data=result["result_data"],
                 execution_time=execution_time
             )
             
@@ -671,7 +671,8 @@ class JsonTool(BuiltinTool):
                 "success": True,
                 "value": current,
                 "value_type": type(current).__name__,
-                "value_json": json.dumps(current, indent=2, ensure_ascii=False) if isinstance(current, (dict, list)) else str(current)
+                "value_json": json.dumps(current, indent=2, ensure_ascii=False) if isinstance(current, (dict, list)) else str(current),
+                "result_data": json.dumps(current, indent=2, ensure_ascii=False) if isinstance(current, (dict, list)) else str(current)
             }
             
         except (KeyError, IndexError, TypeError) as e:
@@ -680,7 +681,8 @@ class JsonTool(BuiltinTool):
                 "json_path": json_path,
                 "success": False,
                 "error": str(e),
-                "value": None
+                "value": None,
+                "result_data": None
             }
     
     def _analyze_json_structure(self, data: Any, depth: int = 0) -> Dict[str, Any]:


### PR DESCRIPTION
built-in tools output modifications to adapt to workflow nodes

## Summary by Sourcery

使内置的 datetime、JSON 和搜索工具适配为提供标准化的主载荷字段，以便工作流节点消费。

新特性：
- 在内置 datetime 和 JSON 工具中暴露专用的 `result_data` 字段，用于表示其供工作流节点使用的主要输出值。
- 标准化百度搜索工具的输出，使其仅返回搜索结果列表作为主要数据载荷。

增强改进：
- 优化 JSON 工具的参数描述，将 `extract` 从列出的 JSON 路径操作中移除，使其与当前行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt builtin datetime, JSON, and search tools to provide a standardized primary payload field for workflow node consumption.

New Features:
- Expose a dedicated result_data field in builtin datetime and JSON tools to represent their primary output value for workflow nodes.
- Standardize Baidu search tool output to return only the search results list as the main data payload.

Enhancements:
- Refine JSON tool parameter description to remove extract from the listed JSON path operations, keeping it aligned with current behavior.

</details>