### PR TITLE
[changes] keep two decimals

### DIFF
--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -619,7 +619,7 @@ class MemoryForgetService:
                     recent_trends.append({
                         'date': date_str,
                         'merged_count': record.merged_count,
-                        'average_activation': record.average_activation_value,
+                        'average_activation': round(record.average_activation_value, 2) if record.average_activation_value is not None else None,
                         'total_nodes': record.total_nodes,
                         'execution_time': int(record.execution_time.timestamp() * 1000)
                     })


### PR DESCRIPTION
## 由 Sourcery 提供的总结

在安全处理缺失值的同时，将遗忘统计中的激活平均值四舍五入到小数点后两位。

错误修复：
- 当激活平均值缺失时，通过返回 null 而不是原始值来防止报错。

改进：
- 将遗忘统计中报告的激活平均值统一规范为保留两位小数，以保持展示的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Round forgetting statistics activation averages to two decimal places while safely handling missing values.

Bug Fixes:
- Prevent errors when average activation values are missing by returning null instead of a raw value.

Enhancements:
- Normalize reported average activation values in forgetting statistics to two decimal places for consistent presentation.

</details>