### PR TITLE
feat(plan): bump free plan model quota from 1 to 4

### DIFF
--- a/api/app/config/default_free_plan.py
+++ b/api/app/config/default_free_plan.py
@@ -62,7 +62,7 @@ def _build_default_free_plan():
             "memory_engine_quota": 1,
             "end_user_quota": 1,
             "ontology_project_quota": 3,
-            "model_quota": 1,
+            "model_quota": 4,
             "api_ops_rate_limit": 50,
         },
     }

--- a/api/app/core/quota_manager.py
+++ b/api/app/core/quota_manager.py
@@ -179,11 +179,18 @@ class QuotaUsageRepository:
     def count_end_users(self, tenant_id: UUID) -> int:
         from app.models.end_user_model import EndUser
         from app.models.workspace_model import Workspace
-        return self.db.query(EndUser).join(
+        from app.models.user_model import User
+        trial_user_ids = [
+            str(u.id) for u in self.db.query(User.id).filter(User.tenant_id == tenant_id).all()
+        ]
+        query = self.db.query(EndUser).join(
             Workspace, EndUser.workspace_id == Workspace.id
         ).filter(
             Workspace.tenant_id == tenant_id
-        ).count()
+        )
+        if trial_user_ids:
+            query = query.filter(~EndUser.other_id.in_(trial_user_ids))
+        return query.count()
 
     def count_models(self, tenant_id: UUID) -> int:
         from app.models.models_model import ModelConfig


### PR DESCRIPTION
- Increase the model quota for the free tier from 1 to 4.

## Summary by Sourcery

新功能：
- 将免费层的模型配额从 1 个扩展至 4 个模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Expand the free tier model quota from 1 to 4 models.

</details>