### PR TITLE
fix(api): correct import paths in memory_read and celery task command

### DIFF
--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,8 +1,8 @@
 from app.core.memory.enums import SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
 from app.core.memory.pipelines.base_pipeline import ModelClientMixin, DBRequiredPipeline
-from core.memory.read_services.search_engine.content_search import Neo4jSearchService, RAGSearchService
-from core.memory.read_services.generate_engine.query_preprocessor import QueryPreprocessor
+from app.core.memory.read_services.search_engine.content_search import Neo4jSearchService, RAGSearchService
+from app.core.memory.read_services.generate_engine.query_preprocessor import QueryPreprocessor
 
 
 class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - .env
     volumes:
       - /etc/localtime:/etc/localtime:ro
-    command: python app/celery_task_scheduler.py
+    command: python -m app.celery_task_scheduler
     restart: unless-stopped
     healthcheck:
       test:  CMD curl -f 127.0.0.1:8001 || exit 1


### PR DESCRIPTION
- Fix relative imports in memory_read.py to use absolute app paths
- Change celery scheduler command from `python app/celery_task_scheduler.py` to `python -m app.celery_task_scheduler`

## Summary by Sourcery

修正 `memory_read` 流水线中的导入路径，并更新 Docker 配置中的 Celery 调度命令。

Bug 修复：
- 修复 `memory_read` 流水线，使其通过应用的绝对路径导入服务。
- 更新 `docker-compose` 中的 Celery 任务调度命令，改为使用模块调用而不是脚本路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct import paths in memory_read pipeline and update Celery scheduler command in Docker configuration.

Bug Fixes:
- Fix memory_read pipeline to import services via absolute app paths.
- Update Celery task scheduler command in docker-compose to use module invocation instead of a script path.

</details>