### PR TITLE
fix(mcp)

### DIFF
--- a/api/app/core/tools/mcp/base.py
+++ b/api/app/core/tools/mcp/base.py
@@ -123,7 +123,7 @@ class MCPTool(BaseTool):
             # 确定要调用的工具名称
             # 优先使用参数中的 tool_name，否则使用当前工具名（从 available_tools 提取）
             tool_name = kwargs.pop("tool_name", None) or self.name
-            arguments = kwargs.pop("arguments", {}) if "arguments" in kwargs else kwargs  # 剩余参数作为工具参数
+            arguments = kwargs.pop("arguments", kwargs)  # 剩余参数作为工具参数
             
             from .client import SimpleMCPClient
             

--- a/api/app/core/tools/mcp/base.py
+++ b/api/app/core/tools/mcp/base.py
@@ -123,7 +123,7 @@ class MCPTool(BaseTool):
             # 确定要调用的工具名称
             # 优先使用参数中的 tool_name，否则使用当前工具名（从 available_tools 提取）
             tool_name = kwargs.pop("tool_name", None) or self.name
-            arguments = kwargs  # 剩余参数作为工具参数
+            arguments = kwargs.pop("arguments", {}) if "arguments" in kwargs else kwargs  # 剩余参数作为工具参数
             
             from .client import SimpleMCPClient
             


### PR DESCRIPTION
extract arguments from kwargs in base tool execution

## Summary by Sourcery

错误修复：
- 确保 MCP 基础工具从 `kwargs` 中提取嵌套的 `arguments` 负载，而不是将其视为扁平的参数字典。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure MCP base tool extracts the nested `arguments` payload from kwargs instead of treating it as a flat parameter dict.

</details>