### PR TITLE
fix(web): upload cancel add refresh

### DIFF
--- a/web/src/views/ApplicationManagement/components/UploadModal.tsx
+++ b/web/src/views/ApplicationManagement/components/UploadModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-28 14:08:14 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-06 12:05:46
+ * @Last Modified time: 2026-03-12 17:19:46
  */
 /**
  * UploadModal Component
@@ -63,6 +63,7 @@ const UploadModal = forwardRef<UploadModalRef, UploadModalProps>(({
    * Resets all states and form fields
    */
   const handleClose = () => {
+    refresh()
     setVisible(false);
     form.resetFields();
     setCurrent(0);
@@ -211,7 +212,6 @@ const UploadModal = forwardRef<UploadModalRef, UploadModalProps>(({
               fileSize={100}
               maxCount={1}
               fileType={['yml']}
-              draggerHeight={200}
             />
           </Form.Item>
         </Form>

--- a/web/src/views/ApplicationManagement/components/UploadWorkflowModal.tsx
+++ b/web/src/views/ApplicationManagement/components/UploadWorkflowModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-28 14:08:14 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-06 12:05:46
+ * @Last Modified time: 2026-03-12 17:19:33
  */
 /**
  * UploadWorkflowModal Component
@@ -72,6 +72,7 @@ const UploadWorkflowModal = forwardRef<UploadWorkflowModalRef, UploadWorkflowMod
     setFirstFormData(null);
     setAppId(null);
     setLoading(false);
+    refresh()
   };
 
   /**


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

确保上传模态框在关闭时重置状态并触发数据刷新，同时调整上传组件的布局。

错误修复：
- 在关闭应用上传模态框时触发数据刷新，以便立即反映已取消的上传。
- 在关闭工作流上传模态框时触发数据刷新，以便在取消上传后保持应用列表同步。

改进：
- 通过移除固定的拖拽区域高度配置来简化上传模态框布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure upload modals reset state and trigger a data refresh when closed, and adjust upload component layout.

Bug Fixes:
- Trigger a data refresh when closing the application upload modal to reflect cancelled uploads immediately.
- Trigger a data refresh when closing the workflow upload modal to keep the application list in sync after cancellations.

Enhancements:
- Simplify the upload modal layout by removing a fixed dragger height configuration.

</details>