### PR TITLE
feat(celery): add dedicated periodic tasks worker and queue

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -67,11 +67,11 @@ celery_app.conf.update(
         'app.core.rag.tasks.parse_document': {'queue': 'document_tasks'},
         'app.core.rag.tasks.build_graphrag_for_kb': {'queue': 'document_tasks'},
         
-        # Beat/periodic tasks → document_tasks queue (prefork worker)
-        'app.tasks.workspace_reflection_task': {'queue': 'document_tasks'},
-        'app.tasks.regenerate_memory_cache': {'queue': 'document_tasks'},
-        'app.tasks.run_forgetting_cycle_task': {'queue': 'document_tasks'},
-        'app.controllers.memory_storage_controller.search_all': {'queue': 'document_tasks'},
+        # Beat/periodic tasks → periodic_tasks queue (dedicated periodic worker)
+        'app.tasks.workspace_reflection_task': {'queue': 'periodic_tasks'},
+        'app.tasks.regenerate_memory_cache': {'queue': 'periodic_tasks'},
+        'app.tasks.run_forgetting_cycle_task': {'queue': 'periodic_tasks'},
+        'app.controllers.memory_storage_controller.search_all': {'queue': 'periodic_tasks'},
     },
 )
 

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     depends_on:
       - worker-memory
       - worker-document
+      - worker-periodic
 
   # Memory worker - Memory read/write tasks (threads pool for asyncio)
   worker-memory:
@@ -44,6 +45,20 @@ services:
       - ./files:/files
       - /etc/localtime:/etc/localtime:ro
     command: celery -A app.celery_worker.celery_app worker -E --loglevel=info --pool=prefork --concurrency=4 --queues=document_tasks --max-tasks-per-child=100 -n document_worker@%h
+    restart: unless-stopped
+    networks:
+      - celery
+
+  # Periodic worker - Scheduled/beat tasks (prefork, low concurrency)
+  worker-periodic:
+    image: redbear-mem-open:latest
+    container_name: worker-periodic
+    env_file:
+      - .env
+    volumes:
+      - ./files:/files
+      - /etc/localtime:/etc/localtime:ro
+    command: celery -A app.celery_worker.celery_app worker -E --loglevel=info --pool=prefork --concurrency=2 --queues=periodic_tasks --max-tasks-per-child=50 -n periodic_worker@%h
     restart: unless-stopped
     networks:
       - celery


### PR DESCRIPTION
## Summary by Sourcery

添加一个专用的 Celery worker 和队列用于周期性任务，并将计划任务路由到该队列，而不是使用文档处理队列。

New Features:
- 在 docker-compose 中为计划任务引入一个专用的周期性 Celery worker 服务，并使用其独立的队列。

Enhancements:
- 将现有的 beat/周期性任务路由到新的 `periodic_tasks` 队列，以使其与文档处理工作负载隔离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated Celery worker and queue for periodic tasks and route scheduled jobs to it instead of the document-processing queue.

New Features:
- Introduce a dedicated periodic Celery worker service in docker-compose for scheduled tasks, using its own queue.

Enhancements:
- Route existing beat/periodic tasks to a new periodic_tasks queue to isolate them from document-processing workloads.

</details>