### PR TITLE
feat(web): app share

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1423,6 +1423,7 @@ export const en = {
       souceStatus: 'Source App Status',
       confirmCopyDesc: 'Are you sure to copy 【{{app}}】 app?',
       noShareAuth: 'No permission to share apps',
+      appCount: '{{count}} apps shared to this space',
     },
     userMemory: {
       userMemory: 'User Memory',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -807,6 +807,7 @@ export const zh = {
       souceStatus: '源应用状态',
       confirmCopyDesc: '确定复制【{{app}}】应用？',
       noShareAuth: '无共享应用的权限',
+      appCount: '{{count}}个应用共享到此空间',
     },
     table: {
       totalRecords: '共 {{total}} 条记录'

--- a/web/src/views/ApplicationManagement/MySharing.tsx
+++ b/web/src/views/ApplicationManagement/MySharing.tsx
@@ -2,11 +2,11 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 16:19:37
+ * @Last Modified time: 2026-03-13 17:36:16
  */
 import React, { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, App, Flex, Row, Col, Collapse, Tag } from 'antd';
+import { Button, App, Flex, Row, Col, Collapse } from 'antd';
 import clsx from 'clsx';
 
 import type { MySharedOutItem } from './types';
@@ -88,14 +88,15 @@ const MySharing: React.FC = () => {
                       {workspace.target_workspace_name[0]}
                     </div>
                 }
-                <span className="rb:font-medium">{workspace.target_workspace_name}</span>
-                <Tag color="blue">{t('application.appCount', { count: items.length })}</Tag>
+                <div>
+                  <span className="rb:font-medium">{workspace.target_workspace_name}</span>
+                  <div className="rb:text-[#5B6167] rb:text-[12px]">{t('application.appCount', { count: items.length })}</div>
+                </div>
               </Flex>
             ),
             extra: (
               <Button
                 size="small"
-                danger
                 onClick={e => { e.stopPropagation(); handleAllCancel(workspace); }}
               >
                 {t('application.allCancel')}


### PR DESCRIPTION
## Summary by Sourcery

更新应用共享视图，以在每个工作区显示描述性已共享应用数量，并调整页眉布局。

新功能：
- 在“我的共享”视图中，显示一条本地化消息，指示有多少应用已共享到每个目标工作区。

增强项：
- 优化“我的共享”视图中的工作区页眉布局，将名称与已共享应用数量进行分组，并从批量取消按钮中移除破坏性样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the application sharing view to display a descriptive shared-app count per workspace and adjust the header layout.

New Features:
- Show a localized message indicating how many apps are shared to each target workspace in the My Sharing view.

Enhancements:
- Refine the workspace header layout in the My Sharing view by grouping the name and shared-app count and removing the destructive styling from the bulk cancel button.

</details>