### PR TITLE
Fix/default indication

### DIFF
--- a/api/app/cache/__init__.py
+++ b/api/app/cache/__init__.py
@@ -4,10 +4,8 @@ Cache 缓存模块
 提供各种缓存功能的统一入口
 注意：隐性记忆和情绪建议已迁移到数据库存储，不再使用Redis缓存
 """
-from .memory import EmotionMemoryCache, ImplicitMemoryCache, InterestMemoryCache
+from .memory import InterestMemoryCache
 
 __all__ = [
-    "EmotionMemoryCache",
-    "ImplicitMemoryCache",
     "InterestMemoryCache",
 ]

--- a/api/app/cache/memory/__init__.py
+++ b/api/app/cache/memory/__init__.py
@@ -4,12 +4,8 @@ Memory 缓存模块
 提供记忆系统相关的缓存功能
 注意：隐性记忆和情绪建议已迁移到数据库存储，不再使用Redis缓存
 """
-from .emotion_memory import EmotionMemoryCache
-from .implicit_memory import ImplicitMemoryCache
 from .interest_memory import InterestMemoryCache
 
 __all__ = [
-    "EmotionMemoryCache",
-    "ImplicitMemoryCache",
     "InterestMemoryCache",
 ]

--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -612,7 +612,7 @@ async def get_scenes(
     workspace_id: Optional[str] = None,
     scene_name: Optional[str] = None,
     page: Optional[int] = None,
-    pagesize: Optional[int] = None,
+    page_size: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -652,7 +652,7 @@ async def get_scenes(
         - 不分页时，page 字段为 null
     """
     from app.controllers.ontology_secondary_routes import scenes_handler
-    return await scenes_handler(workspace_id, scene_name, page, pagesize, db, current_user)
+    return await scenes_handler(workspace_id, scene_name, page, page_size, db, current_user)
 
 
 # ==================== 本体类型管理接口 ====================

--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -612,7 +612,7 @@ async def get_scenes(
     workspace_id: Optional[str] = None,
     scene_name: Optional[str] = None,
     page: Optional[int] = None,
-    page_size: Optional[int] = None,
+    pagesize: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -652,7 +652,7 @@ async def get_scenes(
         - 不分页时，page 字段为 null
     """
     from app.controllers.ontology_secondary_routes import scenes_handler
-    return await scenes_handler(workspace_id, scene_name, page, page_size, db, current_user)
+    return await scenes_handler(workspace_id, scene_name, page, pagesize, db, current_user)
 
 
 # ==================== 本体类型管理接口 ====================

--- a/api/app/controllers/ontology_secondary_routes.py
+++ b/api/app/controllers/ontology_secondary_routes.py
@@ -58,7 +58,7 @@ async def scenes_handler(
     workspace_id: Optional[str] = None,
     scene_name: Optional[str] = None,
     page: Optional[int] = None,
-    page_size: Optional[int] = None,
+    pagesize: Optional[int] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -71,14 +71,14 @@ async def scenes_handler(
         workspace_id: 工作空间ID（可选，默认当前用户工作空间）
         scene_name: 场景名称关键词（可选，支持模糊匹配）
         page: 页码（可选，从1开始，仅在全量查询时有效）
-        page_size: 每页数量（可选，仅在全量查询时有效）
+        pagesize: 每页数量（可选，仅在全量查询时有效）
         db: 数据库会话
         current_user: 当前用户
     """
     operation = "search" if scene_name else "list"
     api_logger.info(
         f"Scene {operation} requested by user {current_user.id}, "
-        f"workspace_id={workspace_id}, keyword={scene_name}, page={page}, page_size={page_size}"
+        f"workspace_id={workspace_id}, keyword={scene_name}, page={page}, pagesize={pagesize}"
     )
     
     try:
@@ -105,13 +105,13 @@ async def scenes_handler(
                 api_logger.warning(f"Invalid page number: {page}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "页码必须大于0")
             
-            if page_size is not None and page_size < 1:
-                api_logger.warning(f"Invalid page_size: {page_size}")
+            if pagesize is not None and pagesize < 1:
+                api_logger.warning(f"Invalid pagesize: {pagesize}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "每页数量必须大于0")
             
-            # 如果只提供了page或page_size中的一个，返回错误
-            if (page is not None and page_size is None) or (page is None and page_size is not None):
-                api_logger.warning(f"Incomplete pagination params: page={page}, page_size={page_size}")
+            # 如果只提供了page或pagesize中的一个，返回错误
+            if (page is not None and pagesize is None) or (page is None and pagesize is not None):
+                api_logger.warning(f"Incomplete pagination params: page={page}, pagesize={pagesize}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "分页参数page和pagesize必须同时提供")
             
             # 模糊搜索场景（支持分页）
@@ -119,17 +119,15 @@ async def scenes_handler(
             total = len(scenes)
             
             # 如果提供了分页参数，进行分页处理
-            if page is not None and page_size is not None:
-                start_idx = (page - 1) * page_size
-                end_idx = start_idx + page_size
+            if page is not None and pagesize is not None:
+                start_idx = (page - 1) * pagesize
+                end_idx = start_idx + pagesize
                 scenes = scenes[start_idx:end_idx]
             
             # 构建响应
             items = []
             for scene in scenes:
-                # 获取前3个class_name作为entity_type
                 entity_type = [cls.class_name for cls in scene.classes[:3]] if scene.classes else None
-                # 动态计算 type_num
                 type_num = len(scene.classes) if scene.classes else 0
                 
                 items.append(SceneResponse(
@@ -141,17 +139,16 @@ async def scenes_handler(
                     workspace_id=scene.workspace_id,
                     created_at=scene.created_at,
                     updated_at=scene.updated_at,
-                    classes_count=type_num
+                    classes_count=type_num,
+                    is_system_default=scene.is_system_default
                 ))
             
             # 构建响应（包含分页信息）
-            if page is not None and page_size is not None:
-                # 计算是否有下一页
-                hasnext = (page * page_size) < total
-                
+            if page is not None and pagesize is not None:
+                hasnext = (page * pagesize) < total
                 pagination_info = PaginationInfo(
                     page=page,
-                    pagesize=page_size,
+                    pagesize=pagesize,
                     total=total,
                     hasnext=hasnext
                 )
@@ -165,28 +162,25 @@ async def scenes_handler(
             )
         else:
             # 获取所有场景（支持分页）
-            # 验证分页参数
             if page is not None and page < 1:
                 api_logger.warning(f"Invalid page number: {page}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "页码必须大于0")
             
-            if page_size is not None and page_size < 1:
-                api_logger.warning(f"Invalid page_size: {page_size}")
+            if pagesize is not None and pagesize < 1:
+                api_logger.warning(f"Invalid pagesize: {pagesize}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "每页数量必须大于0")
             
-            # 如果只提供了page或page_size中的一个，返回错误
-            if (page is not None and page_size is None) or (page is None and page_size is not None):
-                api_logger.warning(f"Incomplete pagination params: page={page}, page_size={page_size}")
+            # 如果只提供了page或pagesize中的一个，返回错误
+            if (page is not None and pagesize is None) or (page is None and pagesize is not None):
+                api_logger.warning(f"Incomplete pagination params: page={page}, pagesize={pagesize}")
                 return fail(BizCode.BAD_REQUEST, "请求参数无效", "分页参数page和pagesize必须同时提供")
             
-            scenes, total = service.list_scenes(ws_uuid, page, page_size)
+            scenes, total = service.list_scenes(ws_uuid, page, pagesize)
             
             # 构建响应
             items = []
             for scene in scenes:
-                # 获取前3个class_name作为entity_type
                 entity_type = [cls.class_name for cls in scene.classes[:3]] if scene.classes else None
-                # 动态计算 type_num
                 type_num = len(scene.classes) if scene.classes else 0
                 
                 items.append(SceneResponse(
@@ -198,17 +192,16 @@ async def scenes_handler(
                     workspace_id=scene.workspace_id,
                     created_at=scene.created_at,
                     updated_at=scene.updated_at,
-                    classes_count=type_num
+                    classes_count=type_num,
+                    is_system_default=scene.is_system_default
                 ))
             
             # 构建响应（包含分页信息）
-            if page is not None and page_size is not None:
-                # 计算是否有下一页
-                hasnext = (page * page_size) < total
-                
+            if page is not None and pagesize is not None:
+                hasnext = (page * pagesize) < total
                 pagination_info = PaginationInfo(
                     page=page,
-                    pagesize=page_size,
+                    pagesize=pagesize,
                     total=total,
                     hasnext=hasnext
                 )

--- a/api/app/schemas/ontology_schemas.py
+++ b/api/app/schemas/ontology_schemas.py
@@ -241,6 +241,7 @@ class SceneResponse(BaseModel):
     created_at: datetime.datetime = Field(..., description="创建时间（毫秒时间戳）")
     updated_at: datetime.datetime = Field(..., description="更新时间（毫秒时间戳）")
     classes_count: int = Field(0, description="类型数量")
+    is_system_default: bool = Field(False, description="是否为系统默认场景")
     
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -211,6 +211,7 @@ class DataConfigService: # 数据配置服务类（PostgreSQL）
                 "apply_id": config.apply_id,
                 "scene_id": str(config.scene_id) if config.scene_id else None,
                 "scene_name": scene_name,  # 新增：场景名称
+                "is_system_default": config.is_default,  # 是否为系统默认配置
                 "llm_id": config.llm_id,
                 "embedding_id": config.embedding_id,
                 "rerank_id": config.rerank_id,


### PR DESCRIPTION
## 由 Sourcery 生成的总结

更新场景列表 API 的分页参数，并在清理已废弃的内存缓存导出时，公开默认场景元数据。

新功能：
- 在场景 API 响应和内存存储配置中暴露 `is_system_default` 标志，用于指示某个场景/配置是否是系统默认。

增强改进：
- 在处理逻辑和日志中，将场景列表分页参数命名统一为 `pagesize`。
- 在迁移到基于数据库的存储之后，从缓存模块中移除已废弃的 `EmotionMemoryCache` 和 `ImplicitMemoryCache` 导出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update scene listing API pagination parameters and expose default scene metadata while cleaning up deprecated memory cache exports.

New Features:
- Expose an is_system_default flag on scene API responses and memory storage configurations to indicate whether a scene/configuration is a system default.

Enhancements:
- Align scene listing pagination parameter naming to pagesize across handler logic and logging.
- Remove deprecated EmotionMemoryCache and ImplicitMemoryCache exports from cache modules after migration to database-backed storage.

</details>