### PR TITLE
feat(web): skill keywords not required

### DIFF
--- a/web/src/views/Skills/pages/SkillConfig.tsx
+++ b/web/src/views/Skills/pages/SkillConfig.tsx
@@ -182,7 +182,6 @@ const SkillConfig: FC = () => {
               <Form.Item
                 name={['config', 'keywords']}
                 label={t('skills.keywords')}
-                rules={[{ required: true, message: t('common.inputPlaceholder', { title: t('skills.keywords') }) }]}
               >
                 <Select
                   mode="tags"


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 放宽对技能关键词字段的校验，使其不再为必填项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Relax validation on the skill keywords field so it is no longer mandatory.

</details>