### PR TITLE
fix(web): order

### DIFF
--- a/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
+++ b/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
@@ -69,6 +69,10 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef, { current
       onCancel={handleCancel}
       footer={(detail?.package_plan?.billing_cycle === 'permanent_free' && detail?.package_plan?.tier_level === 0)
         ? null
+        : detail?.package_plan?.billing_cycle === 'permanent_free'
+        ? [
+          <Button type="primary" onClick={handleUpgrade}>{t('pricing.upgrade')}</Button>
+        ]
         : [
           <Button onClick={handleRenewal}>{t('pricing.renewal')}</Button>,
           <Button type="primary" onClick={handleUpgrade}>{t('pricing.upgrade')}</Button>

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2777,6 +2777,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       comboName: 'Combo Name',
       spAndTa: 'Solution positioning and target audience',
       versionInformation: 'Version information',
+      multiplier: 'Order Cycle',
       orderCycle: 'Order Cycle',
       orderAmount: 'Order Amount',
       personal: {

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2743,6 +2743,7 @@ export const zh = {
       comboName: '套餐名称',
       spAndTa: '方案定位与目标人群',
       versionInformation: '版本信息',
+      multiplier: '订购周期',
       orderCycle: '订购周期',
       orderAmount: '订单金额',
       personal: {

--- a/web/src/views/OrderHistory/components/OrderDetail.tsx
+++ b/web/src/views/OrderHistory/components/OrderDetail.tsx
@@ -48,7 +48,7 @@ const OrderDetail = forwardRef<OrderDetailRef, { getProductType: (type: string) 
   const formatItems = useMemo(() => {
     if (!data) return []
     const items: DescriptionsProps['items'] = [];
-    ['order_no', 'package_snapshot', 'payable_amount', 'status', 'reject_reason', 'pay_time', 'created_at'].forEach(key => {
+    ['order_no', 'package_snapshot', 'payable_amount', 'multiplier', 'business_type', 'status', 'reject_reason', 'pay_time', 'created_at'].forEach(key => {
       const value = data[key as keyof Order]
 
       if (key === 'reject_reason' && !value) {
@@ -65,6 +65,12 @@ const OrderDetail = forwardRef<OrderDetailRef, { getProductType: (type: string) 
           label: t(`pricing.${key}`),
           children: (['pay_time', 'created_at'].includes(key) && value
             ? dayjs(value as number).format('YYYY-MM-DD HH:mm:ss')
+            : key === 'multiplier' && data.package_snapshot?.billing_cycle === 'permanent_free'
+            ? t(`package.${data.package_snapshot?.billing_cycle}`)
+            : key === 'multiplier'
+            ? <>{value}{t(`package.${data.package_snapshot?.billing_cycle}`)}</>
+            : key === 'business_type' && value
+            ? t(`pricing.${value}`)
             : key === 'status' && value
               ? t(`pricing.${STATUS[value as keyof typeof STATUS].key}`)
               : key === 'package_snapshot'

--- a/web/src/views/OrderPayment/index.tsx
+++ b/web/src/views/OrderPayment/index.tsx
@@ -255,7 +255,17 @@ const OrderPayment: React.FC = () => {
                   </td>
                   <td className="rb:px-4 rb:py-2 rb:w-32 rb:text-[#5B6167]">
                     <Form.Item name="multiplier" initialValue={1}>
-                      <InputNumber min={1} max={100} precision={0} suffix={t(`package.${pkg?.billing_cycle}`)} />
+                      <InputNumber 
+                        min={1} 
+                        max={100} 
+                        precision={0} 
+                        suffix={t(`package.${pkg?.billing_cycle}`)} 
+                        onChange={(value) => {
+                          if (value === null || value === undefined) {
+                            form.setFieldsValue({ multiplier: 1 });
+                          }
+                        }}
+                      />
                     </Form.Item>
                   </td>
                   <td className="rb:px-4 rb:py-2">


### PR DESCRIPTION
## Summary by Sourcery

确保订单详情正确显示倍数和业务类型，并调整永久免费套餐和订单倍数输入框的 UI 行为。

Bug Fixes:
- 通过在输入被清空时将订单倍数重置为 1，防止订单倍数输入框保持为 null。
- 在订单详情视图中显示倍数和业务类型字段，并针对永久免费套餐和本地化标签使用合适的格式进行展示。
- 在订阅详情弹窗中，对于非免费的永久套餐，仅显示“升级”操作的底部区域，而不是完全隐藏底部区域。

Enhancements:
- 为倍数/订单周期字段新增本地化标签，覆盖英文和中文文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure order details correctly display multiplier and business type and adjust UI behavior for permanent free plans and order multiplier input.

Bug Fixes:
- Prevent the order multiplier input from remaining null by resetting it to 1 when cleared.
- Display multiplier and business type fields in the order detail view with appropriate formatting for permanent free packages and localized labels.
- Show an upgrade-only footer action in the subscription detail modal for non-free permanent plans instead of hiding the footer entirely.

Enhancements:
- Add localized labels for the multiplier/order cycle field in both English and Chinese copy.

</details>