### PR TITLE
fix(web): model list remove is_active

### DIFF
--- a/web/src/views/ModelManagement/List.tsx
+++ b/web/src/views/ModelManagement/List.tsx
@@ -23,7 +23,6 @@ const ModelList: FC<{ query: any }> = ({ query }) => {
     getModelNewList({
       ...query,
       is_composite: false,
-      is_active: true,
     })
       .then(res => {
         setList((res || []) as ProviderModelItem[])


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过从数据查询中移除 `is_active` 过滤条件，将非激活模型也包含在模型管理列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include inactive models in the model management list by removing the is_active filter from the data query.

</details>