### PR TITLE
fix(web): the memoryContent field is compatible with numbers and strings

### DIFF
--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -126,12 +126,16 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     getApplicationConfig(id as string).then(res => {
       const response = res as Config
       let allTools = Array.isArray(response.tools) ? response.tools : []
+      const memoryContent = response.memory?.memory_content
+      const parsedMemoryContent = memoryContent === null || memoryContent === '' 
+        ? undefined 
+        : !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
       form.setFieldsValue({
         ...response,
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: response.memory?.memory_content ? Number(response.memory?.memory_content) : undefined
+          memory_content: parsedMemoryContent
         }
       })
       setData({


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 允许代理配置表单中的 `memory_content` 字段接受并保留数值和字符串两种类型的值，并能优雅地处理 `null` 和空值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow the memory_content field in the agent configuration form to accept and preserve both numeric and string values, handling null and empty values gracefully.

</details>