### PR TITLE
fix(api_key): bypass publication check for SERVICE type API keys

### DIFF
--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 
 from app.aioRedis import aio_redis
-from app.models.api_key_model import ApiKey
+from app.models.api_key_model import ApiKey, ApiKeyType
 from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
 from app.schemas import api_key_schema
 from app.schemas.response_schema import PageData, PageMeta
@@ -65,7 +65,8 @@ class ApiKeyService:
                         BizCode.BAD_REQUEST
                     )
 
-            if data.resource_id:
+            # SERVICE 类型的 resource_id 指向 workspace，非应用，跳过应用发布校验
+            if data.resource_id and data.type != ApiKeyType.SERVICE.value:
                 app = db.get(App, data.resource_id)
                 if not app or not app.current_release_id:
                     raise BusinessException("该应用未发布", BizCode.APP_NOT_PUBLISHED)
@@ -452,8 +453,11 @@ class ApiKeyAuthService:
     def check_app_published(db: Session, api_key_obj: ApiKey) -> None:
         """
         检查应用是否已发布，未发布则抛出异常
+        SERVICE 类型的 api_key 不绑定应用（resource_id 指向 workspace），跳过校验
         """
         if not api_key_obj.resource_id:
+            return
+        if api_key_obj.type == ApiKeyType.SERVICE.value:
             return
         app = db.get(App, api_key_obj.resource_id)
         if not app or not app.current_release_id:


### PR DESCRIPTION
- Exclude SERVICE type keys from application publication validation since their resource_id targets the workspace instead of an application.

## Summary by Sourcery

错误修复：
- 修复在创建或验证绑定到工作区而非应用程序的 SERVICE 类型 API 密钥时，错误触发应用程序发布验证失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent erroneous application-publication validation failures when creating or validating SERVICE-type API keys that are bound to workspaces instead of applications.

</details>