### PR TITLE
feat(web): add SYSTEM_DEFAULT_SCENE_CANNOT_DELETE error i18n

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -440,6 +440,7 @@ export const en = {
       logoutApiCannotRefreshToken: 'Logout API cannot refresh token',
       publicApiCannotRefreshToken: 'Public API cannot refresh token',
       refreshTokenNotExist: 'Refresh token does not exist',
+      SYSTEM_DEFAULT_SCENE_CANNOT_DELETE: 'This is a system preset scene and cannot be deleted',
       reset: 'Reset',
       refresh: 'Refresh',
       return: 'Return',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1016,6 +1016,7 @@ export const zh = {
       logoutApiCannotRefreshToken: '退出登录接口不能刷新token',
       publicApiCannotRefreshToken: '公共接口不能刷新token',
       refreshTokenNotExist: '刷新token不存在',
+      SYSTEM_DEFAULT_SCENE_CANNOT_DELETE: '该场景为系统预设场景，不允许删除',
       reset: '重置',
       refresh: '刷新',
       return: '返回',

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -183,7 +183,9 @@ service.interceptors.response.use(
         msg = msg || i18n.t('common.serverError');
         break;
       default:
-        if (!msg && Array.isArray(error.response?.data?.detail)) {
+        if (msg === 'SYSTEM_DEFAULT_SCENE_CANNOT_DELETE') {
+          msg = i18n.t(`common.${msg}`)
+        } else if (!msg && Array.isArray(error.response?.data?.detail)) {
           msg = error.response?.data?.detail?.map((item: { msg: string }) => item.msg).join(';')
         } else {
           msg = msg || i18n.t('common.unknownError');

--- a/web/src/views/Ontology/index.tsx
+++ b/web/src/views/Ontology/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:15 
  * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 14:10:15 
+ * @Last Modified time: 2026-03-05 10:57:53 
  */
 import { type FC, useState, useRef, type MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -164,11 +164,13 @@ const Ontology: FC = () => {
               </div>
             ))}
             <Divider size="middle" />
-            <Flex gap={8} wrap>
+            <Flex gap={8} wrap align="center">
               <div className="rb:text-[#5B6167] rb:leading-4.5">{t('ontology.entityTypes')}: </div>
-              {item.entity_type?.map((type, i) => (
-                <Tag key={i} color={i % 2 ? 'processing' : 'success'}>{type}</Tag>
-              ))}
+              <div className="rb:flex-1 rb:overflow-hidden rb:wrap-break-word! rb:line-clamp-1!">
+                {item.entity_type?.map((type, i) => (
+                  <Tag key={i} color={i % 2 ? 'processing' : 'success'} className="rb:ml-2">{type}</Tag>
+                ))}
+              </div>
               {item.type_num > 3 && (
                 <Tag color="default">+{item.type_num - 3}</Tag>
               )}


### PR DESCRIPTION
## Summary by Sourcery

为新的系统场景删除错误添加本地化处理，并调整本体实体类型显示布局。

新功能：
- 为后端错误信息 `SYSTEM_DEFAULT_SCENE_CANNOT_DELETE` 在英文和中文中引入 i18n 支持。

优化：
- 改进本体实体类型列表布局，更好地对齐内容，并在标签列表中处理内容溢出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add localized handling for a new system scene deletion error and adjust ontology entity type display layout.

New Features:
- Introduce i18n support for the SYSTEM_DEFAULT_SCENE_CANNOT_DELETE backend error message in both English and Chinese.

Enhancements:
- Improve the ontology entity type list layout to better align content and handle overflow within the tag list.

</details>