### PR TITLE
fix(web): FileUpload bugfix

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:39 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-10 12:18:23
+ * @Last Modified time: 2026-02-10 17:40:15
  */
 /**
  * Chat debugging component for application testing
@@ -366,10 +366,8 @@ const Chat: FC<ChatProps> = ({ chatList, data, updateChatList, handleSave, sourc
   const handleMessageChange = (message: string) => {
     setMessage(message)
   }
-  const [update, setUpdate] = useState(false)
   const fileChange = (file?: any) => {
     setFileList([...fileList, file])
-    setUpdate(prev => !prev)
   }
   // const handleRecordingComplete = async (file: any) => {
   //   console.log('file', file)
@@ -456,29 +454,27 @@ const Chat: FC<ChatProps> = ({ chatList, data, updateChatList, handleSave, sourc
             onChange={handleMessageChange}
           >
             <Flex justify="space-between" className="rb:flex-1">
-                <Flex gap={8} align="center">
-                  <Dropdown
-                    menu={{
-                      items: [
-                        { key: 'define', label: t('memoryConversation.addRemoteFile') },
-                        {
-                          key: 'upload', label: (
-                            <UploadFiles
-                              fileType={['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg']}
-                              onChange={fileChange}
-                              fileList={[]}
-                              update={update}
-                            />
-                          )
-                        },
-                      ],
-                      onClick: handleShowUpload
-                    }}
-                  >
-                    <div
-                      className="rb:size-6 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/link.svg')] rb:hover:bg-[url('@/assets/images/conversation/link_hover.svg')]"
-                    ></div>
-                  </Dropdown>
+              <Flex gap={8} align="center">
+                <Dropdown
+                  menu={{
+                    items: [
+                      { key: 'define', label: t('memoryConversation.addRemoteFile') },
+                      {
+                        key: 'upload', label: (
+                          <UploadFiles
+                            fileType={['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg']}
+                            onChange={fileChange}
+                          />
+                        )
+                      },
+                    ],
+                    onClick: handleShowUpload
+                  }}
+                >
+                  <div
+                    className="rb:size-6 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/link.svg')] rb:hover:bg-[url('@/assets/images/conversation/link_hover.svg')]"
+                  ></div>
+                </Dropdown>
               </Flex>
               {/* <Flex align="center">
                 <AudioRecorder onRecordingComplete={handleRecordingComplete} />

--- a/web/src/views/Conversation/components/FileUpload.tsx
+++ b/web/src/views/Conversation/components/FileUpload.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:09:42 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 16:41:31
+ * @Last Modified time: 2026-02-10 17:40:08
  */
 /**
  * File Upload Component
@@ -55,8 +55,6 @@ interface UploadFilesProps extends Omit<UploadProps, 'onChange'> {
   maxCount?: number;
   /** Custom file removal callback */
   onRemove?: (file: UploadFile) => boolean | void | Promise<boolean | void>;
-  /** Trigger to reset file list */
-  update?: boolean;
 }
 // Mapping of file extensions to MIME types
 const ALL_FILE_TYPE: {
@@ -109,7 +107,6 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
   isAutoUpload = true,
   maxCount = 1,
   onRemove: customOnRemove,
-  update,
   requestConfig,
   ...props
 }, ref) => {
@@ -117,11 +114,6 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
   const { message } = App.useApp()
   const [fileList, setFileList] = useState<UploadFile[]>(propFileList);
   const [accept, setAccept] = useState<string | undefined>();
-
-  // Reset file list when update prop changes
-  useEffect(() => {
-    setFileList([])
-  }, [update])
 
   /**
    * Validates file type and size before upload
@@ -185,9 +177,7 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
   /**
    * Handles upload state changes
    */
-  const handleChange: UploadProps['onChange'] = ({ fileList: newFileList, event }) => {
-    console.log('event', event)
-    setFileList(newFileList);
+  const handleChange: UploadProps['onChange'] = ({ fileList: newFileList }) => {
     if (onChange) {
       onChange(maxCount === 1 ? newFileList[0] : newFileList);
     }

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 20:20:01
+ * @Last Modified time: 2026-02-10 17:41:05
  */
 /**
  * Conversation Page
@@ -254,10 +254,8 @@ const Conversation: FC = () => {
       })
   }
 
-  const [update, setUpdate] = useState(false)
   const fileChange = (file?: any) => {
     form.setFieldValue('files', [...(queryValues.files || []), file])
-    setUpdate(prev => !prev)
   }
   // const handleRecordingComplete = async (file: any) => {
   //   console.log('file', file)
@@ -353,8 +351,6 @@ const Conversation: FC = () => {
                               action={shareFileUploadUrlWithoutApiPrefix}
                               fileType={['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg']}
                               onChange={fileChange}
-                              fileList={[]}
-                              update={update}
                               requestConfig={{
                                 headers: {
                                   'Content-Type': 'multipart/form-data',

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:10:56 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-10 12:17:41
+ * @Last Modified time: 2026-02-10 17:41:24
  */
 /**
  * Workflow Chat Component
@@ -343,13 +343,11 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
   const handleMessageChange = (message: string) => {
     setMessage(message)
   }
-  const [update, setUpdate] = useState(false)
   /**
    * Handles file upload from local device
    */
   const fileChange = (file?: any) => {
     setFileList([...fileList, file])
-    setUpdate(prev => !prev)
   }
   // const handleRecordingComplete = async (file: any) => {
   //   console.log('file', file)
@@ -517,8 +515,6 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
                         <UploadFiles
                           fileType={['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg']}
                           onChange={fileChange}
-                          fileList={[]}
-                          update={update}
                         />
                       )
                     },


### PR DESCRIPTION
## Summary by Sourcery

通过在共享的 FileUpload 组件中依赖内部状态管理，并移除未使用的更新开关，简化并稳定聊天和会话组件中的文件上传行为。

Bug Fixes:
- 通过从 FileUpload 组件中移除外部的 update 属性及其相关的 effect，防止在上传过程中出现意外的文件列表重置。

Enhancements:
- 清理 FileUpload 及其使用方，移除未使用的 props 和控制台日志输出，依赖组件自身管理的文件列表，而不是由父组件强制重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify and stabilize file upload behavior across chat and conversation components by removing unused update toggles and relying on internal state management in the shared FileUpload component.

Bug Fixes:
- Prevent unintended file list resets during uploads by removing the external update prop and its associated effect from the FileUpload component.

Enhancements:
- Clean up FileUpload and its consumers by removing unused props and console logging, relying on the component's own managed file list instead of forcing resets from parents.

</details>