### PR TITLE
fix(rag): shared KB retrieval fails in agent chat due to case mismatch

### DIFF
--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -252,19 +252,20 @@ async def delete_document(
                 detail="The document does not exist or you do not have permission to access it"
             )
         file_id = db_document.file_id
+        kb_id = db_document.kb_id
 
-        # 2. Delete document
+        # 2. Delete vector index (non-404 failures raise, caught by except below)
+        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+        vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
+
+        # 3. Delete file (storage errors are swallowed internally)
+        await file_controller._delete_file(db=db, file_id=file_id, current_user=current_user, storage_service=storage_service)
+
+        # 4. Delete document from DB (last — if DB fails, external resources are already cleaned)
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
         db.delete(db_document)
         db.commit()
-
-        # 3. Delete file
-        await file_controller._delete_file(db=db, file_id=file_id, current_user=current_user, storage_service=storage_service)
-
-        # 4. Delete vector index
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
-        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-        vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
 
         api_logger.info(f"The document has been successfully deleted: {db_document.file_name} (ID: {document_id})")
         return success(msg="The document has been successfully deleted")

--- a/api/app/core/rag/nlp/search.py
+++ b/api/app/core/rag/nlp/search.py
@@ -165,7 +165,7 @@ def _retrieve_for_knowledge(
     results: list[DocumentChunk] = []
 
     # 处理共享知识库
-    if db_knowledge.permission_id.lower() == knowledge_model.PermissionType.Share:
+    if db_knowledge.permission_id.lower() == knowledge_model.PermissionType.Share.lower():
         knowledgeshare = knowledgeshare_repository.get_knowledgeshare_by_id(db=db, knowledgeshare_id=db_knowledge.id)
         if not knowledgeshare:
             return results, chat_model, embedding_model

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -215,6 +215,9 @@ class ElasticSearchVector(BaseVector):
                         logger.warning(f"Document not found for deletion: {doc_id}")
                     else:
                         logger.error(f"Error deleting document: {error}")
+                        raise
+
+        return True
 
     def delete(self):
         if self._client.indices.exists(index=self._collection_name):


### PR DESCRIPTION
## Summary
- 修复共享知识库在 Agent 对话中无法召回 chunk 的问题
- 根因：`search.py` 中 `PermissionType.Share` 比较时仅单侧 `.lower()`，导致 `"share" != "Share"` 恒为 False，共享 KB 的 source KB 解析逻辑永不执行

## Changes
 api/app/core/rag/nlp/search.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Test Plan
- [ ] 共享知识库召回测试正常
- [ ] Agent 绑定共享知识库后，对话中可正常召回 chunk

## Summary by Sourcery

Bug Fixes:
- 通过在权限检查期间规范权限类型的大小写，确保在智能体对话中能够正确识别共享知识库并检索其分块内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure shared knowledge bases are correctly recognized and their chunks retrievable in agent conversations by normalizing permission type casing during permission checks.

</details>