### PR TITLE
Fix/release web zy

### DIFF
--- a/web/src/views/ModelManagement/components/ModelListDetail.tsx
+++ b/web/src/views/ModelManagement/components/ModelListDetail.tsx
@@ -144,7 +144,7 @@ const ModelListDetail = forwardRef<ModelListDetailRef, ModelListDetailProps>(({ 
                   {item.name[0]}
                 </div>
               }
-              extra={<Switch defaultChecked={item.is_active} disabled={loading} onChange={() => handleChange(item)} />}
+              extra={<Switch checked={item.is_active} disabled={loading} onChange={() => handleChange(item)} />}
               bodyClassName="rb:relative rb:pb-[64px]! rb:h-[calc(100%-64px)]!"
             >
               <Tooltip title={item.description}>

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -95,7 +95,7 @@ const Properties: FC<PropertiesProps> = ({
           initialValue[key] = config[key].defaultValue
         }
       })
-      
+
       form.setFieldsValue({
         type,
         id: selectedNode.id,
@@ -114,16 +114,16 @@ const Properties: FC<PropertiesProps> = ({
    */
   const updateNodeLabel = (newLabel: string) => {
     if (selectedNode && form) {
-      const nodeData = selectedNode.data as NodeProperties;
+      const nodeData = selectedNode.getData() as NodeProperties;
       selectedNode.setAttrByPath('text/text', `${nodeData.icon} ${newLabel}`);
-      selectedNode.setData({ ...selectedNode.data, name: newLabel });
+      selectedNode.setData({ ...selectedNode.getData(), name: newLabel });
     }
   };
 
   useEffect(() => {
     if (values && selectedNode) {
       const { id, knowledge_retrieval, group, group_variables, ...rest } = values
-      const { knowledge_bases = [], ...restKnowledgeConfig } = (knowledge_retrieval as any) || {}
+      const { knowledge_bases = [], name: _name, description: _description, ...restKnowledgeConfig } = (knowledge_retrieval as any) || {}
 
       let allRest = {
         ...rest,
@@ -136,21 +136,23 @@ const Properties: FC<PropertiesProps> = ({
         }))
       }
 
+      const nodeData = selectedNode.getData()
+
       Object.keys(values).forEach(key => {
-        if (selectedNode.data?.config?.[key]) {
+        if (nodeData?.config?.[key]) {
           // Create a deep copy to avoid reference sharing between nodes
-          if (!selectedNode.data.config[key]) {
-            selectedNode.data.config[key] = {};
+          if (!nodeData.config[key]) {
+            nodeData.config[key] = {};
           }
-          selectedNode.data.config[key] = {
-            ...selectedNode.data.config[key],
+          nodeData.config[key] = {
+            ...nodeData.config[key],
             defaultValue: values[key]
           };
         }
       })
 
       selectedNode?.setData({
-        ...selectedNode.data,
+        ...nodeData,
         ...allRest,
       })
     }


### PR DESCRIPTION
## Summary by Sourcery

修复工作流节点属性更新问题，并将模型列表中的开关改为受控组件。

Bug 修复：
- 确保工作流节点标签和配置更新使用图节点的当前数据，而不是过期的数据引用。
- 在将工作流表单的值同步回节点数据时，从知识检索配置中排除非配置字段。
- 使模型管理列表中的模型激活开关由最新的激活状态控制，而不是依赖初始默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow node property updates and make model list switches controlled components.

Bug Fixes:
- Ensure workflow node label and configuration updates use the graph node's current data instead of stale data references.
- Exclude non-config fields from knowledge retrieval configuration when syncing workflow form values back to node data.
- Make model activation switches in the model management list controlled by the latest active state rather than an initial default.

</details>