### PR TITLE
Release/v0.2.3

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -3,8 +3,9 @@ import platform
 from datetime import timedelta
 from urllib.parse import quote
 
-from app.core.config import settings
 from celery import Celery
+
+from app.core.config import settings
 
 # 创建 Celery 应用实例
 # broker: 任务队列（使用 Redis DB 0）
@@ -79,40 +80,40 @@ celery_app.conf.update(
 celery_app.autodiscover_tasks(['app'])
 
 # Celery Beat schedule for periodic tasks
-memory_increment_schedule = timedelta(hours=settings.MEMORY_INCREMENT_INTERVAL_HOURS)
-memory_cache_regeneration_schedule = timedelta(hours=settings.MEMORY_CACHE_REGENERATION_HOURS)
-workspace_reflection_schedule = timedelta(seconds=30)  # 每30秒运行一次settings.REFLECTION_INTERVAL_TIME
-forgetting_cycle_schedule = timedelta(hours=24)  # 每24小时运行一次遗忘周期
+# memory_increment_schedule = timedelta(hours=settings.MEMORY_INCREMENT_INTERVAL_HOURS)
+# memory_cache_regeneration_schedule = timedelta(hours=settings.MEMORY_CACHE_REGENERATION_HOURS)
+# workspace_reflection_schedule = timedelta(seconds=30)  # 每30秒运行一次settings.REFLECTION_INTERVAL_TIME
+# forgetting_cycle_schedule = timedelta(hours=24)  # 每24小时运行一次遗忘周期
 
 # 构建定时任务配置
-beat_schedule_config = {
-    "run-workspace-reflection": {
-        "task": "app.tasks.workspace_reflection_task",
-        "schedule": workspace_reflection_schedule,
-        "args": (),
-    },
-    "regenerate-memory-cache": {
-        "task": "app.tasks.regenerate_memory_cache",
-        "schedule": memory_cache_regeneration_schedule,
-        "args": (),
-    },
-    "run-forgetting-cycle": {
-        "task": "app.tasks.run_forgetting_cycle_task",
-        "schedule": forgetting_cycle_schedule,
-        "kwargs": {
-            "config_id": None,  # 使用默认配置，可以通过环境变量配置
-        },
-    },
-}
+# beat_schedule_config = {
+#     "run-workspace-reflection": {
+#         "task": "app.tasks.workspace_reflection_task",
+#         "schedule": workspace_reflection_schedule,
+#         "args": (),
+#     },
+#     "regenerate-memory-cache": {
+#         "task": "app.tasks.regenerate_memory_cache",
+#         "schedule": memory_cache_regeneration_schedule,
+#         "args": (),
+#     },
+#     "run-forgetting-cycle": {
+#         "task": "app.tasks.run_forgetting_cycle_task",
+#         "schedule": forgetting_cycle_schedule,
+#         "kwargs": {
+#             "config_id": None,  # 使用默认配置，可以通过环境变量配置
+#         },
+#     },
+# }
 
 # 如果配置了默认工作空间ID，则添加记忆总量统计任务
-if settings.DEFAULT_WORKSPACE_ID:
-    beat_schedule_config["write-total-memory"] = {
-        "task": "app.controllers.memory_storage_controller.search_all",
-        "schedule": memory_increment_schedule,
-        "kwargs": {
-            "workspace_id": settings.DEFAULT_WORKSPACE_ID,
-        },
-    }
+# if settings.DEFAULT_WORKSPACE_ID:
+#     beat_schedule_config["write-total-memory"] = {
+#         "task": "app.controllers.memory_storage_controller.search_all",
+#         "schedule": memory_increment_schedule,
+#         "kwargs": {
+#             "workspace_id": settings.DEFAULT_WORKSPACE_ID,
+#         },
+#     }
 
-celery_app.conf.beat_schedule = beat_schedule_config
+# celery_app.conf.beat_schedule = beat_schedule_config

--- a/api/app/core/memory/agent/langgraph_graph/write_graph.py
+++ b/api/app/core/memory/agent/langgraph_graph/write_graph.py
@@ -39,7 +39,6 @@ async def make_write_graph():
     graph = workflow.compile()
 
     yield graph
-
 async def long_term_storage(long_term_type:str="chunk",langchain_messages:list=[],memory_config:str='',end_user_id:str='',scope:int=6):
     from app.core.memory.agent.langgraph_graph.routing.write_router import memory_long_term_storage, window_dialogue,aggregate_judgment
     from app.core.memory.agent.langgraph_graph.tools.write_tool import chat_data_format
@@ -49,7 +48,7 @@ async def long_term_storage(long_term_type:str="chunk",langchain_messages:list=[
     db_session = next(get_db())
     config_service = MemoryConfigService(db_session)
     memory_config = config_service.load_memory_config(
-        config_id="08ed205c-0f05-49c3-8e0c-a580d28f5fd4",  # 改为整数
+        config_id=memory_config,  # 改为整数
         service_name="MemoryAgentService"
     )
     if long_term_type=='chunk':
@@ -63,7 +62,7 @@ async def long_term_storage(long_term_type:str="chunk",langchain_messages:list=[
         """方案三：聚合判断"""
         await aggregate_judgment(end_user_id, langchain_messages, memory_config)
 
-#
+
 # async def main():
 #     """主函数 - 运行工作流"""
 #     langchain_messages = [
@@ -80,14 +79,7 @@ async def long_term_storage(long_term_type:str="chunk",langchain_messages:list=[
 #     end_user_id = '837fee1b-04a2-48ee-94d7-211488908940'  # 组ID
 #     memory_config="08ed205c-0f05-49c3-8e0c-a580d28f5fd4"
 #     # await long_term_storage(long_term_type="chunk",langchain_messages=langchain_messages,memory_config=memory_config,end_user_id=end_user_id,scope=2)
-#     from app.core.memory.agent.utils.redis_tool import write_store
-#     result=write_store.get_session_by_userid(end_user_id)
-#     data=await format_parsing(result,"dict")
-#     chunk_data=data[:6]
-#
-#     long_time_data = write_store.find_user_recent_sessions(end_user_id, 240)
-#     long_=await messages_parse(long_time_data)
-#     print(long_)
+#     result=await long_term_storage(long_term_type="chunk",langchain_messages=langchain_messages,memory_config=memory_config,end_user_id=end_user_id,scope=2)
 #
 #
 # if __name__ == "__main__":

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -877,7 +877,8 @@ RETURN
     CASE
       WHEN ms:ExtractedEntity THEN {
         text: ms.name,
-        created_at: ms.created_at
+        created_at: ms.created_at,
+        type: "情景记忆" 
       }
     END
   ) AS ExtractedEntity,
@@ -887,7 +888,8 @@ RETURN
     CASE
       WHEN n:MemorySummary THEN {
         text: n.content,
-        created_at: n.created_at
+        created_at: n.created_at,
+        type: "长期沉淀" 
       }
     END
   ) AS MemorySummary,
@@ -895,7 +897,8 @@ RETURN
   collect(
     DISTINCT {
       text: e.statement,
-      created_at: e.created_at
+      created_at: e.created_at,
+      type: "情绪记忆" 
     }
   ) AS statement;
 """

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,4 +1,5 @@
 """会话服务"""
+import os
 import uuid
 from datetime import datetime, timedelta
 from typing import Annotated
@@ -529,12 +530,12 @@ class ConversationService:
                 takeaways=[],
                 info_score=0,
             )
-
-        with open('app/services/prompt/conversation_summary_system.jinja2', 'r', encoding='utf-8') as f:
+        prompt_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'prompt')
+        with open(os.path.join(prompt_path, 'conversation_summary_system.jinja2'), 'r', encoding='utf-8') as f:
             system_prompt = f.read()
         rendered_system_message = Template(system_prompt).render()
 
-        with open('app/services/prompt/conversation_summary_user.jinja2', 'r', encoding='utf-8') as f:
+        with open(os.path.join(prompt_path, 'conversation_summary_user.jinja2'), 'r', encoding='utf-8') as f:
             user_prompt = f.read()
         rendered_user_message = Template(user_prompt).render(
             language=language,

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -678,6 +678,11 @@ class DraftRunService:
 
             elapsed_time = time.time() - start_time
 
+            if sub_agent:
+                yield self._format_sse_event("sub_usage", {
+                        "total_tokens": total_tokens
+                    })
+
             # 10. 保存会话消息
             if not sub_agent and agent_config.memory and agent_config.memory.get("enabled"):
                 await self._save_conversation_message(

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -286,7 +286,7 @@ class MemoryReflectionService:
                 # 检查是否需要执行反思
                 should_execute = False
                 hours_diff = 0
-                
+
                 if current_reflection_time is None:
                     # 首次执行反思
                     should_execute = True
@@ -298,11 +298,11 @@ class MemoryReflectionService:
                             reflection_time = datetime.fromisoformat(current_reflection_time)
                         else:
                             reflection_time = current_reflection_time
-                        
+
                         current_time = datetime.now()
                         time_diff = current_time - reflection_time
                         hours_diff = int(time_diff.total_seconds() / 3600)
-                        
+
                         # 检查是否达到反思周期
                         if hours_diff >= iteration_period:
                             should_execute = True
@@ -312,7 +312,7 @@ class MemoryReflectionService:
                     except (ValueError, TypeError) as e:
                         api_logger.warning(f"解析反思时间失败: {e}，将执行反思")
                         should_execute = True
-                
+
                 if should_execute:
                     api_logger.info(f"与上次的反思时间间隔为: {hours_diff} 小时")
                     # 3. 执行反思引擎
@@ -345,7 +345,7 @@ class MemoryReflectionService:
                         "next_reflection_in_hours": iteration_period - hours_diff
                     }
 
-            
+
         except Exception as e:
             config_id = config_data.get("config_id", "unknown")
             api_logger.error(f"启动反思失败，config_id: {config_id}, end_user_id: {end_user_id}, 错误: {str(e)}")
@@ -356,7 +356,7 @@ class MemoryReflectionService:
                 "end_user_id": end_user_id,
                 "config_data": config_data
             }
-    
+
     def _create_reflection_config_from_data(self, config_data: Dict[str, Any]) -> ReflectionConfig:
         """Create reflective configuration objects from configuration data"""
 
@@ -364,12 +364,12 @@ class MemoryReflectionService:
         if reflexion_range_value is None or reflexion_range_value == "":
             reflexion_range_value = "partial"
         reflexion_range = ReflectionRange(reflexion_range_value)
-        
+
         baseline_value = config_data.get("baseline")
         if baseline_value is None or baseline_value == "":
             baseline_value = "TIME"
         baseline = ReflectionBaseline(baseline_value)
-        
+
         # iteration_period =
         iteration_period = config_data.get("iteration_period", 24)
         if isinstance(iteration_period, str):
@@ -377,7 +377,6 @@ class MemoryReflectionService:
                 iteration_period = int(iteration_period)
             except (ValueError, TypeError):
                 iteration_period = 24  # 默认24小时
-        
         return ReflectionConfig(
             enabled=config_data.get("enable_self_reflexion", False),
             iteration_period=str(iteration_period),  # ReflectionConfig期望字符串

--- a/api/app/services/multi_agent_service.py
+++ b/api/app/services/multi_agent_service.py
@@ -1,5 +1,6 @@
 """多 Agent 配置管理服务"""
 import uuid
+import json
 from typing import Optional, List, Tuple, Any, Annotated
 
 from fastapi import Depends
@@ -427,6 +428,23 @@ class MultiAgentService:
             memory=getattr(request, 'memory', True)  # 记忆功能参数
         )
 
+        await self._save_conversation_message(
+            conversation_id=request.conversation_id,
+            user_message=request.message,
+            assistant_message=result.get("message", ""),
+            app_id=app_id,
+            user_id=request.user_id,
+            meta_data={
+                "mode": result.get("mode"),
+                "elapsed_time": result.get("elapsed_time"),
+                "usage": result.get("usage", {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0
+                })
+            }
+        )
+
         return result
 
     async def run_stream(
@@ -451,10 +469,13 @@ class MultiAgentService:
             raise ResourceNotFoundException("多 Agent 配置", str(app_id))
 
         if not config.is_active:
-            raise BusinessException("多 Agent 配置已禁用", BizCode.RESOURCE_DISABLED)
+            raise BusinessException("多 Agent 配置已禁用", BizCode.NOT_FOUND)
 
         # 2. 创建编排器
         orchestrator = MultiAgentOrchestrator(self.db, config)
+
+        full_content = ""
+        total_tokens = 0
 
         # 3. 流式执行任务
         async for event in orchestrator.execute_stream(
@@ -468,7 +489,88 @@ class MultiAgentService:
             storage_type=storage_type,
             user_rag_memory_id=user_rag_memory_id
         ):
-            yield event
+            if "sub_usage" in event:
+                if "data:" in event:
+                    try:
+                        data_line = event.split("data: ", 1)[1].strip()
+                        data = json.loads(data_line)
+                        if "total_tokens" in data:
+                            total_tokens += data["total_tokens"]
+                    except:
+                        pass
+            else:
+                yield event
+                if "data:" in event:
+                    try:
+                        data_line = event.split("data: ", 1)[1].strip()
+                        data = json.loads(data_line)
+                        if "content" in data:
+                            full_content += data["content"]
+                    except:
+                        pass
+
+        await self._save_conversation_message(
+            conversation_id=request.conversation_id,
+            user_message=request.message,
+            assistant_message=full_content,
+            app_id=app_id,
+            user_id=request.user_id,
+            meta_data={
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": total_tokens
+                }
+            }
+        )
+
+    async def _save_conversation_message(
+        self,
+        conversation_id: uuid.UUID,
+        user_message: str,
+        assistant_message: str,
+        meta_data: dict,
+        app_id: Optional[uuid.UUID] = None,
+        user_id: Optional[str] = None
+    ) -> None:
+        """保存会话消息
+
+        Args:
+            conversation_id: 会话ID
+            user_message: 用户消息
+            assistant_message: AI 回复消息
+            meta_data: 元数据（包括 token 消耗）
+            app_id: 应用ID
+            user_id: 用户ID
+        """
+        try:
+            from app.services.conversation_service import ConversationService
+
+            conversation_service = ConversationService(self.db)
+
+            conversation_service.add_message(
+                conversation_id=conversation_id,
+                role="user",
+                content=user_message
+            )
+            conversation_service.add_message(
+                conversation_id=conversation_id,
+                role="assistant",
+                content=assistant_message,
+                meta_data=meta_data
+            )
+
+            logger.debug(
+                "保存多 Agent 会话消息",
+                extra={
+                    "conversation_id": conversation_id,
+                    "user_message_length": len(user_message),
+                    "assistant_message_length": len(assistant_message)
+                }
+            )
+
+        except Exception as e:
+            logger.warning("保存会话消息失败", extra={"error": str(e)})
 
     # def add_sub_agent(
     #     self,

--- a/api/app/services/prompt_optimizer_service.py
+++ b/api/app/services/prompt_optimizer_service.py
@@ -1,3 +1,4 @@
+import os
 import re
 import uuid
 from typing import Any, AsyncGenerator
@@ -182,11 +183,12 @@ class PromptOptimizerService:
             base_url=api_config.api_base
         ), type=ModelType(model_config.type))
         try:
-            with open('app/services/prompt/prompt_optimizer_system.jinja2', 'r', encoding='utf-8') as f:
+            prompt_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'prompt')
+            with open(os.path.join(prompt_path, 'prompt_optimizer_system.jinja2'), 'r', encoding='utf-8') as f:
                 opt_system_prompt = f.read()
             rendered_system_message = Template(opt_system_prompt).render()
 
-            with open('app/services/prompt/prompt_optimizer_user.jinja2', 'r', encoding='utf-8') as f:
+            with open(os.path.join(prompt_path, 'prompt_optimizer_user.jinja2'), 'r', encoding='utf-8') as f:
                 opt_user_prompt = f.read()
         except FileNotFoundError:
             raise BusinessException(message="System prompt template not found", code=BizCode.NOT_FOUND)

--- a/web/src/components/PageScrollList/index.tsx
+++ b/web/src/components/PageScrollList/index.tsx
@@ -26,6 +26,7 @@ interface PageScrollListProps<T, Q = Record<string, unknown>> {
   query?: Q;
   column?: number;
   className?: string;
+  needLoading?: boolean;
 }
 const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   renderItem, 
@@ -33,6 +34,7 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   url,
   column = 4,
   className = '',
+  needLoading = true,
 }: PageScrollListProps<T, Q>, ref: React.Ref<PageScrollListRef>) => {
   useImperativeHandle(ref, () => ({
     refresh,
@@ -104,9 +106,10 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
           dataLength={data.length}
           next={loadMoreData}
           hasMore={hasMore}
-          loader={<PageLoading />}
+          loader={needLoading ? <PageLoading /> : undefined}
           // endMessage={<Divider plain>It is all, nothing more 🤐</Divider>}
           scrollableTarget="scrollableDiv"
+          className='rb:h-full!'
         >
           {data.length > 0 ? (
             <List

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -181,3 +181,6 @@ body {
   min-height: 100%;
   max-height: 100%;
 }
+#scrollableDiv .infinite-scroll-component__outerdiv {
+  height: 100%;
+}

--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
@@ -64,7 +64,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
       ...item,
       config: {
         similarity_threshold: 0.7,
-        strategy: "hybrid",
+        retrieve_type: "hybrid",
         top_k: 3,
         weight: 1,
       }

--- a/web/src/views/Prompt/History.tsx
+++ b/web/src/views/Prompt/History.tsx
@@ -50,6 +50,7 @@ const History: React.FC<{ query: HistoryQuery; edit: (item: HistoryItem) => void
         url={getPromptReleaseListUrl}
         query={query}
         column={3}
+        needLoading={false}
         renderItem={(item) => {
           const historyItem = item as unknown as HistoryItem;
           return (

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
@@ -64,7 +64,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
       ...item,
       config: {
         similarity_threshold: 0.7,
-        strategy: "hybrid",
+        retrieve_type: "hybrid",
         top_k: 3,
         weight: 1,
       }

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -885,7 +885,7 @@ export const useWorkflowGraph = ({
                   ...itemConfig,
                   ...(data.config[key].defaultValue || {}),
                   knowledge_bases: knowledge_bases?.map((vo: any) => {
-                    const kb_config = vo.config || { similarity_threshold: vo.similarity_threshold, strategy: vo.strategy, top_k: vo.top_k, weight: vo.weight }
+                    const kb_config = vo.config || { similarity_threshold: vo.similarity_threshold, retrieve_type: vo.retrieve_type, top_k: vo.top_k, weight: vo.weight }
                     return { kb_id: vo.kb_id || vo.id, ...kb_config, }
                   })
                 }


### PR DESCRIPTION
## Summary by Sourcery

跟踪并持久化多智能体与交接（handoff）聊天的用量和消息，调整相关流式行为，临时禁用 Celery 中与记忆相关的定时任务，并优化用于知识库和历史记录视图的 UI 行为和配置映射。

New Features:
- 持久化多智能体会话消息及其 token 用量，支持普通与流式两种流程。
- 捕获并暴露来自交接聊天及流式子事件的 token 用量元数据。

Bug Fixes:
- 在多智能体配置被禁用时，修正业务错误码。
- 修复对话摘要与提示优化的提示模板文件路径解析，使其可在任意工作目录下正常工作。
- 在应用与工作流配置中，将知识库配置字段从 `strategy` 统一为 `retrieve_type`。

Enhancements:
- 在多智能体编排器中聚合并返回子智能体的总 token 用量，包括模式相关的元数据。
- 在草稿与交接流式流程中发出 `sub_usage` SSE 事件，以便向客户端暴露 token 用量。
- 为 Neo4j 记忆查询结果添加明确的记忆 `type` 标签，以区分不同记忆类别。
- 优化无限滚动列表组件，使其可选隐藏加载动画，并在历史记录等视图中更好地填充可用高度。

Build:
- 临时注释掉 Celery Beat 中与记忆相关的周期任务调度，以停止后台记忆任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and persist multi-agent and handoff chat usage and messages, adjust related streaming behavior, temporarily disable scheduled Celery memory tasks, and refine UI behavior and configuration mappings for knowledge bases and history views.

New Features:
- Persist multi-agent conversation messages and token usage for both normal and streaming flows.
- Capture and expose token usage metadata from handoff chats and streaming sub-events.

Bug Fixes:
- Correct business error code when multi-agent configuration is disabled.
- Fix prompt template file path resolution for conversation summaries and prompt optimization to work from any working directory.
- Align knowledge base config fields from `strategy` to `retrieve_type` across application and workflow configuration.

Enhancements:
- Aggregate and return total token usage from sub-agents within the multi-agent orchestrator, including mode metadata.
- Emit `sub_usage` SSE events in draft and handoff streaming flows to surface token usage to clients.
- Annotate Neo4j memory query results with explicit memory `type` labels for different memory categories.
- Refine infinite scroll list component to optionally hide loaders and better fill available height in history and other views.

Build:
- Temporarily comment out Celery Beat memory-related periodic task schedules to stop background memory jobs.

</details>