### PR TITLE
feat(web): assigner add operate

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2470,6 +2470,10 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
           subtract: '-=',
           multiply: '*=',
           divide: '/=',
+          append: 'Append',
+          remove_last: 'Remove Last',
+          remove_first: 'Remove First',
+          extend: 'Extend',
         },
         iteration: {
           input: 'Input Variable',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2434,6 +2434,10 @@ export const zh = {
           subtract: '-=',
           multiply: '*=',
           divide: '/=',
+          append: '追加',
+          remove_last: '移除末项',
+          remove_first: '移除首项',
+          extend: '扩展',
         },
         iteration: {
           input: '输入变量',

--- a/web/src/views/Workflow/components/Properties/AssignmentList/index.tsx
+++ b/web/src/views/Workflow/components/Properties/AssignmentList/index.tsx
@@ -28,26 +28,45 @@ const operationsObj = {
     { value: 'clear', label: 'workflow.config.assigner.clear' },
     { value: 'assign', label: 'workflow.config.assigner.assign' },
   ],
+  array: [
+    { value: 'cover', label: 'workflow.config.assigner.cover' },
+    { value: 'clear', label: 'workflow.config.assigner.clear' },
+    { value: 'assign', label: 'workflow.config.assigner.assign' },
+    { value: 'append', label: 'workflow.config.assigner.append' },
+    { value: 'extend', label: 'workflow.config.assigner.extend' },
+    { value: 'remove_first', label: 'workflow.config.assigner.remove_first' },
+    { value: 'remove_last', label: 'workflow.config.assigner.remove_last' },
+  ],
 }
 
-const filterByDataType = (options: Suggestion[], dataType: string): Suggestion[] =>
-  options.reduce<Suggestion[]>((acc, vo) => {
+const filterByDataType = (options: Suggestion[], dataType: string, curOperation?: string): Suggestion[] => {
+  // When curOperation is 'append', extract the inner type from array[type]
+  let targetType = dataType;
+  if (curOperation === 'append' && dataType?.includes('array[')) {
+    const match = dataType.match(/array\[(\w+)\]/);
+    if (match) {
+      targetType = match[1];
+    }
+  }
+
+  return options.reduce<Suggestion[]>((acc, vo) => {
     if (vo.children?.length) {
       const children = vo.children.reduce<Suggestion[]>((cacc, child) => {
         if (child.children?.length) {
-          const grandchildren = child.children.filter(gc => gc.dataType === dataType);
+          const grandchildren = child.children.filter(gc => gc.dataType === targetType);
           if (grandchildren.length) cacc.push({ ...child, children: grandchildren });
-        } else if (child.dataType === dataType) {
+        } else if (child.dataType === targetType) {
           cacc.push(child);
         }
         return cacc;
       }, []);
       if (children.length) acc.push({ ...vo, children });
-    } else if (vo.dataType === dataType) {
+    } else if (vo.dataType === targetType) {
       acc.push(vo);
     }
     return acc;
   }, []);
+};
 
 const AssignmentList: FC<AssignmentListProps> = ({
   parentName,
@@ -82,7 +101,7 @@ const AssignmentList: FC<AssignmentListProps> = ({
                 ?? options.flatMap(o => o.children ?? []).find(child => `{{${child.value}}}` === variableSelector)
                 ?? options.flatMap(o => o.children ?? []).flatMap((c: any) => c.children ?? []).find((gc: any) => `{{${gc.value}}}` === variableSelector);
               const dataType = selectedOption?.dataType;
-              const operationOptions = dataType === 'number' ? operationsObj.number : operationsObj.default;
+              const operationOptions = dataType?.includes('array') ? operationsObj.array : dataType === 'number' ? operationsObj.number : operationsObj.default;
               
               return (
                 <Flex key={key} gap={4} align="start">
@@ -129,7 +148,7 @@ const AssignmentList: FC<AssignmentListProps> = ({
                     <Form.Item shouldUpdate noStyle>
                       {(form) => {
                         const operation = form.getFieldValue([parentName, name, 'operation']);
-                        if (operation === 'clear') return null;
+                        if (['clear', 'remove_last', 'remove_first'].includes(operation)) return null;
 
                         return (
                           <Form.Item
@@ -171,7 +190,7 @@ const AssignmentList: FC<AssignmentListProps> = ({
                                   </>
                                   : <VariableSelect
                                     placeholder={t('common.pleaseSelect')}
-                                    options={dataType ? filterByDataType(options, dataType) : options}
+                                    options={dataType ? filterByDataType(options, dataType, operation) : options}
                                     size={size}
                                     className="rb:flex-1!"
                                     variant="filled"


### PR DESCRIPTION
## Summary by Sourcery

在工作流赋值配置中新增数组专用的赋值操作，并相应更新变量过滤逻辑。

新功能：
- 在工作流赋值界面中引入数组专用赋值操作，包括：`cover`、`clear`、`assign`、`append`、`extend`、`remove_first` 和 `remove_last`。
- 在变量建议中，当使用 `append` 操作时支持选择数组元素类型。

增强：
- 调整赋值字段的可见性，使 `clear`、`remove_first` 和 `remove_last` 等操作不再需要目标值。
- 为新的数组赋值操作添加英文和中文本地化条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new array-specific assignment operations to workflow assignment configuration and update variable filtering accordingly.

New Features:
- Introduce array-specific assignment operations including cover, clear, assign, append, extend, remove_first, and remove_last in the workflow assignment UI.
- Support selection of array element types when using the append operation in variable suggestions.

Enhancements:
- Adjust assignment field visibility so that operations like clear, remove_first, and remove_last do not require a target value.
- Add English and Chinese localization entries for the new array assignment operations.

</details>