### PR TITLE
fix(memory): remove alias invalidation logic from merge pipeline

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -455,18 +455,16 @@ class WritePipeline:
     # ──────────────────────────────────────────────
 
     def _merge_alias_in_memory(self, result: ExtractionResult) -> None:
-        """别名归并（内存侧）：处理 predicate="别名属于" 和 predicate="别名失效" 的边。
+        """别名归并（内存侧）：处理 predicate="别名属于" 的边。
 
         在写入 Neo4j 之前执行，确保写入的数据已经完成别名归并：
         - 别名属于：将别名实体的 name 追加到目标实体的 aliases
         - 别名属于：将别名实体的 description 拼接到目标实体的 description
-        - 别名失效：从目标实体的 aliases 中移除对应的旧别名
         - 重定向指向别名节点的边到目标节点
 
         纯内存操作，不涉及 Neo4j。
         """
         ALIAS_PREDICATE = "别名属于"
-        ALIAS_INVALID_PREDICATE = "别名失效"
 
         alias_edges = [
             e
@@ -474,15 +472,9 @@ class WritePipeline:
             if getattr(e, "relation_type", "") == ALIAS_PREDICATE
             or getattr(e, "predicate", "") == ALIAS_PREDICATE
         ]
-        invalid_alias_edges = [
-            e
-            for e in result.entity_entity_edges
-            if getattr(e, "relation_type", "") == ALIAS_INVALID_PREDICATE
-            or getattr(e, "predicate", "") == ALIAS_INVALID_PREDICATE
-        ]
 
-        if not alias_edges and not invalid_alias_edges:
-            logger.debug("[AliasMerge] 无 '别名属于'/'别名失效' 关系，跳过")
+        if not alias_edges:
+            logger.debug("[AliasMerge] 无 '别名属于' 关系，跳过")
             return
 
         try:
@@ -516,52 +508,29 @@ class WritePipeline:
                             f"{tgt_desc}；{src_desc}" if tgt_desc else src_desc
                         )
 
-            # ── 处理 别名失效：从 aliases 中移除旧别名 ──
-            invalid_alias_to_target: dict[str, str] = {}
-            for edge in invalid_alias_edges:
-                source_node = entity_map.get(edge.source)
-                target_node = entity_map.get(edge.target)
-                if not source_node or not target_node:
-                    continue
-
-                invalid_alias_to_target[edge.source] = edge.target
-
-                # 从 target.aliases 中移除 source.name（忽略大小写）
-                invalid_name = (source_node.name or "").strip()
-                if invalid_name and target_node.aliases:
-                    target_node.aliases = [
-                        a for a in target_node.aliases
-                        if a.lower() != invalid_name.lower()
-                    ]
-                    logger.debug(
-                        f"[AliasMerge] 从 '{target_node.name}' 的 aliases 中移除失效别名 '{invalid_name}'"
-                    )
-
             # 重定向指向别名节点的边到目标节点
-            alias_ids = set(alias_to_target.keys()) | set(invalid_alias_to_target.keys())
-            all_alias_map = {**alias_to_target, **invalid_alias_to_target}
+            alias_ids = set(alias_to_target.keys())
             redirected_ee_count = 0
             redirected_se_count = 0
 
             for edge in result.entity_entity_edges:
                 rel_type = getattr(edge, "relation_type", "")
-                if rel_type in (ALIAS_PREDICATE, ALIAS_INVALID_PREDICATE):
+                if rel_type == ALIAS_PREDICATE:
                     continue
                 if edge.source in alias_ids:
-                    edge.source = all_alias_map[edge.source]
+                    edge.source = alias_to_target[edge.source]
                     redirected_ee_count += 1
                 if edge.target in alias_ids:
-                    edge.target = all_alias_map[edge.target]
+                    edge.target = alias_to_target[edge.target]
                     redirected_ee_count += 1
 
             for edge in result.stmt_entity_edges:
                 if edge.target in alias_ids:
-                    edge.target = all_alias_map[edge.target]
+                    edge.target = alias_to_target[edge.target]
                     redirected_se_count += 1
 
             logger.info(
                 f"[AliasMerge] 内存归并完成，处理 {len(alias_edges)} 条 '别名属于' 边，"
-                f"{len(invalid_alias_edges)} 条 '别名失效' 边，"
                 f"重定向 entity_entity 边 {redirected_ee_count} 次，"
                 f"重定向 stmt_entity 边 {redirected_se_count} 次"
             )

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1354,18 +1354,18 @@ WHERE r.predicate = '别名属于'
 WITH target,
      coalesce(target.aliases, []) AS existing_aliases,
      coalesce(target.description, '') AS tgt_desc,
-     collect(source.name) AS source_names,
-     collect(coalesce(source.description, '')) AS source_descs
+     collect(DISTINCT source.name) AS source_names,
+     collect(DISTINCT coalesce(source.description, '')) AS source_descs
 
 // 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值）
-WITH target, tgt_desc, source_names, source_descs,
+WITH target, tgt_desc, source_names, source_descs, existing_aliases,
      existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT n IN existing_aliases] AS new_aliases
 
 // 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
-WITH target, new_aliases, source_descs,
+WITH target, new_aliases, existing_aliases, source_descs,
      reduce(desc = tgt_desc, src IN source_descs |
          CASE
-             WHEN src <> '' AND NOT src IN desc
+             WHEN src <> '' AND NOT desc CONTAINS src
              THEN CASE WHEN desc = '' THEN src ELSE desc + '；' + src END
              ELSE desc
          END
@@ -1374,7 +1374,7 @@ WITH target, new_aliases, source_descs,
 SET target.aliases = new_aliases,
     target.description = new_description
 
-RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_aliases) - size(coalesce(target.aliases, [])) AS added_count
+RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_aliases) - size(existing_aliases) AS added_count
 """
 
 # 边重定向：将指向别名节点（"别名属于"关系的 source）的所有其他边，重定向到用户节点（target）。

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1347,30 +1347,34 @@ RETURN (
 # 别名归并：将 predicate="别名属于" 的 EXTRACTED_RELATIONSHIP 边的 source.name
 # 合并进 target.aliases（去重），并将 source.description 追加到 target.description（分号分隔）
 MERGE_ALIAS_BELONGS_TO = """
+// 先按 target 分组，将所有 source.name 和 source.description 聚合，
+// 再一次性 SET，避免多条 别名属于 边对同一 target 反复覆盖。
 MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
 WHERE r.predicate = '别名属于'
-WITH source, target,
+WITH target,
      coalesce(target.aliases, []) AS existing_aliases,
-     source.name AS source_name,
-     coalesce(source.description, '') AS src_desc,
-     coalesce(target.description, '') AS tgt_desc
+     coalesce(target.description, '') AS tgt_desc,
+     collect(source.name) AS source_names,
+     collect(coalesce(source.description, '')) AS source_descs
 
-// 1. 合并 aliases：将 source.name 追加到 target.aliases（去重）
-WITH source, target, src_desc, tgt_desc,
-     CASE
-         WHEN source_name IS NOT NULL AND source_name <> '' AND NOT source_name IN existing_aliases
-         THEN existing_aliases + source_name
-         ELSE existing_aliases
-     END AS new_aliases
+// 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值）
+WITH target, tgt_desc, source_names, source_descs,
+     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT n IN existing_aliases] AS new_aliases
+
+// 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
+WITH target, new_aliases, source_descs,
+     reduce(desc = tgt_desc, src IN source_descs |
+         CASE
+             WHEN src <> '' AND NOT src IN desc
+             THEN CASE WHEN desc = '' THEN src ELSE desc + '；' + src END
+             ELSE desc
+         END
+     ) AS new_description
 
 SET target.aliases = new_aliases,
-    target.description = CASE
-        WHEN src_desc <> '' AND NOT src_desc IN tgt_desc
-        THEN CASE WHEN tgt_desc = '' THEN src_desc ELSE tgt_desc + '；' + src_desc END
-        ELSE tgt_desc
-    END
+    target.description = new_description
 
-RETURN source.name AS merged_alias, target.name AS target_name, new_aliases AS updated_aliases
+RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_aliases) - size(coalesce(target.aliases, [])) AS added_count
 """
 
 # 边重定向：将指向别名节点（"别名属于"关系的 source）的所有其他边，重定向到用户节点（target）。
@@ -1379,16 +1383,16 @@ RETURN source.name AS merged_alias, target.name AS target_name, new_aliases AS u
 #   2. STATEMENT_ENTITY：陈述句 → 别名节点
 # 对于每条需要重定向的边，创建一条指向用户节点的新边（复制所有属性），然后删除旧边。
 REDIRECT_ALIAS_EDGES = """
-// 找到所有 别名→用户 的映射（包含 别名属于 和 别名失效 两种 predicate）
+// 找到所有 别名→用户 的映射
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar.predicate IN ['别名属于', '别名失效']
+WHERE ar.predicate = '别名属于'
 WITH collect({alias_id: elementId(alias), user_id: elementId(user), alias_eid: alias.id, user_eid: user.id}) AS mappings
 
 // 1. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 target 的情况
 UNWIND mappings AS m
 MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias:ExtractedEntity {end_user_id: $end_user_id})
 WHERE alias.id = m.alias_eid
-  AND NOT (r.predicate IN ['别名属于', '别名失效'])
+  AND r.predicate <> '别名属于'
   AND other.id <> m.user_eid
 WITH m, other, r, alias
 MATCH (user:ExtractedEntity {id: m.user_eid, end_user_id: $end_user_id})
@@ -1399,10 +1403,10 @@ WITH count(*) AS redirected_incoming
 
 // 2. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 source 的情况
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar2.predicate IN ['别名属于', '别名失效']
+WHERE ar2.predicate = '别名属于'
 WITH alias, user2, redirected_incoming
 MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
-WHERE NOT (r.predicate IN ['别名属于', '别名失效'])
+WHERE r.predicate <> '别名属于'
   AND other.id <> user2.id
 WITH user2, other, r, redirected_incoming
 CREATE (user2)-[nr:EXTRACTED_RELATIONSHIP]->(other)
@@ -1412,7 +1416,7 @@ WITH redirected_incoming, count(*) AS redirected_outgoing
 
 // 3. 重定向 STATEMENT_ENTITY 边：陈述句 → 别名节点
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar3.predicate IN ['别名属于', '别名失效']
+WHERE ar3.predicate = '别名属于'
 WITH alias, user3, redirected_incoming, redirected_outgoing
 MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
 WITH user3, stmt, r, redirected_incoming, redirected_outgoing
@@ -1429,24 +1433,10 @@ RETURN redirected_incoming, redirected_outgoing, count(*) AS redirected_stmt
 # 使用 DETACH DELETE 一并删除节点和该关系。
 DELETE_ALIAS_NODES = """
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-WHERE r.predicate IN ['别名属于', '别名失效']
+WHERE r.predicate = '别名属于'
 WITH alias, count(r) AS rel_count
 DETACH DELETE alias
 RETURN count(alias) AS deleted_count
-"""
-
-# 失效别名处理：将 predicate="别名失效" 的 source.name 从 target.aliases 中移除。
-# 在 MERGE_ALIAS_BELONGS_TO（追加新别名）之后、DELETE_ALIAS_NODES（删除节点）之前执行。
-REMOVE_INVALID_ALIASES = """
-MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
-WHERE r.predicate = '别名失效'
-WITH source, target,
-     coalesce(target.aliases, []) AS existing_aliases,
-     source.name AS invalid_name
-
-SET target.aliases = [a IN existing_aliases WHERE toLower(a) <> toLower(invalid_name)]
-
-RETURN source.name AS removed_alias, target.name AS target_name
 """
 
 CHECK_COMMUNITY_IS_COMPLETE_WITH_EMBEDDING = """

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1802,7 +1802,6 @@ def post_store_dedup_and_alias_merge_task(
             MERGE_ALIAS_BELONGS_TO,
             REDIRECT_ALIAS_EDGES,
             DELETE_ALIAS_NODES,
-            REMOVE_INVALID_ALIASES,
         )
 
         connector = Neo4jConnector()
@@ -1821,28 +1820,6 @@ def post_store_dedup_and_alias_merge_task(
             except Exception as e:
                 logger.warning(f"[PostStore] Neo4j 别名归并失败: {e}")
                 result_info["alias_merge_error"] = str(e)
-
-            # ── 1.5 Neo4j 失效别名移除（从 aliases 中删除旧别名） ──
-            try:
-                invalid_records = await connector.execute_query(
-                    REMOVE_INVALID_ALIASES,
-                    end_user_id=end_user_id,
-                )
-                invalid_count = len(invalid_records) if invalid_records else 0
-                result_info["invalid_aliases_removed"] = invalid_count
-                logger.info(f"[PostStore] 失效别名移除完成，影响 {invalid_count} 条记录")
-
-                # 同步删除 PostgreSQL end_user_info.aliases 中的失效别名
-                if invalid_records:
-                    removed_names = [
-                        r.get("removed_alias") for r in invalid_records
-                        if r.get("removed_alias")
-                    ]
-                    if removed_names:
-                        _remove_invalid_aliases_pg(end_user_id, removed_names)
-            except Exception as e:
-                logger.warning(f"[PostStore] 失效别名移除失败: {e}")
-                result_info["invalid_alias_error"] = str(e)
 
             # ── 2. Neo4j 边重定向 ──
             try:
@@ -2069,38 +2046,6 @@ def _sync_end_user_info_pg(
     except Exception as e:
         logger.warning(
             f"[Metadata][PG] 同步 end_user_info 失败（不影响主流程）: "
-            f"end_user_id={end_user_id}, error={e}",
-            exc_info=True,
-        )
-
-
-def _remove_invalid_aliases_pg(
-    end_user_id: str,
-    aliases_to_remove: List[str],
-) -> None:
-    """将失效别名从 PostgreSQL end_user_info.aliases 中移除。
-
-    失败只记日志，不抛异常，不影响主流程。
-    """
-    try:
-        import uuid as _uuid
-        from app.db import get_db_context
-        from app.repositories.end_user_info_repository import EndUserInfoRepository
-
-        eu_uuid = _uuid.UUID(end_user_id)
-        with get_db_context() as db:
-            info_repo = EndUserInfoRepository(db)
-            info_repo.remove_aliases(
-                end_user_id=eu_uuid,
-                aliases_to_remove=aliases_to_remove,
-            )
-        logger.info(
-            f"[PostStore][PG] 失效别名已从 end_user_info 移除: "
-            f"end_user_id={end_user_id}, removed={aliases_to_remove}"
-        )
-    except Exception as e:
-        logger.warning(
-            f"[PostStore][PG] 移除失效别名失败（不影响主流程）: "
             f"end_user_id={end_user_id}, error={e}",
             exc_info=True,
         )


### PR DESCRIPTION
The "别名失效" predicate handling is no longer needed. This removes it from the memory-side merge, Neo4j Cypher queries, and the Celery task orchestration. Also refactors MERGE_ALIAS_BELONGS_TO to aggregate multiple aliases per target using collect() instead of processing one row at a time, fixing potential overwrite issues.

## Summary by Sourcery

在内存、Neo4j 和任务编排中移除对 “别名失效”（invalid alias）谓词的支持，同时改进别名合并聚合逻辑，以避免覆盖问题。

Bug Fixes（错误修复）:
- 在 Neo4j 中按目标聚合别名合并，防止多个别名关系覆盖别名和描述。

Enhancements（功能增强）:
- 简化内存中的别名合并逻辑，仅处理 “别名属于” 边，并基于有效的别名映射来精简边的重定向流程。

Chores（杂项/维护）:
- 从任务流水线和 PostgreSQL 同步层中移除未使用的无效别名清理查询和辅助函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove support for the "别名失效" (invalid alias) predicate across memory, Neo4j, and task orchestration, while improving alias merge aggregation to avoid overwrite issues.

Bug Fixes:
- Aggregate alias merges per target in Neo4j to prevent multiple alias relationships from overwriting aliases and descriptions.

Enhancements:
- Simplify in-memory alias merge logic to only handle "别名属于" edges and streamline edge redirection based on valid alias mappings.

Chores:
- Remove unused invalid-alias cleanup queries and helper functions from the task pipeline and PostgreSQL sync layer.

</details>