### PR TITLE
fix(web): model config support thinking only

### DIFF
--- a/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
@@ -386,7 +386,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
                           name={[field, 'enable']}
                           noStyle
                         >
-                          <Switch disabled={isThinkingOnly} />
+                          <Switch disabled={isThinkingOnly && field === 'thinking'} />
                         </FormItem>
                         <Flex align="center" gap={4}>
                           {t(`workflow.config.llm.${field}`)}
@@ -439,7 +439,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
                             name={[field, 'budget', 'enable']}
                             noStyle
                           >
-                            <Switch disabled={isThinkingOnly} />
+                            <Switch disabled={isThinkingOnly && field === 'thinking'} />
                           </FormItem>
                           <Flex align="center" gap={4}>
                             {t(`workflow.config.llm.${field}_budget`)}


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当启用仅思考模式（thinking-only mode）时，允许与思考无关的字段和预算保持可配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow non-thinking fields and budgets to remain configurable when thinking-only mode is enabled.

</details>