### PR TITLE
Release/v0.2.2

### DIFF
--- a/api/app/repositories/model_repository.py
+++ b/api/app/repositories/model_repository.py
@@ -631,6 +631,13 @@ class ModelBaseRepository:
         return model_base
 
     @staticmethod
+    def get_by_name_and_provider(db: Session, name: str, provider: str) -> Optional['ModelBase']:
+        return db.query(ModelBase).filter(
+            ModelBase.name == name,
+            ModelBase.provider == provider
+        ).first()
+
+    @staticmethod
     def update(db: Session, model_base_id: uuid.UUID, data: dict) -> Optional['ModelBase']:
         model_base = db.query(ModelBase).filter(ModelBase.id == model_base_id).first()
         if not model_base:

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -508,10 +508,7 @@ class ModelApiKeyService:
             )
             if not validation_result["valid"]:
                 # 记录验证失败的模型，但不抛出异常
-                failed_models.append({
-                    "model_name": model_name,
-                    "error": validation_result["error"]
-                })
+                failed_models.append(model_name)
                 continue
             
             # 创建API Key
@@ -692,6 +689,9 @@ class ModelBaseService:
 
     @staticmethod
     def create_model_base(db: Session, data: model_schema.ModelBaseCreate):
+        existing = ModelBaseRepository.get_by_name_and_provider(db, data.name, data.provider)
+        if existing:
+            raise BusinessException("模型已存在", BizCode.DUPLICATE_NAME)
         model_base = ModelBaseRepository.create(db, data.model_dump())
         db.commit()
         db.refresh(model_base)

--- a/api/migrations/versions/5de9b1e28509_20260129212722.py
+++ b/api/migrations/versions/5de9b1e28509_20260129212722.py
@@ -1,0 +1,80 @@
+"""20260129212722
+
+Revision ID: 5de9b1e28509
+Revises: 5ca246ee7dd4
+Create Date: 2026-01-29 21:34:30.978031
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '5de9b1e28509'
+down_revision: Union[str, None] = '5ca246ee7dd4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Neo4j migration: rename group_id to end_user_id
+    import asyncio
+
+    from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+    
+    async def run_neo4j_upgrade():
+        connector = Neo4jConnector()
+        try:
+            async def transaction_func(tx):
+                result = await tx.run("""
+                    MATCH (n)
+                    WHERE n.group_id IS NOT NULL
+                    SET n.end_user_id = n.group_id
+                    REMOVE n.group_id
+                    WITH count(n) AS node_count
+                    MATCH ()-[r]->()
+                    WHERE r.group_id IS NOT NULL
+                    SET r.end_user_id = r.group_id
+                    REMOVE r.group_id
+                    RETURN node_count, count(r) AS rel_count
+                """)
+                return await result.data()
+            
+            await connector.execute_write_transaction(transaction_func)
+        finally:
+            await connector.close()
+    
+    asyncio.run(run_neo4j_upgrade())
+
+
+def downgrade() -> None:
+    # Neo4j migration: rename end_user_id back to group_id
+    import asyncio
+
+    from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+    
+    async def run_neo4j_downgrade():
+        connector = Neo4jConnector()
+        try:
+            async def transaction_func(tx):
+                result = await tx.run("""
+                    MATCH (n)
+                    WHERE n.end_user_id IS NOT NULL
+                    SET n.group_id = n.end_user_id
+                    REMOVE n.end_user_id
+                    WITH count(n) AS node_count
+                    MATCH ()-[r]->()
+                    WHERE r.end_user_id IS NOT NULL
+                    SET r.group_id = r.end_user_id
+                    REMOVE r.end_user_id
+                    RETURN node_count, count(r) AS rel_count
+                """)
+                return await result.data()
+            
+            await connector.execute_write_transaction(transaction_func)
+        finally:
+            await connector.close()
+    
+    asyncio.run(run_neo4j_downgrade())

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -126,12 +126,16 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     getApplicationConfig(id as string).then(res => {
       const response = res as Config
       let allTools = Array.isArray(response.tools) ? response.tools : []
+      const memoryContent = response.memory?.memory_content
+      const parsedMemoryContent = memoryContent === null || memoryContent === '' 
+        ? undefined 
+        : !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
       form.setFieldsValue({
         ...response,
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: response.memory?.memory_content ? Number(response.memory?.memory_content) : undefined
+          memory_content: parsedMemoryContent
         }
       })
       setData({

--- a/web/src/views/ModelManagement/components/KeyConfigModal.tsx
+++ b/web/src/views/ModelManagement/components/KeyConfigModal.tsx
@@ -72,7 +72,7 @@ const KeyConfigModal = forwardRef<KeyConfigModalRef, KeyConfigModalProps>(({
         <Form.Item
           name="api_key"
           label={t('modelNew.api_key')}
-          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.apiKey') }) }]}
+          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_key') }) }]}
         >
           <Input.Password placeholder={t('common.pleaseEnter')} />
         </Form.Item>

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -431,32 +431,32 @@ export const nodeLibrary: NodeLibrary[] = [
           }
         }
       },
-      { type: "code", icon: codeExecutionIcon,
-        config: {
-          input_variables: {
-            type: 'inputList',
-            defaultValue: [{ name: 'arg1' }, { name: 'arg2' }]
-          },
-          language: {
-            type: 'select',
-            defaultValue: 'python3'
-          },
-          code: {
-            type: 'messageEditor',
-            isArray: false,
-            language: ['python3', 'javascript'],
-            titleVariant: 'borderless',
-            defaultValue: `def main(arg1: str, arg2: str):
-    return {
-        "result": arg1 + arg2,
-    }`
-          },
-          output_variables: {
-            type: 'outputList',
-            defaultValue: [{name: 'result', type: 'string'}]
-          },
-        }
-      },
+    //   { type: "code", icon: codeExecutionIcon,
+    //     config: {
+    //       input_variables: {
+    //         type: 'inputList',
+    //         defaultValue: [{ name: 'arg1' }, { name: 'arg2' }]
+    //       },
+    //       language: {
+    //         type: 'select',
+    //         defaultValue: 'python3'
+    //       },
+    //       code: {
+    //         type: 'messageEditor',
+    //         isArray: false,
+    //         language: ['python3', 'javascript'],
+    //         titleVariant: 'borderless',
+    //         defaultValue: `def main(arg1: str, arg2: str):
+    // return {
+    //     "result": arg1 + arg2,
+    // }`
+    //       },
+    //       output_variables: {
+    //         type: 'outputList',
+    //         defaultValue: [{name: 'result', type: 'string'}]
+    //       },
+    //     }
+    //   },
       { type: "jinja-render", icon: templateRenderingIcon,
         config: {
           mapping: {


### PR DESCRIPTION
## Summary by Sourcery

为 v0.2.2 版本发布做准备，本次更新包括：加强数据库迁移的健壮性、强化模型唯一性约束、调整 UI 校验逻辑，以及重命名图数据库中的标识符。

Bug 修复：
- 当现有 `memory_config.apply_id` 值为 null 或无效时，通过生成 UUID 来防止迁移失败。
- 避免对 agent 的 `memory_content` 强制进行数值类型转换，以便在表单中正确保留非数值内容。
- 修复 API key 表单校验信息，确保引用正确的 i18n key。
- 简化失败模型校验的跟踪方式，仅存储模型名称。

功能增强：
- 通过在创建前检查既有的“名称/提供方”组合并抛出“重复名称”的业务异常，来确保每个提供方下模型基座的唯一性。
- 新增仓储（repository）辅助方法，用于根据名称和提供方获取模型基座，方便在多个服务间复用。
- 临时在节点库配置中禁用 workflow code 节点。

部署：
- 新增 Neo4j 迁移脚本，将节点和关系上的 `group_id` 重命名为 `end_user_id`，并提供可逆的降级脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare v0.2.2 release with DB migration hardening, model uniqueness enforcement, UI validation tweaks, and graph DB identifier renaming.

Bug Fixes:
- Prevent migration failure by generating UUIDs when existing memory_config.apply_id values are null or invalid.
- Avoid forcing numeric casting of agent memory_content so non-numeric values are preserved correctly in the form.
- Fix API key form validation message to reference the correct i18n key.
- Simplify tracking of failed model validations by storing only model names.

Enhancements:
- Enforce uniqueness of model bases per provider by checking for existing name/provider combinations before creation and raising a duplicate-name business exception.
- Add repository helper to fetch a model base by name and provider for reuse across services.
- Temporarily disable the workflow code node in the node library configuration.

Deployment:
- Add Neo4j migration to rename group_id to end_user_id on nodes and relationships, with a reversible downgrade script.

</details>