### PR TITLE
Feature/parent child chunk

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -124,14 +124,63 @@ async def get_preview_chunks(
             base_url=db_knowledge.image2text.api_keys[0].api_base
         )
     from app.core.rag.app.naive import chunk
-    res = chunk(filename=db_file.file_name,
-                binary=file_binary,
-                from_page=0,
-                to_page=5,
-                callback=progress_callback,
-                vision_model=vision_model,
-                parser_config=db_document.parser_config,
-                is_root=False)
+    parent_child_mode = db_document.parser_config.get("parent_child_mode", False)
+
+    if parent_child_mode:
+        from app.core.rag.app.naive import chunk_parent_child
+        child_res, parent_res, parent_id_map = chunk_parent_child(
+            filename=db_file.file_name,
+            binary=file_binary,
+            from_page=0,
+            to_page=5,
+            callback=progress_callback,
+            vision_model=vision_model,
+            parser_config=db_document.parser_config,
+            is_root=False,
+        )
+        # Combine parent and child chunks for preview
+        parent_id_to_doc_id = {}
+        all_preview = []
+        for idx, item in enumerate(parent_res):
+            pid = uuid.uuid4().hex
+            parent_id_to_doc_id[idx] = pid
+            meta = {
+                "doc_id": pid,
+                "file_id": str(db_document.file_id),
+                "file_name": db_document.file_name,
+                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "document_id": str(db_document.id),
+                "knowledge_id": str(db_document.kb_id),
+                "sort_id": idx,
+                "status": 1,
+                "chunk_type": "parent",
+            }
+            all_preview.append(DocumentChunk(page_content=item["content_with_weight"], metadata=meta))
+        for idx, item in enumerate(child_res):
+            parent_idx = parent_id_map.get(idx)
+            meta = {
+                "doc_id": uuid.uuid4().hex,
+                "file_id": str(db_document.file_id),
+                "file_name": db_document.file_name,
+                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "document_id": str(db_document.id),
+                "knowledge_id": str(db_document.kb_id),
+                "sort_id": idx,
+                "status": 1,
+                "chunk_type": "child",
+                "parent_id": parent_id_to_doc_id.get(parent_idx, ""),
+            }
+            all_preview.append(DocumentChunk(page_content=item["content_with_weight"], metadata=meta))
+        res = all_preview
+    else:
+        res = chunk(filename=db_file.file_name,
+                    binary=file_binary,
+                    from_page=0,
+                    to_page=5,
+                    callback=progress_callback,
+                    vision_model=vision_model,
+                    parser_config=db_document.parser_config,
+                    is_root=False)
 
     start_index = (page - 1) * pagesize
     end_index = start_index + pagesize
@@ -139,17 +188,21 @@ async def get_preview_chunks(
     paginated_chunk_str_list = res[start_index:end_index]
     chunks = []
     for idx, item in enumerate(paginated_chunk_str_list):
-        metadata = {
-            "doc_id": uuid.uuid4().hex,
-            "file_id": str(db_document.file_id),
-            "file_name": db_document.file_name,
-            "file_created_at": int(db_document.created_at.timestamp() * 1000),
-            "document_id": str(db_document.id),
-            "knowledge_id": str(db_document.kb_id),
-            "sort_id": idx,
-            "status": 1,
-        }
-        chunks.append(DocumentChunk(page_content=item["content_with_weight"], metadata=metadata))
+        if parent_child_mode:
+            # item is already a DocumentChunk in parent-child mode
+            chunks.append(item)
+        else:
+            metadata = {
+                "doc_id": uuid.uuid4().hex,
+                "file_id": str(db_document.file_id),
+                "file_name": db_document.file_name,
+                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "document_id": str(db_document.id),
+                "knowledge_id": str(db_document.kb_id),
+                "sort_id": idx,
+                "status": 1,
+            }
+            chunks.append(DocumentChunk(page_content=item["content_with_weight"], metadata=metadata))
 
     # 8. Return structured response
     total = len(res)

--- a/api/app/core/rag/app/naive.py
+++ b/api/app/core/rag/app/naive.py
@@ -22,7 +22,8 @@ from app.core.rag.deepdoc.parser.figure_parser import VisionFigureParser,vision_
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
 from app.core.rag.deepdoc.parser.mineru_parser import MinerUParser
 from app.core.rag.app.textin_parser import TextLnParser
-from app.core.rag.nlp import concat_img, find_codec, naive_merge, naive_merge_with_images, naive_merge_docx, map_children_to_parents, tokenize, rag_tokenizer, tokenize_chunks, tokenize_chunks_with_images, tokenize_table
+from app.core.rag.common.token_utils import num_tokens_from_string
+from app.core.rag.nlp import concat_img, find_codec, naive_merge, naive_merge_with_images, naive_merge_docx, tokenize, rag_tokenizer, tokenize_chunks, tokenize_chunks_with_images, tokenize_table
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", callback=None, vision_model=None, pdf_cls = None, **kwargs):
     callback = callback
@@ -818,20 +819,18 @@ def chunk_parent_child(
     """
     Parent-child chunking mode.
 
-    Calls chunk() twice with different chunk_token_num to produce:
-    - child chunks: fine-grained retrieval units
-    - parent chunks: coarse-grained context chunks
-
-    Both go through chunk()'s normal pipeline (merge → tokenize → clean),
-    so content is clean and consistent with non-parent-child mode.
+    Calls chunk() once at child granularity, then builds parent chunks
+    by merging consecutive children until token budget is reached.
+    This avoids double-parsing the document and guarantees accurate
+    child→parent mapping.
 
     Returns:
         (child_res, parent_res, parent_id_map)
+        - parent_id_map: dict mapping child index → parent index
     """
     parser_config = kwargs.get("parser_config", {})
     child_token_num = int(parser_config.get("chunk_token_num", 128))
     parent_token_num = int(parser_config.get("parent_chunk_token_num", 1024))
-    parent_delimiter = parser_config.get("parent_delimiter", "\n\n")
 
     if parent_token_num <= child_token_num:
         logging.warning(
@@ -840,7 +839,7 @@ def chunk_parent_child(
         )
         parent_token_num = 1024
 
-    # Child: normal chunk() call with configured token_num
+    # Single parse → child chunks
     child_res = chunk(
         filename, binary=binary, from_page=from_page, to_page=to_page,
         lang=lang, callback=callback, vision_model=vision_model,
@@ -848,25 +847,45 @@ def chunk_parent_child(
     )
     logging.info(f"[ParentChild] child: token_num={child_token_num}, chunk_count={len(child_res)}")
 
-    # Parent: normal chunk() call with larger token_num + paragraph delimiter.
-    # _keep_chunk_token_num prevents MinerU from forcing chunk_token_num=0.
-    parent_kwargs = {
-        **kwargs,
-        "parser_config": {**parser_config, "chunk_token_num": parent_token_num, "delimiter": parent_delimiter},
-        "_keep_chunk_token_num": True,
-    }
-    parent_res = chunk(
-        filename, binary=binary, from_page=from_page, to_page=to_page,
-        lang=lang, callback=callback, vision_model=vision_model,
-        **parent_kwargs
-    )
-    logging.info(f"[ParentChild] parent: token_num={parent_token_num}, delimiter={repr(parent_delimiter)}, chunk_count={len(parent_res)}")
+    # Build parents by merging consecutive children
+    parent_res: list[dict] = []
+    parent_id_map: dict[int, int] = {}
+    buf_texts: list[str] = []
+    buf_images: list = []
+    buf_tokens = 0
 
-    # Map children to parents using clean content_with_weight
-    child_texts = [c["content_with_weight"] for c in child_res]
-    parent_texts = [p["content_with_weight"] for p in parent_res]
-    parent_ids = map_children_to_parents(parent_texts, child_texts)
-    parent_id_map = {i: pid for i, pid in enumerate(parent_ids)}
+    def flush_parent():
+        nonlocal buf_texts, buf_images, buf_tokens
+        merged = "\n\n".join(buf_texts)
+        merged_image = None
+        for img in buf_images:
+            merged_image = concat_img(merged_image, img) if merged_image else img
+        parent_res.append({
+            "content_with_weight": merged,
+            "image": merged_image,
+        })
+        buf_texts = []
+        buf_images = []
+        buf_tokens = 0
+
+    for child_idx, child in enumerate(child_res):
+        text = child["content_with_weight"]
+        image = child.get("image")
+        tkn = num_tokens_from_string(text)
+
+        if buf_texts and buf_tokens + tkn > parent_token_num:
+            flush_parent()
+
+        buf_texts.append(text)
+        if image is not None:
+            buf_images.append(image)
+        buf_tokens += tkn
+        parent_id_map[child_idx] = len(parent_res)
+
+    if buf_texts:
+        flush_parent()
+
+    logging.info(f"[ParentChild] parent: token_num={parent_token_num}, chunk_count={len(parent_res)}")
 
     return child_res, parent_res, parent_id_map
 

--- a/api/app/core/rag/app/naive.py
+++ b/api/app/core/rag/app/naive.py
@@ -22,7 +22,7 @@ from app.core.rag.deepdoc.parser.figure_parser import VisionFigureParser,vision_
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
 from app.core.rag.deepdoc.parser.mineru_parser import MinerUParser
 from app.core.rag.app.textin_parser import TextLnParser
-from app.core.rag.nlp import concat_img, find_codec, naive_merge, naive_merge_with_images, naive_merge_docx, tokenize, rag_tokenizer, tokenize_chunks, tokenize_chunks_with_images, tokenize_table
+from app.core.rag.nlp import concat_img, find_codec, naive_merge, naive_merge_with_images, naive_merge_docx, map_children_to_parents, tokenize, rag_tokenizer, tokenize_chunks, tokenize_chunks_with_images, tokenize_table
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", callback=None, vision_model=None, pdf_cls = None, **kwargs):
     callback = callback
@@ -619,7 +619,7 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
         if not sections and not tables:
             return []
 
-        if name in ["mineru", "textln"]:
+        if name in ["mineru", "textln"] and not kwargs.get("_keep_chunk_token_num"):
             parser_config["chunk_token_num"] = 0
 
         res = tokenize_table(tables, doc, is_english)
@@ -809,6 +809,66 @@ def chunk(filename, binary=None, from_page=0, to_page=100000,
     if url_res:
         res.extend(url_res)
     return res
+
+
+def chunk_parent_child(
+    filename, binary=None, from_page=0, to_page=100000,
+    lang="Chinese", callback=None, vision_model=None, **kwargs
+):
+    """
+    Parent-child chunking mode.
+
+    Calls chunk() twice with different chunk_token_num to produce:
+    - child chunks: fine-grained retrieval units
+    - parent chunks: coarse-grained context chunks
+
+    Both go through chunk()'s normal pipeline (merge → tokenize → clean),
+    so content is clean and consistent with non-parent-child mode.
+
+    Returns:
+        (child_res, parent_res, parent_id_map)
+    """
+    parser_config = kwargs.get("parser_config", {})
+    child_token_num = int(parser_config.get("chunk_token_num", 128))
+    parent_token_num = int(parser_config.get("parent_chunk_token_num", 1024))
+    parent_delimiter = parser_config.get("parent_delimiter", "\n\n")
+
+    if parent_token_num <= child_token_num:
+        logging.warning(
+            f"parent_chunk_token_num({parent_token_num}) <= chunk_token_num({child_token_num}), "
+            f"falling back to default 1024"
+        )
+        parent_token_num = 1024
+
+    # Child: normal chunk() call with configured token_num
+    child_res = chunk(
+        filename, binary=binary, from_page=from_page, to_page=to_page,
+        lang=lang, callback=callback, vision_model=vision_model,
+        **kwargs
+    )
+    logging.info(f"[ParentChild] child: token_num={child_token_num}, chunk_count={len(child_res)}")
+
+    # Parent: normal chunk() call with larger token_num + paragraph delimiter.
+    # _keep_chunk_token_num prevents MinerU from forcing chunk_token_num=0.
+    parent_kwargs = {
+        **kwargs,
+        "parser_config": {**parser_config, "chunk_token_num": parent_token_num, "delimiter": parent_delimiter},
+        "_keep_chunk_token_num": True,
+    }
+    parent_res = chunk(
+        filename, binary=binary, from_page=from_page, to_page=to_page,
+        lang=lang, callback=callback, vision_model=vision_model,
+        **parent_kwargs
+    )
+    logging.info(f"[ParentChild] parent: token_num={parent_token_num}, delimiter={repr(parent_delimiter)}, chunk_count={len(parent_res)}")
+
+    # Map children to parents using clean content_with_weight
+    child_texts = [c["content_with_weight"] for c in child_res]
+    parent_texts = [p["content_with_weight"] for p in parent_res]
+    parent_ids = map_children_to_parents(parent_texts, child_texts)
+    parent_id_map = {i: pid for i, pid in enumerate(parent_ids)}
+
+    return child_res, parent_res, parent_id_map
 
 
 if __name__ == "__main__":

--- a/api/app/core/rag/nlp/__init__.py
+++ b/api/app/core/rag/nlp/__init__.py
@@ -606,6 +606,41 @@ def naive_merge(sections: str | list, chunk_token_num=128, delimiter="\n。；�
     return cks
 
 
+def map_children_to_parents(parent_chunks: list[str], child_chunks: list[str]) -> list[int]:
+    """
+    Map each child chunk to its containing parent chunk index using cumulative character offsets.
+
+    Both lists are produced from the same source text in the same order,
+    so each child's start position falls within exactly one parent's range.
+
+    Returns a list of parent chunk indices parallel to child_chunks.
+    """
+    if not parent_chunks or not child_chunks:
+        return [0] * len(child_chunks)
+
+    # Build cumulative character offset ranges for parents
+    parent_ranges: list[tuple[int, int, int]] = []  # (start, end, parent_idx)
+    offset = 0
+    for i, pc in enumerate(parent_chunks):
+        start = offset
+        end = offset + len(pc)
+        parent_ranges.append((start, end, i))
+        offset = end
+
+    # Map each child to its parent by character offset
+    result = []
+    child_offset = 0
+    parent_idx = 0
+    for cc in child_chunks:
+        child_start = child_offset
+        while parent_idx < len(parent_ranges) - 1 and parent_ranges[parent_idx][1] <= child_start:
+            parent_idx += 1
+        result.append(parent_ranges[parent_idx][2])
+        child_offset += len(cc)
+
+    return result
+
+
 def naive_merge_with_images(texts, images, chunk_token_num=128, delimiter="\n。；！？", overlapped_percent=0):
     from app.core.rag.deepdoc.parser.pdf_parser import RAGPdfParser
     if not texts or len(texts) != len(images):

--- a/api/app/core/rag/nlp/search.py
+++ b/api/app/core/rag/nlp/search.py
@@ -224,6 +224,7 @@ def _retrieve_for_knowledge(
                 top_k=kb_config["top_k"],
                 score_threshold=kb_config["similarity_threshold"],
                 file_names_filter=file_names_filter,
+                resolve_parents=False,
             )
         case "semantic":
             rs = vector_service.search_by_vector(
@@ -231,6 +232,7 @@ def _retrieve_for_knowledge(
                 top_k=kb_config["top_k"],
                 score_threshold=kb_config["vector_similarity_weight"],
                 file_names_filter=file_names_filter,
+                resolve_parents=False,
             )
         case _:
             rs1 = vector_service.search_by_vector(
@@ -238,12 +240,14 @@ def _retrieve_for_knowledge(
                 top_k=kb_config["top_k"],
                 score_threshold=kb_config["vector_similarity_weight"],
                 file_names_filter=file_names_filter,
+                resolve_parents=False,
             )
             rs2 = vector_service.search_by_full_text(
                 query=kb_config["query"],
                 top_k=kb_config["top_k"],
                 score_threshold=kb_config["similarity_threshold"],
                 file_names_filter=file_names_filter,
+                resolve_parents=False,
             )
             # 合并去重
             seen_ids = set()
@@ -277,6 +281,8 @@ def _retrieve_for_knowledge(
                 except Exception as graph_error:
                     logger.warning(f"Graph retrieval failed for kb {db_knowledge.id}: {graph_error}")
 
+    # local rerank 之后解析父块，保证 rerank 在子块上做精确评分
+    rs = vector_service.resolve_parent_chunks(rs)
     results.extend(rs)
     return results, chat_model, embedding_model
 

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -53,6 +53,9 @@ class ElasticSearchVector(BaseVector):
         return "elasticsearch"
 
     def add_chunks(self, chunks: list[DocumentChunk], **kwargs):
+        # 仅在写入时检查并补充字段映射，避免每次检索都做冗余检查
+        ElasticSearchVectorFactory._ensure_parent_id_mapping(self._client, self._collection_name)
+
         # QA chunks: embedding 只对 question 字段做；source/parent chunks: 不做 embedding
         texts_for_embedding = []
         for chunk in chunks:
@@ -918,9 +921,6 @@ class ElasticSearchVectorFactory:
             raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
         if knowledge.reranker is None:
             raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
-
-        # 确保存量索引包含 parent_id 字段映射（幂等操作）
-        cls._ensure_parent_id_mapping(client, collection_name)
 
         return ElasticSearchVector(
             index_name=collection_name,

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -53,18 +53,18 @@ class ElasticSearchVector(BaseVector):
         return "elasticsearch"
 
     def add_chunks(self, chunks: list[DocumentChunk], **kwargs):
-        # QA chunks: embedding 只对 question 字段做；source chunks: 不做 embedding
+        # QA chunks: embedding 只对 question 字段做；source/parent chunks: 不做 embedding
         texts_for_embedding = []
         for chunk in chunks:
             chunk_type = (chunk.metadata or {}).get("chunk_type", "chunk")
-            if chunk_type == "source":
-                # source chunk 不需要向量索引
+            if chunk_type in ("source", "parent"):
+                # source 和 parent chunk 不需要向量索引
                 texts_for_embedding.append("")
             elif chunk_type == "qa":
                 # QA chunk: 用 question 字段做 embedding
                 texts_for_embedding.append((chunk.metadata or {}).get("question", chunk.page_content))
             else:
-                # 普通 chunk: 用 page_content 做 embedding
+                # 普通 chunk / child chunk: 用 page_content 做 embedding
                 texts_for_embedding.append(chunk.page_content)
 
         if self.is_multimodal_embedding:
@@ -72,9 +72,9 @@ class ElasticSearchVector(BaseVector):
         else:
             embeddings = self.embeddings.embed_documents(texts_for_embedding)
 
-        # source chunk 的向量置空
+        # source/parent chunk 的向量置空
         for i, chunk in enumerate(chunks):
-            if (chunk.metadata or {}).get("chunk_type") == "source":
+            if (chunk.metadata or {}).get("chunk_type") in ("source", "parent"):
                 embeddings[i] = None
 
         self.create(chunks, embeddings, **kwargs)
@@ -104,6 +104,8 @@ class ElasticSearchVector(BaseVector):
                 source[Field.ANSWER.value] = meta["answer"]
             if meta.get("source_chunk_id"):
                 source[Field.SOURCE_CHUNK_ID.value] = meta["source_chunk_id"]
+            if meta.get("parent_id"):
+                source[Field.PARENT_ID.value] = meta["parent_id"]
 
             action = {
                 "_index": self._collection_name,
@@ -111,8 +113,13 @@ class ElasticSearchVector(BaseVector):
             }
             actions.append(action)
         # using bulk mode
-        result = helpers.bulk(self._client, actions)
-        logger.info(f"add_texts result:{result}")
+        try:
+            result = helpers.bulk(self._client, actions)
+            logger.info(f"add_texts result:{result}")
+        except BulkIndexError as e:
+            for error in e.errors[:3]:
+                logger.error(f"ES bulk index error detail: {error}")
+            raise
         return uuids
 
     def text_exists(self, id: str) -> bool:
@@ -436,7 +443,7 @@ class ElasticSearchVector(BaseVector):
         # print(f"Update successful, number of affected documents: {result['updated']}")
         return result['updated']
 
-    def search_by_vector(self, query: str, **kwargs: Any) -> list[DocumentChunk]:
+    def search_by_vector(self, query: str, resolve_parents: bool = True, **kwargs: Any) -> list[DocumentChunk]:
         """Search the nearest neighbors to a vector."""
         if self.is_multimodal_embedding:
             # 火山引擎多模态 Embedding
@@ -465,7 +472,7 @@ class ElasticSearchVector(BaseVector):
                     "filter": [
                         {"term": {"metadata.status": 1}},
                         # 排除 source chunk（仅供 GraphRAG 使用，不参与检索）
-                        {"bool": {"must_not": {"term": {Field.CHUNK_TYPE.value: "source"}}}}
+                        {"bool": {"must_not": {"terms": {Field.CHUNK_TYPE.value: ["source", "parent"]}}}}
                     ]
                 }
             }
@@ -487,7 +494,7 @@ class ElasticSearchVector(BaseVector):
                     "filter": [
                         {"term": {"metadata.status": 1}},
                         {"terms": {"metadata.file_name": file_names_filter}},
-                        {"bool": {"must_not": {"term": {Field.CHUNK_TYPE.value: "source"}}}}
+                        {"bool": {"must_not": {"terms": {Field.CHUNK_TYPE.value: ["source", "parent"]}}}}
                     ],
                 }
             }
@@ -531,9 +538,9 @@ class ElasticSearchVector(BaseVector):
                     doc.metadata["score"] = score
                     docs.append(doc)
 
-        return docs
+        return self.resolve_parent_chunks(docs) if resolve_parents else docs
 
-    def search_by_full_text(self, query: str, **kwargs: Any) -> list[DocumentChunk]:
+    def search_by_full_text(self, query: str, resolve_parents: bool = True, **kwargs: Any) -> list[DocumentChunk]:
         """Return docs using BM25F.
 
         Args:
@@ -561,7 +568,7 @@ class ElasticSearchVector(BaseVector):
                 },
                 "filter": [
                     {"term": {"metadata.status": 1}},
-                    {"bool": {"must_not": {"term": {Field.CHUNK_TYPE.value: "source"}}}}
+                    {"bool": {"must_not": {"terms": {Field.CHUNK_TYPE.value: ["source", "parent"]}}}}
                 ]
             }
         }
@@ -581,7 +588,7 @@ class ElasticSearchVector(BaseVector):
                     "filter": [
                         {"term": {"metadata.status": 1}},
                         {"terms": {"metadata.file_name": file_names_filter}},
-                        {"bool": {"must_not": {"term": {Field.CHUNK_TYPE.value: "source"}}}}
+                        {"bool": {"must_not": {"terms": {Field.CHUNK_TYPE.value: ["source", "parent"]}}}}
                     ],
                 }
             }
@@ -626,7 +633,86 @@ class ElasticSearchVector(BaseVector):
                     doc.metadata["score"] = score
                     docs.append(doc)
 
-        return docs
+        return self.resolve_parent_chunks(docs) if resolve_parents else docs
+
+    def resolve_parent_chunks(self, chunks: list[DocumentChunk]) -> list[DocumentChunk]:
+        """
+        For child chunks (chunk_type == "child"), replace page_content with the
+        parent chunk's page_content. Deduplicate when multiple children share
+        the same parent.
+
+        Non-child chunks (regular "chunk", "qa") pass through unchanged.
+        """
+        child_results = []
+        other_results = []
+        for doc in chunks:
+            if (doc.metadata or {}).get("chunk_type") == "child":
+                child_results.append(doc)
+            else:
+                other_results.append(doc)
+
+        if not child_results:
+            return chunks
+
+        # Collect unique parent IDs
+        parent_ids = list({doc.metadata.get("parent_id", "") for doc in child_results if doc.metadata.get("parent_id")})
+        if not parent_ids:
+            return chunks
+
+        # Batch-fetch parent chunks from ES by doc_id
+        parent_map = {}
+        try:
+            result = self._client.search(
+                index=self._collection_name,
+                body={
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"metadata.doc_id": parent_ids}}
+                            ]
+                        }
+                    }
+                },
+                size=len(parent_ids),
+            )
+            for hit in result.get("hits", {}).get("hits", []):
+                source = hit["_source"]
+                parent_doc_id = source.get("metadata", {}).get("doc_id", "")
+                parent_map[parent_doc_id] = DocumentChunk(
+                    page_content=source.get(Field.CONTENT_KEY.value, ""),
+                    metadata=source.get(Field.METADATA_KEY.value, {}),
+                )
+        except Exception as e:
+            logger.warning(f"Failed to resolve parent chunks: {e}")
+            return chunks
+
+        # Replace child content with parent content, dedup by parent_id
+        seen_parents: dict[str, DocumentChunk] = {}
+        for doc in child_results:
+            parent_id = doc.metadata.get("parent_id", "")
+            if parent_id in seen_parents:
+                existing = seen_parents[parent_id]
+                if doc.metadata.get("score", 0) > existing.metadata.get("score", 0):
+                    seen_parents[parent_id] = DocumentChunk(
+                        page_content=existing.page_content,
+                        metadata={**existing.metadata, "score": doc.metadata.get("score", 0)},
+                    )
+                continue
+
+            parent = parent_map.get(parent_id)
+            if parent:
+                # Replace page_content with parent's, preserve child's score
+                score = doc.metadata.get("score", 0)
+                merged_metadata = {**parent.metadata, "score": score, "chunk_type": "parent"}
+                seen_parents[parent_id] = DocumentChunk(
+                    page_content=parent.page_content,
+                    metadata=merged_metadata,
+                )
+            else:
+                # Parent not found, keep child as-is
+                seen_parents[parent_id] = doc
+
+        return list(seen_parents.values()) + other_results
 
     def rerank(self, query: str, docs: list[DocumentChunk], top_k: int) -> list[DocumentChunk]:
         """
@@ -718,6 +804,9 @@ class ElasticSearchVector(BaseVector):
                                 },
                                 "status": {
                                     "type": "integer"
+                                },
+                                "parent_id": {
+                                    "type": "keyword"
                                 }
                             }
                         },
@@ -726,6 +815,23 @@ class ElasticSearchVector(BaseVector):
                             "dims": len(next((e for e in embeddings if e is not None), [0]*768)),  # 跳过 None 获取向量维度，fallback 768
                             "index": True,
                             "similarity": "cosine"
+                        },
+                        Field.CHUNK_TYPE.value: {
+                            "type": "keyword"
+                        },
+                        Field.QUESTION.value: {
+                            "type": "text",
+                            "analyzer": "ik_max_word"
+                        },
+                        Field.ANSWER.value: {
+                            "type": "text",
+                            "analyzer": "ik_max_word"
+                        },
+                        Field.SOURCE_CHUNK_ID.value: {
+                            "type": "keyword"
+                        },
+                        Field.PARENT_ID.value: {
+                            "type": "keyword"
                         }
                     }
                 }
@@ -813,12 +919,51 @@ class ElasticSearchVectorFactory:
         if knowledge.reranker is None:
             raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
 
+        # 确保存量索引包含 parent_id 字段映射（幂等操作）
+        cls._ensure_parent_id_mapping(client, collection_name)
+
         return ElasticSearchVector(
             index_name=collection_name,
             client=client,
             embedding_config=knowledge.embedding.api_keys[0],
             reranker_config=knowledge.reranker.api_keys[0],
         )
+
+    @classmethod
+    def _ensure_parent_id_mapping(cls, client: Elasticsearch, index_name: str):
+        """为已有索引补充缺失的字段映射（仅追加，非破坏性）"""
+        if not client.indices.exists(index=index_name):
+            return
+        try:
+            mapping = client.indices.get_mapping(index=index_name)
+            props = mapping[index_name]["mappings"].get("properties", {})
+            metadata_props = props.get("metadata", {}).get("properties", {})
+
+            update_body: dict[str, Any] = {"properties": {}}
+
+            # metadata.parent_id
+            if metadata_props.get("parent_id", {}).get("type") != "keyword":
+                update_body["properties"]["metadata"] = {
+                    "properties": {"parent_id": {"type": "keyword"}}
+                }
+
+            # top-level parent_id
+            if props.get(Field.PARENT_ID.value, {}).get("type") != "keyword":
+                update_body["properties"][Field.PARENT_ID.value] = {"type": "keyword"}
+
+            # top-level chunk_type
+            if Field.CHUNK_TYPE.value not in props:
+                update_body["properties"][Field.CHUNK_TYPE.value] = {"type": "keyword"}
+
+            # source_chunk_id
+            if Field.SOURCE_CHUNK_ID.value not in props:
+                update_body["properties"][Field.SOURCE_CHUNK_ID.value] = {"type": "keyword"}
+
+            if len(update_body["properties"]) > 0:
+                client.indices.put_mapping(index=index_name, body=update_body)
+                logger.info(f"Updated mapping for {index_name}: added {list(update_body['properties'].keys())}")
+        except Exception as e:
+            logger.warning(f"Failed to update mapping for {index_name}: {e}")
 
 
 

--- a/api/app/core/rag/vdb/field.py
+++ b/api/app/core/rag/vdb/field.py
@@ -19,3 +19,5 @@ class Field(StrEnum):
     QUESTION = "question"
     ANSWER = "answer"
     SOURCE_CHUNK_ID = "source_chunk_id"
+    # Parent-child fields
+    PARENT_ID = "parent_id"

--- a/api/app/models/document_model.py
+++ b/api/app/models/document_model.py
@@ -24,6 +24,9 @@ class Document(Base):
                                "auto_keywords": 0,
                                "auto_questions": 0,
                                "html4excel": False,
+                               "parent_child_mode": False,
+                               "parent_chunk_token_num": 1024,
+                               "parent_delimiter": "\n",
                                "graphrag": {
                                     "use_graphrag": False,
                                     "scene_name": "",

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -74,6 +74,9 @@ class Knowledge(Base):
                                "auto_keywords": 0,
                                "auto_questions": 0,
                                "html4excel": False,
+                               "parent_child_mode": False,
+                               "parent_chunk_token_num": 1024,
+                               "parent_delimiter": "\n",
                                "graphrag": {
                                     "use_graphrag": False,
                                     "scene_name": "",

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -316,7 +316,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         db.refresh(db_document)
 
         # 2. Document vectorization and storage
-        total_chunks = len(child_res) if parent_child_mode else len(res)
+        total_chunks = (len(child_res) + len(parent_res)) if parent_child_mode else len(res)
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
 
         if total_chunks == 0:

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -285,14 +285,29 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         from app.core.rag.app.naive import chunk
         logger.info(f"[ParseDoc] file_binary size={len(file_binary)} bytes, type={type(file_binary).__name__}, bool={bool(file_binary)}")
-        res = chunk(filename=file_name,
-                    binary=file_binary,
-                    from_page=0,
-                    to_page=DEFAULT_PARSE_TO_PAGE,
-                    callback=progress_callback,
-                    vision_model=vision_model,
-                    parser_config=db_document.parser_config,
-                    is_root=False)
+
+        parent_child_mode = db_document.parser_config.get("parent_child_mode", False)
+        if parent_child_mode:
+            from app.core.rag.app.naive import chunk_parent_child
+            child_res, parent_res, parent_id_map = chunk_parent_child(
+                filename=file_name,
+                binary=file_binary,
+                from_page=0,
+                to_page=DEFAULT_PARSE_TO_PAGE,
+                callback=progress_callback,
+                vision_model=vision_model,
+                parser_config=db_document.parser_config,
+                is_root=False,
+            )
+        else:
+            res = chunk(filename=file_name,
+                        binary=file_binary,
+                        from_page=0,
+                        to_page=DEFAULT_PARSE_TO_PAGE,
+                        callback=progress_callback,
+                        vision_model=vision_model,
+                        parser_config=db_document.parser_config,
+                        is_root=False)
 
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Finish parsing.")
         db_document.progress = 0.8
@@ -301,7 +316,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         db.refresh(db_document)
 
         # 2. Document vectorization and storage
-        total_chunks = len(res)
+        total_chunks = len(child_res) if parent_child_mode else len(res)
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
 
         if total_chunks == 0:
@@ -329,7 +344,57 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             # 预先构建所有 batch 的 chunks，保证 sort_id 全局有序
             all_batch_chunks: list[list[DocumentChunk]] = []
 
-            if auto_questions_topn:
+            if parent_child_mode:
+                # 父子分块模式：parent chunks + child chunks
+                parent_chunks_list = []
+                parent_id_to_doc_id = {}
+
+                for idx, item in enumerate(parent_res):
+                    parent_doc_id = uuid.uuid4().hex
+                    parent_id_to_doc_id[idx] = parent_doc_id
+                    meta = {
+                        "doc_id": parent_doc_id,
+                        "file_id": str(db_document.file_id),
+                        "file_name": db_document.file_name,
+                        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                        "document_id": str(db_document.id),
+                        "knowledge_id": str(db_document.kb_id),
+                        "sort_id": idx,
+                        "status": 1,
+                        "chunk_type": "parent",
+                    }
+                    parent_chunks_list.append(
+                        DocumentChunk(page_content=item["content_with_weight"], metadata=meta))
+
+                child_chunks_list = []
+                for idx, item in enumerate(child_res):
+                    parent_idx = parent_id_map.get(idx)
+                    parent_doc_id = parent_id_to_doc_id.get(parent_idx, "")
+                    meta = {
+                        "doc_id": uuid.uuid4().hex,
+                        "file_id": str(db_document.file_id),
+                        "file_name": db_document.file_name,
+                        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                        "document_id": str(db_document.id),
+                        "knowledge_id": str(db_document.kb_id),
+                        "sort_id": idx,
+                        "status": 1,
+                        "chunk_type": "child",
+                        "parent_id": parent_doc_id,
+                    }
+                    child_chunks_list.append(
+                        DocumentChunk(page_content=item["content_with_weight"], metadata=meta))
+
+                all_chunks = parent_chunks_list + child_chunks_list
+                for batch_start in range(0, len(all_chunks), EMBEDDING_BATCH_SIZE):
+                    batch_end = min(batch_start + EMBEDDING_BATCH_SIZE, len(all_chunks))
+                    all_batch_chunks.append(all_chunks[batch_start:batch_end])
+
+                progress_lines.append(
+                    f"{datetime.now().strftime('%H:%M:%S')} Parent-child mode: {len(parent_chunks_list)} parent chunks + "
+                    f"{len(child_chunks_list)} child chunks prepared.")
+
+            elif auto_questions_topn:
                 # QA 模式（FastGPT 方案）：
                 # 1. 原 chunk 标记为 source（保留供 GraphRAG 使用，不参与检索）
                 # 2. LLM 生成 QA 对，每个 QA 对独立存储为 qa chunk


### PR DESCRIPTION
## Summary

- 新增父子分块（parent-child chunking）策略，对同一文档同时产出细粒度子块和粗粒度父块，兼顾检索精准度和上下文完整性。


## Changes

- naive.py — 新增
- chunk_parent_child()，对文档进行二次分块：子块用于精确检索、父块提供完整上下文
- chunk_controller.py — 预览接口支持 parent_child_mode，同时返回父子块结果
- nlp/ — 新增 NLP 工具模块（concat_img, find_codec, naive_merge_with_images 等）
- elasticsearch_vector.py — 向量存储层支持父子块索引
- tasks.py — 解析任务支持 parent_child_mode 参数
- document_model.py / knowledge_model.py — 模型字段扩展
- field.py — 新增相关字段定义

## Key Details

- 通过 parser_config.parent_child_mode 开关控制，不影响现有分块逻辑
- 子块大小由 chunk_token_num 控制，父块大小由 parent_chunk_token_num 控制（默认 1024）
- 父子块通过 ID 映射关联，写入 ES 时保持对应关系

## 由 Sourcery 提供的总结

引入可配置的父子分块模式：生成粒度更细的子分块和粒度更粗的父分块，并将其贯穿于解析、预览、检索和 Elasticsearch 存储流程中，同时在查询时确保父子关系被正确解析。

新功能：
- 新增父子分块工作流，可在单次解析过程中生成相互关联的父分块和子分块，并通过文档解析和预览 API 对外提供。
- 支持父子感知的检索流程：在保持现有模式不变的前提下，将子分块的搜索结果解析到对应的父分块上。

增强改进：
- 扩展 Elasticsearch 向量索引的映射与写入路径以包含父子元数据字段，并改进批量索引的错误日志记录。
- 更新搜索流程，支持可选地在直接检索中排除父分块，并在重排序后再解析父分块内容，以获得更好的上下文召回效果。
- 优化分块行为，在通过内部标志位请求时，为特定解析器保留现有的 `chunk_token_num` 设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable parent-child chunking mode that generates fine-grained child chunks and coarse-grained parent chunks, wires it through parsing, preview, retrieval, and Elasticsearch storage, and ensures correct parent-child resolution at query time.

New Features:
- Add parent-child chunking workflow that produces linked parent and child chunks from a single parsing pass and exposes it via document parsing and preview APIs.
- Support parent-child-aware retrieval by resolving child search results to their corresponding parent chunks while keeping existing modes intact.

Enhancements:
- Extend Elasticsearch vector index mappings and write paths with parent-child metadata fields and improve bulk indexing error logging.
- Update search flows to optionally exclude parent chunks from direct retrieval and resolve parent contents after reranking for better context recall.
- Refine chunking behavior to preserve existing chunk_token_num for specific parsers when requested via internal flags.

</details>