### PR TITLE
feat(knowledge): support downloading modified QA content for QA-format documents

### DIFF
--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -23,6 +23,7 @@ from app.services.file_storage_service import (
     generate_kb_file_key,
     get_file_storage_service,
 )
+from app.services.file_service import _is_qa_doc, _build_qa_export
 from app.core.quota_stub import check_knowledge_capacity_quota
 
 api_logger = get_api_logger()
@@ -210,13 +211,27 @@ async def custom_text(
 @router.get("/{file_id}", response_model=Any)
 async def get_file(
         file_id: uuid.UUID,
+        original: bool = Query(False, description="QA 文档是否下载原始文件（默认从 ES 导出修改后内容）"),
         db: Session = Depends(get_db),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ) -> Any:
-    """Download file by file_id"""
+    """Download file by file_id — QA 文档默认从 ES 导出修改后内容，?original=true 下载原始文件"""
     db_file = file_service.get_file_by_id(db, file_id=file_id)
     if not db_file:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+
+    # QA 文档：默认从 ES 导出修改后的内容
+    if not original and _is_qa_doc(db, file_id):
+        result = _build_qa_export(db, file_id, db_file.kb_id)
+        if result:
+            content, filename, media_type = result
+            from urllib.parse import quote
+            return Response(
+                content=content,
+                media_type=media_type,
+                headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}"}
+            )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="QA document has no exportable content")
 
     if not db_file.file_key:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File has no storage key (legacy data not migrated)")
@@ -245,7 +260,9 @@ async def batch_download_files(
         db: Session = Depends(get_db),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
-    """批量下载文件，边打包边推流（streaming ZIP，内存占用恒定）"""
+    """批量下载文件，边打包边推流（streaming ZIP，内存占用恒定）。
+    QA 文档从 ES 导出修改后的内容，其余从存储下载。
+    """
 
     files = db.query(file_model.File).filter(
         file_model.File.id.in_(request_body.file_ids)
@@ -264,12 +281,21 @@ async def batch_download_files(
             detail="所选文件均无有效存储Key",
         )
 
+    # 预取 QA 文档内容，非 QA 文档走原下载逻辑
+    pre_fetched: dict[str, bytes] = {}
+    for f in valid_files:
+        if _is_qa_doc(db, f.id):
+            result = _build_qa_export(db, f.id, f.kb_id)
+            if result:
+                content, _, _ = result
+                pre_fetched[f.file_key] = content
+
     entries = file_service.build_zip_arcnames(valid_files)
     zip_name = file_service.make_zip_filename(valid_files, request_body.zip_filename)
 
     from urllib.parse import quote
     return StreamingResponse(
-        file_service.stream_zip_files(entries, storage_service, api_logger),
+        file_service.stream_zip_files(entries, storage_service, api_logger, pre_fetched),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -30,6 +30,7 @@ from app.schemas import file_schema
 from app.schemas.response_schema import ApiResponse
 from app.services import knowledge_service, document_service
 from app.services import file_service
+from app.services.file_service import _is_qa_doc, _build_qa_export
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.model_service import ModelConfigService
 from app.core.quota_stub import check_knowledge_capacity_quota
@@ -289,12 +290,21 @@ async def kb_batch_download(
             detail="该知识库下没有可下载的文件",
         )
 
+    # 预取 QA 文档内容
+    pre_fetched: dict[str, bytes] = {}
+    for f in files:
+        if _is_qa_doc(db, f.id):
+            result = _build_qa_export(db, f.id, f.kb_id)
+            if result:
+                content, _, _ = result
+                pre_fetched[f.file_key] = content
+
     entries = file_service.build_zip_arcnames(files)
     zip_name = file_service.make_zip_filename(files, request_body.zip_filename, base_name=db_knowledge.name)
 
     from urllib.parse import quote
     return StreamingResponse(
-        file_service.stream_zip_files(entries, storage_service, api_logger),
+        file_service.stream_zip_files(entries, storage_service, api_logger, pre_fetched),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -1,4 +1,6 @@
 import asyncio
+import csv as csv_module
+import io
 import struct
 import uuid
 import zlib
@@ -93,6 +95,75 @@ def delete_file_by_id(db: Session, file_id: uuid.UUID, current_user: User) -> No
         raise
 
 
+def _is_qa_doc(db: Session, file_id: uuid.UUID) -> bool:
+    """文件关联的文档是否为 QA CSV/XLSX 导入类型"""
+    from app.models.document_model import Document
+    doc = db.query(Document).filter(Document.file_id == file_id).first()
+    if not doc or not doc.parser_config:
+        return False
+    return doc.parser_config.get("doc_type") == "qa"
+
+
+def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple[bytes, str, str] | None:
+    """从 ES 导出 QA 问答对，保留原始文件格式（CSV 或 XLSX）。
+    返回 (content_bytes, filename, media_type)，文档非 QA 类型或无数据时返回 None。
+    """
+    from app.models.document_model import Document
+    from app.models.knowledge_model import Knowledge
+    from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
+
+    db_file = db.query(File).filter(File.id == file_id).first()
+    doc = db.query(Document).filter(Document.file_id == file_id).first()
+    if not db_file or not doc:
+        return None
+
+    db_knowledge = db.query(Knowledge).filter(Knowledge.id == kb_id).first()
+    if not db_knowledge:
+        return None
+
+    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+    total, items = vector_service.search_by_segment(
+        document_id=str(doc.id), pagesize=10000, page=1, asc=True
+    )
+
+    qa_pairs = []
+    for item in items:
+        if (item.metadata or {}).get("chunk_type") == "qa":
+            qa_pairs.append({
+                "question": (item.metadata or {}).get("question", ""),
+                "answer": (item.metadata or {}).get("answer", ""),
+            })
+
+    if not qa_pairs:
+        return None
+
+    file_ext_lower = db_file.file_ext.lower() if db_file.file_ext else ".csv"
+    is_xlsx = file_ext_lower in (".xlsx", ".xls")
+
+    if is_xlsx:
+        import openpyxl
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(["question", "answer"])
+        for pair in qa_pairs:
+            ws.append([pair["question"], pair["answer"]])
+        output = io.BytesIO()
+        wb.save(output)
+        content = output.getvalue()
+        wb.close()
+        media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    else:
+        text_output = io.StringIO()
+        writer = csv_module.writer(text_output)
+        writer.writerow(["question", "answer"])
+        for pair in qa_pairs:
+            writer.writerow([pair["question"], pair["answer"]])
+        content = text_output.getvalue().encode("utf-8-sig")
+        media_type = "text/csv"
+
+    return content, db_file.file_name, media_type
+
+
 def build_zip_arcnames(files: list[Any]) -> list[tuple[str, str, str]]:
     """同名文件自动去重，返回 [(file_name, file_key, arc_name), ...]"""
     seen: set[str] = set()
@@ -135,9 +206,13 @@ async def stream_zip_files(
     entries: list[tuple[str, str, str]],  # [(file_name, file_key, arc_name), ...]
     storage_service: Any,
     logger: Logger,
+    pre_fetched: dict[str, bytes] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """逐文件下载 → 实时 deflate 压缩 → yield ZIP 数据块，全程不落盘。
-    单个文件下载失败时跳过并记录，最终 ZIP 内含 _skipped_files.txt 清单。"""
+    单个文件下载失败时跳过并记录，最终 ZIP 内含 _skipped_files.txt 清单。
+
+    pre_fetched: key=file_key 的预取内容字典，QA 文档命中时直接用，不走 storage 下载。
+    """
 
     central_entries: list[tuple[bytes, int, int, int, int]] = []
     skipped_files: list[str] = []
@@ -145,8 +220,11 @@ async def stream_zip_files(
 
     for file_name, file_key, arc_name in entries:
         try:
-            async with asyncio.timeout(120):
-                content = await storage_service.download_file(file_key)
+            if pre_fetched and file_key in pre_fetched:
+                content = pre_fetched[file_key]
+            else:
+                async with asyncio.timeout(120):
+                    content = await storage_service.download_file(file_key)
 
             arc_name_bytes = arc_name.encode("utf-8")
             crc = zlib.crc32(content) & 0xFFFFFFFF

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -122,7 +122,7 @@ def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple
         return None
 
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-    total, items = vector_service.search_by_segment(
+    _, items = vector_service.search_by_segment(
         document_id=str(doc.id), pagesize=10000, page=1, asc=True
     )
 


### PR DESCRIPTION
## Summary
- QA 文档（doc_type=qa）下载时从 ES 导出修改后的 QA 内容，而非返回过时的原始文件
- `GET /files/{file_id}` 默认导出修改后内容，`?original=true` 强制下载原始文件
- `POST /files/batch-download` 和 `POST /knowledges/{kb_id}/batch-download` ZIP 内 QA 文档自动替换为导出内容
- CSV/XLSX 导出格式与导入格式保持一致（csv→csv, xlsx→xlsx）

## Changes
```
 api/app/controllers/file_controller.py      | 32 +++++++++--
 api/app/controllers/knowledge_controller.py | 12 ++++-
 api/app/services/file_service.py            | 84 +++++++++++++++++++++++++++--
 3 files changed, 121 insertions(+), 7 deletions(-)
```

## Test Plan
- [ ] QA CSV 导入后修改内容，单文件下载验证导出 CSV 包含修改后内容
- [ ] QA XLSX 导入后修改内容，单文件下载验证导出 XLSX 包含修改后内容
- [ ] 非 QA 文档下载不受影响
- [ ] `?original=true` 下载 QA 文档原始文件
- [ ] 知识库打包下载 QA + 非 QA 混合文档
- [ ] QA 文档无数据时返回 404

## Summary by Sourcery

在下载 QA 格式文档时，从 Elasticsearch 导出最新的 QA 内容，并将其集成到单个和批量下载流程中。

新特性：
- 在单文件下载时，对于 QA 文档，从 Elasticsearch 提供最新的 QA CSV/XLSX 内容，并支持通过 `original` 标记强制返回最初上传的文件。
- 在文件和知识库的批量 ZIP 下载中，为 QA 文档包含最新的 QA 导出内容，同时保留非 QA 文件。

增强：
- 扩展流式 ZIP 生成逻辑，以接收预先获取的文件内容，从而使 QA 导出可以绕过对象存储下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Export up-to-date QA content from Elasticsearch when downloading QA-format documents and integrate this into single and batch download flows.

New Features:
- Serve updated QA CSV/XLSX content from Elasticsearch for QA documents on single-file download, with an `original` flag to force returning the original uploaded file.
- Include updated QA exports for QA documents in file and knowledge-base batch ZIP downloads while preserving non-QA files.

Enhancements:
- Extend streaming ZIP generation to accept pre-fetched file contents so QA exports can bypass object storage downloads.

</details>

新功能：
- 支持在下载时，从 Elasticsearch 以更新后的 QA 对（而非最初上传的文件）的形式导出 QA 格式（CSV/XLSX）文档。
- 为单文件下载添加 `original` 查询参数，以便对 QA 文档强制返回原始文件。
- 在文件和知识库的批量 ZIP 下载中，为 QA 文档包含更新后的 QA 导出内容，并像往常一样与非 QA 文件混合打包。

增强：
- 扩展 ZIP 流式处理以接受预先获取的文件内容，使 QA 导出可以绕过对象存储下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在下载 QA 格式文档时，从 Elasticsearch 导出最新的 QA 内容，并将其集成到单个和批量下载流程中。

新特性：
- 在单文件下载时，对于 QA 文档，从 Elasticsearch 提供最新的 QA CSV/XLSX 内容，并支持通过 `original` 标记强制返回最初上传的文件。
- 在文件和知识库的批量 ZIP 下载中，为 QA 文档包含最新的 QA 导出内容，同时保留非 QA 文件。

增强：
- 扩展流式 ZIP 生成逻辑，以接收预先获取的文件内容，从而使 QA 导出可以绕过对象存储下载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Export up-to-date QA content from Elasticsearch when downloading QA-format documents and integrate this into single and batch download flows.

New Features:
- Serve updated QA CSV/XLSX content from Elasticsearch for QA documents on single-file download, with an `original` flag to force returning the original uploaded file.
- Include updated QA exports for QA documents in file and knowledge-base batch ZIP downloads while preserving non-QA files.

Enhancements:
- Extend streaming ZIP generation to accept pre-fetched file contents so QA exports can bypass object storage downloads.

</details>

</details>