### PR TITLE
fix(web): ui update

### DIFF
--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 13:38:20
+ * @Last Modified time: 2026-03-19 19:45:40
  */
 import { type FC, useRef, useEffect, useState } from 'react'
 import clsx from 'clsx'
@@ -143,15 +143,20 @@ const ChatContent: FC<ChatContentProps> = ({
                     }
                     return (
                       <div key={file.url || file.uid} className="rb:relative rb:rounded-lg rb:bg-[#F0F3F8] rb:p-1! rb:cursor-pointer" onClick={() => handleDownload(file)}>
-                        {(file.type.includes('doc') || file.type.includes('docx') || file.type.includes('word') || file.type.includes('wordprocessingml.document')) && <div
-                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/word.svg')]"
-                        ></div>}
-                        {(file.type.includes('pdf')) && <div
-                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/pdf.svg')]"
-                        ></div>}
-                        {(file.type.includes('excel') || file.type.includes('spreadsheetml.sheet') || file.type.includes('csv')) && <div
-                          className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/excel.svg')]"
-                        ></div>}
+                        {(file.type.includes('excel') || file.type.includes('spreadsheetml.sheet') || file.type.includes('csv'))
+                          ? <div
+                            className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/excel.svg')]"
+                          ></div>
+                          :(file.type.includes('pdf'))
+                          ? <div
+                            className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/pdf.svg')]"
+                          ></div>
+                          : (file.type.includes('doc') || file.type.includes('docx') || file.type.includes('word') || file.type.includes('wordprocessingml.document'))
+                          ? <div
+                            className="rb:size-10 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/conversation/word.svg')]"
+                          ></div>
+                          : null
+                        }
                       </div>
                     )
                   })}


### PR DESCRIPTION
## Summary by Sourcery

调整聊天文件附件预览图标的显示逻辑，使其根据文件类型优先选择并仅展示最合适的图标。

Bug Fixes:
- 确保聊天附件只渲染一个文件类型图标，解决之前单个文件可能出现多个图标的情况。

Enhancements:
- 优化聊天附件的文件类型检测逻辑，对 Excel、PDF 和 Word 文档采用有优先级的条件渲染策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust chat file attachment preview icons to prioritize and exclusively display the most appropriate icon based on file type.

Bug Fixes:
- Ensure only one file-type icon is rendered for chat attachments, resolving cases where multiple icons could appear for a single file.

Enhancements:
- Refine file-type detection logic for chat attachments to use prioritized conditional rendering for Excel, PDF, and Word documents.

</details>