### PR TITLE
fix(multi agent and mcp tool)

### DIFF
--- a/api/app/core/tools/mcp/client.py
+++ b/api/app/core/tools/mcp/client.py
@@ -96,10 +96,7 @@ class SimpleMCPClient:
         """初始化 SSE MCP 会话 - 参考 Dify 实现"""
         try:
             # 建立 SSE 连接
-            response = await self._session.get(
-                self.server_url,
-                headers={"Accept": "text/event-stream"}
-            )
+            response = await self._session.get(self.server_url)
             
             if response.status != 200:
                 error_text = await response.text()

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -245,7 +245,8 @@ class DraftRunService:
         storage_type: Optional[str] = None,
         user_rag_memory_id: Optional[str] = None,
         web_search: bool = True,
-        memory: bool = True
+        memory: bool = True,
+        sub_agent: bool = False
     ) -> Dict[str, Any]:
         """执行试运行（使用 LangChain Agent）
 
@@ -435,7 +436,7 @@ class DraftRunService:
             elapsed_time = time.time() - start_time
 
             # 8. 保存会话消息
-            if agent_config.memory and agent_config.memory.get("enabled"):
+            if not sub_agent and agent_config.memory and agent_config.memory.get("enabled"):
                 await self._save_conversation_message(
                     conversation_id=conversation_id,
                     user_message=message,

--- a/api/app/services/multi_agent_orchestrator.py
+++ b/api/app/services/multi_agent_orchestrator.py
@@ -1327,7 +1327,8 @@ class MultiAgentOrchestrator:
             web_search=web_search,
             memory=memory,
             storage_type=storage_type,
-            user_rag_memory_id=user_rag_memory_id
+            user_rag_memory_id=user_rag_memory_id,
+            sub_agent=True
         )
 
         return result


### PR DESCRIPTION
1. non-streaming output sub-nodes do not record the generated the content of the conversation
2. bug fix for the sse protocol request header in the mcp tool

## Summary by Sourcery

调整多代理草稿运行行为，并纠正 MCP SSE 客户端配置。

Bug Fixes:
- 防止子代理运行将会话消息持久化到记忆中，从而确保只有主代理记录历史。
- 通过移除错误硬编码的 `Accept` 请求头修复 MCP SSE 客户端请求问题，该请求头会破坏协议协商。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust multi-agent draft run behavior and correct MCP SSE client configuration.

Bug Fixes:
- Prevent sub-agent runs from persisting conversation messages to memory so only primary agents record history.
- Fix MCP SSE client request by removing an incorrect hardcoded Accept header that broke the protocol negotiation.

</details>