### PR TITLE
feat(llm): add business debug logging for penalty parameters

### DIFF
--- a/api/app/core/models/llm.py
+++ b/api/app/core/models/llm.py
@@ -260,6 +260,19 @@ class RedBearLLM(BaseLLM):
         """
         llm_class = get_provider_llm_class(config, type)
         model_params = RedBearModelFactory.get_model_params(config)
+
+        # ===== 调试日志：追踪惩罚参数是否真正传入 =====
+        penalty_keys = {"repetition_penalty", "frequency_penalty", "presence_penalty"}
+        penalty_in_params = {k: v for k, v in model_params.items() if k in penalty_keys}
+        import logging
+        _penalty_logger = logging.getLogger("business")
+        _penalty_logger.info(
+            f"[LLM惩罚参数追踪] provider={config.provider}, model={config.model_name}, "
+            f"llm_class={llm_class.__name__}, "
+            f"penalty_params={penalty_in_params or '无'}"
+        )
+        # ===== 调试日志 END =====
+
         return llm_class(**model_params)
     
     def get_config(self) -> RedBearModelConfig:


### PR DESCRIPTION
Add business debug logs for LLM penalty parameters to trace whether parameters such as `repetition_penalty` are passed correctly.

## 由 Sourcery 提供的总结

新功能：
- 在创建模型时，将与 LLM 惩罚相关的参数记录到业务日志中，以便调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Log LLM penalty-related parameters to the business logger during model creation for debugging.

</details>