### PR TITLE
fix(user)

### DIFF
--- a/api/app/repositories/user_repository.py
+++ b/api/app/repositories/user_repository.py
@@ -297,6 +297,10 @@ def get_user_by_id(db: Session, user_id: uuid.UUID) -> Optional[User]:
     """根据ID获取用户"""
     return UserRepository(db).get_user_by_id(user_id)
 
+def get_user_by_id_regardless_active(db: Session, user_id: uuid.UUID) -> Optional[User]:
+    """根据ID获取用户（不过滤 is_active，用于启用/禁用场景）"""
+    return db.query(User).filter(User.id == user_id).first()
+
 def get_user_by_email(db: Session, email: str) -> Optional[User]:
     """根据邮箱获取用户"""
     return UserRepository(db).get_user_by_email(email)

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -73,15 +73,14 @@ class AppDslService:
             AppType.MULTI_AGENT: "multi_agent_config",
             AppType.WORKFLOW: "workflow"
         }.get(app.type, "config")
-        config_data = self._enrich_release_config(app.type, release.config or {})
+        config_data = self._enrich_release_config(app.type, release.config or {}, release.default_model_config_id)
         dsl = {**meta, "app": app_meta, config_key: config_data}
         return yaml.dump(dsl, default_flow_style=False, allow_unicode=True), f"{release.name}_v{release.version_name}.yaml"
 
-    def _enrich_release_config(self, app_type: str, cfg: dict) -> dict:
+    def _enrich_release_config(self, app_type: str, cfg: dict, default_model_config_id=None) -> dict:
         if app_type == AppType.AGENT:
             enriched = {**cfg}
-            if "default_model_config_id" in cfg:
-                enriched["default_model_config_ref"] = self._model_ref(cfg["default_model_config_id"])
+            enriched["default_model_config_ref"] = self._model_ref(default_model_config_id)
             if "knowledge_retrieval" in cfg:
                 enriched["knowledge_retrieval"] = self._enrich_knowledge_retrieval(cfg["knowledge_retrieval"])
             if "tools" in cfg:
@@ -91,8 +90,7 @@ class AppDslService:
             return enriched
         if app_type == AppType.MULTI_AGENT:
             enriched = {**cfg}
-            if "default_model_config_id" in cfg:
-                enriched["default_model_config_ref"] = self._model_ref(cfg["default_model_config_id"])
+            enriched["default_model_config_ref"] = self._model_ref(default_model_config_id)
             if "master_agent_id" in cfg:
                 enriched["master_agent_ref"] = self._release_ref(cfg["master_agent_id"])
             if "sub_agents" in cfg:

--- a/api/app/services/user_service.py
+++ b/api/app/services/user_service.py
@@ -285,7 +285,7 @@ def activate_user(db: Session, user_id_to_activate: uuid.UUID, current_user: Use
     try:
         # 查找用户
         business_logger.debug(f"查找待激活用户: {user_id_to_activate}")
-        db_user = user_repository.get_user_by_id(db, user_id=user_id_to_activate)
+        db_user = user_repository.get_user_by_id_regardless_active(db, user_id=user_id_to_activate)
         if not db_user:
             business_logger.warning(f"用户不存在: {user_id_to_activate}")
             raise BusinessException("用户不存在", code=BizCode.USER_NOT_FOUND)


### PR DESCRIPTION
add user retrieval regardless of active status and update DSL config enrichment

Added `get_user_by_id_regardless_active` in user repository to support activation/deactivation workflows, updated `user_service` to use it, and refactored `_enrich_release_config` in `app_dsl_service` to accept `default_model_config_id` as a parameter instead of reading from config dict.

## Summary by Sourcery

允许用户激活工作流在不考虑用户当前启用状态的情况下运行，并调整 DSL 版本导出逻辑，以显式接收默认模型配置 ID。

New Features:
- 暴露一个仓库辅助方法，用于在启用/禁用工作流中按 ID 获取用户时不再根据启用状态进行过滤。

Enhancements:
- 更新用户激活服务逻辑以使用新的仓库辅助方法，从而可以重新激活已被停用的用户。
- 优化版本配置富集逻辑，使其通过参数接收默认模型配置 ID，而不是从配置负载中读取。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow user activation workflows to operate on users regardless of active status and adjust DSL release export to receive the default model config ID explicitly.

New Features:
- Expose a repository helper to fetch a user by ID without filtering by active status for enable/disable workflows.

Enhancements:
- Update user activation service logic to use the new repository helper so deactivated users can be reactivated.
- Refine release config enrichment to accept the default model config ID as a parameter instead of reading it from the config payload.

</details>