### PR TITLE
Fix/celery env hijack

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ REDIS_PORT=6379
 REDIS_DB=1 
 
 # Celery (Using Redis as broker)
-BROKER_URL=redis://127.0.0.1:6379/0
-RESULT_BACKEND=redis://127.0.0.1:6379/0
+REDIS_DB_CELERY_BROKER=1
+REDIS_DB_CELERY_BACKEND=2
 
 # JWT Secret Key (Formation method: openssl rand -hex 32)
 SECRET_KEY=your-secret-key-here

--- a/README_CN.md
+++ b/README_CN.md
@@ -201,8 +201,8 @@ REDIS_PORT=6379
 REDIS_DB=1 
 
 # Celery (使用Redis作为broker)
-BROKER_URL=redis://127.0.0.1:6379/0
-RESULT_BACKEND=redis://127.0.0.1:6379/0
+REDIS_DB_CELERY_BROKER=1
+REDIS_DB_CELERY_BACKEND=2
 
 # JWT密钥 (生成方式: openssl rand -hex 32)
 SECRET_KEY=your-secret-key-here

--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -29,7 +29,12 @@ _broker_url = f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:
 _backend_url = f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_CELERY_BACKEND}"
 os.environ["CELERY_BROKER_URL"] = _broker_url
 os.environ["CELERY_RESULT_BACKEND"] = _backend_url
+# Neutralize legacy Celery env vars that can be hijacked by Celery's CLI/Click
+# integration and accidentally override our canonical URLs.
 os.environ.pop("BROKER_URL", None)
+os.environ.pop("RESULT_BACKEND", None)
+os.environ.pop("CELERY_BROKER", None)
+os.environ.pop("CELERY_BACKEND", None)
 
 celery_app = Celery(
     "redbear_tasks",

--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -1,27 +1,49 @@
 import os
 import platform
 from datetime import timedelta
-from celery.schedules import crontab
 from urllib.parse import quote
 
 from celery import Celery
 from celery.schedules import crontab
 
 from app.core.config import settings
+from app.core.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 # macOS fork() safety - must be set before any Celery initialization
 if platform.system() == 'Darwin':
     os.environ.setdefault('OBJC_DISABLE_INITIALIZE_FORK_SAFETY', 'YES')
 
 # 创建 Celery 应用实例
-# broker: 任务队列（使用 Redis DB 0）
-# backend: 结果存储（使用 Redis DB 10）
+# broker: 任务队列（使用 Redis DB，由 CELERY_BROKER_DB 指定）
+# backend: 结果存储（使用 Redis DB，由 CELERY_BACKEND_DB 指定）
+# NOTE: 不要在 .env 中设置 BROKER_URL / RESULT_BACKEND / CELERY_BROKER / CELERY_BACKEND，
+#       这些名称会被 Celery CLI 的 Click 框架劫持，详见 docs/celery-env-bug-report.md
+
+# Build canonical broker/backend URLs and force them into os.environ so that
+# Celery's Settings.broker_url property (which checks CELERY_BROKER_URL first)
+# cannot be overridden by stray env vars.
+# See: https://github.com/celery/celery/issues/4284
+_broker_url = f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_CELERY_BROKER}"
+_backend_url = f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.REDIS_DB_CELERY_BACKEND}"
+os.environ["CELERY_BROKER_URL"] = _broker_url
+os.environ["CELERY_RESULT_BACKEND"] = _backend_url
+os.environ.pop("BROKER_URL", None)
+
 celery_app = Celery(
     "redbear_tasks",
-    broker=f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.CELERY_BROKER}",
-    backend=f"redis://:{quote(settings.REDIS_PASSWORD)}@{settings.REDIS_HOST}:{settings.REDIS_PORT}/{settings.CELERY_BACKEND}",
+    broker=_broker_url,
+    backend=_backend_url,
 )
 
+logger.info(
+    "Celery app initialized",
+    extra={
+        "broker": _broker_url.replace(quote(settings.REDIS_PASSWORD), "***"),
+        "backend": _backend_url.replace(quote(settings.REDIS_PASSWORD), "***"),
+    },
+)
 # Default queue for unrouted tasks
 celery_app.conf.task_default_queue = 'memory_tasks'
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -190,8 +190,10 @@ class Settings:
     LOG_FILE_MAX_SIZE_MB: int = int(os.getenv("LOG_FILE_MAX_SIZE_MB", "10"))  # 10MB
 
     # Celery configuration (internal)
-    CELERY_BROKER: int = int(os.getenv("CELERY_BROKER", "1"))
-    CELERY_BACKEND: int = int(os.getenv("CELERY_BACKEND", "2"))
+    # NOTE: 变量名不以 CELERY_ 开头，避免被 Celery CLI 的前缀匹配机制劫持
+    # 详见 docs/celery-env-bug-report.md
+    REDIS_DB_CELERY_BROKER: int = int(os.getenv("REDIS_DB_CELERY_BROKER", "1"))
+    REDIS_DB_CELERY_BACKEND: int = int(os.getenv("REDIS_DB_CELERY_BACKEND", "2"))
 
     # SMTP Email Configuration
     SMTP_SERVER: str = os.getenv("SMTP_SERVER", "smtp.gmail.com")

--- a/api/env.example
+++ b/api/env.example
@@ -29,10 +29,10 @@ REDIS_DB=
 REDIS_PASSWORD=password
 
 #celery
-BROKER_URL= 
-RESULT_BACKEND= 
-CELERY_BROKER=
-CELERY_BACKEND=
+# NOTE: 不要使用 BROKER_URL / RESULT_BACKEND / CELERY_BROKER / CELERY_BACKEND，
+#       这些名称会被 Celery CLI 劫持，详见 docs/celery-env-bug-report.md
+REDIS_DB_CELERY_BROKER=
+REDIS_DB_CELERY_BACKEND=
 
 # Memory Cache Regeneration Configuration
 # Interval in hours for regenerating memory insight and user summary cache


### PR DESCRIPTION
## Summary by Sourcery

防止 Celery 配置因环境变量命名冲突而被覆盖，并明确 Celery broker 和 backend 使用的 Redis 数据库配置。

Bug 修复：
- 通过从内部设置中强制使用规范的 `CELERY_*` 配置值，修复了 Celery broker/backend 配置被通用环境变量 `BROKER_URL` / `RESULT_BACKEND` 劫持的问题。

功能增强：
- 为 Celery broker 和 backend 引入专用的 Redis 数据库配置环境变量，这些变量不再使用 `CELERY_` 前缀，以避免在命令行中发生前缀匹配冲突。
- 在日志中记录 Celery 初始化信息，并对 broker 和 backend 的 URL 进行脱敏处理，以提升可观测性且不泄露凭据。

文档：
- 更新英文和中文 README 示例，使用新的 Celery Redis 数据库环境变量来替代 `BROKER_URL` / `RESULT_BACKEND`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent Celery configuration from being overridden by environment variable name collisions and clarify Redis DB usage for Celery broker and backend.

Bug Fixes:
- Fix Celery broker/backend configuration being hijacked by generic BROKER_URL/RESULT_BACKEND environment variables by forcing canonical CELERY_* values from internal settings.

Enhancements:
- Introduce dedicated Redis DB configuration variables for Celery broker and backend that avoid the CELERY_ prefix to prevent CLI prefix-matching conflicts.
- Log Celery initialization with masked broker and backend URLs for better observability without exposing credentials.

Documentation:
- Update English and Chinese README examples to use the new Celery Redis DB environment variables instead of BROKER_URL/RESULT_BACKEND.

</details>