### PR TITLE
feat(workflow): move conversation file content into metadata

### DIFF
--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -8,6 +8,7 @@ from app.core.response_utils import success
 from app.db import get_db
 from app.dependencies import get_current_user
 from app.models import User
+from app.schemas import conversation_schema
 from app.schemas.response_schema import ApiResponse
 from app.services.conversation_service import ConversationService
 
@@ -90,11 +91,7 @@ def get_messages(
         conversation_id,
     )
     messages = [
-        {
-            "role": message.role,
-            "content": message.content,
-            "created_at": int(message.created_at.timestamp() * 1000),
-        }
+        conversation_schema.Message.model_validate(message)
         for message in messages_obj
     ]
     return success(data=messages, msg="get conversation history success")

--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -13,7 +13,6 @@ from app.core.logging_config import get_business_logger
 from app.core.response_utils import success, fail
 from app.db import get_db, get_db_read
 from app.dependencies import get_share_user_id, ShareTokenData
-from app.models.app_model import App
 from app.models.app_model import AppType
 from app.repositories import knowledge_repository
 from app.repositories.end_user_repository import EndUserRepository
@@ -618,11 +617,11 @@ async def chat(
 
         # 多 Agent 非流式返回
         result = await app_chat_service.workflow_chat(
-
             message=payload.message,
             conversation_id=conversation.id,  # 使用已创建的会话 ID
             user_id=end_user_id,  # 转换为字符串
             variables=payload.variables,
+            files=payload.files,
             config=config,
             web_search=payload.web_search,
             memory=payload.memory,

--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -280,6 +280,7 @@ async def chat(
             memory=memory,
             storage_type=storage_type,
             user_rag_memory_id=user_rag_memory_id,
+            files=payload.files,
             app_id=app.id,
             workspace_id=workspace_id,
             release_id=app.current_release.id

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -51,6 +51,10 @@ class Message(BaseModel):
     def _serialize_created_at(self, dt: datetime.datetime):
         return int(dt.timestamp() * 1000) if dt else None
 
+    @field_serializer("meta_data", when_used="json")
+    def _serialize_meta_data(self, data: Optional[Dict[str, Any]]):
+        return data or {}
+
 
 class Conversation(BaseModel):
     """会话输出"""

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -585,6 +585,7 @@ class AppChatService:
             app_id: uuid.UUID,
             release_id: uuid.UUID,
             workspace_id: uuid.UUID,
+            files: Optional[List[FileInput]] = None,
             user_id: Optional[str] = None,
             variables: Optional[Dict[str, Any]] = None,
             web_search: bool = False,
@@ -598,7 +599,8 @@ class AppChatService:
             variables=variables,
             conversation_id=str(conversation_id),
             stream=True,
-            user_id=user_id
+            user_id=user_id,
+            files=files
         )
         return await self.workflow_service.run(
             app_id=app_id,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -802,30 +802,33 @@ class WorkflowService:
                         final_messages = event.get("data", {}).get("messages", [])[init_message_length:]
                         human_message = ""
                         assistant_message = ""
+                        human_meta = {
+                            "files": []
+                        }
                         for message in final_messages:
                             if message["role"] == "user":
                                 if isinstance(message["content"], str):
                                     human_message += message["content"]
                                 elif isinstance(message["content"], list):
                                     for file in message["content"]:
-                                        if file.get("type") == FileType.IMAGE:
-                                            human_message += f"![image]({file.get('url', '')})"
-                                        else:
-                                            human_message += f"[{file.get('type')}]({file.get('url', '')})"
+                                        human_meta["files"].append({
+                                            "type": file.get("type"),
+                                            "url": file.get("url")
+                                        })
                             if message["role"] == "assistant":
                                 assistant_message = message["content"]
                         self.conversation_service.add_message(
                             conversation_id=conversation_id_uuid,
                             role="user",
                             content=human_message,
-                            meta_data=None
+                            meta_data=human_meta
                         )
                         self.conversation_service.add_message(
                             message_id=message_id,
                             conversation_id=conversation_id_uuid,
                             role="assistant",
                             content=assistant_message,
-                            meta_data={"usage": token_usage}
+                            meta_data={"usage": token_usage, "audio_url": None}
                         )
                         self.update_execution_status(
                             execution.execution_id,


### PR DESCRIPTION
## Summary by Sourcery

将工作流会话中的文件数据从已渲染的消息内容中移出，存入结构化的元数据中，并通过工作流聊天 API 传递文件输入。

New Features:
- 在用户工作流消息中，将上传文件的引用作为结构化元数据保存，而不是嵌入到消息文本中。
- 在工作流聊天端点中接受可选的文件输入，并将其传递给工作流服务。

Enhancements:
- 通过 Message 模式在内存工作控制器的响应中序列化会话消息，以确保结构和元数据处理的一致性。
- 确保消息元数据始终被序列化为对象，在缺失时默认为空映射。
- 扩展助手消息元数据，加入显式的 `audio_url` 字段，并将其初始化为 `null`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move workflow conversation file data from rendered message content into structured metadata and propagate file inputs through workflow chat APIs.

New Features:
- Include uploaded file references as structured metadata on user workflow messages instead of embedding them in message text.
- Accept optional file inputs in workflow chat endpoints and pass them through to the workflow service.

Enhancements:
- Serialize conversation messages via the Message schema in memory working controller responses to ensure consistent structure and metadata handling.
- Ensure message metadata is always serialized as an object, defaulting to an empty map when absent.
- Extend assistant message metadata to include an explicit audio_url field initialized to null.

</details>