### PR TITLE
Fix/release web zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/Editor/index.tsx
+++ b/web/src/views/ApplicationConfig/components/Editor/index.tsx
@@ -9,6 +9,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import InitialValuePlugin from './plugin/InitialValuePlugin'
 import LineBreakPlugin from './plugin/LineBreakPlugin';
 import InsertTextPlugin from './plugin/InsertTextPlugin';
+import EditablePlugin from './plugin/EditablePlugin';
 
 export interface EditorRef {
   insertText: (text: string) => void;
@@ -23,6 +24,7 @@ interface LexicalEditorProps {
   value?: string;
   onChange?: (value: string) => void;
   height?: number;
+  disabled?: boolean;
 }
 
 const theme = {
@@ -38,6 +40,7 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
   value,
   placeholder = "请输入内容...",
   onChange,
+  disabled
 }, ref) => {
   const [editor] = useLexicalComposerContext();
   
@@ -92,7 +95,11 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
       <RichTextPlugin
         contentEditable={
           <ContentEditable
-            className={clsx("rb:outline-none rb:resize-none rb:text-[14px] rb:leading-5 rb:px-4 rb:py-5 rb:bg-[#FBFDFF] rb:border rb:border-[#DFE4ED] rb:rounded-lg rb:overflow-auto", className)}
+            className={clsx(
+              "rb:outline-none rb:resize-none rb:text-[14px] rb:leading-5 rb:px-4 rb:py-5 rb:bg-[#FBFDFF] rb:border rb:border-[#DFE4ED] rb:rounded-lg rb:overflow-auto",
+              disabled && "rb:cursor-not-allowed rb:bg-[#F6F8FC] rb:text-[#5B6167]",
+              className
+            )}
           />
         }
         placeholder={
@@ -105,6 +112,7 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
       <LineBreakPlugin onChange={onChange} />
       <InitialValuePlugin value={value} />
       <InsertTextPlugin />
+      <EditablePlugin disabled={disabled} />
     </div>
   );
 });
@@ -114,6 +122,7 @@ const Editor = forwardRef<EditorRef, LexicalEditorProps>((props, ref) => {
     namespace: 'Editor',
     theme,
     nodes: [],
+    editable: !props.disabled,
     onError: (error: Error) => {
       console.error(error);
     },

--- a/web/src/views/ApplicationConfig/components/Editor/plugin/EditablePlugin.tsx
+++ b/web/src/views/ApplicationConfig/components/Editor/plugin/EditablePlugin.tsx
@@ -1,0 +1,48 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-02-04 11:20:49 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-02-04 11:20:49 
+ */
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+
+/**
+ * Props for the EditablePlugin component
+ */
+interface EditablePluginProps {
+  /** Whether the editor should be disabled (read-only mode) */
+  disabled?: boolean;
+}
+
+/**
+ * EditablePlugin - A Lexical editor plugin that controls the editable state of the editor
+ * 
+ * This plugin allows you to dynamically toggle between editable and read-only modes.
+ * When disabled is true, the editor becomes read-only and users cannot modify content.
+ * When disabled is false or undefined, the editor is fully editable.
+ * 
+ * @param {EditablePluginProps} props - Component props
+ * @param {boolean} [props.disabled] - Controls whether the editor is in read-only mode
+ * @returns {null} This plugin doesn't render any UI elements
+ * 
+ * @example
+ * ```tsx
+ * <LexicalComposer>
+ *   <EditablePlugin disabled={isReadOnly} />
+ * </LexicalComposer>
+ * ```
+ */
+export default function EditablePlugin({ disabled }: EditablePluginProps) {
+  // Get the editor instance from Lexical composer context
+  const [editor] = useLexicalComposerContext();
+
+  // Update editor's editable state whenever the disabled prop changes
+  useEffect(() => {
+    // Set editor to editable when disabled is false, read-only when disabled is true
+    editor.setEditable(!disabled);
+  }, [editor, disabled]);
+
+  // This plugin doesn't render any UI, it only manages editor state
+  return null;
+}

--- a/web/src/views/Prompt/Prompt.tsx
+++ b/web/src/views/Prompt/Prompt.tsx
@@ -140,7 +140,6 @@ const Prompt: FC<{ editVo: HistoryItem | null; refresh: () => void; }> = ({ edit
     refresh()
   }
 
-  console.log(values)
   return (
     <>
       <Form form={form}>
@@ -199,12 +198,13 @@ const Prompt: FC<{ editVo: HistoryItem | null; refresh: () => void; }> = ({ edit
                 ref={editorRef}
                 placeholder={t('prompt.promptPlaceholder')}
                 className="rb:h-[calc(100vh-260px)]"
+                disabled={loading}
                 // onChange={(value) => form.setFieldValue('current_prompt', value)}
               />
             </Form.Item>
             <div className="rb:grid rb:grid-cols-2 rb:gap-4 rb:mt-6">
-              <Button type="primary" block disabled={!values?.current_prompt} onClick={handleSave}>{t('common.save')}</Button>
-              <Button block disabled={!values?.current_prompt} onClick={handleCopy}>{t('common.copy')}</Button>
+              <Button type="primary" block disabled={!values?.current_prompt || loading} onClick={handleSave}>{t('common.save')}</Button>
+              <Button block disabled={!values?.current_prompt || loading} onClick={handleCopy}>{t('common.copy')}</Button>
             </div>
           </div>
         </div>

--- a/web/src/views/SpaceManagement/components/SpaceModal.tsx
+++ b/web/src/views/SpaceManagement/components/SpaceModal.tsx
@@ -85,6 +85,8 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
             }).catch(() => {
               handleUpdate(formData)
             })
+          } else {
+            handleUpdate(formData)
           }
         }
       })
@@ -139,6 +141,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
           label={t('space.spaceIcon')}
           valuePropName="fileList"
           hidden={currentStep === 1}
+          rules={[{ required: true, message: t('common.selectPlaceholder', { title: t('space.spaceIcon') }) }]}
         >
           <UploadImages />
         </Form.Item>

--- a/web/src/views/Workflow/components/Editor/index.tsx
+++ b/web/src/views/Workflow/components/Editor/index.tsx
@@ -242,7 +242,7 @@ const Editor: FC<LexicalEditorProps> =({
         {enableLineNumbers && <LineNumberPlugin />}
         <AutocompletePlugin options={options} enableJinja2={enableJinja2} />
         <CharacterCountPlugin setCount={(count) => { setCount(count) }} onChange={onChange} />
-        <InitialValuePlugin value={value} options={options} enableJinja2={enableJinja2} />
+        <InitialValuePlugin value={value} options={options} enableLineNumbers={enableLineNumbers} />
         {enableLineNumbers && <BlurPlugin />}
       </div>
     </LexicalComposer>

--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -8,12 +8,13 @@ import { type Suggestion } from '../plugin/AutocompletePlugin'
 interface InitialValuePluginProps {
   value: string;
   options?: Suggestion[];
-  enableJinja2?: boolean;
+  enableLineNumbers?: boolean;
 }
 
-const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options = [], enableJinja2 = false }) => {
+const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options = [], enableLineNumbers = false }) => {
   const [editor] = useLexicalComposerContext();
   const prevValueRef = useRef<string>('');
+  const prevEnableLineNumbersRef = useRef<boolean>(enableLineNumbers);
   const isUserInputRef = useRef(false);
 
   useEffect(() => {
@@ -32,7 +33,7 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
   }, [editor]);
 
   useEffect(() => {
-    if (value !== prevValueRef.current && !isUserInputRef.current) {
+    if ((value !== prevValueRef.current || enableLineNumbers !== prevEnableLineNumbersRef.current) && !isUserInputRef.current) {
       queueMicrotask(() => {
         editor.update(() => {
         const root = $getRoot();
@@ -40,7 +41,7 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
 
         const parts = value.split(/(\{\{[^}]+\}\})/);
 
-        if (enableJinja2) {
+        if (enableLineNumbers) {
           // Handle newlines properly in Jinja2 mode
           const lines = value.split('\n');
           lines.forEach((line) => {
@@ -104,8 +105,9 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
     }
     
     prevValueRef.current = value;
+    prevEnableLineNumbersRef.current = enableLineNumbers;
     isUserInputRef.current = false;
-  }, [value, options, editor, enableJinja2]);
+  }, [value, options, editor, enableLineNumbers]);
 
   return null;
 };

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -111,7 +111,7 @@ export const useWorkflowGraph = ({
               nodeLibraryConfig.config[key].defaultValue = Object.entries(config[key]).map(([name, value]) => ({ name, value }))
             } else if (type === 'code' && key === 'code' && config[key] && nodeLibraryConfig.config && nodeLibraryConfig.config[key]) {
               try {
-                nodeLibraryConfig.config[key].defaultValue = atob(config[key] as string)
+                nodeLibraryConfig.config[key].defaultValue = decodeURIComponent(atob(config[key] as string))
               } catch {
                 nodeLibraryConfig.config[key].defaultValue = config[key]
               }
@@ -851,7 +851,7 @@ export const useWorkflowGraph = ({
                 const code = data.config[key].defaultValue || ''
                 itemConfig = {
                   ...itemConfig,
-                  code: btoa(code || '')
+                  code: btoa(encodeURIComponent(code || ''))
                 }
               } else if (key === 'memory' && data.config[key] && 'defaultValue' in data.config[key]) {
                 const { messages, ...rest } = data.config[key].defaultValue


### PR DESCRIPTION
## Summary by Sourcery

更新多个 Web 编辑器组件，以更好地处理只读状态、编码后的工作流代码值以及必填的空间配置字段。

新功能：
- 在 ApplicationConfig 编辑器中增加 `EditablePlugin`，根据 `disabled` 属性在可编辑和只读模式之间切换。
- 扩展 ApplicationConfig 编辑器的 props 以支持禁用状态，并在编辑器被禁用时调整样式。

错误修复：
- 确保工作流代码配置通过 URI 安全的 base64 编码/解码进行安全转换，以防止字符损坏。
- 更新工作流 `InitialValuePlugin`，使其在行号设置变更时重新初始化，并将类 Jinja 的渲染逻辑正确绑定到行号模式。
- 修复空间管理弹窗，使在频道绑定失败时仍能正常更新，并强制要求必须选择空间图标。
- 在加载期间禁用提示编辑器及其保存/复制操作，以防止意外修改或操作。

改进：
- 为 ApplicationConfig 编辑器内容区域添加可感知禁用状态的样式，以便更清晰地展示只读状态。
- 移除提示视图中遗留的控制台日志输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update multiple web editor components to better handle read-only states, encoded workflow code values, and required space configuration fields.

New Features:
- Add an EditablePlugin to the ApplicationConfig editor to toggle between editable and read-only modes based on a disabled prop.
- Extend ApplicationConfig editor props to support a disabled state and adjust styling when the editor is disabled.

Bug Fixes:
- Ensure workflow code configuration is safely encoded and decoded using URI-safe base64 transformations to prevent character corruption.
- Update workflow InitialValuePlugin to reinitialize when line number settings change and correctly tie Jinja-style rendering to line-number mode.
- Fix space management modal so that updates proceed correctly when channel binding fails and enforce that a space icon must be selected.
- Disable prompt editor and its save/copy actions while loading to prevent unintended modifications or actions.

Enhancements:
- Add disabled-aware styling to the ApplicationConfig editor content area for clearer read-only presentation.
- Remove leftover console logging from the prompt view.

</details>