### PR TITLE
fix(web): emotion add default value

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2451,6 +2451,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       involved_objects: 'Involved Objects',
       content_records: 'Episode Content Records',
       emotion: 'Emotion and State Records',
+      none: 'None',
     },
     implicitDetail: {
       title: 'The invisible forces that shaped me',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2546,6 +2546,7 @@ export const zh = {
       involved_objects: '涉及对象',
       content_records: '情景内容记录',
       emotion: '情绪与状态记录',
+      none: '无',
     },
     implicitDetail: {
       title: '那些塑造了我的无形力量',

--- a/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
@@ -242,7 +242,7 @@ const EpisodicDetail: FC = () => {
                       {detail.content_records.map((vo, index) => <div key={index} className="rb:text-[#5B6167] rb:leading-5">- {vo}</div>)}
                     </div>
                     <RbAlert>
-                      {t('episodicDetail.emotion')}: {t(`statementDetail.${detail.emotion}`)}
+                      {t('episodicDetail.emotion')}: {t(`episodicDetail.${detail.emotion || 'none'}`)}
                     </RbAlert>
                   </Space>
                 )


### PR DESCRIPTION
## Summary by Sourcery

在情节详情视图中处理缺失的情绪值，并添加相应的国际化（i18n）标签。

Bug 修复：
- 通过回退到默认值，防止未定义的情绪键在翻译查找时导致错误。

文档：
- 在情节详情的翻译中，为默认/无情绪状态新增英文和中文标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing emotion values in episodic detail view and add corresponding i18n labels.

Bug Fixes:
- Prevent undefined emotion keys from breaking translation lookup by falling back to a default value.

Documentation:
- Add English and Chinese labels for the default/none emotion state in episodic detail translations.

</details>