### PR TITLE
refactor(memory): load MemoryConfig via service and initialize Memory Context in MemoryService

### DIFF
--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -26,6 +26,7 @@ from app.schemas.response_schema import ApiResponse
 from app.services import task_service, workspace_service
 from app.services.memory_agent_service import MemoryAgentService
 from app.services.memory_agent_service import get_end_user_connected_config as get_config
+from app.services.memory_config_service import MemoryConfigService
 from app.services.model_service import ModelConfigService
 from app.utils.tmp_session import ChatSessionCache
 
@@ -308,10 +309,14 @@ async def read_server(
     api_logger.info(
         f"Read service: group={user_input.end_user_id}, storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}, workspace_id={workspace_id}, session_id={session_id}")
     try:
-        memory_config = get_config(user_input.end_user_id, db)
+        config_info = get_config(user_input.end_user_id, db)
+        memory_config_service = MemoryConfigService(db)
+        memory_config = memory_config_service.load_memory_config(
+            config_id=config_info["memory_config_id"],
+            workspace_id=config_info["workspace_id"]
+        )
         service = MemoryService(
-            db,
-            memory_config["memory_config_id"],
+            memory_config=memory_config,
             end_user_id=user_input.end_user_id
         )
         session_cache = ChatSessionCache(session_id)

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
 
 from app.core.memory.enums import SearchStrategy
-from app.core.memory.models.service_models import MemorySearchResult
+from app.core.memory.models.service_models import MemoryContext, MemorySearchResult
 from app.core.memory.pipelines.memory_read import ReadPipeLine
 from app.db import get_db_context
 
@@ -53,6 +53,10 @@ class MemoryService:
         """
         self.memory_config = memory_config
         self.end_user_id = end_user_id
+        self.ctx = MemoryContext(
+            end_user_id=end_user_id,
+            memory_config=memory_config,
+        )
 
     async def write(
         self,

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -1,17 +1,18 @@
-from typing import Any, Self
+from typing import Self
 
-from pydantic import BaseModel, Field, field_serializer, ConfigDict, model_validator, computed_field
+from pydantic import BaseModel, Field, field_serializer, ConfigDict, computed_field
 
 from app.core.memory.enums import Neo4jNodeType, StorageType
-from app.core.validators import file_validator
 from app.schemas.memory_config_schema import MemoryConfig
 
 
 class MemoryContext(BaseModel):
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+    # Tell Pydantic v2 to skip coercion for the stdlib dataclass MemoryConfig
+    # while keeping the concrete type annotation for static analysis.
+    model_config = ConfigDict(frozen=True, ignored_types=(MemoryConfig,))
 
     end_user_id: str
-    memory_config: Any  # MemoryConfig is a stdlib dataclass; use Any to bypass Pydantic v2 dataclass coercion
+    memory_config: MemoryConfig
     storage_type: StorageType = StorageType.NEO4J
     user_rag_memory_id: str | None = None
     language: str = "zh"

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -1,4 +1,4 @@
-from typing import Self
+from typing import Any, Self
 
 from pydantic import BaseModel, Field, field_serializer, ConfigDict, model_validator, computed_field
 
@@ -11,7 +11,7 @@ class MemoryContext(BaseModel):
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     end_user_id: str
-    memory_config: MemoryConfig
+    memory_config: Any  # MemoryConfig is a stdlib dataclass; use Any to bypass Pydantic v2 dataclass coercion
     storage_type: StorageType = StorageType.NEO4J
     user_rag_memory_id: str | None = None
     language: str = "zh"


### PR DESCRIPTION
- Replace direct config_id injection in MemoryService with pre-loaded MemoryConfig object
- Use MemoryConfigService.load_memory_config() in read_server to resolve config before constructing MemoryService
- Initialize self.ctx (MemoryContext) in MemoryService.__init__ for downstream pipeline use
- Change MemoryContext.memory_config type to Any to avoid Pydantic v2 dataclass coercion

## Summary by Sourcery

重构内存配置处理逻辑，在构造 `MemoryService` 之前加载完整的 `MemoryConfig`，并在服务内部初始化可复用的 `MemoryContext`。

New Features:
- 在构造 `MemoryService` 时初始化一个 `MemoryContext` 实例，以供下游流水线使用。

Enhancements:
- 在 `read_server` 中通过 `MemoryConfigService` 解析 `MemoryConfig`，而不是将原始的 `config_id` 直接传入 `MemoryService`。
- 将 `MemoryContext.memory_config` 的类型放宽为 `Any`，以避免 Pydantic v2 在 dataclass 上的强制转换问题，并更好地支持现有的 `MemoryConfig` dataclass。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor memory configuration handling to load full MemoryConfig before constructing MemoryService and to initialize a reusable MemoryContext within the service.

New Features:
- Initialize a MemoryContext instance on MemoryService construction for downstream pipeline use.

Enhancements:
- Resolve MemoryConfig via MemoryConfigService in read_server instead of passing a raw config_id into MemoryService.
- Relax MemoryContext.memory_config type to Any to avoid Pydantic v2 dataclass coercion issues and better support the existing MemoryConfig dataclass.

</details>