### PR TITLE
fix(app_chat_service): modify file handling in message construction

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -234,7 +234,7 @@ class AppChatService:
             file_list = []
             for file in files:
                 file_dict = file.model_dump()
-                file_dict["upload_file_id"] = str(file_dict["upload_file_id"])
+                file_dict["upload_file_id"] = str(file_dict["upload_file_id"]) if file_dict["upload_file_id"] else None
                 file_list.append(file_dict)
             messages = [
                 {"role": "user", "content": message, "files": file_list},
@@ -514,7 +514,7 @@ class AppChatService:
                 file_list = []
                 for file in files:
                     file_dict = file.model_dump()
-                    file_dict["upload_file_id"] = str(file_dict["upload_file_id"])
+                    file_dict["upload_file_id"] = str(file_dict["upload_file_id"]) if file_dict["upload_file_id"] else None
                     file_list.append(file_dict)
                 messages = [
                     {"role": "user", "content": message, "files": file_list},


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在为聊天消息构建文件元数据时，避免将缺失或为 null 的 `upload_file_id` 值强制转换为字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid casting missing or null upload_file_id values to strings when building file metadata for chat messages.

</details>