### PR TITLE
fix(agent and model)

### DIFF
--- a/api/app/controllers/model_controller.py
+++ b/api/app/controllers/model_controller.py
@@ -371,6 +371,11 @@ def update_model(
 
     if model_data.type is not None or model_data.provider is not None:
         raise BusinessException("不允许更改模型类型和供应商", BizCode.INVALID_PARAMETER)
+
+    if model_data.is_active:
+        active_keys = ModelApiKeyService.get_api_keys_by_model(db=db, model_config_id=model_id, is_active=model_data.is_active)
+        if not active_keys:
+            raise BusinessException("请先为该模型配置可用的 API Key", BizCode.INVALID_PARAMETER)
     
     try:
         api_logger.debug(f"开始更新模型配置: model_id={model_id}")

--- a/api/app/schemas/model_schema.py
+++ b/api/app/schemas/model_schema.py
@@ -23,6 +23,7 @@ class ModelConfigBase(BaseModel):
     load_balance_strategy: Optional[str] = Field(LoadBalanceStrategy.NONE.value, description="负载均衡策略")
     capability: List[str] = Field(default_factory=list, description="模型能力列表")
     is_omni: bool = Field(False, description="是否为Omni模型")
+    model_id: Optional[uuid.UUID] = Field(None, description="基础模型ID")
 
 
 class ApiKeyCreateNested(BaseModel):

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -703,7 +703,7 @@ class AppService:
             self.db.flush()
 
             # 如果是 agent 类型，复制 AgentConfig
-            if source_app.type == "agent":
+            if source_app.type == AppType.AGENT:
                 source_config = self.db.query(AgentConfig).filter(
                     AgentConfig.app_id == source_app.id
                 ).first()
@@ -719,6 +719,50 @@ class AppService:
                         memory=source_config.memory.copy() if source_config.memory else None,
                         variables=source_config.variables.copy() if source_config.variables else [],
                         tools=source_config.tools.copy() if source_config.tools else [],
+                        is_active=True,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    self.db.add(new_config)
+
+            elif source_app.type == AppType.WORKFLOW:
+                source_config = self.db.query(WorkflowConfig).filter(
+                    WorkflowConfig.app_id == source_app.id
+                ).first()
+
+                if source_config:
+                    new_config = WorkflowConfig(
+                        id=uuid.uuid4(),
+                        app_id=new_app.id,
+                        nodes=source_config.nodes.copy() if source_config.nodes else [],
+                        edges=source_config.edges.copy() if source_config.edges else [],
+                        variables=source_config.variables.copy() if source_config.variables else [],
+                        execution_config=source_config.execution_config.copy() if source_config.execution_config else {},
+                        triggers=source_config.triggers.copy() if source_config.triggers else [],
+                        is_active=True,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    self.db.add(new_config)
+
+            elif source_app.type == AppType.MULTI_AGENT:
+                source_config = self.db.query(MultiAgentConfig).filter(
+                    MultiAgentConfig.app_id == source_app.id
+                ).first()
+
+                if source_config:
+                    new_config = MultiAgentConfig(
+                        id=uuid.uuid4(),
+                        app_id=new_app.id,
+                        master_agent_id=source_config.master_agent_id,
+                        master_agent_name=source_config.master_agent_name,
+                        default_model_config_id=source_config.default_model_config_id,
+                        model_parameters=source_config.model_parameters,
+                        orchestration_mode=source_config.orchestration_mode,
+                        sub_agents=source_config.sub_agents.copy() if source_config.sub_agents else [],
+                        routing_rules=source_config.routing_rules.copy() if source_config.routing_rules else None,
+                        execution_config=source_config.execution_config.copy() if source_config.execution_config else {},
+                        aggregation_strategy=source_config.aggregation_strategy,
                         is_active=True,
                         created_at=now,
                         updated_at=now,

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -780,6 +780,7 @@ class ModelBaseService:
             "description": model_base.description,
             "capability": model_base.capability,
             "is_omni": model_base.is_omni,
+            "is_active": False,
             "is_composite": False
         }
         model_config = ModelConfigRepository.create(db, model_config_data)


### PR DESCRIPTION
1. From the model square to the model list, the added models are initially set to be inactive. When manually activating them, a mandatory API key configuration is required.
2. Copying of applications (agent, workflow, multi_agent)

## Summary by Sourcery

在激活模型时强制执行 API 密钥要求，并扩展应用复制功能，以支持工作流和多代理配置，同时保持通过 plaza 导入的模型默认处于未激活状态。

Bug Fixes（错误修复）:
- 防止在未配置至少一个启用的 API 密钥时，将模型状态更改为激活。
- 确保在复制智能体应用时，使用正确的 `AppType` 枚举进行类型检查。

Enhancements（功能增强）:
- 在复制应用时，支持复制工作流应用和多代理应用的配置信息。
- 在模型配置模式（schema）中包含基础模型 ID，以便更好地关联配置与其底层模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce API key requirements when activating models and extend app copying to support workflow and multi-agent configurations while keeping plaza-imported models inactive by default.

Bug Fixes:
- Prevent changing a model to active status without at least one active API key configured.
- Ensure agent app copying uses the correct AppType enum for type checks.

Enhancements:
- Support copying configuration for workflow and multi-agent apps when duplicating an application.
- Include base model ID in the model configuration schema for better linkage between configs and underlying models.

</details>