### PR TITLE
fix(api): add default dialog_at timestamp for messages without one

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1538,6 +1538,13 @@ def write_message_task(
             logger.info(
                 f"[CELERY WRITE] Executing MemoryAgentService.write_memory "
                 f"with config_id = {actual_config_id} (type: {type(actual_config_id).__name__}), language={language}")
+
+            from datetime import datetime, timezone
+            _default_dialog_at = datetime.now(timezone.utc).isoformat()
+            for msg in message:
+                if isinstance(msg, dict) and not msg.get("dialog_at"):
+                    msg["dialog_at"] = _default_dialog_at
+
             service = MemoryAgentService()
             result = await service.write_memory(
                 WriteMemoryRequest(


### PR DESCRIPTION
## Summary
- Messages without `dialog_at` field now get the current UTC time as a default value before being written to memory
- Prevents missing timestamp issues in `write_message_task` 

## Test plan
- [ ] Verify messages without `dialog_at` are written with the current UTC timestamp
- [ ] Verify messages that already have `dialog_at` are not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- 为缺少 `dialog_at` 时间戳的消息设置默认的 UTC `dialog_at` 时间戳，以防止在内存写入任务期间出现缺失时间戳的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set a default UTC dialog_at timestamp on messages that lack one to prevent missing timestamp issues during the memory write task.

</details>