### PR TITLE
Fix/release web zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:39 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 16:27:39 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 10:52:55
  */
 /**
  * Chat debugging component for application testing
@@ -424,9 +424,9 @@ const Chat: FC<ChatProps> = ({ chatList, data, updateChatList, handleSave, sourc
               }
               <ChatContent
                 classNames={{
-                  'rb:mx-[16px] rb:pt-[24px]': true,
-                  'rb:h-[calc(100vh-258px)]': isCluster,
-                  'rb:h-[calc(100vh-356px)]': !isCluster,
+                  'rb:mx-[16px] rb:mt-6': true,
+                  'rb:h-[calc(100vh-282px)]': isCluster,
+                  'rb:h-[calc(100vh-380px)]': !isCluster,
                 }} 
                 contentClassNames={{
                   'rb:max-w-[400px]!': chatList.length === 1,

--- a/web/src/views/ApplicationManagement/index.tsx
+++ b/web/src/views/ApplicationManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-06 11:10:16
+ * @Last Modified time: 2026-02-09 13:52:22
  */
 /**
  * Application Management Page
@@ -83,9 +83,9 @@ const ApplicationManagement: React.FC = () => {
     setQuery(prev => ({...prev, type: value}))
   }
 
-  const handleImport = () => {
-    uploadWorkflowModalRef.current?.handleOpen()
-  }
+  // const handleImport = () => {
+  //   uploadWorkflowModalRef.current?.handleOpen()
+  // }
   return (
     <>
       <Row gutter={16} className="rb:mb-4">
@@ -111,9 +111,9 @@ const ApplicationManagement: React.FC = () => {
         </Col>
         <Col span={12} className="rb:text-right">
           <Space size={12}>
-            <Button onClick={handleImport}>
+            {/* <Button onClick={handleImport}>
               {t('application.importWorkflow')}
-            </Button>
+            </Button> */}
             <Button type="primary" onClick={handleCreate}>
               {t('application.createApplication')}
             </Button>


### PR DESCRIPTION
## Summary by Sourcery

暂时在应用管理视图中禁用工作流导入操作，并调整集群模式和非集群模式下的聊天调试面板布局间距和高度。

Enhancements:
- 优化聊天调试区域的间距，并基于视口高度调整集群模式和非集群模式下的高度表现。

Chores:
- 在应用管理页面中注释掉工作流导入按钮及其处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Temporarily disable the workflow import action in the application management view and adjust the chat debugging panel layout spacing and height for clustered and non-clustered modes.

Enhancements:
- Refine chat debugging area spacing and viewport-based height for both cluster and non-cluster modes.

Chores:
- Comment out the workflow import button and handler in the application management page.

</details>