### PR TITLE
feat(workflow node)

### DIFF
--- a/api/app/core/workflow/nodes/tool/node.py
+++ b/api/app/core/workflow/nodes/tool/node.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import uuid
 from typing import Any
 
 from app.core.workflow.nodes.base_node import BaseNode, WorkflowState
@@ -24,10 +25,10 @@ class ToolNode(BaseNode):
         # 获取租户ID和用户ID
         tenant_id = self.get_variable("sys.tenant_id", state)
         user_id = self.get_variable("sys.user_id", state)
+        workspace_id = self.get_variable("sys.workspace_id", state)
         
         # 如果没有租户ID，尝试从工作流ID获取
         if not tenant_id:
-            workspace_id = self.get_variable("sys.workspace_id", state)
             if workspace_id:
                 from app.repositories.tool_repository import ToolRepository
                 with get_db_read() as db:
@@ -62,7 +63,8 @@ class ToolNode(BaseNode):
                 tool_id=self.typed_config.tool_id,
                 parameters=rendered_parameters,
                 tenant_id=tenant_id,
-                user_id=user_id
+                user_id=uuid.UUID(user_id),
+                workspace_id=uuid.UUID(workspace_id)
             )
 
         if result.success:

--- a/api/app/models/tool_model.py
+++ b/api/app/models/tool_model.py
@@ -211,12 +211,11 @@ class ToolExecution(Base):
     token_usage = Column(JSON)
     
     # 用户信息
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), index=True)
+    user_id = Column(UUID(as_uuid=True), index=True, nullable=True)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, index=True)
     
     # 关联关系
     tool_config = relationship("ToolConfig", back_populates="executions")
-    user = relationship("User")
     workspace = relationship("Workspace")
     
     def __repr__(self):


### PR DESCRIPTION
The execution records of the tool remove the foreign key that binds to the user, and directly store the user ID

## Summary by Sourcery

通过在执行元数据中直接存储用户和工作区标识符，将工具执行记录与用户实体解耦。

改进内容：
- 更新工作流工具节点执行逻辑，在调用工具执行服务时，以 UUID 形式传递用户和工作区 ID。
- 将 `ToolExecution.user_id` 列放宽为可为空，并移除其到 `User` 模型的外键和 ORM 关系，同时保留与工作区的关联。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple tool execution records from the user entity by storing user and workspace identifiers directly in execution metadata.

Enhancements:
- Update workflow tool node execution to pass user and workspace IDs as UUIDs when invoking tool execution services.
- Relax the ToolExecution.user_id column to be nullable and remove its foreign key and ORM relationship to the User model while keeping workspace linkage.

</details>