### PR TITLE
fix(web): chat statement variable replace

### DIFF
--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -179,9 +179,10 @@ const Conversation: FC = () => {
         })
     } else {
       if (features?.opening_statement?.enabled && features?.opening_statement?.statement) {
+        const variables = toolbarRef.current?.getVariables() || []
         setChatList([{
           role: 'assistant',
-          content: features.opening_statement.statement,
+          content: replaceVariables(features?.opening_statement.statement, variables as unknown as AppVariable[]),
           created_at: Date.now(),
           meta_data: {
             suggested_questions: features.opening_statement?.suggested_questions
@@ -435,7 +436,6 @@ const Conversation: FC = () => {
   const handleChangeVariables = (variables: Variable[]) => {
     setChatList(prev => {
       const firstMsg = prev[0]
-      console.log('firstMsg', firstMsg)
       if (firstMsg && firstMsg.role === 'assistant' && firstMsg.content && features?.opening_statement?.enabled && features?.opening_statement.statement && variables.length > 0) {
         firstMsg.content = replaceVariables(features?.opening_statement.statement, variables as unknown as AppVariable[])
         return [firstMsg, ...prev.slice(1)]


### PR DESCRIPTION
## Summary by Sourcery

更新会话开场助手消息，使其使用工具栏提供的变量进行变量替换，并移除变量变更处理过程中残留的调试日志。

Bug Fixes:
- 确保初始开场助手消息能够使用当前工具栏中的变量正确替换模板变量。

Enhancements:
- 当会话视图中的变量发生变化时，移除不必要的控制台日志输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the conversation opening assistant message to apply variable replacement using toolbar-provided variables and remove leftover debug logging from variable change handling.

Bug Fixes:
- Ensure the initial opening assistant message correctly replaces template variables using the current toolbar variables.

Enhancements:
- Remove unnecessary console logging when variables change in the conversation view.

</details>