### PR TITLE
feat(web): extraction  engine add ontology

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1588,6 +1588,11 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       creating_nodes_edges_desc: 'Entity relationship creation completed, {{num}} relationships in total',
       deduplication_desc: 'Deduplication and disambiguation completed, {{count}} unique entities in total',
       custom_text: 'Debug Text',
+      ontologyCoverage: 'Ontology Type',
+      entity_total: 'Total {{num}} entities',
+      scene_type_distribution: 'Scene Type Distribution',
+      general_type_distribution: 'General Type Distribution',
+      unmatched: 'Unmatched',
     },
     memoryConversation: {
       searchPlaceholder: 'Enter user ID...',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1668,6 +1668,11 @@ export const zh = {
       creating_nodes_edges_desc: '实体关系创建完成，共{{num}}条关系',
       deduplication_desc: '去重消歧完成，最终{{count}}个唯一实体',
       custom_text: '调试文本',
+      ontologyCoverage: '本体类型',
+      entity_total: '一共{{num}}个实体',
+      scene_type_distribution: '场景类型',
+      general_type_distribution: '通用类型',
+      unmatched: '未匹配',
     },
     memoryConversation: {
       chatEmpty:'有什么我可以帮您的吗？',

--- a/web/src/views/MemoryExtractionEngine/components/Result.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/Result.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:30:11 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-04 10:08:49
+ * @Last Modified time: 2026-02-09 21:04:14
  */
 /**
  * Result Component
@@ -21,7 +21,7 @@ import type { AnyObject } from 'antd/es/_util/type';
 import Card from './Card'
 import RbCard from '@/components/RbCard/Card'
 import RbAlert from '@/components/RbAlert'
-import type { TestResult } from '../types'
+import type { TestResult, OntologyCoverage } from '../types'
 import { pilotRunMemoryExtractionConfig } from '@/api/memory'
 import { type SSEMessage } from '@/utils/stream'
 import Tag, { type TagProps } from '@/components/Tag'
@@ -78,6 +78,7 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
   const [knowledgeExtraction, setKnowledgeExtraction] = useState<ModuleItem>(initObj as ModuleItem)
   const [creatingNodesEdges, setCreatingNodesEdges] = useState<ModuleItem>(initObj as ModuleItem)
   const [deduplication, setDeduplication] = useState<ModuleItem>(initObj as ModuleItem)
+  const [ontologyCoverage, setOntologyCoverage] = useState<OntologyCoverage>({} as OntologyCoverage)
 
   const [runForm] = Form.useForm()
 
@@ -181,6 +182,7 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
             break
           case 'result': // Result
             setTestResult(data.data?.extracted_result)
+            setOntologyCoverage(data.data?.ontology_coverage)
             break
         }
       })
@@ -284,8 +286,8 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
             headerType="borderL"
             headerClassName="rb:before:bg-[#155EEF]!"
           >
-            {knowledgeExtraction.data.map(vo => 
-              <div key={vo.statement_index} className="rb:mb-3 rb:text-[12px] rb:text-[#5B6167] rb:leading-4 rb:font-regular">{vo.statement}</div>
+            {knowledgeExtraction.data.map((vo, index) => 
+              <div key={index} className="rb:mb-3 rb:text-[12px] rb:text-[#5B6167] rb:leading-4 rb:font-regular">{vo.statement}</div>
             )}
             {formatTime(knowledgeExtraction)}
             {knowledgeExtraction.result && <RbAlert color="blue" icon={<CheckCircleFilled />} className="rb:mt-3">
@@ -450,6 +452,36 @@ const Result: FC<ResultProps> = ({ loading, handleSave }) => {
               </RbAlert>
             </RbCard>
           }
+          {ontologyCoverage && Object.keys(ontologyCoverage).length > 0 &&
+            <RbCard
+              title={<>{t('memoryExtractionEngine.ontologyCoverage')}({ontologyCoverage.total_entities})</>}
+              headerType="borderL"
+              headerClassName="rb:before:bg-[#369F21]!"
+            >
+              <div className="rb:grid rb:grid-cols-2 rb:gap-3">
+                {(['scene_type_distribution', 'general_type_distribution', 'unmatched'] as const).map((key, idx) => {
+                  if (!ontologyCoverage[key]) return null
+                  return (
+                    <div key={idx} className="rb:text-[12px]">
+                      <div className="rb:text-[#369F21] rb:font-medium">{t(`memoryExtractionEngine.${key}`)}({ontologyCoverage[key].type_count})</div>
+                      <div>{t('memoryExtractionEngine.entity_total', { num: ontologyCoverage[key].entity_total })}</div>
+                      <div>
+                        {ontologyCoverage[key].types.map((type, index) => {
+                          if (!type.type || type.type === '') return null
+                          return (
+                            <div key={index} className="rb:text-[#5B6167] rb:font-regular rb:leading-4">
+                              -{type.type}({type.count})
+                            </div>
+                          )
+                        })}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </RbCard>
+          }
+
         </Space>
       </div>
 

--- a/web/src/views/MemoryExtractionEngine/types.ts
+++ b/web/src/views/MemoryExtractionEngine/types.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:29:55 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 17:29:55 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-09 20:56:31
  */
 /**
  * Memory Extraction Engine Configuration Form Types
@@ -106,4 +106,17 @@ export interface TestResult {
     predicate: string;
     object: string;
   }[];
+}
+
+interface OntologyCoverageItem {
+  type_count: number;
+  entity_total: number;
+  types: Array<{ type: string; count: number; }>
+}
+export interface OntologyCoverage {
+  scene_type_distribution: OntologyCoverageItem;
+  general_type_distribution: OntologyCoverageItem;
+  unmatched: OntologyCoverageItem;
+  total_entities: number;
+  time: number;
 }


### PR DESCRIPTION
## Summary by Sourcery

在内存抽取引擎（Memory Extraction Engine）的结果视图中添加本体覆盖率统计显示。

新功能：
- 在抽取结果面板中显示本体覆盖率摘要，包括实体总数和类型分布。

改进：
- 调整知识抽取列表的渲染方式，使用稳定的基于索引的键，而非基于语句索引的键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add ontology coverage statistics display to the Memory Extraction Engine results view.

New Features:
- Display ontology coverage summary, including total entities and type distributions, in the extraction result panel.

Enhancements:
- Adjust knowledge extraction list rendering to use stable index-based keys instead of statement indices.

</details>