### PR TITLE
fix(web): agent's knowledge_bases bugfix

### DIFF
--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -212,7 +212,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
         ...data.knowledge_retrieval,
         ...knowledgeRest,
         knowledge_bases: knowledge_bases.map(item => ({
-          kb_id: item.id,
+          kb_id: item.kb_id || item.id,
           ...(item.config || {})
         }))
       } as KnowledgeConfig : null,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复代理配置序列化逻辑：当存在 `kb_id` 字段时优先使用该字段，若不存在则回退为知识库条目的 `id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix agent configuration serialization to use an existing kb_id field when present, falling back to id for knowledge base entries.

</details>