### PR TITLE
feat(workflow): 

### DIFF
--- a/api/app/core/workflow/utils/template_renderer.py
+++ b/api/app/core/workflow/utils/template_renderer.py
@@ -46,10 +46,18 @@ class TemplateRenderer:
     @staticmethod
     def normalize_template(template: str) -> str:
         """Normalize template syntax (convert numeric node reference to dict access)"""
-        return _NORMALIZE_PATTERN.sub(
+        template = _NORMALIZE_PATTERN.sub(
             r'{{ node["\1"].\2 }}',
             template
         )
+        # Handle node IDs with hyphens: convert {{node-id.var}} to {{node["node-id"].var}}
+        # This prevents Jinja2 from interpreting hyphen as subtraction
+        template = re.sub(
+            r'\{\{\s*([a-zA-Z_][\w-]*-[\w-]+)\.',
+            r'{{ node["\1"].',
+            template
+        )
+        return template
 
     def render(
             self,


### PR DESCRIPTION
support hyphenated node IDs in template renderer

## 由 Sourcery 提供的摘要

新功能：
- 通过将包含连字符的节点 ID 规范化为字典风格的访问方式，允许对这些节点引用进行模板渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow template rendering of node references whose IDs contain hyphens by normalizing them to dictionary-style access.

</details>