### PR TITLE
chore: remove redbear-mem-benchmark submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "redbear-mem-benchmark"]
-	path = redbear-mem-benchmark
-	url = git@github.com:SuanmoSuanyangTechnology/redbear-mem-benchmark.git

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -862,17 +862,20 @@ async def retrieve_chunks(
 
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
+    # default value is topk
+    topn = retrieve_data.top_k
+
     # 1 participle search, 2 semantic search, 3 hybrid search
     match retrieve_data.retrieve_type:
         case chunk_schema.RetrieveType.PARTICIPLE:
-            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
+            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case chunk_schema.RetrieveType.SEMANTIC:
-            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
+            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case _:
-            rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
-            rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
+            rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
+            rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
             # Efficient deduplication
             seen_ids = set()
             unique_rs = []
@@ -881,8 +884,10 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
+            # api_logger.debug(f"Rerank result before: {rs}")
             rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
             rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
+            # api_logger.debug(f"Rerank result  after: {rs}")
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -536,6 +536,7 @@ class ElasticSearchVector(BaseVector):
 
             docs_and_scores.append((DocumentChunk(page_content=page_content, metadata=metadata), score))
 
+        # docs = [doc for doc, score in docs_and_scores]
         docs = []
         for doc, score in docs_and_scores:
             # check score threshold
@@ -630,7 +631,8 @@ class ElasticSearchVector(BaseVector):
             # Normalize the score to the [0,1] interval
             normalized_score = res["_score"] / max_score
             docs_and_scores.append((DocumentChunk(page_content=page_content, metadata=metadata), normalized_score))
-        
+
+        # docs = [doc for doc, score in docs_and_scores]
         docs = []
         for doc, score in docs_and_scores:
             # check score threshold
@@ -722,43 +724,29 @@ class ElasticSearchVector(BaseVector):
 
     def rerank(self, query: str, docs: list[DocumentChunk], top_k: int) -> list[DocumentChunk]:
         """
-        Reorder the list of document blocks and return the top_k results most relevant to the query
-        Args:
-            query: query string
-            docs: List of document chunk to be rearranged
-            top_k: The number of top-level documents returned
-
-        Returns:
-            Rearranged document chunk list (sorted in descending order of relevance)
-
-        Raises:
-            ValueError: If the input document list is empty or top_k is invalid
+        Reorder the list of document blocks and return the top_k results most relevant to the query.
+        Falls back to the original docs (truncated to top_k) if reranking fails.
         """
-        # parameter validation
         if not docs:
             raise ValueError("retrieval chunks be empty")
         if top_k <= 0:
             raise ValueError("top_k must be a positive integer")
         try:
-            # Convert to LangChain Document object
             documents = [
                 Document(
-                    page_content=doc.page_content,  # Ensure that DocumentChunk possesses this attribute
-                    metadata=doc.metadata or {}  # Deal with possible None metadata
+                    page_content=doc.page_content,
+                    metadata=doc.metadata or {}
                 )
                 for doc in docs
             ]
 
-            # Perform reordering (compress_documents will automatically handle relevance scores and indexing)
             reranked_docs = list(self.reranker.compress_documents(documents, query))
             print(reranked_docs)
 
-            # Sort in descending order based on relevance score
             reranked_docs.sort(
                 key=lambda x: x.metadata.get("relevance_score", 0),
                 reverse=True
             )
-            # Convert back to a list of DocumentChunk, and save the relevance_score to metadata["score"]
             result = []
             for item in reranked_docs[:top_k]:
                 for doc in docs:
@@ -767,7 +755,11 @@ class ElasticSearchVector(BaseVector):
                         result.append(doc)
             return result
         except Exception as e:
-            raise RuntimeError(f"Failed to rerank documents: {str(e)}") from e
+            logger.warning(f"Rerank failed, falling back to original results: {str(e)}")
+            for doc in docs[:top_k]:
+                if doc.metadata is not None and "score" not in doc.metadata:
+                    doc.metadata["score"] = 0.5
+            return docs[:top_k]
 
     def create_collection(
         self,


### PR DESCRIPTION
## Summary
- chore: remove redbear-mem-benchmark submodule

## Changes
```
 api/app/controllers/app_log_controller.py          |   1 -
 api/app/controllers/chunk_controller.py            |   3 +-
 api/app/controllers/public_share_controller.py     |   3 -
 api/app/core/memory/sliding_window/flush_task.py   |  63 -------  api/app/core/memory/sliding_window/window_utils.py |  12 +-
 api/app/repositories/conversation_repository.py    |   5 +-
 api/app/schemas/app_log_schema.py                  |   2 +-
 api/app/schemas/app_schema.py                      |   1 -
 api/app/services/auth_service.py                   |   2 +-
 api/app/tasks.py                                   |  34 ----
 web/src/api/application.ts                         |  41 ++---
 web/src/api/knowledgeBase.ts                       |   6 +-
 web/src/components/AudioRecorder/index.tsx         |  19 +-
 web/src/components/Chat/AudioPlayer.tsx            |  43 +----
 web/src/components/Chat/ChatContent.tsx            |  14 +-
 web/src/components/Chat/MessageFiles.tsx           |   4 +-
 web/src/components/Table/index.tsx                 |  20 +--
 web/src/i18n/en.ts                                 |   4 +-
 web/src/i18n/zh.ts                                 |  18 +-
 web/src/views/ApplicationConfig/Logs.tsx           |  33 ++--
 .../ApplicationConfig/components/ConfigHeader.tsx  |   8 +-
 .../views/Conversation/components/ReportModal.tsx  |  25 ++-
 .../views/Conversation/components/ShareModal.tsx   |  37 ++--
 web/src/views/Conversation/index.tsx               | 115 ++++--------
 .../[knowledgeBaseId]/CreateDataset.tsx            | 132 +++++++++-----
 .../components/ParentChildBlockConfig.tsx          | 199 +++++++++++++++++++++
 web/src/views/KnowledgeBase/types.ts               |   5 +
 web/src/views/MemoryConversation/index.tsx         |   5 +-
 web/src/views/ModelManagement/index.tsx            |   2 +-
 .../views/Workflow/components/CheckList/index.tsx  |   4 +-
 .../Editor/plugin/AutocompletePlugin.tsx           |   6 +-
 .../Properties/ModelConfig/ModelConfigModal.tsx    |  67 ++-----
 .../views/Workflow/components/Properties/Retry.tsx |   4 +-
 .../Properties/VariableList/VariableEditModal.tsx  |  23 +--
 .../views/Workflow/components/Properties/index.tsx |   3 +-
 .../Workflow/components/SingleNodeRun/index.tsx    |   4 +-
 web/src/views/Workflow/constant.ts                 |   4 +-
 37 files changed, 476 insertions(+), 495 deletions(-)
```

## Test Plan
- [ ] 验证 submodule 移除后项目正常构建

## Summary by Sourcery

移除未使用的基准测试子模块，并改进混合检索重排序的健壮性和参数处理。

改进内容：
- 提高基于 Elasticsearch 的重排序容错能力：当重排序失败时，回退到原始搜索结果，并使用默认分数。
- 通过本地变量统一检索控制器对 `top_k` 参数的使用，并优化重排序后的分数筛选逻辑。
- 清理仓库配置，移除 `redbear-mem-benchmark` 子模块及其在 `.gitmodules` 中的条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove an unused benchmarking submodule and improve hybrid retrieval reranking robustness and parameter handling.

Enhancements:
- Make Elasticsearch-based reranking more fault-tolerant by falling back to original search results with default scores when reranking fails.
- Normalize retrieval controller use of the top_k parameter via a local variable and refine post-rerank score filtering.
- Clean up repository configuration by removing the redbear-mem-benchmark submodule and its .gitmodules entry.

</details>