### PR TITLE
Revert "feat(web): move prompt menu"

### DIFF
--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createHashRouter, createRoutesFromElements, Route } from 'react-router-
 
 // 导入路由配置JSON
 import routesConfig from './routes.json';
+import Ontology from '@/views/Ontology';
 
 
 // 递归函数，用于生成路由元素

--- a/web/src/routes/routes.json
+++ b/web/src/routes/routes.json
@@ -7,7 +7,6 @@
       { "path": "/model", "element": "ModelManagement" },
       { "path": "/space", "element": "SpaceManagement" },
       { "path": "/tool", "element": "ToolManagement" },
-      { "path": "/prompt", "element": "Prompt" },
       { "path": "/pricing", "element": "Pricing" },
       { "path": "/order-pay", "element": "OrderPayment" },
       { "path": "/orders", "element": "OrderHistory" },
@@ -36,6 +35,7 @@
       { "path": "/reflection-engine/:id", "element": "SelfReflectionEngine" },
       { "path": "/space-config", "element": "SpaceConfig" },
       { "path": "/ontology", "element": "Ontology" },
+      { "path": "/prompt", "element": "Prompt" },
       { "path": "/no-permission", "element": "NoPermission" },
       { "path": "/*", "element": "NotFound" }
     ]

--- a/web/src/store/menu.json
+++ b/web/src/store/menu.json
@@ -53,21 +53,6 @@
       "subs": []
     },
     {
-      "id": 20,
-      "parent": 0,
-      "code": "prompt",
-      "label": "提示词",
-      "i18nKey": "menu.prompt",
-      "path": "/prompt",
-      "enable": true,
-      "display": true,
-      "level": 1,
-      "sort": 0,
-      "icon": null,
-      "iconActive": null,
-      "subs": null
-    },
-    {
       "id": 6,
       "parent": 0,
       "code": "pricing",
@@ -384,6 +369,21 @@
       "label": "API KEY管理",
       "i18nKey": "menu.apiKeyManagement",
       "path": "/api-key",
+      "enable": true,
+      "display": true,
+      "level": 1,
+      "sort": 0,
+      "icon": null,
+      "iconActive": null,
+      "subs": null
+    },
+    {
+      "id": 20,
+      "parent": 0,
+      "code": "prompt",
+      "label": "提示词",
+      "i18nKey": "menu.prompt",
+      "path": "/prompt",
       "enable": true,
       "display": true,
       "level": 1,


### PR DESCRIPTION
This reverts commit 9e6e8f50f8136fb8c963af34d9446dc49a237cad.

## 由 Sourcery 提供的摘要

增强内容：
- 通过撤销之前的重新布局更改，恢复提示菜单的原始布局和配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Restore the original layout and configuration for the prompt menu by undoing the previous relocation changes.

</details>