### PR TITLE
fix(web): list operator add form reset

### DIFF
--- a/web/src/views/Workflow/components/Properties/ListOperator/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ListOperator/index.tsx
@@ -23,6 +23,29 @@ const ListOperator: FC<ListOperatorProps> = ({ options }) => {
   const variableOption = options.find(option => `{{${option.value}}}` === values?.input_list)
   const variableType = variableOption?.dataType
 
+  const handleChangeInputList = (value: string | string[]) => {
+    form.setFieldsValue({
+      input_list: value,
+      filter_by: {
+        enabled: false,
+        conditions: [{}]
+      },
+      order_by: {
+        enabled: false,
+        key: variableType === 'array[file]' ? 'name' : '',
+        value: 'asc'
+      },
+      extract_by: {
+        enabled: false,
+        serial: undefined
+      },
+      limit: {
+        enabled: false,
+        size: 1
+      }
+    })
+  }
+
   return (
     <>
       <Form.Item name="input_list" label={t('workflow.config.list-operator.variable')} required>
@@ -30,6 +53,7 @@ const ListOperator: FC<ListOperatorProps> = ({ options }) => {
           placeholder={t('common.pleaseSelect')}
           options={options.filter(vo => vo.dataType.includes('array') && vo.dataType !== 'array[object]')}
           size="small"
+          onChange={handleChangeInputList}
         />
       </Form.Item>
 
@@ -58,6 +82,7 @@ const ListOperator: FC<ListOperatorProps> = ({ options }) => {
                 <Select
                   options={fileSubVariable}
                   fieldNames={{ value: 'filed', label: 'label' }}
+                  placeholder={t('common.pleaseSelect')}
                 />
               </Form.Item>
             </Col>


### PR DESCRIPTION
## Summary by Sourcery

当输入列表变量发生变化时，重置依赖列表算子配置，并改进文件子变量选择器的用户体验。

Bug Fixes（错误修复）:
- 当更改输入列表变量时，清空并禁用 filter、order、extract 和 limit 配置，以避免使用过期设置。

Enhancements（功能增强）:
- 在文件子变量选择框上设置占位符，使所需的用户操作更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reset dependent list operator configuration when the input list variable changes and improve the file sub-variable selector UX.

Bug Fixes:
- Clear and disable filter, order, extract, and limit configuration when changing the input list variable to avoid stale settings.

Enhancements:
- Set a placeholder on the file sub-variable select to make the required user action clearer.

</details>