### PR TITLE
fix(workflow): rename output message field

### DIFF
--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -295,12 +295,12 @@ class WorkflowExecutor:
                             self.graph,
                             self.execution_context.checkpoint_config
                     ):
-                        full_content += msg_event["data"]['chunk']
+                        full_content += msg_event["data"]['content']
                         yield msg_event
 
             # Flush any remaining chunks
             async for msg_event in self.stream_coordinator.flush_remaining_chunk(self.variable_pool):
-                full_content += msg_event["data"]['chunk']
+                full_content += msg_event["data"]['content']
                 yield msg_event
 
             result = graph.get_state(self.execution_context.checkpoint_config).values


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正用于流式工作流响应的累加器，在构建完整消息时，改为使用 `content` 字段，而不是已弃用的 `chunk` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the accumulator for streaming workflow responses to use the `content` field instead of the deprecated `chunk` field when building the full message.

</details>