### PR TITLE
fix(web): local_deployment hide upgrade/renewal

### DIFF
--- a/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
+++ b/web/src/components/SiderMenu/SubscriptionDetailModal.tsx
@@ -67,7 +67,7 @@ const SubscriptionDetailModal = forwardRef<SubscriptionDetailModalRef, { current
       title={[t('package.packageDetail'), detail?.package_plan?.[getKeyWithLanguage('name')]].filter(item => item).join(' - ')}
       open={open}
       onCancel={handleCancel}
-      footer={(detail?.package_plan?.billing_cycle === 'permanent_free' && detail?.package_plan?.tier_level === 0)
+      footer={(detail?.package_plan?.billing_cycle === 'permanent_free' && detail?.package_plan?.tier_level === 0) || detail?.package_plan?.billing_cycle === 'local_deployment'
         ? null
         : detail?.package_plan?.billing_cycle === 'permanent_free'
         ? [


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 对于本地部署的计费方案，隐藏订阅弹窗底部的操作按钮，以防止显示不合适的升级或续订选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Hide subscription modal footer actions for local deployment billing plans to prevent inappropriate upgrade or renewal options from showing.

</details>