### PR TITLE
fix(multimodal): temporarily limit API to image-only modality

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -580,6 +580,7 @@ async def chat(
                         conversation_id=conversation.id,  # 使用已创建的会话 ID
                         user_id=end_user_id,  # 转换为字符串
                         variables=payload.variables,
+                        files=payload.files,
                         config=config,
                         web_search=payload.web_search,
                         memory=payload.memory,

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -40,10 +40,7 @@ class FileInput(BaseModel):
     @classmethod
     def validate_type(cls, v):
         """验证文件类型"""
-        try:
-            return FileType.trans(v)
-        except ValueError:
-            raise ValueError(f"无效的文件类型: {v}")
+        return FileType.trans(v)
 
     @field_validator("upload_file_id")
     @classmethod

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -655,6 +655,7 @@ class AppChatService:
             workspace_id: uuid.UUID,
             user_id: str = None,
             variables: Optional[Dict[str, Any]] = None,
+            files: Optional[List[FileInput]] = None,
             web_search: bool = False,
             memory: bool = True,
             storage_type: Optional[str] = None,
@@ -669,7 +670,8 @@ class AppChatService:
             variables=variables,
             conversation_id=str(conversation_id),
             stream=True,
-            user_id=user_id
+            user_id=user_id,
+            files=files
         )
         async for event in workflow_service.run_stream(
                 app_id=app_id,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -446,19 +446,9 @@ class WorkflowService:
                 code=BizCode.CONFIG_MISSING,
                 message=f"工作流配置不存在: app_id={app_id}"
             )
-        files = []
-        if payload.files:
-            for file in payload.files:
-                files.append(
-                    {
-                        "type": file.type,
-                        "url": await self.multimodal_service.get_file_url(file),
-                        "__file": True
-                    }
-                )
 
         input_data = {"message": payload.message, "variables": payload.variables,
-                      "conversation_id": payload.conversation_id, "files": files}
+                      "conversation_id": payload.conversation_id, "files": [file.model_dump() for file in payload.files]}
 
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
@@ -488,6 +478,17 @@ class WorkflowService:
         from app.core.workflow.executor import execute_workflow
 
         try:
+            files = []
+            if payload.files:
+                for file in payload.files:
+                    files.append(
+                        {
+                            "type": file.type,
+                            "url": await self.multimodal_service.get_file_url(file),
+                            "__file": True
+                        }
+                    )
+            input_data["files"] = files
             # 更新状态为运行中
             self.update_execution_status(execution.execution_id, "running")
 
@@ -634,19 +635,8 @@ class WorkflowService:
                 message=f"工作流配置不存在: app_id={app_id}"
             )
 
-        files = []
-        if payload.files:
-            for file in payload.files:
-                files.append(
-                    {
-                        "type": file.type,
-                        "url": await self.multimodal_service.get_file_url(file),
-                        "__file": True
-                    }
-                )
-
         input_data = {"message": payload.message, "variables": payload.variables,
-                      "conversation_id": payload.conversation_id, "files": files}
+                      "conversation_id": payload.conversation_id, "files": [file.model_dump() for file in payload.files]}
 
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
@@ -670,12 +660,18 @@ class WorkflowService:
             "execution_config": config.execution_config
         }
 
-        # 4. 获取工作空间 ID（从 app 获取）
-
-        # 5. 流式执行工作流
-
         try:
-            # 更新状态为运行中
+            files = []
+            if payload.files:
+                for file in payload.files:
+                    files.append(
+                        {
+                            "type": file.type,
+                            "url": await self.multimodal_service.get_file_url(file),
+                            "__file": True
+                        }
+                    )
+            input_data["files"] = files
             self.update_execution_status(execution.execution_id, "running")
             executions = self.execution_repo.get_by_conversation_id(conversation_id=conversation_id_uuid)
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

将多模态工作流聊天限制为仅支持图像文件，并在工作流聊天相关的端点中传递文件输入。

Bug 修复：
- 校验并规范化文件类型，目前仅接受基于图像的输入，拒绝不支持的模态。

增强功能：
- 通过工作流聊天流式 API 和公共分享的工作流聊天传递文件输入，以支持可控的多模态使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict multimodal workflow chat to image-only files and propagate file inputs through workflow chat endpoints.

Bug Fixes:
- Validate and normalize file types so only image-based inputs are accepted for now, rejecting unsupported modalities.

Enhancements:
- Wire file inputs through workflow chat streaming APIs and public share workflow chats to support controlled multimodal usage.

</details>