### PR TITLE
fix(web): add loading

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1564,6 +1564,7 @@ export const en = {
       summary: 'Summary',
       core_entities: 'Core Entities',
       communityDetailEmptyDesc: 'Click on a community in the chart on the left to view details',
+      communityLoadingTip: 'Generating community graph',
     },
     space: {
       createSpace: 'Create Space',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1562,6 +1562,7 @@ export const zh = {
       summary: '摘要',
       core_entities: '核心实体',
       communityDetailEmptyDesc: '点击左侧图表中的社区查看详情',
+      communityLoadingTip: '社区图谱生成中',
     },
     space: {
       createSpace: '创建空间',

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-18 21:25:23
+ * @Last Modified time: 2026-03-19 17:13:54
  */
 import { type FC, useRef, useMemo, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -212,7 +212,7 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
             className={styles.tabs}
           />
         </div>
-        {application?.type === 'workflow' && source !== 'sharing'
+        {application?.type === 'workflow' && source !== 'sharing' && activeTab === 'arrangement'
           ? <div className="rb:h-8 rb:flex rb:items-center rb:justify-end rb:gap-2.5">
             <FeaturesConfig source={application?.type} value={features as FeaturesConfigForm} refresh={handleSaveFeaturesConfig} />
             <Button onClick={clear}>{t('workflow.clear')}</Button>

--- a/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
@@ -1,6 +1,8 @@
 import React, { useState, type FC, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { Spin, Flex } from 'antd';
+
 import type { CommunityD3Node, CommunityGraphData, RawCommunityGraphData, RawCommunityNode } from '@/components/D3Graph/types'
 import { buildCommunityGraphData } from '@/components/D3Graph/utils'
 import CommunityGraph from '@/components/D3Graph/CommunityGraph'
@@ -40,14 +42,17 @@ const NodeTooltip: FC<{ node: CommunityD3Node }> = ({ node }) => {
 
 const CommunityNetwork: FC<{ onSelectCommunity?: (node: RawCommunityNode) => void }> = ({ onSelectCommunity }) => {
   const { id } = useParams()
+  const { t } = useTranslation()
   const [graphData, setGraphData] = useState<CommunityGraphData | null>(null)
   const [empty, setEmpty] = useState(false)
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     if (!id) return
     const controller = new AbortController()
     setEmpty(false)
     setGraphData(null)
+    setLoading(true)
     getMemoryCommunityGraph(id, { signal: controller.signal }).then(res => {
       const raw = res as RawCommunityGraphData
       if (!raw.nodes?.length) { setEmpty(true); return }
@@ -55,8 +60,17 @@ const CommunityNetwork: FC<{ onSelectCommunity?: (node: RawCommunityNode) => voi
       if (!built) { setEmpty(true); return }
       setGraphData(built)
     }).catch((e) => { if (e?.code !== 'ERR_CANCELED') setEmpty(true) })
+      .finally(() => setLoading(false))
     return () => controller.abort()
   }, [id])
+
+  if (loading) {
+    return <Flex align="center" justify="center" className="rb:w-full rb:h-full">
+      <Spin tip={t('userMemory.communityLoadingTip')} size="large">
+        <div className="rb:w-64 rb:h-64" />
+      </Spin>
+      </Flex>
+  }
 
   return (
     <CommunityGraph


### PR DESCRIPTION
## Summary by Sourcery

在生成社区图时添加加载状态和加载动画，并优化工作流配置标题的行为。

新功能：
- 在为某个记忆生成社区图时，显示居中的加载动画。

增强改进：
- 将应用配置标题中的工作流功能配置控件限制为仅在“Arrangement”标签页中显示。
- 为社区图加载提示添加本地化文案，支持英文和中文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a loading state and spinner while the community graph is being generated and refine workflow configuration header behavior.

New Features:
- Display a centered loading spinner while the community community graph is being generated for a memory.

Enhancements:
- Restrict workflow feature configuration controls in the application config header to only show on the arrangement tab.
- Add localized copy for the community graph loading tip in both English and Chinese.

</details>