### PR TITLE
fix(web): remove delete confirm content

### DIFF
--- a/web/src/views/ModelManagement/components/ModelImplement/index.tsx
+++ b/web/src/views/ModelManagement/components/ModelImplement/index.tsx
@@ -27,7 +27,6 @@ const ModelImplement: FC<ModelImplementProps> = ({ type, value, onChange }) => {
   const handleDelete = (vo: any) => {
     modal.confirm({
       title: t('common.confirmDeleteDesc', { name: [vo.model_name, vo.api_key].join(' / ') }),
-      content: t('application.apiKeyDeleteContent'),
       okText: t('common.delete'),
       cancelText: t('common.cancel'),
       okType: 'danger',

--- a/web/src/views/Prompt/History.tsx
+++ b/web/src/views/Prompt/History.tsx
@@ -25,7 +25,6 @@ const History: React.FC<{ query: HistoryQuery; edit: (item: HistoryItem) => void
     e?.stopPropagation();
     modal.confirm({
       title: t('common.confirmDeleteDesc', { name: item.title }),
-      content: t('application.apiKeyDeleteContent'),
       okText: t('common.delete'),
       cancelText: t('common.cancel'),
       okType: 'danger',


### PR DESCRIPTION
## Summary by Sourcery

通过从模型实现和提示历史的模态框中移除多余的描述性内容，简化删除确认对话框。

Bug 修复：
- 从模型实现删除模态框中移除不必要的删除确认正文文本。
- 从提示历史删除模态框中移除不必要的删除确认正文文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify delete confirmation dialogs by removing redundant descriptive content from model implementation and prompt history modals.

Bug Fixes:
- Remove unnecessary delete confirmation body text from model implementation delete modal.
- Remove unnecessary delete confirmation body text from prompt history delete modal.

</details>