### PR TITLE
Release/v0.2.2

### DIFF
--- a/api/app/repositories/model_repository.py
+++ b/api/app/repositories/model_repository.py
@@ -631,6 +631,13 @@ class ModelBaseRepository:
         return model_base
 
     @staticmethod
+    def get_by_name_and_provider(db: Session, name: str, provider: str) -> Optional['ModelBase']:
+        return db.query(ModelBase).filter(
+            ModelBase.name == name,
+            ModelBase.provider == provider
+        ).first()
+
+    @staticmethod
     def update(db: Session, model_base_id: uuid.UUID, data: dict) -> Optional['ModelBase']:
         model_base = db.query(ModelBase).filter(ModelBase.id == model_base_id).first()
         if not model_base:

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -508,10 +508,7 @@ class ModelApiKeyService:
             )
             if not validation_result["valid"]:
                 # 记录验证失败的模型，但不抛出异常
-                failed_models.append({
-                    "model_name": model_name,
-                    "error": validation_result["error"]
-                })
+                failed_models.append(model_name)
                 continue
             
             # 创建API Key
@@ -692,6 +689,9 @@ class ModelBaseService:
 
     @staticmethod
     def create_model_base(db: Session, data: model_schema.ModelBaseCreate):
+        existing = ModelBaseRepository.get_by_name_and_provider(db, data.name, data.provider)
+        if existing:
+            raise BusinessException("模型已存在", BizCode.DUPLICATE_NAME)
         model_base = ModelBaseRepository.create(db, data.model_dump())
         db.commit()
         db.refresh(model_base)

--- a/api/migrations/versions/5de9b1e28509_20260129212722.py
+++ b/api/migrations/versions/5de9b1e28509_20260129212722.py
@@ -1,0 +1,80 @@
+"""20260129212722
+
+Revision ID: 5de9b1e28509
+Revises: 5ca246ee7dd4
+Create Date: 2026-01-29 21:34:30.978031
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '5de9b1e28509'
+down_revision: Union[str, None] = '5ca246ee7dd4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Neo4j migration: rename group_id to end_user_id
+    import asyncio
+
+    from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+    
+    async def run_neo4j_upgrade():
+        connector = Neo4jConnector()
+        try:
+            async def transaction_func(tx):
+                result = await tx.run("""
+                    MATCH (n)
+                    WHERE n.group_id IS NOT NULL
+                    SET n.end_user_id = n.group_id
+                    REMOVE n.group_id
+                    WITH count(n) AS node_count
+                    MATCH ()-[r]->()
+                    WHERE r.group_id IS NOT NULL
+                    SET r.end_user_id = r.group_id
+                    REMOVE r.group_id
+                    RETURN node_count, count(r) AS rel_count
+                """)
+                return await result.data()
+            
+            await connector.execute_write_transaction(transaction_func)
+        finally:
+            await connector.close()
+    
+    asyncio.run(run_neo4j_upgrade())
+
+
+def downgrade() -> None:
+    # Neo4j migration: rename end_user_id back to group_id
+    import asyncio
+
+    from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+    
+    async def run_neo4j_downgrade():
+        connector = Neo4jConnector()
+        try:
+            async def transaction_func(tx):
+                result = await tx.run("""
+                    MATCH (n)
+                    WHERE n.end_user_id IS NOT NULL
+                    SET n.group_id = n.end_user_id
+                    REMOVE n.end_user_id
+                    WITH count(n) AS node_count
+                    MATCH ()-[r]->()
+                    WHERE r.end_user_id IS NOT NULL
+                    SET r.group_id = r.end_user_id
+                    REMOVE r.end_user_id
+                    RETURN node_count, count(r) AS rel_count
+                """)
+                return await result.data()
+            
+            await connector.execute_write_transaction(transaction_func)
+        finally:
+            await connector.close()
+    
+    asyncio.run(run_neo4j_downgrade())

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -126,12 +126,16 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     getApplicationConfig(id as string).then(res => {
       const response = res as Config
       let allTools = Array.isArray(response.tools) ? response.tools : []
+      const memoryContent = response.memory?.memory_content
+      const parsedMemoryContent = memoryContent === null || memoryContent === '' 
+        ? undefined 
+        : !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
       form.setFieldsValue({
         ...response,
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: response.memory?.memory_content ? Number(response.memory?.memory_content) : undefined
+          memory_content: parsedMemoryContent
         }
       })
       setData({

--- a/web/src/views/ModelManagement/components/KeyConfigModal.tsx
+++ b/web/src/views/ModelManagement/components/KeyConfigModal.tsx
@@ -72,7 +72,7 @@ const KeyConfigModal = forwardRef<KeyConfigModalRef, KeyConfigModalProps>(({
         <Form.Item
           name="api_key"
           label={t('modelNew.api_key')}
-          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.apiKey') }) }]}
+          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_key') }) }]}
         >
           <Input.Password placeholder={t('common.pleaseEnter')} />
         </Form.Item>

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -431,32 +431,32 @@ export const nodeLibrary: NodeLibrary[] = [
           }
         }
       },
-      { type: "code", icon: codeExecutionIcon,
-        config: {
-          input_variables: {
-            type: 'inputList',
-            defaultValue: [{ name: 'arg1' }, { name: 'arg2' }]
-          },
-          language: {
-            type: 'select',
-            defaultValue: 'python3'
-          },
-          code: {
-            type: 'messageEditor',
-            isArray: false,
-            language: ['python3', 'javascript'],
-            titleVariant: 'borderless',
-            defaultValue: `def main(arg1: str, arg2: str):
-    return {
-        "result": arg1 + arg2,
-    }`
-          },
-          output_variables: {
-            type: 'outputList',
-            defaultValue: [{name: 'result', type: 'string'}]
-          },
-        }
-      },
+    //   { type: "code", icon: codeExecutionIcon,
+    //     config: {
+    //       input_variables: {
+    //         type: 'inputList',
+    //         defaultValue: [{ name: 'arg1' }, { name: 'arg2' }]
+    //       },
+    //       language: {
+    //         type: 'select',
+    //         defaultValue: 'python3'
+    //       },
+    //       code: {
+    //         type: 'messageEditor',
+    //         isArray: false,
+    //         language: ['python3', 'javascript'],
+    //         titleVariant: 'borderless',
+    //         defaultValue: `def main(arg1: str, arg2: str):
+    // return {
+    //     "result": arg1 + arg2,
+    // }`
+    //       },
+    //       output_variables: {
+    //         type: 'outputList',
+    //         defaultValue: [{name: 'result', type: 'string'}]
+    //       },
+    //     }
+    //   },
       { type: "jinja-render", icon: templateRenderingIcon,
         config: {
           mapping: {


### PR DESCRIPTION
## Summary by Sourcery

改进模型管理校验、增强数据库迁移的健壮性，并调整前端配置和 i18n 处理方式。

New Features:
- 添加一个 Neo4j 迁移，用于将 `group_id` 属性和关系重命名为 `end_user_id`，并提供可逆的降级操作。

Bug Fixes:
- 修复应用内存配置表单，使其在处理 `memory_content` 时保留非数字值，而不是强制进行数字转换。
- 更正 API key 表单的校验消息，使其引用正确的 API key 标签 i18n 文案键。

Enhancements:
- 放宽模型 API key 校验的错误收集逻辑，仅保存失败的模型名称，而不是完整的错误对象。
- 通过对名称和提供方进行唯一性检查并抛出业务异常，防止创建重复的模型基础配置。
- 加强 `memory_config` 迁移逻辑，对 `apply_id` 为 `NULL` 或无效的情况，通过生成 UUID 来安全处理，而不是直接失败。
- 通过注释掉相关配置，暂时在节点库中禁用 workflow code 节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve model management validation, harden database migrations, and adjust frontend configuration and i18n handling.

New Features:
- Add a Neo4j migration to rename group_id properties and relationships to end_user_id, with a reversible downgrade.

Bug Fixes:
- Fix application memory configuration form to preserve non-numeric memory_content values instead of forcing numeric conversion.
- Correct the API key form validation message to reference the proper i18n key for the API key label.

Enhancements:
- Relax model API key validation error collection to store only failed model names instead of full error objects.
- Prevent creation of duplicate model bases by enforcing a name and provider uniqueness check with a business exception.
- Strengthen the memory_config migration to safely handle NULL or invalid apply_id values by generating UUIDs instead of failing.
- Temporarily disable the workflow code node in the node library by commenting out its configuration.

</details>