### PR TITLE
Fix/ontology v1 bug

### DIFF
--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -182,14 +182,6 @@ def _get_ontology_service(
                 detail=f"找不到指定的LLM模型: {llm_id}"
             )
         
-        # 检查是否为组合模型
-        if hasattr(model_config, 'is_composite') and model_config.is_composite:
-            logger.error(f"Model {llm_id} is a composite model, which is not supported for ontology extraction")
-            raise HTTPException(
-                status_code=400,
-                detail="本体提取不支持使用组合模型，请选择单个模型"
-            )
-        
         # 验证模型配置了API密钥
         if not model_config.api_keys:
             logger.error(f"Model {llm_id} has no API key configuration")

--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -116,14 +116,6 @@ def _get_ontology_service(
                 detail=f"找不到指定的LLM模型: {llm_id}"
             )
         
-        # 检查是否为组合模型
-        if hasattr(model_config, 'is_composite') and model_config.is_composite:
-            logger.error(f"Model {llm_id} is a composite model, which is not supported for ontology extraction")
-            raise HTTPException(
-                status_code=400,
-                detail="本体提取不支持使用组合模型，请选择单个模型"
-            )
-        
         # 验证模型配置了API密钥
         if not model_config.api_keys:
             logger.error(f"Model {llm_id} has no API key configuration")

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -235,6 +235,8 @@ class MemoryConfigRepository:
                 llm_id=params.llm_id,
                 embedding_id=params.embedding_id,
                 rerank_id=params.rerank_id,
+                reflection_model_id=params.reflection_model_id,
+                emotion_model_id=params.emotion_model_id,
             )
             db.add(db_config)
             db.flush()  # 获取自增ID但不提交事务

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -236,6 +236,8 @@ class ConfigParamsCreate(BaseModel):  # 创建配置参数模型（仅 body，�
     llm_id: Optional[str] = Field(None, description="LLM模型配置ID")
     embedding_id: Optional[str] = Field(None, description="嵌入模型配置ID")
     rerank_id: Optional[str] = Field(None, description="重排序模型配置ID")
+    reflection_model_id: Optional[str] = Field(None, description="反思模型ID，默认与llm_id一致")
+    emotion_model_id: Optional[str] = Field(None, description="情绪分析模型ID，默认与llm_id一致")
 
 
 class ConfigParamsDelete(BaseModel):  # 删除配置参数模型（请求体）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -71,13 +71,14 @@ def get_workspace_end_users(
         app_ids = [app.id for app in apps_orm]
         
         # 批量查询所有 end_users（一次查询而非循环查询）
-        # 按 updated_at 降序排序，NULL 值排在最后
+        # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
         ).order_by(
-            nullslast(desc(EndUserModel.updated_at))
+            nullslast(desc(EndUserModel.updated_at)),
+            desc(EndUserModel.id)
         ).all()
         
         # 转换为 Pydantic 模型（只在需要时转换）

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -209,7 +209,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "end_user_id": config.end_user_id,
                 "config_id_old": config_id_old,
                 "apply_id": config.apply_id,
-                "scene_id": str(config.scene_id) if config.scene_id else None,
+                "scene_id": config.scene_id,
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -129,6 +129,12 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
             if not params.rerank_id:
                 params.rerank_id = configs.get('rerank')
 
+        # reflection_model_id 和 emotion_model_id 默认与 llm_id 一致
+        if not params.reflection_model_id:
+            params.reflection_model_id = params.llm_id
+        if not params.emotion_model_id:
+            params.emotion_model_id = params.llm_id
+
         config = MemoryConfigRepository.create(self.db, params)
         self.db.commit()
         return {"affected": 1, "config_id": config.config_id}

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -203,6 +203,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "end_user_id": config.end_user_id,
                 "config_id_old": config_id_old,
                 "apply_id": config.apply_id,
+                "scene_id": str(config.scene_id) if config.scene_id else None,
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,


### PR DESCRIPTION
已经修复的有:
1.移除本体类型提取检查是否为组合模型的内容
2.修复根据空间模型设置记忆配置模型默认值
3."/end_user"接口返回内容,按照updated_at降序排序

## Summary by Sourcery

修复与本体相关的内存配置问题，并调整终端用户列表排序顺序。

Bug 修复：
- 按 `updated_at` 降序排序工作区终端用户 API 响应，并将 `NULL` 排在最后，以确保排序结果一致。
- 通过移除不正确的校验逻辑块，允许本体抽取使用复合模型。
- 在创建内存配置时，将 `reflection_model_id` 和 `emotion_model_id` 默认设置为所选的 `llm_id`，以避免因缺少模型配置而导致的错误。

功能增强：
- 在内存配置记录中持久化存储 `reflection_model_id` 和 `emotion_model_id`，并在内存配置列表中暴露 `scene_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ontology-related memory configuration issues and adjust end-user listing order.

Bug Fixes:
- Sort workspace end-user API responses by updated_at descending with NULLs last to ensure consistent ordering.
- Allow ontology extraction to use composite models by removing an incorrect validation block.
- Default reflection_model_id and emotion_model_id to the selected llm_id when creating memory configs to avoid missing model configuration errors.

Enhancements:
- Persist reflection_model_id and emotion_model_id in memory configuration records and expose scene_id in memory config listings.

</details>