### PR TITLE
fix(web): package support unlimited

### DIFF
--- a/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
+++ b/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
@@ -2,11 +2,11 @@
  * @Author: ZhaoYing 
  * @Date: 2026-04-14 12:28:23 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 17:34:02
+ * @Last Modified time: 2026-04-21 15:46:35
  */
 
 import { useState, forwardRef, useImperativeHandle } from 'react';
-import { Flex, Tooltip, Divider } from 'antd';
+import { Flex, Divider } from 'antd';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -82,8 +82,7 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef>((_props, 
       {/* Features */}
       <Flex gap={12} vertical className="rb:space-y-3 rb:mb-4 rb:h-[calc(100vh-341px)]! rb:overflow-y-auto">
         {billingUnits.map(({ key, unit, icon }) => {
-          const value = detail?.quotas[key as keyof Subscription['quotas']];
-          if (value === undefined || value === null) return null;
+          const value = detail?.quotas?.[key as keyof Subscription['quotas']];
           return (
             <UnitWrapper
               key={key}
@@ -95,7 +94,7 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef>((_props, 
             />
           )
         })}
-        {detail?.package_plan?.tech_support && (
+        {detail?.package_plan?.tech_support && detail?.package_plan?.[getKeyWithLanguage('tech_support')] && (
           <UnitWrapper
             titleKey="tech_support"
             value={String(detail?.package_plan?.[getKeyWithLanguage('tech_support')] ?? '')}
@@ -103,7 +102,7 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef>((_props, 
             theme_color={detail?.package_plan?.theme_color}
           />
         )}
-        {detail?.package_plan?.sla_compliance && (
+        {detail?.package_plan?.sla_compliance && detail?.package_plan?.[getKeyWithLanguage('sla_compliance')] && (
           <UnitWrapper
             titleKey="sla"
             value={String(detail?.package_plan?.[getKeyWithLanguage('sla_compliance')] ?? '')}

--- a/web/src/components/SiderMenu/index.tsx
+++ b/web/src/components/SiderMenu/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 15:25:31 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-20 10:15:20 
+ * @Last Modified time: 2026-04-21 15:46:03
  */
 /**
  * SiderMenu Component
@@ -417,7 +417,7 @@ const Menu: FC<{
           <div className="rb:grid rb:grid-cols-4 rb:mt-4">
             {['workspace_quota', 'skill_quota', 'app_quota', 'model_quota'].map(key => (
               <div key={key} className="rb:text-center">
-                <div className="rb:text-[13px] rb:font-[MiSans-Semibold] rb:font-semibold">{subscription.quotas?.[key as keyof typeof subscription.quotas]}</div>
+                <div className="rb:text-[13px] rb:font-[MiSans-Semibold] rb:font-semibold">{subscription.quotas?.[key as keyof typeof subscription.quotas] ?? t('package.noLimit')}</div>
                 <div className="rb:mt-1 rb:text-[#5B6167] rb:text-[10px] rb:leading-3.5">{t(`index.${key}`)}</div>
               </div>
             ))}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -3093,6 +3093,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       editPackage: 'Edit Package',
 
       viewDetail: 'View full package details',
+      noLimit: 'Unlimited',
     },
   },
 };

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -3057,6 +3057,7 @@ export const zh = {
       editPackage: '编辑套餐',
 
       viewDetail: '查看完整套餐详情',
+      noLimit: '不限制',
     },
   },
 }

--- a/web/src/views/Package/constant.ts
+++ b/web/src/views/Package/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-04-14 11:43:57 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-14 11:44:40
+ * @Last Modified time: 2026-04-21 15:44:13
  */
 export const billingUnits = [
   {
@@ -42,7 +42,7 @@ export const billingUnits = [
   },
   {
     key: 'model_quota',
-    unit: 'ops', placeholder: 'numberPlaceholder',
+    unit: 'pcs', placeholder: 'numberPlaceholder',
     icon: 'model',
   },
   {

--- a/web/src/views/Package/index.tsx
+++ b/web/src/views/Package/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-04-14 11:34:42 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 17:23:49
+ * @Last Modified time: 2026-04-21 15:45:30
  */
 /**
  * Package Component
@@ -60,7 +60,7 @@ const btnClassNames = {
   default: 'rb:h-10! rb:rounded-[8px]! rb:bg-[#212332]! rb:text-white! rb:border-0! rb:hover:border-0! rb:hover:opacity-[0.8]',
 }
 
-export const UnitWrapper = ({ titleKey, value, icon, unit, theme_color = '#171719' }: { titleKey: string; value: number | string; icon: string; unit?: string; theme_color?: string; }) => {
+export const UnitWrapper = ({ titleKey, value, icon, unit, theme_color = '#171719' }: { titleKey: string; value?: number | string | null; icon: string; unit?: string; theme_color?: string; }) => {
   const { t } = useTranslation();
 
   const renderFeatureIcon = (iconKey: string, color: string) => {
@@ -78,7 +78,7 @@ export const UnitWrapper = ({ titleKey, value, icon, unit, theme_color = '#17171
       >{renderFeatureIcon(icon, theme_color)}</Flex>
       <div className="rb:text-[13px] rb:leading-4.5">
         <div className="rb:text-[#5F6266]">{t(`package.${titleKey}`)}</div>
-        <div>{value} {unit ? t(`package.${unit}`) : ''}</div>
+        {value ? <div>{value} {unit ? t(`package.${unit}`) : ''}</div> : <div>{t('package.noLimit')}</div>}
       </div>
     </Flex>
   )
@@ -252,7 +252,6 @@ const Package: FC = () => {
                     >
                       {billingUnits.map(({ key, unit, icon }) => {
                         const value = pkg?.quotas?.[key as keyof Package['quotas']];
-                        if (value === undefined || value === null) return null;
                         return (
                           <UnitWrapper
                             key={key}
@@ -264,7 +263,7 @@ const Package: FC = () => {
                           />
                         )
                       })}
-                      {pkg.tech_support && (
+                      {pkg.tech_support && pkg[getKeyWithLanguage('tech_support')] && (
                         <UnitWrapper
                             titleKey="tech_support"
                             value={String(pkg[getKeyWithLanguage('tech_support')] ?? '')}
@@ -272,7 +271,7 @@ const Package: FC = () => {
                             theme_color={pkg.theme_color}
                           />
                       )}
-                      {pkg.sla_compliance && (
+                      {pkg.sla_compliance && pkg[getKeyWithLanguage('sla_compliance')] && (
                         <UnitWrapper
                           titleKey="sla"
                           value={String(pkg[getKeyWithLanguage('sla_compliance')] ?? '')}


### PR DESCRIPTION
## Summary by Sourcery

处理无限制套餐和订阅配额的显示，并添加相应的 i18n 标签。

新功能：
- 当套餐或订阅配额未设置时，显示本地化的「Unlimited」标签。

错误修复：
- 仅在存在相应本地化描述时，显示技术支持和 SLA 功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle display of unlimited package and subscription quotas and add corresponding i18n labels.

New Features:
- Show a localized 'Unlimited' label when package or subscription quotas are not set.

Bug Fixes:
- Ensure tech support and SLA features are only shown when corresponding localized descriptions exist.

</details>