### PR TITLE
ci(wechat-notify): refactor AI summary generation to Python

### DIFF
--- a/.github/workflows/release-notify-wechat.yml
+++ b/.github/workflows/release-notify-wechat.yml
@@ -49,19 +49,37 @@ jobs:
       - name: AI Summary (Qwen)
         if: steps.check.outputs.ok == 'true'
         id: ai
+        env:
+          DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
         run: |
-          CONTENT=$(cat commits.txt | sed ':a;N;$!ba;s/\n/\\n/g')
+          python3 << 'PYEOF'
+          import json, os, urllib.request
 
-          SUMMARY=$(curl -s https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation \
-            -H "Authorization: Bearer ${{ secrets.DASHSCOPE_API_KEY }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"model\": \"qwen-plus\",
-              \"input\": {
-                \"prompt\": \"请用中文总结以下代码提交，输出3-5条要点，面向测试人员。直接输出编号列表，不要输出标题或前言：\\n$CONTENT\"
-              }
-            }" | jq -r '.output.text')
+          with open("commits.txt", "r") as f:
+            commits = f.read().strip()
 
+          prompt = "请用中文总结以下代码提交，输出3-5条要点，面向测试人员。直接输出编号列表，不要输出标题或前言：\n" + commits
+          payload = {"model": "qwen-plus", "input": {"prompt": prompt}}
+          data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+          req = urllib.request.Request(
+            "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation",
+            data=data,
+            headers={
+              "Authorization": "Bearer " + os.environ["DASHSCOPE_API_KEY"],
+              "Content-Type": "application/json"
+            }
+          )
+          resp = urllib.request.urlopen(req)
+          result = json.loads(resp.read().decode())
+          summary = result.get("output", {}).get("text", "AI 摘要生成失败")
+          print(summary)
+
+          with open("ai_summary.txt", "w", encoding="utf-8") as f:
+            f.write(summary)
+          PYEOF
+
+          SUMMARY=$(cat ai_summary.txt)
           echo "summary<<EOF" >> $GITHUB_OUTPUT
           echo "$SUMMARY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Replace curl with urllib.request for API calls to improve portability
- Move API key to environment variable for better security practices
- Inline Python script using heredoc for cleaner workflow definition
- Add intermediate file (ai_summary.txt) to separate concerns between API call and output handling
- Simplify JSON payload construction using Python's json module
- Improve error handling with fallback message for failed AI generation

## Summary by Sourcery

重构微信发布通知工作流中的 AI 摘要步骤，改为使用内联 Python 脚本调用 DashScope API，并处理生成的摘要输出。

CI：
- 将微信发布通知工作流中的 AI 摘要生成方式，从使用 curl/jq 的 shell 命令切换为使用 `urllib` 和 `json` 的内联 Python 脚本，从 `commits.txt` 读取内容并将结果写入 `ai_summary.txt`。
- 使用从 GitHub secrets 获取的 `DASHSCOPE_API_KEY` 环境变量对 DashScope API 请求进行鉴权，并在 AI 生成失败时添加一个回退的摘要消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the WeChat release notification workflow’s AI summary step to use an inline Python script for calling the DashScope API and handling the generated summary output.

CI:
- Switch the AI summary generation in the WeChat release notification workflow from curl/jq shell commands to an inline Python script using urllib and json, reading from commits.txt and writing the result to ai_summary.txt.
- Use a DASHSCOPE_API_KEY environment variable sourced from GitHub secrets for authenticating DashScope API requests and add a fallback summary message when AI generation fails.

</details>