### PR TITLE
fix(workflow): fix compatibility issues when importing workflows from dify

### DIFF
--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -185,6 +185,9 @@ class DifyConverter(BaseConverter):
             "not empty": ComparisonOperator.NOT_EMPTY,
             "start with": ComparisonOperator.START_WITH,
             "end with": ComparisonOperator.END_WITH,
+            "not contains": ComparisonOperator.NOT_CONTAINS,
+            "exists": ComparisonOperator.NOT_EMPTY,
+            "not exists": ComparisonOperator.EMPTY
         }
         return operator_map.get(operator, operator)
 
@@ -364,7 +367,7 @@ class DifyConverter(BaseConverter):
         node_data = node["data"]
         cases = []
         for case in node_data["cases"]:
-            case_id = case["id"]
+            case_id = case.get("id") or case.get("case_id")
             logical_operator = case["logical_operator"]
             conditions = []
             for condition in case["conditions"]:
@@ -540,7 +543,8 @@ class DifyConverter(BaseConverter):
                 ] = self.trans_variable_format(content["value"])
         else:
             if node_data["body"]["data"]:
-                body_content = node_data["body"]["data"][0]["value"]
+                body_content = (node_data["body"]["data"][0].get("value") or
+                                self._process_list_variable_litearl(node_data["body"]["data"][0].get("file")))
             else:
                 body_content = ""
 

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -44,7 +44,8 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         "parameter-extractor": NodeType.PARAMETER_EXTRACTOR,
         "question-classifier": NodeType.QUESTION_CLASSIFIER,
         "variable-aggregator": NodeType.VAR_AGGREGATOR,
-        "tool": NodeType.TOOL
+        "tool": NodeType.TOOL,
+        "": NodeType.NOTES
     }
 
     def __init__(self, config: dict[str, Any]):
@@ -165,7 +166,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             return NodeDefinition(
                 id=node["id"],
                 type=self.map_node_type(node_data["type"]),
-                name=node_data.get("title"),
+                name=node_data.get("title") or "notes",
                 cycle=node.get("parentId"),
                 description=None,
                 config=self._convert_node_config(node),
@@ -209,16 +210,15 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
 
             source = edge["source"]
             target = edge["target"]
-            edge_id = edge["id"]
             label = None
             if source in self.branch_node_cache:
-                case_id = "-".join(edge_id.split("-")[1:-2])
+                case_id = edge["sourceHandle"]
                 if case_id == "false":
                     label = f'CASE{len(self.branch_node_cache[source])+1}'
                 else:
                     label = f'CASE{self.branch_node_cache[source].index(case_id) + 1}'
             if source in self.error_branch_node_cache:
-                case_id = "-".join(edge_id.split("-")[1:-2])
+                case_id = edge["sourceHandle"]
                 if case_id == "source":
                     label = "SUCCESS"
                 else:
@@ -243,6 +243,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
                 name=variable["name"],
                 default=variable["value"],
                 type=self.variable_type_map(variable["value_type"]),
+                description=variable.get("description")
             )
         except Exception as e:
             self.errors.append(ExceptionDefineition(

--- a/api/app/core/workflow/engine/graph_builder.py
+++ b/api/app/core/workflow/engine/graph_builder.py
@@ -292,6 +292,8 @@ class GraphBuilder:
         """
         for node in self.nodes:
             node_type = node.get("type")
+            if node_type == NodeType.NOTES:
+                continue
             node_id = node.get("id")
             cycle_node = node.get("cycle")
             if cycle_node:

--- a/api/app/core/workflow/nodes/enums.py
+++ b/api/app/core/workflow/nodes/enums.py
@@ -25,6 +25,7 @@ class NodeType(StrEnum):
     MEMORY_WRITE = "memory-write"
 
     UNKNOWN = "unknown"
+    NOTES = "notes"
 
 
 BRANCH_NODES = [NodeType.IF_ELSE, NodeType.HTTP_REQUEST, NodeType.QUESTION_CLASSIFIER]

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -180,6 +180,8 @@ class KnowledgeRetrievalNode(BaseNode):
             RuntimeError: If no valid knowledge base is found or access is denied.
         """
         self.typed_config = KnowledgeRetrievalNodeConfig(**self.config)
+        if not self.typed_config.knowledge_bases:
+            return []
         query = self._render_template(self.typed_config.query, variable_pool)
         with get_db_read() as db:
             knowledge_bases = self.typed_config.knowledge_bases

--- a/api/app/core/workflow/validator.py
+++ b/api/app/core/workflow/validator.py
@@ -138,7 +138,7 @@ class WorkflowValidator:
                     errors.append("工作流必须至少有一个 end 节点")
 
             # 3. 验证节点 ID 唯一性
-            node_ids = [n.get("id") for n in nodes]
+            node_ids = [n.get("id") for n in nodes if n.get("type") != NodeType.NOTES]
             if len(node_ids) != len(set(node_ids)):
                 duplicates = [nid for nid in node_ids if node_ids.count(nid) > 1]
                 errors.append(f"节点 ID 必须唯一，重复的 ID: {set(duplicates)}")


### PR DESCRIPTION
## Summary by Sourcery

在导入和执行工作流时改进工作流引擎与 Dify 适配器的兼容性，包括更好地处理备注、条件、HTTP 请求体以及知识库。

Bug 修复：
- 将类型为空的 Dify 节点视为备注节点，在构建图和进行节点 ID 校验时跳过它们，以避免冲突。
- 通过使用边的 source handle，而不是解析边 ID，解决分支边标签标注问题。
- 在知识检索节点中，当关联的知识库缺失时，返回空结果而不是执行失败。
- 支持在 Dify if-else 分支配置中同时使用 `id` 或 `case_id` 字段来表示条件。
- 修复在导入 HTTP 节点时，当请求体内容通过文件引用而不是 value 字段提供时的处理问题。

功能增强：
- 将更多 Dify 比较运算符（`not contains`、`exists`、`not exists`）映射到内部比较运算符。
- 在将 Dify 变量转换为内部工作流变量时保留变量描述信息。
- 当备注节点未提供标题时，为其设置合理的默认名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve workflow engine and Dify adapter compatibility when importing and executing workflows, including better handling of notes, conditions, HTTP bodies, and knowledge bases.

Bug Fixes:
- Treat Dify nodes with empty type as notes and skip them in graph building and node ID validation to avoid conflicts.
- Resolve branch edge labeling issues by using the edge source handle instead of parsing the edge ID.
- Handle missing knowledge bases in the knowledge retrieval node by returning an empty result instead of failing.
- Support Dify if-else case configurations that use either id or case_id fields for conditions.
- Fix HTTP node body import when content is provided via file references rather than value fields.

Enhancements:
- Map additional Dify comparison operators (not contains, exists, not exists) to internal comparison operators.
- Preserve variable descriptions when converting Dify variables into internal workflow variables.
- Default note node names to a sensible fallback when no title is provided.

</details>