### PR TITLE
fix(workflow): Fix LLM node, resolve abnormal field reading issue in message caching functionality

### DIFF
--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -639,8 +639,8 @@ class BaseNode(ABC):
             return content
 
         elif isinstance(content, FileObject):
-            if content.content_cache.get(f"{provider}_{ModelInfo.is_omni}"):
-                return content.content_cache[f"{provider}_{ModelInfo.is_omni}"]
+            if content.content_cache.get(f"{provider}_{api_config.is_omni}"):
+                return content.content_cache[f"{provider}_{api_config.is_omni}"]
             with get_db_read() as db:
                 multimodal_service = MultimodalService(db, api_config=api_config)
                 file_obj = FileInput(
@@ -656,7 +656,7 @@ class BaseNode(ABC):
                 )
                 content.set_content(file_obj.get_content())
                 if message:
-                    content.content_cache[f"{provider}_{ModelInfo.is_omni}"] = message
+                    content.content_cache[f"{provider}_{api_config.is_omni}"] = message
                     return message
                 return None
         raise TypeError(f'Unexpected input value type - {type(content)}')


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过使用 API 配置中的 omni 标志，修正 LLM 节点中基于文件内容的消息缓存键生成方式，从而避免异常字段读取和缓存不匹配问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct message cache key generation for file-based content in LLM nodes by using the API config omni flag, avoiding abnormal field reads and cache mismatches.

</details>