### PR TITLE
fix(workflow): fix improper merge of execution flows caused by multi-branch routing

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.error_codes import BizCode
 from app.core.logging_config import get_business_logger
-from app.core.response_utils import success
+from app.core.response_utils import success, fail
 from app.db import get_db
 from app.dependencies import get_current_user, cur_workspace_access_guard
 from app.models import User
@@ -660,6 +660,11 @@ async def draft_run(
         return success(
             data=result,
             msg="工作流任务执行成功"
+        )
+    else:
+        return fail(
+            msg="未知应用类型",
+            code=422
         )
 
 

--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -54,6 +54,8 @@ class WorkflowExecutor:
         self.edges = workflow_config.get("edges", [])
         self.execution_config = workflow_config.get("execution_config", {})
 
+        self.start_node_id = None
+
         self.checkpoint_config = RunnableConfig(
             configurable={
                 "thread_id": uuid.uuid4(),
@@ -131,76 +133,11 @@ class WorkflowExecutor:
                 for node in self.workflow_config.get("nodes")
                 if node.get("type") in [NodeType.LOOP, NodeType.ITERATION]
             ],  # loop, iteration node id
-            "looping": False  # loop runing flag, only use in loop node,not use in main loop
+            "looping": False,  # loop runing flag, only use in loop node,not use in main loop
+            "activate": {
+                self.start_node_id: True
+            }
         }
-
-    def _analyze_end_node_prefixes(self) -> tuple[dict[str, str], set[str]]:
-        """分析 End 节点的前缀配置
-        
-        检查每个 End 节点的模板，找到直接上游节点的引用，
-        提取该引用之前的前缀部分。
-        
-        Returns:
-            元组：({上游节点ID: End节点前缀}, {与End相邻且被引用的节点ID集合})
-        """
-        import re
-
-        prefixes = {}
-        adjacent_and_referenced = set()  # 记录与 End 节点相邻且被引用的节点
-
-        # 找到所有 End 节点
-        end_nodes = [node for node in self.nodes if node.get("type") == "end"]
-        logger.info(f"[前缀分析] 找到 {len(end_nodes)} 个 End 节点")
-
-        for end_node in end_nodes:
-            end_node_id = end_node.get("id")
-            output_template = end_node.get("config", {}).get("output")
-
-            logger.info(f"[前缀分析] End 节点 {end_node_id} 模板: {output_template}")
-
-            if not output_template:
-                continue
-
-            # 找到所有直接连接到 End 节点的上游节点
-            direct_upstream_nodes = []
-            for edge in self.edges:
-                if edge.get("target") == end_node_id:
-                    source_node_id = edge.get("source")
-                    direct_upstream_nodes.append(source_node_id)
-
-            logger.info(f"[前缀分析] End 节点的直接上游节点: {direct_upstream_nodes}")
-
-            # 查找模板中引用了哪些节点
-            # 匹配 {{node_id.xxx}} 或 {{ node_id.xxx }} 格式（支持空格）
-            pattern = r'\{\{\s*([a-zA-Z0-9_]+)\.[a-zA-Z0-9_]+\s*\}\}'
-            matches = list(re.finditer(pattern, output_template))
-
-            logger.info(f"[前缀分析] 模板中找到 {len(matches)} 个节点引用")
-
-            # 找到第一个直接上游节点的引用
-            for match in matches:
-                referenced_node_id = match.group(1)
-                logger.info(f"[前缀分析] 检查引用: {referenced_node_id}")
-
-                if referenced_node_id in direct_upstream_nodes:
-                    # 这是直接上游节点的引用，提取前缀
-                    prefix = output_template[:match.start()]
-
-                    logger.info(f"[前缀分析] ✅ 找到直接上游节点 {referenced_node_id} 的引用，前缀: '{prefix}'")
-
-                    # 标记这个节点为"相邻且被引用"
-                    adjacent_and_referenced.add(referenced_node_id)
-
-                    if prefix:
-                        prefixes[referenced_node_id] = prefix
-                        logger.info(f"✅ [前缀分析] 为节点 {referenced_node_id} 配置前缀: '{prefix[:50]}...'")
-
-                    # 只处理第一个直接上游节点的引用
-                    break
-
-        logger.info(f"[前缀分析] 最终配置: {prefixes}")
-        logger.info(f"[前缀分析] 与 End 相邻且被引用的节点: {adjacent_and_referenced}")
-        return prefixes, adjacent_and_referenced
 
     def _build_final_output(self, result, elapsed_time):
         node_outputs = result.get("node_outputs", {})
@@ -231,10 +168,12 @@ class WorkflowExecutor:
             编译后的状态图
         """
         logger.info(f"开始构建工作流图: execution_id={self.execution_id}")
-        graph = GraphBuilder(
+        builder = GraphBuilder(
             self.workflow_config,
             stream=stream,
-        ).build()
+        )
+        self.start_node_id = builder.start_node_id
+        graph = builder.build()
         logger.info(f"工作流图构建完成: execution_id={self.execution_id}")
 
         return graph
@@ -375,13 +314,15 @@ class WorkflowExecutor:
                     payload = data.get("payload", {})
                     node_name = payload.get("name")
 
+                    if node_name and node_name.startswith("nop"):
+                        continue
+
                     if event_type == "task":
                         # Node starts execution
                         inputv = payload.get("input", {})
-                        variables = inputv.get("variables", {})
-                        variables_sys = variables.get("sys", {})
+                        if not inputv.get("activate", {}).get(node_name):
+                            continue
                         conversation_id = input_data.get("conversation_id")
-                        execution_id = variables_sys.get("execution_id")
                         logger.info(f"[NODE-START] Node starts execution: {node_name} "
                                     f"- execution_id: {self.execution_id}")
 
@@ -390,18 +331,18 @@ class WorkflowExecutor:
                             "data": {
                                 "node_id": node_name,
                                 "conversation_id": conversation_id,
-                                "execution_id": execution_id,
-                                "timestamp": data.get("timestamp")
+                                "execution_id": self.execution_id,
+                                "timestamp": data.get("timestamp"),
+                                "activate": inputv.get("activate"),
                             }
                         }
                     elif event_type == "task_result":
                         # Node execution completed
                         result = payload.get("result", {})
-                        inputv = result.get("input", {})
-                        variables = inputv.get("variables", {})
-                        variables_sys = variables.get("sys", {})
+                        if not result.get("activate", {}).get(node_name):
+                            continue
+
                         conversation_id = input_data.get("conversation_id")
-                        execution_id = variables_sys.get("execution_id")
                         logger.info(f"[NODE-END] Node execution completed: {node_name} "
                                     f"- execution_id: {self.execution_id}")
 
@@ -410,9 +351,10 @@ class WorkflowExecutor:
                             "data": {
                                 "node_id": node_name,
                                 "conversation_id": conversation_id,
-                                "execution_id": execution_id,
+                                "execution_id": self.execution_id,
                                 "timestamp": data.get("timestamp"),
                                 "state": result.get("node_outputs", {}).get(node_name),
+                                "activate": payload,
                             }
                         }
 

--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -333,7 +333,6 @@ class WorkflowExecutor:
                                 "conversation_id": conversation_id,
                                 "execution_id": self.execution_id,
                                 "timestamp": data.get("timestamp"),
-                                "activate": inputv.get("activate"),
                             }
                         }
                     elif event_type == "task_result":
@@ -354,7 +353,6 @@ class WorkflowExecutor:
                                 "execution_id": self.execution_id,
                                 "timestamp": data.get("timestamp"),
                                 "state": result.get("node_outputs", {}).get(node_name),
-                                "activate": payload,
                             }
                         }
 

--- a/api/app/core/workflow/graph_builder.py
+++ b/api/app/core/workflow/graph_builder.py
@@ -1,14 +1,16 @@
 import logging
 import uuid
+from collections import defaultdict
 from typing import Any
 
-from langgraph.graph.state import CompiledStateGraph, StateGraph
-from langgraph.graph import START, END
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import START, END
+from langgraph.graph.state import CompiledStateGraph, StateGraph
+from langgraph.types import Send
 
 from app.core.workflow.expression_evaluator import evaluate_condition
 from app.core.workflow.nodes import WorkflowState, NodeFactory
-from app.core.workflow.nodes.enums import NodeType
+from app.core.workflow.nodes.enums import NodeType, BRANCH_NODES
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +30,10 @@ class GraphBuilder:
         self.start_node_id = None
         self.end_node_ids = []
 
-        self.graph: StateGraph | CompiledStateGraph | None = None
+        self.graph = StateGraph(WorkflowState)
+        self.add_nodes()
+        self.add_edges()
+        # EDGES MUST BE ADDED AFTER NODES ARE ADDED.
 
     @property
     def nodes(self) -> list[dict[str, Any]]:
@@ -39,74 +44,98 @@ class GraphBuilder:
         return self.workflow_config.get("edges", [])
 
     def _analyze_end_node_prefixes(self) -> tuple[dict[str, str], set[str]]:
-        """分析 End 节点的前缀配置
+        """
+        Analyze the prefix configuration for End nodes.
 
-        检查每个 End 节点的模板，找到直接上游节点的引用，
-        提取该引用之前的前缀部分。
+        This function scans each End node's output template, identifies
+        references to its direct upstream nodes, and extracts the prefix
+        string appearing before the first reference.
 
         Returns:
-            元组：({上游节点ID: End节点前缀}, {与End相邻且被引用的节点ID集合})
+            tuple:
+                - dict[str, str]: Mapping from upstream node ID to its End node prefix
+                - set[str]: Set of node IDs that are directly adjacent to End nodes and referenced
         """
         import re
 
         prefixes = {}
-        adjacent_and_referenced = set()  # 记录与 End 节点相邻且被引用的节点
+        adjacent_and_referenced = set()  # Record nodes directly adjacent to End and referenced
 
         # 找到所有 End 节点
         end_nodes = [node for node in self.nodes if node.get("type") == "end"]
-        logger.info(f"[前缀分析] 找到 {len(end_nodes)} 个 End 节点")
+        logger.info(f"[Prefix Analysis] Found {len(end_nodes)} End nodes")
 
         for end_node in end_nodes:
             end_node_id = end_node.get("id")
             output_template = end_node.get("config", {}).get("output")
 
-            logger.info(f"[前缀分析] End 节点 {end_node_id} 模板: {output_template}")
+            logger.info(f"[Prefix Analysis] End node {end_node_id} template: {output_template}")
 
             if not output_template:
                 continue
 
-            # 查找模板中引用了哪些节点
-            # 匹配 {{node_id.xxx}} 或 {{ node_id.xxx }} 格式（支持空格）
+            # Find all node references in the template
+            # Matches {{node_id.xxx}} or {{ node_id.xxx }} format (allowing spaces)
             pattern = r'\{\{\s*([a-zA-Z0-9_-]+)\.[a-zA-Z0-9_]+\s*\}\}'
             matches = list(re.finditer(pattern, output_template))
 
-            logger.info(f"[前缀分析] 模板中找到 {len(matches)} 个节点引用")
+            logger.info(f"[Prefix Analysis] 模板中找到 {len(matches)} 个节点引用")
 
-            # 找到所有直接连接到 End 节点的上游节点
+            # Identify all direct upstream nodes connected to the End node
             direct_upstream_nodes = []
             for edge in self.edges:
                 if edge.get("target") == end_node_id:
                     source_node_id = edge.get("source")
                     direct_upstream_nodes.append(source_node_id)
 
-            logger.info(f"[前缀分析] End 节点的直接上游节点: {direct_upstream_nodes}")
+            logger.info(f"[Prefix Analysis] Direct upstream nodes of End node: {direct_upstream_nodes}")
 
             # 找到第一个直接上游节点的引用
             for match in matches:
                 referenced_node_id = match.group(1)
-                logger.info(f"[前缀分析] 检查引用: {referenced_node_id}")
+                logger.info(f"[Prefix Analysis] Checking reference: {referenced_node_id}")
 
                 if referenced_node_id in direct_upstream_nodes:
                     # 这是直接上游节点的引用，提取前缀
                     prefix = output_template[:match.start()]
 
-                    logger.info(f"[前缀分析] ✅ 找到直接上游节点 {referenced_node_id} 的引用，前缀: '{prefix}'")
+                    logger.info(f"[Prefix Analysis] "
+                                f"✅ Found reference to direct upstream node {referenced_node_id}, prefix: '{prefix}'")
 
                     # 标记这个节点为"相邻且被引用"
                     adjacent_and_referenced.add(referenced_node_id)
 
                     if prefix:
                         prefixes[referenced_node_id] = prefix
-                        logger.info(f"✅ [前缀分析] 为节点 {referenced_node_id} 配置前缀: '{prefix[:50]}...'")
+                        logger.info(f"[Prefix Analysis] "
+                                    f"✅ Assign prefix for node {referenced_node_id}: '{prefix[:50]}...'")
 
                     # 只处理第一个直接上游节点的引用
                     break
 
-        logger.info(f"[前缀分析] 最终配置: {prefixes}")
-        logger.info(f"[前缀分析] 与 End 相邻且被引用的节点: {adjacent_and_referenced}")
+        logger.info(f"[Prefix Analysis] Final prefixes: {prefixes}")
+        logger.info(f"[Prefix Analysis] Nodes adjacent to End and referenced: {adjacent_and_referenced}")
         return prefixes, adjacent_and_referenced
 
     def add_nodes(self):
+        """Add all nodes from the workflow configuration to the state graph.
+
+        This method handles:
+        - Creation of node instances using NodeFactory.
+        - Special handling for start, end, and cycle nodes.
+        - Injection of End node prefixes for streaming mode.
+        - Marking nodes as adjacent to End nodes if referenced.
+        - Wrapping node run methods as async functions or async generators
+          depending on streaming mode.
+
+        Notes:
+            Loop nodes (nodes with `cycle` property) are handled separately
+            via CycleGraphNode when building subgraphs.
+
+        Returns:
+            None
+        """
+        # Analyze End node prefixes if in stream mode
         end_prefixes, adjacent_and_referenced = self._analyze_end_node_prefixes() if self.stream else ({}, set())
 
         for node in self.nodes:
@@ -114,21 +143,21 @@ class GraphBuilder:
             node_id = node.get("id")
             cycle_node = node.get("cycle")
             if cycle_node:
-                # 处于循环子图中的节点由 CycleGraphNode 进行构建处理
+                # Nodes within a loop subgraph are constructed by CycleGraphNode
                 if not self.subgraph:
                     continue
 
-            # 记录 start 和 end 节点 ID
+            # Record start and end node IDs
             if node_type in [NodeType.START, NodeType.CYCLE_START]:
                 self.start_node_id = node_id
             elif node_type == NodeType.END:
                 self.end_node_ids.append(node_id)
 
-            # 创建节点实例（现在 start 和 end 也会被创建）
+            # Create node instance (start and end nodes are also created)
             # NOTE:Loop node creation automatically removes the nodes and edges of the subgraph from the current graph
             node_instance = NodeFactory.create_node(node, self.workflow_config)
 
-            if node_type in [NodeType.IF_ELSE, NodeType.HTTP_REQUEST, NodeType.QUESTION_CLASSIFIER]:
+            if node_type in BRANCH_NODES:
 
                 # Find all edges whose source is the current node
                 related_edge = [edge for edge in self.edges if edge.get("source") == node_id]
@@ -142,26 +171,23 @@ class GraphBuilder:
                     related_edge[idx]['condition'] = f"node.{node_id}.output == '{related_edge[idx]['label']}'"
 
             if node_instance:
-                # 如果是流式模式，且节点有 End 前缀配置，注入配置
+                # Inject End node prefix configuration if in stream mode
                 if self.stream and node_id in end_prefixes:
-                    # 将 End 前缀配置注入到节点实例
                     node_instance._end_node_prefix = end_prefixes[node_id]
-                    logger.info(f"为节点 {node_id} 注入 End 前缀配置")
+                    logger.info(f"Injected End prefix for node {node_id}")
 
-                # 如果是流式模式，标记节点是否与 End 相邻且被引用
+                # Mark nodes as adjacent and referenced to End node in stream mode
                 if self.stream:
                     node_instance._is_adjacent_to_end = node_id in adjacent_and_referenced
                     if node_id in adjacent_and_referenced:
-                        logger.info(f"节点 {node_id} 标记为与 End 相邻且被引用")
+                        logger.info(f"Node {node_id} marked as adjacent and referenced to End node")
 
-                # 包装节点的 run 方法
-                # 使用函数工厂避免闭包问题
+                # Wrap node's run method to avoid closure issues
                 if self.stream:
-                    # 流式模式：创建 async generator 函数
-                    # LangGraph 会收集所有 yield 的值，最后一个 yield 的字典会被合并到 state
+                    # Stream mode: create an async generator function
+                    # LangGraph collects all yielded values; the last yielded dictionary is merged into the state
                     def make_stream_func(inst):
                         async def node_func(state: WorkflowState):
-                            # logger.debug(f"流式执行节点: {inst.node_id}, 支持流式: {inst.supports_streaming()}")
                             async for item in inst.run_stream(state):
                                 yield item
 
@@ -169,7 +195,7 @@ class GraphBuilder:
 
                     self.graph.add_node(node_id, make_stream_func(node_instance))
                 else:
-                    # 非流式模式：创建 async function
+                    # Non-stream mode: create an async function
                     def make_func(inst):
                         async def node_func(state: WorkflowState):
                             return await inst.run(state)
@@ -178,45 +204,110 @@ class GraphBuilder:
 
                     self.graph.add_node(node_id, make_func(node_instance))
 
-                logger.debug(f"添加节点: {node_id} (type={node_type}, stream={self.stream})")
+                logger.debug(f"Added node: {node_id} (type={node_type}, stream={self.stream})")
 
     def add_edges(self):
+        """Add all edges (normal, waiting, and conditional) to the state graph.
+
+        This method handles:
+        - Connecting the START node to the workflow's start node.
+        - Collecting waiting edges for nodes with multiple sources.
+        - Collecting conditional edges for routing to NOP nodes.
+        - Adding NOP nodes for conditional branches to allow later merging.
+        - Wrapping routing logic in a router function that evaluates conditions.
+        - Connecting End nodes to the global END node.
+
+        Notes:
+            - NOP nodes are used to ensure that multiple branches can merge
+              correctly without modifying the workflow state.
+            - Waiting edges are automatically handled by LangGraph to schedule
+              nodes only after all sources are activated.
+
+        Returns:
+            None
+        """
+        # Connect the START node to the workflow's start node
         if self.start_node_id:
             self.graph.add_edge(START, self.start_node_id)
-            logger.debug(f"添加边: START -> {self.start_node_id}")
+            logger.debug(f"Added edge: START -> {self.start_node_id}")
+
+        # Collect all sources for each target node for normal/waiting edges
+        waiting_edges = defaultdict(list)
+        # Collect all conditional edges for each source node to construct routing
+        conditional_edges = defaultdict(list)
 
         for edge in self.edges:
             source = edge.get("source")
             target = edge.get("target")
-            edge_type = edge.get("type")
             condition = edge.get("condition")
+            edge_type = edge.get("type")
 
-            # 跳过从 start 节点出发的边（因为已经从 START 连接到 start）
-            if source == self.start_node_id:
-                # 但要连接 start 到下一个节点
-                self.graph.add_edge(source, target)
-                logger.debug(f"添加边: {source} -> {target}")
-                continue
-
-            # # 处理到 end 节点的边
-            # if target in end_node_ids:
-            #     # 连接到 end 节点
-            #     workflow.add_edge(source, target)
-            #     logger.debug(f"添加边: {source} -> {target}")
-            #     continue
-
-            # 跳过错误边（在节点内部处理）
+            # Skip error edges (handled within nodes)
             if edge_type == "error":
                 continue
 
             if condition:
-                # 条件边
-                def make_router(cond, tgt):
-                    """Dynamically generate a conditional router function to ensure each branch has a unique name."""
+                # Conditional edges: group by source node
+                conditional_edges[source].append({
+                    "target": target,
+                    "condition": condition,
+                    "label": edge.get("label")
+                })
+            else:
+                # Normal edges: group by target node (used for waiting edges)
+                waiting_edges[target].append(source)
 
-                    def router_fn(state: WorkflowState):
+        # Add conditional edges
+        for source_node, branches in conditional_edges.items():
+            def make_router(src, branch_list):
+                """reate a router function for each source node that routes to a NOP node for later merging."""
+                def make_branch_node(node_name, targets):
+                    def node(s):
+                        # NOTE: NOP NODE MUST NOT MODIFY STATE
+                        return {
+                            "activate": {
+                                node_id: s["activate"][node_name]
+                                for node_id in targets
+                            }
+                        }
+
+                    return node
+
+                unique_branch = {}
+                for branch in branch_list:
+                    if branch.get("label") not in unique_branch.keys():
+                        nop_node_name = f"nop_{uuid.uuid4().hex[:8]}"
+                        logger.info(f"Binding NOP: {source_node} {branch.get('label')} -> {nop_node_name}")
+                        unique_branch[branch["label"]] = {
+                            "condition": branch["condition"],
+                            "node": {
+                                "name": nop_node_name,
+                            },
+                            "target": [branch["target"]]
+                        }
+                    else:
+                        unique_branch[branch["label"]]["target"].append(branch["target"])
+
+                # Add NOP nodes and connect them to downstream nodes
+                for label, branch_info in unique_branch.items():
+                    self.graph.add_node(
+                        branch_info["node"]["name"],
+                        make_branch_node(
+                            branch_info["node"]["name"],
+                            branch_info["target"]
+                        )
+                    )
+                    for target in branch_info["target"]:
+                        waiting_edges[target].append(branch_info["node"]["name"])
+
+                def router_fn(state: WorkflowState) -> list[Send]:
+                    branch_activate = []
+                    new_state = state.copy()
+                    new_state["activate"] = dict(state.get("activate", {}))  # deep copy of activate
+
+                    for label, branch in unique_branch.items():
                         if evaluate_condition(
-                                cond,
+                                branch["condition"],
                                 state.get("variables", {}),
                                 state.get("runtime_vars", {}),
                                 {
@@ -225,30 +316,47 @@ class GraphBuilder:
                                     "user_id": state.get("user_id")
                                 }
                         ):
-                            return tgt
-                        return END
+                            logger.debug(f"Conditional routing {src}: selected branch {label}")
+                            new_state["activate"][branch["node"]["name"]] = True
+                            logger.info(state)
+                            continue
+                        new_state["activate"][branch["node"]["name"]] = False
+                        logger.info(f"False{state}")
+                    for label, branch in unique_branch.items():
+                        branch_activate.append(
+                            Send(
+                                branch['node']['name'],
+                                new_state
+                            )
+                        )
+                    return branch_activate
 
-                    # 动态修改函数名，避免重复
-                    router_fn.__name__ = f"router_{uuid.uuid4().hex[:8]}_{tgt}"
-                    return router_fn
+                # Dynamically set function name
+                router_fn.__name__ = f"router_{uuid.uuid4().hex[:8]}_{src}"
+                return router_fn
 
-                router_fn = make_router(condition, target)
-                self.graph.add_conditional_edges(source, router_fn)
-                logger.debug(f"添加条件边: {source} -> {target} (condition={condition})")
+            router_fn = make_router(source_node, branches)
+            self.graph.add_conditional_edges(source_node, router_fn)
+            logger.debug(f"Added conditional edges: {source_node} -> {[b['target'] for b in branches]}")
+
+        # Add normal/waiting edges
+        for target, sources in waiting_edges.items():
+            if len(sources) == 1:
+                # Single source: normal edge
+                self.graph.add_edge(sources[0], target)
+                logger.debug(f"Added edge: {sources[0]} -> {target}")
             else:
-                # 普通边
-                self.graph.add_edge(source, target)
-                logger.debug(f"添加边: {source} -> {target}")
+                # Multiple sources: waiting edge
+                self.graph.add_edge(sources, target)
+                logger.debug(f"Added waiting edge: {sources} -> {target}")
 
-        # 从 end 节点连接到 END
+        # Connect End nodes to the global END node
         for end_node_id in self.end_node_ids:
             self.graph.add_edge(end_node_id, END)
-            logger.debug(f"添加边: {end_node_id} -> END")
+            logger.debug(f"Added edge: {end_node_id} -> END")
         return
 
     def build(self) -> CompiledStateGraph:
-        self.graph = StateGraph(WorkflowState)
-        self.add_nodes()
-        self.add_edges()  # 添加边必须在添加节点之后
         checkpointer = InMemorySaver()
-        return self.graph.compile(checkpointer=checkpointer)
+        self.graph = self.graph.compile(checkpointer=checkpointer)
+        return self.graph

--- a/api/app/core/workflow/graph_builder.py
+++ b/api/app/core/workflow/graph_builder.py
@@ -318,10 +318,8 @@ class GraphBuilder:
                         ):
                             logger.debug(f"Conditional routing {src}: selected branch {label}")
                             new_state["activate"][branch["node"]["name"]] = True
-                            logger.info(state)
                             continue
                         new_state["activate"][branch["node"]["name"]] = False
-                        logger.info(f"False{state}")
                     for label, branch in unique_branch.items():
                         branch_activate.append(
                             Send(

--- a/api/app/core/workflow/nodes/assigner/node.py
+++ b/api/app/core/workflow/nodes/assigner/node.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 class AssignerNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any]):
         super().__init__(node_config, workflow_config)
+        self.variable_updater = True
         self.typed_config: AssignerNodeConfig | None = None
 
     async def execute(self, state: WorkflowState) -> Any:

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 def merget_activate_state(x, y):
-    logger.info(f"merge: {x}, {y}")
     return {
         k: x.get(k, False) or y.get(k, False)
         for k in set(x) | set(y)

--- a/api/app/core/workflow/nodes/enums.py
+++ b/api/app/core/workflow/nodes/enums.py
@@ -26,6 +26,9 @@ class NodeType(StrEnum):
     MEMORY_WRITE = "memory-write"
 
 
+BRANCH_NODES = [NodeType.IF_ELSE, NodeType.HTTP_REQUEST, NodeType.QUESTION_CLASSIFIER]
+
+
 class ComparisonOperator(StrEnum):
     EMPTY = "empty"
     NOT_EMPTY = "not_empty"

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1445,7 +1445,7 @@ class AppService:
             target_workspace_ids: List[uuid.UUID],
             user_id: uuid.UUID,
             workspace_id: Optional[uuid.UUID] = None
-    ) -> AppShare:
+    ) -> list[AppShare]:
         """分享应用到其他工作空间
 
         Args:


### PR DESCRIPTION
### Problem
In the workflow engine, when a node has multiple outgoing branches, the execution flows 
of downstream nodes were not merged as expected. This caused nodes that depend on multiple 
upstream branches to either execute prematurely or not at all.

### Solution
- Introduce NOP nodes for each branch to ensure all branches can be individually scheduled.
- Adjust router function to properly set the 'activate' state per NOP node.
- Ensure downstream nodes receive the merged activation state, so they execute only 
  after all upstream branches are evaluated.

### Impact
- Fixes the issue where parallel branches were not correctly merged.
- No impact on single-branch workflows.
- Maintains backward compatibility with existing workflows.

## 由 Sourcery 提供的摘要

修复工作流执行逻辑，使多分支路由能够正确合并，并且只有在所有必需分支都已评估后节点才会运行。

错误修复：
- 通过引入“分支感知”的路由和激活控制，解决多分支工作流中并行分支执行和合并不正确的问题。

改进增强：
- 在工作流状态和基础节点执行中引入显式的节点激活机制，以控制节点何时运行以及下游激活如何传播。
- 重构图构建逻辑，实现节点和边只构建一次，为条件分支添加 NOP 路由节点，并支持多源等待边以实现正确的同步。
- 通过共享的 `BRANCH_NODES` 枚举统一分支节点类型，并调整执行器的流式事件以遵循节点激活规则，同时忽略内部的 NOP 节点。
- 允许特定节点（例如 Assigner）在保持标准化输出包装的同时更新工作流变量。

文档：
- 改进有关 End 节点前缀分析、节点/边构建以及工作流流式行为的行内文档和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow execution so that multi-branch routes merge correctly and nodes only run when all required branches have been evaluated.

Bug Fixes:
- Resolve incorrect execution and merging of parallel branches in multi-branch workflows by introducing branch-aware routing and activation control.

Enhancements:
- Introduce an explicit node activation mechanism in workflow state and base node execution to control when nodes run and how downstream activation propagates.
- Refactor graph building to construct nodes and edges once, add NOP routing nodes for conditional branches, and support multi-source waiting edges for proper synchronization.
- Unify branch node typing via a shared BRANCH_NODES enum and adjust executor streaming events to respect node activation and ignore internal NOP nodes.
- Allow specific nodes (e.g., Assigner) to update workflow variables while preserving standardized output wrapping.

Documentation:
- Improve inline documentation and logging around End node prefix analysis, node/edge construction, and streaming behavior for workflows.

</details>