### PR TITLE
refactor(memory_agent_service, memory_perceptual_service): Simplify audit logger import and usage

### DIFF
--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -37,6 +37,7 @@ from app.core.memory.agent.utils.type_classifier import status_typle
 from app.core.memory.agent.utils.write_tools import write as write_neo4j
 from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
+from app.core.memory.utils.log.audit_logger import audit_logger
 from app.db import get_db_context
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -49,10 +50,6 @@ from app.services.memory_konwledges_server import (
 )
 from app.services.memory_perceptual_service import MemoryPerceptualService
 
-try:
-    from app.core.memory.utils.log.audit_logger import audit_logger
-except ImportError:
-    audit_logger = None
 logger = get_logger(__name__)
 config_logger = get_config_logger()
 
@@ -68,24 +65,22 @@ class MemoryAgentService:
         if str(messages) == 'success':
             logger.info(f"Write operation successful for group {end_user_id} with config_id {config_id}")
             # 记录成功的操作
-            if audit_logger:
-                audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
-                                           success=True,
-                                           duration=duration, details={"message_length": len(message)})
+            audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
+                                       success=True,
+                                       duration=duration, details={"message_length": len(message)})
             return context
         else:
             logger.warning(f"Write operation failed for group {end_user_id}")
 
             # 记录失败的操作
-            if audit_logger:
-                audit_logger.log_operation(
-                    operation="WRITE",
-                    config_id=config_id,
-                    end_user_id=end_user_id,
-                    success=False,
-                    duration=duration,
-                    error=f"写入失败: {messages[:100]}"
-                )
+            audit_logger.log_operation(
+                operation="WRITE",
+                config_id=config_id,
+                end_user_id=end_user_id,
+                success=False,
+                duration=duration,
+                error=f"写入失败: {messages[:100]}"
+            )
 
             raise ValueError(f"写入失败: {messages}")
 
@@ -338,10 +333,9 @@ class MemoryAgentService:
             logger.error(error_msg)
 
             # Log failed operation
-            if audit_logger:
-                duration = time.time() - start_time
-                audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
-                                           success=False, duration=duration, error=error_msg)
+            duration = time.time() - start_time
+            audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
+                                       success=False, duration=duration, error=error_msg)
 
             raise ValueError(error_msg)
 
@@ -401,10 +395,10 @@ class MemoryAgentService:
             # Ensure proper error handling and logging
             error_msg = f"Write operation failed: {str(e)}"
             logger.error(error_msg)
-            if audit_logger:
-                duration = time.time() - start_time
-                audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
-                                           success=False, duration=duration, error=error_msg)
+
+            duration = time.time() - start_time
+            audit_logger.log_operation(operation="WRITE", config_id=config_id, end_user_id=end_user_id,
+                                       success=False, duration=duration, error=error_msg)
             raise ValueError(error_msg)
 
     async def read_memory(
@@ -469,10 +463,9 @@ class MemoryAgentService:
         logger.info(f"Read operation for group {end_user_id} with config_id {config_id}")
 
         # 导入审计日志记录器
-        try:
-            from app.core.memory.utils.log.audit_logger import audit_logger
-        except ImportError:
-            audit_logger = None
+
+
+
 
         config_load_start = time.time()
         try:
@@ -492,16 +485,15 @@ class MemoryAgentService:
             logger.error(error_msg)
 
             # Log failed operation
-            if audit_logger:
-                duration = time.time() - start_time
-                audit_logger.log_operation(
-                    operation="READ",
-                    config_id=config_id,
-                    end_user_id=end_user_id,
-                    success=False,
-                    duration=duration,
-                    error=error_msg
-                )
+            duration = time.time() - start_time
+            audit_logger.log_operation(
+                operation="READ",
+                config_id=config_id,
+                end_user_id=end_user_id,
+                success=False,
+                duration=duration,
+                error=error_msg
+            )
 
             raise ValueError(error_msg)
 
@@ -633,15 +625,15 @@ class MemoryAgentService:
                 total_time = time.time() - start_time
                 logger.info(
                     f"[PERF] read_memory completed successfully in {total_time:.4f}s (config: {config_load_time:.4f}s, graph: {graph_exec_time:.4f}s)")
-                if audit_logger:
-                    duration = time.time() - start_time
-                    audit_logger.log_operation(
-                        operation="READ",
-                        config_id=config_id,
-                        end_user_id=end_user_id,
-                        success=True,
-                        duration=duration
-                    )
+
+                duration = time.time() - start_time
+                audit_logger.log_operation(
+                    operation="READ",
+                    config_id=config_id,
+                    end_user_id=end_user_id,
+                    success=True,
+                    duration=duration
+                )
 
                 return {
                     "answer": summary,
@@ -651,16 +643,16 @@ class MemoryAgentService:
             # Ensure proper error handling and logging
             error_msg = f"Read operation failed: {str(e)}"
             logger.error(error_msg)
-            if audit_logger:
-                duration = time.time() - start_time
-                audit_logger.log_operation(
-                    operation="READ",
-                    config_id=config_id,
-                    end_user_id=end_user_id,
-                    success=False,
-                    duration=duration,
-                    error=error_msg
-                )
+
+            duration = time.time() - start_time
+            audit_logger.log_operation(
+                operation="READ",
+                config_id=config_id,
+                end_user_id=end_user_id,
+                success=False,
+                duration=duration,
+                error=error_msg
+            )
             raise ValueError(error_msg)
 
     def get_messages_list(self, user_input: Write_UserInput) -> list[dict]:

--- a/api/app/services/memory_perceptual_service.py
+++ b/api/app/services/memory_perceptual_service.py
@@ -244,6 +244,8 @@ class MemoryPerceptualService:
             file: FileInput
     ):
         llm, model_config = self._get_mutlimodal_client(file.type, memory_config)
+        if model_config is None or llm is None:
+            return None
         multimodel_service = MultimodalService(self.db, ModelInfo(
             model_name=model_config.model_name,
             provider=model_config.provider,
@@ -265,15 +267,20 @@ class MemoryPerceptualService:
             with open(os.path.join(prompt_path, 'perceptual_summary_system.jinja2'), 'r', encoding='utf-8') as f:
                 opt_system_prompt = f.read()
             rendered_system_message = Template(opt_system_prompt).render(file_type=file.type, language='zh')
-        except FileNotFoundError:
-            raise BusinessException(message="System prompt template not found", code=BizCode.NOT_FOUND)
+        except FileNotFoundError as e:
+            business_logger.error(f"Failed to generate perceptual memory: {str(e)}")
+            return None
         messages = [
             {"role": RoleType.SYSTEM.value, "content": [{"type": "text", "text": rendered_system_message}]},
             {"role": RoleType.USER.value, "content": [
                 {"type": "text", "text": "Summarize the following file"}, file_message
             ]}
         ]
-        result = await llm.ainvoke(messages)
+        try:
+            result = await llm.ainvoke(messages)
+        except Exception as e:
+            business_logger.error(f"Failed to generate perceptual memory: {str(e)}")
+            return None
         content = result.content
         final_output = ""
         if isinstance(content, list):


### PR DESCRIPTION
- Removed try-except block for importing `audit_logger` and directly imported it.
- Removed redundant checks for `audit_logger` being `None` before logging operations.
- Added a check in `MemoryPerceptualService` to return `None` if `model_config` or `llm` is `None`.

## Summary by Sourcery

简化内存服务中的审计日志使用方式，并增强感知记忆生成在缺少配置和运行时失败情况下的健壮性。

Bug 修复：
- 当模型配置、LLM 客户端、提示模板或 LLM 调用不可用时，通过返回 `None` 并记录错误日志来防止感知记忆生成崩溃。

增强功能：
- 在内存代理操作中强制要求审计记录器必须可用，并移除其使用周围的条件检查。
- 在感知记忆生成中，当无法获取模型配置或 LLM 客户端时提前返回，并在模板缺失或 LLM 调用失败时记录错误日志，而不是抛出异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify audit logging usage in memory services and harden perceptual memory generation against missing configuration and runtime failures.

Bug Fixes:
- Prevent perceptual memory generation from crashing when model configuration, LLM client, prompt templates, or LLM calls are unavailable by returning None and logging errors instead.

Enhancements:
- Require the audit logger to be available in memory agent operations and remove conditional checks around its usage.
- Add early return in perceptual memory generation when model configuration or LLM client cannot be obtained, and log errors instead of raising for missing templates or LLM invocation failures.

</details>