### PR TITLE
fix(workflow): enhance Dify import types, templates and tool nodes

### DIFF
--- a/api/app/core/workflow/adapters/base_adapter.py
+++ b/api/app/core/workflow/adapters/base_adapter.py
@@ -68,6 +68,8 @@ class BasePlatformAdapter(ABC):
         self.branch_node_cache = defaultdict(list)
         self.error_branch_node_cache = []
 
+        self.node_output_map = {}
+
     @abstractmethod
     def get_metadata(self) -> PlatformMetadata:
         """get platform metadata"""

--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -44,6 +44,7 @@ class DifyConverter(BaseConverter):
     warnings: list
     branch_node_cache: dict
     error_branch_node_cache: list
+    node_output_map: dict
 
     def __init__(self):
         self.CONFIG_CONVERT_MAP = {
@@ -60,7 +61,8 @@ class DifyConverter(BaseConverter):
             "knowledge-retrieval": self.convert_knowledge_node_config,
             "parameter-extractor": self.convert_parameter_extractor_node_config,
             "question-classifier": self.convert_question_classifier_node_config,
-            "variable-aggregator": self.convert_variable_aggregator,
+            "variable-aggregator": self.convert_variable_aggregator_node_config,
+            "tool": self.convert_tool_node_config,
             "loop-start": lambda x: {},
             "iteration-start": lambda x: {},
             "loop-end": lambda x: {},
@@ -74,8 +76,7 @@ class DifyConverter(BaseConverter):
     def is_variable(expression) -> bool:
         return bool(re.match(r"\{\{#(.*?)#}}", expression))
 
-    @staticmethod
-    def process_var_selector(var_selector):
+    def process_var_selector(self, var_selector):
         if not var_selector:
             return ""
         selector = var_selector.split('.')
@@ -86,7 +87,7 @@ class DifyConverter(BaseConverter):
         var_selector = ".".join(selector)
         mapping = {
             "sys.query": "sys.message"
-        }
+        } | self.node_output_map
 
         var_selector = mapping.get(var_selector, var_selector)
         return var_selector
@@ -124,6 +125,8 @@ class DifyConverter(BaseConverter):
             "checkbox": VariableType.BOOLEAN,
             "file-list": VariableType.ARRAY_FILE,
             "select": VariableType.STRING,
+            "integer": VariableType.NUMBER,
+            "float": VariableType.NUMBER,
         }
         var_type = type_map.get(source_type, source_type)
         return var_type
@@ -160,6 +163,8 @@ class DifyConverter(BaseConverter):
             "≥": ComparisonOperator.GE,
             "≤": ComparisonOperator.LE,
             "not empty": ComparisonOperator.NOT_EMPTY,
+            "start with": ComparisonOperator.START_WITH,
+            "end with": ComparisonOperator.END_WITH,
         }
         return operator_map.get(operator, operator)
 
@@ -633,7 +638,7 @@ class DifyConverter(BaseConverter):
             prompt=node_data["instruction"]
         ).model_dump()
 
-    def convert_variable_aggregator(self, node: dict) -> dict:
+    def convert_variable_aggregator_node_config(self, node: dict) -> dict:
         node_data = node["data"]
         group_enable = node_data["advanced_settings"]["group_enabled"]
         group_variables = {}
@@ -657,3 +662,13 @@ class DifyConverter(BaseConverter):
             group_variables=group_variables,
             group_type=group_type,
         ).model_dump()
+
+    def convert_tool_node_config(self, node: dict) -> dict:
+        node_data = node["data"]
+        self.warnings.append(ExceptionDefineition(
+            node_id=node["id"],
+            node_name=node_data["title"],
+            type=ExceptionType.CONFIG,
+            detail=f"Please reconfigure the tool node.",
+        ))
+        return {}

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -43,7 +43,8 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         "knowledge-retrieval": NodeType.KNOWLEDGE_RETRIEVAL,
         "parameter-extractor": NodeType.PARAMETER_EXTRACTOR,
         "question-classifier": NodeType.QUESTION_CLASSIFIER,
-        "variable-aggregator": NodeType.VAR_AGGREGATOR
+        "variable-aggregator": NodeType.VAR_AGGREGATOR,
+        "tool": NodeType.TOOL
     }
 
     def __init__(self, config: dict[str, Any]):
@@ -89,6 +90,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         return True
 
     def parse_workflow(self) -> WorkflowParserResult:
+        self._init_node_output_map()
         for node in self.origin_nodes:
             node = self._convert_node(node)
             if node:
@@ -127,6 +129,11 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             warnings=self.warnings,
             errors=self.errors
         )
+
+    def _init_node_output_map(self):
+        for node in self.origin_nodes:
+            if self.map_node_type(node["data"]["type"]) == NodeType.LLM:
+                self.node_output_map[f"{node['id']}.text"] = f"{node['id']}.output"
 
     def _convert_cycle_node_position(self, node_id: str, position: dict):
         for node in self.origin_nodes:
@@ -214,6 +221,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
                 type=ExceptionType.EDGE,
                 detail=f"convert edge error - {e}",
             ))
+            logger.debug(f"convert edge error - {e}", exc_info=True)
             return None
 
     def _convert_variable(self, variable) -> VariableDefinition | None:
@@ -221,7 +229,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             return VariableDefinition(
                 name=variable["name"],
                 default=variable["value"],
-                type=variable["value_type"],
+                type=self.variable_type_map(variable["value_type"]),
             )
         except Exception as e:
             self.errors.append(ExceptionDefineition(

--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -175,7 +175,7 @@ class WorkflowExecutor:
             elapsed_time = (end_time - start_time).total_seconds()
 
             logger.info(
-                f"Workflow execution completed: execution_id={self.execution_context.execution_id}, elapsed_time={elapsed_time:.2f}s")
+                f"Workflow execution completed: execution_id={self.execution_context.execution_id}, elapsed_time={elapsed_time:.2f}ms")
 
             return self.result_builder.build_final_output(result, self.variable_pool, elapsed_time, full_content)
 
@@ -322,7 +322,7 @@ class WorkflowExecutor:
             )
             logger.info(
                 f"Workflow execution completed (streaming), "
-                f"elapsed: {elapsed_time:.2f}s, execution_id: {self.execution_context.execution_id}"
+                f"elapsed: {elapsed_time:.2f}ms, execution_id: {self.execution_context.execution_id}"
             )
 
             yield {

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -196,7 +196,7 @@ class BaseNode(ABC):
                 timeout=timeout
             )
 
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
 
             # Extract processed outputs using subclass-defined logic.
             extracted_output = self._extract_output(business_result)
@@ -219,7 +219,7 @@ class BaseNode(ABC):
             } | self.trans_activate(state)
 
         except TimeoutError:
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
             logger.error(
                 f"Node {self.node_id} execution timed out ({timeout} seconds)."
             )
@@ -230,7 +230,7 @@ class BaseNode(ABC):
                 variable_pool,
             )
         except Exception as e:
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
             logger.error(
                 f"Node {self.node_id} execution failed: {e}",
                 exc_info=True,
@@ -307,10 +307,10 @@ class BaseNode(ABC):
                         "done": done
                     })
 
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
 
             logger.info(f"Node {self.node_id} streaming execution finished, "
-                        f"time elapsed: {elapsed_time:.2f}s, chunks: {chunk_count}")
+                        f"time elapsed: {elapsed_time:.2f}ms, chunks: {chunk_count}")
 
             # Extract processed output (call subclass's _extract_output)
             extracted_output = self._extract_output(final_result)
@@ -337,7 +337,7 @@ class BaseNode(ABC):
             yield state_update | self.trans_activate(state)
 
         except TimeoutError:
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
             logger.error(f"Node {self.node_id} execution timed out ({timeout}s)")
             error_output = self._wrap_error(
                 f"Node execution timed out ({timeout}s)",
@@ -347,7 +347,7 @@ class BaseNode(ABC):
             )
             yield error_output
         except Exception as e:
-            elapsed_time = time.time() - start_time
+            elapsed_time = (time.time() - start_time) * 1000
             logger.error(f"Node {self.node_id} execution failed: {e}", exc_info=True)
             error_output = self._wrap_error(str(e), elapsed_time, state, variable_pool)
             yield error_output

--- a/api/app/core/workflow/utils/expression_evaluator.py
+++ b/api/app/core/workflow/utils/expression_evaluator.py
@@ -12,9 +12,20 @@ class ExpressionEvaluator:
     
     # Reserved namespaces
     RESERVED_NAMESPACES = {"var", "node", "sys", "nodes"}
-    
-    @staticmethod
+
+    @classmethod
+    def normalize_template(cls, template: str) -> str:
+        pattern = re.compile(
+            r"\{\{\s*(\d+)\.(\w+)\s*}}"
+        )
+        return pattern.sub(
+            r'{{ node["\1"].\2 }}',
+            template
+        )
+
+    @classmethod
     def evaluate(
+        cls,
         expression: str,
         conv_vars: dict[str, Any],
         node_outputs: dict[str, Any],
@@ -37,6 +48,7 @@ class ExpressionEvaluator:
         """
         # Remove Jinja2-style brackets if present
         expression = expression.strip()
+        expression = cls.normalize_template(expression)
         pattern = r"\{\{\s*(.*?)\s*\}\}"
         expression = re.sub(pattern, r"\1", expression).strip()
 

--- a/api/app/core/workflow/utils/template_renderer.py
+++ b/api/app/core/workflow/utils/template_renderer.py
@@ -5,6 +5,7 @@
 """
 
 import logging
+import re
 from typing import Any
 
 from jinja2 import TemplateSyntaxError, UndefinedError, Environment, StrictUndefined, Undefined
@@ -37,6 +38,16 @@ class TemplateRenderer:
         self.env = Environment(
             undefined=StrictUndefined if strict else SafeUndefined,
             autoescape=False  # 不自动转义，因为我们处理的是文本而非 HTML
+        )
+
+    @staticmethod
+    def normalize_template(template: str) -> str:
+        pattern = re.compile(
+            r"\{\{\s*(\d+)\.(\w+)\s*}}"
+        )
+        return pattern.sub(
+            r'{{ node["\1"].\2 }}',
+            template
         )
 
     def render(
@@ -95,7 +106,7 @@ class TemplateRenderer:
             context.update(conv_vars)
 
         context["nodes"] = node_outputs or {}  # 旧语法兼容
-
+        template = self.normalize_template(template)
         try:
             tmpl = self.env.from_string(template)
             return tmpl.render(**context)

--- a/api/app/schemas/workflow_schema.py
+++ b/api/app/schemas/workflow_schema.py
@@ -68,7 +68,7 @@ class WorkflowImportSave(BaseModel):
     """工作流导入请求"""
     temp_id: str
     name: str
-    description: str
+    description: str | None = Field(default=None)
 
 
 # ==================== 工作流配置 ====================


### PR DESCRIPTION
## Summary by Sourcery

改进 Dify 工作流导入的兼容性和错误处理，同时使变量、表达式和时间语义与内部工作流的预期保持一致。

Bug 修复：
- 将从 Dify 导入的变量类型映射到内部变量类型（包括 integer 和 float），以防止与类型相关的错误。
- 规范化节点引用表达式和模板（例如 `{{1767595893910.topic}}`），使其在求值和渲染期间可以通过 `node[...]` 正确解析。
- 修正变量聚合器节点转换的连线问题，并通过节点输出别名扩展变量选择器映射，以避免表达式查找失败。
- 确保节点执行耗时始终以毫秒（milliseconds）而不是秒（seconds）为单位进行度量和记录。
- 将缺失的工作流描述作为导入时的可选字段处理，以避免校验失败。

增强功能：
- 增加对导入 Dify 工具节点的支持，通过发出配置警告提示用户手动重新配置这些节点。
- 为导入工作流中的条件逻辑扩展比较运算符支持，新增“start with”和“end with”选项。
- 添加边转换失败的调试日志，以帮助排查工作流导入问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Dify workflow import compatibility and error handling while aligning variable, expression, and timing semantics with internal workflow expectations.

Bug Fixes:
- Map imported variable types from Dify to internal variable types, including integer and float, to prevent type-related errors.
- Normalize node-reference expressions and templates (e.g. `{{1767595893910.topic}}`) so they correctly resolve via `node[...]` during evaluation and rendering.
- Correct variable-aggregator node conversion wiring and extend variable selector mapping with node output aliases to avoid expression lookup failures.
- Ensure node execution elapsed time is consistently measured and logged in milliseconds instead of seconds.
- Handle missing workflow description as an optional field during import to avoid validation failures.

Enhancements:
- Add support for importing Dify tool nodes by emitting configuration warnings that prompt users to reconfigure them manually.
- Extend comparison operator support with "start with" and "end with" options for conditional logic in imported workflows.
- Add debug logging for edge conversion failures to aid troubleshooting of workflow imports.

</details>