### PR TITLE
fix(web): stream add default error message

### DIFF
--- a/web/src/utils/stream.ts
+++ b/web/src/utils/stream.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 16:35:43 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-18 14:32:40
+ * @Last Modified time: 2026-04-22 10:16:43
  */
 /**
  * Server-Sent Events (SSE) Stream Utility Module
@@ -176,12 +176,12 @@ export const handleSSE = async (url: string, data: any, onMessage?: (data: SSEMe
       case 500:
       case 502:
         const errorData = await response.json();
-        const errorInfo = errorData.error || i18n.t('common.serviceUpgrading');
+        const errorInfo = errorData.error || errorData.msg || i18n.t('common.serviceUpgrading');
         message.warning(errorInfo);
         throw new Error(errorData);
       case 400:
         const error = await response.json();
-        const error400 = error.error || 'Bad Request';
+        const error400 = error.error || error.msg || 'Bad Request';
         message.warning(error400);
         throw new Error(error);
       case 403:
@@ -190,7 +190,7 @@ export const handleSSE = async (url: string, data: any, onMessage?: (data: SSEMe
         throw new Error(errors);
       case 504:
         const errorJson = await response.json();
-        const errorMsg = errorJson.error || i18n.t('common.serverError');
+        const errorMsg = errorJson.error || errorJson.msg || i18n.t('common.serverError');
         message.warning(errorMsg);
         throw new Error(errorJson);
       case 401:
@@ -204,6 +204,13 @@ export const handleSSE = async (url: string, data: any, onMessage?: (data: SSEMe
           return;
         }
         break;
+      default:
+        if (!response.ok) {
+          const defaultData = await response.json().catch(() => ({}));
+          const defaultMsg = defaultData.error || defaultData.msg;
+          if (defaultMsg) message.warning(defaultMsg);
+          throw new Error(defaultMsg || `HTTP ${response.status}`);
+        }
     }
     if (!response.body) throw new Error('No response body');
 


### PR DESCRIPTION
## Summary by Sourcery

改进 SSE 的 HTTP 错误处理，以展示后端提供的错误信息，并为未显式处理的 HTTP 状态码添加默认处理逻辑。

Bug 修复：
- 确保在 HTTP 400、500、502 和 504 响应中，当不存在 `error` 字段时，SSE 错误通知也会回退使用 `msg` 字段。
- 在 SSE 中处理意外的非 2xx HTTP 响应时，提取并显示任何 `error`/`msg` 信息；若无可用信息，则回退到通用的 HTTP 状态错误提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve SSE HTTP error handling to surface backend-provided messages and add a default handler for non-explicit HTTP status codes.

Bug Fixes:
- Ensure SSE error notifications also fall back to a `msg` field when `error` is absent in HTTP 400, 500, 502, and 504 responses.
- Handle unexpected non-OK HTTP responses in SSE by extracting and displaying any `error`/`msg` message or falling back to a generic HTTP status error.

</details>