### PR TITLE
fix(memory): add forward reference quotes for type hints

### DIFF
--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -79,7 +79,7 @@ class MemoryService:
             progress_callback: Optional[
                 Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
             ] = None,
-    ) -> WriteResult:
+    ) -> "WriteResult":
         """写入记忆：对话 → 萃取 → 存储 → 聚类 → 摘要
 
         Args:
@@ -108,12 +108,12 @@ class MemoryService:
 
     async def pilot_write(
             self,
-            chunked_dialogs: List[DialogData],
+            chunked_dialogs: List["DialogData"],
             language: str = "zh",
             progress_callback: Optional[
                 Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
             ] = None,
-    ) -> PilotWriteResult:
+    ) -> "PilotWriteResult":
         """试运行写入：只执行萃取链路，不写入 Neo4j
 
         Args:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将内存服务结果和对话框类型提示包裹在前向引用字符串中，以防止在运行时发生名称解析错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Wrap memory service result and dialog type hints in forward-reference strings to prevent name resolution errors at runtime.

</details>