### PR TITLE
fix(flush): skip conversations without active memory config to reduce log noise

### DIFF
--- a/api/app/core/memory/sliding_window/flush_task.py
+++ b/api/app/core/memory/sliding_window/flush_task.py
@@ -68,6 +68,14 @@ class FlushTask:
 
         write_cursor, end_user_id, workspace_id = conversation_info
 
+        # Step 1.5: 提前校验 memory_config，避免下层抛 ConfigurationError 产生 ERROR 日志噪音
+        if not self._has_active_memory_config(workspace_id):
+            logger.warning(
+                f"[FlushTask] workspace 无活跃记忆配置，跳过 flush: "
+                f"conv={conversation_id}, workspace={workspace_id}"
+            )
+            return
+
         # Step 2: 通过 Layer 2 执行所有 pending user 消息
         # execute_pending_from_pool 内部处理：
         #   - should_memorize=FALSE → 推进 write_cursor
@@ -184,6 +192,48 @@ class FlushTask:
                 exc_info=True,
             )
             return None
+
+    def _has_active_memory_config(self, workspace_id: str | None) -> bool:
+        """检查 workspace 是否存在活跃的 memory_config。
+
+        用于在执行 flush 前预校验，避免下层抛 ConfigurationError 产生 ERROR 日志噪音。
+        校验自身出错时返回 True（不阻断主流程，让下层兜底处理）。
+
+        Args:
+            workspace_id: 对话所属工作空间 ID（字符串形式）
+
+        Returns:
+            True 表示 workspace 存在活跃配置或校验失败；False 表示明确无配置应跳过。
+        """
+        if not workspace_id:
+            return True
+
+        import uuid as _uuid
+
+        try:
+            ws_uuid = _uuid.UUID(workspace_id)
+        except (ValueError, AttributeError):
+            return True
+
+        try:
+            from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
+
+            with get_db_context() as db:
+                exists = db.execute(
+                    select(MemoryConfigModel.config_id)
+                    .where(
+                        MemoryConfigModel.workspace_id == ws_uuid,
+                        MemoryConfigModel.state.is_(True),
+                    )
+                    .limit(1)
+                ).scalar_one_or_none()
+                return exists is not None
+        except Exception as e:
+            logger.warning(
+                f"[FlushTask] memory_config 预校验异常（继续执行）: "
+                f"workspace={workspace_id}, err={e}"
+            )
+            return True
 
     def _get_write_cursor(self, conversation_id: str) -> int | None:
         """查询 write_cursor。"""

--- a/api/app/core/memory/sliding_window/flush_task.py
+++ b/api/app/core/memory/sliding_window/flush_task.py
@@ -231,7 +231,8 @@ class FlushTask:
         except Exception as e:
             logger.warning(
                 f"[FlushTask] memory_config 预校验异常（继续执行）: "
-                f"workspace={workspace_id}, err={e}"
+                f"workspace={workspace_id}, err={e}",
+                exc_info=True,
             )
             return True
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4356,32 +4356,26 @@ def scan_idle_conversations_task() -> None:
         if candidate_conv_ids:
             try:
                 from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
-                from sqlalchemy import distinct
 
                 with get_db_context() as db:
-                    valid_workspace_ids = {
-                        str(wid) for wid in db.execute(
-                            select(distinct(MemoryConfigModel.workspace_id))
-                            .where(MemoryConfigModel.state.is_(True))
+                    # 单条 JOIN 查询：直接按"存在活跃 memory_config"过滤候选对话
+                    # distinct 防止 workspace 配置多条 active 记录导致 conv_id 重复
+                    valid_conv_ids = [
+                        str(cid) for cid in db.execute(
+                            select(Conversation.id)
+                            .join(
+                                MemoryConfigModel,
+                                MemoryConfigModel.workspace_id == Conversation.workspace_id,
+                            )
+                            .where(
+                                Conversation.id.in_(candidate_conv_ids),
+                                MemoryConfigModel.state.is_(True),
+                            )
+                            .distinct()
                         ).scalars().all()
-                    }
+                    ]
 
-                    workspace_map = {
-                        str(cid): str(wid) for cid, wid in db.execute(
-                            select(Conversation.id, Conversation.workspace_id)
-                            .where(Conversation.id.in_(candidate_conv_ids))
-                        ).all()
-                    }
-
-                valid_conv_ids: list[str] = []
-                skipped_no_config = 0
-                for cid in candidate_conv_ids:
-                    ws_id = workspace_map.get(cid)
-                    if ws_id and ws_id in valid_workspace_ids:
-                        valid_conv_ids.append(cid)
-                    else:
-                        skipped_no_config += 1
-
+                skipped_no_config = len(candidate_conv_ids) - len(valid_conv_ids)
                 if skipped_no_config:
                     logger.info(
                         f"[ScanIdle] 跳过 {skipped_no_config} 个无活跃 memory_config 的对话"

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4352,6 +4352,46 @@ def scan_idle_conversations_task() -> None:
 
         logger.info(f"[ScanIdle] 发现 {len(candidate_conv_ids)} 个对话存在未写入消息")
 
+        # 过滤掉无活跃 memory_config 的对话（避免无效派发）
+        if candidate_conv_ids:
+            try:
+                from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
+                from sqlalchemy import distinct
+
+                with get_db_context() as db:
+                    valid_workspace_ids = {
+                        str(wid) for wid in db.execute(
+                            select(distinct(MemoryConfigModel.workspace_id))
+                            .where(MemoryConfigModel.state.is_(True))
+                        ).scalars().all()
+                    }
+
+                    workspace_map = {
+                        str(cid): str(wid) for cid, wid in db.execute(
+                            select(Conversation.id, Conversation.workspace_id)
+                            .where(Conversation.id.in_(candidate_conv_ids))
+                        ).all()
+                    }
+
+                valid_conv_ids: list[str] = []
+                skipped_no_config = 0
+                for cid in candidate_conv_ids:
+                    ws_id = workspace_map.get(cid)
+                    if ws_id and ws_id in valid_workspace_ids:
+                        valid_conv_ids.append(cid)
+                    else:
+                        skipped_no_config += 1
+
+                if skipped_no_config:
+                    logger.info(
+                        f"[ScanIdle] 跳过 {skipped_no_config} 个无活跃 memory_config 的对话"
+                    )
+                candidate_conv_ids = valid_conv_ids
+            except Exception as e:
+                logger.warning(
+                    f"[ScanIdle] 过滤无配置对话失败，将走 FlushTask 兜底校验: err={e}"
+                )
+
         for conv_id_str in candidate_conv_ids:
             # 检查 conv_active key 是否存在（存在则对话仍活跃，跳过）
             # conv_active 写在 settings.REDIS_DB（DB 13），需要用专属 client 读取


### PR DESCRIPTION
Pre-check workspace memory_config before flush to avoid downstream ConfigurationError producing ERROR-level log noise. Also filter no-config conversations in scan_idle task before dispatching.

## Summary by Sourcery

跳过为那些工作区缺少激活内存配置的会话执行内存刷新操作，并减少在刷新任务和空闲扫描任务中的不必要日志噪音。

Bug Fixes:
- 当工作区没有激活内存配置时，通过提前短路避免在刷新过程中触发下游的 `ConfigurationError`。
- 在空闲扫描任务中筛除其工作区没有激活内存配置的空闲会话，避免为这些会话派发刷新任务。

Enhancements:
- 在刷新任务中增加对激活内存配置的预验证，并在验证错误时进行优雅降级回退。
- 改进针对被跳过会话和预验证失败的日志记录，使内存刷新行为在生产日志中更加清晰明了。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip flushing memory for conversations whose workspaces lack active memory configuration and reduce unnecessary log noise in flush and idle scan tasks.

Bug Fixes:
- Avoid triggering downstream ConfigurationError during flush when a workspace has no active memory configuration by short-circuiting early.
- Prevent dispatching flush tasks for idle conversations whose workspaces have no active memory configuration by filtering them out in the idle scan task.

Enhancements:
- Add pre-validation of active memory configuration in the flush task with graceful fallback on validation errors.
- Improve logging around skipped conversations and pre-validation failures to make memory flush behavior clearer in production logs.

</details>