### PR TITLE
fix(web): chat input add composition

### DIFF
--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -27,6 +27,7 @@ const ChatInput: FC<ChatInputProps> = ({
 }) => {
   const [inputValue, setInputValue] = useState('')
   const [isFocus, setIsFocus] = useState(false)
+  const [isComposing, setIsComposing] = useState(false)
 
   // Clear input when external message is cleared
   useEffect(() => {
@@ -78,9 +79,11 @@ const ChatInput: FC<ChatInputProps> = ({
             setInputValue(e.target.value)
             onChange?.(e.target.value)
           }}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           onKeyDown={(e) => {
             // Enter to send, Shift+Enter for new line
-            if (e.key === 'Enter' && !e.shiftKey && (e.target as HTMLTextAreaElement).value?.trim() !== '' && !loading) {
+            if (e.key === 'Enter' && !e.shiftKey && !isComposing && (e.target as HTMLTextAreaElement).value?.trim() !== '' && !loading) {
               e.preventDefault();
               handleSend();
             }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 防止在用户仍处于聊天文本区域的输入法（IME）组合过程中时，按下 Enter 键就发送消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Enter key from sending messages while the user is in the middle of IME composition in the chat textarea.

</details>