### PR TITLE
Fix/workflow zy

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,15 +30,12 @@ import 'dayjs/plugin/utc'
 import { cookieUtils } from './utils/request';
 
 
-
-
-
 function App() {
   const { t } = useTranslation();
   const { locale, language, timeZone } = useI18n()
   useEffect(() => {
     const authToken = cookieUtils.get('authToken')
-    if (!authToken && !window.location.hash.includes('#/login')) {
+    if (!authToken && !window.location.hash.includes('#/login') && !window.location.hash.includes('#/conversation/')) {
       window.location.href = `/#/login`;
     }
   }, [])

--- a/web/src/components/Layout/NoAuthLayout.tsx
+++ b/web/src/components/Layout/NoAuthLayout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+import { type FC } from 'react';
+
+// 基础布局组件，用于展示内容并保留用户信息获取功能
+const NoAuthLayout: FC = () => {
+
+  return (
+    <div className="rb:relative rb:h-full rb:w-full">
+      <Outlet />
+    </div>
+  )
+};
+
+export default NoAuthLayout;

--- a/web/src/components/Markdown/Code.tsx
+++ b/web/src/components/Markdown/Code.tsx
@@ -81,7 +81,7 @@ const Code: FC<ICodeProps> = (props) => {
     </div>
     )
   }
-  return <span className="rb:bg-[#F0F3F8] rb:px-1 rb:py-0.5 rb:rounded rb:text-sm rb:font-mono">{children}</span>
+  return <code className="rb:bg-[#F0F3F8] rb:px-1 rb:py-0.5 rb:rounded rb:text-sm rb:font-mono rb:whitespace-break-spaces">{children}</code>
 }
 
 export default Code

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1960,6 +1960,9 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       addMessage: 'Add Message',
       answerDesc: 'Reply',
       addNode: 'Add Node',
+      arrange: 'Arrange',
+      redo: 'Redo',
+      undo: 'Undo',
     },
     emotionEngine: {
       emotionEngineConfig: 'Emotion Engine Configuration',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2057,6 +2057,9 @@ export const zh = {
       addMessage: '添加消息',
       answerDesc: '回复',
       addNode: '添加节点',
+      arrange: '整理',
+      redo: '重做',
+      undo: '撤销',
     },
     emotionEngine: {
       emotionEngineConfig: '情感引擎配置',

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -34,6 +34,7 @@ const componentMap: Record<string, LazyExoticComponent<ComponentType<object>>> =
   AuthSpaceLayout: lazy(() => import('@/components/Layout/AuthSpaceLayout')),
   BasicLayout: lazy(() => import('@/components/Layout/BasicLayout')),
   LoginLayout: lazy(() => import('@/components/Layout/LoginLayout')),
+  NoAuthLayout: lazy(() => import('@/components/Layout/NoAuthLayout')),
   // 视图组件
   Index: lazy(() => import('@/views/Index')),
   Home: lazy(() => import('@/views/Home')),

--- a/web/src/routes/routes.json
+++ b/web/src/routes/routes.json
@@ -42,10 +42,15 @@
     "element": "BasicLayout",
     "children": [
       { "path": "/application/config/:id", "element": "ApplicationConfig" },
-      { "path": "/conversation/:token", "element": "Conversation" },
       { "path": "/user-memory/neo4j/:id", "element": "Neo4jUserMemoryDetail" },
       { "path": "/statement/:id", "element": "StatementDetail" },
       { "path": "/user-memory/detail/:id/:type", "element": "MemoryNodeDetail" }
+    ]
+  },
+  {
+    "element": "NoAuthLayout",
+    "children": [
+      { "path": "/conversation/:token", "element": "Conversation" }
     ]
   },
   {

--- a/web/src/views/UserMemory/index.tsx
+++ b/web/src/views/UserMemory/index.tsx
@@ -41,7 +41,9 @@ export default function UserMemory() {
         navigate(`/user-memory/${id}`)
     }
   }
-  const handleViewMemoryConfig = () => {
+  const handleViewMemoryConfig = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     navigate(`/memory`)
   }
 
@@ -84,8 +86,9 @@ export default function UserMemory() {
                     title={name || '-'}
                     extra={<div
                       className="rb:w-7 rb:h-7 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/userMemory/goto.svg')]"
-                      onClick={() => handleViewDetail(end_user.id)}
                     ></div>}
+                    className="rb:cursor-pointer"
+                    onClick={() => handleViewDetail(end_user.id)}
                   >
                     <div className="rb:flex rb:justify-between rb:items-center">
                       <div>{t('userMemory.capacity')}</div>
@@ -96,7 +99,7 @@ export default function UserMemory() {
                       <div>{t(`userMemory.${item.type || 'person'}`)}</div>
                     </div>
 
-                    <div className="rb:mt-3 rb:bg-[#F6F8FC] rb:rounded-lg rb:border rb:border-[#DFE4ED] rb:py-2 rb:px-3" onClick={handleViewMemoryConfig}>
+                    <div className="rb:relative rb:z-2 rb:mt-3 rb:bg-[#F6F8FC] rb:rounded-lg rb:border rb:border-[#DFE4ED] rb:py-2 rb:px-3" onClick={handleViewMemoryConfig}>
                       <div className="rb:text-[#5B6167] rb:leading-5 rb:flex rb:justify-between rb:items-center">
                         {t('userMemory.memory_config_name')}
                         <div

--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -81,12 +81,14 @@ const RelationshipNetwork:FC = () => {
           name: displayName,
           category: categoryIndex >= 0 ? categoryIndex : 0,
           symbolSize: symbolSize, // 根据连接数调整节点大小
-          itemStyle: {
-            color: colors[categoryIndex % 8]
-          }
         })
       })
       
+      // 创建节点ID到标签的映射
+      const nodeIdToLabel: Record<string, string> = {}
+      nodes.forEach(node => {
+        nodeIdToLabel[node.id] = node.label
+      })
       // 处理边数据
       edges.forEach(edge => {
         curEdges.push({

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -40,7 +40,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
       const curVariables = startNodes[0].config.variables?.defaultValue
 
       curVariables.forEach((vo: StartVariableItem) => {
-        if (vo.default) {
+        if (typeof vo.default !== 'undefined') {
           vo.value = vo.default
         }
         const lastVo = variables.find(item => item.name === vo.name)

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -55,6 +55,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
     setOpen(false)
     setChatList([])
     setVariables([])
+    setConversationId(null)
   }
   const handleEditVariables = () => {
     variableConfigModalRef.current?.handleOpen(variables)

--- a/web/src/views/Workflow/components/Nodes/AddNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/AddNode.tsx
@@ -13,11 +13,12 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
   const handleNodeSelect = (selectedNodeType: any) => {
     const parentBBox = node.getBBox();
     const cycleId = data.cycle;
+    const horizontalSpacing = 20;
 
     const id = `${selectedNodeType.type.replace(/-/g, '_') }_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
     const newNode = graph.addNode({
       ...(graphNodeLibrary[selectedNodeType.type] || graphNodeLibrary.default),
-      x: parentBBox.x,
+      x: parentBBox.x + horizontalSpacing,
       y: parentBBox.y,
       id,
       data: {
@@ -35,7 +36,7 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
     if (cycleId) {
       const parentNode = graph.getNodes().find((n: any) => n.getData()?.id === cycleId);
       if (parentNode) {
-        parentNode.addChild(newNode);
+        parentNode.insertChild(newNode);
       }
     }
 
@@ -47,7 +48,7 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         source: { cell: edge.getSourceCellId(), port: edge.getSourcePortId() },
         target: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'left')?.id || 'left' },
         attrs: edge.getAttrs(),
-        zIndex: 3
+        zIndex: 1,
       });
     });
 
@@ -58,7 +59,7 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         source: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'right')?.id || 'right' },
         target: { cell: edge.getTargetCellId(), port: targetPortId },
         attrs: edge.getAttrs(),
-        zIndex: 3
+        zIndex: 1,
       });
     });
 

--- a/web/src/views/Workflow/components/Nodes/AddNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/AddNode.tsx
@@ -36,7 +36,7 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
     if (cycleId) {
       const parentNode = graph.getNodes().find((n: any) => n.getData()?.id === cycleId);
       if (parentNode) {
-        parentNode.insertChild(newNode);
+        parentNode.addChild(newNode);
       }
     }
 
@@ -48,7 +48,6 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         source: { cell: edge.getSourceCellId(), port: edge.getSourcePortId() },
         target: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'left')?.id || 'left' },
         attrs: edge.getAttrs(),
-        zIndex: 1,
       });
     });
 
@@ -59,7 +58,6 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         source: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'right')?.id || 'right' },
         target: { cell: edge.getTargetCellId(), port: targetPortId },
         attrs: edge.getAttrs(),
-        zIndex: 1,
       });
     });
 

--- a/web/src/views/Workflow/components/Nodes/LoopNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/LoopNode.tsx
@@ -18,7 +18,7 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
     }, 50)
     
     return () => clearTimeout(timer)
-  }, [])
+  }, [graph])
 
   const checkAndAddAddNode = () => {
     if (!graph) return;
@@ -44,15 +44,15 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         },
       });
       
-      node.insertChild(addNode);
+      node.addChild(addNode);
       
       // 连接cycle-start和add-node
       const sourcePorts = cycleStartNode.getPorts();
       const targetPorts = addNode.getPorts();
       const sourcePort = sourcePorts.find((port: any) => port.group === 'right')?.id || 'right';
       const targetPort = targetPorts.find((port: any) => port.group === 'left')?.id || 'left';
-      
-      // 直接创建连线，不使用异步
+
+      // 然后创建连线
       graph.addEdge({
         source: { cell: cycleStartNode.id, port: sourcePort },
         target: { cell: addNode.id, port: targetPort },
@@ -107,8 +107,8 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         cycle: data.id,
       },
     });
-    node.insertChild(cycleStartNode)
-    node.insertChild(addNode)
+    node.addChild(cycleStartNode)
+    node.addChild(addNode)
     const sourcePorts = cycleStartNode.getPorts()
     const targetPorts = addNode.getPorts()
     let sourcePort = sourcePorts.find((port: any) => port.group === 'right')?.id || 'right';
@@ -133,7 +133,6 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         },
       },
     }
-
     graph.addEdge(edgeConfig)
   }
 

--- a/web/src/views/Workflow/components/Nodes/LoopNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/LoopNode.tsx
@@ -11,9 +11,13 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
   const { t } = useTranslation()
 
   useEffect(() => {
-    initNodes()
-    // 检查是否需要添加add-node
-    checkAndAddAddNode()
+    // 使用setTimeout确保在所有节点都添加完成后再创建连线
+    const timer = setTimeout(() => {
+      initNodes()
+      checkAndAddAddNode()
+    }, 50)
+    
+    return () => clearTimeout(timer)
   }, [])
 
   const checkAndAddAddNode = () => {
@@ -29,7 +33,7 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
       
       const addNode = graph.addNode({
         ...graphNodeLibrary.addStart,
-        x: cycleStartBBox.x + 64,
+        x: cycleStartBBox.x + 84,
         y: cycleStartBBox.y,
         data: {
           type: 'add-node',
@@ -40,7 +44,7 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         },
       });
       
-      node.addChild(addNode);
+      node.insertChild(addNode);
       
       // 连接cycle-start和add-node
       const sourcePorts = cycleStartNode.getPorts();
@@ -48,6 +52,7 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
       const sourcePort = sourcePorts.find((port: any) => port.group === 'right')?.id || 'right';
       const targetPort = targetPorts.find((port: any) => port.group === 'left')?.id || 'left';
       
+      // 直接创建连线，不使用异步
       graph.addEdge({
         source: { cell: cycleStartNode.id, port: sourcePort },
         target: { cell: addNode.id, port: targetPort },
@@ -61,7 +66,6 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
             },
           },
         },
-        zIndex: 10
       });
     }
   }
@@ -93,7 +97,7 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
     });
     const addNode = graph.addNode({
       ...graphNodeLibrary.addStart,
-      x: centerX + 64,
+      x: centerX + 84,
       y: centerY,
       data: {
         type: 'add-node',
@@ -103,8 +107,8 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         cycle: data.id,
       },
     });
-    node.addChild(cycleStartNode)
-    node.addChild(addNode)
+    node.insertChild(cycleStartNode)
+    node.insertChild(addNode)
     const sourcePorts = cycleStartNode.getPorts()
     const targetPorts = addNode.getPorts()
     let sourcePort = sourcePorts.find((port: any) => port.group === 'right')?.id || 'right';
@@ -124,11 +128,10 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
           strokeWidth: 1,
           targetMarker: {
             name: 'block',
-            size: 8,
+            size: 2,
           },
         },
       },
-      zIndex: 10
     }
 
     graph.addEdge(edgeConfig)

--- a/web/src/views/Workflow/components/PortClickHandler.tsx
+++ b/web/src/views/Workflow/components/PortClickHandler.tsx
@@ -129,7 +129,7 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
     if (sourceNodeData.cycle) {
       const parentNode = graph.getNodes().find((n: any) => n.getData()?.id === sourceNodeData.cycle);
       if (parentNode) {
-        parentNode.insertChild(newNode);
+        parentNode.addChild(newNode);
       }
     }
 
@@ -159,7 +159,7 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
             },
           },
         },
-        zIndex: sourceNodeData.cycle && sourceNodeType == 'cycle-start' ? 1 : sourceNodeData.cycle ? 2 : 0
+        // zIndex: sourceNodeData.cycle && sourceNodeType == 'cycle-start' ? 1 : sourceNodeData.cycle ? 2 : 0
       });
       
       // 循环节点内子节点通过连接桩添加时，调整循环节点大小

--- a/web/src/views/Workflow/components/PortClickHandler.tsx
+++ b/web/src/views/Workflow/components/PortClickHandler.tsx
@@ -36,11 +36,77 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
     if (!sourceNode || !graph) return;
 
     const sourceNodeData = sourceNode.getData();
+    const sourceNodeType = sourceNodeData?.type;
     
-    // 计算新节点位置（在源节点右侧）
+    // 如果是cycle-start节点，需要处理add-node节点
+    let addNodePosition = null;
+    if (sourceNodeType === 'cycle-start' && sourceNodeData.cycle) {
+      const cycleId = sourceNodeData.cycle;
+      const addNodes = graph.getNodes().filter((n: any) => 
+        n.getData()?.type === 'add-node' && n.getData()?.cycle === cycleId
+      );
+      
+      if (addNodes.length > 0) {
+        const addNode = addNodes[0];
+        addNodePosition = addNode.getBBox();
+        addNode.remove();
+      }
+    }
+    
+    // 计算新节点位置，避免重叠
     const sourceBBox = sourceNode.getBBox();
-    const newX = sourceBBox.x + sourceBBox.width + 50;
-    const newY = sourceBBox.y;
+    const nodeWidth = graphNodeLibrary[selectedNodeType.type]?.width || 120;
+    const nodeHeight = graphNodeLibrary[selectedNodeType.type]?.height || 88;
+    const horizontalSpacing = sourceNodeType === 'cycle-start' ? 40 : 80;
+    const verticalSpacing = 10;
+    
+    // 获取源连接桩的group信息
+    const sourcePortInfo = sourceNode.getPorts().find((p: any) => p.id === sourcePort);
+    const sourcePortGroup = sourcePortInfo?.group || sourcePort;
+    console.log('sourcePortGroup', sourcePortGroup, sourcePortInfo)
+    
+    // 如果有add-node位置，使用该位置，否则计算新位置
+    let newX, newY;
+    if (addNodePosition) {
+      newX = addNodePosition.x;
+      newY = addNodePosition.y;
+    } else {
+      // 根据连接桩位置决定节点放置方向
+      if (sourcePortGroup === 'left') {
+        // 左侧连接桩，在左侧添加节点
+        newX = sourceBBox.x - nodeWidth*2 - horizontalSpacing;
+        newY = sourceBBox.y;
+      } else {
+        // 右侧连接桩，在右侧添加节点
+        newX = sourceBBox.x + sourceBBox.width + horizontalSpacing;
+        newY = sourceBBox.y;
+      }
+      
+      // 检查位置是否与现有节点重叠（只考虑与当前节点相连的节点）
+      const checkOverlap = (x: number, y: number) => {
+        // 获取与源节点相连的节点
+        const connectedNodes = new Set();
+        graph.getConnectedEdges(sourceNode).forEach((edge: any) => {
+          const sourceId = edge.getSourceCellId();
+          const targetId = edge.getTargetCellId();
+          if (sourceId !== sourceNode.id) connectedNodes.add(sourceId);
+          if (targetId !== sourceNode.id) connectedNodes.add(targetId);
+        });
+        
+        return graph.getNodes().some((node: any) => {
+          if (node.id === sourceNode.id) return false;
+          if (!connectedNodes.has(node.id)) return false; // 只考虑相连的节点
+          const bbox = node.getBBox();
+          return !(x + nodeWidth < bbox.x || x > bbox.x + bbox.width || 
+                  y + nodeHeight < bbox.y || y > bbox.y + bbox.height);
+        });
+      };
+      
+      // 如果位置被占用，向下寻找空位
+      while (checkOverlap(newX, newY)) {
+        newY += nodeHeight + verticalSpacing;
+      }
+    }
     
     // 创建新节点
     const id = `${selectedNodeType.type.replace(/-/g, '_')}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
@@ -63,14 +129,22 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
     if (sourceNodeData.cycle) {
       const parentNode = graph.getNodes().find((n: any) => n.getData()?.id === sourceNodeData.cycle);
       if (parentNode) {
-        parentNode.addChild(newNode);
+        parentNode.insertChild(newNode);
       }
     }
 
     // 创建连线
     setTimeout(() => {
       const targetPorts = newNode.getPorts();
-      const targetPort = targetPorts.find((port: any) => port.group === 'left')?.id || 'left';
+      let targetPort;
+      
+      if (sourcePortGroup === 'left') {
+        // 从左侧连接桩连出，连接到新节点的右侧
+        targetPort = targetPorts.find((port: any) => port.group === 'right')?.id || 'right';
+      } else {
+        // 从右侧连接桩连出，连接到新节点的左侧
+        targetPort = targetPorts.find((port: any) => port.group === 'left')?.id || 'left';
+      }
       
       graph.addEdge({
         source: { cell: sourceNode.id, port: sourcePort },
@@ -85,7 +159,7 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
             },
           },
         },
-        zIndex: 0
+        zIndex: sourceNodeData.cycle && sourceNodeType == 'cycle-start' ? 1 : sourceNodeData.cycle ? 2 : 0
       });
       
       // 循环节点内子节点通过连接桩添加时，调整循环节点大小
@@ -108,8 +182,9 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
               }, { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity });
               
               const padding = 20;
+              const bottomPadding = 50;
               const newWidth = Math.max(240, bounds.maxX - bounds.minX + padding * 2);
-              const newHeight = Math.max(120, bounds.maxY - bounds.minY + padding * 2);
+              const newHeight = Math.max(120, bounds.maxY - bounds.minY + padding + bottomPadding);
 
               parentNode.prop('size', { width: newWidth, height: newHeight });
             }

--- a/web/src/views/Workflow/components/Properties/VariableEditModal.tsx
+++ b/web/src/views/Workflow/components/Properties/VariableEditModal.tsx
@@ -110,6 +110,7 @@ const VariableEditModal = forwardRef<VariableEditModalRef, VariableEditModalProp
               value: key,
               label: t(`workflow.config.start.${key}`),
             }))}
+            onChange={() => form.setFieldValue('default', undefined)}
             labelRender={(props) => <div className="rb:flex rb:justify-between rb:items-center">{props.label} <Tag color="blue">{variableType[props.value as keyof typeof variableType]}</Tag></div>}
             optionRender={(props) => <div className="rb:flex rb:justify-between rb:items-center">{props.label} <Tag color="blue">{variableType[props.value as keyof typeof variableType]}</Tag></div>}
           />

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -242,6 +242,7 @@ const Properties: FC<PropertiesProps> = ({
   }, [values, selectedNode, form])
 
   const handleAddVariable = () => {
+    setEditIndex(null)
     variableModalRef.current?.handleOpen()
   }
   const handleEditVariable = (index: number, vo: StartVariableItem) => {
@@ -250,6 +251,7 @@ const Properties: FC<PropertiesProps> = ({
   }
   const handleRefreshVariable = (value: StartVariableItem) => {
     if (!selectedNode) return
+
     if (editIndex !== null) {
       const defaultValue = selectedNode.data.config.variables.defaultValue ?? []
       defaultValue[editIndex] = value
@@ -260,7 +262,7 @@ const Properties: FC<PropertiesProps> = ({
     }
     selectedNode?.setData({ ...selectedNode.data})
 
-    setConfigs({ ...selectedNode.data.config})
+    setConfigs({ ...selectedNode.data.config })
   }
   const handleDeleteVariable = (index: number, vo: StartVariableItem) => {
     if (!selectedNode) return

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Graph, Node } from '@antv/x6';
 import { Form, Input, Button, Select, InputNumber, Slider, Space, Divider, App, Switch } from 'antd'
 
-import type { NodeConfig, NodeProperties, StartVariableItem, VariableEditModalRef } from '../../types'
+import type { NodeConfig, NodeProperties, StartVariableItem, VariableEditModalRef, ChatVariable } from '../../types'
 import Empty from '@/components/Empty';
 import emptyIcon from '@/assets/images/workflow/empty.png'
 import CustomSelect from "@/components/CustomSelect";
@@ -34,11 +34,12 @@ interface PropertiesProps {
   copyEvent: () => void;
   parseEvent: () => void;
   config?: any;
+  chatVariables: ChatVariable[];
 }
 const Properties: FC<PropertiesProps> = ({
   selectedNode,
   graphRef,
-  config: workflowConfig,
+  chatVariables
 }) => {
   const { t } = useTranslation()
   const { modal } = App.useApp()
@@ -47,6 +48,7 @@ const Properties: FC<PropertiesProps> = ({
   const values = Form.useWatch([], form);
   const variableModalRef = useRef<VariableEditModalRef>(null)
   const [editIndex, setEditIndex] = useState<number | null>(null)
+  const [graphUpdateTrigger, setGraphUpdateTrigger] = useState(0)
   const prevMappingNamesRef = useRef<string[]>([])
   const prevTemplateVarsRef = useRef<string[]>([])
   const syncTimeoutRef = useRef<number | null>(null)
@@ -349,11 +351,9 @@ const Properties: FC<PropertiesProps> = ({
       const parentPreviousNodeIds = getAllPreviousNodes(parentLoopNode.id);
       allRelevantNodeIds.push(...parentPreviousNodeIds);
     }
-    
-
 
     // Add conversation variables from global config
-    const conversationVariables = workflowConfig?.variables || [];
+    const conversationVariables = chatVariables || [];
 
     conversationVariables.forEach((variable: any) => {
       const key = `CONVERSATION_${variable.name}`;
@@ -763,7 +763,36 @@ const Properties: FC<PropertiesProps> = ({
     }
 
     return variableList;
-  }, [selectedNode, graphRef, workflowConfig?.variables]);
+  }, [selectedNode, graphRef, graphUpdateTrigger, chatVariables]);
+
+  // Trigger variableList update when graph edges or nodes change
+  useEffect(() => {
+    if (!graphRef?.current) return;
+    
+    const graph = graphRef.current;
+    const handleGraphChange = () => {
+      console.log('handleGraphChange')
+      // Force variableList recalculation by updating trigger
+      setGraphUpdateTrigger(prev => prev + 1);
+    };
+    
+    // Listen to graph changes
+    graph.on('edge:added', handleGraphChange);
+    graph.on('edge:removed', handleGraphChange);
+    graph.on('edge:changed', handleGraphChange);
+    graph.on('node:added', handleGraphChange);
+    graph.on('node:removed', handleGraphChange);
+    graph.on('node:change:data', handleGraphChange);
+    
+    return () => {
+      graph.off('edge:added', handleGraphChange);
+      graph.off('edge:removed', handleGraphChange);
+      graph.off('edge:changed', handleGraphChange);
+      graph.off('node:added', handleGraphChange);
+      graph.off('node:removed', handleGraphChange);
+      graph.off('node:change:data', handleGraphChange);
+    };
+  }, [graphRef]);
 
   // Filter out boolean type variables for loop and llm nodes
   const getFilteredVariableList = (nodeType?: string, key?: string) => {

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -54,7 +54,7 @@ export const useWorkflowGraph = ({
   const historyRef = useRef<{ undoStack: string[], redoStack: string[] }>({ undoStack: [], redoStack: [] });
   const [canUndo, setCanUndo] = useState(false);
   const [canRedo, setCanRedo] = useState(false);
-  const [isHandMode, setIsHandMode] = useState(false);
+  const [isHandMode, setIsHandMode] = useState(true);
   const [config, setConfig] = useState<WorkflowConfig | null>(null);
   const [chatVariables, setChatVariables] = useState<ChatVariable[]>([])
 
@@ -235,7 +235,7 @@ export const useWorkflowGraph = ({
           if (parentNode) {
             const addedChild = graphRef.current?.addNode(childNode)
             if (addedChild) {
-              parentNode.insertChild(addedChild)
+              parentNode.addChild(addedChild)
             }
           }
         }
@@ -354,7 +354,7 @@ export const useWorkflowGraph = ({
                 },
               },
             },
-            zIndex: loopIterationCount
+            // zIndex: loopIterationCount
           }
 
           return edgeConfig
@@ -694,10 +694,9 @@ export const useWorkflowGraph = ({
           thickness: 1, // 网点大小
         }
       },
-      panning: false,
+      panning: isHandMode,
       mousewheel: {
         enabled: true,
-        modifiers: ['ctrl', 'meta'],
       },
       connecting: {
         // router: 'orth',

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -235,7 +235,7 @@ export const useWorkflowGraph = ({
           if (parentNode) {
             const addedChild = graphRef.current?.addNode(childNode)
             if (addedChild) {
-              parentNode.addChild(addedChild)
+              parentNode.insertChild(addedChild)
             }
           }
         }
@@ -275,6 +275,11 @@ export const useWorkflowGraph = ({
       }, 100)
     }
     if (edges.length) {
+      // 计算loop和iteration类型节点的数量
+      const loopIterationCount = nodes.filter(node => 
+        node.type === 'loop' || node.type === 'iteration'
+      ).length;
+      
       // 去重处理：对于if-else和question-classifier节点，不同连接桩允许连接到相同节点
       const uniqueEdges = edges.filter((edge, index, arr) => {
         return arr.findIndex(e => {
@@ -349,7 +354,7 @@ export const useWorkflowGraph = ({
                 },
               },
             },
-            zIndex: targetCell.getData()?.cycle ? 3 : 0
+            zIndex: loopIterationCount
           }
 
           return edgeConfig
@@ -725,7 +730,6 @@ export const useWorkflowGraph = ({
                 },
               },
             },
-            zIndex: 0,
           });
         },
         validateConnection({ sourceCell, targetCell, targetMagnet }) {
@@ -762,9 +766,8 @@ export const useWorkflowGraph = ({
       },
       embedding: {
         enabled: true,
-        validate (this, { parent }) {
-        const parentData = parent.getData()
-          return parentData.type === 'iteration' || parentData.type === 'loop'
+        validate (this) {
+          return false
         }
       },
       translating: {

--- a/web/src/views/Workflow/index.tsx
+++ b/web/src/views/Workflow/index.tsx
@@ -107,6 +107,7 @@ const Workflow = forwardRef<WorkflowRef>((_props, ref) => {
         copyEvent={copyEvent}
         parseEvent={parseEvent}
         config={config}
+        chatVariables={chatVariables}
       />
       <Chat
         ref={chatRef}


### PR DESCRIPTION
## Summary by Sourcery

改进工作流图中的节点放置、循环处理以及在工作流、聊天和 Markdown 组件中的 UI 行为。

新功能：
- 通过新的 `NoAuthLayout` 和在应用入口中放宽的鉴权重定向，允许未认证访问某些路由。

缺陷修复：
- 修复在添加或删除分支时，工作流条件（case）节点端口和边的重新连接逻辑，包括正确的 ELSE 映射。
- 确保聊天变量在默认值为假值（falsy）时也能正确初始化默认值，并在关闭时重置会话状态。
- 在访问会话路由时，如果没有鉴权令牌，阻止登录重定向行为。
- 在变量编辑弹窗中更改变量类型时，重置变量编辑的默认值。
- 使用语义化的 `code` 元素渲染行内 Markdown 代码，并保留空白换行行为。

增强优化：
- 优化循环/环路节点的工作流节点插入、定位和边路由，包括更好的间距、避免重叠以及 z-index 分层。
- 稳定循环节点初始化和子节点插入时机，避免在创建内部节点和边时出现竞态条件。
- 禁用工作流图中的嵌套（embedding）行为，以防止节点被意外挂载为子节点。
- 调整循环添加节点的视觉效果和位置，使布局和边的样式更加一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve workflow graph node placement, loop handling, and UI behaviors across workflow, chat, and markdown components.

New Features:
- Allow unauthenticated access to certain routes via a new NoAuthLayout and relaxed auth redirect in the app entry.

Bug Fixes:
- Fix workflow case node port and edge reconnection logic when adding or removing branches, including proper ELSE mapping.
- Ensure chat variables correctly initialize default values even when default is falsy and reset conversation state on close.
- Prevent login redirect when accessing conversation routes without an auth token.
- Reset variable edit default value when changing variable type in the variable edit modal.
- Render inline markdown code using a semantic code element with preserved whitespace wrapping.

Enhancements:
- Refine workflow node insertion, positioning, and edge routing for loop/cycle nodes, including better spacing, overlap avoidance, and z-index layering.
- Stabilize loop node initialization and child insertion timing to avoid race conditions when creating internal nodes and edges.
- Disable embedding behavior in the workflow graph to prevent unintended node nesting.
- Adjust loop add-node visuals and positioning for more consistent layout and edge styling.

</details>