### PR TITLE
fix(web): remove calculateVariableList

### DIFF
--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -22,7 +22,7 @@ import ConditionList from './ConditionList'
 import CycleVarsList from './CycleVarsList'
 import AssignmentList from './AssignmentList'
 import ToolConfig from './ToolConfig'
-import { calculateVariableList } from './utils/variableListCalculator'
+// import { calculateVariableList } from './utils/variableListCalculator'
 
 interface PropertiesProps {
   selectedNode?: Node | null; 
@@ -1022,10 +1022,10 @@ const Properties: FC<PropertiesProps> = ({
     return addParentIterationVars(baseList);
   };
 
-  const defaultVariableList = calculateVariableList(selectedNode as Node, graphRef, workflowConfig )
+  // const defaultVariableList = calculateVariableList(selectedNode as Node, graphRef, workflowConfig )
 
   console.log('values', values)
-  console.log('variableList', variableList, defaultVariableList)
+  // console.log('variableList', variableList, defaultVariableList)
 
   return (
     <div className="rb:w-75 rb:fixed rb:right-0 rb:top-16 rb:bottom-0 rb:p-3">


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在工作流的 Properties 视图中移除对已弃用的 `calculateVariableList` 辅助函数的使用，并清理相关日志。

增强内容：
- 在 Properties 面板中，将使用 `calculateVariableList` 进行默认变量列表计算的代码注释掉。

杂项：
- 移除现在未使用的 `calculateVariableList` 引用，并在 Properties 视图中关闭相关的调试日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove usage of the deprecated calculateVariableList helper in the workflow Properties view and clean up related logging.

Enhancements:
- Comment out the default variable list calculation using calculateVariableList in the Properties panel.

Chores:
- Remove now-unused import of calculateVariableList and silence related debug logging in the Properties view.

</details>