### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -363,11 +363,12 @@ class KnowledgeRetrievalNode(BaseNode):
             seen_doc_ids = set()
             for chunk in final_rs:
                 meta = chunk.metadata or {}
-                doc_id = meta.get("document_id") or meta.get("doc_id")
-                if doc_id and doc_id not in seen_doc_ids:
-                    seen_doc_ids.add(doc_id)
+                document_id = meta.get("document_id")
+                if document_id and document_id not in seen_doc_ids:
+                    seen_doc_ids.add(document_id)
                     citations.append({
-                        "document_id": str(doc_id),
+                        "document_id": str(document_id),
+                        "doc_id": meta.get("doc_id", ""),
                         "file_name": meta.get("file_name", ""),
                         "knowledge_id": str(meta.get("knowledge_id", kb_config.kb_id)),
                         "score": meta.get("score", 0.0),

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -205,6 +205,7 @@ class CitationConfig(BaseModel):
 
 class Citation(BaseModel):
     document_id: str
+    doc_id: str
     file_name: str
     knowledge_id: str
     score: float

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -242,11 +242,12 @@ def create_knowledge_retrieval_tool(kb_config, kb_ids, user_id, citations_collec
                     seen_doc_ids = {c.get("document_id") for c in citations_collector}
                     for chunk in retrieve_chunks_result:
                         meta = chunk.metadata or {}
-                        doc_id = meta.get("document_id") or meta.get("doc_id")
-                        if doc_id and doc_id not in seen_doc_ids:
-                            seen_doc_ids.add(doc_id)
+                        document_id = meta.get("document_id")
+                        if document_id and document_id not in seen_doc_ids:
+                            seen_doc_ids.add(document_id)
                             citations_collector.append(Citation(
-                                document_id=doc_id,
+                                document_id=str(document_id),
+                                doc_id=meta.get("doc_id", ""),
                                 file_name=meta.get("file_name", ""),
                                 knowledge_id=str(meta.get("knowledge_id", "")),
                                 score=meta.get("score", 0)


### PR DESCRIPTION
support doc_id in citation metadata and unify document_id handling

## Summary by Sourcery

标准化引文元数据，一致使用 `document_id`，同时暴露原始的 `doc_id` 值。

新功能：
- 在引文元数据和模式中同时包含 `doc_id` 与 `document_id`。

改进：
- 在知识工作流执行和草稿运行的知识检索中统一文档标识符的处理，依赖 `document_id` 进行去重和存储。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize citation metadata to consistently use `document_id` while also exposing the original `doc_id` value.

New Features:
- Include `doc_id` alongside `document_id` in citation metadata and schema.

Enhancements:
- Unify document identifier handling across knowledge workflow execution and draft run knowledge retrieval to rely on `document_id` for de-duplication and storage.

</details>