### PR TITLE
fix(web): update retrieve_type key

### DIFF
--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
@@ -64,7 +64,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
       ...item,
       config: {
         similarity_threshold: 0.7,
-        strategy: "hybrid",
+        retrieve_type: "hybrid",
         top_k: 3,
         weight: 1,
       }

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
@@ -64,7 +64,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
       ...item,
       config: {
         similarity_threshold: 0.7,
-        strategy: "hybrid",
+        retrieve_type: "hybrid",
         top_k: 3,
         weight: 1,
       }

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -885,7 +885,7 @@ export const useWorkflowGraph = ({
                   ...itemConfig,
                   ...(data.config[key].defaultValue || {}),
                   knowledge_bases: knowledge_bases?.map((vo: any) => {
-                    const kb_config = vo.config || { similarity_threshold: vo.similarity_threshold, strategy: vo.strategy, top_k: vo.top_k, weight: vo.weight }
+                    const kb_config = vo.config || { similarity_threshold: vo.similarity_threshold, retrieve_type: vo.retrieve_type, top_k: vo.top_k, weight: vo.weight }
                     return { kb_id: vo.kb_id || vo.id, ...kb_config, }
                   })
                 }


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在应用和工作流的知识库弹窗以及工作流图的处理逻辑中，将知识库配置与更新后的 `retrieve_type` 字段对齐，替换掉已弃用的 `strategy` 键。

错误修复：
- 更新知识列表弹窗中的默认知识库配置，将 `strategy` 替换为 `retrieve_type`。
- 调整工作流图中的知识库配置映射逻辑，在未提供显式配置时，读取并持久化 `retrieve_type` 而不是 `strategy`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align knowledge base configuration with the updated `retrieve_type` field instead of the deprecated `strategy` key in both application and workflow knowledge modals and workflow graph handling.

Bug Fixes:
- Update default knowledge base config in knowledge list modals to use `retrieve_type` instead of `strategy`.
- Adjust workflow graph knowledge base config mapping to read and persist `retrieve_type` instead of `strategy` when no explicit config is provided.

</details>