### PR TITLE
refactor(memory): insert new metadata values at list head for recency…

### DIFF
--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -401,12 +401,21 @@ class UserMemoryService:
             # 构建响应数据（转换时间为毫秒时间戳）
             # 将 meta_data 中的 profile、knowledge_tags、behavioral_hints 平铺到顶层
             meta = end_user_info_record.meta_data or {}
+
+            # profile 列表字段截断：只返回前 MAX_PROFILE_LIST_SIZE 条（按时间从新到旧）
+            MAX_PROFILE_LIST_SIZE = 5
+            profile = meta.get("profile")
+            if isinstance(profile, dict):
+                for key in ("role", "domain", "expertise", "interests"):
+                    if isinstance(profile.get(key), list):
+                        profile[key] = profile[key][:MAX_PROFILE_LIST_SIZE]
+
             response_data = {
                 "end_user_info_id": str(end_user_info_record.id),
                 "end_user_id": str(end_user_info_record.end_user_id),
                 "other_name": end_user_info_record.other_name,
                 "aliases": end_user_info_record.aliases,
-                "profile": meta.get("profile"),
+                "profile": profile,
                 "knowledge_tags": meta.get("knowledge_tags"),
                 "behavioral_hints": meta.get("behavioral_hints"),
                 "created_at": datetime_to_timestamp(end_user_info_record.created_at),

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3160,7 +3160,8 @@ def extract_user_metadata_task(
 
                         if action == "set":
                             if value not in current_list:
-                                current_list.append(value)
+                                # 新值插入列表头部，保证按时间从新到旧排序
+                                current_list.insert(0, value)
                                 target[leaf] = current_list
                             logger.info(f"[CELERY METADATA] set {field_path} = {value}")
 
@@ -3223,7 +3224,8 @@ def extract_user_metadata_task(
                         leaf = parts[-1]
                         current_list = target.get(leaf, [])
                         if change.value not in current_list:
-                            current_list.append(change.value)
+                            # 新值插入列表头部，保证按时间从新到旧排序
+                            current_list.insert(0, change.value)
                         target[leaf] = current_list
 
                 if first_alias or initial_meta:


### PR DESCRIPTION
… ordering

Change list.append() to list.insert(0, ...) in extract_user_metadata_task so that newly extracted user metadata values appear at the front of each field list, maintaining a newest-first ordering.

## Summary by Sourcery

增强功能：
- 将新的用户元数据值存储在各自列表的开头，以保持基于最近使用的排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Store new user metadata values at the head of their respective lists to maintain recency-based ordering.

</details>