### PR TITLE
fix(memory): add dialog_at/files support and sync memory_count after …

### DIFF
--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -185,10 +185,32 @@ async def write_server(
                 config_id=config_id,
                 storage_type=storage_type,
                 user_rag_memory_id=user_rag_memory_id,
-                language=language,
+                language=language
             ),
             db,
         )
+
+        # ── 方案A：写入成功后同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
+        if storage_type == "neo4j":
+            try:
+                from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
+                from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+                connector = Neo4jConnector()
+                try:
+                    _new_count = await sync_end_user_memory_count_from_neo4j(
+                        user_input.end_user_id, connector
+                    )
+                    api_logger.info(
+                        f"[writer_service] memory_count 同步完成: "
+                        f"end_user_id={user_input.end_user_id}, count={_new_count}"
+                    )
+                finally:
+                    await connector.close()
+            except Exception as _sync_e:
+                api_logger.warning(
+                    f"[writer_service] memory_count 同步失败（不影响主流程）: "
+                    f"end_user_id={user_input.end_user_id}, error={_sync_e}"
+                )
 
         return success(data=result, msg="写入成功")
     except BaseException as e:
@@ -200,66 +222,66 @@ async def write_server(
             return fail(BizCode.INTERNAL_ERROR, "写入失败", detailed_error)
         api_logger.error(f"Write operation error: {str(e)}", exc_info=True)
         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
-
-
-@router.post("/writer_service_async", response_model=ApiResponse)
-@cur_workspace_access_guard()
-async def write_server_async(
-        user_input: Write_UserInput,
-        language_type: str = Header(default=None, alias="X-Language-Type"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
-):
-    """
-    Async write service endpoint - enqueues write processing to Celery
-
-    Args:
-        user_input: Write request containing message and end_user_id
-        language_type: 语言类型 ("zh" 中文, "en" 英文)，通过 X-Language-Type Header 传递
-
-    Returns:
-        Task ID for tracking async operation
-        Use GET /memory/write_result/{task_id} to check task status and get result
-    """
-    # 使用集中化的语言校验
-    language = get_language_from_header(language_type)
-
-    config_id = user_input.config_id
-    workspace_id = current_user.current_workspace_id
-    api_logger.info(
-        f"Async write service: workspace_id={workspace_id}, config_id={config_id}, language_type={language}")
-
-    # 获取 storage_type，如果为 None 则使用默认值
-    storage_type = workspace_service.get_workspace_storage_type(
-        db=db,
-        workspace_id=workspace_id,
-        user=current_user
-    )
-    if storage_type is None: storage_type = 'neo4j'
-    user_rag_memory_id = ''
-    if workspace_id:
-
-        knowledge = knowledge_repository.get_knowledge_by_name(
-            db=db,
-            name="USER_RAG_MERORY",
-            workspace_id=workspace_id
-        )
-        if knowledge: user_rag_memory_id = str(knowledge.id)
-    api_logger.info(f"Async write: storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}")
-    try:
-        # 获取标准化的消息列表
-        messages_list = memory_agent_service.get_messages_list(user_input)
-
-        task = celery_app.send_task(
-            "app.core.memory.agent.write_message",
-            args=[user_input.end_user_id, messages_list, config_id, storage_type, user_rag_memory_id, language]
-        )
-        api_logger.info(f"Write task queued: {task.id}")
-
-        return success(data={"task_id": task.id}, msg="写入任务已提交")
-    except Exception as e:
-        api_logger.error(f"Async write operation failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
+#
+#
+# @router.post("/writer_service_async", response_model=ApiResponse)
+# @cur_workspace_access_guard()
+# async def write_server_async(
+#         user_input: Write_UserInput,
+#         language_type: str = Header(default=None, alias="X-Language-Type"),
+#         db: Session = Depends(get_db),
+#         current_user: User = Depends(get_current_user)
+# ):
+#     """
+#     Async write service endpoint - enqueues write processing to Celery
+#
+#     Args:
+#         user_input: Write request containing message and end_user_id
+#         language_type: 语言类型 ("zh" 中文, "en" 英文)，通过 X-Language-Type Header 传递
+#
+#     Returns:
+#         Task ID for tracking async operation
+#         Use GET /memory/write_result/{task_id} to check task status and get result
+#     """
+#     # 使用集中化的语言校验
+#     language = get_language_from_header(language_type)
+#
+#     config_id = user_input.config_id
+#     workspace_id = current_user.current_workspace_id
+#     api_logger.info(
+#         f"Async write service: workspace_id={workspace_id}, config_id={config_id}, language_type={language}")
+#
+#     # 获取 storage_type，如果为 None 则使用默认值
+#     storage_type = workspace_service.get_workspace_storage_type(
+#         db=db,
+#         workspace_id=workspace_id,
+#         user=current_user
+#     )
+#     if storage_type is None: storage_type = 'neo4j'
+#     user_rag_memory_id = ''
+#     if workspace_id:
+#
+#         knowledge = knowledge_repository.get_knowledge_by_name(
+#             db=db,
+#             name="USER_RAG_MERORY",
+#             workspace_id=workspace_id
+#         )
+#         if knowledge: user_rag_memory_id = str(knowledge.id)
+#     api_logger.info(f"Async write: storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}")
+#     try:
+#         # 获取标准化的消息列表
+#         messages_list = memory_agent_service.get_messages_list(user_input)
+#
+#         task = celery_app.send_task(
+#             "app.core.memory.agent.write_message",
+#             args=[user_input.end_user_id, messages_list, config_id, storage_type, user_rag_memory_id, language]
+#         )
+#         api_logger.info(f"Write task queued: {task.id}")
+#
+#         return success(data={"task_id": task.id}, msg="写入任务已提交")
+#     except Exception as e:
+#         api_logger.error(f"Async write operation failed: {str(e)}")
+#         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
 
 
 @router.post("/read_service", response_model=ApiResponse)

--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -192,25 +192,8 @@ async def write_server(
 
         # ── 方案A：写入成功后同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
         if storage_type == "neo4j":
-            try:
-                from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
-                from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-                connector = Neo4jConnector()
-                try:
-                    _new_count = await sync_end_user_memory_count_from_neo4j(
-                        user_input.end_user_id, connector
-                    )
-                    api_logger.info(
-                        f"[writer_service] memory_count 同步完成: "
-                        f"end_user_id={user_input.end_user_id}, count={_new_count}"
-                    )
-                finally:
-                    await connector.close()
-            except Exception as _sync_e:
-                api_logger.warning(
-                    f"[writer_service] memory_count 同步失败（不影响主流程）: "
-                    f"end_user_id={user_input.end_user_id}, error={_sync_e}"
-                )
+            from app.core.memory.utils.memory_count_utils import _async_sync_memory_count_neo4j
+            await _async_sync_memory_count_neo4j(end_user_id=user_input.end_user_id)
 
         return success(data=result, msg="写入成功")
     except BaseException as e:

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -1,9 +1,14 @@
+import asyncio
+import logging
 from uuid import UUID
 
 from app.db import get_db_context
 from app.models.end_user_model import EndUser
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+_logger = logging.getLogger(__name__)
+_LOG_PREFIX = "[MEMORY_COUNT_SYNC]"
 
 
 async def sync_end_user_memory_count_from_neo4j(
@@ -33,4 +38,55 @@ async def sync_end_user_memory_count_from_neo4j(
         )
         db.commit()
 
+    _logger.info(f"{_LOG_PREFIX} 同步完成: end_user_id={end_user_id}, count={node_count}")
     return node_count
+
+
+async def _async_sync_memory_count_neo4j(
+    end_user_id: str,
+    connector: Neo4jConnector | None = None,
+) -> int:
+    """
+    Async helper: sync memory count, optionally managing the connector lifecycle.
+
+    If *connector* is None, a new Neo4jConnector is created and closed internally.
+    If *connector* is provided, the caller is responsible for closing it.
+    """
+    owned = connector is None
+    if owned:
+        connector = Neo4jConnector()
+    try:
+        return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+    except Exception as exc:
+        _logger.warning(
+            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"
+        )
+        return 0
+    finally:
+        if owned:
+            await connector.close()
+
+
+def sync_memory_count_neo4j(end_user_id: str) -> None:
+    """
+    Synchronous wrapper for use in Celery tasks and other sync contexts.
+
+    Reuses the current event loop if available and open; otherwise creates a
+    new one.  All exceptions are caught and logged so callers never need an
+    extra try/except just for logging.
+    """
+    try:
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_closed():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        loop.run_until_complete(_async_sync_memory_count_neo4j(end_user_id))
+    except Exception as exc:
+        _logger.warning(
+            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"
+        )

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -1,10 +1,12 @@
 import uuid
 from abc import ABC
 from enum import Enum
-from typing import Any, Optional
-from pydantic import Field
+from typing import Any
+from typing import Optional, List
 
 from pydantic import BaseModel, Field
+
+from app.schemas.app_schema import FileInput
 
 
 class StorageType(str, Enum):
@@ -41,8 +43,19 @@ class UserInput(BaseModel):
     config_id: Optional[str] = None
 
 
+class WriteMessageItem(BaseModel):
+    """写入记忆的单条消息"""
+    role: str = Field(..., description="消息角色: user 或 assistant")
+    content: str = Field(..., description="消息内容")
+    dialog_at: Optional[str] = Field(
+        None,
+        description="该条消息发生的绝对时间（ISO 8601 格式），不传则使用服务端当前时间",
+    )
+    files: Optional[List[FileInput]] = Field(default=None, description="附带的文件列表（图片/文档/音频/视频）")
+
+
 class Write_UserInput(BaseModel):
-    messages: list[dict]
+    messages: List[WriteMessageItem] = Field(..., description="消息列表")
     end_user_id: str
     config_id: Optional[str] = None
 

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -433,8 +433,11 @@ class MemoryAgentService:
                 if file_object is None:
                     continue
                 if isinstance(message, dict):
+                    message["content"] = f"<input-file-summary>{file_object.summary}</input-file-summary>" + message[
+                        "content"]
                     message["file_content"].append((file_object, file["type"]))
                 else:
+                    message.content = f"<input-file-summary>{file_object.summary}</input-file-summary>" + message.content
                     message.file_content.append((file_object, file["type"]))
         logger.info(messages)
         return messages
@@ -742,7 +745,7 @@ class MemoryAgentService:
             user_input: Write_UserInput object
         
         Returns:
-            list[dict]: Message list, each message contains role and content
+            list[dict]: Message list, each message contains role, content, and optionally files
             
         Raises:
             ValueError: If messages is empty or format is incorrect
@@ -754,31 +757,25 @@ class MemoryAgentService:
             logger.error("Validation failed: Message list cannot be empty")
             raise ValueError("Message list cannot be empty")
 
+        result = []
         for idx, msg in enumerate(user_input.messages):
-            if not isinstance(msg, dict):
-                logger.error(f"Validation failed: Message {idx} is not a dict: {type(msg)}")
-                raise ValueError(
-                    f"Message format error: Message must be a dictionary. Error message index: {idx}, type: {type(msg)}")
+            if msg.role not in ['user', 'assistant']:
+                logger.error(f"Validation failed: Message {idx} invalid role: {msg.role}")
+                raise ValueError(f"Role must be 'user' or 'assistant', got: {msg.role}. Message index: {idx}")
 
-            if 'role' not in msg:
-                logger.error(f"Validation failed: Message {idx} missing 'role' field: {msg}")
-                raise ValueError(f"Message format error: Message must contain 'role' field. Error message index: {idx}")
-
-            if 'content' not in msg:
-                logger.error(f"Validation failed: Message {idx} missing 'content' field: {msg}")
-                raise ValueError(
-                    f"Message format error: Message must contain 'content' field. Error message index: {idx}")
-
-            if msg['role'] not in ['user', 'assistant']:
-                logger.error(f"Validation failed: Message {idx} invalid role: {msg['role']}")
-                raise ValueError(f"Role must be 'user' or 'assistant', got: {msg['role']}. Message index: {idx}")
-
-            if not msg['content'] or not msg['content'].strip():
+            if not msg.content or not msg.content.strip():
                 logger.error(f"Validation failed: Message {idx} content is empty")
-                raise ValueError(f"Message content cannot be empty. Message index: {idx}, role: {msg['role']}")
+                raise ValueError(f"Message content cannot be empty. Message index: {idx}, role: {msg.role}")
 
-        logger.info(f"Validation successful: Structured message list, count: {len(user_input.messages)}")
-        return user_input.messages
+            msg_dict = {"role": msg.role, "content": msg.content}
+            if msg.dialog_at:
+                msg_dict["dialog_at"] = msg.dialog_at
+            if msg.files:
+                msg_dict["files"] = [f.model_dump(exclude_none=True) for f in msg.files]
+            result.append(msg_dict)
+
+        logger.info(f"Validation successful: Structured message list, count: {len(result)}")
+        return result
 
     async def classify_message_type(
             self,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1531,6 +1531,32 @@ def write_message_task(
                 )
         except Exception as _e:
             logger.warning(f"[CELERY WRITE] 写入 last_done 时间戳失败（不影响主流程）: {_e}")
+
+        # ── 方案A：写入成功后同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
+        if storage_type == "neo4j":
+            try:
+                from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
+                from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+                async def _sync_count():
+                    connector = Neo4jConnector()
+                    try:
+                        return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+                    finally:
+                        await connector.close()
+
+                _sync_loop = set_asyncio_event_loop()
+                _new_count = _sync_loop.run_until_complete(_sync_count())
+                logger.info(
+                    f"[CELERY WRITE] memory_count 同步完成: "
+                    f"end_user_id={end_user_id}, count={_new_count}"
+                )
+            except Exception as _sync_e:
+                logger.warning(
+                    f"[CELERY WRITE] memory_count 同步失败（不影响主流程）: "
+                    f"end_user_id={end_user_id}, error={_sync_e}"
+                )
+
         # 将 result 转为 JSON 安全结构，避免 Celery JSON 序列化 pydantic BaseModel / UUID 失败
         try:
             safe_result = jsonable_encoder(result)
@@ -1983,6 +2009,32 @@ def post_store_dedup_and_alias_merge_task(
         logger.info(
             f"[PostStore] 任务完成: {result}, 耗时={elapsed:.2f}s, task_id={task_id}"
         )
+
+        # ── 方案A：去重归并完成后同步 memory_count 到 PostgreSQL ──
+        # 第二层去重可能合并/删除节点，导致节点数减少，需要重新同步
+        try:
+            from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
+            from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+            async def _sync_count_post():
+                connector = Neo4jConnector()
+                try:
+                    return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+                finally:
+                    await connector.close()
+
+            _sync_loop = set_asyncio_event_loop()
+            _new_count = _sync_loop.run_until_complete(_sync_count_post())
+            logger.info(
+                f"[PostStore] memory_count 同步完成: "
+                f"end_user_id={end_user_id}, count={_new_count}"
+            )
+        except Exception as _sync_e:
+            logger.warning(
+                f"[PostStore] memory_count 同步失败（不影响主流程）: "
+                f"end_user_id={end_user_id}, error={_sync_e}"
+            )
+
         return {
             "status": "SUCCESS",
             **result,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1534,28 +1534,8 @@ def write_message_task(
 
         # ── 方案A：写入成功后同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
         if storage_type == "neo4j":
-            try:
-                from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
-                from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-
-                async def _sync_count():
-                    connector = Neo4jConnector()
-                    try:
-                        return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
-                    finally:
-                        await connector.close()
-
-                _sync_loop = set_asyncio_event_loop()
-                _new_count = _sync_loop.run_until_complete(_sync_count())
-                logger.info(
-                    f"[CELERY WRITE] memory_count 同步完成: "
-                    f"end_user_id={end_user_id}, count={_new_count}"
-                )
-            except Exception as _sync_e:
-                logger.warning(
-                    f"[CELERY WRITE] memory_count 同步失败（不影响主流程）: "
-                    f"end_user_id={end_user_id}, error={_sync_e}"
-                )
+            from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
+            sync_memory_count_neo4j(end_user_id=end_user_id)
 
         # 将 result 转为 JSON 安全结构，避免 Celery JSON 序列化 pydantic BaseModel / UUID 失败
         try:
@@ -2012,28 +1992,8 @@ def post_store_dedup_and_alias_merge_task(
 
         # ── 方案A：去重归并完成后同步 memory_count 到 PostgreSQL ──
         # 第二层去重可能合并/删除节点，导致节点数减少，需要重新同步
-        try:
-            from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
-            from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-
-            async def _sync_count_post():
-                connector = Neo4jConnector()
-                try:
-                    return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
-                finally:
-                    await connector.close()
-
-            _sync_loop = set_asyncio_event_loop()
-            _new_count = _sync_loop.run_until_complete(_sync_count_post())
-            logger.info(
-                f"[PostStore] memory_count 同步完成: "
-                f"end_user_id={end_user_id}, count={_new_count}"
-            )
-        except Exception as _sync_e:
-            logger.warning(
-                f"[PostStore] memory_count 同步失败（不影响主流程）: "
-                f"end_user_id={end_user_id}, error={_sync_e}"
-            )
+        from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
+        sync_memory_count_neo4j(end_user_id=end_user_id)
 
         return {
             "status": "SUCCESS",


### PR DESCRIPTION
- Add WriteMessageItem schema with dialog_at and files fields
- Refactor message validation to use Pydantic models instead of dicts
- Sync end_user memory_count to PostgreSQL after neo4j write and dedup
- Disable async write endpoint

## Summary by Sourcery

添加结构化消息模式（schema），支持可选的对话时间戳和文件；增强消息预处理；将 Neo4j 中的终端用户记忆计数同步到 PostgreSQL；并禁用异步记忆写入接口。

New Features:
- 引入 `WriteMessageItem` 模式（schema），以支持结构化写入消息，并带有可选的 `dialog_at` 时间戳和附加文件。

Bug Fixes:
- 确保在写入操作和存储后去重（post-store deduplication）之后，PostgreSQL 中的 `end_user` 的 `memory_count` 与 Neo4j 保持同步。

Enhancements:
- 优化消息校验逻辑，改用 Pydantic 模型，并返回规范化的消息字典，其中包含可选的 `dialog_at` 和 `files` 字段。
- 增强文件预处理逻辑，将输入文件摘要注入到消息内容中，以便下游处理。

Chores:
- 通过注释掉 `writer_service_async` 异步端点（endpoint）来禁用该接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add structured message schema with optional dialog timestamps and files, enhance message preprocessing, synchronize end-user memory counts from Neo4j to PostgreSQL, and disable the async memory write endpoint.

New Features:
- Introduce a WriteMessageItem schema to support structured write messages with optional dialog_at timestamps and attached files.

Bug Fixes:
- Ensure end_user memory_count in PostgreSQL is kept in sync with Neo4j after write operations and post-store deduplication.

Enhancements:
- Refine message validation to use Pydantic models and return normalized message dictionaries including optional dialog_at and files fields.
- Augment file preprocessing to inject input file summaries into message content for downstream processing.

Chores:
- Disable the async writer_service_async endpoint by commenting it out.

</details>