### PR TITLE
feat(rag): add Chinese output support for document image parsing

### DIFF
--- a/api/app/core/rag/deepdoc/parser/figure_parser.py
+++ b/api/app/core/rag/deepdoc/parser/figure_parser.py
@@ -99,7 +99,7 @@ class VisionFigureParser:
             description_text = picture_vision_llm_chunk(
                 binary=figure_binary,
                 vision_model=self.vision_model,
-                prompt=vision_llm_figure_describe_prompt(),
+                prompt=vision_llm_figure_describe_prompt(lang=getattr(self.vision_model, "lang", "Chinese")),
                 callback=callback,
             )
             return figure_idx, description_text

--- a/api/app/core/rag/deepdoc/parser/pdf_parser.py
+++ b/api/app/core/rag/deepdoc/parser/pdf_parser.py
@@ -1367,7 +1367,7 @@ class VisionParser(RAGPdfParser):
             text = picture_vision_llm_chunk(
                 binary=img_binary,
                 vision_model=self.vision_model,
-                prompt=vision_llm_describe_prompt(page=pdf_page_num + 1),
+                prompt=vision_llm_describe_prompt(page=pdf_page_num + 1, lang=getattr(self.vision_model, "lang", "Chinese")),
                 callback=callback,
             )
 

--- a/api/app/core/rag/llm/cv_model.py
+++ b/api/app/core/rag/llm/cv_model.py
@@ -168,7 +168,7 @@ class Base(ABC):
         return [
             {
                 "role": "user",
-                "content": self._image_prompt(prompt if prompt else vision_llm_describe_prompt(), b64)
+                "content": self._image_prompt(prompt if prompt else vision_llm_describe_prompt(lang=self.lang), b64)
             }
         ]
 

--- a/api/app/core/rag/prompts/generator.py
+++ b/api/app/core/rag/prompts/generator.py
@@ -272,15 +272,15 @@ def content_tagging(chat_mdl, content, all_tags, examples, topn=3):
     return res
 
 
-def vision_llm_describe_prompt(page=None) -> str:
+def vision_llm_describe_prompt(page=None, lang="Chinese") -> str:
     template = PROMPT_JINJA_ENV.from_string(VISION_LLM_DESCRIBE_PROMPT)
 
-    return template.render(page=page)
+    return template.render(page=page, lang=lang)
 
 
-def vision_llm_figure_describe_prompt() -> str:
+def vision_llm_figure_describe_prompt(lang="Chinese") -> str:
     template = PROMPT_JINJA_ENV.from_string(VISION_LLM_FIGURE_DESCRIBE_PROMPT)
-    return template.render()
+    return template.render(lang=lang)
 
 
 def tool_schema(tools_description: list[dict], complete_task=False):

--- a/api/app/core/rag/prompts/vision_llm_describe_prompt.md
+++ b/api/app/core/rag/prompts/vision_llm_describe_prompt.md
@@ -1,3 +1,32 @@
+{% if lang == "Chinese" %}
+
+## 指令
+将提供的PDF页面图片内容转录为清晰的Markdown格式。
+
+- 仅输出图片中转录的内容。
+- 不要输出此指令或任何其他解释。
+- 如果内容缺失或你无法理解输入，返回空字符串。
+- 所有输出内容请用中文。
+
+## 规则
+1. 不要生成示例、演示或模板。
+2. 不要输出任何额外文本，如"示例"、"示例输出"等。
+3. 不要生成任何图片中未明确出现的表格、标题或内容。
+4. 逐字转录内容，不要修改、翻译或省略任何内容。
+5. 不要解释Markdown或提及你正在使用Markdown。
+6. 不要将输出包裹在```markdown或```代码块中。
+7. 仅根据图片的布局对标题、段落、列表和表格应用Markdown结构。除非图片中存在真实的表格，否则不要创建表格。
+8. 保留图片中显示的原始语言、信息和顺序。
+9. 你的输出语言必须与图片内容的语言一致。如果图片包含中文文本，输出中文。如果是英文，输出英文。切勿翻译。
+
+{% if page %}
+在转录的末尾添加分页标记：`--- 第 {{ page }} 页 ---`。
+{% endif %}
+
+> 如果你在图片中未检测到有效内容，返回空字符串。
+
+{% else %}
+
 ## INSTRUCTION
 Transcribe the content from the provided PDF page image into clean Markdown format.
 
@@ -21,4 +50,6 @@ At the end of the transcription, add the page divider: `--- Page {{ page }} ---`
 {% endif %}
 
 > If you do not detect valid content in the image, return an empty string.
+
+{% endif %}
 

--- a/api/app/core/rag/prompts/vision_llm_figure_describe_prompt.md
+++ b/api/app/core/rag/prompts/vision_llm_figure_describe_prompt.md
@@ -1,3 +1,31 @@
+{% if lang == "Chinese" %}
+
+## 角色
+你是一名专业的视觉数据分析专家。
+
+## 目标
+分析图片并提供其内容的全面描述。重点关注识别视觉数据表示的类型（如柱状图、饼图、折线图、表格、流程图）、其结构，以及图片中包含的任何文字标题或标签。
+
+## 任务
+1. 描述视觉表示的整体结构。说明它是图表、图形、表格还是示意图。
+2. 识别并提取图片中存在的所有坐标轴、图例、标题或标签。尽可能提供确切的文字。
+3. 从视觉元素中提取数据点（如柱状图高度、折线图坐标、饼图段落、表格行和列）。
+4. 分析并解释数据中显示的任何趋势、比较或模式。
+5. 捕获所有注释、标题或脚注，并解释它们与图片的相关性。
+6. 仅包含图片中明确存在的细节。如果某个元素（如坐标轴、图例或标题）不存在或不可见，不要提及。
+
+## 输出格式（仅包含与图片内容相关的部分）
+- 视觉类型：[类型]
+- 标题：[标题文字，如有]
+- 坐标轴 / 图例 / 标签：[详细信息，如有]
+- 数据点：[提取的数据]
+- 趋势 / 洞察：[分析与解读]
+- 注释 / 说明：[文字及其相关性，如有]
+
+> 请用中文输出分析结果。确保分析具有高准确性、清晰性和完整性，仅包含图片中存在的信息。避免对缺失元素的不必要说明。
+
+{% else %}
+
 ## ROLE
 You are an expert visual data analyst.
 
@@ -21,4 +49,6 @@ Analyze the image and provide a comprehensive description of its content. Focus 
 - Captions / Annotations: [Text and relevance, if available]
 
 > Ensure high accuracy, clarity, and completeness in your analysis, and include only the information present in the image. Avoid unnecessary statements about missing elements.
+
+{% endif %}
 


### PR DESCRIPTION
## Summary
- 文档内嵌图片解析的视觉模型 prompt 中文化，修复上传 PDF/DOCX中包含图片时分块结果输出英文的问题。

## Changes
- vision_llm_describe_prompt.md — PDF 页面图片转写 prompt 增加 lang 参数，Chinese
分支输出简体中文
- vision_llm_figure_describe_prompt.md — 图表分析 prompt 增加 lang 参数，Chinese
分支全中文化
- generator.py — vision_llm_describe_prompt() / vision_llm_figure_describe_prompt()
函数签名增加 lang 参数
- pdf_parser.py / figure_parser.py / cv_model.py — 调用链逐层传递 vision_model.lang

## Key Details
- 所有 vision model 默认 lang="Chinese"，非中文环境传入 lang="English" 走原英文 prompt

## Summary by Sourcery

为文档图片和图表添加具备语言感知能力的视觉大模型（vision LLM）提示词，对输出默认使用中文，同时保留可配置为英文的选项。

New Features:
- 在视觉 RAG 流水线中，为 PDF 页面图像转写和图表分析引入中文本地化的提示词变体。
- 允许通过 `lang` 参数配置视觉模型提示词语言，支持英文和中文分支。

Enhancements:
- 在 PDF 解析器、图表解析器以及 CV 模型中传递视觉模型的 `lang` 设置，从而确保基于图像的分块遵循所配置的输出语言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add language-aware vision LLM prompts for document images and figures, defaulting to Chinese output while preserving English as a configurable option.

New Features:
- Introduce Chinese-localized prompt variants for PDF page image transcription and figure analysis in the vision RAG pipeline.
- Allow configuring the vision model prompt language via a lang parameter, with English and Chinese branches.

Enhancements:
- Propagate the vision model lang setting through PDF and figure parsers and the CV model so image-based chunks respect the configured output language.

</details>