### PR TITLE
fix(agent): fix issue where default runtime file list configuration was empty

### DIFF
--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -433,7 +433,7 @@ class AppChatRequest(BaseModel):
     user_id: Optional[str] = Field(default=None, description="用户ID（用于会话管理）")
     variables: Optional[Dict[str, Any]] = Field(default=None, description="自定义变量参数值")
     stream: bool = Field(default=False, description="是否流式返回")
-    files: Optional[List[FileInput]] = Field(default=list, description="附件列表（支持多文件）")
+    files: List[FileInput] = Field(default_factory=list, description="附件列表（支持多文件）")
 
 
 class DraftRunRequest(BaseModel):


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过使用合适的列表默认值，防止聊天请求的默认运行时文件列表配置为空列表或为 `None`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the default runtime file list configuration for chat requests from being empty or None by using a proper list default.

</details>