### PR TITLE
fix(qa-import): use parent_id from query param instead of hardcoded zero UUID

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -560,6 +560,7 @@ async def create_chunks_batch(
 async def import_qa_new_doc(
         kb_id: uuid.UUID,
         file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
+        parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_user),
         storage_service: FileStorageService = Depends(get_file_storage_service),
@@ -593,7 +594,7 @@ async def import_qa_new_doc(
     # 4. 创建 File 记录
     file_data = file_schema.FileCreate(
         kb_id=kb_id, created_by=current_user.id,
-        parent_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),
+        parent_id=parent_id,
         file_name=filename, file_ext=file_ext, file_size=file_size,
     )
     db_file = file_service.create_file(db=db, file=file_data, current_user=current_user)


### PR DESCRIPTION
## Summary
- fix(qa-import): use parent_id from query param instead of hardcoded zero UUID

## Changes
```
 api/app/controllers/chunk_controller.py | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)
```

## Test Plan
- [ ] QA 导入 CSV 到文件夹后，通过 /{kb_id}/documents?parent_id={folder_id} 能正确返回该 CSV 文档

## Summary by Sourcery

错误修复：
- 在进行 QA CSV/Excel 导入时创建文件记录时，正确遵循 `parent_id` 查询参数，以确保导入的文档出现在正确的文件夹下。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Respect the parent_id query parameter when creating file records during QA CSV/Excel import so imported documents appear under the correct folder.

</details>