### PR TITLE
fix(prompt): rename history-file-info tag to history-file-input for consistency

### DIFF
--- a/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
+++ b/api/app/core/memory/agent/utils/prompt/direct_summary_prompt.jinja2
@@ -5,6 +5,7 @@
 # 输入信息
 - 历史对话：{{history}}
 - 检索信息：{{retrieve_info}}
+- 对历史发送的文件在检索信息内使用<history-file-input>标签包裹
 # 用户问题
 {{query}}
 # 回答指南

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -145,7 +145,7 @@ class PerceptualBuilder(BaseBuilder):
 
     @property
     def content(self) -> str:
-        parts = ["<history-file-info>"]
+        parts = ["<history-file-input>"]
         fields = [
             ("file-name", self.record.get("file_name", "")),
             ("file-path", self.record.get("file_path", "")),
@@ -158,7 +158,7 @@ class PerceptualBuilder(BaseBuilder):
         for tag, value in fields:
             if value:
                 parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</history-file-info>")
+        parts.append("</history-file-input>")
         return "".join(parts)
 
 


### PR DESCRIPTION
## Summary by Sourcery

通过重命名历史文件标签，使搜索结果和提示文档中的历史文件元数据标记保持一致。

Bug Fixes:
- 在搜索引擎结果内容中，将历史文件的类 XML 标签从 `history-file-info` 重命名为 `history-file-input`，以匹配预期的提示格式。

Documentation:
- 在“直接总结”提示模板中澄清检索到的信息中，历史文件输入是如何使用 `<history-file-input>` 标签进行包裹的。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align history file metadata tagging in search results and prompt documentation by renaming the history file tag for consistency.

Bug Fixes:
- Rename the history file XML-like tag from history-file-info to history-file-input in search engine result content to match expected prompt formatting.

Documentation:
- Clarify in the direct summary prompt template how history file inputs are wrapped using the <history-file-input> tag within retrieved information.

</details>