### PR TITLE
Fix/release web zy

### DIFF
--- a/web/src/views/Prompt/Prompt.tsx
+++ b/web/src/views/Prompt/Prompt.tsx
@@ -138,6 +138,7 @@ const Prompt: FC<{ editVo: HistoryItem | null; refresh: () => void; }> = ({ edit
     currentPromptValueRef.current = undefined;
     setChatList([])
     refresh()
+    updateSession()
   }
 
   return (

--- a/web/src/views/Workflow/components/Editor/index.tsx
+++ b/web/src/views/Workflow/components/Editor/index.tsx
@@ -242,7 +242,7 @@ const Editor: FC<LexicalEditorProps> =({
         {enableLineNumbers && <LineNumberPlugin />}
         <AutocompletePlugin options={options} enableJinja2={enableJinja2} />
         <CharacterCountPlugin setCount={(count) => { setCount(count) }} onChange={onChange} />
-        <InitialValuePlugin value={value} options={options} enableLineNumbers={enableLineNumbers} />
+        <InitialValuePlugin key={language} value={value} options={options} enableLineNumbers={enableLineNumbers} />
         {enableLineNumbers && <BlurPlugin />}
       </div>
     </LexicalComposer>

--- a/web/src/views/Workflow/components/Editor/plugin/BlurPlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/BlurPlugin.tsx
@@ -16,6 +16,12 @@ export default function BlurPlugin() {
             return;
           }
           
+          // 检查是否是粘贴操作导致的焦点变化
+          const relatedTarget = e.relatedTarget as HTMLElement;
+          if (!relatedTarget || relatedTarget === document.body) {
+            return;
+          }
+          
           editor.update(() => {
             $setSelection(null);
           });

--- a/web/src/views/Workflow/components/Properties/CodeExecution/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CodeExecution/index.tsx
@@ -33,7 +33,6 @@ const codeTemplate = {
 const CodeExecution: FC<CodeExecutionProps> = ({ options }) => {
   const { t } = useTranslation()
   const form = Form.useFormInstance()
-  const values = Form.useWatch([], form) || {}
 
   const handleRefresh = () => {
     const code = form.getFieldValue('code') || ''
@@ -66,7 +65,6 @@ const CodeExecution: FC<CodeExecutionProps> = ({ options }) => {
     form.setFieldValue('code', newTemplate)
   }
   const handleChangeLanguage = (value: string) => {
-    form.setFieldValue('code', codeTemplate[value as keyof typeof codeTemplate])
     form.setFieldsValue({
       input_variables: [{ name: 'arg1' }, { name: 'arg2' }],
       code: codeTemplate[value as keyof typeof codeTemplate]
@@ -109,8 +107,12 @@ const CodeExecution: FC<CodeExecutionProps> = ({ options }) => {
             </Form.Item>
           </Col>
         </Row>
-        <Form.Item name="code" noStyle>
-          <Editor size="small" language={values.language} />
+        <Form.Item noStyle shouldUpdate={(prev, curr) => prev.language !== curr.language}>
+          {() => (
+            <Form.Item name="code" noStyle>
+              <Editor size="small" language={form.getFieldValue('language')} />
+            </Form.Item>
+          )}
         </Form.Item>
       </Space>
       


### PR DESCRIPTION
## Summary by Sourcery

改进编辑器在代码执行工作流和特定语言高亮方面的行为。

Bug 修复：
- 防止在粘贴操作期间或对已带有样式的文本节点执行时运行 JavaScript 和 Python 语法高亮。
- 避免在由粘贴相关的焦点变化引起的 blur 事件中清除编辑器选区。
- 确保在代码执行属性表单中的语言发生变化时，代码编辑器能够正确重新初始化。
- 在重置提示时触发会话更新，以保持状态一致。

增强功能：
- 通过移除不必要的表单监听逻辑，并将基于语言的代码模板更新进行集中管理，简化代码执行表单的状态处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve editor behavior for code execution workflows and language-specific highlighting.

Bug Fixes:
- Prevent JavaScript and Python syntax highlighting from running during paste operations or on already styled text nodes.
- Avoid clearing editor selection on blur events caused by paste-related focus changes.
- Ensure the code editor reinitializes correctly when the language changes in the code execution properties form.
- Trigger session updates when resetting prompts to keep state consistent.

Enhancements:
- Simplify code execution form state handling by removing unnecessary form watch logic and centralizing language-based code template updates.

</details>