### PR TITLE
fix: standardize app list pagination and fix session log isolation

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -95,7 +95,12 @@ def list_apps(
         if app_ids:
             items_orm = app_service.get_apps_by_ids(db, app_ids, workspace_id)
             items = [service._convert_to_schema(app, workspace_id) for app in items_orm]
-            return success(data=items)
+            # 返回标准分页格式
+            meta = PageMeta(page=1, pagesize=len(items), total=len(items), hasnext=False)
+            return success(data=PageData(page=meta, items=items))
+        # ids 为空时，返回空列表
+        meta = PageMeta(page=1, pagesize=0, total=0, hasnext=False)
+        return success(data=PageData(page=meta, items=[]))
 
     # 正常分页查询
     items_orm, total = app_service.list_apps(

--- a/api/app/controllers/app_log_controller.py
+++ b/api/app/controllers/app_log_controller.py
@@ -35,6 +35,7 @@ def list_app_logs(
     - 支持按 user_id 筛选
     - 支持按 is_draft 筛选（草稿会话 / 发布会话）
     - 按最新更新时间倒序排列
+    - 所有人（包括共享者和被共享者）都只能查看自己的会话记录
     """
     workspace_id = current_user.current_workspace_id
 
@@ -47,6 +48,9 @@ def list_app_logs(
         Conversation.workspace_id == workspace_id,
         Conversation.is_active.is_(True),
     )
+    
+    # 所有人只能查看自己的会话记录
+    stmt = stmt.where(Conversation.user_id == str(current_user.id))
 
     if user_id:
         stmt = stmt.where(Conversation.user_id == user_id)
@@ -86,6 +90,7 @@ def get_app_log_detail(
 
     - 返回会话基本信息 + 所有消息（按时间正序）
     - 消息 meta_data 包含模型名、token 用量等信息
+    - 所有人（包括共享者和被共享者）都只能查看自己的会话详情
     """
     workspace_id = current_user.current_workspace_id
 
@@ -100,6 +105,7 @@ def get_app_log_detail(
             Conversation.app_id == app_id,
             Conversation.workspace_id == workspace_id,
             Conversation.is_active.is_(True),
+            Conversation.user_id == str(current_user.id),
         )
     ).first()
 


### PR DESCRIPTION
## Summary by Sourcery

将应用列表响应标准化为始终使用分页数据结构，并收紧应用会话日志的访问控制，确保用户只能查看自己的对话记录。

Bug Fixes:
- 确保针对显式 ID 查询的应用列表响应使用与常规分页查询相同的分页格式，包括在 ID 列表为空时。
- 限制应用会话日志的列表与详情获取，使用户（包括分享者和被分享者）只能访问自己的对话记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize app listing responses to always use the paginated data structure and tighten access control on app session logs so users can only view their own conversations.

Bug Fixes:
- Ensure app list responses for explicit ID queries use the same pagination format as regular paginated queries, including for empty ID lists.
- Restrict app session log listing and detail retrieval so that users, including sharers and share recipients, can only access their own conversation records.

</details>