### PR TITLE
feat(workflow): add session context memory support to LLM nodes

### DIFF
--- a/api/app/controllers/workflow_controller.py
+++ b/api/app/controllers/workflow_controller.py
@@ -39,11 +39,11 @@ router = APIRouter(prefix="/apps", tags=["workflow"])
 @router.post("/{app_id}/workflow")
 @cur_workspace_access_guard()
 async def create_workflow_config(
-    app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
-    config: WorkflowConfigCreate,
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)]
+        app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
+        config: WorkflowConfigCreate,
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)]
 ):
     """创建工作流配置
 
@@ -95,6 +95,7 @@ async def create_workflow_config(
             code=BizCode.INTERNAL_ERROR,
             msg=f"创建工作流配置失败: {str(e)}"
         )
+
 
 #
 # @router.get("/{app_id}/workflow")
@@ -199,10 +200,10 @@ async def create_workflow_config(
 
 @router.delete("/{app_id}/workflow")
 async def delete_workflow_config(
-    app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)]
+        app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)]
 ):
     """删除工作流配置
 
@@ -243,11 +244,11 @@ async def delete_workflow_config(
 
 @router.post("/{app_id}/workflow/validate")
 async def validate_workflow_config(
-    app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)],
-    for_publish: Annotated[bool, Query(description="是否为发布验证")] = False
+        app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)],
+        for_publish: Annotated[bool, Query(description="是否为发布验证")] = False
 ):
     """验证工作流配置
 
@@ -312,12 +313,12 @@ async def validate_workflow_config(
 
 @router.get("/{app_id}/workflow/executions")
 async def get_workflow_executions(
-    app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)],
-    limit: Annotated[int, Query(ge=1, le=100)] = 50,
-    offset: Annotated[int, Query(ge=0)] = 0
+        app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)],
+        limit: Annotated[int, Query(ge=1, le=100)] = 50,
+        offset: Annotated[int, Query(ge=0)] = 0
 ):
     """获取工作流执行记录列表
 
@@ -365,10 +366,10 @@ async def get_workflow_executions(
 
 @router.get("/workflow/executions/{execution_id}")
 async def get_workflow_execution(
-    execution_id: Annotated[str, Path(description="执行 ID")],
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)]
+        execution_id: Annotated[str, Path(description="执行 ID")],
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)]
 ):
     """获取工作流执行详情
 
@@ -417,16 +418,14 @@ async def get_workflow_execution(
         )
 
 
-
 # ==================== 工作流执行 ====================
-
 @router.post("/{app_id}/workflow/run")
 async def run_workflow(
-    app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
-    request: WorkflowExecutionRequest,
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)]
+        app_id: Annotated[uuid.UUID, Path(description="应用 ID")],
+        request: WorkflowExecutionRequest,
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)]
 ):
     """执行工作流
 
@@ -487,22 +486,22 @@ async def run_workflow(
                 """
                 try:
                     async for event in await service.run_workflow(
-                        app_id=app_id,
-                        input_data=input_data,
-                        triggered_by=current_user.id,
-                        conversation_id=uuid.UUID(request.conversation_id) if request.conversation_id else None,
-                        stream=True
+                            app_id=app_id,
+                            input_data=input_data,
+                            triggered_by=current_user.id,
+                            conversation_id=uuid.UUID(request.conversation_id) if request.conversation_id else None,
+                            stream=True
                     ):
                         # 提取事件类型和数据
                         event_type = event.get("event", "message")
                         event_data = event.get("data", {})
-                        
+
                         # 转换为标准 SSE 格式（字符串）
                         # event: <type>
                         # data: <json>
                         sse_message = f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
                         yield sse_message
-                        
+
                 except Exception as e:
                     logger.error(f"流式执行异常: {e}", exc_info=True)
                     # 发送错误事件
@@ -554,10 +553,10 @@ async def run_workflow(
 
 @router.post("/workflow/executions/{execution_id}/cancel")
 async def cancel_workflow_execution(
-    execution_id: Annotated[str, Path(description="执行 ID")],
-    db: Annotated[Session, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_user)],
-    service: Annotated[WorkflowService, Depends(get_workflow_service)]
+        execution_id: Annotated[str, Path(description="执行 ID")],
+        db: Annotated[Session, Depends(get_db)],
+        current_user: Annotated[User, Depends(get_current_user)],
+        service: Annotated[WorkflowService, Depends(get_workflow_service)]
 ):
     """取消工作流执行
 
@@ -602,7 +601,7 @@ async def cancel_workflow_execution(
 
     except BusinessException as e:
         logger.warning(f"取消工作流执行失败: {e.message}")
-        return fail(code=e.error_code, msg=e.message)
+        return fail(code=e.code, msg=e.message)
     except Exception as e:
         logger.error(f"取消工作流执行异常: {e}", exc_info=True)
         return fail(

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -7,17 +7,18 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 class Settings:
     ENABLE_SINGLE_WORKSPACE: bool = os.getenv("ENABLE_SINGLE_WORKSPACE", "true").lower() == "true"
     # API Keys Configuration
     OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
     DASHSCOPE_API_KEY: str = os.getenv("DASHSCOPE_API_KEY", "")
-    
+
     # Neo4j Configuration (记忆系统数据库)
     NEO4J_URI: str = os.getenv("NEO4J_URI", "bolt://1.94.111.67:7687")
     NEO4J_USERNAME: str = os.getenv("NEO4J_USERNAME", "neo4j")
     NEO4J_PASSWORD: str = os.getenv("NEO4J_PASSWORD", "")
-    
+
     # Database configuration (Postgres)
     DB_HOST: str = os.getenv("DB_HOST", "127.0.0.1")
     DB_PORT: int = int(os.getenv("DB_PORT", "5432"))
@@ -37,7 +38,7 @@ class Settings:
     REDIS_PORT: int = int(os.getenv("REDIS_PORT", "6379"))
     REDIS_DB: int = int(os.getenv("REDIS_DB", "1"))
     REDIS_PASSWORD: str = os.getenv("REDIS_PASSWORD", "")
-    
+
     # ElasticSearch configuration
     ELASTICSEARCH_HOST: str = os.getenv("ELASTICSEARCH_HOST", "https://127.0.0.1")
     ELASTICSEARCH_PORT: int = int(os.getenv("ELASTICSEARCH_PORT", "9200"))
@@ -48,7 +49,7 @@ class Settings:
     ELASTICSEARCH_REQUEST_TIMEOUT: int = int(os.getenv("ELASTICSEARCH_REQUEST_TIMEOUT", "100000"))
     ELASTICSEARCH_RETRY_ON_TIMEOUT: bool = os.getenv("ELASTICSEARCH_RETRY_ON_TIMEOUT", "True").lower() == "true"
     ELASTICSEARCH_MAX_RETRIES: int = int(os.getenv("ELASTICSEARCH_MAX_RETRIES", "10"))
-    
+
     # Xinference configuration
     XINFERENCE_URL: str = os.getenv("XINFERENCE_URL", "http://127.0.0.1")
 
@@ -57,17 +58,17 @@ class Settings:
     LANGCHAIN_TRACING: bool = os.getenv("LANGCHAIN_TRACING", "false").lower() == "true"
     LANGCHAIN_API_KEY: str = os.getenv("LANGCHAIN_API_KEY", "")
     LANGCHAIN_ENDPOINT: str = os.getenv("LANGCHAIN_ENDPOINT", "")
-    
+
     # LLM Request Configuration
     LLM_TIMEOUT: float = float(os.getenv("LLM_TIMEOUT", "120.0"))
     LLM_MAX_RETRIES: int = int(os.getenv("LLM_MAX_RETRIES", "2"))
-    
+
     # JWT Token Configuration
     SECRET_KEY: str = os.getenv("SECRET_KEY", "a_default_secret_key_that_is_long_and_random")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
-    
+
     # Single Sign-On configuration
     ENABLE_SINGLE_SESSION: bool = os.getenv("ENABLE_SINGLE_SESSION", "false").lower() == "true"
 
@@ -86,19 +87,19 @@ class Settings:
     LANGFUSE_PUBLIC_KEY: str = os.getenv("LANGFUSE_PUBLIC_KEY", "")
     LANGFUSE_SECRET_KEY: str = os.getenv("LANGFUSE_SECRET_KEY", "")
     LANGFUSE_HOST: str = os.getenv("LANGFUSE_HOST", "")
-    
+
     # Server Configuration
     SERVER_IP: str = os.getenv("SERVER_IP", "127.0.0.1")
 
     # ========================================================================
     # Internal Configuration (not in .env, used by application code)
     # ========================================================================
-    
+
     # Superuser settings (internal defaults)
     FIRST_SUPERUSER_EMAIL: str = os.getenv("FIRST_SUPERUSER_EMAIL", "admin@example.com")
     FIRST_SUPERUSER_USERNAME: str = os.getenv("FIRST_SUPERUSER_USERNAME", "admin")
     FIRST_SUPERUSER_PASSWORD: str = os.getenv("FIRST_SUPERUSER_PASSWORD", "admin_password")
-    
+
     # Generic File Upload (internal)
     GENERIC_FILE_PATH: str = os.getenv("GENERIC_FILE_PATH", "/uploads")
     ENABLE_FILE_COMPRESSION: bool = os.getenv("ENABLE_FILE_COMPRESSION", "false").lower() == "true"
@@ -123,7 +124,7 @@ class Settings:
     LOG_BACKUP_COUNT: int = int(os.getenv("LOG_BACKUP_COUNT", "5"))
     LOG_TO_CONSOLE: bool = os.getenv("LOG_TO_CONSOLE", "true").lower() == "true"
     LOG_TO_FILE: bool = os.getenv("LOG_TO_FILE", "true").lower() == "true"
-    
+
     # Sensitive Data Filtering
     ENABLE_SENSITIVE_DATA_FILTER: bool = os.getenv("ENABLE_SENSITIVE_DATA_FILTER", "true").lower() == "true"
 
@@ -142,7 +143,6 @@ class Settings:
     LOG_STREAM_BUFFER_SIZE: int = int(os.getenv("LOG_STREAM_BUFFER_SIZE", "8192"))  # 8KB
     LOG_FILE_MAX_SIZE_MB: int = int(os.getenv("LOG_FILE_MAX_SIZE_MB", "10"))  # 10MB
 
-
     # Celery configuration (internal)
     CELERY_BROKER: int = int(os.getenv("CELERY_BROKER", "1"))
     CELERY_BACKEND: int = int(os.getenv("CELERY_BACKEND", "2"))
@@ -150,15 +150,15 @@ class Settings:
     HEALTH_CHECK_SECONDS: float = float(os.getenv("HEALTH_CHECK_SECONDS", "600"))
     MEMORY_INCREMENT_INTERVAL_HOURS: float = float(os.getenv("MEMORY_INCREMENT_INTERVAL_HOURS", "24"))
     DEFAULT_WORKSPACE_ID: Optional[str] = os.getenv("DEFAULT_WORKSPACE_ID", None)
-    REFLECTION_INTERVAL_TIME:Optional[str] = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
-    
+    REFLECTION_INTERVAL_TIME: Optional[str] = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
+
     # Memory Cache Regeneration Configuration
     MEMORY_CACHE_REGENERATION_HOURS: int = int(os.getenv("MEMORY_CACHE_REGENERATION_HOURS", "24"))
 
     # Memory Module Configuration (internal)
     MEMORY_OUTPUT_DIR: str = os.getenv("MEMORY_OUTPUT_DIR", "logs/memory-output")
     MEMORY_CONFIG_DIR: str = os.getenv("MEMORY_CONFIG_DIR", "app/core/memory")
-    
+
     # Tool Management Configuration
     TOOL_CONFIG_DIR: str = os.getenv("TOOL_CONFIG_DIR", "app/core/tools")
     TOOL_EXECUTION_TIMEOUT: int = int(os.getenv("TOOL_EXECUTION_TIMEOUT", "60"))
@@ -167,7 +167,10 @@ class Settings:
 
     # official environment system version
     SYSTEM_VERSION: str = os.getenv("SYSTEM_VERSION", "v0.2.0")
-    
+
+    # workflow config
+    WORKFLOW_NODE_TIMEOUT: int = os.getenv("WORKFLOW_NODE_TIMEOUT", 600)
+
     def get_memory_output_path(self, filename: str = "") -> str:
         """
         Get the full path for memory module output files.
@@ -182,7 +185,7 @@ class Settings:
         if filename:
             return str(base_path / filename)
         return str(base_path)
-    
+
     def ensure_memory_output_dir(self) -> None:
         """
         Ensure the memory output directory exists.

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -169,7 +169,7 @@ class Settings:
     SYSTEM_VERSION: str = os.getenv("SYSTEM_VERSION", "v0.2.0")
 
     # workflow config
-    WORKFLOW_NODE_TIMEOUT: int = os.getenv("WORKFLOW_NODE_TIMEOUT", 600)
+    WORKFLOW_NODE_TIMEOUT: int = int(os.getenv("WORKFLOW_NODE_TIMEOUT", 600))
 
     def get_memory_output_path(self, filename: str = "") -> str:
         """

--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -74,6 +74,7 @@ class WorkflowExecutor:
             初始化的工作流状态
         """
         user_message = input_data.get("message") or ""
+        conversation_messages = input_data.get("conv_messages") or []
 
         # 会话变量处理：从配置文件获取变量定义列表，转换为字典（name -> default value）
         config_variables_list = self.workflow_config.get("variables") or []
@@ -114,7 +115,7 @@ class WorkflowExecutor:
         }
 
         return {
-            "messages": [('user', user_message)],
+            "messages": conversation_messages,
             "variables": variables,
             "node_outputs": {},
             "runtime_vars": {},  # 运行时节点变量（简化版，供快速访问）

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -11,12 +11,12 @@ class MessageConfig(BaseModel):
     """消息配置"""
 
     role: str = Field(
-        ...,
+        default='user',
         description="消息角色：system, user, assistant"
     )
 
     content: str = Field(
-        ...,
+        default="",
         description="消息内容，支持模板变量，如：{{ sys.message }}"
     )
 
@@ -28,6 +28,23 @@ class MessageConfig(BaseModel):
         if v.lower() not in allowed_roles:
             raise ValueError(f"角色必须是以下之一: {', '.join(allowed_roles)}")
         return v.lower()
+
+
+class MemoryWindowSetting(BaseModel):
+    enable: bool = Field(
+        default=False,
+        description="启用记忆"
+    )
+
+    enable_window: bool = Field(
+        default=False,
+        description="启用记忆窗口"
+    )
+
+    window_size: int = Field(
+        default=20,
+        description="记忆窗口大小"
+    )
 
 
 class LLMNodeConfig(BaseNodeConfig):
@@ -46,6 +63,11 @@ class LLMNodeConfig(BaseNodeConfig):
     context: Any = Field(
         default="",
         description="上下文"
+    )
+
+    memory: MemoryWindowSetting = Field(
+        ...,
+        description="对话上下文窗口"
     )
 
     # 简单模式

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -102,7 +102,7 @@ class LLMNode(BaseNode):
                 elif role in ["user", "human"]:
                     messages.append({"role": "user", "content": content})
                 elif role in ["ai", "assistant"]:
-                    messages.append({"role": "user", "content": content})
+                    messages.append({"role": "assistant", "content": content})
                 else:
                     logger.warning(f"未知的消息角色: {role}，默认使用 user")
                     messages.append({"role": "user", "content": content})

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -41,6 +41,7 @@ class ToolConfig(BaseModel):
     tool_id: Optional[str] = Field(default=None, description="工具ID")
     operation: Optional[str] = Field(default=None, description="工具特定配置")
 
+
 class ToolOldConfig(BaseModel):
     """工具配置"""
     enabled: bool = Field(default=False, description="是否启用该工具")
@@ -347,6 +348,7 @@ class AppChatRequest(BaseModel):
     user_id: Optional[str] = Field(default=None, description="用户ID（用于会话管理）")
     variables: Optional[Dict[str, Any]] = Field(default=None, description="自定义变量参数值")
     stream: bool = Field(default=False, description="是否流式返回")
+
 
 class DraftRunRequest(BaseModel):
     """试运行请求"""

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -2,12 +2,11 @@
 工作流服务层
 """
 import datetime
-import json
 import logging
 import uuid
-import datetime
 from typing import Any, Annotated, AsyncGenerator
 
+from deprecated import deprecated
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
@@ -16,15 +15,16 @@ from app.core.exceptions import BusinessException
 from app.core.workflow.validator import validate_workflow_config
 from app.db import get_db, get_db_context
 from app.models.workflow_model import WorkflowConfig, WorkflowExecution
+from app.repositories.conversation_repository import MessageRepository
+from app.models.conversation_model import Message
 from app.repositories.end_user_repository import EndUserRepository
-from app.services.multi_agent_service import convert_uuids_to_str
 from app.repositories.workflow_repository import (
     WorkflowConfigRepository,
     WorkflowExecutionRepository,
     WorkflowNodeExecutionRepository
 )
 from app.schemas import DraftRunRequest
-from app.utils.sse_utils import format_sse_message
+from app.services.multi_agent_service import convert_uuids_to_str
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class WorkflowService:
         self.config_repo = WorkflowConfigRepository(db)
         self.execution_repo = WorkflowExecutionRepository(db)
         self.node_execution_repo = WorkflowNodeExecutionRepository(db)
+        self.message_repo = MessageRepository(db)
 
     # ==================== 配置管理 ====================
 
@@ -418,14 +419,13 @@ class WorkflowService:
         """运行工作流
 
         Args:
+            workspace_id:
+            config:
+            payload:
             app_id: 应用 ID
-            input_data: 输入数据（包含 message 和 variables）
-            triggered_by: 触发用户 ID
-            conversation_id: 会话 ID（可选）
-            stream: 是否流式返回
 
         Returns:
-            执行结果（非流式）或生成器（流式）
+            执行结果（非流式）
 
         Raises:
             BusinessException: 配置不存在或执行失败时抛出
@@ -438,7 +438,8 @@ class WorkflowService:
                 code=BizCode.CONFIG_MISSING,
                 message=f"工作流配置不存在: app_id={app_id}"
             )
-        input_data = {"message": payload.message, "variables": payload.variables, "conversation_id": payload.conversation_id}
+        input_data = {"message": payload.message, "variables": payload.variables,
+                      "conversation_id": payload.conversation_id}
 
         # 转换 user_id 为 UUID
         triggered_by_uuid = None
@@ -461,7 +462,7 @@ class WorkflowService:
             workflow_config_id=config.id,
             app_id=app_id,
             trigger_type="manual",
-            triggered_by=triggered_by_uuid,
+            triggered_by=None,
             conversation_id=conversation_id_uuid,
             input_data=input_data
         )
@@ -500,7 +501,10 @@ class WorkflowService:
                         variables = last_state.get("variables", {})
                         conv_vars = variables.get("conv", {})
                         input_data["conv"] = conv_vars
+                        input_data["conv_messages"] = last_state.get("messages") or []
                         break
+
+            init_message_length = len(input_data.get("conv_messages", []))
 
             result = await execute_workflow(
                 workflow_config=workflow_config_dict,
@@ -517,6 +521,17 @@ class WorkflowService:
                     "completed",
                     output_data=result
                 )
+                final_messages = result.get("messages", [])[init_message_length:]
+                for message in final_messages:
+                    message_obj = Message(
+                        conversation_id=conversation_id_uuid,
+                        role=message["role"],
+                        content=message["content"],
+                    )
+                    self.message_repo.add_message(message_obj)
+                self.db.commit()
+                logger.info(f"Workflow Run Success, "
+                            f"execution_id: {execution.execution_id}, message count: {len(final_messages)}")
             else:
                 self.update_execution_status(
                     execution.execution_id,
@@ -529,6 +544,7 @@ class WorkflowService:
                 "execution_id": execution.execution_id,
                 "status": result.get("status"),
                 "variables": result.get("variables"),
+                "messages": result.get("messages"),
                 "output": result.get("output"),  # 最终输出（字符串）
                 "output_data": result.get("node_outputs", {}),  # 所有节点输出（详细数据）
                 "conversation_id": result.get("conversation_id"),  # 所有节点输出（详细数据）payload.,  # 会话 ID
@@ -559,6 +575,7 @@ class WorkflowService:
         """运行工作流（流式）
 
         Args:
+            workspace_id:
             app_id: 应用 ID
             payload: 请求对象（包含 message, variables, conversation_id 等）
             config: 存储类型（可选）
@@ -601,7 +618,7 @@ class WorkflowService:
             workflow_config_id=config.id,
             app_id=app_id,
             trigger_type="manual",
-            triggered_by=triggered_by_uuid,
+            triggered_by=None,
             conversation_id=conversation_id_uuid,
             input_data=input_data
         )
@@ -638,17 +655,46 @@ class WorkflowService:
                         variables = last_state.get("variables", {})
                         conv_vars = variables.get("conv", {})
                         input_data["conv"] = conv_vars
+                        input_data["conv_messages"] = last_state.get("messages") or []
                         break
+            init_message_length = len(input_data.get("conv_messages", []))
+            from app.core.workflow.executor import execute_workflow_stream
 
-            # 调用流式执行（executor 会发送 workflow_start 和 workflow_end 事件）
-            async for event in self._run_workflow_stream(
+            async for event in execute_workflow_stream(
                     workflow_config=workflow_config_dict,
                     input_data=input_data,
                     execution_id=execution.execution_id,
                     workspace_id=str(workspace_id),
                     user_id=end_user_id
             ):
-                # 直接转发 executor 的事件（已经是正确的格式）
+                if event.get("event") == "workflow_end":
+
+                    status = event.get("data", {}).get("status")
+                    if status == "completed":
+                        self.update_execution_status(
+                            execution.execution_id,
+                            "completed",
+                            output_data=event.get("data")
+                        )
+                        final_messages = event.get("data", {}).get("messages", [])[init_message_length:]
+                        for message in final_messages:
+                            message_obj = Message(
+                                conversation_id=conversation_id_uuid,
+                                role=message["role"],
+                                content=message["content"],
+                            )
+                            self.message_repo.add_message(message_obj)
+                        self.db.commit()
+                        logger.info(f"Workflow Run Success, "
+                                    f"execution_id: {execution.execution_id}, message count: {len(final_messages)}")
+                    elif status == "failed":
+                        self.update_execution_status(
+                            execution.execution_id,
+                            "failed",
+                            output_data=event.get("data")
+                        )
+                    else:
+                        logger.error(f"unexpect workflow run status, status: {status}")
                 yield event
 
         except Exception as e:
@@ -667,6 +713,8 @@ class WorkflowService:
                 }
             }
 
+    @deprecated(reason="This method is deprecated. "
+                       "Please use WorkflowService.run / run_stream instead.")
     async def run_workflow(
             self,
             app_id: uuid.UUID,
@@ -819,6 +867,7 @@ class WorkflowService:
 
         return clean_value(event)
 
+    @deprecated(reason="This method is deprecated. Please use WorkflowService.run_stream instead.")
     async def _run_workflow_stream(
             self,
             workflow_config: dict[str, Any],

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -136,7 +136,8 @@ dependencies = [
     "markdown-to-json==2.1.1",
     "valkey==6.0.2",
     "python-calamine>=0.4.0",
-    "xlrd==2.0.2"
+    "xlrd==2.0.2",
+    "deprecated>=1.3.1",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary by Sourcery

重构工作流聊天端点以使用新的 `WorkflowService.run` 和 `run_stream` API，同时为工作流执行和 LLM 节点添加基于会话的消息上下文支持。

Bug 修复：
- 修复工作流执行取消时的错误响应，确保返回正确的 `BusinessException` `code` 字段。
- 规范 LLM 节点消息提取中的消息角色处理，改为使用显式的角色键，而不是 LangChain 的消息类型名称。

增强功能：
- 统一非流式和流式工作流聊天路径，将执行委托给携带 `DraftRunRequest` 负载的 `WorkflowService.run` 和 `run_stream`。
- 扩展工作流执行状态以携带完整的消息历史，并在 `run` 和 `run_stream` 结果中对下游使用方暴露这些历史。
- 通过 `WORKFLOW_NODE_TIMEOUT` 设置引入可配置的工作流节点超时时间，并在基础节点超时逻辑中使用该配置。
- 更新 LLM 节点配置以支持记忆窗口设置，并在启用时使用先前会话消息作为上下文。
- 调整工作流结束节点逻辑，在正常和流式执行场景下，将用户和助手消息追加到工作流状态中，以启用会话记忆。
- 重构工作流执行器，从持久化的会话消息历史中初始化状态消息，而不是仅从最新的用户消息初始化。
- 在成功执行或触发 `workflow_end` 事件后，将新生成的工作流消息持久化到会话消息存储库中。
- 弃用旧的 `workflow_service.run_workflow` 和 `_run_workflow_stream` 方法，转而使用新的 `run`/`run_stream` API。

构建：
- 添加已弃用库依赖，用于为旧工作流服务方法提供弃用注解支持。

杂项：
- 在聊天和工作流控制器模块中进行轻微的代码风格和格式清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor workflow chat endpoints to use the new WorkflowService.run and run_stream APIs while adding session-based message context support to workflow executions and LLM nodes.

Bug Fixes:
- Fix workflow execution cancellation error response to return the correct BusinessException code field.
- Normalize message role handling in LLM node message extraction to use explicit role keys instead of LangChain message type names.

Enhancements:
- Unify non-streaming and streaming workflow chat paths to delegate execution to WorkflowService.run and run_stream with DraftRunRequest payloads.
- Extend workflow execution state to carry full message histories and expose them in run and run_stream results for downstream consumers.
- Introduce configurable workflow node timeouts via WORKFLOW_NODE_TIMEOUT setting and use it in the base node timeout logic.
- Update LLM node configuration to support a memory window setting and use prior conversation messages as context when enabled.
- Adjust workflow end node logic to append user and assistant messages into the workflow state for both normal and streaming executions, enabling session memory.
- Refactor workflow executor to initialize state messages from persisted conversation message history instead of the latest user message only.
- Persist newly generated workflow messages to the conversation message repository upon successful execution or workflow_end events.
- Deprecate legacy workflow_service.run_workflow and _run_workflow_stream methods in favor of the new run/run_stream APIs.

Build:
- Add deprecated library dependency to support deprecation annotations for legacy workflow service methods.

Chores:
- Apply minor code style and formatting cleanups across chat and workflow controller modules.

</details>