### PR TITLE
feat(workflow): add support for notes nodes

### DIFF
--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -8,34 +8,59 @@ from typing import Any
 from urllib.parse import quote
 
 from app.core.workflow.adapters.base_converter import BaseConverter
-from app.core.workflow.adapters.errors import UnsupportVariableType, UnknowModelWarning, ExceptionDefineition, \
+from app.core.workflow.adapters.errors import (
+    UnsupportVariableType,
+    UnknowModelWarning,
+    ExceptionDefineition,
     ExceptionType
-from app.core.workflow.nodes.assigner import AssignerNodeConfig
+)
 from app.core.workflow.nodes.assigner.config import AssignmentItem
 from app.core.workflow.nodes.base_config import VariableDefinition, BaseNodeConfig
-from app.core.workflow.nodes.code import CodeNodeConfig
 from app.core.workflow.nodes.code.config import InputVariable, OutputVariable
-from app.core.workflow.nodes.configs import StartNodeConfig, LLMNodeConfig
-from app.core.workflow.nodes.cycle_graph import LoopNodeConfig, IterationNodeConfig
-from app.core.workflow.nodes.cycle_graph.config import ConditionDetail as LoopConditionDetail, ConditionsConfig, \
+from app.core.workflow.nodes.configs import (
+    StartNodeConfig,
+    LLMNodeConfig,
+    AssignerNodeConfig,
+    CodeNodeConfig,
+    LoopNodeConfig,
+    IterationNodeConfig,
+    EndNodeConfig,
+    HttpRequestNodeConfig,
+    IfElseNodeConfig,
+    JinjaRenderNodeConfig,
+    KnowledgeRetrievalNodeConfig,
+    NoteNodeConfig,
+    ParameterExtractorNodeConfig,
+    QuestionClassifierNodeConfig,
+    VariableAggregatorNodeConfig
+)
+from app.core.workflow.nodes.cycle_graph.config import (
+    ConditionDetail as LoopConditionDetail,
+    ConditionsConfig,
     CycleVariable
-from app.core.workflow.nodes.end import EndNodeConfig
-from app.core.workflow.nodes.enums import ValueInputType, ComparisonOperator, AssignmentOperator, HttpAuthType, \
-    HttpContentType, HttpErrorHandle
-from app.core.workflow.nodes.http_request import HttpRequestNodeConfig
-from app.core.workflow.nodes.http_request.config import HttpAuthConfig, HttpContentTypeConfig, HttpFormData, \
-    HttpTimeOutConfig, HttpRetryConfig, HttpErrorDefaultTamplete, HttpErrorHandleConfig
-from app.core.workflow.nodes.if_else import IfElseNodeConfig
+)
+from app.core.workflow.nodes.enums import (
+    ValueInputType,
+    ComparisonOperator,
+    AssignmentOperator,
+    HttpAuthType,
+    HttpContentType,
+    HttpErrorHandle
+)
+from app.core.workflow.nodes.http_request.config import (
+    HttpAuthConfig,
+    HttpContentTypeConfig,
+    HttpFormData,
+    HttpTimeOutConfig,
+    HttpRetryConfig,
+    HttpErrorDefaultTamplete,
+    HttpErrorHandleConfig
+)
 from app.core.workflow.nodes.if_else.config import ConditionDetail, ConditionBranchConfig
-from app.core.workflow.nodes.jinja_render import JinjaRenderNodeConfig
 from app.core.workflow.nodes.jinja_render.config import VariablesMappingConfig
-from app.core.workflow.nodes.knowledge import KnowledgeRetrievalNodeConfig
 from app.core.workflow.nodes.llm.config import MemoryWindowSetting, MessageConfig
-from app.core.workflow.nodes.parameter_extractor import ParameterExtractorNodeConfig
 from app.core.workflow.nodes.parameter_extractor.config import ParamsConfig
-from app.core.workflow.nodes.question_classifier import QuestionClassifierNodeConfig
 from app.core.workflow.nodes.question_classifier.config import ClassifierConfig
-from app.core.workflow.nodes.variable_aggregator import VariableAggregatorNodeConfig
 from app.core.workflow.variable.base_variable import VariableType, DEFAULT_VALUE
 
 
@@ -63,6 +88,7 @@ class DifyConverter(BaseConverter):
             "question-classifier": self.convert_question_classifier_node_config,
             "variable-aggregator": self.convert_variable_aggregator_node_config,
             "tool": self.convert_tool_node_config,
+            "": self.convert_notes_config,
             "loop-start": lambda x: {},
             "iteration-start": lambda x: {},
             "loop-end": lambda x: {},
@@ -732,3 +758,12 @@ class DifyConverter(BaseConverter):
             detail=f"Please reconfigure the tool node.",
         ))
         return {}
+
+    @staticmethod
+    def convert_notes_config(node: dict):
+        node_data = node["data"]
+        result = NoteNodeConfig.model_construct(
+            author=node_data.get("author", ""),
+            text=node_data.get("text", "")
+        ).model_dump()
+        return result

--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -764,6 +764,10 @@ class DifyConverter(BaseConverter):
         node_data = node["data"]
         result = NoteNodeConfig.model_construct(
             author=node_data.get("author", ""),
-            text=node_data.get("text", "")
+            text=node_data.get("text", ""),
+            width=node_data.get("width", 80),
+            height=node_data.get("height", 80),
+            theme=node_data.get("theme", "blue"),
+            show_author=node_data.get("showAuthor", True)
         ).model_dump()
         return result

--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -45,7 +45,8 @@ from app.core.workflow.nodes.enums import (
     AssignmentOperator,
     HttpAuthType,
     HttpContentType,
-    HttpErrorHandle
+    HttpErrorHandle,
+    NodeType
 )
 from app.core.workflow.nodes.http_request.config import (
     HttpAuthConfig,
@@ -73,25 +74,24 @@ class DifyConverter(BaseConverter):
 
     def __init__(self):
         self.CONFIG_CONVERT_MAP = {
-            "start": self.convert_start_node_config,
-            "llm": self.convert_llm_node_config,
-            "answer": self.convert_end_node_config,
-            "if-else": self.convert_if_else_node_config,
-            "loop": self.convert_loop_node_config,
-            "iteration": self.convert_iteration_node_config,
-            "assigner": self.convert_assigner_node_config,
-            "code": self.convert_code_node_config,
-            "http-request": self.convert_http_node_config,
-            "template-transform": self.convert_jinja_render_node_config,
-            "knowledge-retrieval": self.convert_knowledge_node_config,
-            "parameter-extractor": self.convert_parameter_extractor_node_config,
-            "question-classifier": self.convert_question_classifier_node_config,
-            "variable-aggregator": self.convert_variable_aggregator_node_config,
-            "tool": self.convert_tool_node_config,
-            "": self.convert_notes_config,
-            "loop-start": lambda x: {},
-            "iteration-start": lambda x: {},
-            "loop-end": lambda x: {},
+            NodeType.START: self.convert_start_node_config,
+            NodeType.LLM: self.convert_llm_node_config,
+            NodeType.END: self.convert_end_node_config,
+            NodeType.IF_ELSE: self.convert_if_else_node_config,
+            NodeType.LOOP: self.convert_loop_node_config,
+            NodeType.ITERATION: self.convert_iteration_node_config,
+            NodeType.ASSIGNER: self.convert_assigner_node_config,
+            NodeType.CODE: self.convert_code_node_config,
+            NodeType.HTTP_REQUEST: self.convert_http_node_config,
+            NodeType.JINJARENDER: self.convert_jinja_render_node_config,
+            NodeType.KNOWLEDGE_RETRIEVAL: self.convert_knowledge_node_config,
+            NodeType.PARAMETER_EXTRACTOR: self.convert_parameter_extractor_node_config,
+            NodeType.QUESTION_CLASSIFIER: self.convert_question_classifier_node_config,
+            NodeType.VAR_AGGREGATOR: self.convert_variable_aggregator_node_config,
+            NodeType.TOOL: self.convert_tool_node_config,
+            NodeType.NOTES: self.convert_notes_config,
+            NodeType.CYCLE_START: lambda x: {},
+            NodeType.BREAK: lambda x: {},
         }
 
     def get_node_convert(self, node_type):

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -50,7 +50,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
 
     def __init__(self, config: dict[str, Any]):
         DifyConverter.__init__(self)
-        BasePlatformAdapter.__init__(self,  config)
+        BasePlatformAdapter.__init__(self, config)
 
     def get_metadata(self) -> PlatformMetadata:
         return PlatformMetadata(
@@ -84,7 +84,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         require_fields = frozenset({'app', 'kind', 'version', 'workflow'})
         if not all(field in self.config for field in require_fields):
             return False
-        if self.config.get("app",{}).get("mode") == "workflow":
+        if self.config.get("app", {}).get("mode") == "workflow":
             self.errors.append(ExceptionDefineition(
                 type=ExceptionType.PLATFORM,
                 detail="workflow mode is not supported"
@@ -163,13 +163,14 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
     def _convert_node(self, node: dict[str, Any]) -> NodeDefinition | None:
         node_data = node["data"]
         try:
+            node_type = self.map_node_type(node_data["type"])
             return NodeDefinition(
                 id=node["id"],
-                type=self.map_node_type(node_data["type"]),
+                type=node_type,
                 name=node_data.get("title") or "notes",
                 cycle=node.get("parentId"),
                 description=None,
-                config=self._convert_node_config(node),
+                config=self._convert_node_config(node_type, node),
                 position={
                     "x": node["position"]["x"],
                     "y": node["position"]["y"]
@@ -183,17 +184,16 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         except Exception as e:
             logger.debug(f"convert node error - {e}", exc_info=True)
 
-    def _convert_node_config(self, node: dict):
-        node_data = node["data"]
-        node_type = node_data["type"]
+    def _convert_node_config(self, node_type: str, node: dict):
         try:
+            node_data = node["data"]
             converter = self.get_node_convert(node_type)
-            if node_type not in self.CONFIG_CONVERT_MAP:
+            if node_type == NodeType.UNKNOWN:
                 self.errors.append(ExceptionDefineition(
                     type=ExceptionType.NODE,
                     node_id=node["id"],
                     node_name=node["data"]["title"],
-                    detail=f"node type {node_type} is unsupported",
+                    detail=f"node type {node_data.get('type')} is unsupported",
                 ))
             return converter(node)
         except Exception as e:
@@ -214,7 +214,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             if source in self.branch_node_cache:
                 case_id = edge["sourceHandle"]
                 if case_id == "false":
-                    label = f'CASE{len(self.branch_node_cache[source])+1}'
+                    label = f'CASE{len(self.branch_node_cache[source]) + 1}'
                 else:
                     label = f'CASE{self.branch_node_cache[source].index(case_id) + 1}'
             if source in self.error_branch_node_cache:
@@ -257,5 +257,3 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
 
     def _convert_execution(self, execution: dict[str, Any]) -> ExecutionConfig:
         return ExecutionConfig()
-
-

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -193,7 +193,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
                     type=ExceptionType.NODE,
                     node_id=node["id"],
                     node_name=node["data"]["title"],
-                    detail=f"node type {node_type if node_type else 'notes'} is unsupported",
+                    detail=f"node type {node_type} is unsupported",
                 ))
             return converter(node)
         except Exception as e:

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -59,7 +59,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             support_node_types=list(self.NODE_TYPE_MAPPING.keys())
         )
 
-    def map_node_type(self, platform_node_type) -> str:
+    def map_node_type(self, platform_node_type) -> NodeType:
         return self.NODE_TYPE_MAPPING.get(platform_node_type, NodeType.UNKNOWN)
 
     @property
@@ -184,7 +184,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
         except Exception as e:
             logger.debug(f"convert node error - {e}", exc_info=True)
 
-    def _convert_node_config(self, node_type: str, node: dict):
+    def _convert_node_config(self, node_type: NodeType, node: dict):
         try:
             node_data = node["data"]
             converter = self.get_node_convert(node_type)

--- a/api/app/core/workflow/nodes/configs.py
+++ b/api/app/core/workflow/nodes/configs.py
@@ -23,6 +23,7 @@ from app.core.workflow.nodes.question_classifier.config import QuestionClassifie
 from app.core.workflow.nodes.start.config import StartNodeConfig
 from app.core.workflow.nodes.tool.config import ToolNodeConfig
 from app.core.workflow.nodes.variable_aggregator.config import VariableAggregatorNodeConfig
+from app.core.workflow.nodes.notes.config import NoteNodeConfig
 
 __all__ = [
     # 基础类
@@ -47,5 +48,6 @@ __all__ = [
     "ToolNodeConfig",
     "MemoryReadNodeConfig",
     "MemoryWriteNodeConfig",
-    "CodeNodeConfig"
+    "CodeNodeConfig",
+    "NoteNodeConfig"
 ]

--- a/api/app/core/workflow/nodes/notes/config.py
+++ b/api/app/core/workflow/nodes/notes/config.py
@@ -4,5 +4,9 @@ from app.core.workflow.nodes.base_config import BaseNodeConfig
 
 
 class NoteNodeConfig(BaseNodeConfig):
-    author: str = Field(..., description="author")
-    text: str = Field(..., description="note context")
+    author: str = Field(default="", description="author")
+    text: str = Field(default="", description="note content")
+    width: int = Field(default=80)
+    height: int = Field(default=80)
+    theme: str = Field(default="blue")
+    show_author: bool = Field(default=True)

--- a/api/app/core/workflow/nodes/notes/config.py
+++ b/api/app/core/workflow/nodes/notes/config.py
@@ -1,0 +1,8 @@
+from pydantic import Field
+
+from app.core.workflow.nodes.base_config import BaseNodeConfig
+
+
+class NoteNodeConfig(BaseNodeConfig):
+    author: str = Field(..., description="author")
+    text: str = Field(..., description="note context")


### PR DESCRIPTION
## Summary by Sourcery

在 Dify 工作流转换和节点配置中新增对备注节点的支持。

新功能：
- 引入用于备注节点的 `NoteNodeConfig`，包含作者 (`author`) 和文本 (`text`) 字段。
- 在 Dify 工作流适配器中支持备注节点配置的转换。

增强改进：
- 重构 DifyConverter 的配置映射，使用 `NodeType` 枚举而非字符串字面量。
- 在 Dify 适配器中改进节点类型处理和错误报告，以便在转换节点配置时提供更好的反馈。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for notes nodes in Dify workflow conversion and node configuration.

New Features:
- Introduce a NoteNodeConfig with author and text fields for notes nodes.
- Support conversion of notes node configurations within the Dify workflow adapter.

Enhancements:
- Refactor DifyConverter configuration mapping to use NodeType enums instead of string literals.
- Improve node type handling and error reporting in the Dify adapter when converting node configs.

</details>