### PR TITLE
ci: add WeChat release notification workflow

### DIFF
--- a/.github/workflows/release-notify-wechat.yml
+++ b/.github/workflows/release-notify-wechat.yml
@@ -1,0 +1,100 @@
+name: Release Notify Workflow
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.base.ref, 'release')
+    runs-on: ubuntu-latest
+
+    steps:
+      # 防止 GitHub HEAD 未同步
+      - name: Wait for ref sync
+        run: sleep 3
+
+      # 1️⃣ 获取分支 HEAD
+      - name: Get HEAD
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          HEAD_SHA=$(curl -s \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/$REPO/git/ref/heads/$BASE_REF" \
+            | jq -r '.object.sha')
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
+      # 2️⃣ 判断是否最终PR
+      - name: Check Latest
+        id: check
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          HEAD_SHA: ${{ steps.head.outputs.head_sha }}
+        run: |
+          if [ "$MERGE_SHA" = "$HEAD_SHA" ]; then
+            echo "ok=true" >> $GITHUB_OUTPUT
+          else
+            echo "ok=false" >> $GITHUB_OUTPUT
+          fi
+
+      # 3️⃣ 获取 commits
+      - name: Get Commits
+        if: steps.check.outputs.ok == 'true'
+        id: commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+        run: |
+          curl -s \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "$COMMITS_URL" \
+            | jq -r '.[].commit.message' | head -n 20 > commits.txt
+
+      # 4️⃣ 阿里 AI 总结（通义千问）
+      - name: AI Summary (Qwen)
+        if: steps.check.outputs.ok == 'true'
+        id: ai
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+        run: |
+          COMMIT_MESSAGES=$(cat commits.txt)
+
+          jq -n --arg msgs "请用中文总结以下代码提交，输出3-5条，面向测试人员：
+          $COMMIT_MESSAGES" \
+            '{"model": "qwen-plus", "input": {"prompt": $msgs}}' > ai_payload.json
+
+          SUMMARY=$(curl -s https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation \
+            -H "Authorization: Bearer $DASHSCOPE_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @ai_payload.json | jq -r '.output.text')
+
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      # 5️⃣ 企业微信通知（Markdown）
+      - name: Notify WeChat
+        if: steps.check.outputs.ok == 'true'
+        env:
+          WECHAT_WEBHOOK: ${{ secrets.WECHAT_WEBHOOK }}
+          BRANCH: ${{ github.event.pull_request.base.ref }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          AI_SUMMARY: ${{ steps.ai.outputs.summary }}
+        run: |
+          CONTENT=$(printf '## 🚀 Release 发布通知\n> 📦 **分支**: %s\n> 👤 **提交人**: %s\n> 📝 **标题**: %s\n\n### 🧠 AI变更摘要\n%s\n\n---\n🔗 [查看PR详情](%s)' \
+            "$BRANCH" "$AUTHOR" "$PR_TITLE" "$AI_SUMMARY" "$PR_URL")
+
+          jq -n --arg content "$CONTENT" \
+            '{"msgtype": "markdown", "markdown": {"content": $content}}' > wechat_payload.json
+
+          curl -s "$WECHAT_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d @wechat_payload.json


### PR DESCRIPTION
- Add GitHub Actions workflow to notify WeChat on release branch merges
- Implement multi-step pipeline: sync ref, verify latest PR, fetch commits
- Integrate Aliyun Qwen AI for automated Chinese commit message summarization
- Send formatted Markdown notifications to WeChat webhook with release details
- Include branch, author, PR title, AI summary, and PR link in notifications

## 由 Sourcery 生成的摘要

添加一个自动化工作流，当合并的拉取请求进入发布分支时，向企业微信发送发布通知。

新功能：
- 引入一个 GitHub Actions 工作流，当拉取请求被合并到发布分支时触发，并向企业微信发送格式化的 Markdown 通知。
- 使用阿里云 Qwen 为发布分支的拉取请求生成基于最近提交信息的中文 AI 摘要，并将其包含在通知中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an automated workflow to send WeChat release notifications when release branches receive merged pull requests.

New Features:
- Introduce a GitHub Actions workflow that triggers on merged pull requests targeting release branches and sends formatted Markdown notifications to WeChat.
- Generate Chinese AI-based summaries of recent commit messages for release pull requests using Aliyun Qwen and include them in the notification.

</details>