### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1196,6 +1196,10 @@ class WorkflowService:
                 var_type = VariableType.type_map(value)
                 await variable_pool.new(ref_node_id, var_name, value, var_type, mut=False)
 
+        cycle_nodes = [
+            n.get("id") for n in workflow_config_dict.get("nodes", [])
+            if n.get("type") in [NodeType.LOOP, NodeType.ITERATION]
+        ]
         state = WorkflowState(
             messages=input_data.get("conv_messages", []),
             node_outputs={},
@@ -1204,7 +1208,7 @@ class WorkflowService:
             user_id=input_data.get("user_id", ""),
             error=None,
             error_node=None,
-            cycle_nodes=[],
+            cycle_nodes=cycle_nodes,
             looping=0,
             activate={node_id: True},
             memory_storage_type=storage_type,


### PR DESCRIPTION
support cycle nodes detection in workflow state initialization

## Summary by Sourcery

错误修复：
- 根据工作流配置中的循环节点和迭代节点填充工作流状态的 `cycle_nodes` 字段，而不是将其留空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Populate workflow state's cycle_nodes field based on loop and iteration nodes from the workflow configuration instead of leaving it empty.

</details>