### PR TITLE
fix(web): change model list provider logo

### DIFF
--- a/web/src/views/ModelManagement/List.tsx
+++ b/web/src/views/ModelManagement/List.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:10 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 16:50:10 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-27 10:20:51
  */
 /**
  * Model List View
@@ -21,7 +21,7 @@ import PageEmpty from '@/components/Empty/PageEmpty';
 import Tag from '@/components/Tag';
 import KeyConfigModal from './components/KeyConfigModal'
 import ModelListDetail from './components/ModelListDetail'
-import { getLogoUrl } from './utils'
+import { getListLogoUrl } from './utils'
 
 /**
  * Model list component
@@ -70,7 +70,7 @@ const ModelList = forwardRef<BaseRef, { query: any; handleEdit: (vo?: ModelListI
               <RbCard
                 key={item.provider}
                 title={t(`modelNew.${item.provider}`)}
-                avatarUrl={getLogoUrl(item.logo)}
+                avatarUrl={getListLogoUrl(item.provider, item.logo)}
                 avatar={
                   <div className="rb:w-12 rb:h-12 rb:rounded-lg rb:mr-3.25 rb:bg-[#155eef] rb:flex rb:items-center rb:justify-center rb:text-[28px] rb:text-[#ffffff]">
                     {item.provider[0].toUpperCase()}

--- a/web/src/views/ModelManagement/utils.ts
+++ b/web/src/views/ModelManagement/utils.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:22 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 16:50:22 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-02-27 10:22:46
  */
 /**
  * Utility functions for Model Management
@@ -33,6 +33,27 @@ export const ICONS = {
  * @returns Logo URL or undefined
  */
 export const getLogoUrl = (logo?: string) => {
+  if (!logo) {
+    return undefined
+  }
+  if (logo.startsWith('http')) {
+    return logo
+  }
+
+  return ICONS[logo as keyof typeof ICONS] || undefined
+}
+
+/**
+ * Get logo URL from provider name or URL
+ * @param provider - Provider name
+ * @param logo - Provider name or logo URL
+ * @returns Logo URL or undefined
+ */
+export const getListLogoUrl = (provider?: string, logo?: string) => {
+  let url = ICONS[provider as keyof typeof ICONS]
+
+  if (url) return url
+
   if (!logo) {
     return undefined
   }


### PR DESCRIPTION
## Summary by Sourcery

更新模型列表，以优先使用基于提供方的徽标，并更好地处理徽标 URL。

错误修复：
- 确保模型列表头像在回退到徽标 URL 之前，能够正确解析提供方徽标。

功能增强：
- 新增专用工具函数，用于根据提供方名称或徽标 URL 解析列表项徽标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update model list to prefer provider-based logos and better handle logo URLs.

Bug Fixes:
- Ensure model list avatars correctly resolve provider logos before falling back to logo URLs.

Enhancements:
- Add a dedicated utility for resolving list item logos from provider names or logo URLs.

</details>