### PR TITLE
feat(web): Keep the last 4 characters of the API key as original

### DIFF
--- a/web/src/utils/apiKeyReplacer.ts
+++ b/web/src/utils/apiKeyReplacer.ts
@@ -43,7 +43,8 @@ export const maskApiKeys = (text: string): string => {
     result = result.replace(API_KEY_PATTERNS[key as keyof typeof API_KEY_PREFIX], (match) => {
       const prefixLength = API_KEY_PREFIX[key].length
       const prefix = match.substring(0, prefixLength)
-      return prefix + '*'.repeat(match.length - prefixLength)
+      const suffix = match.slice(-4)
+      return prefix + '*'.repeat(match.length - prefixLength - 4) + suffix
     })
   })
 


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 更新 API 密钥掩码逻辑，将只保留最后四个字符可见，而不是将整个后缀全部掩码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update API key masking logic to keep the last four characters visible instead of masking the entire suffix.

</details>