### PR TITLE
fix(mcp)

### DIFF
--- a/api/app/controllers/mcp_market_config_controller.py
+++ b/api/app/controllers/mcp_market_config_controller.py
@@ -70,10 +70,7 @@ async def get_mcp_servers(
     if not db_mcp_market_config:
         api_logger.warning(
             f"The mcp market config does not exist or access is denied: mcp_market_config_id={mcp_market_config_id}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The mcp market config does not exist or access is denied"
-        )
+        return success(msg='The mcp market config does not exist or access is denied')
 
     # 3. Execute paged query
     token = db_mcp_market_config.token
@@ -151,10 +148,7 @@ async def get_operational_mcp_servers(
     if not db_mcp_market_config:
         api_logger.warning(
             f"The mcp market config does not exist or access is denied: mcp_market_config_id={mcp_market_config_id}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The mcp market config does not exist or access is denied"
-        )
+        return success(msg='The mcp market config does not exist or access is denied')
 
     # 2. Execute paged query
     token = db_mcp_market_config.token
@@ -214,10 +208,7 @@ async def get_mcp_server(
     if not db_mcp_market_config:
         api_logger.warning(
             f"The mcp market config does not exist or access is denied: mcp_market_config_id={mcp_market_config_id}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The mcp market config does not exist or access is denied"
-        )
+        return success(msg='The mcp market config does not exist or access is denied')
 
     # 2. Get detailed information for a specific MCP Server
     token = db_mcp_market_config.token
@@ -283,10 +274,7 @@ async def get_mcp_market_config(
         db_mcp_market_config = mcp_market_config_service.get_mcp_market_config_by_id(db, mcp_market_config_id=mcp_market_config_id, current_user=current_user)
         if not db_mcp_market_config:
             api_logger.warning(f"The mcp market config does not exist or access is denied: mcp_market_config_id={mcp_market_config_id}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The mcp market config does not exist or access is denied"
-            )
+            return success(msg='The mcp market config does not exist or access is denied')
 
         api_logger.info(f"mcp market config query successful: (ID: {db_mcp_market_config.id})")
         return success(data=jsonable_encoder(mcp_market_config_schema.McpMarketConfig.model_validate(db_mcp_market_config)),
@@ -316,10 +304,7 @@ async def get_mcp_market_config_by_mcp_market_id(
         db_mcp_market_config = mcp_market_config_service.get_mcp_market_config_by_mcp_market_id(db, mcp_market_id=mcp_market_id, current_user=current_user)
         if not db_mcp_market_config:
             api_logger.warning(f"The mcp market config does not exist or access is denied: mcp_market_id={mcp_market_id}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The mcp market config does not exist or access is denied"
-            )
+            return success(msg='The mcp market config does not exist or access is denied')
 
         api_logger.info(f"mcp market config query successful: (ID: {db_mcp_market_config.id})")
         return success(data=jsonable_encoder(mcp_market_config_schema.McpMarketConfig.model_validate(db_mcp_market_config)),
@@ -345,10 +330,7 @@ async def update_mcp_market_config(
     if not db_mcp_market_config:
         api_logger.warning(
             f"The mcp market config does not exist or you do not have permission to access it: mcp_market_config_id={mcp_market_config_id}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The mcp market config does not exist or you do not have permission to access it"
-        )
+        return success(msg='The mcp market config does not exist or access is denied')
 
     # 2. Update fields (only update non-null fields)
     api_logger.debug(f"Start updating the mcp market config fields: {mcp_market_config_id}")
@@ -402,10 +384,7 @@ async def delete_mcp_market_config(
         if not db_mcp_market_config:
             api_logger.warning(
                 f"The mcp market config does not exist or you do not have permission to access it: mcp_market_config_id={mcp_market_config_id}")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The mcp market config does not exist or you do not have permission to access it"
-            )
+            return success(msg='The mcp market config does not exist or access is denied')
 
         # 2. Deleting mcp market config
         mcp_market_config_service.delete_mcp_market_config_by_id(db, mcp_market_config_id=mcp_market_config_id, current_user=current_user)

--- a/api/app/core/tools/mcp/client.py
+++ b/api/app/core/tools/mcp/client.py
@@ -53,6 +53,7 @@ class SimpleMCPClient:
             else:
                 await self._connect_http()
         except Exception as e:
+            await self.disconnect()
             logger.error(f"MCP连接失败: {self.server_url}, 错误: {e}")
             raise MCPConnectionError(f"连接失败: {e}")
     


### PR DESCRIPTION
bug fix

## Summary by Sourcery

更优雅地处理缺失的 MCP 市场配置，并在出现错误时改进 MCP 客户端连接的清理行为。

Bug 修复：
- 当 MCP 市场配置缺失或在 MCP 市场配置控制器端点中访问被拒绝时，不再抛出 HTTP 400，而是返回带有说明性消息的成功响应。
- 确保在连接尝试失败时，MCP 客户端能够正常断开并完成清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing MCP market configurations more gracefully and improve MCP client connection cleanup on errors.

Bug Fixes:
- Return a success response with an explanatory message instead of raising HTTP 400 when an MCP market config is missing or access is denied in MCP market config controller endpoints.
- Ensure the MCP client disconnects and cleans up properly when a connection attempt fails.

</details>