### PR TITLE
[changes] Remove the non-existent "storage_type"

### DIFF
--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -247,7 +247,6 @@ class EndUserRepository:
                         EndUser.user_summary: user_summary,
                         EndUser.rag_tags: rag_tags,
                         EndUser.rag_personas: rag_personas,
-                        EndUser.storage_type: "rag",
                         EndUser.rag_summary_updated_at: datetime.datetime.now(),
                     },
                     synchronize_session=False
@@ -286,7 +285,6 @@ class EndUserRepository:
                 .update(
                     {
                         EndUser.memory_insight: memory_insight,
-                        EndUser.storage_type: "rag",
                         EndUser.memory_insight_updated_at: datetime.datetime.now(),
                     },
                     synchronize_session=False


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

错误修复：
- 在更新 RAG 摘要和洞见时，避免引用已删除/不存在的 `EndUser.storage_type` 列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid referencing the removed/non-existent EndUser.storage_type column when updating RAG summaries and insights.

</details>