### PR TITLE
fix(mineru): use tempfile for zip and sanitize filename

### DIFF
--- a/api/app/core/rag/deepdoc/parser/mineru_parser.py
+++ b/api/app/core/rag/deepdoc/parser/mineru_parser.py
@@ -174,7 +174,7 @@ class MinerUParser(RAGPdfParser):
             self._run_mineru_executable(input_path, output_dir, method, backend, lang, server_url, callback)
 
     def _run_mineru_api(self, input_path: Path, output_dir: Path, method: str = "auto", backend: str = "pipeline", lang: Optional[str] = None, callback: Optional[Callable] = None):
-        OUTPUT_ZIP_PATH = os.path.join(str(output_dir), "output.zip")
+        OUTPUT_ZIP_PATH = tempfile.mktemp(suffix=".zip", prefix="mineru_zip_")
 
         pdf_file_path = str(input_path)
 
@@ -455,9 +455,9 @@ class MinerUParser(RAGPdfParser):
         temp_pdf = None
         created_tmp_dir = False
 
-        # remove spaces, or mineru crash, and _read_output fail too
+        # Sanitize filename: remove chars that cause API/handler mismatches
         file_path = Path(filepath)
-        pdf_file_name = file_path.stem.replace(" ", "") + ".pdf"
+        pdf_file_name = re.sub(r'[^a-zA-Z0-9_.-]', '_', file_path.stem) + ".pdf"
         pdf_file_path_valid = os.path.join(file_path.parent, pdf_file_name)
 
         if binary:


### PR DESCRIPTION
## Summary
- MinerU 解析结果的 zip 从固定路径 `/files/output.zip` 改为 tempfile，避免多 worker 并发覆盖
- 文件名 sanitize 从只去空格改为 regex 去所有特殊字符（如 `+`），避免 MinerU API 返回的 zip 内目录名与本地解压路径不匹配

## Changes
 api/app/core/rag/deepdoc/parser/mineru_parser.py | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

## Test Plan
- [ ] 含 `+` 号文件名的 PDF 用 MinerU 解析正常
- [ ] 并发解析不会互相覆盖 zip

## Summary by Sourcery

使用临时 ZIP 路径并清理 MinerU 输入文件名，以提高 PDF 解析的健壮性。

Bug Fixes:
- 通过使用临时 ZIP 文件路径，防止在多个 worker 并发运行时 MinerU API 输出的 ZIP 文件互相覆盖。
- 确保带有特殊字符（例如 `'+'`）的文件名被规范化，使 MinerU API 输出目录与本地解压路径保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a temporary ZIP path and sanitize MinerU input filenames to improve robustness of PDF parsing.

Bug Fixes:
- Prevent MinerU API output ZIP files from clobbering each other when multiple workers run concurrently by using a temporary ZIP file path.
- Ensure filenames with special characters (e.g., '+') are sanitized so MinerU API output directories match local extraction paths.

</details>