### PR TITLE
Fix/celery task

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -65,7 +65,7 @@ celery_app.conf.update(
     
     # 时区
     timezone='Asia/Shanghai',
-    enable_utc=True,
+    enable_utc=False,
     
     # 任务追踪
     task_track_started=True,

--- a/api/app/controllers/mcp_market_config_controller.py
+++ b/api/app/controllers/mcp_market_config_controller.py
@@ -19,7 +19,7 @@ from app.models import mcp_market_config_model
 from app.models.user_model import User
 from app.schemas import mcp_market_config_schema
 from app.schemas.response_schema import ApiResponse
-from app.services import mcp_market_config_service
+from app.services import mcp_market_config_service, mcp_market_service
 
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
@@ -115,6 +115,17 @@ async def get_mcp_servers(
             "has_next": True if page * pagesize < total else False
         }
     }
+    # 5. Update mck_market.mcp_count
+    db_mcp_market = mcp_market_service.get_mcp_market_by_id(db, mcp_market_id=db_mcp_market_config.mcp_market_id, current_user=current_user)
+    if not db_mcp_market:
+        api_logger.warning(f"The mcp market does not exist or access is denied: mcp_market_id={db_mcp_market_config.mcp_market_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The mcp market does not exist or access is denied"
+        )
+    db_mcp_market.mcp_count = total
+    db.commit()
+    db.refresh(db_mcp_market)
     return success(data=result, msg="Query of mcp servers list successful")
 
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

更新 MCP 服务器列表，以保持关联市场的 MCP 计数同步，并调整 Celery 的时区处理。

错误修复：
- 确保 MCP 市场的 `mcp_count` 字段会更新为当前由 listing 接口返回的 MCP 服务器数量。
- 通过禁用 UTC 来对齐 Celery 的时区配置，使定时任务按照 Asia/Shanghai 时区设置运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MCP server listing to keep associated market MCP counts in sync and adjust Celery timezone handling.

Bug Fixes:
- Ensure the MCP market's mcp_count field is updated to reflect the current number of MCP servers returned by the listing endpoint.
- Align Celery's timezone configuration by disabling UTC so scheduled tasks run according to the Asia/Shanghai timezone setting.

</details>