### PR TITLE
fix(workflow):

### DIFF
--- a/api/app/core/workflow/nodes/list_operator/node.py
+++ b/api/app/core/workflow/nodes/list_operator/node.py
@@ -52,7 +52,7 @@ class ListOperatorNode(BaseNode):
             result = [result[idx]]
 
         # 3. Order
-        if cfg.order_by.enabled and cfg.order_by.key:
+        if cfg.order_by.enabled:
             reverse = cfg.order_by.value == "desc"
             key_fn = self._make_sort_key(cfg.order_by.key)
             result = sorted(result, key=key_fn, reverse=reverse)


### PR DESCRIPTION
Sorting of list operation nodes

## Summary by Sourcery

错误修复：
- 确保在启用排序时，列表操作节点始终执行排序，防止由于缺少或为假值的 `order-by` 键配置而导致跳过排序的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure list operation nodes perform sorting whenever ordering is enabled, preventing cases where sorting was skipped due to a missing or falsy order-by key configuration.

</details>