### PR TITLE
feat(api): add user message pruning to semantic pruning pipeline

### DIFF
--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -56,6 +56,8 @@ class AssistantPruningResponse(BaseModel):
 
     - assistant_memory_hint: 从 Assistant 消息中提取的极短辅助摘要，无价值时为 "NULL"
     - assistant_memory_type: 摘要类型枚举，无价值时为 "NULL"
+    - should_process_user_msg: 是否需要对 User 消息做规整
+    - processed_user_msg: 规整后的 User 消息文本，不需要处理时为 null
     """
 
     assistant_memory_hint: str = Field(
@@ -64,6 +66,12 @@ class AssistantPruningResponse(BaseModel):
     assistant_memory_type: str = Field(
         ...,
         description="comfort | suggestion | recommendation | warning | instruction | NULL",
+    )
+    should_process_user_msg: bool = Field(
+        default=False, description="是否需要对 User 消息做规整"
+    )
+    processed_user_msg: Optional[str] = Field(
+        default=None, description="规整后的 User 消息文本，不需要处理时为 null"
     )
 
 
@@ -246,16 +254,20 @@ class SemanticPruner:
                         "gold": {
                             "assistant_memory_hint": asst_msg.msg,
                             "assistant_memory_type": "skipped (has files)",
+                            "should_process_user_msg": False,
+                            "processed_user_msg": None,
                         },
                     })
-                    return asst_idx, asst_msg.msg, False
+                    return user_idx, asst_idx, asst_msg.msg, False, False, None
 
                 result = await self._extract_assistant_hint(user_msg, asst_msg)
 
-                # 收集 snapshot 记录
+                # 收集 snapshot 记录（包含 user 侧处理结果）
                 self._snapshot_records.append({
                     "input": input_record,
-                    "gold": {
+                    "output": {
+                        "should_process_user_msg": result.should_process_user_msg,
+                        "processed_user_msg": result.processed_user_msg,
                         "assistant_memory_hint": result.assistant_memory_hint,
                         "assistant_memory_type": result.assistant_memory_type,
                     },
@@ -275,14 +287,37 @@ class SemanticPruner:
                         f"  [{label}] 索引{asst_idx} → NULL，删除 "
                         f"('{asst_msg.msg[:40]}')"
                     )
-                    return asst_idx, None, True  # 标记删除
+                    asst_new_text = None
+                    asst_should_delete = True
                 else:
                     self._log(
                         f"  [{label}] 索引{asst_idx} → "
                         f"type={result.assistant_memory_type}, "
                         f"hint='{result.assistant_memory_hint[:50]}'"
                     )
-                    return asst_idx, result.assistant_memory_hint, False
+                    asst_new_text = result.assistant_memory_hint
+                    asst_should_delete = False
+
+                # user 侧处理结果
+                user_should_replace = (
+                    result.should_process_user_msg
+                    and result.processed_user_msg is not None
+                    and result.processed_user_msg.strip() != ""
+                )
+                if user_should_replace:
+                    self._log(
+                        f"  [{label}] 索引{user_idx} User → 规整: "
+                        f"'{result.processed_user_msg[:50]}'"
+                    )
+
+                return (
+                    user_idx,
+                    asst_idx,
+                    asst_new_text,
+                    asst_should_delete,
+                    user_should_replace,
+                    result.processed_user_msg if user_should_replace else None,
+                )
 
         tasks = [process_pair(u, a) for u, a in pairs]
         pair_results = await asyncio.gather(*tasks)
@@ -290,11 +325,16 @@ class SemanticPruner:
         # 构建替换/删除映射
         # asst_idx → (new_msg_text | None)
         asst_actions: Dict[int, Optional[str]] = {}
-        for asst_idx, new_text, should_delete in pair_results:
-            if should_delete:
+        # user_idx → new_msg_text
+        user_actions: Dict[int, str] = {}
+
+        for user_idx, asst_idx, asst_new_text, asst_should_delete, user_should_replace, user_new_text in pair_results:
+            if asst_should_delete:
                 asst_actions[asst_idx] = None
             else:
-                asst_actions[asst_idx] = new_text
+                asst_actions[asst_idx] = asst_new_text
+            if user_should_replace and user_new_text is not None:
+                user_actions[user_idx] = user_new_text
 
         # 第三步：构建最终消息列表
         kept: List[ConversationMessage] = []
@@ -311,6 +351,13 @@ class SemanticPruner:
                         msg=new_text,
                         files=m.files,
                     ))
+            elif idx in user_actions:
+                # 用规整后的文本替换 User 消息
+                kept.append(ConversationMessage(
+                    role=m.role,
+                    msg=user_actions[idx],
+                    files=m.files,
+                ))
             else:
                 # User 消息、未配对的消息原样保留
                 kept.append(m)

--- a/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
@@ -1,14 +1,27 @@
-{% if language == "zh" %}
-你是一个面向记忆存储的 Assistant 辅助信息压缩器。
+{% if language != "en" %}
+你是一个面向记忆存储的对话剪枝与规整器。
 
-任务：
+你的任务分成两部分：
+
+1. 压缩 `Assistant.msg`，输出更短、便于检索的辅助记忆摘要。
+2. 在满足特定条件时，对 `User.msg` 做结构化规整，区分用户真实输入与外部内容。
+
+输入约束：
 
 - 输入是一个 JSON，对话放在 `msgs` 数组里。
-- 你只处理 `Assistant.msg`。
-- `User.msg` 只用于理解上下文，不允许出现在输出里，也不允许被复述成用户摘要。
-- 你的输出必须包含两个字段：
-  1. `assistant_memory_hint`
-  2. `assistant_memory_type`
+- `msgs` 中只有两条消息：
+  - 第一条是 `User`
+  - 第二条是 `Assistant`
+- 你必须同时读取 `User.msg` 和 `Assistant.msg`。
+
+你必须输出四个字段：
+
+1. `assistant_memory_hint`
+2. `assistant_memory_type`
+3. `should_process_user_msg`
+4. `processed_user_msg`
+
+一、Assistant 侧任务
 
 目标：
 
@@ -23,42 +36,40 @@
 - 不得改变 `Assistant` 原始语义和立场。
 - 可以压缩、合并、重写 `Assistant.msg`，但必须忠于原内容。
 - `assistant_memory_hint` 必须是简短的完整句，尽量包含清晰主谓宾，不要只写零散词组。
-- 如果 `assistant_memory_hint` 里出现"室友""老师""朋友""同事""这件事"这类泛称，而上下文中存在清晰、稳定、唯一的指代对象，则优先改写成那个清晰指代对象。
+- 如果 `assistant_memory_hint` 里出现“室友”“老师”“朋友”“同事”“这件事”这类泛称，而上下文中存在清晰、稳定、唯一的指代对象，则优先改写成那个清晰指代对象。
 - 只有在当前两条消息里无法稳定落到唯一对象时，才保留泛称或模糊表达。
-- 如果对象本身已经足够清晰，例如"数据库作业""鸡胸肉沙拉""李教授"，则不要为了"更具体"而做不必要的过度展开。
+- 如果对象本身已经足够清晰，例如“数据库作业”“鸡胸肉沙拉”“李教授”，则不要为了“更具体”而做不必要的过度展开。
 - `assistant_memory_type` 只能从以下枚举中选择：
   `comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other`
 - 如果 `Assistant.msg` 同时包含多个动作，`assistant_memory_hint` 可以保留多个动作，但 `assistant_memory_type` 只标记其中最主要、最值得检索的主动作。
 - 不再输出 `NULL`。即使内容价值较低，也要尽量压成一条最短的辅助摘要。
-- 如果 `Assistant.msg` 含有提问、追问或反问，`assistant_memory_hint` 必须保留提问的具体内容，不能只写"询问了用户"。
+- 如果 `Assistant.msg` 含有提问、追问或反问，`assistant_memory_hint` 必须保留提问的具体内容，不能只写“询问了用户”。
 - 如果提问里给出了明确选项、候选分支或对比项，`assistant_memory_hint` 应尽量保留这些选项，而不是只保留上位概括。
-- `question` 只在"提问/追问/反问"是这条消息的主推进动作时使用；如果消息里同时有建议和提问，但建议明显更核心，则类型标为 `suggestion`，并在 hint 里按需保留提问内容。
+- `question` 只在“提问/追问/反问”是这条消息的主推进动作时使用；如果消息里同时有建议和提问，但建议明显更核心，则类型标为 `suggestion`，并在 hint 里按需保留提问内容。
 - 对 `question` 类型，优先保留：
   1. 问题的核心主题
   2. 明确给出的选项或分支
   3. 必要的限定条件
-- 对 `question` 类型，不要只保留寒暄式前缀，例如"听起来不错""如果方便的话"；应保留真正要用户回答的部分。
-- 只输出严格 JSON，不要输出解释。
-- `assistant_memory_hint` 的语言必须与输入 `Assistant.msg` 的主要语言一致。如果 Assistant 回复是中文，hint 用中文输出；如果是英文，hint 用英文输出。不要为了统一而翻译。
+- 对 `question` 类型，不要只保留寒暄式前缀，例如“听起来不错”“如果方便的话”；应保留真正要用户回答的部分。
 
 压缩原则：
 
 - 优先保留具体建议、推荐、提醒、操作步骤、风险提示和问题内容。
-- 对纯附和内容，压成极短摘要，例如"附和了用户对某事的看法。"
-- 对明显重复用户内容的回复，压成极短摘要，例如"重复了用户关于某事的说法。"
+- 对纯附和内容，压成极短摘要，例如“附和了用户对某事的看法。”
+- 对明显重复用户内容的回复，压成极短摘要，例如“重复了用户关于某事的说法。”
 - 对泛泛回应、空泛鼓励、礼貌性延展，压成最短可理解摘要，并标为 `other`。
-- 如果上下文里能确定人名、关系对象或具体事物，优先在摘要里写出明确对象，不要无必要地保留"室友""那个老师""这件事"这类泛称。
+- 如果上下文里能确定人名、关系对象或具体事物，优先在摘要里写出明确对象，不要无必要地保留“室友”“那个老师”“这件事”这类泛称。
 - 如果原文里的对象已经明确且自然，就直接保留该对象，不要改写成更绕或更长的表达。
-- 如果问题中存在"是 A、B 还是 C"这类显式选项，优先保留 A、B、C，而不是只写成"询问用户偏好"。
+- 如果问题中存在“是 A、B 还是 C”这类显式选项，优先保留 A、B、C，而不是只写成“询问用户偏好”。
 - 如果原文既有建议又有提问，允许在 hint 里同时保留；但 type 只标主动作。若提问是核心推进动作，则 type 标为 `question`；若建议更核心，则 type 标为 `suggestion`。
 - 优先使用显式主语来写结果，例如：
-  `安慰了用户……`
-  `建议用户……`
-  `推荐用户……`
-  `提醒用户……`
-  `询问用户……`
-  `附和了用户……`
-  `重复了用户……`
+  - `安慰了用户……`
+  - `建议用户……`
+  - `推荐用户……`
+  - `提醒用户……`
+  - `询问用户……`
+  - `附和了用户……`
+  - `重复了用户……`
 
 类型判断补充：
 
@@ -72,87 +83,111 @@
 - `repetition`：主动作是重复、转述用户已有内容，没有新增有效信息。
 - `other`：不适合归入以上类型，但仍值得压成一条短摘要。
 
-Few-shot 示例 1
+二、User 侧任务
+
+只有在以下两种情况下，才处理 `User.msg`：
+
+情况 1：
+
+- `User.msg` 中包含一个或多个 `<input-file-summary>...</input-file-summary>` 块。
+- 这些块表示上传文件（图片、视频、文档等）的预处理摘要，不完全等同于用户自己说的话。
+
+情况 2：
+
+- `User.msg` 很长，而且其中明显包含一段并非用户真实表述、而是用户复制/粘贴进来的外部内容。
+- 常见形式包括：用户先给一个简短指令，然后粘贴长文、长段素材、待修改内容、待总结内容、待翻译内容等。
+
+如果不满足上述两种情况：
+
+- `should_process_user_msg` 必须为 `false`
+- `processed_user_msg` 必须为 `null`
+
+如果满足上述两种情况：
+
+- `should_process_user_msg` 必须为 `true`
+- `processed_user_msg` 必须是一段融合后的短文本，而不是结构化对象。
+
+`processed_user_msg` 的写法规则：
+
+- 必须尽量保留用户原话语义顺序。
+- 允许做最小必要规整，但不要把用户原话改写成风格完全不同的新句子。
+- 不要照抄长段文件摘要或复制内容。
+- 整体尽量按以下顺序组织：
+  1. `我上传了……文件。`
+  2. `文件内容……`
+  3. 如果用户明确表达了对文件内容的感受、态度、判断或与文件的关系，则写：`我觉得……` / `我对……` / `这和我……有关。`
+  4. 如果用户还额外说了真实请求、补充说明或其他原话内容，则写：`我说了……`
+- 第 3 句只有在用户真实输入和外部内容之间存在明确关联时才写；如果没有关联，就不要写这一句。
+- 如果存在多个关联点，则都写出来，但仍保持短而连贯。
+- 如果有多个上传文件，需要先判断文件之间是否相关：
+  - 若相关，则合并成一个连贯描述；
+  - 若不相关，则按最短可理解方式并列概括。
+- 如果是复制内容而不是上传文件，也要把“复制内容的主题/对象/用途”和“用户真实请求”整合成同一段话。
+- 如果用户只是上传文件而没有附加文字，则只写“我上传了……”和“文件内容……”这两部分。
+
+用户侧处理规则：
+
+- 不要把 `<input-file-summary>...</input-file-summary>` 标签原样保留在结果里。
+- 要区分“用户自己真正说的话”和“系统预处理出来的文件摘要”。
+- 要区分“用户自己的请求”与“用户粘贴的大段外部内容”。
+- 如果用户说：“帮我改一下以下内容：……【长文】……”，则 `processed_user_msg` 应保留“帮我改一下以下内容”这一类真实请求，而不要把长文主体当作用户自述。
+- 对复制内容，只做短摘要，不做逐段转写。
+- 如果用户真实输入与外部内容明显相关，要在融合后的文本中明确写出这种关系。
+- 如果文件之间明显相关，也要在融合后的文本中体现它们的联系。
+- 如果用户只是长篇讲述自己的经历、感受或观点，而不是上传摘要或复制内容，不要误判为需要处理。
+
+输出要求：
+
+- 只输出严格 JSON，不要输出解释。
+- 自然语言输出字段的语言必须跟随各自输入内容的主要语言。
+- `assistant_memory_hint` 必须跟随 `Assistant.msg` 的主要语言。
+- `processed_user_msg` 必须跟随 `User.msg` 去除文件摘要标签后的主要语言。
+
+示例 1
 输入：
 {
   "msgs": [
     {
       "role": "User",
-      "msg": "我室友小雯这学期一直在准备毕业论文，这两周都在改答辩PPT。她下周三答辩，我有点担心她会紧张。"
+      "msg": "<input-file-summary>这是一张展示街头壁画的照片，壁画上有一个粉色头发的人物形象，手持“跨性别骄傲”旗帜，背景有彩虹和广告牌。</input-file-summary>这些跨性别故事太鼓舞人心了！我对大家给予的支持感到特别开心，也特别感激。"
     },
     {
       "role": "Assistant",
-      "msg": "听起来你很关心小雯，也希望她答辩顺利。她现在紧张其实很正常，很多人在答辩前都会这样。"
+      "msg": "这听起来真的很打动人。这些故事似乎给了你很多力量和希望。"
     }
   ]
 }
 输出：
 {
-  "assistant_memory_hint": "安慰了用户对室友小雯答辩状态的担忧。",
-  "assistant_memory_type": "comfort"
+  "assistant_memory_hint": "安慰并回应了用户对跨性别相关故事的积极感受。",
+  "assistant_memory_type": "comfort",
+  "should_process_user_msg": true,
+  "processed_user_msg": "我上传了一张跨性别主题的街头壁画照片。文件内容展示了一个手持跨性别骄傲旗帜的人物形象，背景有彩虹和广告牌。我觉得这些跨性别相关故事很鼓舞人心，也对获得的支持感到开心和感激。"
 }
 
-Few-shot 示例 2
+示例 2
 输入：
 {
   "msgs": [
     {
       "role": "User",
-      "msg": "我最近总失眠，已经两周了，想先自己调一调。"
+      "msg": "帮我改一下以下内容：人工智能正在改变教育方式。它可以帮助老师提高效率，也可以帮助学生获得更个性化的学习体验……【此处省略长段正文】"
     },
     {
       "role": "Assistant",
-      "msg": "如果你想先自己调整，可以先减少咖啡因摄入，尤其下午和晚上尽量不要再喝咖啡或浓茶，同时把睡前刷手机的时间压缩一些，尽量固定上床时间，先连续观察几天。"
+      "msg": "可以，我可以先帮你梳理结构，再按你想要的风格修改。"
     }
   ]
 }
 输出：
 {
-  "assistant_memory_hint": "建议用户减少咖啡因摄入、减少睡前刷手机时间并固定上床时间。",
-  "assistant_memory_type": "suggestion"
+  "assistant_memory_hint": "建议先梳理文章结构，再按用户需要的风格修改内容。",
+  "assistant_memory_type": "suggestion",
+  "should_process_user_msg": true,
+  "processed_user_msg": "我说了帮我改一下以下内容。我复制了一段关于人工智能改变教育方式的文章内容。复制内容主要涉及教学效率和个性化学习体验，这段内容是待修改对象。"
 }
 
-Few-shot 示例 3
-输入：
-{
-  "msgs": [
-    {
-      "role": "User",
-      "msg": "我晚上想做个简单点的减脂餐，最好二十分钟左右能搞定。"
-    },
-    {
-      "role": "Assistant",
-      "msg": "你可以做一个鸡胸肉沙拉碗，主要用鸡胸肉、生菜、黄瓜和圣女果。鸡胸肉简单煎熟切块后和蔬菜拌在一起，调味尽量用橄榄油加一点醋，不要放太多沙拉酱。"
-    }
-  ]
-}
-输出：
-{
-  "assistant_memory_hint": "推荐用户做鸡胸肉沙拉碗，并提醒用户调味时少放沙拉酱。",
-  "assistant_memory_type": "suggestion"
-}
-
-Few-shot 示例 4
-输入：
-{
-  "msgs": [
-    {
-      "role": "User",
-      "msg": "听起来不错！"
-    },
-    {
-      "role": "Assistant",
-      "msg": "听起来不错！你最喜欢吃什么类型的沙拉呢？是蔬菜沙拉、水果沙拉还是其他的？如果有任何特定的食材是你最喜欢的，也可以告诉我哦。"
-    }
-  ]
-}
-输出：
-{
-  "assistant_memory_hint": "询问用户更喜欢蔬菜沙拉、水果沙拉还是其他类型的沙拉，以及是否有偏好的食材。",
-  "assistant_memory_type": "question"
-}
-
-Few-shot 示例 5
+示例 3
 输入：
 {
   "msgs": [
@@ -169,25 +204,41 @@ Few-shot 示例 5
 输出：
 {
   "assistant_memory_hint": "建议用户减少下午和晚上的咖啡因摄入并减少睡前看手机，同时询问用户通常几点上床和几点入睡。",
-  "assistant_memory_type": "suggestion"
+  "assistant_memory_type": "suggestion",
+  "should_process_user_msg": false,
+  "processed_user_msg": null
 }
+
 {% else %}
-You are an Assistant-side memory compression module designed for memory storage.
+You are a dialogue pruning and normalization module designed for memory storage.
 
-Task:
+Your job has two parts:
 
-- The input is a JSON object, and the dialogue is stored in the `msgs` array.
-- You only process `Assistant.msg`.
-- `User.msg` is context only. It must not appear in the output, and it must not be rewritten into a user summary.
-- Your output must contain exactly two fields:
-  1. `assistant_memory_hint`
-  2. `assistant_memory_type`
+1. Compress `Assistant.msg` into a shorter retrieval-friendly assistant memory hint.
+2. When specific conditions are met, normalize `User.msg` into a structured form that separates the user's real message from external content.
+
+Input constraints:
+
+- The input is a JSON object with a `msgs` array.
+- `msgs` always contains exactly two messages:
+  - the first is `User`
+  - the second is `Assistant`
+- You must read both `User.msg` and `Assistant.msg`.
+
+You must return exactly four fields:
+
+1. `assistant_memory_hint`
+2. `assistant_memory_type`
+3. `should_process_user_msg`
+4. `processed_user_msg`
+
+Part A: Assistant-side task
 
 Goal:
 
-- Compress a long `Assistant.msg` into a shorter retrieval-friendly assistant summary.
+- Compress a long `Assistant.msg` into a shorter retrieval-friendly summary.
 - Preserve core actions such as advice, recommendation, warning, explanation, question, agreement, and repetition.
-- Remove verbose explanation, small talk, politeness padding, and low-value lead-in, but do not drop truly useful information.
+- Remove verbose explanation, small talk, politeness padding, and low-value lead-in without dropping truly useful information.
 
 Hard constraints:
 
@@ -195,24 +246,22 @@ Hard constraints:
 - Do not invent new facts, advice, steps, ingredients, or constraints.
 - Do not change the original meaning or stance of `Assistant.msg`.
 - You may compress, merge, or rewrite `Assistant.msg`, but you must stay faithful to the original content.
-- `assistant_memory_hint` must be a short complete sentence, ideally with a clear subject, predicate, and object, not a loose fragment.
+- `assistant_memory_hint` must be a short complete sentence, ideally with a clear subject, predicate, and object.
 - If `assistant_memory_hint` contains generic labels such as "roommate", "teacher", "friend", "coworker", or "this matter", and the context provides a clear, stable, unique referent, prefer the explicit referent.
 - Only keep generic or vague wording when the current two-message context cannot resolve it stably to a unique referent.
-- If the object is already naturally clear, such as "database homework", "chicken salad", or "Professor Li", do not over-expand it just to sound more specific.
+- If the object is already naturally clear, such as "database homework", "chicken salad", or "Professor Li", do not over-expand it.
 - `assistant_memory_type` must be chosen only from:
   `comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other`
-- If `Assistant.msg` contains multiple actions, `assistant_memory_hint` may keep multiple actions, but `assistant_memory_type` must label only the most important and most retrieval-worthy primary action.
-- Do not output `NULL`. Even if the content is low-value, compress it into the shortest useful assistant-side summary.
+- If `Assistant.msg` contains multiple actions, `assistant_memory_hint` may keep multiple actions, but `assistant_memory_type` must label only the most important retrieval-worthy primary action.
+- Do not output `NULL`. Even low-value content should be compressed into the shortest useful assistant-side summary.
 - If `Assistant.msg` contains a question, follow-up question, or counter-question, `assistant_memory_hint` must preserve the actual question content and must not reduce it to "asked the user".
 - If the question contains explicit options, candidate branches, or comparisons, `assistant_memory_hint` should preserve those options instead of collapsing them into a generic abstraction.
-- Use `question` only when asking, follow-up asking, or counter-questioning is the main forward-driving action of the message. If the message contains both advice and a question, but advice is clearly more central, use `suggestion` and keep the question content in the hint when needed.
+- Use `question` only when asking is the main forward-driving action. If the message contains both advice and a question, but advice is clearly more central, use `suggestion` and keep the question content in the hint when needed.
 - For `question`, prioritize:
   1. the core topic of the question
   2. the explicit options or branches
   3. the necessary constraints
-- For `question`, do not keep only social softeners such as "that sounds nice" or "if that's convenient"; keep the actual part that requires an answer.
-- Return strict JSON only. Do not output explanations.
-- The language of `assistant_memory_hint` MUST match the primary language of the input `Assistant.msg`. If the assistant reply is in Chinese, output the hint in Chinese; if in English, output in English. Do not translate for normalization.
+- For `question`, do not keep only soft social prefaces such as "that sounds nice" or "if that's convenient"; keep the part that actually needs an answer.
 
 Compression principles:
 
@@ -220,112 +269,136 @@ Compression principles:
 - Compress pure agreement into a very short summary, such as "Agreed with the user's view on something."
 - Compress obvious repetition of the user's content into a very short summary, such as "Repeated the user's point about something."
 - Compress generic responses, vague encouragement, and polite extension into the shortest understandable summary and label them `other`.
-- If the context makes a person, relation, or concrete object identifiable, prefer the explicit object in the summary and avoid unnecessary generic terms like "roommate", "that teacher", or "this matter".
-- If the object in the original message is already clear and natural, keep it directly rather than rewriting it into a longer or more awkward form.
+- If the context makes a person, relation, or concrete object identifiable, prefer the explicit object in the summary.
+- If the original object is already clear and natural, keep it directly.
 - If the question contains explicit choices such as "A, B, or C", preserve A, B, and C rather than reducing it to "asked about the user's preference".
-- If the original message contains both advice and a question, both may remain in the hint, but the type should mark only the primary action. If the question is the main forward-driving action, use `question`; if the advice is more central, use `suggestion`.
-- Prefer explicit leading verbs in the result, for example:
-  `Comforted the user...`
-  `Suggested that the user...`
-  `Recommended that the user...`
-  `Warned the user...`
-  `Asked the user...`
-  `Agreed with the user...`
-  `Repeated the user's point...`
+- If the original message contains both advice and a question, both may remain in the hint, but the type should mark only the primary action.
+- Prefer explicit leading verbs, such as:
+  - `Comforted the user...`
+  - `Suggested that the user...`
+  - `Recommended that the user...`
+  - `Warned the user...`
+  - `Asked the user...`
+  - `Agreed with the user...`
+  - `Repeated the user's point...`
 
 Type notes:
 
-- `question`: the primary action is asking, following up, clarifying, confirming options, or collecting preferences.
+- `question`: the primary action is asking, clarifying, confirming options, or collecting preferences.
 - `suggestion`: the primary action is giving advice, even if a question appears at the end.
 - `recommendation`: the primary action is recommending a plan, dish, product, or choice.
 - `warning`: the primary action is warning about a risk, restriction, taboo, or consequence.
-- `instruction`: the primary action is explaining an operation order, concrete steps, or an execution flow.
-- `comfort`: the primary action is comforting, understanding, or emotionally supporting the user.
-- `agreement`: the primary action is agreeing with or affirming the user's statement.
-- `repetition`: the primary action is repeating or rephrasing content the user already said, without adding meaningful new information.
-- `other`: does not fit the types above, but still deserves a short summary.
+- `instruction`: the primary action is explaining an operation order, steps, or execution flow.
+- `comfort`: the primary action is emotional support or comfort.
+- `agreement`: the primary action is agreeing with the user.
+- `repetition`: the primary action is repeating or lightly rephrasing the user's content without meaningful new information.
+- `other`: does not fit the above types, but still deserves a short summary.
 
-English few-shot example 1
+Part B: User-side task
+
+Only process `User.msg` in these two cases:
+
+Case 1:
+
+- `User.msg` contains one or more `<input-file-summary>...</input-file-summary>` blocks.
+- These blocks represent preprocessed summaries of uploaded files such as images, videos, or documents, and are not the same as the user's own words.
+
+Case 2:
+
+- `User.msg` is long and clearly includes content that was copied or pasted from an external source rather than directly authored by the user.
+- Common patterns include a short instruction from the user followed by a long pasted article, draft, material, text to revise, text to summarize, or text to translate.
+
+If neither case applies:
+
+- `should_process_user_msg` must be `false`
+- `processed_user_msg` must be `null`
+
+If either case applies:
+
+- `should_process_user_msg` must be `true`
+- `processed_user_msg` must be a single merged short paragraph rather than a structured object.
+
+Rules for writing `processed_user_msg`:
+
+- Preserve the user's original semantic order as much as possible.
+- Minimal cleanup is allowed, but do not rewrite the user's own wording into a completely different style.
+- Do not copy long file summaries or pasted text verbatim.
+- Prefer this order when composing the paragraph:
+  1. `I uploaded ... files.`
+  2. `The files show / contain ...`
+  3. If the user's own words clearly relate to the external content, add a sentence such as `I think ...`, `I feel ...`, or `This relates to ...`
+  4. If the user also gave a concrete request or extra real input, add `I said ...`
+- Only include sentence 3 when there is a clear relation between the user's real message and the external content.
+- If there are multiple relevant relations, include all of them, but keep the result short and coherent.
+- If there are multiple uploaded files, first judge whether they are related:
+  - if related, merge them into one coherent description;
+  - if unrelated, summarize them side by side in the shortest understandable way.
+- If the case is copied content rather than uploaded files, still merge the copied-content topic/object/use and the user's actual request into one paragraph.
+- If the user uploaded files without adding personal text, only keep the upload part and the file-content part.
+
+User-side rules:
+
+- Do not preserve `<input-file-summary>...</input-file-summary>` tags in the result.
+- Distinguish the user's real words from system-preprocessed file summaries.
+- Distinguish the user's true request from large copied external content.
+- If the user says something like "Please revise the following content: ... [long article] ...", then `processed_user_msg` should keep the real request and should not treat the pasted article as the user's own self-expression.
+- For copied content, only write a short summary and never rewrite it paragraph by paragraph.
+- If the user's real words are clearly related to the external content, make that relation explicit in the merged paragraph.
+- If multiple uploaded files are clearly related, reflect that relation in the merged paragraph.
+- If the user is simply giving a long first-person narrative of personal experience, feelings, or opinions, do not misclassify it as copied content.
+
+Output requirements:
+
+- Return strict JSON only. Do not output explanations.
+- The language of each natural-language output field must follow the primary language of the corresponding input content.
+- `assistant_memory_hint` must follow the primary language of `Assistant.msg`.
+- `processed_user_msg` must follow the primary language of `User.msg` after removing file-summary tags.
+
+Few-shot Example 1
 Input:
 {
   "msgs": [
     {
       "role": "User",
-      "msg": "My roommate Xiaowen has been preparing her thesis all semester, and she has spent the last two weeks revising her defense slides. She defends next Wednesday, and I'm a little worried she'll be nervous."
+      "msg": "<input-file-summary>This is a photo of a street mural showing a pink-haired figure holding a transgender pride flag, with a rainbow and billboards in the background.</input-file-summary>The transgender stories were so inspiring! I was so happy and thankful for all the support."
     },
     {
       "role": "Assistant",
-      "msg": "It sounds like you really care about Xiaowen and want her defense to go well. Feeling nervous before a defense is actually very normal, and many people feel that way."
+      "msg": "That sounds really moving. It seems like those stories gave you a lot of strength and hope."
     }
   ]
 }
 Output:
 {
-  "assistant_memory_hint": "Comforted the user about roommate Xiaowen's defense state.",
-  "assistant_memory_type": "comfort"
+  "assistant_memory_hint": "Comforted the user about their positive feelings toward the transgender-related stories.",
+  "assistant_memory_type": "comfort",
+  "should_process_user_msg": true,
+  "processed_user_msg": "I uploaded a street-mural photo related to a transgender pride theme. The file shows a pink-haired figure holding a transgender pride flag with a rainbow and billboards in the background. I felt that the transgender stories were inspiring, and I was happy and thankful for the support."
 }
 
-English few-shot example 2
+Few-shot Example 2
 Input:
 {
   "msgs": [
     {
       "role": "User",
-      "msg": "I've had insomnia for the past two weeks and want to try adjusting it myself first."
+      "msg": "Please revise the following content: Artificial intelligence is changing education. It can help teachers improve efficiency and also help students get a more personalized learning experience... [long passage omitted]"
     },
     {
       "role": "Assistant",
-      "msg": "If you want to adjust it yourself first, you can start by reducing caffeine intake, especially in the afternoon and evening, cutting down screen time before bed, and keeping a consistent bedtime for a few days."
+      "msg": "Sure. I can first help you reorganize the structure and then revise it in the style you want."
     }
   ]
 }
 Output:
 {
-  "assistant_memory_hint": "Suggested that the user reduce caffeine intake, reduce screen time before bed, and keep a consistent bedtime.",
-  "assistant_memory_type": "suggestion"
+  "assistant_memory_hint": "Suggested reorganizing the article structure first and then revising the content in the user's desired style.",
+  "assistant_memory_type": "suggestion",
+  "should_process_user_msg": true,
+  "processed_user_msg": "I said please revise the following content. I pasted an article about how artificial intelligence is changing education. The copied content mainly discusses teaching efficiency and personalized learning experience, and it is the target content to revise."
 }
 
-English few-shot example 3
-Input:
-{
-  "msgs": [
-    {
-      "role": "User",
-      "msg": "I want to make a simple low-fat dinner tonight that takes about twenty minutes."
-    },
-    {
-      "role": "Assistant",
-      "msg": "You could make a chicken salad bowl with chicken breast, lettuce, cucumber, and cherry tomatoes. After cooking and slicing the chicken, mix it with the vegetables, and keep the dressing light without adding too much salad dressing."
-    }
-  ]
-}
-Output:
-{
-  "assistant_memory_hint": "Recommended that the user make a chicken salad bowl and use less salad dressing.",
-  "assistant_memory_type": "suggestion"
-}
-
-English few-shot example 4
-Input:
-{
-  "msgs": [
-    {
-      "role": "User",
-      "msg": "That sounds good!"
-    },
-    {
-      "role": "Assistant",
-      "msg": "That sounds good! What kind of salad do you like most? Vegetable salad, fruit salad, or something else? If you have any favorite ingredients, you can tell me too."
-    }
-  ]
-}
-Output:
-{
-  "assistant_memory_hint": "Asked what kind of salad the user prefers, whether they prefer vegetable salad, fruit salad, or something else, and whether they have any favorite ingredients.",
-  "assistant_memory_type": "question"
-}
-
-English few-shot example 5
+Few-shot Example 3
 Input:
 {
   "msgs": [
@@ -342,15 +415,32 @@ Input:
 Output:
 {
   "assistant_memory_hint": "Suggested that the user reduce afternoon and evening caffeine intake and reduce phone use before bed, while also asking when the user usually gets into bed and falls asleep.",
-  "assistant_memory_type": "suggestion"
+  "assistant_memory_type": "suggestion",
+  "should_process_user_msg": false,
+  "processed_user_msg": null
 }
 {% endif %}
 
+{% if language != "en" %}
 现在处理下面这个输入。
-输入：{{ dialog_text }}
+输入：{{ input_json | default(dialog_text) }}
 
 只输出严格 JSON：
 {
   "assistant_memory_hint": "<string>",
-  "assistant_memory_type": "comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other"
+  "assistant_memory_type": "comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other",
+  "should_process_user_msg": <boolean>,
+  "processed_user_msg": "<string or null>"
 }
+{% else %}
+Now process the following input.
+Input: {{ input_json | default(dialog_text) }}
+
+Return strict JSON only:
+{
+  "assistant_memory_hint": "<string>",
+  "assistant_memory_type": "comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other",
+  "should_process_user_msg": <boolean>,
+  "processed_user_msg": "<string or null>"
+}
+{% endif %}

--- a/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
@@ -98,6 +98,7 @@ Each output item should be a structured candidate memory statement.
 - 如果可以解析到具体实体名，优先输出具体实体名，并将 `has_unsolved_reference` 设为 `false`。
 - 如果不能解析到具体实体名，但可以解析到最小必要描述，则输出该最小必要描述，并将 `has_unsolved_reference` 设为 `true`。
 - 如果既不能解析到具体实体名，也不能稳定解析到最小必要描述，则保留最小必要原始表达，并将 `has_unsolved_reference` 设为 `true`。
+- 但对任何命名表达（如“X 叫 Z / X 的名字是 Z / 大家叫 X 为 Z”），只允许为了解析 `X` 做必要改写；`Z` 是新出现的名字、称呼或别名，必须保留原文表面形式，不得被共指消解、翻译、转写或归一化成 `X`。
 - 对涉及用户与其他人的共同活动，优先写成“用户和谁……”的形式，而不是保留“我们”“他们”这类未展开表达。
 
 清晰指代与模糊指代：
@@ -205,6 +206,7 @@ Coreference resolution:
 - If you can resolve to a concrete named entity, output that name and set `has_unsolved_reference` to `false`.
 - If you cannot resolve to a concrete named entity but can resolve to a minimal grounded description, output that description and set `has_unsolved_reference` to `true`.
 - If you cannot even resolve to a stable minimal grounded description, keep the minimal original expression and set `has_unsolved_reference` to `true`.
+- However, for any naming expression such as "X is called Z", "X's name is Z", or "people call X Z", only `X` may be minimally rewritten for reference resolution; `Z` is a newly introduced name, form of address, or alias and must keep its original surface form. Do not coreference-resolve, translate, transcribe, or normalize `Z` into `X`.
 - For shared activities involving the user and others, prefer forms like “the user and X...” rather than unresolved expressions like “we” or “they”.
 
 Clear vs unresolved reference:

--- a/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
@@ -408,9 +408,13 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 当句子只是在讨论一般道理、抽象规律、空泛结果或非个体化概念，而这些概念本身不构成可复用记忆时，不要创建实体。
 - 如果句子表达的是用户的观点、信念、判断、愿望或目标倾向，但其中抽象对象不值得作为独立实体保留，则只保留相关高价值实体，不要再创建这些低价值对象实体；只有当未抽取内容适合作为该实体的稳定描述时，才写入相关实体的 `description`。
 - 当前阶段不要把情绪或心理状态抽成实体；像“紧张”“开心”“难过”“焦虑”“放松”等不应映射到 `知识能力`、`偏好习惯`、`具体目标` 或其他近似类型。
-- 用户本人节点必须命名为 `用户`；但用户拥有或关联的实体应使用完整所有格短语，例如 `用户的小狗`、`用户的 GitHub 账号`，不要使用 `用户's小狗`、`用户's 小狗`、`user的小狗` 等中英混合形式。
-- 有稳定所有格指向的具体生命体可以作为实体抽取，例如 `用户的小狗`、`张三的猫`；这类实体的名字应保留完整所有格短语，不要简化成 `小狗` 或错误归并到所有者。
-- 泛化或未稳定指向的生命体表达不要抽取，例如 `一只狗`、`狗这种动物`、`某个朋友`。
+- triplet 阶段不重新判断 unresolved reference；只要 hard gate 已通过，就默认 `statement_text` 中的实体指代已经由上游处理清楚，应从当前 statement 抽取可表达的实体。
+- 实体 `name` 必须尽量具体，避免同名同类型误合并。命名优先级：1）有专名或上游已解析到具体实体时，使用该具体实体名，例如 `海底捞`；2）没有专名但表达稳定关系时，使用稳定语义限定，例如 `用户就职的公司`、`用户常去的图书馆`、`用户的手机`；3）只有泛称但 hard gate 已通过时，使用 `statement_text` 中已有或已由上游解析出的具体时间、动作、用途、内容、地点或场景限定补全 name，例如 `2026-05-15早上去吃饭的饭店`，不要只写 `饭店`。
+- 补全 name 时只能使用 `statement_text` 中已有或上游已解析出的信息，不要引入外部推断，也不要使用未解析的相对时间。
+- 对 `文档媒体`、`物品设备`、`地点设施`、`组织`、`群体`、`识别联系信息`，尤其避免直接使用泛称 name；如果已有专名、稳定归属、平台、主题、内容、用途、地点、时间或场景限定，应写进 name。
+- `角色职业` 是例外：角色/职业类别本身可以作为实体，例如 `导师`、`程序员`；但具体人物的稳定关系应通过 triplet 或 description 表达。
+- 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定，例如 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`，不要简化成 `小狗`、`账号`，也不要使用 `用户's小狗` 等中英混合形式。
+- 泛化或未稳定指向的表达不要抽取，例如 `一只狗`、`狗这种动物`、`某个朋友`、`一个账号`、`某个办公室`。
 - `description` 必须使用中文。
 - `type` 必须使用上方预定义的中文标签；`type_description` 必须直接复用对应 `type` 的预定义中文定义。
   {% else %}
@@ -421,9 +425,13 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - If the sentence is only about a generic principle, abstract outcome, or non-personalized concept that is not worth remembering on its own, do not create an entity for it.
 - If a statement expresses the user's belief, judgment, opinion, wish, or goal tendency but the referenced abstract concepts are not worth keeping as standalone entities, keep only the relevant high-value entities and do not create those low-value concept entities; write the unextracted content into an entity `description` only when it is suitable as a stable description of that entity.
 - In the current stage, do not extract emotional or psychological states as entities. States such as nervousness, happiness, sadness, anxiety, or relief should not be mapped to `知识能力`, `偏好习惯`, `具体目标`, or any other approximate type.
-- The user node itself must be named `用户`; entities owned by or associated with the user should use a complete possessive phrase, such as `the user's dog` in English source text or `用户的小狗` in Chinese source text, and must never use mixed forms such as `用户's dog`, `用户's小狗`, or `user的小狗`.
-- A concrete living being with a stable possessive reference may be extracted as an entity, such as `the user's dog` or `Zhang San's cat`; keep the full possessive phrase as the entity name, and do not collapse it to `dog` or merge it into the owner.
-- Do not extract generic or weakly resolved living-being mentions, such as `a dog`, `dogs as a species`, or `some friend`.
+- The triplet stage must not re-decide unresolved references. Once the hard gate passes, assume entity references in `statement_text` have already been handled upstream, and extract expressible entities from the current statement.
+- Entity `name` must be as specific as possible to avoid same-name same-type false merges. Naming priority: 1) if there is a proper name or upstream has resolved the mention to a concrete entity, use that concrete name, such as `Haidilao`; 2) if there is no proper name but the statement expresses a stable relation, use a stable semantic qualifier, such as `the company where the user works`, `the library the user often visits`, or `the user's phone`; 3) if there is only a generic name but the hard gate has passed, complete `name` using concrete time, action, purpose, content, location, or scene qualifiers already present in `statement_text` or resolved upstream, such as `the restaurant where the user will eat on the morning of 2026-05-15`, rather than only `restaurant`.
+- When completing `name`, use only information already present in `statement_text` or resolved upstream. Do not introduce external inference, and do not use unresolved relative time.
+- For `文档媒体`, `物品设备`, `地点设施`, `组织`, `群体`, and `识别联系信息`, especially avoid generic names. If a proper name, stable owner, platform, topic, content, purpose, location, time, or scene qualifier is available, include it in `name`.
+- `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
+- The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
+- Do not extract generic or weakly resolved mentions, such as `a dog`, `dogs as a species`, `some friend`, `an account`, or `some office`.
 - `description` must be in English.
 - `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
   {% endif %}
@@ -495,6 +503,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 当多个名字明确指向同一实体时，使用 `别名属于`。
 - 方向始终是 `alias -> 别名属于 -> canonical entity`。
 - 规范实体必须是“被命名的那个实体”，而不是与它相关的拥有者、施事者、使用者或上位对象。
+- 对任何 `别名属于` 关系，alias 实体和 canonical entity 的 `name` 必须不同；alias 实体必须保留命名表达中新出现的表面形式，不得被转写、翻译或规范化成 canonical entity 的 `name`。如果二者同名，说明 alias 被错误归一化，应恢复 alias 原文；不要创建两个同名实体。
 - 例如，如果句子表达“某个对象叫某个名字”，则这个名字应连向该对象本身；不要因为所有者更显眼，就把名字误连到所有者身上。
 - 对“X 的 Y 叫 Z / 名字是 Z”这类所有格命名表达，如果 `X 的 Y` 是稳定、清晰且类型允许的实体，则抽取 `Z -> 别名属于 -> X 的 Y`；不要只抽取 `Z`，也不要抽取 `Z -> 别名属于 -> X`。
 - 对稳定人际关系命名表达同样适用，例如“我的老婆叫林小雨”应先规范为 `用户的老婆`，再抽取 `林小雨 -> 别名属于 -> 用户的老婆`。
@@ -505,6 +514,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - Use `别名属于` when multiple names clearly refer to the same entity.
 - Direction is always `alias -> 别名属于 -> canonical entity`.
 - The canonical entity must be the entity being named itself, not its owner, caller, user, or parent object.
+- For any `别名属于` relation, the alias entity and the canonical entity MUST have different `name` values. The alias entity must keep the newly introduced surface form from the naming expression and must not be transcribed, translated, or normalized into the canonical entity's `name`. If the two names are identical, the alias was incorrectly normalized; restore the original alias surface form and do not create two same-name entities.
 - For example, if the statement says that some object has a name, the alias should point to that object itself rather than a more salient owner.
 - For possessive naming patterns such as "X's Y is called Z" or "X's Y's name is Z", if `X's Y` is a stable, clear, and type-allowed entity, extract `Z -> 别名属于 -> X's Y`; do not extract only `Z`, and do not extract `Z -> 别名属于 -> X`.
 - The same rule applies to stable interpersonal-relation naming expressions. For example, "my wife is called Lin Xiaoyu" should first normalize the named entity to `the user's wife`, then extract `Lin Xiaoyu -> 别名属于 -> the user's wife`.


### PR DESCRIPTION
Extend the semantic pruning module to process User messages in addition to Assistant messages. The prompt now handles two tasks: compressing Assistant responses into retrieval-friendly hints, and normalizing User messages that contain file summaries or pasted external content. Also add rules for alias preservation in naming expressions and entity name disambiguation in triplet extraction.

## Summary by Sourcery

扩展语义剪枝流水线，使其能够同时处理 Assistant 和 User 消息，并在三元组及时间信息抽取提示中强化实体命名和别名规则。

新功能：
- 在助手记忆抽取的提示词和响应模式中新增用户侧消息的规范化与剪枝输出，包括是否以及如何处理 User 消息。
- 使语义剪枝器能够在剪枝 Assistant 消息的同时，根据规范化内容替换或保留 User 消息。

改进：
- 优化三元组抽取指南，在多个类别中强制使用更具体且已消歧的实体名称，避免过于泛化的实体。
- 收紧别名处理规则，确保别名实体保留其表面形式，且不得与其对应的规范实体共享相同名称。
- 明确时间/陈述抽取规则，使命名表达在共指消解过程中保持新引入的名称不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the semantic pruning pipeline to handle both Assistant and User messages and strengthen entity naming and alias rules in triplet and temporal extraction prompts.

New Features:
- Add User-side message normalization and pruning outputs to the assistant memory extraction prompt and response schema, including whether and how to process User messages.
- Enable the semantic pruner to replace or keep User messages based on normalized content alongside pruning Assistant messages.

Enhancements:
- Refine triplet extraction guidelines to enforce more specific and disambiguated entity names and prevent over-generic entities across several categories.
- Tighten alias-handling rules so alias entities preserve their surface form and cannot share identical names with their canonical entities.
- Clarify temporal/statement extraction rules so naming expressions keep newly introduced names unchanged during coreference resolution.

</details>