### PR TITLE
fix(web): ontology class default tag bugfix

### DIFF
--- a/web/src/views/Ontology/pages/Detail.tsx
+++ b/web/src/views/Ontology/pages/Detail.tsx
@@ -102,10 +102,10 @@ const Detail: FC = () => {
       <PageHeader
         name={<Space>
           {data.scene_name}
-          <Tag color="warning">{t('common.default')}</Tag>
+          {data.is_system_default ? <Tag color="warning">{t('common.default')}</Tag> : undefined}
         </Space>}
         subTitle={<Tooltip title={data.scene_description}><div className="rb:h-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{data.scene_description}</div></Tooltip>}
-        extra={!data.is_system_default ? undefined : (<Space>
+        extra={data.is_system_default ? undefined : (<Space>
           <Button type="primary" ghost className="rb:h-6! rb:px-2! rb:leading-5.5!" onClick={handleAdd}>+ {t('ontology.addClass')}</Button>
           <Button className="rb:h-6! rb:px-2! rb:leading-5.5!" type="primary" onClick={handleExtract}>+ {t('ontology.extract')}</Button>
         </Space>)}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 仅在场景被标记为系统默认时正确显示“default”标签，在其他情况下将其隐藏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correctly show the 'default' tag only when the scene is marked as the system default and hide it otherwise.

</details>