### PR TITLE
Fix/memory work

### DIFF
--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -516,8 +516,16 @@ class ConversationService:
 
         conversation_messages = self.get_conversation_history(
             conversation_id=conversation_id,
-            max_history=30
+            max_history=20
         )
+        if len(conversation_messages) == 0:
+            return ConversationOut(
+                theme="",
+                question=[],
+                summary="",
+                takeaways=[],
+                info_score=0,
+            )
 
         with open('app/services/prompt/conversation_summary_system.jinja2', 'r', encoding='utf-8') as f:
             system_prompt = f.read()
@@ -536,6 +544,7 @@ class ConversationService:
         ]
         logger.info(f"Invoking LLM for conversation_id={conversation_id}")
         model_resp = await llm.ainvoke(messages)
+
         try:
             if isinstance(model_resp.content, str):
                 result = json_repair.repair_json(model_resp.content, return_objects=True)


### PR DESCRIPTION
## Summary by Sourcery

在生成会话详情时处理空的会话历史，并减少所使用的历史记录量。

Bug Fixes:
- 当会话没有任何消息时，返回一个默认的空 `ConversationOut`，以避免下游错误。

Enhancements:
- 将获取的会话历史限制在较小的时间窗口内，以在生成会话详情时降低负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty conversation histories when generating conversation details and reduce the amount of history used.

Bug Fixes:
- Return a default empty ConversationOut when a conversation has no messages to avoid downstream errors.

Enhancements:
- Limit retrieved conversation history to a smaller window to reduce load when generating conversation details.

</details>