### PR TITLE
feat(api): add v1 import_qa endpoint with API key auth

### DIFF
--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -3,7 +3,7 @@
 from typing import Any, Optional, Union
 import uuid
 
-from fastapi import APIRouter, Body, Depends, Request, status, Query
+from fastapi import APIRouter, Body, Depends, File, Request, status, Query, UploadFile
 from sqlalchemy.orm import Session
 
 from app.controllers import chunk_controller
@@ -16,6 +16,7 @@ from app.schemas import chunk_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
+from app.services.file_storage_service import FileStorageService, get_file_storage_service
 
 
 router = APIRouter(prefix="/chunks", tags=["V1 - RAG API"])
@@ -247,4 +248,30 @@ async def retrieve_chunks(
     return await chunk_controller.retrieve_chunks(retrieve_data=retrieve_data,
                                                   db=db,
                                                   current_user=current_user)
+
+
+@router.post("/{kb_id}/import_qa", response_model=ApiResponse)
+@require_api_key(scopes=["rag"])
+async def import_qa_new_doc(
+    kb_id: uuid.UUID,
+    request: Request,
+    file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
+    api_key_auth: ApiKeyAuth = None,
+    db: Session = Depends(get_db),
+    storage_service: FileStorageService = Depends(get_file_storage_service),
+):
+    """
+    导入 QA 问答对并新建文档（CSV/Excel），异步处理（API Key 认证）
+    """
+    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    current_user = api_key.creator
+    current_user.current_workspace_id = api_key_auth.workspace_id
+
+    return await chunk_controller.import_qa_new_doc(
+        kb_id=kb_id,
+        file=file,
+        db=db,
+        current_user=current_user,
+        storage_service=storage_service,
+    )
 


### PR DESCRIPTION
## Summary
- Add `POST /v1/chunks/{kb_id}/import_qa` endpoint for external API key-authenticated QA import
- Reuses existing `chunk_controller.import_qa_new_doc` business logic from the manager API
- Auth via `@require_api_key(scopes=["rag"])`, consistent with all other v1 endpoints

## Changes
 .../service/rag_api_chunk_controller.py | 29 +++++++++++++++++++++-
 1 file changed, 28 insertions(+), 1 deletion(-)

## Test Plan
- [ ] 用带 `rag` scope 的 API Key 调用 `POST /v1/chunks/{kb_id}/import_qa`，上传 CSV/Excel，验证返回 task_id、document_id、file_id
- [ ] 验证无 API Key 时返回 401
- [ ] 验证 API Key 无 `rag` scope 时返回权限错误

## Summary by Sourcery

新增一个 v1 RAG API 端点，用于通过 API Key 认证将问答对（QA pairs）导入到知识库中。

新功能：
- 引入 `POST /v1/chunks/{kb_id}/import_qa` 端点，用于通过外部 RAG API 上传 QA CSV/Excel 文件。
- 支持在重用现有分片（chunk）导入业务逻辑的基础上，将 QA 对导入到一个新的文档中。
- 通过共享的文件存储服务依赖，为 QA 导入请求启用文件存储处理能力。

增强：
- 将 QA 导入的 API Key 认证与现有 v1 RAG API 基于作用域（scope）的认证对齐，并使用 `rag` 作用域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new v1 RAG API endpoint to import QA pairs into a knowledge base using API key authentication.

New Features:
- Introduce POST /v1/chunks/{kb_id}/import_qa endpoint for uploading QA CSV/Excel files via the external RAG API.
- Support importing QA pairs into a new document while reusing existing chunk import business logic.
- Enable file storage handling for QA import requests through the shared file storage service dependency.

Enhancements:
- Align API key authentication for QA import with existing v1 RAG API scope-based auth using the rag scope.

</details>