### PR TITLE
fix(web): audio recorder add max size check

### DIFF
--- a/web/src/components/AudioRecorder/index.tsx
+++ b/web/src/components/AudioRecorder/index.tsx
@@ -2,10 +2,12 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:11:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-16 18:06:00
+ * @Last Modified time: 2026-03-17 18:39:09
  */
 import { type FC, useRef, useState } from 'react'
 import RecordRTC from 'recordrtc'
+import { App } from 'antd'
+import { useTranslation } from 'react-i18next';
 
 import { fileUploadUrlWithoutApiPrefix } from '@/api/fileStorage'
 import { request } from '@/utils/request'
@@ -20,6 +22,7 @@ interface AudioRecorderProps {
   /** Additional config passed to the upload request */
   requestConfig?: Record<string, any>;
   disabled?: boolean;
+  maxSize?: number;
 }
 
 const AudioRecorder: FC<AudioRecorderProps> = ({
@@ -27,8 +30,11 @@ const AudioRecorder: FC<AudioRecorderProps> = ({
   className = '',
   action = fileUploadUrlWithoutApiPrefix,
   requestConfig = {},
-  disabled = false
+  disabled = false,
+  maxSize,
 }) => {
+  const { message } = App.useApp()
+  const { t } = useTranslation();
   // Whether the recorder is currently capturing audio
   const [isRecording, setIsRecording] = useState(false)
   // Holds the RecordRTC instance across renders
@@ -57,6 +63,12 @@ const AudioRecorder: FC<AudioRecorderProps> = ({
       recorderRef.current.stopRecording(() => {
         const blob = recorderRef.current!.getBlob()
         const url = recorderRef.current!.toURL()
+
+        if (maxSize && blob.size > maxSize * 1024 * 1024) {
+          message.error(t('common.fileSizeTip', { size: maxSize }));
+          return
+        }
+
         const formData = new FormData()
         formData.append('file', blob, `recording_${Date.now()}.webm`)
         request

--- a/web/src/components/Chat/ChatToolbar.tsx
+++ b/web/src/components/Chat/ChatToolbar.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-03-17 14:22:25 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-03-17 14:22:25 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-03-17 18:39:49
  */
 // Toolbar component for chat input area, supporting file upload, audio recording, and variable configuration
 import { useRef, forwardRef, useImperativeHandle, type ReactNode, useEffect } from 'react'
@@ -151,8 +151,6 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
     })
   }
 
-  console.log('queryValues', queryValues)
-
   return (
     <Form form={form} initialValues={{ files: [], variables: [] }}>
       <Flex justify="space-between" className="rb:flex-1">
@@ -183,6 +181,7 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
               action={uploadAction}
               requestConfig={uploadRequestConfig}
               onRecordingComplete={handleRecordingComplete}
+              maxSize={file_upload?.audio_max_size_mb}
             />
             <Divider type="vertical" className="rb:ml-1.5! rb:mr-3!" />
           </Flex>

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-17 15:39:17
+ * @Last Modified time: 2026-03-17 18:30:58
  */
 /**
  * Conversation Page
@@ -369,7 +369,7 @@ const Conversation: FC = () => {
             }}
             extra={
               <>
-                {features.web_search?.enabled &&
+                {features?.web_search?.enabled &&
                   <ButtonCheckbox
                     icon={OnlineIcon}
                     checkedIcon={OnlineCheckedIcon}


### PR DESCRIPTION
## Summary by Sourcery

为 Web 音频录制器添加可配置的最大文件大小校验，并将其与聊天上传设置连接起来，同时进行一些小的 UI 稳定性改进与清理更新。

新功能：
- 为 `AudioRecorder` 组件引入可选的 `maxSize` 属性，用于在上传前强制限制录音的最大大小。
- 将聊天工具栏设置中配置的音频文件大小上限传递给音频录制器组件。

错误修复：
- 通过安全处理未定义的 `features` 对象，防止在访问 `web_search` 功能开关时出现运行时错误。
- 当录音超过配置的大小限制时阻止提交，避免上传超大音频文件。

改进：
- 从聊天工具栏组件中移除遗留的调试日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable maximum file size validation to the web audio recorder and wire it to chat upload settings, while performing minor UI robustness and cleanup updates.

New Features:
- Introduce an optional maxSize prop to the AudioRecorder component to enforce a maximum recording size before upload.
- Pass the configured audio file size limit from chat toolbar settings into the audio recorder component.

Bug Fixes:
- Prevent runtime errors when accessing the web_search feature flag by safely handling an undefined features object.
- Avoid uploading oversized audio recordings by blocking submission when they exceed the configured limit.

Enhancements:
- Remove leftover debug logging from the chat toolbar component.

</details>