### PR TITLE
fix(web): prompt input add composition

### DIFF
--- a/web/src/views/ApplicationConfig/components/AiPromptModal.tsx
+++ b/web/src/views/ApplicationConfig/components/AiPromptModal.tsx
@@ -185,6 +185,7 @@ const AiPromptModal = forwardRef<AiPromptModalRef, AiPromptModalProps>(({
     handleOpen,
   }));
   const [isFocus, setIsFocus] = useState(false)
+  const [isComposing, setIsComposing] = useState(false)
   const handleFocus = () => {
     setIsFocus(true)
   }
@@ -236,7 +237,9 @@ const AiPromptModal = forwardRef<AiPromptModalRef, AiPromptModalProps>(({
               <Form.Item name="message" className="rb:flex-1 rb:mb-0!">
                 <Input
                   placeholder={t(`${source}.promptChatPlaceholder`)}
-                  onPressEnter={handleSend}
+                  onCompositionStart={() => setIsComposing(true)}
+                  onCompositionEnd={() => setIsComposing(false)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && !isComposing) handleSend() }}
                   variant="borderless"
                   className="rb:p-0!"
                   onFocus={handleFocus}

--- a/web/src/views/Prompt/index.tsx
+++ b/web/src/views/Prompt/index.tsx
@@ -169,6 +169,7 @@ const Prompt: FC = () => {
     updateSession()
   }
   const [isFocus, setIsFocus] = useState(false)
+  const [isComposing, setIsComposing] = useState(false)
   const handleFocus = () => {
     setIsFocus(true)
   }
@@ -209,7 +210,9 @@ const Prompt: FC = () => {
                 <Form.Item name="message" className="rb:flex-1 rb:mb-0!">
                   <Input
                     placeholder={t(`prompt.promptChatPlaceholder`)}
-                    onPressEnter={handleSend}
+                    onCompositionStart={() => setIsComposing(true)}
+                    onCompositionEnd={() => setIsComposing(false)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' && !isComposing) handleSend() }}
                     variant="borderless"
                     className="rb:p-0!"
                     onFocus={handleFocus}


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在 AI 提示模态框和主提示视图中，当用户使用输入法编辑器（IME）进行文本输入组合时，防止在按下 Enter 键时发送提示消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent prompt messages from being sent on Enter keypress while the user is composing text with an IME in both the AI prompt modal and the main prompt view.

</details>