### PR TITLE
fix(multimodal_service)

### DIFF
--- a/api/app/services/multimodal_service.py
+++ b/api/app/services/multimodal_service.py
@@ -95,7 +95,7 @@ class DashScopeFormatStrategy(MultimodalFormatStrategy):
         """通义千问文档格式"""
         return True, {
             "type": "text",
-            "text": f"<document name=\"{file_name}\">\n{text}\n</document>"
+            "text": f"<document name=\"{file_name}\">\n文档内容：\n{text}\n</document>"
         }
 
     async def format_audio(
@@ -167,6 +167,7 @@ class BedrockFormatStrategy(MultimodalFormatStrategy):
     async def format_document(self, file_name: str, text: str) -> tuple[bool, Dict[str, Any]]:
         """Bedrock/Anthropic 文档格式（需要 base64 编码）"""
         # Bedrock 文档需要 base64 编码
+        text = f"文档内容：\n{text}\n"
         text_bytes = text.encode('utf-8')
         base64_text = base64.b64encode(text_bytes).decode('utf-8')
 
@@ -223,7 +224,7 @@ class OpenAIFormatStrategy(MultimodalFormatStrategy):
         """OpenAI 文档格式"""
         return True, {
             "type": "text",
-            "text": f"<document name=\"{file_name}\">\n{text}\n</document>"
+            "text": f"<document name=\"{file_name}\">\n文档内容：\n{text}\n</document>"
         }
 
     async def format_audio(
@@ -395,7 +396,7 @@ class MultimodalService:
                             ext = img_info.get("ext", "png")
                             try:
                                 _, img_url = await self._save_doc_image_to_storage(img_info["bytes"], ext, tenant_id, workspace_id)
-                                placeholder = f"第{page}页 第{index + 1}张图片" if page > 0 else f"第{index + 1}张图片"
+                                placeholder = f"第{page}页 第{index + 1}张" if page > 0 else f"第{index + 1}张"
                                 # 在文本内容中追加图片位置标记
                                 if result and result[-1].get("type") in ("text", "document"):
                                     key = "text" if "text" in result[-1] else list(result[-1].keys())[-1]


### PR DESCRIPTION
add '文档内容：' prefix to document text and simplify image placeholder text

## Summary by Sourcery

为不同提供商统一多模态文档和图片占位符，以提升文档内容格式的一致性。

Bug Fixes:
- 为通义千问、Bedrock/Anthropic 和 OpenAI 的文档格式中的文本文档内容，统一添加一致的前缀“文档内容：”。
- 通过缩短内嵌图片的文本标签，简化处理后文档中生成的图片占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize multimodal document and image placeholders for different providers to improve consistency of document content formatting.

Bug Fixes:
- Add a consistent '文档内容：' prefix to document text for Tongyi Qianwen, Bedrock/Anthropic, and OpenAI document formats.
- Simplify generated image placeholders in processed documents by shortening the text label for embedded images.

</details>