### PR TITLE
fix(web): deep_thinking reset

### DIFF
--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -155,12 +155,10 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
         </FormItem>
         {['model', 'chat'].includes(source) && <>
           <FormItem name="capability" hidden />
-          {(values?.deep_thinking || values?.capability?.includes('thinking')) && (
-            <FormItem name="deep_thinking" valuePropName="checked">
-              <Checkbox>{t('application.deep_thinking')}</Checkbox>
-            </FormItem>
-          )}
         </>}
+        <FormItem name="deep_thinking" valuePropName="checked" hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}>
+          <Checkbox>{t('application.deep_thinking')}</Checkbox>
+        </FormItem>
         {source === 'chat' && <FormItem name="label" hidden />}
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过始终包含深度思考配置的表单字段并仅切换其可见性（而不是有条件地渲染），防止该配置被重置或丢失。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the deep thinking configuration from being reset or lost by always including its form field and toggling visibility instead of conditionally rendering it.

</details>