### PR TITLE
fix: workflow execution fails with foreign key violation when running shared app

### DIFF
--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1453,8 +1453,11 @@ class AppService:
         cfg = release.config or {}
         now = release.created_at or datetime.datetime.now()
         from app.models.workflow_model import WorkflowConfig as WorkflowConfigModel
+        # 查出源应用真实的 WorkflowConfig id，供 workflow_executions 外键使用
+        real_config = WorkflowConfigRepository(self.db).get_by_app_id(release.app_id)
+        real_id = real_config.id if real_config else uuid.uuid4()
         wf_cfg = WorkflowConfigModel(
-            id=uuid.uuid4(),
+            id=real_id,
             app_id=release.app_id,
             nodes=cfg.get("nodes", []),
             edges=cfg.get("edges", []),


### PR DESCRIPTION
## Problem

When running a shared workflow app via `draft_run`, the temporary `WorkflowConfig` object was created with a random UUID that doesn't exist in the `workflow_configs` table. This caused a foreign key violation when `workflow_executions` tried to reference it.

## Fix

`_workflow_config_from_release` now fetches the real `WorkflowConfig.id` from the database (belonging to the source app) and uses it for the reconstructed object, satisfying the foreign key constraint while still serving the release snapshot config to recipients.

## Summary by Sourcery

Bug Fixes:
- 通过复用源应用现有的工作流配置 ID，而不是生成随机 ID，防止在运行共享工作流应用时出现外键约束冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent foreign key violations when running shared workflow apps by reusing the source app's existing workflow configuration ID instead of generating a random one.

</details>