### PR TITLE
fix(workflow): fix loop node scheduling and I/O issues

### DIFF
--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -9,7 +9,6 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, AsyncGenerator
 
-from langchain_core.messages import AIMessage
 from langgraph.config import get_stream_writer
 from typing_extensions import TypedDict, Annotated
 

--- a/api/app/core/workflow/nodes/cycle_graph/iteration.py
+++ b/api/app/core/workflow/nodes/cycle_graph/iteration.py
@@ -24,6 +24,7 @@ class IterationRuntime:
 
     def __init__(
             self,
+            start_id: str,
             graph: CompiledStateGraph,
             node_id: str,
             config: dict[str, Any],
@@ -38,6 +39,7 @@ class IterationRuntime:
             config: Dictionary containing iteration node configuration.
             state: Current workflow state at the point of iteration.
         """
+        self.start_id = start_id
         self.graph = graph
         self.state = state
         self.node_id = node_id
@@ -70,6 +72,7 @@ class IterationRuntime:
             "index": idx,
         }
         loopstate["looping"] = True
+        loopstate["activate"][self.start_id] = True
         return loopstate
 
     async def run_task(self, item, idx):

--- a/api/app/core/workflow/nodes/cycle_graph/loop.py
+++ b/api/app/core/workflow/nodes/cycle_graph/loop.py
@@ -26,6 +26,7 @@ class LoopRuntime:
 
     def __init__(
             self,
+            start_id: str,
             graph: CompiledStateGraph,
             node_id: str,
             config: dict[str, Any],
@@ -40,6 +41,7 @@ class LoopRuntime:
             config: Raw configuration dictionary for the loop node.
             state: The current workflow state before entering the loop.
         """
+        self.start_id = start_id
         self.graph = graph
         self.state = state
         self.node_id = node_id
@@ -87,6 +89,7 @@ class LoopRuntime:
             **self.state
         )
         loopstate["looping"] = True
+        loopstate["activate"][self.start_id] = True
         return loopstate
 
     @staticmethod


### PR DESCRIPTION
## Summary by Sourcery

通过在循环子图中正确初始化和使用循环起始节点，修复循环与迭代工作流的周期调度问题。

Bug 修复：
- 确保循环和迭代运行时时间能够识别周期子图的正确起始节点，用于激活和调度。
- 初始化循环迭代状态以激活计算得到的起始节点，使循环执行从预期的入口点开始。
- 从周期图节点中移除未使用的终止节点追踪逻辑，避免对周期边界的不一致处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix loop and iteration workflow cycle scheduling by correctly initializing and using the cycle start node within the loop subgraph.

Bug Fixes:
- Ensure loop and iteration runtimes know the correct start node of the cycle subgraph for activation and scheduling.
- Initialize loop iteration state to activate the computed start node so loop executions begin at the intended entry point.
- Remove unused end-node tracking from cycle graph nodes to avoid inconsistent cycle boundary handling.

</details>