### PR TITLE
feat(web): start/chat variable name cannot be duplicated

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2453,7 +2453,8 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
         value: 'Value',
         addCase: 'Add Condition',
         addVariable: 'Add Variables',
-        output: 'Output Variable'
+        output: 'Output Variable',
+        duplicateName: 'Variable name cannot be duplicated',
       },
 
       clear: 'Clear',
@@ -2480,7 +2481,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
         input_cycle_vars: 'Initial Loop Variables',
         output_cycle_vars: 'Final Loop Variables',
       },
-      sureReplace: '确认替换',
+      sureReplace: 'Confirm Replace',
       checkList: 'Check List',
       checkListDesc: 'Ensure all issues are resolved before publishing',
       checkListEmpty: 'No issues found',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2417,7 +2417,8 @@ export const zh = {
         value: '值',
         addCase: '添加条件',
         addVariable: '添加变量',
-        output: '输出变量'
+        output: '输出变量',
+        duplicateName: '变量名不能重复',
       },
 
       clear: '清空',

--- a/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
+++ b/web/src/views/Workflow/components/AddChatVariable/ChatVariableModal.tsx
@@ -45,6 +45,7 @@ const array_object_placeholder = `# example
 
 interface ChatVariableModalProps {
   refresh: (value: ChatVariable, editIndex?: number) => void;
+  variables?: ChatVariable[];
 }
 
 const types = [
@@ -61,7 +62,8 @@ const types = [
 ]
 
 const ChatVariableModal = forwardRef<ChatVariableModalRef, ChatVariableModalProps>(({
-  refresh
+  refresh,
+  variables
 }, ref) => {
   const { t } = useTranslation();
   const uploadFileListModalRef = useRef<UploadFileListModalRef>(null);
@@ -244,6 +246,12 @@ const ChatVariableModal = forwardRef<ChatVariableModalRef, ChatVariableModalProp
           rules={[
             { required: true, message: t('common.pleaseEnter') },
             { pattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/, message: t('workflow.config.parameter-extractor.invalidParamName') },
+            {
+              validator: (_, value) => {
+                const duplicate = variables?.some((v, i) => v.name === value && i !== editIndex);
+                return duplicate ? Promise.reject(t('workflow.config.duplicateName')) : Promise.resolve();
+              }
+            },
           ]}
         >
           <Input placeholder={t('common.enter')} />

--- a/web/src/views/Workflow/components/AddChatVariable/index.tsx
+++ b/web/src/views/Workflow/components/AddChatVariable/index.tsx
@@ -104,6 +104,7 @@ const AddChatVariable = forwardRef<AddChatVariableRef, AddChatVariableProps>(({
       <ChatVariableModal
         ref={chatVariableRef}
         refresh={handleSave}
+        variables={variables}
       />
     </RbDrawer>
   );

--- a/web/src/views/Workflow/components/Properties/VariableList/VariableEditModal.tsx
+++ b/web/src/views/Workflow/components/Properties/VariableList/VariableEditModal.tsx
@@ -10,6 +10,7 @@ const FormItem = Form.Item;
 
 interface VariableEditModalProps {
   refresh: (values: Variable) => void;
+  variables?: Variable[];
 }
 
 const types = [
@@ -32,7 +33,8 @@ const initialValues = {
 }
 
 const VariableEditModal = forwardRef<VariableEditModalRef, VariableEditModalProps>(({
-  refresh
+  refresh,
+  variables
 }, ref) => {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
@@ -123,6 +125,12 @@ const VariableEditModal = forwardRef<VariableEditModalRef, VariableEditModalProp
           rules={[
             { required: true, message: t('common.pleaseEnter') },
             { pattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/, message: t('workflow.config.start.invalidVariableName') },
+            {
+              validator: (_, value) => {
+                const duplicate = variables?.some(v => v.name === value && v.name !== editVo?.name);
+                return duplicate ? Promise.reject(t('workflow.config.duplicateName')) : Promise.resolve();
+              }
+            },
           ]}
         >
           <Input placeholder={t('common.enter')} onBlur={nameChange} />

--- a/web/src/views/Workflow/components/Properties/VariableList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/VariableList/index.tsx
@@ -104,6 +104,7 @@ const VariableList: FC<VariableListProps> = ({
       <VariableEditModal
         ref={variableModalRef}
         refresh={handleRefreshVariable}
+        variables={value}
       />
     </div>
   )


### PR DESCRIPTION
## Summary by Sourcery

在工作流聊天与启动变量的弹窗中强制变量名唯一，并更新相关的 UI 文本。

New Features:
- 添加校验，在创建或编辑工作流聊天变量时，防止聊天变量名重复。
- 添加校验，在工作流变量编辑弹窗中，防止启动变量名重复。

Enhancements:
- 将已有变量列表传入聊天和变量编辑弹窗，以支持重复名称检查。
- 为重复变量名错误添加 i18n 文案，并优化现有的一条英文确认消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce uniqueness of variable names in workflow chat and start variable modals and update related UI text.

New Features:
- Add validation to prevent duplicate chat variable names when creating or editing workflow chat variables.
- Add validation to prevent duplicate start variable names in the workflow variable edit modal.

Enhancements:
- Pass existing variable lists into chat and variable edit modals to support duplicate-name checks.
- Add i18n strings for duplicate variable name errors and refine an existing English confirmation message.

</details>