### PR TITLE
fix(web): ui update

### DIFF
--- a/web/src/views/Ontology/components/PageHeader.tsx
+++ b/web/src/views/Ontology/components/PageHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:24 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-03 14:10:56
+ * @Last Modified time: 2026-02-09 18:02:13
  */
 import { type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -45,7 +45,7 @@ const PageHeader: FC<ConfigHeaderProps> = ({
   }
   return (
     <Header className="rb:w-full rb:h-16 rb:flex rb:justify-between rb:p-[0_16px_0_24px]! rb:border-b rb:border-[#EAECEE] rb:leading-8">
-      <div className="rb:flex rb:flex-col rb:justify-center rb:gap-1 rb:mr-4">
+      <div className="rb:flex rb:flex-col rb:justify-center rb:gap-1 rb:mr-4 rb:max-w-[calc(100%-300px)]">
         <div className="rb:text-[16px] rb:leading-6 rb:font-medium">
           {name}
         </div>

--- a/web/src/views/Ontology/pages/Detail.tsx
+++ b/web/src/views/Ontology/pages/Detail.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:20 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 14:10:20 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 17:56:35
  */
 import { type FC, useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom';
@@ -100,7 +100,7 @@ const Detail: FC = () => {
     <>
       <PageHeader
         name={data.scene_name}
-        subTitle={<div>{data.scene_description}</div>}
+        subTitle={<Tooltip title={data.scene_description}><div className="rb:h-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{data.scene_description}</div></Tooltip>}
         extra={<Space>
           <Button type="primary" ghost className="rb:h-6! rb:px-2! rb:leading-5.5!" onClick={handleAdd}>+ {t('ontology.addClass')}</Button>
           <Button className="rb:h-6! rb:px-2! rb:leading-5.5!" type="primary" onClick={handleExtract}>+ {t('ontology.extract')}</Button>


### PR DESCRIPTION
## Summary by Sourcery

优化本体详情页头部布局，以更好地处理较长的场景描述并防止布局溢出。

增强内容：
- 限制页面头部标题容器的宽度，为其他头部操作留出空间。
- 将场景描述显示为单行截断的副标题，并通过工具提示展示完整文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the ontology detail page header layout to better handle long scene descriptions and prevent layout overflow.

Enhancements:
- Constrain the page header title container width to leave space for other header actions.
- Display the scene description in a single-line, truncated subtitle with a tooltip showing the full text.

</details>