### PR TITLE
fix(web): chat remove error desc

### DIFF
--- a/web/src/views/ApplicationConfig/TestChat/index.tsx
+++ b/web/src/views/ApplicationConfig/TestChat/index.tsx
@@ -624,7 +624,7 @@ const TestChat: FC<TestChatProps> = ({
             toolbarRef.current?.setFiles(list || [])
           }}
           labelFormat={(item) => item.role === 'user' ? t('application.you') : dayjs(item.created_at).locale('en').format('MMMM D, YYYY [at] h:mm A')}
-          errorDesc={t('application.ReplyException')}
+          // errorDesc={t('application.ReplyException')}
           renderRuntime={application?.type === 'workflow' ? (item, index) => <Runtime item={item} index={index} /> : undefined}
         >
           <ChatToolbar

--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -636,7 +636,7 @@ const Chat: FC<ChatProps> = ({
                   streamLoading={compareLoadingRef.current}
                   labelPosition="top"
                   labelFormat={(item) => item.role === 'user' ? t('application.you') : chat.label || t(`application.ai`)}
-                  errorDesc={t('application.ReplyException')}
+                  // errorDesc={t('application.ReplyException')}
                 />
               </Flex>
             ))}

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -476,7 +476,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef; data: Work
         streamLoading={streamLoading}
         labelPosition="bottom"
         labelFormat={(item) => dayjs(item.created_at).locale('en').format('MMMM D, YYYY [at] h:mm A')}
-        errorDesc={t('application.ReplyException')}
+        // errorDesc={t('application.ReplyException')}
         renderRuntime={(item, index) => {
           return <Runtime item={item} index={index} />
         }}


### PR DESCRIPTION
## Summary by Sourcery

从应用和工作流配置视图中的聊天组件中移除错误描述消息，以停止显示通用的回复异常文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove error description messaging from chat components in application and workflow configuration views to stop displaying the generic reply exception text.

</details>