### PR TITLE
feat(web): memory conversation add communities

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1771,6 +1771,8 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       memoryConversationAnalysisEmpty: 'No conversation analysis available.',
       memoryConversationAnalysisEmptySubTitle: 'Conversation analysis will appear here.',
 
+      communities: 'Cluster Communities',
+      summaries: 'Memory Summaries',
       uploadFile: 'Upload File',
       fileType: 'File Type',
       image: 'Image',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1767,6 +1767,8 @@ export const zh = {
       memoryConversationAnalysisEmpty: '目前没有可用的对话分析内容',
       memoryConversationAnalysisEmptySubTitle: '输入您的用户ID后，点击"测试记忆"查看对话记忆',
 
+      communities: '聚类社区',
+      summaries: '记忆摘要',
       uploadFile: '上传文件',
       fileType: '文件类型',
       image: '图片',

--- a/web/src/views/MemoryConversation/index.tsx
+++ b/web/src/views/MemoryConversation/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:09:03 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 17:09:03 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-03-17 16:21:47
  */
 /**
  * Memory Conversation Page
@@ -92,7 +92,7 @@ export interface LogItem {
   type: string;
   title: string;
   data?: DataItem[] | AnyObject;
-  raw_results?: string | AnyObject;
+  raw_results?: string | Record<string, AnyObject>;
   summary?: string;
   query?: string;
   reason?: string;
@@ -264,22 +264,25 @@ const MemoryConversation: FC = () => {
                           </ContentWrapper>
                         ))}
                       </Space>
-                      : log.type === 'search_result' && log.raw_results
+                      : log.type === 'search_result' && log.raw_results && typeof log.raw_results !== 'string'
                       ? <ContentWrapper>
                         <div className="rb:font-medium rb:text-[#212332] rb:mb-2">{log.query}</div>
-                          <div className='rb:mt-2 rb:text-[12px] rb:text-[#5B6167]'>
-                            {typeof log.raw_results === 'string'
-                              ? <Markdown content={log.raw_results} />
-                              : <>
-                                {log.raw_results.reranked_results?.statements.length > 0 && log.raw_results.reranked_results?.statements.map((item: { statement: string }, index: number) => (
-                                  <div key={index}>{item.statement}</div>
-                                ))}
-                                {log.raw_results.reranked_results?.summaries.length > 0 && log.raw_results.reranked_results?.summaries.map((item: { content: string }, index: number) => (
-                                  <div key={index}>{item.content}</div>
-                                ))}
-                              </> 
-                            }
-                          </div>
+                        {(log.raw_results.reranked_results as AnyObject)?.communities?.length > 0 && <>
+                          <div className="rb:font-medium rb:text-[#212332] rb:text-[12px]">{t('memoryConversation.communities')}</div>
+                          <ul className='rb:mt-2 rb:text-[12px] rb:text-[#5B6167] rb:list-disc rb:pl-4'>
+                              {((log.raw_results.reranked_results as AnyObject)?.communities as { content: string }[]).map((item, index: number) => (
+                              <li key={index}>{item.content}</li>
+                            ))}
+                          </ul>
+                        </>}
+                        {(log.raw_results.reranked_results as AnyObject)?.summaries?.length > 0 && <>
+                          <div className="rb:font-medium rb:text-[#212332] rb:text-[12px]">{t('memoryConversation.summaries')}</div>
+                          <ul className='rb:mt-2 rb:text-[12px] rb:text-[#5B6167] rb:list-disc rb:pl-4'>
+                                {((log.raw_results.reranked_results as AnyObject)?.summaries as { content: string }[]).map((item, index: number) => (
+                              <li key={index}>{item.content}</li>
+                            ))}
+                          </ul>
+                        </>}
                         </ContentWrapper>
                       : log.type === 'retrieval_summary' && log.summary
                       ? <ContentWrapper><div className="rb:text-[12px] rb:text-[#5B6167]">{log.summary}</div></ContentWrapper>
@@ -296,22 +299,22 @@ const MemoryConversation: FC = () => {
                       </ContentWrapper>
                       : log.type === 'input_summary' && log.raw_results
                       ? <ContentWrapper>
-                          <div className="rb:font-medium rb:text-[#212332] rb:mb-2">{log.query}</div>
-                          <div className="rb:font-medium rb:text-[12px] rb:text-[#5B6167] rb:mb-2">{log.summary}</div>
-                          <div className='rb:mt-2 rb:text-[12px] rb:text-[#5B6167]'>
-                            {typeof log.raw_results === 'string'
-                              ? <Markdown content={log.raw_results} />
-                              : <>
-                                {log.raw_results.reranked_results?.statements.length > 0 && log.raw_results.reranked_results?.statements.map((item: { statement: string; } , index: number) => (
-                                  <div key={index}>{item.statement}</div>
-                                ))}
-                                {log.raw_results.reranked_results?.summaries.length > 0 && log.raw_results.reranked_results?.summaries.map((item: { content: string; }, index: number) => (
-                                  <div key={index}>{item.content}</div>
-                                ))}
-                              </> 
-                            }
-                          </div>
-                        </ContentWrapper>
+                        <div className="rb:font-medium rb:text-[#212332] rb:mb-2">{log.query}</div>
+                        <div className="rb:font-medium rb:text-[12px] rb:text-[#5B6167] rb:mb-2">{log.summary}</div>
+                        <div className='rb:mt-2 rb:text-[12px] rb:text-[#5B6167]'>
+                          {typeof log.raw_results === 'string'
+                            ? <Markdown content={log.raw_results} />
+                            : <>
+                              {(log.raw_results.reranked_results as AnyObject)?.statements?.length > 0 && ((log.raw_results.reranked_results as AnyObject)?.statements as { statement: string }[]).map((item, index: number) => (
+                                <div key={index}>{item.statement}</div>
+                              ))}
+                              {(log.raw_results.reranked_results as AnyObject)?.summaries?.length > 0 && ((log.raw_results.reranked_results as AnyObject)?.summaries as { content: string }[]).map((item, index: number) => (
+                                <div key={index}>{item.content}</div>
+                              ))}
+                            </>
+                          }
+                        </div>
+                      </ContentWrapper>
                       : null
                     }
                   </div>


### PR DESCRIPTION
## Summary by Sourcery

在「记忆对话（Memory Conversation）」视图中展示更多结构化搜索结果，包括聚类社区和相关日志的记忆总结。

新功能：
- 当原始重排序结果中可用时，为 `search_result` 日志展示聚类社区条目（cluster community items）。
- 为 `search_result` 日志展示记忆总结条目（memory summary items），并使用中英文本地化标签。

增强改进：
- 优化对原始搜索结果的处理，通过区分字符串与对象类型的有效负载，并为重排序结果提供更安全的类型定义。
- 调整 `input_summary` 的渲染逻辑，对陈述和总结使用类型化访问，同时在结果为字符串时保留 Markdown 渲染能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display additional structured search results in the Memory Conversation view, including cluster communities and memory summaries for relevant logs.

New Features:
- Show cluster community items for search_result logs when available in raw reranked results.
- Show memory summary items for search_result logs using localized labels in both English and Chinese.

Enhancements:
- Refine handling of raw search results by distinguishing between string and object payloads, with safer typing for reranked results.
- Adjust input_summary rendering to use typed access for statements and summaries while preserving Markdown rendering for string results.

</details>