### PR TITLE
fix(web): ui

### DIFF
--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -397,7 +397,7 @@ body {
   background-color: #171719;
 }
 
-.spin.ant-spin-nested-loading .ant-spin-container::after {
+.spin .ant-spin-nested-loading .ant-spin-container::after {
   background: transparent;
 }
 .upload-block,

--- a/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
@@ -65,8 +65,8 @@ const CommunityNetwork: FC<{ onSelectCommunity?: (node: RawCommunityNode) => voi
   }, [id])
 
   if (loading) {
-    return <Flex align="center" justify="center" className="rb:w-full rb:h-full">
-      <Spin tip={t('userMemory.communityLoadingTip')} size="large" className="rb:text-[#5B6167]! spin">
+  return <Flex align="center" justify="center" className="rb:w-full rb:h-full spin">
+      <Spin tip={t('userMemory.communityLoadingTip')} size="large" className="rb:text-[#5B6167]!">
         <div className="rb:w-64 rb:h-64" />
       </Spin>
       </Flex>


### PR DESCRIPTION
## Summary by Sourcery

调整 CommunityNetwork 视图中的加载旋转器样式，以修复遮罩层行为。

Bug 修复：
- 更正 CommunityNetwork 加载状态下的旋转器包装标记和类的使用，以确保布局正确。
- 将全局旋转遮罩层的 CSS 限制在 `.spin` 容器内的元素中，以避免在其他位置产生意外样式影响。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust loading spinner styling for the CommunityNetwork view to fix overlay behavior.

Bug Fixes:
- Correct spinner wrapper markup and class usage in the CommunityNetwork loading state to ensure proper layout.
- Restrict the global spin overlay CSS to elements within a .spin container to avoid unintended styling elsewhere.

</details>