### PR TITLE
fix(neo4j): correct community property name in search queries

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1236,7 +1236,7 @@ RETURN s.id AS id,
 SEARCH_COMMUNITIES_BY_USER_ID = """
 MATCH (c:Community)
 WHERE c.end_user_id = $end_user_id
-RETURN c.id AS id,
+RETURN c.community_id AS id,
        c.summary_embedding AS embedding
 """
 
@@ -1467,7 +1467,7 @@ LIMIT $limit
 SEARCH_COMMUNITIES_BY_KEYWORD = """
 CALL db.index.fulltext.queryNodes("communitiesFulltext", $query) YIELD node AS c, score
 WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
-RETURN c.id AS id,
+RETURN c.community_id AS id,
        c.name AS name,
        c.summary AS content,
        c.core_entities AS core_entities,


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复社区搜索查询，在返回结果时使用正确的 `community_id` 属性而不是 `id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix community search queries to use the correct community_id property instead of id when returning results.

</details>