### PR TITLE
fix(workflow): allow right-hand operand to be optional when not required by comparison

### DIFF
--- a/api/app/core/workflow/engine/graph_builder.py
+++ b/api/app/core/workflow/engine/graph_builder.py
@@ -456,7 +456,7 @@ class GraphBuilder:
                     branch_activate = []
                     new_state = state.copy()
                     new_state["activate"] = dict(state.get("activate", {}))  # deep copy of activate
-                    node_output = variable_pool.get_node_output(src, defalut=dict(), strict=False)
+                    node_output = variable_pool.get_node_output(src, default=dict(), strict=False)
                     for label, branch in unique_branch.items():
                         if node_output and evaluate_condition(
                                 branch["condition"],

--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -351,12 +351,12 @@ class VariablePool:
             }
         return runtime_vars
 
-    def get_node_output(self, node_id: str, defalut: Any = None, strict: bool = True) -> dict[str, Any] | None:
+    def get_node_output(self, node_id: str, default: Any = None, strict: bool = True) -> dict[str, Any] | None:
         """获取指定节点的输出（运行时变量）
         
         Args:
             node_id: 节点 ID
-            defalut: 默认值
+            default: 默认值
             strict: 是否严格模式
         
         Returns:
@@ -368,7 +368,7 @@ class VariablePool:
         if strict:
             raise KeyError(f"node {node_id} output not exist")
         else:
-            return defalut
+            return default
 
     def copy(self, pool: 'VariablePool'):
         self.variables = deepcopy(pool.variables)

--- a/api/app/core/workflow/nodes/cycle_graph/config.py
+++ b/api/app/core/workflow/nodes/cycle_graph/config.py
@@ -51,7 +51,7 @@ class ConditionDetail(BaseModel):
     )
 
     right: Any = Field(
-        ...,
+        default=None,
         description="Right-hand operand of the comparison expression"
     )
 

--- a/api/app/core/workflow/nodes/cycle_graph/loop.py
+++ b/api/app/core/workflow/nodes/cycle_graph/loop.py
@@ -158,7 +158,7 @@ class LoopRuntime:
         self.variable_pool.variables["conv"].update(
             self.child_variable_pool.variables["conv"]
         )
-        loop_vars = self.child_variable_pool.get_node_output(self.node_id, defalut={}, strict=False)
+        loop_vars = self.child_variable_pool.get_node_output(self.node_id, default={}, strict=False)
         loopstate["node_outputs"][self.node_id] = loop_vars
 
     def evaluate_conditional(self) -> bool:
@@ -261,4 +261,4 @@ class LoopRuntime:
             idx += 1
 
         logger.info(f"loop node {self.node_id}: execution completed")
-        return self.child_variable_pool.get_node_output(self.node_id) | {"__child_state": child_state}
+        return self.child_variable_pool.get_node_output(self.node_id, default={}, strict=False) | {"__child_state": child_state}

--- a/api/app/core/workflow/nodes/if_else/config.py
+++ b/api/app/core/workflow/nodes/if_else/config.py
@@ -18,7 +18,7 @@ class ConditionDetail(BaseModel):
     )
 
     right: Any = Field(
-        ...,
+        default=None,
         description="Value to compare with"
     )
 

--- a/api/app/core/workflow/nodes/if_else/node.py
+++ b/api/app/core/workflow/nodes/if_else/node.py
@@ -31,7 +31,7 @@ class IfElseNode(BaseNode):
                 expressions.append({
                     "left": self.get_variable(expression.left, variable_pool, strict=False),
                     "right": expression.right
-                    if expression.input_type == ValueInputType.CONSTANT
+                    if expression.input_type == ValueInputType.CONSTANT or expression.right is None
                     else self.get_variable(expression.right, variable_pool, strict=False),
                     "operator": str(expression.operator),
                 })

--- a/api/app/core/workflow/nodes/operators.py
+++ b/api/app/core/workflow/nodes/operators.py
@@ -250,6 +250,8 @@ class ConditionBase(ABC):
         self.type_limit = getattr(self, "type_limit", None)
 
     def resolve_right_literal_value(self):
+        if self.right_selector is None:
+            return None
         if self.input_type == ValueInputType.VARIABLE:
             pattern = r"\{\{\s*(.*?)\s*\}\}"
             right_expression = re.sub(pattern, r"\1", self.right_selector).strip()

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -65,6 +65,7 @@ def get_db_read() -> Generator[Session, None, None]:
             yield db
         finally:
             db.rollback()  # 只读任务无需 commit
+            db.close()
 
 
 def get_pool_status():

--- a/api/tests/workflow/executor/test_vairable_pool.py
+++ b/api/tests/workflow/executor/test_vairable_pool.py
@@ -303,7 +303,7 @@ async def test_get_node_output_not_exist_with_default():
     """测试获取不存在的节点输出（使用默认值）"""
     pool = VariablePool()
     
-    result = pool.get_node_output("nonexistent_node", defalut=None, strict=False)
+    result = pool.get_node_output("nonexistent_node", default=None, strict=False)
     
     assert result is None
 


### PR DESCRIPTION
## Summary by Sourcery

使工作流条件的右侧操作数变为可选，并在各节点中安全地处理缺失的右侧值。

Bug 修复：
- 当比较运算不需要右侧操作数时，允许在条件配置中省略右侧操作数。
- 在未提供选择器时，通过返回 `None` 来防止解析右侧字面量值时出现错误。
- 当子节点输出缺失时，通过默认使用空输出但保留子节点状态，避免在循环节点完成时发生失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make workflow condition right-hand operands optional and handle missing right-hand values safely across nodes.

Bug Fixes:
- Allow condition configurations to omit the right-hand operand when not required by the comparison.
- Prevent errors when resolving right-hand literal values by returning None when no selector is provided.
- Avoid failures in loop node completion when child output is missing by defaulting to an empty output while preserving child state.

</details>