### PR TITLE
fix(web): change http body key name

### DIFF
--- a/web/src/views/Workflow/components/Properties/HttpRequest/EditableTable.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/EditableTable.tsx
@@ -85,9 +85,9 @@ const EditableTable: FC<EditableTableProps> = ({
     return [
       {
         title: t('workflow.config.name'),
-        dataIndex: 'name',
+        dataIndex: 'key',
         render: (_: any, __: TableRow, index: number) => (
-          <Form.Item name={[index, 'name']} className={formClassName}>
+          <Form.Item name={[index, 'key']} className={formClassName}>
             <Editor
               options={namefilterOptions}
               type="input"

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-13 15:33:58
+ * @Last Modified time: 2026-04-14 15:05:33
  */
 import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, type Edge } from '@antv/x6';
 import { register } from '@antv/x6-react-shape';
@@ -204,7 +204,7 @@ export const useWorkflowGraph = ({
                 ? Object.entries(group_variables as Record<string, any>).map(([key, value]) => ({ key, value }))
                 : group_variables
             } else if (type === 'http-request' && (key === 'headers' || key === 'params') && config[key] && typeof config[key] === 'object' && !Array.isArray(config[key]) && nodeLibraryConfig.config && nodeLibraryConfig.config[key]) {
-              nodeLibraryConfig.config[key].defaultValue = Object.entries(config[key]).map(([name, value]) => ({ name, value }))
+              nodeLibraryConfig.config[key].defaultValue = Object.entries(config[key]).map(([key, value]) => ({ key, value }))
             } else if (type === 'code' && key === 'code' && config[key] && nodeLibraryConfig.config && nodeLibraryConfig.config[key]) {
               try {
                 nodeLibraryConfig.config[key].defaultValue = decodeURIComponent(atob(config[key] as string))
@@ -1259,7 +1259,7 @@ export const useWorkflowGraph = ({
                 itemConfig[key] = {}
                 if (value.length > 0) {
                   value.forEach((vo: any) => {
-                    itemConfig[key][vo.name] = vo.value
+                    itemConfig[key][vo.key] = vo.value
                   })
                 }
               } else if (data.config[key] && 'defaultValue' in data.config[key] && key !== 'knowledge_retrieval') {


### PR DESCRIPTION
## Summary by Sourcery

使 HTTP 请求配置处理方式与更新后的请求条目键名保持一致。

Bug Fixes:
- 将 HTTP 请求可编辑表格中的请求体字段从使用 `name` 改为使用 `key`。
- 修正 HTTP 头和参数在序列化与反序列化时的逻辑，在 UI 行与工作流配置之间映射时改为使用 `key` 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align HTTP request configuration handling with updated key naming for request entries.

Bug Fixes:
- Update HTTP request editable table to use 'key' instead of 'name' for request body fields.
- Correct serialization and deserialization of HTTP headers and params to use the 'key' property when mapping between UI rows and workflow config.

</details>