### PR TITLE
feat(web): ApplicationManagement add type filter

### DIFF
--- a/web/src/views/ApplicationManagement/components/ApplicationModal.tsx
+++ b/web/src/views/ApplicationManagement/components/ApplicationModal.tsx
@@ -35,7 +35,7 @@ interface ApplicationModalProps {
 /**
  * Supported application types
  */
-const types = [
+export const types = [
   'agent',
   'multi_agent',
   'workflow'

--- a/web/src/views/ApplicationManagement/index.tsx
+++ b/web/src/views/ApplicationManagement/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 16:34:12 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-04 18:57:35
  */
 /**
  * Application Management Page
@@ -12,12 +12,12 @@
 
 import React, { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, Row, Col, App } from 'antd';
+import { Button, Row, Col, App, Select } from 'antd';
 import clsx from 'clsx';
 import { DeleteOutlined } from '@ant-design/icons';
 
 import type { Application, ApplicationModalRef, Query } from './types';
-import ApplicationModal from './components/ApplicationModal';
+import ApplicationModal, { types } from './components/ApplicationModal';
 import SearchInput from '@/components/SearchInput'
 import RbCard from '@/components/RbCard/Card'
 import { getApplicationListUrl, deleteApplication } from '@/api/application'
@@ -65,10 +65,25 @@ const ApplicationManagement: React.FC = () => {
       }
     })
   }
+  const handleChangeType = (value?: string) => {
+    setQuery(prev => ({...prev, type: value}))
+  }
   return (
     <>
       <Row gutter={16} className="rb:mb-4">
-        <Col span={12}>
+        <Col span={3}>
+          <Select
+            placeholder={t('application.applicationType')}
+            options={types.map((type) => ({
+              value: type,
+              label: t(`application.${type}`),
+            }))}
+            allowClear
+            className="rb:w-full"
+            onChange={handleChangeType}
+          />
+        </Col>
+        <Col span={9}>
           <SearchInput
             placeholder={t('application.searchPlaceholder')}
             onSearch={(value) => setQuery({ search: value })}


### PR DESCRIPTION
## Summary by Sourcery

在应用管理页面中添加应用类型筛选功能，并使用共享的应用类型定义。

新功能：
- 在应用管理页面中添加类型筛选下拉框，用于按类型筛选应用。

增强内容：
- 导出共享的支持应用类型列表，以便在应用管理视图中复用。
- 调整应用管理搜索布局，以适配新的类型筛选控件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add application type filtering to the Application Management page using shared application type definitions.

New Features:
- Introduce a type filter dropdown on the Application Management page to filter applications by type.

Enhancements:
- Export the shared list of supported application types for reuse by the Application Management view.
- Adjust the Application Management search layout to accommodate the new type filter control.

</details>