### PR TITLE
fix(tool and api key)

### DIFF
--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -15,7 +15,7 @@ class ApiKeyCreate(BaseModel):
     type: ApiKeyType = Field(..., description="API Key 类型")
     scopes: List[str] = Field(default_factory=list, description="权限范围列表")
     resource_id: Optional[uuid.UUID] = Field(None, description="关联资源ID")
-    rate_limit: Optional[int] = Field(10, ge=1, le=1000, description="QPS限制（请求/秒）")
+    rate_limit: Optional[int] = Field(100, ge=1, le=1000, description="QPS限制（请求/秒）")
     daily_request_limit: Optional[int] = Field(10000, description="日请求限制", ge=1)
     quota_limit: Optional[int] = Field(None, description="配额限制（总请求数）", ge=1)
     expires_at: Optional[datetime.datetime] = Field(None, description="过期时间")

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
 from app.core.tools.mcp import MCPToolManager, SimpleMCPClient
 from app.repositories.tool_repository import (
     ToolRepository, BuiltinToolRepository, CustomToolRepository,
@@ -79,6 +81,18 @@ class ToolService:
         config = self.tool_repo.find_by_id_and_tenant(self.db, uuid.UUID(tool_id), tenant_id)
         return self._config_to_info(config) if config else None
 
+    def _check_name_duplicate(self, name: str, tool_type: ToolType, tenant_id: uuid.UUID, exclude_id: Optional[uuid.UUID] = None):
+        """检查工具名称是否重复"""
+        query = self.db.query(ToolConfig).filter(
+            ToolConfig.name == name,
+            ToolConfig.tool_type == tool_type.value,
+            ToolConfig.tenant_id == tenant_id
+        )
+        if exclude_id:
+            query = query.filter(ToolConfig.id != exclude_id)
+        if query.first():
+            raise BusinessException(f"工具名称 '{name}' 已存在", BizCode.DUPLICATE_NAME)
+
     def create_tool(
             self,
             name: str,
@@ -92,6 +106,7 @@ class ToolService:
         """创建工具"""
         if tool_type == ToolType.BUILTIN:
             raise ValueError("内置工具不允许创建")
+        self._check_name_duplicate(name, tool_type, tenant_id)
 
         try:
             # 创建基础配置
@@ -141,6 +156,7 @@ class ToolService:
                 raise ValueError("内置工具不允许修改名称、描述和图标")
         try:
             if name:
+                self._check_name_duplicate(name, config_obj.tool_type, tenant_id, exclude_id=config_obj.id)
                 config_obj.name = name
             if description:
                 config_obj.description = description


### PR DESCRIPTION
1. Tool name duplication check;
2. The default QPS value of API key is set to 100.

## Summary by Sourcery

对每个租户强制使用唯一的工具名称，并调整默认 API 密钥的速率限制。

Bug 修复：
- 防止在同一租户和相同工具类型下创建或更新名称重复的工具。

功能增强：
- 将新创建的 API 密钥默认 QPS 限制从 10 提高到 100。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce unique tool names per tenant and adjust default API key rate limits.

Bug Fixes:
- Prevent creation or update of tools with duplicate names within the same tenant and tool type.

Enhancements:
- Increase the default QPS limit for newly created API keys from 10 to 100.

</details>