### PR TITLE
feat(memory): make ontology type_id/predicate_id optional with None for unknown values

### DIFF
--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -160,7 +160,7 @@ class EntityEntityEdge(Edge):
         invalid_at: Optional end date of temporal validity
     """
     relation_type: str = Field(..., description="Relation type as defined in ontology")
-    relation_type_id: int = Field(..., description="Ontology ID for predicate (1-13), must match the canonical predicate label")
+    relation_type_id: Optional[int] = Field(default=None, description="Ontology ID for predicate (1-13). None indicates unknown/unmapped predicate.")
     relation_type_surface: str = Field(..., description="Source-text relation phrase expressing this predicate")
     relation_type_description: str = Field(default="", description="Chinese definition of the relation type from ontology")
     relation_value: Optional[str] = Field(None, description="Value of the relation")
@@ -413,7 +413,7 @@ class ExtractedEntityNode(Node):
     entity_idx: int = Field(..., description="Unique identifier for the entity")
     statement_id: str = Field(..., description="Statement this entity was extracted from")
     entity_type: str = Field(..., description="Type of the entity")
-    type_id: int = Field(..., description="Ontology ID for entity type (1-13), must match the canonical type label")
+    type_id: Optional[int] = Field(default=None, description="Ontology ID for entity type (1-13). None indicates unknown/unmapped type.")
     type_description: str = Field(default="", description="Chinese definition of the entity type from ontology")
     description: str = Field(..., description="Entity description")
     example: str = Field(

--- a/api/app/core/memory/models/triplet_models.py
+++ b/api/app/core/memory/models/triplet_models.py
@@ -37,7 +37,7 @@ class Entity(BaseModel):
     name: str = Field(..., description="Name of the entity")
     name_embedding: Optional[List[float]] = Field(None, description="Embedding vector for the entity name")
     type: str = Field(..., description="Type/category of the entity")
-    type_id: int = Field(..., description="Ontology ID for entity type (1-13), must match the canonical type label")
+    type_id: Optional[int] = Field(default=None, description="Ontology ID for entity type (1-13). None indicates unknown/unmapped type.")
     type_description: str = Field(default="", description="Chinese definition of the entity type from ontology")
     description: str = Field(..., description="Description of the entity")
     example: str = Field(
@@ -81,7 +81,7 @@ class Triplet(BaseModel):
     subject_name: str = Field(..., description="Name of the subject entity")
     subject_id: int = Field(..., description="ID of the subject entity")
     predicate: str = Field(..., description="Relationship/predicate between subject and object")
-    predicate_id: int = Field(..., description="Ontology ID for predicate (1-13), must match the canonical predicate label")
+    predicate_id: Optional[int] = Field(default=None, description="Ontology ID for predicate (1-13). None indicates unknown/unmapped predicate.")
     predicate_surface: str = Field(..., description="Source-text relation phrase expressing this predicate")
     predicate_description: str = Field(default="", description="Chinese definition of the predicate from ontology")
     object_name: str = Field(..., description="Name of the object entity")

--- a/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
+++ b/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
@@ -257,11 +257,11 @@ def _normalize_special_entity_names(
         if name_lower in _USER_PLACEHOLDER_NAMES:
             ent.name = _CANONICAL_USER_NAME
             ent.entity_type = _CANONICAL_USER_TYPE
-            # type_id 保持不变（LLM 提取时已正确设置为"生命体"对应的 1）
+            ent.type_id = 1  # "生命体" 对应的本体 ID
         elif name_lower in _ASSISTANT_PLACEHOLDER_NAMES:
             ent.name = _CANONICAL_ASSISTANT_NAME
             ent.entity_type = _CANONICAL_ASSISTANT_TYPE
-            # type_id 保持不变
+            ent.type_id = 1  # "生命体" 对应的本体 ID
 
     # 第二步：清洗用户/AI助手之间的别名交叉污染（复用 clean_cross_role_aliases）
     clean_cross_role_aliases(entity_nodes)

--- a/api/app/core/memory/storage_services/extraction_engine/steps/schema/extraction_step_schema.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/schema/extraction_step_schema.py
@@ -6,7 +6,7 @@ Embedding generation, and shared types used across stages.
 Malformed LLM JSON will raise ``ValidationError`` and trigger stage-level retry.
 """
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
@@ -76,7 +76,7 @@ class EntityItem(BaseModel):
     entity_idx: int
     name: str
     type: str
-    type_id: int
+    type_id: Optional[int] = None
     type_description: str = ""
     description: str
     is_explicit_memory: bool = False
@@ -88,7 +88,7 @@ class TripletItem(BaseModel):
     subject_name: str
     subject_id: int
     predicate: str
-    predicate_id: int
+    predicate_id: Optional[int] = None
     predicate_surface: str
     predicate_description: str = ""
     object_name: str

--- a/api/app/core/memory/utils/data/ontology.py
+++ b/api/app/core/memory/utils/data/ontology.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Optional
 
 
 # ── 本体 ID 映射（与 extract_triplet.jinja2 中的枚举一一对应） ──
@@ -36,14 +37,14 @@ PREDICATE_TO_ID: dict[str, int] = {
 }
 
 
-def get_type_id(entity_type: str) -> int:
-    """根据实体类型中文标签获取本体 ID。找不到时返回 0。"""
-    return ENTITY_TYPE_TO_ID.get((entity_type or "").strip(), 0)
+def get_type_id(entity_type: str) -> Optional[int]:
+    """根据实体类型中文标签获取本体 ID。找不到时返回 None。"""
+    return ENTITY_TYPE_TO_ID.get((entity_type or "").strip())
 
 
-def get_predicate_id(predicate: str) -> int:
-    """根据关系谓词中文标签获取本体 ID。找不到时返回 0。"""
-    return PREDICATE_TO_ID.get((predicate or "").strip(), 0)
+def get_predicate_id(predicate: str) -> Optional[int]:
+    """根据关系谓词中文标签获取本体 ID。找不到时返回 None。"""
+    return PREDICATE_TO_ID.get((predicate or "").strip())
 
 
 # Use jinja template.render
@@ -266,4 +267,3 @@ class TemporalInfo(StrEnum):
 class RelevenceInfo(StrEnum):
     RELEVANT = "RELEVANT"
     IRRELEVANT = "IRRELEVANT"
-

--- a/api/app/repositories/neo4j/entity_repository.py
+++ b/api/app/repositories/neo4j/entity_repository.py
@@ -61,8 +61,8 @@ class EntityRepository(BaseNeo4jRepository[ExtractedEntityNode]):
         n['last_access_time'] = n.get('last_access_time')
         n['access_count'] = n.get('access_count', 0)
         
-        # 确保 type_id 字段存在（历史数据可能没有此属性，根据 entity_type 反查）
-        if 'type_id' not in n or n['type_id'] is None:
+        # 确保 type_id 字段存在（历史数据可能没有此属性或为 0，根据 entity_type 反查）
+        if not n.get('type_id'):
             n['type_id'] = get_type_id(n.get('entity_type', ''))
         
         return ExtractedEntityNode(**n)
@@ -79,4 +79,3 @@ class EntityRepository(BaseNeo4jRepository[ExtractedEntityNode]):
         """
         return await self.find({"entity_type": entity_type}, limit=limit)
     
-


### PR DESCRIPTION
Change type_id and predicate_id from required int to Optional[int] across models, schema, dedup, and Neo4j repository. get_type_id() and get_predicate_id() now return None instead of 0 when unmapped. Dedup layer explicitly sets type_id=1 for user/assistant placeholders.

## 由 Sourcery 提供的摘要

允许在未知时将本体类型和谓词 ID 设为未设置（unset），并在内存模型、模式（schema）、本体工具以及 Neo4j 实体映射中传播这种可选性。

新功能：
- 在整个内存提取和存储管道中，支持将 `None` 作为本体 `type_id` 和 `predicate_id` 的未知值。

增强：
- 使本体查询辅助函数在实体类型或谓词未映射时返回 `None`，而不是默认为 `0`。
- 更新去重逻辑，为用户和助手的占位实体显式分配规范（canonical）的 `type_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow ontology type and predicate IDs to be unset when unknown and propagate this optionality across memory models, schemas, ontology utilities, and Neo4j entity mapping.

New Features:
- Support None as an unknown value for ontology type_id and predicate_id throughout memory extraction and storage pipelines.

Enhancements:
- Make ontology lookup helpers return None instead of defaulting to 0 when an entity type or predicate is unmapped.
- Update deduplication logic to explicitly assign the canonical type_id for user and assistant placeholder entities.

</details>