### PR TITLE
Fix/workflow zy

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1221,7 +1221,7 @@ export const en = {
       IMPLICIT_MEMORY: 'Implicit Memory',
       EMOTIONAL_MEMORY: 'Emotional Memory',
       EPISODIC_MEMORY: 'Episodic Memory',
-      FORGETTING_MANAGEMENT: 'Forgetting Management',
+      FORGET_MEMORY: 'Forget Memory',
 
       endUserProfile: 'Core Profile',
       editEndUserProfile: 'Edit',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1299,8 +1299,8 @@ export const zh = {
       IMPLICIT_MEMORY: '隐性记忆',
       EMOTIONAL_MEMORY: '情绪记忆',
       EPISODIC_MEMORY: '情景记忆',
-      FORGETTING_MANAGEMENT: '遗忘',
-
+      FORGET_MEMORY: '遗忘记忆',
+      
       endUserProfile: '核心档案',
       editEndUserProfile: '编辑',
       other_name: '姓名',

--- a/web/src/views/ApplicationConfig/Api.tsx
+++ b/web/src/views/ApplicationConfig/Api.tsx
@@ -16,7 +16,7 @@ import { maskApiKeys } from '@/utils/apiKeyReplacer'
 
 const Api: FC<{ application: Application | null }> = ({ application }) => {
   const { t } = useTranslation();
-  const activeMethods = ['GET'];
+  const activeMethods = ['POST'];
   const { message, modal } = App.useApp()
   const copyContent = window.location.origin + '/v1/chat'
   const apiKeyModalRef = useRef<ApiKeyModalRef>(null);

--- a/web/src/views/Pricing/index.tsx
+++ b/web/src/views/Pricing/index.tsx
@@ -10,6 +10,7 @@ import commerce from '@/assets/images/order/commerce.png'
 import checkIcon from '@/assets/images/login/checkBg.png'
 import alertIcon from '@/assets/images/order/alert.svg';
 import { useUser } from '@/store/user'
+import { useI18n } from '@/store/locale'
 
 interface PriceItem {
   type: string;
@@ -116,6 +117,7 @@ const PricingView: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useUser();
+  const { language } = useI18n()
 
   const handleChoosePlan = (type: string) => {
     switch(type) {
@@ -127,6 +129,7 @@ const PricingView: React.FC = () => {
         navigate(user.current_workspace_id ? '/' : '/space');
         break
       case 'commerce':
+        window.open(`https://docs.redbearai.com/s/${language || 'en'}-memorybear`, '_blank')
         break
     }
   };

--- a/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
+++ b/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
@@ -32,7 +32,7 @@ const typeList = [
       { key: 'EXPLICIT_MEMORY' }
     ]
   },
-  { key: 'FORGETTING_MANAGEMENT', bg: 5 },
+  { key: 'FORGET_MEMORY', bg: 5 },
 ]
 
 const NodeStatistics: FC = () => {

--- a/web/src/views/UserMemoryDetail/pages/index.tsx
+++ b/web/src/views/UserMemoryDetail/pages/index.tsx
@@ -38,7 +38,7 @@ const Detail: FC = () => {
     })
   }
   const items = useMemo(() => {
-    return ['PERCEPTUAL_MEMORY', 'WORKING_MEMORY', 'EMOTIONAL_MEMORY', 'SHORT_TERM_MEMORY', 'IMPLICIT_MEMORY', 'EPISODIC_MEMORY', 'EXPLICIT_MEMORY', 'FORGETTING_MANAGEMENT']
+    return ['PERCEPTUAL_MEMORY', 'WORKING_MEMORY', 'EMOTIONAL_MEMORY', 'SHORT_TERM_MEMORY', 'IMPLICIT_MEMORY', 'EPISODIC_MEMORY', 'EXPLICIT_MEMORY', 'FORGET_MEMORY']
       .map(key => ({ key, label: t(`userMemory.${key}`) }))
   }, [t])
   const onClick = ({ key }: { key: string }) => {
@@ -67,7 +67,7 @@ const Detail: FC = () => {
             </div>
           </Dropdown>
         }
-        extra={type === 'FORGETTING_MANAGEMENT' &&
+        extra={type === 'FORGET_MEMORY' &&
           <Button type="primary" ghost className="rb:group rb:h-6! rb:px-2!" onClick={handleRefresh}>
             <img src={refreshIcon} className="rb:w-4 rb:h-4" />
             {t('common.refresh')}
@@ -75,7 +75,7 @@ const Detail: FC = () => {
       />
       <div className="rb:h-[calc(100vh-64px)] rb:overflow-y-auto rb:py-3 rb:px-4">
         {type === 'EMOTIONAL_MEMORY' && <StatementDetail />}
-        {type === 'FORGETTING_MANAGEMENT' && <ForgetDetail ref={forgetDetailRef} />}
+        {type === 'FORGET_MEMORY' && <ForgetDetail ref={forgetDetailRef} />}
         {type === 'IMPLICIT_MEMORY' && <ImplicitDetail />}
         {type === 'SHORT_TERM_MEMORY' && <ShortTermDetail />}
         {type === 'PERCEPTUAL_MEMORY' && <PerceptualDetail />}

--- a/web/src/views/Workflow/components/PortClickHandler.tsx
+++ b/web/src/views/Workflow/components/PortClickHandler.tsx
@@ -234,9 +234,9 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
           filteredNodes = category.nodes.filter(nodeType => !['start', 'end', 'loop', 'cycle-start', 'iteration'].includes(nodeType.type));
         } else {
           // Original filtering for non-loop child nodes
-          filteredNodes = category.nodes.filter(nodeType => !['start', 'end', 'break', 'cycle-start'].includes(nodeType.type));
+          filteredNodes = category.nodes.filter(nodeType => !['start', 'break', 'cycle-start'].includes(nodeType.type));
           filteredNodes = category.nodes.filter(nodeType =>
-            nodeType.type !== 'start' && nodeType.type !== 'end' && nodeType.type !== 'cycle-start' && nodeType.type !== 'break'
+            nodeType.type !== 'start' && nodeType.type !== 'cycle-start' && nodeType.type !== 'break'
           );
         }
         


### PR DESCRIPTION
## Summary by Sourcery

在整个应用中重命名与遗忘相关的记忆类型，调整工作流节点过滤逻辑，更新商用方案的定价行为，并修改默认启用的 API 请求方式。

Bug 修复：
- 在各个视图和 i18n 资源中统一调整“遗忘记忆”标签页的键值和标签，统一使用 `FORGET_MEMORY`。
- 调整工作流端口点击过滤逻辑，以允许在非循环的子类别中选择终端节点。
- 在选择商用定价方案时，以新标签页打开本地化的文档页面。
- 将应用的 API 配置由默认使用 `GET` 改为默认使用 `POST` 作为启用的 HTTP 请求方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the forgetting-related memory type across the app, adjust workflow node filtering, update pricing behavior for the commerce plan, and change the default active API method.

Bug Fixes:
- Align the forgetting memory tab key and labels across views and i18n resources to use FORGET_MEMORY consistently.
- Adjust workflow port click filtering to allow end nodes in non-loop child categories.
- Open localized documentation in a new tab when selecting the commerce pricing plan.
- Switch the application API configuration to use POST as the active HTTP method instead of GET.

</details>