### PR TITLE
fix(app_chat_service): modify file handling in message construction

### DIFF
--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -32,7 +32,7 @@ class ChatRequest(BaseModel):
     web_search: bool = Field(default=False, description="是否启用网络搜索")
     memory: bool = Field(default=True, description="是否启用记忆功能")
     thinking: bool = Field(default=False, description="是否启用深度思考（需Agent配置支持）")
-    files: Optional[List[FileInput]] = Field(default=None, description="附件列表（支持多文件）")
+    files: List[FileInput] = Field(default_factory=list, description="附件列表（支持多文件）")
 
 
 # ---------- Output Schemas ----------

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -231,8 +231,13 @@ class AppChatService:
         if memory_flag:
             connected_config = get_end_user_connected_config(user_id, self.db)
             memory_config_id: str = connected_config.get("memory_config_id")
+            file_list = []
+            for file in files:
+                file_dict = file.model_dump()
+                file_dict["upload_file_id"] = str(file_dict["upload_file_id"])
+                file_list.append(file_dict)
             messages = [
-                {"role": "user", "content": message, "files": [file.model_dump() for file in files]},
+                {"role": "user", "content": message, "files": file_list},
                 {"role": "assistant", "content": result["content"]}
             ]
             if memory_config_id:
@@ -506,8 +511,13 @@ class AppChatService:
             if memory_flag:
                 connected_config = get_end_user_connected_config(user_id, self.db)
                 memory_config_id: str = connected_config.get("memory_config_id")
+                file_list = []
+                for file in files:
+                    file_dict = file.model_dump()
+                    file_dict["upload_file_id"] = str(file_dict["upload_file_id"])
+                    file_list.append(file_dict)
                 messages = [
-                    {"role": "user", "content": message, "files": [file.model_dump() for file in files]},
+                    {"role": "user", "content": message, "files": file_list},
                     {"role": "assistant", "content": full_content}
                 ]
                 if memory_config_id:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在聊天消息中规范上传文件的元数据：在标准和流式聊天流程中，将 `upload_file_id` 的值统一转换为字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Normalize uploaded file metadata in chat messages by converting upload_file_id values to strings in both standard and streaming chat flows.

</details>