### PR TITLE
fix(web): object chat variable

### DIFF
--- a/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
+++ b/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-30 13:59:36 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-07 20:17:59
+ * @Last Modified time: 2026-04-08 00:08:50
  */
 import { forwardRef, useImperativeHandle, useState, useRef, useMemo } from 'react';
 import { Form, Input, Select, InputNumber, Button, Row, Col, Flex, Spin } from 'antd';
@@ -137,6 +137,8 @@ const ChatVariableModal = forwardRef<ChatVariableModalRef, ChatVariableModalProp
     form.validateFields().then((values) => {
       const defaultValue = Array.isArray(values.defaultValue)
         ? values.defaultValue.filter((v: any) => v !== undefined && v !== null && v !== '')
+        : values.type.includes('object')
+        ? JSON.parse(values.defaultValue)
         : values.defaultValue;
       refresh({ ...values, defaultValue }, editIndex);
       handleClose();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在刷新工作流配置之前，确保类型为 object 的聊天变量，其 `defaultValue` 能够从 JSON 中被正确解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure defaultValue is correctly parsed from JSON for chat variables of type object before refreshing the workflow configuration.

</details>