### PR TITLE
fix: add rerank_score_threshold to filter low-relevance results after rerank

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -727,8 +727,8 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
-            if retrieve_data.rerank_score_threshold is not None:
-                rs = [doc for doc in rs if doc.metadata.get("score", 0) > retrieve_data.rerank_score_threshold]
+            rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else 0.1
+            rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -727,6 +727,8 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
+            if retrieve_data.rerank_score_threshold is not None:
+                rs = [doc for doc in rs if doc.metadata.get("score", 0) > retrieve_data.rerank_score_threshold]
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -78,6 +78,7 @@ class ChunkRetrieve(BaseModel):
     vector_similarity_weight: float | None = Field(None)
     top_k: int | None = Field(None)
     retrieve_type: RetrieveType | None = Field(None)
+    rerank_score_threshold: float | None = Field(None, ge=0, le=1)
 
 
 class ChunkBatchCreate(BaseModel):


### PR DESCRIPTION
## Summary
- 新增 `rerank_score_threshold` 参数，重排后过滤低分结果
- 默认值 0.1，不传时自动过滤 score ≤ 0.1 的文档

## Root Cause
Hybrid 检索在 rerank 后没有阈值检查，向量/BM25 通过但 reranker 打出近零分的文档被直接返回。

## Changes
2 files, +3 lines
- `chunk_schema.py` — ChunkRetrieve 新增 `rerank_score_threshold: float | None = Field(None, ge=0, le=1)`
- `chunk_controller.py` — hybrid/graph 分支 rerank 后按阈值过滤，默认 0.1

## Summary by Sourcery

在混合/图重排（hybrid/graph reranking）之后，引入可配置的重排分数阈值，用于过滤低相关度文档。

Bug Fixes:
- 过滤掉混合检索和图检索结果中，重排分数低于可配置阈值的内容，以避免返回几乎无相关性的文档。

Enhancements:
- 在分块检索请求中新增可选字段 `rerank_score_threshold`，并对其进行校验以确保取值范围在 0 到 1 之间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable rerank score threshold to filter out low-relevance documents after hybrid/graph reranking.

Bug Fixes:
- Filter out hybrid and graph retrieval results whose rerank scores fall below a configurable threshold to avoid returning near-zero-relevance documents.

Enhancements:
- Add an optional rerank_score_threshold field to chunk retrieval requests, with validation to constrain values between 0 and 1.

</details>