### PR TITLE
fix(mcp)

### DIFF
--- a/api/app/controllers/mcp_market_config_controller.py
+++ b/api/app/controllers/mcp_market_config_controller.py
@@ -55,6 +55,12 @@ async def get_mcp_servers(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The paging parameter must be greater than 0"
         )
+    if page * pagesize > 100:
+        api_logger.warning(f"Paging parameters exceed ModelScope limit: page={page}, pagesize={pagesize}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"page × pagesize must not exceed 100 (got {page} × {pagesize} = {page * pagesize})"
+        )
 
     # 2. Query mcp market config information from the database
     api_logger.debug(f"Query mcp market config: {mcp_market_config_id}")


### PR DESCRIPTION
The MCP Square can obtain a maximum of 100 MCP services.

## Summary by Sourcery

Bug Fixes:
- 当 `page × pagesize` 超过 100 时拒绝 MCP 服务器列表请求，并返回带有描述性消息的 400 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reject MCP server list requests where page × pagesize exceeds 100, returning a 400 error with a descriptive message.

</details>