### PR TITLE
Hotfix/v0.2.10

### DIFF
--- a/api/app/core/workflow/engine/graph_builder.py
+++ b/api/app/core/workflow/engine/graph_builder.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # Example:
 #   "Hello {{user.name}}!" ->
 #   ["Hello ", "{{user.name}}", "!"]
-_OUTPUT_PATTERN = re.compile(r'\{\{.*?}}|[^{}]+')
+_OUTPUT_PATTERN = re.compile(r'\{\{.*?}}|[^{]+|{')
 # Strict variable format: {{ node_id.field_name }}
 _VARIABLE_PATTERN = re.compile(r'\{\{\s*[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\s*}}')
 

--- a/api/app/core/workflow/nodes/cycle_graph/node.py
+++ b/api/app/core/workflow/nodes/cycle_graph/node.py
@@ -55,9 +55,9 @@ class CycleGraphNode(BaseNode):
             if config.output_type in [
                 VariableType.ARRAY_FILE,
                 VariableType.ARRAY_STRING,
-                VariableType.NUMBER,
+                VariableType.ARRAY_NUMBER,
                 VariableType.ARRAY_OBJECT,
-                VariableType.BOOLEAN
+                VariableType.ARRAY_BOOLEAN
             ]:
                 if config.flatten:
                     outputs['output'] = config.output_type


### PR DESCRIPTION
## Summary by Sourcery

调整循环图节点输出的类型定义，并放宽图构建器对输出的模式匹配，以正确处理工作流模板中的大括号。

Bug Fixes:
- 修复循环图节点输出类型的处理逻辑，对于数组类型的 number 和 boolean 变量进行正确处理，而不是按标量 number 和 boolean 类型处理。
- 更新工作流引擎的输出分词正则表达式，以正确解析在模板表达式中包含不成对或字面量花括号的字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust cycle graph node output typing and relax graph builder output pattern matching to correctly handle braces in workflow templates.

Bug Fixes:
- Correct cycle graph node output type handling for array number and array boolean variables instead of scalar number and boolean types.
- Update workflow engine output tokenization regex to properly parse strings containing unmatched or literal curly braces in template expressions.

</details>