### PR TITLE
fix(workflow): fix loop node termination and iteration node startup issues

### DIFF
--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -133,7 +133,7 @@ class WorkflowExecutor:
                 for node in self.workflow_config.get("nodes")
                 if node.get("type") in [NodeType.LOOP, NodeType.ITERATION]
             ],  # loop, iteration node id
-            "looping": False,  # loop runing flag, only use in loop node,not use in main loop
+            "looping": 0,  # loop runing flag, only use in loop node,not use in main loop
             "activate": {
                 self.start_node_id: True
             }
@@ -358,6 +358,7 @@ class WorkflowExecutor:
 
                 elif mode == "updates":
                     # Handle state updates - store final state
+                    # TODO:流式输出点
                     logger.debug(f"[UPDATES] 收到 state 更新 from {list(data.keys())} "
                                  f"- execution_id: {self.execution_id}")
 

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -19,11 +19,15 @@ from app.core.workflow.variable_pool import VariablePool
 logger = logging.getLogger(__name__)
 
 
-def merget_activate_state(x, y):
+def merge_activate_state(x, y):
     return {
         k: x.get(k, False) or y.get(k, False)
         for k in set(x) | set(y)
     }
+
+
+def merge_looping_state(x, y):
+    return y if y > x else x
 
 
 class WorkflowState(TypedDict):
@@ -36,7 +40,7 @@ class WorkflowState(TypedDict):
 
     # Set of loop node IDs, used for assigning values in loop nodes
     cycle_nodes: list
-    looping: Annotated[bool, lambda x, y: x and y]
+    looping: Annotated[int, merge_looping_state]
 
     # Input variables (passed from configured variables)
     # Uses a deep merge function, supporting nested dict updates (e.g., conv.xxx)
@@ -68,7 +72,7 @@ class WorkflowState(TypedDict):
     streaming_buffer: Annotated[dict[str, Any], lambda x, y: {**x, **y}]
 
     # node activate status
-    activate: Annotated[dict[str, bool], merget_activate_state]
+    activate: Annotated[dict[str, bool], merge_activate_state]
 
 
 class BaseNode(ABC):

--- a/api/app/core/workflow/nodes/breaker/node.py
+++ b/api/app/core/workflow/nodes/breaker/node.py
@@ -28,6 +28,6 @@ class BreakNode(BaseNode):
         Returns:
             Optional dictionary indicating the loop has been stopped.
         """
-        state["looping"] = False
+        state["looping"] = 2
         logger.info(f"Setting cycle node exit flag, cycle={self.cycle}, looping={state['looping']}")
 

--- a/api/app/core/workflow/nodes/cycle_graph/iteration.py
+++ b/api/app/core/workflow/nodes/cycle_graph/iteration.py
@@ -58,10 +58,10 @@ class IterationRuntime:
             idx: Index of the element in the input array.
 
         Returns:
-            A deep copy of the workflow state with iteration-specific variables set.
+            A copy of the workflow state with iteration-specific variables set.
         """
         loopstate = WorkflowState(
-            **copy.deepcopy(self.state)
+            **self.state
         )
         loopstate["runtime_vars"][self.node_id] = {
             "item": item,
@@ -71,7 +71,7 @@ class IterationRuntime:
             "item": item,
             "index": idx,
         }
-        loopstate["looping"] = True
+        loopstate["looping"] = 1
         loopstate["activate"][self.start_id] = True
         return loopstate
 
@@ -89,7 +89,7 @@ class IterationRuntime:
             self.result.extend(output)
         else:
             self.result.append(output)
-        if not result["looping"]:
+        if result["looping"] == 2:
             self.looping = False
         return result
 
@@ -150,10 +150,9 @@ class IterationRuntime:
                     self.result.extend(output)
                 else:
                     self.result.append(output)
-                if not result["looping"]:
+                if result["looping"] == 2:
                     self.looping = False
                 idx += 1
-
         logger.info(f"Iteration node {self.node_id}: execution completed")
         return {
             "output": self.result,


### PR DESCRIPTION
## Summary by Sourcery

调整工作流循环和迭代节点的行为，以在各次迭代中正确传递并遵守循环状态。

Bug Fixes:
- 确保循环节点的终止由最新的子执行结果控制，而不是由初始工作流状态控制。
- 修复迭代节点，使其始终从每个子结果更新其循环状态，并在初始化迭代状态时避免不必要的深拷贝。
- 更正工作流状态的循环状态聚合方式，使最新值覆盖先前值，而不是对其进行逻辑与（AND）运算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust workflow loop and iteration node behavior to correctly propagate and respect the looping state across iterations.

Bug Fixes:
- Ensure loop node termination is controlled by the latest child execution result instead of the initial workflow state.
- Fix iteration node to always update its looping status from each child result and correctly initialize iteration state without unnecessary deep copying.
- Correct workflow state looping aggregation so that the latest value overrides prior values instead of being ANDed.

</details>