### PR TITLE
fix(web): use modal.warning replace modal.confirm

### DIFF
--- a/web/src/views/UserMemoryDetail/components/Suggestions.tsx
+++ b/web/src/views/UserMemoryDetail/components/Suggestions.tsx
@@ -4,7 +4,7 @@
  * @Last Modified by: ZhaoYing
  * @Last Modified time: 2026-03-04 16:22:03
  */
-import { useEffect, useState, forwardRef, useImperativeHandle } from 'react'
+import { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { App } from 'antd'
@@ -43,9 +43,11 @@ const Suggestions = forwardRef<{ handleRefresh: () => void; }, { refresh: () => 
   const { modal } = App.useApp()
   const [loading, setLoading] = useState(false)
   const [suggestions, setSuggestions] = useState<Suggestions | null>(null)
+  const modalInstanceRef = useRef<{ destroy: () => void } | null>(null)
 
   useEffect(() => {
     getSuggestionData()
+    return () => modalInstanceRef.current?.destroy()
   }, [id])
 
   const getSuggestionData = () => {
@@ -57,10 +59,9 @@ const Suggestions = forwardRef<{ handleRefresh: () => void; }, { refresh: () => 
       .then((res) => {
         const response = res as Suggestions
         if (!response.exists && (!response.suggestions || !response.suggestions?.length)) {
-          modal.confirm({
+          modalInstanceRef.current = modal.warning({
             title: t('statementDetail.noData'),
             okText: t('common.refresh'),
-            cancelText: t('common.cancel'),
             onOk: () => {
               refresh()
             }

--- a/web/src/views/UserMemoryDetail/pages/ImplicitDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/ImplicitDetail.tsx
@@ -36,19 +36,20 @@ const ImplicitDetail = forwardRef<{ handleRefresh: () => void; }, { refresh: () 
   // Check if implicit data exists, prompt user to initialize if not
   useEffect(() => {
     if (!id) return
+    let modalInstance: { destroy: () => void } | null = null
     implicitCheckData(id)
       .then(res => {
         if (!(res as { exists: boolean }).exists) {
-            modal.confirm({
-              title: t('implicitDetail.noData'),
-              okText: t('common.refresh'),
-              cancelText: t('common.cancel'),
-              onOk: () => {
-                refresh()
-              }
-            })
+          modalInstance = modal.warning({
+            title: t('implicitDetail.noData'),
+            okText: t('common.refresh'),
+            onOk: () => {
+              refresh()
+            }
+          })
         }
       })
+    return () => modalInstance?.destroy()
   }, [id])
 
   // Refresh all implicit memory components by regenerating profile


### PR DESCRIPTION
## Summary by Sourcery

将用于缺失隐式数据和建议数据的确认对话框替换为警告对话框，并确保在组件卸载时正确清理模态框实例。

Bug 修复：
- 通过在显示隐式数据或建议数据对话框时跟踪并销毁模态框实例，防止确认对话框残留。

增强：
- 在隐式数据或建议数据缺失时，使用警告样式的模态框代替确认对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace confirmation modals with warning modals for missing implicit and suggestion data and ensure modal instances are properly cleaned up on unmount.

Bug Fixes:
- Prevent lingering confirmation dialogs by tracking and destroying modal instances when implicit or suggestion data dialogs are shown.

Enhancements:
- Use warning-style modals instead of confirmation dialogs when implicit or suggestion data is missing.

</details>