### PR TITLE
[add] Change the "last_done" storage to UTC and remove the intermedia…

### DIFF
--- a/api/app/repositories/implicit_emotions_storage_repository.py
+++ b/api/app/repositories/implicit_emotions_storage_repository.py
@@ -5,7 +5,7 @@ Implicit Emotions Storage Repository
 事务由调用方控制，仓储层只使用 flush/refresh
 """
 import logging
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from typing import Generator, Optional
 
 
@@ -177,22 +177,21 @@ class ImplicitEmotionsStorageRepository:
                     if raw is None:
                         continue
                     try:
-                        CST = timezone(timedelta(hours=8))
                         last_done = datetime.fromisoformat(raw)
-                        # last_done 写入时已是 CST naive，直接使用，无需转换
-                        if last_done.tzinfo is not None:
-                            last_done = last_done.astimezone(CST).replace(tzinfo=None)
+                        # last_done 写入时已是 UTC aware（+00:00），确保有 tzinfo
+                        if last_done.tzinfo is None:
+                            last_done = last_done.replace(tzinfo=timezone.utc)
 
                         if updated_at is None:
                             yield end_user_id
                             continue
-                        # updated_at 数据库存的是 UTC naive，转为 CST naive 再比较
+                        # updated_at 数据库存的是 UTC naive，补上 UTC tzinfo 再比较
                         if updated_at.tzinfo is None:
-                            updated_at_cst = updated_at.replace(tzinfo=timezone.utc).astimezone(CST).replace(tzinfo=None)
+                            updated_at_utc = updated_at.replace(tzinfo=timezone.utc)
                         else:
-                            updated_at_cst = updated_at.astimezone(CST).replace(tzinfo=None)
+                            updated_at_utc = updated_at.astimezone(timezone.utc)
 
-                        if last_done > updated_at_cst:
+                        if last_done > updated_at_utc:
                             yield end_user_id
                     except Exception as e:
                         logger.warning(f"解析 last_done 时间戳失败: end_user_id={end_user_id}, raw={raw}, error={e}")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1158,13 +1158,11 @@ def write_message_task(self, end_user_id: str, message: list[dict], config_id: s
         try:
             _r = get_sync_redis_client()
             if _r is not None:
-                from datetime import timedelta as _td
                 from datetime import timezone as _tz
-                _CST = _tz(_td(hours=8))
-                _now_cst = datetime.now(_CST).replace(tzinfo=None).isoformat()
+                _now_utc = datetime.now(_tz.utc).isoformat()
                 _r.set(
                     f"write_message:last_done:{end_user_id}",
-                    _now_cst,
+                    _now_utc,
                     ex=86400 * 30,
                 )
         except Exception as _e:


### PR DESCRIPTION
…te conversion.

## Summary by Sourcery

在存储和比较逻辑中，将隐式情绪刷新时间戳统一标准化为使用带有 UTC 时区信息的 datetime。

Bug Fixes:
- 修复由于混用 CST 和 UTC 导致的 Redis 中 `last_done` 时间戳与数据库 `updated_at` 值比较不正确的问题。

Enhancements:
- 在 Redis 中将 `last_done` 时间戳存储为带有 UTC 时区信息的 ISO 字符串，并与带有 UTC 时区信息的 `updated_at` 值进行比较，以简化时区处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize implicit emotions refresh timestamps to use UTC-aware datetimes in storage and comparison logic.

Bug Fixes:
- Fix incorrect comparison between Redis last_done timestamps and database updated_at values caused by mixed CST and UTC handling.

Enhancements:
- Store last_done timestamps in Redis as UTC-aware ISO strings and compare them against UTC-aware updated_at values to simplify time zone handling.

</details>