### PR TITLE
feat(memory): add pagination support for conversation list in working memory

### DIFF
--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -33,35 +33,47 @@ def get_memory_count(
 @router.get("/{end_user_id}/conversations", response_model=ApiResponse)
 def get_conversations(
         end_user_id: uuid.UUID,
+        page: int = 1,
+        page_size: int = 20,
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db)
 ):
     """
-    Retrieve all conversations for the current user in a specific group.
+    Retrieve conversations for the current user in a specific group with pagination.
 
     Args:
         end_user_id (UUID): The group identifier.
+        page (int): Page number (1-based). Defaults to 1.
+        page_size (int): Number of items per page. Defaults to 20.
         current_user (User, optional): The authenticated user.
         db (Session, optional): SQLAlchemy session.
 
     Returns:
-        ApiResponse: Contains a list of conversation IDs.
-
-    Notes:
-        - Initializes the ConversationService with the current DB session.
-        - Returns only conversation IDs for lightweight response.
-        - Logs can be added to trace requests in production.
+        ApiResponse: Contains a paginated list of conversations.
     """
+    page = max(1, page)
+    page_size = max(1, min(page_size, 100))  # Limit page size between 1 and 100
     conversation_service = ConversationService(db)
-    conversations = conversation_service.get_user_conversations(
-        end_user_id
+    conversations, total = conversation_service.get_user_conversations(
+        end_user_id,
+        page=page,
+        page_size=page_size
     )
-    return success(data=[
-        {
-            "id": conversation.id,
-            "title": conversation.title
-        } for conversation in conversations
-    ], msg="get conversations success")
+    return success(data={
+        "items": [
+            {
+                "id": conversation.id,
+                "title": conversation.title
+            } for conversation in conversations
+        ],
+        "total": total,
+        "page": {
+            "page": page,
+            "pagesize": page_size,
+            "total": total,
+            "hasnext": (page * page_size) < total
+        },
+    }, msg="get conversations success")
 
 
 @router.get("/{end_user_id}/messages", response_model=ApiResponse)

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -90,27 +90,27 @@ class ConversationRepository:
             self,
             user_id: uuid.UUID,
             workspace_id: uuid.UUID = None,
-            limit: int = 10,
-            is_activate: bool = True
-    ) -> list[Conversation]:
+            is_activate: bool = True,
+            page: int = 1,
+            page_size: int = 20
+    ) -> tuple[list[Conversation], int]:
         """
-        Retrieve recent conversations for a specific user.
+        Retrieve recent conversations for a specific user with pagination.
 
         This method queries conversations associated with the given user ID,
         optionally scoped to a specific workspace. Results are ordered by the
-        most recently updated conversations and limited to a fixed number.
+        most recently updated conversations.
 
         Args:
             user_id (uuid.UUID): Unique identifier of the user.
             workspace_id (uuid.UUID, optional): Workspace scope for the query.
                 If provided, only conversations under this workspace will be returned.
-            limit (int): Maximum number of conversations to return.
-                Defaults to 10.
-            is_activate (bool): Convsersation State limit
+            is_activate (bool): Conversation State limit.
+            page (int): Page number (1-based). Defaults to 1.
+            page_size (int): Number of items per page. Defaults to 20.
 
         Returns:
-            list[Conversation]: A list of conversation entities ordered by
-            last updated time (descending).
+            tuple[list[Conversation], int]: A list of conversation entities and total count.
         """
         logger.info(f"Fetching conversation by user_id: {user_id}")
 
@@ -122,18 +122,25 @@ class ConversationRepository:
         if workspace_id:
             stmt = stmt.where(Conversation.workspace_id == workspace_id)
 
-        stmt = stmt.order_by(desc(Conversation.updated_at))
-        stmt = stmt.limit(limit)
+        # Calculate total count
+        total = int(self.db.execute(
+            select(func.count()).select_from(stmt.subquery())
+        ).scalar_one())
 
-        convsersations = list(self.db.scalars(stmt).all())
+        # Apply ordering and pagination
+        stmt = stmt.order_by(desc(Conversation.updated_at))
+        stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+
+        conversations = list(self.db.scalars(stmt).all())
         logger.info(
             "Conversation fetched successfully",
             extra={
                 "user_id": str(user_id),
                 "workspace_id": str(workspace_id),
+                "total": total,
             }
         )
-        return convsersations
+        return conversations, total
 
     def list_conversations(
             self,

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -119,25 +119,27 @@ class ConversationService:
 
     def get_user_conversations(
             self,
-            user_id: uuid.UUID
-    ) -> list[Conversation]:
+            user_id: uuid.UUID,
+            page: int = 1,
+            page_size: int = 20
+    ) -> tuple[list[Conversation], int]:
         """
-        Retrieve recent conversations for a specific user
-
-        This method delegates persistence logic to the repository layer and
-        applies service-level defaults (e.g. recent conversation limit).
+        Retrieve recent conversations for a specific user with pagination.
 
         Args:
             user_id (uuid.UUID): Unique identifier of the user.
+            page (int): Page number (1-based). Defaults to 1.
+            page_size (int): Number of items per page. Defaults to 20.
 
         Returns:
-            list[Conversation]: A list of recent conversation entities.
+            tuple[list[Conversation], int]: A list of recent conversation entities and total count.
         """
-        conversations = self.conversation_repo.get_conversation_by_user_id(
+        conversations, total = self.conversation_repo.get_conversation_by_user_id(
             user_id,
-            limit=10
+            page=page,
+            page_size=page_size
         )
-        return conversations
+        return conversations, total
 
     def list_conversations(
             self,

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -1408,12 +1408,11 @@ async def analytics_memory_types(
     if end_user_id:
         try:
             conversation_repo = ConversationRepository(db)
-            conversations = conversation_repo.get_conversation_by_user_id(
+            conversations, total = conversation_repo.get_conversation_by_user_id(
                 user_id=uuid.UUID(end_user_id),
-                limit=100,  # 获取更多会话以准确统计
                 is_activate=True
             )
-            work_count = len(conversations)
+            work_count = total
             logger.debug(f"工作记忆数量（会话数）: {work_count} (end_user_id={end_user_id})")
         except Exception as e:
             logger.warning(f"获取会话数量失败，工作记忆数量设为0: {str(e)}")


### PR DESCRIPTION
## 由 Sourcery 提供的总结

为工作记忆 API 中的会话列表添加分页支持，并在仓储层和服务层中传递总数信息。

新增功能：
- 在工作记忆会话 API 中引入分页式会话获取功能，在响应中包含分页元数据。

增强与改进：
- 拓展会话仓储和服务方法以支持分页，并返回用户的会话总数。
- 更新分析中的记忆类型计算逻辑，从使用受限结果集长度改为使用仓储返回的会话总数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pagination support to conversation listing in working memory APIs and propagate total counts through repository and service layers.

New Features:
- Introduce paginated conversation retrieval in the working memory conversations API, including page metadata in the response.

Enhancements:
- Extend conversation repository and service methods to support pagination and return total conversation counts for a user.
- Update analytics memory type calculations to use total conversation count from the repository instead of the length of a limited result set.

</details>