### PR TITLE
fix(web): table request add AbortController

### DIFF
--- a/web/src/components/Table/index.tsx
+++ b/web/src/components/Table/index.tsx
@@ -111,6 +111,7 @@ const RbTable = forwardRef(<T = Record<string, unknown>, Q = Record<string, unkn
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [computedScrollY, setComputedScrollY] = useState<number | undefined>(undefined)
   const debounceTimerRef = useRef<number | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
 
   // fillHeight 模式：用 ResizeObserver 动态计算 tbody 可用高度
   const measureHeight = useCallback(() => {
@@ -142,16 +143,16 @@ const RbTable = forwardRef(<T = Record<string, unknown>, Q = Record<string, unkn
 
   /** Initialize table and load data from first page with debounce */
   const loadData = () => {
+    if (!apiUrl) return
+
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current)
     }
     debounceTimerRef.current = setTimeout(() => {
-      if (apiUrl) {
-        getList({
-          ...currentPagination,
-          page: 1
-        })
-      }
+      getList({
+        ...currentPagination,
+        page: 1
+      })
     }, 300)
   }
 
@@ -160,6 +161,14 @@ const RbTable = forwardRef(<T = Record<string, unknown>, Q = Record<string, unkn
     if (!apiUrl) {
       return
     }
+
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort()
+    }
+
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+
     let params = dealSo(apiParams || {})
     if (pagination) {
       setCurrentPagination({
@@ -170,7 +179,7 @@ const RbTable = forwardRef(<T = Record<string, unknown>, Q = Record<string, unkn
     }
     setLoading(true)
     /** Build query parameters and call API */
-    request.get(apiUrl, params)
+    request.get(apiUrl, params, { signal: abortController.signal })
       .then((res: any) => {
         /** Support two response formats: direct total or total in page object */
         const totalCount = res.page?.total ?? res.total ?? 0;
@@ -179,7 +188,9 @@ const RbTable = forwardRef(<T = Record<string, unknown>, Q = Record<string, unkn
         setLoading(false)
       })
       .catch(err => {
-        console.log('err', err)
+        if (err.name !== 'AbortError') {
+          console.log('err', err)
+        }
         setLoading(false)
       })
   }


### PR DESCRIPTION
## Summary by Sourcery

使用 AbortController 为表格数据获取逻辑添加请求取消支持，以防止过时或重叠的 API 调用。

Bug 修复：
- 确保在缺少 `apiUrl` 时不会发送表格数据请求。
- 通过在发起新请求时中止进行中的表格请求，并忽略 `AbortError` 响应，防止竞争条件和不必要的日志输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add request cancellation support to the table data fetching logic using AbortController to prevent outdated or overlapping API calls.

Bug Fixes:
- Ensure table data requests are not sent when apiUrl is missing.
- Prevent race conditions and unnecessary logging by aborting in-flight table requests when a new one is initiated and ignoring AbortError responses.

</details>