### PR TITLE
fix(web): app sharing bugfix

### DIFF
--- a/web/src/views/ApplicationConfig/components/AppSharingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/AppSharingModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-13 17:19:13 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 17:26:57
+ * @Last Modified time: 2026-03-18 10:47:17
  */
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { Checkbox, App, Form } from 'antd';
@@ -147,6 +147,7 @@ const AppSharingModal = forwardRef<AppSharingModalRef, AppSharingModalProps>(({ 
                   <Checkbox
                     checked={isShared || selectedIds.includes(space.id)}
                     disabled={isShared} // already-shared workspaces cannot be unselected
+                    onClick={(e) => e.stopPropagation()}
                     onChange={() => handleToggle(space.id, isShared)}
                   />
                   <span className="rb:flex-1 rb:text-sm">{space.name}</span>

--- a/web/src/views/ApplicationManagement/MySharing.tsx
+++ b/web/src/views/ApplicationManagement/MySharing.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 17:36:16
+ * @Last Modified time: 2026-03-18 10:44:32
  */
 import React, { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -107,7 +107,7 @@ const MySharing: React.FC = () => {
                 {items.map(item => (
                   <Col key={item.id} span={6} className="rb:bg-[#F6F6F6] rb:rounded-lg rb:py-3! rb:px-4! rb:relative">
                     <div
-                      className="rb:absolute rb:top-3 rb:right-3 rb:cursor-pointer rb:size-4 rb:bg-cover rb:bg-[url('src/assets/images/close.svg')]"
+                      className="rb:absolute rb:top-3 rb:right-3 rb:cursor-pointer rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/close.svg')]"
                       onClick={() => handleCancelOne(item)}
                     />
                     <Flex gap={8} align="center">

--- a/web/src/views/ApplicationManagement/index.tsx
+++ b/web/src/views/ApplicationManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:12 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-16 09:56:02
+ * @Last Modified time: 2026-03-18 10:50:33
  */
 /**
  * Application Management Page
@@ -185,7 +185,7 @@ const ApplicationManagement: React.FC = () => {
         <PageScrollList<Application, Query>
           ref={scrollListRef}
           url={getApplicationListUrl}
-          query={{ ...query, shared_only: activeTab === 'sharing' }}
+          query={{ ...query, shared_only: activeTab === 'sharing', include_shared: activeTab !== 'apps' }}
           renderItem={(item) => (
             <RbCard
               title={item.name}

--- a/web/src/views/ApplicationManagement/types.ts
+++ b/web/src/views/ApplicationManagement/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-16 09:55:52
+ * @Last Modified time: 2026-03-18 10:50:27
  */
 /**
  * Type definitions for Application Management
@@ -16,6 +16,7 @@ export interface Query {
   search: string;
   type?: string;
   shared_only?: boolean;
+  include_shared?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

修复应用管理和应用共享模态视图中的应用共享行为及相关 UI 交互。

Bug 修复：
- 确保应用列表查询在不同激活标签页下，能够适当地包含共享应用。
- 通过控制点击事件传播，防止在应用共享模态框中点击行元素时误触发工作区选择复选框的切换。
- 更正“我的共享”视图中关闭图标的资源路径，确保移除操作图标能够正确显示。

增强功能：
- 为应用查询类型扩展 `include_shared` 标志，用于对共享应用进行更精细的过滤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix application sharing behavior and related UI interactions in the Application Management and App Sharing modal views.

Bug Fixes:
- Ensure application list queries include shared apps appropriately depending on the active tab.
- Prevent workspace selection checkboxes in the app sharing modal from toggling when their row is clicked via click event propagation control.
- Correct the close icon asset path in the My Sharing view so the remove action icon renders properly.

Enhancements:
- Extend the application query type with an include_shared flag to support refined filtering of shared applications.

</details>