### PR TITLE
fix(api): preserve dialog_at timestamp in SemanticPruner message cons…

### DIFF
--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -349,6 +349,7 @@ class SemanticPruner:
                     kept.append(ConversationMessage(
                         role=m.role,
                         msg=new_text,
+                        dialog_at=m.dialog_at,
                         files=m.files,
                     ))
             elif idx in user_actions:
@@ -356,6 +357,7 @@ class SemanticPruner:
                 kept.append(ConversationMessage(
                     role=m.role,
                     msg=user_actions[idx],
+                    dialog_at=m.dialog_at,
                     files=m.files,
                 ))
             else:


### PR DESCRIPTION
…truction

## Summary by Sourcery

Bug Fixes:
- 确保在修剪过程中，重建的 `ConversationMessage` 对象保留其原始的 `dialog_at` 时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure reconstructed ConversationMessage objects retain their original dialog_at timestamp during pruning.

</details>