### PR TITLE
fix(memory): use mode="json" for FileInput model_dump calls

### DIFF
--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -111,7 +111,7 @@ class MemoryWriteNode(BaseNode):
                         upload_file_id=instence.value.file_id,
                         url=instence.value.url,
                         file_type=instence.value.origin_file_type
-                    ).model_dump())
+                    ).model_dump(mode="json"))
                 elif isinstance(instence, ArrayVariable) and instence.child_type == FileVariable:
                     for file_instence in instence.value:
                         file_info.append(FileInput(
@@ -120,7 +120,7 @@ class MemoryWriteNode(BaseNode):
                             upload_file_id=file_instence.value.file_id,
                             url=file_instence.value.url,
                             file_type=file_instence.value.origin_file_type
-                        ).model_dump())
+                        ).model_dump(mode="json"))
             messages.append({
                 "role": message.role,
                 "content": self._render_template(content, variable_pool),


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复内存节点执行中 `FileInput` 对象的序列化问题，通过在 `model_dump` 中使用 JSON 模式来避免生成非 JSON 兼容的输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix serialization of FileInput objects in memory node execution by using JSON mode for model_dump to avoid non-JSON-compatible output.

</details>