### PR TITLE
Write Missing None

### DIFF
--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -269,7 +269,7 @@ async def save_dialog_and_statements_to_neo4j(
                     "expired_at": edge.expired_at.isoformat() if edge.expired_at else None,
                     "run_id": edge.run_id,
                     "end_user_id": edge.end_user_id,
-                    "connect_strength": edge.connect_strength if hasattr(edge, 'connect_strength') else 'strong',
+                    "connect_strength": getattr(edge, "connect_strength", "strong"),
                 })
             result = await tx.run(STATEMENT_ENTITY_EDGE_SAVE, relationships=se_edge_data)
             se_uuids = [record["uuid"] async for record in result]

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -228,8 +228,8 @@ async def save_dialog_and_statements_to_neo4j(
                     'statement': edge.statement,
                     'valid_at': edge.valid_at.isoformat() if edge.valid_at else None,
                     'invalid_at': edge.invalid_at.isoformat() if edge.invalid_at else None,
-                    'created_at': edge.created_at.isoformat() if edge.created_at else None,
-                    'expired_at': edge.expired_at.isoformat() if edge.expired_at else None,
+                    'created_at': edge.created_at.isoformat(),
+                    'expired_at': edge.expired_at.isoformat(),
                     'run_id': edge.run_id,
                     'end_user_id': edge.end_user_id,
                 })
@@ -248,7 +248,7 @@ async def save_dialog_and_statements_to_neo4j(
                     "source": edge.source,
                     "target": edge.target,
                     "created_at": edge.created_at.isoformat() if edge.created_at else None,
-                    "expired_at": edge.expired_at.isoformat() if edge.expired_at else None,
+                    "expired_at": edge.expired_at.isoformat()if edge.expired_at else None,
                     "run_id": edge.run_id,
                     "end_user_id": edge.end_user_id,
                 })

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -42,8 +42,8 @@ async def save_entities_and_relationships(
             'statement': edge.statement,
             'valid_at': edge.valid_at.isoformat() if edge.valid_at else None,
             'invalid_at': edge.invalid_at.isoformat() if edge.invalid_at else None,
-            'created_at': edge.created_at.isoformat(),
-            'expired_at': edge.expired_at.isoformat(),
+            'created_at': edge.created_at.isoformat() if edge.created_at else None,
+            'expired_at': edge.expired_at.isoformat() if edge.expired_at else None,
             'run_id': edge.run_id,
             'end_user_id': edge.end_user_id,
         }
@@ -228,8 +228,8 @@ async def save_dialog_and_statements_to_neo4j(
                     'statement': edge.statement,
                     'valid_at': edge.valid_at.isoformat() if edge.valid_at else None,
                     'invalid_at': edge.invalid_at.isoformat() if edge.invalid_at else None,
-                    'created_at': edge.created_at.isoformat(),
-                    'expired_at': edge.expired_at.isoformat(),
+                    'created_at': edge.created_at.isoformat() if edge.created_at else None,
+                    'expired_at': edge.expired_at.isoformat() if edge.expired_at else None,
                     'run_id': edge.run_id,
                     'end_user_id': edge.end_user_id,
                 })
@@ -248,7 +248,7 @@ async def save_dialog_and_statements_to_neo4j(
                     "source": edge.source,
                     "target": edge.target,
                     "created_at": edge.created_at.isoformat() if edge.created_at else None,
-                    "expired_at": edge.expired_at.isoformat()if edge.expired_at else None,
+                    "expired_at": edge.expired_at.isoformat() if edge.expired_at else None,
                     "run_id": edge.run_id,
                     "end_user_id": edge.end_user_id,
                 })

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -281,8 +281,13 @@ async def save_dialog_and_statements_to_neo4j(
     try:
         # 使用显式写事务执行所有操作，避免死锁
         results = await connector.execute_write_transaction(_save_all_in_transaction)
-        logger.info(f"Transaction completed, results: {results}")
-        print(f"Successfully saved all data to Neo4j in a single transaction. Results: {results}")
+        summary = {
+            key: len(value)
+            for key, value in results.items()
+            if isinstance(value, (list, tuple, set))
+        }
+        logger.info("Transaction completed. Summary: %s", summary)
+        logger.debug("Full transaction results: %r", results)
         return True
 
     except Exception as e:


### PR DESCRIPTION
Write Missing None

## Summary by Sourcery

处理可为空的时间戳，并更新 Neo4j 中关于 chunk 与 entity 关系的边持久化逻辑。

Bug Fixes（错误修复）:
- 允许在保存到 Neo4j 时 `created_at` 和 `expired_at` 边的时间戳为 null，以防止序列化错误。

Enhancements（改进）:
- 将 statement-chunk 边的保存切换为使用更新后的 `CHUNK_STATEMENT_EDGE_SAVE` 查询和参数命名。
- 调整 statement-entity 边的持久化逻辑，以包含连接强度（connection strength）元数据，并使用更新后的关系参数名称。
- 使用结构化日志记录和结果输出，改进 Neo4j 事务日志记录和错误报告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle nullable timestamps and update Neo4j edge persistence for chunk and entity relationships.

Bug Fixes:
- Allow created_at and expired_at edge timestamps to be null when saving to Neo4j to prevent serialization errors.

Enhancements:
- Switch statement-chunk edge saving to use the updated CHUNK_STATEMENT_EDGE_SAVE query and parameter naming.
- Adjust statement-entity edge persistence to include connection strength metadata and use the updated parameter name for relationships.
- Improve Neo4j transaction logging and error reporting with structured logger calls and result output.

</details>