### PR TITLE
Fix/v0.2.8 zy

### DIFF
--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 10:35:21
+ * @Last Modified time: 2026-03-19 10:37:01
  */
 import { type FC, useRef, useEffect, useState } from 'react'
 import clsx from 'clsx'
@@ -59,8 +59,8 @@ const ChatContent: FC<ChatContentProps> = ({
     const handleScroll = () => {
       if (scrollContainerRef.current) {
         const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current;
-        // Consider user is at bottom if within 20px of the bottom
-        isScrolledToBottomRef.current = scrollHeight - scrollTop - clientHeight < 20;
+        // Consider user is at bottom if within 100px of the bottom
+        isScrolledToBottomRef.current = scrollHeight - scrollTop - clientHeight < 100;
       }
     };
     
@@ -88,6 +88,7 @@ const ChatContent: FC<ChatContentProps> = ({
         // Auto-scroll if data length changed OR user is currently at bottom
         if (data.length !== prevDataLengthRef.current || isScrolledToBottomRef.current) {
           scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight;
+          isScrolledToBottomRef.current = true;
         }
         prevDataLengthRef.current = data.length;
       }

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 10:06:31
+ * @Last Modified time: 2026-03-19 10:35:21
  */
 import { type FC, useRef, useEffect, useState } from 'react'
 import clsx from 'clsx'
@@ -141,21 +141,17 @@ const ChatContent: FC<ChatContentProps> = ({
                       )
                     }
                     return (
-                      <Flex gap={10} align="center" key={file.url || file.uid} className="rb:w-45 rb:text-[12px] rb:group rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:py-2! rb:px-2.5! rb:cursor-pointer" onClick={() => handleDownload(file)}>
+                      <div key={file.url || file.uid} className="rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:p-1! rb:cursor-pointer" onClick={() => handleDownload(file)}>
                         {(file.type.includes('doc') || file.type.includes('docx') || file.type.includes('word') || file.type.includes('wordprocessingml.document')) && <div
-                          className="rb:size-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/word_disabled.svg')] rb:hover:bg-[url('@/assets/images/conversation/word.svg')]"
+                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/word.svg')]"
                         ></div>}
                         {(file.type.includes('pdf')) && <div
-                          className="rb:size-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/pdf_disabled.svg')] rb:hover:bg-[url('@/assets/images/conversation/pdf.svg')]"
+                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/pdf.svg')]"
                         ></div>}
                         {(file.type.includes('excel') || file.type.includes('spreadsheetml.sheet') || file.type.includes('csv')) && <div
-                          className="rb:size-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/excel_disabled.svg')] rb:hover:bg-[url('@/assets/images/conversation/excel.svg')]"
+                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/excel.svg')]"
                         ></div>}
-                        <div className="rb:flex-1 rb:w-32.5">
-                          <div className="rb:leading-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{file.name}</div>
-                          <div className="rb:leading-3.5 rb:mt-0.5 rb:text-[#5B6167] rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{file.type} · {file.size}</div>
-                        </div>
-                      </Flex>
+                      </div>
                     )
                   })}
                 </Flex>}

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,14 +2,19 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-18 20:48:03
+ * @Last Modified time: 2026-03-19 10:06:31
  */
 import { type FC, useRef, useEffect, useState } from 'react'
 import clsx from 'clsx'
 import Markdown from '@/components/Markdown'
 import type { ChatContentProps } from './types'
-import { Spin, Divider, Space } from 'antd'
+import { Spin, Divider, Space, Image, Flex } from 'antd'
 import { SoundOutlined } from '@ant-design/icons'
+
+
+const getFileUrl = (file: any) => {
+  return file.thumbUrl || file.url || (file.originFileObj ? URL.createObjectURL(file.originFileObj) : undefined)
+}
 
 /**
  * Chat Content Display Component
@@ -88,6 +93,10 @@ const ChatContent: FC<ChatContentProps> = ({
       }
     }, 0);
   }, [data])
+
+  const handleDownload = (file: any) => {
+    window.open(getFileUrl(file), '_blank')
+  }
   return (
     <div ref={scrollContainerRef} className={clsx("rb:relative rb:overflow-y-auto", classNames)}>
       {data.length === 0 
@@ -108,31 +117,31 @@ const ChatContent: FC<ChatContentProps> = ({
                     {labelFormat(item)}
                   </div>
                 }
-                {item.meta_data?.files && item.meta_data?.files.length > 0 && <div>
+                {item.meta_data?.files && item.meta_data?.files.length > 0 && <Flex vertical align="end">
                   {item.meta_data?.files?.map((file) => {
                     if (file.type.includes('image')) {
                       return (
                         <div key={file.url || file.uid} className={`rb:inline-block rb:group rb:relative rb:rounded-lg ${contentClassNames}`}>
-                          <img src={file.url} alt={file.name} className="rb:w-full rb:max-w-80 rb:rounded-lg rb:object-cover rb:cursor-pointer" />
+                          <Image src={getFileUrl(file)} alt={file.name} className="rb:w-full rb:max-w-80 rb:rounded-lg rb:object-cover rb:cursor-pointer" />
                         </div>
                       )
                     }
                     if (file.type.includes('video')) {
                       return (
-                        <div key={file.url || file.uid} className="rb:w-45 rb:h-16 rb:inline-block rb:group rb:relative rb:rounded-lg">
-                          <video src={file.url} controls className="rb:w-45 rb:h-16 rb:rounded-lg rb:object-cover rb:cursor-pointer" />
+                        <div key={file.url || file.uid} className="rb:inline-block rb:group rb:relative rb:rounded-lg">
+                          <video src={getFileUrl(file)} controls className="rb:max-w-80 rb:rounded-lg rb:object-cover rb:cursor-pointer" />
                         </div>
                       )
                     }
                     if (file.type.includes('audio')) {
                       return (
-                        <div key={file.url || file.uid} className="rb:w-45 rb:h-16 rb:inline-flex rb:items-center rb:group rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:py-2 rb:px-2.5 rb:gap-2">
-                          <audio src={file.url} controls className="rb:w-45 rb:h-16" />
+                        <div key={file.url || file.uid} className="rb:inline-flex rb:items-center rb:group rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:py-2 rb:px-2.5 rb:gap-2">
+                          <audio src={getFileUrl(file)} controls className="rb:max-w-80" />
                         </div>
                       )
                     }
                     return (
-                      <div key={file.url || file.uid} className="rb:w-45 rb:text-[12px] rb:gap-2.5 rb:flex rb:items-center rb:group rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:py-2 rb:px-2.5">
+                      <Flex gap={10} align="center" key={file.url || file.uid} className="rb:w-45 rb:text-[12px] rb:group rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:py-2! rb:px-2.5! rb:cursor-pointer" onClick={() => handleDownload(file)}>
                         {(file.type.includes('doc') || file.type.includes('docx') || file.type.includes('word') || file.type.includes('wordprocessingml.document')) && <div
                           className="rb:size-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/word_disabled.svg')] rb:hover:bg-[url('@/assets/images/conversation/word.svg')]"
                         ></div>}
@@ -146,10 +155,10 @@ const ChatContent: FC<ChatContentProps> = ({
                           <div className="rb:leading-4 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{file.name}</div>
                           <div className="rb:leading-3.5 rb:mt-0.5 rb:text-[#5B6167] rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap">{file.type} · {file.size}</div>
                         </div>
-                      </div>
+                      </Flex>
                     )
                   })}
-                </div>}
+                </Flex>}
                 {/* Message bubble */}
                 <div className={clsx('rb:border rb:text-left rb:rounded-lg rb:mt-1.5 rb:leading-4.5 rb:p-[10px_12px_2px_12px] rb:inline-block rb:max-w-130 rb:wrap-break-word', contentClassNames, {
                   // Error message style (content is null and not assistant message)

--- a/web/src/components/Markdown/index.tsx
+++ b/web/src/components/Markdown/index.tsx
@@ -136,7 +136,7 @@ const RbMarkdown: FC<RbMarkdownProps> = ({
 
   /** Sync edit content when external content changes */
   useEffect(() => {
-    setEditContent(content)
+    setEditContent(prev => prev !== content ? content : prev)
   }, [content])
 
   /** Handle textarea content changes and trigger callback */

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-05 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-18 20:29:28
+ * @Last Modified time: 2026-03-19 09:59:42
  */
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { Form, InputNumber, Flex, Switch, Row, Col, Radio } from 'antd';
@@ -112,7 +112,6 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
       open={visible}
       onCancel={handleClose}
       onOk={handleSave}
-      width={600}
     >
       <Form form={form} layout="vertical" initialValues={defaultValues}>
         <Form.Item


### PR DESCRIPTION
## Summary by Sourcery

调整聊天内容的滚动行为和文件附件的渲染方式，并优化 Markdown 编辑同步以及文件上传设置的布局。

新功能：
- 支持从聊天消息中在新标签页打开无法预览的文件附件。

缺陷修复：
- 当外部内容未发生变化时，避免不必要的 Markdown 编辑器重新渲染。
- 在新消息到达或附件渲染时，更可靠地保持聊天自动滚动在底部。
- 支持展示仅提供缩略图 URL 或原始文件对象（而非直接 URL）的文件附件。

优化增强：
- 改进聊天附件 UI，统一尺寸、使用仅图标的文档卡片，并采用右对齐布局。
- 增加底部滚动容差，以更好地检测用户是否已滚动到聊天记录末尾。
- 简化文件上传设置弹窗，允许其宽度由布局默认值自动决定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust chat content scrolling behavior and file attachment rendering, and refine markdown editing synchronization and file upload settings layout.

New Features:
- Support opening non-previewable file attachments in a new tab from chat messages.

Bug Fixes:
- Prevent unnecessary markdown editor re-renders when external content remains unchanged.
- Ensure chat auto-scroll stays at the bottom more reliably when new messages arrive or attachments are rendered.
- Support displaying file attachments that only provide a thumb URL or origin file object rather than a direct URL.

Enhancements:
- Improve chat attachment UI with consistent sizing, icon-only document tiles, and right-aligned layout.
- Increase bottom scroll tolerance to better detect when the user is at the end of the chat history.
- Simplify the file upload settings modal by allowing the width to be determined by layout defaults.

</details>