### PR TITLE
fix(api): convert end_user_id to string in write_router

### DIFF
--- a/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
+++ b/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
@@ -94,9 +94,9 @@ async def write(
         # )
         scheduler.push_task(
             "app.core.memory.agent.write_message",
-            actual_end_user_id,
+            str(actual_end_user_id),
             {
-                "end_user_id": actual_end_user_id,
+                "end_user_id": str(actual_end_user_id),
                 "message": structured_messages,
                 "config_id": str(actual_config_id),
                 "storage_type": storage_type,
@@ -177,9 +177,9 @@ async def window_dialogue(end_user_id, langchain_messages, memory_config, scope)
 
         scheduler.push_task(
             "app.core.memory.agent.write_message",
-            end_user_id,
+            str(end_user_id),
             {
-                "end_user_id": end_user_id,
+                "end_user_id": str(end_user_id),
                 "message": redis_messages,
                 "config_id": config_id,
                 "storage_type": AgentMemory_Long_Term.STORAGE_NEO4J,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在将 `end_user_id` 值加入 `write_message` 任务队列之前先转换为字符串，以防止在路由过程中出现与类型相关的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Convert end_user_id values to strings before enqueueing write_message tasks to prevent type-related issues in routing.

</details>