### PR TITLE
fix(memory): use end_user.workspace_id instead of app.workspace_id in…

### DIFF
--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -1280,7 +1280,7 @@ def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, An
     }
 
     logger.info(
-        f"Successfully retrieved connected config: memory_config_id={memory_config_id}, workspace_id={app.workspace_id}")
+        f"Successfully retrieved connected config: memory_config_id={memory_config_id}, workspace_id={end_user.workspace_id}")
     return result
 
 


### PR DESCRIPTION
… log message

Corrected variable reference in get_end_user_connected_config log statement. The previous code referenced app.workspace_id which could be incorrect or undefined in this context.

## 由 Sourcery 提供的摘要

错误修复：
- 通过使用 `end_user.workspace_id`，修复了 `get_end_user_connected_config` 日志输出中 `workspace_id` 值不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect workspace_id value in get_end_user_connected_config log output by using end_user.workspace_id.

</details>