### PR TITLE
fix(web): check list add vision_input

### DIFF
--- a/web/src/components/ModelSelect/index.tsx
+++ b/web/src/components/ModelSelect/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-07 16:49:59 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-17 10:11:54
+ * @Last Modified time: 2026-04-20 18:14:34
  */
 import { type FC, useEffect, useState } from 'react';
 import { Select, Flex, Space } from 'antd';
@@ -56,7 +56,7 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
 
   useEffect(() => {
     if (updateOptions) updateOptions([...options, ...initialData]);
-  }, [options, initialData])
+  }, [JSON.stringify(options), JSON.stringify(initialData)])
 
   return (
     <Select

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2537,6 +2537,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       checkListErrors: {
         'llm.model_id': 'Model',
         'llm.messages': 'Messages',
+        'llm.vision_input': 'Vision Variable',
         'end.output': 'Output',
         'knowledge-retrieval.knowledge_retrieval': 'Knowledge bases',
         'parameter-extractor.model_id': 'Model',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2501,6 +2501,7 @@ export const zh = {
       checkListErrors: {
         'llm.model_id': '模型',
         'llm.messages': '提示词',
+        'llm.vision_input': '视觉变量',
         'end.output': '回复',
         'knowledge-retrieval.knowledge_retrieval': '知识库',
         'parameter-extractor.model_id': '模型',

--- a/web/src/views/Workflow/components/CheckList/index.tsx
+++ b/web/src/views/Workflow/components/CheckList/index.tsx
@@ -106,6 +106,18 @@ function validateNode(type: string, config: Record<string, any>): CheckError[] {
     if (isInvalid) errors.push({ key: specialKey, message: '' })
   })
 
+  // llm: vision_input required when vision is enabled
+  if (type === 'llm') {
+    const vision = get('vision')
+    if (vision === true || vision === 'true') {
+      const visionInput = get('vision_input')
+      console.log('vision', vision, isEmpty(visionInput))
+      if (isEmpty(visionInput)) {
+        errors.push({ key: 'llm.vision_input', message: '' })
+      }
+    }
+  }
+
   // http-request body.data (binary) — not a top-level required field, check separately
   if (type === 'http-request') {
     const body = get('body')


### PR DESCRIPTION
## Summary by Sourcery

当启用视觉功能时，对 LLM 工作流节点的视觉输入配置进行强制校验，并相应调整相关的 UI 行为和标签。

Bug Fixes:
- 当启用视觉功能时，要求 LLM 节点必须配置视觉输入，以防止工作流配置不完整。
- 通过让副作用依赖于序列化后的选项，而不是直接依赖数组引用，来稳定模型选择选项的更新行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce vision input configuration validation for LLM workflow nodes when vision is enabled and adjust related UI behavior and labels.

Bug Fixes:
- Require an LLM node vision input when vision is enabled to prevent incomplete workflow configuration.
- Stabilize model selection option updates by making the effect depend on serialized options instead of direct array references.

</details>