### PR TITLE
fix(web): model bugfix

### DIFF
--- a/web/src/views/ModelManagement/components/CustomModelModal.tsx
+++ b/web/src/views/ModelManagement/components/CustomModelModal.tsx
@@ -44,7 +44,8 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
   };
   const handleUpdate = (data: CustomModelForm) => {
     setLoading(true)
-    const res = isEdit ? updateCustomModel(model.id, data) : addCustomModel(data)
+    const { type, provider, ...rest} = data
+    const res = isEdit ? updateCustomModel(model.id, rest) : addCustomModel(data)
 
     res.then(() => {
       refresh && refresh()

--- a/web/src/views/ModelManagement/components/GroupModelModal.tsx
+++ b/web/src/views/ModelManagement/components/GroupModelModal.tsx
@@ -75,8 +75,9 @@ const GroupModelModal = forwardRef<GroupModelModalRef, GroupModelModalProps>(({
 
   const handleUpdate = (data: CompositeModelForm) => {
     setLoading(true)
+    const { type, ...rest } = data
     const res = isEdit
-      ? updateCompositeModel(model.id, data)
+      ? updateCompositeModel(model.id, { ...rest })
       : addCompositeModel(data)
 
     res.then(() => {

--- a/web/src/views/ModelManagement/types.ts
+++ b/web/src/views/ModelManagement/types.ts
@@ -17,7 +17,7 @@ export interface DescriptionItem {
 export interface CompositeModelForm {
   logo?: any;
   name: string;
-  type: string;
+  type?: string;
   description: string;
   api_key_ids: ModelApiKey[] | string[];
 }
@@ -119,8 +119,8 @@ export interface ModelSquareDetailRef {
 }
 export interface CustomModelForm {
   name: string;
-  type: string;
-  provider: string;
+  type?: string;
+  provider?: string;
   logo?: any;
   description: string;
   is_official: boolean;


### PR DESCRIPTION
## Summary by Sourcery

放宽模型表单字段的必填要求，并在更新模型时避免发送不可变字段。

Bug 修复：
- 允许组合模型表单和自定义模型表单在适当情况下省略 `type` 和 `provider` 字段。
- 在更新请求中避免发送 `type` 和 `provider` 字段，以防止在模型更新过程中覆盖由后端管理的属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax model form field requirements and prevent sending immutable fields when updating models.

Bug Fixes:
- Allow composite and custom model forms to omit type and provider fields where appropriate.
- Avoid sending type and provider fields in update requests so that backend-managed properties are not overwritten during model updates.

</details>