### PR TITLE
Ontology v1 bug

### DIFF
--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -182,14 +182,6 @@ def _get_ontology_service(
                 detail=f"找不到指定的LLM模型: {llm_id}"
             )
         
-        # 检查是否为组合模型
-        if hasattr(model_config, 'is_composite') and model_config.is_composite:
-            logger.error(f"Model {llm_id} is a composite model, which is not supported for ontology extraction")
-            raise HTTPException(
-                status_code=400,
-                detail="本体提取不支持使用组合模型，请选择单个模型"
-            )
-        
         # 验证模型配置了API密钥
         if not model_config.api_keys:
             logger.error(f"Model {llm_id} has no API key configuration")

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -235,6 +235,8 @@ class MemoryConfigRepository:
                 llm_id=params.llm_id,
                 embedding_id=params.embedding_id,
                 rerank_id=params.rerank_id,
+                reflection_model_id=params.reflection_model_id,
+                emotion_model_id=params.emotion_model_id,
             )
             db.add(db_config)
             db.flush()  # 获取自增ID但不提交事务

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -236,6 +236,8 @@ class ConfigParamsCreate(BaseModel):  # 创建配置参数模型（仅 body，�
     llm_id: Optional[str] = Field(None, description="LLM模型配置ID")
     embedding_id: Optional[str] = Field(None, description="嵌入模型配置ID")
     rerank_id: Optional[str] = Field(None, description="重排序模型配置ID")
+    reflection_model_id: Optional[str] = Field(None, description="反思模型ID，默认与llm_id一致")
+    emotion_model_id: Optional[str] = Field(None, description="情绪分析模型ID，默认与llm_id一致")
 
 
 class ConfigParamsDelete(BaseModel):  # 删除配置参数模型（请求体）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,6 +57,10 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -73,6 +77,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,10 +57,6 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
-    
-    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
-    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -77,7 +73,6 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
-        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -68,9 +68,13 @@ def get_workspace_end_users(
         app_ids = [app.id for app in apps_orm]
         
         # 批量查询所有 end_users（一次查询而非循环查询）
+        # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
+        ).order_by(
+            nullslast(desc(EndUserModel.updated_at)),
+            desc(EndUserModel.id)
         ).all()
         
         # 转换为 Pydantic 模型（只在需要时转换）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -53,7 +53,10 @@ def get_workspace_end_users(
     workspace_id: uuid.UUID, 
     current_user: User
 ) -> List[EndUser]:
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）"""
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -70,6 +73,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
         ).order_by(

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -203,6 +203,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "end_user_id": config.end_user_id,
                 "config_id_old": config_id_old,
                 "apply_id": config.apply_id,
+                "scene_id": config.scene_id,
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -129,6 +129,12 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
             if not params.rerank_id:
                 params.rerank_id = configs.get('rerank')
 
+        # reflection_model_id 和 emotion_model_id 默认与 llm_id 一致
+        if not params.reflection_model_id:
+            params.reflection_model_id = params.llm_id
+        if not params.emotion_model_id:
+            params.emotion_model_id = params.llm_id
+
         config = MemoryConfigRepository.create(self.db, params)
         self.db.commit()
         return {"affected": 1, "config_id": config.config_id}


### PR DESCRIPTION
本体工程提取增加多 API Key 负载均衡

## Summary by Sourcery

更新本体提取功能，以支持具有主动 API 密钥选择和负载均衡的复合 LLM 模型，优化记忆仪表板终端用户排序，并扩展记忆配置的默认值和模式以包含反思和情绪模型。

New Features:
- 在本体提取中为复合 LLM 模型引入负载均衡的 API 密钥选择机制，包括轮询（round-robin）和基于优先级的策略。
- 允许在记忆存储中配置反思和情绪模型的 ID；当未提供这些 ID 时，将它们默认设为主 LLM 的 ID。

Bug Fixes:
- 通过移除之前的限制并基于所选 API 密钥正确解析提供商，防止在使用复合 LLM 模型时本体提取失败。

Enhancements:
- 在与本体相关的模型调用中仅使用处于激活状态的 API 密钥，并记录所选提供商及其是否为复合模型的状态。
- 将 workspace 终端用户按最近更新时间优先排序，空时间戳排在最后，并使用 ID 作为确定性的次级排序条件。
- 在记忆配置的获取和持久化路径中暴露 `scene_id` 和新的模型 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update ontology extraction to support composite LLM models with active API key selection and load balancing, refine memory dashboard end-user ordering, and extend memory configuration defaults and schema to include reflection and emotion models.

New Features:
- Introduce load-balanced API key selection for composite LLM models in ontology extraction, including round-robin and priority-based strategies.
- Allow configuration of reflection and emotion model IDs in memory storage, defaulting them to the primary LLM ID when not provided.

Bug Fixes:
- Prevent ontology extraction from failing when using composite LLM models by removing the previous restriction and correctly resolving provider from the chosen API key.

Enhancements:
- Use only active API keys for ontology-related model invocations and log the selected provider and composite status.
- Sort workspace end users by most recently updated first, with null timestamps last and deterministic secondary ordering by ID.
- Expose scene_id and new model IDs in memory configuration retrieval and persistence paths.

</details>