### PR TITLE
feat(web): file type add default value

### DIFF
--- a/web/src/views/Conversation/components/FileUpload.tsx
+++ b/web/src/views/Conversation/components/FileUpload.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:09:42 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-04 18:54:47
+ * @Last Modified time: 2026-03-05 15:09:22
  */
 /**
  * File Upload Component
@@ -206,7 +206,7 @@ const UploadFiles = forwardRef<UploadFilesRef, UploadFilesProps>(({
    */
   const handleChange: UploadProps['onChange'] = ({ fileList: newFileList }) => {
     newFileList.map(file => {
-      const type = (file.type && transform_file_type[file.type as keyof typeof transform_file_type]) || file.type
+      const type = (file.type && transform_file_type[file.type as keyof typeof transform_file_type]) || file.type || 'document'
       file.type = type
     })
     setFileList(newFileList);


### PR DESCRIPTION
## Summary by Sourcery

新功能：
- 当未检测到文件类型时，将上传文件的文件类型默认设置为 `document`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Default the file type of uploaded files to 'document' when no type is detected.

</details>