### PR TITLE
fix(workspace member)

### DIFF
--- a/api/app/repositories/workspace_repository.py
+++ b/api/app/repositories/workspace_repository.py
@@ -115,6 +115,7 @@ class WorkspaceRepository:
                 self.db.query(Workspace)
                 .join(WorkspaceMember, Workspace.id == WorkspaceMember.workspace_id)
                 .filter(WorkspaceMember.user_id == user_id)
+                .filter(WorkspaceMember.is_active.is_(True))
                 .filter(Workspace.is_active.is_(True))
                 .order_by(Workspace.updated_at.desc())
                 .all()

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -70,10 +70,10 @@ def  delete_workspace_member(
         _check_workspace_admin_permission(db, workspace_id, user)
         workspace_member = workspace_repository.get_member_by_id(db=db, member_id=member_id)
         if not workspace_member:
-                raise BusinessException(f"工作空间成员 {member_id} 不存在", BizCode.WORKSPACE_MEMBER_NOT_FOUND)
+                raise BusinessException(f"工作空间成员 {member_id} 不存在", BizCode.WORKSPACE_NOT_FOUND)
 
         if workspace_member.workspace_id != workspace_id:
-                raise BusinessException(f"工作空间成员 {member_id} 不存在于工作空间 {workspace_id}", BizCode.WORKSPACE_MEMBER_NOT_FOUND)
+                raise BusinessException(f"工作空间成员 {member_id} 不存在于工作空间 {workspace_id}", BizCode.WORKSPACE_NOT_FOUND)
 
         try:
             workspace_member.is_active = False


### PR DESCRIPTION
After the space inviter is removed, it can still be invited again.

## Summary by Sourcery

确保在成员处于非活跃状态或不存在时，工作区成员删除和工作区检索行为正确。

Bug 修复：
- 当尝试删除不存在或未关联的工作区成员时，返回“未找到工作区”错误。
- 在为用户列出工作区时，排除非活跃的工作区成员关系。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure workspace member deletion and workspace retrieval behave correctly for inactive or missing members.

Bug Fixes:
- Return a workspace not found error when attempting to delete a non-existent or non-associated workspace member.
- Exclude inactive workspace memberships when listing workspaces for a user.

</details>