### PR TITLE
fix(web): agent knowledge

### DIFF
--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -229,10 +229,11 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
         ...knowledgeRest,
         knowledge_bases: knowledge_bases.map(item => ({
           kb_id: item.kb_id || item.id,
+          retrieve_type: item.retrieve_type,
           top_k: item.top_k,
           similarity_threshold: item.similarity_threshold,
           vector_similarity_weight: item.vector_similarity_weight,
-          ...(item.config || {})
+          // ...(item.config || {})
         }))
       } as KnowledgeConfig : null,
       tools: tools.map(vo => {

--- a/web/src/views/ApplicationConfig/components/Knowledge/Knowledge.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/Knowledge.tsx
@@ -117,6 +117,7 @@ const Knowledge: FC<{value?: KnowledgeConfig; onChange?: (config: KnowledgeConfi
       const list = [...knowledgeList]
       list[index] = {
         ...list[index],
+        ...values,
         config: {...values as KnowledgeConfigForm}
       }
       setKnowledgeList([...list])

--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
@@ -88,6 +88,10 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
   const handleSave = () => {
     refresh(selectedRows.map(item => ({
       ...item,
+      similarity_threshold: 0.7,
+      retrieve_type: "hybrid",
+      top_k: 3,
+      weight: 1,
       config: {
         similarity_threshold: 0.7,
         retrieve_type: "hybrid",

--- a/web/src/views/Workflow/components/Properties/CaseList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CaseList/index.tsx
@@ -61,6 +61,20 @@ const CaseList: FC<CaseListProps> = ({
   const { t } = useTranslation();
   const form = Form.useFormInstance();
 
+  const bringLoopChildrenToFront = (cell: any) => {
+    const type = cell?.getData()?.type;
+    if ((type !== 'loop' && type !== 'iteration') || !graphRef?.current) return;
+    const cycleId = cell.getData().id;
+    graphRef.current.getEdges().forEach((edge: any) => {
+      const src = graphRef.current?.getCellById(edge.getSourceCellId());
+      const tgt = graphRef.current?.getCellById(edge.getTargetCellId());
+      if (src?.getData()?.cycle === cycleId || tgt?.getData()?.cycle === cycleId) edge.toFront();
+    });
+    graphRef.current.getNodes().forEach((n: any) => {
+      if (n.getData()?.cycle === cycleId) n.toFront();
+    });
+  };
+
   // Recalculate node height and port Y positions without rebuilding ports
   const updateNodeLayout = (cases: any[]) => {
     if (!selectedNode || !graphRef?.current) return;
@@ -141,6 +155,8 @@ const CaseList: FC<CaseListProps> = ({
           }
           sourceCell.toFront()
           selectedNode.toFront()
+          bringLoopChildrenToFront(sourceCell)
+          bringLoopChildrenToFront(selectedNode)
           graphRef.current?.removeCell(edge);
           return;
         }
@@ -186,7 +202,9 @@ const CaseList: FC<CaseListProps> = ({
               ...edgeAttrs
             });
             selectedNode.toFront()
+            bringLoopChildrenToFront(selectedNode)
             targetCell.toFront()
+            bringLoopChildrenToFront(targetCell)
           }
         }
         

--- a/web/src/views/Workflow/components/Properties/CategoryList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CategoryList/index.tsx
@@ -25,6 +25,20 @@ const CategoryList: FC<CategoryListProps> = ({ parentName, selectedNode, graphRe
   const form = Form.useFormInstance();
   const formValues = Form.useWatch([parentName], form);
 
+  const bringLoopChildrenToFront = (cell: any) => {
+    const type = cell?.getData()?.type;
+    if ((type !== 'loop' && type !== 'iteration') || !graphRef?.current) return;
+    const cycleId = cell.getData().id;
+    graphRef.current.getEdges().forEach((edge: any) => {
+      const src = graphRef.current?.getCellById(edge.getSourceCellId());
+      const tgt = graphRef.current?.getCellById(edge.getTargetCellId());
+      if (src?.getData()?.cycle === cycleId || tgt?.getData()?.cycle === cycleId) edge.toFront();
+    });
+    graphRef.current.getNodes().forEach((n: any) => {
+      if (n.getData()?.cycle === cycleId) n.toFront();
+    });
+  };
+
   // Update node ports based on category count changes (add/remove categories)
   const updateNodePorts = (caseCount: number, removedCaseIndex?: number) => {
     if (!selectedNode || !graphRef?.current) return;
@@ -89,7 +103,9 @@ const CategoryList: FC<CategoryListProps> = ({ parentName, selectedNode, graphRe
               ...edgeAttrs
             });
             sourceCell.toFront()
+            bringLoopChildrenToFront(sourceCell)
             selectedNode.toFront()
+            bringLoopChildrenToFront(selectedNode)
           }
           return;
         }
@@ -122,7 +138,9 @@ const CategoryList: FC<CategoryListProps> = ({ parentName, selectedNode, graphRe
               ...edgeAttrs
             });
             selectedNode.toFront()
+            bringLoopChildrenToFront(selectedNode)
             targetCell.toFront()
+            bringLoopChildrenToFront(targetCell)
           }
         }
       });


### PR DESCRIPTION
## Summary by Sourcery

在保存和编辑知识库时，确保代理的知识配置能够被一致、正确地填充。

错误修复：
- 在保存时，使用默认的检索配置值填充顶层知识库字段。
- 在构建代理配置时，保留并暴露知识库条目中的 `retrieve_type` 字段。
- 在更新嵌套配置之前，将已编辑的知识库值同步回内存中的列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure agent knowledge configuration is consistently populated when saving and editing knowledge bases.

Bug Fixes:
- Populate top-level knowledge base fields with default retrieval configuration values when saving.
- Preserve and expose the retrieve_type field on knowledge base items when building the agent configuration.
- Sync edited knowledge base values back to the in-memory list before updating nested config.

</details>