### PR TITLE
fix(public_share_chat)

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -27,6 +27,7 @@ from app.services.conversation_service import ConversationService
 from app.services.release_share_service import ReleaseShareService
 from app.services.shared_chat_service import SharedChatService
 from app.services.workflow_service import WorkflowService
+from app.models.file_metadata_model import FileMetadata
 from app.utils.app_config_utils import workflow_config_4_app_release, \
     agent_config_4_app_release, multi_agent_config_4_app_release
 
@@ -259,8 +260,19 @@ def get_conversation(
     conv_service = ConversationService(db)
     messages = conv_service.get_messages(conversation_id)
 
-    # 构建响应
-    conv_dict = conversation_schema.Conversation.model_validate(conversation).model_dump()
+    # 为 assistant 消息查询 audio_url 状态
+    for m in messages:
+        if m.role == "assistant" and m.meta_data:
+            audio_url = m.meta_data.get("audio_url")
+            if audio_url:
+                try:
+                    file_id = uuid.UUID(audio_url.rstrip("/").split("/")[-1])
+                    file_meta = db.get(FileMetadata, file_id)
+                    m.meta_data["audio_status"] = file_meta.status if file_meta else "unknown"
+                except (ValueError, IndexError):
+                    m.meta_data["audio_status"] = "unknown"
+
+    conv_dict = conversation_schema.Conversation.model_validate(conversation).model_dump(mode="json")
     conv_dict["messages"] = [
         conversation_schema.Message.model_validate(m) for m in messages
     ]

--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -260,17 +260,39 @@ def get_conversation(
     conv_service = ConversationService(db)
     messages = conv_service.get_messages(conversation_id)
 
-    # 为 assistant 消息查询 audio_url 状态
-    for m in messages:
+    file_ids = []
+    message_file_id_map = {}
+
+    # 第一次遍历：解析 audio_url，收集所有有效的 file_id
+    for idx, m in enumerate(messages):
         if m.role == "assistant" and m.meta_data:
             audio_url = m.meta_data.get("audio_url")
-            if audio_url:
-                try:
-                    file_id = uuid.UUID(audio_url.rstrip("/").split("/")[-1])
-                    file_meta = db.get(FileMetadata, file_id)
-                    m.meta_data["audio_status"] = file_meta.status if file_meta else "unknown"
-                except (ValueError, IndexError):
-                    m.meta_data["audio_status"] = "unknown"
+            if not audio_url:
+                continue
+            try:
+                file_id = uuid.UUID(audio_url.rstrip("/").split("/")[-1])
+            except (ValueError, IndexError):
+                # audio_url 无法解析为 UUID，标记为 unknown
+                m.meta_data["audio_status"] = "unknown"
+                continue
+
+            file_ids.append(file_id)
+            message_file_id_map[idx] = file_id
+
+    # 批量查询所有相关的 FileMetadata
+    file_status_map = {}
+    if file_ids:
+        file_metas = (
+            db.query(FileMetadata)
+            .filter(FileMetadata.id.in_(set(file_ids)))
+            .all()
+        )
+        file_status_map = {fm.id: fm.status for fm in file_metas}
+
+    # 第二次遍历：将查询结果映射回消息
+    for idx, file_id in message_file_id_map.items():
+        m = messages[idx]
+        m.meta_data["audio_status"] = file_status_map.get(file_id, "unknown")
 
     conv_dict = conversation_schema.Conversation.model_validate(conversation).model_dump(mode="json")
     conv_dict["messages"] = [


### PR DESCRIPTION
History conversation message returns audio status

## 由 Sourcery 提供的总结

在公开共享的对话历史响应中，为助手消息包含音频状态。

错误修复：
- 确保在公开分享的响应中，对话历史消息在现有音频 URL 的基础上同时暴露音频生成状态。

增强：
- 通过在导出对话模型时使用 JSON 模式来规范对话序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include audio status for assistant messages in public shared conversation history responses.

Bug Fixes:
- Ensure history conversation messages expose the audio generation status alongside existing audio URLs in public share responses.

Enhancements:
- Normalize conversation serialization by using JSON mode when dumping conversation models.

</details>