### PR TITLE
fix(web): workflow memory not allowed change

### DIFF
--- a/web/src/components/ButtonCheckbox/index.tsx
+++ b/web/src/components/ButtonCheckbox/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 15:01:59 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-17 15:35:34
+ * @Last Modified time: 2026-03-19 13:41:26
  */
 
 /**
@@ -42,7 +42,8 @@ const ButtonCheckbox: FC<ButtonCheckboxProps> = ({
   icon,
   checkedIcon,
   children,
-  cicle = false
+  cicle = false,
+  disabled,
 }) => {
   // Listen to value changes and trigger side effects via onValueChange callback
   useEffect(() => {
@@ -70,6 +71,7 @@ const ButtonCheckbox: FC<ButtonCheckboxProps> = ({
         "rb:bg-[rgba(21,94,239,0.06)] rb:border-[rgba(21,94,239,0.25)] rb:hover:bg-[rgba(21,94,239,0.06)] rb:text-[#155EEF]": checked,
         // Unchecked state: gray border and dark text
         "rb:border-[#DFE4ED] rb:text-[#212332]": !checked,
+        "rb:opacity-65 rb:cursor-not-allowed!": disabled
       })} 
       onClick={handleChange}
     >

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 10:37:01
+ * @Last Modified time: 2026-03-19 13:38:20
  */
 import { type FC, useRef, useEffect, useState } from 'react'
 import clsx from 'clsx'
@@ -118,7 +118,7 @@ const ChatContent: FC<ChatContentProps> = ({
                     {labelFormat(item)}
                   </div>
                 }
-                {item.meta_data?.files && item.meta_data?.files.length > 0 && <Flex vertical align="end">
+                {item.meta_data?.files && item.meta_data?.files.length > 0 && <Flex gap={8} vertical align="end">
                   {item.meta_data?.files?.map((file) => {
                     if (file.type.includes('image')) {
                       return (

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-18 20:54:00
+ * @Last Modified time: 2026-03-19 12:30:41
  */
 /**
  * Conversation Page
@@ -63,6 +63,7 @@ const Conversation: FC = () => {
   const [isHasMemory, setIsHasMemory] = useState(false)
   const [memory, setMemory] = useState(true)
   const [features, setFeatures] = useState<FeaturesConfigForm>({} as FeaturesConfigForm)
+  const [config, setConfig] = useState<Record<string, any>>({})
 
   useEffect(() => {
     const shareToken = localStorage.getItem(`shareToken_${token}`)
@@ -88,6 +89,7 @@ const Conversation: FC = () => {
         .then(res => {
           const response = res as { variables: Variable[]; features: FeaturesConfigForm; app_type: string; memory?: boolean; }
           toolbarRef.current?.setVariables(response.variables || [])
+          setConfig(response)
           setFeatures(response.features)
           setIsHasMemory((response.app_type === 'workflow' && response.memory) || (response.app_type !== 'workflow'))
         })
@@ -284,6 +286,7 @@ const Conversation: FC = () => {
   }
 
   const handleChangeMemory = (value: boolean) => {
+    if (config.app_type === 'workflow') return;
     modal.confirm({
       title: value ? t('memoryConversation.memoryTipTitle') : t('memoryConversation.memoryCancelTipTitle'),
       okText: t('common.confirm'),
@@ -388,6 +391,7 @@ const Conversation: FC = () => {
                     icon={MemoryFunctionIcon}
                     checkedIcon={MemoryFunctionCheckedIcon}
                     checked={memory}
+                    disabled={config.app_type === 'workflow'}
                     onChange={handleChangeMemory}
                   >
                     {t('memoryConversation.memory')}


### PR DESCRIPTION
## Summary by Sourcery

对工作流类型应用禁用会话记忆切换，并调整相关的 UI 行为。

Bug 修复：
- 当会话关联到工作流类型应用时，禁止用户更改记忆设置。

增强功能：
- 为 ButtonCheckbox 组件添加禁用样式支持，以用于非交互状态。
- 在显示多个文件时改进聊天附件布局的间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable conversation memory toggling for workflow-type apps and adjust related UI behavior.

Bug Fixes:
- Prevent users from changing the memory setting when the conversation is associated with a workflow-type app.

Enhancements:
- Add disabled styling support to the ButtonCheckbox component for non-interactive states.
- Improve chat attachment layout spacing when multiple files are displayed.

</details>