### PR TITLE
[fix] The "write_tools" module actively shuts down the client, and it…

### DIFF
--- a/api/app/core/memory/agent/utils/write_tools.py
+++ b/api/app/core/memory/agent/utils/write_tools.py
@@ -274,5 +274,21 @@ async def write(
     except Exception as cache_err:
         logger.warning(f"[WRITE] 写入活动统计缓存失败（不影响主流程）: {cache_err}", exc_info=True)
 
+    # Close LLM/Embedder underlying httpx clients to prevent
+    # 'RuntimeError: Event loop is closed' during garbage collection
+    for client_obj in (llm_client, embedder_client):
+        try:
+            underlying = getattr(client_obj, 'client', None) or getattr(client_obj, 'model', None)
+            if underlying is None:
+                continue
+            # Unwrap RedBearLLM / RedBearEmbeddings to get the LangChain model
+            inner = getattr(underlying, '_model', underlying)
+            # LangChain OpenAI models expose async_client (httpx.AsyncClient)
+            http_client = getattr(inner, 'async_client', None)
+            if http_client is not None and hasattr(http_client, 'aclose'):
+                await http_client.aclose()
+        except Exception:
+            pass
+
     logger.info("=== Pipeline Complete ===")
     logger.info(f"Total execution time: {total_time:.2f} seconds")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -101,10 +101,11 @@ def get_sync_redis_client() -> Optional[redis.StrictRedis]:
 
 
 def set_asyncio_event_loop():
-    """Set the asyncio event loop for the current thread.
+    """Ensure an open asyncio event loop exists for the current thread.
 
-    Always creates a fresh event loop to avoid 'Event loop is closed' errors
-    caused by stale httpx.AsyncClient objects from previous task runs.
+    Reuses the existing event loop if one is available and still open.
+    Creates and installs a new event loop only when the current one is
+    closed or missing (e.g. after ``_shutdown_loop_gracefully``).
     """
     try:
         loop = asyncio.get_event_loop()
@@ -122,6 +123,9 @@ def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
 
     This prevents 'RuntimeError: Event loop is closed' from httpx.AsyncClient.__del__
     by giving pending aclose() coroutines a chance to run before the loop is discarded.
+
+    Note: This only tears down the given loop. Callers that need a fresh event
+    loop afterwards should use ``set_asyncio_event_loop()`` explicitly.
     """
     try:
         # Cancel and collect all remaining tasks
@@ -136,9 +140,6 @@ def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
         pass
     finally:
         loop.close()
-        # Set a new event loop so subsequent tasks get a fresh one
-        new_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(new_loop)
 
 
 @celery_app.task(name="tasks.process_item")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -101,7 +101,11 @@ def get_sync_redis_client() -> Optional[redis.StrictRedis]:
 
 
 def set_asyncio_event_loop():
-    """Set the asyncio event loop for the current thread."""
+    """Set the asyncio event loop for the current thread.
+
+    Always creates a fresh event loop to avoid 'Event loop is closed' errors
+    caused by stale httpx.AsyncClient objects from previous task runs.
+    """
     try:
         loop = asyncio.get_event_loop()
         if loop.is_closed():
@@ -111,6 +115,30 @@ def set_asyncio_event_loop():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     return loop
+
+
+def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
+    """Gracefully shutdown pending async generators and tasks on the event loop.
+
+    This prevents 'RuntimeError: Event loop is closed' from httpx.AsyncClient.__del__
+    by giving pending aclose() coroutines a chance to run before the loop is discarded.
+    """
+    try:
+        # Cancel and collect all remaining tasks
+        all_tasks = asyncio.all_tasks(loop)
+        if all_tasks:
+            for task in all_tasks:
+                task.cancel()
+            loop.run_until_complete(asyncio.gather(*all_tasks, return_exceptions=True))
+        # Shutdown async generators (triggers __aclose__ on httpx clients etc.)
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    except Exception:
+        pass
+    finally:
+        loop.close()
+        # Set a new event loop so subsequent tasks get a fresh one
+        new_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(new_loop)
 
 
 @celery_app.task(name="tasks.process_item")
@@ -1216,11 +1244,12 @@ def write_message_task(
             "task_id": self.request.id
         }
     finally:
-        if lock is not None:
-            try:
-                lock.release()
-            except Exception as e:
-                logger.warning(f"[CELERY WRITE] 释放锁失败: {e}")
+        # Gracefully shutdown the event loop to prevent
+        # 'RuntimeError: Event loop is closed' from httpx.AsyncClient.__del__
+        _shutdown_loop_gracefully(loop)
+
+
+# unused task
 # @celery_app.task(name="app.core.memory.agent.health.check_read_service")
 # def check_read_service_task() -> Dict[str, str]:
 #     """Call read_service and write latest status to Redis.

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1244,6 +1244,11 @@ def write_message_task(
             "task_id": self.request.id
         }
     finally:
+        if lock is not None:
+            try:
+                lock.release()
+            except Exception as e:
+                logger.warning(f"[CELERY WRITE] 释放锁失败: {e}")
         # Gracefully shutdown the event loop to prevent
         # 'RuntimeError: Event loop is closed' from httpx.AsyncClient.__del__
         _shutdown_loop_gracefully(loop)


### PR DESCRIPTION
… closes before the task event loop is completed.

## Summary by Sourcery

优雅地关闭 Celery 任务事件循环及其底层 HTTP 客户端，避免在异步客户端清理过程中出现 “Event loop is closed” 运行时错误。

Bug 修复：
- 确保 Celery 任务事件循环被优雅关闭，在关闭前取消挂起的任务和异步生成器，以防止在执行 `httpx.AsyncClient` 清理时出现运行时错误。
- 在写入操作结束时显式关闭用于 LLM 和嵌入工具的底层异步 HTTP 客户端，以避免在垃圾回收期间出现 “Event loop is closed” 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gracefully shut down Celery task event loops and underlying HTTP clients to avoid 'Event loop is closed' runtime errors during async client cleanup.

Bug Fixes:
- Ensure Celery task event loops are gracefully shut down, cancelling pending tasks and async generators before closing to prevent runtime errors from httpx.AsyncClient cleanup.
- Explicitly close underlying async HTTP clients for LLM and embedding tools at the end of write operations to avoid 'Event loop is closed' errors during garbage collection.

</details>