### PR TITLE
fix(dashboard): dashboard-celery-perf

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -173,8 +173,11 @@ def get_workspace_end_users(
 
     # 触发社区聚类补全任务（异步，不阻塞接口响应）
     try:
-        from app.tasks import init_community_clustering_for_users
-        init_community_clustering_for_users.delay(end_user_ids=end_user_ids, workspace_id=str(workspace_id))
+        from app.celery_app import celery_app as _celery_app
+        _celery_app.send_task(
+            "app.tasks.init_community_clustering_for_users",
+            kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
+        )
         api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
     except Exception as e:
         api_logger.warning(f"触发社区聚类补全任务失败（不影响主流程）: {str(e)}")


### PR DESCRIPTION
…latency

Replace 'from app.tasks import ...' + .delay() with celery send_task() string-based invocation to avoid importing the heavy app.tasks module (~12s cold-start due to GraphRAG/ES/LLM initialization) on first request.

Reduces /dashboard/end_users response time from ~13s to ~250ms on first call.

## 由 Sourcery 提供的摘要

增强功能：
- 通过 Celery 的基于字符串的 `send_task` API 调用社区聚类初始化任务，以避免在每个请求中导入体量较大的任务模块，从而降低冷启动延迟。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Invoke the community clustering initialization task via Celery's string-based send_task API to avoid importing the heavy task module on each request and reduce cold-start latency.

</details>