### PR TITLE
fix(api): convert config_id to string in write_router

### DIFF
--- a/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
+++ b/api/app/core/memory/agent/langgraph_graph/routing/write_router.py
@@ -181,7 +181,7 @@ async def window_dialogue(end_user_id, langchain_messages, memory_config, scope)
             {
                 "end_user_id": str(end_user_id),
                 "message": redis_messages,
-                "config_id": config_id,
+                "config_id": str(config_id),
                 "storage_type": AgentMemory_Long_Term.STORAGE_NEO4J,
                 "user_rag_memory_id": ""
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保 `write_router` 在对话写入负载中将 `config_id` 作为字符串发送，以避免在下游出现与类型相关的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure write_router sends config_id as a string in the dialogue write payload to avoid type-related issues downstream.

</details>