### PR TITLE
feat(models)

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -651,6 +651,7 @@ async def config_query(
     if release.app.type == AppType.WORKFLOW:
         workflow_service = WorkflowService(db)
         content = {
+            "app_name": release.app.name,
             "app_type": release.app.type,
             "variables": workflow_service.get_start_node_variables(release.config),
             "memory":  workflow_service.is_memory_enable(release.config),
@@ -658,6 +659,7 @@ async def config_query(
         }
     elif release.app.type == AppType.AGENT:
         content = {
+            "app_name": release.app.name,
             "app_type": release.app.type,
             "variables": release.config.get("variables"),
             "memory": release.config.get("memory", {}).get("enabled"),
@@ -666,6 +668,7 @@ async def config_query(
         }
     elif release.app.type == AppType.MULTI_AGENT:
         content = {
+            "app_name": release.app.name,
             "app_type": release.app.type,
             "variables": [],
             "features": release.config.get("features")

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
-from app.models.models_model import ModelProvider, ModelType
+from app.models.models_model import ModelProvider, ModelType, ModelCapability
 from app.core.models.compatible_chat import CompatibleChatOpenAI
 
 T = TypeVar("T")
@@ -41,13 +41,22 @@ class RedBearModelConfig(BaseModel):
     def _resolve_capabilities(self) -> "RedBearModelConfig":
         from app.core.logging_config import get_business_logger
         logger = get_business_logger()
-        if self.deep_thinking and "thinking" not in self.capability:
+
+        has_thinking = ModelCapability.THINKING in self.capability
+        has_thinking_only = ModelCapability.THINKING_ONLY in self.capability
+
+        if self.deep_thinking and not has_thinking and not has_thinking_only:
             logger.warning(
-                f"模型 {self.model_name} 不支持深度思考（capability 中无 'thinking'），已自动关闭 deep_thinking"
+                f"模型 {self.model_name} 不支持深度思考（capability 中无 'thinking'/'thinking_only'），已自动关闭 deep_thinking"
             )
             self.deep_thinking = False
             self.thinking_budget_tokens = None
-        if self.json_output and "json_output" not in self.capability:
+
+        # thinking_only 模型始终处于思考状态，deep_thinking 标志强制为 True
+        if has_thinking_only:
+            self.deep_thinking = True
+
+        if self.json_output and ModelCapability.JSON_OUTPUT not in self.capability:
             logger.warning(
                 f"模型 {self.model_name} 不支持 JSON 输出（capability 中无 'json_output'），已自动关闭 json_output"
             )
@@ -92,15 +101,18 @@ class RedBearModelFactory:
             is_streaming = bool(config.extra_params.get("streaming"))
             if is_streaming:
                 params["stream_usage"] = True
-            # 支持 thinking 的模型始终传 enable_thinking，关闭时显式传 False 避免模型默认开启思考
-            if "thinking" in config.capability:
+            # thinking 参数处理：
+            # - thinking_only（B类）：不能传 enable_thinking，不做任何处理
+            # - thinking（A类）：混合思考，流式可开关，非流式必须关闭
+            if ModelCapability.THINKING in config.capability:
                 extra_body = params.setdefault("extra_body", {})
-                if config.deep_thinking:
-                    extra_body["enable_thinking"] = False
-                    if is_streaming:
-                        extra_body["enable_thinking"] = True
+                if config.deep_thinking and is_streaming:
+                    extra_body["enable_thinking"] = True
                     if config.thinking_budget_tokens:
                         extra_body["thinking_budget"] = config.thinking_budget_tokens
+                else:
+                    # 非流式或未开启思考：显式关闭，避免模型默认开启
+                    extra_body["enable_thinking"] = False
             # JSON 输出模式
             if config.json_output:
                 model_kwargs = params.setdefault("model_kwargs", {})
@@ -130,22 +142,25 @@ class RedBearModelFactory:
             is_streaming = bool(config.extra_params.get("streaming"))
             if is_streaming:
                 params["stream_usage"] = True
-            # 支持 thinking 的模型始终传 enable_thinking，关闭时显式传 False 避免模型默认开启思考
-            if "thinking" in config.capability:
-                # VOLCANO 深度思考仅流式支持
+            # thinking 参数处理：
+            # - thinking_only（B类）：不能传 enable_thinking，不做任何处理
+            # - thinking（A类）：混合思考，流式可开关，非流式必须关闭
+            if ModelCapability.THINKING in config.capability:
                 if provider == ModelProvider.VOLCANO:
-                    thinking_config: Dict[str, Any] = {"type": "enabled" if config.deep_thinking else "disabled"}
-                    if config.deep_thinking and config.thinking_budget_tokens:
-                        thinking_config["budget_tokens"] = config.thinking_budget_tokens
-                    params["extra_body"] = {"thinking": thinking_config}
+                    # Volcano 思考仅流式支持，非流式不传任何 thinking 参数
+                    if is_streaming:
+                        thinking_config: Dict[str, Any] = {"type": "enabled" if config.deep_thinking else "disabled"}
+                        if config.deep_thinking and config.thinking_budget_tokens:
+                            thinking_config["budget_tokens"] = config.thinking_budget_tokens
+                        params["extra_body"] = {"thinking": thinking_config}
                 else:
                     extra_body = params.setdefault("extra_body", {})
-                    if config.deep_thinking:
-                        extra_body["enable_thinking"] = False
-                        if is_streaming:
-                            extra_body["enable_thinking"] = True
+                    if config.deep_thinking and is_streaming:
+                        extra_body["enable_thinking"] = True
                         if config.thinking_budget_tokens:
                             extra_body["thinking_budget"] = config.thinking_budget_tokens
+                    else:
+                        extra_body["enable_thinking"] = False
             # JSON 输出模式
             if config.json_output:
                 model_kwargs = params.setdefault("model_kwargs", {})
@@ -160,17 +175,20 @@ class RedBearModelFactory:
                 "max_retries": config.max_retries,
                 **config.extra_params
             }
-            # 支持 thinking 的模型始终传 enable_thinking，关闭时显式传 False 避免模型默认开启思考
-            if "thinking" in config.capability:
+            # thinking 参数处理：
+            # - thinking_only（B类）：不能传 enable_thinking，不做任何处理
+            # - thinking（A类）：混合思考，流式可开关，非流式必须关闭
+            if ModelCapability.THINKING in config.capability:
                 is_streaming = bool(config.extra_params.get("streaming"))
                 model_kwargs = params.setdefault("model_kwargs", {})
-                if config.deep_thinking:
-                    model_kwargs["enable_thinking"] = False
-                    if is_streaming:
-                        model_kwargs["enable_thinking"] = True
-                        model_kwargs["incremental_output"] = True
+                if config.deep_thinking and is_streaming:
+                    model_kwargs["enable_thinking"] = True
                     if config.thinking_budget_tokens:
                         model_kwargs["thinking_budget"] = config.thinking_budget_tokens
+                    model_kwargs["incremental_output"] = True
+                else:
+                    # 非流式或未开启思考：显式关闭，避免模型默认开启
+                    model_kwargs["enable_thinking"] = False
             if config.json_output:
                 model_kwargs = params.setdefault("model_kwargs", {})
                 model_kwargs["response_format"] = {"type": "json_object"}

--- a/api/app/core/models/scripts/bedrock_models.yaml
+++ b/api/app/core/models/scripts/bedrock_models.yaml
@@ -12,7 +12,6 @@ models:
   tags:
   - 大语言模型
   logo: bedrock
-
 - name: amazon nova
   type: llm
   provider: bedrock
@@ -20,8 +19,9 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - json_output
+  - vision
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -30,7 +30,6 @@ models:
   - stream-tool-call
   - vision
   logo: bedrock
-
 - name: anthropic claude
   type: llm
   provider: bedrock
@@ -38,9 +37,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -50,7 +50,6 @@ models:
   - stream-tool-call
   - document
   logo: bedrock
-
 - name: cohere
   type: llm
   provider: bedrock
@@ -59,6 +58,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -66,7 +66,6 @@ models:
   - tool-call
   - stream-tool-call
   logo: bedrock
-
 - name: deepseek
   type: llm
   provider: bedrock
@@ -74,9 +73,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -85,7 +85,6 @@ models:
   - tool-call
   - stream-tool-call
   logo: bedrock
-
 - name: meta
   type: llm
   provider: bedrock
@@ -94,13 +93,13 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   - tool-call
   logo: bedrock
-
 - name: mistral
   type: llm
   provider: bedrock
@@ -109,13 +108,13 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   - tool-call
   logo: bedrock
-
 - name: openai
   type: llm
   provider: bedrock
@@ -124,6 +123,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -131,7 +131,6 @@ models:
   - tool-call
   - stream-tool-call
   logo: bedrock
-
 - name: qwen
   type: llm
   provider: bedrock
@@ -140,6 +139,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -147,7 +147,6 @@ models:
   - tool-call
   - stream-tool-call
   logo: bedrock
-
 - name: amazon.rerank-v1:0
   type: rerank
   provider: bedrock
@@ -159,7 +158,6 @@ models:
   tags:
   - 重排序模型
   logo: bedrock
-
 - name: cohere.rerank-v3-5:0
   type: rerank
   provider: bedrock
@@ -171,7 +169,6 @@ models:
   tags:
   - 重排序模型
   logo: bedrock
-
 - name: amazon.nova-2-multimodal-embeddings-v1:0
   type: embedding
   provider: bedrock
@@ -179,13 +176,12 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 文本嵌入模型
   - vision
   logo: bedrock
-
 - name: amazon.titan-embed-text-v1
   type: embedding
   provider: bedrock
@@ -197,7 +193,6 @@ models:
   tags:
   - 文本嵌入模型
   logo: bedrock
-
 - name: amazon.titan-embed-text-v2:0
   type: embedding
   provider: bedrock
@@ -209,7 +204,6 @@ models:
   tags:
   - 文本嵌入模型
   logo: bedrock
-
 - name: cohere.embed-english-v3
   type: embedding
   provider: bedrock
@@ -221,7 +215,6 @@ models:
   tags:
   - 文本嵌入模型
   logo: bedrock
-
 - name: cohere.embed-multilingual-v3
   type: embedding
   provider: bedrock

--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -7,14 +7,12 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-r1-distill-qwen-32b
   type: llm
   provider: dashscope
@@ -22,14 +20,12 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-r1
   type: llm
   provider: dashscope
@@ -37,14 +33,12 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-v3.1
   type: llm
   provider: dashscope
@@ -58,7 +52,6 @@ models:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-v3.2-exp
   type: llm
   provider: dashscope
@@ -72,7 +65,6 @@ models:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-v3.2
   type: llm
   provider: dashscope
@@ -86,7 +78,6 @@ models:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: deepseek-v3
   type: llm
   provider: dashscope
@@ -100,7 +91,6 @@ models:
   - 大语言模型
   - agent-thought
   logo: dashscope
-
 - name: farui-plus
   type: llm
   provider: dashscope
@@ -109,6 +99,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -116,7 +107,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: glm-4.7
   type: llm
   provider: dashscope
@@ -125,6 +115,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -132,7 +123,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qvq-max-latest
   type: llm
   provider: dashscope
@@ -141,8 +131,7 @@ models:
   is_official: true
   capability:
   - vision
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
@@ -150,7 +139,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qvq-max
   type: llm
   provider: dashscope
@@ -159,8 +147,7 @@ models:
   is_official: true
   capability:
   - vision
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
@@ -168,7 +155,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-coder-turbo-0919
   type: llm
   provider: dashscope
@@ -182,7 +168,6 @@ models:
   - 代码模型
   - agent-thought
   logo: dashscope
-
 - name: qwen-max-latest
   type: llm
   provider: dashscope
@@ -192,6 +177,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -199,7 +185,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-max-longcontext
   type: llm
   provider: dashscope
@@ -214,7 +199,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-max
   type: llm
   provider: dashscope
@@ -223,6 +207,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -230,7 +215,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-mt-plus
   type: llm
   provider: dashscope
@@ -244,7 +228,6 @@ models:
   - 翻译模型
   - agent-thought
   logo: dashscope
-
 - name: qwen-mt-turbo
   type: llm
   provider: dashscope
@@ -258,7 +241,6 @@ models:
   - 翻译模型
   - agent-thought
   logo: dashscope
-
 - name: qwen-plus-0112
   type: llm
   provider: dashscope
@@ -273,7 +255,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-0125
   type: llm
   provider: dashscope
@@ -288,7 +269,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-0723
   type: llm
   provider: dashscope
@@ -303,7 +283,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-0806
   type: llm
   provider: dashscope
@@ -318,7 +297,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-0919
   type: llm
   provider: dashscope
@@ -333,7 +311,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-1125
   type: llm
   provider: dashscope
@@ -348,7 +325,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-1127
   type: llm
   provider: dashscope
@@ -363,7 +339,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-plus-1220
   type: llm
   provider: dashscope
@@ -378,7 +353,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen-vl-max
   type: chat
   provider: dashscope
@@ -397,7 +371,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen-vl-plus-0809
   type: chat
   provider: dashscope
@@ -415,7 +388,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen-vl-plus-2025-01-02
   type: chat
   provider: dashscope
@@ -433,7 +405,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen-vl-plus-2025-01-25
   type: chat
   provider: dashscope
@@ -451,7 +422,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen-vl-plus-latest
   type: chat
   provider: dashscope
@@ -470,7 +440,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen-vl-plus
   type: chat
   provider: dashscope
@@ -489,7 +458,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen2.5-0.5b-instruct
   type: llm
   provider: dashscope
@@ -505,7 +473,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-14b
   type: llm
   provider: dashscope
@@ -515,6 +482,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -522,7 +490,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-235b-a22b-instruct-2507
   type: llm
   provider: dashscope
@@ -531,6 +498,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -538,7 +506,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-235b-a22b-thinking-2507
   type: llm
   provider: dashscope
@@ -546,7 +513,7 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
+  - thinking_only
   - json_output
   is_omni: false
   tags:
@@ -555,7 +522,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-235b-a22b
   type: llm
   provider: dashscope
@@ -565,6 +531,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -572,7 +539,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-30b-a3b-instruct-2507
   type: llm
   provider: dashscope
@@ -581,6 +547,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -588,7 +555,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-30b-a3b
   type: llm
   provider: dashscope
@@ -598,6 +564,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -605,7 +572,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-32b
   type: llm
   provider: dashscope
@@ -615,6 +581,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -622,7 +589,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-4b
   type: llm
   provider: dashscope
@@ -632,6 +598,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -639,7 +606,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-8b
   type: llm
   provider: dashscope
@@ -649,6 +615,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -656,7 +623,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-coder-30b-a3b-instruct
   type: llm
   provider: dashscope
@@ -671,7 +637,6 @@ models:
   - 代码模型
   - agent-thought
   logo: dashscope
-
 - name: qwen3-coder-480b-a35b-instruct
   type: llm
   provider: dashscope
@@ -686,7 +651,6 @@ models:
   - 代码模型
   - agent-thought
   logo: dashscope
-
 - name: qwen3-coder-plus-2025-09-23
   type: llm
   provider: dashscope
@@ -702,7 +666,6 @@ models:
   - 代码模型
   - agent-thought
   logo: dashscope
-
 - name: qwen3-coder-plus
   type: llm
   provider: dashscope
@@ -718,7 +681,6 @@ models:
   - 代码模型
   - agent-thought
   logo: dashscope
-
 - name: qwen3-max-2025-09-23
   type: llm
   provider: dashscope
@@ -728,6 +690,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -736,7 +699,6 @@ models:
   - stream-tool-call
   - 联网搜索
   logo: dashscope
-
 - name: qwen3-max-2026-01-23
   type: llm
   provider: dashscope
@@ -746,6 +708,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -754,7 +717,6 @@ models:
   - stream-tool-call
   - 联网搜索
   logo: dashscope
-
 - name: qwen3-max-preview
   type: llm
   provider: dashscope
@@ -764,6 +726,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -771,7 +734,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-max
   type: llm
   provider: dashscope
@@ -781,6 +743,7 @@ models:
   capability:
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -789,7 +752,6 @@ models:
   - stream-tool-call
   - 联网搜索
   logo: dashscope
-
 - name: qwen3-next-80b-a3b-instruct
   type: llm
   provider: dashscope
@@ -805,7 +767,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-next-80b-a3b-thinking
   type: llm
   provider: dashscope
@@ -813,7 +774,7 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
+  - thinking_only
   - json_output
   is_omni: false
   tags:
@@ -822,7 +783,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwen3-omni-flash-2025-12-01
   type: llm
   provider: dashscope
@@ -844,7 +804,6 @@ models:
   - video
   - audio
   logo: dashscope
-
 - name: qwen3-vl-235b-a22b-instruct
   type: chat
   provider: dashscope
@@ -855,6 +814,7 @@ models:
   - vision
   - video
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -865,7 +825,6 @@ models:
   - vision
   - video
   logo: dashscope
-
 - name: qwen3-vl-235b-a22b-thinking
   type: chat
   provider: dashscope
@@ -875,7 +834,7 @@ models:
   capability:
   - vision
   - video
-  - thinking
+  - thinking_only
   - json_output
   is_omni: false
   tags:
@@ -887,7 +846,6 @@ models:
   - vision
   - video
   logo: dashscope
-
 - name: qwen3-vl-30b-a3b-instruct
   type: chat
   provider: dashscope
@@ -898,6 +856,7 @@ models:
   - vision
   - video
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -908,7 +867,6 @@ models:
   - vision
   - video
   logo: dashscope
-
 - name: qwen3-vl-30b-a3b-thinking
   type: chat
   provider: dashscope
@@ -918,7 +876,7 @@ models:
   capability:
   - vision
   - video
-  - thinking
+  - thinking_only
   - json_output
   is_omni: false
   tags:
@@ -930,7 +888,6 @@ models:
   - vision
   - video
   logo: dashscope
-
 - name: qwen3-vl-flash
   type: chat
   provider: dashscope
@@ -942,6 +899,7 @@ models:
   - video
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -952,7 +910,6 @@ models:
   - vision
   - video
   logo: dashscope
-
 - name: qwen3-vl-plus-2025-09-23
   type: chat
   provider: dashscope
@@ -972,7 +929,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwen3-vl-plus
   type: chat
   provider: dashscope
@@ -984,6 +940,7 @@ models:
   - video
   - thinking
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -992,7 +949,6 @@ models:
   - agent-thought
   - video
   logo: dashscope
-
 - name: qwq-32b
   type: llm
   provider: dashscope
@@ -1000,15 +956,13 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwq-plus-0305
   type: llm
   provider: dashscope
@@ -1016,15 +970,13 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: qwq-plus
   type: llm
   provider: dashscope
@@ -1032,15 +984,13 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-  - thinking
-  - json_output
+  - thinking_only
   is_omni: false
   tags:
   - 大语言模型
   - agent-thought
   - stream-tool-call
   logo: dashscope
-
 - name: gte-rerank-v2
   type: rerank
   provider: dashscope
@@ -1052,7 +1002,6 @@ models:
   tags:
   - 重排序模型
   logo: dashscope
-
 - name: gte-rerank
   type: rerank
   provider: dashscope
@@ -1064,7 +1013,6 @@ models:
   tags:
   - 重排序模型
   logo: dashscope
-
 - name: multimodal-embedding-v1
   type: embedding
   provider: dashscope
@@ -1079,7 +1027,6 @@ models:
   - 多模态模型
   - vision
   logo: dashscope
-
 - name: text-embedding-v1
   type: embedding
   provider: dashscope
@@ -1092,7 +1039,6 @@ models:
   - 嵌入模型
   - 文本嵌入
   logo: dashscope
-
 - name: text-embedding-v2
   type: embedding
   provider: dashscope
@@ -1105,7 +1051,6 @@ models:
   - 嵌入模型
   - 文本嵌入
   logo: dashscope
-
 - name: text-embedding-v3
   type: embedding
   provider: dashscope
@@ -1118,7 +1063,6 @@ models:
   - 嵌入模型
   - 文本嵌入
   logo: dashscope
-
 - name: text-embedding-v4
   type: embedding
   provider: dashscope

--- a/api/app/core/models/scripts/openai_models.yaml
+++ b/api/app/core/models/scripts/openai_models.yaml
@@ -7,10 +7,11 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - audio
-    - video
-    - json_output
+  - vision
+  - audio
+  - video
+  - json_output
+  - function_call
   is_omni: true
   tags:
   - 大语言模型
@@ -21,7 +22,6 @@ models:
   - audio
   - video
   logo: openai
-
 - name: gpt-3.5-turbo-0125
   type: llm
   provider: openai
@@ -30,6 +30,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -37,7 +38,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-3.5-turbo-1106
   type: llm
   provider: openai
@@ -46,6 +46,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -53,7 +54,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-3.5-turbo-16k
   type: llm
   provider: openai
@@ -62,6 +62,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -69,7 +70,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-3.5-turbo-instruct
   type: llm
   provider: openai
@@ -81,7 +81,6 @@ models:
   tags:
   - 大语言模型
   logo: openai
-
 - name: gpt-3.5-turbo
   type: llm
   provider: openai
@@ -90,6 +89,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -97,7 +97,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-4-0125-preview
   type: llm
   provider: openai
@@ -106,6 +105,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -113,7 +113,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-4-1106-preview
   type: llm
   provider: openai
@@ -122,6 +121,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -129,7 +129,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-4-turbo-2024-04-09
   type: llm
   provider: openai
@@ -137,8 +136,9 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - json_output
+  - vision
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -147,7 +147,6 @@ models:
   - stream-tool-call
   - vision
   logo: openai
-
 - name: gpt-4-turbo-preview
   type: llm
   provider: openai
@@ -156,6 +155,7 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -163,7 +163,6 @@ models:
   - agent-thought
   - stream-tool-call
   logo: openai
-
 - name: gpt-4-turbo
   type: llm
   provider: openai
@@ -171,8 +170,9 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - json_output
+  - vision
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -181,7 +181,6 @@ models:
   - stream-tool-call
   - vision
   logo: openai
-
 - name: o1-preview
   type: llm
   provider: openai
@@ -194,7 +193,6 @@ models:
   - 大语言模型
   - agent-thought
   logo: openai
-
 - name: o1
   type: llm
   provider: openai
@@ -202,9 +200,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -214,7 +213,6 @@ models:
   - vision
   - structured-output
   logo: openai
-
 - name: o3-2025-04-16
   type: llm
   provider: openai
@@ -222,9 +220,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -234,7 +233,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: o3-mini-2025-01-31
   type: llm
   provider: openai
@@ -242,8 +240,9 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - thinking
-    - json_output
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -252,7 +251,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: o3-mini
   type: llm
   provider: openai
@@ -260,8 +258,9 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - thinking
-    - json_output
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -270,7 +269,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: o3-pro-2025-06-10
   type: llm
   provider: openai
@@ -278,9 +276,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -289,7 +288,6 @@ models:
   - vision
   - structured-output
   logo: openai
-
 - name: o3-pro
   type: llm
   provider: openai
@@ -297,9 +295,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -308,7 +307,6 @@ models:
   - vision
   - structured-output
   logo: openai
-
 - name: o3
   type: llm
   provider: openai
@@ -316,9 +314,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -328,7 +327,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: o4-mini-2025-04-16
   type: llm
   provider: openai
@@ -336,9 +334,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -348,7 +347,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: o4-mini
   type: llm
   provider: openai
@@ -356,9 +354,10 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - thinking
-    - json_output
+  - vision
+  - thinking_only
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
@@ -368,7 +367,6 @@ models:
   - stream-tool-call
   - structured-output
   logo: openai
-
 - name: text-embedding-3-large
   type: embedding
   provider: openai
@@ -380,7 +378,6 @@ models:
   tags:
   - 文本向量模型
   logo: openai
-
 - name: text-embedding-3-small
   type: embedding
   provider: openai
@@ -392,7 +389,6 @@ models:
   tags:
   - 文本向量模型
   logo: openai
-
 - name: text-embedding-ada-002
   type: embedding
   provider: openai

--- a/api/app/core/models/scripts/volcano_models.yaml
+++ b/api/app/core/models/scripts/volcano_models.yaml
@@ -1,6 +1,5 @@
 provider: volcano
 models:
-# Doubao-Seed 2.0 系列
 - name: doubao-seed-2-0-pro-260215
   type: chat
   provider: volcano
@@ -8,15 +7,15 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-2-0-lite-260215
   type: chat
   provider: volcano
@@ -24,15 +23,15 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-2-0-mini-260215
   type: chat
   provider: volcano
@@ -40,33 +39,33 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-2-0-code-preview-260215
   type: chat
   provider: volcano
-  description: 面向真实编程环境优化的 Coding 模型，能稳定调用 Claude Code 等常见 IDE 中的工具。模型特别优化了前端能力，在使用常见的前端框架时能有良好表现。模型支持使用 Skills，可以配合多种自定义技能使用。Seed 2.0 的编程加强版，更适合 Agentic Coding。
+  description: 面向真实编程环境优化的 Coding 模型，能稳定调用 Claude Code 等常见 IDE 中的工具。模型特别优化了前端能力，在使用常见的前端框架时能有良好表现。模型支持使用
+    Skills，可以配合多种自定义技能使用。Seed 2.0 的编程加强版，更适合 Agentic Coding。
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   - 代码模型
   logo: volcano
-
-# Doubao-Seed 1.x 系列
 - name: doubao-seed-1-8-251228
   type: chat
   provider: volcano
@@ -74,30 +73,31 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - json_output
+  - vision
+  - video
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-1-6-251015
   type: chat
   provider: volcano
-  description: Doubao-Seed-1.6全新多模态深度思考模型，同时支持minimal/low/medium/high 四种reasoning effort。 更强模型效果，服务复杂任务和有挑战场景。支持 256k 上下文窗口，输出长度支持最大 32k tokens。
+  description: Doubao-Seed-1.6全新多模态深度思考模型，同时支持minimal/low/medium/high 四种reasoning
+    effort。 更强模型效果，服务复杂任务和有挑战场景。支持 256k 上下文窗口，输出长度支持最大 32k tokens。
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-1-6-lite-251015
   type: chat
   provider: volcano
@@ -105,31 +105,32 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-1-6-flash-250828
   type: chat
   provider: volcano
-  description: Doubao-Seed-1.6-flash推理速度极致的多模态深度思考模型，TPOT低至10ms； 同时支持文本和视觉理解，文本理解能力超过上一代lite，视觉理解比肩友商pro系列模型。支持 256k 上下文窗口，输出长度支持最大 16k tokens。
+  description: Doubao-Seed-1.6-flash推理速度极致的多模态深度思考模型，TPOT低至10ms； 同时支持文本和视觉理解，文本理解能力超过上一代lite，视觉理解比肩友商pro系列模型。支持
+    256k 上下文窗口，输出长度支持最大 16k tokens。
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-seed-code-preview-251028
   type: chat
   provider: volcano
@@ -137,16 +138,16 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   - 代码模型
   logo: volcano
-
 - name: doubao-seed-1-6-vision-250815
   type: chat
   provider: volcano
@@ -154,31 +155,29 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-    - video
-    - thinking
-    - json_output
+  - vision
+  - video
+  - thinking
+  - json_output
   is_omni: false
   tags:
   - 大语言模型
   - 多模态模型
   logo: volcano
-
-# Doubao 1.5 系列
 - name: doubao-1-5-vision-pro-32k-250115
   type: chat
   provider: volcano
-  description: 全新升级的多模态大模型，支持任意分辨率和极端长宽比图像识别，增强视觉推理、文档识别、细节信息理解和指令遵循能力。支持 32k 上下文窗口，输出长度支持最大 12k tokens。
+  description: 全新升级的多模态大模型，支持任意分辨率和极端长宽比图像识别，增强视觉推理、文档识别、细节信息理解和指令遵循能力。支持 32k 上下文窗口，输出长度支持最大
+    12k tokens。
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 大语言模型
   - 多模态模型
   logo: volcano
-
 - name: doubao-1-5-pro-32k-250115
   type: chat
   provider: volcano
@@ -187,11 +186,11 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
 - name: doubao-1-5-lite-32k-250115
   type: chat
   provider: volcano
@@ -200,12 +199,11 @@ models:
   is_official: true
   capability:
   - json_output
+  - function_call
   is_omni: false
   tags:
   - 大语言模型
   logo: volcano
-
-# Doubao-Seedance 视频生成系列
 - name: doubao-seedance-1-5-pro-251215
   type: video
   provider: volcano
@@ -213,25 +211,24 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
-  is_omni: false
-  tags:
-  - 视频生成
-  logo:  volcano
-
-- name: doubao-seedance-1-0-pro-250528
-  type: video
-  provider: volcano
-  description: 一款支持多镜头叙事的视频生成基础模型，在各维度表现出色。它在语义理解与指令遵循能力上取得突破，能生成运动流畅、细节丰富、风格多样且具备影视级美感的 1080P 高清视频
-  is_deprecated: false
-  is_official: true
-  capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 视频生成
   logo: volcano
-
+- name: doubao-seedance-1-0-pro-250528
+  type: video
+  provider: volcano
+  description: 一款支持多镜头叙事的视频生成基础模型，在各维度表现出色。它在语义理解与指令遵循能力上取得突破，能生成运动流畅、细节丰富、风格多样且具备影视级美感的
+    1080P 高清视频
+  is_deprecated: false
+  is_official: true
+  capability:
+  - vision
+  is_omni: false
+  tags:
+  - 视频生成
+  logo: volcano
 - name: doubao-seedance-1-0-pro-fast-251015
   type: video
   provider: volcano
@@ -239,12 +236,11 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 视频生成
   logo: volcano
-
 - name: doubao-seedance-1-0-lite-i2v-250428
   type: video
   provider: volcano
@@ -252,13 +248,12 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 视频生成
   - 图生视频
   logo: volcano
-
 - name: doubao-seedance-1-0-lite-t2v-250428
   type: video
   provider: volcano
@@ -271,8 +266,6 @@ models:
   - 视频生成
   - 文生视频
   logo: volcano
-
-# Doubao-Seedream 图像生成系列
 - name: doubao-seedream-5-0-260128
   type: image
   provider: volcano
@@ -280,12 +273,11 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 图像生成
   logo: volcano
-
 - name: doubao-seedream-4-5-251128
   type: image
   provider: volcano
@@ -293,25 +285,24 @@ models:
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 图像生成
   logo: volcano
-
 - name: doubao-seedream-4-0-250828
   type: image
   provider: volcano
-  description: 基于领先架构的SOTA级多模态图像创作模型，其生成美感、指令遵循、结构完整度、主体保持一致性处于世界头部水平。模型采用同一套架构实现文生图与编辑能力的统一，原生支持文本 、单图和多图输入，并能通过对提示词的深度推理，自动适配最优的图像比例尺寸与生成数量，可一次性连续输出最多 15 张内容关联的图像，支持 4K 超高清输出。
+  description: 基于领先架构的SOTA级多模态图像创作模型，其生成美感、指令遵循、结构完整度、主体保持一致性处于世界头部水平。模型采用同一套架构实现文生图与编辑能力的统一，原生支持文本
+    、单图和多图输入，并能通过对提示词的深度推理，自动适配最优的图像比例尺寸与生成数量，可一次性连续输出最多 15 张内容关联的图像，支持 4K 超高清输出。
   is_deprecated: false
   is_official: true
   capability:
-    - vision
+  - vision
   is_omni: false
   tags:
   - 图像生成
   logo: volcano
-
 - name: doubao-seedream-3-0-t2i-250415
   type: image
   provider: volcano
@@ -324,8 +315,6 @@ models:
   - 图像生成
   - 文生图
   logo: volcano
-
-# Doubao 翻译系列
 - name: doubao-seed-translation-250915
   type: chat
   provider: volcano
@@ -337,8 +326,6 @@ models:
   tags:
   - 翻译模型
   logo: volcano
-
-# Doubao Embedding 系列
 - name: doubao-embedding-vision-251215
   type: embedding
   provider: volcano

--- a/api/app/models/models_model.py
+++ b/api/app/models/models_model.py
@@ -32,6 +32,17 @@ class ModelType(StrEnum):
     VIDEO = "video"
 
 
+class ModelCapability(StrEnum):
+    """模型能力枚举"""
+    VISION = "vision"
+    AUDIO = "audio"
+    VIDEO = "video"
+    THINKING = "thinking"
+    THINKING_ONLY = "thinking_only"
+    JSON_OUTPUT = "json_output"
+    FUNCTION_CALL = "function_call"
+
+
 class ModelProvider(StrEnum):
     """模型提供商枚举"""
     OPENAI = "openai"

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -14,6 +14,7 @@ from app.core.memory.agent.langgraph_graph.write_graph import write_long_term
 from app.db import get_db
 from app.models import MultiAgentConfig, AgentConfig, ModelType
 from app.models import WorkflowConfig
+from app.models.models_model import ModelCapability
 from app.repositories.tool_repository import ToolRepository
 from app.schemas import DraftRunRequest
 from app.schemas.app_schema import FileInput, FileType
@@ -27,6 +28,7 @@ from app.services.multi_agent_orchestrator import MultiAgentOrchestrator
 from app.services.multimodal_service import MultimodalService
 from app.services.workflow_service import WorkflowService
 from app.models.file_metadata_model import FileMetadata
+from app.services.tool_orchestrator import ToolOrchestrator
 
 logger = get_business_logger()
 
@@ -157,7 +159,7 @@ class AppChatService:
                 workspace_id=workspace_id
             )
             logger.info(f"处理了 {len(processed_files)} 个文件")
-            if doc_img_recognition and "vision" in (api_key_obj.capability or []) and any(
+            if doc_img_recognition and ModelCapability.VISION in (api_key_obj.capability or []) and any(
                 f.type == FileType.DOCUMENT for f in files
             ):
                 system_prompt += (
@@ -166,6 +168,29 @@ class AppChatService:
                     "重要：图片 URL 中包含 UUID（如 /storage/permanent/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx），"
                     "必须将 src 属性的值原封不动复制到 Markdown 的括号中，不得增删任何字符。"
                 )
+
+        # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
+        capability = api_key_obj.capability or []
+        if ModelCapability.FUNCTION_CALL not in capability and tools:
+            _api_key_config = {
+                "model_name": api_key_obj.model_name,
+                "api_key": api_key_obj.api_key,
+                "provider": api_key_obj.provider,
+                "api_base": api_key_obj.api_base,
+                "is_omni": api_key_obj.is_omni,
+                "capability": capability,
+            }
+            system_prompt = await ToolOrchestrator.create_and_run(
+                tools=tools,
+                system_prompt=system_prompt,
+                message=message,
+                history=history,
+                api_key_config=_api_key_config,
+                model_config=model_info,
+                effective_params=model_parameters,
+                processed_files=processed_files,
+            )
+            tools = []
 
         # 创建 LangChain Agent
         agent = LangChainAgent(
@@ -181,7 +206,7 @@ class AppChatService:
             deep_thinking=model_parameters.get("deep_thinking", False),
             thinking_budget_tokens=model_parameters.get("thinking_budget_tokens"),
             json_output=model_parameters.get("json_output", False),
-            capability=api_key_obj.capability or [],
+            capability=capability,
         )
 
         # 为需要运行时上下文的工具注入上下文
@@ -446,7 +471,7 @@ class AppChatService:
                     workspace_id=workspace_id
                 )
                 logger.info(f"处理了 {len(processed_files)} 个文件")
-                if doc_img_recognition and "vision" in (api_key_obj.capability or []) and any(
+                if doc_img_recognition and ModelCapability.VISION in (api_key_obj.capability or []) and any(
                     f.type == FileType.DOCUMENT for f in files
                 ):
                     from langchain.agents import create_agent
@@ -456,6 +481,29 @@ class AppChatService:
                         "重要：图片 URL 中包含 UUID（如 /storage/permanent/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx），"
                         "必须将 src 属性的值原封不动复制到 Markdown 的括号中，不得增删任何字符。"
                     )
+
+            # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
+            capability = api_key_obj.capability or []
+            if ModelCapability.FUNCTION_CALL not in capability and tools:
+                _api_key_config = {
+                    "model_name": api_key_obj.model_name,
+                    "api_key": api_key_obj.api_key,
+                    "provider": api_key_obj.provider,
+                    "api_base": api_key_obj.api_base,
+                    "is_omni": api_key_obj.is_omni,
+                    "capability": capability,
+                }
+                system_prompt = await ToolOrchestrator.create_and_run(
+                    tools=tools,
+                    system_prompt=system_prompt,
+                    message=message,
+                    history=history,
+                    api_key_config=_api_key_config,
+                    model_config=model_info,
+                    effective_params=model_parameters,
+                    processed_files=processed_files,
+                )
+                tools = []
 
             # 创建 LangChain Agent
             agent = LangChainAgent(
@@ -472,7 +520,7 @@ class AppChatService:
                 deep_thinking=model_parameters.get("deep_thinking", False),
                 thinking_budget_tokens=model_parameters.get("thinking_budget_tokens"),
                 json_output=model_parameters.get("json_output", False),
-                capability=api_key_obj.capability or [],
+                capability=capability,
             )
 
             # 为需要运行时上下文的工具注入上下文

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -27,6 +27,7 @@ from app.core.memory.memory_service import MemoryService
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.db import get_db_context
 from app.models import AgentConfig, ModelConfig
+from app.models.models_model import ModelCapability
 from app.repositories.tool_repository import ToolRepository
 from app.schemas.app_schema import FileInput, Citation, FileType
 from app.schemas.model_schema import ModelInfo
@@ -37,6 +38,7 @@ from app.services.model_parameter_merger import ModelParameterMerger
 from app.services.model_service import ModelApiKeyService
 from app.services.multimodal_service import MultimodalService
 from app.services.tool_service import ToolService
+from app.services.tool_orchestrator import ToolOrchestrator
 
 logger = get_business_logger()
 
@@ -647,7 +649,7 @@ class AgentRunService:
                 capability = api_key_config.get("capability", [])
                 has_doc_with_images = (
                     doc_img_recognition
-                    and "vision" in capability
+                    and ModelCapability.VISION in capability
                     and any(f.type == FileType.DOCUMENT for f in files)
                 )
             if has_doc_with_images:
@@ -657,6 +659,23 @@ class AgentRunService:
                     "重要：图片 URL 中包含 UUID（如 /storage/permanent/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx），"
                     "必须将 src 属性的值原封不动复制到 Markdown 的括号中，不得增删任何字符。"
                 )
+
+            # 7. 根据模型能力选择执行路径
+            capability = api_key_config.get("capability", [])
+            use_agent_mode = ModelCapability.FUNCTION_CALL in capability
+            if not use_agent_mode and tools:
+                # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
+                system_prompt = await ToolOrchestrator.create_and_run(
+                    tools=tools,
+                    system_prompt=system_prompt,
+                    message=message,
+                    history=history,
+                    api_key_config=api_key_config,
+                    model_config=model_config,
+                    effective_params=effective_params,
+                    processed_files=processed_files,
+                )
+                tools = []
 
             agent = LangChainAgent(
                 model_name=api_key_config["model_name"],
@@ -671,10 +690,9 @@ class AgentRunService:
                 deep_thinking=effective_params.get("deep_thinking", False),
                 thinking_budget_tokens=effective_params.get("thinking_budget_tokens"),
                 json_output=effective_params.get("json_output", False),
-                capability=api_key_config.get("capability", []),
+                capability=capability,
             )
 
-            # 为需要运行时上下文的工具注入上下文
             for t in tools:
                 if hasattr(t, 'tool_instance') and hasattr(t.tool_instance, 'set_runtime_context'):
                     t.tool_instance.set_runtime_context(
@@ -682,21 +700,19 @@ class AgentRunService:
                         conversation_id=str(conversation_id) if conversation_id else None,
                         uploaded_files=processed_files or []
                     )
-            # 7. 知识库检索
             context = None
 
             logger.debug(
                 "准备调用 LangChain Agent",
                 extra={
                     "model": api_key_config["model_name"],
+                    "use_agent_mode": use_agent_mode,
                     "has_history": bool(history),
-                    "has_context": bool(context),
                     "has_files": bool(processed_files)
                 }
             )
 
             memory_config_ = agent_config.memory
-            # 兼容新旧字段名：优先使用 memory_config_id，回退到 memory_content
             config_id = memory_config_.get("memory_config_id") or memory_config_.get("memory_content", None)
 
             # 8. 调用 Agent（支持多模态）
@@ -924,7 +940,7 @@ class AgentRunService:
                 capability = api_key_config.get("capability", [])
                 has_doc_with_images = (
                     doc_img_recognition
-                    and "vision" in capability
+                    and ModelCapability.VISION in capability
                     and any(f.type == FileType.DOCUMENT for f in files)
                 )
             if has_doc_with_images:
@@ -934,6 +950,23 @@ class AgentRunService:
                     "重要：图片 URL 中包含 UUID（如 /storage/permanent/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx），"
                     "必须将 src 属性的值原封不动复制到 Markdown 的括号中，不得增删任何字符。"
                 )
+
+            # 7. 根据模型能力选择执行路径
+            capability = api_key_config.get("capability", [])
+            use_agent_mode = ModelCapability.FUNCTION_CALL in capability
+            if not use_agent_mode and tools:
+                # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
+                system_prompt = await ToolOrchestrator.create_and_run(
+                    tools=tools,
+                    system_prompt=system_prompt,
+                    message=message,
+                    history=history,
+                    api_key_config=api_key_config,
+                    model_config=model_config,
+                    effective_params=effective_params,
+                    processed_files=processed_files,
+                )
+                tools = []
 
             # 创建 LangChain Agent
             agent = LangChainAgent(
@@ -950,10 +983,9 @@ class AgentRunService:
                 deep_thinking=effective_params.get("deep_thinking", False),
                 thinking_budget_tokens=effective_params.get("thinking_budget_tokens"),
                 json_output=effective_params.get("json_output", False),
-                capability=api_key_config.get("capability", []),
+                capability=capability,
             )
 
-            # 为需要运行时上下文的工具注入上下文
             for t in tools:
                 if hasattr(t, 'tool_instance') and hasattr(t.tool_instance, 'set_runtime_context'):
                     t.tool_instance.set_runtime_context(
@@ -961,7 +993,6 @@ class AgentRunService:
                         conversation_id=str(conversation_id) if conversation_id else None,
                         uploaded_files=processed_files or []
                     )
-            # 7. 知识库检索
             context = None
 
             # 8. 发送开始事件

--- a/api/app/services/multimodal_service.py
+++ b/api/app/services/multimodal_service.py
@@ -34,6 +34,7 @@ from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.models import ModelApiKey
 from app.models.file_metadata_model import FileMetadata
+from app.models.models_model import ModelCapability
 from app.schemas.app_schema import FileInput, FileType, TransferMethod
 from app.schemas.model_schema import ModelInfo
 from app.services.audio_transcription_service import AudioTranscriptionService
@@ -377,14 +378,14 @@ class MultimodalService:
             if not file.url:
                 file.url = await self.get_file_url(file)
             try:
-                if file.type == FileType.IMAGE and "vision" in self.capability:
+                if file.type == FileType.IMAGE and ModelCapability.VISION in self.capability:
                     is_support, content = await self._process_image(file, strategy)
                     result.append(content)
                 elif file.type == FileType.DOCUMENT:
                     is_support, content = await self._process_document(file, strategy)
                     result.append(content)
                     # 仅当开关开启且模型支持视觉时，才提取文档内嵌图片
-                    if document_image_recognition and "vision" in self.capability:
+                    if document_image_recognition and ModelCapability.VISION in self.capability:
                         img_infos = await self.extract_document_images(file)
                         from app.models.workspace_model import Workspace as WorkspaceModel
                         ws = self.db.query(WorkspaceModel).filter(WorkspaceModel.id == workspace_id).first()

--- a/api/app/services/tool_orchestrator.py
+++ b/api/app/services/tool_orchestrator.py
@@ -1,0 +1,289 @@
+"""
+工具编排器 - Prompt 驱动的 ReAct 多轮工具调用
+
+弱模型场景下，通过 ReAct 格式的 system prompt 让模型自主决策工具调用，
+多轮执行直到模型给出最终答案，将完整的工具调用过程注入 system_prompt。
+"""
+import asyncio
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.logging_config import get_business_logger
+
+logger = get_business_logger()
+
+# 解析模型输出的 Thought/Action/Input 三段式
+_ACTION_PATTERN = re.compile(
+    r"Thought[：:]\s*(.*?)\s*Action[：:]\s*(\S+)\s*Input[：:]\s*([\s\S]*?\{[\s\S]*?})",
+    re.DOTALL,
+)
+
+_REACT_SYSTEM_TEMPLATE = """\
+你是具备工具调用能力的智能助手，可根据用户问题自主判断是否使用工具、选择哪个工具、分多轮完成复杂任务。
+
+# 可用工具列表
+{all_tools_info}
+
+# 基础规则
+1. 只能从上面列出的工具中选择，严禁编造不存在的工具名称。
+2. 每一轮思考**只能调用一个工具**，不允许一轮同时列出多个工具。
+3. 若任务需要多个步骤、依赖多个工具（如先查时间再查天气），必须分多轮依次调用。
+4. 参考历史已有的工具返回结果，自动复用已有信息，无需重复调用工具。
+5. 如果用户问题不需要任何工具就能回答，直接给出最终答案，不输出工具调用格式。
+6. 工具参数缺失时，不要编造参数，正常推理是否需要继续调用或询问用户。
+
+# 输出格式（强制严格遵守，只能按以下三段式输出，禁止额外多余话术）
+Thought：你的思考过程，分析用户需求、是否需要调用工具、应该选哪个工具、缺少什么信息
+Action：选中的工具名称（必须和工具列表里的名称完全一致）
+Input：JSON格式工具入参，无参数则填空对象 {{}}
+
+# 终止条件
+当已经收集到全部所需信息、无需再调用任何工具时，直接整理信息给出自然语言最终回答，不再输出 Thought/Action/Input 格式。
+
+# 上下文说明
+你能看到历史对话和上一轮工具返回的观察结果，请基于已有结果继续推理下一步动作。\
+"""
+
+
+def _build_tools_info(tools: Dict[str, Any]) -> str:
+    """将工具列表格式化为 prompt 中的工具描述"""
+    lines = []
+    for name, tool in tools.items():
+        desc = getattr(tool, "description", "") or ""
+        schema = getattr(tool, "args_schema", None)
+        if schema:
+            try:
+                from pydantic_core import PydanticUndefined
+                fields = schema.model_fields
+                param_parts = []
+                for k, v in fields.items():
+                    type_name = v.annotation.__name__ if hasattr(v.annotation, '__name__') else str(v.annotation)
+                    param_desc = v.description or ""
+                    default = v.default
+                    part = f"{k}({type_name}"
+                    if param_desc:
+                        part += f", 说明: {param_desc}"
+                    if default is not None and default is not PydanticUndefined:
+                        part += f", 默认: {default}"
+                    part += ")"
+                    param_parts.append(part)
+                lines.append(f"- {name}[{', '.join(param_parts)}]: {desc}")
+            except Exception:
+                lines.append(f"- {name}: {desc}")
+        else:
+            lines.append(f"- {name}: {desc}")
+    return "\n".join(lines)
+
+
+def _parse_action(text: str, valid_tools: set = None) -> Optional[Tuple[str, str, dict]]:
+    """从模型输出中解析 Thought/Action/Input，返回 (thought, action, input_dict) 或 None"""
+    m = _ACTION_PATTERN.search(text)
+    if not m:
+        return None
+    thought = m.group(1).strip()
+    action = m.group(2).strip()
+    input_str = m.group(3).strip()
+    # action 必须在工具列表中，否则视为终止语言（如“无”、“无需调用”）
+    if valid_tools is not None and action not in valid_tools:
+        return None
+    try:
+        brace_start = input_str.index("{")
+        input_dict = json.loads(input_str[brace_start:])
+    except (ValueError, json.JSONDecodeError):
+        input_dict = {}
+    return thought, action, input_dict
+
+
+class ToolOrchestrator:
+    """
+    Prompt 驱动的 ReAct 多轮工具调用编排器。
+
+    通过 ReAct 格式 system prompt 让弱模型自主决策工具调用，
+    多轮执行直到模型输出最终答案，返回完整的工具调用轨迹供注入 system_prompt。
+
+    适用场景：
+    - 模型不支持 function calling（capability 中无 'function_call'）
+    - 需要降低工具调用对模型能力的依赖
+    """
+
+    def __init__(self, tools: list, max_rounds: int = 5):
+        """
+        Args:
+            tools: LangChain tool 列表
+            max_rounds: 最大工具调用轮数，防止死循环
+        """
+        self.tools: Dict[str, Any] = {t.name: t for t in tools}
+        self.max_rounds = max_rounds
+
+    @classmethod
+    async def create_and_run(
+        cls,
+        tools: list,
+        system_prompt: str,
+        message: str,
+        history: List[Dict],
+        api_key_config: Dict[str, Any],
+        model_config: Any,
+        effective_params: Dict[str, Any],
+        processed_files: Optional[List[Dict]] = None,
+        max_rounds: int = 5,
+    ) -> str:
+        """
+        创建编排器并执行 ReAct 循环。
+
+        Returns:
+            更新后的 system_prompt（包含工具调用结果）
+        """
+        from app.core.models import RedBearLLM, RedBearModelConfig
+
+        orchestrator = cls(tools, max_rounds=max_rounds)
+        react_system_prompt = orchestrator.build_react_system_prompt(system_prompt)
+
+        _react_llm = RedBearLLM(
+            RedBearModelConfig(
+                model_name=api_key_config["model_name"],
+                provider=api_key_config.get("provider", "openai"),
+                api_key=api_key_config["api_key"],
+                base_url=api_key_config.get("api_base"),
+                capability=api_key_config.get("capability", []),
+                is_omni=api_key_config.get("is_omni", False),
+                extra_params={"temperature": effective_params.get("temperature", 0.7)}
+            ),
+            type=model_config.type if hasattr(model_config, 'type') else model_config.model_type
+        )
+
+        async def _llm_caller(msgs):
+            full_msgs = [{"role": "system", "content": react_system_prompt}] + msgs
+            resp = await _react_llm.ainvoke(full_msgs)
+            content = resp.content if hasattr(resp, "content") else str(resp)
+            if isinstance(content, list):
+                content = "".join(
+                    item.get("text", "") if isinstance(item, dict) else str(item)
+                    for item in content
+                )
+            return content
+
+        react_message = (
+            [{"type": "text", "text": message}] + processed_files
+            if processed_files else message
+        )
+
+        final_answer, trajectory_context = await orchestrator.run(
+            llm_caller=_llm_caller,
+            message=react_message,
+            history=history
+        )
+        logger.info("ReAct 工具调用完成", extra={"final_answer_len": len(final_answer)})
+
+        updated_system_prompt = (
+            react_system_prompt + trajectory_context
+            + f"\n\n工具调用已完成，调用结果：{final_answer}\n请直接将以上答案整理后回复用户，不要再输出 Thought/Action/Input 格式。"
+        )
+        return updated_system_prompt
+
+    def build_react_system_prompt(self, original_system_prompt: str) -> str:
+        """
+        将原始 system_prompt 与 ReAct 工具调用指令合并。
+        ReAct 指令附加在原始提示词之后。
+        """
+        tools_info = _build_tools_info(self.tools)
+        react_block = _REACT_SYSTEM_TEMPLATE.format(all_tools_info=tools_info)
+        if original_system_prompt:
+            return f"{original_system_prompt}\n\n{react_block}"
+        return react_block
+
+    async def _call_tool(self, name: str, input_dict: dict) -> str:
+        """执行单个工具调用"""
+        tool = self.tools.get(name)
+        if not tool:
+            return f"[错误：工具 '{name}' 不存在]"
+        try:
+            # LangchainToolWrapper 使用 _arun，@tool 装饰器生成的工具使用 func
+            if hasattr(tool, 'func') and callable(tool.func):
+                result = await asyncio.to_thread(tool.func, **input_dict)
+            else:
+                # LangchainToolWrapper: 工具名可能含 operation 后缀（如 datetime_tool_now）
+                # 需要从工具名中提取 operation 并注入参数
+                tool_instance = getattr(tool, 'tool_instance', None)
+                if tool_instance and not input_dict.get('operation') and hasattr(tool_instance, 'operation'):
+                    operation = getattr(tool_instance, 'operation', '')
+                    input_dict = {**input_dict, 'operation': operation}
+                result = await tool._arun(**input_dict)
+            logger.debug(f"工具 '{name}' 执行成功，结果长度={len(str(result))}")
+            return str(result)
+        except Exception as e:
+            logger.warning(f"工具 '{name}' 执行失败: {e}")
+            return f"[工具调用失败: {e}]"
+
+    async def run(self, llm_caller, message: str | list, history: List[Dict]) -> Tuple[str, str]:
+        """
+        执行 ReAct 多轮工具调用循环。
+
+        Args:
+            llm_caller: 异步函数，签名 async (messages: list) -> str，调用底层 LLM
+            message: 用户当前消息，字符串或多模态 content 列表
+            history: 历史对话列表
+
+        Returns:
+            (final_answer, trajectory_context):
+            - final_answer: 模型最终自然语言回答
+            - trajectory_context: 完整工具调用轨迹，用于注入 system_prompt
+        """
+        # 构建初始消息列表（历史 + 当前用户消息，支持多模态 content）
+        messages = list(history) + [{"role": "user", "content": message}]
+
+        trajectory: List[str] = []  # 记录每轮 thought/action/observation
+        final_answer = ""
+        response = ""
+
+        for round_idx in range(self.max_rounds):
+            response = await llm_caller(messages)
+
+            parsed = _parse_action(response, valid_tools=set(self.tools.keys()))
+
+            if parsed is None:
+                # 去除可能残留的 Thought/Action/Input 块，保留其后的自然语言
+                clean = re.sub(
+                    r"Thought[：:][\s\S]*?Input[：:]\s*\{[^{}]*}\s*",
+                    "",
+                    response,
+                ).strip()
+                final_answer = clean or response.strip()
+                logger.info(f"ReAct 第 {round_idx + 1} 轮：模型给出最终答案")
+                break
+
+            thought, action, input_dict = parsed
+            logger.info(f"ReAct 第 {round_idx + 1} 轮：调用工具 '{action}'，参数={input_dict}")
+
+            # 执行工具
+            observation = await self._call_tool(action, input_dict)
+
+            # 记录本轮轨迹
+            trajectory.append(
+                f"Thought：{thought}\n"
+                f"Action：{action}\n"
+                f"Input：{json.dumps(input_dict, ensure_ascii=False)}\n"
+                f"Observation：{observation}"
+            )
+
+            # 将本轮 ReAct 轨迹合并为一条 assistant 消息，供下一轮推理
+            messages.append({"role": "assistant", "content": f"{response}\nObservation：{observation}"})
+
+        else:
+            # 达到最大轮数，强制用最后一次模型输出作为答案
+            logger.warning(f"ReAct 达到最大轮数 {self.max_rounds}，强制终止")
+            final_answer = response.strip() if response else "已达到最大思考轮次，无法继续"
+
+        trajectory_context = self.build_trajectory_context(trajectory)
+        return final_answer, trajectory_context
+
+    @staticmethod
+    def build_trajectory_context(trajectory: List[str]) -> str:
+        """将工具调用轨迹格式化为注入 system_prompt 的上下文段落"""
+        if not trajectory:
+            return ""
+        parts = ["\n\n---\n以下是工具调用过程与结果，请基于这些信息给出最终回答："]
+        parts.extend(trajectory)
+        parts.append("---")
+        return "\n\n".join(parts)


### PR DESCRIPTION
add function_call capability to bedrock and volcano models and update public share controller with app_name

- Added function_call capability to multiple bedrock and volcano models in their respective YAML configuration files
- Updated multimodal_service.py to use ModelCapability.VISION enum instead of string literal for vision capability check
- Added app_name field to public_share_controller.py response content for WORKFLOW, AGENT, and MULTI_AGENT app types

## Summary by Sourcery

扩展模型能力元数据，并为不具备原生函数调用能力的模型引入基于 ReAct 的工具编排路径，同时在公开分享配置中暴露应用名称。

新功能：
- 在部分 Bedrock、Volcano、DashScope 和 OpenAI 模型配置中新增 `function_call` 能力标记，用于区分支持原生工具调用的模型。
- 引入 `ToolOrchestrator` 服务，为缺乏原生 `function_call` 支持的模型执行 ReAct 风格的多轮工具调用，并将其集成到 agent 和 draft 运行流程中。
- 在 workflow、agent 和 multi-agent 应用的公开分享配置响应中，与 `app_type` 和配置信息一起暴露 `app_name`。

增强改进：
- 通过 `ModelCapability` 枚举优化模型能力处理，并根据不同服务商行为调整深度思考 / `json_output` 参数映射，包括仅思考（`thinking_only`）模型。
- 更新多模态和 agent 服务，使用 `ModelCapability` 枚举进行视觉能力检查，并根据 `function_call` 支持情况路由工具使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend model capability metadata and introduce a ReAct-based tool orchestration path for models without native function calling, while exposing app names in public share configs.

New Features:
- Add function_call capability flags to selected Bedrock, Volcano, DashScope, and OpenAI model configurations to distinguish models that support native tool calling.
- Introduce a ToolOrchestrator service that performs ReAct-style, multi-round tool calling for models lacking native function_call support, integrating its usage into agent and draft run flows.
- Expose app_name alongside app_type and configuration details in public share config responses for workflow, agent, and multi-agent apps.

Enhancements:
- Refine model capability handling via a ModelCapability enum and adjust deep thinking / json_output parameter mapping for different provider behaviors, including thinking_only models.
- Update multimodal and agent services to use the ModelCapability enum for vision checks and to route tool usage based on function_call support.

</details>