### PR TITLE
Revert/memory service

### DIFF
--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -10,21 +10,22 @@ MemoryService — 记忆模块统一入口（Facade）
 
 依赖方向：外部调用方 → MemoryService → Pipeline → Engine → Repository
 """
-from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.memory.enums import SearchStrategy, StorageType
+from app.core.memory.models.service_models import MemoryContext, MemorySearchResult
+from app.core.memory.pipelines.memory_read import ReadPipeLine
+from app.db import get_db_context
+from services.memory_config_service import MemoryConfigService
 
 if TYPE_CHECKING:
     from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
     from app.core.memory.pipelines.write_pipeline import WriteResult
     from app.core.memory.models.message_models import DialogData
-    from app.schemas.memory_config_schema import MemoryConfig
-
-from app.core.memory.enums import SearchStrategy
-from app.core.memory.models.service_models import MemoryContext, MemorySearchResult
-from app.core.memory.pipelines.memory_read import ReadPipeLine
-from app.db import get_db_context
 
 logger = logging.getLogger(__name__)
 
@@ -42,31 +43,42 @@ class MemoryService:
     """
 
     def __init__(
-        self,
-        memory_config: MemoryConfig,
-        end_user_id: str,
+            self,
+            db: Session,
+            config_id: str | None,
+            end_user_id: str,
+            workspace_id: str | None = None,
+            storage_type: str = "neo4j",
+            user_rag_memory_id: str | None = None,
+            language: str = "zh",
     ):
-        """
-        Args:
-            memory_config: 已加载的不可变配置对象
-            end_user_id: 终端用户 ID
-        """
-        self.memory_config = memory_config
-        self.end_user_id = end_user_id
+        config_service = MemoryConfigService(db)
+        memory_config = None
+        if config_id is not None:
+            memory_config = config_service.load_memory_config(
+                config_id=config_id,
+                workspace_id=workspace_id,
+                service_name="MemoryService",
+            )
+        if memory_config is None and storage_type.lower() == "neo4j":
+            raise RuntimeError("Memory configuration for unspecified users")
         self.ctx = MemoryContext(
             end_user_id=end_user_id,
             memory_config=memory_config,
+            storage_type=StorageType(storage_type),
+            user_rag_memory_id=user_rag_memory_id,
+            language=language,
         )
 
     async def write(
-        self,
-        messages: List[dict],
-        language: str = "zh",
-        ref_id: str = "",
-        is_pilot_run: bool = False,
-        progress_callback: Optional[
-            Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
-        ] = None,
+            self,
+            messages: List[dict],
+            language: str = "zh",
+            ref_id: str = "",
+            is_pilot_run: bool = False,
+            progress_callback: Optional[
+                Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
+            ] = None,
     ) -> WriteResult:
         """写入记忆：对话 → 萃取 → 存储 → 聚类 → 摘要
 
@@ -83,8 +95,8 @@ class MemoryService:
         from app.core.memory.pipelines.write_pipeline import WritePipeline
 
         pipeline = WritePipeline(
-            memory_config=self.memory_config,
-            end_user_id=self.end_user_id,
+            memory_config=self.ctx.memory_config,
+            end_user_id=self.ctx.end_user_id,
             language=language,
             progress_callback=progress_callback,
         )
@@ -95,12 +107,12 @@ class MemoryService:
         )
 
     async def pilot_write(
-        self,
-        chunked_dialogs: List[DialogData],
-        language: str = "zh",
-        progress_callback: Optional[
-            Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
-        ] = None,
+            self,
+            chunked_dialogs: List[DialogData],
+            language: str = "zh",
+            progress_callback: Optional[
+                Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
+            ] = None,
     ) -> PilotWriteResult:
         """试运行写入：只执行萃取链路，不写入 Neo4j
 
@@ -115,8 +127,8 @@ class MemoryService:
         from app.core.memory.pipelines.pilot_write_pipeline import PilotWritePipeline
 
         pipeline = PilotWritePipeline(
-            memory_config=self.memory_config,
-            end_user_id=self.end_user_id,
+            memory_config=self.ctx.memory_config,
+            end_user_id=self.ctx.end_user_id,
             language=language,
             progress_callback=progress_callback,
         )
@@ -135,7 +147,7 @@ class MemoryService:
             return await ReadPipeLine(self.ctx, db).run(query, search_switch, history, limit)
 
     async def forget(
-        self, max_batch: int = 100, min_days: int = 30
+            self, max_batch: int = 100, min_days: int = 30
     ) -> dict:
         """遗忘：识别低激活节点并融合"""
         raise NotImplementedError("ForgettingPipeline 尚未实现")

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -7,9 +7,7 @@ from app.schemas.memory_config_schema import MemoryConfig
 
 
 class MemoryContext(BaseModel):
-    # Tell Pydantic v2 to skip coercion for the stdlib dataclass MemoryConfig
-    # while keeping the concrete type annotation for static analysis.
-    model_config = ConfigDict(frozen=True, ignored_types=(MemoryConfig,))
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     end_user_id: str
     memory_config: MemoryConfig


### PR DESCRIPTION
- Replace direct MemoryConfig dependency with DB session and config_id
- Move MemoryConfig loading to MemoryConfigService
- Add storage_type, user_rag_memory_id, language to MemoryContext
- Update service_models.py to use arbitrary_types_allowed

## Summary by Sourcery

重构内存服务初始化逻辑，通过专用服务加载配置，并为内存上下文补充更多元数据。

Enhancements:
- 将 `MemoryService` 与直接注入 `MemoryConfig` 解耦，通过接收数据库会话和配置标识符，并使用 `MemoryConfigService` 解析配置。
- 扩展 `MemoryContext`，增加存储类型、用户 RAG 内存标识符以及语言元数据，以更好地捕获请求上下文。
- 放宽 `MemoryContext` 中 Pydantic 模型的配置，允许嵌入的配置对象使用任意类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor memory service initialization to load configurations via a dedicated service and enrich the memory context with additional metadata.

Enhancements:
- Decouple MemoryService from direct MemoryConfig injection by accepting a DB session and config identifier and resolving configurations through MemoryConfigService.
- Extend MemoryContext with storage type, user RAG memory identifier, and language metadata to better capture request context.
- Relax Pydantic model configuration in MemoryContext to allow arbitrary types for embedded configuration objects.

</details>