### PR TITLE
fix(workspace)

### DIFF
--- a/api/app/controllers/workspace_controller.py
+++ b/api/app/controllers/workspace_controller.py
@@ -221,7 +221,7 @@ def update_workspace_members(
 
 @router.delete("/members/{member_id}", response_model=ApiResponse)
 @cur_workspace_access_guard()
-def delete_workspace_member(
+async def delete_workspace_member(
     member_id: uuid.UUID,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -230,7 +230,7 @@ def delete_workspace_member(
     workspace_id = current_user.current_workspace_id
     api_logger.info(f"用户 {current_user.username} 请求删除工作空间 {workspace_id} 的成员 {member_id}")
 
-    workspace_service.delete_workspace_member(
+    await workspace_service.delete_workspace_member(
         db=db,
         workspace_id=workspace_id,
         member_id=member_id,

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -216,7 +216,7 @@ class RedBearModelFactory:
             # 深度思考模式：Claude 3.7 Sonnet 等支持思考的模型
             # 通过 additional_model_request_fields 传递 thinking 块，关闭时不传（Bedrock 无 disabled 选项）
             if config.deep_thinking:
-                budget = config.thinking_budget_tokens or 10000
+                budget = config.thinking_budget_tokens or 1024
                 params["additional_model_request_fields"] = {
                     "thinking": {"type": "enabled", "budget_tokens": budget}
                 }

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -250,7 +250,7 @@ class ModelParameters(BaseModel):
     n: int = Field(default=1, ge=1, le=10, description="生成的回复数量")
     stop: Optional[List[str]] = Field(default=None, description="停止序列")
     deep_thinking: bool = Field(default=False, description="是否启用深度思考模式（需模型支持，如 DeepSeek-R1、QwQ 等）")
-    thinking_budget_tokens: Optional[int] = Field(default=None, ge=1024, le=131072, description="深度思考 token 预算（仅部分模型支持）")
+    thinking_budget_tokens: Optional[int] = Field(default=None, ge=1, le=131072, description="深度思考 token 预算（仅部分模型支持）")
     json_output: bool = Field(default=False, description="是否强制 JSON 格式输出（需模型支持 json_output 能力）")
 
 

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -20,6 +20,7 @@ from app.models.workspace_model import (
 )
 from app.repositories import workspace_repository
 from app.repositories.workspace_invite_repository import WorkspaceInviteRepository
+from app.services.session_service import SessionService
 from app.schemas.workspace_schema import (
     InviteAcceptRequest,
     InviteValidateResponse,
@@ -58,7 +59,7 @@ def switch_workspace(
         raise BusinessException(f"切换工作空间失败: {str(e)}", BizCode.INTERNAL_ERROR)
 
 
-def delete_workspace_member(
+async def delete_workspace_member(
         db: Session,
         workspace_id: uuid.UUID,
         member_id: uuid.UUID,
@@ -80,6 +81,9 @@ def delete_workspace_member(
         workspace_member.user.current_workspace_id = None
         db.commit()
         business_logger.info(f"用户 {user.username} 成功删除工作空间 {workspace_id} 的成员 {member_id}")
+
+        # 使被删除成员的所有 token 立即失效
+        await SessionService.invalidate_all_user_tokens(str(workspace_member.user_id))
     except Exception as e:
         db.rollback()
         business_logger.error(f"删除工作空间成员失败 - 工作空间: {workspace_id}, 成员: {member_id}, 错误: {str(e)}")


### PR DESCRIPTION
make delete workspace member async and invalidate user tokens

## Summary by Sourcery

使工作区成员删除操作异步化，并确保被移除的成员会立即从该工作区登出。

Bug Fixes（错误修复）:
- 当用户被从某个工作区移除时，使其所有令牌失效，以防止继续访问。

Enhancements（功能增强）:
- 将工作区成员删除服务和控制器端点改为异步，以支持异步令牌失效处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make workspace member deletion asynchronous and ensure removed members are immediately logged out from the workspace.

Bug Fixes:
- Invalidate all tokens of a user when they are removed from a workspace to prevent further access.

Enhancements:
- Convert the workspace member deletion service and controller endpoint to async to support asynchronous token invalidation.

</details>