### PR TITLE
fix(web): update request headers key

### DIFF
--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 16:37:49
+ * @Last Modified time: 2026-02-09 20:20:01
  */
 /**
  * Conversation Page
@@ -358,7 +358,7 @@ const Conversation: FC = () => {
                               requestConfig={{
                                 headers: {
                                   'Content-Type': 'multipart/form-data',
-                                  authorization: `Bearer ${shareToken || ''}`,
+                                  Authorization: `Bearer ${shareToken || ''}`,
                               } }}
                             />
                           )


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在 Conversation 文件中，将用于 Bearer Token 的请求头键名从 `authorization` 修改为 `Authorization`，以修复请求头键名不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect request header key by changing `authorization` to `Authorization` for bearer token usage in the Conversation file.

</details>