### PR TITLE
fix(web): thinking_budget_tokens add dependencies

### DIFF
--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -187,11 +187,12 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
           label={t('application.thinking_budget_tokens')}
           hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
           extra={<>{t('application.range')}: [{minThinkingBudgetTokens}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
+          dependencies={['max_tokens']}
           rules={[
             { required: values?.deep_thinking, message: t('common.pleaseEnter') },
             {
               validator: (_, value) => {
-                const maxTokens = values?.max_tokens
+                const maxTokens = form.getFieldValue('max_tokens')
                 const deep_thinking = values?.deep_thinking;
                 if (deep_thinking && value !== undefined) {
                   if (value < minThinkingBudgetTokens) {


### PR DESCRIPTION
## Summary by Sourcery

确保 “thinking budget tokens” 字段与最大 token 配置保持同步，并且在最大 token 发生变化时仍能正确校验。

Bug 修复：
- 使 `thinking_budget_tokens` 的校验从当前表单状态中获取 `max_tokens`，以避免使用过期值。
- 通过添加显式字段依赖，在 `max_tokens` 变化时触发对 `thinking_budget_tokens` 的重新校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the thinking budget tokens field stays in sync with max token configuration and validates correctly when max tokens change.

Bug Fixes:
- Make thinking_budget_tokens validation derive max_tokens from current form state to avoid using stale values.
- Trigger revalidation of thinking_budget_tokens whenever max_tokens changes by adding an explicit field dependency.

</details>