### PR TITLE
[changes] average_activation_value, rounded to two decimal places

### DIFF
--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -518,7 +518,7 @@ class MemoryForgetService:
                 'total_nodes': result['total_nodes'] or 0,
                 'nodes_with_activation': result['nodes_with_activation'] or 0,
                 'nodes_without_activation': result['nodes_without_activation'] or 0,
-                'average_activation_value': result['average_activation'],
+                'average_activation_value': round(result['average_activation'], 2) if result['average_activation'] is not None else None,
                 'low_activation_nodes': result['low_activation_nodes'] or 0,
                 'forgetting_threshold': forgetting_threshold,
                 'timestamp': int(datetime.now().timestamp() * 1000)


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在计算遗忘统计数据时，安全地处理空（null）的平均激活值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle null average activation values safely when computing forgetting stats.

</details>