### PR TITLE
fix(web): knowledge config init

### DIFF
--- a/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/ApplicationConfig/components/Knowledge/KnowledgeListModal.tsx
@@ -88,11 +88,13 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
   const handleSave = () => {
     refresh(selectedRows.map(item => ({
       ...item,
+      vector_similarity_weight: 0.5,
       similarity_threshold: 0.7,
       retrieve_type: "hybrid",
       top_k: 3,
       weight: 1,
       config: {
+        vector_similarity_weight: 0.5,
         similarity_threshold: 0.7,
         retrieve_type: "hybrid",
         top_k: 3,

--- a/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/views/Workflow/components/Properties/Knowledge/KnowledgeListModal.tsx
@@ -66,6 +66,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
     refresh(selectedRows.map(item => ({
       ...item,
       config: {
+        vector_similarity_weight: 0.5,
         similarity_threshold: 0.7,
         retrieve_type: "hybrid",
         top_k: 3,


### PR DESCRIPTION
## 由 Sourcery 提供的总结

错误修复：
- 确保从应用和工作流模态窗口保存的知识项设置了默认的向量相似度权重，以避免缺少配置值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure knowledge items saved from application and workflow modals have default vector similarity weight set to avoid missing config values.

</details>