### PR TITLE
feat(web): agent support reset model config

### DIFF
--- a/web/src/api/application.ts
+++ b/web/src/api/application.ts
@@ -175,3 +175,7 @@ export const getAppLogsUrl = (app_id: string) => `/apps/${app_id}/logs`
 export const getAppLogDetail = (app_id: string, conversation_id: string) => {
   return request.get(`/apps/${app_id}/logs/${conversation_id}`)
 }
+// Reset agent model config to default
+export const resetAppModelConfig = (app_id: string) => {
+  return request.get(`/apps/${app_id}/model/parameters/default`)
+}

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -11,14 +11,16 @@
  */
 
 import { forwardRef, useImperativeHandle, useState, useEffect } from 'react';
-import { Form, type SelectProps, Checkbox } from 'antd';
+import { Form, type SelectProps, Checkbox, Button } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 
 import type { ModelConfig, ModelConfigModalRef, Config, Source } from '../types'
 import type { Model } from '@/views/ModelManagement/types'
 import RbModal from '@/components/RbModal'
 import RbSlider from '@/components/RbSlider'
 import ModelSelect from '@/components/ModelSelect'
+import { resetAppModelConfig } from '@/api/application';
 
 const FormItem = Form.Item;
 
@@ -52,6 +54,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
   data,
 }, ref) => {
   const { t } = useTranslation();
+  const { id } = useParams();
   const [visible, setVisible] = useState(false);
   const [form] = Form.useForm<ModelConfig>();
   const [source, setSource] = useState<Source>('model')
@@ -124,14 +127,23 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
     form.setFieldsValue(rest)
   }, [values?.default_model_config_id])
 
+  const handleReset = () => {
+    if (!id) return
+    resetAppModelConfig(id).then((res) => {
+      const { deep_thinking: _, json_output: __, ...rest } = (res || {}) as Config['model_parameters']
+      form.setFieldsValue(rest)
+    })
+  }
+
   return (
     <RbModal
       title={t('application.modelConfig')}
       open={visible}
       onCancel={handleClose}
-      cancelText={t('application.resetDefault')}
-      okText={t('application.apply')}
-      onOk={handleSave}
+      footer={[
+        <Button onClick={handleReset}>{t('application.resetDefault')}</Button>,
+        <Button type="primary" onClick={handleSave}>{t('application.apply')}</Button>,
+      ]}
     >
       <Form
         form={form}


### PR DESCRIPTION
## Summary by Sourcery

为应用的代理模型配置添加支持，可在模型配置弹窗中将其重置为默认值。

新功能：
- 引入一个 API 助手方法，用于将应用的模型参数重置为默认配置。
- 在模型配置弹窗中提供“重置为默认值”操作，并将其连接到新的重置端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resetting an application's agent model configuration back to its default values from the model configuration modal.

New Features:
- Introduce an API helper to reset an application's model parameters to their default configuration.
- Expose a reset-to-default action in the model configuration modal, wiring it to the new reset endpoint.

</details>