### PR TITLE
fix(web): share app chat support statement

### DIFF
--- a/web/src/components/Chat/ChatToolbar.tsx
+++ b/web/src/components/Chat/ChatToolbar.tsx
@@ -82,6 +82,7 @@ const ChatToolbar = forwardRef<ChatToolbarRef, ChatToolbarProps>(({
     setVariables: (variables) => {
       console.log('variables', variables)
       form.setFieldValue('variables', variables)
+      onVariablesChange?.(variables)
     },
   }))
 

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:21 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-31 16:50:10
+ * @Last Modified time: 2026-04-07 18:04:49
  */
 import { useEffect, useRef, useState, forwardRef, useImperativeHandle, useMemo } from 'react';
 import { useTranslation } from 'react-i18next'
@@ -354,6 +354,25 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
 
   const handleSaveFeaturesConfig = (value: FeaturesConfigForm) => {
     form.setFieldValue('features', value)
+    const { statement = '' } = value?.opening_statement || {}
+    onFeaturesLoad?.(value)
+
+    const usedVars = [...new Set([...(statement?.matchAll(/\{\{(\w+)\}\}/g) ?? [])].map(m => m[1]))]
+    const variables = values?.variables
+    const validNames = new Set(variables.map(v => v.name))
+    const invalid = usedVars.filter(v => !validNames.has(v))
+    if (invalid.length > 0) {
+      const newVars = invalid.map((name, i) => ({
+        index: variables.length + i,
+        name,
+        display_name: name,
+        type: 'text',
+        required: true,
+        max_length: 48,
+      }))
+
+      form.setFieldValue('variables', [...variables, ...newVars])
+    }
   }
   const modelLogo = useMemo(() => {
     return defaultModel?.name && getListLogoUrl(defaultModel.provider, defaultModel.logo as string)
@@ -385,7 +404,8 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
           if (vo.list?.length === 0) {
             return { ...vo, list: [assistantMsg] }
           } else if (vo.list && vo.list[0].role === 'assistant') {
-            return { ...vo, list: [assistantMsg, ...vo.list.slice(1)] }
+            vo.list[0] = assistantMsg
+            return { ...vo, list: [...vo.list] }
           } else {
             return { ...vo, list: [assistantMsg, ...(vo.list || [])] }
           }

--- a/web/src/views/ApplicationConfig/TestChat/index.tsx
+++ b/web/src/views/ApplicationConfig/TestChat/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-13 17:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-02 17:58:07
+ * @Last Modified time: 2026-04-07 18:08:18
  */
 import { type FC, useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -27,6 +27,7 @@ import type { TestChatProps } from './type'
 import type { SSEMessage } from '@/utils/stream'
 import type { FeaturesConfigForm } from '@/views/ApplicationConfig/types'
 import { getFileStatusById } from '@/api/fileStorage'
+import { replaceVariables } from '@/views/ApplicationConfig/Agent'
 
 const formatParams = (message: string, conversation_id: string | null, files: any[] = [], variables: Record<string, any>) => {
   return {
@@ -86,6 +87,7 @@ const TestChat: FC<TestChatProps> = ({
   const [message, setMessage] = useState<string | undefined>(undefined)
   const [fileList, setFileList] = useState<any[]>([])
   const [features, setFeatures] = useState<FeaturesConfigForm>({} as FeaturesConfigForm)
+  const [variables, setVariables] = useState<Variable[]>([])
   
   const audioPollingRef = useRef<Map<string, ReturnType<typeof setInterval>>>(new Map())
   const [audioStatusMap, setAudioStatusMap] = useState<Record<string, string>>({})
@@ -107,7 +109,7 @@ const TestChat: FC<TestChatProps> = ({
     setFeatures(config?.features || {} as FeaturesConfigForm)
 
 
-    if (config?.features?.opening_statement?.statement && config?.features?.opening_statement?.statement.trim() !== '') {
+    if (config?.features?.opening_statement.enabled && config?.features?.opening_statement?.statement && config?.features?.opening_statement?.statement.trim() !== '') {
       setChatList(prev => [...prev, {
         role: 'assistant',
         created_at: Date.now(),
@@ -144,6 +146,7 @@ const TestChat: FC<TestChatProps> = ({
     }
 
     toolbarRef.current?.setVariables([...initVariables])
+    setVariables([...initVariables])
   }
 
   const addUserMessage = (message: string, files: any[]) => {
@@ -560,6 +563,24 @@ const TestChat: FC<TestChatProps> = ({
     })
   }
 
+  useEffect(() => {
+    const opening_statement = features?.opening_statement
+
+    if (opening_statement?.enabled && opening_statement?.statement && opening_statement?.statement.trim() !== '') {
+      const assistantMsg: ChatItem = {
+        role: 'assistant',
+        content: replaceVariables(opening_statement.statement, variables as any),
+        meta_data: {
+          suggested_questions: opening_statement?.suggested_questions
+        }
+      }
+      setChatList(prev => {
+        prev[0] = assistantMsg
+        return [...prev]
+      })
+    }
+  }, [chatList.length, features?.opening_statement, variables])
+
   return (
     <div className="rb:w-250 rb:mx-auto rb:h-full">
       <RbCard
@@ -592,6 +613,7 @@ const TestChat: FC<TestChatProps> = ({
             ref={toolbarRef}
             features={features}
             onFilesChange={setFileList}
+            onVariablesChange={setVariables}
           />
         </Chat>
       </RbCard>

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:58:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-31 16:24:47
+ * @Last Modified time: 2026-04-07 18:08:52
  */
 /**
  * Conversation Page
@@ -178,7 +178,7 @@ const Conversation: FC = () => {
           }))
         })
     } else {
-      if (features?.opening_statement?.statement) {
+      if (features?.opening_statement.enabled && features?.opening_statement?.statement) {
         setChatList([{
           role: 'assistant',
           content: features.opening_statement.statement,

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:10:56 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-07 17:06:02
+ * @Last Modified time: 2026-04-07 18:07:38
  */
 /**
  * Workflow Chat Component
@@ -68,8 +68,8 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef; data: Work
   const handleOpen = () => {
     setOpen(true)
 
-    if (features?.opening_statement?.statement && features?.opening_statement?.statement.trim() !== '') {
-      setChatList(prev => [...prev, {
+    if (features?.opening_statement?.enabled && features?.opening_statement?.statement && features?.opening_statement?.statement.trim() !== '') {
+      setChatList([{
         role: 'assistant',
         created_at: Date.now(),
         content: features?.opening_statement?.statement,
@@ -431,8 +431,12 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef; data: Work
           suggested_questions: opening_statement?.suggested_questions
         }
       }
-      console.log('variables', assistantMsg)
-      setChatList(prev => [assistantMsg, ...prev.slice(1)])
+      setChatList(prev => {
+        if (prev[0]?.role === 'assistant') {
+          prev[0] = assistantMsg
+        }
+        return [...prev]
+      })
     }
   }, [chatList.length, features?.opening_statement, variables])
 


### PR DESCRIPTION
## Summary by Sourcery

确保聊天体验中的开场语句遵守功能启用标志，支持变量替换，并在测试聊天、工作流聊天和会话视图之间保持同步。

新功能：
- 根据占位符的使用情况，自动生成开场语句中引用但缺失的变量。
- 将聊天工具栏中的变量更改回传到父组件，以实现开场语句的动态渲染。

错误修复：
- 在测试聊天、工作流聊天和会话视图中，将初始开场语句统一受 `opening_statement.enabled` 标志控制。
- 当开场语句发生变化时，更新聊天列表中的首条助手消息而不是重复新增。

增强：
- 在测试聊天和工作流聊天中对开场语句应用变量替换，使用户看到的是解析后的值而不是原始占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure opening statements in chat experiences respect the feature enable flag, support variable substitution, and stay synchronized across test chat, workflow chat, and conversation views.

New Features:
- Auto-generate missing variables referenced in the opening statement based on placeholder usage.
- Propagate variable changes from the chat toolbar back to parent components for dynamic opening statement rendering.

Bug Fixes:
- Gate initial opening statements behind the opening_statement.enabled flag across test chat, workflow chat, and conversation views.
- Keep the first assistant message in chat lists updated rather than duplicated when the opening statement changes.

Enhancements:
- Apply variable replacement to opening statements in test chat and workflow chat so users see resolved values instead of raw placeholders.

</details>