### PR TITLE
fix(flush-task): resolve memory_config from app release instead of workspace default

### DIFF
--- a/api/app/core/memory/sliding_window/flush_task.py
+++ b/api/app/core/memory/sliding_window/flush_task.py
@@ -12,11 +12,14 @@ Requirements: 4.3, 4.4, 4.5
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Tuple
+import uuid
+from typing import List, Tuple
 
 from sqlalchemy import select
 
 from app.db import get_db_context
+from app.models.app_model import App
+from app.models.app_release_model import AppRelease
 from app.models.conversation_model import Conversation
 from app.models.memory_message_model import MemoryMessage
 
@@ -80,11 +83,21 @@ class FlushTask:
 
         write_cursor, end_user_id, workspace_id = conversation_info
 
-        # Step 1.5: 提前校验 memory_config，避免下层抛 ConfigurationError 产生 ERROR 日志噪音
-        if not self._has_active_memory_config(workspace_id):
+        # Step 1.5: 解析当前应用 release 中绑定的 memory_config_id
+        # 路径: conversation.app_id → app.current_release_id → app_releases.config.memory.memory_config_id
+        release_config_id = self._resolve_release_memory_config_id(conversation_id)
+        if release_config_id is None:
             logger.warning(
-                f"[FlushTask] workspace 无活跃记忆配置，跳过 flush: "
+                f"[FlushTask] 未能从应用发布配置解析到 memory_config_id，跳过 flush: "
                 f"conv={conversation_id}, workspace={workspace_id}"
+            )
+            return
+
+        # Step 1.6: 校验该 memory_config 仍然存在且处于活跃状态，避免下层 ERROR 日志噪音
+        if not self._has_active_memory_config(release_config_id):
+            logger.warning(
+                f"[FlushTask] memory_config 不存在或未启用，跳过 flush: "
+                f"conv={conversation_id}, config_id={release_config_id}"
             )
             return
 
@@ -98,7 +111,8 @@ class FlushTask:
         user_processed = await execute_pending_from_pool(
             conversation_id=conversation_id,
             end_user_id=end_user_id,
-            workspace_id=workspace_id,
+            config_id=str(release_config_id),
+            workspace_id=workspace_id or "",
             enforce_window=False,  # 兜底路径，详见 execute_pending_from_pool docstring
         )
         logger.info(
@@ -122,13 +136,11 @@ class FlushTask:
             logger.info(f"[FlushTask] 处理完成: conv={conversation_id}")
             return
 
-        memory_config = self._load_memory_config(
-            end_user_id=end_user_id,
-            workspace_id=workspace_id,
-        )
+        memory_config = self._load_memory_config(config_id=release_config_id)
         if memory_config is None:
             logger.error(
-                f"[FlushTask] 无法加载 memory_config 处理 assistant 消息: conv={conversation_id}"
+                f"[FlushTask] 无法加载 memory_config 处理 assistant 消息: "
+                f"conv={conversation_id}, config_id={release_config_id}"
             )
             return
 
@@ -205,27 +217,24 @@ class FlushTask:
             )
             return None
 
-    def _has_active_memory_config(self, workspace_id: str | None) -> bool:
-        """检查 workspace 是否存在活跃的 memory_config。
+    def _has_active_memory_config(self, config_id: uuid.UUID | None) -> bool:
+        """检查指定 memory_config 是否存在。
 
         用于在执行 flush 前预校验，避免下层抛 ConfigurationError 产生 ERROR 日志噪音。
         校验自身出错时返回 True（不阻断主流程，让下层兜底处理）。
 
+        说明：``MemoryConfig.state`` 表示"是否为 workspace 当前激活的默认配置"，
+        而 release 中绑定的配置通常并非 workspace 默认（可能是用户自建配置），
+        因此这里只检查存在性，不再过滤 ``state=True``。
+
         Args:
-            workspace_id: 对话所属工作空间 ID（字符串形式）
+            config_id: release 中绑定的 memory_config_id（UUID）
 
         Returns:
-            True 表示 workspace 存在活跃配置或校验失败；False 表示明确无配置应跳过。
+            True 表示配置存在或校验过程异常；False 表示明确不存在应跳过。
         """
-        if not workspace_id:
-            return True
-
-        import uuid as _uuid
-
-        try:
-            ws_uuid = _uuid.UUID(workspace_id)
-        except (ValueError, AttributeError):
-            return True
+        if not config_id:
+            return False
 
         try:
             from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
@@ -233,20 +242,98 @@ class FlushTask:
             with get_db_context() as db:
                 exists = db.execute(
                     select(MemoryConfigModel.config_id)
-                    .where(
-                        MemoryConfigModel.workspace_id == ws_uuid,
-                        MemoryConfigModel.state.is_(True),
-                    )
+                    .where(MemoryConfigModel.config_id == config_id)
                     .limit(1)
                 ).scalar_one_or_none()
                 return exists is not None
         except Exception as e:
             logger.warning(
                 f"[FlushTask] memory_config 预校验异常（继续执行）: "
-                f"workspace={workspace_id}, err={e}",
+                f"config_id={config_id}, err={e}",
                 exc_info=True,
             )
             return True
+
+    def _resolve_release_memory_config_id(
+        self, conversation_id: str
+    ) -> uuid.UUID | None:
+        """从应用当前发布版本的 config 中解析 memory_config_id。
+
+        查询链路：
+            conversations.id → conversations.app_id
+            → apps.current_release_id
+            → app_releases.config["memory"]["memory_config_id"]
+
+        通过 ``MemoryConfigService.extract_memory_config_id`` 解析 release 配置，
+        从而兼容 agent / workflow 类型应用以及旧的 int 形态 config_id_old。
+
+        Args:
+            conversation_id: 对话 ID
+
+        Returns:
+            解析出的 memory_config_id（UUID）；未配置或解析失败时返回 None。
+        """
+        try:
+            from app.services.memory_config_service import MemoryConfigService
+
+            with get_db_context() as db:
+                row = db.execute(
+                    select(
+                        App.id,
+                        App.type,
+                        App.current_release_id,
+                        AppRelease.config,
+                    )
+                    .select_from(Conversation)
+                    .join(App, App.id == Conversation.app_id)
+                    .outerjoin(AppRelease, AppRelease.id == App.current_release_id)
+                    .where(Conversation.id == conversation_id)
+                ).one_or_none()
+
+                if row is None:
+                    logger.warning(
+                        f"[FlushTask] 未找到对话对应的 app 或 release: conv={conversation_id}"
+                    )
+                    return None
+
+                app_id, app_type, current_release_id, release_config = row
+
+                if not current_release_id:
+                    logger.warning(
+                        f"[FlushTask] 应用尚未发布，无法解析 memory_config_id: "
+                        f"conv={conversation_id}, app={app_id}"
+                    )
+                    return None
+
+                if not isinstance(release_config, dict) or not release_config:
+                    logger.warning(
+                        f"[FlushTask] release.config 为空或格式异常: "
+                        f"conv={conversation_id}, app={app_id}, "
+                        f"release={current_release_id}"
+                    )
+                    return None
+
+                config_id, is_legacy_int = MemoryConfigService(db).extract_memory_config_id(
+                    app_type=str(app_type) if app_type else "",
+                    config=release_config,
+                )
+
+                if config_id is None:
+                    logger.warning(
+                        f"[FlushTask] release.config 中未配置 memory_config_id: "
+                        f"conv={conversation_id}, app={app_id}, "
+                        f"release={current_release_id}, is_legacy_int={is_legacy_int}"
+                    )
+                    return None
+
+                return config_id
+        except Exception as e:
+            logger.error(
+                f"[FlushTask] 解析 release memory_config_id 异常: "
+                f"conv={conversation_id}, err={e}",
+                exc_info=True,
+            )
+            return None
 
     def _get_write_cursor(self, conversation_id: str) -> int | None:
         """查询 write_cursor。"""
@@ -298,91 +385,30 @@ class FlushTask:
             )
             return []
 
-    def _load_memory_config(
-        self,
-        end_user_id: str | None = None,
-        workspace_id: str | None = None,
-    ):
-        """加载 memory_config。
+    def _load_memory_config(self, config_id: uuid.UUID):
+        """按指定 ``config_id`` 加载完整 ``MemoryConfig``。
 
-        优先通过 workspace_id 直接加载（workspace 默认配置）。
-        若 workspace_id 为空，回退到通过 end_user_id 查关联配置。
+        ``config_id`` 由 ``_resolve_release_memory_config_id`` 从应用 release
+        中提取，绕过 workspace 默认配置。
 
         Args:
-            end_user_id: 终端用户 ID（回退路径）
-            workspace_id: 工作空间 ID（优先路径）
+            config_id: 要加载的记忆配置 UUID
 
         Returns:
-            MemoryConfig 对象，加载失败时返回 None
+            MemoryConfig 对象；加载失败时返回 None。
         """
         try:
             from app.services.memory_config_service import MemoryConfigService
-            import uuid as _uuid
-
-            # 优先路径：直接用 workspace_id 加载 workspace 默认配置
-            if workspace_id:
-                try:
-                    ws_uuid = _uuid.UUID(str(workspace_id))
-                    with get_db_context() as db:
-                        memory_config = MemoryConfigService(db).load_memory_config(
-                            config_id=None,
-                            workspace_id=ws_uuid,
-                            service_name="FlushTask",
-                        )
-                    return memory_config
-                except Exception as e:
-                    logger.warning(
-                        f"[FlushTask] 通过 workspace_id 加载配置失败，尝试 end_user_id 回退: "
-                        f"workspace_id={workspace_id}, err={e}"
-                    )
-
-            # 回退路径：通过 end_user_id 查关联配置
-            if not end_user_id:
-                logger.error("[FlushTask] workspace_id 和 end_user_id 均为空，无法加载配置")
-                return None
-
-            from app.services.memory_agent_service import get_end_user_connected_config
 
             with get_db_context() as db:
-                connected_config = get_end_user_connected_config(end_user_id, db)
-
-            config_id_raw = connected_config.get("memory_config_id")
-            workspace_id_raw = connected_config.get("workspace_id")
-
-            config_id = None
-            if config_id_raw and config_id_raw != "None":
-                try:
-                    config_id = _uuid.UUID(str(config_id_raw))
-                except (ValueError, AttributeError):
-                    config_id = None
-
-            fallback_workspace_id = None
-            if workspace_id_raw and workspace_id_raw != "None":
-                try:
-                    fallback_workspace_id = _uuid.UUID(str(workspace_id_raw))
-                except (ValueError, AttributeError):
-                    fallback_workspace_id = None
-
-            if config_id is None and fallback_workspace_id is None:
-                logger.error(
-                    f"[FlushTask] 无法解析 config_id 和 workspace_id: "
-                    f"end_user_id={end_user_id}"
-                )
-                return None
-
-            with get_db_context() as db:
-                memory_config = MemoryConfigService(db).load_memory_config(
+                return MemoryConfigService(db).load_memory_config(
                     config_id=config_id,
-                    workspace_id=fallback_workspace_id,
+                    workspace_id=None,
                     service_name="FlushTask",
                 )
-
-            return memory_config
-
         except Exception as e:
             logger.error(
-                f"[FlushTask] 加载 memory_config 失败: "
-                f"end_user_id={end_user_id}, workspace_id={workspace_id}, err={e}",
+                f"[FlushTask] 加载 memory_config 失败: config_id={config_id}, err={e}",
                 exc_info=True,
             )
             return None

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4352,38 +4352,35 @@ def scan_idle_conversations_task() -> None:
 
         logger.info(f"[ScanIdle] 发现 {len(candidate_conv_ids)} 个对话存在未写入消息")
 
-        # 过滤掉无活跃 memory_config 的对话（避免无效派发）
+        # 过滤：确保对话所属 app 已存在已发布版本（current_release_id IS NOT NULL）。
+        # 真正的 memory_config_id 解析（agent / workflow + legacy 兼容）由 FlushTask
+        # 内的 _resolve_release_memory_config_id 完成，这里只做粗筛避免每分钟空跑刷 WARN。
         if candidate_conv_ids:
             try:
-                from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
+                from app.models.app_model import App
 
                 with get_db_context() as db:
-                    # 单条 JOIN 查询：直接按"存在活跃 memory_config"过滤候选对话
-                    # distinct 防止 workspace 配置多条 active 记录导致 conv_id 重复
                     valid_conv_ids = [
                         str(cid) for cid in db.execute(
                             select(Conversation.id)
-                            .join(
-                                MemoryConfigModel,
-                                MemoryConfigModel.workspace_id == Conversation.workspace_id,
-                            )
+                            .join(App, App.id == Conversation.app_id)
                             .where(
                                 Conversation.id.in_(candidate_conv_ids),
-                                MemoryConfigModel.state.is_(True),
+                                App.current_release_id.isnot(None),
                             )
                             .distinct()
                         ).scalars().all()
                     ]
 
-                skipped_no_config = len(candidate_conv_ids) - len(valid_conv_ids)
-                if skipped_no_config:
+                skipped_no_release = len(candidate_conv_ids) - len(valid_conv_ids)
+                if skipped_no_release:
                     logger.info(
-                        f"[ScanIdle] 跳过 {skipped_no_config} 个无活跃 memory_config 的对话"
+                        f"[ScanIdle] 跳过 {skipped_no_release} 个 app 未发布的对话"
                     )
                 candidate_conv_ids = valid_conv_ids
             except Exception as e:
                 logger.warning(
-                    f"[ScanIdle] 过滤无配置对话失败，将走 FlushTask 兜底校验: err={e}"
+                    f"[ScanIdle] 过滤未发布 app 失败，将走 FlushTask 兜底校验: err={e}"
                 )
 
         for conv_id_str in candidate_conv_ids:


### PR DESCRIPTION
## Summary
- 重构 FlushTask 的 memory_config 解析链路：从 workspace 默认配置改为通过 app release 中 `config.memory.memory_config_id` 解析
- `scan_idle_conversations_task` 粗筛条件改为 `current_release_id IS NOT NULL`，细粒度校验下沉到 FlushTask

## Changes
- **`flush_task.py`**: 新增 `_resolve_release_memory_config_id()` 方法，从 app release config 解析 memory_config_id；`_has_active_memory_config` 改为按 config_id 校验；`_load_memory_config` 简化为直接按 config_id 加载
- **`tasks.py`**: 预过滤改为检查 app 已发布（有 release），而非 workspace 默认配置存在

## Test plan
- [ ] 对已发布 app 触发 flush，确认能正确解析 release 中绑定的 memory_config
- [ ] agent / workflow 类型应用及旧 int 形态 config_id_old 兼容性验证
- [ ] app 未发布场景不产生 ERROR 日志噪音

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

从应用的当前版本（release）而不是工作区默认值中解析滑动窗口 FlushTask 的内存配置，并将空闲会话扫描与基于版本的过滤逻辑对齐。

Bug Fixes（错误修复）:
- 通过从绑定的应用版本中解析 `memory_config_id`，防止 FlushTask 使用过期或缺失的工作区级内存配置。
- 通过在解析出的配置 ID 上添加预检查并收紧错误处理逻辑，在内存配置缺失或无效时避免产生 ERROR 级别的噪声日志。

Enhancements（增强改进）:
- 在 FlushTask 中集中处理基于版本的 `memory_config_id` 解析逻辑，包括对不同应用类型以及历史配置 ID 的兼容支持。
- 简化内存配置的加载逻辑，直接以 `config_id` 为键进行加载，将其与工作区及终端用户的回退逻辑解耦。
- 修改空闲会话扫描逻辑，仅为其应用拥有当前版本的会话入队，将更详细的内存配置检查责任下放给 FlushTask。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve sliding window FlushTask memory configuration from the app’s current release instead of workspace defaults and align idle conversation scanning with release-based filtering.

Bug Fixes:
- Prevent FlushTask from using outdated or missing workspace-level memory configurations by resolving memory_config_id from the bound app release.
- Avoid ERROR-level noise when memory configuration is missing or invalid by adding pre-checks on resolved config IDs and tightening error handling.

Enhancements:
- Centralize release-based memory_config_id resolution in FlushTask, including compatibility with different app types and legacy config IDs.
- Simplify memory configuration loading to be keyed directly by config_id, decoupling it from workspace and end-user fallbacks.
- Change idle conversation scanning to only enqueue conversations whose apps have a current release, delegating detailed memory config checks to FlushTask.

</details>