### PR TITLE
refactor(neo4j): rename execute_query parameter from query to cypher

### DIFF
--- a/api/app/repositories/neo4j/neo4j_connector.py
+++ b/api/app/repositories/neo4j/neo4j_connector.py
@@ -77,11 +77,11 @@ class Neo4jConnector:
         """
         await self.driver.close()
 
-    async def execute_query(self, query: str, json_format=False, **kwargs: Any) -> List[Dict[str, Any]]:
+    async def execute_query(self, cypher: str, json_format=False, **kwargs: Any) -> List[Dict[str, Any]]:
         """执行Cypher查询
         
         Args:
-            query: Cypher查询语句
+            cypher: Cypher查询语句
             json_format: json格式化
             **kwargs: 查询参数，将作为参数传递给Cypher查询
             
@@ -92,7 +92,7 @@ class Neo4jConnector:
 
         """
         result = await self.driver.execute_query(
-            query,
+            cypher,
             database="neo4j",
             **kwargs
         )


### PR DESCRIPTION
Improves readability by making the parameter name explicitly reflect that it expects a Cypher query string rather than a generic query.

## 由 Sourcery 提供的摘要

改进内容：
- 通过在 Neo4j 连接器中将 `execute_query` API 的参数名从 `query` 重命名为 `cypher`，来明确该 API 的含义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Clarify the execute_query API by renaming the query argument to cypher in the Neo4j connector.

</details>