### PR TITLE
fix(workflow http-request)

### DIFF
--- a/api/app/core/workflow/nodes/http_request/config.py
+++ b/api/app/core/workflow/nodes/http_request/config.py
@@ -72,8 +72,8 @@ class HttpContentTypeConfig(BaseModel):
     @classmethod
     def validate_data(cls, v, info):
         content_type = info.data.get("content_type")
-        if content_type == HttpContentType.FROM_DATA and not isinstance(v, HttpFormData):
-            raise ValueError("When content_type is 'form-data', data must be of type HttpFormData")
+        if content_type == HttpContentType.FROM_DATA and not isinstance(v, list):
+            raise ValueError("When content_type is 'form-data', data must be a list of HttpFormData")
         elif content_type in [HttpContentType.JSON] and not isinstance(v, str):
             raise ValueError("When content_type is JSON, data must be of type str")
         elif content_type in [HttpContentType.WWW_FORM] and not isinstance(v, dict):

--- a/api/app/core/workflow/nodes/http_request/node.py
+++ b/api/app/core/workflow/nodes/http_request/node.py
@@ -260,17 +260,22 @@ class HttpRequestNode(BaseNode):
                 ))
             case HttpContentType.FROM_DATA:
                 data = {}
-                content["files"] = {}
+                files = []
                 for item in self.typed_config.body.data:
+                    key = self._render_template(item.key, variable_pool)
                     if item.type == "text":
-                        data[self._render_template(item.key, variable_pool)] = self._render_template(item.value,
-                                                                                                     variable_pool)
+                        data[key] = self._render_template(item.value, variable_pool)
                     elif item.type == "file":
-                        content["files"][self._render_template(item.key, variable_pool)] = (
-                            uuid.uuid4().hex,
-                            await variable_pool.get_instance(item.value).get_content()
-                        )
+                        file_instance = variable_pool.get_instance(item.value)
+                        if isinstance(file_instance, ArrayVariable):
+                            for v in file_instance.value:
+                                if isinstance(v, FileVariable):
+                                    files.append((key, (uuid.uuid4().hex, await v.get_content())))
+                        elif isinstance(file_instance, FileVariable):
+                            files.append((key, (uuid.uuid4().hex, await file_instance.get_content())))
                 content["data"] = data
+                if files:
+                    content["files"] = files
             case HttpContentType.BINARY:
                 content["files"] = []
                 file_instence = variable_pool.get_instance(self.typed_config.body.data)

--- a/api/app/core/workflow/variable/variable_objects.py
+++ b/api/app/core/workflow/variable/variable_objects.py
@@ -84,7 +84,7 @@ class FileVariable(BaseVariable):
         total_bytes = 0
         chunks = []
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             async with client.stream("GET", self.value.url) as resp:
                 resp.raise_for_status()
                 async for chunk in resp.aiter_bytes(8192):


### PR DESCRIPTION
support array and file variables in form-data files upload

- Updated form-data handling to accept both single FileVariable and ArrayVariable containing FileVariable for file uploads
- Fixed HTTP client redirect handling by enabling follow_redirects=True when downloading remote files
- Adjusted config validation to correctly require list type for form-data fields instead of HttpFormData class

## Summary by Sourcery

在工作流的 HTTP 请求节点中，支持在 HTTP `form-data` 上传中使用数组和文件变量，并修复远程文件下载处理。

新增功能：
- 允许 `form-data` 中的文件字段同时支持单个文件变量和文件变量数组进行上传。

错误修复：
- 在获取文件变量内容时，确保远程文件下载会跟随 HTTP 重定向。
- 修正 `form-data` 内容配置校验逻辑，从原来要求单个 `HttpFormData` 实例改为要求 `form-data` 条目列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support array and file variables in HTTP form-data uploads and fix remote file download handling in the workflow HTTP request node.

New Features:
- Allow form-data file fields to accept both single file variables and arrays of file variables for upload.

Bug Fixes:
- Ensure remote file downloads follow HTTP redirects when fetching file variable content.
- Correct form-data content configuration validation to require a list of form-data items rather than a single HttpFormData instance.

</details>