### PR TITLE
fix: update app_shares.is_active and updated_at when deleting shared app

### DIFF
--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -758,11 +758,14 @@ class AppService:
         # 逻辑删除应用
         app.is_active = False
         
-        # 更新 app_shares 表中该应用的所有共享记录为失效状态
+        # 更新 app_shares 表中该应用的所有共享记录为失效状态，并更新 updated_at 时间
         stmt = sa_update(AppShare).where(
             AppShare.source_app_id == app_id,
             AppShare.is_active.is_(True)
-        ).values(is_active=False)
+        ).values(
+            is_active=False,
+            updated_at=datetime.datetime.now()
+        )
         self.db.execute(stmt)
         
         self.db.commit()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当源应用被逻辑删除时，将 `app_shares.is_active` 设置为 `false`，并更新 `updated_at` 以反映该变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set app_shares.is_active to false when the source app is logically deleted and update updated_at to reflect the change.

</details>