### PR TITLE
fix(prompt): rename history-file-info tag to history-file-input for consistency

### DIFF
--- a/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
+++ b/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
@@ -5,6 +5,7 @@
 # 输入信息
 - 历史对话：{{history}}
 - 检索信息：{{retrieve_info}}
+- 对历史发送的文件在检索信息内使用<history-file-input>标签包裹
 # 用户问题
 {{query}}
 # 回答指南

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -145,7 +145,7 @@ class PerceptualBuilder(BaseBuilder):
 
     @property
     def content(self) -> str:
-        parts = ["<history-file-info>"]
+        parts = ["<history-file-input>"]
         fields = [
             ("file-name", self.record.get("file_name", "")),
             ("file-path", self.record.get("file_path", "")),
@@ -158,7 +158,7 @@ class PerceptualBuilder(BaseBuilder):
         for tag, value in fields:
             if value:
                 parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</history-file-info>")
+        parts.append("</history-file-input>")
         return "".join(parts)
 
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在搜索结果和提示词之间对齐历史文件标签，以保持提示词格式一致。

错误修复：
- 将搜索结果中的历史文件包装标签从 `history-file-info` 重命名为 `history-file-input`，以匹配预期的提示词格式。

文档：
- 更新直接摘要提示模板，以说明用于已检索历史文件的新 `<history-file-input>` 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align history file tagging between search results and prompts for consistent prompt formatting.

Bug Fixes:
- Rename the history file wrapper tag from history-file-info to history-file-input in search results to match the expected prompt format.

Documentation:
- Update the direct summary prompt template to describe the new <history-file-input> tag used for retrieved history files.

</details>