### PR TITLE
feat(web): app api support shared_only key

### DIFF
--- a/web/src/views/ApplicationManagement/index.tsx
+++ b/web/src/views/ApplicationManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 17:03:40
+ * @Last Modified time: 2026-03-16 09:56:02
  */
 /**
  * Application Management Page
@@ -185,7 +185,7 @@ const ApplicationManagement: React.FC = () => {
         <PageScrollList<Application, Query>
           ref={scrollListRef}
           url={getApplicationListUrl}
-          query={{ ...query, include_shared: activeTab === 'sharing' }}
+          query={{ ...query, shared_only: activeTab === 'sharing' }}
           renderItem={(item) => (
             <RbCard
               title={item.name}

--- a/web/src/views/ApplicationManagement/types.ts
+++ b/web/src/views/ApplicationManagement/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 17:01:06
+ * @Last Modified time: 2026-03-16 09:55:52
  */
 /**
  * Type definitions for Application Management
@@ -15,7 +15,7 @@ export interface Query {
   /** Search keyword */
   search: string;
   type?: string;
-  include_shared?: boolean;
+  shared_only?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 将应用列表查询参数从 `include_shared` 重命名为 `shared_only`，以与更新后的 API 合约保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Rename the application list query parameter from include_shared to shared_only to align with the updated API contract.

</details>