### PR TITLE
fix(web): jinja2 editor bugfix

### DIFF
--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -35,6 +35,12 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
 
   useEffect(() => {
     if (value !== prevValueRef.current || enableLineNumbers !== prevEnableLineNumbersRef.current) {
+      // Skip reset if the change was triggered by user input (avoid cursor jump)
+      if (isUserInputRef.current && enableLineNumbers === prevEnableLineNumbersRef.current) {
+        prevValueRef.current = value;
+        isUserInputRef.current = false;
+        return;
+      }
       queueMicrotask(() => {
         editor.update(() => {
         const root = $getRoot();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过在用户发起内容更改时跳过对初始值的重置，避免工作流 Jinja2 编辑器中的光标跳动问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid cursor jumps in the workflow Jinja2 editor by skipping initial value reset on user-initiated content changes.

</details>