### PR TITLE
feat(web): llm node config add vision,vision_input

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1882,6 +1882,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
           enable_window: 'Memory Window',
           inner: 'Built-in',
           messagesPlaceholder: 'Write prompts here, type "{" to insert variables, type "insert" to insert',
+          vision: 'Vision',
         },
         start: {
           variables: 'Input Fields',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1970,6 +1970,7 @@ export const zh = {
           enable_window: '记忆窗口',
           inner: '内置',
           messagesPlaceholder: '在此处编写提示，输入“{”插入变量，输入“insert”插入',
+          vision: '视觉',
         },
         start: {
           variables: '输入字段',

--- a/web/src/views/Workflow/components/Properties/MemoryConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/MemoryConfig/index.tsx
@@ -55,7 +55,7 @@ const MemoryConfig: FC<{ options: Suggestion[]; parentName: string; }> = ({
             <Form.Item layout="horizontal" name={[parentName, 'enable_window']} noStyle>
               <Switch />
             </Form.Item>
-            <span className="rb:ml-2">{t('workflow.config.llm.enable_window')}</span>
+            <span className="rb:ml-2 rb:text-[12px]">{t('workflow.config.llm.enable_window')}</span>
           </Col>
           <Col span={14}>
             <Form.Item layout="horizontal" name={[parentName, 'window_size']} noStyle>

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:39:59 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 15:39:59 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-05 14:21:45
  */
 import { type FC, useEffect, useState, useMemo } from "react";
 import clsx from 'clsx'
@@ -612,11 +612,19 @@ const Properties: FC<PropertiesProps> = ({
                 )
               }
 
+              if (key === 'vision_input' && !values?.vision) {
+                return null
+              }
+
               return (
                 <Form.Item 
                   key={key} 
                   name={key}
-                  label={key === 'parallel_count' ? <span className="rb:text-[10px] rb:text-[#5B6167] rb:leading-3.5 rb:-mb-1!">{t(`workflow.config.${selectedNode?.data?.type}.${key}`)}</span> : t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
+                  label={key === 'vision_input'
+                    ? undefined : key === 'parallel_count'
+                    ? <span className="rb:text-[10px] rb:text-[#5B6167] rb:leading-3.5 rb:-mb-1!">{t(`workflow.config.${selectedNode?.data?.type}.${key}`)}</span>
+                    : t(`workflow.config.${selectedNode?.data?.type}.${key}`)
+                  }
                   layout={config.type === 'switch' ? 'horizontal' : 'vertical'}
                   className={key === 'parallel_count' ? 'rb:-mt-3! rb:leading-3.5!' : ''}
                 >
@@ -655,12 +663,15 @@ const Properties: FC<PropertiesProps> = ({
                         // Apply filtering if specified in config
                         if (config.filterNodeTypes || config.filterVariableNames) {
                           return baseVariableList.filter(variable => {
-                            const nodeTypeMatch = !config.filterNodeTypes || 
+                            const nodeTypeMatch = !config.filterNodeTypes ||
                               (Array.isArray(config.filterNodeTypes) && config.filterNodeTypes.includes(variable.nodeData?.type));
-                            const variableNameMatch = !config.filterVariableNames || 
+                            const variableNameMatch = !config.filterVariableNames ||
                               (Array.isArray(config.filterVariableNames) && config.filterVariableNames.includes(variable.label));
                             return nodeTypeMatch || variableNameMatch;
                           });
+                        }
+                        if (config.onFilterVariableNames) {
+                          return baseVariableList.filter(variable => Array.isArray(config.onFilterVariableNames) && config.onFilterVariableNames.includes(variable.label));
                         }
                         // Filter child nodes for iteration output
                         if (config.filterChildNodes && selectedNode) {
@@ -685,7 +696,13 @@ const Properties: FC<PropertiesProps> = ({
                       size="small"
                     />
                     : config.type === 'switch'
-                    ? <Switch onChange={key === 'group' ? () => { form.setFieldValue('group_variables', []) } : undefined} />
+                    ? <Switch onChange={
+                        key === 'group'
+                        ? () => { form.setFieldValue('group_variables', []) }
+                        : key === 'vision'
+                        ? () => { form.setFieldValue('vision_input', undefined) }
+                        : undefined
+                      } />
                     : config.type === 'categoryList'
                     ? <CategoryList 
                       parentName={key} 

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:06:18 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-03 15:25:25
+ * @Last Modified time: 2026-02-05 14:15:13
  */
 import LoopNode from './components/Nodes/LoopNode';
 import NormalNode from './components/Nodes/NormalNode';
@@ -91,6 +91,11 @@ export const nodeLibrary: NodeLibrary[] = [
                 type: "string",
                 readonly: true
               },
+              {
+                name: "files",
+                type: "array[file]",
+                readonly: true
+              },
             ],
             defaultValue: []
           }
@@ -155,6 +160,13 @@ export const nodeLibrary: NodeLibrary[] = [
               enable_window: false,
               window_size: 20
             }
+          },
+          vision: {
+            type: 'switch'
+          },
+          vision_input: {
+            type: 'variableList',
+            onFilterVariableNames: ['sys.files']
           }
         }
       },


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

为 LLM 工作流节点添加视觉（vision）配置和视觉输入支持，并调整相关 UI 和变量过滤逻辑。

新功能：
- 为 LLM 工作流节点引入视觉开关（vision toggle）和 `vision_input` 变量列表配置，仅过滤到基于文件的变量。
- 在起始节点（start node）上暴露一个只读的 `files` 数组输出，用作视觉输入。

增强：
- 在未启用视觉功能时隐藏 `vision_input` 字段，并在关闭视觉开关时清空 `vision_input`。
- 通过可选的 `onFilterVariableNames` 配置细化变量列表过滤，实现更精确的选择。
- 微调记忆窗口（memory window）标签样式，以获得更好的视觉一致性。

文档：
- 为新的视觉配置选项添加英文和中文的 i18n 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add vision configuration and vision input support to LLM workflow nodes and adjust related UI and variable filtering.

New Features:
- Introduce a vision toggle and vision_input variable list configuration for LLM workflow nodes, filtering to file-based variables.
- Expose a readonly files array output on the start node for use as vision input.

Enhancements:
- Hide the vision_input field unless vision is enabled and clear vision_input when vision is toggled off.
- Refine variable list filtering with an optional onFilterVariableNames configuration for more precise selection.
- Tweak the memory window label styling for better visual consistency.

Documentation:
- Add English and Chinese i18n labels for the new vision configuration option.

</details>