### PR TITLE
fix(workflow): adapt memory node write behavior

### DIFF
--- a/api/app/core/workflow/nodes/memory/config.py
+++ b/api/app/core/workflow/nodes/memory/config.py
@@ -1,8 +1,31 @@
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import BaseModel, field_validator, Field
 
 from app.core.workflow.nodes.base_config import BaseNodeConfig
+
+
+class MessageConfig(BaseModel):
+    """消息配置"""
+
+    role: str = Field(
+        default='user',
+        description="消息角色：system, user, assistant"
+    )
+
+    content: str = Field(
+        default="",
+        description="消息内容，支持模板变量，如：{{ sys.message }}"
+    )
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        """验证角色"""
+        allowed_roles = ["system", "user", "human", "assistant", "ai"]
+        if v.lower() not in allowed_roles:
+            raise ValueError(f"角色必须是以下之一: {', '.join(allowed_roles)}")
+        return v.lower()
 
 
 class MemoryReadNodeConfig(BaseNodeConfig):
@@ -23,6 +46,10 @@ class MemoryReadNodeConfig(BaseNodeConfig):
 class MemoryWriteNodeConfig(BaseNodeConfig):
     message: str = Field(
         ...
+    )
+
+    messages: list[MessageConfig] = Field(
+        default_factory=list
     )
 
     config_id: UUID | int = Field(

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -55,10 +55,22 @@ class MemoryWriteNode(BaseNode):
 
         if not end_user_id:
             raise RuntimeError("End user id is required")
+        messages = []
+        if self.typed_config.message:
+            messages.append({
+                "role": "user",
+                "content": self._render_template(self.typed_config.message, variable_pool)
+            })
+
+        for message in self.typed_config.messages:
+            messages.append({
+                "role": message.role,
+                "content": self._render_template(message.content, variable_pool)
+            })
 
         write_message_task.delay(
             end_user_id,
-            self._render_template(self.typed_config.message, variable_pool),
+            messages,
             str(self.typed_config.config_id),
             "neo4j",
             ""

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -981,7 +981,7 @@ def read_message_task(self, end_user_id: str, message: str, history: List[Dict[s
 
 
 @celery_app.task(name="app.core.memory.agent.write_message", bind=True)
-def write_message_task(self, end_user_id: str, message: str, config_id: str, storage_type: str, user_rag_memory_id: str,
+def write_message_task(self, end_user_id: str, message: list[dict], config_id: str, storage_type: str, user_rag_memory_id: str,
                        language: str = "zh") -> Dict[str, Any]:
     """Celery task to process a write message via MemoryAgentService.
 


### PR DESCRIPTION
## Summary by Sourcery

支持在 memory 工作流节点中写入带有角色的多条模板消息，而不是单一的纯文本字符串消息。

新特性：
- 引入 `MessageConfig` 模型，用于为 memory 写入节点配置包含角色和模板化内容的单条消息。
- 允许 `MemoryWriteNode` 向 memory 写入的 Celery 任务发送消息列表，而不是单一的字符串消息。

改进：
- 在 memory 节点配置中，根据允许的角色集合校验消息角色，并将其规范化为小写。
- 更新 memory 写入 Celery 任务的函数签名，以接收结构化的消息列表用于后续处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support writing multiple templated messages with roles to the memory workflow node instead of a single plain string message.

New Features:
- Introduce a MessageConfig model to configure individual messages with role and templated content for memory write nodes.
- Allow MemoryWriteNode to send a list of messages to the memory write Celery task instead of a single message string.

Enhancements:
- Validate message roles against an allowed set and normalize them to lowercase in memory node configuration.
- Update the memory write Celery task signature to accept structured message lists for downstream processing.

</details>