### PR TITLE
fix(api): auto-detect user language and align LLM output language throughout memory pipeline

### DIFF
--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -102,7 +102,16 @@ async def get_chunked_dialogs(
                             llm_client = factory.get_llm_client_from_config(memory_config)
                             
                             # 执行剪枝 - 使用 prune_dataset 支持消息级剪枝
-                            pruner = SemanticPruner(config=pruning_config, llm_client=llm_client, snapshot=snapshot)
+                            import re
+                            import langid
+                            user_text = " ".join(
+                                re.sub(r"<input-file-summary>.*?</input-file-summary>", "", m.msg, flags=re.DOTALL).strip()
+                                for m in dialog_data.context.msgs if m.role == "user" and m.msg
+                            )
+                            pruning_language = langid.classify(user_text)[0] if user_text else "zh"
+                            if pruning_language not in ("zh", "en"):
+                                pruning_language = "en"
+                            pruner = SemanticPruner(config=pruning_config, llm_client=llm_client, language=pruning_language, snapshot=snapshot)
                             original_msg_count = len(dialog_data.context.msgs)
                             
                             # 使用 prune_dataset 而不是 prune_dialog

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -172,6 +172,19 @@ class WritePipeline:
         if not ref_id:
             ref_id = uuid.uuid4().hex
 
+        # 根据用户消息内容自动检测语言，确保输出语言与输入语言一致
+        import re
+        import langid
+        user_content = " ".join(
+            re.sub(r"<input-file-summary>.*?</input-file-summary>", "", msg.get("content", ""), flags=re.DOTALL).strip()
+            for msg in messages
+            if isinstance(msg, dict) and msg.get("role") == "user" and msg.get("content")
+        )
+        if user_content:
+            detected = langid.classify(user_content)[0]
+            self.language = detected if detected in ("zh", "en") else "en"
+            logger.info(f"[LanguageDetect] detected={detected}, language={self.language}, text_len={len(user_content)}")
+
         mode = "试运行" if is_pilot_run else "正式"
         extraction_result = None
 
@@ -658,6 +671,7 @@ class WritePipeline:
                         if self.memory_config.embedding_model_id
                         else None
                     ),
+                    "language": self.language,
                 },
                 priority=3,
             )

--- a/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
+++ b/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
@@ -71,11 +71,13 @@ class LabelPropagationEngine:
         connector: Neo4jConnector,
         llm_model_id: Optional[str] = None,
         embedding_model_id: Optional[str] = None,
+        language: str = "zh",
     ):
         self.connector = connector
         self.repo = CommunityRepository(connector)
         self.llm_model_id = llm_model_id
         self.embedding_model_id = embedding_model_id
+        self.language = language
         # 缓存客户端实例，避免重复初始化
         self._llm_client = None
         self._embedder_client = None
@@ -526,18 +528,32 @@ class LabelPropagationEngine:
                         for r in relationships
                         if r.get("subject") and r.get("predicate") and r.get("object")
                     ]
-                    rel_section = (
-                        f"\n实体间关系：\n" + "\n".join(rel_lines)
-                        if rel_lines else ""
-                    )
-                    prompt = (
-                        f"以下是一组语义相关的实体：\n{entity_list_str}{rel_section}\n\n"
-                        f"请为这组实体所代表的主题：\n"
-                        f"1. 起一个简洁的中文名称（不超过10个字）\n"
-                        f"2. 写一句话摘要（不超过80个字）\n\n"
-                        f"严格按以下格式输出，不要有其他内容：\n"
-                        f"名称：<名称>\n摘要：<摘要>"
-                    )
+                    if self.language == "en":
+                        rel_section = (
+                            f"\nRelationships between entities:\n" + "\n".join(rel_lines)
+                            if rel_lines else ""
+                        )
+                        prompt = (
+                            f"The following is a group of semantically related entities:\n{entity_list_str}{rel_section}\n\n"
+                            f"For the topic represented by this group of entities:\n"
+                            f"1. Give a concise name (no more than 10 words)\n"
+                            f"2. Write a one-sentence summary (no more than 80 words)\n\n"
+                            f"Output strictly in the following format, nothing else:\n"
+                            f"Name: <name>\nSummary: <summary>"
+                        )
+                    else:
+                        rel_section = (
+                            f"\n实体间关系：\n" + "\n".join(rel_lines)
+                            if rel_lines else ""
+                        )
+                        prompt = (
+                            f"以下是一组语义相关的实体：\n{entity_list_str}{rel_section}\n\n"
+                            f"请为这组实体所代表的主题：\n"
+                            f"1. 起一个简洁的中文名称（不超过10个字）\n"
+                            f"2. 写一句话摘要（不超过80个字）\n\n"
+                            f"严格按以下格式输出，不要有其他内容：\n"
+                            f"名称：<名称>\n摘要：<摘要>"
+                        )
 
                 return {
                     "community_id": cid,
@@ -612,6 +628,10 @@ class LabelPropagationEngine:
                                 meta["name"] = line[3:].strip()
                             elif line.startswith("摘要："):
                                 meta["summary"] = line[3:].strip()
+                            elif line.startswith("Name:"):
+                                meta["name"] = line[5:].strip()
+                            elif line.startswith("Summary:"):
+                                meta["summary"] = line[8:].strip()
                     
                     logger.info(f"[Clustering] LLM 批量生成完成")
 

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -435,7 +435,7 @@ class SemanticPruner:
             del self._cache[oldest]
 
         # 渲染模板
-        rendered = self.template.render(dialog_text=dialog_text)
+        rendered = self.template.render(dialog_text=dialog_text, language=self.language)
         log_template_rendering("extract_pruning.jinja2", {
             "language": self.language,
         })

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3850,6 +3850,7 @@ def run_incremental_clustering(
     new_entity_ids: List[str],
     llm_model_id: Optional[str] = None,
     embedding_model_id: Optional[str] = None,
+    language: str = "zh",
 ) -> Dict[str, Any]:
     """增量聚类任务：处理新增实体的社区分配和元数据生成。
     
@@ -3860,6 +3861,7 @@ def run_incremental_clustering(
         new_entity_ids: 新增实体 ID 列表
         llm_model_id: LLM 模型 ID（可选）
         embedding_model_id: Embedding 模型 ID（可选）
+        language: 语言类型 ("zh" | "en")
     
     Returns:
         包含任务执行结果的字典
@@ -3883,6 +3885,7 @@ def run_incremental_clustering(
                 connector=connector,
                 llm_model_id=llm_model_id,
                 embedding_model_id=embedding_model_id,
+                language=language,
             )
 
             # 执行增量聚类


### PR DESCRIPTION
Use langid to detect user message language (zh/en) and pass it through SemanticPruner, LabelPropagationEngine, WritePipeline, and incremental clustering so that prompts, extraction, and community naming all produce output in the user's language.

## Summary by Sourcery

通过内存和聚类管线传播自动检测到的用户语言，使剪枝、抽取以及社区元数据生成在中文和英文场景下都能使用与语言一致的提示词和解析逻辑。

New Features:
- 在写入管线和语义剪枝对话中使用 langid 检测用户消息语言，将支持的语言限制为中文和英文，其余情况默认使用英文。
- 在标签传播聚类引擎中支持与语言相关的提示词和输出解析，用于社区命名和总结，使其同时支持中文和英文。
- 在增量聚类及相关组件中传递 language 参数，使下游任务能够根据检测到的语言对齐 LLM 的交互。

Enhancements:
- 在渲染剪枝模板时加入语言上下文，以便在抽取过程中更好地控制 LLM 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate automatically detected user language through the memory and clustering pipelines so that pruning, extraction, and community metadata generation use language-consistent prompts and parsing for Chinese and English.

New Features:
- Detect user message language with langid in the write pipeline and semantic pruning dialogs, constraining supported languages to Chinese and English and defaulting to English otherwise.
- Support language-aware prompts and output parsing in the label propagation clustering engine for community naming and summaries in both Chinese and English.
- Thread a language parameter through incremental clustering and related components so downstream tasks can align LLM interactions with the detected language.

Enhancements:
- Include language context when rendering pruning templates to better control LLM behavior during extraction.

</details>