### PR TITLE
Feature/app zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 17:12:59
+ * @Last Modified time: 2026-03-16 15:58:10
  */
 import { type FC, useRef, useMemo, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -97,10 +97,16 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
         applicationModalRef.current?.handleOpen(application)
         break;
       case 'copy':
-        copyModalRef.current?.handleOpen()
+        appRef?.current?.handleSave(false)
+          .then(() => {
+            copyModalRef.current?.handleOpen()
+          })
         break;
       case 'export':
-        appExport(application.id, application.name)
+        appRef?.current?.handleSave(false)
+          .then(() => {
+            appExport(application.id, application.name)
+          })
         break;
       case 'delete':
         handleDelete()

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:39:59 
- * @Last Modified by: ZhaoYing 
- * @Last Modified time: 2026-03-02 17:06:41 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-03-16 16:11:28
  */
 import { type FC, useEffect, useState, useMemo } from "react";
 import clsx from 'clsx'
@@ -88,7 +88,7 @@ const Properties: FC<PropertiesProps> = ({
 
   useEffect(() => {
     if (selectedNode && form) {
-      const { type = 'default', name = '', config } = selectedNode.getData() || {}
+      const { type = 'default', name = '', config, id } = selectedNode.getData() || {}
       const initialValue: Record<string, any> = {}
       Object.keys(config || {}).forEach(key => {
         if (config && config[key] && 'defaultValue' in config[key]) {
@@ -98,7 +98,7 @@ const Properties: FC<PropertiesProps> = ({
 
       form.setFieldsValue({
         type,
-        id: selectedNode.id,
+        id,
         name,
         ...initialValue,
       })

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-07 15:23:39
+ * @Last Modified time: 2026-03-16 16:11:01
  */
 import { useRef, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -593,6 +593,13 @@ export const useWorkflowGraph = ({
     if (!graphRef.current) return false;
     const selectedNodes = graphRef.current.getNodes().filter(node => node.getData()?.isSelected);
     if (selectedNodes.length) {
+      selectedNodes.forEach(node => {
+        const data = node.getData();
+        node.setData({
+          ...data,
+          id: `${(data.type as string).replace(/-/g, '_')}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+        });
+      });
       graphRef.current.copy(selectedNodes);
     }
     return false;


### PR DESCRIPTION
## Summary by Sourcery

在执行复制或导出操作之前，确保应用配置已保存，并调整工作流节点处理逻辑，使复制的节点能够获得新的 ID，并在属性面板中始终一致地使用这些 ID。

新功能：
- 在复制工作流节点时，自动为其分配新的唯一 ID。

错误修复：
- 在打开复制弹窗或导出应用之前触发应用配置保存，以避免使用过期数据。
- 在属性表单中使用工作流节点的数据 ID 而不是图节点 ID，从而使显示的 ID 与节点数据保持同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure application configuration is saved before performing copy or export actions and adjust workflow node handling so copied nodes receive new IDs that are used consistently in the properties panel.

New Features:
- Automatically assign a new unique ID to workflow nodes when they are copied.

Bug Fixes:
- Trigger a save of the application configuration before opening the copy modal or exporting an application to avoid working with stale data.
- Use the workflow node's data ID rather than the graph node ID in the properties form to keep the displayed ID in sync with node data.

</details>