### PR TITLE
Fix/release web zy

### DIFF
--- a/web/src/api/fileStorage.ts
+++ b/web/src/api/fileStorage.ts
@@ -1,15 +1,16 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 13:59:56 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 13:59:56 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 16:24:05
  */
 import { request, API_PREFIX } from '@/utils/request'
 
 // Upload file，file storage has expiration period
-export const fileUploadUrl = `${API_PREFIX}/storage/files`
+export const fileUploadUrlWithoutApiPrefix = '/storage/files'
+export const fileUploadUrl = `${API_PREFIX}${fileUploadUrlWithoutApiPrefix}`
 export const fileUpload = (formData?: unknown) => {
-  return request.uploadFile('/storage/files', formData)
+  return request.uploadFile(fileUploadUrlWithoutApiPrefix, formData)
 }
 
 // Get file access URL (no token required)
@@ -30,4 +31,5 @@ export const deleteFile = (fileId: string) => {
   return request.delete(deleteFileUrl(fileId))
 }
 
-export const shareFileUploadUrl = `${API_PREFIX}/storage/share/files`
+export const shareFileUploadUrlWithoutApiPrefix = `/storage/share/files`
+export const shareFileUploadUrl = `${API_PREFIX}${shareFileUploadUrlWithoutApiPrefix}`

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:21 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 10:33:21
+ * @Last Modified time: 2026-02-09 16:56:27
  */
 import { type FC, type ReactNode, useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react';
 import clsx from 'clsx'
@@ -210,7 +210,7 @@ const Agent = forwardRef<AgentRef>((_props, ref) => {
       })
       if (default_model_config_id === values?.default_model_config_id) {
         setChatList([{
-          label: vo.label || '',
+          label: defaultModel?.id === default_model_config_id && defaultModel?.name ? defaultModel.name :  vo.label || '',
           model_config_id: default_model_config_id || '',
           model_parameters: {...rest},
           list: []

--- a/web/src/views/Conversation/components/FileUpload.tsx
+++ b/web/src/views/Conversation/components/FileUpload.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:09:42 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-06 21:09:42 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 16:41:31
  */
 /**
  * File Upload Component
@@ -25,8 +25,8 @@ import { Upload, Progress, App } from 'antd';
 import type { UploadProps, UploadFile } from 'antd';
 import type { UploadProps as RcUploadProps } from 'antd/es/upload/interface';
 import { useTranslation } from 'react-i18next';
-import { cookieUtils } from '@/utils/request'
-import { fileUploadUrl } from '@/api/fileStorage'
+import { request } from '@/utils/request'
+import { fileUploadUrlWithoutApiPrefix } from '@/api/fileStorage'
 
 interface UploadFilesProps extends Omit<UploadProps, 'onChange'> {
   /** Upload API endpoint */
@@ -99,7 +99,7 @@ export interface UploadFilesRef {
  * Supports single/multiple file uploads, drag-and-drop, file validation, and preview
  */
 const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
-  action = fileUploadUrl,
+  action = fileUploadUrlWithoutApiPrefix,
   multiple = false,
   fileList: propFileList = [],
   onChange,
@@ -110,6 +110,7 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
   maxCount = 1,
   onRemove: customOnRemove,
   update,
+  requestConfig,
   ...props
 }, ref) => {
   const { t } = useTranslation();
@@ -164,6 +165,24 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
   };
 
   /**
+   * Custom upload request handler
+   */
+  const handleCustomRequest: RcUploadProps['customRequest'] = async (options) => {
+    const { file, onSuccess, onError } = options;
+    
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      
+      const response = await request.uploadFile(action, formData, requestConfig);
+      
+      onSuccess?.({data: response});
+    } catch (error) {
+      onError?.(error as Error);
+    }
+  };
+
+  /**
    * Handles upload state changes
    */
   const handleChange: UploadProps['onChange'] = ({ fileList: newFileList, event }) => {
@@ -207,13 +226,10 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
 
   // Generate upload component configuration
   const uploadProps: UploadProps = {
-    action,
+    customRequest: handleCustomRequest,
     multiple: multiple && maxCount > 1,
     fileList,
     beforeUpload,
-    headers: {
-      authorization: `Bearer ${cookieUtils.get('authToken')}`,
-    },
     onChange: handleChange,
     accept,
     disabled,

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-06 21:11:23
+ * @Last Modified time: 2026-02-09 16:37:49
  */
 /**
  * Conversation Page
@@ -35,7 +35,7 @@ import MemoryFunctionCheckedIcon from '@/assets/images/conversation/memoryFuncti
 import { type SSEMessage } from '@/utils/stream'
 import UploadFiles from './components/FileUpload'
 // import AudioRecorder from '@/components/AudioRecorder'
-import { shareFileUploadUrl } from '@/api/fileStorage'
+import { shareFileUploadUrlWithoutApiPrefix } from '@/api/fileStorage'
 import UploadFileListModal from './components/UploadFileListModal'
 
 /**
@@ -350,11 +350,16 @@ const Conversation: FC = () => {
                         {
                           key: 'upload', label: (
                             <UploadFiles
-                              action={shareFileUploadUrl}
+                              action={shareFileUploadUrlWithoutApiPrefix}
                               fileType={['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg']}
                               onChange={fileChange}
                               fileList={[]}
                               update={update}
+                              requestConfig={{
+                                headers: {
+                                  'Content-Type': 'multipart/form-data',
+                                  authorization: `Bearer ${shareToken || ''}`,
+                              } }}
                             />
                           )
                         },


### PR DESCRIPTION
## Summary by Sourcery

调整会话附件和文件存储的文件上传端点与身份验证处理方式，并优化智能体配置中的默认对话标签选择。

Bug Fixes:
- 修复会话图片上传逻辑，改为使用基于 share-token 的认证上传端点，而不是依赖全局 API 前缀和 cookies。
- 更正初始对话标签：当所选默认模型有自己的名称时，确保标签设置正确，避免标签错误或缺失。

Enhancements:
- 为文件上传和分享文件上传新增不带全局前缀的 API 路径，以支持更灵活的请求配置。
- 将 `FileUpload` 组件切换为使用带可配置请求头的自定义上传请求助手，从而与基于 cookie 的认证以及内置的 `Upload` 动作处理解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust file upload endpoints and authentication handling for conversation attachments and file storage, and refine default chat label selection in the agent configuration.

Bug Fixes:
- Fix conversation image upload to use a share-token–based authenticated upload endpoint instead of relying on the global API prefix and cookies.
- Correct the initial chat label when the selected default model has its own name, avoiding incorrect or missing labels.

Enhancements:
- Introduce API paths without the global prefix for file and share-file uploads to support more flexible request configuration.
- Switch the FileUpload component to use a custom upload request helper with configurable headers, decoupling it from cookie-based auth and built-in Upload action handling.

</details>