### PR TITLE
Feature/distinction role

### DIFF
--- a/api/app/core/memory/agent/langgraph_graph/write_graph.py
+++ b/api/app/core/memory/agent/langgraph_graph/write_graph.py
@@ -14,7 +14,6 @@ from app.db import get_db
 from app.core.logging_config import get_agent_logger
 from app.core.memory.agent.utils.llm_tools import WriteState
 from app.core.memory.agent.langgraph_graph.nodes.write_nodes import write_node
-from app.core.memory.agent.langgraph_graph.nodes.data_nodes import content_input_write
 from app.services.memory_config_service import MemoryConfigService
 
 warnings.filterwarnings("ignore", category=RuntimeWarning)
@@ -27,18 +26,12 @@ async def make_write_graph():
     """
     Create a write graph workflow for memory operations.
 
-    Args:
-        user_id: User identifier
-        tools: MCP tools loaded from session
-        apply_id: Application identifier
-        group_id: Group identifier
-        memory_config: MemoryConfig object containing all configuration
+    The workflow directly processes messages from the initial state
+    and saves them to Neo4j storage.
     """
     workflow = StateGraph(WriteState)
-    workflow.add_node("content_input", content_input_write)
     workflow.add_node("save_neo4j", write_node)
-    workflow.add_edge(START, "content_input")
-    workflow.add_edge("content_input", "save_neo4j")
+    workflow.add_edge(START, "save_neo4j")
     workflow.add_edge("save_neo4j", END)
 
     graph = workflow.compile()

--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -12,32 +12,49 @@ async def get_chunked_dialogs(
         group_id: str = "group_1",
         user_id: str = "user1",
         apply_id: str = "applyid",
-        content: str = "这是用户的输入",
+        messages: list = None,
         ref_id: str = "wyl_20251027",
         config_id: str = None
 ) -> List[DialogData]:
-    """Generate chunks from all test data entries using the specified chunker strategy.
+    """Generate chunks from structured messages using the specified chunker strategy.
 
     Args:
         chunker_strategy: The chunking strategy to use (default: RecursiveChunker)
         group_id: Group identifier
         user_id: User identifier
         apply_id: Application identifier
-        content: Dialog content
+        messages: Structured message list [{"role": "user", "content": "..."}, ...]
         ref_id: Reference identifier
         config_id: Configuration ID for processing
 
     Returns:
-        List of DialogData objects with generated chunks for each test entry
+        List of DialogData objects with generated chunks
     """
-    dialog_data_list = []
-    messages = []
-
-    messages.append(ConversationMessage(role="用户", msg=content))
-
-    # Create DialogData
-    conversation_context = ConversationContext(msgs=messages)
-    # Create DialogData with group_id based on the entry's id for uniqueness
+    from app.core.logging_config import get_agent_logger
+    logger = get_agent_logger(__name__)
+    
+    if not messages or not isinstance(messages, list) or len(messages) == 0:
+        raise ValueError("messages parameter must be a non-empty list")
+    
+    conversation_messages = []
+    
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict) or 'role' not in msg or 'content' not in msg:
+            raise ValueError(f"Message {idx} format error: must contain 'role' and 'content' fields")
+        
+        role = msg['role']
+        content_text = msg['content']
+        
+        if role not in ['user', 'assistant']:
+            raise ValueError(f"Message {idx} role must be 'user' or 'assistant', got: {role}")
+        
+        if content_text.strip():
+            conversation_messages.append(ConversationMessage(role=role, msg=content_text.strip()))
+    
+    if not conversation_messages:
+        raise ValueError("Message list cannot be empty after filtering")
+                
+    conversation_context = ConversationContext(msgs=conversation_messages)
     dialog_data = DialogData(
         context=conversation_context,
         ref_id=ref_id,
@@ -46,25 +63,11 @@ async def get_chunked_dialogs(
         apply_id=apply_id,
         config_id=config_id
     )
-    # Create DialogueChunker and process the dialogue
+    
     chunker = DialogueChunker(chunker_strategy)
     extracted_chunks = await chunker.process_dialogue(dialog_data)
     dialog_data.chunks = extracted_chunks
+    
+    logger.info(f"DialogData created with {len(extracted_chunks)} chunks")
 
-    dialog_data_list.append(dialog_data)
-
-    # Convert to dict with datetime serialized
-    def serialize_datetime(obj):
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
-
-    combined_output = [dd.model_dump() for dd in dialog_data_list]
-
-    print(dialog_data_list)
-
-    # with open(os.path.join(os.path.dirname(__file__), "chunker_test_output.txt"), "w", encoding="utf-8") as f:
-    #     json.dump(combined_output, f, ensure_ascii=False, indent=4, default=serialize_datetime)
-
-
-    return dialog_data_list
+    return [dialog_data]

--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -43,13 +43,13 @@ async def get_chunked_dialogs(
             raise ValueError(f"Message {idx} format error: must contain 'role' and 'content' fields")
         
         role = msg['role']
-        content_text = msg['content']
+        content = msg['content']
         
         if role not in ['user', 'assistant']:
             raise ValueError(f"Message {idx} role must be 'user' or 'assistant', got: {role}")
         
-        if content_text.strip():
-            conversation_messages.append(ConversationMessage(role=role, msg=content_text.strip()))
+        if content.strip():
+            conversation_messages.append(ConversationMessage(role=role, msg=content.strip()))
     
     if not conversation_messages:
         raise ValueError("Message list cannot be empty after filtering")

--- a/api/app/core/memory/agent/utils/write_tools.py
+++ b/api/app/core/memory/agent/utils/write_tools.py
@@ -31,25 +31,22 @@ logger = get_agent_logger(__name__)
 
 
 async def write(
-    content: str,
     user_id: str,
     apply_id: str,
     group_id: str,
     memory_config: MemoryConfig,
+    messages: list,
     ref_id: str = "wyl20251027",
 ) -> None:
     """
     Execute the complete knowledge extraction pipeline.
     
-    Only MemoryConfig is needed - LLM and embedding clients are constructed
-    internally from the config.
-
     Args:
-        content: Dialogue content to process
         user_id: User identifier
         apply_id: Application identifier
         group_id: Group identifier
         memory_config: MemoryConfig object containing all configuration
+        messages: Structured message list [{"role": "user", "content": "..."}, ...]
         ref_id: Reference ID, defaults to "wyl20251027"
     """
     # Extract config values
@@ -91,7 +88,7 @@ async def write(
         group_id=group_id,
         user_id=user_id,
         apply_id=apply_id,
-        content=content,
+        messages=messages,
         ref_id=ref_id,
         config_id=config_id,
     )

--- a/api/app/core/memory/agent/utils/write_tools.py
+++ b/api/app/core/memory/agent/utils/write_tools.py
@@ -29,25 +29,22 @@ logger = get_agent_logger(__name__)
 
 
 async def write(
-    content: str,
     user_id: str,
     apply_id: str,
     group_id: str,
     memory_config: MemoryConfig,
+    messages: list,
     ref_id: str = "wyl20251027",
 ) -> None:
     """
     Execute the complete knowledge extraction pipeline.
     
-    Only MemoryConfig is needed - LLM and embedding clients are constructed
-    internally from the config.
-
     Args:
-        content: Dialogue content to process
         user_id: User identifier
         apply_id: Application identifier
         group_id: Group identifier
         memory_config: MemoryConfig object containing all configuration
+        messages: Structured message list [{"role": "user", "content": "..."}, ...]
         ref_id: Reference ID, defaults to "wyl20251027"
     """
     # Extract config values
@@ -89,7 +86,7 @@ async def write(
         group_id=group_id,
         user_id=user_id,
         apply_id=apply_id,
-        content=content,
+        messages=messages,
         ref_id=ref_id,
         config_id=config_id,
     )

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -224,6 +224,7 @@ class StatementNode(Node):
         chunk_id: ID of the parent chunk this statement belongs to
         stmt_type: Type of the statement (from ontology)
         statement: The actual statement text content
+        speaker: Optional speaker identifier ('用户' for user messages, 'AI' for AI responses)
         emotion_intensity: Optional emotion intensity (0.0-1.0) - displayed on node
         emotion_target: Optional emotion target (person or object name)
         emotion_subject: Optional emotion subject (self/other/object)
@@ -248,6 +249,12 @@ class StatementNode(Node):
     chunk_id: str = Field(..., description="ID of the parent chunk")
     stmt_type: str = Field(..., description="Type of the statement")
     statement: str = Field(..., description="The statement text content")
+    
+    # Speaker identification
+    speaker: Optional[str] = Field(
+        None,
+        description="Speaker identifier: 'user' for user messages, 'assistant' for AI responses"
+    )
     
     # Emotion fields (ordered as requested, emotion_intensity first for display)
     emotion_intensity: Optional[float] = Field(

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from app.core.memory.models.message_models import DialogData, Statement
-
-#避免在测试收集阶段因为 OpenAIClient 间接引入 langfuse 导致 ModuleNotFoundError 。这只是类型注解与导入时机的调整，不改变实现。
 from app.core.memory.models.variate_config import StatementExtractionConfig
 from app.core.memory.utils.data.ontology import (
     LABEL_DEFINITIONS,
@@ -22,11 +20,10 @@ logger = logging.getLogger(__name__)
 class ExtractedStatement(BaseModel):
     """Schema for extracted statement from LLM"""
     statement: str = Field(..., description="The extracted statement text")
-    statement_type: str = Field(..., description="FACT, OPINION,SUGGESTION or PREDICTION")
+    statement_type: str = Field(..., description="FACT, OPINION, SUGGESTION or PREDICTION")
     temporal_type: str = Field(..., description="STATIC, DYNAMIC, ATEMPORAL")
     relevence: str = Field(..., description="RELEVANT or IRRELEVANT")
 
-# 统一使用 StatementExtractionResponse 作为 LLM 的结构化返回（仅语句）
 class StatementExtractionResponse(BaseModel):
     statements: List[ExtractedStatement] = Field(default_factory=list, description="List of extracted statements")
     
@@ -58,10 +55,9 @@ class StatementExtractionResponse(BaseModel):
         return v
 
 class StatementExtractor:
-    """Class for extracting statements from dialog chunks using LLM (relations separated)"""
+    """Class for extracting statements from dialog chunks using LLM"""
 
     def __init__(self, llm_client: Any, config: StatementExtractionConfig = None):
-        # 避免在测试收集阶段因为 OpenAIClient 间接引入 langfuse 导致 ModuleNotFoundError 。这只是类型注解与导入时机的调整，不改变实现。
         """Initialize the StatementExtractor with an LLM client and configuration
 
         Args:
@@ -70,6 +66,21 @@ class StatementExtractor:
         """
         self.llm_client = llm_client
         self.config = config or StatementExtractionConfig()
+
+    def _get_speaker_from_chunk(self, chunk) -> Optional[str]:
+        """Get speaker directly from Chunk
+        
+        Args:
+            chunk: Chunk object containing speaker field
+            
+        Returns:
+            Speaker role ("user"/"assistant") or None if cannot be determined
+        """
+        if hasattr(chunk, 'speaker') and chunk.speaker:
+            return chunk.speaker
+        
+        logger.warning(f"Chunk {getattr(chunk, 'id', 'unknown')} has no speaker field or is empty")
+        return None
 
     async def _extract_statements(self, chunk, group_id: Optional[str] = None, dialogue_content: str = None) -> List[Statement]:
         """Process a single chunk and return extracted statements
@@ -82,10 +93,12 @@ class StatementExtractor:
         Returns:
             List of ExtractedStatement objects extracted from the chunk
         """
-        # Prepare the chunk content for processing
         chunk_content = chunk.content
+        
+        if not chunk_content or len(chunk_content.strip()) < 5:
+            logger.warning(f"Chunk {chunk.id} content too short or empty, skipping")
+            return []
 
-        # Render the prompt using helper function
         prompt_content = await render_statement_extraction_prompt(
             chunk_content=chunk_content,
             definitions=LABEL_DEFINITIONS,
@@ -136,7 +149,9 @@ class StatementExtractor:
                     relevence_info = RelevenceInfo[relevence_str] if relevence_str in RelevenceInfo.__members__ else RelevenceInfo.RELEVANT
                 except (KeyError, ValueError):
                     relevence_info = RelevenceInfo.RELEVANT
-
+               
+                chunk_speaker = self._get_speaker_from_chunk(chunk)
+            
                 chunk_statement = Statement(
                     statement=extracted_stmt.statement,
                     stmt_type=stmt_type,
@@ -144,7 +159,9 @@ class StatementExtractor:
                     relevence_info=relevence_info,
                     chunk_id=chunk.id,
                     group_id=group_id,
+                    speaker=chunk_speaker,
                 )
+                
                 chunk_statements.append(chunk_statement)
 
             # 分离强弱关系分类：不在句子提取阶段进行，也不写入 chunk.metadata
@@ -226,12 +243,7 @@ class StatementExtractor:
         return output_path
 
     def save_relations(self, dialogs: List[DialogData], output_path: str = None) -> str:
-        """按对话分组聚合强/弱关系并写入 TXT 文件。
-        - 每个对话单独成段：输出该对话的 `Dialog ID`、`Group ID`、`Content`
-        - 在该对话段内再分为 Strong Relations / Weak Relations 两部分
-        - Strong: 逐条输出 `Chunk ID` 与 `Triple`
-        - Weak: 逐条输出 `Chunk ID` 与 `Entity`
-        """
+        """Group and aggregate strong/weak relations by dialogue and write to TXT file."""
         print("\n=== Relations Classify ===")
 
         # 使用全局配置的输出路径

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -101,6 +101,8 @@ async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jC
                 #     "entities": [entity.model_dump() for entity in statement.triplet_extraction_info.entities] if statement.triplet_extraction_info else []
                 # }) if statement.triplet_extraction_info else json.dumps({"triplets": [], "entities": []}),
                 "statement_embedding": statement.statement_embedding if statement.statement_embedding else None,
+                # 添加 speaker 字段（用于基于角色的情绪提取）
+                "speaker": statement.speaker if hasattr(statement, 'speaker') else None,
                 # 添加情绪字段处理
                 "emotion_type": statement.emotion_type,
                 "emotion_intensity": statement.emotion_intensity,
@@ -163,7 +165,9 @@ async def add_chunk_nodes(chunks: List[ChunkNode], connector: Neo4jConnector) ->
                 "chunk_embedding": chunk.chunk_embedding if chunk.chunk_embedding else None,
                 "sequence_number": chunk.sequence_number,
                 "start_index": metadata.get("start_index"),
-                "end_index": metadata.get("end_index")
+                "end_index": metadata.get("end_index"),
+                # 添加 speaker 字段（用于基于角色的情绪提取）
+                "speaker": chunk.speaker if hasattr(chunk, 'speaker') else None
             }
             flattened_chunks.append(flattened_chunk)
 

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -12,7 +12,7 @@ class UserInput(BaseModel):
 
 
 class Write_UserInput(BaseModel):
-    message: str
+    messages: list[dict]
     group_id: str
     config_id: Optional[str] = None
 

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -592,49 +592,6 @@ class MemoryAgentService:
         
         logger.info(f"Validation successful: Structured message list, count: {len(user_input.messages)}")
         return user_input.messages
-    def get_messages_list(self, user_input: Write_UserInput) -> list[dict]:
-        """
-        Get standardized message list from user input.
-        
-        Args:
-            user_input: Write_UserInput object
-        
-        Returns:
-            list[dict]: Message list, each message contains role and content
-            
-        Raises:
-            ValueError: If messages is empty or format is incorrect
-        """
-        from app.core.logging_config import get_api_logger
-        logger = get_api_logger()
-        
-        if len(user_input.messages) == 0:
-            logger.error("Validation failed: Message list cannot be empty")
-            raise ValueError("Message list cannot be empty")
-        
-        for idx, msg in enumerate(user_input.messages):
-            if not isinstance(msg, dict):
-                logger.error(f"Validation failed: Message {idx} is not a dict: {type(msg)}")
-                raise ValueError(f"Message format error: Message must be a dictionary. Error message index: {idx}, type: {type(msg)}")
-            
-            if 'role' not in msg:
-                logger.error(f"Validation failed: Message {idx} missing 'role' field: {msg}")
-                raise ValueError(f"Message format error: Message must contain 'role' field. Error message index: {idx}")
-            
-            if 'content' not in msg:
-                logger.error(f"Validation failed: Message {idx} missing 'content' field: {msg}")
-                raise ValueError(f"Message format error: Message must contain 'content' field. Error message index: {idx}")
-            
-            if msg['role'] not in ['user', 'assistant']:
-                logger.error(f"Validation failed: Message {idx} invalid role: {msg['role']}")
-                raise ValueError(f"Role must be 'user' or 'assistant', got: {msg['role']}. Message index: {idx}")
-            
-            if not msg['content'] or not msg['content'].strip():
-                logger.error(f"Validation failed: Message {idx} content is empty")
-                raise ValueError(f"Message content cannot be empty. Message index: {idx}, role: {msg['role']}")
-        
-        logger.info(f"Validation successful: Structured message list, count: {len(user_input.messages)}")
-        return user_input.messages
 
     async def classify_message_type(self, message: str, config_id: int, db: Session) -> Dict:
         """

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -26,6 +26,7 @@ from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.db import get_db_context
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.schemas.memory_agent_schema import Write_UserInput
 from app.schemas.memory_config_schema import ConfigurationError
 from app.services.memory_base_service import Translation_English
 from app.services.memory_config_service import MemoryConfigService

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -20,6 +20,7 @@ from app.core.memory.agent.langgraph_graph.write_graph import make_write_graph
 from app.core.memory.agent.logger_file.log_streamer import LogStreamer
 from app.core.memory.agent.utils.messages_tools import merge_multiple_search_results, reorder_output_results
 from app.core.memory.agent.utils.type_classifier import status_typle
+from app.core.memory.agent.utils.write_tools import write  # 新增：直接导入 write 函数
 from app.core.memory.analytics.hot_memory_tags import get_hot_memory_tags
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.db import get_db_context
@@ -54,7 +55,6 @@ class MemoryAgentService:
 
         if str(messages) == 'success':
             logger.info(f"Write operation successful for group {group_id} with config_id {config_id}")
-            # 记录成功的操作
             if audit_logger:
                 audit_logger.log_operation(operation="WRITE", config_id=config_id, group_id=group_id, success=True,
                                            duration=duration, details={"message_length": len(message)})
@@ -62,7 +62,6 @@ class MemoryAgentService:
         else:
             logger.warning(f"Write operation failed for group {group_id}")
 
-            # 记录失败的操作
             if audit_logger:
                 audit_logger.log_operation(
                     operation="WRITE",
@@ -266,7 +265,7 @@ class MemoryAgentService:
 
         Args:
             group_id: Group identifier (also used as end_user_id)
-            message: Message to write
+            message: Structured message list [{"role": "user", "content": "..."}, ...]
             config_id: Configuration ID from database
             db: SQLAlchemy database session
             storage_type: Storage type (neo4j or rag)
@@ -287,7 +286,7 @@ class MemoryAgentService:
                     raise ValueError(f"No memory configuration found for end_user {group_id}. Please ensure the user has a connected memory configuration.")
             except Exception as e:
                 if "No memory configuration found" in str(e):
-                    raise  # Re-raise our specific error
+                    raise
                 logger.error(f"Failed to get connected config for end_user {group_id}: {e}")
                 raise ValueError(f"Unable to determine memory configuration for end_user {group_id}: {e}")
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -473,17 +473,12 @@ def read_message_task(self, group_id: str, message: str, history: List[Dict[str,
 
 @celery_app.task(name="app.core.memory.agent.write_message", bind=True)
 def write_message_task(self, group_id: str, message, config_id: str, storage_type: str, user_rag_memory_id: str) -> Dict[str, Any]:
-def write_message_task(self, group_id: str, message, config_id: str, storage_type: str, user_rag_memory_id: str) -> Dict[str, Any]:
     """Celery task to process a write message via MemoryAgentService.
     
     支持两种消息格式：
     1. 字符串格式（向后兼容）：message="user: xxx\nassistant: yyy"
     2. 结构化消息列表（推荐）：message=[{"role": "user", "content": "xxx"}, {"role": "assistant", "content": "yyy"}]
-    
-    支持两种消息格式：
-    1. 字符串格式（向后兼容）：message="user: xxx\nassistant: yyy"
-    2. 结构化消息列表（推荐）：message=[{"role": "user", "content": "xxx"}, {"role": "assistant", "content": "yyy"}]
-    
+
     Args:
         group_id: Group ID for the memory agent (also used as end_user_id)
         message: Message to write (str or list[dict])
@@ -563,8 +558,6 @@ def write_message_task(self, group_id: str, message, config_id: str, storage_typ
             "result": result,
             "group_id": group_id,
             "config_id": config_id,
-            "message_type": message_type,
-            "message_type": message_type,
             "elapsed_time": elapsed_time,
             "task_id": self.request.id
         }

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -472,13 +472,19 @@ def read_message_task(self, group_id: str, message: str, history: List[Dict[str,
 
 
 @celery_app.task(name="app.core.memory.agent.write_message", bind=True)
-def write_message_task(self, group_id: str, message: str, config_id: str,storage_type:str,user_rag_memory_id:str) -> Dict[str, Any]:
+def write_message_task(self, group_id: str, message, config_id: str, storage_type: str, user_rag_memory_id: str) -> Dict[str, Any]:
     """Celery task to process a write message via MemoryAgentService.
+    
+    支持两种消息格式：
+    1. 字符串格式（向后兼容）：message="user: xxx\nassistant: yyy"
+    2. 结构化消息列表（推荐）：message=[{"role": "user", "content": "xxx"}, {"role": "assistant", "content": "yyy"}]
     
     Args:
         group_id: Group ID for the memory agent (also used as end_user_id)
-        message: Message to write
+        message: Message to write (str or list[dict])
         config_id: Optional configuration ID
+        storage_type: Storage type (neo4j/rag)
+        user_rag_memory_id: RAG memory ID
         
     Returns:
         Dict containing the result and metadata
@@ -549,6 +555,7 @@ def write_message_task(self, group_id: str, message: str, config_id: str,storage
             "result": result,
             "group_id": group_id,
             "config_id": config_id,
+            "message_type": message_type,
             "elapsed_time": elapsed_time,
             "task_id": self.request.id
         }

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -555,7 +555,6 @@ def write_message_task(self, group_id: str, message, config_id: str, storage_typ
             "result": result,
             "group_id": group_id,
             "config_id": config_id,
-            "message_type": message_type,
             "elapsed_time": elapsed_time,
             "task_id": self.request.id
         }

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -472,13 +472,19 @@ def read_message_task(self, group_id: str, message: str, history: List[Dict[str,
 
 
 @celery_app.task(name="app.core.memory.agent.write_message", bind=True)
-def write_message_task(self, group_id: str, message: str, config_id: str,storage_type:str,user_rag_memory_id:str) -> Dict[str, Any]:
+def write_message_task(self, group_id: str, message, config_id: str, storage_type: str, user_rag_memory_id: str) -> Dict[str, Any]:
     """Celery task to process a write message via MemoryAgentService.
+    
+    支持两种消息格式：
+    1. 字符串格式（向后兼容）：message="user: xxx\nassistant: yyy"
+    2. 结构化消息列表（推荐）：message=[{"role": "user", "content": "xxx"}, {"role": "assistant", "content": "yyy"}]
     
     Args:
         group_id: Group ID for the memory agent (also used as end_user_id)
-        message: Message to write
+        message: Message to write (str or list[dict])
         config_id: Optional configuration ID
+        storage_type: Storage type (neo4j/rag)
+        user_rag_memory_id: RAG memory ID
         
     Returns:
         Dict containing the result and metadata
@@ -532,11 +538,15 @@ def write_message_task(self, group_id: str, message: str, config_id: str,storage
         result = loop.run_until_complete(_run())
         elapsed_time = time.time() - start_time
         
+        # 记录消息类型用于调试
+        message_type = "structured" if isinstance(message, list) else "string"
+        
         return {
             "status": "SUCCESS",
             "result": result,
             "group_id": group_id,
             "config_id": config_id,
+            "message_type": message_type,
             "elapsed_time": elapsed_time,
             "task_id": self.request.id
         }


### PR DESCRIPTION
## Summary by Sourcery

在整个记忆处理流水线中采用结构化、基于角色的消息格式，并将说话人信息传播到分块处理、知识抽取和存储阶段，以支持基于角色的行为与分析。

New Features:
- 在各类 memory API 和 Celery 任务中，支持使用带有显式角色（user/assistant）的结构化消息列表进行写入和处理，而不是仅使用单一的原始消息字符串。
- 引入“按消息分块”的机制，使每条对话消息被拆分为一个或多个分块（chunk），并在分块中继承和存储说话人信息，以用于后续处理。

Enhancements:
- 将对话角色统一标准化为 `user` 和 `assistant`，并更新 LLM 提示词、文档字符串和模型以使用英文描述。
- 重构写入图（write graph）和写入节点（write nodes），使其直接在结构化消息列表上运行，而不是依赖中间内容字符串。
- 收紧对消息列表和分块过程的校验与错误处理，确保消息非空且格式正确，并在无法生成分块时快速失败。
- 将说话人元数据传播到分块、抽取出的陈述、情绪抽取结果、图节点以及 Neo4j 存储中，以支持基于角色的情绪与知识分析。
- 将情绪抽取限定为仅针对 user 端陈述，并为被过滤的陈述及分块结果增加日志记录。
- 简化分块回退逻辑，移除自动“单分块”回退策略，当无法生成任何分块时直接抛出明确错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt structured role-based messages throughout the memory pipeline and propagate speaker information into chunking, knowledge extraction, and storage to support role-aware behavior and analysis.

New Features:
- Support writing and processing structured message lists with explicit roles (user/assistant) instead of a single raw message string across memory APIs and Celery tasks.
- Introduce per-message chunking where each conversation message becomes one or more chunks that inherit and store speaker information for downstream processing.

Enhancements:
- Standardize conversation roles to 'user' and 'assistant' and update LLM prompts, docstrings, and models to use English descriptions.
- Refactor the write graph and write nodes to operate directly on structured message lists rather than intermediate content strings.
- Tighten validation and error handling for message lists and chunking, ensuring non-empty, well-formed messages and failing fast when chunks cannot be generated.
- Propagate speaker metadata into chunks, extracted statements, emotion extraction, graph nodes, and Neo4j storage to enable role-aware emotion and knowledge analysis.
- Restrict emotion extraction to user statements only and add logging around filtered statements and chunking results.
- Simplify chunking fallbacks by removing automatic single-chunk fallbacks and surfacing explicit errors when no chunks are produced.

</details>