### PR TITLE
Fix/v0.3.0 zy

### DIFF
--- a/web/src/views/UserMemoryDetail/components/InterestAreas.tsx
+++ b/web/src/views/UserMemoryDetail/components/InterestAreas.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 18:32:53 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-16 14:27:12
+ * @Last Modified time: 2026-04-13 13:37:43
  */
 import { useEffect, useState, forwardRef, useImperativeHandle, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -93,7 +93,7 @@ const InterestAreas = forwardRef<{ handleRefresh: () => void; }>((_props, ref) =
             ref={chartRef}
             option={{
               color: Colors,
-              grid: { top: 8, left: 38, right: 8, bottom: 24 },
+              grid: { top: 14, left: 38, right: 8, bottom: 24 },
               xAxis: {
                 type: 'category',
                 data: keys.map(k => t(`implicitDetail.${k}`)),

--- a/web/src/views/Workflow/components/Editor/plugin/AutocompletePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/AutocompletePlugin.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-13 11:12:18
+ * @Last Modified time: 2026-04-13 14:00:07
  */
 import { useEffect, useLayoutEffect, useState, useRef, type FC } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -285,23 +285,24 @@ const AutocompletePlugin: FC<{ options: Suggestion[] }> = ({ options }) => {
       ref={popupRef}
       data-autocomplete-popup="true"
       onMouseDown={(e) => e.preventDefault()}
-      className="rb:min-w-70 rb:max-h-57.5 rb:overflow-y-auto rb:fixed rb:z-1000 rb:bg-white rb:rounded-lg rb:border-[0.5px] rb:border-[#EBEBEB] rb:shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] rb:py-3 rb:px-2"
+      className="rb:fixed rb:z-1000 rb:bg-white rb:rounded-lg rb:border-[0.5px] rb:border-[#EBEBEB] rb:shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] rb:py-3 rb:px-2"
       style={{
         top: popupPosition.top,
         left: popupPosition.left,
       }}
     >
-      <Flex vertical gap={12}>
-        {Object.entries(groupedSuggestions).map(([nodeId, nodeOptions]) => {
-          const nodeName = nodeOptions[0]?.nodeData?.name || nodeId;
-          return (
-            <div key={nodeId} className="rb:text-[12px]">
-              {nodeName !== 'undefined' &&
-                <div className="rb:px-2 rb:leading-4.25 rb:mb-1.25 rb:font-medium rb:text-[#5B6167]">
-                  {nodeName}
-                </div>
-              }
-              <Flex vertical gap={2}>
+      <div className="rb:min-w-70 rb:max-h-57.5 rb:overflow-y-auto">
+        <Flex vertical gap={12}>
+          {Object.entries(groupedSuggestions).map(([nodeId, nodeOptions]) => {
+            const nodeName = nodeOptions[0]?.nodeData?.name || nodeId;
+            return (
+              <div key={nodeId} className="rb:text-[12px]">
+                {nodeName !== 'undefined' &&
+                  <div className="rb:px-2 rb:leading-4.25 rb:mb-1.25 rb:font-medium rb:text-[#5B6167]">
+                    {nodeName}
+                  </div>
+                }
+                <Flex vertical gap={2}>
                 {nodeOptions.map((option) => {
                   const globalIndex = flatOptions.indexOf(option);
                   const isExpanded = expandedParent?.key === option.key;
@@ -344,20 +345,21 @@ const AutocompletePlugin: FC<{ options: Suggestion[] }> = ({ options }) => {
                       }
                       <Space size={2}>
                         {option.dataType && <span>{option.dataType}</span>}
-                        {hasChildren && <div className="rb:size-3 rb:bg-cover rb:bg-[url('src/assets/images/common/arrow_up.svg')] rb:rotate-90"></div>}
+                        {hasChildren && <div className="rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/arrow_up.svg')] rb:rotate-90"></div>}
                       </Space>
                     </Flex>
                   );
                 })}
-              </Flex>
-            </div>
-          );
-        })}
-      </Flex>
+                </Flex>
+              </div>
+            );
+          })}
+        </Flex>
+      </div>
       {/* Child variables panel - floats to the left */}
       {expandedParent?.children?.length && (
         <div
-          className="rb:min-w-70 rb:max-h-57.5 rb:overflow-y-auto rb:text-[12px] rb:fixed rb:z-1000 rb:bg-white rb:rounded-lg rb:border-[0.5px] rb:border-[#EBEBEB] rb:shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] rb:py-3 rb:px-2"
+          className="rb:absolute rb:min-w-70 rb:max-h-57.5 rb:overflow-y-auto rb:text-[12px] rb:z-1000 rb:bg-white rb:rounded-lg rb:border-[0.5px] rb:border-[#EBEBEB] rb:shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] rb:py-3 rb:px-2"
           style={{
             top: childPanelTop,
             right: 'calc(100% + 8px)',
@@ -387,7 +389,9 @@ const AutocompletePlugin: FC<{ options: Suggestion[] }> = ({ options }) => {
                 onClick={() => !child.disabled && insertMention(child)}
                 onMouseEnter={() => setSelectedIndex(childIndex)}
               >
-                <span className="rb:font-medium">{child.label}</span>
+                <span className="rb:font-medium">
+                  <span className="rb:text-[#155EEF]">{`{x}`}</span> {child.label}
+                </span>
                 {child.dataType && <span>{child.dataType}</span>}
               </Flex>
             );

--- a/web/src/views/Workflow/components/Properties/VariableSelect.tsx
+++ b/web/src/views/Workflow/components/Properties/VariableSelect.tsx
@@ -334,7 +334,7 @@ const VariableSelect: FC<VariableSelectProps> = ({
 
                         <Space size={2}>
                           {s.dataType && <span>{s.dataType}</span>}
-                          {hasChildren && <div className="rb:size-3 rb:bg-cover rb:bg-[url('src/assets/images/common/arrow_up.svg')] rb:rotate-90"></div>}
+                          {hasChildren && <div className="rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/arrow_up.svg')] rb:rotate-90"></div>}
                         </Space>
                       </Flex>
                     );


### PR DESCRIPTION
## Summary by Sourcery

调整自动完成弹出窗口布局和子面板定位，微调兴趣区域图表间距，并更新变量选择器的资源和显示效果。

Bug Fixes:
- 通过将可滚动内容与固定容器分离，并对子变量面板使用绝对定位，修复自动完成建议弹出窗口的滚动和定位问题。

Enhancements:
- 在自动完成子面板中为子变量标签添加前缀标记以突出显示，便于更清晰地识别。
- 增加兴趣区域图表中顶部网格的填充，以改善图表内容的视觉间距。

Chores:
- 更新变量选择器和自动完成组件，使其对箭头图标使用别名后的资源路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust autocomplete popup layout and child panel positioning, tweak interest areas chart spacing, and update variable selector assets and display.

Bug Fixes:
- Fix autocomplete suggestion popup scrolling and positioning by separating scrollable content from the fixed container and using absolute positioning for the child variables panel.

Enhancements:
- Highlight child variable labels with a prefix marker in the autocomplete child panel for clearer identification.
- Increase top grid padding in the interest areas chart to improve visual spacing of chart content.

Chores:
- Update variable selector and autocomplete components to use the aliased asset path for the arrow icon.

</details>