### PR TITLE
fix: default rerank_score_threshold to 0.1 when not set

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -727,7 +727,7 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
-            rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else 0.1
+            rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
             rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -727,8 +727,8 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
-            if retrieve_data.rerank_score_threshold is not None:
-                rs = [doc for doc in rs if doc.metadata.get("score", 0) > retrieve_data.rerank_score_threshold]
+            rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else 0.1
+            rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -727,6 +727,8 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
+            if retrieve_data.rerank_score_threshold is not None:
+                rs = [doc for doc in rs if doc.metadata.get("score", 0) > retrieve_data.rerank_score_threshold]
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -78,6 +78,7 @@ class ChunkRetrieve(BaseModel):
     vector_similarity_weight: float | None = Field(None)
     top_k: int | None = Field(None)
     retrieve_type: RetrieveType | None = Field(None)
+    rerank_score_threshold: float | None = Field(None, ge=0, le=1)
 
 
 class ChunkBatchCreate(BaseModel):


### PR DESCRIPTION
## Summary
- Add `rerank_score_threshold` filter to chunk retrieval to prevent near-zero relevance docs from leaking into recall test results
- Default `rerank_score_threshold` to 0.1 when not explicitly set

## Changes
```
api/app/controllers/chunk_controller.py | 2 ++
api/app/schemas/chunk_schema.py         | 1 +
2 files changed, 3 insertions(+)
```

## Test Plan
- [ ] Verify rerank threshold filtering works in hybrid retrieve mode
- [ ] Verify default threshold of 0.1 is applied when param is omitted

## Summary by Sourcery

通过可配置的相关性阈值（带有默认值）过滤重排序后的检索结果。

新功能：
- 在分块检索请求中添加一个重排序得分阈值参数，用于控制返回文档的最低相关性。

错误修复：
- 当未提供阈值时，应用默认阈值 `0.1`，从重排序后的检索结果中排除相关性接近于零的文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Filter reranked retrieval results by a configurable relevance threshold with a default value.

New Features:
- Add a rerank score threshold parameter to chunk retrieval requests to control minimum relevance of returned documents.

Bug Fixes:
- Exclude near-zero relevance documents from reranked retrieval results by applying a default threshold of 0.1 when no threshold is provided.

</details>