### PR TITLE
fix(muti agent)

### DIFF
--- a/api/app/core/tools/mcp/client.py
+++ b/api/app/core/tools/mcp/client.py
@@ -96,10 +96,7 @@ class SimpleMCPClient:
         """初始化 SSE MCP 会话 - 参考 Dify 实现"""
         try:
             # 建立 SSE 连接
-            response = await self._session.get(
-                self.server_url,
-                headers={"Accept": "text/event-stream"}
-            )
+            response = await self._session.get(self.server_url)
             
             if response.status != 200:
                 error_text = await response.text()

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -245,7 +245,8 @@ class DraftRunService:
         storage_type: Optional[str] = None,
         user_rag_memory_id: Optional[str] = None,
         web_search: bool = True,
-        memory: bool = True
+        memory: bool = True,
+        sub_agent: bool = False
     ) -> Dict[str, Any]:
         """执行试运行（使用 LangChain Agent）
 
@@ -435,7 +436,7 @@ class DraftRunService:
             elapsed_time = time.time() - start_time
 
             # 8. 保存会话消息
-            if agent_config.memory and agent_config.memory.get("enabled"):
+            if not sub_agent and agent_config.memory and agent_config.memory.get("enabled"):
                 await self._save_conversation_message(
                     conversation_id=conversation_id,
                     user_message=message,

--- a/api/app/services/multi_agent_orchestrator.py
+++ b/api/app/services/multi_agent_orchestrator.py
@@ -1327,7 +1327,8 @@ class MultiAgentOrchestrator:
             web_search=web_search,
             memory=memory,
             storage_type=storage_type,
-            user_rag_memory_id=user_rag_memory_id
+            user_rag_memory_id=user_rag_memory_id,
+            sub_agent=True
         )
 
         return result


### PR DESCRIPTION
non-streaming output sub-nodes do not record the generated content of the conversation

## Summary by Sourcery

Bug Fixes:
- 通过标记子代理执行并跳过对其的记忆写入，停止为非流式的子代理运行保存会话历史。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop saving conversation history for non-streaming sub-agent runs by flagging sub-agent executions and skipping memory writes for them.

</details>