### PR TITLE
fix(app):

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -112,7 +112,7 @@ class RedBearModelFactory:
                 params["stream_usage"] = True
             # 深度思考模式
             is_streaming = bool(config.extra_params.get("streaming"))
-            if is_streaming:
+            if is_streaming and not config.is_omni:
                 if provider == ModelProvider.VOLCANO:
                     # 火山引擎深度思考仅流式调用支持，非流式时不传 thinking 参数
                     thinking_config: Dict[str, Any] = {

--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -483,11 +483,11 @@ class DifyConverter(BaseConverter):
         node_data = node["data"]
         result = IterationNodeConfig.model_construct(
             input=self._process_list_variable_literal(node_data["iterator_selector"]),
-            parallel=node_data["is_parallel"],
-            parallel_count=node_data["parallel_nums"],
+            parallel=node_data.get("is_parallel", False),
+            parallel_count=node_data.get("parallel_nums", 4),
             output=self._process_list_variable_literal(node_data["output_selector"]),
             output_type=self.variable_type_map(node_data.get("output_type")),
-            flatten=node_data["flatten_output"],
+            flatten=node_data.get("flatten_output", False),
         ).model_dump()
 
         self.config_validate(node["id"], node["data"]["title"], IterationNodeConfig, result)

--- a/api/app/core/workflow/nodes/list_operator/node.py
+++ b/api/app/core/workflow/nodes/list_operator/node.py
@@ -11,7 +11,7 @@ from app.core.workflow.variable.base_variable import VariableType
 logger = logging.getLogger(__name__)
 
 # File object fields that hold string values
-_FILE_STRING_KEYS = {"name", "extension", "mime_type", "url", "transfer_method", "origin_file_type", "file_id"}
+_FILE_STRING_KEYS = {"type", "name", "url", "extension", "mime_type", "transfer_method", "origin_file_type", "file_id"}
 _FILE_NUMBER_KEYS = {"size"}
 
 
@@ -100,10 +100,17 @@ class ListOperatorNode(BaseNode):
         else:
             left = item  # primitive array: compare element directly
 
+        # Determine if this field should be compared as a string
+        is_string_field = isinstance(item, dict) and cond.key in _FILE_STRING_KEYS
+
         # Numeric operators
         if op == ComparisonOperator.EQ:
+            if is_string_field:
+                return str(left) == str(value)
             return self._safe_num(left) == self._safe_num(value)
         if op == ComparisonOperator.NE:
+            if is_string_field:
+                return str(left) != str(value)
             return self._safe_num(left) != self._safe_num(value)
         if op == ComparisonOperator.LT:
             return self._safe_num(left) < self._safe_num(value)


### PR DESCRIPTION
1. List operation node sub-variable comparison；
2. Non-Dashscope Omni model processing； 
3. 4.Handling the issue of disappearing iterative nodes

## Summary by Sourcery

调整针对文件类型字段的列表运算符比较方式，使迭代节点转换在缺少配置标志时更加健壮，并避免为 omni 模型启用流式模式。

Bug Fixes:
- 将列表操作中的文件元数据字段作为字符串而非数字进行比较，以确保筛选行为正确。
- 为迭代节点的并行度和扁平化标志提供默认值，防止缺失字段问题导致迭代节点消失。
- 在使用 omni 模型时禁用特定于流式传输的参数，以避免错误的深度思考模式行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust list operator comparisons for file-type fields, make iteration node conversion robust to missing configuration flags, and avoid enabling streaming mode for omni models.

Bug Fixes:
- Compare list operation file metadata fields as strings rather than numbers to ensure correct filter behavior.
- Provide default values for iteration node parallelism and flatten flags to prevent missing-field issues that caused iteration nodes to disappear.
- Disable streaming-specific parameters when using omni models to avoid incorrect deep-thinking mode behavior.

</details>