### PR TITLE
fix(web): if-else node case show

### DIFF
--- a/web/src/views/Workflow/components/Nodes/ConditionNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/ConditionNode.tsx
@@ -14,7 +14,7 @@ const caculateIsSet = (item: any, type: string) => {
     case 'cases': {
       if (!item.left) return false
       if (['not_empty', 'empty'].includes(item.operator)) return true
-      return !!item.left && (!!item.right || typeof item.right === 'boolean')
+      return !!item.left && (!!item.right || typeof item.right === 'boolean' || typeof item.right === 'number')
     }
   }
 }
@@ -22,7 +22,7 @@ const ConditionNode: ReactShapeConfig['component'] = ({ node }) => {
   const data = node?.getData() || {};
   const { t } = useTranslation()
   const graphRef = useRef(node?.model?.graph)
-  const variableList = useVariableList(node ?? null, graphRef, [])
+  const variableList = useVariableList(node ?? null, graphRef, data.chatVariables ?? [])
 
   const getLocaleField = (field: string, filedType: string) => {
     const key = filedType === 'boolean' ? `workflow.config.if-else..boolean.${field}` : filedType === 'number' ? `workflow.config.if-else.num.${field}` : `workflow.config.if-else.${field}`

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -107,6 +107,16 @@ export const useWorkflowGraph = ({
   const featuresRef = useRef<FeaturesConfigForm | undefined>(undefined)
 
   useEffect(() => {
+    if (!graphRef.current) return
+    graphRef.current.getNodes().forEach(node => {
+      const data = node.getData()
+      if (data?.type === 'if-else' || data?.type === 'question-classifier') {
+        node.setData({ ...data, chatVariables }, { silent: true })
+      }
+    })
+  }, [chatVariables])
+
+  useEffect(() => {
     getConfig()
   }, [id])
   /**
@@ -211,7 +221,7 @@ export const useWorkflowGraph = ({
           id,
           type,
           name,
-          data: { ...node, ...nodeLibraryConfig},
+          data: { ...node, ...nodeLibraryConfig, ...((type === 'if-else' || type === 'question-classifier') ? { chatVariables } : {}) },
           ...position,
         }
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

更新工作流图和条件节点对 if-else 和 question-classifier 节点的处理方式，以正确传播聊天变量，并在条件判断中将数值型右侧值视为有效配置。

Bug 修复：
- 确保 if-else 和 question-classifier 节点在初次创建时以及聊天变量发生变化时，都能接收到更新后的聊天变量。
- 允许在 if-else 分支条件中，将数值型右侧操作数识别为已正确配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update workflow graph and condition node handling for if-else and question-classifier nodes to correctly propagate chat variables and treat numeric right-hand values as valid in case conditions.

Bug Fixes:
- Ensure if-else and question-classifier nodes receive updated chat variables both on initial creation and when chat variables change.
- Allow numeric right-hand operands to be recognized as properly configured in if-else case conditions.

</details>