### PR TITLE
fix(memory): re-sync memory_count after writes with reusable utilities

### DIFF
--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -46,9 +46,8 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
     """
     Synchronous wrapper for use in Celery tasks and other sync contexts.
 
-    Reuses the current event loop if available and open; otherwise creates a
-    new one. All exceptions are caught and logged so callers never need an
-    extra try/except just for logging.
+    Uses asyncio.run() which creates a fresh event loop, runs the coroutine,
+    and closes the loop automatically — no resource leaks.
     """
     async def _run():
         connector = Neo4jConnector()
@@ -58,16 +57,7 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
             await connector.close()
 
     try:
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_closed():
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-        loop.run_until_complete(_run())
+        asyncio.run(_run())
     except Exception as exc:
         _logger.warning(
             f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -1,9 +1,14 @@
+import asyncio
+import logging
 from uuid import UUID
 
 from app.db import get_db_context
 from app.models.end_user_model import EndUser
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+_logger = logging.getLogger(__name__)
+_LOG_PREFIX = "[MEMORY_COUNT_SYNC]"
 
 
 async def sync_end_user_memory_count_from_neo4j(
@@ -33,4 +38,37 @@ async def sync_end_user_memory_count_from_neo4j(
         )
         db.commit()
 
+    _logger.info(f"{_LOG_PREFIX} 同步完成: end_user_id={end_user_id}, count={node_count}")
     return node_count
+
+
+def sync_memory_count_neo4j(end_user_id: str) -> None:
+    """
+    Synchronous wrapper for use in Celery tasks and other sync contexts.
+
+    Reuses the current event loop if available and open; otherwise creates a
+    new one. All exceptions are caught and logged so callers never need an
+    extra try/except just for logging.
+    """
+    async def _run():
+        connector = Neo4jConnector()
+        try:
+            await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+        finally:
+            await connector.close()
+
+    try:
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_closed():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        loop.run_until_complete(_run())
+    except Exception as exc:
+        _logger.warning(
+            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"
+        )

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -38,6 +38,7 @@ from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
 from app.core.memory.memory_service import MemoryService
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.core.memory.utils.log.audit_logger import audit_logger
+from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.db import get_db_context
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -313,6 +314,16 @@ class MemoryAgentService:
 
                 # ── Step 4: 后处理 ── 失效缓存、序列化文件路径、记录审计日志并返回结果
                 await self._invalidate_interest_cache(end_user_id)
+
+                # ── Step 5: 同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
+                _connector = Neo4jConnector()
+                try:
+                    await sync_end_user_memory_count_from_neo4j(end_user_id, _connector)
+                except Exception as _sync_e:
+                    logger.warning(f"[MEMORY_COUNT_SYNC] 同步失败（不影响主流程）: end_user_id={end_user_id}, error={_sync_e}")
+                finally:
+                    await _connector.close()
+
                 for message in messages:
                     if isinstance(message, dict):
                         message["file_content"] = [

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -44,7 +44,7 @@ from app.schemas.memory_agent_schema import WriteMemoryRequest
 from app.services.memory_forget_service import MemoryForgetService
 from app.utils.config_utils import resolve_config_id
 from app.utils.redis_lock import RedisFairLock
-from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
+from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 
 logger = get_logger(__name__)
 
@@ -1974,6 +1974,17 @@ def post_store_dedup_and_alias_merge_task(
         finally:
             await connector.close()
 
+        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
+        _count_connector = Neo4jConnector()
+        try:
+            await sync_end_user_memory_count_from_neo4j(end_user_id, _count_connector)
+        except Exception as _sync_e:
+            logger.warning(
+                f"[MEMORY_COUNT_SYNC] 同步失败（不影响主流程）: end_user_id={end_user_id}, error={_sync_e}"
+            )
+        finally:
+            await _count_connector.close()
+
         return result_info
 
     loop = None
@@ -1984,9 +1995,6 @@ def post_store_dedup_and_alias_merge_task(
         logger.info(
             f"[PostStore] 任务完成: {result}, 耗时={elapsed:.2f}s, task_id={task_id}"
         )
-
-        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
-        sync_memory_count_neo4j(end_user_id=end_user_id)
 
         return {
             "status": "SUCCESS",

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -44,6 +44,7 @@ from app.schemas.memory_agent_schema import WriteMemoryRequest
 from app.services.memory_forget_service import MemoryForgetService
 from app.utils.config_utils import resolve_config_id
 from app.utils.redis_lock import RedisFairLock
+from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
 
 logger = get_logger(__name__)
 
@@ -1983,6 +1984,10 @@ def post_store_dedup_and_alias_merge_task(
         logger.info(
             f"[PostStore] 任务完成: {result}, 耗时={elapsed:.2f}s, task_id={task_id}"
         )
+
+        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
+        sync_memory_count_neo4j(end_user_id=end_user_id)
+
         return {
             "status": "SUCCESS",
             **result,


### PR DESCRIPTION
## Summary by Sourcery

添加可复用的实用工具，在内存写入和存储后任务之后，将终端用户的 `memory_count` 从 Neo4j 重新同步到 PostgreSQL，从而提高两个存储之间的一致性。

Bug Fixes:
- 确保在可能合并或删除节点的 Neo4j 写入流程之后，PostgreSQL 中的 `memory_count` 会被重新同步，防止计数器数据陈旧。

Enhancements:
- 引入一个可复用的同步包装器，用于封装异步的 `memory_count` 同步逻辑，以便在 Celery 和其他同步上下文中使用，并具备健壮的事件循环处理和日志记录。
- 在 `memory_count` 同步成功和失败路径上添加结构化日志，以提升可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add reusable utilities to resync end-user memory_count from Neo4j to PostgreSQL after memory writes and post-store tasks, improving consistency between the two stores.

Bug Fixes:
- Ensure memory_count in PostgreSQL is resynchronized after Neo4j write flows that may merge or delete nodes, preventing stale counters.

Enhancements:
- Introduce a reusable synchronous wrapper around the async memory_count sync logic for use in Celery and other sync contexts, with robust event-loop handling and logging.
- Add structured logging around memory_count synchronization success and failure paths for better observability.

</details>