### PR TITLE
fix(workspace)

### DIFF
--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -77,8 +77,24 @@ async def delete_workspace_member(
                                 BizCode.WORKSPACE_NOT_FOUND)
 
     try:
+        deleted_user = workspace_member.user
         workspace_member.is_active = False
-        workspace_member.user.current_workspace_id = None
+        deleted_user.current_workspace_id = None
+
+        # 若被删除成员不是超级管理员且没有其他可用工作空间，则禁用该用户
+        if not deleted_user.is_superuser:
+            remaining = (
+                db.query(WorkspaceMember)
+                .filter(
+                    WorkspaceMember.user_id == deleted_user.id,
+                    WorkspaceMember.workspace_id != workspace_id,
+                    WorkspaceMember.is_active.is_(True),
+                )
+                .count()
+            )
+            if remaining == 0:
+                deleted_user.is_active = False
+
         db.commit()
         business_logger.info(f"用户 {user.username} 成功删除工作空间 {workspace_id} 的成员 {member_id}")
 


### PR DESCRIPTION
deactivate user when removed from last active workspace

## Summary by Sourcery

错误修复：
- 当非超级用户从其最后一个活跃工作区中被移除，且不再拥有任何活跃的工作区成员关系时，将其账户设为停用状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Deactivate non-superuser accounts when they are removed from their final active workspace with no remaining active workspace memberships.

</details>