### PR TITLE
fix(web): chat loading fix

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:39 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-03 14:21:54
+ * @Last Modified time: 2026-03-04 18:05:36
  */
 /**
  * Chat debugging component for application testing
@@ -217,6 +217,8 @@ const Chat: FC<ChatProps> = ({ chatList, data, updateChatList, handleSave, sourc
             }
           }
           if (!isCanSend) {
+            setLoading(false)
+            setCompareLoading(false)
             return
           }
           runCompare(data.app_id, {


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当聊天消息无法发送时，同时重置主加载指示器和对比加载指示器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reset both primary and comparison loading indicators when a chat message cannot be sent.

</details>