### PR TITLE
fix(mcp)

### DIFF
--- a/api/app/controllers/mcp_market_config_controller.py
+++ b/api/app/controllers/mcp_market_config_controller.py
@@ -59,7 +59,7 @@ async def get_mcp_servers(
         api_logger.warning(f"Paging parameters exceed ModelScope limit: page={page}, pagesize={pagesize}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"page × pagesize must not exceed 100 (got {page} × {pagesize} = {page * pagesize})"
+            detail=f"The maximum number of MCP services can view is 100. Please visit the ModelScope MCP Plaza."
         )
 
     # 2. Query mcp market config information from the database
@@ -238,7 +238,26 @@ async def create_mcp_market_config(
 
     try:
         api_logger.debug(f"Start creating the mcp market config: {create_data.mcp_market_id}")
-        # 1. Check if the mcp market name already exists
+        # 1. Validate token can access ModelScope MCP market
+        if not create_data.token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Token is required to access ModelScope MCP market"
+            )
+        try:
+            api = MCPApi()
+            api.login(create_data.token)
+            body = {'filter': {}, 'page_number': 1, 'page_size': 1, 'search': None}
+            cookies = api.get_cookies(create_data.token)
+            r = api.session.put(url=api.mcp_base_url, headers=api.builder_headers(api.headers), json=body, cookies=cookies)
+            raise_for_http_status(r)
+        except Exception as e:
+            api_logger.warning(f"Token validation failed for ModelScope MCP market: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unable to access ModelScope MCP market with the provided token: {str(e)}"
+            )
+        # 2. Check if the mcp market name already exists
         db_mcp_market_config_exist = mcp_market_config_service.get_mcp_market_config_by_mcp_market_id(db, mcp_market_id=create_data.mcp_market_id, current_user=current_user)
         if db_mcp_market_config_exist:
             api_logger.warning(f"The mcp market id already exists: {create_data.mcp_market_id}")
@@ -332,7 +351,23 @@ async def update_mcp_market_config(
             f"The mcp market config does not exist or you do not have permission to access it: mcp_market_config_id={mcp_market_config_id}")
         return success(msg='The mcp market config does not exist or access is denied')
 
-    # 2. Update fields (only update non-null fields)
+    # 2. Validate new token if provided
+    if update_data.token is not None:
+        try:
+            api = MCPApi()
+            api.login(update_data.token)
+            body = {'filter': {}, 'page_number': 1, 'page_size': 1, 'search': None}
+            cookies = api.get_cookies(update_data.token)
+            r = api.session.put(url=api.mcp_base_url, headers=api.builder_headers(api.headers), json=body, cookies=cookies)
+            raise_for_http_status(r)
+        except Exception as e:
+            api_logger.warning(f"Token validation failed for ModelScope MCP market: {str(e)}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unable to access ModelScope MCP market with the provided token: {str(e)}"
+            )
+
+    # 3. Update fields (only update non-null fields)
     api_logger.debug(f"Start updating the mcp market config fields: {mcp_market_config_id}")
     update_dict = update_data.dict(exclude_unset=True)
     updated_fields = []
@@ -347,7 +382,7 @@ async def update_mcp_market_config(
     if updated_fields:
         api_logger.debug(f"updated fields: {', '.join(updated_fields)}")
 
-    # 3. Save to database
+    # 4. Save to database
     try:
         db.commit()
         db.refresh(db_mcp_market_config)


### PR DESCRIPTION
The token configuration modification of MCP Market needs to be verified.

## Summary by Sourcery

在创建或更新 MCP 市场配置时验证 MCP 市场令牌，并明确 MCP 服务分页相关的报错信息。

Bug 修复：
- 当分页请求超过 100 条时，强制限制可查看的 MCP 服务数量上限，并提供更清晰的错误信息。

增强功能：
- 在创建新的 MCP 市场配置时，针对 ModelScope MCP 市场进行令牌校验，以确保该令牌具备访问该市场的权限。
- 在保存配置变更之前，对更新后的 MCP 市场令牌（如果提供）进行验证，防止无效的市场访问令牌被保存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate MCP market tokens when creating or updating MCP market configurations and clarify MCP service pagination error messaging.

Bug Fixes:
- Enforce a maximum viewable MCP services limit with a clearer error message when pagination exceeds 100 items.

Enhancements:
- Add token validation against the ModelScope MCP market when creating a new MCP market configuration to ensure the token can access the market.
- Validate updated MCP market tokens, when provided, before persisting configuration changes to prevent invalid market access tokens from being saved.

</details>