### PR TITLE
ci(wechat-notify): replace curl with urllib for webhook request

### DIFF
--- a/.github/workflows/release-notify-wechat.yml
+++ b/.github/workflows/release-notify-wechat.yml
@@ -78,7 +78,7 @@ jobs:
           AI_SUMMARY: ${{ steps.ai.outputs.summary }}
         run: |
           python3 << 'PYEOF'
-          import json, os
+          import json, os, urllib.request
           content = (
             "## 🚀 Release 发布通知\n"
             "> 📦 **分支**: " + os.environ["BRANCH"] + "\n"
@@ -90,10 +90,12 @@ jobs:
             "🔗 [查看PR详情](" + os.environ["PR_URL"] + ")"
           )
           payload = {"msgtype": "markdown", "markdown": {"content": content}}
-          with open("wechat.json", "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False)
+          data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+          req = urllib.request.Request(
+            os.environ["WECHAT_WEBHOOK"],
+            data=data,
+            headers={"Content-Type": "application/json"}
+          )
+          resp = urllib.request.urlopen(req)
+          print(resp.read().decode())
           PYEOF
-
-          curl -s "$WECHAT_WEBHOOK" \
-            -H 'Content-Type: application/json' \
-            -d @wechat.json


### PR DESCRIPTION
- Replace curl command with Python urllib.request for direct HTTP POST
- Remove intermediate wechat.json file write, send payload directly
- Add urllib.request import to Python script
- Simplify workflow by eliminating file I/O and shell command dependency
- Improves reliability by keeping notification logic entirely within Python

## Summary by Sourcery

CI:
- 更新发布通知的 GitHub Actions 工作流，改为使用 Python 的 `urllib.request` 携带内存中的 JSON 负载发送 WeChat webhook 请求，移除对 `curl` 的依赖以及临时文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the release notification GitHub Actions workflow to send the WeChat webhook request using Python's urllib.request with an in-memory JSON payload, removing the curl dependency and temporary file.

</details>