### PR TITLE
fix: update app_shares.is_active to false when deleting shared app

### DIFF
--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -757,6 +757,17 @@ class AppService:
 
         # 逻辑删除应用
         app.is_active = False
+        
+        # 更新 app_shares 表中该应用的所有共享记录为失效状态
+        from app.models import AppShare
+        from sqlalchemy import update as sa_update
+        self.db.execute(
+            sa_update(AppShare).where(
+                AppShare.source_app_id == app_id,
+                AppShare.is_active.is_(True)
+            ).values(is_active=False)
+        )
+        
         self.db.commit()
 
         logger.info(

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -13,7 +13,7 @@ import uuid
 from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 from fastapi import Depends
-from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy import and_, delete, func, or_, select, update as sa_update
 from sqlalchemy.orm import Session
 
 from app.core.error_codes import BizCode
@@ -759,14 +759,11 @@ class AppService:
         app.is_active = False
         
         # 更新 app_shares 表中该应用的所有共享记录为失效状态
-        from app.models import AppShare
-        from sqlalchemy import update as sa_update
-        self.db.execute(
-            sa_update(AppShare).where(
-                AppShare.source_app_id == app_id,
-                AppShare.is_active.is_(True)
-            ).values(is_active=False)
-        )
+        stmt = sa_update(AppShare).where(
+            AppShare.source_app_id == app_id,
+            AppShare.is_active.is_(True)
+        ).values(is_active=False)
+        self.db.execute(stmt)
         
         self.db.commit()
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当源应用被删除时，将相关的 `app_shares` 记录标记为非活跃状态，以保持共享状态的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Mark related app_shares records as inactive when their source app is deleted to keep share state consistent.

</details>