### PR TITLE
Feature/kb batch download

### DIFF
--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -1,7 +1,4 @@
-import asyncio
 import os
-import struct
-import zlib
 from typing import Any, Optional
 import uuid
 
@@ -267,158 +264,16 @@ async def batch_download_files(
             detail="所选文件均无有效存储Key",
         )
 
-    # 同名文件自动去重 — 在流式之前预分配文件名
-    name_counter: dict[str, int] = {}
-    arc_names: list[str] = []
-
-    def unique_name(original: str) -> str:
-        if original not in name_counter:
-            name_counter[original] = 0
-            return original
-        name_counter[original] += 1
-        stem, *ext_parts = original.rsplit(".", 1)
-        ext = f".{ext_parts[0]}" if ext_parts else ""
-        return f"{stem}_{name_counter[original]}{ext}"
-
-    for f in valid_files:
-        arc_names.append(unique_name(f.file_name))
-
-    expected_count = len(valid_files)
-
-    async def stream_zip():
-        """逐文件下载 → 实时压缩 → yield ZIP 数据块，全程不落盘。"""
-        central_entries: list[tuple[bytes, int, int, int, int]] = []
-        skipped_files: list[str] = []
-        offset = 0
-
-        for f, arc_name in zip(valid_files, arc_names):
-            try:
-                async with asyncio.timeout(120):
-                    content = await storage_service.download_file(f.file_key)
-            except Exception as e:
-                api_logger.warning(f"跳过文件 {f.file_name} (id={f.id}): {e}")
-                skipped_files.append(f.file_name)
-                continue
-
-            arc_name_bytes = arc_name.encode("utf-8")
-            crc = zlib.crc32(content) & 0xFFFFFFFF
-            uncompressed_size = len(content)
-            compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
-            compressed_data = compressor.compress(content) + compressor.flush()
-            compressed_size = len(compressed_data)
-
-            # --- Local File Header (30 bytes + name) ---
-            local_header = struct.pack(
-                "<4sHHHHHIIIHH",
-                b"PK\x03\x04",
-                20,                # version needed
-                0x08,              # flags: data descriptor
-                8,                 # compression: deflate
-                0, 0,              # mod time/date
-                0,                 # crc (unused with data descriptor)
-                0,                 # compressed size (unused with data descriptor)
-                0,                 # uncompressed size (unused with data descriptor)
-                len(arc_name_bytes),
-                0,                 # extra field length
-            ) + arc_name_bytes
-
-            # --- Compressed data ---
-            yield local_header
-            yield compressed_data
-
-            # --- Data Descriptor (12 bytes, no signature) ---
-            descriptor = struct.pack(
-                "<III",
-                crc,
-                compressed_size,
-                uncompressed_size,
-            )
-            yield descriptor
-
-            header_data_len = len(local_header) + compressed_size
-            central_entries.append((arc_name_bytes, crc, compressed_size, uncompressed_size, offset))
-            offset += header_data_len + 12
-
-        if skipped_files:
-            lines = "\n".join(f"- {name}" for name in skipped_files)
-            content = f"以下文件下载失败，未包含在此ZIP包中：\n\n{lines}\n".encode("utf-8")
-            crc = zlib.crc32(content) & 0xFFFFFFFF
-            uncompressed_size = len(content)
-            compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
-            compressed_data = compressor.compress(content) + compressor.flush()
-            compressed_size = len(compressed_data)
-            name_bytes = "_skipped_files.txt".encode("utf-8")
-
-            local_header = struct.pack(
-                "<4sHHHHHIIIHH",
-                b"PK\x03\x04", 20, 0x08, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
-            ) + name_bytes
-            descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
-
-            yield local_header
-            yield compressed_data
-            yield descriptor
-
-            header_data_len = len(local_header) + compressed_size
-            central_entries.append((name_bytes, crc, compressed_size, uncompressed_size, offset))
-            offset += header_data_len + 12
-
-        # --- Central Directory ---
-        central_offset = offset
-        for arc_name_bytes, crc, compressed_size, uncompressed_size, local_offset in central_entries:
-            entry = struct.pack(
-                "<4sHHHHHHIIIHHHHHII",
-                b"PK\x01\x02",
-                20,                # version made by
-                20,                # version needed
-                0x08,              # flags
-                8,                 # compression
-                0, 0,              # mod time/date
-                crc,
-                compressed_size,
-                uncompressed_size,
-                len(arc_name_bytes),
-                0, 0,              # extra/comment length
-                0,                 # disk start
-                0,                 # internal attrs
-                0,                 # external attrs
-                local_offset,
-            ) + arc_name_bytes
-            yield entry
-            offset += len(entry)
-
-        central_size = offset - central_offset
-
-        # --- End of Central Directory (22 bytes) ---
-        eocd = struct.pack(
-            "<4sHHHHIIH",
-            b"PK\x05\x06",
-            0, 0,
-            len(central_entries),
-            len(central_entries),
-            central_size,
-            central_offset,
-            0,
-        )
-        yield eocd
-
-    if request_body.zip_filename:
-        zip_name = request_body.zip_filename
-    else:
-        first_name = valid_files[0].file_name
-        stem = first_name.rsplit(".", 1)[0] if "." in first_name else first_name
-        count = len(valid_files)
-        zip_name = f"{stem}.zip" if count == 1 else f"{stem}_等{count}个文件.zip"
-    if not zip_name.endswith(".zip"):
-        zip_name += ".zip"
+    entries = file_service.build_zip_arcnames(valid_files)
+    zip_name = file_service.make_zip_filename(valid_files, request_body.zip_filename)
 
     from urllib.parse import quote
     return StreamingResponse(
-        stream_zip(),
+        file_service.stream_zip_files(entries, storage_service, api_logger),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",
-            "X-Total-Files": str(expected_count),
+            "X-Total-Files": str(len(valid_files)),
         },
     )
 

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -290,7 +290,7 @@ async def kb_batch_download(
         )
 
     entries = file_service.build_zip_arcnames(files)
-    zip_name = file_service.make_zip_filename(files, request_body.zip_filename)
+    zip_name = file_service.make_zip_filename(files, request_body.zip_filename, base_name=db_knowledge.name)
 
     from urllib.parse import quote
     return StreamingResponse(

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -5,6 +5,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.encoders import jsonable_encoder
+from fastapi.responses import StreamingResponse
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
@@ -22,10 +23,14 @@ from app.core.response_utils import success, fail
 from app.db import get_db
 from app.dependencies import get_current_user
 from app.models import knowledge_model
+from app.models import file_model
 from app.models.user_model import User
 from app.schemas import knowledge_schema
+from app.schemas import file_schema
 from app.schemas.response_schema import ApiResponse
 from app.services import knowledge_service, document_service
+from app.services import file_service
+from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.model_service import ModelConfigService
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -250,6 +255,52 @@ async def update_knowledge(
     api_logger.info(f"Update knowledge base request: knowledge_id={knowledge_id}, username: {current_user.username}")
     db_knowledge = await _update_knowledge(knowledge_id=knowledge_id, update_data=update_data, db=db, current_user=current_user)
     return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="The knowledge base information has been successfully updated")
+
+
+@router.post("/{kb_id}/batch-download")
+async def kb_batch_download(
+        kb_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user),
+        storage_service: FileStorageService = Depends(get_file_storage_service),
+        request_body: file_schema.KBBatchDownloadRequest = file_schema.KBBatchDownloadRequest(),
+):
+    """知识库文件一键下载 — 将该知识库下所有文件打包为 ZIP 流式下载"""
+    api_logger.info(f"KB batch download: kb_id={kb_id}, username={current_user.username}")
+
+    db_knowledge = knowledge_service.get_knowledge_by_id(
+        db, knowledge_id=kb_id, current_user=current_user
+    )
+    if not db_knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="知识库不存在或无权访问",
+        )
+
+    files = db.query(file_model.File).filter(
+        file_model.File.kb_id == kb_id,
+        file_model.File.file_key.isnot(None),
+        file_model.File.file_key != "",
+    ).all()
+
+    if not files:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="该知识库下没有可下载的文件",
+        )
+
+    entries = file_service.build_zip_arcnames(files)
+    zip_name = file_service.make_zip_filename(files, request_body.zip_filename)
+
+    from urllib.parse import quote
+    return StreamingResponse(
+        file_service.stream_zip_files(entries, storage_service, api_logger),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",
+            "X-Total-Files": str(len(files)),
+        },
+    )
 
 
 async def _update_knowledge(

--- a/api/app/schemas/file_schema.py
+++ b/api/app/schemas/file_schema.py
@@ -18,6 +18,13 @@ class BatchDownloadRequest(BaseModel):
     )
 
 
+class KBBatchDownloadRequest(BaseModel):
+    zip_filename: Optional[str] = Field(
+        None,
+        description="ZIP文件名，不传则自动生成",
+    )
+
+
 class FileBase(BaseModel):
     kb_id: uuid.UUID
     created_by: uuid.UUID | None = None

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -112,13 +112,13 @@ def build_zip_arcnames(files: list[Any]) -> list[tuple[str, str, str]]:
     return result
 
 
-def make_zip_filename(files: list[Any], custom_name: str | None = None) -> str:
-    """生成 ZIP 文件名：自定义 / 基于首个文件名自动生成"""
+def make_zip_filename(files: list[Any], custom_name: str | None = None, base_name: str | None = None) -> str:
+    """生成 ZIP 文件名：自定义 / base_name / 基于首个文件名自动生成"""
     if custom_name:
         zip_name = custom_name
     else:
-        first_name = files[0].file_name
-        stem = first_name.rsplit(".", 1)[0] if "." in first_name else first_name
+        stem = base_name or files[0].file_name
+        stem = stem.rsplit(".", 1)[0] if "." in stem else stem
         count = len(files)
         zip_name = f"{stem}.zip" if count == 1 else f"{stem}_等{count}个文件.zip"
     if not zip_name.endswith(".zip"):

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -1,4 +1,10 @@
+import asyncio
+import struct
 import uuid
+import zlib
+from typing import Any, AsyncGenerator
+from logging import Logger
+
 from sqlalchemy.orm import Session
 from app.models.user_model import User
 from app.models.file_model import File
@@ -85,3 +91,127 @@ def delete_file_by_id(db: Session, file_id: uuid.UUID, current_user: User) -> No
     except Exception as e:
         business_logger.error(f"Failed to delete file: file_id={file_id} - {str(e)}")
         raise
+
+
+def build_zip_arcnames(files: list[Any]) -> list[tuple[str, str, str]]:
+    """同名文件自动去重，返回 [(file_name, file_key, arc_name), ...]"""
+    name_counter: dict[str, int] = {}
+    result: list[tuple[str, str, str]] = []
+
+    def unique_name(original: str) -> str:
+        if original not in name_counter:
+            name_counter[original] = 0
+            return original
+        name_counter[original] += 1
+        stem, *ext_parts = original.rsplit(".", 1)
+        ext = f".{ext_parts[0]}" if ext_parts else ""
+        return f"{stem}_{name_counter[original]}{ext}"
+
+    for f in files:
+        result.append((f.file_name, f.file_key, unique_name(f.file_name)))
+    return result
+
+
+def make_zip_filename(files: list[Any], custom_name: str | None = None) -> str:
+    """生成 ZIP 文件名：自定义 / 基于首个文件名自动生成"""
+    if custom_name:
+        zip_name = custom_name
+    else:
+        first_name = files[0].file_name
+        stem = first_name.rsplit(".", 1)[0] if "." in first_name else first_name
+        count = len(files)
+        zip_name = f"{stem}.zip" if count == 1 else f"{stem}_等{count}个文件.zip"
+    if not zip_name.endswith(".zip"):
+        zip_name += ".zip"
+    return zip_name
+
+
+async def stream_zip_files(
+    entries: list[tuple[str, str, str]],  # [(file_name, file_key, arc_name), ...]
+    storage_service: Any,
+    logger: Logger,
+) -> AsyncGenerator[bytes, None]:
+    """逐文件下载 → 实时 deflate 压缩 → yield ZIP 数据块，全程不落盘。
+    单个文件下载失败时跳过并记录，最终 ZIP 内含 _skipped_files.txt 清单。"""
+
+    central_entries: list[tuple[bytes, int, int, int, int]] = []
+    skipped_files: list[str] = []
+    offset = 0
+
+    for file_name, file_key, arc_name in entries:
+        try:
+            async with asyncio.timeout(120):
+                content = await storage_service.download_file(file_key)
+        except Exception as e:
+            logger.warning(f"跳过文件 {file_name}: {e}")
+            skipped_files.append(file_name)
+            continue
+
+        arc_name_bytes = arc_name.encode("utf-8")
+        crc = zlib.crc32(content) & 0xFFFFFFFF
+        uncompressed_size = len(content)
+        compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+        compressed_data = compressor.compress(content) + compressor.flush()
+        compressed_size = len(compressed_data)
+
+        local_header = struct.pack(
+            "<4sHHHHHIIIHH",
+            b"PK\x03\x04", 20, 0x08, 8, 0, 0, 0, 0, 0, len(arc_name_bytes), 0,
+        ) + arc_name_bytes
+
+        yield local_header
+        yield compressed_data
+
+        descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
+        yield descriptor
+
+        header_data_len = len(local_header) + compressed_size
+        central_entries.append((arc_name_bytes, crc, compressed_size, uncompressed_size, offset))
+        offset += header_data_len + 12
+
+    # --- skipped_files manifest ---
+    if skipped_files:
+        lines = "\n".join(f"- {name}" for name in skipped_files)
+        content = f"以下文件下载失败，未包含在此ZIP包中：\n\n{lines}\n".encode("utf-8")
+        crc = zlib.crc32(content) & 0xFFFFFFFF
+        uncompressed_size = len(content)
+        compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+        compressed_data = compressor.compress(content) + compressor.flush()
+        compressed_size = len(compressed_data)
+        name_bytes = "_skipped_files.txt".encode("utf-8")
+
+        local_header = struct.pack(
+            "<4sHHHHHIIIHH",
+            b"PK\x03\x04", 20, 0x08, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
+        ) + name_bytes
+        descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
+
+        yield local_header
+        yield compressed_data
+        yield descriptor
+
+        header_data_len = len(local_header) + compressed_size
+        central_entries.append((name_bytes, crc, compressed_size, uncompressed_size, offset))
+        offset += header_data_len + 12
+
+    # --- Central Directory ---
+    central_offset = offset
+    for arc_name_bytes, crc, compressed_size, uncompressed_size, local_offset in central_entries:
+        entry = struct.pack(
+            "<4sHHHHHHIIIHHHHHII",
+            b"PK\x01\x02", 20, 20, 0x08, 8, 0, 0,
+            crc, compressed_size, uncompressed_size,
+            len(arc_name_bytes), 0, 0, 0, 0, 0, local_offset,
+        ) + arc_name_bytes
+        yield entry
+        offset += len(entry)
+
+    central_size = offset - central_offset
+
+    eocd = struct.pack(
+        "<4sHHHHIIH",
+        b"PK\x05\x06", 0, 0,
+        len(central_entries), len(central_entries),
+        central_size, central_offset, 0,
+    )
+    yield eocd


### PR DESCRIPTION
Title: feat: 知识库文件全量下载接口

  Body:

  Summary

  新增 POST /api/knowledges/{kb_id}/batch-download 接口，给定知识库
  ID，将该知识库下所有文件打包为 ZIP 流式下载。

  主要改动

  - 提取共享 helper 到 file_service.py：build_zip_arcnames（同名去重）、make_zip_filename（ZIP
   命名）、stream_zip_files（流式 deflate 压缩）
  - 重构 POST /files/batch-download 调用共享 helper，删减 ~120 行内联逻辑
  - 新增 POST /knowledges/{kb_id}/batch-download，验证知识库权限后查询 File.kb_id 全量打包
  - 默认 ZIP 命名使用知识库名称（如 产品文档_等50个文件.zip），支持 zip_filename 自定义

  接口

  POST /api/knowledges/{kb_id}/batch-download
  Content-Type: application/json
  Authorization: Bearer <JWT>

  {}  或  {"zip_filename": "自定义名称.zip"}

  响应：200 application/zip，响应头 X-Total-Files。单个文件下载失败自动跳过，ZIP 内含
  _skipped_files.txt 清单。

  测试

  8 个新增测试覆盖：参数校验、正常下载、多文件、自定义文件名、空知识库
  404、下载失败跳过、同名去重、X-Total-Files 响应头。

## Summary by Sourcery

为知识库中的所有文件新增流式 ZIP 批量下载能力，并重构现有的批量下载逻辑以复用共享的辅助方法。

新功能：
- 暴露 POST /api/knowledges/{kb_id}/batch-download 接口，用于将某个知识库中的所有文件作为流式 ZIP 压缩包下载，并支持自定义文件名（可选）。

增强与改进：
- 在 file_service 中提取可复用的辅助方法，用于构建唯一的 ZIP 条目名称、生成 ZIP 文件名以及流式创建 ZIP，并将现有的文件批量下载端点迁移为使用这些辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a streamed ZIP batch-download capability for all files in a knowledge base and refactor existing batch download logic to reuse shared helpers.

New Features:
- Expose POST /api/knowledges/{kb_id}/batch-download to download all files in a knowledge base as a streamed ZIP archive with optional custom filename.

Enhancements:
- Extract reusable helpers in file_service for building unique ZIP entry names, generating ZIP filenames, and streaming ZIP creation, and migrate the existing file batch-download endpoint to use them.

</details>