### PR TITLE
fix(app):

### DIFF
--- a/api/app/core/agent/langchain_agent.py
+++ b/api/app/core/agent/langchain_agent.py
@@ -14,6 +14,7 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
+from langgraph.errors import GraphRecursionError
 
 from app.core.logging_config import get_business_logger
 from app.core.models import RedBearLLM, RedBearModelConfig
@@ -377,7 +378,7 @@ class LangChainAgent:
                     {"messages": messages},
                     config={"recursion_limit": self.max_iterations}
                 )
-            except RecursionError as e:
+            except (RecursionError, GraphRecursionError) as e:
                 logger.warning(
                     f"Agent 达到最大迭代次数限制 ({self.max_iterations})，可能存在工具调用循环",
                     extra={"error": str(e)}
@@ -612,6 +613,12 @@ class LangChainAgent:
                         yield stream_total_tokens
                         break
 
+            except GraphRecursionError:
+                logger.warning(
+                    f"Agent 达到最大迭代次数限制 ({self.max_iterations})，模型可能不支持正确的工具调用停止判断"
+                )
+                if not full_content:
+                    yield "抱歉，我在处理您的请求时遇到了问题（已达最大处理步骤限制）。请尝试简化问题或更换模型后重试。"
             except Exception as e:
                 logger.error(f"Agent astream_events 失败: {str(e)}", exc_info=True)
                 raise

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -79,8 +79,10 @@ class RedBearModelFactory:
                 model_kwargs: Dict[str, Any] = config.extra_params.get("model_kwargs", {})
                 if is_streaming:
                     model_kwargs["enable_thinking"] = config.deep_thinking
-                    if config.deep_thinking and config.thinking_budget_tokens:
-                        model_kwargs["thinking_budget"] = config.thinking_budget_tokens
+                    if config.deep_thinking:
+                        model_kwargs["incremental_output"] = True
+                        if config.thinking_budget_tokens:
+                            model_kwargs["thinking_budget"] = config.thinking_budget_tokens
                 else:
                     model_kwargs["enable_thinking"] = False
                 params["model_kwargs"] = model_kwargs
@@ -140,8 +142,10 @@ class RedBearModelFactory:
                 model_kwargs: Dict[str, Any] = config.extra_params.get("model_kwargs", {})
                 if is_streaming:
                     model_kwargs["enable_thinking"] = config.deep_thinking
-                    if config.deep_thinking and config.thinking_budget_tokens:
-                        model_kwargs["thinking_budget"] = config.thinking_budget_tokens
+                    if config.deep_thinking:
+                        model_kwargs["incremental_output"] = True
+                        if config.thinking_budget_tokens:
+                            model_kwargs["thinking_budget"] = config.thinking_budget_tokens
                 else:
                     model_kwargs["enable_thinking"] = False
                 params["model_kwargs"] = model_kwargs

--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -1,5 +1,5 @@
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 from langchain_core.embeddings import Embeddings
 
 from app.core.models.base import RedBearModelConfig, get_provider_embedding_class, RedBearModelFactory
@@ -22,7 +22,8 @@ class RedBearEmbeddings(Embeddings):
             self._model = self._create_model(config)
             self._client = None
 
-    def _create_model(self, config: RedBearModelConfig) -> Embeddings:
+    @staticmethod
+    def _create_model(config: RedBearModelConfig) -> Embeddings:
         """根据配置创建 LangChain 模型"""
         embedding_class = get_provider_embedding_class(config.provider)
         provider = config.provider.lower()
@@ -36,6 +37,8 @@ class RedBearEmbeddings(Embeddings):
                 "api_key": config.api_key,
                 "timeout": httpx.Timeout(timeout=config.timeout, connect=60.0),
                 "max_retries": config.max_retries,
+                "check_embedding_ctx_length": False,
+                "encoding_format": "float"
             }
         elif provider == ModelProvider.DASHSCOPE:
             params = {

--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -803,7 +803,6 @@ models:
   - vision
   - video
   - audio
-  - thinking
   is_omni: true
   tags:
   - 大语言模型

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -4,6 +4,10 @@ from typing import Optional, Any, List, Dict, Union
 from enum import Enum, StrEnum
 
 from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator
+
+from app.schemas.workflow_schema import WorkflowConfigCreate
+
+
 # ---------- Multimodal File Support ----------
 
 class FileType(StrEnum):
@@ -313,7 +317,7 @@ class AppCreate(BaseModel):
     # only for type=multi_agent
     multi_agent_config: Optional[Dict[str, Any]] = None
 
-    workflow_config: Optional[Dict[str, Any]] = None
+    workflow_config: Optional[WorkflowConfigCreate] = None
 
 
 class AppUpdate(BaseModel):


### PR DESCRIPTION
1. Import issue handling；
2. embedding model checkout;
3. omni model removes thinking

## Summary by Sourcery

更稳健地处理智能体递归错误，调整思考模型参数，更新 workflow 配置的类型定义，并改进 embedding 模型创建方式以及 omni 模型的能力设置。

Bug 修复：
- 在智能体对话流程中，将 `GraphRecursionError` 与 `RecursionError` 视为同类错误处理，并在递归达到上限时，在流式输出模式下向用户提供可见提示信息。
- 更正 `AppCreate` 中 `workflow_config` 的类型，将其从通用的 `dict` 修改为使用 `WorkflowConfigCreate` 模式(schema)。

功能增强：
- 在深度思考模式启用时支持增量输出，并且仅在有相应配置时才设置思考预算。
- 将 embedding 模型的创建改为静态方法，同时在标准化 embedding 编码格式为 `float` 的过程中禁用上下文长度检查。
- 从 `qwen-omni` 模型定义中移除思考能力（thinking capability）标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle agent recursion errors more robustly, adjust thinking model parameters, update workflow config typing, and refine embedding model creation and omni model capabilities.

Bug Fixes:
- Treat GraphRecursionError the same as RecursionError in agent chat flows and provide a user-facing message in streaming mode when recursion limits are hit.
- Correct the type of workflow_config in AppCreate to use the WorkflowConfigCreate schema instead of a generic dict.

Enhancements:
- Enable incremental output when deep thinking is active and set thinking budget only when configured.
- Update embedding model creation to be a static method and disable context length checks while standardizing embedding encoding format to float.
- Remove the thinking capability flag from the qwen-omni model definition.

</details>