### PR TITLE
fix(memory): remove user-entity alias write guard in MERGE_ENTITY

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -99,8 +99,6 @@ SET e.name = CASE WHEN entity.name IS NOT NULL AND entity.name <> '' THEN entity
     END,
     e.statement_id = CASE WHEN entity.statement_id IS NOT NULL AND entity.statement_id <> '' THEN entity.statement_id ELSE e.statement_id END,
     e.aliases = CASE
-        // 用户实体的 aliases 由 PgSQL end_user_info 作为唯一权威源，知识抽取完全不写入
-        WHEN entity.name IN ['用户', '我', 'User', 'I'] THEN e.aliases
         WHEN entity.aliases IS NOT NULL AND size(entity.aliases) > 0
         THEN CASE 
             WHEN e.aliases IS NULL THEN entity.aliases 


### PR DESCRIPTION
The guard prevented aliases from being set on user entities during knowledge extraction, but PgSQL is the authoritative source for user info — when aliases are provided in the extraction pipeline they should be written like any other entity.

## Summary by Sourcery

错误修复：
- 移除在知识抽取期间阻止用户实体别名更新的写保护，以便来自流水线的别名可以被持久化保存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove the write guard that blocked alias updates for user entities during knowledge extraction so aliases from the pipeline are persisted.

</details>