### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/controllers/tool_controller.py
+++ b/api/app/controllers/tool_controller.py
@@ -173,6 +173,8 @@ async def delete_tool(
         return success(msg="工具删除成功")
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -249,6 +251,8 @@ async def parse_openapi_schema(
         if result["success"] is False:
             raise HTTPException(status_code=400, detail=result["message"])
         return success(data=result, msg="Schema解析完成")
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -334,7 +334,8 @@ class KnowledgeRetrievalNode(BaseNode):
             for kb_config in knowledge_bases:
                 db_knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=kb_config.kb_id)
                 if not (db_knowledge and db_knowledge.chunk_num > 0 and db_knowledge.status == 1):
-                    raise RuntimeError("The knowledge base does not exist or access is denied.")
+                    logger.warning("The knowledge base does not exist or access is denied.")
+                    continue
                 tasks.append(self.knowledge_retrieval(db, query, db_knowledge, kb_config))
             if tasks:
                 result = await asyncio.gather(*tasks)

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Optional, Any, List, Dict, Union
 from enum import Enum, StrEnum
 
-from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator
+from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator, model_serializer
 
 from app.schemas.workflow_schema import WorkflowConfigCreate
 
@@ -661,9 +661,11 @@ class DraftRunResponse(BaseModel):
     suggested_questions: List[str] = Field(default_factory=list, description="下一步建议问题")
     citations: List[Dict[str, Any]] = Field(default_factory=list, description="引用来源")
     audio_url: Optional[str] = Field(default=None, description="TTS 语音URL")
+    audio_status: Optional[str] = Field(default=None, description="TTS 语音状态")
 
-    def model_dump(self, **kwargs):
-        data = super().model_dump(**kwargs)
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
         if not data.get("reasoning_content"):
             data.pop("reasoning_content", None)
         return data

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -2,7 +2,7 @@
 import uuid
 import datetime
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field, ConfigDict, field_serializer
+from pydantic import BaseModel, Field, ConfigDict, field_serializer, model_serializer
 
 # 导入 FileInput（用于体验运行）
 from app.schemas.app_schema import FileInput
@@ -94,6 +94,18 @@ class ChatResponse(BaseModel):
     message_id: str
     usage: Optional[Dict[str, Any]] = None
     elapsed_time: Optional[float] = None
+    reasoning_content: Optional[str] = None
+    suggested_questions: Optional[List[str]] = None
+    citations: Optional[List[Any]] = None
+    audio_url: Optional[str] = None
+    audio_status: Optional[str] = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if not data.get("reasoning_content"):
+            data.pop("reasoning_content", None)
+        return data
 
 
 # ---------- Conversation Summary Schemas ----------

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -96,7 +96,7 @@ class ChatResponse(BaseModel):
     elapsed_time: Optional[float] = None
     reasoning_content: Optional[str] = None
     suggested_questions: Optional[List[str]] = None
-    citations: Optional[List[Any]] = None
+    citations: Optional[List[Dict[str, Any]]] = None
     audio_url: Optional[str] = None
     audio_status: Optional[str] = None
 

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -317,7 +317,7 @@ class AppChatService:
             "suggested_questions": suggested_questions,
             "citations": filtered_citations,
             "audio_url": audio_url,
-            "audio_status": "pending"
+            "audio_status": "pending" if audio_url else None
         }
 
     async def agnet_chat_stream(

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -754,7 +754,7 @@ class AgentRunService:
                 ) if not sub_agent else [],
                 "citations": filtered_citations,
                 "audio_url": audio_url,
-                "audio_status": "pending"
+                "audio_status": "pending" if audio_url else None
             }
 
             logger.info(


### PR DESCRIPTION
add reasoning content, suggested questions, citations and audio status support

- Introduce `reasoning_content`, `suggested_questions`, `citations`, and `audio_status` fields in conversation and app response schemas
- Conditionally set `audio_status` to `"pending"` only when `audio_url` is present
- Replace `model_dump` override with `@model_serializer(mode="wrap")` for cleaner serialization logic
- Change knowledge base validation failure from `RuntimeError` to warning + `continue` to avoid halting retrieval on invalid KB

## Summary by Sourcery

为聊天和草稿响应添加更丰富的元数据，同时提升 TTS（文本转语音）和知识库处理的健壮性。

New Features:
- 扩展聊天响应的 schema，增加可选的推理内容、推荐问题、引用信息，以及包含音频状态的 TTS 字段。
- 在草稿运行（draft run）响应中，与音频 URL 一并暴露音频状态元数据。

Bug Fixes:
- 当未生成音频 URL 时，避免将音频状态标记为 pending。
- 当已配置的知识库缺失或无效时，通过记录警告并跳过该知识库，防止知识检索整体失败。

Enhancements:
- 使用 Pydantic 模型级序列化钩子，在 API 响应中省略空的推理内容字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add richer metadata to chat and draft responses while making TTS and knowledge base handling more robust.

New Features:
- Extend chat response schema with optional reasoning content, suggested questions, citations, and TTS fields including audio status.
- Expose audio status metadata alongside audio URL in draft run responses.

Bug Fixes:
- Avoid marking audio status as pending when no audio URL is generated.
- Prevent knowledge retrieval from failing entirely when a configured knowledge base is missing or invalid by logging a warning and skipping it.

Enhancements:
- Use Pydantic model-level serialization hooks to omit empty reasoning content fields from API responses.

</details>