### PR TITLE
Feature/if else zy

### DIFF
--- a/web/src/views/Workflow/components/Properties/CaseList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CaseList/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:24:53 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-17 19:58:13
+ * @Last Modified time: 2026-04-17 20:45:31
  */
 import { useEffect, useMemo, type FC } from 'react'
 import clsx from 'clsx'
@@ -23,7 +23,7 @@ interface SubCondition {
   key: string;
   operator: string;
   value: string | number;
-  var_type: string;
+  input_type: string;
 }
 
 interface SubVariableCondition {
@@ -303,7 +303,7 @@ const ArrayFileSubConditions: FC<ArrayFileSubConditionsProps> = ({ conditionFiel
                 })}
               </div>
               <Button
-                onClick={() => { addSub({ key: undefined, operator: undefined, value: undefined, var_type: undefined }); }}
+                onClick={() => { addSub({ key: undefined, operator: undefined, value: undefined, input_type: undefined }); }}
                 className="rb:py-0! rb:px-1! rb:h-4.5! rb:rounded-sm! rb:text-[12px]!"
                 size="small"
               >

--- a/web/src/views/Workflow/components/Properties/CaseList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CaseList/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:24:53 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-17 20:45:31
+ * @Last Modified time: 2026-04-17 20:47:49
  */
 import { useEffect, useMemo, type FC } from 'react'
 import clsx from 'clsx'
@@ -22,8 +22,8 @@ import { typeOptions } from '../ListOperator/FilterConditions'
 interface SubCondition {
   key: string;
   operator: string;
-  value: string | number;
-  input_type: string;
+  value?: string | number;
+  input_type?: string;
 }
 
 interface SubVariableCondition {
@@ -32,8 +32,8 @@ interface SubVariableCondition {
 }
 
 interface Expression {
-  left: string;
-  operator: string;
+  left?: string;
+  operator?: string;
   right?: string | number;
   input_type?: string;
   sub_variable_condition?: SubVariableCondition;


### PR DESCRIPTION
## Summary by Sourcery

放宽对条件表达式中 case 列表的类型要求，并使字段命名与输入类型的使用保持一致。

增强内容：
- 使子条件中的 `value` 和 `input_type` 变为可选，同时允许 case 列表属性中的表达式将 `left`/`operator` 设为可选。
- 在子条件初始化中将 `var_type` 重命名为 `input_type`，以匹配更新后的类型定义和语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax type requirements for case list condition expressions and align field naming with input type usage.

Enhancements:
- Make value and input_type optional on sub-conditions and allow left/operator to be optional on expressions in case list properties.
- Rename var_type to input_type in sub-condition initialization to match updated typing and semantics.

</details>