### PR TITLE
fix(tool_orchestrator)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -174,15 +174,15 @@ class AppChatService:
         # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
         capability = api_key_obj.capability or []
         orchestrator_node_executions = []
+        _api_key_config = {
+            "model_name": api_key_obj.model_name,
+            "api_key": api_key_obj.api_key,
+            "provider": api_key_obj.provider,
+            "api_base": api_key_obj.api_base,
+            "is_omni": api_key_obj.is_omni,
+            "capability": capability,
+        }
         if ModelCapability.FUNCTION_CALL not in capability and tools:
-            _api_key_config = {
-                "model_name": api_key_obj.model_name,
-                "api_key": api_key_obj.api_key,
-                "provider": api_key_obj.provider,
-                "api_base": api_key_obj.api_base,
-                "is_omni": api_key_obj.is_omni,
-                "capability": capability,
-            }
             system_prompt, orchestrator_node_executions = await ToolOrchestrator.create_and_run(
                 tools=tools,
                 system_prompt=system_prompt,
@@ -274,8 +274,7 @@ class AppChatService:
         if isinstance(sq_config, dict) and sq_config.get("enabled"):
             suggested_questions = await self.agent_service._generate_suggested_questions(
                 features_config, result["content"],
-                {"model_name": api_key_obj.model_name, "api_key": api_key_obj.api_key,
-                 "api_base": api_key_obj.api_base}, {}
+                _api_key_config, {}
             )
 
         audio_url = await self.agent_service._generate_tts(
@@ -536,15 +535,15 @@ class AppChatService:
             # 弱模型：用 ReAct prompt 驱动多轮工具调用，将轨迹注入 system_prompt
             capability = api_key_obj.capability or []
             orchestrator_node_executions = []
+            _api_key_config = {
+                "model_name": api_key_obj.model_name,
+                "api_key": api_key_obj.api_key,
+                "provider": api_key_obj.provider,
+                "api_base": api_key_obj.api_base,
+                "is_omni": api_key_obj.is_omni,
+                "capability": capability,
+            }
             if ModelCapability.FUNCTION_CALL not in capability and tools:
-                _api_key_config = {
-                    "model_name": api_key_obj.model_name,
-                    "api_key": api_key_obj.api_key,
-                    "provider": api_key_obj.provider,
-                    "api_base": api_key_obj.api_base,
-                    "is_omni": api_key_obj.is_omni,
-                    "capability": capability,
-                }
                 system_prompt, orchestrator_node_executions = await ToolOrchestrator.create_and_run(
                     tools=tools,
                     system_prompt=system_prompt,
@@ -669,8 +668,7 @@ class AppChatService:
             if isinstance(sq_config, dict) and sq_config.get("enabled"):
                 suggested_questions = await self.agent_service._generate_suggested_questions(
                     features_config, full_content,
-                    {"model_name": api_key_obj.model_name, "api_key": api_key_obj.api_key,
-                     "api_base": api_key_obj.api_base}, {}
+                    _api_key_config, {}
                 )
                 end_data["suggested_questions"] = suggested_questions
             end_data["audio_url"] = stream_audio_url

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -1772,7 +1772,11 @@ class AgentRunService:
                 f"根据以下AI回复，生成3个用户可能继续追问的简短问题，每行一个，不加序号：\n\n{assistant_message}"
             )
             resp = await llm.ainvoke([HumanMessage(content=prompt)])
-            lines = [l.strip() for l in resp.content.strip().split("\n") if l.strip()]
+            content = resp.content
+            # 兼容 content 为 list 的情况（部分模型返回结构化内容）
+            if isinstance(content, list):
+                content = "".join(str(c) if isinstance(c, str) else c.get("text", "") for c in content)
+            lines = [l.strip() for l in content.strip().split("\n") if l.strip()]
             return lines[:3]
         except Exception as e:
             logger.warning(f"生成建议问题失败: {e}")

--- a/api/app/services/tool_orchestrator.py
+++ b/api/app/services/tool_orchestrator.py
@@ -63,6 +63,18 @@ Input：JSON格式工具入参，无参数则填空对象 {{}}
 你能看到历史对话和上一轮工具返回的观察结果，请基于已有结果继续推理下一步动作。\
 """
 
+# 最终回答专用提示词（给最终大模型使用，不含工具调用指令）
+_FINAL_ANSWER_SYSTEM_TEMPLATE = """\
+你是专业、友好、准确的智能助手。
+请严格基于下方提供的【工具调用过程与结果】来回答用户问题。
+
+规则：
+1. 只使用工具返回的信息回答，不编造、不脑补、不扩展无关内容
+2. 回答语言自然、通顺、礼貌，符合正常对话风格
+3. 如果工具返回结果为空或失败，请如实告知用户
+4. 不要输出任何 Thought/Action/Input 格式内容，只输出自然语言回答
+"""
+
 
 def _build_tools_info(tools: Dict[str, Any]) -> str:
     """将工具列表格式化为 prompt 中的工具描述"""
@@ -200,7 +212,8 @@ class ToolOrchestrator:
         logger.info("ReAct 工具调用完成", extra={"final_answer_len": len(final_answer)})
 
         updated_system_prompt = (
-            react_system_prompt + trajectory_context
+            system_prompt + f"\n\n{_FINAL_ANSWER_SYSTEM_TEMPLATE}"
+            + trajectory_context
             + f"\n\n工具调用已完成，调用结果：{final_answer}"
         )
         return updated_system_prompt, node_executions


### PR DESCRIPTION
add final answer system prompt and refactor api key config reuse

- Introduce dedicated system prompt for final answer generation in tool orchestrator, enforcing strict grounding in tool results and natural language output
- Refactor API key configuration to be defined once and reused across multiple conditional branches in app_chat_service and draft_run_service
- Add content normalization logic in draft_run_service to handle list-type LLM responses for suggested questions

## Summary by Sourcery

优化工具编排的最终回答提示词，并在提升推荐问题生成稳健性的同时复用 API Key 配置。

增强内容：
- 在工具编排器中引入专用的最终回答系统提示词，以基于工具结果来约束回复，并强制输出仅为自然语言。
- 重构聊天服务中的 API Key 配置处理逻辑，将其定义在单一位置，并在工具编排和推荐问题生成调用中复用。
- 通过在解析行之前，先将列表结构的 LLM 响应规范化为纯文本，来改进推荐问题生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine tool orchestration final-answer prompting and reuse API key configuration while improving robustness of suggested question generation.

Enhancements:
- Introduce a dedicated final-answer system prompt in the tool orchestrator to ground responses in tool results and enforce natural-language-only output.
- Refactor API key configuration handling in chat services to define it once and reuse across tool orchestration and suggested question generation calls.
- Improve suggested question generation by normalizing list-structured LLM responses into plain text before parsing lines.

</details>