### PR TITLE
fix(web): regenerate message version

### DIFF
--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -172,8 +172,10 @@ const ChatContent: FC<ChatContentProps> = ({
     }
     return items
   }
-  const handlePageChange = (page: number, item: ChatItem[]) => {
-    handleVersionChange?.(page, item[page - 1])
+  const handlePageChange = (page: number, vo: ChatItem[]) => {
+    const nextItem = vo.find(v => v.version === page)
+    if (!nextItem) return
+    handleVersionChange?.(page, nextItem)
   }
   return (
     <div ref={scrollContainerRef} className={clsx("rb:relative rb:overflow-y-auto", classNames)}>
@@ -319,7 +321,7 @@ const ChatContent: FC<ChatContentProps> = ({
                                 current={item.version}
                                 defaultCurrent={item.version}
                                 total={vo.length}
-                                onChange={(page) => handlePageChange(page, vo)}
+                                onChange={(page: number) => handlePageChange(page, vo)}
                               />
                             }
                             {handleFeedback && <>

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -281,11 +281,11 @@ const Conversation: FC = () => {
           const newFilterItem = [
             ...(Array.isArray(lastChatList[filterIndex])
               ? [...lastChatList[filterIndex].map(v => ({ ...v, is_current: false }))]
-              : [{...filterItem, is_current: false}]
+              : [{...filterItem, version: 1, is_current: false}]
             ),
             {
               ...assistantMsg,
-              version: Array.isArray(lastChatList[filterIndex]) ? lastChatList[filterIndex].length + 2 : 2
+              version: Array.isArray(lastChatList[filterIndex]) ? lastChatList[filterIndex].length + 1 : 2
             }
           ]
           lastChatList[filterIndex] = newFilterItem
@@ -761,12 +761,12 @@ const Conversation: FC = () => {
           if (filterIndex < 0) return lastList
           
           const currentItem: ChatItem[] = lastList[filterIndex] as ChatItem[]
-          lastList[filterIndex] = currentItem.map(msg => {
+          lastList[filterIndex] = [...currentItem.map(msg => {
             return {
               ...msg,
               is_current: msg.id === item.id,
             }
-          })
+          })]
 
           return [...lastList]
         })


### PR DESCRIPTION
## Summary by Sourcery

调整网页会话界面中聊天消息版本处理与当前消息状态的更新。

Bug 修复：
- 在基于页面的版本切换时，通过匹配版本号而不是数组索引来选择正确的聊天条目。
- 在对会话中的助手消息进行重新生成时，修正初始和后续的版本编号。
- 通过克隆映射后的数组来更新当前聊天条目列表，以避免状态被意外修改的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust chat message version handling and current message state updates in the web conversation UI.

Bug Fixes:
- Ensure page-based version changes select the correct chat item by matching on version instead of array index.
- Correct initial and subsequent version numbering when regenerating assistant messages in a conversation.
- Fix updating of the current chat item list by cloning the mapped array to avoid state mutation issues.

</details>