### PR TITLE
fix(web): max_file_count limit 1

### DIFF
--- a/web/src/components/Chat/ChatToolbar.tsx
+++ b/web/src/components/Chat/ChatToolbar.tsx
@@ -49,6 +49,7 @@ interface FormValues {
   memory?: boolean;
 }
 
+const max_file_count = 1;
 const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
   features,
   extra,
@@ -136,8 +137,8 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
       key: 'url',
       label: t('memoryConversation.addRemoteFile'),
       onClick: () => {
-        if ((queryValues?.files?.length || 0) >= file_upload.max_file_count) {
-          messageApi.warning(t('common.fileNumTip', { num: file_upload.max_file_count }))
+        if ((queryValues?.files?.length || 0) >= max_file_count) {
+          messageApi.warning(t('common.fileNumTip', { num: max_file_count }))
           return
         }
         uploadFileListModalRef.current?.handleOpen()
@@ -153,7 +154,7 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
           onChange={fileChange}
           requestConfig={uploadRequestConfig}
           featureConfig={file_upload}
-          disabled={(queryValues?.files?.length || 0) >= file_upload.max_file_count}
+          disabled={(queryValues?.files?.length || 0) >= max_file_count}
         />
       )
     })
@@ -185,7 +186,7 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
         {file_upload?.audio_enabled && file_upload?.allowed_transfer_methods?.includes('local_file') && (
           <Flex align="center">
             <AudioRecorder
-              disabled={(queryValues?.files?.length || 0) >= file_upload.max_file_count}
+              disabled={(queryValues?.files?.length || 0) >= max_file_count}
               action={uploadAction}
               requestConfig={uploadRequestConfig}
               onRecordingComplete={handleRecordingComplete}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -460,6 +460,7 @@ export const en = {
       nameInvalid: 'Name cannot start or end with a space',
       notAllSpaces: 'Cannot be all spaces',
       view: 'View',
+      callbackUrlInvalid: 'Please enter a valid URL',
     },
     model: {
       searchPlaceholder: 'search model…',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1093,6 +1093,7 @@ export const zh = {
       nameInvalid: '不能是空格开头或结尾',
       notAllSpaces: '不能是纯空格',
       view: '查看',
+      callbackUrlInvalid: '请输入有效的 URL',
     },
     model: {
       searchPlaceholder: '搜索模型…',

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
@@ -24,7 +24,7 @@ interface FeaturesConfigModalProps {
   refresh: (value: FeaturesConfigForm) => void;
   source?: Application['type'];
 }
-
+const max_file_count = 1;
 /**
  * Modal for copying applications
  */
@@ -133,7 +133,7 @@ const FeaturesConfigModal = forwardRef<FeaturesConfigModalRef, FeaturesConfigMod
                     </div>
                     <div>
                       <div className="rb:text-[12px] rb:text-[#5B6167] rb:py-1">{t('application.maxCount')}</div>
-                      {fu.max_file_count} {t('application.unix')}
+                      {max_file_count} {t('application.unix')}
                     </div>
                   </Flex>
                   <Button block onClick={handleOpenSettings}>{t('application.setting')}</Button>

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -102,7 +102,7 @@ const defaultValues: FileUpload = {
     "mp4",
     "mov",
   ],
-  max_file_count: 5,
+  max_file_count: 1,
   allowed_transfer_methods: 'both'
 }
 
@@ -167,8 +167,8 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
           </Radio.Group>
         </Form.Item>
 
-        <div className="rb:text-[12px] rb:text-[#5B6167] rb:mb-1">{t('application.maxCount')}</div>
-        <Form.Item label={t('application.maxCount')} name="max_file_count">
+        {/* <div className="rb:text-[12px] rb:text-[#5B6167] rb:mb-1">{t('application.maxCount')}</div> */}
+        <Form.Item label={t('application.maxCount')} name="max_file_count" hidden>
           <InputNumber min={1} max={20} precision={0} className="rb:w-full!" placeholder={t('common.pleaseEnter')} />
         </Form.Item>
 

--- a/web/src/views/Conversation/components/UploadFileListModal.tsx
+++ b/web/src/views/Conversation/components/UploadFileListModal.tsx
@@ -19,7 +19,10 @@
  * @component
  */
 import { forwardRef, useImperativeHandle, useState, useMemo } from 'react';
-import { Form, Input, Select, Button, Flex } from 'antd';
+import { Form, Input, Select,
+  // Button,
+  Flex
+} from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { UploadFileListModalRef } from '../types'
@@ -105,9 +108,11 @@ const UploadFileListModal = forwardRef<UploadFileListModalRef, UploadFileListMod
       onOk={handleSave}
       confirmLoading={loading}
     >
-      <Form form={form} layout="vertical">
+      <Form form={form} layout="vertical" initialValues={{ files: [{ type: undefined, url: undefined }] }}>
         <Form.List name="files">
-          {(fields, { add, remove }) => (
+          {(fields,
+            // { add, remove }
+          ) => (
             <>
               {/* Render each file entry with type selector and URL input */}
               {fields.map(({ key, name, ...restField }) => (
@@ -131,23 +136,23 @@ const UploadFileListModal = forwardRef<UploadFileListModalRef, UploadFileListMod
                     name={[name, 'url']}
                     rules={[
                       { required: true, message: t('common.pleaseEnter') },
-                      { type: 'url'}
+                      { type: 'url', message: t('common.callbackUrlInvalid') },
                     ]}
                     className="rb:mb-0! rb:flex-1!"
                   >
                     <Input placeholder={t('memoryConversation.fileUrl')} />
                   </FormItem>
-                  <div
+                  {/* <div
                     className="rb:w-5 rb:h-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/delete.svg')] rb:hover:bg-[url('@/assets/images/delete_hover.svg')]"
                     onClick={() => remove(name)}
-                  ></div>
+                  ></div> */}
                 </Flex>
               ))}
-              <Form.Item noStyle>
+              {/* <Form.Item noStyle>
                 <Button type="dashed" onClick={() => add()} block>
                   + {t('common.add')}
                 </Button>
-              </Form.Item>
+              </Form.Item> */}
             </>
           )}
         </Form.List>


### PR DESCRIPTION
## Summary by Sourcery

在聊天工具栏和配置界面中统一强制单文件上传限制，并相应调整远程文件 URL 表单及其校验逻辑。

新功能：
- 为无效的回调/远程文件 URL 新增本地化校验提示信息（支持英文和中文）。

缺陷修复：
- 在远程文件列表表单中初始化一个默认文件条目，避免在上传 URL 时出现空状态问题。

功能改进：
- 在聊天工具栏逻辑和功能配置展示中，将最大文件数统一标准化为 1，并将其与可配置项解耦。
- 在文件上传设置弹窗中隐藏“最大文件数”输入框，同时将其值固定为 1。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a single-file upload limit across the chat toolbar and configuration UI and align the remote file URL form and validation accordingly.

New Features:
- Add localized validation message for invalid callback/remote file URLs in both English and Chinese.

Bug Fixes:
- Initialize the remote file list form with a default file entry to prevent empty state issues when uploading URLs.

Enhancements:
- Standardize the maximum file count to 1 in chat toolbar logic and feature configuration display, decoupling it from configurable values.
- Hide the max file count input in the file upload settings modal while keeping the value fixed to 1.

</details>