### PR TITLE
fix: tuple truthiness check in by_mineru bypasses install guard

### DIFF
--- a/api/app/core/rag/app/naive.py
+++ b/api/app/core/rag/app/naive.py
@@ -48,7 +48,7 @@ def by_mineru(filename, binary=None, from_page=0, to_page=100000, lang="Chinese"
     mineru_api = os.environ.get("MINERU_APISERVER", "http://host.docker.internal:9987")
     pdf_parser = MinerUParser(mineru_path=mineru_executable, mineru_api=mineru_api)
 
-    if not pdf_parser.check_installation():
+    if not pdf_parser.check_installation()[0]:
         callback(-1, "MinerU not found.")
         return None, None, pdf_parser
 


### PR DESCRIPTION
## Summary
- `check_installation()` returns `tuple[bool, str]`, but `by_mineru` checked `if not check_installation()` which is always `True` for a non-empty tuple, so failed install checks were silently skipped
- When `mineru` is not installed and no API is reachable, the code falls through to `subprocess.Popen(["mineru", ...])` which raises `FileNotFoundError` instead of the graceful "MinerU not found." callback

## Changes
```
 api/app/core/rag/app/naive.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Test Plan
- [x] 未安装 mineru 且 API 不可达时，by_mineru 应 callback(-1) 并提前返回

## Summary by Sourcery

Bug Fixes:
- 修正 MinerU 安装验证中对元组真值的检查方式，使检查失败时能够触发预期的回调函数，而不是继续执行到子进程调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct tuple truthiness check in MinerU installation validation so failed checks trigger the expected callback instead of falling through to subprocess execution.

</details>