### PR TITLE
fix(app)

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -982,6 +982,9 @@ async def regenerate_message(
     # 获取配置
     agent_cfg = agent_config_4_app_release(release)
 
+    if not (agent_cfg.model_parameters.get("deep_thinking", False) and payload.thinking):
+        agent_cfg.model_parameters["deep_thinking"] = False
+
     # 获取存储类型
     storage_type = workspace_service.get_workspace_storage_type_without_auth(db=db, workspace_id=workspace_id)
     if storage_type is None:

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -847,6 +847,7 @@ class RegenerateRequest(BaseModel):
     web_search: bool = Field(default=False, description="是否启用网络搜索")
     memory: bool = Field(default=True, description="是否启用长期记忆")
     stream: bool = Field(default=False, description="是否流式返回")
+    thinking: bool = Field(default=False, description="是否启用深度思考（需Agent配置支持）")
 
 
 class RegenerateResponse(BaseModel):


### PR DESCRIPTION
regenerate api add thinking parameter for deep thinking support

## Summary by Sourcery

在消息重新生成期间新增对由客户端控制的深度思考选项的支持，并确保仅在代理配置支持的情况下才启用该功能。

新功能：
- 在重新生成请求的 schema 中引入 `thinking` 标志，用于在消息重新生成时切换深度思考功能。

错误修复：
- 在重新生成过程中对深度思考功能的激活进行保护，除非代理配置和请求同时显式启用，否则将其禁用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a client-controlled deep thinking option during message regeneration while ensuring it is only enabled when supported by the agent configuration.

New Features:
- Introduce a `thinking` flag in the regenerate request schema to allow toggling deep thinking for message regeneration.

Bug Fixes:
- Guard deep thinking activation during regeneration so it is disabled unless both the agent configuration and request explicitly enable it.

</details>