### PR TITLE
Fix/v0.3.1 zy

### DIFF
--- a/web/src/views/ApplicationManagement/components/UploadModal.tsx
+++ b/web/src/views/ApplicationManagement/components/UploadModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-28 14:08:14 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-13 18:17:32
+ * @Last Modified time: 2026-04-20 16:52:32
  */
 /**
  * UploadModal Component
@@ -16,6 +16,7 @@
 import { forwardRef, useImperativeHandle, useState, useMemo } from 'react';
 import { Form, Steps, Flex, Alert, Button, Result, message } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 
 import type { Application, UploadModalRef } from '../types'
 import RbModal from '@/components/RbModal'
@@ -51,6 +52,7 @@ const UploadModal = forwardRef<UploadModalRef, UploadModalProps>(({
   id
 }, ref) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   // State management
   const [visible, setVisible] = useState(false);           // Modal visibility
@@ -146,6 +148,10 @@ const UploadModal = forwardRef<UploadModalRef, UploadModalProps>(({
             window.open(`/#/application/config/${appId}`, '_blank');
           }
           break;
+        case 'list':
+          if (id) {
+            navigate('/application')
+          }
       }
     }, 100)
   };

--- a/web/src/views/MemoryConversation/index.tsx
+++ b/web/src/views/MemoryConversation/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:09:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-31 12:21:56
+ * @Last Modified time: 2026-04-20 16:59:25
  */
 /**
  * Memory Conversation Page
@@ -78,8 +78,8 @@ interface DataItem {
     id: string;
     question: string;
     type: string;
-    reason: string;
-  }
+    reason?: string;
+}
 /**
  * Log item for conversation analysis
  */
@@ -88,13 +88,15 @@ export interface LogItem {
   title: string;
   data?: DataItem[] | AnyObject;
   raw_results?: string | Record<string, AnyObject>;
+  raw_result?: Array<AnyObject>;
   summary?: string;
   query?: string;
   reason?: string;
   result?: string;
-  original_query: string;
+  original_query?: string;
   index?: number;
   result_count?: number;
+  total?: number;
 }
 
 /**
@@ -242,7 +244,6 @@ const MemoryConversation: FC = () => {
                           <ContentWrapper key={vo.id}>
                             <>
                               <div className="rb:font-medium rb:text-[#212332]">{vo.id}. {vo.question}</div>
-                              <div className="rb:mt-2 rb:text-[#5B6167]">{vo.reason}</div>
                             </>
                           </ContentWrapper>
                         ))}
@@ -260,25 +261,9 @@ const MemoryConversation: FC = () => {
                           </ContentWrapper>
                         ))}
                       </Flex>
-                      : log.type === 'search_result' && log.raw_results && typeof log.raw_results !== 'string'
+                      : log.type === 'search_result' && log.result
                       ? <ContentWrapper>
-                          <div className="rb:font-medium rb:text-[#212332] rb:mb-2">{log.query}</div>
-                          {(log.raw_results.reranked_results as AnyObject)?.communities?.length > 0 && <>
-                            <div className="rb:font-medium rb:text-[#212332]">{t('memoryConversation.communities')}</div>
-                            <ul className='rb:mt-2 rb:text-[#5B6167] rb:list-disc rb:pl-4'>
-                                {((log.raw_results.reranked_results as AnyObject)?.communities as { content: string }[]).map((item, index: number) => (
-                                <li key={index}>{item.content}</li>
-                              ))}
-                            </ul>
-                          </>}
-                          {(log.raw_results.reranked_results as AnyObject)?.summaries?.length > 0 && <>
-                            <div className="rb:font-medium rb:text-[#212332]">{t('memoryConversation.summaries')}</div>
-                            <ul className='rb:mt-2 rb:text-[#5B6167] rb:list-disc rb:pl-4'>
-                              {((log.raw_results.reranked_results as AnyObject)?.summaries as { content: string }[]).map((item, index: number) => (
-                                <li key={index}>{item.content}</li>
-                              ))}
-                            </ul>
-                          </>}
+                          <Markdown content={log.result} />
                         </ContentWrapper>
                     : log.type === 'retrieval_summary' && log.summary
                     ? <ContentWrapper>


### PR DESCRIPTION
## Summary by Sourcery

放宽内存会话日志条目的类型限制并调整搜索结果的 UI 渲染方式，同时在摄取完成后更新上传行为。

增强内容：
- 将内存会话数据模型中的部分字段改为可选，以支持更灵活的日志载荷格式。
- 简化内存会话搜索结果的展示方式，将最终结果渲染为 Markdown，而不是结构化的社区和摘要列表。
- 在内存会话列表视图中停止显示问题原因文本，以获得更简洁的界面。
- 在配置允许的情况下，上传并成功完成摄取后，从上传弹窗添加返回应用列表视图的导航。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax memory conversation log item types and adjust UI rendering of search results while updating upload behavior after ingestion.

Enhancements:
- Make certain fields in memory conversation data models optional to support more flexible log payloads.
- Simplify memory conversation search result display to render the final result as Markdown instead of structured community and summary lists.
- Stop displaying the question reason text in the memory conversation list view for a cleaner UI.
- Add navigation from the upload modal back to the application list view after a successful ingestion when configured.

</details>