### PR TITLE
feat(web): knowledge base chunk size

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -817,7 +817,7 @@ const CreateDataset = () => {
                     </div>
                     <DelimiterSelector value={delimiter} onChange={setDelimiter} />
                   </div>
-                  <SliderInput label={t('knowledgeBase.suggestedBlockSize')} max={1024} min={1} step={1} value={blockSize} onChange={handleChange} />
+                  <SliderInput label={t('knowledgeBase.suggestedBlockSize')} max={12000} min={6} step={1} value={blockSize} onChange={handleChange} />
                 </div>
                 <div>
                   <div className='rb:w-full rb:text-[#5B6167] rb:leading-5 rb:mb-2 rb:mt-4'>


### PR DESCRIPTION
## Summary by Sourcery

增强：
- 提高知识库数据集创建视图中建议块大小滑块的上限，以支持更大的数据块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Raise the upper limit of the suggested block size slider in the knowledge base dataset creation view to support larger chunks.

</details>