### PR TITLE
fix(api): make unused message body parameter optional in create_end_user

### DIFF
--- a/api/app/controllers/service/end_user_api_controller.py
+++ b/api/app/controllers/service/end_user_api_controller.py
@@ -47,7 +47,7 @@ async def create_end_user(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
-    message: str = Body(..., description="Request body"),
+    message: str = Body(None, description="Request body"),
 ):
     """
     Create or retrieve an end user for the workspace.


### PR DESCRIPTION
Change Body(...) to Body(None) for the message parameter which is never used directly (request body is read via request.json() instead). The required marker caused unnecessary 422 validation errors.

## Summary by Sourcery

错误修复：
- 将 `create_end_user` 端点的消息主体参数设为可选，以防止出现多余的 422 验证失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Make the create_end_user endpoint's message body parameter optional to prevent spurious 422 validation failures.

</details>