### PR TITLE
feat(web): agent model config add thinking_budget_tokens

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1534,6 +1534,8 @@ export const en = {
       uploadCover: 'Import and Overwrite',
       refresh: 'Refresh Current Page',
       json_output: 'Support JSON formatted output',
+      thinking_budget_tokens: 'thinking budget tokens',
+      thinking_budget_tokens_max_error: "Cannot exceed the max tokens limit ({{max}})",
     },
     userMemory: {
       userMemory: 'User Memory',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -864,6 +864,8 @@ export const zh = {
       uploadCover: '导入并覆盖',
       refresh: '刷新当前页',
       json_output: '支持JSON格式化输出',
+      thinking_budget_tokens: '深度思考预算Token数',
+      thinking_budget_tokens_max_error: "不能超过 最大令牌数 ({{max}})",
     },
     table: {
       totalRecords: '共 {{total}} 条记录'

--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -218,17 +218,22 @@ const Chat: FC<ChatProps> = ({
         const modelChatList = [...prev]
         const curModelChat = modelChatList[targetIndex]
         const curChatMsgList = curModelChat.list || []
-        const lastMsg = curChatMsgList[curChatMsgList.length - 2]
-        modelChatList[targetIndex] = {
-          ...modelChatList[targetIndex],
-          list: [
-            ...curChatMsgList.slice(0, curChatMsgList.length - 2),
-            {
-              ...lastMsg,
-              ...(lastMsg.role === 'user' ? { status: 'error' } : { content: null })
-            }
-          ]
+        const lastUserMsg = curChatMsgList[curChatMsgList.length - 2]
+        const lastAssistantMsg = curChatMsgList[curChatMsgList.length - 1]
+
+        if (!lastAssistantMsg.meta_data?.reasoning_content || lastAssistantMsg.meta_data?.reasoning_content.length === 0) {
+          modelChatList[targetIndex] = {
+            ...modelChatList[targetIndex],
+            list: [
+              ...curChatMsgList.slice(0, curChatMsgList.length - 2),
+              {
+                ...lastUserMsg,
+                ...(lastUserMsg.role === 'user' ? { status: 'error' } : { content: null })
+              }
+            ]
+          }
         }
+
         return [...modelChatList]
       }
 

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -178,6 +178,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
           name="thinking_budget_tokens"
           label={t('application.thinking_budget_tokens')}
           hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
+          extra={<>{t('application.range')}: [{0}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
           rules={[
             { required: values?.deep_thinking, message: t('common.pleaseEnter') },
             {
@@ -192,7 +193,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
           ]}
         >
           <RbSlider
-            step={0}
+            step={1}
             min={0}
             max={32000}
             isInput={true}

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -108,7 +108,8 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
     const newValues: ModelConfig = {
       capability: (option as Model).capability,
       deep_thinking: false,
-      json_output: false
+      thinking_budget_tokens: undefined,
+      json_output: false,
     }
     if (source === 'chat') {
       newValues.label = (option as Model).name
@@ -124,8 +125,8 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
 
   useEffect(() => {
     const { deep_thinking: _, json_output: __, ...rest } = data?.model_parameters || {}
-    form.setFieldsValue(rest)
-  }, [values?.default_model_config_id])
+    form.setFieldsValue({ ...rest })
+  }, [data?.default_model_config_id])
 
   const handleReset = () => {
     if (!id) return
@@ -167,11 +168,36 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
         {['model', 'chat'].includes(source) && <>
           <FormItem name="capability" hidden />
         </>}
+        <FormItem name="json_output" valuePropName="checked" hidden={!(values?.capability?.includes('json_output'))}>
+          <Checkbox>{t('application.json_output')}</Checkbox>
+        </FormItem>
         <FormItem name="deep_thinking" valuePropName="checked" hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}>
           <Checkbox>{t('application.deep_thinking')}</Checkbox>
         </FormItem>
-        <FormItem name="json_output" valuePropName="checked" hidden={!(values?.capability?.includes('json_output'))}>
-          <Checkbox>{t('application.json_output')}</Checkbox>
+        <FormItem
+          name="thinking_budget_tokens"
+          label={t('application.thinking_budget_tokens')}
+          hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
+          rules={[
+            { required: values?.deep_thinking, message: t('common.pleaseEnter') },
+            {
+              validator: (_, value) => {
+                const maxTokens = values?.max_tokens
+                if (value !== undefined && maxTokens !== undefined && value > maxTokens) {
+                  return Promise.reject(t('application.thinking_budget_tokens_max_error', { max: maxTokens }))
+                }
+                return Promise.resolve()
+              }
+            }
+          ]}
+        >
+          <RbSlider
+            step={0}
+            min={0}
+            max={32000}
+            isInput={true}
+            disabled={!values?.deep_thinking}
+          />
         </FormItem>
         {source === 'chat' && <FormItem name="label" hidden />}
 

--- a/web/src/views/ApplicationConfig/types.ts
+++ b/web/src/views/ApplicationConfig/types.ts
@@ -38,6 +38,7 @@ export interface ModelConfig {
   /** Stop sequences */
   stop?: string;
   deep_thinking?: boolean;
+  thinking_budget_tokens?: number;
   json_output?: boolean;
 }
 

--- a/web/src/views/UserMemoryDetail/pages/ExplicitDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/ExplicitDetail.tsx
@@ -276,7 +276,7 @@ const ExplicitDetail: FC = () => {
                   {total > PAGE_SIZE && (
                     <Pagination
                       current={currentPagination.page}
-                      pageSize={PAGE_SIZE}
+                      pageSize={currentPagination.pagesize}
                       total={total}
                       onChange={handlePageChange}
                       size="small"


### PR DESCRIPTION
## Summary by Sourcery

为代理模型添加思考 Token 预算配置支持，并调整推理响应时的聊天重试行为。

New Features:
- 在代理模型配置中引入可配置的 `thinking_budget_tokens` 参数，提供相应的 UI 控件，并根据模型的最大 Token 限制进行校验。

Bug Fixes:
- 当最后一次助手回复包含推理内容时，防止聊天重试错误地重写之前的消息历史。

Documentation:
- 为思考预算 Token 选项及相关校验错误信息新增英文和中文的 i18n 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration support for a thinking token budget on agent models and adjust chat retry behavior for reasoning responses.

New Features:
- Introduce a configurable thinking_budget_tokens parameter in the agent model configuration with UI controls and validation against the model max token limit.

Bug Fixes:
- Prevent chat retry from incorrectly rewriting the previous message history when the last assistant reply contains reasoning content.

Documentation:
- Add English and Chinese i18n strings for the thinking budget tokens option and related validation error message.

</details>