### PR TITLE
fix(web): workflow upload bugfix

### DIFF
--- a/web/src/views/ApplicationManagement/components/UploadWorkflowModal.tsx
+++ b/web/src/views/ApplicationManagement/components/UploadWorkflowModal.tsx
@@ -101,6 +101,7 @@ const UploadWorkflowModal = forwardRef<UploadWorkflowModalRef, UploadWorkflowMod
         formData.append('platform', values.platform);
         formData.append('file', values.file[0]);
 
+        setLoading(true)
         // Call import workflow API
         importWorkflow(formData)
           .then(res => {
@@ -114,21 +115,24 @@ const UploadWorkflowModal = forwardRef<UploadWorkflowModalRef, UploadWorkflowMod
             } else {
               setCurrent(2);
               // Pre-fill form with file information
+              const fileNameSplit = values.file[0].name.split('.')
               form.setFieldsValue({
-                name: values.file[0].name.split('.')[0],
+                name: fileNameSplit.slice(0, fileNameSplit.length - 1).join('.'),
                 platform: values.platform,
                 fileName: values.file[0].name,
                 fileSize: values.file[0].size,
               });
             }
-          });
+          })
+          .finally(() => setLoading(false));
         break;
       case 1: // Step 2: Error/warning display
         if (firstFormData) {
           const { file, platform } = firstFormData;
+          const fileNameSplit = firstFormData.file[0].name.split('.')
           // Pre-fill form with file information
           form.setFieldsValue({
-            name: file[0].name.split('.')[0],
+            name: fileNameSplit.slice(0, fileNameSplit.length - 1).join('.'),
             platform: platform,
             fileName: file[0].name,
             fileSize: file[0].size,
@@ -175,7 +179,9 @@ const UploadWorkflowModal = forwardRef<UploadWorkflowModalRef, UploadWorkflowMod
     }
 
     // Reset form if not going back to error/warning step
-    if (newStep !== 1) {
+    if (newStep === 0) {
+      form.setFieldsValue(firstFormData || {})
+    } else if (newStep !== 1) {
       form.resetFields();
     }
     setCurrent(newStep);

--- a/web/src/views/Ontology/pages/Detail.tsx
+++ b/web/src/views/Ontology/pages/Detail.tsx
@@ -105,7 +105,7 @@ const Detail: FC = () => {
           <Tag color="warning">{t('common.default')}</Tag>
         </Space>}
         subTitle={<Tooltip title={data.scene_description}><div className="rb:h-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{data.scene_description}</div></Tooltip>}
-        extra={data.is_system_default ? undefined : (<Space>
+        extra={!data.is_system_default ? undefined : (<Space>
           <Button type="primary" ghost className="rb:h-6! rb:px-2! rb:leading-5.5!" onClick={handleAdd}>+ {t('ontology.addClass')}</Button>
           <Button className="rb:h-6! rb:px-2! rb:leading-5.5!" type="primary" onClick={handleExtract}>+ {t('ontology.extract')}</Button>
         </Space>)}


### PR DESCRIPTION
## Summary by Sourcery

修复工作流上传弹窗行为，并根据默认状态调整本体详情页控件。

错误修复：
- 防止在导入调用完成后，工作流上传弹窗仍然保持在加载状态。
- 修正预填充的工作流名称处理逻辑，以便能够正确解析包含多个点号的文件名。
- 确保在返回初始步骤时，工作流表单字段能够被正确恢复。
- 修复本体详情页，使操作按钮仅在场景不是系统默认时才显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow upload modal behavior and adjust ontology detail page controls based on default status.

Bug Fixes:
- Prevent the workflow upload modal from remaining in a loading state after the import call completes.
- Correct pre-filled workflow name handling so filenames with multiple dots are parsed correctly.
- Ensure workflow form fields are restored correctly when navigating back to the initial step.
- Fix the ontology detail page so action buttons are only shown when the scene is not the system default.

</details>