### PR TITLE
feat(web): memory-write add messages config

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2105,7 +2105,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
           search_switch: 'Search Mode',
         },
         'memory-write': {
-          message: 'Message',
+          messages: 'Message',
           config_id: 'Memory Configuration',
           search_switch: 'Search Mode',
         },

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2200,7 +2200,7 @@ export const zh = {
           search_switch: '检索模式',
         },
         'memory-write': {
-          message: '消息',
+          messages: '消息',
           config_id: '记忆配置',
           search_switch: '检索模式',
         },

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:39:59 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-05 14:21:45
+ * @Last Modified time: 2026-02-09 19:56:42
  */
 import { type FC, useEffect, useState, useMemo } from "react";
 import clsx from 'clsx'
@@ -491,7 +491,7 @@ const Properties: FC<PropertiesProps> = ({
 
               if (config.type === 'messageEditor') {
                 return (
-                  <Form.Item key={key} name={key}>
+                  <Form.Item key={key} name={key} label={selectedNode?.data?.type === 'memory-write' ? t(`workflow.config.${selectedNode?.data?.type}.${key}`) : undefined }>
                     <MessageEditor 
                       title={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
                       isArray={!!config.isArray} 

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:06:18 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-05 14:15:13
+ * @Last Modified time: 2026-02-09 20:08:03
  */
 import LoopNode from './components/Nodes/LoopNode';
 import NormalNode from './components/Nodes/NormalNode';
@@ -241,6 +241,12 @@ export const nodeLibrary: NodeLibrary[] = [
           message: {
             type: 'editor',
             isArray: false
+          },
+          messages: {
+            type: 'messageEditor',
+            defaultValue: [],
+            placeholder: 'workflow.config.llm.messagesPlaceholder',
+            isArray: true
           },
           config_id: {
             type: 'customSelect',

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 15:17:48 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 20:05:04
  */
 import { useRef, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -135,7 +135,10 @@ export const useWorkflowGraph = ({
 
         if (nodeLibraryConfig?.config) {
           Object.keys(nodeLibraryConfig.config).forEach(key => {
-            if (key === 'memory' && nodeLibraryConfig.config && nodeLibraryConfig.config[key]) {
+            if (type === 'memory-write' && key === 'message' && nodeLibraryConfig.config) {
+              nodeLibraryConfig.config['messages'].defaultValue = [{ role: 'USER', content: config[key] }]
+              delete nodeLibraryConfig.config[key]
+            } else if (key === 'memory' && nodeLibraryConfig.config && nodeLibraryConfig.config[key]) {
               const { memory, messages } = config as any;
               if (memory?.enable && messages && messages.length > 0) {
                 const lastMessage = messages[messages.length - 1]


### PR DESCRIPTION
## Summary by Sourcery

为 memory-write 工作流节点添加可配置的多消息支持，并更新相关的 UI 标签和初始化行为。

新功能：
- 为 memory-write 工作流节点引入一个 `messages` 配置字段，使用支持多条消息的消息编辑器。

改进：
- 调整工作流图初始化逻辑，将现有的单条消息配置迁移到 memory-write 节点的新 `messages` 数组中。
- 更新表单渲染逻辑，基于 i18n 键为 memory-write 消息编辑器字段提供合适的标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable multi-message support to the memory-write workflow node and update related UI labels and initialization behavior.

New Features:
- Introduce a messages configuration field for the memory-write workflow node using a message editor supporting multiple messages.

Enhancements:
- Adjust workflow graph initialization to migrate existing single message configuration into the new messages array for memory-write nodes.
- Update form rendering to provide appropriate labels for memory-write message editor fields based on i18n keys.

</details>