### PR TITLE
fix(web): if-else & question-classifier edge label bugfix

### DIFF
--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:06:18 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-09 13:41:19
+ * @Last Modified time: 2026-03-17 09:59:56
  */
 import LoopNode from './components/Nodes/LoopNode';
 import NormalNode from './components/Nodes/NormalNode';
@@ -783,7 +783,7 @@ export const graphNodeLibrary: Record<string, NodeConfig> = {
         { group: 'left' },
         ...(['IF', 'ELSE'].map((text, index) => ({
           group: 'right',
-          id: `CASE${index}`,
+          id: `CASE${index + 1}`,
           args: {
             ...portArgs,
             y: 30 * index + 42,
@@ -803,7 +803,7 @@ export const graphNodeLibrary: Record<string, NodeConfig> = {
         { group: 'left' },
         ...(['分类1', '分类2'].map((text, index) => ({
           group: 'right',
-          id: `CASE${index}`,
+          id: `CASE${index + 1}`,
           args: {
             ...portArgs,
             y: 30 * index + 42,

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-16 18:56:30
+ * @Last Modified time: 2026-03-17 10:00:10
  */
 import { useRef, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -222,7 +222,7 @@ export const useWorkflowGraph = ({
           for (let i = 0; i < totalPorts; i++) {
             portItems.push({
               group: 'right',
-              id: `CASE${i}`,
+              id: `CASE${i + 1}`,
               args: {
                 x: nodeWidth,
                 y: 30 * i + 42,
@@ -253,7 +253,7 @@ export const useWorkflowGraph = ({
           config.categories.forEach((_category: any, index: number) => {
             portItems.push({
               group: 'right',
-              id: `CASE${index}`,
+              id: `CASE${index + 1}`,
               args: {
                 x: nodeWidth,
                 y: 30 * index + 42,


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

修复工作流图中 IF/ELSE 和 question-classifier 节点的边端口标识符，使其使用从 1 开始的 CASE 索引。

错误修复：
- 更正 IF/ELSE 节点上的 CASE 端口 ID，使边标签与预期的从 1 开始编号保持一致。
- 更正 question-classifier 节点上的 CASE 端口 ID，使边标签与预期的从 1 开始编号保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow graph edge port identifiers for IF/ELSE and question-classifier nodes to use one-based CASE indices.

Bug Fixes:
- Correct CASE port IDs on IF/ELSE nodes to align edge labels with expected one-based numbering.
- Correct CASE port IDs on question-classifier nodes to align edge labels with expected one-based numbering.

</details>