### PR TITLE
fix(memory-api): enable async write endpoint and align V1 routes 

### DIFF
--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -200,66 +200,66 @@ async def write_server(
             return fail(BizCode.INTERNAL_ERROR, "写入失败", detailed_error)
         api_logger.error(f"Write operation error: {str(e)}", exc_info=True)
         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
-#
-#
-# @router.post("/writer_service_async", response_model=ApiResponse)
-# @cur_workspace_access_guard()
-# async def write_server_async(
-#         user_input: Write_UserInput,
-#         language_type: str = Header(default=None, alias="X-Language-Type"),
-#         db: Session = Depends(get_db),
-#         current_user: User = Depends(get_current_user)
-# ):
-#     """
-#     Async write service endpoint - enqueues write processing to Celery
-#
-#     Args:
-#         user_input: Write request containing message and end_user_id
-#         language_type: 语言类型 ("zh" 中文, "en" 英文)，通过 X-Language-Type Header 传递
-#
-#     Returns:
-#         Task ID for tracking async operation
-#         Use GET /memory/write_result/{task_id} to check task status and get result
-#     """
-#     # 使用集中化的语言校验
-#     language = get_language_from_header(language_type)
-#
-#     config_id = user_input.config_id
-#     workspace_id = current_user.current_workspace_id
-#     api_logger.info(
-#         f"Async write service: workspace_id={workspace_id}, config_id={config_id}, language_type={language}")
-#
-#     # 获取 storage_type，如果为 None 则使用默认值
-#     storage_type = workspace_service.get_workspace_storage_type(
-#         db=db,
-#         workspace_id=workspace_id,
-#         user=current_user
-#     )
-#     if storage_type is None: storage_type = 'neo4j'
-#     user_rag_memory_id = ''
-#     if workspace_id:
-#
-#         knowledge = knowledge_repository.get_knowledge_by_name(
-#             db=db,
-#             name="USER_RAG_MERORY",
-#             workspace_id=workspace_id
-#         )
-#         if knowledge: user_rag_memory_id = str(knowledge.id)
-#     api_logger.info(f"Async write: storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}")
-#     try:
-#         # 获取标准化的消息列表
-#         messages_list = memory_agent_service.get_messages_list(user_input)
-#
-#         task = celery_app.send_task(
-#             "app.core.memory.agent.write_message",
-#             args=[user_input.end_user_id, messages_list, config_id, storage_type, user_rag_memory_id, language]
-#         )
-#         api_logger.info(f"Write task queued: {task.id}")
-#
-#         return success(data={"task_id": task.id}, msg="写入任务已提交")
-#     except Exception as e:
-#         api_logger.error(f"Async write operation failed: {str(e)}")
-#         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
+
+
+@router.post("/writer_service_async", response_model=ApiResponse)
+@cur_workspace_access_guard()
+async def write_server_async(
+        user_input: Write_UserInput,
+        language_type: str = Header(default=None, alias="X-Language-Type"),
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
+):
+    """
+    Async write service endpoint - enqueues write processing to Celery
+
+    Args:
+        user_input: Write request containing message and end_user_id
+        language_type: 语言类型 ("zh" 中文, "en" 英文)，通过 X-Language-Type Header 传递
+
+    Returns:
+        Task ID for tracking async operation
+        Use GET /memory/write_result/{task_id} to check task status and get result
+    """
+    # 使用集中化的语言校验
+    language = get_language_from_header(language_type)
+
+    config_id = user_input.config_id
+    workspace_id = current_user.current_workspace_id
+    api_logger.info(
+        f"Async write service: workspace_id={workspace_id}, config_id={config_id}, language_type={language}")
+
+    # 获取 storage_type，如果为 None 则使用默认值
+    storage_type = workspace_service.get_workspace_storage_type(
+        db=db,
+        workspace_id=workspace_id,
+        user=current_user
+    )
+    if storage_type is None: storage_type = 'neo4j'
+    user_rag_memory_id = ''
+    if workspace_id:
+
+        knowledge = knowledge_repository.get_knowledge_by_name(
+            db=db,
+            name="USER_RAG_MERORY",
+            workspace_id=workspace_id
+        )
+        if knowledge: user_rag_memory_id = str(knowledge.id)
+    api_logger.info(f"Async write: storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}")
+    try:
+        # 获取标准化的消息列表
+        messages_list = memory_agent_service.get_messages_list(user_input)
+
+        task = celery_app.send_task(
+            "app.core.memory.agent.write_message",
+            args=[user_input.end_user_id, messages_list, config_id, storage_type, user_rag_memory_id, language]
+        )
+        api_logger.info(f"Write task queued: {task.id}")
+
+        return success(data={"task_id": task.id}, msg="写入任务已提交")
+    except Exception as e:
+        api_logger.error(f"Async write operation failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
 
 
 @router.post("/read_service", response_model=ApiResponse)

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -42,14 +42,14 @@ async def get_memory_info():
     return success(data={}, msg="Memory API - Coming Soon")
 
 
-@router.post("/writer_service")
+@router.post("/write/sync")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_sync(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
-    message: str = Body(None, description="Request body"),
+    body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
     language_type: str = Header(default=None, alias="X-Language-Type"),
 ):
     """
@@ -75,13 +75,13 @@ async def write_memory_sync(
     return _encode_result(result)
 
 
-@router.post("/read_service")
+@router.post("/read/sync")
 @require_api_key(scopes=["memory"])
 async def read_memory_sync(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
-    message: str = Body(None, description="Request body"),
+    body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
 ):
     """
     Read memory synchronously.
@@ -105,21 +105,21 @@ async def read_memory_sync(
     return _encode_result(result)
 
 
-@router.post("/writer_service_async")
+@router.post("/write")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_async(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
-    message: str = Body(None, description="Request body"),
+    body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
     language_type: str = Header(default=None, alias="X-Language-Type"),
 ):
     """
     Write memory asynchronously (Celery task).
 
     Requires API Key with 'memory' scope.
-    Returns task_id for polling via GET /write_result/.
+    Returns task_id for polling via GET /write/status.
     """
     body = await request.json()
     payload = Write_UserInput(**body)
@@ -138,19 +138,19 @@ async def write_memory_async(
     return _encode_result(result)
 
 
-@router.post("/read_service_async")
+@router.post("/read")
 @require_api_key(scopes=["memory"])
 async def read_memory_async(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
-    message: str = Body(None, description="Request body"),
+    body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
 ):
     """
     Read memory asynchronously (Celery task).
 
     Requires API Key with 'memory' scope.
-    Returns task_id for polling via GET /read_result/.
+    Returns task_id for polling via GET /read/status.
     """
     body = await request.json()
     payload = UserInput(**body)
@@ -167,7 +167,7 @@ async def read_memory_async(
     )
     return _encode_result(result)
 
-@router.get("/write_result")
+@router.get("/write/status")
 @require_api_key(scopes=["memory"])
 async def get_write_task_status(
     request: Request,
@@ -186,7 +186,7 @@ async def get_write_task_status(
     return _encode_result(result)
 
 
-@router.get("/read_result")
+@router.get("/read/status")
 @require_api_key(scopes=["memory"])
 async def get_read_task_status(
     request: Request,

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -42,7 +42,7 @@ async def get_memory_info():
     return success(data={}, msg="Memory API - Coming Soon")
 
 
-@router.post("/write/sync")
+@router.post("/writer_service")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_sync(
@@ -75,7 +75,7 @@ async def write_memory_sync(
     return _encode_result(result)
 
 
-@router.post("/read/sync")
+@router.post("/read_service")
 @require_api_key(scopes=["memory"])
 async def read_memory_sync(
     request: Request,
@@ -105,41 +105,40 @@ async def read_memory_sync(
     return _encode_result(result)
 
 
-# NOTE: 内部 memory_agent_controller.write_server_async 当前已注释，V1 端同步注释，待恢复后同步启用
-#
-# @router.post("/write")
-# @require_api_key(scopes=["memory"])
-# async def write_memory_async(
-#     request: Request,
-#     api_key_auth: ApiKeyAuth = None,
-#     db: Session = Depends(get_db),
-#     message: str = Body(None, description="Request body"),
-#     language_type: str = Header(default=None, alias="X-Language-Type"),
-# ):
-#     """
-#     Write memory asynchronously (Celery task).
-#
-#     Requires API Key with 'memory' scope.
-#     Returns task_id for polling via GET /write/status.
-#     """
-#     body = await request.json()
-#     payload = Write_UserInput(**body)
-#
-#     current_user = get_current_user_from_api_key(db, api_key_auth)
-#     validate_end_user_in_workspace(db, payload.end_user_id, api_key_auth.workspace_id)
-#
-#     logger.info(f"V1 memory write (async) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
-#
-#     result = await memory_agent_controller.write_server_async(
-#         user_input=payload,
-#         language_type=language_type,
-#         db=db,
-#         current_user=current_user,
-#     )
-#     return _encode_result(result)
+@router.post("/writer_service_async")
+@require_api_key(scopes=["memory"])
+@check_end_user_quota
+async def write_memory_async(
+    request: Request,
+    api_key_auth: ApiKeyAuth = None,
+    db: Session = Depends(get_db),
+    message: str = Body(None, description="Request body"),
+    language_type: str = Header(default=None, alias="X-Language-Type"),
+):
+    """
+    Write memory asynchronously (Celery task).
+
+    Requires API Key with 'memory' scope.
+    Returns task_id for polling via GET /write_result/.
+    """
+    body = await request.json()
+    payload = Write_UserInput(**body)
+
+    current_user = get_current_user_from_api_key(db, api_key_auth)
+    validate_end_user_in_workspace(db, payload.end_user_id, api_key_auth.workspace_id)
+
+    logger.info(f"V1 memory write (async) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
+
+    result = await memory_agent_controller.write_server_async(
+        user_input=payload,
+        language_type=language_type,
+        db=db,
+        current_user=current_user,
+    )
+    return _encode_result(result)
 
 
-@router.post("/read")
+@router.post("/read_service_async")
 @require_api_key(scopes=["memory"])
 async def read_memory_async(
     request: Request,
@@ -151,7 +150,7 @@ async def read_memory_async(
     Read memory asynchronously (Celery task).
 
     Requires API Key with 'memory' scope.
-    Returns task_id for polling via GET /read/status.
+    Returns task_id for polling via GET /read_result/.
     """
     body = await request.json()
     payload = UserInput(**body)
@@ -168,27 +167,26 @@ async def read_memory_async(
     )
     return _encode_result(result)
 
-# NOTE: /write/status 已禁用，因为其生产者（POST /write → write_server_async）当前已注释。
-# 恢复时需同时启用 POST /write 和 GET /write/status 两个端点。
-#
-# @router.get("/write/status")
-# @require_api_key(scopes=["memory"])
-# async def get_write_task_status(
-#     request: Request,
-#     task_id: str = Query(..., description="Celery task ID"),
-#     api_key_auth: ApiKeyAuth = None,
-#     db: Session = Depends(get_db),
-# ):
-#     """查询异步写入任务状态"""
-#     logger.info(f"V1 write task status - task_id: {task_id}")
-#
-#     from app.celery_task_scheduler import scheduler
-#     result = scheduler.get_task_status(task_id)
-#
-#     return success(data=jsonable_encoder(result), msg="Task status retrieved")
+@router.get("/write_result")
+@require_api_key(scopes=["memory"])
+async def get_write_task_status(
+    request: Request,
+    task_id: str = Query(..., description="Celery task ID"),
+    api_key_auth: ApiKeyAuth = None,
+    db: Session = Depends(get_db),
+):
+    """查询异步写入任务状态"""
+    logger.info(f"V1 write task status - task_id: {task_id}")
+
+    current_user = get_current_user_from_api_key(db, api_key_auth)
+    result = await memory_agent_controller.get_write_task_result(
+        task_id=task_id,
+        current_user=current_user,
+    )
+    return _encode_result(result)
 
 
-@router.get("/read/status")
+@router.get("/read_result")
 @require_api_key(scopes=["memory"])
 async def get_read_task_status(
     request: Request,
@@ -196,14 +194,12 @@ async def get_read_task_status(
     api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
 ):
-    """
-    Check the status of a memory read task.
-
-    Requires API Key with 'memory' scope.
-    """
+    """查询异步读取任务状态"""
     logger.info(f"V1 read task status - task_id: {task_id}")
 
-    from app.services.task_service import get_task_memory_read_result
-    result = get_task_memory_read_result(task_id)
-
-    return success(data=jsonable_encoder(result), msg="Task status retrieved")
+    current_user = get_current_user_from_api_key(db, api_key_auth)
+    result = await memory_agent_controller.get_read_task_result(
+        task_id=task_id,
+        current_user=current_user,
+    )
+    return _encode_result(result)


### PR DESCRIPTION
enable async write endpoint and align V1 routes 

- Enable writer_service_async endpoint on internal memory controller
- Add /write_result/ status polling endpoint on V1 memory API
- Replace scheduler-based task lookup with direct Celery AsyncResult query
- Rename V1 routes to match internal API naming convention (write/sync -> writer_service, read/sync -> read_service, etc.)

## Summary by Sourcery

在 V1 API 中启用异步内存写入支持，并使其路由与内部内存控制器保持一致。

New Features:
- 在 V1 内存 API 上暴露一个异步内存写入端点，并将请求委托给内部异步写入服务。
- 添加专用端点，以通过任务 ID 获取异步写入和读取任务结果。

Enhancements:
- 重命名 V1 内存 API 路由，使其在同步和异步读/写操作上与内部服务的命名约定保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable asynchronous memory write support in the V1 API and align its routes with the internal memory controller.

New Features:
- Expose an async memory write endpoint on the V1 memory API that delegates to the internal async writer service.
- Add dedicated endpoints to fetch async write and read task results via task IDs.

Enhancements:
- Rename V1 memory API routes to match internal service naming conventions for sync and async read/write operations.

</details>