### PR TITLE
ci(gitee): update Gitee repository path in sync workflow

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Sync to Gitee
         run: |
-          GITEE_URL="https://${{ secrets.GITEE_USERNAME }}:${{ secrets.GITEE_TOKEN }}@gitee.com/${{ secrets.GITEE_USERNAME }}/MemoryBear.git"
+          GITEE_URL="https://${{ secrets.GITEE_USERNAME }}:${{ secrets.GITEE_TOKEN }}@gitee.com/hangzhou-hongxiong-intelligent_1/MemoryBear.git"
           git remote add gitee "$GITEE_URL"
 
           # 遍历并推送所有分支


### PR DESCRIPTION
- Replace dynamic username variable with static repository path
- Update Gitee remote URL to use correct organization namespace
- Ensure sync workflow targets the correct Gitee repository

## Summary by Sourcery

CI:
- 将同步工作流中的 Gitee 远程 URL 修改为使用固定的组织命名空间，而不是基于动态用户名的路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change the Gitee remote URL in the sync workflow to use a fixed organization namespace instead of a dynamic username-based path.

</details>