### PR TITLE
fix(web): breadcrumb ui

### DIFF
--- a/web/src/components/Header/index.module.css
+++ b/web/src/components/Header/index.module.css
@@ -12,6 +12,14 @@
   font-weight: 500;
   font-style: normal;
 }
+.breadcrumbTitle {
+  display: inline-block;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
 .header :global(.ant-breadcrumb) {
   line-height: 31px;
 }

--- a/web/src/components/Header/index.tsx
+++ b/web/src/components/Header/index.tsx
@@ -14,7 +14,7 @@
  */
 
 import { type FC, useRef, useState } from 'react';
-import { Layout, Dropdown, Breadcrumb, Flex } from 'antd';
+import { Layout, Dropdown, Breadcrumb, Flex, Tooltip } from 'antd';
 import type { MenuProps, BreadcrumbProps } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -136,27 +136,28 @@ const AppHeader: FC<{source?: 'space' | 'manage';}> = ({source = 'manage'}) => {
    */
   const formatBreadcrumbNames = () => {
     return breadcrumbs.filter(item => item.type !== 'group').map((menu, index) => {
+      const label = menu.i18nKey ? t(menu.i18nKey) : menu.label;
+      const isLast = index === breadcrumbs.length - 1;
       const item: any = {
-        title: menu.i18nKey ? t(menu.i18nKey) : menu.label,
+        title: (
+          <Tooltip title={label} placement="bottom">
+            <span className={styles.breadcrumbTitle}>{label}</span>
+          </Tooltip>
+        ),
       };
       
-      // If it's the last item, don't set path
-      if (index === breadcrumbs.length - 1) {
-        return item;
+      if (!isLast) {
+        if ((menu as any).onClick) {
+          item.onClick = (e: React.MouseEvent) => {
+            e.preventDefault();
+            (menu as any).onClick(e);
+          };
+          item.href = '#';
+        } else if (menu.path && menu.path !== '#') {
+          item.path = menu.path;
+        }
       }
-      
-      // If has custom onClick, use onClick and set href to '#' to show pointer cursor
-      if ((menu as any).onClick) {
-        item.onClick = (e: React.MouseEvent) => {
-          e.preventDefault();
-          (menu as any).onClick(e);
-        };
-        item.href = '#';
-      } else if (menu.path && menu.path !== '#') {
-        // Only set path when path is not '#'
-        item.path = menu.path;
-      }
-      
+
       return item;
     });
   }


### PR DESCRIPTION
## Summary by Sourcery

改进网页头部组件中的面包屑渲染和交互。

增强点：
- 为面包屑标签添加带工具提示的截断显示，以提升长标题的可读性。
- 阻止最后一个面包屑项的导航和路径跳转，同时保留中间项上的自定义点击处理和链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve breadcrumb rendering and interaction in the web header component.

Enhancements:
- Add tooltip-wrapped, truncating breadcrumb labels to improve readability for long titles.
- Prevent navigation and paths on the last breadcrumb item while preserving custom click handling and links on intermediate items.

</details>