### PR TITLE
refactor(memory): simplify MemoryService initialization and fix import paths

### DIFF
--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -26,7 +26,6 @@ from app.schemas.response_schema import ApiResponse
 from app.services import task_service, workspace_service
 from app.services.memory_agent_service import MemoryAgentService
 from app.services.memory_agent_service import get_end_user_connected_config as get_config
-from app.services.memory_config_service import MemoryConfigService
 from app.services.model_service import ModelConfigService
 from app.utils.tmp_session import ChatSessionCache
 
@@ -309,15 +308,11 @@ async def read_server(
     api_logger.info(
         f"Read service: group={user_input.end_user_id}, storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}, workspace_id={workspace_id}, session_id={session_id}")
     try:
-        config_info = get_config(user_input.end_user_id, db)
-        memory_config_service = MemoryConfigService(db)
-        memory_config = memory_config_service.load_memory_config(
-            config_id=config_info["memory_config_id"],
-            workspace_id=config_info["workspace_id"]
-        )
+        memory_config = get_config(user_input.end_user_id, db)
         service = MemoryService(
-            memory_config=memory_config,
-            end_user_id=user_input.end_user_id
+            db,
+            memory_config["memory_config_id"],
+            end_user_id=user_input.end_user_id,
         )
         session_cache = ChatSessionCache(session_id)
         search_result = await service.read(

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -12,7 +12,7 @@ MemoryService — 记忆模块统一入口（Facade）
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+from typing import  Any, Awaitable, Callable, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -20,12 +20,11 @@ from app.core.memory.enums import SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemoryContext, MemorySearchResult
 from app.core.memory.pipelines.memory_read import ReadPipeLine
 from app.db import get_db_context
-from services.memory_config_service import MemoryConfigService
+from app.services.memory_config_service import MemoryConfigService
 
-if TYPE_CHECKING:
-    from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
-    from app.core.memory.pipelines.write_pipeline import WriteResult
-    from app.core.memory.models.message_models import DialogData
+from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
+from app.core.memory.pipelines.write_pipeline import WriteResult
+from app.core.memory.models.message_models import DialogData
 
 logger = logging.getLogger(__name__)
 

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -309,7 +309,7 @@ class MemoryAgentService:
                 await write_rag(end_user_id, message_text, user_rag_memory_id)
                 return "success"
             else:
-                await self._write_neo4j(end_user_id, messages, memory_config, language)
+                await self._write_neo4j(end_user_id, messages, memory_config, language, db)
 
                 # ── Step 4: 后处理 ── 失效缓存、序列化文件路径、记录审计日志并返回结果
                 await self._invalidate_interest_cache(end_user_id)
@@ -445,13 +445,18 @@ class MemoryAgentService:
             messages: list[MessageItem] | list[dict],
             memory_config,
             language: Language | str,
+            db: Session,
     ) -> None:
         """使用新流水线（MemoryService → WritePipeline）写入 Neo4j。"""
         messages_dict = [
             msg if isinstance(msg, dict) else msg.model_dump(exclude_none=True)
             for msg in messages
         ]
-        service = MemoryService(memory_config=memory_config, end_user_id=end_user_id)
+        service = MemoryService(
+            db=db,
+            config_id=memory_config.config_id,
+            end_user_id=end_user_id,
+        )
         result = await service.write(
             messages=messages_dict, language=language, ref_id='',
         )


### PR DESCRIPTION
- Fix incorrect import path for MemoryConfigService in memory_service.py (services. -> app.services.)
- Replace TYPE_CHECKING guards with direct imports for PilotWriteResult, WriteResult, and DialogData
- Simplify read_server in controller by removing redundant MemoryConfigService call; pass config_id directly to MemoryService
- Add db session parameter to _write_neo4j and update MemoryService instantiation to use config_id instead of pre-loaded memory_config object

## Summary by Sourcery

简化在各个控制器和服务中对内存服务的初始化和配置使用方式。

Bug 修复：
- 更正 memory 服务模块中 `MemoryConfigService` 的导入路径。

增强项：
- 重构控制器中 `MemoryService` 的构造方式，改为直接使用 `get_config` 返回的 `config_id`，而不是预先加载的 `memory_config` 对象。
- 更新 `MemoryService`，直接导入流水线结果和对话数据类型，而不是使用 `TYPE_CHECKING` 守卫。
- 调整 `memory_agent_service`，将数据库会话传入 Neo4j 写入辅助方法，并使用 `config_id` 来构造 `MemoryService`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify memory service initialization and configuration usage across controllers and services.

Bug Fixes:
- Correct the import path for MemoryConfigService in the memory service module.

Enhancements:
- Refactor MemoryService construction in the controller to use config_id directly from get_config instead of a pre-loaded memory_config object.
- Update MemoryService to directly import pipeline result and dialog data types instead of using TYPE_CHECKING guards.
- Adjust memory_agent_service to pass the DB session into the Neo4j write helper and construct MemoryService using a config_id.

</details>