### PR TITLE
fix(web): if-else/question-classifier add node front

### DIFF
--- a/web/src/views/Workflow/components/Nodes/AddNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/AddNode.tsx
@@ -49,23 +49,24 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
 
     const incomingEdges = graph.getIncomingEdges(node);
     const outgoingEdges = graph.getOutgoingEdges(node);
-    
-    incomingEdges?.forEach(edge => {
-      graph.addEdge({
+    const addedEdges: any[] = [];
+
+    incomingEdges?.forEach((edge: any) => {
+      addedEdges.push(graph.addEdge({
         source: { cell: edge.getSourceCellId(), port: edge.getSourcePortId() },
         target: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'left')?.id || 'left' },
         ...edgeAttrs
-      });
+      }));
     });
 
-    outgoingEdges?.forEach(edge => {
+    outgoingEdges?.forEach((edge: any) => {
       const targetCell = graph.getCellById(edge.getTargetCellId()) as any;
       const targetPortId = targetCell?.getPorts?.()?.find((port: any) => port.group === 'left')?.id || edge.getTargetPortId();
-      graph.addEdge({
+      addedEdges.push(graph.addEdge({
         source: { cell: newNode.id, port: newNode.getPorts().find((port: any) => port.group === 'right')?.id || 'right' },
         target: { cell: edge.getTargetCellId(), port: targetPortId },
         ...edgeAttrs
-      });
+      }));
     });
 
     // Remove all add-node type nodes
@@ -74,6 +75,15 @@ const AddNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         n.remove();
       }
     });
+
+    setTimeout(() => {
+      addedEdges.forEach(e => {
+        const src = graph.getCellById(e.getSourceCellId());
+        const tgt = graph.getCellById(e.getTargetCellId());
+        if (src?.isNode()) src.toFront();
+        if (tgt?.isNode()) tgt.toFront();
+      });
+    }, 50);
 
     // Automatically adjust loop node size
     const loopNode = graph.getNodes().find((n: any) => n.getData()?.id === cycleId);

--- a/web/src/views/Workflow/components/Nodes/LoopNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/LoopNode.tsx
@@ -59,6 +59,9 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
         target: { cell: addNode.id, port: targetPort },
         ...edgeAttrs,
       });
+
+      cycleStartNode.toFront()
+      addNode.toFront()
     }
   }
 
@@ -117,6 +120,12 @@ const LoopNode: ReactShapeConfig['component'] = ({ node, graph }) => {
       ...edgeAttrs
     }
     graph.addEdge(edgeConfig)
+
+    setTimeout(() => {
+
+      cycleStartNode.toFront()
+      addNode.toFront()
+    }, 0)
   }
 
   return (

--- a/web/src/views/Workflow/components/Properties/CaseList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CaseList/index.tsx
@@ -139,6 +139,8 @@ const CaseList: FC<CaseListProps> = ({
               ...edgeAttrs,
             });
           }
+          sourceCell.toFront()
+          selectedNode.toFront()
           graphRef.current?.removeCell(edge);
           return;
         }
@@ -183,6 +185,8 @@ const CaseList: FC<CaseListProps> = ({
               target: { cell: targetCellId, port: targetPortId },
               ...edgeAttrs
             });
+            selectedNode.toFront()
+            targetCell.toFront()
           }
         }
         

--- a/web/src/views/Workflow/components/Properties/CategoryList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CategoryList/index.tsx
@@ -88,6 +88,8 @@ const CategoryList: FC<CategoryListProps> = ({ parentName, selectedNode, graphRe
               target: { cell: selectedNode.id, port: targetPortId },
               ...edgeAttrs
             });
+            sourceCell.toFront()
+            selectedNode.toFront()
           }
           return;
         }
@@ -119,6 +121,8 @@ const CategoryList: FC<CategoryListProps> = ({ parentName, selectedNode, graphRe
               target: { cell: targetCellId, port: targetPortId },
               ...edgeAttrs
             });
+            selectedNode.toFront()
+            targetCell.toFront()
           }
         }
       });


### PR DESCRIPTION
## Summary by Sourcery

确保在新建边时，将涉及到的工作流图节点置于前端，以保持正确的视觉层级顺序。

Bug 修复：
- 修复在创建或更新边时，新插入或重新连接的工作流节点有时会渲染在其他元素后面的问题。

增强：
- 追踪新添加的边，并在边创建后，通过程序将其源/目标节点在添加节点、循环节点以及分支/类别属性流等场景中提升到最前层。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure workflow graph nodes involved in newly created edges are brought to the front to maintain correct visual stacking order.

Bug Fixes:
- Fix newly inserted or reconnected workflow nodes sometimes rendering behind other elements when edges are created or updated.

Enhancements:
- Track newly added edges and programmatically raise their source/target nodes to the front after edge creation across add-node, loop-node, and case/category property flows.

</details>