### PR TITLE
Ontology v1 bug

### DIFF
--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -182,14 +182,6 @@ def _get_ontology_service(
                 detail=f"找不到指定的LLM模型: {llm_id}"
             )
         
-        # 检查是否为组合模型
-        if hasattr(model_config, 'is_composite') and model_config.is_composite:
-            logger.error(f"Model {llm_id} is a composite model, which is not supported for ontology extraction")
-            raise HTTPException(
-                status_code=400,
-                detail="本体提取不支持使用组合模型，请选择单个模型"
-            )
-        
         # 验证模型配置了API密钥
         if not model_config.api_keys:
             logger.error(f"Model {llm_id} has no API key configuration")

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -235,6 +235,8 @@ class MemoryConfigRepository:
                 llm_id=params.llm_id,
                 embedding_id=params.embedding_id,
                 rerank_id=params.rerank_id,
+                reflection_model_id=params.reflection_model_id,
+                emotion_model_id=params.emotion_model_id,
             )
             db.add(db_config)
             db.flush()  # 获取自增ID但不提交事务

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -236,6 +236,8 @@ class ConfigParamsCreate(BaseModel):  # 创建配置参数模型（仅 body，�
     llm_id: Optional[str] = Field(None, description="LLM模型配置ID")
     embedding_id: Optional[str] = Field(None, description="嵌入模型配置ID")
     rerank_id: Optional[str] = Field(None, description="重排序模型配置ID")
+    reflection_model_id: Optional[str] = Field(None, description="反思模型ID，默认与llm_id一致")
+    emotion_model_id: Optional[str] = Field(None, description="情绪分析模型ID，默认与llm_id一致")
 
 
 class ConfigParamsDelete(BaseModel):  # 删除配置参数模型（请求体）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,6 +57,10 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -73,6 +77,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -57,10 +57,6 @@ def get_workspace_end_users(
     
     返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
     """
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
-    
-    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
-    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -77,7 +73,6 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
-        from sqlalchemy import desc, nullslast
         from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -68,9 +68,13 @@ def get_workspace_end_users(
         app_ids = [app.id for app in apps_orm]
         
         # 批量查询所有 end_users（一次查询而非循环查询）
+        # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
+        ).order_by(
+            nullslast(desc(EndUserModel.updated_at)),
+            desc(EndUserModel.id)
         ).all()
         
         # 转换为 Pydantic 模型（只在需要时转换）

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -53,7 +53,10 @@ def get_workspace_end_users(
     workspace_id: uuid.UUID, 
     current_user: User
 ) -> List[EndUser]:
-    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）"""
+    """获取工作空间的所有宿主（优化版本：减少数据库查询次数）
+    
+    返回结果按 updated_at 从新到旧排序（NULL 值排在最后）
+    """
     business_logger.info(f"获取工作空间宿主列表: workspace_id={workspace_id}, 操作者: {current_user.username}")
     
     try:        
@@ -70,6 +73,7 @@ def get_workspace_end_users(
         # 批量查询所有 end_users（一次查询而非循环查询）
         # 按 updated_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
         from app.models.end_user_model import EndUser as EndUserModel
+        from sqlalchemy import desc, nullslast
         end_users_orm = db.query(EndUserModel).filter(
             EndUserModel.app_id.in_(app_ids)
         ).order_by(

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -203,6 +203,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "end_user_id": config.end_user_id,
                 "config_id_old": config_id_old,
                 "apply_id": config.apply_id,
+                "scene_id": config.scene_id,
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -129,6 +129,12 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
             if not params.rerank_id:
                 params.rerank_id = configs.get('rerank')
 
+        # reflection_model_id 和 emotion_model_id 默认与 llm_id 一致
+        if not params.reflection_model_id:
+            params.reflection_model_id = params.llm_id
+        if not params.emotion_model_id:
+            params.emotion_model_id = params.llm_id
+
         config = MemoryConfigRepository.create(self.db, params)
         self.db.commit()
         return {"affected": 1, "config_id": config.config_id}


### PR DESCRIPTION
## Summary by Sourcery

通过复合 LLM 模型支持本体（ontology）抽取，并改进相关的记忆配置和查询行为。

新功能：
- 为复合 LLM 模型启用基于使用次数或优先级的负载均衡 API Key 选择。
- 新增反思（reflection）和情绪（emotion）模型 ID 的默认值，当未提供时回退到主 LLM ID。
- 在记忆配置列表中包含 `scene_id`，供下游使用方消费。

缺陷修复：
- 过滤掉非激活状态的 API Key，当某个模型没有可用的激活 Key 时，显式返回错误。
- 确保工作区终端用户按更新时间以确定顺序返回（最新优先），`null` 排在最后，并使用 ID 作为最终的排序依据（tiebreaker）。

增强：
- 对于复合模型，从选中的 API Key 推导实际的服务提供方（provider），而不是从基础模型配置中获取。
- 在记忆配置记录中持久化反思和情绪模型 ID，以便后续检索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support ontology extraction with composite LLM models and improve related memory configuration and querying behavior.

New Features:
- Enable load-balanced API key selection for composite LLM models based on usage count or priority.
- Add default reflection and emotion model IDs that fall back to the main LLM ID when not provided.
- Include scene_id in memory configuration listings for downstream consumers.

Bug Fixes:
- Filter out inactive API keys and surface an explicit error when no active keys are available for a model.
- Ensure workspace end users are returned in a deterministic order by updated time (newest first) with nulls last and ID as a tiebreaker.

Enhancements:
- Derive the actual provider for composite models from the selected API key instead of the base model configuration.
- Persist reflection and emotion model IDs in memory configuration records for later retrieval.

</details>