### PR TITLE
fix(token)

### DIFF
--- a/api/app/controllers/auth_controller.py
+++ b/api/app/controllers/auth_controller.py
@@ -61,6 +61,7 @@ async def login_for_access_token(
                 user = auth_service.register_user_with_invite(
                 db=db,
                 email=form_data.email,
+                username=form_data.username,
                 password=form_data.password,
                 invite_token=form_data.invite,
                 workspace_id=invite_info.workspace_id

--- a/api/app/schemas/token_schema.py
+++ b/api/app/schemas/token_schema.py
@@ -26,5 +26,6 @@ class RefreshTokenRequest(BaseModel):
 class TokenRequest(BaseModel):
     email: EmailStr
     password: str
-    invite: Optional[str] = None
+    invite: Optional[str] = None,
+    username: Optional[str] = None
 

--- a/api/app/services/auth_service.py
+++ b/api/app/services/auth_service.py
@@ -129,7 +129,8 @@ def register_user_with_invite(
     email: str,
     password: str,
     invite_token: str,
-    workspace_id: str
+    workspace_id: str,
+    username: Optional[str] = None,
 ) -> User:
     """
     使用邀请码注册新用户并加入工作空间
@@ -139,6 +140,7 @@ def register_user_with_invite(
     :param password: 用户密码
     :param invite_token: 邀请令牌
     :param workspace_id: 工作空间ID
+    :param username: 用户名
     :return: 创建的用户对象
     """
     from app.schemas.user_schema import UserCreate
@@ -154,7 +156,7 @@ def register_user_with_invite(
         user_create = UserCreate(
             email=email,
             password=password,
-            username=email.split('@')[0]
+            username=email.split('@')[0] if not username else username
         )
         user = user_service.create_user(db=db, user=user_create)
         logger.info(f"用户创建成功: {user.email} (ID: {user.id})")


### PR DESCRIPTION
If the "username" is provided, then use "username" as the username.

## Summary by Sourcery

允许基于邀请的注册接受一个可选的用户名，而不是总是从邮箱前缀派生用户名。

New Features:
- 支持在使用邀请请求令牌时提供一个可选的用户名，而不是始终使用从邮箱派生的用户名。

Enhancements:
- 将可选用户名从令牌请求通过认证控制器传递到基于邀请的用户注册流程中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow invite-based registration to accept an optional username instead of always deriving it from the email prefix.

New Features:
- Support providing an optional username when requesting a token with an invite, rather than always using the email-derived username.

Enhancements:
- Propagate the optional username from the token request through the auth controller into invite-based user registration.

</details>