### PR TITLE
Fix/flush redis pending set cleanup

### DIFF
--- a/api/app/core/memory/sliding_window/flush_task.py
+++ b/api/app/core/memory/sliding_window/flush_task.py
@@ -58,8 +58,20 @@ class FlushTask:
 
         Requirements: 4.3, 4.5
         """
+        from app.core.memory.sliding_window.window_utils import unmark_conversation_pending
+
         logger.info(f"[FlushTask] 开始处理: conv={conversation_id}")
 
+        try:
+            await self._run_inner(conversation_id)
+        finally:
+            # 兜底清理 Redis Set：本次 flush 已尽力处理（无论成功/早退/异常）
+            # 后续若有新消息写入，实时路径会重新 mark；若处理失败但还需处理，
+            # ScanIdle 的 DB 回退查询（max_seq > write_cursor）仍能发现并派发。
+            unmark_conversation_pending(conversation_id)
+
+    async def _run_inner(self, conversation_id: str) -> None:
+        """run() 的内部实现，提取出来便于 try/finally 统一收尾。"""
         # Step 1: 查询对话信息（end_user_id + workspace_id）
         conversation_info = self._get_conversation_info(conversation_id)
         if conversation_info is None:

--- a/api/app/core/memory/sliding_window/window_utils.py
+++ b/api/app/core/memory/sliding_window/window_utils.py
@@ -731,6 +731,8 @@ async def execute_pending_from_pool(
             f"[execute_pending_from_pool] 无待处理消息: "
             f"conv={conversation_id}, write_cursor={write_cursor}"
         )
+        # cursor 已追上 max_seq，主动清理 Redis Set 残留，避免后续 ScanIdle 反复派发空 flush
+        unmark_conversation_pending(conversation_id)
         return 0
 
     logger.info(
@@ -807,9 +809,13 @@ async def execute_pending_from_pool(
         f"[execute_pending_from_pool] 完成: conv={conversation_id}, processed={processed}"
     )
 
-    # 如果所有 pending 消息都已处理完毕，从 Redis Set 中移除该对话
-    # （下次有新消息写入时会重新 mark）
-    if processed >= len([m for m in pending if m.get("role") == "user" or not m.get("should_memorize", True)]):
+    # 清理 Redis Set 时机：本轮所有"应处理"的消息（user 或 should_memorize=false）都已处理完
+    # processed/expected 同为 0 时也应清理（说明 pending 中只剩 assistant 消息或本轮无可处理）
+    expected = sum(
+        1 for m in pending
+        if m.get("role") == "user" or not m.get("should_memorize", True)
+    )
+    if processed >= expected:
         unmark_conversation_pending(conversation_id)
 
     return processed


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

确保在刷新处理（flush）之后可靠地清除 Redis 中的待处理会话标记，以避免陈旧条目和多余的刷新任务。

错误修复：
- 在刷新尝试后，将清除 Redis 待处理集合标记的逻辑放入 `finally` 块中，这样即使在提前退出或发生错误时，会话也能被取消标记。
- 当会话没有待处理消息，或所有符合条件的待处理消息都已被处理时，移除 Redis 中的陈旧待处理标记。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Redis pending conversation markers are reliably cleared after flush processing to avoid stale entries and redundant flush tasks.

Bug Fixes:
- Clear Redis pending-set markers in a finally block after flush attempts so conversations are unmarked even on early exit or errors.
- Remove stale Redis pending markers when a conversation has no pending messages or when all eligible pending messages have been processed.

</details>