### PR TITLE
feat(mcp): add memory read/write tools and auth middleware

### DIFF
--- a/api/app/controllers/service/mcp_auth_middleware.py
+++ b/api/app/controllers/service/mcp_auth_middleware.py
@@ -1,0 +1,179 @@
+"""
+API Key authentication middleware for MCP routes.
+
+Intercepts requests to /v1/mcp/* and:
+1. Validates the API key (Authorization / X-API-Key header).
+2. Reads the end user's other_id from X-End-User-Other-Id header.
+3. Resolves other_id + workspace_id → end_user.
+4. Resolves config_id: end_user.memory_config_id → workspace default.
+5. Resolves storage_type from workspace configuration.
+6. Stores workspace_id, end_user_id, config_id, storage_type via contextvars.
+
+All identity and configuration is determined server-side from headers —
+the client never passes end_user_id, config_id, or storage_type as tool
+parameters.
+"""
+
+import logging
+import uuid
+from contextvars import ContextVar
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.api_key_auth import extract_api_key_from_request
+from app.core.error_codes import BizCode
+from app.db import get_db_context
+
+logger = logging.getLogger(__name__)
+
+MCP_PATH_PREFIX = "/v1/mcp"
+OTHER_ID_HEADER = "X-End-User-Other-Id"
+
+# ContextVars shared between this middleware and MCP tools.
+mcp_workspace_id: ContextVar[uuid.UUID | None] = ContextVar(
+    "mcp_workspace_id", default=None
+)
+mcp_end_user_id: ContextVar[str | None] = ContextVar(
+    "mcp_end_user_id", default=None
+)
+mcp_config_id: ContextVar[str | None] = ContextVar(
+    "mcp_config_id", default=None
+)
+mcp_storage_type: ContextVar[str | None] = ContextVar(
+    "mcp_storage_type", default=None
+)
+
+
+class MCPAuthMiddleware(BaseHTTPMiddleware):
+    """Middleware that authenticates and resolves context for MCP requests.
+
+    Header requirements for /v1/mcp/* requests:
+      - Authorization: Bearer <api_key>   (or X-API-Key: <api_key>)
+      - X-End-User-Other-Id: <other_id>    (external user identifier)
+
+    Resolved context (stored in ContextVars):
+      - workspace_id: from the API key
+      - end_user_id:  looked up from (workspace_id, other_id)
+      - config_id:    end_user.memory_config_id, or workspace default
+      - storage_type: from workspace configuration (defaults to "neo4j")
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if not request.url.path.startswith(MCP_PATH_PREFIX):
+            return await call_next(request)
+
+        # 1. Validate API key
+        api_key = extract_api_key_from_request(request)
+        if not api_key:
+            return self._unauthorized("API Key 不存在", BizCode.API_KEY_NOT_FOUND)
+
+        from app.services.api_key_service import ApiKeyAuthService
+
+        with get_db_context() as db:
+            api_key_obj = ApiKeyAuthService.validate_api_key(db, api_key)
+            if not api_key_obj:
+                return self._unauthorized(
+                    "API Key 无效或已过期", BizCode.API_KEY_INVALID
+                )
+            ApiKeyAuthService.check_app_published(db, api_key_obj)
+
+            if not ApiKeyAuthService.check_scope(api_key_obj, "memory"):
+                return self._forbidden(
+                    "缺少 memory 权限范围", BizCode.API_KEY_INVALID_SCOPE
+                )
+
+            workspace_id = api_key_obj.workspace_id
+
+            # 2. Read other_id from header
+            other_id = request.headers.get(OTHER_ID_HEADER, "").strip()
+            if not other_id:
+                return self._unauthorized(
+                    f"缺少 {OTHER_ID_HEADER} 请求头", BizCode.INVALID_PARAMETER
+                )
+
+            # 3. Resolve other_id → end_user (scoped to workspace)
+            end_user = self._find_end_user(db, other_id, workspace_id)
+            if end_user is None:
+                return self._unauthorized(
+                    f"未找到 other_id='{other_id}' 对应的终端用户",
+                    BizCode.USER_NOT_FOUND,
+                )
+
+            end_user_id = str(end_user.id)
+
+            # 4. Resolve config_id: end_user → workspace default
+            config_id = self._resolve_config_id(db, end_user, workspace_id)
+            if config_id is None:
+                return self._unauthorized(
+                    "未找到可用的记忆配置，请先为 workspace 设置默认配置",
+                    BizCode.MEMORY_CONFIG_NOT_FOUND,
+                )
+
+            # 5. Resolve storage_type from workspace
+            storage_type = self._resolve_storage_type(db, workspace_id)
+
+        mcp_workspace_id.set(workspace_id)
+        mcp_end_user_id.set(end_user_id)
+        mcp_config_id.set(config_id)
+        mcp_storage_type.set(storage_type)
+
+        return await call_next(request)
+
+    @staticmethod
+    def _find_end_user(db, other_id: str, workspace_id: uuid.UUID):
+        from app.models.end_user_model import EndUser
+
+        return (
+            db.query(EndUser)
+            .filter(
+                EndUser.other_id == other_id,
+                EndUser.workspace_id == workspace_id,
+            )
+            .order_by(EndUser.created_at.asc())
+            .first()
+        )
+
+    @staticmethod
+    def _resolve_config_id(db, end_user, workspace_id: uuid.UUID) -> str | None:
+        if end_user.memory_config_id is not None:
+            return str(end_user.memory_config_id)
+
+        from app.services.memory_config_service import MemoryConfigService
+
+        config_service = MemoryConfigService(db)
+        default_config = config_service.get_workspace_default_config(workspace_id)
+        if default_config is not None:
+            return str(default_config.config_id)
+
+        return None
+
+    @staticmethod
+    def _resolve_storage_type(db, workspace_id: uuid.UUID) -> str:
+        from app.services.workspace_service import get_workspace_storage_type_without_auth
+
+        storage_type = get_workspace_storage_type_without_auth(db, workspace_id)
+        return storage_type if storage_type else "neo4j"
+
+    @staticmethod
+    def _unauthorized(message: str, code: BizCode) -> JSONResponse:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "success": False,
+                "error_code": code.value,
+                "message": message,
+            },
+        )
+
+    @staticmethod
+    def _forbidden(message: str, code: BizCode) -> JSONResponse:
+        return JSONResponse(
+            status_code=403,
+            content={
+                "success": False,
+                "error_code": code.value,
+                "message": message,
+            },
+        )

--- a/api/app/controllers/service/mcp_memory.py
+++ b/api/app/controllers/service/mcp_memory.py
@@ -1,0 +1,148 @@
+"""
+MCP (Model Context Protocol) tools for memory read and write operations.
+
+Exposes tools that AI models can call to store and retrieve memories
+for end users. All identity and configuration is resolved server-side
+by MCPAuthMiddleware — the client only provides message content.
+
+Client configuration (all in headers, never in tool parameters):
+  - Authorization: Bearer <api_key>
+  - X-End-User-Other-Id: <other_id>
+"""
+
+import uuid
+import warnings
+
+from fastmcp import FastMCP
+
+from app.celery_task_scheduler import scheduler
+from app.controllers.service.mcp_auth_middleware import (
+    mcp_config_id,
+    mcp_end_user_id,
+    mcp_storage_type,
+    mcp_workspace_id,
+)
+from app.core.logging_config import get_logger
+from app.core.memory.enums import SearchStrategy
+from app.core.memory.memory_service import MemoryService
+from app.db import get_db_context
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="scipy")
+
+logger = get_logger(__name__)
+
+mcp = FastMCP("记忆服务")
+
+
+def _resolve_context() -> tuple[uuid.UUID, str, str, str]:
+    """Return (workspace_id, end_user_id, config_id, storage_type) from the middleware."""
+    ws_id = mcp_workspace_id.get()
+    eu_id = mcp_end_user_id.get()
+    cfg_id = mcp_config_id.get()
+    st = mcp_storage_type.get()
+    if ws_id is None or eu_id is None or cfg_id is None or st is None:
+        raise RuntimeError("未提供有效的 API Key、X-End-User-Other-Id 或记忆配置")
+    return ws_id, eu_id, cfg_id, st
+
+
+_SEARCH_MAP = {
+    "0": SearchStrategy.DEEP,
+    "1": SearchStrategy.NORMAL,
+    "2": SearchStrategy.QUICK,
+}
+
+
+@mcp.tool
+async def write_memory(
+        message: str,
+) -> dict:
+    """将用户的重要信息持久化存储，供后续对话召回。
+
+    应在以下场景调用：
+    - 用户明确表达了偏好、习惯、计划或个人信息
+    - 对话中出现了值得在未来参考的事实、决定或背景
+
+    写入内容应简洁、结构化，只包含关键信息，避免冗余。
+    例如："用户喜欢喝冰美式咖啡，不加糖" 比 "用户在今天的对话中提到他喜欢喝咖啡，
+    具体来说是冰美式，而且不加糖" 更好。
+
+    Args:
+        message: 需要存储的记忆内容，用自然语言描述即可。
+    """
+    try:
+        workspace_id, end_user_id, config_id, storage_type = _resolve_context()
+    except RuntimeError as e:
+        return {"success": False, "error": str(e)}
+
+    try:
+        msg_id = scheduler.push_task(
+            "app.core.memory.agent.write_message",
+            end_user_id,
+            {
+                "end_user_id": end_user_id,
+                "message": [{"role": "user", "content": message}],
+                "config_id": config_id,
+                "storage_type": storage_type,
+                "user_rag_memory_id": "",
+                "workspace_id": str(workspace_id),
+            },
+        )
+        logger.info(f"MCP write_memory queued: msg_id={msg_id}, end_user={end_user_id}")
+        return {"success": True, "msg_id": msg_id}
+    except Exception as e:
+        logger.error(f"MCP write_memory failed for end_user={end_user_id}: {e}")
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool
+async def read_memory(
+        message: str,
+        search_switch: str = "0",
+) -> dict:
+    """检索与当前上下文相关的历史记忆。
+
+    应在以下场景调用：
+    - 开始对话或切换话题时，先回忆用户之前的偏好和背景
+    - 用户提问涉及之前聊过的话题，需要获取历史上下文
+    - 需要确认用户之前提过的信息，避免重复询问
+
+    返回结果为自然语言文本，可直接用于辅助生成回复。
+
+    Args:
+        message: 检索查询，用自然语言描述想查找什么。越具体效果越好。
+                 例如："用户对咖啡有什么偏好"、"上次讨论的旅行计划"。
+        search_switch: 检索深度。"0"=深度检索+交叉验证（默认，适合复杂问题），
+                       "1"=深度检索（适合一般回忆），"2"=快速检索（适合简单查询）。
+    """
+    try:
+        workspace_id, end_user_id, config_id, storage_type = _resolve_context()
+    except RuntimeError as e:
+        return {"success": False, "error": str(e)}
+
+    strategy = _SEARCH_MAP.get(search_switch, SearchStrategy.DEEP)
+
+    with get_db_context() as db:
+        try:
+            service = MemoryService(
+                db=db,
+                config_id=config_id,
+                end_user_id=end_user_id,
+                workspace_id=str(workspace_id),
+                storage_type=storage_type,
+            )
+            result = await service.read(
+                query=message,
+                search_switch=strategy,
+            )
+            logger.info(f"MCP read_memory succeeded for end_user={end_user_id}")
+            return {
+                "success": True,
+                "content": result.content,
+                "count": result.count,
+            }
+        except Exception as e:
+            logger.error(f"MCP read_memory failed for end_user={end_user_id}: {e}")
+            return {"success": False, "error": str(e)}
+
+
+mcp_app = mcp.http_app(path="/memory", transport="streamable-http")

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -16,6 +16,9 @@ from fastapi.responses import JSONResponse
 from app.controllers import manager_router
 # 服务端 API (API Key 认证)
 from app.controllers.service import service_router
+# MCP
+from app.controllers.service import mcp_app
+from app.controllers.service.mcp_auth_middleware import MCPAuthMiddleware
 from app.core.config import settings
 from app.core.error_codes import BizCode, HTTP_MAPPING
 from app.core.exceptions import BusinessException
@@ -69,8 +72,8 @@ async def lifespan(app: FastAPI):
     logger.info("All neo4j indexes and constraints created successfully!")
     logger.info("应用程序启动完成")
 
-
-    yield
+    async with mcp_app.lifespan(app):
+        yield
     # 应用关闭事件
     logger.info("应用程序正在关闭")
 
@@ -104,6 +107,9 @@ app.add_middleware(
 from app.i18n.middleware import LanguageMiddleware
 app.add_middleware(LanguageMiddleware)
 
+# MCP API Key 鉴权中间件（仅拦截 /mcp/* 路径）
+app.add_middleware(MCPAuthMiddleware)
+
 logger.info("FastAPI应用程序启动")
 
 
@@ -125,6 +131,9 @@ app.include_router(manager_router, prefix="/api")
 
 # 服务端 API (API Key 认证)
 app.include_router(service_router, prefix="/v1")
+
+# MCP
+app.mount("/v1/mcp", mcp_app)
 
 logger.info("所有路由已注册完成")
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -17,7 +17,7 @@ from app.controllers import manager_router
 # 服务端 API (API Key 认证)
 from app.controllers.service import service_router
 # MCP
-from app.controllers.service import mcp_app
+from app.controllers.service.mcp_memory import mcp_app
 from app.controllers.service.mcp_auth_middleware import MCPAuthMiddleware
 from app.core.config import settings
 from app.core.error_codes import BizCode, HTTP_MAPPING

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -3,6 +3,8 @@ import logging
 import time
 from typing import Any, Dict, List, Optional, Coroutine
 
+import numpy as np
+
 from app.core.memory.enums import Neo4jNodeType
 from app.core.memory.llm_tools import OpenAIEmbedderClient
 from app.core.memory.utils.data.text_utils import escape_lucene_query
@@ -27,11 +29,40 @@ from app.repositories.neo4j.cypher_queries import (
     SEARCH_USER_METADATA,
     SEARCH_ENITITES_BY_RELATIONSHIP,
     SEARCH_RELATION_BETWEEN_ENTITIES,
-    SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS,
+    SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS, SEARCH_PERCEPTUAL_BY_USER_ID, SEARCH_PERCEPTUAL_BY_IDS,
+    USER_ID_QUERY_CYPHER_MAPPING,
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 logger = logging.getLogger(__name__)
+
+
+def cosine_similarity_search(
+        query: list[float],
+        vectors: list[list[float]],
+        limit: int
+) -> dict[int, float]:
+    if not vectors:
+        return {}
+    vectors: np.ndarray = np.array(vectors, dtype=np.float32)
+    vectors_norm = vectors / np.linalg.norm(vectors, axis=1, keepdims=True)
+    query: np.ndarray = np.array(query, dtype=np.float32)
+    norm = np.linalg.norm(query)
+    if norm == 0:
+        return {}
+    query_norm = query / norm
+
+    similarities = vectors_norm @ query_norm
+    similarities = np.clip(similarities, 0, 1)
+    top_k = min(limit, similarities.shape[0])
+    if top_k <= 0:
+        return {}
+    top_indices = np.argpartition(-similarities, top_k - 1)[:top_k]
+    top_indices = top_indices[np.argsort(-similarities[top_indices])]
+    result = {}
+    for idx in top_indices:
+        result[idx] = float(similarities[idx])
+    return result
 
 
 async def _update_activation_values_batch(
@@ -261,19 +292,45 @@ async def search_perceptual_by_embedding(
         end_user_id: Optional[str] = None,
         limit: int = 10,
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Search Perceptual nodes using gds.similarity.cosine in Cypher."""
+    """
+    Search Perceptual memory nodes using embedding-based semantic search.
+
+    Uses cosine similarity on summary_embedding via the perceptual_summary_embedding_index.
+
+    Args:
+        connector: Neo4j connector
+        embedder_client: Embedding client with async response() method
+        query_text: Query text to embed
+        end_user_id: Optional user filter
+        limit: Max results
+
+    Returns:
+        Dictionary with 'perceptuals' key containing matched perceptual memory nodes
+    """
     embeddings = await embedder_client.response([query_text])
     if not embeddings or not embeddings[0]:
         logger.warning(f"search_perceptual_by_embedding: embedding generation failed for '{query_text[:50]}'")
         return {"perceptuals": []}
 
+    embedding = embeddings[0]
     try:
         perceptuals = await connector.execute_query(
-            COSINE_SEARCH_CYPHER_MAPPING[Neo4jNodeType.PERCEPTUAL],
+            SEARCH_PERCEPTUAL_BY_USER_ID,
             end_user_id=end_user_id,
-            embedding=embeddings[0],
-            limit=limit,
         )
+        ids = [item['id'] for item in perceptuals]
+        vectors = [item['summary_embedding'] for item in perceptuals]
+        sim_res = cosine_similarity_search(embedding, vectors, limit=limit)
+        perceptual_res = {
+            ids[idx]: score
+            for idx, score in sim_res.items()
+        }
+        perceptuals = await connector.execute_query(
+            SEARCH_PERCEPTUAL_BY_IDS,
+            ids=list(perceptual_res.keys())
+        )
+        for perceptual in perceptuals:
+            perceptual["score"] = perceptual_res[perceptual["id"]]
     except Exception as e:
         logger.warning(f"search_perceptual_by_embedding: vector search failed: {e}")
         perceptuals = []
@@ -311,11 +368,24 @@ async def search_by_embedding(
     """Cosine similarity search using gds.similarity.cosine in Cypher, single query."""
     try:
         records = await connector.execute_query(
-            COSINE_SEARCH_CYPHER_MAPPING[node_type],
+            USER_ID_QUERY_CYPHER_MAPPING[node_type],
             end_user_id=end_user_id,
-            embedding=query_embedding,
-            limit=limit,
         )
+        records = [record for record in records if record and record.get("embedding") is not None]
+        ids = [item['id'] for item in records]
+        vectors = [item['embedding'] for item in records]
+        sim_res = cosine_similarity_search(query_embedding, vectors, limit=limit)
+        records_score_map = {
+            ids[idx]: score
+            for idx, score in sim_res.items()
+        }
+        records = await connector.execute_query(
+            NODE_ID_QUERY_CYPHER_MAPPING[node_type],
+            ids=list(records_score_map.keys()),
+            json_format=True
+        )
+        for record in records:
+            record["score"] = records_score_map[record["id"]]
     except Exception as e:
         logger.warning(f"search_by_embedding: vector search failed: {e}, node_type:{node_type.value}",
                        exc_info=True)


### PR DESCRIPTION
Introduce MCP (Model Context Protocol) memory service with two tools (write_memory, read_memory) and an authentication middleware that resolves identity and configuration from request headers.

## Summary by Sourcery

引入基于 MCP 的内存服务（memory service），提供带身份验证的读/写工具，并将其集成到现有的 FastAPI 应用中。

新功能：
- 添加 MCP memory HTTP 应用，暴露 `write_memory` 和 `read_memory` 工具，用于存储和检索用户记忆信息。
- 为 MCP 路由引入身份验证和上下文解析中间件，通过请求头和 API Key 元数据解析工作空间、终端用户、配置和存储设置。

增强：
- 使用 MCP 应用的生命周期包装主 FastAPI 应用的生命周期，并将 MCP 路由挂载在 `/v1/mcp` 路径下。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an MCP-based memory service with authenticated read/write tools and integrate it into the existing FastAPI app.

New Features:
- Add MCP memory HTTP app exposing write_memory and read_memory tools for storing and retrieving user memories.
- Introduce authentication and context-resolution middleware for MCP routes that derives workspace, end user, configuration, and storage settings from request headers and API key metadata.

Enhancements:
- Wrap the main FastAPI application lifespan with the MCP app lifespan and mount the MCP routes under the /v1/mcp path.

</details>