### PR TITLE
feat: add versioned app chat API and fix release isolation bug

### DIFF
--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -91,16 +91,16 @@ async def chat(
     Agent/Workflow 聊天接口
 
     - 不传 version：使用当前生效版本（current_release，回滚后为回滚目标版本）
-    - 传 version=N：使用指定版本号的历史快照，例如 {"version": 2}
+    - 传 version=release_id：使用指定版本uuid的历史快照，例如 {"version": "{{release_id}}"}
     """
     body = await request.json()
     payload = AppChatRequest(**body)
 
     app = app_service.get_app(api_key_auth.resource_id, api_key_auth.workspace_id)
 
-    # 版本切换：指定 version 时查找对应历史快照，否则使用当前激活版本
+    # 版本切换：指定 release_id 时查找对应历史快照，否则使用当前激活版本
     if payload.version is not None:
-        active_release = app_service.get_release_by_version(app.id, payload.version)
+        active_release = app_service.get_release_by_id(app.id, payload.version)
     else:
         active_release = app.current_release
     other_id = payload.user_id

--- a/api/app/repositories/app_repository.py
+++ b/api/app/repositories/app_repository.py
@@ -63,13 +63,13 @@ def get_apps_by_id(db: Session, app_id: uuid.UUID) -> App:
     return repo.get_apps_by_id(app_id)
 
 
-def get_release_by_version(db: Session, app_id: uuid.UUID, version: int):
-    """根据版本号查询发布快照（仅返回激活状态）"""
+def get_release_by_version(db: Session, app_id: uuid.UUID, release_id: uuid.UUID):
+    """根据发布版本ID查询发布快照（仅返回激活状态）"""
     from app.models.app_release_model import AppRelease
     return db.scalars(
         select(AppRelease).where(
             AppRelease.app_id == app_id,
-            AppRelease.version == version,
+            AppRelease.id == release_id,
             AppRelease.is_active.is_(True),
         )
     ).first()

--- a/api/app/repositories/app_repository.py
+++ b/api/app/repositories/app_repository.py
@@ -63,7 +63,7 @@ def get_apps_by_id(db: Session, app_id: uuid.UUID) -> App:
     return repo.get_apps_by_id(app_id)
 
 
-def get_release_by_version(db: Session, app_id: uuid.UUID, release_id: uuid.UUID):
+def get_release_by_id(db: Session, app_id: uuid.UUID, release_id: uuid.UUID):
     """根据发布版本ID查询发布快照（仅返回激活状态）"""
     from app.models.app_release_model import AppRelease
     return db.scalars(

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -616,7 +616,7 @@ class AppChatRequest(BaseModel):
     stream: bool = Field(default=False, description="是否流式返回")
     thinking: bool = Field(default=False, description="是否启用深度思考（需Agent配置支持）")
     files: List[FileInput] = Field(default_factory=list, description="附件列表（支持多文件）")
-    version: Optional[int] = Field(default=None, description="指定发布版本号，不传则使用当前发布版本")
+    version: Optional[uuid.UUID] = Field(default=None, description="指定发布版本ID，不传则使用当前生效版本")
 
 
 class DraftRunRequest(BaseModel):

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -619,7 +619,7 @@ class AppService:
         self._validate_app_accessible(app, workspace_id)
         return app
 
-    def get_release_by_version(self, app_id: uuid.UUID, release_id: uuid.UUID) -> AppRelease:
+    def get_release_by_id(self, app_id: uuid.UUID, release_id: uuid.UUID) -> AppRelease:
         """按发布版本ID获取发布快照
 
         Args:
@@ -632,8 +632,8 @@ class AppService:
         Raises:
             BusinessException: 版本不存在或已下线
         """
-        from app.repositories.app_repository import get_release_by_version
-        release = get_release_by_version(self.db, app_id, release_id)
+        from app.repositories.app_repository import get_release_by_id
+        release = get_release_by_id(self.db, app_id, release_id)
         if not release:
             raise BusinessException(
                 f"版本 {release_id} 不存在或已下线",

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -619,12 +619,12 @@ class AppService:
         self._validate_app_accessible(app, workspace_id)
         return app
 
-    def get_release_by_version(self, app_id: uuid.UUID, version: int) -> AppRelease:
-        """按版本号获取发布快照
+    def get_release_by_version(self, app_id: uuid.UUID, release_id: uuid.UUID) -> AppRelease:
+        """按发布版本ID获取发布快照
 
         Args:
             app_id: 应用ID
-            version: 版本号（整数，按应用内递增）
+            release_id: 发布版本ID
 
         Returns:
             AppRelease: 发布快照
@@ -633,10 +633,10 @@ class AppService:
             BusinessException: 版本不存在或已下线
         """
         from app.repositories.app_repository import get_release_by_version
-        release = get_release_by_version(self.db, app_id, version)
+        release = get_release_by_version(self.db, app_id, release_id)
         if not release:
             raise BusinessException(
-                f"版本 {version} 不存在或已下线",
+                f"版本 {release_id} 不存在或已下线",
                 BizCode.RELEASE_NOT_FOUND,
             )
         return release


### PR DESCRIPTION
## Summary by Sourcery

将版本查询和应用内聊天请求从使用数字版本号切换为使用发布 ID。

Bug Fixes:
- 修复版本获取逻辑，改为通过发布 ID 查询，确保返回正确的当前生效版本快照。

Enhancements:
- 更新应用内聊天请求的 schema，将用于指定目标版本的字段从整型版本号改为接受 UUID 类型的发布 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch release lookup and app chat request to use release IDs instead of numeric version numbers.

Bug Fixes:
- Fix release retrieval to query by release ID, ensuring the correct active release snapshot is returned.

Enhancements:
- Update app chat request schema to accept a UUID release ID instead of an integer version for specifying the target release.

</details>