### PR TITLE
refactor(conversation_repo): optimize message query logic by adding current_only parameter

### DIFF
--- a/api/app/core/workflow/nodes/start/node.py
+++ b/api/app/core/workflow/nodes/start/node.py
@@ -122,9 +122,8 @@ class StartNode(BaseNode):
                         except (json.JSONDecodeError, TypeError):
                             raise ValueError(f"变量 '{var_name}' 不是有效的 JSON 对象")
 
-                # paragraph: 长度校验
-                if var_type == VariableType.STRING and ui_type == "paragraph":
-                    max_len = var_def.max_length or 2000
+                if var_type == VariableType.STRING and ui_type != "select":
+                    max_len = var_def.max_length
                     if isinstance(value, str) and len(value) > max_len:
                         raise ValueError(
                             f"变量 '{var_name}' 超过最大长度限制 ({max_len})"

--- a/api/app/core/workflow/validator.py
+++ b/api/app/core/workflow/validator.py
@@ -191,6 +191,18 @@ class WorkflowValidator:
             var_errors = ExpressionEvaluator.validate_variable_names(variables)
             errors.extend(var_errors)
 
+            # 9. 验证开始节点变量的默认值长度
+            for node in nodes:
+                if node.get("type") not in [NodeType.START, NodeType.CYCLE_START]:
+                    continue
+                for var_def in node.get("config", {}).get("variables", []):
+                    if var_def.get("type") == "string" and isinstance(var_def.get("default"), str):
+                        max_length = var_def.get("max_length")
+                        if max_length is not None and len(var_def["default"]) > max_length:
+                            errors.append(
+                                f"开始节点变量 '{var_def.get('name')}' 的默认值长度 ({len(var_def['default'])}) 超过最大长度限制 ({max_length})"
+                            )
+
         return len(errors) == 0, errors
 
     @staticmethod

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -399,13 +399,16 @@ class MessageRepository:
 
     def get_messages_by_conversation(
             self,
-            conversation_id: uuid.UUID
+            conversation_id: uuid.UUID,
+            current_only: bool = True
     ) -> list[Message]:
         """
         查询会话的所有消息（按时间正序）
 
         Args:
             conversation_id: 会话 ID
+            current_only: If True, only return messages where is_current=True.
+                         If False, return all messages (including all versions).
 
         Returns:
             List[Message]: 消息列表
@@ -413,8 +416,12 @@ class MessageRepository:
         stmt = select(Message).where(
             Message.conversation_id == conversation_id,
             Message.is_deleted == False,
-            Message.is_current == True,
-        ).order_by(Message.created_at)
+        )
+
+        if current_only:
+            stmt = stmt.where(Message.is_current == True)
+
+        stmt = stmt.order_by(Message.created_at)
 
         messages = list(self.db.scalars(stmt).all())
 

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1619,6 +1619,20 @@ class AppService:
 
         self._validate_app_writable(app, workspace_id)
 
+        config_dict = {
+            "nodes": [node.model_dump() for node in data.nodes] if data.nodes else [],
+            "edges": [edge.model_dump() for edge in data.edges] if data.edges else [],
+            "variables": [var.model_dump() for var in data.variables] if data.variables else [],
+            "execution_config": data.execution_config.model_dump() if data.execution_config else {},
+            "triggers": [trigger.model_dump() for trigger in data.triggers] if data.triggers else [],
+        }
+        is_valid, errors = WorkflowValidator.validate(config_dict)
+        if not is_valid:
+            raise BusinessException(
+                code=BizCode.INVALID_PARAMETER,
+                message=f"工作流配置无效: {'; '.join(errors)}"
+            )
+
         # 获取现有配置
         repo = WorkflowConfigRepository(self.db)
         workflow_cfg = repo.get_by_app_id(app_id)


### PR DESCRIPTION
Adjust the `get_messages_by_conversation` method by introducing the `current_only` parameter to control whether only messages from the current version are returned. Move the `is_current` filter condition into the parameter judgment branch to enhance code flexibility.

## Summary by Sourcery

在会话消息查询中引入可选的 `current_only` 标志，用于控制返回仅当前版本的消息，还是返回会话中的所有版本。

New Features:
- 为会话消息检索新增 `current_only` 参数，用于可选地包含所有消息版本。

Enhancements:
- 优化会话消息查询的构建逻辑，根据 `current_only` 标志有条件地应用 `is_current` 过滤器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an optional current_only flag to control whether message queries return only the current version or all versions in a conversation.

New Features:
- Add a current_only parameter to conversation message retrieval to optionally include all message versions.

Enhancements:
- Refine conversation message query construction by conditionally applying the is_current filter based on the current_only flag.

</details>