### PR TITLE
Fix/v0.3.1 zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/Knowledge/Knowledge.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/Knowledge.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:25:32 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-04 10:34:43
+ * @Last Modified time: 2026-04-21 13:34:52
  */
 /**
  * Knowledge Base Component
@@ -54,7 +54,7 @@ const Knowledge: FC<{value?: KnowledgeConfig; onChange?: (config: KnowledgeConfi
       const basesWithoutName = knowledge_bases.filter(base => !base.name)
       if (basesWithoutName.length > 0) {
         // Call API to get complete knowledge base information
-        getKnowledgeBaseList().then(res => {
+        getKnowledgeBaseList(undefined, { kb_ids: basesWithoutName.map(vo => vo.kb_id).join(',') }).then(res => {
           const fullBases = knowledge_bases.map(base => {
             if (!base.name) {
               const fullBase = res.items.find((item: any) => item.id === base.kb_id)

--- a/web/src/views/ModelManagement/components/CustomModelModal.tsx
+++ b/web/src/views/ModelManagement/components/CustomModelModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:28 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 18:03:53
+ * @Last Modified time: 2026-04-21 15:02:53
  */
 /**
  * Custom Model Modal
@@ -230,21 +230,23 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
           <Input.TextArea placeholder={t('common.pleaseEnter')} />
         </Form.Item>
 
-        <Form.Item
-          name={["api_keys", 0, "api_key"]}
-          label={t('modelNew.api_key')}
-          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_key') }) }]}
-        >
-          <Input.Password placeholder={t('common.pleaseEnter')} />
-        </Form.Item>
+        {!isEdit && <>
+          <Form.Item
+            name={["api_keys", 0, "api_key"]}
+            label={t('modelNew.api_key')}
+            rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_key') }) }]}
+          >
+            <Input.Password placeholder={t('common.pleaseEnter')} />
+          </Form.Item>
 
-        <Form.Item
-          name={["api_keys", 0, "api_base"]}
-          label={t('modelNew.api_base')}
-          rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_base') }) }]}
-        >
-          <Input placeholder="https://api.example.com/v1" />
-        </Form.Item>
+          <Form.Item
+            name={["api_keys", 0, "api_base"]}
+            label={t('modelNew.api_base')}
+            rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('modelNew.api_base') }) }]}
+          >
+            <Input placeholder="https://api.example.com/v1" />
+          </Form.Item>
+        </>}
 
         {['llm', 'chat'].includes(modelType as string) &&
           <Row gutter={16}>

--- a/web/src/views/Workflow/components/Properties/Knowledge/Knowledge.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/Knowledge.tsx
@@ -29,12 +29,13 @@ const Knowledge: FC<{value?: KnowledgeConfig; onChange?: (config: KnowledgeConfi
     if (value && JSON.stringify(value) !== JSON.stringify(editConfig)) {
       setEditConfig({ ...(value || {}) })
       const knowledge_bases = [...(value.knowledge_bases || [])]
+      setKnowledgeList(knowledge_bases)
       
       // 检查是否有knowledge_bases缺少name字段
       const basesWithoutName = knowledge_bases.filter(base => !base.name)
       if (basesWithoutName.length > 0) {
         // 调用接口获取完整的知识库信息
-        getKnowledgeBaseList().then(res => {
+        getKnowledgeBaseList(undefined, { kb_ids: basesWithoutName.map(vo => vo.kb_id).join(',') }).then(res => {
           const fullBases = knowledge_bases.map(base => {
             if (!base.name) {
               const fullBase = res.items.find((item: any) => item.id === base.kb_id)


### PR DESCRIPTION
## Summary by Sourcery

调整自定义模型弹窗和知识库加载行为，更好地处理编辑场景和部分已填充的知识库条目。

Bug 修复：
- 在编辑已有自定义模型时隐藏 API Key 和 Base URL 字段，以避免强制进行不必要的凭据修改。
- 在应用和工作流视图中，通过将知识库 ID 传给知识库列表 API，仅请求那些名称缺失的特定知识库配置。
- 确保工作流中的知识属性根据当前的配置值初始化显示的知识列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust custom model modal and knowledge base loading behaviour to better handle edit scenarios and partially populated knowledge base entries.

Bug Fixes:
- Hide API key and base URL fields when editing an existing custom model to avoid forcing unnecessary credential changes.
- Request only specific knowledge bases missing names when loading configurations by passing their IDs to the knowledge base list API in application and workflow views.
- Ensure workflow knowledge properties initialise the displayed knowledge list from the current value configuration.

</details>