### PR TITLE
feat(web): icon update

### DIFF
--- a/web/src/assets/images/application/export.svg
+++ b/web/src/assets/images/application/export.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>导出</title>
+    <g id="空间里层页面优化" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-573, -158)" stroke="#171719">
+            <g id="导出" transform="translate(573, 158)">
+                <g id="编组-54" transform="translate(3, 3)">
+                    <path d="M10,6 L10,7.5 C10,8.88071187 8.88071187,10 7.5,10 L2.5,10 C1.11928813,10 0,8.88071187 0,7.5 L0,6 L0,6" id="路径"></path>
+                    <g id="编组-11" transform="translate(2, 0)">
+                        <line x1="3" y1="0.08499952" x2="3" y2="6.99635859" id="路径-24"></line>
+                        <polyline id="路径-25" stroke-linejoin="round" points="0 3 2.98005548 6.08298138e-18 6 3"></polyline>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/web/src/assets/images/application/import.svg
+++ b/web/src/assets/images/application/import.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>导入</title>
+    <g id="空间里层页面优化" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-555, -158)" stroke="#171719">
+            <g id="导入" transform="translate(555, 158)">
+                <g id="编组-54" transform="translate(3, 3)">
+                    <path d="M10,6 L10,7.5 C10,8.88071187 8.88071187,10 7.5,10 L2.5,10 C1.11928813,10 0,8.88071187 0,7.5 L0,6 L0,6" id="路径"></path>
+                    <g id="编组-11" transform="translate(5, 3.4982) scale(1, -1) translate(-5, -3.4982)translate(2, 0)">
+                        <line x1="3" y1="0.08499952" x2="3" y2="6.99635859" id="路径-24"></line>
+                        <polyline id="路径-25" stroke-linejoin="round" points="0 3 2.98005548 6.08298138e-18 6 3"></polyline>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-13 18:19:27
+ * @Last Modified time: 2026-04-17 14:53:21
  */
 import { type FC, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -37,7 +37,8 @@ const sharingTabKeys = [
 const menuIcons: Record<string, string> = {
   edit: "rb:bg-[url('@/assets/images/common/edit_bold.svg')]",
   copy: "rb:bg-[url('@/assets/images/copy_hover.svg')]",
-  export: "rb:bg-[url('@/assets/images/export_hover.svg')]",
+  export: "rb:bg-[url('@/assets/images/application/export.svg')]",
+  uploadCover: "rb:bg-[url('@/assets/images/application/import.svg')]",
   delete: "rb:bg-[url('@/assets/images/common/delete_red_big.svg')]"
 }
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

更新应用配置页标题中的图标，使用新的导出图标资源，并新增专用的上传封面图标。

新功能：
- 为应用配置页标题菜单新增一个“上传封面”图标的映射。

改进：
- 将应用配置页标题中的导出图标替换为新的、针对本应用的 SVG 资源。
- 为应用导出和导入图标新增 SVG 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update application configuration header icons to use new export artwork and introduce a dedicated upload cover icon.

New Features:
- Add a new upload cover icon mapping to the application config header menu.

Enhancements:
- Replace the export icon in the application config header with a new application-specific SVG asset.
- Add new SVG assets for application export and import icons.

</details>