### PR TITLE
feat(web): change memory extraction pruning_scene control

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1572,7 +1572,7 @@ export const en = {
       intelligentSemanticPruningFunction: 'Intelligent Semantic Pruning Function',
       intelligentSemanticPruningFunctionDesc: 'Whether to activate intelligent semantic pruning (true/false).',
       intelligentSemanticPruningScene: 'Intelligent Semantic Pruning Scene',
-      intelligentSemanticPruningSceneDesc: 'Select intelligent semantic pruning scene (education, online_service, outbound).',
+      intelligentSemanticPruningSceneDesc: 'Semantic pruning scenarios are consistent with ontology engineering scenarios',
       intelligentSemanticPruningThreshold: 'Intelligent Semantic Pruning Threshold',
       intelligentSemanticPruningThresholdDesc: 'Set intelligent semantic pruning threshold (0-0.9).',
       reflectionEngine: 'Self-Reflexion Engine',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1571,7 +1571,7 @@ export const zh = {
       intelligentSemanticPruningFunction: '智能语义修剪功能',
       intelligentSemanticPruningFunctionDesc: '是否激活智能语义修剪（true/false）。',
       intelligentSemanticPruningScene: '智能语义修剪场景',
-      intelligentSemanticPruningSceneDesc: '选择智能语义修剪场景（education、online_service、outbound）。',
+      intelligentSemanticPruningSceneDesc: '语义剪枝场景与本体工程场景一致',
       intelligentSemanticPruningThreshold: '智能语义修剪阈值',
       intelligentSemanticPruningThresholdDesc: '设置智能语义修剪阈值（0-0.9）。',
       reflectionEngine: '自我反思引擎',

--- a/web/src/views/MemoryExtractionEngine/constant.ts
+++ b/web/src/views/MemoryExtractionEngine/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:30:06 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-04 10:09:45
+ * @Last Modified time: 2026-03-06 13:49:00
  */
 /**
  * Memory Extraction Engine Configuration Constants
@@ -140,13 +140,8 @@ export const configList: ConfigVo[] = [
           {
             label: 'intelligentSemanticPruningScene',
             variableName: 'pruning_scene',
-            control: 'select',
+            control: 'text',
             type: 'enum',
-            options: [
-              { label: 'education', value: 'education' },
-              { label: 'online_service', value: 'online_service' },
-              { label: 'outbound', value: 'outbound' },
-            ],
             meaning: 'intelligentSemanticPruningSceneDesc',
           },
           // Intelligent semantic pruning阈值

--- a/web/src/views/MemoryExtractionEngine/index.tsx
+++ b/web/src/views/MemoryExtractionEngine/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:30:02 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 17:30:02 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-03-06 13:50:05
  */
 /**
  * Memory Extraction Engine Configuration Page
@@ -13,7 +13,7 @@
 import { type FC, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
-import { Row, Col, Space, Select, InputNumber, Slider, App, Form } from 'antd'
+import { Row, Col, Space, Select, InputNumber, Slider, App, Form, Input } from 'antd'
 import clsx from 'clsx'
 
 import Card from './components/Card'
@@ -35,15 +35,15 @@ const keys = [
 /**
  * Configuration description component
  */
-const ConfigDesc: FC<{ config: Variable, className?: string }> = ({config, className}) => {
+const ConfigDesc: FC<{ config: Variable, className?: string; onlyMeaning?: boolean; }> = ({ config, className, onlyMeaning = false}) => {
   const { t } = useTranslation();
   return (
     <div className={className}>
-      <Space size={8} className={clsx("rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4 ")}>
+      {!onlyMeaning && <Space size={8} className={clsx("rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4 ")}>
         {config.variableName && <span className="rb:font-regular">{t('memoryExtractionEngine.variableName')}: {config.variableName}</span>}
         {config.control && <span className="rb:font-regular">{t('memoryExtractionEngine.control')}: {t(`memoryExtractionEngine.${config.control}`)}</span>}
         {config.type && <span className="rb:font-regular">{t('memoryExtractionEngine.type')}: {config.type}</span>}
-      </Space>
+      </Space>}
       {config.meaning && <div className={clsx("rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4 ")}>{t('memoryExtractionEngine.Meaning')}: {t(`memoryExtractionEngine.${config.meaning}`)}</div>}
     </div>
   )
@@ -250,6 +250,21 @@ const MemoryExtractionEngine: FC = () => {
                                     <InputNumber min={config.min || 0} style={{ width: '100%' }} placeholder={t('common.pleaseEnter')} />
                                   </Form.Item>
                                   <ConfigDesc config={config} className="rb:-mt-4!" />
+                                </div>
+                              </>
+                            }
+                            {config.control === 'text' &&
+                              <>
+                                <div className="rb:text-[14px] rb:font-medium rb:leading-5 rb:mt-6 rb:mb-2">
+                                  -{t(`memoryExtractionEngine.${config.label}`)}
+                                </div>
+                                <div className="rb:pl-2">
+                                  <Form.Item
+                                    name={config.variableName}
+                                  >
+                                    <Input placeholder={t('common.pleaseEnter')} disabled />
+                                  </Form.Item>
+                                  <ConfigDesc config={config} onlyMeaning={true} className="rb:-mt-4!" />
                                 </div>
                               </>
                             }

--- a/web/src/views/MemoryManagement/index.tsx
+++ b/web/src/views/MemoryManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:33:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-05 16:28:58
+ * @Last Modified time: 2026-03-06 13:53:53
  */
 /**
  * Memory Management Page
@@ -154,10 +154,10 @@ const MemoryManagement: React.FC = () => {
                       className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/edit.svg')] rb:hover:bg-[url('@/assets/images/edit_hover.svg')]" 
                       onClick={() => handleEdit(item)}
                     ></div>
-                    <div 
+                    {!item.is_system_default && <div 
                       className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/delete.svg')] rb:hover:bg-[url('@/assets/images/delete_hover.svg')]" 
                       onClick={() => handleDelete(item)}
-                    ></div>
+                    ></div>}
                   </Space>
                 </div>
               </RbCard>


### PR DESCRIPTION
## Summary by Sourcery

调整记忆抽取配置界面，以适配智能语义裁剪场景，并保护默认记忆配置不被删除。

新功能：
- 以只读输入框和说明文展示仅文本形式的智能语义裁剪场景配置。

增强与改进：
- 将 `pruning_scene` 控件由可选项改为信息展示型文本字段，使其与本体工程场景对齐。
- 当只需展示语义说明文本时，在配置说明中隐藏变量元数据。
- 在记忆管理页面中阻止系统默认记忆配置被删除。

文档：
- 更新智能语义裁剪场景的中英文描述，使其引用本体工程相关场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust memory extraction configuration UI for intelligent semantic pruning scenes and protect default memory configurations from deletion.

New Features:
- Display text-only intelligent semantic pruning scene configuration with read-only input and description.

Enhancements:
- Change pruning_scene control from selectable options to an informational text field aligned with ontology engineering scenarios.
- Hide variable metadata in configuration descriptions when only the meaning text is required.
- Prevent deletion of system default memory configurations in the memory management page.

Documentation:
- Update English and Chinese descriptions for intelligent semantic pruning scene to reference ontology engineering scenarios.

</details>