### PR TITLE
feat(web): default ontology hidden operate

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -440,9 +440,6 @@ export const en = {
       logoutApiCannotRefreshToken: 'Logout API cannot refresh token',
       publicApiCannotRefreshToken: 'Public API cannot refresh token',
       refreshTokenNotExist: 'Refresh token does not exist',
-      SYSTEM_DEFAULT_SCENE_CANNOT_DELETE: 'This is a system preset scene and cannot be deleted',
-      SYSTEM_DEFAULT_CLASS_CANNOT_DELETE: 'This class is a system preset class and cannot be deleted',
-      SYSTEM_DEFAULT_SCENE_CANNOT_UPDATE: 'This scene is a system preset scene and cannot be modified',
       reset: 'Reset',
       refresh: 'Refresh',
       return: 'Return',
@@ -2619,6 +2616,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       updated_at: 'Updated At',
       entityTypes: 'Entity Types',
 
+      classSearchPlaceholder: 'Search types',
       addClass: 'Add Type',
       class_name: 'Type Name',
       class_description: 'Type Definition',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1020,9 +1020,6 @@ export const zh = {
       logoutApiCannotRefreshToken: '退出登录接口不能刷新token',
       publicApiCannotRefreshToken: '公共接口不能刷新token',
       refreshTokenNotExist: '刷新token不存在',
-      SYSTEM_DEFAULT_SCENE_CANNOT_DELETE: '该场景为系统预设场景，不允许删除',
-      SYSTEM_DEFAULT_CLASS_CANNOT_DELETE: '该类型为系统预设类型，不允许删除',
-      SYSTEM_DEFAULT_SCENE_CANNOT_UPDATE: '该场景为系统预设场景，不允许修改',
       reset: '重置',
       refresh: '刷新',
       return: '返回',
@@ -2620,6 +2617,7 @@ export const zh = {
       updated_at: '更新时间',
       entityTypes: '实体类型',
 
+      classSearchPlaceholder: '搜索类型',
       addClass: '添加类型',
       class_name: '类型名称',
       class_description: '类型定义',

--- a/web/src/views/Ontology/components/PageHeader.tsx
+++ b/web/src/views/Ontology/components/PageHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:24 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 18:02:13
+ * @Last Modified time: 2026-03-06 11:25:59
  */
 import { type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -17,7 +17,7 @@ const { Header } = Layout;
  */
 interface ConfigHeaderProps {
   /** Page title/name */
-  name?: string;
+  name?: string | ReactNode;
   /** Subtitle content displayed below the title */
   subTitle?: ReactNode | string;
   /** Extra content displayed on the right side */

--- a/web/src/views/Ontology/index.tsx
+++ b/web/src/views/Ontology/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-05 16:28:53
+ * @Last Modified time: 2026-03-06 10:56:44
  */
 import { type FC, useState, useRef, type MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -181,8 +181,8 @@ const Ontology: FC = () => {
               )}
             </Flex>
 
-            <div className="rb:mt-4 rb:text-[12px] rb:leading-4 rb:font-regular rb:text-[#5B6167] rb:flex rb:items-center rb:justify-end">
-              <Space size={16}>
+            <div className="rb:mt-4 rb:h-5 rb:text-[12px] rb:leading-4 rb:font-regular rb:text-[#5B6167] rb:flex rb:items-center rb:justify-end">
+              {!item.is_system_default && <Space size={16}>
                 <div
                   className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/edit.svg')] rb:hover:bg-[url('@/assets/images/edit_hover.svg')]"
                   onClick={(e) => handleEdit(item, e)}
@@ -191,7 +191,7 @@ const Ontology: FC = () => {
                   className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/delete.svg')] rb:hover:bg-[url('@/assets/images/delete_hover.svg')]"
                   onClick={(e) => handleDelete(item, e)}
                 ></div>
-              </Space>
+              </Space>}
             </div>
           </RbCard>
         )}

--- a/web/src/views/Ontology/pages/Detail.tsx
+++ b/web/src/views/Ontology/pages/Detail.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:20 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-09 17:56:35
+ * @Last Modified time: 2026-03-06 11:26:49
  */
 import { type FC, useEffect, useState, useRef } from 'react'
 import { useParams } from 'react-router-dom';
@@ -17,6 +17,7 @@ import OntologyClassModal from '../components/OntologyClassModal'
 import SearchInput from '@/components/SearchInput';
 import OntologyClassExtractModal from '../components/OntologyClassExtractModal'
 import BodyWrapper from '@/components/Empty/BodyWrapper'
+import Tag from '@/components/Tag'
 
 /**
  * Ontology detail page component
@@ -99,19 +100,22 @@ const Detail: FC = () => {
   return (
     <>
       <PageHeader
-        name={data.scene_name}
+        name={<Space>
+          {data.scene_name}
+          <Tag color="warning">{t('common.default')}</Tag>
+        </Space>}
         subTitle={<Tooltip title={data.scene_description}><div className="rb:h-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{data.scene_description}</div></Tooltip>}
-        extra={<Space>
+        extra={data.is_system_default ? undefined : (<Space>
           <Button type="primary" ghost className="rb:h-6! rb:px-2! rb:leading-5.5!" onClick={handleAdd}>+ {t('ontology.addClass')}</Button>
           <Button className="rb:h-6! rb:px-2! rb:leading-5.5!" type="primary" onClick={handleExtract}>+ {t('ontology.extract')}</Button>
-        </Space>}
+        </Space>)}
       />
 
       <div className="rb:h-[calc(100vh-64px)] rb:overflow-y-auto rb:py-3 rb:px-4">
         <Row gutter={16} className="rb:mb-4">
           <Col span={6} offset={18}>
             <SearchInput
-              placeholder={t('ontology.searchPlaceholder')}
+              placeholder={t('ontology.classSearchPlaceholder')}
               onSearch={(value) => setQuery({ class_name: value })}
               className="rb:w-full!"
             />
@@ -123,10 +127,10 @@ const Detail: FC = () => {
               <Col key={item.class_id} span={6}>
                 <RbCard
                   title={item.class_name}
-                  extra={<div
+                  extra={data.is_system_default ? undefined : (<div
                     className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/delete.svg')] rb:hover:bg-[url('@/assets/images/delete_hover.svg')]"
                     onClick={() => handleDelete(item)}
-                  ></div>}
+                  ></div>)}
                   className="rb:bg-transparent!"
                 >
                   <Tooltip title={item.class_description}>

--- a/web/src/views/Ontology/types.ts
+++ b/web/src/views/Ontology/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:10:10 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-05 16:18:56
+ * @Last Modified time: 2026-03-06 10:55:23
  */
 /**
  * Query parameters for ontology list pagination and filtering
@@ -94,6 +94,7 @@ export interface OntologyClassData {
   scene_description: string;
   /** Array of class items */
   items: OntologyClassItem[];
+  is_system_default: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

在界面中标示系统默认本体场景，并在更新相关标签时禁止编辑或删除这些场景。

新功能：
- 在系统默认本体场景名称旁显示带有警示颜色的「默认」标签。
- 为本体类搜索输入框添加专用占位文本。

增强改进：
- 对于系统默认本体场景和类型，隐藏添加/提取按钮以及类删除控件，而不是依赖错误消息。
- 扩展本体类数据和页面标题组件，以支持系统默认标记以及更丰富的标题内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Indicate system-default ontology scenes in the UI and prevent editing or deleting them while updating related labels.

New Features:
- Display a warning-colored default tag next to system-default ontology scene names.
- Add a dedicated placeholder text for ontology class search inputs.

Enhancements:
- Hide add/extract buttons and class delete controls for system-default ontology scenes and types instead of relying on error messages.
- Extend ontology class data and page header components to support system-default flags and richer title content.

</details>