### PR TITLE
fix(web): node status

### DIFF
--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -117,6 +117,13 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef; data: Work
    * Closes the drawer and resets all state
    */
   const handleClose = () => {
+    setChatHistory(conversationIdRef.current, chatList.map((item: ChatItem) => ({
+      ...item,
+      subContent: item.subContent?.map(sub => ({
+        ...sub,
+        status: sub.status === 'running' ? undefined : sub.status
+      }))
+    })))
     abortRef.current?.()
     abortRef.current = null;
     setOpen(false)
@@ -454,6 +461,7 @@ const Chat = forwardRef<ChatRef, { appId: string; graphRef: GraphRef; data: Work
   }, [chatList.length, features?.opening_statement, variables])
 
   useEffect(() => {
+    if (chatList.length < 1) return
     setChatHistory(conversationIdRef.current, chatList)
   }, [chatList])
 

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -121,6 +121,7 @@ export const useWorkflowGraph = ({
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [zoomLevel, setZoomLevel] = useState(1);
   const [isHandMode, setIsHandMode] = useState(true);
+  const isHandModeRef = useRef(true)
   const [config, setConfig] = useState<WorkflowConfig | null>(null);
   const [chatVariables, setChatVariables] = useState<ChatVariable[]>([])
   const featuresRef = useRef<FeaturesConfigForm | undefined>(undefined)
@@ -144,6 +145,10 @@ export const useWorkflowGraph = ({
   useEffect(() => {
     getConfig()
   }, [id])
+
+  useEffect(() => {
+    isHandModeRef.current = isHandMode
+  }, [isHandMode])
   /**
    * Fetch workflow configuration from API
    */
@@ -761,7 +766,7 @@ export const useWorkflowGraph = ({
   // 控制框选：isHandMode = false 时启用框选
   useEffect(() => {
     if (!graphRef.current) return;
-    if (isHandMode) {
+    if (isHandModeRef.current) {
       graphRef.current?.enablePanning();
       graphRef.current?.disableSelection();
       graphRef.current?.cleanSelection()
@@ -769,7 +774,7 @@ export const useWorkflowGraph = ({
       graphRef.current?.disablePanning();
       graphRef.current?.enableSelection();
     }
-  }, [isHandMode, graphRef.current]);
+  }, [isHandModeRef.current, graphRef.current]);
   // 显示/隐藏连接桩
   // const showPorts = (show: boolean) => {
   //   const container = containerRef.current!;
@@ -925,7 +930,7 @@ export const useWorkflowGraph = ({
   const copyEvent = () => {
     if (!graphRef.current) return false;
     let selectedNodes = []
-    if (isHandMode) {
+    if (isHandModeRef.current) {
       selectedNodes = graphRef.current.getNodes().filter(node => node.getData()?.isSelected);
     } else {
      selectedNodes = graphRef.current.getSelectedCells();
@@ -941,6 +946,7 @@ export const useWorkflowGraph = ({
    */
   const parseEvent = () => {
     if (!graphRef.current?.isClipboardEmpty()) {
+      graphRef.current?.startBatch('copy');
       const pastedNodes = graphRef.current?.paste({ offset: 32 }) ?? [];
       pastedNodes.forEach(cell => {
         if (cell.isNode()) {
@@ -950,6 +956,7 @@ export const useWorkflowGraph = ({
         }
       });
       blankClick();
+      graphRef.current?.stopBatch('copy');
     }
     return false;
   };
@@ -1166,7 +1173,7 @@ export const useWorkflowGraph = ({
           thickness: 1, // Grid dot size
         }
       },
-      panning: isHandMode,
+      panning: isHandModeRef.current,
       mousewheel: {
         enabled: true,
         factor: 0.1,


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

修复工作流图交互模式的处理方式，并在关闭或更新会话时保留正确的聊天消息状态。

Bug 修复：
- 通过使用 ref 跟踪用于平移、选择和复制行为的手型模式状态，防止工作流图中的手型模式状态过期。
- 通过对复制操作进行批处理，确保在工作流图中粘贴的节点以原子方式更新。
- 在关闭抽屉时持久化聊天历史记录，并在保存时避免消息卡在“运行中”状态。
- 当聊天列表为空时，防止出现不必要的聊天历史写入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix workflow graph interaction mode handling and preserve correct chat message statuses when closing or updating conversations.

Bug Fixes:
- Prevent stale hand-mode state in the workflow graph by tracking it via a ref for panning, selection, and copy behavior.
- Ensure pasted nodes in the workflow graph are updated atomically by batching the copy operation.
- Persist chat history on drawer close and avoid leaving messages stuck in a running status when saving.
- Prevent unnecessary chat history writes when the chat list is empty.

</details>