### PR TITLE
Fix/v0.2.8 zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-05 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 14:59:34
+ * @Last Modified time: 2026-03-19 15:18:20
  */
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { Form, InputNumber, Flex, Switch, Row, Col, Radio } from 'antd';
@@ -27,22 +27,43 @@ const fileTypeOptions = [
   {
     type: 'document',
     icon: <div className="rb:size-9 rb:bg-cover rb:bg-[url('@/assets/images/file/txt.svg')]"></div>,
-    formats: 'TXT, PDF, DOC, DOCX, XLSX, CSV, JSON',
+    formats: [
+      "pdf",
+      "docx",
+      "doc",
+      "xlsx",
+      "xls",
+      "txt",
+      "csv",
+      "json",
+      "md",
+    ],
   },
   {
     type: 'image',
     icon: <div className="rb:size-9 rb:bg-cover rb:bg-[url('@/assets/images/file/image.svg')]"></div>,
-    formats: 'JPG, JPEG, PNG, GIF, WEBP',
+    formats: [
+      "png",
+      "jpg",
+      "jpeg"
+    ],
   },
   {
     type: 'audio',
     icon: <div className="rb:size-9 rb:bg-cover rb:bg-[url('@/assets/images/file/audio.svg')]"></div>,
-    formats: 'MP3, M4A, WAV, OGG, FLAC',
+    formats: [
+      "mp3",
+      "wav",
+      "m4a",
+    ],
   },
   {
     type: 'video',
     icon: <div className="rb:size-9 rb:bg-cover rb:bg-[url('@/assets/images/file/video.svg')]"></div>,
-    formats: 'MP4, MOV, AVI, WEBM',
+    formats: [
+      "mp4",
+      "mov",
+    ],
   },
 ];
 
@@ -50,16 +71,38 @@ const defaultValues: FileUpload = {
   enabled: false,
   image_enabled: false,
   image_max_size_mb: 20,
-  image_allowed_extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'],
+  image_allowed_extensions: [
+    "png",
+    "jpg",
+    "jpeg"
+  ],
   audio_enabled: false,
   audio_max_size_mb: 50,
-  audio_allowed_extensions: ['mp3', 'wav', 'm4a', 'ogg', 'flac'],
+  audio_allowed_extensions: [
+    "mp3",
+    "wav",
+    "m4a",
+    "ogg",
+    "flac"
+  ],
   document_enabled: false,
   document_max_size_mb: 100,
-  document_allowed_extensions: ['pdf', 'docx', 'xlsx', 'txt', 'csv', 'json'],
+  document_allowed_extensions: [
+    "pdf",
+    "docx",
+    "xlsx",
+    "txt",
+    "csv",
+    "json"
+  ],
   video_enabled: false,
   video_max_size_mb: 100,
-  video_allowed_extensions: ['mp4', 'mov', 'avi', 'webm'],
+  video_allowed_extensions: [
+    "mp4",
+    "mov",
+    "avi",
+    "webm"
+  ],
   max_file_count: 5,
   allowed_transfer_methods: 'both'
 }
@@ -149,7 +192,7 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
                       <Flex align="center" justify="space-between">
                         <Flex vertical>
                           <div className="rb:font-medium">{t(`application.${option.type}`)}</div>
-                          <div className="rb:text-[12px] rb:text-[#5B6167]">{option.formats}</div>
+                          <div className="rb:text-[12px] rb:text-[#5B6167]">{option.formats.map(item => item.toUpperCase()).join(', ')}</div>
                         </Flex>
                         <Form.Item name={enabledKey} valuePropName="checked" noStyle>
                           <Switch />

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-05 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 14:31:20
+ * @Last Modified time: 2026-03-19 14:59:34
  */
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { Form, InputNumber, Flex, Switch, Row, Col, Radio } from 'antd';
@@ -127,7 +127,7 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
 
         <div className="rb:text-[12px] rb:text-[#5B6167] rb:mb-1">{t('application.maxCount')}</div>
         <Form.Item label={t('application.maxCount')} name="max_file_count">
-          <InputNumber min={1} max={100} precision={0} className="rb:w-full!" placeholder={t('common.pleaseEnter')} />
+          <InputNumber min={1} max={20} precision={0} className="rb:w-full!" placeholder={t('common.pleaseEnter')} />
         </Form.Item>
 
         <Form.Item label={t('application.supportedTypes')}>


### PR DESCRIPTION
## Summary by Sourcery

更新文件上传配置的默认值以及 UI 中对支持类型和文件数量的限制。

Bug 修复：
- 使界面中显示的支持文件格式与为每种文件类型配置的允许扩展名保持一致。

增强：
- 在设置弹窗中，将可配置的单次文件上传最大数量从 100 限制为 20。
- 将文档、图片、音频和视频格式的元数据由字符串改为数组，以便进行更结构化的处理和展示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update file upload configuration defaults and UI constraints for supported types and file counts.

Bug Fixes:
- Align displayed supported file formats with the configured allowed extensions for each file type.

Enhancements:
- Restrict the maximum configurable file upload count from 100 to 20 in the settings modal.
- Switch document, image, audio, and video format metadata from strings to arrays for more structured handling and display.

</details>