### PR TITLE
fix(web): workflow bugfix

### DIFF
--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -181,10 +181,15 @@ const Conversation: FC = () => {
             currentConversationId = newId
             break
           case 'message':
-            const { content } = item.data as { content: string  }
-            updateAssistantMessage(content)
+            const { content, chunk, conversation_id: curId } = item.data as { content: string; chunk: string; conversation_id: string;  }
+            updateAssistantMessage(content ?? chunk)
+
+            if (curId) {
+              currentConversationId = curId;
+            }
             break
           case 'end':
+          case 'workflow_end':
             setLoading(false)
             if (currentConversationId && currentConversationId !== conversation_id) {
               setConversationId(currentConversationId)

--- a/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
+++ b/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
@@ -103,7 +103,11 @@ const ChatVariableModal = forwardRef<ChatVariableModalRef, ChatVariableModalProp
           label={t('workflow.config.parameter-extractor.default')}
         >
           {type === 'number'
-            ? <InputNumber placeholder={t('common.enter')} style={{ width: '100%' }} />
+            ? <InputNumber 
+              placeholder={t('common.enter')} 
+              style={{ width: '100%' }}
+              onChange={(value) => form.setFieldValue('defaultValue', value)}
+            />
             : type === 'boolean'
             ? <Select
               placeholder={t('common.pleaseSelect')}

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -54,6 +54,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
   const handleClose = () => {
     setOpen(false)
     setChatList([])
+    setVariables([])
   }
   const handleEditVariables = () => {
     variableConfigModalRef.current?.handleOpen(variables)

--- a/web/src/views/Workflow/components/Chat/VariableConfigModal.tsx
+++ b/web/src/views/Workflow/components/Chat/VariableConfigModal.tsx
@@ -80,7 +80,7 @@ const VariableConfigModal = forwardRef<VariableConfigModalRef, VariableEditModal
                       field.type === 'string' && <Input placeholder={t('common.pleaseEnter')} />
                     }
                     {
-                      field.type === 'number' && <InputNumber placeholder={t('common.pleaseEnter')} style={{ width: '100%' }} />
+                      field.type === 'number' && <InputNumber placeholder={t('common.pleaseEnter')} style={{ width: '100%' }} onChange={(value) => form.setFieldValue(['variables', name, 'value'], value)} />
                     }
                     {
                       field.type === 'boolean' && <Checkbox>{`${field.name}·${field.description}`}</Checkbox>

--- a/web/src/views/Workflow/components/Nodes/AddNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/AddNode.tsx
@@ -46,7 +46,8 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
       graph.addEdge({
         source: { cell: edge.getSourceCellId(), port: edge.getSourcePortId() },
         target: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'left')?.id || 'left' },
-        attrs: edge.getAttrs()
+        attrs: edge.getAttrs(),
+        zIndex: 3
       });
     });
 

--- a/web/src/views/Workflow/components/PortClickHandler.tsx
+++ b/web/src/views/Workflow/components/PortClickHandler.tsx
@@ -85,6 +85,7 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
             },
           },
         },
+        zIndex: 0
       });
       
       // 循环节点内子节点通过连接桩添加时，调整循环节点大小

--- a/web/src/views/Workflow/components/Properties/AssignmentList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/AssignmentList/index.tsx
@@ -60,7 +60,7 @@ const AssignmentList: FC<AssignmentListProps> = ({
                     >
                       <VariableSelect
                         placeholder={t('common.pleaseSelect')}
-                        options={options.filter(vo => vo.nodeData.type === 'loop' || vo.value.includes('conv.'))}
+                        options={options.filter(vo => vo.nodeData.type === 'loop' || vo.value.includes('conv.') || (vo.nodeData.type === 'iteration' && (vo.label === 'item' || vo.label === 'index')))}
                         popupMatchSelectWidth={false}
                         onChange={() => {
                           form.setFieldValue([parentName, name, 'operation'], undefined);

--- a/web/src/views/Workflow/components/Properties/ConditionList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ConditionList/index.tsx
@@ -53,6 +53,7 @@ const operatorsObj: { [key: string]: SelectProps['options'] } = {
 const ConditionList: FC<CaseListProps> = ({
   options,
   parentName,
+  selectedNode,
 }) => {
   const { t } = useTranslation();
   const form = Form.useFormInstance();
@@ -114,7 +115,12 @@ const ConditionList: FC<CaseListProps> = ({
                       <Col span={14}>
                         <Form.Item name={[field.name, 'left']} noStyle>
                           <VariableSelect
-                            options={options.filter(vo => vo.value.includes('sys.') || vo.value.includes('conv.') || vo.nodeData.type === 'loop')}
+                            options={options.filter(vo => 
+                              vo.value.includes('sys.') || 
+                              vo.value.includes('conv.') || 
+                              vo.nodeData.type === 'loop' ||
+                              (vo.nodeData.cycle && vo.nodeData.cycle === selectedNode?.id)
+                            )}
                             size="small"
                             allowClear={false}
                             popupMatchSelectWidth={false}


### PR DESCRIPTION
## Summary by Sourcery

修复了多个影响变量处理、条件配置、节点连接和会话更新的工作流编辑器与聊天相关的错误。

Bug 修复：
- 删除在工作流属性中重复生成的 HTTP 错误变量，以及不正确的循环错误变量处理。
- 确保在对多种节点类型进行类型过滤之前包含父级迭代变量，并在配置循环条件时暴露循环子节点输出。
- 调整 case 分支端口重新连接逻辑，在删除分支时能正确重新映射 ELSE 连接，而不会保留已移除的端口，并简化布尔运算符选项。
- 在合适的场景下允许在条件和赋值中选择循环/迭代子变量，包括迭代项变量和索引变量。
- 通过将 `InputNumber` 的变更同步回表单状态，正确持久化聊天变量弹窗中的数值型默认值。
- 处理可能以完整内容或分片形式提供的流式会话消息，并支持 `workflow_end` 事件以可靠地结束加载状态。
- 在关闭工作流聊天面板时重置聊天变量，避免使用到陈旧的变量状态。
- 通过显式设置边（edge）的 z-index 值，在添加节点或端口时保持正确的边叠放顺序。

增强功能：
- 在工作流属性中记录计算后的变量列表，以便更轻松地调试变量解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix multiple workflow editor and chat bugs affecting variable handling, condition configuration, node connections, and conversation updates.

Bug Fixes:
- Remove duplicated HTTP error variable generation and incorrect loop error variable handling in workflow properties.
- Ensure parent iteration variables are included before type filtering for several node types, and expose loop child node outputs when configuring loop conditions.
- Adjust case branch port reconnection so ELSE connections remap correctly when cases are deleted, without preserving removed ports, and simplify boolean operator options.
- Allow loop/iteration child variables to be selected in conditions and assignments where appropriate, including iteration item and index variables.
- Persist numeric default values correctly in chat variable modals by syncing InputNumber changes back into the form state.
- Handle streaming conversation messages that may provide either full content or chunks and support workflow_end events to stop loading state reliably.
- Reset chat variables when closing the workflow chat panel to avoid stale variable state.
- Maintain correct edge stacking order when adding nodes or ports by explicitly setting edge z-index values.

Enhancements:
- Log the computed variable list in workflow properties for easier debugging of variable resolution.

</details>