### PR TITLE
fix(web): Row flex add wrap

### DIFF
--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FileUploadSettingModal.tsx
@@ -205,7 +205,7 @@ const FileUploadSettingModal = forwardRef<FileUploadSettingModalRef, FileUploadS
                     'rb:bg-[#f5f7fc]': isEnabled
                   })}
                 >
-                  <Row gutter={12}>
+                  <Row gutter={12} wrap={false}>
                     <Col flex="36px" className="rb:self-center">{option.icon}</Col>
                     <Col flex="1">
                       <Flex align="center" justify="space-between">

--- a/web/src/views/ApplicationManagement/MySharing.tsx
+++ b/web/src/views/ApplicationManagement/MySharing.tsx
@@ -114,7 +114,7 @@ const MySharing: React.FC = () => {
 
   return (
     <BodyWrapper loading={loading} empty={data.length === 0}>
-      <Row gutter={12}>
+      <Row gutter={12} wrap={false}>
         <Col flex="384px">
           <Flex vertical gap={12}>
             {grouped.map(({ workspace, items }) => (

--- a/web/src/views/ToolManagement/Market.tsx
+++ b/web/src/views/ToolManagement/Market.tsx
@@ -458,7 +458,7 @@ const Market: React.FC<{ getStatusTag?: (status: string) => ReactNode }> = () =>
   };
 
   return (
-    <Row gutter={16}>
+    <Row gutter={16} wrap={false}>
       <Col flex="380px">
         <Flex vertical gap={16}>
           <div className="rb:font-[MiSans-Bold] rb:font-bold rb:text-[16px] rb:leading-5.5">{t('tool.mcpMarket')}</div>

--- a/web/src/views/UserMemoryDetail/components/PerceptualLastInfo.tsx
+++ b/web/src/views/UserMemoryDetail/components/PerceptualLastInfo.tsx
@@ -134,7 +134,7 @@ const PerceptualLastInfo: FC = () => {
       </Flex>
       {loading
         ? <Skeleton active />
-        : <Flex vertical gap={16} className="rb:w-108">
+        : <Flex vertical gap={16} className="rb:w-107">
             {data.file_path
               ? <>
                 {/\.(jpg|jpeg|png|gif|webp|svg)$/i.test(data.file_name)

--- a/web/src/views/UserMemoryDetail/components/Timeline.tsx
+++ b/web/src/views/UserMemoryDetail/components/Timeline.tsx
@@ -94,7 +94,7 @@ const Timeline: FC = () => {
         ? <Empty />
         : <Flex gap={12} vertical>
             {data.map((vo, index) => (
-              <Row key={vo.id}className="rb:flex rb:gap-6 rb:min-h-16">
+              <Row key={vo.id} wrap={false} className="rb:flex rb:gap-6 rb:min-h-16">
                 <Col flex="90px" className="rb:leading-5 rb:font-semibold">
                   <Flex vertical gap={12} align="center" justify="center" className="rb:h-full!">
                     <span className="rb:text-center">{formatDateTime(vo.created_time)}</span>

--- a/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
@@ -148,7 +148,7 @@ const EpisodicDetail: FC = () => {
   }
 
   return (
-    <Row gutter={16} className="rb:h-full!">
+    <Row gutter={16} wrap={false} className="rb:h-full!">
       <Col flex="400px" className="rb:h-full!">
         <RbCard
           title={<div className="rb:leading-5.5!">

--- a/web/src/views/UserMemoryDetail/pages/GraphDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/GraphDetail.tsx
@@ -112,7 +112,7 @@ const GraphDetail = forwardRef<GraphDetailRef>((_props, ref) => {
           </Space>
         }
       />
-      <Row gutter={12} className="rb:p-3! rb:pr-0! rb:h-[calc(100vh-64px)] rb:w-full! rb:flex-nowrap! rb:overflow-hidden!">
+      <Row gutter={12} wrap={false} className="rb:p-3! rb:pr-0! rb:h-[calc(100vh-64px)] rb:w-full! rb:flex-nowrap! rb:overflow-hidden!">
         <Col flex="480px" className="rb:h-full!">
           <RbCard
             title={t('userMemory.relationshipEvolution')}

--- a/web/src/views/UserMemoryDetail/pages/PerceptualDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/PerceptualDetail.tsx
@@ -22,7 +22,7 @@ import Timeline from '../components/Timeline'
 const PerceptualDetail: FC = () => {
 
   return (
-    <Row gutter={12} className="rb:h-full!">
+    <Row gutter={12} wrap={false} className="rb:h-full!">
       <Col flex="480px" className="rb:h-full!">
         <PerceptualLastInfo />
       </Col>

--- a/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
@@ -155,7 +155,7 @@ const WorkingDetail: FC = () => {
         : data.length === 0
         ? <Empty />
         :(
-          <Row gutter={16} className="rb:h-full!">
+          <Row gutter={16} wrap={false} className="rb:h-full!">
             <Col span={5} className="rb:h-full!">
               <RbCard
                 title={t('workingDetail.conversation')}

--- a/web/src/views/Workflow/components/Properties/CaseList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/CaseList/index.tsx
@@ -174,7 +174,7 @@ const ArrayFileSubConditions: FC<ArrayFileSubConditionsProps> = ({ conditionFiel
   }, [subValues])
 
   return (
-    <div className="rb:bg-white rb:rounded-lg rb:p-1 rb:w-62">
+    <div className="rb:bg-white rb:rounded-lg rb:p-1 rb:w-60">
       <Form.List name={[conditionFieldName, 'sub_variable_condition', 'conditions']}>
         {(subFields, { add: addSub, remove: removeSub }) => {
           const subLogicalOperator = form.getFieldValue([name, caseIndex, 'expressions', conditionIndex, 'sub_variable_condition', 'logical_operator']) || 'and';
@@ -208,7 +208,7 @@ const ArrayFileSubConditions: FC<ArrayFileSubConditionsProps> = ({ conditionFiel
                         'rb:w-43.5': subFields.length > 1,
                         'rb:w-54.5': subFields.length === 1
                       })}>
-                        <Row className={clsx('rb:p-1!', { 'rb-border-b': !hideSubRight })}>
+                        <Row wrap={false} className={clsx('rb:p-1!', { 'rb-border-b': !hideSubRight })}>
                           <Col flex="100px">
                             <Form.Item name={[subField.name, 'key']} noStyle>
                               <Select
@@ -508,7 +508,7 @@ const CaseList: FC<CaseListProps> = ({
                   {(conditionFields, { add: addCondition, remove: removeCondition }) => {
                     const logicalOperator = form.getFieldValue(name)?.[caseIndex]?.logical_operator || 'and'
                     return (
-                      <Row className="rb:text-[12px] rb:mb-4!">
+                      <Row wrap={false} className="rb:text-[12px] rb:mb-4!">
                         <Col flex="44px">
                           <div className="rb:font-medium rb:leading-4.5">{caseIndex === 0 ? 'IF' : 'ELIF'}</div>
                           {caseFields.length > 1 && <div className="rb:text-[10px] rb:text-[#5B6167] rb:leading-2.5"> {`CASE ${caseIndex + 1}`}</div>}
@@ -549,7 +549,7 @@ const CaseList: FC<CaseListProps> = ({
                               return (
                                 <Flex key={conditionField.key} gap={4} align="start" className="rb:mb-2!">
                                   <div className="rb:flex-1 rb:bg-[#F6F6F6] rb:rounded-lg">
-                                    <Row className={clsx("rb:px-1!", {
+                                    <Row wrap={false} className={clsx("rb:px-1!", {
                                       'rb-border-b': !hideRightField
                                     })}>
                                       <Col flex="144px">
@@ -658,7 +658,7 @@ const CaseList: FC<CaseListProps> = ({
                               )
                             })}
                           </div>
-                          <Row>
+                          <Row wrap={false}>
                             <Col flex="1">
                               <Button
                                 onClick={() => {

--- a/web/src/views/Workflow/components/Properties/ConditionList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ConditionList/index.tsx
@@ -178,7 +178,7 @@ const ConditionList: FC<CaseListProps> = ({
                         className="rb:mb-2!"
                       >
                         <div className="rb:flex-1 rb:bg-[#F6F6F6] rb:rounded-lg">
-                          <Row className={clsx("rb:px-1!", {
+                          <Row wrap={false} className={clsx("rb:px-1!", {
                             'rb-border-b': !hideRightField
                           })}>
                             <Col flex="1">

--- a/web/src/views/Workflow/components/Properties/ListOperator/FilterConditions/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ListOperator/FilterConditions/index.tsx
@@ -1,5 +1,4 @@
 import { type FC } from 'react'
-import clsx from 'clsx'
 import { useTranslation } from 'react-i18next';
 import { Form, Button, Select, type SelectProps, Flex, Row, Col } from 'antd'
 
@@ -114,7 +113,7 @@ const FilterConditions: FC<FilterConditionsProps> = ({
                             />
                           </Form.Item>
                         }
-                        <Row gutter={8}>
+                        <Row gutter={8} wrap={false}>
                           <Col flex={hideValueField ? '1' : "96px"}>
                             <Form.Item name={[field.name, 'comparison_operator']} noStyle>
                               <Select

--- a/web/src/views/Workflow/components/Properties/ListOperator/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ListOperator/index.tsx
@@ -23,7 +23,7 @@ const ListOperator: FC<ListOperatorProps> = ({ options }) => {
   const variableOption = options.find(option => `{{${option.value}}}` === values?.input_list)
   const variableType = variableOption?.dataType
 
-  const handleChangeInputList = (value: string | string[]) => {
+  const handleChangeInputList = (value?: string | string[]) => {
     form.setFieldsValue({
       input_list: value,
       filter_by: {
@@ -74,7 +74,7 @@ const ListOperator: FC<ListOperatorProps> = ({ options }) => {
         <Switch />
       </Form.Item>
       {values?.order_by?.enabled &&
-        <Row gutter={8}>
+        <Row gutter={8} wrap={false}>
           {/* 仅 array[file]有效 */}
           {variableType === 'array[file]' &&
             <Col flex="200px">


### PR DESCRIPTION
## Summary by Sourcery

确保在工作流、列表操作符、应用配置、分享、工具市场以及用户记忆详情视图中使用一致的不换行行布局，并调整宽度。

增强内容：
- 将多个 Ant Design 的 Row 组件设置为不换行布局（`wrap={false}`），以在复杂的 UI 区域中稳定水平对齐效果。
- 微调工作流案例列表和用户记忆感知信息中部分容器的固定宽度工具类，使其更好地适配内容。
- 放宽列表操作符中输入列表的变更处理函数，允许接受 `undefined` 值，以实现更安全的表单状态更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure consistent non-wrapping row layouts and adjusted widths across workflow, list operator, application config, sharing, tool market, and user memory detail views.

Enhancements:
- Set multiple Ant Design Row components to use non-wrapping layout (wrap={false}) to stabilize horizontal alignment in complex UI sections.
- Fine-tune fixed width utility classes for specific containers in workflow case lists and user memory perceptual info to better fit content.
- Relax the input list change handler in the list operator to accept undefined values for safer form state updates.

</details>