### PR TITLE
[changes] The timing of the memory increment task has been changed fr…

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from datetime import timedelta
+from celery.schedules import crontab
 from urllib.parse import quote
 
 from celery import Celery
@@ -90,9 +91,8 @@ celery_app.conf.update(
 celery_app.autodiscover_tasks(['app'])
 
 # Celery Beat schedule for periodic tasks
-memory_increment_schedule = timedelta(hours=settings.MEMORY_INCREMENT_INTERVAL_HOURS)
+memory_increment_schedule = crontab(hour=2, minute=0)  # 每天凌晨 2:00 执行
 memory_cache_regeneration_schedule = timedelta(hours=settings.MEMORY_CACHE_REGENERATION_HOURS)
-# 这个30秒的设计不合理
 workspace_reflection_schedule = timedelta(seconds=30)  # 每30秒运行一次settings.REFLECTION_INTERVAL_TIME
 forgetting_cycle_schedule = timedelta(hours=24)  # 每24小时运行一次遗忘周期
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -200,7 +200,6 @@ class Settings:
 
     REFLECTION_INTERVAL_SECONDS: float = float(os.getenv("REFLECTION_INTERVAL_SECONDS", "300"))
     HEALTH_CHECK_SECONDS: float = float(os.getenv("HEALTH_CHECK_SECONDS", "600"))
-    MEMORY_INCREMENT_INTERVAL_HOURS: float = float(os.getenv("MEMORY_INCREMENT_INTERVAL_HOURS", "24"))
     REFLECTION_INTERVAL_TIME: Optional[str] = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
 
     # Memory Cache Regeneration Configuration


### PR DESCRIPTION
…om relative time to absolute time.

## Summary by Sourcery

将内存递增的 Celery 任务调整为在固定的每日时间运行，并移除未使用的间隔配置。

Enhancements:
- 将内存递增的周期性任务从基于时间间隔的调度更改为每天凌晨 2:00 运行的 crontab 调度。

Chores:
- 移除已不再使用的 `MEMORY_INCREMENT_INTERVAL_HOURS` 配置项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Schedule the memory increment Celery task to run at a fixed daily time and remove the unused interval configuration.

Enhancements:
- Change the memory increment periodic task from an interval-based schedule to a daily 2:00 AM crontab schedule.

Chores:
- Remove the MEMORY_INCREMENT_INTERVAL_HOURS configuration setting that is no longer used.

</details>