### PR TITLE
fix(web): no workspace_id user jump url update

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,15 +28,19 @@ import 'dayjs/locale/zh-cn'
 import 'dayjs/plugin/timezone'
 import 'dayjs/plugin/utc'
 import { cookieUtils } from './utils/request';
+import { useUser } from '@/store/user';
 
 
 function App() {
   const { t } = useTranslation();
   const { locale, language, timeZone } = useI18n()
+  const { checkJump } = useUser();
   useEffect(() => {
     const authToken = cookieUtils.get('authToken')
     if (!authToken && !window.location.hash.includes('#/login') && !window.location.hash.includes('#/conversation/')) {
       window.location.href = `/#/login`;
+    } else {
+      checkJump()
     }
   }, [])
 

--- a/web/src/store/user.ts
+++ b/web/src/store/user.ts
@@ -21,7 +21,14 @@ export interface UserState {
   clearUserInfo: () => void;
   logout: () => void;
   getStorageType: () => void;
+  checkJump: () => void;
 }
+
+export const whitePage = [
+  '/conversation',
+  '/login',
+  '/invite-register'
+]
 
 export const useUser = create<UserState>((set, get) => ({
   user: localStorage.getItem('user') ? JSON.parse(localStorage.getItem('user') || '{}') as User : {} as User,
@@ -36,8 +43,10 @@ export const useUser = create<UserState>((set, get) => ({
     if (!cookieUtils.get('authToken')) {
       return
     }
+    const { checkJump } = get()
     const localUser = JSON.parse(localStorage.getItem('user') || '{}') as User;
     if (localUser.id) {
+      checkJump()
       return
     }
     getUsers()
@@ -87,5 +96,14 @@ export const useUser = create<UserState>((set, get) => ({
       .catch(() => {
         console.error('Failed to load storage type');
       })
-  }
+  },
+  checkJump: () => {
+    const localUser = JSON.parse(localStorage.getItem('user') || '{}') as User;
+    const hash = window.location.hash;
+
+    if (localUser.id && (!localUser.current_workspace_id || localUser.current_workspace_id === '') && !whitePage.find(vo => hash.includes(vo))) {
+      console.log('whitePage', whitePage.find(vo => hash.includes(vo)))
+      window.location.href = '/#/index'
+    }
+  },
 }))


### PR DESCRIPTION
## Summary by Sourcery

确保已认证用户在没有当前 workspace 的情况下访问非白名单路由时，会被重定向到首页。

Bug 修复：
- 修复已登录但没有当前 workspace 的用户在访问非白名单页面时缺少重定向的问题。

功能增强：
- 将跳转/重定向逻辑集中到用户存储（user store）中，并在应用初始化时复用该逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure authenticated users without a current workspace are redirected to the index page unless visiting whitelisted routes.

Bug Fixes:
- Fix missing redirect for logged-in users with no current workspace when accessing non-whitelisted pages.

Enhancements:
- Centralize jump/redirect logic in the user store and reuse it on app initialization.

</details>