### PR TITLE
feat(web): agent prompt support variables

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1483,6 +1483,8 @@ export const en = {
       allow_download: 'Allow downloading cited source text',
       invalidVariablesTitle: "The following undefined variables are referenced in the conversation opening. Do you want to save the opening configuration?",
       deep_thinking: 'Enable Deep Thinking',
+      promptInvalidVariablesTitle: 'The following undefined variables are referenced in the conversation opening. Do you want to save the opening configuration?',
+      addNewVariable: 'Add New Variable',
 
       apps: 'My Apps',
       sharing: 'Sharing',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -814,6 +814,8 @@ export const zh = {
       allow_download: '允许下载引用原文',
       invalidVariablesTitle: "对话开场白中引用了以下未定义的变量，是否保存开场白配置？",
       deep_thinking: '开启深度思考',
+      promptInvalidVariablesTitle: '提示词中引用了未定义的变量，是否自动添加到用户输入表单中？',
+      addNewVariable: '添加新变量',
 
       apps: '我的应用',
       sharing: '共享',

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -2,12 +2,12 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:21 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-07 18:04:49
+ * @Last Modified time: 2026-05-19 17:12:37
  */
-import { useEffect, useRef, useState, forwardRef, useImperativeHandle, useMemo } from 'react';
+import { useEffect, useRef, useState, forwardRef, useImperativeHandle, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom';
-import { Row, Col, Space, Form, Input, Button, App, Flex } from 'antd'
+import { Row, Col, Space, Form, Button, App, Flex } from 'antd'
 
 import Chat from './components/Chat'
 import RbCard from '@/components/RbCard/Card'
@@ -45,6 +45,8 @@ import DescWrapper from '@/components/FormItem/DescWrapper'
 import FeaturesConfig from './components/FeaturesConfig'
 import { getListLogoUrl } from '@/views/ModelManagement/utils';
 import type { ChatItem } from '@/components/Chat/types'
+import Editor from './components/Editor'
+import Tag from '@/components/Tag'
 
 export const replaceVariables = (statement: string, variables: Variable[]) => {
   return statement.replace(/\{\{([^}]+)\}\}/g, (match, name) => {
@@ -60,7 +62,7 @@ export const replaceVariables = (statement: string, variables: Variable[]) => {
 const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigForm | undefined) => void }>(({ onFeaturesLoad }, ref) => {
   const { t } = useTranslation()
   const { id } = useParams();
-  const { message } = App.useApp()
+  const { message, modal } = App.useApp()
   const [form] = Form.useForm()
   const [data, setData] = useState<Config | null>(null);
   const modelConfigModalRef = useRef<ModelConfigModalRef>(null)
@@ -310,7 +312,8 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
    * Update prompt and extract variables
    * @param value - New prompt value
    */
-  const updatePrompt = (value: string) => {
+  const updatePrompt = (value?: string) => {
+    if (!value) return
     form.setFieldValue('system_prompt', value)
     const variables = value.match(/\{\{([^}]+)\}\}/g)?.map(match => match.slice(2, -2)) || []
     const uniqueVariables = [...new Set(variables)]
@@ -415,8 +418,35 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
       })
     }
   }, [defaultModel, chatList.length, form.getFieldValue(['features', 'opening_statement']), chatVariables])
-  
-  console.log('agent values', values)
+
+  const updateVariables = useCallback((value?: string) => {
+    if (!value) return
+    const usedVars = [...new Set([...value.matchAll(/\{\{(\w+)\}\}/g)].map(m => m[1]))]
+    const validNames = new Set(chatVariables.map((v: Variable) => v.name))
+    const invalid = usedVars.filter(v => !validNames.has(v))
+
+    if (invalid.length > 0) {
+      modal.confirm({
+        title: t('application.promptInvalidVariablesTitle'),
+        content: <Flex gap={8} wrap>{invalid.map((vo, index) => <Tag key={index}>{'{{'}{vo}{'}}'}</Tag>)}</Flex>,
+        okText: t('common.confirm'),
+        cancelText: t('common.cancel'),
+        onOk: () => {
+          const uniqueVariables = [...new Set(invalid)]
+          const newVariableList: Variable[] = uniqueVariables.map((name, index) => ({
+            index,
+            type: 'text',
+            name,
+            display_name: name,
+            required: false
+          }))
+
+          updateVariableList([...chatVariables, ...newVariableList])
+        },
+      })
+    }
+  }, [chatVariables])
+
   return (
     <>
       <Row className="rb:h-full!" gutter={12}>
@@ -468,15 +498,12 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
                   </div>
 
                   <Form.Item name="system_prompt" className="rb:mb-0!">
-                    <Input.TextArea
+                    <Editor
+                      options={chatVariables.map(v => ({ label: v.display_name, value: `{{${v.name}}}` }))}
                       placeholder={t('application.promptPlaceholder')}
-                      styles={{
-                        textarea: {
-                          minHeight: '200px',
-                          borderRadius: '8px',
-                          padding: '12px'
-                        },
-                      }}
+                      className="rb:h-50 rb:bg-[#FFFFFF]"
+                      onBlur={updateVariables}
+                      disabled={false}
                     />
                   </Form.Item>
                 </Card>

--- a/web/src/views/ApplicationConfig/components/Editor/commands/index.ts
+++ b/web/src/views/ApplicationConfig/components/Editor/commands/index.ts
@@ -1,0 +1,21 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-05-19 17:11:13 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-05-19 17:11:13 
+ */
+import { createCommand, type LexicalCommand } from 'lexical';
+
+export interface OptionItem {
+  key?: string;
+  label: string;
+  value: string;
+}
+
+export interface InsertOptionCommandPayload {
+  data: OptionItem;
+}
+
+export const INSERT_OPTION_COMMAND: LexicalCommand<InsertOptionCommandPayload> = createCommand('INSERT_OPTION_COMMAND');
+
+export const CLOSE_AUTOCOMPLETE_COMMAND: LexicalCommand<void> = createCommand('CLOSE_AUTOCOMPLETE_COMMAND');

--- a/web/src/views/ApplicationConfig/components/Editor/index.tsx
+++ b/web/src/views/ApplicationConfig/components/Editor/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:25:17 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-26 11:18:04
+ * @Last Modified time: 2026-05-18 12:24:31
  */
 /**
  * Rich text editor component using Lexical framework
@@ -22,6 +22,8 @@ import InitialValuePlugin from './plugin/InitialValuePlugin'
 import LineBreakPlugin from './plugin/LineBreakPlugin';
 import InsertTextPlugin from './plugin/InsertTextPlugin';
 import EditablePlugin from './plugin/EditablePlugin';
+import AutocompletePlugin from './plugin/AutocompletePlugin';
+import BlurPlugin from './plugin/BlurPlugin';
 
 /**
  * Editor ref methods exposed to parent components
@@ -52,6 +54,8 @@ interface LexicalEditorProps {
   /** Editor height in pixels */
   height?: number;
   disabled?: boolean;
+  options?: Array<{label: string, value: string}>
+  onBlur?: (value?: string) => void;
 }
 
 /**
@@ -73,7 +77,9 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
   value,
   placeholder = "Please enter content...",
   onChange,
-  disabled
+  disabled,
+  options = [],
+  onBlur,
 }, ref) => {
   const [editor] = useLexicalComposerContext();
   
@@ -136,14 +142,13 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
         contentEditable={
           <ContentEditable
             className={clsx(
-              "rb:outline-none rb:resize-none rb:text-[14px] rb:leading-5 rb:px-4 rb:py-5 rb:bg-[#FBFDFF] rb-border rb:rounded-lg rb:overflow-auto",
-              disabled && "rb:cursor-not-allowed rb:bg-[#F6F8FC] rb:text-[#5B6167]",
-              className
-            )}
+              "rb:outline-none rb:resize-none rb:text-[14px] rb:leading-5 rb:px-4 rb:py-5 rb:bg-[#FBFDFF] rb-border rb:rounded-lg rb:overflow-auto",{
+              "rb:cursor-not-allowed rb:bg-[#F6F8FC] rb:text-[#5B6167]": disabled,
+            }, className)}
           />
         }
         placeholder={
-          <div className="rb:absolute rb:top-0 rb:px-4 rb:py-5 rb:text-[14px] rb:text-[#5B6167] rb:leading-5 rb:pointer-none">
+          <div className="rb:absolute rb:top-0 rb:px-4 rb:py-5 rb:text-[14px] rb:text-[rgba(23,23,25,0.25)] rb:leading-5 rb:pointer-none">
             {placeholder}
           </div>
         }
@@ -153,6 +158,8 @@ const EditorContent = forwardRef<EditorRef, LexicalEditorProps>(({
       <InitialValuePlugin value={value} />
       <InsertTextPlugin />
       <EditablePlugin disabled={disabled} />
+      <AutocompletePlugin options={options} />
+      <BlurPlugin onBlur={onBlur} />
     </div>
   );
 });

--- a/web/src/views/ApplicationConfig/components/Editor/plugin/AutocompletePlugin.tsx
+++ b/web/src/views/ApplicationConfig/components/Editor/plugin/AutocompletePlugin.tsx
@@ -1,0 +1,332 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-05-19 17:11:30 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-05-19 17:11:30 
+ */
+import { useEffect, useState, useRef, useMemo, type FC } from 'react';
+import { createPortal } from 'react-dom';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $createTextNode, $setSelection, $createRangeSelection, $isTextNode, $getSelection, $isRangeSelection, COMMAND_PRIORITY_HIGH, KEY_ENTER_COMMAND, KEY_ARROW_DOWN_COMMAND, KEY_ARROW_UP_COMMAND, KEY_ESCAPE_COMMAND } from 'lexical';
+import { Flex } from 'antd';
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+
+import { INSERT_OPTION_COMMAND, CLOSE_AUTOCOMPLETE_COMMAND, type OptionItem } from '../commands';
+
+interface AutocompletePluginProps {
+  options: OptionItem[];
+}
+
+
+const AutocompletePlugin: FC<AutocompletePluginProps> = ({ options }) => {
+  const { t } = useTranslation();
+  const [editor] = useLexicalComposerContext();
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [popupPosition, setPopupPosition] = useState({ top: 0, left: 0 });
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  const filteredOptions = options.map((option, index) => ({
+    ...option,
+    key: option.key || `option-${index}`
+  }));
+
+  const ADD_NEW_VARIABLE_OPTION: OptionItem = useMemo(() => ({
+    key: '__add_new_variable__',
+    label: t('application.addNewVariable'),
+    value: ''
+  }), [t]);
+  const allOptions = useMemo(
+    () => [ADD_NEW_VARIABLE_OPTION, ...filteredOptions],
+    [ADD_NEW_VARIABLE_OPTION, filteredOptions]
+  );
+
+  const resetState = () => {
+    setShowSuggestions(false);
+    setSelectedIndex(0);
+  };
+
+  useEffect(() => {
+    const editorElement = editor.getRootElement();
+    const handleBlur = (e: FocusEvent) => {
+      const relatedTarget = e.relatedTarget as Node | null;
+      if (relatedTarget && editorElement?.contains(relatedTarget)) {
+        return;
+      }
+      setShowSuggestions(false);
+    };
+    
+    editorElement?.addEventListener('blur', handleBlur, true);
+    return () => {
+      editorElement?.removeEventListener('blur', handleBlur, true);
+    };
+  }, [editor]);
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        const selection = $getSelection();
+        
+        if (!selection || !$isRangeSelection(selection)) {
+          setShowSuggestions(false);
+          return;
+        }
+
+        const anchorNode = selection.anchor.getNode();
+        const anchorOffset = selection.anchor.offset;
+        const nodeText = anchorNode.getTextContent();
+        const textBeforeCursor = nodeText.substring(0, anchorOffset);
+        const shouldShow = textBeforeCursor.endsWith('/') || 
+                          (textBeforeCursor === '/' && anchorOffset === 1);
+        
+        setShowSuggestions(shouldShow);
+        if (!shouldShow) {
+          setSelectedIndex(0);
+        }
+
+        if (shouldShow) {
+          const domSelection = window.getSelection();
+          if (domSelection && domSelection.rangeCount > 0) {
+            const range = domSelection.getRangeAt(0);
+            const rect = range.getBoundingClientRect();
+            setPopupPosition({ top: rect.bottom + 4, left: rect.left });
+          }
+        }
+      });
+    });
+  }, [editor]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      CLOSE_AUTOCOMPLETE_COMMAND,
+      () => {
+        resetState();
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+  }, [editor]);
+
+  const insertOption = (option: OptionItem) => {
+    editor.dispatchCommand(INSERT_OPTION_COMMAND, { data: option });
+    resetState();
+  };
+
+  const insertNewVariable = () => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!selection || !$isRangeSelection(selection)) return;
+      
+      const anchorNode = selection.anchor.getNode();
+      const anchorOffset = selection.anchor.offset;
+      
+      if ($isTextNode(anchorNode)) {
+        const nodeText = anchorNode.getTextContent();
+        const textBeforeCursor = nodeText.substring(0, anchorOffset);
+        const textAfterCursor = nodeText.substring(anchorOffset);
+        
+        const lastSlashIndex = textBeforeCursor.lastIndexOf('/');
+        
+        if (lastSlashIndex !== -1) {
+          const beforeSlash = textBeforeCursor.substring(0, lastSlashIndex);
+          
+          anchorNode.setTextContent(beforeSlash);
+          
+          const openBrace = $createTextNode('{{');
+          const closeBrace = $createTextNode('}}');
+          
+          anchorNode.insertAfter(openBrace);
+          openBrace.insertAfter(closeBrace);
+          
+          if (textAfterCursor) {
+            closeBrace.insertAfter($createTextNode(textAfterCursor));
+          }
+          
+          const newSelection = $createRangeSelection();
+          newSelection.anchor.set(openBrace.getKey(), 2, 'text');
+          newSelection.focus.set(openBrace.getKey(), 2, 'text');
+          $setSelection(newSelection);
+        }
+      }
+    });
+    resetState();
+  };
+
+  useEffect(() => {
+    if (!showSuggestions) return;
+
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event) => {
+        if (!showSuggestions) return false;
+        if (allOptions.length > 0) {
+          const selectedOption = allOptions[selectedIndex];
+          if (selectedOption) {
+            event?.preventDefault();
+            if (selectedOption.key === ADD_NEW_VARIABLE_OPTION.key) {
+              insertNewVariable();
+            } else {
+              insertOption(selectedOption);
+            }
+            return true;
+          }
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+  }, [showSuggestions, selectedIndex, allOptions, insertOption, editor]);
+
+  useEffect(() => {
+    if (!showSuggestions) return;
+
+    const unregisterArrowDown = editor.registerCommand(
+      KEY_ARROW_DOWN_COMMAND,
+      (event) => {
+        if (!showSuggestions) return false;
+        event?.preventDefault();
+        setSelectedIndex(prev => {
+          const next = prev + 1;
+          return next >= allOptions.length ? prev : next;
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+
+    const unregisterArrowUp = editor.registerCommand(
+      KEY_ARROW_UP_COMMAND,
+      (event) => {
+        if (!showSuggestions) return false;
+        event?.preventDefault();
+        setSelectedIndex(prev => Math.max(prev - 1, 0));
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+
+    const unregisterEscape = editor.registerCommand(
+      KEY_ESCAPE_COMMAND,
+      (event) => {
+        if (showSuggestions) {
+          event?.preventDefault();
+          setShowSuggestions(false);
+          return true;
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+
+    return () => {
+      unregisterArrowDown();
+      unregisterArrowUp();
+      unregisterEscape();
+    };
+  }, [showSuggestions, allOptions.length, editor]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      INSERT_OPTION_COMMAND,
+      (payload) => {
+        const { data } = payload;
+        editor.update(() => {
+          const selection = $getSelection();
+          if (!selection || !$isRangeSelection(selection)) return;
+          
+          const anchorNode = selection.anchor.getNode();
+          const anchorOffset = selection.anchor.offset;
+          
+          if ($isTextNode(anchorNode)) {
+            const nodeText = anchorNode.getTextContent();
+            const textBeforeCursor = nodeText.substring(0, anchorOffset);
+            const textAfterCursor = nodeText.substring(anchorOffset);
+            
+            const lastSlashIndex = textBeforeCursor.lastIndexOf('/');
+            
+            if (lastSlashIndex !== -1) {
+              const beforeSlash = textBeforeCursor.substring(0, lastSlashIndex);
+              
+              anchorNode.setTextContent(beforeSlash);
+              
+              const textNode = $createTextNode(data.value);
+              
+              anchorNode.insertAfter(textNode);
+              
+              if (textAfterCursor) {
+                textNode.insertAfter($createTextNode(textAfterCursor));
+              }
+              
+              const newSelection = $createRangeSelection();
+              newSelection.anchor.set(textNode.getKey(), data.value.length, 'text');
+              newSelection.focus.set(textNode.getKey(), data.value.length, 'text');
+              $setSelection(newSelection);
+            }
+          }
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+  }, [editor]);
+
+  if (!showSuggestions) return null;
+  if (allOptions.length === 0) return null;
+
+  return createPortal(
+    <div
+      ref={popupRef}
+      data-autocomplete-popup="true"
+      onMouseDown={(e) => e.preventDefault()}
+      className="rb:fixed rb:z-50 rb:bg-white rb:rounded-lg rb:border-[0.5px] rb:border-[#EBEBEB] rb:shadow-[0px_2px_6px_0px_rgba(0,0,0,0.1)] rb:py-3 rb:px-2"
+      style={{
+        top: popupPosition.top,
+        left: popupPosition.left,
+        minWidth: '200px',
+      }}
+    >
+      <div className="rb:max-h-57.5 rb:overflow-y-auto">
+        <Flex vertical gap={3}>
+          {allOptions.map((option, index) => {
+            const isAddNewVariable = option.key === ADD_NEW_VARIABLE_OPTION.key;
+            return (
+              <Flex
+                key={option.key}
+                className={clsx(
+                  "rb:px-2! rb:py-0.75! rb:rounded-sm rb:text-[14px] rb:leading-4.5 rb:cursor-pointer rb:transition-colors",
+                  {
+                    'rb:bg-[#F6F6F6]': selectedIndex === index,
+                    'rb:hover:bg-[#F6F6F6]': selectedIndex !== index,
+                  }
+                )}
+                align="center"
+                justify="space-between"
+                onClick={() => {
+                  if (isAddNewVariable) {
+                    insertNewVariable();
+                  } else {
+                    insertOption(option);
+                  }
+                }}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                {isAddNewVariable ? (
+                  <span className="rb:font-medium rb:text-[#155EEF]">+ {ADD_NEW_VARIABLE_OPTION.label}</span>
+                ) : (
+                  <>
+                    <span className="rb:font-medium">{option.label}</span>
+                    <span className="rb:text-[#8C8C8C] rb:text-[12px]">{option.value}</span>
+                  </>
+                )}
+              </Flex>
+            );
+          })}
+        </Flex>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default AutocompletePlugin;

--- a/web/src/views/ApplicationConfig/components/Editor/plugin/BlurPlugin.tsx
+++ b/web/src/views/ApplicationConfig/components/Editor/plugin/BlurPlugin.tsx
@@ -1,0 +1,60 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-05-19 17:11:44 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-05-19 17:11:44 
+ */
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useEffect, useRef } from 'react';
+import { $getRoot } from 'lexical';
+
+interface BlurPluginProps {
+  onBlur?: (value: string) => void;
+}
+
+export default function BlurPlugin({ onBlur }: BlurPluginProps) {
+  const [editor] = useLexicalComposerContext();
+  const onBlurRef = useRef(onBlur);
+  const blurredRef = useRef(false);
+
+  useEffect(() => {
+    onBlurRef.current = onBlur;
+  }, [onBlur]);
+
+  useEffect(() => {
+    return editor.registerRootListener((rootElement) => {
+      if (rootElement) {
+        const handleBlur = (event: FocusEvent) => {
+          const relatedTarget = event.relatedTarget as HTMLElement | null;
+          if (relatedTarget && rootElement.contains(relatedTarget)) {
+            return;
+          }
+          
+          if (blurredRef.current) return;
+          blurredRef.current = true;
+          
+          const currentOnBlur = onBlurRef.current;
+          if (currentOnBlur) {
+            let text = '';
+            editor.update(() => {
+              const root = $getRoot();
+              text = root.getTextContent();
+            }, { discrete: true });
+            currentOnBlur(text);
+          }
+          
+          setTimeout(() => {
+            blurredRef.current = false;
+          }, 0);
+        };
+        rootElement.addEventListener('blur', handleBlur, true);
+        return () => {
+          rootElement.removeEventListener('blur', handleBlur, true);
+        };
+      }
+      return () => {};
+    });
+  }, [editor]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary by Sourcery

为智能体提示添加支持变量感知的富文本编辑器，并在失焦时校验未定义变量。

New Features:
- 将系统提示的 `textarea` 替换为支持通过自动补全插入预定义变量占位符的富文本编辑器。
- 在智能体提示失焦时自动检测未定义变量，并提供将其添加到变量列表的选项。

Enhancements:
- 调整编辑器样式和占位符颜色，以改进提示编辑的用户体验。
- 为提示变量校验和添加新变量增加 i18n 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add variable-aware rich text editor support for agent prompts and validate undefined variables on blur.

New Features:
- Replace the system prompt textarea with a rich text editor that supports inserting predefined variable placeholders via autocomplete.
- Automatically detect undefined variables in the agent prompt on blur and offer to add them to the variable list.

Enhancements:
- Adjust editor styling and placeholder colors for improved prompt editing UX.
- Add i18n strings for prompt variable validation and adding new variables.

</details>