### PR TITLE
[add] Default label for the entity type

### DIFF
--- a/api/app/controllers/ontology_secondary_routes.py
+++ b/api/app/controllers/ontology_secondary_routes.py
@@ -636,6 +636,7 @@ async def classes_handler(
             scene_id=scene_uuid,
             scene_name=scene.scene_name,
             scene_description=scene.scene_description,
+            is_system_default=scene.is_system_default,
             items=items
         )
         

--- a/api/app/repositories/ontology_scene_repository.py
+++ b/api/app/repositories/ontology_scene_repository.py
@@ -374,7 +374,7 @@ class OntologySceneRepository:
             
             count = self.db.query(OntologyScene).filter(
                 OntologyScene.scene_id == scene_id,
-                OntologyScene.workspace_id == workspace_id
+                (OntologyScene.workspace_id == workspace_id) | (OntologyScene.is_system_default == True)
             ).count()
             
             is_owner = count > 0

--- a/api/app/schemas/ontology_schemas.py
+++ b/api/app/schemas/ontology_schemas.py
@@ -463,6 +463,7 @@ class ClassListResponse(BaseModel):
     scene_id: UUID = Field(..., description="所属场景ID")
     scene_name: str = Field(..., description="场景名称")
     scene_description: Optional[str] = Field(None, description="场景描述")
+    is_system_default: bool = Field(False, description="是否为系统默认场景")
     items: List[ClassResponse] = Field(..., description="类型列表")
 
 


### PR DESCRIPTION
## Summary by Sourcery

允许将系统默认的本体场景视为已拥有的资源，并在类列表响应中暴露其默认状态。

New Features:
- 在本体类列表 API 响应中包含 `is_system_default` 标志，用于指示系统默认场景。

Bug Fixes:
- 在检查工作区场景所有权时，将系统默认的本体场景视为已拥有的场景。

Enhancements:
- 扩展本体场景列表响应模式，以携带系统默认标识的相关元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow system default ontology scenes to be treated as owned and expose their default status in class list responses.

New Features:
- Include the is_system_default flag in ontology class list API responses to indicate system default scenes.

Bug Fixes:
- Treat system default ontology scenes as owned when checking scene ownership for a workspace.

Enhancements:
- Extend ontology scene list response schema to carry system default indicator metadata.

</details>