### PR TITLE
fix(workflow): persist citations in conversation message meta_data

### DIFF
--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -728,12 +728,15 @@ class WorkflowService:
                 filtered_citations = (
                     citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
                 )
+                assistant_meta = {"usage": token_usage, "audio_url": None}
+                if filtered_citations:
+                    assistant_meta["citations"] = filtered_citations
                 self.conversation_service.add_message(
                     message_id=message_id,
                     conversation_id=conversation_id_uuid,
                     role="assistant",
                     content=assistant_message,
-                    meta_data={"usage": token_usage, "audio_url": None, "citations": filtered_citations}
+                    meta_data=assistant_meta
                 )
                 self.update_execution_status(
                     execution.execution_id,
@@ -923,12 +926,15 @@ class WorkflowService:
                         filtered_citations = (
                             citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
                         )
+                        assistant_meta = {"usage": token_usage, "audio_url": None}
+                        if filtered_citations:
+                            assistant_meta["citations"] = filtered_citations
                         self.conversation_service.add_message(
                             message_id=message_id,
                             conversation_id=conversation_id_uuid,
                             role="assistant",
                             content=assistant_message,
-                            meta_data={"usage": token_usage, "audio_url": None, "citations": filtered_citations}
+                            meta_data=assistant_meta
                         )
                         self.update_execution_status(
                             execution.execution_id,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -722,12 +722,18 @@ class WorkflowService:
                     content=human_message,
                     meta_data=human_meta
                 )
+                # 过滤 citations
+                citations = result.get("citations", [])
+                citation_cfg = feature_configs.get("citation", {})
+                filtered_citations = (
+                    citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
+                )
                 self.conversation_service.add_message(
                     message_id=message_id,
                     conversation_id=conversation_id_uuid,
                     role="assistant",
                     content=assistant_message,
-                    meta_data={"usage": token_usage, "audio_url": None}
+                    meta_data={"usage": token_usage, "audio_url": None, "citations": filtered_citations}
                 )
                 self.update_execution_status(
                     execution.execution_id,
@@ -746,13 +752,7 @@ class WorkflowService:
                 )
                 logger.error(f"Workflow Run Failed, execution_id: {execution.execution_id},"
                              f" error: {result.get('error')}")
-
-            # 过滤 citations
-            citations = result.get("citations", [])
-            citation_cfg = feature_configs.get("citation", {})
-            filtered_citations = (
-                citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
-            )
+                filtered_citations = []
 
             # 返回增强的响应结构
             return {
@@ -917,24 +917,24 @@ class WorkflowService:
                             content=human_message,
                             meta_data=human_meta
                         )
+                        # 过滤 citations
+                        citations = event.get("data", {}).get("citations", [])
+                        citation_cfg = feature_configs.get("citation", {})
+                        filtered_citations = (
+                            citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
+                        )
                         self.conversation_service.add_message(
                             message_id=message_id,
                             conversation_id=conversation_id_uuid,
                             role="assistant",
                             content=assistant_message,
-                            meta_data={"usage": token_usage, "audio_url": None}
+                            meta_data={"usage": token_usage, "audio_url": None, "citations": filtered_citations}
                         )
                         self.update_execution_status(
                             execution.execution_id,
                             "completed",
                             output_data=event.get("data"),
                             token_usage=token_usage.get("total_tokens", None)
-                        )
-                        # 注入 citations 到 workflow_end 事件
-                        citations = event.get("data", {}).get("citations", [])
-                        citation_cfg = feature_configs.get("citation", {})
-                        filtered_citations = (
-                            citations if isinstance(citation_cfg, dict) and citation_cfg.get("enabled") else []
                         )
                         event.setdefault("data", {})["citations"] = filtered_citations
                         logger.info(f"Workflow Run Success, "


### PR DESCRIPTION
## 由 Sourcery 提供的总结

调整工作流服务，以控制在普通运行和流式运行中，引用（citations）如何被过滤并存储到助手消息的元数据中。

增强内容：
- 仅在引用功能启用时，才过滤并附加引用到助手消息的元数据中。
- 确保失败的工作流执行返回一个空的引用列表，而不是传播部分引用数据。
- 对齐流式工作流的处理方式，使引用通过会话元数据进行管理，而不是被注入到 `workflow_end` 事件中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust workflow service to control how citations are filtered and stored in assistant message metadata for both normal and streaming runs.

Enhancements:
- Filter and attach citations to assistant message metadata only when the citation feature is enabled.
- Ensure failed workflow executions return an empty citations list instead of propagating partial citation data.
- Align streaming workflow handling so citations are managed via conversation metadata rather than being injected into workflow_end events.

</details>