### PR TITLE
feat: block deactivating user who is tenant contact

### DIFF
--- a/api/app/models/tenant_model.py
+++ b/api/app/models/tenant_model.py
@@ -23,6 +23,17 @@ class Tenants(Base):
     # 国际化语言配置字段
     default_language = Column(String(10), nullable=False, default='zh', server_default='zh', index=True)  # 租户默认语言
     supported_languages = Column(ARRAY(String(10)), nullable=False, default=lambda: ['zh', 'en'], server_default=text("'{zh,en}'"))  # 租户支持的语言列表
+
+    # 租户联系信息
+    contact_name = Column(String(100), nullable=True)   # 联系人姓名
+    contact_email = Column(String(255), nullable=True)  # 联系人邮箱
+    contact_phone = Column(String(50), nullable=True)   # 联系人电话
+
+    # 租户套餐信息
+    plan = Column(String(50), nullable=True)                        # 套餐类型
+    plan_expired_at = Column(DateTime, nullable=True)               # 套餐到期时间
+    api_ops_rate_limit = Column(String(100), nullable=True)         # API 调用频率限制
+    status = Column(String(50), nullable=True, default='active')    # 租户状态
     
     # Relationship to users - one tenant has many users
     users = relationship("User", back_populates="tenant")

--- a/api/app/services/user_service.py
+++ b/api/app/services/user_service.py
@@ -250,6 +250,20 @@ def deactivate_user(db: Session, user_id_to_deactivate: uuid.UUID, current_user:
                     }
                 )
 
+        # 检查是否为租户联系人
+        from app.models.tenant_model import Tenants
+        tenant = db.query(Tenants).filter(Tenants.id == db_user.tenant_id).first()
+        if tenant and tenant.contact_email and tenant.contact_email == db_user.email:
+            business_logger.warning(f"尝试停用租户联系人: {db_user.email}, tenant_id={db_user.tenant_id}")
+            raise BusinessException(
+                "该管理员是租户联系人，请先在租户信息中更换联系邮箱，再禁用此管理员",
+                code=BizCode.FORBIDDEN,
+                context={
+                    "user_id": str(user_id_to_deactivate),
+                    "tenant_id": str(db_user.tenant_id)
+                }
+            )
+
         # 停用用户
         business_logger.debug(f"执行用户停用: {db_user.username} (ID: {user_id_to_deactivate})")
         db_user.is_active = False


### PR DESCRIPTION
## Summary by Sourcery

防止停用被指定为租户联系人（tenant contact）的用户，并为租户模型扩展联系人和订阅计划的元数据。

New Features:
- 当用户被设置为租户的联系邮箱时，阻止停用该用户。
- 存储租户联系人的详细信息，包括姓名、邮箱和电话号码。
- 存储租户订阅计划信息，包括类型、到期时间、API 速率限制以及状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent deactivation of users who are designated as tenant contacts and extend the tenant model with contact and plan metadata.

New Features:
- Block deactivation of a user when they are set as the tenant's contact email.
- Store tenant contact details including name, email, and phone number.
- Store tenant subscription plan information including type, expiration time, API rate limit, and status.

</details>