### PR TITLE
feat(web): kb batch download

### DIFF
--- a/web/src/api/knowledgeBase.ts
+++ b/web/src/api/knowledgeBase.ts
@@ -341,3 +341,7 @@ export const rebuildKnowledgeGraph = async (kb_id: string) => {
   const response = await request.post(`${apiPrefix}/knowledges/${kb_id}/knowledge_graph`);
   return response;
 };
+export const batchDownloadFilesByKb = async (kb_id: string, fileName: string, callback: () => void) => {
+  const response = await request.downloadFile(`/knowledges/${kb_id}/batch-download`, fileName, undefined, callback);
+  return response;
+};

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -679,6 +679,8 @@ export const en = {
       feishuAuthSuccess: 'Feishu authentication successful',
       authFailed: 'Authentication failed, please check your credentials',
       recallTest: 'Recall Test',
+      batchDownload: 'Batch Download',
+      batchDownloadSuccess: 'Batch download successful',
       testQuestion: 'Test Question',
       doc_num: 'Document Number',
       chunk_num: 'Total data Size',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -166,6 +166,8 @@ export const zh = {
       feishuAuthSuccess: '飞书认证成功',
       authFailed: '认证失败，请检查您的凭证',
       recallTest: '召回测试',
+      batchDownload: '导出知识库',
+      batchDownloadSuccess: '批量导出成功',
       testQuestion: '测试问题',
       doc_num: '文档数量',
       chunk_num: '数据总量',

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -817,7 +817,7 @@ const CreateDataset = () => {
                     </div>
                     <DelimiterSelector value={delimiter} onChange={setDelimiter} />
                   </div>
-                  <SliderInput label={t('knowledgeBase.suggestedBlockSize')} max={12000} min={6} step={1} value={blockSize} onChange={handleChange} />
+                  <SliderInput label={t('knowledgeBase.suggestedBlockSize')} max={1024} min={1} step={1} value={blockSize} onChange={handleChange} />
                 </div>
                 <div>
                   <div className='rb:w-full rb:text-[#5B6167] rb:leading-5 rb:mb-2 rb:mt-4'>

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
@@ -14,7 +14,7 @@ import textIcon from '@/assets/images/knowledgeBase/text.png';
 import editIcon from '@/assets/images/knowledgeBase/edit.png';
 // import blankIcon from '@/assets/images/knowledgeBase/blankDocument.png';
 // import imageIcon from '@/assets/images/knowledgeBase/image.png'
-import { getKnowledgeBaseDetail, deleteDocument, downloadFile, updateKnowledgeBase, createSync } from '@/api/knowledgeBase';
+import { getKnowledgeBaseDetail, deleteDocument, downloadFile, updateKnowledgeBase, createSync, batchDownloadFilesByKb } from '@/api/knowledgeBase';
 import { 
   type CreateModalRef, 
   type KnowledgeBaseListItem, 
@@ -781,6 +781,12 @@ const Private: FC = () => {
     messageApi.success(t('common.copySuccess'))
   }
 
+  const handleBatchDownload = () => {
+    batchDownloadFilesByKb(knowledgeBase.id, `${knowledgeBase.name}.zip`, () => {
+      messageApi.success(t('knowledgeBase.batchDownloadSuccess'))
+    })
+  }
+
   return (
     <>
     <div className="rb:flex rb:h-full rb:bg-white rb:rounded-xl">
@@ -842,6 +848,7 @@ const Private: FC = () => {
             <Button onClick={handleShare}>{t('knowledgeBase.share')}</Button>
             <Button onClick={handleRecallTest}>{t('knowledgeBase.recallTest')}</Button>
             <Button onClick={handleSetting}>{t('knowledgeBase.knowledgeBase')} {t('knowledgeBase.setting')}</Button>
+            <Button onClick={handleBatchDownload}>{t('knowledgeBase.batchDownload')}</Button>
             {(knowledgeBase?.type === 'Web' || knowledgeBase?.type === 'Third-party') && (
               <Button 
                 type="primary" 

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -96,6 +96,8 @@ export interface ParserConfig {
   auto_questions?: number; // 自动问题
   html4excel?: boolean; // 是否为Excel文件
   graphrag?: GraphragConfig; // 知识图谱生成
+
+  doc_type?: string;
   
   // Web 类型特有字段
   entry_url?: string; // 入口网址


### PR DESCRIPTION
## Summary by Sourcery

为知识库文件添加批量下载支持，并调整数据集解析器的配置选项。

新功能：
- 在知识库详情视图中新增批量下载操作，用于将所有文件导出为 ZIP 压缩包。

改进：
- 暴露用于批量下载知识库文件的新 API 辅助方法。
- 为批量下载的标签和成功消息添加中英文 i18n 文本。
- 在数据集创建视图中收紧建议块大小滑块的取值范围。
- 在解析器配置类型中新增可选的文档类型字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add batch download support for knowledge base files and adjust dataset parser configuration options.

New Features:
- Introduce a batch download action in the knowledge base detail view to export all files as a ZIP archive.

Enhancements:
- Expose a new API helper for batch downloading knowledge base files.
- Add i18n strings for batch download labels and success messages in English and Chinese.
- Tighten suggested block size slider limits in the dataset creation view.
- Extend parser configuration type with an optional document type field.

</details>