### PR TITLE
fix(workspace member)

### DIFF
--- a/api/app/repositories/workspace_repository.py
+++ b/api/app/repositories/workspace_repository.py
@@ -115,6 +115,7 @@ class WorkspaceRepository:
                 self.db.query(Workspace)
                 .join(WorkspaceMember, Workspace.id == WorkspaceMember.workspace_id)
                 .filter(WorkspaceMember.user_id == user_id)
+                .filter(WorkspaceMember.is_active.is_(True))
                 .filter(Workspace.is_active.is_(True))
                 .order_by(Workspace.updated_at.desc())
                 .all()

--- a/api/app/schemas/token_schema.py
+++ b/api/app/schemas/token_schema.py
@@ -26,6 +26,6 @@ class RefreshTokenRequest(BaseModel):
 class TokenRequest(BaseModel):
     email: EmailStr
     password: str
-    invite: Optional[str] = None,
+    invite: Optional[str] = None
     username: Optional[str] = None
 

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -70,10 +70,10 @@ def  delete_workspace_member(
         _check_workspace_admin_permission(db, workspace_id, user)
         workspace_member = workspace_repository.get_member_by_id(db=db, member_id=member_id)
         if not workspace_member:
-                raise BusinessException(f"工作空间成员 {member_id} 不存在", BizCode.WORKSPACE_MEMBER_NOT_FOUND)
+                raise BusinessException(f"工作空间成员 {member_id} 不存在", BizCode.WORKSPACE_NOT_FOUND)
 
         if workspace_member.workspace_id != workspace_id:
-                raise BusinessException(f"工作空间成员 {member_id} 不存在于工作空间 {workspace_id}", BizCode.WORKSPACE_MEMBER_NOT_FOUND)
+                raise BusinessException(f"工作空间成员 {member_id} 不存在于工作空间 {workspace_id}", BizCode.WORKSPACE_NOT_FOUND)
 
         try:
             workspace_member.is_active = False


### PR DESCRIPTION
After the space inviter is removed, it can still be invited again.

## Summary by Sourcery

调整工作区成员删除行为和工作区获取逻辑，以尊重成员的激活状态。

Bug 修复：
- 当工作区成员不存在或不属于该工作区时，返回“未找到工作区”的错误码。
- 在为用户列出工作区时排除非激活的工作区成员关系，防止已被移除的成员被重新以激活状态邀请。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust workspace member deletion behavior and workspace retrieval to respect active status.

Bug Fixes:
- Return a workspace not found error code when a workspace member does not exist or does not belong to the workspace.
- Exclude inactive workspace memberships when listing workspaces for a user so removed members cannot be reinvited as active.

</details>