### PR TITLE
fix(api_key): bypass publication check for SERVICE type API keys

### DIFF
--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import select
 
 from app.aioRedis import aio_redis
-from app.models.api_key_model import ApiKey
+from app.models.api_key_model import ApiKey, ApiKeyType
 from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
 from app.schemas import api_key_schema
 from app.schemas.response_schema import PageData, PageMeta
@@ -65,7 +65,8 @@ class ApiKeyService:
                         BizCode.BAD_REQUEST
                     )
 
-            if data.resource_id:
+            # SERVICE 类型的 resource_id 指向 workspace，非应用，跳过应用发布校验
+            if data.resource_id and data.type != ApiKeyType.SERVICE.value:
                 app = db.get(App, data.resource_id)
                 if not app or not app.current_release_id:
                     raise BusinessException("该应用未发布", BizCode.APP_NOT_PUBLISHED)
@@ -452,8 +453,11 @@ class ApiKeyAuthService:
     def check_app_published(db: Session, api_key_obj: ApiKey) -> None:
         """
         检查应用是否已发布，未发布则抛出异常
+        SERVICE 类型的 api_key 不绑定应用（resource_id 指向 workspace），跳过校验
         """
         if not api_key_obj.resource_id:
+            return
+        if api_key_obj.type == ApiKeyType.SERVICE.value:
             return
         app = db.get(App, api_key_obj.resource_id)
         if not app or not app.current_release_id:


### PR DESCRIPTION
Exclude SERVICE type keys from application publication validation since their resource_id targets the workspace instead of an application.

## Summary by Sourcery

为 `SERVICE` 类型的 API key 绕过应用发布验证，当其 `resource_id` 指向的是 workspace 而不是 application 时。

Bug 修复：
- 在创建 `SERVICE` 类型的 API key 时跳过应用发布检查，以避免对以 workspace 为作用域的 key 进行错误拒绝。
- 在验证已存在的 `SERVICE` 类型 API key 时，如果其 `resource_id` 并未引用某个 application，则跳过应用发布检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bypass application publication validation for SERVICE-type API keys whose resource_id points to a workspace instead of an application.

Bug Fixes:
- Skip application published checks when creating SERVICE-type API keys so workspace-scoped keys are not incorrectly rejected.
- Skip application published checks when validating existing SERVICE-type API keys whose resource_id does not reference an application.

</details>