### PR TITLE
fix(custome tool)

### DIFF
--- a/api/app/core/tools/custom/schema_parser.py
+++ b/api/app/core/tools/custom/schema_parser.py
@@ -10,9 +10,6 @@ from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
 
-# 为了兼容性，创建别名
-# SchemaParser = OpenAPISchemaParser = None
-
 
 class OpenAPISchemaParser:
     """OpenAPI Schema解析器 - 解析OpenAPI 3.0规范"""
@@ -213,7 +210,9 @@ class OpenAPISchemaParser:
                 
                 if not isinstance(operation, dict):
                     continue
-                
+
+                summary = operation.get("summary", "")
+
                 # 生成操作ID
                 operation_id = operation.get("operationId")
                 if not operation_id:
@@ -223,7 +222,7 @@ class OpenAPISchemaParser:
                 operations[operation_id] = {
                     "method": method.upper(),
                     "path": path,
-                    "summary": operation_id,
+                    "summary": summary if summary else operation_id,
                     "description": operation.get("description", ""),
                     "parameters": self._extract_parameters(operation),
                     "request_body": self._extract_request_body(operation),

--- a/api/app/core/tools/custom/schema_parser.py
+++ b/api/app/core/tools/custom/schema_parser.py
@@ -223,7 +223,7 @@ class OpenAPISchemaParser:
                 operations[operation_id] = {
                     "method": method.upper(),
                     "path": path,
-                    "summary": operation.get("summary", ""),
+                    "summary": operation_id,
                     "description": operation.get("description", ""),
                     "parameters": self._extract_parameters(operation),
                     "request_body": self._extract_request_body(operation),


### PR DESCRIPTION
get the name of the custom tool schema

## 由 Sourcery 提供的总结

确保从 OpenAPI 模式派生的自定义工具操作始终具有有意义的显示名称，并清理已废弃的模式解析器代码。

错误修复：
- 当 OpenAPI 模式未提供 summary 时，将操作的 summary 默认设置为 operationId，以便自定义工具仍然显示有意义的名称。

增强改进：
- 从自定义 OpenAPI 模式解析器中移除过时的、已被注释掉的别名定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure custom tool operations derived from OpenAPI schemas always have meaningful display names and clean up obsolete schema parser code.

Bug Fixes:
- Default the operation summary to the operationId when the OpenAPI schema omits a summary so custom tools still show a meaningful name.

Enhancements:
- Remove outdated, commented alias definitions from the custom OpenAPI schema parser.

</details>

Bug Fixes（错误修复）:
- 当 OpenAPI schema 中未提供 summary 时，将操作摘要默认设置为 `operationId`，以确保自定义工具具有有意义的显示名称。

Enhancements（增强）:
- 从自定义 schema 解析器中移除过时的、已被注释掉的别名定义。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

确保从 OpenAPI 模式派生的自定义工具操作始终具有有意义的显示名称，并清理已废弃的模式解析器代码。

错误修复：
- 当 OpenAPI 模式未提供 summary 时，将操作的 summary 默认设置为 operationId，以便自定义工具仍然显示有意义的名称。

增强改进：
- 从自定义 OpenAPI 模式解析器中移除过时的、已被注释掉的别名定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure custom tool operations derived from OpenAPI schemas always have meaningful display names and clean up obsolete schema parser code.

Bug Fixes:
- Default the operation summary to the operationId when the OpenAPI schema omits a summary so custom tools still show a meaningful name.

Enhancements:
- Remove outdated, commented alias definitions from the custom OpenAPI schema parser.

</details>

</details>