### PR TITLE
Ontology v1 bug

### DIFF
--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -182,14 +182,6 @@ def _get_ontology_service(
                 detail=f"找不到指定的LLM模型: {llm_id}"
             )
         
-        # 检查是否为组合模型
-        if hasattr(model_config, 'is_composite') and model_config.is_composite:
-            logger.error(f"Model {llm_id} is a composite model, which is not supported for ontology extraction")
-            raise HTTPException(
-                status_code=400,
-                detail="本体提取不支持使用组合模型，请选择单个模型"
-            )
-        
         # 验证模型配置了API密钥
         if not model_config.api_keys:
             logger.error(f"Model {llm_id} has no API key configuration")

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -235,6 +235,8 @@ class MemoryConfigRepository:
                 llm_id=params.llm_id,
                 embedding_id=params.embedding_id,
                 rerank_id=params.rerank_id,
+                reflection_model_id=params.reflection_model_id,
+                emotion_model_id=params.emotion_model_id,
             )
             db.add(db_config)
             db.flush()  # 获取自增ID但不提交事务

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -236,6 +236,8 @@ class ConfigParamsCreate(BaseModel):  # 创建配置参数模型（仅 body，�
     llm_id: Optional[str] = Field(None, description="LLM模型配置ID")
     embedding_id: Optional[str] = Field(None, description="嵌入模型配置ID")
     rerank_id: Optional[str] = Field(None, description="重排序模型配置ID")
+    reflection_model_id: Optional[str] = Field(None, description="反思模型ID，默认与llm_id一致")
+    emotion_model_id: Optional[str] = Field(None, description="情绪分析模型ID，默认与llm_id一致")
 
 
 class ConfigParamsDelete(BaseModel):  # 删除配置参数模型（请求体）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,6 +57,10 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -73,6 +77,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,10 +57,6 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
-    
-    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
-    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -77,7 +73,6 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
-        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -68,9 +68,13 @@ def get_workspace_end_users(
         app_ids = [app.id for app in apps_orm]
         
         # 批量查询所有 end_users（一次查询而非循环查询）
+        # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
+        ).order_by(
+            nullslast(desc(EndUserModel.updated_at)),
+            desc(EndUserModel.id)
         ).all()
         
         # 转换为 Pydantic 模型（只在需要时转换）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -53,7 +53,10 @@ def get_workspace_end_users(
     workspace_id: uuid.UUID, 
     current_user: User
 ) -> List[EndUser]:
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）"""
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -70,6 +73,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
         ).order_by(

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -203,6 +203,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "end_user_id": config.end_user_id,
                 "config_id_old": config_id_old,
                 "apply_id": config.apply_id,
+                "scene_id": config.scene_id,
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -129,6 +129,12 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
             if not params.rerank_id:
                 params.rerank_id = configs.get('rerank')
 
+        # reflection_model_id 和 emotion_model_id 默认与 llm_id 一致
+        if not params.reflection_model_id:
+            params.reflection_model_id = params.llm_id
+        if not params.emotion_model_id:
+            params.emotion_model_id = params.llm_id
+
         config = MemoryConfigRepository.create(self.db, params)
         self.db.commit()
         return {"affected": 1, "config_id": config.config_id}


### PR DESCRIPTION
已经修复的有:
1.移除本体类型提取检查是否为组合模型的内容
2.修复根据空间模型设置记忆配置模型默认值
3."/end_user"接口返回内容,按照updated_at降序排序


## Summary by Sourcery

更新内存配置和仪表盘行为，并放宽本体模型限制。

新功能：
- 在创建内存配置的 schema 中添加 `reflection_model_id` 和 `emotion_model_id` 字段，默认值与 `llm_id` 保持一致。
- 在内存配置列表的响应中包含 `scene_id`。
- 按 `updated_at` 降序排序工作区终端用户，将空值排在最后，并使用 `id` 作为次级键以保证排序结果具有确定性。

错误修复：
- 通过移除阻止复合模型的限制，允许本体抽取使用复合模型。
- 确保反思和情绪模型 ID 始终被设置：当未提供时，将其默认设置为主 LLM 的 ID。

增强：
- 在内存配置记录中持久化存储 `reflection_model_id` 和 `emotion_model_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update memory configuration and dashboard behavior and relax ontology model restrictions.

New Features:
- Add reflection_model_id and emotion_model_id fields to memory configuration creation schema with defaults aligned to llm_id.
- Include scene_id in the memory configuration listing response.
- Sort workspace end users by updated_at descending with null values last and id as a secondary key for deterministic ordering.

Bug Fixes:
- Allow ontology extraction to use composite models by removing a restriction that blocked them.
- Ensure reflection and emotion model IDs are always set by defaulting them to the primary LLM ID when not provided.

Enhancements:
- Persist reflection_model_id and emotion_model_id in memory configuration records.

</details>