### PR TITLE
feat(app): add cross-workspace app sharing backend

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -53,6 +53,7 @@ def list_apps(
         status: str | None = None,
         search: str | None = None,
         include_shared: bool = True,
+        shared_only: bool = False,
         page: int = 1,
         pagesize: int = 10,
         ids: Optional[str] = None,
@@ -84,6 +85,7 @@ def list_apps(
         status=status,
         search=search,
         include_shared=include_shared,
+        shared_only=shared_only,
         page=page,
         pagesize=pagesize,
     )
@@ -105,6 +107,23 @@ def list_my_shared_out(
     shares = service.list_my_shared_out(workspace_id=workspace_id)
     data = [app_schema.AppShare.model_validate(s) for s in shares]
     return success(data=data)
+
+
+@router.delete("/share/{target_workspace_id}", summary="取消对某工作空间的所有应用分享")
+@cur_workspace_access_guard()
+def unshare_all_apps_to_workspace(
+        target_workspace_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """Cancel all app shares from current workspace to a target workspace."""
+    workspace_id = current_user.current_workspace_id
+    service = app_service.AppService(db)
+    count = service.unshare_all_apps_to_workspace(
+        target_workspace_id=target_workspace_id,
+        workspace_id=workspace_id
+    )
+    return success(msg=f"已取消 {count} 个应用的分享")
 
 
 @router.get("/{app_id}", summary="获取应用详情")
@@ -395,6 +414,23 @@ def list_app_shares(
 
     data = [app_schema.AppShare.model_validate(s) for s in shares]
     return success(data=data)
+
+
+@router.delete("/shared/{source_workspace_id}", summary="批量移除某来源工作空间的所有共享应用")
+@cur_workspace_access_guard()
+def remove_all_shared_apps_from_workspace(
+        source_workspace_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """Remove all shared apps from a specific source workspace (recipient operation)."""
+    workspace_id = current_user.current_workspace_id
+    service = app_service.AppService(db)
+    count = service.remove_all_shared_apps_from_workspace(
+        source_workspace_id=source_workspace_id,
+        workspace_id=workspace_id
+    )
+    return success(msg=f"已移除 {count} 个共享应用")
 
 
 @router.delete("/{app_id}/shared", summary="移除共享给我的应用")

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -12,7 +12,7 @@ import uuid
 from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 from fastapi import Depends
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.orm import Session
 
 from app.core.error_codes import BizCode
@@ -878,6 +878,7 @@ class AppService:
             status: Optional[str] = None,
             search: Optional[str] = None,
             include_shared: bool = True,
+            shared_only: bool = False,
             page: int = 1,
             pagesize: int = 10,
     ) -> Tuple[List[App], int]:
@@ -924,7 +925,14 @@ class AppService:
             filters.append(func.lower(App.name).like(f"%{search.lower()}%"))
 
         # 基础查询：本工作空间的应用
-        if include_shared:
+        if shared_only:
+            # 只返回共享给本工作空间的应用，不含自有应用
+            shared_app_ids_stmt = (
+                select(AppShare.source_app_id)
+                .where(AppShare.target_workspace_id == workspace_id)
+            )
+            stmt = select(App).where(App.id.in_(shared_app_ids_stmt))
+        elif include_shared:
             # 查询本工作空间的应用 + 分享给本工作空间的应用
             # 使用 OR 条件：workspace_id = current OR app_id IN (shared apps)
 
@@ -1891,6 +1899,39 @@ class AppService:
             extra={"app_id": str(app_id), "target_workspace_id": str(target_workspace_id)}
         )
 
+    def unshare_all_apps_to_workspace(
+            self,
+            *,
+            target_workspace_id: uuid.UUID,
+            workspace_id: uuid.UUID
+    ) -> int:
+        """Cancel all app shares from current workspace to a target workspace.
+
+        Args:
+            target_workspace_id: Target workspace ID to cancel all shares to
+            workspace_id: Current workspace ID (source)
+
+        Returns:
+            Number of share records deleted
+        """
+        from app.models import AppShare
+
+        logger.info(
+            "取消对目标工作空间的所有应用分享",
+            extra={"target_workspace_id": str(target_workspace_id), "workspace_id": str(workspace_id)}
+        )
+
+        stmt = delete(AppShare).where(
+            AppShare.source_workspace_id == workspace_id,
+            AppShare.target_workspace_id == target_workspace_id
+        )
+        result = self.db.execute(stmt)
+        self.db.commit()
+
+        count = result.rowcount
+        logger.info("已取消分享记录数", extra={"count": count})
+        return count
+
     def list_app_shares(
             self,
             *,
@@ -1975,6 +2016,39 @@ class AppService:
             "共享应用已移除",
             extra={"app_id": str(app_id), "workspace_id": str(workspace_id)}
         )
+
+    def remove_all_shared_apps_from_workspace(
+            self,
+            *,
+            source_workspace_id: uuid.UUID,
+            workspace_id: uuid.UUID
+    ) -> int:
+        """Remove all shared apps from a specific source workspace.
+
+        Args:
+            source_workspace_id: The workspace that shared the apps
+            workspace_id: Current workspace ID (recipient)
+
+        Returns:
+            Number of share records deleted
+        """
+        from app.models import AppShare
+
+        logger.info(
+            "批量移除来源工作空间的共享应用",
+            extra={"source_workspace_id": str(source_workspace_id), "workspace_id": str(workspace_id)}
+        )
+
+        stmt = delete(AppShare).where(
+            AppShare.source_workspace_id == source_workspace_id,
+            AppShare.target_workspace_id == workspace_id
+        )
+        result = self.db.execute(stmt)
+        self.db.commit()
+
+        count = result.rowcount
+        logger.info("已移除共享记录数", extra={"count": count})
+        return count
 
     def list_my_shared_out(
             self,
@@ -2139,6 +2213,7 @@ def list_apps(
         status: Optional[str] = None,
         search: Optional[str] = None,
         include_shared: bool = True,
+        shared_only: bool = False,
         page: int = 1,
         pagesize: int = 10,
 ) -> Tuple[List[App], int]:
@@ -2151,6 +2226,7 @@ def list_apps(
         status=status,
         search=search,
         include_shared=include_shared,
+        shared_only=shared_only,
         page=page,
         pagesize=pagesize,
     )


### PR DESCRIPTION
## Summary

Implement cross-workspace app sharing backend. A workspace owner can share their `agent` or `workflow` apps to other workspaces with configurable permissions.

## Changes

- Add `app_shares` table and `AppShare` model with cascade delete on source app removal
- Add service methods: `share_app`, `unshare_app`, `remove_shared_app`, `list_my_shared_out`, `update_share_permission`
- Add `shared_only` query param to `GET /apps` for fetching only shared-in apps
- Add batch unshare endpoints:
  - `DELETE /apps/share/{target_workspace_id}` — source side, cancel all shares to a workspace
  - `DELETE /apps/shared/{source_workspace_id}` — recipient side, remove all shared apps from a workspace
- Add endpoints:
  - `POST /apps/{app_id}/share`
  - `GET /apps/my-shared-out`
  - `GET /apps/{app_id}/shares`
  - `PATCH /apps/{app_id}/share/{target_workspace_id}`
  - `DELETE /apps/{app_id}/share/{target_workspace_id}`
  - `DELETE /apps/{app_id}/shared`

## Permission Model

| Mode | Key | Description |
|------|-----|-------------|
| Read-only | `readonly` | Use app only (chat, API, stats) |
| Copyable | `editable` | readonly + copy + export |

## Notes

- `multi_agent` type is not supported for sharing
- Duplicate share to same workspace is silently skipped
- Source app deletion cascades to all share records
- Frontend implementation is handled separately

## 由 Sourcery 提供的摘要

为跨工作区的应用共享以及跨工作区的批量共享管理添加后端支持。

新功能：
- 通过在应用列表 API 中新增 `shared_only` 过滤器，允许只列出共享到当前工作区的应用。
- 添加服务层和控制器端点，可在一次操作中取消当前工作区到目标工作区的所有应用共享。
- 添加服务层和控制器端点，可在一次操作中移除从特定源工作区共享到当前工作区的所有应用。

改进：
- 扩展应用列表服务和控制器，以支持对“自有应用”和“共享应用”进行更灵活的过滤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add backend support for cross-workspace app sharing and bulk share management between workspaces.

New Features:
- Allow listing only apps that are shared into the current workspace via a new shared_only filter on app listing APIs.
- Add service and controller endpoints to cancel all app shares from the current workspace to a target workspace in one operation.
- Add service and controller endpoints to remove all apps shared from a specific source workspace into the current workspace in one operation.

Enhancements:
- Extend app listing service and controller to support more flexible filtering of own vs shared apps.

</details>