### PR TITLE
Revert "fix(prompt): rename history-file-info tag to history-file-input for consistency"

### DIFF
--- a/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
+++ b/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
@@ -5,7 +5,6 @@
 # 输入信息
 - 历史对话：{{history}}
 - 检索信息：{{retrieve_info}}
-- 对历史发送的文件在检索信息内使用<history-file-input>标签包裹
 # 用户问题
 {{query}}
 # 回答指南

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -145,7 +145,7 @@ class PerceptualBuilder(BaseBuilder):
 
     @property
     def content(self) -> str:
-        parts = ["<history-file-input>"]
+        parts = ["<history-file-info>"]
         fields = [
             ("file-name", self.record.get("file_name", "")),
             ("file-path", self.record.get("file_path", "")),
@@ -158,7 +158,7 @@ class PerceptualBuilder(BaseBuilder):
         for tag, value in fields:
             if value:
                 parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</history-file-input>")
+        parts.append("</history-file-info>")
         return "".join(parts)
 
 


### PR DESCRIPTION
Reverts SuanmoSuanyangTechnology/MemoryBear#1167

## Summary by Sourcery

在搜索结果中还原标题用于历史文件元数据的提示标签名，并移除现已不正确的提示注释。

Bug Fixes:
- 将搜索结果内容中的历史文件元数据标签名从 `<history-file-input>` 恢复为 `<history-file-info>`，以保持与现有使用方的兼容性。

Documentation:
- 更新直接摘要提示模板，移除关于已回退的历史文件标签的过时说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the prompt tag name used for history file metadata in search results and remove the now-incorrect prompt comment.

Bug Fixes:
- Restore the history file metadata tag name in search result content from <history-file-input> back to <history-file-info> for compatibility with existing consumers.

Documentation:
- Update the direct summary prompt template to remove outdated guidance about the reverted history file tag.

</details>