### PR TITLE
feat(rag): support chunk_type for parent-child chunk creation

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -565,6 +565,25 @@ async def create_chunk(
             detail="The document does not exist or you do not have permission to access it"
         )
 
+    # 校验 chunk_type 与文档分块模式的一致性
+    if db_document.is_parent_child_mode:
+        if create_data.chunk_type not in (chunk_schema.ChunkType.PARENT, chunk_schema.ChunkType.CHILD):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="父子分块模式下仅允许创建 parent 或 child 类型块"
+            )
+        if create_data.chunk_type == chunk_schema.ChunkType.CHILD and not create_data.parent_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="创建子块时必须提供 parent_id"
+            )
+    else:
+        if create_data.chunk_type in (chunk_schema.ChunkType.PARENT, chunk_schema.ChunkType.CHILD):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="当前文档未启用父子分块模式，不允许创建 parent/child 类型块"
+            )
+
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
     # 2. Get the sort ID
@@ -584,8 +603,9 @@ async def create_chunk(
         "knowledge_id": str(kb_id),
         "sort_id": sort_id,
         "status": 1,
+        **create_data.type_metadata,
     }
-    # QA chunk: 注入 chunk_type/question/answer 到 metadata
+    # QA chunk: 注入 question/answer 到 metadata
     if create_data.is_qa:
         metadata.update(create_data.qa_metadata)
     chunk = DocumentChunk(page_content=content, metadata=metadata)
@@ -626,6 +646,27 @@ async def create_chunks_batch(
     if not db_document:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The document does not exist or you do not have permission to access it")
 
+    # 批量校验 chunk_type
+    if db_document.is_parent_child_mode:
+        for item in batch_data.items:
+            if item.chunk_type not in (chunk_schema.ChunkType.PARENT, chunk_schema.ChunkType.CHILD):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="父子分块模式下仅允许创建 parent 或 child 类型块"
+                )
+            if item.chunk_type == chunk_schema.ChunkType.CHILD and not item.parent_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="创建子块时必须提供 parent_id"
+                )
+    else:
+        for item in batch_data.items:
+            if item.chunk_type in (chunk_schema.ChunkType.PARENT, chunk_schema.ChunkType.CHILD):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="当前文档未启用父子分块模式，不允许创建 parent/child 类型块"
+                )
+
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
     # Get current max sort_id
@@ -647,6 +688,7 @@ async def create_chunks_batch(
             "knowledge_id": str(kb_id),
             "sort_id": sort_id,
             "status": 1,
+            **create_data.type_metadata,
         }
         if create_data.is_qa:
             metadata.update(create_data.qa_metadata)

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -13,10 +13,20 @@ class RetrieveType(StrEnum):
     Graph = "graph"
 
 
+class ChunkType(StrEnum):
+    """Chunk type enumeration"""
+    CHUNK = "chunk"
+    PARENT = "parent"
+    CHILD = "child"
+    QA = "qa"
+
+
 class ChunkCreate(BaseModel):
     content: Union[str, QAChunk] = Field(
         description="Content can be either a string or a QAChunk object"
     )
+    chunk_type: ChunkType = Field(default=ChunkType.CHUNK, description="chunk 类型")
+    parent_id: str | None = Field(default=None, description="父块 doc_id（仅 child 类型必填）")
 
     @property
     def chunk_content(self) -> str:
@@ -27,7 +37,7 @@ class ChunkCreate(BaseModel):
 
     @property
     def is_qa(self) -> bool:
-        return isinstance(self.content, QAChunk)
+        return isinstance(self.content, QAChunk) or self.chunk_type == ChunkType.QA
 
     @property
     def qa_metadata(self) -> dict:
@@ -39,6 +49,14 @@ class ChunkCreate(BaseModel):
                 "answer": self.content.answer,
             }
         return {}
+
+    @property
+    def type_metadata(self) -> dict:
+        """根据 chunk_type 返回对应的 metadata 字段"""
+        meta = {"chunk_type": self.chunk_type.value}
+        if self.chunk_type == ChunkType.CHILD and self.parent_id:
+            meta["parent_id"] = self.parent_id
+        return meta
 
 
 class ChunkUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- ChunkCreate schema: add chunk_type (chunk/parent/child/qa) and parent_id fields
- Single creation: validate chunk_type against document's parent_child_mode
- Batch creation: same validation per item
- Parent-child documents: only allow parent/child types, child requires parent_id
- Normal documents: reject parent/child types
- Type metadata auto-injected into ES metadata (chunk_type, parent_id)

## Changes

## Summary by Sourcery

为“typed chunks”提供支持，并根据文档的父子模式（parent-child mode）强制执行父子块创建规则。

新功能：
- 在块创建时引入 `chunk_type` 字段和可选的 `parent_id`，以区分普通块、父块、子块和 QA 块。
- 自动将块类型和父子关系元数据注入到存储的块元数据中，包括 Elasticsearch 负载。

增强内容：
- 在单个和批量块创建时验证 `chunk_type` 和 `parent_id`，以与文档的父子配置保持一致。
- 扩展 QA 检测逻辑，在基于 QA 内容结构的基础上，额外考虑显式的 QA `chunk_type`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for typed chunks and enforce parent-child chunk creation rules based on the document’s parent-child mode.

New Features:
- Introduce a chunk_type field and optional parent_id for chunk creation to distinguish between normal, parent, child, and QA chunks.
- Automatically inject chunk type and parent-child relationship metadata into stored chunk metadata, including Elasticsearch payloads.

Enhancements:
- Validate chunk_type and parent_id during single and batch chunk creation to align with the document’s parent-child configuration.
- Extend QA detection logic to consider the explicit QA chunk_type in addition to the QA content structure.

</details>