### PR TITLE
fix(memory tag)：optimize hot memory tags query performance

### DIFF
--- a/api/app/core/memory/analytics/hot_memory_tags.py
+++ b/api/app/core/memory/analytics/hot_memory_tags.py
@@ -218,7 +218,6 @@ async def get_raw_tags_batch(
     """
     批量查询多个用户的实体标签频率（单次 Cypher 查询替代 N 次循环）。
     
-    利用 end_user_id 上的 RANGE INDEX 进行高效 IN 查询，
     在数据库侧完成聚合和排序，减少网络往返和应用层计算。
 
     Args:

--- a/api/app/core/memory/analytics/hot_memory_tags.py
+++ b/api/app/core/memory/analytics/hot_memory_tags.py
@@ -210,6 +210,47 @@ async def get_raw_tags_from_db(
     
     return [(record["name"], record["frequency"]) for record in results]
 
+async def get_raw_tags_batch(
+    connector: Neo4jConnector,
+    end_user_ids: List[str],
+    limit: int
+) -> List[Tuple[str, int]]:
+    """
+    批量查询多个用户的实体标签频率（单次 Cypher 查询替代 N 次循环）。
+    
+    利用 end_user_id 上的 RANGE INDEX 进行高效 IN 查询，
+    在数据库侧完成聚合和排序，减少网络往返和应用层计算。
+
+    Args:
+        connector: Neo4j连接器实例
+        end_user_ids: end_user_id 列表
+        limit: 返回的标签数量限制
+        
+    Returns:
+        List[Tuple[str, int]]: 标签名称和频率的元组列表，按频率降序
+    """
+    names_to_exclude = ['AI', 'Caroline', 'Melanie', 'Jon', 'Gina', '用户', 'AI助手', 'John', 'Maria']
+
+    query = (
+        "MATCH (e:ExtractedEntity) "
+        "WHERE e.end_user_id IN $ids "
+        "AND e.entity_type <> '生命体' "
+        "AND e.name IS NOT NULL "
+        "AND NOT e.name IN $names_to_exclude "
+        "RETURN e.name AS name, count(e) AS frequency "
+        "ORDER BY frequency DESC "
+        "LIMIT $limit"
+    )
+
+    results = await connector.execute_query(
+        query,
+        ids=end_user_ids,
+        limit=limit,
+        names_to_exclude=names_to_exclude
+    )
+
+    return [(record["name"], record["frequency"]) for record in results]
+
 async def get_hot_memory_tags(end_user_id: str, limit: int = 10, by_user: bool = False) -> List[Tuple[str, int]]:
     """
     获取原始标签，然后使用LLM进行筛选，返回最终的热门标签列表。

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 from app.core.logging_config import get_config_logger, get_logger
 from app.core.memory.analytics.hot_memory_tags import (
     filter_tags_with_llm,
-    get_raw_tags_batch,  
+    get_raw_tags_batch,
 )
 from app.core.memory.analytics.recent_activity_stats import get_recent_activity_stats
 from app.models.user_model import User
@@ -622,8 +622,15 @@ async def analytics_hot_memory_tags(
     workspace_id = current_user.current_workspace_id
     raw_limit = limit * 4
 
+    from app.db import SessionLocal
     from app.services.memory_dashboard_service import get_workspace_end_users
-    end_users = await asyncio.to_thread(get_workspace_end_users, db, workspace_id, current_user)
+
+    def _get_end_users_in_thread():
+        """在独立线程中使用独立 session，避免跨线程共享连接"""
+        with SessionLocal() as thread_db:
+            return get_workspace_end_users(thread_db, workspace_id, current_user)
+
+    end_users = await asyncio.to_thread(_get_end_users_in_thread)
 
     if not end_users:
         return []
@@ -649,7 +656,8 @@ async def analytics_hot_memory_tags(
         filtered_tag_names = await filter_tags_with_llm(tag_names, first_end_user_id)
 
         # 根据 LLM 结果过滤，保留频率和顺序
-        final_tags = [(tag, freq) for tag, freq in sorted_tags if tag in filtered_tag_names]
+        filtered_set = set(filtered_tag_names)
+        final_tags = [(tag, freq) for tag, freq in sorted_tags if tag in filtered_set]
         top_tags = final_tags[:limit]
 
         return [{"name": t, "frequency": f} for t, f in top_tags]

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -16,8 +16,8 @@ from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_config_logger, get_logger
 from app.core.memory.analytics.hot_memory_tags import (
-    get_raw_tags_from_db,
     filter_tags_with_llm,
+    get_raw_tags_batch,  
 )
 from app.core.memory.analytics.recent_activity_stats import get_recent_activity_stats
 from app.models.user_model import User
@@ -600,72 +600,56 @@ async def analytics_hot_memory_tags(
     """
     获取热门记忆标签，按数量排序并返回前N个
     
+    原方案的策略：
+
+        1.获取 workspace 下所有 end_user
+        2.逐个用户串行查询 Neo4j，每人取 top 40 标签
+        3.应用层合并所有结果，相同标签频率累加
+        4.排序取 top 40
+        5.调用一次 LLM 筛选
+        6. 返回前 limit 个
+
     优化策略：
-    1. 先从所有用户收集原始标签（不调用LLM）
-    2. 聚合并合并相同标签的频率
-    3. 排序后取前N个
-    4. 只调用一次LLM进行筛选
+        1. 获取 workspace 下所有 end_user_id
+        2. 单次批量 Cypher 查询聚合所有用户的标签频率（替代 N 次串行查询）
+        3. 调用一次 LLM 进行筛选
+        4. 返回前 limit 个
+    
+    性能对比：
+    - 优化前：N 次 Neo4j 往返 + 应用层聚合 → ~600-1600ms（N=20）
+    - 优化后：1 次 Neo4j 往返（数据库侧聚合）→ ~30-80ms
     """
     workspace_id = current_user.current_workspace_id
-    # 获取更多标签供LLM筛选（获取limit*4个标签）
     raw_limit = limit * 4
+
     from app.services.memory_dashboard_service import get_workspace_end_users
-    # 使用 asyncio.to_thread 避免阻塞事件循环
     end_users = await asyncio.to_thread(get_workspace_end_users, db, workspace_id, current_user)
 
     if not end_users:
         return []
 
-    # 步骤1: 收集所有用户的原始标签（不调用LLM）
+    # 收集所有 end_user_id
+    end_user_ids = [str(eu.id) for eu in end_users]
+
     connector = Neo4jConnector()
     try:
-        all_raw_tags = []
-        for end_user in end_users:
-            raw_tags = await get_raw_tags_from_db(
-                connector,
-                str(end_user.id),
-                limit=raw_limit,
-                by_user=False
-            )
-            if raw_tags:
-                all_raw_tags.extend(raw_tags)
-
-        if not all_raw_tags:
-            return []
-
-        # 步骤2: 聚合相同标签的频率
-        tag_frequency_map = {}
-        for tag_name, frequency in all_raw_tags:
-            if tag_name in tag_frequency_map:
-                tag_frequency_map[tag_name] += frequency
-            else:
-                tag_frequency_map[tag_name] = frequency
-
-        # 步骤3: 按频率降序排序，取前raw_limit个
-        sorted_tags = sorted(
-            tag_frequency_map.items(),
-            key=lambda x: x[1],
-            reverse=True
-        )[:raw_limit]
+        # 单次批量查询：在 Neo4j 侧完成聚合 + 排序 + 截断
+        sorted_tags = await get_raw_tags_batch(
+            connector,
+            end_user_ids,
+            limit=raw_limit
+        )
 
         if not sorted_tags:
             return []
 
-        # 步骤4: 只调用一次LLM进行筛选
+        # LLM 筛选
         tag_names = [tag for tag, _ in sorted_tags]
-
-        # 使用第一个用户的end_user_id来获取LLM配置
-        # 因为同一工作空间下的用户应该使用相同的配置
-        first_end_user_id = str(end_users[0].id)
+        first_end_user_id = end_user_ids[0]
         filtered_tag_names = await filter_tags_with_llm(tag_names, first_end_user_id)
 
-        # 步骤5: 根据LLM筛选结果构建最终列表（保留频率）
-        final_tags = []
-        for tag, freq in sorted_tags:
-            if tag in filtered_tag_names:
-                final_tags.append((tag, freq))
-
-        # 步骤6: 只返回前limit个
+        # 根据 LLM 结果过滤，保留频率和顺序
+        final_tags = [(tag, freq) for tag, freq in sorted_tags if tag in filtered_tag_names]
         top_tags = final_tags[:limit]
 
         return [{"name": t, "frequency": f} for t, f in top_tags]


### PR DESCRIPTION
Replace N serial per-user Neo4j queries with a single batch Cypher IN query in analytics_hot_memory_tags, reducing Neo4j round-trips from ~1200ms to ~178ms (6.7x improvement with 18 end_users).

## Summary by Sourcery

优化热记忆标签分析逻辑，将原本的按用户查询改为在单个批量 Neo4j 查询中聚合结果，从而提升性能，并保持只进行一次 LLM 过滤步骤。

Enhancements:
- 添加批量 Neo4j 查询辅助方法，在单个 Cypher `IN` 查询中聚合多个终端用户的标签频次。
- 优化热记忆标签分析流程：先收集终端用户 ID，一次性向 Neo4j 查询聚合并排序后的标签结果，然后在合并后的结果上应用基于 LLM 的过滤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize hot memory tags analytics to aggregate results in a single batched Neo4j query instead of per-user queries, improving performance and keeping a single LLM filtering step.

Enhancements:
- Add a batch Neo4j query helper to aggregate tag frequencies across multiple end users in one Cypher IN query.
- Refine hot memory tags analytics flow to collect end user IDs, query Neo4j once for aggregated/sorted tags, then apply LLM-based filtering on the combined result.

</details>