### PR TITLE
fix(model)

### DIFF
--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -717,7 +717,7 @@ models:
   - video
   logo: dashscope
 - name: qwq-32b
-  type: chat
+  type: llm
   provider: dashscope
   description: qwq-32b大语言模型，支持智能体思考、流式工具调用，131072上下文窗口，对话模式
   is_deprecated: false

--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -285,7 +285,7 @@ models:
   - stream-tool-call
   logo: dashscope
 - name: qwen-vl-max
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-max多模态大模型，支持视觉理解、智能体思考、视频理解，131072上下文窗口，对话模式，未废弃
   is_deprecated: false
@@ -298,7 +298,7 @@ models:
   - video
   logo: dashscope
 - name: qwen-vl-plus-0809
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-plus-0809多模态大模型，支持视觉理解、智能体思考、视频理解，32768上下文窗口，对话模式，已废弃
   is_deprecated: true
@@ -311,7 +311,7 @@ models:
   - video
   logo: dashscope
 - name: qwen-vl-plus-2025-01-02
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-plus-2025-01-02多模态大模型，支持视觉理解、智能体思考、视频理解，32768上下文窗口，对话模式，未废弃
   is_deprecated: false
@@ -324,7 +324,7 @@ models:
   - video
   logo: dashscope
 - name: qwen-vl-plus-2025-01-25
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-plus-2025-01-25多模态大模型，支持视觉理解、智能体思考、视频理解，131072上下文窗口，对话模式，未废弃
   is_deprecated: false
@@ -337,7 +337,7 @@ models:
   - video
   logo: dashscope
 - name: qwen-vl-plus-latest
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-plus-latest多模态大模型，支持视觉理解、智能体思考、视频理解，131072上下文窗口，对话模式，未废弃
   is_deprecated: false
@@ -350,7 +350,7 @@ models:
   - video
   logo: dashscope
 - name: qwen-vl-plus
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen-vl-plus多模态大模型，支持视觉理解、智能体思考、视频理解，131072上下文窗口，对话模式，未废弃
   is_deprecated: false
@@ -616,7 +616,7 @@ models:
   - audio
   logo: dashscope
 - name: qwen3-vl-235b-a22b-instruct
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-235b-a22b-instruct多模态大语言模型，支持多工具调用、智能体思考、流式工具调用、视觉、视频能力，131072上下文窗口，对话模式
   is_deprecated: false
@@ -631,7 +631,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-235b-a22b-thinking
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-235b-a22b-thinking多模态大语言模型，支持多工具调用、智能体思考、流式工具调用、视觉、视频能力，131072上下文窗口，对话模式
   is_deprecated: false
@@ -646,7 +646,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-30b-a3b-instruct
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-30b-a3b-instruct多模态大语言模型，支持多工具调用、智能体思考、流式工具调用、视觉、视频能力，131072上下文窗口，对话模式
   is_deprecated: false
@@ -661,7 +661,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-30b-a3b-thinking
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-30b-a3b-thinking多模态大语言模型，支持多工具调用、智能体思考、流式工具调用、视觉、视频能力，131072上下文窗口，对话模式
   is_deprecated: false
@@ -676,7 +676,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-flash
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-flash多模态大语言模型，支持多工具调用、智能体思考、流式工具调用、视觉、视频能力，131072上下文窗口，对话模式
   is_deprecated: false
@@ -691,7 +691,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-plus-2025-09-23
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-plus-2025-09-23多模态大语言模型，支持视觉、智能体思考、视频能力，262144上下文窗口，对话模式
   is_deprecated: false
@@ -704,7 +704,7 @@ models:
   - video
   logo: dashscope
 - name: qwen3-vl-plus
-  type: llm
+  type: chat
   provider: dashscope
   description: qwen3-vl-plus多模态大语言模型，支持视觉、智能体思考、视频能力，262144上下文窗口，对话模式
   is_deprecated: false
@@ -717,7 +717,7 @@ models:
   - video
   logo: dashscope
 - name: qwq-32b
-  type: llm
+  type: chat
   provider: dashscope
   description: qwq-32b大语言模型，支持智能体思考、流式工具调用，131072上下文窗口，对话模式
   is_deprecated: false


### PR DESCRIPTION
change the "vl" model type of dashscope to "chat"

## Summary by Sourcery

Bug 修复：
- 将 DashScope `qwen-vl` 以及相关多模态/聊天模型的模型类型分类，从 `llm` 更正为 `chat`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct model type classification for DashScope qwen-vl and related multimodal/chat models from llm to chat.

</details>