### PR TITLE
fix(web): add notes node; jinja2 editor bugfix

### DIFF
--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -25,6 +25,7 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
         const textContent = root.getTextContent();
         if (textContent !== prevValueRef.current) {
           isUserInputRef.current = true;
+          prevValueRef.current = textContent;
         }
       });
     });
@@ -33,7 +34,7 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
   }, [editor]);
 
   useEffect(() => {
-    if ((value !== prevValueRef.current || enableLineNumbers !== prevEnableLineNumbersRef.current) && !isUserInputRef.current) {
+    if (value !== prevValueRef.current || enableLineNumbers !== prevEnableLineNumbersRef.current) {
       queueMicrotask(() => {
         editor.update(() => {
         const root = $getRoot();

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -529,6 +529,10 @@ export const unknownNode = {
   type: 'unknown',
   icon: unknownIcon
 }
+export const noteNode = {
+  type: 'notes',
+  icon: unknownIcon
+}
 
 export const nodeWidth = 240;
 /**

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -12,7 +12,7 @@ import { Graph, Node, MiniMap, Snapline, Clipboard, Keyboard, type Edge } from '
 import { register } from '@antv/x6-react-shape';
 import type { PortMetadata } from '@antv/x6/lib/model/port';
 
-import { nodeRegisterLibrary, graphNodeLibrary, nodeLibrary, portMarkup, portAttrs, edgeAttrs, edge_color, edge_selected_color, portTextAttrs, defaultAbsolutePortGroups, nodeWidth, unknownNode } from '../constant';
+import { nodeRegisterLibrary, graphNodeLibrary, nodeLibrary, portMarkup, portAttrs, edgeAttrs, edge_color, edge_selected_color, portTextAttrs, defaultAbsolutePortGroups, nodeWidth, unknownNode, noteNode } from '../constant';
 import type { WorkflowConfig, NodeProperties, ChatVariable } from '../types';
 import { getWorkflowConfig, saveWorkflowConfig } from '@/api/application'
 
@@ -128,7 +128,7 @@ export const useWorkflowGraph = ({
     if (nodes.length) {
       const nodeList = nodes.map(node => {
         const { id, type, name, position, config = {} } = node
-        let nodeLibraryConfig = [...nodeLibrary, { nodes: [unknownNode] }]
+        let nodeLibraryConfig = [...nodeLibrary, { nodes: [unknownNode, noteNode] }]
           .flatMap(category => category.nodes)
           .find(n => n.type === type)
         nodeLibraryConfig = JSON.parse(JSON.stringify({ config: {}, ...nodeLibraryConfig })) as NodeProperties


### PR DESCRIPTION
## Summary by Sourcery

在工作流图中新增对备注节点的支持，并修复编辑器初始值同步行为。

新功能：
- 引入备注节点类型，并将其与现有的工作流节点类型一起注册。

错误修复：
- 修正编辑器初始值插件，确保外部值变更能够被持续应用，并使内部状态与用户输入保持同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a notes node in the workflow graph and fix editor initial-value syncing behavior.

New Features:
- Introduce a notes node type and register it alongside existing workflow node types.

Bug Fixes:
- Correct the editor initial-value plugin so external value changes are consistently applied and internal state stays in sync with user input.

</details>