### PR TITLE
Feature/app zy

### DIFF
--- a/web/src/components/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeConfigModal.tsx
@@ -54,10 +54,14 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
 
   useEffect(() => {
     if (values?.retrieve_type) {
+      const resetValues: KnowledgeConfigForm = {}
       const fieldsToReset = Object.keys(values).filter(key =>
         key !== 'kb_id' && key !== 'retrieve_type' && key !== 'top_k'
       ) as (keyof KnowledgeConfigForm)[];
-      form.resetFields(fieldsToReset);
+      fieldsToReset.forEach(key => {
+        resetValues[key] = undefined
+      })
+      form.setFieldsValue(resetValues);
     }
   }, [values?.retrieve_type])
 

--- a/web/src/components/Knowledge/KnowledgeGlobalConfigModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeGlobalConfigModal.tsx
@@ -40,7 +40,8 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
 
   useEffect(() => {
     if (values?.rerank_model) {
-      form.setFieldsValue({ ...data })
+      const { rerank_model, ...rest } = data;
+      form.setFieldsValue({ ...rest })
     } else {
       form.setFieldsValue({ reranker_id: undefined, reranker_top_k: undefined })
     }

--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeConfigModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:25:37 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-07 22:35:08
+ * @Last Modified time: 2026-04-29 17:21:46
  */
 /**
  * Knowledge Configuration Modal
@@ -91,10 +91,14 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
 
   useEffect(() => {
     if (values?.retrieve_type) {
-      const fieldsToReset = Object.keys(values).filter(key => 
+      const resetValues: KnowledgeConfigForm = {}
+      const fieldsToReset = Object.keys(values).filter(key =>
         key !== 'kb_id' && key !== 'retrieve_type' && key !== 'top_k'
       ) as (keyof KnowledgeConfigForm)[];
-      form.resetFields(fieldsToReset);
+      fieldsToReset.forEach(key => {
+        resetValues[key] = undefined
+      })
+      form.setFieldsValue(resetValues);
     }
   }, [values?.retrieve_type])
 

--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeGlobalConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeGlobalConfigModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:25:42 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-07 17:03:22
+ * @Last Modified time: 2026-04-29 17:21:05
  */
 /**
  * Knowledge Global Configuration Modal
@@ -67,7 +67,8 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
 
   useEffect(() => {
     if (values?.rerank_model) {
-      form.setFieldsValue({ ...data })
+      const { rerank_model, ...rest } = data;
+      form.setFieldsValue({ ...rest })
     } else {
       form.setFieldsValue({ reranker_id: undefined, reranker_top_k: undefined })
     }

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeConfigModal.tsx
@@ -67,10 +67,14 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
 
   useEffect(() => {
     if (values?.retrieve_type) {
+      const resetValues: KnowledgeConfigForm = {}
       const fieldsToReset = Object.keys(values).filter(key => 
         key !== 'kb_id' && key !== 'retrieve_type' && key !== 'top_k'
       ) as (keyof KnowledgeConfigForm)[];
-      form.resetFields(fieldsToReset);
+      fieldsToReset.forEach(key => {
+        resetValues[key] = undefined
+      })
+      form.setFieldsValue(resetValues);
     }
   }, [values?.retrieve_type])
 

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeGlobalConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeGlobalConfigModal.tsx
@@ -47,7 +47,8 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
 
   useEffect(() => {
     if (values?.rerank_model) {
-      form.setFieldsValue({ ...data })
+      const { rerank_model, ...rest } = data;
+      form.setFieldsValue({ ...rest })
     } else {
       form.setFieldsValue({ reranker_id: undefined, reranker_top_k: undefined })
     }

--- a/web/src/views/Workflow/components/Properties/ModelConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-03-07 14:55:04 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-04-17 10:05:32 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-04-29 17:08:19
  */
 import { type FC, useEffect, useState } from "react";
 import { useTranslation } from 'react-i18next'
@@ -28,7 +28,6 @@ const ModelConfig: FC = () => {
     if (model_id && options) {
       const model = options.find(item => item.id === model_id)
       setSelectedModel(model || null)
-      form.setFieldValue('json_output', false)
     } else {
       setSelectedModel(null)
     }
@@ -47,6 +46,7 @@ const ModelConfig: FC = () => {
           params={{ type: 'llm,chat' }}
           className="rb:w-full!"
           size="small"
+          onChange={() => form.setFieldValue('json_output', false)}
           updateOptions={updateOptions}
         />
       </Form.Item>


### PR DESCRIPTION
## Summary by Sourcery

调整知识和模型配置表单，在关键选项变更时更精确地重置依赖字段。

Bug Fixes:
- 确保在检索类型变更时，知识配置表单会显式清空依赖字段的值，而不是依赖部分表单重置。
- 通过仅在存在重排序模型时更新非模型字段，防止更改重排序模型时无意间覆盖相关表单字段。
- 仅在模型选择实际发生变化时重置 JSON 输出选项，而不是在工作流模型配置中每次进行模型查询时都重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust knowledge and model configuration forms to reset dependent fields more precisely when key options change.

Bug Fixes:
- Ensure knowledge configuration forms explicitly clear dependent field values when the retrieve type changes instead of relying on partial form resets.
- Prevent rerank model changes from unintentionally overwriting related form fields by only updating non-model fields when a rerank model is present.
- Reset the JSON output option only when the model selection actually changes rather than on every model lookup in the workflow model configuration.

</details>