### PR TITLE
Revert "feat(web): update read_all_config select valueKey"

### DIFF
--- a/web/src/components/CustomSelect/index.tsx
+++ b/web/src/components/CustomSelect/index.tsx
@@ -15,7 +15,7 @@ interface ApiResponse<T> {
 interface CustomSelectProps extends Omit<SelectProps, 'filterOption'> {
   url: string;
   params?: Record<string, unknown>;
-  valueKey?: string | string[];
+  valueKey?: string;
   labelKey?: string;
   placeholder?: string;
   hasAll?: boolean;
@@ -66,18 +66,11 @@ const CustomSelect: FC<CustomSelectProps> = ({
       {...props}
     >
       {hasAll && <Select.Option value={null}>{allTitle || t('common.all')}</Select.Option>}
-      {displayOptions.map((option) => {
-        const getValue = () => {
-          if (typeof valueKey === 'string') return option[valueKey];
-          return valueKey.find(key => option[key] != null) ? option[valueKey.find(key => option[key] != null)!] : undefined;
-        };
-        const value = getValue();
-        return (
-          <Select.Option key={value} value={value}>
-            {String(option[labelKey])}
-          </Select.Option>
-        );
-      })}
+      {displayOptions.map((option) => (
+        <Select.Option key={option[valueKey]} value={option[valueKey]}>
+          {String(option[labelKey])}
+        </Select.Option>
+      ))}
     </Select>
   );
 };

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -79,7 +79,7 @@ const SelectWrapper: FC<{ title: string, desc: string, name: string | string[], 
           placeholder={t('common.pleaseSelect')}
           url={url}
           hasAll={false}
-          valueKey={['config_id_old', 'config_id']}
+          valueKey='config_id'
           labelKey="config_name"
         />
       </Form.Item>
@@ -126,14 +126,12 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     getApplicationConfig(id as string).then(res => {
       const response = res as Config
       let allTools = Array.isArray(response.tools) ? response.tools : []
-      const memoryContent = response.memory?.memory_content
-      const convertedMemoryContent = memoryContent && !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
       form.setFieldsValue({
         ...response,
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: convertedMemoryContent
+          memory_content: response.memory?.memory_content ? Number(response.memory?.memory_content) : undefined
         }
       })
       setData({

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -200,7 +200,7 @@ export const nodeLibrary: NodeLibrary[] = [
           config_id: {
             type: 'customSelect',
             url: memoryConfigListUrl,
-            valueKey: ['config_id_old', 'config_id'],
+            valueKey: 'config_id',
             labelKey: 'config_name'
           },
           search_switch: {
@@ -223,7 +223,7 @@ export const nodeLibrary: NodeLibrary[] = [
           config_id: {
             type: 'customSelect',
             url: memoryConfigListUrl,
-            valueKey: ['config_id_old', 'config_id'],
+            valueKey: 'config_id',
             labelKey: 'config_name'
           }
         }

--- a/web/src/views/Workflow/types.ts
+++ b/web/src/views/Workflow/types.ts
@@ -14,7 +14,7 @@ export interface NodeConfig {
 
   url?: string;
   params?: { [key: string]: unknown; }
-  valueKey?: string | string[];
+  valueKey?: string;
   labelKey?: string;
 
   defaultValue?: any;


### PR DESCRIPTION
This reverts commit 46f0f3cee90f7cf852bf5bcf89866b57448f1ffa.

## Summary by Sourcery

恢复对 CustomSelect 中多值键支持的回退，并还原到单一键值处理方式。

Bug Fixes:
- 将 CustomSelect 的值处理恢复为使用单一的 `valueKey`，避免在确定选项值时产生歧义。
- 调整 Agent 的内存配置解析逻辑：当 `memory_content` 存在时，将其强制转换为数值类型，否则保持为未定义。

Enhancements:
- 将工作流节点配置的类型和常量与回退后的单字符串 `valueKey` API（用于 `CustomSelect`）保持一致对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert support for multiple value keys in CustomSelect and related configurations, restoring single-key value handling.

Bug Fixes:
- Restore CustomSelect value handling to use a single valueKey, avoiding ambiguity when determining option values.
- Adjust Agent memory configuration parsing so memory_content is coerced to a number when present, otherwise left undefined.

Enhancements:
- Align workflow node configuration types and constants with the reverted single-string valueKey API for CustomSelect.

</details>