### PR TITLE
fix(workflow): fix streaming output issues with multi-output End nodes

### DIFF
--- a/api/app/core/workflow/nodes/memory/config.py
+++ b/api/app/core/workflow/nodes/memory/config.py
@@ -25,6 +25,6 @@ class MemoryWriteNodeConfig(BaseNodeConfig):
         ...
     )
 
-    config_id: UUID = Field(
+    config_id: UUID | int = Field(
         ...
     )

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -36,9 +36,10 @@ class MemoryReadNode(BaseNode):
 class MemoryWriteNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any]):
         super().__init__(node_config, workflow_config)
-        self.typed_config = MemoryWriteNodeConfig(**self.config)
+        self.typed_config: MemoryWriteNodeConfig | None = None
 
     async def execute(self, state: WorkflowState) -> Any:
+        self.typed_config = MemoryWriteNodeConfig(**self.config)
         end_user_id = self.get_variable("sys.user_id", state)
 
         if not end_user_id:


### PR DESCRIPTION
End nodes with multiple output segments could cause cursor errors or leave some segments inactive, resulting in incorrect final outputs. Unified _emit_active_chunks and _update_scope_activate to ensure all segments are activated in order and streamed correctly.

## Summary by Sourcery

修复流式工作流执行机制，以便根据上游节点和分支状态，按顺序正确激活并发出多段式 End 节点的输出。

Bug Fixes:
- 通过在所有作用域和控制分支中统一激活和发出（emission）逻辑，解决在对具有多个输出片段的 End 节点进行流式处理时出现的游标和非活动片段问题。

Enhancements:
- 优化 End 节点的流式配置和分支控制分析，通过作用域和分支标签来跟踪激活状态，并将数据分片发出的逻辑集中到一个可复用的辅助方法中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix streaming workflow execution to correctly activate and emit multi-segment End node outputs in order based on upstream node and branch status.

Bug Fixes:
- Resolve cursor and inactive segment issues when streaming End nodes with multiple output segments by unifying activation and emission logic across scopes and control branches.

Enhancements:
- Refine End node streaming configuration and branch control analysis to track activation by scope and branch labels, and to centralize chunk emission into a reusable helper.

</details>