### PR TITLE
feat: nested parent-child chunk query and chunk mode validation

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -115,8 +115,8 @@ async def get_preview_chunks(
             base_url=db_knowledge.image2text.api_keys[0].api_base
         )
     from app.core.rag.app.naive import chunk
-    parent_child_mode = db_document.parser_config.get("parent_child_mode", False)
-
+    parent_child_mode = db_document.is_parent_child_mode
+    api_logger.debug(f"当前文档分块模式：{db_document.is_parent_child_mode}")
     if parent_child_mode:
         from app.core.rag.app.naive import chunk_parent_child
         child_res, parent_res, parent_id_map = chunk_parent_child(
@@ -387,7 +387,8 @@ async def get_chunks(
     Paged query document chunk list
     - Support filtering by document_id
     - Support keyword search for segmented content
-    - Return paging metadata + file list
+    - For parent-child mode: return nested structure (parent chunks with children)
+    - For normal mode: return flat chunk list
     """
     api_logger.info(f"Paged query document chunk list: kb_id={kb_id}, document_id={document_id}, page={page}, pagesize={pagesize}, keywords={keywords}, username: {current_user.username}")
     # 1. parameter validation
@@ -405,12 +406,125 @@ async def get_chunks(
             detail="The knowledge base does not exist or access is denied"
         )
 
-    # 3. Execute paged query
+    # 3. 获取文档并判断分块模式
+    db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+    if not db_document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The document does not exist or you do not have permission to access it"
+        )
+
+    def _build_nested_result(
+        parents: list[DocumentChunk],
+        children: list[DocumentChunk],
+        page_num: int,
+        page_size: int,
+        total: int,
+    ) -> dict:
+        """将 parent chunks 和 child chunks 组装为嵌套结构并返回分页结果."""
+        children_map: dict[str, list[DocumentChunk]] = {}
+        for child in children:
+            pid = child.metadata.get("parent_id")
+            if pid:
+                children_map.setdefault(pid, []).append(child)
+        nested = []
+        for parent in parents:
+            parent.children = children_map.get(parent.metadata.get("doc_id"), [])
+            nested.append(parent)
+        return {
+            "items": nested,
+            "page": {
+                "page": page_num,
+                "pagesize": page_size,
+                "total": total,
+                "has_next": page_num * page_size < total,
+            },
+        }
+
+    # 4. Execute paged query
     try:
         api_logger.debug("Start executing document chunk query")
         vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-        total, items = vector_service.search_by_segment(document_id=str(document_id), query=keywords, pagesize=pagesize, page=page, asc=True)
-        api_logger.info(f"Document chunk query successful: total={total}, returned={len(items)} records")
+        if db_document.is_parent_child_mode:
+            # 方案 1：两次查询 + parent 级分页
+            # 4.1 查询 parent chunks（按 sort_id 排序，分页）
+            total_parents, parent_items = vector_service.search_by_segment(
+                document_id=str(document_id),
+                query=keywords,
+                pagesize=pagesize,
+                page=page,
+                asc=True,
+                chunk_types="parent",
+            )
+
+            # fallback：如果 parent 查询为空（旧数据或 chunk_type 缺失），查所有 chunks 在内存中区分
+            if not parent_items and total_parents == 0:
+                api_logger.debug("Parent query returned empty, falling back to query all chunks")
+                total_all, all_items = vector_service.search_by_segment(
+                    document_id=str(document_id),
+                    query=keywords,
+                    pagesize=10000,
+                    page=1,
+                    asc=True,
+                )
+                parent_items = [item for item in all_items if (item.metadata or {}).get("chunk_type") == "parent"]
+                child_items_fallback = [item for item in all_items if (item.metadata or {}).get("chunk_type") == "child"]
+                total_parents = len(parent_items)
+
+                if not parent_items:
+                    # 仍然没有 parent，按普通分块模式返回
+                    result = {
+                        "items": all_items[(page - 1) * pagesize : page * pagesize],
+                        "page": {
+                            "page": page,
+                            "pagesize": pagesize,
+                            "total": total_all,
+                            "has_next": page * pagesize < total_all,
+                        },
+                    }
+                    return success(data=jsonable_encoder(result), msg="Query of document chunk list succeeded")
+
+                # 内存分页 + 组装
+                paginated_parents = parent_items[(page - 1) * pagesize : page * pagesize]
+                result = _build_nested_result(
+                    paginated_parents, child_items_fallback, page, pagesize, total_parents
+                )
+                return success(data=jsonable_encoder(result), msg="Query of document chunk list succeeded")
+
+            parent_doc_ids = [p.metadata["doc_id"] for p in parent_items]
+
+            # 4.2 查询这些 parent 下的所有 child chunks（按 sort_id 排序，不分页）
+            _, child_items = vector_service.search_by_segment(
+                document_id=str(document_id),
+                pagesize=10000,
+                page=1,
+                asc=True,
+                chunk_types="child",
+                parent_ids=parent_doc_ids,
+            )
+
+            # 4.3 组装嵌套结构
+            result = _build_nested_result(parent_items, child_items, page, pagesize, total_parents)
+        else:
+            # 普通分块模式：原有逻辑
+            total, items = vector_service.search_by_segment(
+                document_id=str(document_id),
+                query=keywords,
+                pagesize=pagesize,
+                page=page,
+                asc=True
+            )
+            result = {
+                "items": items,
+                "page": {
+                    "page": page,
+                    "pagesize": pagesize,
+                    "total": total,
+                    "has_next": page * pagesize < total
+                }
+            }
+
+        api_logger.info(f"Document chunk query successful: returned={len(result['items'])} records")
     except Exception as e:
         api_logger.error(f"Document chunk query failed: {str(e)}")
         raise HTTPException(
@@ -418,16 +532,6 @@ async def get_chunks(
             detail=f"Query failed: {str(e)}"
         )
 
-    # 4. Return structured response
-    result = {
-        "items": items,
-        "page": {
-            "page": page,
-            "pagesize": pagesize,
-            "total": total,
-            "has_next": True if page * pagesize < total else False
-        }
-    }
     return success(data=jsonable_encoder(result), msg="Query of document chunk list succeeded")
 
 

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -6,6 +6,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.celery_app import celery_app
 from app.controllers import file_controller
@@ -186,16 +187,42 @@ async def update_document(
             detail="The document does not exist or you do not have permission to access it"
         )
 
-    # 2. If updating the status, synchronize the document status switch to whether it can be retrieved from the vector database
+    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
+
+    # 2. 校验并处理 parser_config 更新
     update_dict = update_data.dict(exclude_unset=True)
+    if "parser_config" in update_dict:
+        new_config = update_dict["parser_config"]
+        # 与 Document.is_parent_child_mode 保持一致的计算逻辑
+        if "parent_child_mode" in new_config:
+            new_mode_is_parent = new_config["parent_child_mode"]
+        else:
+            new_mode_is_parent = new_config.get("parent_chunk_mode", None) in ["paragraph", "full-doc"]
+        kb_mode = db_knowledge.chunk_mode
+        if kb_mode == 0:
+            # 知识库未设置分块模式：首次设定，同步到知识库
+            db_knowledge.parser_config.update(new_config)
+            flag_modified(db_knowledge, "parser_config")
+        elif (kb_mode == 1 and new_mode_is_parent) or (kb_mode == 2 and not new_mode_is_parent):
+            # 已锁定且不一致：拒绝
+            api_logger.warning(
+                f"Document chunk mode deviates from knowledge base config: "
+                f"document_id={document_id}, kb_mode={kb_mode}, new_mode={new_mode_is_parent}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="禁止变更分块模式"
+            )
+        # kb_mode=1 且 new=False，或 kb_mode=2 且 new=True：通过，不改知识库
+
+    # 3.1 If updating the status, synchronize the document status switch to whether it can be retrieved from the vector database
     if "status" in update_dict:
         new_status = update_dict["status"]
         if new_status != db_document.status:
-            db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
             vector_service.change_status_by_document_id(document_id=str(document_id), status=new_status)
 
-    # 3. Update fields (only update non-null fields)
+    # 3.2 Update fields (only update non-null fields)
     api_logger.debug(f"Start updating the document fields: {document_id}")
     updated_fields = []
     for field, value in update_dict.items():

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -121,7 +121,7 @@ async def get_knowledges(
     - Return paging metadata + file list
     """
     api_logger.info(f"Query knowledge base list: workspace_id={current_user.current_workspace_id}, page={page}, pagesize={pagesize}, keywords={keywords}, kb_ids={kb_ids}, username: {current_user.username}")
-    
+
     # 1. parameter validation
     if page < 1 or pagesize < 1:
         api_logger.warning(f"Error in paging parameters: page={page}, pagesize={pagesize}")
@@ -198,7 +198,7 @@ async def create_knowledge(
     create knowledge
     """
     api_logger.info(f"Request to create a knowledge base: name={create_data.name}, workspace_id={current_user.current_workspace_id}, username: {current_user.username}")
-    
+
     try:
         api_logger.debug(f"Start creating the knowledge base: {create_data.name}")
         # 1. Check if the knowledge base name already exists
@@ -227,7 +227,7 @@ async def get_knowledge(
     Retrieve knowledge base information based on knowledge_id
     """
     api_logger.info(f"Obtain details of the knowledge base: knowledge_id={knowledge_id}, username: {current_user.username}")
-    
+
     try:
         # 1. Query knowledge base information from the database
         api_logger.debug(f"Query knowledge base: {knowledge_id}")
@@ -238,7 +238,7 @@ async def get_knowledge(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="The knowledge base does not exist or access is denied"
             )
-        
+
         api_logger.info(f"Knowledge base query successful: {db_knowledge.name} (ID: {db_knowledge.id})")
         return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="Successfully obtained knowledge base information")
     except HTTPException:
@@ -270,20 +270,11 @@ async def get_knowledge_chunk_policy(
             detail="The knowledge base does not exist or access is denied"
         )
 
-    # 2. 查询该知识库下所有文档的 parser_config
+    # 2. 查询该知识库下第一个文档的 parser_config（同 KB 下文档分块策略一致，取第一个即可）
     try:
-        documents = db.query(Document).filter(Document.kb_id == knowledge_id).all()
-
-        if not documents:
-            # 无文档 → 未锁定
-            api_logger.info(f"Knowledge base chunk policy: knowledge_id={knowledge_id}, locked=null, doc_count=0")
-            return success(data={"parent_child_mode": None}, msg="Successfully obtained knowledge base chunk policy")
-
-        # 有文档 → 取第一个文档的分块模式作为锁定模式
-        # （正常情况下同一知识库下所有文档分块模式一致）
-        first_doc_mode = documents[0].parser_config.get("parent_child_mode", False)
-        api_logger.info(f"Knowledge base chunk policy: knowledge_id={knowledge_id}, parent_child_mode={first_doc_mode}, doc_count={len(documents)}")
-        return success(data={"parent_child_mode": first_doc_mode}, msg="Successfully obtained knowledge base chunk policy")
+        result_map = {0: None,    1: False,    2: True}
+        api_logger.info(f"Knowledge base chunk policy: knowledge_id={knowledge_id}, parent_child_mode={result_map[db_knowledge.chunk_mode]}")
+        return success(data={"parent_child_mode": result_map[db_knowledge.chunk_mode]}, msg="Successfully obtained knowledge base chunk policy")
     except Exception as e:
         api_logger.error(f"Failed to query knowledge base chunk policy: knowledge_id={knowledge_id} - {str(e)}")
         raise HTTPException(
@@ -405,10 +396,10 @@ async def _update_knowledge(
                     # update value
                     setattr(db_knowledge, field, value)
                     updated_fields.append(f"{field}: {old_value} -> {value}")
-        
+
         if updated_fields:
             api_logger.debug(f"updated fields: {', '.join(updated_fields)}")
-        
+
         db_knowledge.updated_at = datetime.datetime.now()
 
         # 3. Save to database
@@ -439,7 +430,7 @@ async def delete_knowledge(
     Soft-delete knowledge base
     """
     api_logger.info(f"Request to delete knowledge base: knowledge_id={knowledge_id}, username: {current_user.username}")
-    
+
     try:
         # 1. Check whether the knowledge base exists
         api_logger.debug(f"Check whether the knowledge base exists: {knowledge_id}")

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -223,7 +223,7 @@ class ElasticSearchVector(BaseVector):
         if self._client.indices.exists(index=self._collection_name):
             self._client.indices.delete(index=self._collection_name, ignore=[400, 404])
 
-    def search_by_segment(self, document_id: str | None = None, query: str | None = None, pagesize: int = 10, page: int = 1, asc: bool = True, **kwargs) -> tuple[int, list[DocumentChunk]]:  # 返回 (total, results):
+    def search_by_segment(self, document_id: str | None = None, query: str | None = None, pagesize: int = 10, page: int = 1, asc: bool = True, chunk_types: list[str] | str | None = None, parent_ids: list[str] | str | None = None, **kwargs) -> tuple[int, list[DocumentChunk]]:  # 返回 (total, results):
         """
         Search documents by segment (pagination) with optional keyword query.
 
@@ -232,6 +232,8 @@ class ElasticSearchVector(BaseVector):
             query: Optional keywords used to match chunk content.
             pagesize: Number of documents per page.
             page: 1-based page number.
+            chunk_types: If provided, filter by chunk_type (e.g., "parent", "child", or ["parent", "child"]).
+            parent_ids: If provided, filter by metadata.parent_id (for child chunks under specific parents).
             **kwargs: Additional search parameters (e.g., indices).
 
         Returns:
@@ -270,6 +272,22 @@ class ElasticSearchVector(BaseVector):
                         "query": query,
                         "analyzer": "ik_max_word"  # Use the same analyzer as in create_collection
                     }
+                }
+            })
+
+        if chunk_types:
+            types = chunk_types if isinstance(chunk_types, list) else [chunk_types]
+            query_str["query"]["bool"]["must"].append({
+                "terms": {
+                    Field.CHUNK_TYPE.value: types
+                }
+            })
+
+        if parent_ids:
+            pids = parent_ids if isinstance(parent_ids, list) else [parent_ids]
+            query_str["query"]["bool"]["must"].append({
+                "terms": {
+                    f"metadata.{Field.PARENT_ID.value}": pids
                 }
             })
 

--- a/api/app/models/document_model.py
+++ b/api/app/models/document_model.py
@@ -51,3 +51,12 @@ class Document(Base):
     status = Column(Integer, default=1, comment="is it validate(0: wasted, 1: validate)")
     created_at = Column(DateTime, default=datetime.datetime.now)
     updated_at = Column(DateTime, default=datetime.datetime.now)
+
+    @property
+    def is_parent_child_mode(self) -> bool:
+        """获取文档是否使用父子分块模式"""
+        # parent_child_mode 显式存在时，以它的值为准
+        if "parent_child_mode" in self.parser_config:
+            return self.parser_config["parent_child_mode"]
+        # 不存在时，fallback 到 parent_chunk_mode 判断
+        return self.parser_config.get("parent_chunk_mode", None) in ["paragraph", "full-doc"]

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -36,11 +36,13 @@ class PermissionType(enum.StrEnum):
     Share = "Share"
     Memory = "Memory"
 
+
 class Knowledge(Base):
     __tablename__ = "knowledges"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
-    external_id = Column(String(36), nullable=True, index=True, unique=False, comment="user-defined external identifier, workspace-unique")
+    external_id = Column(String(36), nullable=True, index=True, unique=False,
+                         comment="user-defined external identifier, workspace-unique")
     workspace_id = Column(UUID(as_uuid=True), nullable=False, comment="workspaces.id")
     created_by = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False, comment="users.id")
     parent_id = Column(UUID(as_uuid=True), nullable=True, default=None, comment="parent folder id when type is Folder")
@@ -49,10 +51,14 @@ class Knowledge(Base):
     avatar = Column(String, comment="avatar url")
     type = Column(String, default="General", comment="Type:General|Web|Third-party|Folder")
     permission_id = Column(String, default="Private", comment="permission ID:Private|Share|Memory")
-    embedding_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True, comment="default embedding model ID")
-    reranker_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True, comment="default reranker model ID")
-    llm_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True, comment="default llm model ID")
-    image2text_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True, comment="default image2text model ID")
+    embedding_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True,
+                          comment="default embedding model ID")
+    reranker_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True,
+                         comment="default reranker model ID")
+    llm_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True,
+                    comment="default llm model ID")
+    image2text_id = Column(UUID(as_uuid=True), ForeignKey('model_configs.id', ondelete="SET NULL"), nullable=True,
+                           comment="default image2text model ID")
     doc_num = Column(Integer, default=0, comment="doc num")
     chunk_num = Column(Integer, default=0, comment="chunk num")
     parser_id = Column(String, index=True, default="naive", comment="default parser ID")
@@ -79,19 +85,19 @@ class Knowledge(Base):
                                "parent_chunk_token_num": 1024,
                                "parent_delimiter": "\n",
                                "graphrag": {
-                                    "use_graphrag": False,
-                                    "scene_name": "",
-                                    "entity_types": [
-                                        "organization",
-                                        "person",
-                                        "geo",
-                                        "event",
-                                        "category"
-                                    ],
-                                    "method": "general",
-                                    "resolution": True,
-                                    "community": True
-                                }
+                                   "use_graphrag": False,
+                                   "scene_name": "",
+                                   "entity_types": [
+                                       "organization",
+                                       "person",
+                                       "geo",
+                                       "event",
+                                       "category"
+                                   ],
+                                   "method": "general",
+                                   "resolution": True,
+                                   "community": True
+                               }
                            },
                            comment="default parser config")
     status = Column(Integer, index=True, default=1, comment="is it validate(0: disable, 1: enable, 2:Soft-delete)")
@@ -104,3 +110,17 @@ class Knowledge(Base):
     reranker = relationship("ModelConfig", foreign_keys=[reranker_id], uselist=False, backref="reranker")
     llm = relationship("ModelConfig", foreign_keys=[llm_id], uselist=False, backref="llm")
     image2text = relationship("ModelConfig", foreign_keys=[image2text_id], uselist=False, backref="image2text")
+
+    @property
+    def chunk_mode(self) -> int:
+        """获取知识库是否已经使用父子分块模式"""
+        # 1. None 还为设置模式
+        if "auto_questions" not in self.parser_config and "parent_chunk_mode" not in self.parser_config:
+            return 0
+        # 2. 此时为通用分块模式
+        elif "auto_questions" in self.parser_config and "parent_chunk_mode" not in self.parser_config and not self.parser_config.get(
+                "parent_child_mode", False):
+            return 1
+        # 3. 此时为父子分块模式
+        else:
+            return 2

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -286,7 +286,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         from app.core.rag.app.naive import chunk
         logger.info(f"[ParseDoc] file_binary size={len(file_binary)} bytes, type={type(file_binary).__name__}, bool={bool(file_binary)}")
 
-        parent_child_mode = db_document.parser_config.get("parent_child_mode", False)
+        parent_child_mode = db_document.is_parent_child_mode
         if parent_child_mode:
             from app.core.rag.app.naive import chunk_parent_child
             child_res, parent_res, parent_id_map = chunk_parent_child(


### PR DESCRIPTION
## Summary
- GET /chunks/{kb_id}/{document_id}/chunks: return nested structure (parent chunks with children) for parent-child mode documents, using two-query approach with parent-level pagination
- Add Document.is_parent_child_mode property for unified chunk mode check
- Add Knowledge.chunk_mode property (0=unset, 1=normal, 2=parent-child)
- search_by_segment(): add chunk_types and parent_ids filter params
- Document update: validate chunk mode against knowledge base config, sync to KB on first setup with flag_modified fix
- chunk-policy endpoint: use Knowledge.chunk_mode instead of querying docs

## Changes

## Summary by Sourcery

在文档处理、查询以及知识库配置中增加对父子分块模式（parent-child chunk mode）的支持，包括嵌套分块检索与集中化的分块模式管理。

New Features:
- 当文档使用父子分块模式时，文档分块列表 API 将返回嵌套的父子分块结构。
- 暴露 `Knowledge.chunk_mode` 属性，用于表示并共享知识库的分块策略。
- 暴露 `Document.is_parent_child_mode` 属性，以便统一检测是否启用父子分块模式。
- 扩展 Elasticsearch 段搜索功能，以支持按分块类型和父 ID 进行过滤，从而实现父子层级查询。

Bug Fixes:
- 使用 `flag_modified` 确保 `parser_config` 的更新能够正确传播到知识库并被持久化。

Enhancements:
- 校验并锁定文档分块模式，使其与所属知识库配置的分块模式保持一致，拒绝不兼容的更改。
- 优化知识库分块策略（chunk-policy）端点，从 `Knowledge.chunk_mode` 派生分块模式，而不是扫描文档。
- 统一并记录父子分块模式在文档解析和后台任务中的使用情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for parent-child chunk mode across document processing, querying, and knowledge base configuration, including nested chunk retrieval and centralized chunk mode management.

New Features:
- Return nested parent-child chunk structures from the document chunk listing API when a document uses parent-child mode.
- Expose a Knowledge.chunk_mode property to represent and share the knowledge base’s chunking strategy.
- Expose a Document.is_parent_child_mode property for consistent detection of parent-child chunking.
- Extend Elasticsearch segment search to filter by chunk types and parent IDs for parent-child hierarchy queries.

Bug Fixes:
- Ensure parser_config updates correctly propagate to the knowledge base using flag_modified to persist changes.

Enhancements:
- Validate and lock document chunk mode against the owning knowledge base’s configured chunk mode, rejecting incompatible changes.
- Refine the knowledge base chunk-policy endpoint to derive mode from Knowledge.chunk_mode instead of scanning documents.
- Unify and log usage of parent-child chunk mode in document parsing and background tasks.

</details>