### PR TITLE
Feature/knowledge base support custom external id

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -593,8 +593,19 @@ async def retrieve_chunks(
     """
     api_logger.info(f"retrieve chunk: query={retrieve_data.query}, username: {current_user.username}")
 
+    # Resolve ex_ids to kb_ids and merge (union)
+    kb_ids = list(retrieve_data.kb_ids)
+    if retrieve_data.ex_ids:
+        resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
+            db=db,
+            external_ids=retrieve_data.ex_ids,
+            workspace_id=current_user.current_workspace_id,
+            current_user=current_user
+        )
+        kb_ids = list(set(kb_ids + resolved_ids))
+
     filters = [
-        knowledge_model.Knowledge.id.in_(retrieve_data.kb_ids),
+        knowledge_model.Knowledge.id.in_(kb_ids),
         knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
         knowledge_model.Knowledge.chunk_num > 0,
         knowledge_model.Knowledge.status == 1
@@ -607,7 +618,7 @@ async def retrieve_chunks(
     private_kb_ids = [item[0] for item in private_items]
     private_workspace_ids = [item[1] for item in private_items]
     filters = [
-        knowledge_model.Knowledge.id.in_(retrieve_data.kb_ids),
+        knowledge_model.Knowledge.id.in_(kb_ids),
         knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
         knowledge_model.Knowledge.chunk_num > 0,
         knowledge_model.Knowledge.status == 1
@@ -619,7 +630,7 @@ async def retrieve_chunks(
     )
     if items:
         filters = [
-            knowledgeshare_model.KnowledgeShare.target_kb_id.in_(retrieve_data.kb_ids)
+            knowledgeshare_model.KnowledgeShare.target_kb_id.in_(kb_ids)
         ]
         share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
             db=db,

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -40,6 +40,7 @@ class Knowledge(Base):
     __tablename__ = "knowledges"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    external_id = Column(String(36), nullable=True, index=True, unique=False, comment="user-defined external identifier, workspace-unique")
     workspace_id = Column(UUID(as_uuid=True), nullable=False, comment="workspaces.id")
     created_by = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False, comment="users.id")
     parent_id = Column(UUID(as_uuid=True), nullable=True, default=None, comment="parent folder id when type is Folder")

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -98,7 +98,7 @@ def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -
 
 def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID) -> Knowledge | None:
     db_logger.debug(f"Query knowledge base based on ID: knowledge_id={knowledge_id}")
-    
+
     try:
         knowledge = db.query(Knowledge).filter(Knowledge.id == knowledge_id).first()
         if knowledge:
@@ -108,6 +108,43 @@ def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID) -> Knowledge | Non
         return knowledge
     except Exception as e:
         db_logger.error(f"Failed to query the knowledge base based on the ID: knowledge_id={knowledge_id} - {str(e)}")
+        raise
+
+
+def get_knowledge_by_external_id(db: Session, external_id: str, workspace_id: uuid.UUID) -> Knowledge | None:
+    db_logger.debug(f"Query knowledge base based on external_id: external_id={external_id}, workspace_id={workspace_id}")
+
+    try:
+        knowledge = db.query(Knowledge).filter(
+            Knowledge.external_id == external_id,
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status == 1
+        ).first()
+        if knowledge:
+            db_logger.debug(f"knowledge base query successful: {knowledge.name} (external_id: {external_id})")
+        else:
+            db_logger.debug(f"knowledge base does not exist: external_id={external_id}")
+        return knowledge
+    except Exception as e:
+        db_logger.error(f"Failed to query the knowledge base based on external_id: external_id={external_id} - {str(e)}")
+        raise
+
+
+def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], workspace_id: uuid.UUID) -> list[uuid.UUID]:
+    """解析 external_ids 为 knowledge UUID 列表（仅返回存在的）"""
+    db_logger.debug(f"Resolve external_ids to knowledge UUIDs: external_ids={external_ids}, workspace_id={workspace_id}")
+
+    try:
+        results = db.query(Knowledge.id).filter(
+            Knowledge.external_id.in_(external_ids),
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status == 1
+        ).all()
+        ids = [r[0] for r in results]
+        db_logger.debug(f"Resolved {len(external_ids)} external_ids to {len(ids)} UUIDs")
+        return ids
+    except Exception as e:
+        db_logger.error(f"Failed to resolve external_ids: external_ids={external_ids} - {str(e)}")
         raise
 
 

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -72,6 +72,7 @@ class ChunkUpdate(BaseModel):
 class ChunkRetrieve(BaseModel):
     query: str
     kb_ids: list[uuid.UUID]
+    ex_ids: list[str] | None = Field(None)
     file_names_filter: list[str] | None = Field(None)
     similarity_threshold: float | None = Field(None)
     vector_similarity_weight: float | None = Field(None)

--- a/api/app/schemas/knowledge_schema.py
+++ b/api/app/schemas/knowledge_schema.py
@@ -24,7 +24,7 @@ class KnowledgeBase(BaseModel):
     chunk_num: int | None = None
     parser_id: str | None = None
     parser_config: dict | None = None
-    external_id: str | None = Field(None, min_length=36, max_length=36)
+    external_id: str | None = Field(None, min_length=1, max_length=36)
 
 
 class KnowledgeCreate(KnowledgeBase):

--- a/api/app/schemas/knowledge_schema.py
+++ b/api/app/schemas/knowledge_schema.py
@@ -24,6 +24,7 @@ class KnowledgeBase(BaseModel):
     chunk_num: int | None = None
     parser_id: str | None = None
     parser_config: dict | None = None
+    external_id: str | None = Field(None, min_length=36, max_length=36)
 
 
 class KnowledgeCreate(KnowledgeBase):

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -7,6 +7,8 @@ from app.models.models_model import ModelConfig
 from app.schemas.knowledge_schema import KnowledgeCreate, KnowledgeUpdate
 from app.repositories import knowledge_repository
 from app.core.logging_config import get_business_logger
+from app.core.exceptions import BusinessException
+from app.core.error_codes import BizCode
 from app.models.models_model import ModelType
 
 business_logger = get_business_logger()
@@ -71,13 +73,19 @@ def create_knowledge(
             knowledge.parent_id = knowledge.workspace_id
 
         if knowledge.external_id:
-            if len(knowledge.external_id) != 36:
-                raise Exception("external_id must be 36 characters")
+            if not (1 <= len(knowledge.external_id) <= 36):
+                raise BusinessException(
+                    "external_id must be between 1 and 36 characters",
+                    code=BizCode.VALIDATION_FAILED,
+                )
             existing = knowledge_repository.get_knowledge_by_external_id(
                 db, knowledge.external_id, knowledge.workspace_id
             )
             if existing:
-                raise Exception(f"external_id already exists in this workspace: {knowledge.external_id}")
+                raise BusinessException(
+                    f"external_id already exists in this workspace: {knowledge.external_id}",
+                    code=BizCode.VALIDATION_FAILED,
+                )
 
         workspace = db.query(Workspace).filter(Workspace.id == knowledge.workspace_id).first()
         if not workspace:

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -70,6 +70,15 @@ def create_knowledge(
         if knowledge.parent_id is None:
             knowledge.parent_id = knowledge.workspace_id
 
+        if knowledge.external_id:
+            if len(knowledge.external_id) != 36:
+                raise Exception("external_id must be 36 characters")
+            existing = knowledge_repository.get_knowledge_by_external_id(
+                db, knowledge.external_id, knowledge.workspace_id
+            )
+            if existing:
+                raise Exception(f"external_id already exists in this workspace: {knowledge.external_id}")
+
         workspace = db.query(Workspace).filter(Workspace.id == knowledge.workspace_id).first()
         if not workspace:
             raise Exception(f"Workspace {knowledge.workspace_id} not found")
@@ -126,6 +135,33 @@ def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: User
         return knowledge
     except Exception as e:
         business_logger.error(f"Failed to query the knowledge base based on the ID: knowledge_id={knowledge_id} - {str(e)}")
+        raise
+
+
+def get_knowledge_by_external_id(db: Session, external_id: str, workspace_id: uuid.UUID, current_user: User) -> Knowledge | None:
+    business_logger.debug(f"Query knowledge base based on external_id: external_id={external_id}, username: {current_user.username}")
+
+    try:
+        knowledge = knowledge_repository.get_knowledge_by_external_id(db=db, external_id=external_id, workspace_id=workspace_id)
+        if knowledge:
+            business_logger.info(f"knowledge base query successful: {knowledge.name} (external_id: {external_id})")
+        else:
+            business_logger.warning(f"knowledge base does not exist: external_id={external_id}")
+        return knowledge
+    except Exception as e:
+        business_logger.error(f"Failed to query the knowledge base based on external_id: external_id={external_id} - {str(e)}")
+        raise
+
+
+def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], workspace_id: uuid.UUID, current_user: User) -> list[uuid.UUID]:
+    business_logger.debug(f"Resolve external_ids to knowledge UUIDs: external_ids={external_ids}, username: {current_user.username}")
+
+    try:
+        ids = knowledge_repository.get_knowledge_ids_by_external_ids(db=db, external_ids=external_ids, workspace_id=workspace_id)
+        business_logger.info(f"Resolved external_ids: {len(external_ids)} -> {len(ids)} UUIDs")
+        return ids
+    except Exception as e:
+        business_logger.error(f"Failed to resolve external_ids: external_ids={external_ids} - {str(e)}")
         raise
 
 


### PR DESCRIPTION
---
  概述

  为知识库新增 external_id 字段，允许用户通过自定义标识符而非仅通过 UUID 来引用知识库，使 API
  集成更具可读性和可移植性。

  变更内容

  - 模型 & 迁移：在 knowledges 表新增 external_id 列（String(36)，可空），并添加部分唯一索引
  (workspace_id, external_id) 以保证工作空间级别的唯一性
  - API Schema：KnowledgeBase/KnowledgeCreate 中增加 external_id 字段；ChunkRetrieve 中增加
  ex_ids 字段，支持按外部 ID 召回
  - Service 层：创建时校验 external_id 长度（1–36 字符）和工作空间内唯一性；新增
  get_knowledge_by_external_id 和 get_knowledge_ids_by_external_ids 查询方法
  - Chunk 召回：retrieve_chunks 端点支持通过 ex_ids 解析为 UUID，与 kb_ids
  取并集，调用方可在一请求中混合使用两种标识方式

  测试计划

  - 使用合法的 external_id 创建知识库 — 成功
  - 在同一工作空间中用相同的 external_id 创建第二个知识库 — 拒绝
  - 创建 external_id 超过 36 字符的知识库 — 拒绝
  - 创建 external_id 为空的知识库 — 拒绝
  - 仅用 ex_ids 召回 Chunk — 返回匹配知识库的结果
  - 混合使用 ex_ids 和 kb_ids 召回 Chunk — 正确取并集
  - ex_ids 中传入不存在的值 — 静默忽略（解析结果为空，不报错）

## Summary by Sourcery

为知识库添加对用户自定义外部标识符的支持，并允许在工作区内通过 UUID 或外部 ID 来检索分块。

新功能：
- 允许知识库拥有可选的 `external_id` 字段，该字段在每个工作区内唯一，并持久化存储在数据库中。
- 支持使用外部知识库 ID (`ex_ids`) 来检索分块，并且可以在单个请求中与现有的 `kb_ids` 组合使用。

增强改进：
- 在创建知识库时验证 `external_id` 的长度以及在工作区层面的唯一性，若验证失败则返回业务校验错误。
- 暴露服务层和仓储层方法，用于通过 `external_id` 查询知识库及其 UUID，以便在整个 API 中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for user-defined external identifiers for knowledge bases and allow chunk retrieval by either UUIDs or external IDs within a workspace.

New Features:
- Allow knowledge bases to have an optional external_id field that is unique per workspace and persisted in the database.
- Support chunk retrieval using external knowledge base IDs (ex_ids), which can be combined with existing kb_ids in a single request.

Enhancements:
- Validate external_id length and workspace-level uniqueness during knowledge base creation, returning business validation errors on failure.
- Expose service and repository methods to look up knowledge bases and their UUIDs by external_id for reuse across the API.

</details>