### PR TITLE
fix(workflow, llm): unify JSON output fallback logic and enhance multi-field streaming support

### DIFF
--- a/api/app/core/agent/langchain_agent.py
+++ b/api/app/core/agent/langchain_agent.py
@@ -90,15 +90,8 @@ class LangChainAgent:
 
         self.system_prompt = system_prompt or "你是一个专业的AI助手"
 
-        # ChatTongyi 要求 messages 含 'json' 字样才能使用 response_format
-        # 在 system prompt 中注入 JSON 要求
-        from app.models.models_model import ModelProvider
-        if json_output and (
-            (provider.lower() == ModelProvider.DASHSCOPE and not is_omni)
-            or provider.lower() == ModelProvider.VOLCANO
-            # 有工具时 response_format 会被移除，所有 provider 都需要 system prompt 注入保证 JSON 输出
-            or bool(tools)
-        ):
+        # 所有 provider 统一注入 JSON prompt 兜底，确保即使 API 层 response_format 未生效也能引导 JSON 输出
+        if json_output:
             self.system_prompt += "\n请以JSON格式输出。"
 
         logger.debug(

--- a/api/app/core/workflow/engine/event_stream_handler.py
+++ b/api/app/core/workflow/engine/event_stream_handler.py
@@ -119,6 +119,14 @@ class EventStreamHandler:
                 return
             current_output = end_info.outputs[end_info.cursor]
             if current_output.is_variable and current_output.depends_on_scope(node_id):
+                # Field-level matching: route real-time chunks only to the segment
+                # that references the same field. Chunks carrying "reasoning_content"
+                # flow to {{node.reasoning_content}}, "output" to {{node.output}}.
+                chunk_field = data.get("field", "output")
+                segment_field = current_output.get_field() or "output"
+                if chunk_field != segment_field:
+                    return
+
                 if data.get("done"):
                     end_info.cursor += 1
                     if end_info.cursor >= len(end_info.outputs):

--- a/api/app/core/workflow/engine/stream_output_coordinator.py
+++ b/api/app/core/workflow/engine/stream_output_coordinator.py
@@ -17,6 +17,10 @@ SCOPE_PATTERN = re.compile(
     r"\{\{\s*([a-zA-Z0-9_]+)\.[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)?\s*}}"
 )
 
+FIELD_PATTERN = re.compile(
+    r"\{\{\s*[a-zA-Z0-9_]+\.([a-zA-Z0-9_]+)(?:\.[a-zA-Z0-9_]+)?\s*}}"
+)
+
 
 class OutputContent(BaseModel):
     """
@@ -59,6 +63,17 @@ class OutputContent(BaseModel):
         matches = SCOPE_PATTERN.findall(self.literal)
         self._SCOPE = matches[0] if matches else None
         return self._SCOPE
+
+    def get_field(self) -> str | None:
+        """Extract the field name from a variable placeholder.
+
+        For example:
+            "{{llm_qa.output}}"             -> "output"
+            "{{llm_qa.reasoning_content}}"  -> "reasoning_content"
+            "{{sys.message}}"               -> "message"
+        """
+        matches = FIELD_PATTERN.findall(self.literal)
+        return matches[0] if matches else None
 
     def depends_on_scope(self, scope: str) -> bool:
         """

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -318,6 +318,7 @@ class BaseNode(ABC):
                     chunk_count += 1
                     content = str(item.get("chunk"))
                     done = item.get("done", False)
+                    field = item.get("field", "output")
                     chunks.append(content)
 
                     # Send chunks for all nodes (including End nodes for suffix)
@@ -328,7 +329,8 @@ class BaseNode(ABC):
                         "type": "node_chunk",
                         "node_id": self.node_id,
                         "chunk": content,
-                        "done": done
+                        "done": done,
+                        "field": field
                     })
 
             elapsed_time = (time.time() - start_time) * 1000

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -322,15 +322,8 @@ class LLMNode(BaseNode):
             rendered = self._render_template(prompt_template, variable_pool)
             self.messages = [{"role": "user", "content": rendered}]
 
-        # ChatTongyi 要求 messages 含 'json' 字样才能使用 response_format，在 system prompt 中注入
-        # VOLCANO 模型不支持 response_format，同样需要 system prompt 注入
-        # thinking（A类）模型启用深度思考时，工厂会跳过 response_format 以避免 API 冲突，需要 prompt 注入兜底
-        need_json_prompt = json_output and (
-            (model_info.provider.lower() == ModelProvider.DASHSCOPE and not model_info.is_omni)
-            or model_info.provider.lower() == ModelProvider.VOLCANO
-            or (deep_thinking and ModelCapability.THINKING in model_info.capability)
-        )
-        if need_json_prompt:
+        # 所有 provider 统一注入 JSON prompt 兜底，确保即使 API 层 response_format 未生效也能引导 JSON 输出
+        if json_output:
             system_msg = next((m for m in self.messages if m["role"] == "system"), None)
             if system_msg:
                 system_msg["content"] += "\n请以JSON格式输出。"
@@ -567,6 +560,7 @@ class LLMNode(BaseNode):
                         reasoning_chunk = additional_kwargs.get("reasoning_content") or additional_kwargs.get("reasoning", "")
                         if reasoning_chunk:
                             full_reasoning_content += reasoning_chunk
+                            yield {"__final__": False, "chunk": reasoning_chunk, "field": "reasoning_content"}
 
                     if content:
                         full_response += content


### PR DESCRIPTION
- Remove JSON output compatibility checks for individual model providers; instead, uniformly inject JSON format prompts for all providers.
- Introduce streaming output field markers to distinguish between reasoning content and regular output content.
- Implement field-based streaming output routing to ensure variables match the corresponding data streams.

## Summary by Sourcery

在各个 LLM 提供方之间统一 JSON 输出提示方式，并增强流式传输能力，以支持对推理内容和主要输出内容进行字段级路由。

新功能：
- 在 LLM 工作流执行中，新增支持将独立的 `reasoning_content` 流式分片与正常输出一同进行流式传输。
- 引入字段级路由，使得流式分片只会发送到引用对应输出字段的模板片段中。

增强改进：
- 统一 JSON 输出回退逻辑：当请求 JSON 输出时，无论使用哪家提供方，系统提示中都会追加 JSON 格式提示信息。
- 扩展变量占位符处理逻辑，以提取字段名，从而对流式输出的投递实现更细粒度的控制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify JSON output prompting across LLM providers and enhance streaming to support field-level routing of reasoning and main output content.

New Features:
- Add support for streaming separate reasoning_content chunks alongside normal output in LLM workflow execution.
- Introduce field-level routing so streamed chunks are delivered only to template segments referencing the corresponding output field.

Enhancements:
- Standardize JSON output fallback by always appending a JSON format hint in system prompts when JSON output is requested, regardless of provider.
- Extend variable placeholder handling to extract field names for finer-grained control of streaming output delivery.

</details>