### PR TITLE
fix(model)

### DIFF
--- a/api/app/repositories/model_repository.py
+++ b/api/app/repositories/model_repository.py
@@ -631,6 +631,13 @@ class ModelBaseRepository:
         return model_base
 
     @staticmethod
+    def get_by_name_and_provider(db: Session, name: str, provider: str) -> Optional['ModelBase']:
+        return db.query(ModelBase).filter(
+            ModelBase.name == name,
+            ModelBase.provider == provider
+        ).first()
+
+    @staticmethod
     def update(db: Session, model_base_id: uuid.UUID, data: dict) -> Optional['ModelBase']:
         model_base = db.query(ModelBase).filter(ModelBase.id == model_base_id).first()
         if not model_base:

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -508,10 +508,7 @@ class ModelApiKeyService:
             )
             if not validation_result["valid"]:
                 # 记录验证失败的模型，但不抛出异常
-                failed_models.append({
-                    "model_name": model_name,
-                    "error": validation_result["error"]
-                })
+                failed_models.append(model_name)
                 continue
             
             # 创建API Key
@@ -692,6 +689,9 @@ class ModelBaseService:
 
     @staticmethod
     def create_model_base(db: Session, data: model_schema.ModelBaseCreate):
+        existing = ModelBaseRepository.get_by_name_and_provider(db, data.name, data.provider)
+        if existing:
+            raise BusinessException("模型已存在", BizCode.DUPLICATE_NAME)
         model_base = ModelBaseRepository.create(db, data.model_dump())
         db.commit()
         db.refresh(model_base)


### PR DESCRIPTION
1. create a basic model to check if the name and provider are duplicated.
2. The result shows error models because the provider created API Keys for all matching models.

## Summary by Sourcery

防止在按服务商创建 API 密钥时生成重复的模型基础记录，并简化失败模型的上报。

Bug 修复：
- 禁止创建名称/服务商组合已存在的模型基础记录，以避免产生重复模型。

增强功能：
- 新增一个仓储辅助方法，用于按名称和服务商获取模型基础记录，并在创建模型基础时使用该方法。
- 简化在创建服务商 API 密钥过程中对验证失败模型的追踪方式，仅存储模型名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent creation of duplicate model base records and simplify failed model reporting when creating API keys by provider.

Bug Fixes:
- Disallow creating a model base with a name/provider combination that already exists to avoid duplicate models.

Enhancements:
- Add a repository helper to fetch model bases by name and provider and use it in model base creation.
- Simplify tracking of models that fail validation during provider API key creation by storing only the model name.

</details>