### PR TITLE
fix(batch-download): set ZIP UTF-8 flag and use BusinessException for…

### DIFF
--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.celery_app import celery_app
 from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
 from app.core.logging_config import get_api_logger
 from app.core.rag.common import settings
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
@@ -272,10 +273,7 @@ async def kb_batch_download(
         db, knowledge_id=kb_id, current_user=current_user
     )
     if not db_knowledge:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="知识库不存在或无权访问",
-        )
+        raise BusinessException("知识库不存在或无权访问", BizCode.NOT_FOUND)
 
     files = db.query(file_model.File).filter(
         file_model.File.kb_id == kb_id,
@@ -284,10 +282,7 @@ async def kb_batch_download(
     ).all()
 
     if not files:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="该知识库下没有可下载的文件",
-        )
+        raise BusinessException("该知识库下没有可下载的文件", BizCode.NOT_FOUND)
 
     entries = file_service.build_zip_arcnames(files)
     zip_name = file_service.make_zip_filename(files, request_body.zip_filename, base_name=db_knowledge.name)

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -157,7 +157,7 @@ async def stream_zip_files(
 
             local_header = struct.pack(
                 "<4sHHHHHIIIHH",
-                b"PK\x03\x04", 20, 0x08, 8, 0, 0, 0, 0, 0, len(arc_name_bytes), 0,
+                b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(arc_name_bytes), 0,
             ) + arc_name_bytes
 
             yield local_header
@@ -187,7 +187,7 @@ async def stream_zip_files(
 
         local_header = struct.pack(
             "<4sHHHHHIIIHH",
-            b"PK\x03\x04", 20, 0x08, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
+            b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
         ) + name_bytes
         descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
 
@@ -204,7 +204,7 @@ async def stream_zip_files(
     for arc_name_bytes, crc, compressed_size, uncompressed_size, local_offset in central_entries:
         entry = struct.pack(
             "<4sHHHHHHIIIHHHHHII",
-            b"PK\x01\x02", 20, 20, 0x08, 8, 0, 0,
+            b"PK\x01\x02", 20, 20, 0x0808, 8, 0, 0,
             crc, compressed_size, uncompressed_size,
             len(arc_name_bytes), 0, 0, 0, 0, 0, local_offset,
         ) + arc_name_bytes


### PR DESCRIPTION
… error handling

- Set bit 11 (Language Encoding Flag) in ZIP general purpose bit flags so Windows unzip tools correctly decode Chinese filenames as UTF-8
- Replace raw HTTPException(404/500) with BusinessException(BizCode.NOT_FOUND) in knowledge base batch-download endpoint, consistent with project error handling conventions

## Summary by Sourcery

使知识库批量下载的错误处理与业务异常保持一致，并确保生成的 ZIP 归档文件的文件名被标记为 UTF-8 编码。

Bug Fixes:
- 设置 ZIP 的通用用途 UTF-8 语言编码标志，以便 Windows 解压工具能正确解码批量下载中的非 ASCII 文件名。

Enhancements:
- 在知识库批量下载接口中，用携带 `BizCode.NOT_FOUND` 的 `BusinessException` 替换原始的 HTTP 404 错误，以与标准化的错误处理方式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align knowledge base batch download error handling with business exceptions and ensure generated ZIP archives mark filenames as UTF-8 encoded.

Bug Fixes:
- Set the ZIP general purpose UTF-8 language encoding flag so Windows unzip tools correctly decode non-ASCII filenames in batch downloads.

Enhancements:
- Replace raw HTTP 404 errors with BusinessException using BizCode.NOT_FOUND in the knowledge base batch download endpoint to match standardized error handling.

</details>