### PR TITLE
feat(conversation)

### DIFF
--- a/api/app/controllers/__init__.py
+++ b/api/app/controllers/__init__.py
@@ -33,6 +33,7 @@ from . import (
     memory_short_term_controller,
     memory_storage_controller,
     memory_working_controller,
+    message_interaction_controller,
     model_controller,
     multi_agent_controller,
     prompt_optimizer_controller,
@@ -101,5 +102,6 @@ manager_router.include_router(skill_controller.router)
 manager_router.include_router(i18n_controller.router)
 manager_router.include_router(tenant_subscription_controller.router)
 manager_router.include_router(tenant_subscription_controller.public_router)
+manager_router.include_router(message_interaction_controller.router)  # 消息交互功能
 
 __all__ = ["manager_router"]

--- a/api/app/controllers/message_interaction_controller.py
+++ b/api/app/controllers/message_interaction_controller.py
@@ -1,0 +1,307 @@
+"""
+消息交互控制器
+
+包含：重新生成、点赞/点踩、分享、举报、删除等功能
+"""
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.response_utils import success
+from app.db import get_db
+from app.dependencies import get_current_user, cur_workspace_access_guard
+from app.models import User, Message
+from app.schemas import app_schema
+from app.services.conversation_service import ConversationService
+from app.services.message_feedback_service import FeedbackService
+from app.services.message_report_service import ReportService
+from app.services.conversation_share_service import ConversationShareService
+from app.services.draft_run_service import AgentRunService
+from app.services.app_service import AppService
+from app.models import ModelConfig
+
+router = APIRouter(prefix="/apps", tags=["Message Interaction"])
+
+
+# ========== 重新生成 ==========
+
+@router.post("/{app_id}/messages/{message_id}/regenerate", summary="重新生成回复")
+@cur_workspace_access_guard()
+async def regenerate_message(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """重新生成 AI 回复，支持多版本切换
+
+    核心逻辑：
+    - 保持同一上下文、同一前置对话、同一用户提问
+    - 不新增用户消息，只是复用当前会话截止到上一轮的 messages 上下文数组
+    - 再次调用 LLM 生成新回答
+    - 多版本历史保留、可切换回看
+    """
+    workspace_id = current_user.current_workspace_id
+
+    # 获取配置
+    service = AppService(db)
+    agent_cfg = service.get_agent_config(app_id=app_id, workspace_id=workspace_id)
+    model_config = None
+    if agent_cfg.default_model_config_id:
+        model_config = db.get(ModelConfig, agent_cfg.default_model_config_id)
+
+    if not model_config:
+        from app.core.exceptions import ResourceNotFoundException
+        raise ResourceNotFoundException("模型配置", str(agent_cfg.default_model_config_id))
+
+    # 调用重新生成服务
+    draft_service = AgentRunService(db)
+    result = await draft_service.regenerate(
+        message_id=message_id,
+        agent_config=agent_cfg,
+        model_config=model_config,
+        workspace_id=workspace_id,
+        user_id=str(current_user.id),
+    )
+
+    return success(data=app_schema.RegenerateResponse(**result))
+
+
+# ========== 消息版本管理 ==========
+
+@router.get("/{app_id}/messages/{message_id}/versions", summary="获取消息的所有版本")
+@cur_workspace_access_guard()
+async def list_message_versions(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """获取重新生成的所有历史版本"""
+    workspace_id = current_user.current_workspace_id
+
+    conv_service = ConversationService(db)
+    versions = conv_service.get_message_versions(message_id)
+
+    return success(data=[app_schema.MessageVersion(**v) for v in versions])
+
+
+@router.post("/{app_id}/messages/{message_id}/switch-version/{version}", summary="切换消息版本")
+@cur_workspace_access_guard()
+async def switch_message_version(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        version: int,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """切换展示的消息版本"""
+    workspace_id = current_user.current_workspace_id
+
+    conv_service = ConversationService(db)
+    result = conv_service.switch_message_version(message_id, version, workspace_id)
+
+    return success(data=result)
+
+
+# ========== 点赞/点踩 ==========
+
+@router.post("/{app_id}/messages/{message_id}/feedback", summary="提交消息反馈")
+@cur_workspace_access_guard()
+async def submit_message_feedback(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        payload: app_schema.MessageFeedbackRequest,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """点赞/点踩 AI 回复
+
+    幂等设计：重复点击可切换取消
+    - 点赞：用户对满意的 AI 回复给予正面反馈
+    - 点踩：用户对不满意的 AI 回复给予负面反馈，可附加文字说明
+    """
+    workspace_id = current_user.current_workspace_id
+
+    # 获取消息以验证存在性和获取 conversation_id
+    message = db.get(Message, message_id)
+    if not message:
+        from app.core.exceptions import BusinessException
+        from app.core.error_codes import BizCode
+        raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+    feedback_service = FeedbackService(db)
+    result = feedback_service.submit_feedback(
+        message_id=message_id,
+        conversation_id=message.conversation_id,
+        workspace_id=workspace_id,
+        user_id=str(current_user.id),
+        feedback_type=payload.feedback_type,
+        feedback_content=payload.feedback_content,
+    )
+
+    return success(data=app_schema.MessageFeedbackResponse(**result))
+
+
+@router.get("/{app_id}/messages/{message_id}/feedback", summary="获取用户对消息的反馈")
+@cur_workspace_access_guard()
+async def get_user_feedback(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """获取当前用户对某条消息的反馈状态"""
+    feedback_service = FeedbackService(db)
+    result = feedback_service.get_user_feedback(message_id, str(current_user.id))
+
+    return success(data=result)
+
+
+# ========== 分享会话 ==========
+
+@router.post("/{app_id}/conversations/{conversation_id}/share", summary="分享会话")
+@cur_workspace_access_guard()
+async def share_conversation(
+        app_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        payload: app_schema.ShareConversationRequest,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """生成会话分享链接
+
+    分享链接：生成可公开访问的对话链接，他人点击即可查看完整对话内容（只读视角）
+    """
+    workspace_id = current_user.current_workspace_id
+
+    share_service = ConversationShareService(db)
+    result = share_service.create_share(
+        conversation_id=conversation_id,
+        workspace_id=workspace_id,
+        user_id=current_user.id,
+        password=payload.password,
+        expire_hours=payload.expire_hours,
+        allow_copy=payload.allow_copy,
+    )
+
+    return success(data=app_schema.ShareConversationResponse(**result))
+
+
+@router.get("/share/{share_uuid}", summary="访问分享的会话")
+async def get_shared_conversation(
+        share_uuid: str,
+        password: Optional[str] = None,
+        db: Session = Depends(get_db),
+):
+    """通过分享链接访问会话（只读模式，无需登录）
+
+    权限控制：
+    - 分享页只读模式：隐藏输入框、重新生成、删除、反馈等操作按钮
+    - 支持设置密码访问、有效期、是否允许复制
+    """
+    share_service = ConversationShareService(db)
+    result = share_service.get_shared_conversation(share_uuid, password)
+
+    return success(data=result)
+
+
+@router.delete("/{app_id}/conversations/{conversation_id}/share/{share_uuid}", summary="撤销分享链接")
+@cur_workspace_access_guard()
+async def revoke_share(
+        app_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        share_uuid: str,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """撤销会话分享链接"""
+    workspace_id = current_user.current_workspace_id
+
+    share_service = ConversationShareService(db)
+    share_service.revoke_share(share_uuid, workspace_id)
+
+    return success(msg="分享链接已撤销")
+
+
+@router.get("/{app_id}/conversations/{conversation_id}/shares", summary="列出会话的分享链接")
+@cur_workspace_access_guard()
+async def list_conversation_shares(
+        app_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """列出会话的所有分享链接"""
+    workspace_id = current_user.current_workspace_id
+
+    share_service = ConversationShareService(db)
+    result = share_service.list_shares(conversation_id, workspace_id)
+
+    return success(data=result)
+
+
+# ========== 举报 ==========
+
+@router.post("/{app_id}/messages/{message_id}/report", summary="举报消息")
+@cur_workspace_access_guard()
+async def report_message(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        payload: app_schema.MessageReportRequest,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """举报消息中的违规内容
+
+    支持选中反馈：
+    - 用户选中回复中的某段文本，提交举报或反馈，标记不当内容
+    - 上报数据包含：message_id + 文本起始偏移、结束偏移
+    """
+    workspace_id = current_user.current_workspace_id
+
+    # 获取消息以验证存在性
+    message = db.get(Message, message_id)
+    if not message:
+        from app.core.exceptions import BusinessException
+        from app.core.error_codes import BizCode
+        raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+    report_service = ReportService(db)
+    result = report_service.submit_report(
+        message_id=message_id,
+        conversation_id=message.conversation_id,
+        workspace_id=workspace_id,
+        reported_by=current_user.id,
+        report_type=payload.report_type,
+        report_reason=payload.report_reason,
+        text_start_offset=payload.text_start_offset,
+        text_end_offset=payload.text_end_offset,
+        selected_text=payload.selected_text,
+    )
+
+    return success(data=app_schema.MessageReportResponse(**result))
+
+
+# ========== 删除消息 ==========
+
+@router.delete("/{app_id}/messages/{message_id}", summary="删除消息")
+@cur_workspace_access_guard()
+async def delete_message(
+        app_id: uuid.UUID,
+        message_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        current_user=Depends(get_current_user),
+):
+    """删除单条消息（逻辑删除）
+
+    删除中间某条消息后，后续会话上下文自动断层，新追问不再携带被删除的消息
+    """
+    workspace_id = current_user.current_workspace_id
+
+    conv_service = ConversationService(db)
+    await conv_service.delete_message(message_id, workspace_id)
+
+    return success(msg="消息已删除")

--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -18,7 +18,7 @@ from app.models.app_model import AppType
 from app.repositories import knowledge_repository
 from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.workflow_repository import WorkflowConfigRepository
-from app.schemas import release_share_schema, conversation_schema
+from app.schemas import release_share_schema, conversation_schema, app_schema
 from app.schemas.response_schema import PageData, PageMeta
 from app.services import workspace_service
 from app.services.app_chat_service import AppChatService, get_app_chat_service
@@ -31,6 +31,8 @@ from app.services.workflow_service import WorkflowService
 from app.models.file_metadata_model import FileMetadata
 from app.utils.app_config_utils import workflow_config_4_app_release, \
     agent_config_4_app_release, multi_agent_config_4_app_release
+from app.services.message_feedback_service import FeedbackService
+from app.models import Message
 
 router = APIRouter(prefix="/public/share", tags=["Public Share"])
 logger = get_business_logger()
@@ -306,10 +308,38 @@ def get_conversation(
         m = messages[idx]
         m.meta_data["audio_status"] = file_status_map.get(file_id, "unknown")
 
+    # 批量查询当前用户对所有助手消息的反馈
+    message_ids = [m.id for m in messages if m.role == "assistant"]
+    user_feedback_map = {}
+    if message_ids:
+        from app.models.message_feedback_model import MessageFeedback
+        feedbacks = db.query(MessageFeedback).filter(
+            MessageFeedback.message_id.in_(message_ids),
+            MessageFeedback.user_id == share_data.user_id,
+        ).all()
+        user_feedback_map = {f.message_id: (f.feedback_type, f.feedback_content) for f in feedbacks}
+
+    # 构建消息响应列表
+    message_responses = []
+    for m in messages:
+        feedback_type, feedback_content = (None, None)
+        if m.role == "assistant" and m.id in user_feedback_map:
+            feedback_type, feedback_content = user_feedback_map[m.id]
+        
+        message_responses.append(conversation_schema.Message(
+            id=m.id,
+            conversation_id=m.conversation_id,
+            role=m.role,
+            content=m.content,
+            status=m.status,
+            meta_data=m.meta_data,
+            created_at=m.created_at,
+            feedback_type=feedback_type,
+            feedback_content=feedback_content,
+        ))
+
     conv_dict = conversation_schema.Conversation.model_validate(conversation).model_dump(mode="json")
-    conv_dict["messages"] = [
-        conversation_schema.Message.model_validate(m) for m in messages
-    ]
+    conv_dict["messages"] = message_responses
 
     return success(data=conv_dict)
 
@@ -676,3 +706,60 @@ async def config_query(
     else:
         return fail(msg="Unsupported app type", code=BizCode.APP_TYPE_NOT_SUPPORTED)
     return success(data=content)
+
+
+# ---------- 消息反馈接口 ----------
+
+@router.post(
+    "/messages/{message_id}/feedback",
+    summary="提交消息反馈"
+)
+async def submit_message_feedback(
+        message_id: uuid.UUID,
+        payload: app_schema.MessageFeedbackRequest,
+        share_data: ShareTokenData = Depends(get_share_user_id),
+        db: Session = Depends(get_db),
+):
+    """点赞/点踩 AI 回复（公开分享场景）
+
+    幂等设计：重复点击可切换取消
+    - 点赞：用户对满意的 AI 回复给予正面反馈
+    - 点踩：用户对不满意的 AI 回复给予负面反馈，可附加文字说明
+    """
+    # 验证消息存在
+    message = db.get(Message, message_id)
+    if not message:
+        raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+    # 通过 share_token 获取 workspace_id
+    service = SharedChatService(db)
+    share, release = service.get_release_by_share_token(share_data.share_token, None)
+    workspace_id = release.app.workspace_id
+
+    feedback_service = FeedbackService(db)
+    result = feedback_service.submit_feedback(
+        message_id=message_id,
+        conversation_id=message.conversation_id,
+        workspace_id=workspace_id,
+        user_id=share_data.user_id,
+        feedback_type=payload.feedback_type,
+        feedback_content=payload.feedback_content,
+    )
+
+    return success(data=app_schema.MessageFeedbackResponse(**result))
+
+
+@router.get(
+    "/messages/{message_id}/feedback",
+    summary="获取用户对消息的反馈"
+)
+async def get_user_feedback(
+        message_id: uuid.UUID,
+        share_data: ShareTokenData = Depends(get_share_user_id),
+        db: Session = Depends(get_db),
+):
+    """获取当前用户对某条消息的反馈状态"""
+    feedback_service = FeedbackService(db)
+    result = feedback_service.get_user_feedback(message_id, share_data.user_id)
+
+    return success(data=result)

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -38,6 +38,9 @@ from .ontology_class import OntologyClass
 from .ontology_scene import OntologyScene
 from .ontology_class import OntologyClass
 from .implicit_emotions_storage_model import ImplicitEmotionsStorage
+from .message_feedback_model import MessageFeedback
+from .message_report_model import MessageReport
+from .conversation_share_model import ConversationShare
 
 __all__ = [
     "Tenants",
@@ -67,6 +70,9 @@ __all__ = [
     "ReleaseShare",
     "Conversation",
     "Message",
+    "MessageFeedback",
+    "MessageReport",
+    "ConversationShare",
     "ApiKey",
     "ApiKeyLog",
     "ApiKeyType",

--- a/api/app/models/conversation_model.py
+++ b/api/app/models/conversation_model.py
@@ -56,6 +56,7 @@ class Conversation(Base):
     app = relationship("App", back_populates="conversations")
     workspace = relationship("Workspace")
     messages = relationship("Message", back_populates="conversation", cascade="all, delete-orphan")
+    shares = relationship("ConversationShare", back_populates="conversation", cascade="all, delete-orphan")
 
 
 class ConversationDetail(Base):
@@ -84,6 +85,19 @@ class Message(Base):
     role = Column(String(20), nullable=False, comment="角色: user/assistant/system")
     content = Column(Text, nullable=False, comment="消息内容")
 
+    # === 版本化支持（重新生成功能） ===
+    version = Column(Integer, default=1, comment="版本号（重新生成时递增）")
+    is_current = Column(Boolean, default=True, comment="是否为当前展示版本")
+    parent_message_id = Column(UUID(as_uuid=True), comment="父消息ID（用于重新生成时关联原用户消息）")
+
+    # === 逻辑删除 ===
+    is_deleted = Column(Boolean, default=False, comment="逻辑删除标记")
+
+    # === 统计字段（冗余，便于查询） ===
+    like_count = Column(Integer, default=0, comment="点赞数")
+    dislike_count = Column(Integer, default=0, comment="点踩数")
+    report_count = Column(Integer, default=0, comment="举报数")
+
     # 元数据（避免使用 metadata 保留字）
     meta_data = Column(JSON, comment="消息元数据（如模型、token使用等）")
 
@@ -95,3 +109,5 @@ class Message(Base):
 
     # 关联关系
     conversation = relationship("Conversation", back_populates="messages")
+    feedbacks = relationship("MessageFeedback", back_populates="message", cascade="all, delete-orphan")
+    reports = relationship("MessageReport", back_populates="message", cascade="all, delete-orphan")

--- a/api/app/models/conversation_share_model.py
+++ b/api/app/models/conversation_share_model.py
@@ -1,0 +1,40 @@
+"""
+会话分享模型
+"""
+import uuid
+import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db import Base
+
+
+class ConversationShare(Base):
+    """会话分享表
+    
+    支持生成只读公开链接，他人点击即可查看完整对话内容。
+    """
+    __tablename__ = "conversation_shares"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=False, comment="会话ID")
+    share_uuid = Column(String(36), unique=True, nullable=False, comment="分享唯一标识")
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, comment="工作空间ID")
+    created_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, comment="创建人ID")
+
+    # 访问控制
+    password = Column(String(100), comment="访问密码（可选）")
+    expire_at = Column(DateTime, comment="过期时间")
+    allow_copy = Column(Boolean, default=True, comment="是否允许复制内容")
+
+    # 统计
+    view_count = Column(Integer, default=0, comment="访问次数")
+
+    is_active = Column(Boolean, default=True, nullable=False, comment="是否有效")
+    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+
+    # 关联关系
+    conversation = relationship("Conversation", back_populates="shares")
+    creator = relationship("User", foreign_keys=[created_by])

--- a/api/app/models/message_feedback_model.py
+++ b/api/app/models/message_feedback_model.py
@@ -1,0 +1,43 @@
+"""
+消息反馈模型（点赞/点踩）
+"""
+import uuid
+import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, Text, Integer, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db import Base
+
+
+class MessageFeedback(Base):
+    """消息反馈表（点赞/点踩）
+    
+    支持用户对 AI 回复进行正面/负面反馈，用于：
+    - 积累高质量问答数据
+    - 模型迭代优化
+    - 问答质量评估
+    """
+    __tablename__ = "message_feedbacks"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    message_id = Column(UUID(as_uuid=True), ForeignKey("messages.id"), nullable=False, comment="消息ID")
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=False, comment="会话ID")
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, comment="工作空间ID")
+    user_id = Column(String, nullable=False, comment="用户ID（EndUser 或 User）")
+
+    # 反馈内容
+    feedback_type = Column(String(20), nullable=False, comment="反馈类型: like/dislike")
+    feedback_content = Column(Text, comment="反馈原因（点踩时填写）")
+
+    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+
+    # 联合唯一约束：一个用户对一条消息只能有一条反馈
+    __table_args__ = (
+        UniqueConstraint('message_id', 'user_id', name='uq_message_feedback'),
+    )
+
+    # 关联关系
+    message = relationship("Message", back_populates="feedbacks")
+    conversation = relationship("Conversation")

--- a/api/app/models/message_report_model.py
+++ b/api/app/models/message_report_model.py
@@ -1,0 +1,56 @@
+"""
+消息举报模型（含选中反馈和审核）
+"""
+import uuid
+import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, Text, Integer
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db import Base
+
+
+class MessageReport(Base):
+    """消息举报表（含选中反馈和审核）
+    
+    支持功能：
+    - 选中反馈：用户选中某段文本提交反馈
+    - 举报：标记不当内容
+    - 审核流程：平台侧对举报数据进行分类、严重度分拣、趋势分析
+    """
+    __tablename__ = "message_reports"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    message_id = Column(UUID(as_uuid=True), ForeignKey("messages.id"), nullable=False, comment="消息ID")
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=False, comment="会话ID")
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, comment="工作空间ID")
+    reported_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, comment="举报人ID")
+
+    # 举报类型
+    report_type = Column(String(50), nullable=False, comment="举报类型: politics/porn/violence/fake/ad/quality/other")
+    report_reason = Column(Text, comment="举报原因详细描述")
+
+    # 选中文本定位（支持选中反馈）
+    text_start_offset = Column(Integer, comment="选中文本起始位置")
+    text_end_offset = Column(Integer, comment="选中文本结束位置")
+    selected_text = Column(Text, comment="选中的违规文本片段")
+
+    # 审核状态
+    status = Column(String(20), server_default="pending", comment="状态: pending/reviewing/resolved/rejected")
+    severity = Column(String(20), comment="严重程度: low/medium/high/critical")
+    reviewer_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), comment="审核人ID")
+    review_note = Column(Text, comment="审核备注")
+    reviewed_at = Column(DateTime, comment="审核时间")
+
+    # 处理结果
+    action_taken = Column(String(50), comment="处理措施: warning/content_removed/user_banned/no_action")
+
+    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+
+    # 关联关系
+    message = relationship("Message", back_populates="reports")
+    conversation = relationship("Conversation")
+    reporter = relationship("User", foreign_keys=[reported_by])
+    reviewer = relationship("User", foreign_keys=[reviewer_id])

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -769,3 +769,68 @@ class DraftRunCompareResponse(BaseModel):
 
     fastest_model: Optional[str] = None
     cheapest_model: Optional[str] = None
+
+
+# ========== 消息交互功能 Schema ==========
+
+class MessageFeedbackRequest(BaseModel):
+    """消息反馈请求（点赞/点踩）"""
+    feedback_type: str = Field(..., pattern="^(like|dislike)$", description="反馈类型: like/dislike")
+    feedback_content: Optional[str] = Field(None, description="反馈内容（点踩时填写原因）")
+
+
+class MessageFeedbackResponse(BaseModel):
+    """消息反馈响应"""
+    action: str = Field(..., description="操作: created/updated/cancelled")
+    feedback_type: Optional[str] = Field(None, description="当前反馈类型")
+
+
+class MessageReportRequest(BaseModel):
+    """消息举报请求（含选中反馈）"""
+    report_type: str = Field(
+        ...,
+        description="举报类型: politics/porn/violence/fake/ad/quality/other"
+    )
+    report_reason: Optional[str] = Field(None, description="举报原因详细描述")
+    text_start_offset: Optional[int] = Field(None, description="选中文本起始位置")
+    text_end_offset: Optional[int] = Field(None, description="选中文本结束位置")
+    selected_text: Optional[str] = Field(None, description="选中的违规文本片段")
+
+
+class MessageReportResponse(BaseModel):
+    """消息举报响应"""
+    report_id: str = Field(..., description="举报ID")
+    status: str = Field(..., description="状态: pending")
+
+
+class ShareConversationRequest(BaseModel):
+    """分享会话请求"""
+    password: Optional[str] = Field(None, description="访问密码（可选）")
+    expire_hours: Optional[int] = Field(None, ge=1, le=720, description="过期时长（小时）")
+    allow_copy: bool = Field(True, description="是否允许复制内容")
+
+
+class ShareConversationResponse(BaseModel):
+    """分享会话响应"""
+    share_id: str = Field(..., description="分享ID")
+    share_uuid: str = Field(..., description="分享唯一标识")
+    share_url: str = Field(..., description="分享链接")
+    expire_at: Optional[int] = Field(None, description="过期时间（毫秒时间戳）")
+    has_password: bool = Field(..., description="是否有密码")
+
+
+class MessageVersion(BaseModel):
+    """消息版本"""
+    message_id: uuid.UUID
+    version: int
+    is_current: bool
+    content: str
+    created_at: int
+
+
+class RegenerateResponse(BaseModel):
+    """重新生成响应"""
+    message_id: uuid.UUID
+    message: str
+    version: int
+    conversation_id: str

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -48,6 +48,9 @@ class Message(BaseModel):
     status: str
     meta_data: Optional[Dict[str, Any]] = None
     created_at: datetime.datetime
+    # 反馈信息（仅助手消息有效，由 controller 注入）
+    feedback_type: Optional[str] = Field(None, description="反馈类型: like/dislike")
+    feedback_content: Optional[str] = Field(None, description="反馈内容")
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from datetime import datetime, timedelta
 from typing import Annotated
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Dict, Any
 
 import json_repair
 from fastapi import Depends
@@ -453,6 +453,134 @@ class ConversationService:
         )
 
         return conversation
+
+    async def delete_message(
+            self,
+            message_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+    ) -> None:
+        """删除单条消息（逻辑删除）
+
+        Args:
+            message_id: 消息ID
+            workspace_id: 工作空间ID
+        """
+        message = self.db.get(Message, message_id)
+        if not message:
+            raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+        # 权限校验：验证会话属于当前工作空间
+        conv = self.db.get(Conversation, message.conversation_id)
+        if conv.workspace_id != workspace_id:
+            raise BusinessException("无权删除此消息", BizCode.PERMISSION_DENIED)
+
+        message.is_deleted = True
+        self.db.commit()
+
+        logger.info(
+            "消息已删除",
+            extra={
+                "message_id": str(message_id),
+                "workspace_id": str(workspace_id),
+            }
+        )
+
+    def get_message_versions(
+            self,
+            message_id: uuid.UUID,
+    ) -> List[Dict[str, Any]]:
+        """获取消息的所有版本
+
+        Args:
+            message_id: 消息ID
+
+        Returns:
+            List[Dict]: 版本列表
+        """
+        message = self.db.get(Message, message_id)
+        if not message:
+            raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+        # 查询同一 parent_message_id 下的所有版本
+        if message.parent_message_id:
+            versions = self.db.query(Message).filter(
+                Message.parent_message_id == message.parent_message_id,
+                Message.role == "assistant",
+                Message.is_deleted == False,
+            ).order_by(Message.version).all()
+        else:
+            # 如果没有 parent_message_id，则只返回自己
+            versions = [message]
+
+        return [
+            {
+                "message_id": str(v.id),
+                "version": v.version,
+                "is_current": v.is_current,
+                "content": v.content,
+                "created_at": int(v.created_at.timestamp() * 1000),
+            }
+            for v in versions
+        ]
+
+    def switch_message_version(
+            self,
+            message_id: uuid.UUID,
+            version: int,
+            workspace_id: uuid.UUID,
+    ) -> Dict[str, Any]:
+        """切换消息版本
+
+        Args:
+            message_id: 当前消息ID
+            version: 目标版本号
+            workspace_id: 工作空间ID
+
+        Returns:
+            Dict: 切换后的消息信息
+        """
+        current_msg = self.db.get(Message, message_id)
+        if not current_msg:
+            raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+        # 验证权限
+        conv = self.db.get(Conversation, current_msg.conversation_id)
+        if conv.workspace_id != workspace_id:
+            raise BusinessException("无权操作此消息", BizCode.PERMISSION_DENIED)
+
+        # 查找目标版本
+        if current_msg.parent_message_id:
+            target_msg = self.db.query(Message).filter(
+                Message.parent_message_id == current_msg.parent_message_id,
+                Message.role == "assistant",
+                Message.version == version,
+                Message.is_deleted == False,
+            ).first()
+        else:
+            target_msg = current_msg if current_msg.version == version else None
+
+        if not target_msg:
+            raise BusinessException("版本不存在", BizCode.NOT_FOUND)
+
+        # 切换 is_current
+        if current_msg.parent_message_id:
+            # 先将所有版本设为非当前
+            all_versions = self.db.query(Message).filter(
+                Message.parent_message_id == current_msg.parent_message_id,
+                Message.role == "assistant",
+            ).all()
+            for v in all_versions:
+                v.is_current = False
+
+            # 设置目标版本为当前
+            target_msg.is_current = True
+            self.db.commit()
+
+        return {
+            "message_id": str(target_msg.id),
+            "version": target_msg.version,
+            "content": target_msg.content,
+        }
 
     async def get_conversation_detail(
             self,

--- a/api/app/services/conversation_share_service.py
+++ b/api/app/services/conversation_share_service.py
@@ -1,0 +1,217 @@
+"""
+会话分享服务
+"""
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, Any, Optional, List
+
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
+from app.core.logging_config import get_business_logger
+from app.core.config import settings
+from app.models import ConversationShare, Message
+
+logger = get_business_logger()
+
+
+class ConversationShareService:
+    """会话分享服务"""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_share(
+        self,
+        conversation_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        user_id: uuid.UUID,
+        password: Optional[str] = None,
+        expire_hours: Optional[int] = None,
+        allow_copy: bool = True,
+    ) -> Dict[str, Any]:
+        """创建分享链接
+
+        Args:
+            conversation_id: 会话ID
+            workspace_id: 工作空间ID
+            user_id: 创建人ID
+            password: 访问密码（可选）
+            expire_hours: 过期时长（小时）
+            allow_copy: 是否允许复制内容
+
+        Returns:
+            Dict: 包含分享链接等信息
+        """
+        from app.models import Conversation
+        # 验证会话存在
+        conv = self.db.get(Conversation, conversation_id)
+        if not conv:
+            raise BusinessException("会话不存在", BizCode.NOT_FOUND)
+
+        # 生成唯一分享标识（8位短链接）
+        share_uuid = str(uuid.uuid4())[:8]
+
+        expire_at = None
+        if expire_hours:
+            expire_at = datetime.now() + timedelta(hours=expire_hours)
+
+        share = ConversationShare(
+            conversation_id=conversation_id,
+            share_uuid=share_uuid,
+            workspace_id=workspace_id,
+            created_by=user_id,
+            password=password,
+            expire_at=expire_at,
+            allow_copy=allow_copy,
+        )
+        self.db.add(share)
+        self.db.commit()
+        self.db.refresh(share)
+
+        share_url = f"{settings.FILE_LOCAL_SERVER_URL}/share/{share_uuid}"
+
+        logger.info(
+            "创建分享链接",
+            extra={
+                "share_uuid": share_uuid,
+                "conversation_id": str(conversation_id),
+                "user_id": str(user_id),
+            }
+        )
+
+        return {
+            "share_id": str(share.id),
+            "share_uuid": share_uuid,
+            "share_url": share_url,
+            "expire_at": int(expire_at.timestamp() * 1000) if expire_at else None,
+            "has_password": bool(password),
+        }
+
+    def get_shared_conversation(
+        self,
+        share_uuid: str,
+        password: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """获取分享的会话（只读模式）
+
+        Args:
+            share_uuid: 分享标识
+            password: 访问密码
+
+        Returns:
+            Dict: 会话消息列表和元数据
+        """
+        share = self.db.query(ConversationShare).filter(
+            ConversationShare.share_uuid == share_uuid,
+            ConversationShare.is_active == True,
+        ).first()
+
+        if not share:
+            raise BusinessException("分享链接不存在或已失效", BizCode.NOT_FOUND)
+
+        # 检查过期
+        if share.expire_at and share.expire_at < datetime.now():
+            raise BusinessException("分享链接已过期", BizCode.FORBIDDEN)
+
+        # 检查密码
+        if share.password and share.password != password:
+            raise BusinessException("访问密码错误", BizCode.FORBIDDEN)
+
+        # 更新访问计数
+        share.view_count += 1
+        self.db.commit()
+
+        # 获取会话消息（排除已删除的）
+        messages = self.db.query(Message).filter(
+            Message.conversation_id == share.conversation_id,
+            Message.is_deleted == False,
+        ).order_by(Message.created_at).all()
+
+        logger.info(
+            "访问分享链接",
+            extra={
+                "share_uuid": share_uuid,
+                "view_count": share.view_count,
+            }
+        )
+
+        return {
+            "conversation_id": str(share.conversation_id),
+            "messages": [
+                {
+                    "id": str(msg.id),
+                    "role": msg.role,
+                    "content": msg.content,
+                    "created_at": int(msg.created_at.timestamp() * 1000),
+                }
+                for msg in messages
+            ],
+            "allow_copy": share.allow_copy,
+            "is_readonly": True,  # 只读标记
+        }
+
+    def revoke_share(
+        self,
+        share_uuid: str,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """撤销分享链接
+
+        Args:
+            share_uuid: 分享标识
+            workspace_id: 工作空间ID
+        """
+        share = self.db.query(ConversationShare).filter(
+            ConversationShare.share_uuid == share_uuid,
+            ConversationShare.workspace_id == workspace_id,
+        ).first()
+
+        if not share:
+            raise BusinessException("分享链接不存在", BizCode.NOT_FOUND)
+
+        share.is_active = False
+        self.db.commit()
+
+        logger.info(
+            "撤销分享链接",
+            extra={
+                "share_uuid": share_uuid,
+                "workspace_id": str(workspace_id),
+            }
+        )
+
+    def list_shares(
+        self,
+        conversation_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> List[Dict[str, Any]]:
+        """列出会话的所有分享链接
+
+        Args:
+            conversation_id: 会话ID
+            workspace_id: 工作空间ID
+
+        Returns:
+            List[Dict]: 分享链接列表
+        """
+        shares = self.db.query(ConversationShare).filter(
+            ConversationShare.conversation_id == conversation_id,
+            ConversationShare.workspace_id == workspace_id,
+            ConversationShare.is_active == True,
+        ).order_by(ConversationShare.created_at.desc()).all()
+
+        return [
+            {
+                "share_id": str(s.id),
+                "share_uuid": s.share_uuid,
+                "share_url": f"{settings.FILE_LOCAL_SERVER_URL}/share/{s.share_uuid}",
+                "view_count": s.view_count,
+                "expire_at": int(s.expire_at.timestamp() * 1000) if s.expire_at else None,
+                "has_password": bool(s.password),
+                "allow_copy": s.allow_copy,
+                "created_at": int(s.created_at.timestamp() * 1000),
+            }
+            for s in shares
+        ]

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -829,8 +829,9 @@ class AgentRunService:
             )) if not sub_agent else []
 
             # 10. 保存会话消息
+            message_id = None
             if not sub_agent:
-                await self._save_conversation_message(
+                message_id = await self._save_conversation_message(
                     conversation_id=conversation_id,
                     user_message=message,
                     assistant_message=result["content"],
@@ -866,6 +867,7 @@ class AgentRunService:
 
             response = {
                 "message": result["content"],
+                "message_id": message_id,
                 "reasoning_content": result.get("reasoning_content"),
                 "conversation_id": conversation_id,
                 "usage": result.get("usage", {
@@ -1216,8 +1218,9 @@ class AgentRunService:
             )) if not sub_agent else []
 
             # 11. 保存会话消息
+            message_id = None
             if not sub_agent:
-                await self._save_conversation_message(
+                message_id = await self._save_conversation_message(
                     conversation_id=conversation_id,
                     user_message=message,
                     assistant_message=full_content,
@@ -1249,6 +1252,7 @@ class AgentRunService:
             # 12. 发送结束事件（包含 suggested_questions、audio_url 和 audio_status）
             end_data: Dict[str, Any] = {
                 "conversation_id": conversation_id,
+                "message_id": message_id,
                 "elapsed_time": elapsed_time,
                 "message_length": len(full_content)
             }
@@ -1568,7 +1572,7 @@ class AgentRunService:
             citations: Optional[List[Any]] = None,
             provider: Optional[str] = None,
             is_omni: Optional[bool] = None
-    ) -> None:
+    ) -> Optional[str]:
         """保存会话消息（会话已通过 _ensure_conversation 确保存在）
 
         Args:
@@ -1584,6 +1588,9 @@ class AgentRunService:
             citations: 引用来源列表
             provider: 模型供应商
             is_omni: 是否为全模态模型
+
+        Returns:
+            Optional[str]: 助手消息ID
         """
         try:
             from app.services.conversation_service import ConversationService
@@ -1632,7 +1639,7 @@ class AgentRunService:
                 }
 
             # 保存用户消息
-            conversation_service.add_message(
+            user_msg = conversation_service.add_message(
                 conversation_id=conv_uuid,
                 role="user",
                 content=user_message,
@@ -1643,24 +1650,33 @@ class AgentRunService:
                 meta_data["audio_url"] = audio_url
             if citations:
                 meta_data["citations"] = citations
-            conversation_service.add_message(
+            assistant_msg = conversation_service.add_message(
                 conversation_id=conv_uuid,
                 role="assistant",
                 content=assistant_message,
                 meta_data=meta_data
             )
 
+            # 设置 parent_message_id（助手消息关联到用户消息）
+            assistant_msg.parent_message_id = user_msg.id
+            self.db.commit()
+
             logger.debug(
                 "保存会话消息",
                 extra={
                     "conversation_id": conversation_id,
                     "user_message_length": len(user_message),
-                    "assistant_message_length": len(assistant_message)
+                    "assistant_message_length": len(assistant_message),
+                    "user_msg_id": str(user_msg.id),
+                    "assistant_msg_id": str(assistant_msg.id),
                 }
             )
 
+            return str(assistant_msg.id)
+
         except Exception as e:
             logger.warning("保存会话消息失败", extra={"error": str(e)})
+            return None
 
     async def _get_config_snapshot(self, app_id: uuid.UUID) -> Dict[str, Any]:
         """获取当前配置快照
@@ -2769,3 +2785,149 @@ class AgentRunService:
                 "total_time": sum(r.get("elapsed_time", 0) for r in results)
             }
         )
+
+    # ==================== 重新生成功能 ====================
+
+    async def regenerate(
+            self,
+            *,
+            message_id: uuid.UUID,
+            agent_config: AgentConfig,
+            model_config: ModelConfig,
+            workspace_id: uuid.UUID,
+            user_id: str,
+            storage_type: Optional[str] = None,
+            user_rag_memory_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """重新生成回复（多版本支持）
+
+        核心逻辑：
+        1. 获取原 assistant 消息及其父 user 消息
+        2. 将原 assistant 消息标记为非当前版本 (is_current=False)
+        3. 复用相同的上下文重新调用 LLM
+        4. 保存新版本 assistant 消息（version+1, is_current=True）
+
+        Args:
+            message_id: 原 AI 回复的消息ID
+            agent_config: Agent 配置
+            model_config: 模型配置
+            workspace_id: 工作空间ID
+            user_id: 用户ID
+            storage_type: 存储类型
+            user_rag_memory_id: RAG 记忆ID
+
+        Returns:
+            Dict: 包含新消息ID、内容、版本号等
+        """
+        from app.models import Message
+
+        # 1. 获取原消息
+        original_msg = self.db.get(Message, message_id)
+        if not original_msg or original_msg.role != "assistant":
+            raise BusinessException("只能重新生成 AI 回复", BizCode.BAD_REQUEST)
+
+        if original_msg.is_deleted:
+            raise BusinessException("消息已被删除", BizCode.BAD_REQUEST)
+
+        # 2. 将原版本标记为非当前
+        original_msg.is_current = False
+        self.db.commit()
+
+        # 3. 获取父用户消息（用于提取原始问题）
+        parent_msg_id = original_msg.parent_message_id
+        if not parent_msg_id:
+            # 如果没有 parent_message_id，则查找上一条 user 消息
+            from sqlalchemy import select as sa_select
+            parent_msg = self.db.scalars(
+                sa_select(Message)
+                .where(
+                    Message.conversation_id == original_msg.conversation_id,
+                    Message.role == "user",
+                    Message.created_at < original_msg.created_at,
+                    Message.is_deleted == False,
+                )
+                .order_by(Message.created_at.desc())
+                .limit(1)
+            ).first()
+            if not parent_msg:
+                raise BusinessException("无法找到原始用户消息", BizCode.NOT_FOUND)
+            parent_msg_id = parent_msg.id
+        else:
+            parent_msg = self.db.get(Message, parent_msg_id)
+
+        user_message_content = parent_msg.content if parent_msg else ""
+
+        # 4. 加载上下文（到父消息为止）
+        conversation_id = str(original_msg.conversation_id)
+        history = await self._load_conversation_history(
+            conversation_id=conversation_id,
+            max_history=agent_config.memory.get("max_history", 10) if agent_config.memory else 10,
+            current_provider=None,
+            current_is_omni=False,
+        )
+
+        filtered_history = []
+        for h in history:
+            # TODO: 需要过滤掉当前消息之后的历史（只保留到父消息）
+            filtered_history.append(h)
+
+        # 5. 调用 LLM（复用现有 run 方法，不保存消息）
+        result = await self.run(
+            agent_config=agent_config,
+            model_config=model_config,
+            message=user_message_content,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            user_id=user_id,
+            storage_type=storage_type,
+            user_rag_memory_id=user_rag_memory_id,
+            sub_agent=True,  # 标记为子调用，避免重复保存
+        )
+
+        # 6. 保存新版本消息
+        new_version = original_msg.version + 1
+        new_msg = Message(
+            conversation_id=original_msg.conversation_id,
+            role="assistant",
+            content=result["message"],
+            version=new_version,
+            is_current=True,
+            parent_message_id=parent_msg_id,
+            meta_data={
+                "usage": result.get("usage"),
+                "reasoning_content": result.get("reasoning_content"),
+                "regenerated_from": str(message_id),
+                "suggested_questions": result.get("suggested_questions", []),
+                "citations": result.get("citations", []),
+            },
+        )
+        self.db.add(new_msg)
+
+        # 更新会话消息计数
+        from app.models import Conversation
+        conv = self.db.get(Conversation, original_msg.conversation_id)
+        if conv:
+            conv.message_count += 1
+
+        self.db.commit()
+        self.db.refresh(new_msg)
+
+        logger.info(
+            "重新生成回复成功",
+            extra={
+                "original_message_id": str(message_id),
+                "new_message_id": str(new_msg.id),
+                "version": new_version,
+                "conversation_id": conversation_id,
+            }
+        )
+
+        return {
+            "message_id": str(new_msg.id),
+            "message": result["message"],
+            "reasoning_content": result.get("reasoning_content"),
+            "version": new_version,
+            "conversation_id": conversation_id,
+            "suggested_questions": result.get("suggested_questions", []),
+            "citations": result.get("citations", []),
+        }

--- a/api/app/services/message_feedback_service.py
+++ b/api/app/services/message_feedback_service.py
@@ -1,0 +1,174 @@
+"""
+消息反馈服务（点赞/点踩）
+"""
+import uuid
+from typing import Dict, Any, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
+from app.core.logging_config import get_business_logger
+from app.models import MessageFeedback, Message
+
+logger = get_business_logger()
+
+
+class FeedbackService:
+    """消息反馈服务"""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def submit_feedback(
+        self,
+        message_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        user_id: str,
+        feedback_type: str,
+        feedback_content: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """提交反馈（点赞/点踩），幂等设计
+
+        Args:
+            message_id: 消息ID
+            conversation_id: 会话ID
+            workspace_id: 工作空间ID
+            user_id: 用户ID
+            feedback_type: 反馈类型 (like/dislike)
+            feedback_content: 反馈内容（点踩时填写原因）
+
+        Returns:
+            Dict: 包含操作结果
+        """
+        # 查找已有反馈
+        existing = self.db.query(MessageFeedback).filter(
+            MessageFeedback.message_id == message_id,
+            MessageFeedback.user_id == user_id,
+        ).first()
+
+        message = self.db.get(Message, message_id)
+        if not message:
+            raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+        if existing:
+            # 重复点击：取消反馈
+            if existing.feedback_type == feedback_type:
+                # 更新计数
+                if feedback_type == "like":
+                    message.like_count = max(0, message.like_count - 1)
+                else:
+                    message.dislike_count = max(0, message.dislike_count - 1)
+
+                self.db.delete(existing)
+                self.db.commit()
+                logger.info(
+                    "取消反馈",
+                    extra={
+                        "message_id": str(message_id),
+                        "user_id": user_id,
+                        "feedback_type": feedback_type,
+                    }
+                )
+                return {"action": "cancelled", "feedback_type": None}
+
+            # 切换类型：like -> dislike 或 dislike -> like
+            if existing.feedback_type == "like":
+                message.like_count = max(0, message.like_count - 1)
+                message.dislike_count += 1
+            else:
+                message.dislike_count = max(0, message.dislike_count - 1)
+                message.like_count += 1
+
+            existing.feedback_type = feedback_type
+            existing.feedback_content = feedback_content
+            self.db.commit()
+            logger.info(
+                "更新反馈",
+                extra={
+                    "message_id": str(message_id),
+                    "user_id": user_id,
+                    "feedback_type": feedback_type,
+                }
+            )
+            return {"action": "updated", "feedback_type": feedback_type}
+
+        # 新增反馈
+        feedback = MessageFeedback(
+            message_id=message_id,
+            conversation_id=conversation_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            feedback_type=feedback_type,
+            feedback_content=feedback_content,
+        )
+        self.db.add(feedback)
+
+        # 更新计数
+        if feedback_type == "like":
+            message.like_count += 1
+        else:
+            message.dislike_count += 1
+
+        self.db.commit()
+        logger.info(
+            "创建反馈",
+            extra={
+                "message_id": str(message_id),
+                "user_id": user_id,
+                "feedback_type": feedback_type,
+            }
+        )
+        return {"action": "created", "feedback_type": feedback_type}
+
+    def get_feedback_statistics(
+        self,
+        message_id: uuid.UUID,
+    ) -> Dict[str, Any]:
+        """获取消息的反馈统计
+
+        Args:
+            message_id: 消息ID
+
+        Returns:
+            Dict: 统计数据
+        """
+        message = self.db.get(Message, message_id)
+        if not message:
+            raise BusinessException("消息不存在", BizCode.NOT_FOUND)
+
+        return {
+            "message_id": str(message_id),
+            "like_count": message.like_count,
+            "dislike_count": message.dislike_count,
+            "report_count": message.report_count,
+        }
+
+    def get_user_feedback(
+        self,
+        message_id: uuid.UUID,
+        user_id: str,
+    ) -> Optional[Dict[str, Any]]:
+        """获取用户对消息的反馈
+
+        Args:
+            message_id: 消息ID
+            user_id: 用户ID
+
+        Returns:
+            Optional[Dict]: 反馈信息，如果没有则返回 None
+        """
+        feedback = self.db.query(MessageFeedback).filter(
+            MessageFeedback.message_id == message_id,
+            MessageFeedback.user_id == user_id,
+        ).first()
+
+        if not feedback:
+            return None
+
+        return {
+            "feedback_type": feedback.feedback_type,
+            "feedback_content": feedback.feedback_content,
+            "created_at": int(feedback.created_at.timestamp() * 1000),
+        }

--- a/api/app/services/message_report_service.py
+++ b/api/app/services/message_report_service.py
@@ -1,0 +1,239 @@
+"""
+消息举报服务（含选中反馈和审核）
+"""
+import uuid
+from datetime import datetime
+from typing import Dict, Any, Optional, List, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
+from app.core.logging_config import get_business_logger
+from app.models import MessageReport, Message
+
+logger = get_business_logger()
+
+
+class ReportService:
+    """消息举报服务"""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def submit_report(
+        self,
+        message_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        reported_by: uuid.UUID,
+        report_type: str,
+        report_reason: Optional[str] = None,
+        text_start_offset: Optional[int] = None,
+        text_end_offset: Optional[int] = None,
+        selected_text: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """提交举报/选中反馈
+
+        Args:
+            message_id: 消息ID
+            conversation_id: 会话ID
+            workspace_id: 工作空间ID
+            reported_by: 举报人ID
+            report_type: 举报类型
+            report_reason: 举报原因
+            text_start_offset: 选中文本起始位置
+            text_end_offset: 选中文本结束位置
+            selected_text: 选中的文本片段
+
+        Returns:
+            Dict: 包含举报ID和状态
+        """
+        report = MessageReport(
+            message_id=message_id,
+            conversation_id=conversation_id,
+            workspace_id=workspace_id,
+            reported_by=reported_by,
+            report_type=report_type,
+            report_reason=report_reason,
+            text_start_offset=text_start_offset,
+            text_end_offset=text_end_offset,
+            selected_text=selected_text,
+        )
+        self.db.add(report)
+
+        # 更新消息举报计数
+        message = self.db.get(Message, message_id)
+        if message:
+            message.report_count += 1
+
+        self.db.commit()
+        self.db.refresh(report)
+
+        logger.info(
+            "提交举报",
+            extra={
+                "report_id": str(report.id),
+                "message_id": str(message_id),
+                "report_type": report_type,
+                "reported_by": str(reported_by),
+            }
+        )
+
+        # 触发自动审核（异步）
+        self._trigger_auto_audit(report.id)
+
+        return {
+            "report_id": str(report.id),
+            "status": "pending",
+        }
+
+    def _trigger_auto_audit(self, report_id: uuid.UUID):
+        """触发自动审核（调用内容安全网关）
+
+        Args:
+            report_id: 举报ID
+        """
+        # TODO: 接入阿里云内容安全、腾讯云天御等
+        # 审核结果更新到 report.status 和 report.severity
+        logger.debug(f"触发自动审核: {report_id}")
+
+    def get_reports_for_review(
+        self,
+        workspace_id: uuid.UUID,
+        status: Optional[str] = None,
+        severity: Optional[str] = None,
+        page: int = 1,
+        pagesize: int = 20,
+    ) -> Tuple[List[MessageReport], int]:
+        """获取待审核举报列表（运营后台）
+
+        Args:
+            workspace_id: 工作空间ID
+            status: 状态过滤
+            severity: 严重程度过滤
+            page: 页码
+            pagesize: 每页数量
+
+        Returns:
+            Tuple[List[MessageReport], int]: 举报列表和总数
+        """
+        query = self.db.query(MessageReport).filter(
+            MessageReport.workspace_id == workspace_id,
+        )
+
+        if status:
+            query = query.filter(MessageReport.status == status)
+        if severity:
+            query = query.filter(MessageReport.severity == severity)
+
+        total = query.count()
+        reports = query.order_by(
+            MessageReport.created_at.desc()
+        ).offset((page - 1) * pagesize).limit(pagesize).all()
+
+        return reports, total
+
+    def review_report(
+        self,
+        report_id: uuid.UUID,
+        reviewer_id: uuid.UUID,
+        severity: str,
+        action_taken: str,
+        review_note: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """审核举报（运营后台）
+
+        Args:
+            report_id: 举报ID
+            reviewer_id: 审核人ID
+            severity: 严重程度
+            action_taken: 处理措施
+            review_note: 审核备注
+
+        Returns:
+            Dict: 审核结果
+        """
+        report = self.db.get(MessageReport, report_id)
+        if not report:
+            raise BusinessException("举报记录不存在", BizCode.NOT_FOUND)
+
+        report.status = "reviewed"
+        report.severity = severity
+        report.action_taken = action_taken
+        report.reviewer_id = reviewer_id
+        report.review_note = review_note
+        report.reviewed_at = datetime.now()
+
+        # 根据处理措施执行相应操作
+        if action_taken == "content_removed":
+            # 标记消息为删除
+            message = self.db.get(Message, report.message_id)
+            if message:
+                message.is_deleted = True
+        elif action_taken == "user_banned":
+            # TODO: 封禁用户逻辑
+            pass
+
+        self.db.commit()
+
+        logger.info(
+            "审核举报",
+            extra={
+                "report_id": str(report_id),
+                "reviewer_id": str(reviewer_id),
+                "severity": severity,
+                "action_taken": action_taken,
+            }
+        )
+
+        return {
+            "report_id": str(report_id),
+            "status": "reviewed",
+            "action_taken": action_taken,
+        }
+
+    def get_reports_statistics(
+        self,
+        workspace_id: uuid.UUID,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        """获取举报统计（平台侧）
+
+        Args:
+            workspace_id: 工作空间ID
+            start_date: 开始日期
+            end_date: 结束日期
+
+        Returns:
+            Dict: 统计数据
+        """
+        query = self.db.query(MessageReport).filter(
+            MessageReport.workspace_id == workspace_id,
+        )
+
+        if start_date:
+            query = query.filter(MessageReport.created_at >= start_date)
+        if end_date:
+            query = query.filter(MessageReport.created_at <= end_date)
+
+        reports = query.all()
+
+        # 按类型分组统计
+        type_stats = {}
+        severity_stats = {}
+        status_stats = {}
+        for r in reports:
+            type_stats[r.report_type] = type_stats.get(r.report_type, 0) + 1
+            if r.severity:
+                severity_stats[r.severity] = severity_stats.get(r.severity, 0) + 1
+            status_stats[r.status] = status_stats.get(r.status, 0) + 1
+
+        return {
+            "total_count": len(reports),
+            "by_type": type_stats,
+            "by_severity": severity_stats,
+            "by_status": status_stats,
+            "pending_count": sum(1 for r in reports if r.status == "pending"),
+        }


### PR DESCRIPTION
add message feedback and conversation sharing capabilities

## Summary by Sourcery

为消息级别交互新增能力，包括反馈、版本化重生成、举报、删除及会话分享，并扩展会话/消息模型和 API 以支持这些交互。

新功能：
- 暴露带多版本管理的消息重生成功能，用于助手回复，包括列出和切换版本，以及从草稿运行中返回消息 ID。
- 引入按消息的点赞/点踩反馈，包含按用户的状态、计数器，以及对公共分享的支持 API。
- 添加消息举报功能，支持带选中文本上下文，并提供用于审计流的界面以支持审核和统计。
- 提供会话分享链接，支持可选密码、过期时间、复制控制、列表和撤销功能，并新增公共只读访问端点。

增强：
- 扩展会话和消息模型及模式，加入版本控制、逻辑删除、反馈/举报计数器，以及消息载荷中的反馈字段。
- 在运行和流式响应中包含助手消息 ID，以便将前端操作关联到具体消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add message-level interaction capabilities including feedback, versioned regeneration, reporting, deletion, and conversation sharing, and enrich conversation/message models and APIs to support these interactions.

New Features:
- Expose message regeneration with multi-version management for assistant replies, including listing and switching versions, and returning message IDs from draft runs.
- Introduce per-message like/dislike feedback with per-user state, counters, and public-share support APIs.
- Add message reporting with selected-text context and an audit workflow surface for moderation and statistics.
- Provide conversation sharing links with optional password, expiry, copy controls, listing, and revocation, plus a public read-only access endpoint.

Enhancements:
- Extend conversation and message models and schemas with versioning, logical deletion, feedback/report counters, and feedback fields in message payloads.
- Include assistant message IDs in run and streaming responses to tie front-end actions to specific messages.

</details>