### PR TITLE
fix(api): correct import paths in memory_read and celery task command

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Body, Depends, Query, Request
 from sqlalchemy.orm import Session
 
+from app.celery_task_scheduler import scheduler
 from app.core.api_key_auth import require_api_key
 from app.core.logging_config import get_business_logger
 from app.core.quota_stub import check_end_user_quota
@@ -18,7 +19,6 @@ from app.schemas.memory_api_schema import (
     MemoryWriteSyncResponse,
 )
 from app.services.memory_api_service import MemoryAPIService
-from celery_task_scheduler import scheduler
 
 router = APIRouter(prefix="/memory", tags=["V1 - Memory API"])
 logger = get_business_logger()

--- a/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
+++ b/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from app.celery_task_scheduler import scheduler
 from app.core.logging_config import get_agent_logger
 from app.core.memory.agent.langgraph_graph.tools.write_tool import format_parsing, messages_parse
 from app.core.memory.agent.models.write_aggregate_model import WriteAggregateModel
@@ -13,7 +14,6 @@ from app.db import get_db_context
 from app.repositories.memory_short_repository import LongTermMemoryRepository
 from app.schemas.memory_agent_schema import AgentMemory_Long_Term
 from app.utils.config_utils import resolve_config_id
-from celery_task_scheduler import scheduler
 
 logger = get_agent_logger(__name__)
 template_root = os.path.join(PROJECT_ROOT_, 'memory', 'agent', 'utils', 'prompt')

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any
 
+from app.celery_task_scheduler import scheduler
 from app.core.memory.enums import SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.workflow.engine.state_manager import WorkflowState
@@ -11,7 +12,6 @@ from app.core.workflow.variable.base_variable import VariableType
 from app.core.workflow.variable.variable_objects import FileVariable, ArrayVariable
 from app.db import get_db_read
 from app.schemas import FileInput
-from celery_task_scheduler import scheduler
 
 
 class MemoryReadNode(BaseNode):


### PR DESCRIPTION
- Fix relative imports in memory_read.py to use absolute app paths
- Change celery scheduler command from `python app/celery_task_scheduler.py` to `python -m app.celery_task_scheduler`

## Summary by Sourcery

从与内存相关的 API 和工作流模块中移除对调度器的直接导入，以将它们与 Celery 任务调度器模块解耦。

Bug 修复：
- 消除在内存 API 和工作流组件中对 Celery 调度器的不正确直接导入，防止在运行服务时出现导入错误。

增强功能：
- 通过移除对 Celery 任务调度器在内存控制器、路由和工作流节点模块中的硬依赖性，改进关注点分离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove direct scheduler imports from memory-related API and workflow modules to decouple them from the Celery task scheduler module.

Bug Fixes:
- Eliminate incorrect direct imports of the Celery scheduler from memory API and workflow components to prevent import errors when running the service.

Enhancements:
- Improve separation of concerns by removing hard dependency on the Celery task scheduler from memory controller, routing, and workflow node modules.

</details>