### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -75,6 +75,7 @@ class LLMNode(BaseNode):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: LLMNodeConfig | None = None
         self.messages = []
+        self.model_info: ModelInfo | None = None
 
     def _output_types(self) -> dict[str, VariableType]:
         return {"output": VariableType.STRING, "branch_signal": VariableType.STRING}
@@ -124,6 +125,7 @@ class LLMNode(BaseNode):
                 is_omni=api_config.is_omni,
                 capability=api_config.capability
             )
+            self.model_info = model_info
 
         # 4. 创建 LLM 实例（使用已提取的数据）
         # 注意：对于流式输出，需要在模型初始化时设置 streaming=True
@@ -297,11 +299,11 @@ class LLMNode(BaseNode):
 
     def _extract_extra_fields(self, business_result: Any) -> dict:
         llm_result = business_result.get("llm_result") if isinstance(business_result, dict) else business_result
-        if isinstance(llm_result, AIMessage) and llm_result.response_metadata:
-            meta = llm_result.response_metadata
+        if isinstance(llm_result, AIMessage):
+            meta = llm_result.response_metadata or {}
             return {"process": {
                 "finish_reason": meta.get("finish_reason") or meta.get("stop_reason"),
-                "model": meta.get("model") or meta.get("model_name"),
+                "model": self.model_info.model_name,
             }}
         return {}
 

--- a/api/app/services/app_log_service.py
+++ b/api/app/services/app_log_service.py
@@ -394,6 +394,7 @@ def _build_nodes_from_output_data(output_data: Optional[dict]) -> list[AppLogNod
         inp = output.pop("input", None)
         elapsed_time = output.pop("elapsed_time", None)
         token_usage = output.pop("token_usage", None)
+        process = output.pop("process", None)
         # execution_order 仅用于排序，不返回给前端
         output.pop("execution_order", None)
         result.append(AppLogNodeExecution(
@@ -403,7 +404,7 @@ def _build_nodes_from_output_data(output_data: Optional[dict]) -> list[AppLogNod
             status=status,
             error=error,
             input=inp,
-            process=None,
+            process=process,
             output=output if output else None,
             cycle_items=cycle_items,
             elapsed_time=elapsed_time,


### PR DESCRIPTION
use model_info.model_name for process.model and pass process to app log

The LLM node now stores model_info during initialization and uses model_info.model_name instead of response_metadata for the process.model field. Additionally, the process field is now correctly passed from workflow output to app log service instead of being hardcoded to None.

## Summary by Sourcery

更新 LLM 工作流节点的元数据处理方式，并将流程信息传递到应用日志中。

Bug 修复：
- 确保 LLM 节点在初始化期间存储模型元数据，并在流程元数据中使用正确的模型名称。
- 将工作流输出中的 `process` 字段传递到应用日志节点的执行中，而不是将其硬编码为 `None`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update LLM workflow node metadata handling and propagate process information into application logs.

Bug Fixes:
- Ensure LLM node stores model metadata during initialization and uses the correct model name for process metadata.
- Pass the process field from workflow output through to app log node executions instead of hardcoding it to None.

</details>