### PR TITLE
Fix/v0.3.3 zy

### DIFF
--- a/web/src/api/user.ts
+++ b/web/src/api/user.ts
@@ -58,7 +58,7 @@ export const changeEmail = (data: ChangeEmailModalForm) => {
   return request.put('/users/change-email', data)
 }
 
-// 获取租户套餐信息
+// Get tenant package information
 export const getTenantSubscription = () => {
   return request.get('/tenant/subscription')
 }

--- a/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
+++ b/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
@@ -67,12 +67,12 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef, { current
       title={[t('package.packageDetail'), detail?.package_plan?.[getKeyWithLanguage('name')]].filter(item => item).join(' - ')}
       open={open}
       onCancel={handleCancel}
-      footer={detail?.package_plan?.billing_cycle && detail?.package_plan?.billing_cycle !== 'permanent_free'
-        ? [
+      footer={(detail?.package_plan?.billing_cycle === 'permanent_free' && detail?.package_plan?.tier_level === 0)
+        ? null
+        : [
           <Button onClick={handleRenewal}>{t('pricing.renewal')}</Button>,
           <Button type="primary" onClick={handleUpgrade}>{t('pricing.upgrade')}</Button>
         ]
-        : null
       }
     >
       {/* Subtitle */}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2869,6 +2869,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       upgradeExpiredAt: 'Upgrade Expiration Date',
       renewalExpiredAt: 'Renewal Expiration Date',
       renewalTip: 'Renew the current package, extending the validity period by {{cycle}}.',
+      reject_reason: 'Reject Reason',
     },
     forgetDetail: {
       title: 'The forgetting management system helps AI intelligently manage memory lifecycle by automatically identifying low-value memories, setting forgetting strategies, and executing regular cleanup to optimize memory storage space and improve retrieval efficiency.',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2835,6 +2835,7 @@ export const zh = {
       upgradeExpiredAt: '升级后有效期至',
       renewalExpiredAt: '续费后有效期至',
       renewalTip: '续费当前套餐，有效期将在原到期日基础上延长 {{cycle}}。续费期间服务不中断。',
+      reject_reason: '拒绝原因',
     },
     forgetDetail: {
       title: '遗忘管理系统帮助AI智能管理记忆生命周期，通过自动识别低价值记忆、设置遗忘策略和执行定期清理，优化记忆库存储空间，提升检索效率。',

--- a/web/src/views/OrderHistory/components/OrderDetail.tsx
+++ b/web/src/views/OrderHistory/components/OrderDetail.tsx
@@ -47,20 +47,34 @@ const OrderDetail = forwardRef<OrderDetailRef, { getProductType: (type: string) 
   /** Format order information items */
   const formatItems = useMemo(() => {
     if (!data) return []
-    return ['order_no', 'package_snapshot', 'payable_amount', 'status', 'pay_time', 'created_at'].map(key => {
+    const items: DescriptionsProps['items'] = [];
+    ['order_no', 'package_snapshot', 'payable_amount', 'status', 'reject_reason', 'pay_time', 'created_at'].forEach(key => {
       const value = data[key as keyof Order]
-      return {
-        key,
-        label: t(`pricing.${key}`),
-        children: ['pay_time', 'created_at'].includes(key) && value
-          ? dayjs(value as number).format('YYYY-MM-DD HH:mm:ss')
-          : key === 'status' && value
-            ? t(`pricing.${STATUS[value as keyof typeof STATUS].key}`)
-            : key === 'package_snapshot'
-              ? (data.from_view === 'platform' ? t(`pricing.${getProductType(data.product_type)}.type`) : (value as Package)[getKeyWithLanguage('name')])
-              : value
+
+      if (key === 'reject_reason' && !value) {
+        if (data.status === 'rejected') {
+        items.push({
+          key,
+          label: t(`pricing.${key}`),
+          children: value || '-'
+        })
+        }
+      } else {
+        items.push({
+          key,
+          label: t(`pricing.${key}`),
+          children: (['pay_time', 'created_at'].includes(key) && value
+            ? dayjs(value as number).format('YYYY-MM-DD HH:mm:ss')
+            : key === 'status' && value
+              ? t(`pricing.${STATUS[value as keyof typeof STATUS].key}`)
+              : key === 'package_snapshot'
+                ? (data.from_view === 'platform' && data.legacy_product_type ? t(`pricing.${getProductType(data.legacy_product_type)}.type`) : (value as Package)[getKeyWithLanguage('name')])
+                : value) as string
+        })
       }
     })
+
+    return items
   }, [data, t, getKeyWithLanguage, getProductType])
   /** Format payment information items */
   const formatPayItems = useMemo(() => {

--- a/web/src/views/OrderHistory/index.tsx
+++ b/web/src/views/OrderHistory/index.tsx
@@ -40,10 +40,6 @@ const OrderHistory: React.FC = () => {
     { label: t('pricing.allType'), value: null },
     { label: t('package.saas_personal'), value: 'saas_personal' },
     { label: t('package.commercial_deployment'), value: 'commercial_deployment' },
-    ...Object.keys(typeMap).map(type => ({
-      label: t(`pricing.${typeMap[type] || 'ENTERPRISE'}.type`),
-      value: type
-    }))
   ]
 
   const businessTypeOptions = [
@@ -87,13 +83,11 @@ const OrderHistory: React.FC = () => {
 
   /** Map product type to translation key */
   const getProductType = (type: string) => {
-    const typeMap: Record<string, string> = {
-      'FREE': 'personal',
-      'TEAM': 'team',
-      'ENTERPRISE': 'biz',
-      'OEM': 'commerce'
-    };
-    return typeMap[type] || 'ENTERPRISE';
+    // Check if type is a valid key in typeMap
+    if (type in typeMap) {
+      return typeMap[type as keyof typeof typeMap];
+    }
+    return 'ENTERPRISE';
   };
   
   const getKeyWithLanguage = useCallback((key: string) => {
@@ -112,7 +106,7 @@ const OrderHistory: React.FC = () => {
       dataIndex: 'package_snapshot',
       key: 'package_snapshot',
       render: (package_snapshot, record) => {
-        return record.from_view === 'platform' ? t(`pricing.${getProductType(record.product_type)}.type`) : package_snapshot[getKeyWithLanguage('name')] || '-'
+        return record.from_view === 'platform' && record.legacy_product_type ? t(`pricing.${getProductType(record.legacy_product_type)}.type`) : package_snapshot[getKeyWithLanguage('name')] || '-'
       }
     },
     {

--- a/web/src/views/OrderHistory/types.ts
+++ b/web/src/views/OrderHistory/types.ts
@@ -31,6 +31,7 @@ export interface Order {
   package_plan_id: string;
   package_version: string;
   product_type: string;
+  legacy_product_type?: string;
   package_snapshot: Package;
   business_type: 'purchase' | 'renewal' | 'upgrade' | 'recharge' | 'downgrade' | 'free';
   multiplier: number;

--- a/web/src/views/OrderPayment/index.tsx
+++ b/web/src/views/OrderPayment/index.tsx
@@ -92,6 +92,7 @@ const OrderPayment: React.FC = () => {
 
   useEffect(() => {
     setUpgradePreview(null)
+    setPkg(null)
     if (location.state?.jumpFrom) {
       setJumpFrom(location.state?.jumpFrom)
 
@@ -125,6 +126,10 @@ const OrderPayment: React.FC = () => {
         setUpgradePreview(res as UpgradePreview)
       })
   }
+
+  useEffect(() => {
+    form.resetFields()
+  }, [pkg?.id])
 
   useEffect(() => {
     if (!multiplierValue || jumpFrom !== '/upgrade') return

--- a/web/src/views/Package/index.tsx
+++ b/web/src/views/Package/index.tsx
@@ -30,6 +30,8 @@ import RbCard from '@/components/RbCard/Card'
 import BodyWrapper from '@/components/Empty/BodyWrapper'
 import { useI18n } from '@/store/locale'
 import { useUser } from '@/store/user'
+import { getTenantSubscription } from '@/api/user';
+import type { Subscription } from '@/components/SiderMenu'
 
 import SpaceSvg from '@/assets/images/package/space.svg?react'
 import SkillSvg from '@/assets/images/package/skill.svg?react'
@@ -145,9 +147,17 @@ const Package: FC = () => {
       setDataReady(true)
     })
   }
+  const [curPkg, setCurPkg] = useState<Subscription | null>(null)
+  const getCurrentPackage = () => {
+    getTenantSubscription()
+      .then(res => {
+        setCurPkg(res as Subscription)
+      })
+  }
 
   useEffect(() => {
     getList()
+    getCurrentPackage()
   }, [])
 
   useEffect(() => {
@@ -177,15 +187,23 @@ const Package: FC = () => {
         navigate(user.current_workspace_id ? '/' : '/space');
         break
       default:
-        navigate(`/order-pay`, {
-          state: {
-            ...pkg,
-            jumpFrom: location.pathname
-          }
-        });
+        if (curPkg?.package_plan?.billing_cycle === 'permanent_free') {
+          navigate(`/order-pay`, {
+            state: {
+              ...pkg,
+              jumpFrom: location.pathname
+            }
+          });
+        } else {
+          navigate(`/order-pay`, {
+            state: {
+              ...pkg,
+              jumpFrom: curPkg?.package_plan_id === pkg.id ? 'renewal' : '/upgrade'
+            }
+          });
+        }
         break
     }
-    // window.open(`https://docs.redbearai.com/s/${language || 'en'}-memorybear`, '_blank')
   };
   /** Navigate to order history */
   const goToHistory = () => {


### PR DESCRIPTION
## Summary by Sourcery

在套餐、订单历史和支付视图中调整订阅和订单处理逻辑，包括改进旧版产品映射以及免费套餐的行为。

Bug 修复：
- 正确解析并展示平台来源订单和订单详情中的旧版产品类型。
- 仅在已被拒绝的订单中显示订单详情里的拒绝原因字段，并提供正确的翻译。
- 在更换套餐时重置订单支付表单和状态，避免使用到陈旧数据。

功能改进：
- 调整导航和弹窗页脚逻辑，在续费和升级流程中对永久免费的基础层订阅做差异化处理。
- 增加当前租户订阅信息的获取逻辑，以支持购买、续费和升级时的上下文感知导航。

文档：
- 为定价订单详情中新添加的拒绝原因标签增加英文和中文翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust subscription and order handling across package, order history, and payment views, including improved legacy product mapping and free-plan behavior.

Bug Fixes:
- Correctly resolve and display legacy product types for platform-origin orders and order details.
- Show a reject reason field in order details only for rejected orders, with proper translations.
- Reset order payment form and state when changing packages to avoid stale data.

Enhancements:
- Change navigation and modal footer logic to treat permanent free base-tier subscriptions differently for renewal and upgrade flows.
- Add retrieval of the current tenant subscription to drive context-aware navigation for purchase, renewal, and upgrade.

Documentation:
- Add English and Chinese translations for the new reject reason label in pricing order details.

</details>