### PR TITLE
Hotfix/v0.2.10

### DIFF
--- a/api/app/core/workflow/engine/graph_builder.py
+++ b/api/app/core/workflow/engine/graph_builder.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 # Example:
 #   "Hello {{user.name}}!" ->
 #   ["Hello ", "{{user.name}}", "!"]
-_OUTPUT_PATTERN = re.compile(r'\{\{.*?}}|[^{}]+')
+_OUTPUT_PATTERN = re.compile(r'\{\{.*?}}|[^{]+|{')
 # Strict variable format: {{ node_id.field_name }}
 _VARIABLE_PATTERN = re.compile(r'\{\{\s*[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+\s*}}')
 

--- a/api/app/core/workflow/nodes/cycle_graph/node.py
+++ b/api/app/core/workflow/nodes/cycle_graph/node.py
@@ -55,9 +55,9 @@ class CycleGraphNode(BaseNode):
             if config.output_type in [
                 VariableType.ARRAY_FILE,
                 VariableType.ARRAY_STRING,
-                VariableType.NUMBER,
+                VariableType.ARRAY_NUMBER,
                 VariableType.ARRAY_OBJECT,
-                VariableType.BOOLEAN
+                VariableType.ARRAY_BOOLEAN
             ]:
                 if config.flatten:
                     outputs['output'] = config.output_type


### PR DESCRIPTION
## Summary by Sourcery

修复对数组类型输出的工作流图处理，并改进输出模板的分词。

错误修复：
- 修正循环图节点输出类型分类，在展开(outputs flattening)时对数组使用特定的数字和布尔类型。
- 调整工作流图构建器的输出解析正则表达式，以正确处理模板中单独出现的左花括号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow graph handling of array-typed outputs and improve output template tokenization.

Bug Fixes:
- Correct cycle graph node output type classification to use array-specific number and boolean types when flattening outputs.
- Adjust workflow graph builder output parsing regex to properly handle lone opening braces in templates.

</details>