### PR TITLE
Revert "fix:index ui"

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -27,5 +27,3 @@ package-lock.json
 # Yalc 本地调试缓存
 .yalc
 yalc.lock
-
-.npmrc

--- a/web/src/views/Index/components/QuickActions.tsx
+++ b/web/src/views/Index/components/QuickActions.tsx
@@ -61,7 +61,7 @@ const QuickActions: FC<QuickActionsProps> = ({ onNavigate }) => {
   ];
 
   return (
-    <div className='rb:w-full rb:bg-white rb:rounded-xl rb:py-3'>
+    <div className='rb:w-full rb:bg-white rb:rounded-xl rb:mt-2.5 rb:py-3'>
       <div className='rb:font-[MiSans-Bold] rb:font-bold rb:leading-5 rb:px-4 rb:pb-3.5'>
         { t('quickActions.title') }
       </div>

--- a/web/src/views/Index/components/TopCardList/index.tsx
+++ b/web/src/views/Index/components/TopCardList/index.tsx
@@ -55,7 +55,7 @@ const list = [
 const TopCardList: FC<{data?: DataResponse}> = ({ data }) => {
   const { t } = useTranslation()
   return (
-    <div className="rb:grid rb:grid-cols-4 rb:gap-3">
+    <div className="rb:grid rb:grid-cols-4 rb:gap-3 rb:mt-3">
       {list.map((item) => {
         return (
           <div 

--- a/web/src/views/Index/components/VersionCard.tsx
+++ b/web/src/views/Index/components/VersionCard.tsx
@@ -3,8 +3,8 @@
  * @Version: 0.0.1
  * @Author: yujiangping
  * @Date: 2026-01-12 16:34:59
- * @LastEditors: yujiangping
- * @LastEditTime: 2026-05-15 15:59:15
+ * @LastEditors: ZhaoYing
+ * @LastEditTime: 2026-04-02 10:36:37 
  */
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +40,7 @@ const VersionCard: React.FC = () => {
   }, []);
     
   return (
-    <div className='rb:w-full rb:h-full rb:p-3 rb:bg-white rb:rounded-xl'>
+    <div className='rb:w-full rb:p-3 rb:bg-white rb:rounded-xl rb:mt-3'>
       <Flex gap={4} className="rb:mb-3">
         <span className="rb:font-[MiSans-Bold] rb:font-bold rb:leading-5">{t('index.latestUpdate')}</span>
         {versionInfo?.version && 

--- a/web/src/views/Index/index.tsx
+++ b/web/src/views/Index/index.tsx
@@ -100,8 +100,8 @@ const Index = () => {
 
   return (
     <Flex gap={12} wrap="nowrap" className="rb:w-full! rb:h-full! rb:overflow-y-auto">
-      <div className="rb:flex-1 rb:min-w-0 rb:min-h-0 rb:space-y-3 rb:flex rb:flex-col">
-        {/* <Flex vertical> */}
+      <div className="rb:flex-1 rb:min-w-0">
+        <Flex vertical>
           <div className='rb:w-full rb:h-26 rb:p-4 rb:bg-cover rb:bg-[url("@/assets/images/index/index_bg.png")] rb:rounded-xl rb:overflow-hidden'>
             <div className="rb:font-[MiSans-Bold] rb:font-bold rb:text-white rb:text-[18px] rb:leading-7">
               {t('index.spaceTitle')}
@@ -110,11 +110,9 @@ const Index = () => {
               {t('index.spaceSubTitle')}
             </div>
           </div>
-          <div className='rb:shrink-0'>
-            {/* 统计卡片 */}
-            <TopCardList data={dashboardData} />
-          </div>
-          <div className="rb:flex-1 rb:rounded-xl rb:bg-white rb:pt-3 rb:px-3 rb:overflow-y-hidden">
+          {/* 统计卡片 */}
+          <TopCardList data={dashboardData} />
+          <div className="rb:rounded-xl rb:bg-white rb:pt-3 rb:px-3 rb:overflow-y-hidden rb:my-3 rb:flex-1">
             <Table
               ref={tableRef}
               apiUrl={tableApi}
@@ -125,19 +123,13 @@ const Index = () => {
               pagination={{pagesize: 10}}
             />
           </div>
-        {/* </Flex> */}
+        </Flex>
       </div>
-      <div className="rb:w-82! rb:flex rb:flex-col rb:min-h-0 rb:space-y-3">
+      <div className="rb:w-82!">
         {/* 引导 */}
-        <div className='rb:shrink-0'>
-          <GuideCard />
-        </div>
-        <div className='rb:flex-1'>
-          <VersionCard />
-        </div>
-        <div className='rb:shrink-0'>
-          <QuickActions onNavigate={navigate} />
-        </div>
+        <GuideCard />
+        <VersionCard />
+        <QuickActions onNavigate={navigate} />
       </div>
     </Flex>
   );


### PR DESCRIPTION
This reverts commit cfa6c1428930b6ca85f5121ccd1ccaf7b94a97af.

## Summary by Sourcery

还原最近对 Index 页面布局所做的调整，以恢复之前的仪表盘结构和间距。

增强内容：
- 将主 Index 仪表盘布局恢复为使用垂直 Flex 堆叠方式来排列页头、统计卡片和表格内容。
- 简化右侧边栏结构，直接渲染指南、版本和快速操作卡片，不再使用 flex 包装容器。
- 调整顶部统计卡片、版本卡片和快速操作的间距和外边距，使其与还原后的布局设计保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert recent Index page layout adjustments to restore the previous dashboard structure and spacing.

Enhancements:
- Restore the main Index dashboard layout to use a vertical Flex stack for the header, statistics cards, and table content.
- Simplify the right-hand sidebar structure by rendering guide, version, and quick actions cards directly without flex wrappers.
- Adjust spacing and margins for top statistics cards, version card, and quick actions to align with the reverted layout design.

</details>