### PR TITLE
ci(wechat-notify): extract payload building logic to Python script

### DIFF
--- a/.github/scripts/build_wechat_payload.py
+++ b/.github/scripts/build_wechat_payload.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+branch = os.environ.get("BRANCH", "")
+author = os.environ.get("AUTHOR", "")
+pr_title = os.environ.get("PR_TITLE", "")
+pr_url = os.environ.get("PR_URL", "")
+ai_summary = os.environ.get("AI_SUMMARY", "")
+
+content = (
+    "## 🚀 Release 发布通知\n"
+    f"> 📦 **分支**: {branch}\n"
+    f"> 👤 **提交人**: {author}\n"
+    f"> 📝 **标题**: {pr_title}\n\n"
+    "### 🧠 AI变更摘要\n"
+    f"{ai_summary}\n\n"
+    "---\n"
+    f"🔗 [查看PR详情]({pr_url})"
+)
+
+payload = {"msgtype": "markdown", "markdown": {"content": content}}
+
+with open("wechat_payload.json", "w", encoding="utf-8") as f:
+    json.dump(payload, f, ensure_ascii=False)

--- a/.github/workflows/release-notify-wechat.yml
+++ b/.github/workflows/release-notify-wechat.yml
@@ -79,6 +79,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       # 5️⃣ 企业微信通知（Markdown）
+      - name: Checkout for script
+        if: steps.check.outputs.ok == 'true'
+        uses: actions/checkout@v4
+
       - name: Notify WeChat
         if: steps.check.outputs.ok == 'true'
         env:
@@ -89,22 +93,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           AI_SUMMARY: ${{ steps.ai.outputs.summary }}
         run: |
-          python3 -c "
-          import json, os
-          content = (
-              '## 🚀 Release 发布通知\n'
-              '> 📦 **分支**: ' + os.environ['BRANCH'] + '\n'
-              '> 👤 **提交人**: ' + os.environ['AUTHOR'] + '\n'
-              '> 📝 **标题**: ' + os.environ['PR_TITLE'] + '\n\n'
-              '### 🧠 AI变更摘要\n'
-              + os.environ['AI_SUMMARY'] + '\n\n'
-              '---\n'
-              '🔗 [查看PR详情](' + os.environ['PR_URL'] + ')'
-          )
-          payload = {'msgtype': 'markdown', 'markdown': {'content': content}}
-          with open('wechat_payload.json', 'w') as f:
-              json.dump(payload, f, ensure_ascii=False)
-          "
+          python3 .github/scripts/build_wechat_payload.py
 
           curl -s "$WECHAT_WEBHOOK" \
             -H 'Content-Type: application/json' \


### PR DESCRIPTION
- Create new `.github/scripts/build_wechat_payload.py` to handle WeChat payload generation
- Replace inline Python string concatenation with dedicated script for better maintainability
- Add checkout step to access the script during workflow execution
- Simplify workflow by delegating payload construction to external script
- Improve code readability and reusability for future notification enhancements

## Summary by Sourcery

将构建微信发布通知负载的逻辑提取到一个独立的 Python 脚本中，并将其接入发布通知工作流。

增强内容：
- 新增一个可复用的 Python 脚本，用于构建用于发布通知的微信 Markdown 消息负载。
- 更新微信发布通知工作流，以调用新的脚本替代内联 Python，并确保在执行前检出代码仓库，以便脚本可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract WeChat release notification payload construction into a dedicated Python script and wire it into the release notification workflow.

Enhancements:
- Add a reusable Python script to build the WeChat markdown payload for release notifications.
- Update the WeChat release notification workflow to invoke the new script instead of inline Python and ensure the repository is checked out so the script is available.

</details>