### PR TITLE
fix(rag)

### DIFF
--- a/api/app/core/rag/deepdoc/parser/excel_parser.py
+++ b/api/app/core/rag/deepdoc/parser/excel_parser.py
@@ -232,14 +232,14 @@ class RAGExcelParser:
                         t = str(ti[i].value) if i < len(ti) else ""
                         t += ("：" if t else "") + str(c.value)
                         fields.append(t)
-                    line = "; ".join(fields)
+                    line = "\n".join(fields)
                     if sheetname.lower().find("sheet") < 0:
-                        line += " ——" + sheetname
+                        line += "\n——" + sheetname
                     res.append(line)
             else:
                 # 只有表头的情况
                 if header_fields:
-                    line = "; ".join(header_fields)
+                    line = "\n".join(header_fields)
                     if sheetname.lower().find("sheet") < 0:
                         line += " ——" + sheetname
                     res.append(line)


### PR DESCRIPTION
replace semicolon separators with newlines in Excel parser output

## Summary by Sourcery

错误修复：
- 修正 Excel 解析器的单元格拼接方式，将字段与工作表注释以换行符分隔，以改进后续处理效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct Excel parser cell concatenation to separate fields and sheet annotations with newlines for improved downstream processing.

</details>