### PR TITLE
Feature/memory relation search

### DIFF
--- a/api/app/core/memory/enums.py
+++ b/api/app/core/memory/enums.py
@@ -1,4 +1,4 @@
-from enum import StrEnum
+from enum import Enum, StrEnum
 
 
 class StorageType(StrEnum):
@@ -29,3 +29,119 @@ class Neo4jNodeType(StrEnum):
 
     RAG = "Rag"
 
+
+class TripletPredicate(Enum):
+    """
+    当前 extract_triplet 使用的一层谓词本体（Predicate Ontology）
+
+    value:
+        给 LLM 输出使用的标准 predicate 名称
+
+    description:
+        当前 predicate 的语义定义与使用约束
+    """
+
+    ALIAS_OF = (
+        "别名属于",
+        "表达实体名称、别名、称呼之间的对应关系；"
+        "仅用于名字性表达，不用于职业、角色、评价词。"
+    )
+
+    IS_A = (
+        "属于类型",
+        "表达主体所属的身份、职业、角色、组织或群体；"
+        "用于稳定归属关系。"
+    )
+
+    LOCATED_IN = (
+        "位于",
+        "表达实体与地点、场所之间的稳定空间位置关系；"
+        "不用于时间表达或未解析位置指代。"
+    )
+
+    VISITS = (
+        "前往",
+        "表达主体前往、到访某地点、组织或场所；"
+        "优先保留具有长期记忆价值的到访关系。"
+    )
+
+    PART_OF = (
+        "组成部分",
+        "表达部分与整体之间的结构包含关系；"
+        "采用 part-to-whole 方向。"
+    )
+
+    OWNS = (
+        "拥有",
+        "表达主体拥有、持有、配有某对象、账号、联系方式或生命体；"
+        "不用于抽象概念或情绪状态。"
+    )
+
+    USES = (
+        "使用",
+        "表达主体使用某工具、平台、语言、资源或设备；"
+        "不用于抽象结果。"
+    )
+
+    CREATED = (
+        "创建了",
+        "表达主体创建、生产、撰写某对象；"
+        "方向为 创建者 -> 创建了 -> 被创建对象。"
+    )
+
+    KNOWS = (
+        "了解",
+        "表达主体对知识、技能、语言或学科具有学习、了解或认知关系；"
+        "关系对象必须属于知识能力类。"
+    )
+
+    PREFERS = (
+        "偏好",
+        "表达主体的稳定偏好、习惯或明确目标倾向；"
+        "不用于抽象愿望或情绪状态。"
+    )
+
+    RESPONSIBLE_FOR = (
+        "负责",
+        "表达主体负责某项事务、工作、项目或职责；"
+        "对象应为具体事务。"
+    )
+
+    COMMUNICATES_WITH = (
+        "沟通于",
+        "表达两个主体之间存在沟通、交流或交互关系；"
+        "两端通常应为可交互主体。"
+    )
+
+    RELATED_TO = (
+        "关联于",
+        "受限弱关联关系；"
+        "仅用于明确稳定但缺少更精确谓词的关系；"
+        "不能作为兜底关系。"
+    )
+
+    def __new__(cls, value: str, description: str):
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.description = description
+        return obj
+
+    @property
+    def predicate(self) -> str:
+        return self._value_
+
+    def to_dict(self) -> dict:
+        return {
+            "predicate": self.value,
+            "description": self.description,
+        }
+
+    @classmethod
+    def prompt_definitions(cls) -> str:
+        """
+        提供给 LLM 的 ontology prompt 文本
+        """
+        return "\n".join(
+            f"- {item.value}: {item.description}"
+            for item in cls
+        )

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -12,19 +12,18 @@ MemoryService — 记忆模块统一入口（Facade）
 """
 
 import logging
-from typing import  Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
 from app.core.memory.enums import SearchStrategy, StorageType
+from app.core.memory.models.message_models import DialogData
 from app.core.memory.models.service_models import MemoryContext, MemorySearchResult
 from app.core.memory.pipelines.memory_read import ReadPipeLine
-from app.db import get_db_context
-from app.services.memory_config_service import MemoryConfigService
-
 from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
 from app.core.memory.pipelines.write_pipeline import WriteResult
-from app.core.memory.models.message_models import DialogData
+from app.db import get_db_context
+from app.services.memory_config_service import MemoryConfigService
 
 logger = logging.getLogger(__name__)
 

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -29,15 +29,43 @@ class Memory(BaseModel):
         return v.value
 
 
+class RelationMemory(BaseModel):
+    source: str = ""
+    relation: str = ""
+    target: str = ""
+    target_desc: str = ""
+    target_id: str = ""
+
+    @property
+    def dedup_key(self) -> tuple:
+        return self.source, self.relation, self.target
+
+
+class EntityPair(BaseModel):
+    source_id: str = ""
+    target_id: str = ""
+
+
+class RelationSearchResult(BaseModel):
+    pairs: list[EntityPair] = Field(default_factory=list)
+
+
 class MemorySearchResult(BaseModel):
     memories: list[Memory]
+    relations: list[RelationMemory] = Field(default_factory=list)
     content_str: str = Field(default="")
 
     @property
     def content(self) -> str:
+        parts = []
         if self.content_str:
-            return self.content_str
-        return "\n".join([memory.content for memory in self.memories])
+            parts.append(self.content_str)
+        else:
+            parts.append("\n".join([memory.content for memory in self.memories]))
+        if self.relations:
+            from app.core.memory.read_services.search_engine.result_builder import build_relation_content
+            parts.append("\n".join([build_relation_content(rel) for rel in self.relations]))
+        return "\n".join(parts)
 
     @computed_field
     @property
@@ -47,6 +75,16 @@ class MemorySearchResult(BaseModel):
     def filter(self, score_threshold: float) -> Self:
         self.memories = [memory for memory in self.memories if memory.score >= score_threshold]
         return self
+
+    def _dedup_relations(self) -> None:
+        seen = set()
+        unique = []
+        for rel in self.relations:
+            key = rel.dedup_key
+            if key not in seen:
+                seen.add(key)
+                unique.append(rel)
+        self.relations = unique
 
     def __add__(self, other: "MemorySearchResult") -> "MemorySearchResult":
         if not isinstance(other, MemorySearchResult):
@@ -61,6 +99,12 @@ class MemorySearchResult(BaseModel):
                 merged.memories.append(memory)
                 ids.add(memory.id)
 
+        merged.relations = list(self.relations)
+        seen_rel_keys = {r.dedup_key for r in merged.relations}
+        for rel in other.relations:
+            key = rel.dedup_key
+            if key not in seen_rel_keys:
+                merged.relations.append(rel)
+                seen_rel_keys.add(key)
+
         return merged
-
-

--- a/api/app/core/memory/pipelines/base_pipeline.py
+++ b/api/app/core/memory/pipelines/base_pipeline.py
@@ -20,8 +20,7 @@ class ModelClientMixin(ABC):
                 provider=api_config.provider,
                 api_key=api_config.api_key,
                 base_url=api_config.api_base,
-                is_omni=api_config.is_omni,
-                support_thinking="thinking" in (api_config.capability or []),
+                is_omni=api_config.is_omni
             )
         )
 

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,9 +1,14 @@
+import asyncio
+import logging
+
 from app.core.memory.enums import SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
 from app.core.memory.pipelines.base_pipeline import ModelClientMixin, DBRequiredPipeline
 from app.core.memory.read_services.generate_engine.query_preprocessor import QueryPreprocessor
 from app.core.memory.read_services.generate_engine.retrieval_summary import RetrievalSummaryProcessor
 from app.core.memory.read_services.search_engine.content_search import Neo4jSearchService, RAGSearchService
+
+logger = logging.getLogger(__name__)
 
 
 class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
@@ -40,6 +45,7 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
             return Neo4jSearchService(
                 self.ctx,
                 self.get_embedding_client(self.db, self.ctx.memory_config.embedding_model_id),
+                self.get_llm_client(self.db, self.ctx.memory_config.llm_model_id),
                 includes=includes,
             )
         else:
@@ -57,8 +63,22 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
         )
         query_results = []
         for question in questions:
-            search_results = await search_service.search(question, limit)
-            query_results.append(search_results)
+            hybrid_task = search_service.hybrid_search(question, limit)
+            relation_task = search_service.relation_search(question)
+            hybrid_search_results, relation_results = await asyncio.gather(
+                hybrid_task, relation_task, return_exceptions=True
+            )
+
+            if isinstance(hybrid_search_results, Exception):
+                logger.warning(f"[DeepRead] hybrid search error: {hybrid_search_results}")
+                hybrid_search_results = MemorySearchResult(memories=[])
+
+            if isinstance(relation_results, Exception):
+                logger.warning(f"[DeepRead] relation search error: {relation_results}")
+                relation_results = MemorySearchResult(memories=[])
+
+            merged = hybrid_search_results + relation_results
+            query_results.append(merged)
         results = sum(query_results, start=MemorySearchResult(memories=[]))
         results.memories.sort(key=lambda x: x.score, reverse=True)
         results.content_str = await RetrievalSummaryProcessor.summary(
@@ -77,7 +97,7 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
         )
         query_results = []
         for question in questions:
-            search_results = await search_service.search(question, limit)
+            search_results = await search_service.hybrid_search(question, limit)
             query_results.append(search_results)
         results = sum(query_results, start=MemorySearchResult(memories=[]))
         results.memories.sort(key=lambda x: x.score, reverse=True)
@@ -90,4 +110,4 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
 
     async def _quick_read(self, query: str, limit: int, includes=None) -> MemorySearchResult:
         search_service = self._get_search_service(includes)
-        return await search_service.search(query, limit)
+        return await search_service.hybrid_search(query, limit)

--- a/api/app/core/memory/prompt/relation_search.jinja2
+++ b/api/app/core/memory/prompt/relation_search.jinja2
@@ -1,0 +1,86 @@
+You are a Relation Search Agent for a knowledge graph memory system. Your task is to explore the user's knowledge graph by traversing entity relationships to find all relevant entities related to the user's query.
+
+## Available Tools
+
+### relation_search_tool
+
+`relation_search_tool(relation_predicates: list[str], source_id: str | None = None)`
+
+Queries Neo4j for entities connected to a source node by one or more relation predicates. Pass multiple predicates to search several relationships in a single call. Omit `source_id` to start from the user's own entity node.
+
+Returns:
+```json
+[{"id": "target entity id", "source_name": "source entity name", "relation_predicate": "predicate used", "target_name": "target entity name"}, ...]
+```
+
+### entity_search_tool
+
+`entity_search_tool(name: str)`
+
+Searches for entities by name (supports partial matching). Use this to look up entity IDs when you need to start a relationship search from a specific entity rather than the user node.
+
+Returns:
+```json
+[{"id": "entity id", "name": "entity name", "entity_type": "entity type"}, ...]
+```
+
+## Predefined Relation Predicates
+
+You MUST use only the following predicate values **exactly as written**. Do not translate, modify, or invent predicates.
+
+{% for pred in predicates %}
+- **{{ pred.value }}**: {{ pred.description }}
+{% endfor %}
+
+## Search Strategy
+
+### Step 1 — Analyze the user query
+Determine which relation predicates are semantically relevant to what the user is asking about.
+
+Common query-to-predicate mappings:
+- Names, aliases, how someone is called → **别名属于**
+- Profession, role, identity, organization → **属于类型**
+- Location, where someone lives → **位于**
+- Places visited, trips, destinations → **前往**
+- Membership, team structure, hierarchy → **组成部分**
+- Possessions, accounts, contacts, pets → **拥有**
+- Tools, platforms, languages, devices → **使用**
+- Things created, projects, authored content → **创建了**
+- Knowledge, skills, expertise → **了解**
+- Preferences, habits, goals, interests → **偏好**
+- Responsibilities, duties, job scope → **负责**
+- Communication, interactions with others → **沟通于**
+- General stable associations → **关联于**
+
+### Step 2 — Look up entities by name if needed
+If the user mentions a specific entity by name (e.g., a person, project, company), call `entity_search_tool` first to find its ID, then use that ID as `source_id` in `relation_search_tool`. Otherwise, start from the user node by omitting `source_id`.
+
+### Step 3 — Start from the user node or specific entity
+Call `relation_search_tool` with the appropriate `source_id` to discover connected entities. To efficiently cover multiple relevant predicates, pass them as a list to a single call rather than making separate calls per predicate.
+
+### Step 4 — Multi-hop exploration
+Use entity IDs returned from previous searches as `source_id` for subsequent calls to traverse deeper relationships. You may call both tools **multiple times** to thoroughly explore the graph. Continue as long as newly discovered entities provide meaningful context.
+
+### Step 5 — Collect relevant entity pairs
+From all the searches performed, identify the source entity and target entity for each relevant relationship discovered. Capture the pair of entity IDs.
+
+## Output Format
+
+After completing your searches, return a JSON object containing all discovered entity ID pairs:
+
+```json
+{"pairs": [{"source_id": "id_of_source_entity", "target_id": "id_of_target_entity"}, ...]}
+```
+
+- `source_id`: The ID of the source entity in the relationship.
+- `target_id`: The ID of the target entity in the relationship.
+- If the source is the user entity, you can use a special marker like `"__user__"` to indicate the user entity, or use the entity ID from the first tool call where `source_id` was omitted.
+
+## Critical Rules
+
+1. **Predicate fidelity**: Use ONLY the exact Chinese predicate values from the predefined list above. Never translate or paraphrase them.
+2. **No fabrication**: Do not invent entity IDs, names, or relationship data. Only report IDs returned by the tool.
+3. **Multi-hop**: Always consider whether additional searches with discovered entity IDs could reveal more relevant information.
+4. **Empty results**: If no relevant entities are found after thorough searching, return `{"pairs": []}`.
+5. **Focus on relevance**: Only include entity ID pairs genuinely relevant to the user's query, not all entities encountered during traversal.
+6. **Pair completeness**: For each discovered relationship, make sure to include both the source and target entity IDs in the output pairs.

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -3,19 +3,25 @@ import logging
 import math
 import uuid
 
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from neo4j import Session
 
-from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.enums import Neo4jNodeType, TripletPredicate
+from app.core.memory.models.service_models import Memory, MemorySearchResult, RelationMemory, RelationSearchResult, \
+    EntityPair
 from app.core.memory.models.service_models import MemoryContext
-from app.core.memory.models.service_models import Memory, MemorySearchResult
+from app.core.memory.prompt import prompt_manager
+from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
-from app.core.models import RedBearEmbeddings
+from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool
+from app.core.memory.utils.llm.llm_utils import StructResponse
+from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.repositories import knowledge_repository
-from app.repositories.neo4j.graph_search import search_graph, search_graph_by_embedding
-from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
+from app.repositories.neo4j.graph_search import get_nodes_by_ids, get_relation_between_entities, search_graph, \
+    search_graph_by_embedding
 from app.repositories.neo4j.graph_search import search_user_metadata
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +30,15 @@ DEFAULT_FULLTEXT_SCORE_THRESHOLD = 1.5
 DEFAULT_COSINE_SCORE_THRESHOLD = 0.5
 DEFAULT_CONTENT_SCORE_THRESHOLD = 0.5
 
+RELATIONSHIP_LOOP_LIMIT = 5
+
 
 class Neo4jSearchService:
     def __init__(
             self,
             ctx: MemoryContext,
             embedder: RedBearEmbeddings,
+            llm: RedBearLLM,
             includes: list[Neo4jNodeType] | None = None,
             alpha: float = DEFAULT_ALPHA,
             fulltext_score_threshold: float = DEFAULT_FULLTEXT_SCORE_THRESHOLD,
@@ -43,18 +52,22 @@ class Neo4jSearchService:
         self.content_score_threshold = content_score_threshold
 
         self.embedder: RedBearEmbeddings = embedder
+        self.llm: RedBearLLM = llm
         self.connector: Neo4jConnector | None = None
 
         self.includes = includes
         if includes is None:
             self.includes = [
                 Neo4jNodeType.STATEMENT,
-                Neo4jNodeType.CHUNK,
+                # Neo4jNodeType.CHUNK,
                 Neo4jNodeType.EXTRACTEDENTITY,
                 Neo4jNodeType.MEMORYSUMMARY,
                 Neo4jNodeType.PERCEPTUAL,
                 Neo4jNodeType.COMMUNITY
             ]
+
+        self.relation_search_tool = make_relation_search_tool(self.ctx)
+        self.entity_search_tool = make_entity_search_tool(self.ctx)
 
     async def _keyword_search(
             self,
@@ -86,7 +99,6 @@ class Neo4jSearchService:
             limit: int,
     ) -> list[dict]:
         keyword_results = self._normalize_kw_scores(keyword_results)
-        embedding_results = embedding_results
 
         kw_norm_map = {}
         for item in keyword_results:
@@ -127,7 +139,7 @@ class Neo4jSearchService:
         # ]
         results = results[:limit]
 
-        logger.info(
+        logger.debug(
             f"[MemorySearch] rerank: merged={len(combined)}, after_threshold={len(results)} "
             f"(alpha={self.alpha})"
         )
@@ -141,7 +153,7 @@ class Neo4jSearchService:
             it[f"normalized_kw_score"] = 1 / (1 + math.exp(-(s - self.fulltext_score_threshold) / 2)) if s else 0
         return items
 
-    async def search(
+    async def hybrid_search(
             self,
             query: str,
             limit: int = 10,
@@ -178,6 +190,169 @@ class Neo4jSearchService:
                 ))
         memories.sort(key=lambda x: x.score, reverse=True)
         return MemorySearchResult(memories=memories[:limit])
+
+    async def _run_relation_agent(self, query: str) -> RelationSearchResult:
+        system_prompt = prompt_manager.render(
+            name="relation_search",
+            predicates=[p.to_dict() for p in TripletPredicate],
+        )
+
+        tools = [self.relation_search_tool, self.entity_search_tool]
+        tool_map = {t.name: t for t in tools}
+        llm_with_tools = self.llm.bind_tools(tools)
+
+        messages: list[SystemMessage | HumanMessage | AIMessage | ToolMessage] = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=(
+                f"<current-entity></current-entity>"
+                f"<user-query>{query}</user-query>"
+            ))
+        ]
+
+        for _ in range(RELATIONSHIP_LOOP_LIMIT):
+            response: AIMessage = await llm_with_tools.ainvoke(messages)
+            messages.append(response)
+
+            if not response.tool_calls:
+                break
+
+            for tc in response.tool_calls:
+                tool = tool_map[tc["name"]]
+                tool_result = await tool.ainvoke(tc["args"])
+                messages.append(ToolMessage(
+                    content=str(tool_result),
+                    tool_call_id=tc["id"],
+                ))
+
+        final_message = next(
+            (m for m in reversed(messages) if isinstance(m, AIMessage)),
+            messages[-1],
+        )
+        try:
+            return final_message | StructResponse(mode="pydantic", model=RelationSearchResult)
+        except Exception:
+            logger.debug(
+                "[RelationSearch] LLM final message parsing failed, "
+                "falling back to tool-call extraction"
+            )
+            return self._extract_pairs_from_messages(messages)
+
+    @staticmethod
+    def _extract_pairs_from_messages(
+        messages: list[SystemMessage | HumanMessage | AIMessage | ToolMessage],
+    ) -> RelationSearchResult:
+        """Extract EntityPairs from relation_search_tool results when LLM output is unusable."""
+        import ast
+
+        tool_results: dict[str, list[dict]] = {}
+        for msg in messages:
+            if isinstance(msg, ToolMessage) and msg.tool_call_id:
+                try:
+                    tool_results[msg.tool_call_id] = ast.literal_eval(msg.content)
+                except (ValueError, SyntaxError):
+                    tool_results[msg.tool_call_id] = []
+
+        pairs: list[EntityPair] = []
+        seen = set()
+        for msg in messages:
+            if not isinstance(msg, AIMessage) or not msg.tool_calls:
+                continue
+            for tc in msg.tool_calls:
+                if tc["name"] != "relation_search_tool":
+                    continue
+                source_id = str(tc.get("args", {}).get("source_id") or "__user__")
+                results = tool_results.get(tc["id"], [])
+                for item in results:
+                    target_id = str(item.get("id", ""))
+                    if not target_id:
+                        continue
+                    key = (source_id, target_id)
+                    if key not in seen:
+                        seen.add(key)
+                        pairs.append(EntityPair(source_id=source_id, target_id=target_id))
+
+        return RelationSearchResult(pairs=pairs)
+
+    async def _fetch_relation_data(
+            self,
+            pairs: list[EntityPair]
+    ) -> tuple[list[dict], list[dict]]:
+        async with Neo4jConnector() as connector:
+            user_meta = await search_user_metadata(connector, self.ctx.end_user_id)
+            user_entity_id = user_meta.get("id", "")
+
+            relation_records = []
+            for pair in pairs:
+                src_id = user_entity_id if pair.source_id == "__user__" else pair.source_id
+                records = await get_relation_between_entities(
+                    connector,
+                    self.ctx.end_user_id,
+                    src_id,
+                    pair.target_id
+                )
+                relation_records.extend(records)
+
+            all_entity_ids = {user_entity_id}
+            for rec in relation_records:
+                all_entity_ids.add(rec.get("source_id", ""))
+                all_entity_ids.add(rec.get("target_id", ""))
+            for pair in pairs:
+                sid = user_entity_id if pair.source_id == "__user__" else pair.source_id
+                all_entity_ids.add(sid)
+                all_entity_ids.add(pair.target_id)
+            all_entity_ids.discard("")
+
+            entity_records = await get_nodes_by_ids(
+                connector,
+                Neo4jNodeType.EXTRACTEDENTITY,
+                list(all_entity_ids)
+            )
+
+        return relation_records, entity_records
+
+    @staticmethod
+    def _build_relation_memories(
+            relation_records: list[dict],
+            entity_records: list[dict]
+    ) -> list[RelationMemory]:
+        name_map = {r.get("id", ""): r.get("name", "") for r in entity_records}
+        desc_map = {r.get("id", ""): r.get("description", "") for r in entity_records}
+
+        relations = []
+        seen = set()
+        for rec in relation_records:
+            rel_key = (
+                str(rec.get("source_id", "")),
+                str(rec.get("relation_predicate", "")),
+                str(rec.get("target_id", ""))
+            )
+            if rel_key in seen:
+                continue
+            seen.add(rel_key)
+            relations.append(RelationMemory(
+                source=name_map.get(rec.get("source_id", ""), rec.get("source_name", "")),
+                relation=str(rec.get("relation_predicate", "")),
+                target=name_map.get(rec.get("target_id", ""), rec.get("target_name", "")),
+                target_desc=desc_map.get(rec.get("target_id", ""), ""),
+                target_id=str(rec.get("target_id", "")),
+            ))
+
+        return relations
+
+    async def relation_search(
+            self,
+            query: str
+    ) -> MemorySearchResult:
+        result = await self._run_relation_agent(query)
+
+        if not result.pairs:
+            return MemorySearchResult(memories=[], relations=[])
+
+        relation_records, entity_records = await self._fetch_relation_data(result.pairs)
+        relations = self._build_relation_memories(relation_records, entity_records)
+
+        logger.info(f"[RelationSearch] resolved {len(relations)} relations from {len(result.pairs)} pairs")
+        return MemorySearchResult(memories=[], relations=relations)
 
     async def memory_l0(self) -> Memory:
         async with Neo4jConnector() as connector:
@@ -227,7 +402,7 @@ class RAGSearchService:
             "reranker_top_k": limit
         }
 
-    async def search(self, query: str, limit: int) -> MemorySearchResult:
+    async def hybrid_search(self, query: str, limit: int) -> MemorySearchResult:
         try:
             kb_config = self.get_kb_config(limit)
         except RuntimeError as e:
@@ -251,3 +426,7 @@ class RAGSearchService:
         except RuntimeError as e:
             logger.error(f"[MemorySearch] rag search error: {e}")
             return MemorySearchResult(memories=[])
+
+    async def relation_search(self, query: str) -> MemorySearchResult:
+        logger.info("RAG not suport releation search")
+        return MemorySearchResult(memories=[])

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -18,7 +18,7 @@ from app.core.memory.utils.llm.llm_utils import StructResponse
 from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.repositories import knowledge_repository
-from app.repositories.neo4j.graph_search import get_nodes_by_ids, get_relation_between_entities, search_graph, \
+from app.repositories.neo4j.graph_search import get_nodes_by_ids, get_relations_between_entity_pairs, search_graph, \
     search_graph_by_embedding
 from app.repositories.neo4j.graph_search import search_user_metadata
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -281,16 +281,16 @@ class Neo4jSearchService:
             user_meta = await search_user_metadata(connector, self.ctx.end_user_id)
             user_entity_id = user_meta.get("id", "")
 
-            relation_records = []
-            for pair in pairs:
-                src_id = user_entity_id if pair.source_id == "__user__" else pair.source_id
-                records = await get_relation_between_entities(
-                    connector,
-                    self.ctx.end_user_id,
-                    src_id,
-                    pair.target_id
-                )
-                relation_records.extend(records)
+            batch_pairs = [
+                {"source_id": user_entity_id if p.source_id == "__user__" else p.source_id,
+                 "target_id": p.target_id}
+                for p in pairs
+            ]
+            relation_records = await get_relations_between_entity_pairs(
+                connector,
+                self.ctx.end_user_id,
+                batch_pairs,
+            )
 
             all_entity_ids = {user_entity_id}
             for rec in relation_records:
@@ -428,5 +428,5 @@ class RAGSearchService:
             return MemorySearchResult(memories=[])
 
     async def relation_search(self, query: str) -> MemorySearchResult:
-        logger.info("RAG not suport releation search")
+        logger.info("RAG does not support relation search")
         return MemorySearchResult(memories=[])

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import TypeVar
 
 from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.models.service_models import RelationMemory
 
 
 class BaseBuilder(ABC):
@@ -205,7 +206,7 @@ class MetadataBuilder(BaseBuilder):
     def content(self) -> str:
         parts = ["<user-info>"]
         fields = [
-            ("description", self.record.get("description", "")),
+            # ("description", self.record.get("description", "")),
             ("aliases", self.record.get("aliases", [])),
             ("anchors", self.record.get("anchors", [])),
             ("beliefs_or_stances", self.record.get("beliefs_or_stances", [])),
@@ -239,3 +240,18 @@ def data_builder_factory(node_type, data: dict) -> T:
             return CommunityBuilder(data)
         case _:
             raise KeyError(f"Unknown node_type: {node_type}")
+
+
+def build_relation_content(rel: RelationMemory) -> str:
+    parts = ["<relationship>"]
+    fields = [
+        ("source", rel.source),
+        ("relation", rel.relation),
+        ("target", rel.target),
+        ("target_desc", rel.target_desc),
+    ]
+    for tag, value in fields:
+        if value:
+            parts.append(f"<{tag}>{value}</{tag}>")
+    parts.append("</relationship>")
+    return "".join(parts)

--- a/api/app/core/memory/read_services/search_engine/tools.py
+++ b/api/app/core/memory/read_services/search_engine/tools.py
@@ -1,0 +1,73 @@
+import logging
+
+from langchain.tools import tool
+from pydantic import BaseModel, Field
+
+from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.models.service_models import MemoryContext
+from app.repositories.neo4j.graph_search import search_by_fulltext, search_graph_by_relationship, search_user_metadata
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = logging.getLogger(__name__)
+
+
+class EntitySearchInput(BaseModel):
+    name: str = Field(description="Entity name to search for, supports partial matching")
+
+
+class RelationSearchInput(BaseModel):
+    source_id: str | None = Field(default=None, description="Starting node ID for relation node query")
+    relation_predicates: list[str] = Field(description="Relational predicate types to be retrieved, supports searching multiple relations at once")
+
+
+def make_entity_search_tool(ctx: MemoryContext):
+    @tool(args_schema=EntitySearchInput)
+    async def entity_search_tool(name: str) -> list[dict]:
+        """Search for entities by name in the knowledge graph. Use this to look up entity IDs by name before using them as source_id in relation_search_tool.
+
+        Args:
+            name: Entity name or partial name to search for.
+
+        Returns:
+            [{"id": "entity id", "name": "entity name", "entity_type": "entity type"}, ...]
+        """
+        async with Neo4jConnector() as connector:
+            res = await search_by_fulltext(
+                connector=connector,
+                node_type=Neo4jNodeType.EXTRACTEDENTITY,
+                end_user_id=ctx.end_user_id,
+                query=name,
+                limit=10,
+            )
+            return [{"id": r["id"], "name": r["name"], "entity_type": r.get("entity_type")} for r in res]
+
+    return entity_search_tool
+
+
+def make_relation_search_tool(ctx: MemoryContext):
+    @tool(args_schema=RelationSearchInput)
+    async def relation_search_tool(relation_predicates: list[str], source_id: str | None = None) -> list[dict]:
+        """Query the knowledge graph for entities connected to a source node by one or more relation predicates.
+
+        Omit source_id to start from the user's own entity node. Use this to discover what the user owns, knows, prefers, uses, created, visits, or is related to.
+
+        Args:
+            source_id: Starting entity node ID, defaults to the user entity if omitted.
+            relation_predicates: Relationship types to query, must match predefined predicate values. Supports multiple predicates at once.
+
+        Returns:
+            [{"id": "target entity id", "source_name": "source entity name", "relation_predicate": "predicate used", "target_name": "target entity name"}, ...]
+        """
+        async with Neo4jConnector() as connector:
+            if not source_id:
+                source_id = (await search_user_metadata(connector, ctx.end_user_id)).get("id")
+            res = await search_graph_by_relationship(
+                connector=connector,
+                end_user_id=ctx.end_user_id,
+                source_id=source_id,
+                predicates=relation_predicates,
+            )
+            logger.info(f"[relation_search_tool] source:{source_id}, predicates:{relation_predicates}, res:{res}")
+            return res
+
+    return relation_search_tool

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1821,6 +1821,25 @@ ORDER BY score DESC
 LIMIT $limit
 """
 
+SEARCH_ENITITES_BY_RELATIONSHIP = """
+MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
+WHERE (n.end_user_id = $end_user_id AND n.id = $source_id AND r.predicate IN $predicates)
+RETURN m.id AS id,
+       n.name AS source_name,
+       r.predicate AS relation_predicate,
+       m.name AS target_name
+"""
+
+SEARCH_RELATION_BETWEEN_ENTITIES = """
+MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
+WHERE n.end_user_id = $end_user_id AND n.id = $source_id AND m.id = $target_id
+RETURN n.id AS source_id,
+       n.name AS source_name,
+       r.predicate AS relation_predicate,
+       m.id AS target_id,
+       m.name AS target_name
+"""
+
 SEARCH_USER_METADATA = """
 MATCH (n:ExtractedEntity)
 WHERE (n.end_user_id = $end_user_id AND n.entity_type ='用户')
@@ -1833,7 +1852,8 @@ RETURN n.description AS description,
        n.goals AS goals,
        n.interests AS interests,
        n.relations AS relations,
-       n.traits AS traits
+       n.traits AS traits,
+       n.id AS id
 """
 
 FULLTEXT_QUERY_CYPHER_MAPPING = {

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1840,6 +1840,17 @@ RETURN n.id AS source_id,
        m.name AS target_name
 """
 
+SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS = """
+UNWIND $pairs AS pair
+MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
+WHERE n.end_user_id = $end_user_id AND n.id = pair.source_id AND m.id = pair.target_id
+RETURN n.id AS source_id,
+       n.name AS source_name,
+       r.predicate AS relation_predicate,
+       m.id AS target_id,
+       m.name AS target_name
+"""
+
 SEARCH_USER_METADATA = """
 MATCH (n:ExtractedEntity)
 WHERE (n.end_user_id = $end_user_id AND n.entity_type ='用户')

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -28,7 +28,9 @@ from app.repositories.neo4j.cypher_queries import (
     FULLTEXT_QUERY_CYPHER_MAPPING,
     USER_ID_QUERY_CYPHER_MAPPING,
     NODE_ID_QUERY_CYPHER_MAPPING,
-    SEARCH_USER_METADATA
+    SEARCH_USER_METADATA,
+    SEARCH_ENITITES_BY_RELATIONSHIP,
+    SEARCH_RELATION_BETWEEN_ENTITIES
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -64,7 +66,6 @@ def cosine_similarity_search(
 
 
 async def _update_activation_values_batch(
-        connector: Neo4jConnector,
         nodes: List[Dict[str, Any]],
         node_label: str,
         end_user_id: Optional[str] = None,
@@ -86,67 +87,68 @@ async def _update_activation_values_batch(
     Returns:
         List[Dict[str, Any]]: 成功更新的节点列表
     """
-    if not nodes:
-        return []
+    async with Neo4jConnector() as connector:
+        if not nodes:
+            return []
 
-    # 延迟导入以避免循环依赖
-    from app.core.memory.storage_services.forgetting_engine.access_history_manager import (
-        AccessHistoryManager,
-    )
-    from app.core.memory.storage_services.forgetting_engine.actr_calculator import (
-        ACTRCalculator,
-    )
-
-    # 创建计算器和管理器实例
-    actr_calculator = ACTRCalculator()
-    access_manager = AccessHistoryManager(
-        connector=connector,
-        actr_calculator=actr_calculator,
-        max_retries=max_retries
-    )
-
-    # 提取节点ID列表并去重（保持原始顺序）
-    seen_ids = set()
-    unique_node_ids = []
-    for node in nodes:
-        node_id = node.get('id')
-        if node_id and node_id not in seen_ids:
-            seen_ids.add(node_id)
-            unique_node_ids.append(node_id)
-
-    if not unique_node_ids:
-        logger.warning("批量更新激活值：没有有效的节点ID")
-        return nodes
-
-    # 记录去重信息（仅针对具有有效 ID 的节点）
-    id_nodes_count = sum(1 for n in nodes if n.get("id"))
-    if len(unique_node_ids) < id_nodes_count:
-        logger.info(
-            f"批量更新激活值：检测到重复节点，具有有效ID的节点数量={id_nodes_count}, "
-            f"去重后唯一ID数量={len(unique_node_ids)}"
+        # 延迟导入以避免循环依赖
+        from app.core.memory.storage_services.forgetting_engine.access_history_manager import (
+            AccessHistoryManager,
+        )
+        from app.core.memory.storage_services.forgetting_engine.actr_calculator import (
+            ACTRCalculator,
         )
 
-    # 批量记录访问
-    try:
-        updated_nodes = await access_manager.record_batch_access(
-            node_ids=unique_node_ids,
-            node_label=node_label,
-            end_user_id=end_user_id
+        # 创建计算器和管理器实例
+        actr_calculator = ACTRCalculator()
+        access_manager = AccessHistoryManager(
+            connector=connector,
+            actr_calculator=actr_calculator,
+            max_retries=max_retries
         )
 
-        logger.info(
-            f"批量更新激活值成功: {node_label}, "
-            f"更新数量={len(updated_nodes)}/{len(unique_node_ids)}"
-        )
+        # 提取节点ID列表并去重（保持原始顺序）
+        seen_ids = set()
+        unique_node_ids = []
+        for node in nodes:
+            node_id = node.get('id')
+            if node_id and node_id not in seen_ids:
+                seen_ids.add(node_id)
+                unique_node_ids.append(node_id)
 
-        return updated_nodes
+        if not unique_node_ids:
+            logger.warning("批量更新激活值：没有有效的节点ID")
+            return nodes
 
-    except Exception as e:
-        logger.error(
-            f"批量更新激活值失败: {node_label}, 错误: {str(e)}"
-        )
-        # 失败时返回原始节点列表
-        return nodes
+        # 记录去重信息（仅针对具有有效 ID 的节点）
+        id_nodes_count = sum(1 for n in nodes if n.get("id"))
+        if len(unique_node_ids) < id_nodes_count:
+            logger.info(
+                f"批量更新激活值：检测到重复节点，具有有效ID的节点数量={id_nodes_count}, "
+                f"去重后唯一ID数量={len(unique_node_ids)}"
+            )
+
+        # 批量记录访问
+        try:
+            updated_nodes = await access_manager.record_batch_access(
+                node_ids=unique_node_ids,
+                node_label=node_label,
+                end_user_id=end_user_id
+            )
+
+            logger.debug(
+                f"批量更新激活值成功: {node_label}, "
+                f"更新数量={len(updated_nodes)}/{len(unique_node_ids)}"
+            )
+
+            return updated_nodes
+
+        except Exception as e:
+            logger.error(
+                f"批量更新激活值失败: {node_label}, 错误: {str(e)}"
+            )
+            # 失败时返回原始节点列表
+            return nodes
 
 
 async def _update_search_results_activation(
@@ -186,7 +188,6 @@ async def _update_search_results_activation(
         if key in results and results[key]:
             update_tasks.append(
                 _update_activation_values_batch(
-                    connector=connector,
                     nodes=results[key],
                     node_label=label,
                     end_user_id=end_user_id
@@ -194,62 +195,63 @@ async def _update_search_results_activation(
             )
             update_keys.append(key)
 
-    if not update_tasks:
-        return results
+    async def _run_updates(tasks):
+        await asyncio.gather(*tasks)
 
-    # 并行执行所有更新
-    update_results = await asyncio.gather(*update_tasks, return_exceptions=True)
+    if update_tasks:
+        asyncio.create_task(_run_updates(update_tasks))
+    return results
 
-    # 更新结果字典，保留原始搜索分数
-    updated_results = results.copy()
-    for key, update_result in zip(update_keys, update_results):
-        if not isinstance(update_result, Exception):
-            # 更新成功，合并原始搜索结果和更新后的激活值数据
-            # 保留原始的 score 字段（BM25/Embedding 分数）
-            original_nodes = results[key]
-            updated_nodes = update_result
+    # # 更新结果字典，保留原始搜索分数
+    # updated_results = results.copy()
+    # for key, update_result in zip(update_keys, update_results):
+    #     if not isinstance(update_result, Exception):
+    #         # 更新成功，合并原始搜索结果和更新后的激活值数据
+    #         # 保留原始的 score 字段（BM25/Embedding 分数）
+    #         original_nodes = results[key]
+    #         updated_nodes = update_result
+    #
+    #         # 创建 ID 到更新节点的映射（用于快速查找激活值数据）
+    #         updated_map = {node.get('id'): node for node in updated_nodes if node.get('id')}
+    #
+    #         # 合并数据：保留所有原始节点（包括重复的），用更新后的激活值数据填充
+    #         merged_nodes = []
+    #         for original_node in original_nodes:
+    #             node_id = original_node.get('id')
+    #             if node_id and node_id in updated_map:
+    #                 # 从原始节点开始，用更新后的激活值数据覆盖
+    #                 merged_node = original_node.copy()
+    #
+    #                 # 更新激活值相关字段
+    #                 activation_fields = {
+    #                     'activation_value',
+    #                     'access_history',
+    #                     'last_access_time',
+    #                     'access_count',
+    #                     'importance_score',
+    #                     'version',
+    #                     'statement',  # Statement 节点的内容字段
+    #                     'content'  # MemorySummary 节点的内容字段
+    #                 }
+    #
+    #                 # 只更新激活值相关字段，保留原始节点的其他字段
+    #                 for field in activation_fields:
+    #                     if field in updated_map[node_id]:
+    #                         merged_node[field] = updated_map[node_id][field]
+    #
+    #                 merged_nodes.append(merged_node)
+    #             else:
+    #                 # 如果没有更新数据，保留原始节点
+    #                 merged_nodes.append(original_node)
+    #
+    #         updated_results[key] = merged_nodes
+    #     else:
+    #         # 更新失败，记录错误但保留原始结果
+    #         logger.warning(
+    #             f"更新 {key} 激活值失败: {str(update_result)}"
+    #         )
 
-            # 创建 ID 到更新节点的映射（用于快速查找激活值数据）
-            updated_map = {node.get('id'): node for node in updated_nodes if node.get('id')}
-
-            # 合并数据：保留所有原始节点（包括重复的），用更新后的激活值数据填充
-            merged_nodes = []
-            for original_node in original_nodes:
-                node_id = original_node.get('id')
-                if node_id and node_id in updated_map:
-                    # 从原始节点开始，用更新后的激活值数据覆盖
-                    merged_node = original_node.copy()
-
-                    # 更新激活值相关字段
-                    activation_fields = {
-                        'activation_value',
-                        'access_history',
-                        'last_access_time',
-                        'access_count',
-                        'importance_score',
-                        'version',
-                        'statement',  # Statement 节点的内容字段
-                        'content'  # MemorySummary 节点的内容字段
-                    }
-
-                    # 只更新激活值相关字段，保留原始节点的其他字段
-                    for field in activation_fields:
-                        if field in updated_map[node_id]:
-                            merged_node[field] = updated_map[node_id][field]
-
-                    merged_nodes.append(merged_node)
-                else:
-                    # 如果没有更新数据，保留原始节点
-                    merged_nodes.append(original_node)
-
-            updated_results[key] = merged_nodes
-        else:
-            # 更新失败，记录错误但保留原始结果
-            logger.warning(
-                f"更新 {key} 激活值失败: {str(update_result)}"
-            )
-
-    return updated_results
+    # return updated_results
 
 
 async def search_perceptual_by_fulltext(
@@ -385,6 +387,31 @@ async def search_by_embedding(
     from app.core.memory.src.search import deduplicate_results
     records = deduplicate_results(records)
     return records
+
+
+async def get_nodes_by_ids(
+        connector: Neo4jConnector,
+        node_type: Neo4jNodeType,
+        ids: list[str],
+) -> list[dict[str, Any]]:
+    return await connector.execute_query(
+        NODE_ID_QUERY_CYPHER_MAPPING[node_type],
+        ids=ids
+    )
+
+
+async def get_relation_between_entities(
+        connector: Neo4jConnector,
+        end_user_id: str,
+        source_id: str,
+        target_id: str,
+) -> list[dict[str, Any]]:
+    return await connector.execute_query(
+        SEARCH_RELATION_BETWEEN_ENTITIES,
+        end_user_id=end_user_id,
+        source_id=source_id,
+        target_id=target_id
+    )
 
 
 async def search_graph(
@@ -555,6 +582,21 @@ async def search_graph_by_embedding(
         logger.info("[PERF] Skipping activation updates (only summaries)")
 
     return results
+
+
+async def search_graph_by_relationship(
+        connector: Neo4jConnector,
+        end_user_id: str,
+        source_id: str,
+        predicates: list[str],
+):
+    related_node = await connector.execute_query(
+        SEARCH_ENITITES_BY_RELATIONSHIP,
+        end_user_id=end_user_id,
+        source_id=source_id,
+        predicates=predicates,
+    )
+    return related_node
 
 
 async def search_user_metadata(

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -30,7 +30,8 @@ from app.repositories.neo4j.cypher_queries import (
     NODE_ID_QUERY_CYPHER_MAPPING,
     SEARCH_USER_METADATA,
     SEARCH_ENITITES_BY_RELATIONSHIP,
-    SEARCH_RELATION_BETWEEN_ENTITIES
+    SEARCH_RELATION_BETWEEN_ENTITIES,
+    SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS,
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -196,7 +197,14 @@ async def _update_search_results_activation(
             update_keys.append(key)
 
     async def _run_updates(tasks):
-        await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for idx, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.error(
+                    "后台激活更新任务失败: task_index=%s exception=%r",
+                    idx,
+                    result,
+                )
 
     if update_tasks:
         asyncio.create_task(_run_updates(update_tasks))
@@ -411,6 +419,21 @@ async def get_relation_between_entities(
         end_user_id=end_user_id,
         source_id=source_id,
         target_id=target_id
+    )
+
+
+async def get_relations_between_entity_pairs(
+        connector: Neo4jConnector,
+        end_user_id: str,
+        pairs: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Batch query relations for multiple (source_id, target_id) pairs using UNWIND."""
+    if not pairs:
+        return []
+    return await connector.execute_query(
+        SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS,
+        end_user_id=end_user_id,
+        pairs=pairs,
     )
 
 

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -18,7 +18,6 @@ from app.core.logging_config import get_config_logger, get_logger
 from app.core.validators.memory_config_validators import (
     validate_and_resolve_model_id,
 )
-from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.schemas.memory_config_schema import (
     ConfigurationError,


### PR DESCRIPTION
Introduce a structured predicate ontology (TripletPredicate) for knowledge graph relation extraction, along with relation search tools and result integration.

- Add TripletPredicate enum with 13 predefined relation types, each with Chinese label and semantic description
- Implement entity and relation search tools for LLM tool-calling
- Add RelationMemory model and integrate relation results into MemorySearchResult
- Add Cypher queries for entity and relation graph search
- Include prompt template for relation extraction ontology definitions

## Summary by Sourcery

通过添加结构化的谓词本体、LLM 驱动的关系搜索工作流和 Neo4j 图关系查询，引入“关系感知”的记忆搜索能力，并将关系搜索结果集成到记忆搜索输出中。

New Features:
- 定义 `TripletPredicate` 本体，枚举支持的关系类型，并为知识图谱抽取提供带标签和语义描述的关系定义。
- 新增 `RelationMemory`、`EntityPair` 和 `RelationSearchResult` 模型，并扩展 `MemorySearchResult`，以便在内容记忆之外携带和渲染基于关系的记忆。
- 引入一个由 LLM 驱动的关系搜索代理，提供实体搜索和关系搜索工具，通过遍历知识图谱来解析与用户查询相关的实体对。
- 暴露新的 Neo4j 图搜索辅助方法和 Cypher 查询，用于通过 ID 获取实体，并使用关系谓词解析实体之间的关系。

Enhancements:
- 重构 Neo4j 搜索服务为 `hybrid_search` API，将关键词搜索与向量嵌入搜索相结合，并在调试级别记录重排序的详细日志。
- 更新记忆读取流水线，在深度读取时并行运行混合内容搜索和关系搜索，并合并它们的结果。
- 扩展结果构建工具，将关系记忆格式化为结构化的关系片段，并调整用户元数据的内容字段。
- 更改激活值批量更新逻辑，使其管理自己的 Neo4j 连接器，并以异步方式运行，从而不阻塞搜索响应。
- 简化 LLM 客户端的构建流程，移除基础流水线中未使用的能力标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce relation-aware memory search by adding a structured predicate ontology, LLM-driven relation search workflow, and Neo4j graph relation queries, and integrate relation results into memory search outputs.

New Features:
- Define a TripletPredicate ontology enumerating supported relation types with labels and semantic descriptions for knowledge graph extraction.
- Add RelationMemory, EntityPair, and RelationSearchResult models and extend MemorySearchResult to carry and render relation-based memories alongside content memories.
- Introduce an LLM-powered relation search agent with entity and relation search tools that traverse the knowledge graph to resolve relevant entity pairs for a user query.
- Expose new Neo4j graph search helpers and Cypher queries to fetch entities by IDs and resolve relationships between entities using relation predicates.

Enhancements:
- Refactor Neo4j search services into a hybrid_search API that combines keyword and embedding search while logging at debug level for reranking details.
- Update the memory read pipeline to run hybrid content search and relation search in parallel during deep reads and merge their results.
- Extend result-building utilities to format relation memories into structured relationship snippets and adjust user metadata content fields.
- Change activation value batch updates to manage their own Neo4j connector and run asynchronously without delaying search responses.
- Simplify LLM client construction by removing unused capability flags in the base pipeline.

</details>