### PR TITLE
Feature/memory UI zy

### DIFF
--- a/web/src/assets/images/application/export.svg
+++ b/web/src/assets/images/application/export.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>导出</title>
+    <title>导入</title>
     <g id="空间里层页面优化" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
-        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-573, -158)" stroke="#171719">
-            <g id="导出" transform="translate(573, 158)">
+        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-555, -158)" stroke="#171719">
+            <g id="导入" transform="translate(555, 158)">
                 <g id="编组-54" transform="translate(3, 3)">
                     <path d="M10,6 L10,7.5 C10,8.88071187 8.88071187,10 7.5,10 L2.5,10 C1.11928813,10 0,8.88071187 0,7.5 L0,6 L0,6" id="路径"></path>
-                    <g id="编组-11" transform="translate(2, 0)">
+                    <g id="编组-11" transform="translate(5, 3.4982) scale(1, -1) translate(-5, -3.4982)translate(2, 0)">
                         <line x1="3" y1="0.08499952" x2="3" y2="6.99635859" id="路径-24"></line>
                         <polyline id="路径-25" stroke-linejoin="round" points="0 3 2.98005548 6.08298138e-18 6 3"></polyline>
                     </g>

--- a/web/src/assets/images/application/import.svg
+++ b/web/src/assets/images/application/import.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>导入</title>
+    <title>导出</title>
     <g id="空间里层页面优化" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
-        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-555, -158)" stroke="#171719">
-            <g id="导入" transform="translate(555, 158)">
+        <g id="记忆库-个人记忆-感知记忆-文本" transform="translate(-573, -158)" stroke="#171719">
+            <g id="导出" transform="translate(573, 158)">
                 <g id="编组-54" transform="translate(3, 3)">
                     <path d="M10,6 L10,7.5 C10,8.88071187 8.88071187,10 7.5,10 L2.5,10 C1.11928813,10 0,8.88071187 0,7.5 L0,6 L0,6" id="路径"></path>
-                    <g id="编组-11" transform="translate(5, 3.4982) scale(1, -1) translate(-5, -3.4982)translate(2, 0)">
+                    <g id="编组-11" transform="translate(2, 0)">
                         <line x1="3" y1="0.08499952" x2="3" y2="6.99635859" id="路径-24"></line>
                         <polyline id="路径-25" stroke-linejoin="round" points="0 3 2.98005548 6.08298138e-18 6 3"></polyline>
                     </g>

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -272,9 +272,8 @@ const ChatContent: FC<ChatContentProps> = ({
                     <Flex vertical gap={4} className="rb:mt-1! rb:pt-3! rb-border-t rb:mb-2!">
                       <div className="rb:font-medium">{t('memoryConversation.citations')}</div>
                       {item.meta_data?.citations?.map((citation, idx) => (
-                        <Flex align="center" gap={12}>
+                        <Flex key={idx} align="center" gap={12}>
                           <div
-                            key={idx}
                             className="rb:text-[#155EEF] rb:leading-5 rb:underline rb:cursor-pointer"
                             onClick={() => {
                               const params = new URLSearchParams({ documentId: citation.document_id, parentId: citation.knowledge_id });

--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -272,14 +272,22 @@ const ChatContent: FC<ChatContentProps> = ({
                     <Flex vertical gap={4} className="rb:mt-1! rb:pt-3! rb-border-t rb:mb-2!">
                       <div className="rb:font-medium">{t('memoryConversation.citations')}</div>
                       {item.meta_data?.citations?.map((citation, idx) => (
-                        <div
-                          key={idx}
-                          className="rb:text-[#155EEF] rb:leading-5 rb:underline rb:cursor-pointer"
-                          onClick={() => {
-                            const params = new URLSearchParams({ documentId: citation.document_id, parentId: citation.knowledge_id });
-                            window.open(`/#/knowledge-base/${citation.knowledge_id}/DocumentDetails?${params}`, '_blank');
-                          }}
-                        >{citation.file_name}</div>
+                        <Flex align="center" gap={12}>
+                          <div
+                            key={idx}
+                            className="rb:text-[#155EEF] rb:leading-5 rb:underline rb:cursor-pointer"
+                            onClick={() => {
+                              const params = new URLSearchParams({ documentId: citation.document_id, parentId: citation.knowledge_id });
+                              window.open(`/#/knowledge-base/${citation.knowledge_id}/DocumentDetails?${params}`, '_blank');
+                            }}
+                          >{citation.file_name}</div>
+
+                          {citation.download_url &&
+                            <div className="rb:size-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/application/export.svg')]"
+                              onClick={() => handleDownload({ url: citation.download_url })}
+                            ></div>
+                          }
+                        </Flex>
                       ))}
                     </Flex>
                   }

--- a/web/src/components/Chat/types.ts
+++ b/web/src/components/Chat/types.ts
@@ -24,7 +24,7 @@ export interface ChatItem {
   subContent?: Record<string, any>[];
   error?: string;
   meta_data?: {
-    audio_url?: string;
+    audio_url?: string | null;
     audio_status?: string;
     files?: any[];
     suggested_questions?: string[];
@@ -33,6 +33,7 @@ export interface ChatItem {
       file_name: string;
       knowledge_id: string;
       score: string;
+      download_url?: string;
     }[];
     reasoning_content?: string;
   },

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1470,6 +1470,7 @@ export const en = {
       add_questions: 'Add Option',
       citation: 'Citation and Attribution',
       citation_desc: 'Display the attribution of source documents and generated content',
+      allow_download: 'Allow downloading cited source text',
       invalidVariablesTitle: "The following undefined variables are referenced in the conversation opening. Do you want to save the opening configuration?",
       deep_thinking: 'Enable Deep Thinking',
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1460,6 +1460,7 @@ export const en = {
       maxCount: 'Max Files',
       singleMaxSize: 'Max Size',
       unix: 'items',
+      document_image_recognition: 'Enable image recognition in documents',
       text_to_speech: 'Text to Speech',
       text_to_speech_desc: 'Text can be converted to speech',
       opening_statement: 'Conversation Opening',
@@ -1536,6 +1537,7 @@ export const en = {
       json_output: 'Support JSON formatted output',
       thinking_budget_tokens: 'thinking budget tokens',
       thinking_budget_tokens_max_error: "Cannot exceed the max tokens limit ({{max}})",
+      logSearchPlaceholder: 'Search log content',
     },
     userMemory: {
       userMemory: 'User Memory',
@@ -2529,6 +2531,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
 
       input_result: 'Input',
       output_result: 'Output',
+      process_result: 'Data Processing',
       error: 'Error Message',
       loopNum: ' loops',
       iterationNum: ' iterations',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -790,6 +790,7 @@ export const zh = {
       maxCount: '最大文件数',
       singleMaxSize: '单文件最大大小',
       unix: '个',
+      document_image_recognition: '是否识别文档中的图片',
       text_to_speech: '文字转语音',
       text_to_speech_desc: '文本可以转换成语音',
       opening_statement: '对话开场白',
@@ -866,6 +867,7 @@ export const zh = {
       json_output: '支持JSON格式化输出',
       thinking_budget_tokens: '深度思考预算Token数',
       thinking_budget_tokens_max_error: "不能超过 最大令牌数 ({{max}})",
+      logSearchPlaceholder: '搜索日志内容',
     },
     table: {
       totalRecords: '共 {{total}} 条记录'
@@ -2493,6 +2495,7 @@ export const zh = {
 
       input_result: '输入',
       output_result: '输出',
+      process_result: '数据处理',
       error: '错误信息',
       loopNum: '个循环',
       iterationNum: '个迭代',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -800,6 +800,7 @@ export const zh = {
       add_questions: '添加选项',
       citation: '引用和归属',
       citation_desc: '显示源文档和生成内容的归属部分',
+      allow_download: '允许下载引用原文',
       invalidVariablesTitle: "对话开场白中引用了以下未定义的变量，是否保存开场白配置？",
       deep_thinking: '开启深度思考',
 

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -357,7 +357,7 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
     const { statement = '' } = value?.opening_statement || {}
     onFeaturesLoad?.(value)
 
-    if (value.opening_statement.enabled) {
+    if (value?.opening_statement?.enabled) {
       const usedVars = [...new Set([...(statement?.matchAll(/\{\{(\w+)\}\}/g) ?? [])].map(m => m[1]))]
       const variables = values?.variables
       const validNames = new Set(variables.map(v => v.name))

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useRef, useState, forwardRef, useImperativeHandle, useMemo } from 'react';
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom';
-import { Row, Col, Space, Form, Input, Button, App, Spin, Flex } from 'antd'
+import { Row, Col, Space, Form, Input, Button, App, Flex } from 'antd'
 
 import Chat from './components/Chat'
 import RbCard from '@/components/RbCard/Card'
@@ -357,21 +357,23 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
     const { statement = '' } = value?.opening_statement || {}
     onFeaturesLoad?.(value)
 
-    const usedVars = [...new Set([...(statement?.matchAll(/\{\{(\w+)\}\}/g) ?? [])].map(m => m[1]))]
-    const variables = values?.variables
-    const validNames = new Set(variables.map(v => v.name))
-    const invalid = usedVars.filter(v => !validNames.has(v))
-    if (invalid.length > 0) {
-      const newVars = invalid.map((name, i) => ({
-        index: variables.length + i,
-        name,
-        display_name: name,
-        type: 'text',
-        required: true,
-        max_length: 48,
-      }))
+    if (value.opening_statement.enabled) {
+      const usedVars = [...new Set([...(statement?.matchAll(/\{\{(\w+)\}\}/g) ?? [])].map(m => m[1]))]
+      const variables = values?.variables
+      const validNames = new Set(variables.map(v => v.name))
+      const invalid = usedVars.filter(v => !validNames.has(v))
+      if (invalid.length > 0) {
+        const newVars = invalid.map((name, i) => ({
+          index: variables.length + i,
+          name,
+          display_name: name,
+          type: 'text',
+          required: true,
+          max_length: 48,
+        }))
 
-      form.setFieldValue('variables', [...variables, ...newVars])
+        form.setFieldValue('variables', [...variables, ...newVars])
+      }
     }
   }
   const modelLogo = useMemo(() => {

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
@@ -155,6 +155,12 @@ const FeaturesConfigModal = forwardRef<FeaturesConfigModalRef, FeaturesConfigMod
                 name={['citation', "enabled"]}
                 desc={t('application.citation_desc')}
               />
+              <SwitchFormItem
+                title={t(`application.allow_download`)}
+                name={['citation', "allow_download"]}
+                disabled={!values?.citation?.enabled}
+                className="rb:mt-2!"
+              />
             </div>
 
             <div className="rb:relative rb:border rb:border-[#DFE4ED] rb:p-3 rb:rounded-lg rb:bg-[#f5f7fc]">

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -97,6 +97,7 @@ export const defaultValues: FileUpload = {
     "json",
     "md",
   ],
+  document_image_recognition: false,
   video_enabled: false,
   video_max_size_mb: 100,
   video_allowed_extensions: [
@@ -219,11 +220,22 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
                     </Col>
                   </Row>
                   {isEnabled && (
-                    <Flex align="center" gap={12} className="rb:mt-3! rb:pt-3! rb:border-t rb:border-[#DFE4ED]">
-                      <div>{t('application.singleMaxSize')}: </div>
-                      <Form.Item name={sizeKey} noStyle>
-                        <InputNumber min={1} max={100} suffix="MB" className="rb:flex-1" />
-                      </Form.Item>
+                    <Flex align="center" gap={16} className="rb:mt-3! rb:pt-3! rb:border-t rb:border-[#DFE4ED]">
+                      <div>
+                        <div>{t('application.singleMaxSize')}</div>
+                        <Form.Item name={sizeKey} noStyle>
+                          <InputNumber min={1} max={100} suffix="MB" className="rb:flex-1" />
+                        </Form.Item>
+                      </div>
+                      {option.type === 'document' &&
+                        <div>
+                          <div>{t('application.document_image_recognition')}</div>
+                          <Form.Item name="document_image_recognition" valuePropName="checked" noStyle>
+                            <Switch className="rb:mt-1.5!" />
+                          </Form.Item>
+                        </div>
+                      }
+
                       <Form.Item name={`${option.type}_allowed_extensions`} hidden />
                     </Flex>
                   )}

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/OpenStatementSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/OpenStatementSettingModal.tsx
@@ -104,6 +104,7 @@ const OpenStatementSettingModal = forwardRef<OpenStatementSettingModalRef, OpenS
         <Form.Item
           label={t('application.opening_statement')}
           name="statement"
+          rules={[{ required: true, message: t('common.pleaseEnter') }]}
         >
           {source === 'workflow'
             ? <Editor options={chatVariables as any} variant="outlined" />

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -184,7 +184,8 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
             {
               validator: (_, value) => {
                 const maxTokens = values?.max_tokens
-                if (value !== undefined && maxTokens !== undefined && value > maxTokens) {
+                const deep_thinking = values?.deep_thinking;
+                if (deep_thinking && value !== undefined && maxTokens !== undefined && value > maxTokens) {
                   return Promise.reject(t('application.thinking_budget_tokens_max_error', { max: maxTokens }))
                 }
                 return Promise.resolve()

--- a/web/src/views/ApplicationConfig/types.ts
+++ b/web/src/views/ApplicationConfig/types.ts
@@ -438,6 +438,7 @@ interface FileSetttings {
   document_enabled: boolean;
   document_max_size_mb: number;
   document_allowed_extensions: string[];
+  document_image_recognition: boolean;
   video_enabled: boolean;
   video_max_size_mb: number;
   video_allowed_extensions: string[];
@@ -499,6 +500,7 @@ export interface LogItem {
   is_draft: boolean;
   created_at: number;
   updated_at: number;
+  node_executions_map?: Record<string, ChatItem['subContent']>
 }
 export interface LogDetailModalRef {
   handleOpen: (vo: LogItem) => void;

--- a/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
+++ b/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
@@ -56,6 +56,8 @@ const NODE_VARIABLES = {
   ],
   'document-extractor': [
     { label: 'text', dataType: 'string', field: 'text' },
+    // { label: 'chunks', dataType: 'array[string]', field: 'chunks' },
+    { label: 'images', dataType: 'array[file]', field: 'images' },
   ],
   'list-operator': [
     { label: 'result', dataType: 'array[string]', field: 'result' },


### PR DESCRIPTION
## Summary by Sourcery

改进应用配置和聊天界面，以支持文档图像识别、引文下载，以及更健壮的校验与日志记录。

新功能：
- 在聊天消息中，当存在下载 URL 时，为被引用的文档添加可选的下载链接。
- 在文件上传设置中引入文档图像识别开关，并将其接入文件设置类型。
- 暴露新的引文配置选项，以允许下载被引用的源文本。
- 支持文档抽取器工作流节点在输出文本的同时输出图像文件。

错误修复：
- 确保仅在启用“开场白”功能时才运行“从开场白自动创建变量”的逻辑。
- 将“思考预算”token 校验限制为只在启用“深度思考”功能时才生效。
- 在配置对话开场白时，要求必须提供开场白内容。

改进：
- 改善聊天引文布局，通过在同一 flex 行中对文件名和操作进行分组，并添加下载图标按钮。
- 允许聊天消息的元数据字段 `audio_url` 为 null，并在引文元数据中扩展可选字段 `download_url`。
- 为日志项扩展可选字段 `node_executions_map`，用于存储节点输出的子内容。
- 添加用于文档图像识别、引文下载权限、日志搜索占位符和处理结果标签的新 i18n 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve application configuration and chat UI to support document image recognition, citation downloads, and more robust validation and logging.

New Features:
- Add optional download links for cited documents in chat messages when a download URL is available.
- Introduce a document image recognition toggle in file upload settings and wire it into file settings types.
- Expose a new citation configuration option to allow downloading cited source text.
- Add support for document extractor workflow nodes to output image files in addition to text.

Bug Fixes:
- Ensure automatic variable creation from opening statements runs only when the opening statement feature is enabled.
- Restrict thinking budget token validation to apply only when deep thinking is enabled.
- Require an opening statement value when configuring conversation openings.

Enhancements:
- Improve the chat citation layout by grouping file names and actions in a flex row and adding a download icon button.
- Allow chat message metadata audio_url to be null and extend citation metadata with an optional download_url field.
- Extend log items with an optional node_executions_map for storing node output subcontent.
- Add new i18n strings for document image recognition, citation download permission, log search placeholder, and process result labels.

</details>