### PR TITLE
feat(web): model's capability add thinking_only/function_call

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -638,7 +638,9 @@ export const en = {
       video: 'Video',
       thinking: 'Deep Thinking',
       is_thinking: 'Deep Thinking Support',
+      thinking_only: 'Only Thinking Support',
       json_output: 'Support JSON formatted output',
+      function_call: 'Tool Call/External Function Call',
     },
     knowledgeBase: {
       home: 'Home',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1327,7 +1327,9 @@ export const zh = {
       video: '视频',
       thinking: '深度思考',
       is_thinking: '支持深度思考',
+      thinking_only: '仅支持思考',
       json_output: '支持JSON格式化输出',
+      function_call: '工具调用/外部函数调用',
     },
     timezones: {
       'Asia/Shanghai': '中国标准时间 (UTC+8)',

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:28:07 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 18:51:01
+ * @Last Modified time: 2026-05-14 18:35:43
  */
 /**
  * Model Configuration Modal
@@ -109,7 +109,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
   const handleChange: SelectProps['onChange'] = (_value, option) => {
     const newValues: ModelConfig = {
       capability: (option as Model).capability,
-      deep_thinking: false,
+      deep_thinking: (option as Model).capability?.includes('thinking_only'),
       thinking_budget_tokens: defaultThinkingBudgetTokens,
       json_output: false,
     }
@@ -179,13 +179,13 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
         <FormItem name="json_output" valuePropName="checked" hidden={!(values?.capability?.includes('json_output'))}>
           <Checkbox>{t('application.json_output')}</Checkbox>
         </FormItem>
-        <FormItem name="deep_thinking" valuePropName="checked" hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}>
-          <Checkbox>{t('application.deep_thinking')}</Checkbox>
+        <FormItem name="deep_thinking" valuePropName="checked" hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking') || values?.capability?.includes('thinking_only'))}>
+          <Checkbox disabled={values?.capability?.includes('thinking_only')}>{t('application.deep_thinking')}</Checkbox>
         </FormItem>
         <FormItem
           name="thinking_budget_tokens"
           label={t('application.thinking_budget_tokens')}
-          hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking'))}
+          hidden={!['model', 'chat'].includes(source) || !(values?.deep_thinking || values?.capability?.includes('thinking') || values?.capability?.includes('thinking_only'))}
           extra={<>{t('application.range')}: [{minThinkingBudgetTokens}, {t(`application.max_tokens`)}: {values?.max_tokens}]</>}
           dependencies={['max_tokens']}
           rules={[

--- a/web/src/views/ModelManagement/components/CustomModelModal.tsx
+++ b/web/src/views/ModelManagement/components/CustomModelModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:28 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-21 15:02:53
+ * @Last Modified time: 2026-05-14 16:32:45
  */
 /**
  * Custom Model Modal
@@ -38,6 +38,8 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
   const [abortController, setAbortController] = useState<AbortController | null>(null)
   const modelType = Form.useWatch(['type'], form);
   const isOmni = Form.useWatch(['is_omni'], form);
+  const isThinking = Form.useWatch(['is_thinking'], form);
+  const thinkingOnly = Form.useWatch(['thinking_only'], form);
 
   useEffect(() => {
     if (isOmni) {
@@ -74,6 +76,8 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
         is_audio: capability?.includes('audio') || false,
         is_thinking: capability?.includes('thinking') || false,
         json_output: capability?.includes('json_output') || false,
+        function_call: capability?.includes('function_call') || false,
+        thinking_only: capability?.includes('thinking_only') || false,
       });
     } else {
       setIsEdit(false);
@@ -103,7 +107,7 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
     form
       .validateFields()
       .then((values) => {
-        const { logo, type, is_vision, is_video, is_audio, is_omni, is_thinking, json_output, ...rest } = values;
+        const { logo, type, is_vision, is_video, is_audio, is_omni, is_thinking, thinking_only, json_output, function_call, ...rest } = values;
         const formData: CustomModelForm = {
           ...rest,
           type,
@@ -125,8 +129,14 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
           if (is_thinking) {
             capability.push('thinking')
           }
+          if (thinking_only) {
+            capability.push('thinking_only')
+          }
           if (json_output) {
             capability.push('json_output')
+          }
+          if (function_call) {
+            capability.push('function_call')
           }
 
           formData.capability = capability
@@ -272,12 +282,22 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
             </Col>
             <Col span={24}>
               <Form.Item name="is_thinking" valuePropName="checked" className="rb:mb-0!">
-                <Checkbox>{t('modelNew.is_thinking')}</Checkbox>
+                <Checkbox disabled={thinkingOnly} onChange={() => form.setFieldValue('thinking_only', undefined)}>{t('modelNew.is_thinking')}</Checkbox>
+              </Form.Item>
+            </Col>
+            <Col span={24}>
+              <Form.Item name="thinking_only" valuePropName="checked" className="rb:mb-0!">
+                <Checkbox disabled={isThinking} onChange={() => form.setFieldValue('is_thinking', undefined)}>{t('modelNew.thinking_only')}</Checkbox>
               </Form.Item>
             </Col>
             <Col span={24}>
               <Form.Item name="json_output" valuePropName="checked" className="rb:mb-0!">
                 <Checkbox>{t('modelNew.json_output')}</Checkbox>
+              </Form.Item>
+            </Col>
+            <Col span={24}>
+              <Form.Item name="function_call" valuePropName="checked" className="rb:mb-0!">
+                <Checkbox>{t('modelNew.function_call')}</Checkbox>
               </Form.Item>
             </Col>
           </Row>

--- a/web/src/views/ModelManagement/types.ts
+++ b/web/src/views/ModelManagement/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:18 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 18:04:46
+ * @Last Modified time: 2026-05-14 16:11:24
  */
 /**
  * Type definitions for Model Management
@@ -296,7 +296,9 @@ export interface CustomModelForm {
   is_audio?: boolean;
   is_omni?: boolean;
   is_thinking?: boolean;
+  thinking_only?: boolean;
   json_output?: boolean;
+  function_call?: boolean;
   capability?: Capability[];
 }
 
@@ -326,7 +328,7 @@ export interface BaseRef {
   modelListDetailRefresh?: () => void;
 }
 
-export type Capability = 'vision' | 'audio' | 'video' | 'thinking' | 'json_output';
+export type Capability = 'vision' | 'audio' | 'video' | 'thinking' | 'thinking_only' | 'json_output' | 'function_call';
 export interface Model {
   name: string;
   type: string;


### PR DESCRIPTION
## Summary by Sourcery

扩展模型能力配置和 UI，以支持仅思考模式（thinking-only）和函数调用模式（function call），并在应用配置中将仅思考模型与深度思考设置集成。

新功能：
- 允许自定义模型声明 `thinking_only` 和 `function_call` 能力，并将其作为模型定义的一部分进行持久化。
- 在自定义模型管理 UI 中新增复选框，用于配置仅思考和函数调用支持；在适用的情况下，对“思考”和“仅思考”进行互斥控制。
- 使应用模型配置能够检测支持 `thinking_only` 的模型，并相应初始化深度思考设置，包括预算 token 可见性。

增强：
- 调整深度思考配置控件以遵从 `thinking_only` 能力：当选择仅思考模型时，禁用手动切换，并更新相关字段的可见性条件。
- 扩展能力类型定义和国际化标签，以涵盖新的 `thinking_only` 和 `function_call` 选项，支持英文和中文本地化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend model capabilities configuration and UI to support thinking-only and function call modes, and integrate thinking-only models with deep thinking settings in application configuration.

New Features:
- Allow custom models to declare thinking_only and function_call capabilities and persist them as part of the model definition.
- Expose new checkboxes in the custom model management UI for configuring thinking-only and function call support, with mutual exclusion between thinking and thinking-only where applicable.
- Enable application model configuration to detect thinking_only-capable models and initialize deep thinking settings accordingly, including budget tokens visibility.

Enhancements:
- Adjust deep thinking configuration controls to respect thinking_only capability, disabling manual toggling when only-thinking models are selected and updating visibility conditions for related fields.
- Extend capability typing and internationalized labels to cover the new thinking_only and function_call options in both English and Chinese locales.

</details>