### PR TITLE
Feature/memory zy

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -256,7 +256,7 @@ export const updateMemoryExtractionConfig = (values: ExtractionConfigForm) => {
   return request.post('/memory-storage/update_config_extracted', values)
 }
 // Memory Extraction Engine - Pilot run
-export const pilotRunMemoryExtractionConfig = (values: { config_id: number | string; dialogue_text: string; }, onMessage?: (data: SSEMessage[]) => void) => {
+export const pilotRunMemoryExtractionConfig = (values: { config_id: number | string; dialogue_text: string; custom_text?: string; }, onMessage?: (data: SSEMessage[]) => void) => {
   return handleSSE('/memory-storage/pilot_run', values, onMessage)
 }
 // Emotion Engine - Get configuration

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1543,7 +1543,8 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       text_preprocessing_desc: 'Text split into {{count}} semantic fragments',
       knowledge_extraction_desc: 'Knowledge extraction completed, identified {{entities}} entities, {{statements}} statements, {{temporal_ranges_count}} temporal extractions, {{triplets}} triplets',
       creating_nodes_edges_desc: 'Entity relationship creation completed, {{num}} relationships in total',
-      deduplication_desc: 'Deduplication and disambiguation completed, {{count}} unique entities in total'
+      deduplication_desc: 'Deduplication and disambiguation completed, {{count}} unique entities in total',
+      custom_text: 'Debug Text',
     },
     memoryConversation: {
       searchPlaceholder: 'Enter user ID...',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1617,7 +1617,8 @@ export const zh = {
       text_preprocessing_desc: '文本切分为{{count}}个语义片段',
       knowledge_extraction_desc: '知识抽取完成，共识别{{entities}}个实体,{{statements}}个句子, {{temporal_ranges_count}}个时间提取, {{triplets}}个三元组',
       creating_nodes_edges_desc: '实体关系创建完成，共{{num}}条关系',
-      deduplication_desc: '去重消歧完成，最终{{count}}个唯一实体'
+      deduplication_desc: '去重消歧完成，最终{{count}}个唯一实体',
+      custom_text: '调试文本',
     },
     memoryConversation: {
       chatEmpty:'有什么我可以帮您的吗？',

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:21 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-04 20:16:45
+ * @Last Modified time: 2026-02-06 11:20:14
  */
 import { type FC, type ReactNode, useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react';
 import clsx from 'clsx'
@@ -38,8 +38,8 @@ import CustomSelect from '@/components/CustomSelect'
 import aiPrompt from '@/assets/images/application/aiPrompt.png'
 import AiPromptModal from './components/AiPromptModal'
 import ToolList from './components/ToolList/ToolList'
-import ChatVariableConfigModal from './components/ChatVariableConfigModal';
 import SkillList from './components/Skill'
+import ChatVariableConfigModal from './components/ChatVariableConfigModal';
 import type { Skill } from '@/views/Skills/types'
 
 /**
@@ -169,7 +169,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
       const { skills } = response
       let allSkills = Array.isArray(skills?.skill_ids) ? skills?.skill_ids.map(vo => ({ id: vo })) : []
       let allTools = Array.isArray(response.tools) ? response.tools : []
-      const memoryContent = response.memory?.memory_content
+      const memoryContent = response.memory?.memory_config_id
       const parsedMemoryContent = memoryContent === null || memoryContent === '' 
         ? undefined 
         : !isNaN(Number(memoryContent)) ? Number(memoryContent) : memoryContent
@@ -178,7 +178,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
         tools: allTools,
         memory: {
           ...response.memory,
-          memory_content: parsedMemoryContent
+          memory_config_id: parsedMemoryContent
         },
         skills: {
           ...skills,
@@ -262,7 +262,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
     if (!isSave || !data) return Promise.resolve()
     const { memory, knowledge_retrieval, tools, skills, ...rest } = values
     const { knowledge_bases = [], ...knowledgeRest } = knowledge_retrieval || {}
-    const { memory_content } = memory || {}
+    const { memory_config_id } = memory || {}
     // Get other necessary properties of memory from original data
     const originalMemory = data.memory || ({} as MemoryConfig)
     
@@ -272,7 +272,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
       memory: {
         ...originalMemory,
         ...memory,
-        memory_content: memory_content ? String(memory_content) : '',
+        memory_config_id: memory_config_id ? String(memory_config_id) : '',
       },
       knowledge_retrieval: knowledge_bases.length > 0 ? {
         ...data.knowledge_retrieval,
@@ -444,7 +444,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
                   <SelectWrapper 
                     title="selectMemoryContent" 
                     desc="selectMemoryContentDesc" 
-                    name={['memory', 'memory_content']}
+                    name={['memory', 'memory_config_id']}
                     url={memoryConfigListUrl}
                   />
                 </Space>

--- a/web/src/views/ApplicationConfig/components/Skill/index.tsx
+++ b/web/src/views/ApplicationConfig/components/Skill/index.tsx
@@ -39,7 +39,7 @@ const processObj = [
  * @param value - Current skill configuration values
  * @param onChange - Callback function when configuration changes
  */
-const Skill: FC<{value?: SkillConfigForm; onChange?: (config: SkillConfigForm) => void}> = () => {
+const SkillList: FC<{value?: SkillConfigForm; onChange?: (config: SkillConfigForm) => void}> = () => {
   const { t } = useTranslation()
   const form = Form.useFormInstance()
   const skillConfig = Form.useWatch(['skills'], form)
@@ -148,4 +148,4 @@ const Skill: FC<{value?: SkillConfigForm; onChange?: (config: SkillConfigForm) =
     </Card>
   )
 }
-export default Skill
+export default SkillList

--- a/web/src/views/ApplicationConfig/types.ts
+++ b/web/src/views/ApplicationConfig/types.ts
@@ -43,7 +43,7 @@ export interface MemoryConfig {
   /** Whether memory is enabled */
   enabled: boolean;
   /** Memory content */
-  memory_content?: string;
+  memory_config_id?: string;
   /** Maximum history length */
   max_history?: number | string;
 }

--- a/web/src/views/MemoryExtractionEngine/components/Result.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/Result.tsx
@@ -13,7 +13,7 @@
 import { type FC, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Space, Button, Progress } from 'antd'
+import { Space, Button, Progress, Form, Input } from 'antd'
 import { ExclamationCircleFilled, CheckCircleFilled, ClockCircleOutlined, LoadingOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
 import type { AnyObject } from 'antd/es/_util/type';
@@ -78,6 +78,8 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
   const [knowledgeExtraction, setKnowledgeExtraction] = useState<ModuleItem>(initObj as ModuleItem)
   const [creatingNodesEdges, setCreatingNodesEdges] = useState<ModuleItem>(initObj as ModuleItem)
   const [deduplication, setDeduplication] = useState<ModuleItem>(initObj as ModuleItem)
+
+  const [runForm] = Form.useForm()
 
   /** Run pilot test */
   const handleRun = () => {
@@ -187,6 +189,7 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
     pilotRunMemoryExtractionConfig({
       config_id: id,
       dialogue_text: t('memoryExtractionEngine.exampleText'),
+      custom_text: runForm.getFieldValue('custom_text')
     }, handleStreamMessage)
     .finally(() => {
       setRunLoading(false)
@@ -222,6 +225,14 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
       headerClassName="rb:pb-0! rb:pt-4!"
       bodyClassName="rb:min-h-[calc(100vh-388px)] rb:p-[16px_20px]!"
     >
+      <Form form={runForm} layout="vertical">
+        <Form.Item
+          name="custom_text"
+          label={t('memoryExtractionEngine.custom_text')}
+        >
+          <Input.TextArea placeholder={t('common.pleaseEnter')} />
+        </Form.Item>
+      </Form>
       <div className="rb:min-h-[calc(100vh-480px)] rb:overflow-y-auto">
         {runLoading
           ? <>


### PR DESCRIPTION
## Summary by Sourcery

在运行内存抽取引擎时，新增对选择内存配置和提供自定义调试文本的支持，并使相关的 Agent 配置类型和组件与新的内存配置字段保持一致。

新功能：
- 允许用户在触发内存抽取引擎的试运行时输入可选的自定义调试文本。

改进：
- 将 Agent 的内存配置统一标准化为使用 `memory_config_id` 字段，覆盖各类类型定义、API 处理以及 UI 绑定。
- 将技能配置组件重命名为 `SkillList`，以获得更清晰的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for selecting a memory configuration and providing custom debug text when running the memory extraction engine, and align related agent config types and components with the new memory configuration field.

New Features:
- Allow users to enter optional custom debug text when triggering a memory extraction engine pilot run.

Enhancements:
- Standardize agent memory configuration to use a memory_config_id field across types, API handling, and UI bindings.
- Rename the skill configuration component to SkillList for clearer semantics.

</details>