### PR TITLE
feat(web): workflow chat use content replace chunk

### DIFF
--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-03 13:46:22
+ * @Last Modified time: 2026-03-04 12:10:44
  */
 /**
  * Conversation Page
@@ -267,8 +267,8 @@ const Conversation: FC = () => {
             currentConversationId = newId
             break
           case 'message':
-            const { content, chunk, conversation_id: curId } = item.data as { content: string; chunk: string; conversation_id: string;  }
-            updateAssistantMessage(content ?? chunk)
+            const { content, conversation_id: curId } = item.data as { content: string; conversation_id: string;  }
+            updateAssistantMessage(content)
 
             if (curId) {
               currentConversationId = curId;

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:10:56 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-28 16:43:06
+ * @Last Modified time: 2026-03-04 12:10:17
  */
 /**
  * Workflow Chat Component
@@ -174,8 +174,8 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
      */
     const handleStreamMessage = (data: SSEMessage[]) => {
       data.forEach(item => {
-        const { chunk, conversation_id, node_id, cycle_id, cycle_idx, input, output, error, elapsed_time, status } = item.data as {
-          chunk: string;
+        const { content, conversation_id, node_id, cycle_id, cycle_idx, input, output, error, elapsed_time, status } = item.data as {
+          content: string;
           conversation_id: string | null;
           cycle_id: string;
           cycle_idx: number;
@@ -202,7 +202,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef }>(({ appId
               if (lastIndex >= 0) {
                 newList[lastIndex] = {
                   ...newList[lastIndex],
-                  content: newList[lastIndex].content + chunk
+                  content: newList[lastIndex].content + content
                 }
               }
               return newList


### PR DESCRIPTION
## Summary by Sourcery

更新网页聊天和会话流式处理程序，以从 SSE 消息中使用统一的 `content` 字段，而不是已弃用的 `chunk` 字段。

改进内容：
- 使工作流聊天消息流式传输与新的 SSE 负载格式保持一致，使用单一的 `content` 字段进行增量更新。
- 简化会话页面中助手消息的更新逻辑，仅依赖 SSE 消息中的 `content` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update web chat and conversation streaming handlers to consume the unified `content` field from SSE messages instead of the deprecated `chunk` field.

Enhancements:
- Align workflow chat message streaming with the new SSE payload format using a single `content` field for incremental updates.
- Simplify conversation page assistant message updates to rely solely on the `content` field from SSE messages.

</details>