### PR TITLE
fix(web): adjust the value of End User Name

### DIFF
--- a/web/src/views/UserMemoryDetail/Neo4j.tsx
+++ b/web/src/views/UserMemoryDetail/Neo4j.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:57:26 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-26 18:59:53
+ * @Last Modified time: 2026-04-14 16:04:08
  */
 /**
  * Neo4j User Memory Detail View
@@ -22,7 +22,7 @@ import InterestDistribution from './components/InterestDistribution'
 import NodeStatistics from './components/NodeStatistics'
 import RelationshipNetwork from './components/RelationshipNetwork'
 import MemoryInsight from './components/MemoryInsight'
-import type { EndUserProfileRef, MemoryInsightRef, AboutMeRef } from './types'
+import type { EndUserProfileRef, MemoryInsightRef, AboutMeRef, EndUser } from './types'
 import {
   analyticsRefresh,
 } from '@/api/memory'
@@ -39,8 +39,10 @@ const Neo4j: FC = () => {
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
 
   /** Update displayed name */
-  const handleNameUpdate = (data: { other_name?: string; id: string }) => {
-    setName(data.other_name && data.other_name !== '' ? data.other_name : data.id)
+  const handleNameUpdate = (data?: EndUser) => {
+    if (!data) return
+    let name = data.other_name && data.other_name !== '' ? data.other_name : data.id || data.end_user_id
+    setName(name)
   }
 
   /** Navigate back */

--- a/web/src/views/UserMemoryDetail/components/EndUserProfile.tsx
+++ b/web/src/views/UserMemoryDetail/components/EndUserProfile.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 18:33:30 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-27 11:11:09
+ * @Last Modified time: 2026-04-14 16:03:41
  */
 /**
  * End User Profile Component
@@ -27,11 +27,11 @@ import type { EndUser, EndUserProfileModalRef, EndUserProfileRef } from '../type
  * Component props
  */
 interface EndUserProfileProps {
-  onDataLoaded?: (data: { other_name?: string; id: string }) => void;
+  onDataLoaded?: (data?: EndUser) => void;
   className?: string;
 }
 
-const EndUserProfile = forwardRef<EndUserProfileRef, EndUserProfileProps>(({ className }, ref) => {
+const EndUserProfile = forwardRef<EndUserProfileRef, EndUserProfileProps>(({ className, onDataLoaded }, ref) => {
   const { t } = useTranslation()
   const { id } = useParams()
   const endUserProfileModalRef = useRef<EndUserProfileModalRef>(null)
@@ -51,6 +51,7 @@ const EndUserProfile = forwardRef<EndUserProfileRef, EndUserProfileProps>(({ cla
       const userData = res as EndUser
       setData(userData)
       setLoading(false) 
+      onDataLoaded?.(userData as EndUser)
     })
     .finally(() => {
       setLoading(false)

--- a/web/src/views/UserMemoryDetail/types.ts
+++ b/web/src/views/UserMemoryDetail/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:57:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-24 17:58:54
+ * @Last Modified time: 2026-04-14 16:03:16
  */
 /**
  * User Memory Detail Types
@@ -172,6 +172,7 @@ export interface EndUser {
   other_name: string;
   aliases: string | null;
   meta_data: Record<string, string>;
+  id?: string;
   end_user_info_id: string;
   end_user_id: string;
   created_at: string;


### PR DESCRIPTION
## Summary by Sourcery

在“用户记忆详情”视图中调整终端用户名称处理逻辑，使用完整的 EndUser 负载，并支持多个标识字段。

Bug 修复：
- 修正终端用户显示名称的解析逻辑：优先使用 `other_name`，在可用时回退到 `id` 或 `end_user_id`。

增强功能：
- 通过更新回调函数签名，将在 EndUserProfile 中加载的 EndUser 对象向上传递给其父组件。
- 为 EndUser 类型扩展一个可选的 `id` 字段，以与用于显示名称的数据保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust end user name handling in the User Memory Detail view to use the full EndUser payload and support multiple identifier fields.

Bug Fixes:
- Correct end user display name resolution by preferring other_name and falling back to id or end_user_id when available.

Enhancements:
- Propagate the loaded EndUser object from EndUserProfile to its parent via an updated callback signature.
- Extend the EndUser type with an optional id field to align with the data used for display names.

</details>