### PR TITLE
fix:Remove "total"

### DIFF
--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -803,7 +803,6 @@ def get_rag_content(
                 "page": {
                     "page": page,
                     "pagesize": pagesize,
-                    "total": 0,
                     "hasnext": False,
                 },
                 "items": []
@@ -897,13 +896,12 @@ def get_rag_content(
             "page": {
                 "page": page,
                 "pagesize": pagesize,
-                "total": global_total,
                 "hasnext": offset_end < global_total,
             },
             "items": conversations
         }
         
-        business_logger.info(f"成功获取RAG内容: total={global_total}, page={page}, 返回={len(conversations)} 条对话")
+        business_logger.info(f"成功获取RAG内容: page={page}, 返回={len(conversations)} 条对话")
         return result
         
     except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

从 RAG 内容分页响应及相关日志中移除未使用/不正确的总数字段。

Bug 修复：
- 从 RAG 内容 API 分页元数据中移除硬编码或不一致的 `total` 字段，以避免暴露错误的总数。

增强：
- 通过从日志消息中移除总数，简化 RAG 内容检索的业务日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused/incorrect total count field from RAG content pagination responses and associated logging.

Bug Fixes:
- Drop the hardcoded or inconsistent total field from RAG content API pagination metadata to avoid exposing incorrect totals.

Enhancements:
- Simplify business logging for RAG content retrieval by removing the total count from the log message.

</details>