### PR TITLE
Fix/content attribute

### DIFF
--- a/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
@@ -626,7 +626,15 @@ class AccessHistoryManager:
                 'MemorySummary': 'n.content as content',
                 'ExtractedEntity': 'null as content_placeholder'  # 占位符，后续会被过滤
             }
-            content_field = content_field_map.get(node_label, 'null as content_placeholder')
+            
+            # 显式检查节点类型，不支持的类型抛出错误
+            if node_label not in content_field_map:
+                raise ValueError(
+                    f"Unsupported node_label: {node_label}. "
+                    f"Supported labels are: {list(content_field_map.keys())}"
+                )
+            
+            content_field = content_field_map[node_label]
             
             # 构建 WHERE 子句
             where_conditions = []

--- a/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
@@ -642,6 +642,7 @@ class AccessHistoryManager:
                 n.version = $new_version
             RETURN n.id as id,
                    n.statement as statement,
+                   n.content as content,
                    n.activation_value as activation_value,
                    n.access_history as access_history,
                    n.last_access_time as last_access_time,
@@ -671,7 +672,22 @@ class AccessHistoryManager:
                     f"Expected version {current_version}, but node was modified by another transaction."
                 )
             
-            return dict(updated_node)
+            # 转换为字典并根据节点类型清理字段
+            result_dict = dict(updated_node)
+            
+            # 根据节点类型保留正确的内容字段
+            if node_label == 'Statement':
+                # Statement 节点：保留 statement 字段，移除 content 字段
+                result_dict.pop('content', None)
+            elif node_label == 'MemorySummary':
+                # MemorySummary 节点：保留 content 字段，移除 statement 字段
+                result_dict.pop('statement', None)
+            elif node_label == 'ExtractedEntity':
+                # ExtractedEntity 节点：移除 statement 和 content 字段
+                result_dict.pop('statement', None)
+                result_dict.pop('content', None)
+            
+            return result_dict
         
         # 执行事务
         try:

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -78,12 +78,13 @@ async def _update_activation_values_batch(
     if not unique_node_ids:
         logger.warning(f"批量更新激活值：没有有效的节点ID")
         return nodes
-    
-    # 记录去重信息
-    if len(unique_node_ids) < len(nodes):
+
+    # 记录去重信息（仅针对具有有效 ID 的节点）
+    id_nodes_count = sum(1 for n in nodes if n.get("id"))
+    if len(unique_node_ids) < id_nodes_count:
         logger.info(
-            f"批量更新激活值：检测到重复节点，原始数量={len(nodes)}, "
-            f"去重后数量={len(unique_node_ids)}"
+            f"批量更新激活值：检测到重复节点，具有有效ID的节点数量={id_nodes_count}, "
+            f"去重后唯一ID数量={len(unique_node_ids)}"
         )
     
     # 批量记录访问

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -175,11 +175,26 @@ async def _update_search_results_activation(
             for original_node in original_nodes:
                 node_id = original_node.get('id')
                 if node_id and node_id in updated_map:
-                    # 使用更新后的激活值数据
-                    merged_node = updated_map[node_id].copy()
-                    # 保留原始的 score 字段（搜索相关性分数）
-                    if 'score' in original_node:
-                        merged_node['score'] = original_node['score']
+                    # 从原始节点开始，用更新后的激活值数据覆盖
+                    merged_node = original_node.copy()
+                    
+                    # 更新激活值相关字段
+                    activation_fields = {
+                        'activation_value',
+                        'access_history',
+                        'last_access_time',
+                        'access_count',
+                        'importance_score',
+                        'version',
+                        'statement',  # Statement 节点的内容字段
+                        'content'     # MemorySummary 节点的内容字段
+                    }
+                    
+                    # 只更新激活值相关字段，保留原始节点的其他字段
+                    for field in activation_fields:
+                        if field in updated_map[node_id]:
+                            merged_node[field] = updated_map[node_id][field]
+                    
                     merged_nodes.append(merged_node)
                 else:
                     # 如果没有更新数据，保留原始节点


### PR DESCRIPTION
## Summary by Sourcery

确保在更新激活值时正确处理重复节点，并针对不同节点类型返回相应的内容字段。

Bug 修复：
- 在批量更新激活值时去重节点 ID，同时保留原有结果顺序和分数。
- 在访问历史更新中，根据不同的节点标签返回正确的内容相关字段，而不是始终使用 `statement` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure activation updates correctly handle duplicate nodes and return appropriate content fields for different node types.

Bug Fixes:
- Deduplicate node IDs when batch updating activation values while preserving original result ordering and scores.
- Return the correct content-related field for different node labels in access history updates instead of always using the statement field.

</details>