### PR TITLE
fix(web): hidden file type chat variable

### DIFF
--- a/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
+++ b/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
@@ -52,7 +52,7 @@ const types = [
   'number',
   'boolean',
   'object',
-  'file',
+  // 'file',
   'array[file]',
   'array[string]',
   'array[number]',


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 阻止用户在 AddChatVariable 模态框中为聊天变量选择不受支持的独立 `file` 类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent users from selecting the unsupported standalone 'file' type for chat variables in the AddChatVariable modal.

</details>