### PR TITLE
fix(memory): harden extraction prompts with speaker field, temporal n…

### DIFF
--- a/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
@@ -11,6 +11,7 @@
 - statement_text
 - statement_type
 - temporal_type
+- speaker
 - has_emotional_state
 - has_unsolved_reference
 - dialog_at
@@ -25,6 +26,7 @@ Your task is to identify and extract declarative statements from the provided ta
 - statement_text
 - statement_type
 - temporal_type
+- speaker
 - has_emotional_state
 - has_unsolved_reference
 - dialog_at
@@ -83,8 +85,10 @@ Each output item should be a structured candidate memory statement.
 
 用户主语归一化：
 
-- 如果陈述句的主语是用户本人，无论上下文中给出的用户名称、昵称、别名或真实姓名是什么，提取后的陈述句统一使用“用户”作为主语，不要使用用户的具体名字或别名。
-- 这是硬规则；如果用户主语没有统一成“用户”，则该 statement 视为不合格。
+- 如果陈述句的主语是用户本人，无论上下文中给出的用户名称、昵称、别名或真实姓名是什么，都必须使用与输出语言一致的用户锚点，不要使用用户的具体名字或别名。
+- 中文输出使用“用户”作为主语。
+- 英文输出使用 `the user` 作为主语。
+- 这是硬规则；如果用户主语没有按输出语言统一成对应锚点，则该 statement 视为不合格。
 
 共指消解：
 
@@ -107,6 +111,13 @@ Each output item should be a structured candidate memory statement.
 
 - 仅提取陈述句。
 - 不要提取问题、命令、问候语或对话填充词。
+
+speaker：
+
+- `speaker` 表示该 statement 在 `target_content` 中的直接说话来源。
+- 如果 statement 来自用户消息，填 `"user"`。
+- 如果 statement 来自助理消息，填 `"assistant"`。
+- 不要省略 `speaker`；每条 statement 都必须输出该字段。
 
 statement_type：
 
@@ -143,6 +154,7 @@ statement_type：
 - `valid_at` 表示陈述开始成立或生效的时间。
 - `invalid_at` 表示陈述结束或不再成立的时间；如果仍在持续，填 `"NULL"`。
 - `dialog_at` 表示当前会话时间，每条 statement 都必须原样复制输入中的 `dialog_at`。
+- 如果输入中缺少 `dialog_at`，则把 `target_message_date` 作为当前会话时间使用，并在每条 statement 的 `dialog_at` 字段中填入 `target_message_date` 的原值。
 - 时间格式优先使用 ISO 8601。
 - 对于只有日期没有时分秒的时间，默认使用整天边界，便于后续检索。
 - 如果没有明确时间，不要编造时间。
@@ -210,6 +222,13 @@ Filtering:
 - Extract only declarative statements.
 - Do not extract questions, commands, greetings, or conversational filler.
 
+speaker:
+
+- `speaker` is the direct speaking source of the statement in `target_content`.
+- If the statement comes from a user message, output `"user"`.
+- If the statement comes from an assistant message, output `"assistant"`.
+- Never omit `speaker`; every statement must include this field.
+
 statement_type:
 
 - `FACT`: user-stated facts, states, relationships, experiences, behaviors, events, or plans.
@@ -245,6 +264,7 @@ Temporal rules:
 - `valid_at` means when the statement became valid or started to hold.
 - `invalid_at` means when the statement ended or stopped being valid; use `"NULL"` if it is still ongoing.
 - `dialog_at` is the session timestamp, and every statement must copy the input `dialog_at` verbatim.
+- If `dialog_at` is missing from the input, use `target_message_date` as the session timestamp and copy the original `target_message_date` value into each statement's `dialog_at` field.
 - Prefer ISO 8601 for time values.
 - When only a date can be resolved, default to full-day boundaries for retrieval use.
 - If no explicit time is available, do not invent one.
@@ -306,6 +326,7 @@ Rewrite boundary:
       "statement_text": "李教授这学期要求很严。",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -317,6 +338,7 @@ Rewrite boundary:
       "statement_text": "李教授讲课清晰透彻。",
       "statement_type": "OPINION",
       "temporal_type": "ATEMPORAL",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -328,6 +350,7 @@ Rewrite boundary:
       "statement_text": "用户每次被李教授点名都有点发怵。",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": true,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -365,6 +388,7 @@ Rewrite boundary:
       "statement_text": "用户截至2026年4月1日之前的最近一段时间在学Python。",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -376,6 +400,7 @@ Rewrite boundary:
       "statement_text": "用户截至2026年4月1日之前的最近一段时间每晚都会练一个小时Python。",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -387,6 +412,7 @@ Rewrite boundary:
       "statement_text": "用户计划在2026年3月30日至2026年4月5日先复习Python的基础语法和函数部分。",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -424,6 +450,7 @@ Rewrite boundary:
       "statement_text": "用户觉得2025年冬天老师布置的那两个项目有点难。",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": true,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -435,6 +462,7 @@ Rewrite boundary:
       "statement_text": "用户2026年3月31日晚上看了半天那两个项目还是没太搞明白。",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -446,6 +474,7 @@ Rewrite boundary:
       "statement_text": "如果到2026年4月4日至2026年4月5日还弄不出来，用户可能会去问助教。",
       "statement_type": "OTHER",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -483,6 +512,7 @@ Example Output: {
       "statement_text": "Professor Li is very strict this semester.",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -494,6 +524,7 @@ Example Output: {
       "statement_text": "Professor Li explains things clearly.",
       "statement_type": "OPINION",
       "temporal_type": "ATEMPORAL",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -505,6 +536,7 @@ Example Output: {
       "statement_text": "The user gets nervous every time Professor Li calls on the user.",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": true,
       "has_unsolved_reference": false,
       "dialog_at": "2023-09-04T18:00:00Z",
@@ -542,6 +574,7 @@ Example Output: {
       "statement_text": "The user has been learning Python recently before April 1, 2026.",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -553,6 +586,7 @@ Example Output: {
       "statement_text": "The user has been practicing Python for an hour every night recently before April 1, 2026.",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -564,6 +598,7 @@ Example Output: {
       "statement_text": "The user plans to review Python basic syntax and functions first during 2026-03-30 to 2026-04-05.",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": false,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -601,6 +636,7 @@ Example Output: {
       "statement_text": "The user thinks the two projects assigned in winter 2025 are difficult.",
       "statement_type": "OPINION",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": true,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -612,6 +648,7 @@ Example Output: {
       "statement_text": "The user spent a long time on the evening of 2026-03-31 looking at those two projects but still did not really understand them.",
       "statement_type": "FACT",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -623,6 +660,7 @@ Example Output: {
       "statement_text": "If the user still cannot finish them by 2026-04-04 to 2026-04-05, the user may ask the TA.",
       "statement_type": "OTHER",
       "temporal_type": "DYNAMIC",
+      "speaker": "user",
       "has_emotional_state": false,
       "has_unsolved_reference": true,
       "dialog_at": "2026-04-01T00:00:00Z",
@@ -631,6 +669,7 @@ Example Output: {
     }
   ]
 }
+
 {% endif %}
 === End of Examples ===
 
@@ -670,6 +709,37 @@ Example Output: {
 4. Do not include line breaks within JSON string values.
 5. Return only the JSON object. Do not add explanations before or after it.
 
+**STATEMENT_TEXT TEMPORAL NORMALIZATION HARD CONSTRAINT:**
+{% if language == "zh" %}
+
+- `statement_text` 是最终记忆文本，必须在文本本身包含已解析后的时间表达，不能只依赖 `valid_at` / `invalid_at` 表示时间。
+- 如果相对时间或开放区间时间可以根据 `dialog_at` 或 `target_message_date` 解析，必须直接改写进 `statement_text`。
+- 不要在 `statement_text` 中保留可解析的原始模糊时间表达。
+- 不要同时保留原始模糊时间表达和解析后的时间表达。
+- `statement_text` 中禁止残留未锚定、未解析的相对时间词，例如：`今天`、`昨天`、`前天`、`明天`、`后天`、`本周`、`这周`、`上周`、`下周`、`本月`、`这个月`、`上个月`、`下个月`、`去年`、`明年`、`最近`、`近来`、`这段时间`、`这些天`、`即将`、`接下来`、`很快`。
+- 如果开放区间词已经被明确锚定到参考时间，则允许保留在锚定表达中，例如 `截至2026年4月1日之前的最近一段时间`。
+- 正确示例：`用户2026年3月28日和小李一起去了咖啡馆。`
+- 错误示例：`用户上周六和小李一起去了咖啡馆。`
+- 正确示例：`用户截至2026年4月1日之前的最近一段时间拿到了腾讯公司的offer。`
+- 错误示例：`用户最近拿到了腾讯公司的offer。`
+  {% else %}
+- `statement_text` is the final memory text, so it must contain the resolved temporal expression itself, not only rely on `valid_at` / `invalid_at`.
+- If a relative or open-interval temporal expression can be resolved from `dialog_at` or `target_message_date`, rewrite it inside `statement_text`.
+- Do not leave a resolvable source temporal phrase in `statement_text`.
+- Do not keep both the vague phrase and the resolved phrase together.
+- `statement_text` must not contain unanchored, unresolved relative temporal words such as: `today`, `yesterday`, `the day before yesterday`, `tomorrow`, `the day after tomorrow`, `this week`, `last week`, `next week`, `this month`, `last month`, `next month`, `last year`, `next year`, `recently`, `lately`, `these days`, `upcoming`, `coming up`, or `soon`.
+- Open-interval words are allowed only when explicitly anchored to the reference time, such as `recently before April 1, 2026`.
+- Correct example: `The user went to the cafe with Xiao Li on March 28, 2026.`
+- Wrong example: `The user went to the cafe with Xiao Li last Saturday.`
+- Correct example: `The user received Tencent's offer recently before April 1, 2026.`
+- Wrong example: `The user recently received Tencent's offer.`
+  {% endif %}
+  {% if language == "zh" %}
+- 例外：如果时间表达确实无法可靠落地，保留最小可信粗粒度表达，但仍应尽量锚定到参考时间，例如写成 `2025年冬天`，而不是保留 `去年冬天`。
+  {% else %}
+- Exception: if the temporal phrase truly cannot be grounded reliably, keep the smallest trustworthy coarse-grained expression, but still anchor it when possible, for example `winter 2025` instead of `last winter`.
+  {% endif %}
+
 **ISO 8601 HARD CONSTRAINT:**
 
 - `dialog_at` must be ISO 8601.
@@ -677,6 +747,17 @@ Example Output: {
 - `valid_at` and `invalid_at` must be ISO 8601, or `"NULL"` when no time is available.
 - Do not output non-ISO values such as `2026/04/01`, `2026-04-01 00:00:00`, `yesterday evening`, or `下周三`.
 - When only a date is known, still output an ISO 8601 datetime boundary.
+
+**SCHEMA HARD CONSTRAINT:**
+
+- Every statement object must include exactly these fields: `statement_id`, `statement_text`, `statement_type`, `temporal_type`, `speaker`, `has_emotional_state`, `has_unsolved_reference`, `dialog_at`, `valid_at`, `invalid_at`.
+- Do not omit `speaker`, `dialog_at`, `valid_at`, or `invalid_at`.
+- Do not output extra fields.
+- `statement_type` must be one of `"FACT"`, `"OPINION"`, `"OTHER"`.
+- `temporal_type` must be one of `"STATIC"`, `"DYNAMIC"`, `"ATEMPORAL"`.
+- `speaker` must be one of `"user"`, `"assistant"`.
+- `has_emotional_state` and `has_unsolved_reference` must be JSON booleans, not strings.
+- Missing time must be the string `"NULL"`, not JSON null.
 
 **LANGUAGE REQUIREMENT:**
 {% if language == "zh" %}
@@ -694,19 +775,20 @@ Example Output: {
 
 现在处理下面这个输入：{{ render_input() }}
 
-Return only a JSON object matching the schema below:
+Return only a JSON object with this top-level shape:
 {
-  "statements": [
-    {
-      "statement_id": "string",
-      "statement_text": "string",
-      "statement_type": "FACT | OPINION | OTHER",
-      "temporal_type": "STATIC | DYNAMIC | ATEMPORAL",
-      "has_emotional_state": "boolean",
-      "has_unsolved_reference": "boolean",
-      "dialog_at": "string",
-      "valid_at": "string | NULL",
-      "invalid_at": "string | NULL"
-    }
-  ]
+  "statements": []
 }
+
+Each item in `statements` must be a JSON object with exactly these fields and value types:
+
+- `statement_id`: string
+- `statement_text`: string
+- `statement_type`: one of `"FACT"`, `"OPINION"`, `"OTHER"`
+- `temporal_type`: one of `"STATIC"`, `"DYNAMIC"`, `"ATEMPORAL"`
+- `speaker`: one of `"user"`, `"assistant"`
+- `has_emotional_state`: boolean, choose `true` or `false` according to the rules above
+- `has_unsolved_reference`: boolean, choose `true` or `false` according to the rules above
+- `dialog_at`: ISO 8601 datetime string
+- `valid_at`: ISO 8601 datetime string or `"NULL"`
+- `invalid_at`: ISO 8601 datetime string or `"NULL"`

--- a/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
@@ -7,10 +7,13 @@ Extract entities and knowledge triplets from the given statement.
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，不要翻译。
 - 但在抽取前，必须先做指代解析。
 - 用户自指表达，如“我”“我的”“我自己”，一律规范为 `用户`。
+- 用户本人这个实体的 `name` 必须始终是 `用户`，不要输出 `user`、`the user` 或其他翻译形式。
+- 用户所有格表达必须按输入语言规范化：中文输入使用 `用户的X`，禁止输出 `用户'sX`、`用户's X`、`user的X` 等中英混合所有格。
 - 非用户自指代词或指示表达，如“他”“她”“它”“这个”“那个”“这家”“那家”“这里”“那里”，如果能从 `supporting_context` 中稳定解析出具体指代，则必须替换为具体指代实体名。
 - 如果上述代词或指示表达不能稳定解析，则整条跳过。
 - 命名关系中新出现的称呼、别名、昵称、产品名保持原样，不做替换。
 - `description` 必须使用中文。
+- 每个实体的 `description` 必须以输入中的 `dialog_at` 时间戳开头，格式为 `[dialog_at] 描述文本`；如果输入中 `dialog_at` 为空或不存在，则使用 `[NULL]`。
 - `type`、`predicate` 必须使用上方预定义的中文标签。
 - 除 `type`、`predicate` 外，其余输出文本字段都必须与输入语言一致；因此在中文输入下，`type_description`、`predicate_description` 也必须使用中文。
 - 每个 `triplet` 都必须携带 `valid_at` 和 `invalid_at`，并直接复制输入中的同名字段，不要自行改写或推断新的时间边界。
@@ -19,10 +22,13 @@ Extract entities and knowledge triplets from the given statement.
 - Keep `name`, `subject_name`, and `object_name` in their original surface form from the source text by default.
 - But you MUST resolve references before extraction.
 - Normalize user self-reference such as "I", "me", and "myself" to `用户`.
+- The entity `name` for the user themself MUST always be `用户`; do not output `user`, `the user`, or any translated variant as the user entity name.
+- Normalize user possessive expressions by input language: for Chinese source text, use `用户的X`; for English source text, use `the user's X`; never output mixed possessives such as `用户'sX`, `用户's X`, or `user的X`.
 - For non-user pronouns or demonstratives such as "he", "she", "it", "this", "that", "this company", "that place", if a stable referent can be resolved from `supporting_context`, replace them with the resolved entity name.
 - If such references cannot be resolved stably, skip the entire statement.
 - Newly introduced names in naming or alias expressions must stay in their original form.
 - Generate `description` in English.
+- Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
 - Except for `type` and `predicate`, all other output text fields must match the input language; therefore under English input, `type_description` and `predicate_description` must be written in English.
 - Every `triplet` MUST include `valid_at` and `invalid_at`, copied directly from the input fields with the same names; do not rewrite or infer new temporal bounds.
@@ -41,7 +47,7 @@ Extract entities and knowledge triplets from the given statement.
 - `supporting_context.msgs[].role`: `User` / `Assistant`
 - `supporting_context.msgs[].msg`: 消息文本
 - `speaker`: `user` / `assistant`
-- `dialog_at`: 会话时间，ISO 8601 时间点
+- `dialog_at`: 会话时间，ISO 8601 时间点；每个实体 `description` 必须复制该值作为开头时间戳
 - `valid_at`: ISO 8601 时间点，或 `NULL`
 - `invalid_at`: ISO 8601 时间点，或 `NULL`
 - `has_unsolved_reference`: 布尔值
@@ -56,7 +62,7 @@ Extract entities and knowledge triplets from the given statement.
 - `supporting_context.msgs[].role`: `User` / `Assistant`
 - `supporting_context.msgs[].msg`: message text
 - `speaker`: `user` / `assistant`
-- `dialog_at`: session time as an ISO 8601 timestamp
+- `dialog_at`: session time as an ISO 8601 timestamp; every entity `description` must copy this value as its leading timestamp
 - `valid_at`: ISO 8601 timestamp or `NULL`
 - `invalid_at`: ISO 8601 timestamp or `NULL`
 - `has_unsolved_reference`: boolean
@@ -402,6 +408,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 当句子只是在讨论一般道理、抽象规律、空泛结果或非个体化概念，而这些概念本身不构成可复用记忆时，不要创建实体。
 - 如果句子表达的是用户的观点、信念、判断、愿望或目标倾向，但其中抽象对象不值得作为独立实体保留，则只保留相关高价值实体，不要再创建这些低价值对象实体；只有当未抽取内容适合作为该实体的稳定描述时，才写入相关实体的 `description`。
 - 当前阶段不要把情绪或心理状态抽成实体；像“紧张”“开心”“难过”“焦虑”“放松”等不应映射到 `知识能力`、`偏好习惯`、`具体目标` 或其他近似类型。
+- 用户本人节点必须命名为 `用户`；但用户拥有或关联的实体应使用完整所有格短语，例如 `用户的小狗`、`用户的 GitHub 账号`，不要使用 `用户's小狗`、`用户's 小狗`、`user的小狗` 等中英混合形式。
 - 有稳定所有格指向的具体生命体可以作为实体抽取，例如 `用户的小狗`、`张三的猫`；这类实体的名字应保留完整所有格短语，不要简化成 `小狗` 或错误归并到所有者。
 - 泛化或未稳定指向的生命体表达不要抽取，例如 `一只狗`、`狗这种动物`、`某个朋友`。
 - `description` 必须使用中文。
@@ -414,6 +421,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - If the sentence is only about a generic principle, abstract outcome, or non-personalized concept that is not worth remembering on its own, do not create an entity for it.
 - If a statement expresses the user's belief, judgment, opinion, wish, or goal tendency but the referenced abstract concepts are not worth keeping as standalone entities, keep only the relevant high-value entities and do not create those low-value concept entities; write the unextracted content into an entity `description` only when it is suitable as a stable description of that entity.
 - In the current stage, do not extract emotional or psychological states as entities. States such as nervousness, happiness, sadness, anxiety, or relief should not be mapped to `知识能力`, `偏好习惯`, `具体目标`, or any other approximate type.
+- The user node itself must be named `用户`; entities owned by or associated with the user should use a complete possessive phrase, such as `the user's dog` in English source text or `用户的小狗` in Chinese source text, and must never use mixed forms such as `用户's dog`, `用户's小狗`, or `user的小狗`.
 - A concrete living being with a stable possessive reference may be extracted as an entity, such as `the user's dog` or `Zhang San's cat`; keep the full possessive phrase as the entity name, and do not collapse it to `dog` or merge it into the owner.
 - Do not extract generic or weakly resolved living-being mentions, such as `a dog`, `dogs as a species`, or `some friend`.
 - `description` must be in English.
@@ -435,17 +443,21 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 **Description:**
 {% if language == "zh" %}
 
-- `description` 应短、直白、与当前上下文相关，并能帮助区分实体。
-- 优先描述实体在当前陈述和必要上下文中的身份、作用或关系。
+- `description` 必须以 `[dialog_at]` 开头，其中 `dialog_at` 直接复制输入中的 `dialog_at` 字段值（ISO 8601 时间点）；如果输入中 `dialog_at` 为空或不存在，则写 `[NULL]`。格式示例：`[2025-03-15T10:00:00Z] 居住在巴黎的说话者`。
+- `description` 应简洁、直白、与当前上下文相关，并能帮助区分实体。
+- 优先描述实体在当前陈述和必要上下文中的身份、作用、关系、归属和限定信息；在不引入额外推断的前提下，尽量包含与该实体直接相关的上下文限定。
+- 对账号、用户名、编号、邮箱等识别联系信息，`description` 应尽量写清它属于哪个实体、哪个账号/平台或哪种联系方式，例如 `用户的 GitHub 账号的用户名`，不要只写成泛泛的 `用户名`。
 - `description` 只保留适合长期附着在该实体上的描述，例如稳定身份、稳定关系、长期偏好/兴趣/习惯、较稳定认知倾向或可用于区分实体的持久特征。
 - 不要把短期状态、一次性事件、临时计划、当前情绪、具体时间锚点，或只在当前句子里短暂成立的信息写进 `description`。
-- 如果实体应保留，但当前 statement 中没有适合长期附着在该实体上的稳定描述，则 `description` 允许为空字符串 `""`。
+- 如果实体应保留，但当前 statement 中没有适合长期附着在该实体上的稳定描述，则 `description` 仍必须保留时间戳前缀，可写为 `[dialog_at]` 或 `[NULL]`，不要输出空字符串。
   {% else %}
-- `description` should be short, context-grounded, and discriminative.
-- Prefer describing the entity's role, identity, or relation in the current statement and necessary supporting context.
+- `description` MUST start with `[dialog_at]`, where `dialog_at` is copied directly from the input `dialog_at` field (ISO 8601 timestamp); if `dialog_at` is empty or absent, write `[NULL]`. Format example: `[2025-03-15T10:00:00Z] The speaker who lives in Paris`.
+- `description` should be concise, context-grounded, and discriminative.
+- Prefer describing the entity's role, identity, relation, ownership, and qualifiers in the current statement and necessary supporting context; include directly related contextual qualifiers as much as possible without adding unsupported inference.
+- For identification/contact information such as accounts, usernames, IDs, emails, or phone numbers, `description` should specify which entity, account/platform, or contact method it belongs to, such as `the username of the user's GitHub account`, rather than a generic `username`.
 - `description` should keep only information suitable to remain attached to the entity over time, such as stable identity, stable relations, long-term preferences/interests/habits, relatively stable beliefs, or persistent distinguishing traits.
 - Do not put short-lived states, one-off events, temporary plans, current emotions, concrete time anchors, or information that only briefly holds in the current sentence into `description`.
-- If an entity should be retained but the current statement does not provide any suitable stable description for it, `description` may be the empty string `""`.
+- If an entity should be retained but the current statement does not provide any suitable stable description for it, `description` must still keep the timestamp prefix and may be `[dialog_at]` or `[NULL]`; do not output an empty string.
   {% endif %}
 
 **Type Description (`type_description`):**
@@ -517,6 +529,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 {% if language == "zh" %}
 **示例 1**
 Statement: "我住在巴黎。"
+Input JSON includes: `"dialog_at": "2025-04-10T14:30:00Z"`
 
 Output:
 {
@@ -524,14 +537,15 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "位于", "predicate_description": "表达实体与地点、场所、空间位置之间的稳定位置关系。", "object_name": "巴黎", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "居住在巴黎的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "巴黎", "type": "地点设施", "type_description": "具有地理意义或功能性空间意义的位置与场所。", "description": "用户居住的城市", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-04-10T14:30:00Z] 居住在巴黎的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "巴黎", "type": "地点设施", "type_description": "具有地理意义或功能性空间意义的位置与场所。", "description": "[2025-04-10T14:30:00Z] 用户居住的城市", "is_explicit_memory": false}
   ]
 }
 
 **示例 2**
 Statement: "他在腾讯工作。"
 Input condition: supporting context has already made it clear that “他” refers to “张明”.
+Input JSON includes: `"dialog_at": "2025-05-01T09:00:00Z"`
 
 Output:
 {
@@ -539,13 +553,14 @@ Output:
     {"subject_name": "张明", "subject_id": 0, "predicate": "属于类型", "predicate_description": "表达主体所属的类别、身份、职业、角色，或其与组织、群体、集合之间的归属关系。", "object_name": "腾讯", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "张明", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "在腾讯工作的人员", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "腾讯", "type": "组织", "type_description": "公司、机构、学校、实验室、团队、社群等组织性主体。", "description": "张明归属的组织", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "张明", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-05-01T09:00:00Z] 在腾讯工作的人员", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "腾讯", "type": "组织", "type_description": "公司、机构、学校、实验室、团队、社群等组织性主体。", "description": "[2025-05-01T09:00:00Z] 张明归属的组织", "is_explicit_memory": false}
   ]
 }
 
 **示例 3**
 Statement: "我常去图书馆学微积分。"
+Input JSON includes: `"dialog_at": "2025-03-20T16:00:00Z"`
 
 Output:
 {
@@ -554,14 +569,15 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "了解", "predicate_description": "表达主体与知识、技能、学科、语言等知识能力对象之间的认知、学习或兴趣关系。", "object_name": "微积分", "object_id": 2, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "经常在图书馆学习微积分的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "图书馆", "type": "地点设施", "type_description": "具有地理意义或功能性空间意义的位置与场所。", "description": "用户经常前往学习的地点", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "微积分", "type": "知识能力", "type_description": "可学习、掌握、使用或讨论的知识主题、技能、学科或语言。", "description": "用户经常学习的主题", "is_explicit_memory": true}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-03-20T16:00:00Z] 经常在图书馆学习微积分的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "图书馆", "type": "地点设施", "type_description": "具有地理意义或功能性空间意义的位置与场所。", "description": "[2025-03-20T16:00:00Z] 用户经常前往学习的地点", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "微积分", "type": "知识能力", "type_description": "可学习、掌握、使用或讨论的知识主题、技能、学科或语言。", "description": "[2025-03-20T16:00:00Z] 用户经常学习的主题", "is_explicit_memory": true}
   ]
 }
 
 **示例 4**
 Statement: "我的朋友都叫我山哥。"
+Input JSON includes: `"dialog_at": "NULL"`
 
 Output:
 {
@@ -569,25 +585,27 @@ Output:
     {"subject_name": "山哥", "subject_id": 2, "predicate": "别名属于", "predicate_description": "表达实体名称、别名、称呼之间的对应关系。", "object_name": "用户", "object_id": 0, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "被朋友称作山哥的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "我的朋友", "type": "群体", "type_description": "边界相对稳定、可被当作整体引用的一组人。", "description": "使用山哥这一称呼的人群", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "山哥", "type": "称呼别名", "type_description": "用于指代或称呼实体的名字。", "description": "朋友用来称呼用户的昵称", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[NULL] 被朋友称作山哥的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "我的朋友", "type": "群体", "type_description": "边界相对稳定、可被当作整体引用的一组人。", "description": "[NULL] 使用山哥这一称呼的人群", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "山哥", "type": "称呼别名", "type_description": "用于指代或称呼实体的名字。", "description": "[NULL] 朋友用来称呼用户的昵称", "is_explicit_memory": false}
   ]
 }
 
 **示例 5**
 Statement: "我认为努力就会有回报。"
+Input JSON includes: `"dialog_at": "2025-06-15T20:00:00Z"`
 
 Output:
 {
   "triplets": [],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "认为努力就会有回报的说话者", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-06-15T20:00:00Z] 认为努力就会有回报的说话者", "is_explicit_memory": false}
   ]
 }
 
 **示例 6**
 Statement: "我的GitHub用户名是chen4。"
+Input JSON includes: `"dialog_at": "2025-02-28T11:00:00Z"`
 
 Output:
 {
@@ -596,14 +614,15 @@ Output:
     {"subject_name": "GitHub账号", "subject_id": 1, "predicate": "拥有", "predicate_description": "表达主体拥有、持有、配有某对象、账号、联系方式或标识的关系。", "object_name": "chen4", "object_id": 2, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "拥有该 GitHub 账号的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "GitHub账号", "type": "识别联系信息", "type_description": "账号、用户名、编号、邮箱、手机号等与识别、联系或登录相关的信息对象。", "description": "用户拥有的 GitHub 账号", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "chen4", "type": "识别联系信息", "type_description": "账号、用户名、编号、邮箱、手机号等与识别、联系或登录相关的信息对象。", "description": "该 GitHub 账号的用户名", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-02-28T11:00:00Z] 拥有该 GitHub 账号的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "GitHub账号", "type": "识别联系信息", "type_description": "账号、用户名、编号、邮箱、手机号等与识别、联系或登录相关的信息对象。", "description": "[2025-02-28T11:00:00Z] 用户拥有的 GitHub 账号", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "chen4", "type": "识别联系信息", "type_description": "账号、用户名、编号、邮箱、手机号等与识别、联系或登录相关的信息对象。", "description": "[2025-02-28T11:00:00Z] 用户的 GitHub 账号的用户名", "is_explicit_memory": false}
   ]
 }
 
 **示例 7**
 Statement: "我想通过雅思。"
+Input JSON includes: `"dialog_at": "2025-07-01T08:30:00Z"`
 
 Output:
 {
@@ -611,13 +630,14 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "偏好", "predicate_description": "表达主体对对象的稳定偏好、厌恶，或对具体明确目标的指向关系。", "object_name": "通过雅思", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "想通过雅思的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "通过雅思", "type": "具体目标", "type_description": "用户具体、明确、可验证、可长期追踪的目标结果或目标性安排。", "description": "用户想达成的具体目标", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-07-01T08:30:00Z] 想通过雅思的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "通过雅思", "type": "具体目标", "type_description": "用户具体、明确、可验证、可长期追踪的目标结果或目标性安排。", "description": "[2025-07-01T08:30:00Z] 用户想达成的具体目标", "is_explicit_memory": false}
   ]
 }
 
 **示例 8**
 Statement: "用户的小狗叫多多。"
+Input JSON includes: `"dialog_at": "2025-01-15T19:00:00Z"`
 
 Output:
 {
@@ -626,15 +646,16 @@ Output:
     {"subject_name": "多多", "subject_id": 2, "predicate": "别名属于", "predicate_description": "表达实体名称、别名、称呼之间的对应关系。", "object_name": "用户的小狗", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "拥有一只叫多多的小狗的说话者", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "用户的小狗", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "用户拥有的、名字叫多多的小狗", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "多多", "type": "称呼别名", "type_description": "用于指代或称呼实体的名字。", "description": "用户的小狗的名字", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-01-15T19:00:00Z] 拥有一只叫多多的小狗的说话者", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "用户的小狗", "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2025-01-15T19:00:00Z] 用户拥有的、名字叫多多的小狗", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "多多", "type": "称呼别名", "type_description": "用于指代或称呼实体的名字。", "description": "[2025-01-15T19:00:00Z] 用户的小狗的名字", "is_explicit_memory": false}
   ]
 }
 
 **示例 9**
 Statement: "他2026年3月加入了这家公司。"
 Input condition: `"has_unsolved_reference": true`
+Input JSON includes: `"dialog_at": "2026-03-01T09:00:00Z"`
 
 Output:
 {
@@ -644,6 +665,7 @@ Output:
 {% else %}
 **Example 1**
 Statement: "I live in Paris."
+Input JSON includes: `"dialog_at": "2025-04-10T14:30:00Z"`
 
 Output:
 {
@@ -651,14 +673,15 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "位于", "predicate_description": "A stable location relation between an entity and a place, facility, or spatial location.", "object_name": "Paris", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who lives in Paris.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "Paris", "type": "地点设施", "type_description": "A location or place with geographic meaning or functional spatial meaning.", "description": "The city where the user lives.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-04-10T14:30:00Z] The speaker who lives in Paris.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "Paris", "type": "地点设施", "type_description": "A location or place with geographic meaning or functional spatial meaning.", "description": "[2025-04-10T14:30:00Z] The city where the user lives.", "is_explicit_memory": false}
   ]
 }
 
 **Example 2**
 Statement: "He works at Tencent."
 Input condition: supporting context has already made it clear that “he” refers to “Zhang Ming”.
+Input JSON includes: `"dialog_at": "2025-05-01T09:00:00Z"`
 
 Output:
 {
@@ -666,13 +689,14 @@ Output:
     {"subject_name": "Zhang Ming", "subject_id": 0, "predicate": "属于类型", "predicate_description": "A relation expressing the type, identity, profession, role, or organizational/group affiliation of a subject.", "object_name": "Tencent", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "Zhang Ming", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "A person who works at Tencent.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "Tencent", "type": "组织", "type_description": "An organizational actor such as a company, institution, school, lab, team, or community.", "description": "The organization Zhang Ming belongs to.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "Zhang Ming", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-05-01T09:00:00Z] A person who works at Tencent.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "Tencent", "type": "组织", "type_description": "An organizational actor such as a company, institution, school, lab, team, or community.", "description": "[2025-05-01T09:00:00Z] The organization Zhang Ming belongs to.", "is_explicit_memory": false}
   ]
 }
 
 **Example 3**
 Statement: "I often go to the library to study calculus."
+Input JSON includes: `"dialog_at": "2025-03-20T16:00:00Z"`
 
 Output:
 {
@@ -681,14 +705,15 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "了解", "predicate_description": "A relation expressing cognition, learning, or knowledge-oriented interest between a subject and a `KnowledgeOrSkill` object.", "object_name": "calculus", "object_id": 2, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who often goes to the library to study calculus.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "the library", "type": "地点设施", "type_description": "A location or place with geographic meaning or functional spatial meaning.", "description": "The place the user often goes to for studying.", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "calculus", "type": "知识能力", "type_description": "A knowledge topic, skill, field, or language that can be learned, mastered, used, or discussed.", "description": "The topic the user often studies.", "is_explicit_memory": true}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-03-20T16:00:00Z] The speaker who often goes to the library to study calculus.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "the library", "type": "地点设施", "type_description": "A location or place with geographic meaning or functional spatial meaning.", "description": "[2025-03-20T16:00:00Z] The place the user often goes to for studying.", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "calculus", "type": "知识能力", "type_description": "A knowledge topic, skill, field, or language that can be learned, mastered, used, or discussed.", "description": "[2025-03-20T16:00:00Z] The topic the user often studies.", "is_explicit_memory": true}
   ]
 }
 
 **Example 4**
 Statement: "My friends all call me Shan Ge."
+Input JSON includes: `"dialog_at": "NULL"`
 
 Output:
 {
@@ -696,25 +721,27 @@ Output:
     {"subject_name": "Shan Ge", "subject_id": 2, "predicate": "别名属于", "predicate_description": "A relation expressing correspondence between names, aliases, and forms of address.", "object_name": "用户", "object_id": 0, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who is called Shan Ge by friends.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "my friends", "type": "群体", "type_description": "A relatively stable group of people that can be referred to as a whole.", "description": "The group of people who use the name Shan Ge.", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "Shan Ge", "type": "称呼别名", "type_description": "A name used to refer to or address an entity.", "description": "The nickname used by the friends to address the user.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[NULL] The speaker who is called Shan Ge by friends.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "my friends", "type": "群体", "type_description": "A relatively stable group of people that can be referred to as a whole.", "description": "[NULL] The group of people who use the name Shan Ge.", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "Shan Ge", "type": "称呼别名", "type_description": "A name used to refer to or address an entity.", "description": "[NULL] The nickname used by the friends to address the user.", "is_explicit_memory": false}
   ]
 }
 
 **Example 5**
 Statement: "I think effort brings reward."
+Input JSON includes: `"dialog_at": "2025-06-15T20:00:00Z"`
 
 Output:
 {
   "triplets": [],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who believes that effort brings reward.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-06-15T20:00:00Z] The speaker who believes that effort brings reward.", "is_explicit_memory": false}
   ]
 }
 
 **Example 6**
 Statement: "My GitHub username is chen4."
+Input JSON includes: `"dialog_at": "2025-02-28T11:00:00Z"`
 
 Output:
 {
@@ -723,14 +750,15 @@ Output:
     {"subject_name": "GitHub account", "subject_id": 1, "predicate": "拥有", "predicate_description": "A relation expressing that a subject owns, holds, carries, or is associated with an identity/contact object.", "object_name": "chen4", "object_id": 2, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who has this GitHub account.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "GitHub account", "type": "识别联系信息", "type_description": "An information object related to identification, contact, or login, such as an account, username, ID number, email, or phone number.", "description": "The GitHub account owned by the user.", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "chen4", "type": "识别联系信息", "type_description": "An information object related to identification, contact, or login, such as an account, username, ID number, email, or phone number.", "description": "The username of the GitHub account.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-02-28T11:00:00Z] The speaker who has this GitHub account.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "GitHub account", "type": "识别联系信息", "type_description": "An information object related to identification, contact, or login, such as an account, username, ID number, email, or phone number.", "description": "[2025-02-28T11:00:00Z] The GitHub account owned by the user.", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "chen4", "type": "识别联系信息", "type_description": "An information object related to identification, contact, or login, such as an account, username, ID number, email, or phone number.", "description": "[2025-02-28T11:00:00Z] The username of the user's GitHub account.", "is_explicit_memory": false}
   ]
 }
 
 **Example 7**
 Statement: "I want to pass IELTS."
+Input JSON includes: `"dialog_at": "2025-07-01T08:30:00Z"`
 
 Output:
 {
@@ -738,13 +766,14 @@ Output:
     {"subject_name": "用户", "subject_id": 0, "predicate": "偏好", "predicate_description": "A relation expressing a stable preference, aversion, or a specific concrete goal of a subject.", "object_name": "pass IELTS", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who wants to pass IELTS.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "pass IELTS", "type": "具体目标", "type_description": "A specific, explicit, verifiable, and trackable goal result or goal-oriented plan of the user.", "description": "A concrete goal the user wants to achieve.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-07-01T08:30:00Z] The speaker who wants to pass IELTS.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "pass IELTS", "type": "具体目标", "type_description": "A specific, explicit, verifiable, and trackable goal result or goal-oriented plan of the user.", "description": "[2025-07-01T08:30:00Z] A concrete goal the user wants to achieve.", "is_explicit_memory": false}
   ]
 }
 
 **Example 8**
 Statement: "My dog is called Duoduo."
+Input JSON includes: `"dialog_at": "2025-01-15T19:00:00Z"`
 
 Output:
 {
@@ -753,15 +782,16 @@ Output:
     {"subject_name": "Duoduo", "subject_id": 2, "predicate": "别名属于", "predicate_description": "A relation expressing correspondence between names, aliases, and forms of address.", "object_name": "the user's dog", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
   ],
   "entities": [
-    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The speaker who has a dog called Duoduo.", "is_explicit_memory": false},
-    {"entity_idx": 1, "name": "the user's dog", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "The dog owned by the user and named Duoduo.", "is_explicit_memory": false},
-    {"entity_idx": 2, "name": "Duoduo", "type": "称呼别名", "type_description": "A name used to refer to or address an entity.", "description": "The name of the user's dog.", "is_explicit_memory": false}
+    {"entity_idx": 0, "name": "用户", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-01-15T19:00:00Z] The speaker who has a dog called Duoduo.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "the user's dog", "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2025-01-15T19:00:00Z] The dog owned by the user and named Duoduo.", "is_explicit_memory": false},
+    {"entity_idx": 2, "name": "Duoduo", "type": "称呼别名", "type_description": "A name used to refer to or address an entity.", "description": "[2025-01-15T19:00:00Z] The name of the user's dog.", "is_explicit_memory": false}
   ]
 }
 
 **Example 9**
 Statement: "He joined this company in March 2026."
 Input condition: `"has_unsolved_reference": true`
+Input JSON includes: `"dialog_at": "2026-03-01T09:00:00Z"`
 
 Output:
 {
@@ -780,7 +810,7 @@ JSON 要求：
 - 不要使用中文引号
 - 字符串值中不要换行
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，但用户自指必须规范成 `用户`，可稳定解析的其他代词必须替换为具体指代实体名
-- `description` 必须使用中文
+- `description` 必须使用中文，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
 - `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用中文说明
 - 每个 triplet 都必须包含 `valid_at` 和 `invalid_at`，并与输入中的同名字段完全一致
 - 如果 `has_unsolved_reference` 是 `true`，输出必须是 `{"entities": [], "triplets": []}`
@@ -793,7 +823,7 @@ JSON 要求：
 - No Chinese quotation marks
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
-- `description` must be in English
+- `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
 - `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
 - Every triplet must include `valid_at` and `invalid_at`, exactly matching the input fields with the same names
 - If `has_unsolved_reference` is `true`, the output must be `{"entities": [], "triplets": []}`
@@ -833,4 +863,3 @@ Output JSON structure:
   ]
 }
 ```
-


### PR DESCRIPTION
…ormalization, and schema constraints

## Summary by Sourcery

通过在三元组和陈述-时间抽取中实施更严格的用户/说话人归一化以及时间/模式约束，强化记忆抽取提示的可靠性。

增强点：
- 在不同语言中统一用户实体命名及其所有格形式，避免在抽取到的实体和关系中出现混合语言或不一致的用户引用。
- 要求实体描述必须以前缀形式包含对话时间戳，并澄清当 `dialog_at` 缺失或为 NULL 时的行为，包括示例更新。
- 扩展陈述-时间抽取模式，新增必填的 `speaker` 字段，并文档化如何根据消息来源来设置该字段。
- 收紧时间归一化规则，使陈述文本必须包含被解析后的时间表达，而不是模糊的相对时间用语，同时提供用于粗粒度锚定的回退方案。
- 为陈述输出模式、布尔类型、允许的枚举值以及所有时间字段的 ISO 8601 使用添加显式的硬性约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden memory extraction prompts by enforcing stricter user/speaker normalization and temporal/schema constraints across triplet and statement-temporal extraction.

Enhancements:
- Standardize user entity naming and possessive forms across languages to avoid mixed-language or inconsistent user references in extracted entities and relations.
- Require entity descriptions to be prefixed with the dialog timestamp and clarify behavior when `dialog_at` is missing or NULL, including example updates.
- Extend statement-temporal extraction schema to include a mandatory `speaker` field and document how to set it based on message source.
- Tighten temporal normalization rules so statement texts must include resolved time expressions rather than vague relative terms, with fallbacks for coarse-grained anchoring.
- Add explicit hard constraints on the statement output schema, boolean typing, allowed enum values, and ISO 8601 usage for all temporal fields.

</details>