### PR TITLE
fix(web): chat share image only show current message

### DIFF
--- a/web/src/views/Conversation/components/ShareModal.tsx
+++ b/web/src/views/Conversation/components/ShareModal.tsx
@@ -14,7 +14,7 @@ import html2canvas from 'html2canvas'
 
 import type {  ShareModalRef } from '../types'
 import RbModal from '@/components/RbModal'
-import { generateShareLink } from '@/api/application'
+import { generateShareLink, getConversationDetail } from '@/api/application'
 import RbAlert from '@/components/RbAlert'
 import ChatContent from '@/components/Chat/ChatContent';
 import type { ChatItem } from '@/components/Chat/types';
@@ -25,7 +25,6 @@ import type { ChatItem } from '@/components/Chat/types';
 interface ShareModalProps {
   /** Version to share */
   conversationId: string | null;
-  chatList: Array<ChatItem | ChatItem[]>;
   streamLoading: boolean;
   shareToken: string | null;
 }
@@ -35,7 +34,6 @@ interface ShareModalProps {
  */
 const ShareModal = forwardRef<ShareModalRef, ShareModalProps>(({
   conversationId,
-  chatList,
   streamLoading,
   shareToken,
 }, ref) => {
@@ -45,6 +43,7 @@ const ShareModal = forwardRef<ShareModalRef, ShareModalProps>(({
   const [loading, setLoading] = useState(false)
   const [shareLink, setShareLink] = useState<string | null>(null)
   const chatContentRef = useRef<HTMLDivElement>(null)
+  const [chatList, setChatList] = useState<Array<ChatItem | ChatItem[]>>([])
 
   /** Close modal */
   const handleClose = () => {
@@ -57,6 +56,7 @@ const ShareModal = forwardRef<ShareModalRef, ShareModalProps>(({
     if (!conversationId || !shareToken || shareToken === '') {
       return
     }
+
     setLoading(true)
     generateShareLink(shareToken, conversationId, { allow_copy: true })
       .then(res => {
@@ -69,7 +69,24 @@ const ShareModal = forwardRef<ShareModalRef, ShareModalProps>(({
       .finally(() => {
         setLoading(false)
       })
+    getChatDetail()
   };
+
+  const getChatDetail = () => {
+    if (!conversationId || !shareToken || shareToken === '') return
+    getConversationDetail(shareToken, conversationId)
+      .then(res => {
+        const response = res as { messages: ChatItem[] }
+        const messages = response?.messages || []
+        setChatList(messages.map(msg => {
+          if (Array.isArray(msg)) {
+            return msg.filter(item => item.is_current)
+          }
+          msg.status = msg.role === 'user' ? undefined : msg.status
+          return msg
+        }))
+      })
+  }
   /** Copy share link to clipboard */
   const handleCopy = () => {
     if (!shareLink) return

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -1030,7 +1030,6 @@ const Conversation: FC = () => {
         <ShareModal
           ref={shareModalRef}
           conversationId={conversation_id as string}
-          chatList={chatList}
           streamLoading={streamLoadingRef.current}
           shareToken={shareToken as string}
         />
@@ -1222,7 +1221,6 @@ const Conversation: FC = () => {
       <ShareModal
         ref={shareModalRef}
         conversationId={conversation_id as string}
-        chatList={chatList}
         streamLoading={streamLoadingRef.current}
         shareToken={shareToken as string}
       />


### PR DESCRIPTION
## Summary by Sourcery

在会话视图中生成分享链接时，将共享聊天内容限制为当前消息。

Bug Fixes:
- 确保在分享弹窗中获取共享聊天数据，并进行过滤，使只有当前消息被包含在共享内容中。

Enhancements:
- 通过让分享弹窗自行加载聊天消息，而不是依赖传入的状态，将分享弹窗与主会话组件解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit shared chat content to the current message when generating share links in the conversation view.

Bug Fixes:
- Ensure shared chat data is fetched within the share modal and filtered so only the current message is included in the shared content.

Enhancements:
- Decouple the share modal from the main conversation component by having it load its own chat messages instead of relying on passed-in state.

</details>