### PR TITLE
fix(web): thinking_budget_tokens add min & default value

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1538,6 +1538,7 @@ export const en = {
       json_output: 'Support JSON formatted output',
       thinking_budget_tokens: 'thinking budget tokens',
       thinking_budget_tokens_max_error: "Cannot exceed the max tokens limit ({{max}})",
+      thinking_budget_tokens_min_error: "Cannot be less than {{min}}",
       logSearchPlaceholder: 'Search log content',
     },
     userMemory: {

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -868,6 +868,7 @@ export const zh = {
       json_output: '支持JSON格式化输出',
       thinking_budget_tokens: '深度思考预算Token数',
       thinking_budget_tokens_max_error: "不能超过 最大令牌数 ({{max}})",
+      thinking_budget_tokens_min_error: "不能小于 {{min}}",
       logSearchPlaceholder: '搜索日志内容',
     },
     table: {

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -49,6 +49,8 @@ const configFields = [
   { key: 'n', max: 10, min: 1, step: 1, defaultValue: 1 },
 ]
 
+const min_thinking_budget_tokens = 128;
+const default_thinking_budget_tokens = 1000;
 const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(({
   refresh,
   data,
@@ -108,7 +110,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
     const newValues: ModelConfig = {
       capability: (option as Model).capability,
       deep_thinking: false,
-      thinking_budget_tokens: undefined,
+      thinking_budget_tokens: default_thinking_budget_tokens,
       json_output: false,
     }
     if (source === 'chat') {
@@ -127,6 +129,12 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
     const { deep_thinking: _, json_output: __, ...rest } = data?.model_parameters || {}
     form.setFieldsValue({ ...rest })
   }, [data?.default_model_config_id])
+
+  useEffect(() => {
+    if (values?.deep_thinking && !values?.thinking_budget_tokens) {
+      form.setFieldValue('thinking_budget_tokens', default_thinking_budget_tokens)
+    }
+  }, [values?.deep_thinking])
 
   const handleReset = () => {
     if (!id) return
@@ -178,7 +186,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
           name="thinking_budget_tokens"
           label={t('application.thinking_budget_tokens')}
           hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
-          extra={<>{t('application.range')}: [{0}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
+          extra={<>{t('application.range')}: [{min_thinking_budget_tokens}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
           rules={[
             { required: values?.deep_thinking, message: t('common.pleaseEnter') },
             {
@@ -195,7 +203,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
         >
           <RbSlider
             step={1}
-            min={0}
+            min={min_thinking_budget_tokens}
             max={32000}
             isInput={true}
             disabled={!values?.deep_thinking}

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -49,8 +49,8 @@ const configFields = [
   { key: 'n', max: 10, min: 1, step: 1, defaultValue: 1 },
 ]
 
-const min_thinking_budget_tokens = 128;
-const default_thinking_budget_tokens = 1000;
+const minThinkingBudgetTokens = 128;
+const defaultThinkingBudgetTokens = 1000;
 const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(({
   refresh,
   data,
@@ -110,7 +110,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
     const newValues: ModelConfig = {
       capability: (option as Model).capability,
       deep_thinking: false,
-      thinking_budget_tokens: default_thinking_budget_tokens,
+      thinking_budget_tokens: defaultThinkingBudgetTokens,
       json_output: false,
     }
     if (source === 'chat') {
@@ -132,7 +132,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
 
   useEffect(() => {
     if (values?.deep_thinking && !values?.thinking_budget_tokens) {
-      form.setFieldValue('thinking_budget_tokens', default_thinking_budget_tokens)
+      form.setFieldValue('thinking_budget_tokens', defaultThinkingBudgetTokens)
     }
   }, [values?.deep_thinking])
 
@@ -186,15 +186,20 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
           name="thinking_budget_tokens"
           label={t('application.thinking_budget_tokens')}
           hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
-          extra={<>{t('application.range')}: [{min_thinking_budget_tokens}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
+          extra={<>{t('application.range')}: [{minThinkingBudgetTokens}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
           rules={[
             { required: values?.deep_thinking, message: t('common.pleaseEnter') },
             {
               validator: (_, value) => {
                 const maxTokens = values?.max_tokens
                 const deep_thinking = values?.deep_thinking;
-                if (deep_thinking && value !== undefined && maxTokens !== undefined && value > maxTokens) {
-                  return Promise.reject(t('application.thinking_budget_tokens_max_error', { max: maxTokens }))
+                if (deep_thinking && value !== undefined) {
+                  if (value < minThinkingBudgetTokens) {
+                    return Promise.reject(t('application.thinking_budget_tokens_min_error', { min: minThinkingBudgetTokens }))
+                  }
+                  if (maxTokens !== undefined && value > maxTokens) {
+                    return Promise.reject(t('application.thinking_budget_tokens_max_error', { max: maxTokens }))
+                  }
                 }
                 return Promise.resolve()
               }
@@ -203,7 +208,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
         >
           <RbSlider
             step={1}
-            min={min_thinking_budget_tokens}
+            min={minThinkingBudgetTokens}
             max={32000}
             isInput={true}
             disabled={!values?.deep_thinking}


### PR DESCRIPTION
## Summary by Sourcery

在模型配置弹窗中，为“思考预算 tokens”配置强制使用合理的默认值，并设置最小范围。

新功能：
- 引入一个默认的“思考预算 token”数值，用于在初始化或启用深度思考时自动应用。

错误修复：
- 通过滑块和辅助文本，防止“思考预算 tokens”被设置为低于最小阈值的数值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce sensible defaults and a minimum range for the thinking budget tokens configuration in the model config modal.

New Features:
- Introduce a default thinking budget token value applied when initializing or enabling deep thinking.

Bug Fixes:
- Prevent thinking budget tokens from being set below a minimum threshold via the slider and helper text.

</details>