### PR TITLE
feat(web): update read_all_config select valueKey

### DIFF
--- a/web/src/components/CustomSelect/index.tsx
+++ b/web/src/components/CustomSelect/index.tsx
@@ -15,7 +15,7 @@ interface ApiResponse<T> {
 interface CustomSelectProps extends Omit<SelectProps, 'filterOption'> {
   url: string;
   params?: Record<string, unknown>;
-  valueKey?: string;
+  valueKey?: string | string[];
   labelKey?: string;
   placeholder?: string;
   hasAll?: boolean;
@@ -66,11 +66,18 @@ const CustomSelect: FC<CustomSelectProps> = ({
       {...props}
     >
       {hasAll && <Select.Option value={null}>{allTitle || t('common.all')}</Select.Option>}
-      {displayOptions.map((option) => (
-        <Select.Option key={option[valueKey]} value={option[valueKey]}>
-          {String(option[labelKey])}
-        </Select.Option>
-      ))}
+      {displayOptions.map((option) => {
+        const getValue = () => {
+          if (typeof valueKey === 'string') return option[valueKey];
+          return valueKey.find(key => option[key] != null) ? option[valueKey.find(key => option[key] != null)!] : undefined;
+        };
+        const value = getValue();
+        return (
+          <Select.Option key={value} value={value}>
+            {String(option[labelKey])}
+          </Select.Option>
+        );
+      })}
     </Select>
   );
 };

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -79,7 +79,7 @@ const SelectWrapper: FC<{ title: string, desc: string, name: string | string[], 
           placeholder={t('common.pleaseSelect')}
           url={url}
           hasAll={false}
-          valueKey='config_id'
+          valueKey={['config_id_old', 'config_id']}
           labelKey="config_name"
         />
       </Form.Item>
@@ -126,12 +126,14 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     getApplicationConfig(id as string).then(res => {
       const response = res as Config
       let allTools = Array.isArray(response.tools) ? response.tools : []
+      const memoryContent = response.memory?.memory_content
+      const convertedMemoryContent = memoryContent && !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
       form.setFieldsValue({
         ...response,
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: response.memory?.memory_content ? Number(response.memory?.memory_content) : undefined
+          memory_content: convertedMemoryContent
         }
       })
       setData({

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -200,7 +200,7 @@ export const nodeLibrary: NodeLibrary[] = [
           config_id: {
             type: 'customSelect',
             url: memoryConfigListUrl,
-            valueKey: 'config_id',
+            valueKey: ['config_id_old', 'config_id'],
             labelKey: 'config_name'
           },
           search_switch: {
@@ -223,7 +223,7 @@ export const nodeLibrary: NodeLibrary[] = [
           config_id: {
             type: 'customSelect',
             url: memoryConfigListUrl,
-            valueKey: 'config_id',
+            valueKey: ['config_id_old', 'config_id'],
             labelKey: 'config_name'
           }
         }

--- a/web/src/views/Workflow/types.ts
+++ b/web/src/views/Workflow/types.ts
@@ -14,7 +14,7 @@ export interface NodeConfig {
 
   url?: string;
   params?: { [key: string]: unknown; }
-  valueKey?: string;
+  valueKey?: string | string[];
   labelKey?: string;
 
   defaultValue?: any;


### PR DESCRIPTION
## Summary by Sourcery

允许 CustomSelect 组件接受多个备用值键，并相应调整相关配置的使用方式。

新功能：
- 在 CustomSelect 和工作流节点配置中支持指定多个备用值键。

错误修复：
- 在填充 Agent 表单时，保留非数字类型的 `memory_content` 值，而不是总是强制转换为数字。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow CustomSelect components to accept multiple fallback value keys and adjust related configuration usage accordingly.

New Features:
- Support specifying multiple fallback value keys in CustomSelect and workflow node configuration.

Bug Fixes:
- Preserve non-numeric memory_content values when populating the Agent form instead of always coercing to a number.

</details>