### PR TITLE
feat(web): model ui update

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -558,6 +558,7 @@ export const en = {
       item: 'item',
       apiKeyNum: ' API Keys',
       official: 'Official',
+      deprecated: 'Deprecated',
 
       llm: 'LLM',
       chat: 'Chat',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1124,6 +1124,7 @@ export const zh = {
       item: '个',
       apiKeyNum: '个 API Key',
       official: '官方',
+      deprecated: '已弃用',
 
       llm: 'LLM',
       chat: 'Chat',

--- a/web/src/views/ModelManagement/Square.tsx
+++ b/web/src/views/ModelManagement/Square.tsx
@@ -80,7 +80,7 @@ const ModelSquare = forwardRef <BaseRef, { query: any; handleEdit: (vo?: ModelPl
                         {!item.is_official && <Button type="primary" disabled={item.is_deprecated} onClick={() => handleEdit(item)}>{t('modelNew.edit')}</Button>}
                         {item.is_added
                           ? <Button type="primary" disabled>{t('modelNew.added')}</Button>
-                          : <Button type="primary" ghost disabled={item.is_deprecated} onClick={() => handleAdd(item)}>+ {t('common.add')}</Button>
+                          : <Button type="primary" ghost disabled={item.is_deprecated} onClick={() => handleAdd(item)}>{item.is_deprecated ? t('modelNew.deprecated') : `+ ${t('common.add')}`}</Button>
                         }
                       </Space>
                     </Flex>

--- a/web/src/views/ModelManagement/components/ModelSquareDetail.tsx
+++ b/web/src/views/ModelManagement/components/ModelSquareDetail.tsx
@@ -89,7 +89,7 @@ const ModelSquareDetail = forwardRef<ModelSquareDetailRef, ModelSquareDetailProp
                       {!item.is_official && <Button type="primary" disabled={item.is_deprecated} onClick={() => handleEdit(item)}>{t('modelNew.edit')}</Button>}
                       {item.is_added
                         ? <Button type="primary" disabled>{t('modelNew.added')}</Button>
-                        : <Button type="primary" ghost disabled={item.is_deprecated} onClick={() => handleAdd(item)}>+ {t('common.add')}</Button>
+                        : <Button type="primary" ghost disabled={item.is_deprecated} onClick={() => handleAdd(item)}>{item.is_deprecated ? t('modelNew.deprecated') : `+ ${t('common.add')}`}</Button>
                       }
                     </Space>
                   </Flex>


### PR DESCRIPTION
## Summary by Sourcery

更新模型管理 UI 标签，当“添加”按钮被禁用时，反映模型已被弃用的状态。

新功能：
- 在模型方块列表视图和详情视图中，对于已弃用的模型，在添加按钮上显示“已弃用”标签。

文档：
- 为“已弃用模型”标签新增英文和中文的 i18n 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update model management UI labels to reflect deprecated models when the add button is disabled.

New Features:
- Show a 'Deprecated' label on the add button for deprecated models in both the model square list and detail views.

Documentation:
- Add English and Chinese i18n strings for the deprecated model label.

</details>