### PR TITLE
fix(web): prompt history remove pageLoading

### DIFF
--- a/web/src/components/PageScrollList/index.tsx
+++ b/web/src/components/PageScrollList/index.tsx
@@ -26,6 +26,7 @@ interface PageScrollListProps<T, Q = Record<string, unknown>> {
   query?: Q;
   column?: number;
   className?: string;
+  needLoading?: boolean;
 }
 const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   renderItem, 
@@ -33,6 +34,7 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   url,
   column = 4,
   className = '',
+  needLoading = true,
 }: PageScrollListProps<T, Q>, ref: React.Ref<PageScrollListRef>) => {
   useImperativeHandle(ref, () => ({
     refresh,
@@ -104,9 +106,10 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
           dataLength={data.length}
           next={loadMoreData}
           hasMore={hasMore}
-          loader={<PageLoading />}
+          loader={needLoading ? <PageLoading /> : undefined}
           // endMessage={<Divider plain>It is all, nothing more 🤐</Divider>}
           scrollableTarget="scrollableDiv"
+          className='rb:h-full!'
         >
           {data.length > 0 ? (
             <List

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -181,3 +181,6 @@ body {
   min-height: 100%;
   max-height: 100%;
 }
+#scrollableDiv .infinite-scroll-component__outerdiv {
+  height: 100%;
+}

--- a/web/src/views/Prompt/History.tsx
+++ b/web/src/views/Prompt/History.tsx
@@ -50,6 +50,7 @@ const History: React.FC<{ query: HistoryQuery; edit: (item: HistoryItem) => void
         url={getPromptReleaseListUrl}
         query={query}
         column={3}
+        needLoading={false}
         renderItem={(item) => {
           const historyItem = item as unknown as HistoryItem;
           return (


### PR DESCRIPTION
## 由 Sourcery 提供的总结

允许 PageScrollList 可选地隐藏加载指示器，并在提示历史视图中为全高度的无限滚动调整布局。

新功能：
- 为 PageScrollList 新增可选的 `needLoading` 属性，用于控制是否显示加载动画。

增强改进：
- 通过 CSS 和组件类名调整，确保无限滚动容器及其内部包装元素占满整个高度。
- 在提示历史视图中应用“无加载”配置，以移除该处的页面加载指示器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow PageScrollList to optionally hide the loading indicator and adjust layout for full-height infinite scroll in the prompt history view.

New Features:
- Add an optional needLoading prop to PageScrollList to control display of the loading spinner.

Enhancements:
- Ensure the infinite scroll container and inner wrapper span full height via CSS and component class adjustments.
- Apply the no-loading configuration to the prompt history view to remove the page loading indicator there.

</details>