### PR TITLE
fix(web): editor third variable init

### DIFF
--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -100,14 +100,28 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
               }
 
               if (match) {
-                const [_, nodeId, label] = match;
+                const [_, nodeId, rest] = match;
+                const restParts = rest.split('.');
+                const isThreeLevel = restParts.length >= 2;
+                const parentLabel = isThreeLevel ? restParts.slice(0, -1).join('.') : undefined;
+                const label = restParts[restParts.length - 1];
 
-                const suggestion = optionsRef.current.find(s => {
+                let suggestion = optionsRef.current.find(s => {
                   if (nodeId === 'sys') {
-                    return s.nodeData.type === 'start' && s.label === `sys.${label}`
+                    return s.nodeData.type === 'start' && s.label === `sys.${rest}`
                   }
-                  return s.nodeData.id === nodeId && s.label === label
+                  return s.nodeData.id === nodeId && s.label === rest
                 });
+
+                // Search in children for three-level variables (e.g. nodeId.parentLabel.label)
+                if (!suggestion && isThreeLevel) {
+                  for (const s of optionsRef.current) {
+                    if (s.nodeData.id === nodeId && s.label === parentLabel && s.children) {
+                      const child = s.children.find(c => c.label === label);
+                      if (child) { suggestion = child; break; }
+                    }
+                  }
+                }
 
                 if (suggestion) {
                   paragraph.append($createVariableNode(suggestion));


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正当变量路径包含三级层级（例如 `nodeId.parent.field`）时的变量建议解析方式，通过相应地在子选项中进行搜索来获得正确的建议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct variable suggestion resolution when the variable path includes three levels (e.g. nodeId.parent.field) by searching child options accordingly.

</details>