### PR TITLE
chore(.gitignore): add redbear-mem-benchmark to ignored paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ time.log
 celerybeat-schedule.db
 search_results.json
 redbear-mem-metrics/
+redbear-mem-benchmark/
 pitch-deck/
 
 api/migrations/versions


### PR DESCRIPTION
- Add redbear-mem-benchmark directory to .gitignore
- Prevents benchmark artifacts from being tracked in version control
- Aligns with existing pattern of ignoring redbear-mem-metrics directory

## Summary by Sourcery

杂务：
- 调整 `.gitignore` 条目，使其与当前项目约定保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Adjust .gitignore entries to align with current project conventions.

</details>