### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from urllib.parse import quote
 
 from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.response_utils import success, fail
 from app.db import get_db
@@ -574,7 +575,6 @@ async def draft_run(
     from app.services.multi_agent_service import MultiAgentService
     from app.models import AgentConfig, ModelConfig, AppRelease
     from sqlalchemy import select
-    from app.core.exceptions import BusinessException
     from app.services.draft_run_service import AgentRunService
 
     service = AppService(db)
@@ -937,8 +937,6 @@ async def draft_run_compare(
     # 1. 验证应用和权限
     app = service._get_app_or_404(app_id)
     if app.type != "agent":
-        from app.core.exceptions import BusinessException
-        from app.core.error_codes import BizCode
         raise BusinessException("只有 Agent 类型应用支持试运行", BizCode.APP_TYPE_NOT_SUPPORTED)
     service._validate_app_accessible(app, workspace_id)
 
@@ -958,8 +956,6 @@ async def draft_run_compare(
     stmt = select(AgentConfig).where(AgentConfig.app_id == app_id)
     agent_cfg = db.scalars(stmt).first()
     if not agent_cfg:
-        from app.core.exceptions import BusinessException
-        from app.core.error_codes import BizCode
         raise BusinessException("Agent 配置不存在", BizCode.AGENT_CONFIG_MISSING)
 
     # 3. 验证所有模型配置
@@ -1086,7 +1082,9 @@ async def run_single_workflow_node(
     - 系统变量: "sys.message"、"sys.files"
     """
     workspace_id = current_user.current_workspace_id
-    config = workflow_service.check_config(app_id)
+    config = workflow_service.get_workflow_config(app_id)
+    if not config:
+        raise BusinessException("工作流配置不存在，无法运行", BizCode.CONFIG_MISSING)
 
     raw_inputs = payload.inputs or {}
     input_data = {

--- a/api/app/core/workflow/nodes/assigner/node.py
+++ b/api/app/core/workflow/nodes/assigner/node.py
@@ -19,6 +19,10 @@ class AssignerNode(BaseNode):
         self.variable_updater = True
         self.typed_config: AssignerNodeConfig | None = None
         self._input_data: dict[str, Any] | None = None
+        self._assignments_process: list = []
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": {"assignments": self._assignments_process}}
 
     def _output_types(self) -> dict[str, VariableType]:
         return {}
@@ -43,6 +47,7 @@ class AssignerNode(BaseNode):
         """
         # 在执行前提取并缓存输入数据（捕获执行前的变量值）
         self._input_data = {"config": self._resolve_config(self.config, variable_pool)}
+        self._assignments_process = []
         
         # Initialize a variable pool for accessing conversation, node, and system variables
         self.typed_config = AssignerNodeConfig(**self.config)
@@ -77,6 +82,7 @@ class AssignerNode(BaseNode):
             )
 
             # Execute the configured assignment operation
+            before_value = variable_pool.get_value(variable_selector)
             match assignment.operation:
                 case AssignmentOperator.COVER:
                     await operator.assign()
@@ -102,4 +108,10 @@ class AssignerNode(BaseNode):
                     await operator.extend()
                 case _:
                     raise ValueError(f"Invalid Operator: {assignment.operation}")
+            self._assignments_process.append({
+                "variable": variable_selector,
+                "operation": str(assignment.operation),
+                "before": before_value,
+                "after": variable_pool.get_value(variable_selector),
+            })
             logger.info(f"Node {self.node_id}: execution completed")

--- a/api/app/core/workflow/nodes/code/node.py
+++ b/api/app/core/workflow/nodes/code/node.py
@@ -55,6 +55,11 @@ class CodeNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: CodeNodeConfig | None = None
+        self._executed_code: str = ""
+        self._language: str = ""
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": {"language": self._language, "code": self._executed_code}}
 
     def _output_types(self) -> dict[str, VariableType]:
         output_dict = {}
@@ -113,6 +118,8 @@ class CodeNode(BaseNode):
             self.typed_config.code
         ).decode("utf-8")
         code = urllib.parse.unquote(code, encoding='utf-8')
+        self._executed_code = code
+        self._language = self.typed_config.language
 
         input_variable_dict = base64.b64encode(
             json.dumps(input_variable_dict).encode("utf-8")

--- a/api/app/core/workflow/nodes/document_extractor/node.py
+++ b/api/app/core/workflow/nodes/document_extractor/node.py
@@ -117,6 +117,15 @@ class DocExtractorNode(BaseNode):
             "images": VariableType.ARRAY_FILE,
         }
 
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        if isinstance(business_result, dict):
+            return {"process": {
+                "files_count": len(business_result.get("chunks", [])),
+                "total_chars": sum(len(c) for c in business_result.get("chunks", [])),
+                "images_count": len(business_result.get("images", [])),
+            }}
+        return {}
+
     def _extract_output(self, business_result: Any) -> Any:
         return business_result
 

--- a/api/app/core/workflow/nodes/if_else/node.py
+++ b/api/app/core/workflow/nodes/if_else/node.py
@@ -17,6 +17,10 @@ class IfElseNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: IfElseNodeConfig | None = None
+        self._condition_results: list = []
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": {"conditions": self._condition_results}}
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -143,6 +147,9 @@ class IfElseNode(BaseNode):
         """
         self.typed_config = IfElseNodeConfig(**self.config)
         expressions = self.evaluate_conditional_edge_expressions(variable_pool)
+        self._condition_results = [
+            {"case": f"CASE{i+1}", "result": v} for i, v in enumerate(expressions[:-1])
+        ] + [{"case": "default", "result": expressions[-1]}]
         for i in range(len(expressions)):
             if expressions[i]:
                 logger.info(f"Node {self.node_id}: switched to branch CASE {i + 1}")

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -49,7 +49,11 @@ class KnowledgeRetrievalNode(BaseNode):
         return []
 
     def _extract_extra_fields(self, business_result: Any) -> dict:
-        return {"citations": self._extract_citations(business_result)}
+        citations = self._extract_citations(business_result)
+        process: dict = {"citations": citations}
+        if isinstance(business_result, dict):
+            process["chunks_count"] = len(business_result.get("chunks", []))
+        return {"citations": citations, "process": process}
 
     def _extract_input(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
         return {

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -295,6 +295,16 @@ class LLMNode(BaseNode):
             }
         }
 
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        llm_result = business_result.get("llm_result") if isinstance(business_result, dict) else business_result
+        if isinstance(llm_result, AIMessage) and llm_result.response_metadata:
+            meta = llm_result.response_metadata
+            return {"process": {
+                "finish_reason": meta.get("finish_reason") or meta.get("stop_reason"),
+                "model": meta.get("model") or meta.get("model_name"),
+            }}
+        return {}
+
     def _extract_output(self, business_result: Any) -> dict:
         """从业务结果中提取输出变量
         

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -18,6 +18,10 @@ class MemoryReadNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: MemoryReadNodeConfig | None = None
+        self._process: dict = {}
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": self._process}
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -40,11 +44,14 @@ class MemoryReadNode(BaseNode):
                 end_user_id=end_user_id,
                 user_rag_memory_id=state["user_rag_memory_id"],
             )
+            query = self._render_template(self.typed_config.message, variable_pool)
+            self._process = {"query": query, "config_id": str(self.typed_config.config_id)}
             # TODO: Historical Messages -> Used to refer to coreference resolution
             search_result = await memory_service.read(
-                self._render_template(self.typed_config.message, variable_pool),
+                query,
                 search_switch=SearchStrategy(self.typed_config.search_switch)
             )
+            self._process["memories_count"] = len(search_result.memories)
             return {
                 "answer": search_result.content,
                 "intermediate_outputs": [_.model_dump() for _ in search_result.memories]
@@ -66,6 +73,10 @@ class MemoryWriteNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: MemoryWriteNodeConfig | None = None
+        self._process: dict = {}
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": self._process}
 
     def _output_types(self) -> dict[str, VariableType]:
         return {"output": VariableType.STRING}
@@ -138,6 +149,11 @@ class MemoryWriteNode(BaseNode):
                 "user_rag_memory_id": state["user_rag_memory_id"]
             }
         )
+        self._process = {
+            "config_id": str(self.typed_config.config_id),
+            "messages": messages,
+            "messages_count": len(messages),
+        }
         # write_message_task.delay(
         #     end_user_id=end_user_id,
         #     message=messages,

--- a/api/app/core/workflow/nodes/parameter_extractor/node.py
+++ b/api/app/core/workflow/nodes/parameter_extractor/node.py
@@ -25,6 +25,7 @@ class ParameterExtractorNode(BaseNode):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: ParameterExtractorNodeConfig | None = None
         self.response_metadata = {}
+        self._last_messages: list = []
 
     def _extract_token_usage(self, business_result: Any) -> dict[str, int] | None:
         if self.response_metadata:
@@ -44,6 +45,12 @@ class ParameterExtractorNode(BaseNode):
             "params": [param.model_dump(mode="json") for param in self.typed_config.params],
             "model_id": str(self.typed_config.model_id),
         }
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": {
+            "messages": self._last_messages,
+            "model_id": str(self.typed_config.model_id) if self.typed_config else None,
+        }}
 
     def _extract_output(self, business_result: Any) -> Any:
         final_output = {}
@@ -206,6 +213,7 @@ class ParameterExtractorNode(BaseNode):
             messages.extend([
                 ("user", rendered_user_prompt),
             ])
+        self._last_messages = [{"role": r, "content": c} for r, c in messages]
 
         model_resp = await llm.ainvoke(messages)
         self.response_metadata = {

--- a/api/app/core/workflow/nodes/question_classifier/node.py
+++ b/api/app/core/workflow/nodes/question_classifier/node.py
@@ -27,6 +27,15 @@ class QuestionClassifierNode(BaseNode):
         self.typed_config: QuestionClassifierNodeConfig | None = None
         self.category_to_case_map = {}
         self.response_metadata = {}
+        self._last_messages: list = []
+        self._classification_result: str = ""
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": {
+            "messages": self._last_messages,
+            "classification_result": self._classification_result,
+            "model_id": str(self.typed_config.model_id) if self.typed_config else None,
+        }}
 
     def _extract_token_usage(self, business_result: Any) -> dict[str, int] | None:
         if self.response_metadata:
@@ -133,9 +142,11 @@ class QuestionClassifierNode(BaseNode):
                 ("system", self.typed_config.system_prompt),
                 ("user", user_prompt),
             ]
+            self._last_messages = [{"role": r, "content": c} for r, c in messages]
 
             response = await llm.ainvoke(messages)
             result = self.process_model_output(response.content)
+            self._classification_result = result
             self.response_metadata = {
                 **response.response_metadata,
                 "token_usage": getattr(response, 'usage_metadata', None) or response.response_metadata.get('token_usage')

--- a/api/app/core/workflow/nodes/tool/node.py
+++ b/api/app/core/workflow/nodes/tool/node.py
@@ -25,6 +25,10 @@ class ToolNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: ToolNodeConfig | None = None
+        self._process: dict = {}
+
+    def _extract_extra_fields(self, business_result: Any) -> dict:
+        return {"process": self._process}
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -73,6 +77,7 @@ class ToolNode(BaseNode):
             rendered_parameters[param_name] = rendered_value
 
         logger.info(f"节点 {self.node_id} 执行工具 {self.typed_config.tool_id}，参数: {rendered_parameters}")
+        self._process = {"tool_id": str(self.typed_config.tool_id), "parameters": rendered_parameters}
 
         # 执行工具
         with get_db_read() as db:
@@ -99,6 +104,7 @@ class ToolNode(BaseNode):
 
         if result.success:
             logger.info(f"节点 {self.node_id} 工具执行成功")
+            self._process["raw_output"] = result.data
             return {
                 "data": result.data if isinstance(result.data, str) else json.dumps(result.data, ensure_ascii=False),
                 "execution_time": result.execution_time

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1196,6 +1196,10 @@ class WorkflowService:
                 var_type = VariableType.type_map(value)
                 await variable_pool.new(ref_node_id, var_name, value, var_type, mut=False)
 
+        cycle_nodes = [
+            n.get("id") for n in workflow_config_dict.get("nodes", [])
+            if n.get("type") in [NodeType.LOOP, NodeType.ITERATION]
+        ]
         state = WorkflowState(
             messages=input_data.get("conv_messages", []),
             node_outputs={},
@@ -1204,7 +1208,7 @@ class WorkflowService:
             user_id=input_data.get("user_id", ""),
             error=None,
             error_node=None,
-            cycle_nodes=[],
+            cycle_nodes=cycle_nodes,
             looping=0,
             activate={node_id: True},
             memory_storage_type=storage_type,
@@ -1237,6 +1241,7 @@ class WorkflowService:
                 "node_type": node_config.get("type"),
                 "inputs": node._extract_input(state, variable_pool),
                 "outputs": node._extract_output(result),
+                "process": node._extract_extra_fields(result).get("process"),
                 "token_usage": node._extract_token_usage(result),
                 "elapsed_time": elapsed,
                 "error": None,
@@ -1296,6 +1301,7 @@ class WorkflowService:
                     "status": "succeeded",
                     "inputs": node._extract_input(state, variable_pool),
                     "outputs": node._extract_output(final_result),
+                    "process": node._extract_extra_fields(final_result).get("process"),
                     "token_usage": node._extract_token_usage(final_result),
                     "elapsed_time": elapsed,
                     "error": None,


### PR DESCRIPTION
add process metadata extraction for workflow nodes

## Summary by Sourcery

添加工作流节点进程元数据提取功能，并将其包含在单节点运行结果中。

新功能：
- 在运行单个节点或流式运行单个节点时，捕获并暴露跨工作流节点的每个节点进程元数据（查询、消息、操作、工具调用等）。

增强：
- 为记忆节点、分配器节点、分类器节点、参数提取器节点、LLM 节点、文档提取器节点、代码节点、if/else 节点、知识节点和工具节点记录详细的进程信息，以提升工作流执行的可观测性和调试能力。
- 在构建工作流状态时，从工作流配置中自动推导循环节点 ID，而不是初始化为空列表。
- 在运行单个工作流节点时改进校验逻辑，通过检查缺失的工作流配置并抛出特定的业务错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add workflow node process metadata extraction and include it in single-node run results.

New Features:
- Capture and expose per-node process metadata (queries, messages, operations, tool calls, etc.) across workflow nodes when running a single node or streaming a single node.

Enhancements:
- Record detailed process information for memory, assigner, classifier, parameter extractor, LLM, document extractor, code, if/else, knowledge, and tool nodes to improve observability and debugging of workflow executions.
- Automatically derive cycle node IDs from workflow config when building workflow state instead of initializing an empty list.
- Improve validation when running a single workflow node by checking for missing workflow configurations and raising a specific business error.

</details>