### PR TITLE
docs: add status badges to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # MemoryBear empowers AI with human-like memory capabilities
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.12+-green?logo=python&logoColor=white)](https://www.python.org/)
+[![Gitee Sync](https://img.shields.io/github/actions/workflow/status/SuanmoSuanyangTechnology/MemoryBear/sync-to-gitee.yml?label=Gitee%20Sync&logo=gitee&logoColor=white)](https://github.com/SuanmoSuanyangTechnology/MemoryBear/actions/workflows/sync-to-gitee.yml)
+
 [中文](./README_CN.md) | English
 
 ### [Installation Guide](#memorybear-installation-guide)

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,6 +2,10 @@
 
 # MemoryBear 让AI拥有如同人类一样的记忆
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.12+-green?logo=python&logoColor=white)](https://www.python.org/)
+[![Gitee Sync](https://img.shields.io/github/actions/workflow/status/SuanmoSuanyangTechnology/MemoryBear/sync-to-gitee.yml?label=Gitee%20Sync&logo=gitee&logoColor=white)](https://github.com/SuanmoSuanyangTechnology/MemoryBear/actions/workflows/sync-to-gitee.yml)
+
 中文 | [English](./README.md)
 
 ### [安装教程](#memorybear安装教程)


### PR DESCRIPTION
- Add Apache 2.0 license badge to both README.md and README_CN.md
- Add Python 3.12+ version badge with logo
- Add Gitee Sync workflow status badge linking to GitHub Actions
- Improve project visibility with standardized badge indicators

## Summary by Sourcery

文档：
- 在 README.md 和 README_CN.md 中添加 Apache 2.0 许可、Python 3.12+ 支持以及 Gitee 同步工作流状态徽章。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add Apache 2.0 license, Python 3.12+ support, and Gitee Sync workflow status badges to both README.md and README_CN.md.

</details>