### PR TITLE
fix(conversation): handle None meta_data in msg to prevent exceptions

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -124,7 +124,7 @@ class AppChatService:
             limit=10
         )
         history = [
-            {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + msg.meta_data.get("files", [])}
+            {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + (msg.meta_data.get("files", []) if msg.meta_data else [])}
             for msg in messages
         ]
 
@@ -317,7 +317,7 @@ class AppChatService:
                     limit=memory_config.get("max_history", 10)
                 )
                 history = [
-                    {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + msg.meta_data.get("files", [])}
+                    {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + (msg.meta_data.get("files", []) if msg.meta_data else [])}
                     for msg in messages
                 ]
 

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -293,7 +293,7 @@ class ConversationService:
         history = [
             {
                 "role": msg.role,
-                "content": [{"type": "text", "text": msg.content}] + msg.meta_data.get("files", [])
+                "content": [{"type": "text", "text": msg.content}] + (msg.meta_data.get("files", []) if msg.meta_data else [])
             }
             for msg in messages
         ]

--- a/api/app/services/shared_chat_service.py
+++ b/api/app/services/shared_chat_service.py
@@ -264,7 +264,7 @@ class SharedChatService:
                 limit=memory_config.get("max_history", 10)
             )
             history = [
-                {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + msg.meta_data.get("files", [])}
+                {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + (msg.meta_data.get("files", []) if msg.meta_data else [])}
                 for msg in messages
             ]
 
@@ -472,7 +472,7 @@ class SharedChatService:
                     limit=memory_config.get("max_history", 10)
                 )
                 history = [
-                    {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + msg.meta_data.get("files", [])}
+                    {"role": msg.role, "content": [{"type": "text", "text": msg.content}] + (msg.meta_data.get("files", []) if msg.meta_data else [])}
                     for msg in messages
                 ]
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当消息的 `metadata` 为 `None` 时，在构建聊天和会话历史记录时防止抛出异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent exceptions when building chat and conversation history for messages whose metadata is None.

</details>