### PR TITLE
Feature/UI upgrade zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeConfigModal.tsx
@@ -33,7 +33,7 @@ interface KnowledgeConfigModalProps {
  * Available retrieval types
  */
 const retrieveTypes: RetrieveType[] = ['participle', 'semantic', 'hybrid',
-  // 'graph'
+  'graph'
 ]
 
 /**

--- a/web/src/views/UserMemoryDetail/components/WordCloud.tsx
+++ b/web/src/views/UserMemoryDetail/components/WordCloud.tsx
@@ -89,14 +89,6 @@ const WordCloud: FC = () => {
     
     return {
       color: ['#155EEF'],
-      tooltip: {
-        trigger: 'item',
-        formatter: (params: any) => {
-          const dataIndex = params.dataIndex
-          const item = radarData[dataIndex]
-          return `${item.name}<br/>${item.percentage.toFixed(1)}%`
-        }
-      },
       radar: {
         indicator: radarData.map(item => ({
           name: t(`statementDetail.${item.name}`),

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeConfigModal.tsx
@@ -13,7 +13,7 @@ interface KnowledgeConfigModalProps {
   refresh: (values: KnowledgeConfigForm, type: 'knowledgeConfig') => void;
 }
 const retrieveTypes: RetrieveType[] = ['participle', 'semantic', 'hybrid',
-  // 'graph'
+  'graph'
 ]
 
 const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfigModalProps>(({


### PR DESCRIPTION
## 由 Sourcery 提供的总结

在知识配置弹窗中启用图检索类型，并通过移除自定义工具提示来简化用户记忆详情词云的可视化。

新功能：
- 在应用层级的知识配置中添加对 `graph` 检索类型的支持。
- 在工作流知识配置中添加对 `graph` 检索类型的支持。

增强改进：
- 从用户记忆详情词云图表配置中移除自定义工具提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable graph retrieval type in knowledge configuration modals and simplify the user memory detail word cloud visualization by removing its custom tooltip.

New Features:
- Add support for the 'graph' retrieval type in application-level knowledge configuration.
- Add support for the 'graph' retrieval type in workflow knowledge configuration.

Enhancements:
- Remove custom tooltip from the user memory detail word cloud chart configuration.

</details>