### PR TITLE
fix(web): editor init

### DIFF
--- a/web/src/views/Workflow/components/Editor/index.tsx
+++ b/web/src/views/Workflow/components/Editor/index.tsx
@@ -149,8 +149,8 @@ const Editor: FC<LexicalEditorProps> =({
         <HistoryPlugin />
         <CommandPlugin />
         <AutocompletePlugin options={options} />
-        <CharacterCountPlugin setCount={setCount} onChange={onChange} />
-        <InitialValuePlugin value={value} options={options} />
+        <CharacterCountPlugin setCount={setCount} />
+        <InitialValuePlugin value={value} options={options} onChange={onChange} />
         <BlurPlugin />
       </div>
     </LexicalComposer>

--- a/web/src/views/Workflow/components/Editor/plugin/CharacterCountPlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/CharacterCountPlugin.tsx
@@ -1,41 +1,22 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { $getRoot, $isParagraphNode } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 
-import { $isVariableNode } from '../nodes/VariableNode';
-
-const CharacterCountPlugin = ({ setCount, onChange }: { setCount: (count: number) => void; onChange?: (value: string) => void }) => {
+const CharacterCountPlugin = ({ setCount }: { setCount: (count: number) => void }) => {
   const [editor] = useLexicalComposerContext();
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
       if (tags.has('programmatic')) return;
       editorState.read(() => {
         const root = $getRoot();
-        let serializedContent = '';
-        
-        // Traverse all nodes and serialize properly
         const paragraphs: string[] = [];
         root.getChildren().forEach(child => {
           if ($isParagraphNode(child)) {
-            let paragraphContent = '';
-            child.getChildren().forEach(node => {
-              if ($isVariableNode(node)) {
-                paragraphContent += node.getTextContent();
-              } else {
-                paragraphContent += node.getTextContent();
-              }
-            });
-            paragraphs.push(paragraphContent);
+            paragraphs.push(child.getChildren().map(n => n.getTextContent()).join(''));
           }
         });
-        
-        serializedContent = paragraphs.join('\n');
-        
-        setCount(serializedContent.length);
-        onChangeRef.current?.(serializedContent);
+        setCount(paragraphs.join('\n').length);
       });
     });
   }, [editor, setCount]);

--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -6,7 +6,7 @@
  */
 import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { $getRoot, $createParagraphNode, $createTextNode } from 'lexical';
+import { $getRoot, $createParagraphNode, $createTextNode, $isParagraphNode } from 'lexical';
 
 import { $createVariableNode } from '../nodes/VariableNode';
 import { type Suggestion } from '../plugin/AutocompletePlugin'
@@ -14,24 +14,34 @@ import { type Suggestion } from '../plugin/AutocompletePlugin'
 interface InitialValuePluginProps {
   value: string;
   options?: Suggestion[];
+  onChange?: (value: string) => void;
 }
 
-const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options = [] }) => {
+const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options = [], onChange }) => {
   const [editor] = useLexicalComposerContext();
   const prevValueRef = useRef<string>('');
   const isUserInputRef = useRef(false);
   const optionsRef = useRef(options);
   optionsRef.current = options;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, tags }) => {
       if (tags.has('programmatic')) return;
       editorState.read(() => {
         const root = $getRoot();
-        const textContent = root.getTextContent();
-        if (textContent !== prevValueRef.current) {
+        const paragraphs: string[] = [];
+        root.getChildren().forEach(child => {
+          if ($isParagraphNode(child)) {
+            paragraphs.push(child.getChildren().map(n => n.getTextContent()).join(''));
+          }
+        });
+        const text = paragraphs.join('\n');
+        if (text !== prevValueRef.current) {
           isUserInputRef.current = true;
-          prevValueRef.current = textContent;
+          prevValueRef.current = text;
+          onChangeRef.current?.(text);
         }
       });
     });


### PR DESCRIPTION
## Summary by Sourcery

通过初始值插件路由编辑器内容更改通知，同时简化字符计数，仅跟踪文本长度。

Bug Fixes:
- 确保编辑器的 `onChange` 仅由源自段落文本的、用户发起的内容更新触发。

Enhancements:
- 简化字符计数计算，通过聚合段落子节点中的文本来完成，而无需对变量节点进行特殊处理。
- 将序列化后的编辑器文本发出逻辑从字符计数插件移动到初始值插件中，以实现变更传播的集中化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route editor content change notifications through the initial value plugin while simplifying character counting to only track text length.

Bug Fixes:
- Ensure editor onChange is only triggered from user-initiated content updates derived from paragraph text.

Enhancements:
- Simplify character count calculation to aggregate text from paragraph children without variable-node special handling.
- Move serialized editor text emission from the character count plugin into the initial value plugin to centralize change propagation.

</details>