### PR TITLE
fix(multimodel): handle 302 redirect when downloading files

### DIFF
--- a/api/app/services/audio_transcription_service.py
+++ b/api/app/services/audio_transcription_service.py
@@ -75,7 +75,7 @@ class AudioTranscriptionService:
         try:
             # 下载音频文件
             async with httpx.AsyncClient(timeout=60.0) as client:
-                audio_response = await client.get(audio_url)
+                audio_response = await client.get(audio_url, follow_redirects=True)
                 audio_response.raise_for_status()
                 audio_data = audio_response.content
                 

--- a/api/app/services/multimodal_service.py
+++ b/api/app/services/multimodal_service.py
@@ -130,7 +130,7 @@ class BedrockFormatStrategy(MultimodalFormatStrategy):
         # 下载图片
         if content is None:
             async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(url)
+                response = await client.get(url, follow_redirects=True)
                 response.raise_for_status()
                 content = response.content
                 self.file.set_content(content)
@@ -236,7 +236,7 @@ class OpenAIFormatStrategy(MultimodalFormatStrategy):
             audio_data = content
             if content is None:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    response = await client.get(url)
+                    response = await client.get(url, follow_redirects=True)
                     response.raise_for_status()
                     audio_data = response.content
                     self.file.set_content(audio_data)
@@ -566,7 +566,7 @@ class MultimodalService:
             file_content = file.get_content()
             if not file_content:
                 async with httpx.AsyncClient(timeout=30.0) as client:
-                    response = await client.get(file.url)
+                    response = await client.get(file.url, follow_redirects=True)
                     response.raise_for_status()
                     file_content = response.content
                     file.set_content(file_content)


### PR DESCRIPTION
## Summary by Sourcery

在多模态和转录服务中下载远程媒体时，正确处理 HTTP 重定向。

Bug 修复：
- 确保在下载图像、音频和文档时能够跟随 HTTP 3xx 重定向，从而成功获取内容。
- 修复当音频转录的来源 URL 返回 HTTP 重定向时，下载失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle HTTP redirects when downloading remote media in multimodal and transcription services.

Bug Fixes:
- Ensure image, audio, and document downloads follow HTTP 3xx redirects to successfully retrieve content.
- Fix audio transcription downloads failing when the source URL responds with an HTTP redirect.

</details>