### PR TITLE
fix(web): Hide error message when workflow node error message equals …

### DIFF
--- a/web/src/views/Workflow/components/Chat/Runtime.tsx
+++ b/web/src/views/Workflow/components/Chat/Runtime.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-24 17:57:08 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-07 14:05:50
+ * @Last Modified time: 2026-04-14 16:33:33
  */
 /*
  * Runtime Component
@@ -161,8 +161,7 @@ const Runtime: FC<{ item: ChatItem; index: number;}> = ({
                 children: (
                   <Flex gap={8} vertical>
                     {/* Display error message for failed nodes */}
-
-                    {item.error &&
+                    {vo.content?.error && vo.content?.error !== '' &&
                       <RbAlert color="orange" className="rb:pb-0!">
                         <Flex vertical className="rb:w-full!">
                           <Flex align="center" justify="space-between">
@@ -219,11 +218,11 @@ const Runtime: FC<{ item: ChatItem; index: number;}> = ({
     </div>
   }
 
-    /** Copy value to clipboard and show success message */
-    const handleCopy = (value: string) => {
-      copy(value)
-      message.success(t('common.copySuccess'))
-    }
+  /** Copy value to clipboard and show success message */
+  const handleCopy = (value: string) => {
+    copy(value)
+    message.success(t('common.copySuccess'))
+  }
 
   return (
     <div
@@ -269,7 +268,7 @@ const Runtime: FC<{ item: ChatItem; index: number;}> = ({
             </div>
           )
           : <div className="rb:mb-4">
-            {item.error &&
+            {item.error && item.error !== '' &&
               <RbAlert color="orange" className="rb:pb-0! rb:mb-2!"><Markdown content={item.error} /></RbAlert>
             }
             {renderChild(item.subContent)}

--- a/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:35:43 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-02 17:17:06
+ * @Last Modified time: 2026-04-14 17:36:53
  */
 import { type FC, useMemo, useRef, useState } from "react";
 import { useTranslation } from 'react-i18next'
@@ -35,9 +35,8 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
     form.setFieldsValue({ auth })
   }
 
-  const handleChangeBodyContentType = (e: any) => {
-    const value = e.target.value || e.target.value
-    form.setFieldValue(['body', 'data'], ['form-data', 'x-www-form-urlencoded'].includes(value) ? [{}] : undefined)
+  const handleChangeBodyContentType = () => {
+    form.setFieldValue(['body', 'data'], undefined)
   }
 
   // Handle error handling method change and update node ports accordingly

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-14 15:05:33
+ * @Last Modified time: 2026-04-14 17:43:14
  */
 import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, type Edge } from '@antv/x6';
 import { register } from '@antv/x6-react-shape';
@@ -1200,9 +1200,6 @@ export const useWorkflowGraph = ({
       }) || [];
       const edges = graphRef.current?.getEdges() || []
 
-
-      console.log('config', config)
-
       const params = {
         ...config,
         features: featuresRef.current,
@@ -1261,6 +1258,14 @@ export const useWorkflowGraph = ({
                   value.forEach((vo: any) => {
                     itemConfig[key][vo.key] = vo.value
                   })
+                }
+              } else if (data.type === 'http-request' && key === 'body' && data.config[key] && 'defaultValue' in data.config[key]) {
+                const value = data.config[key].defaultValue
+                itemConfig[key] = value
+                if (value.content_type === 'json' && value.data && value.data !== '') {
+                  itemConfig[key].data = value.data.replace(/\u00a0/g, ' ')
+                } else {
+                  itemConfig[key].data = value.data
                 }
               } else if (data.config[key] && 'defaultValue' in data.config[key] && key !== 'knowledge_retrieval') {
                 itemConfig[key] = data.config[key].defaultValue


### PR DESCRIPTION
…empty string

## Summary by Sourcery

确保工作流聊天运行时只显示非空错误消息，并保持剪贴板复制行为。

Bug 修复：
- 当工作流节点错误消息为空字符串时，隐藏节点级错误警报。
- 当工作流条目错误消息为空字符串时，隐藏条目级错误警报。

增强：
- 整理运行时聊天组件中的剪贴板复制处理程序定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure workflow chat runtime only displays non-empty error messages and maintain clipboard copy behavior.

Bug Fixes:
- Hide node-level error alerts when the workflow node error message is an empty string.
- Hide item-level error alerts when the workflow item error message is an empty string.

Enhancements:
- Tidy the clipboard copy handler definition in the runtime chat component.

</details>