### PR TITLE
fix(web): kb recall config

### DIFF
--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -135,7 +135,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
               </Form.Item>
 
               {/* Show when retrieve_type = semantic or hybrid */}
-              {(retrieveType === 'semantic' || retrieveType === 'hybrid') && (
+              {(retrieveType === 'participle' || retrieveType === 'hybrid') && (
                   <Form.Item name="similarity_threshold" label={t('knowledgeBase.similarityThreshold')}>
                       <Select
                           options={[
@@ -156,7 +156,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
               )}
 
               {/* Show when retrieve_type = participle or hybrid */}
-              {(retrieveType === 'participle' || retrieveType === 'hybrid') && (
+              {(retrieveType === 'semantic' || retrieveType === 'hybrid') && (
                   <Form.Item name="vector_similarity_weight" label={t('knowledgeBase.semanticSimilarity')}>
                       <Select
                           options={[


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 交换条件渲染逻辑，使在分词/混合类型中显示相似度阈值，在语义/混合检索类型中显示向量相似度权重。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Swap conditional rendering so similarity threshold shows for participle/hybrid and vector similarity weight shows for semantic/hybrid retrieve types.

</details>