### PR TITLE
feat(web): qa not support rechunking

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
@@ -458,29 +458,35 @@ const Private: FC = () => {
 
   }
   // Generate dropdown menu items (based on current row)
-  const getOptMenuItems = (row: KnowledgeBaseListItem): MenuProps['items'] => [
-    {
-      key: '1',
-      label: t('knowledgeBase.rechunking'),
-      onClick: () => {
-        handleRechunking(row);
+  const getOptMenuItems = (row: KnowledgeBaseListItem): MenuProps['items'] => {
+    const options = [{
+        key: '2',
+        label: t('knowledgeBase.download'),
+        onClick: () => {
+          handleDownload(row);
+        },
       },
-    },
-    {
-      key: '2',
-      label: t('knowledgeBase.download'),
-      onClick: () => {
-        handleDownload(row);
-      },
-    },
-    {
-      key: '3',
-      label: t('knowledgeBase.delete'),
-      onClick: () => {
-        handleDelete(row);
-      },
+      {
+        key: '3',
+        label: t('knowledgeBase.delete'),
+        onClick: () => {
+          handleDelete(row);
+        },
+      }]
+    if (row.parser_config?.doc_type === 'qa') {
+      return options
     }
-  ];
+    return [
+      {
+        key: '1',
+        label: t('knowledgeBase.rechunking'),
+        onClick: () => {
+          handleRechunking(row);
+        },
+      },
+      ...options
+    ]
+  };
   const handleRechunking = (item: KnowledgeBaseListItem) => {
     if (!knowledgeBaseId) return;
     const document = item as unknown as KnowledgeBaseDocumentData;


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

新功能：
- 对于 QA 类型的文档，在知识库文档选项菜单中有条件地隐藏重新分块操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Conditionally hide the rechunking action in the knowledge base document options menu for QA-type documents.

</details>