### PR TITLE
Fix/memory count

### DIFF
--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -46,9 +46,8 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
     """
     Synchronous wrapper for use in Celery tasks and other sync contexts.
 
-    Reuses the current event loop if available and open; otherwise creates a
-    new one. All exceptions are caught and logged so callers never need an
-    extra try/except just for logging.
+    Uses asyncio.run() which creates a fresh event loop, runs the coroutine,
+    and closes the loop automatically — no resource leaks.
     """
     async def _run():
         connector = Neo4jConnector()
@@ -58,16 +57,7 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
             await connector.close()
 
     try:
-        try:
-            loop = asyncio.get_event_loop()
-            if loop.is_closed():
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-        loop.run_until_complete(_run())
+        asyncio.run(_run())
     except Exception as exc:
         _logger.warning(
             f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -1,9 +1,14 @@
+import asyncio
+import logging
 from uuid import UUID
 
 from app.db import get_db_context
 from app.models.end_user_model import EndUser
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+_logger = logging.getLogger(__name__)
+_LOG_PREFIX = "[MEMORY_COUNT_SYNC]"
 
 
 async def sync_end_user_memory_count_from_neo4j(
@@ -33,4 +38,37 @@ async def sync_end_user_memory_count_from_neo4j(
         )
         db.commit()
 
+    _logger.info(f"{_LOG_PREFIX} 同步完成: end_user_id={end_user_id}, count={node_count}")
     return node_count
+
+
+def sync_memory_count_neo4j(end_user_id: str) -> None:
+    """
+    Synchronous wrapper for use in Celery tasks and other sync contexts.
+
+    Reuses the current event loop if available and open; otherwise creates a
+    new one. All exceptions are caught and logged so callers never need an
+    extra try/except just for logging.
+    """
+    async def _run():
+        connector = Neo4jConnector()
+        try:
+            await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+        finally:
+            await connector.close()
+
+    try:
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_closed():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
+        loop.run_until_complete(_run())
+    except Exception as exc:
+        _logger.warning(
+            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"
+        )

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -60,5 +60,6 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
         asyncio.run(_run())
     except Exception as exc:
         _logger.warning(
-            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}"
+            f"{_LOG_PREFIX} 同步失败（不影响主流程）: end_user_id={end_user_id}, error={exc}",
+            exc_info=True,
         )

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -38,6 +38,7 @@ from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
 from app.core.memory.memory_service import MemoryService
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.core.memory.utils.log.audit_logger import audit_logger
+from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.db import get_db_context
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -313,6 +314,16 @@ class MemoryAgentService:
 
                 # ── Step 4: 后处理 ── 失效缓存、序列化文件路径、记录审计日志并返回结果
                 await self._invalidate_interest_cache(end_user_id)
+
+                # ── Step 5: 同步 memory_count 到 PostgreSQL（仅 neo4j 模式）──
+                _connector = Neo4jConnector()
+                try:
+                    await sync_end_user_memory_count_from_neo4j(end_user_id, _connector)
+                except Exception as _sync_e:
+                    logger.warning(f"[MEMORY_COUNT_SYNC] 同步失败（不影响主流程）: end_user_id={end_user_id}, error={_sync_e}")
+                finally:
+                    await _connector.close()
+
                 for message in messages:
                     if isinstance(message, dict):
                         message["file_content"] = [

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -44,7 +44,7 @@ from app.schemas.memory_agent_schema import WriteMemoryRequest
 from app.services.memory_forget_service import MemoryForgetService
 from app.utils.config_utils import resolve_config_id
 from app.utils.redis_lock import RedisFairLock
-from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
+from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 
 logger = get_logger(__name__)
 
@@ -1974,6 +1974,17 @@ def post_store_dedup_and_alias_merge_task(
         finally:
             await connector.close()
 
+        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
+        _count_connector = Neo4jConnector()
+        try:
+            await sync_end_user_memory_count_from_neo4j(end_user_id, _count_connector)
+        except Exception as _sync_e:
+            logger.warning(
+                f"[MEMORY_COUNT_SYNC] 同步失败（不影响主流程）: end_user_id={end_user_id}, error={_sync_e}"
+            )
+        finally:
+            await _count_connector.close()
+
         return result_info
 
     loop = None
@@ -1984,9 +1995,6 @@ def post_store_dedup_and_alias_merge_task(
         logger.info(
             f"[PostStore] 任务完成: {result}, 耗时={elapsed:.2f}s, task_id={task_id}"
         )
-
-        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
-        sync_memory_count_neo4j(end_user_id=end_user_id)
 
         return {
             "status": "SUCCESS",

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -44,6 +44,7 @@ from app.schemas.memory_agent_schema import WriteMemoryRequest
 from app.services.memory_forget_service import MemoryForgetService
 from app.utils.config_utils import resolve_config_id
 from app.utils.redis_lock import RedisFairLock
+from app.core.memory.utils.memory_count_utils import sync_memory_count_neo4j
 
 logger = get_logger(__name__)
 
@@ -1983,6 +1984,10 @@ def post_store_dedup_and_alias_merge_task(
         logger.info(
             f"[PostStore] 任务完成: {result}, 耗时={elapsed:.2f}s, task_id={task_id}"
         )
+
+        # ── 第二层去重可能合并/删除节点，重新同步 memory_count ──
+        sync_memory_count_neo4j(end_user_id=end_user_id)
+
         return {
             "status": "SUCCESS",
             **result,


### PR DESCRIPTION
## Summary by Sourcery

确保在执行内存相关操作后，PostgreSQL 中的终端用户内存计数与 Neo4j 保持同步，并为后台任务提供一个安全的同步入口点。

Bug 修复：
- 在后置存储任务中进行二次去重后，从 Neo4j 重新同步终端用户的 `memory_count`，以保持计数准确。
- 在 Neo4j 模式下，在内存写入操作后更新 `memory_count`，以防止 PostgreSQL 中出现过期的计数。

增强功能：
- 为 Neo4j 的 `memory_count` 同步添加一个同步封装，用于 Celery 和其他非异步环境，并对同步成功与失败进行结构化日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure end-user memory counts in PostgreSQL stay in sync with Neo4j after memory operations and provide a safe sync entry point for background tasks.

Bug Fixes:
- Resynchronize end-user memory_count from Neo4j after secondary deduplication in the post-store task to keep counts accurate.
- Update memory_count after memory write operations in Neo4j mode to prevent stale counts in PostgreSQL.

Enhancements:
- Add a synchronous wrapper around the Neo4j memory_count sync for use in Celery and other non-async contexts, with structured logging of sync success and failures.

</details>