### PR TITLE
feat(reflection): add reflection log display query APIs

### DIFF
--- a/api/app/controllers/memory_reflection_controller.py
+++ b/api/app/controllers/memory_reflection_controller.py
@@ -43,7 +43,19 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.utils.config_utils import resolve_config_id
-
+from typing import Optional
+from fastapi import Query, Path
+from app.repositories.reflection_log_repository import ReflectionLogRepository
+from app.schemas.memory_reflection_schemas import (
+    ReflectionLogListItem,
+    ReflectionLogDetail,
+    SubProblemEnum,
+    TriggerTypeEnum,
+    LogStatusEnum,
+)
+from app.core.response_utils import fail
+from app.core.error_codes import BizCode
+from app.models.end_user_model import EndUser
 # Load environment variables for configuration
 load_dotenv()
 
@@ -56,6 +68,132 @@ router = APIRouter(
     tags=["Memory"],
 )
 
+@router.get("/reflection/logs/stats")
+def get_reflection_log_stats(
+    end_user_id: str = Query(..., description="终端用户ID"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """获取反思日志统计概览
+
+    返回该用户的日志总数、各子问题数量、各状态数量和处理率。
+    用于顶部子问题卡片和统计面板。
+    """
+    try:
+        end_user_uuid = uuid.UUID(end_user_id)
+    except (ValueError, AttributeError):
+        return fail(BizCode.INVALID_PARAMETER, "请求参数无效", "无效的终端用户ID格式")
+
+    api_logger.info(f"用户 {current_user.username} 查询反思日志统计: end_user_id={end_user_id}")
+
+    try:
+        # 校验终端用户是否存在
+        from app.repositories.end_user_repository import EndUserRepository
+        end_user_repo = EndUserRepository(db)
+        end_user = end_user_repo.get_end_user_by_id(end_user_uuid)
+        if end_user is None:
+            return fail(BizCode.USER_NOT_FOUND, f"终端用户不存在: {end_user_id}", "end_user not found")
+
+        repo = ReflectionLogRepository(db)
+        stats = repo.get_stats(end_user_id)
+        return success(data=stats, msg="反思日志统计获取成功")
+    except Exception as e:
+        api_logger.error(f"查询反思日志统计失败: end_user_id={end_user_id}, error={e}")
+        return fail(BizCode.INTERNAL_ERROR, "查询统计失败", str(e))
+
+
+@router.get("/reflection/logs/{log_id}")
+def get_reflection_log_detail(
+    log_id: str = Path(..., description="日志ID"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """获取反思日志详情
+
+    返回单条日志的完整信息，包含 trigger_detail、solution_detail、execution_detail。
+    前端根据 sub_problem 字段条件渲染 trigger_detail 区域。
+    """
+    try:
+        uuid.UUID(log_id)
+    except (ValueError, AttributeError):
+        return fail(BizCode.INVALID_PARAMETER, "请求参数无效", "无效的日志ID格式")
+
+    api_logger.info(f"用户 {current_user.username} 查询反思日志详情: log_id={log_id}")
+
+    try:
+        repo = ReflectionLogRepository(db)
+        log = repo.get_by_id(log_id)
+        if not log:
+            return fail(BizCode.NOT_FOUND, "日志不存在")
+        detail = ReflectionLogDetail.model_validate(log)
+        return success(data=detail.model_dump(mode="json"), msg="反思日志详情获取成功")
+    except Exception as e:
+        api_logger.error(f"查询反思日志详情失败: log_id={log_id}, error={e}")
+        return fail(BizCode.INTERNAL_ERROR, "查询详情失败", str(e))
+
+
+@router.get("/reflection/logs")
+def get_reflection_logs(
+    end_user_id: str = Query(..., description="终端用户ID"),
+    sub_problem: Optional[SubProblemEnum] = Query(None, description="子问题类型筛选"),
+    status: Optional[LogStatusEnum] = Query(None, description="状态筛选"),
+    trigger_type: Optional[TriggerTypeEnum] = Query(None, description="触发方式筛选"),
+    page: int = Query(1, ge=1, description="页码，从1开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """获取反思日志列表（分页）
+
+    支持按 sub_problem、status、trigger_type 筛选。
+    按 created_at 倒序排列。
+    """
+    try:
+        end_user_uuid = uuid.UUID(end_user_id)
+    except (ValueError, AttributeError):
+        return fail(BizCode.INVALID_PARAMETER, "请求参数无效", "无效的终端用户ID格式")
+
+    api_logger.info(
+        f"用户 {current_user.username} 查询反思日志列表: "
+        f"end_user_id={end_user_id}, sub_problem={sub_problem}, "
+        f"status={status}, page={page}, pagesize={pagesize}"
+    )
+
+    try:
+        # 校验终端用户是否存在
+        from app.repositories.end_user_repository import EndUserRepository
+        end_user_repo = EndUserRepository(db)
+        end_user = end_user_repo.get_end_user_by_id(end_user_uuid)
+        if end_user is None:
+            return fail(BizCode.USER_NOT_FOUND, f"终端用户不存在: {end_user_id}", "end_user not found")
+
+        repo = ReflectionLogRepository(db)
+        total, items = repo.get_paginated(
+            end_user_id=end_user_id,
+            page=page,
+            pagesize=pagesize,
+            sub_problem=sub_problem.value if sub_problem else None,
+            status=status.value if status else None,
+            trigger_type=trigger_type.value if trigger_type else None,
+        )
+
+        data_items = [
+            ReflectionLogListItem.model_validate(log).model_dump(mode="json")
+            for log in items
+        ]
+
+        return success(data={
+            "items": data_items,
+            "page": {
+                "page": page,
+                "pagesize": pagesize,
+                "total": total,
+                "hasnext": (page * pagesize) < total,
+            },
+        }, msg="反思日志列表获取成功")
+    except Exception as e:
+        api_logger.error(f"查询反思日志列表失败: end_user_id={end_user_id}, error={e}")
+        return fail(BizCode.INTERNAL_ERROR, "查询日志列表失败", str(e))
 
 @router.post("/reflection/save")
 async def save_reflection_config(

--- a/api/app/repositories/reflection_log_repository.py
+++ b/api/app/repositories/reflection_log_repository.py
@@ -1,7 +1,8 @@
 """反思日志 Repository"""
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional,Tuple
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 from app.models.reflection_log_model import MemoryReflectionLog
 
 
@@ -37,3 +38,112 @@ class ReflectionLogRepository:
         self.db.add(log)
         self.db.commit()
         return log
+
+    def get_paginated(
+        self,
+        end_user_id: str,
+        page: int = 1,
+        pagesize: int = 10,
+        sub_problem: Optional[str] = None,
+        status: Optional[str] = None,
+        trigger_type: Optional[str] = None,
+    ) -> Tuple[int, list]:
+        """分页查询反思日志
+
+        Args:
+            end_user_id: 终端用户 ID
+            page: 页码（从1开始）
+            pagesize: 每页数量
+            sub_problem: 子问题类型筛选（可选）
+            status: 状态筛选（可选）
+            trigger_type: 触发方式筛选（可选）
+
+        Returns:
+            (total, items): 总数和当前页 ORM 对象列表
+        """
+        query = self.db.query(MemoryReflectionLog).filter(
+            MemoryReflectionLog.end_user_id == uuid.UUID(end_user_id)
+        )
+
+        if sub_problem:
+            query = query.filter(MemoryReflectionLog.sub_problem == sub_problem)
+        if status:
+            query = query.filter(MemoryReflectionLog.status == status)
+        if trigger_type:
+            query = query.filter(MemoryReflectionLog.trigger_type == trigger_type)
+
+        total = query.count()
+        items = query.order_by(
+            MemoryReflectionLog.created_at.desc()
+        ).offset((page - 1) * pagesize).limit(pagesize).all()
+
+        return total, items
+
+
+    def get_by_id(self, log_id: str) -> Optional[MemoryReflectionLog]:
+        """按 ID 查询单条日志
+
+        Args:
+            log_id: 日志 UUID 字符串
+
+        Returns:
+            MemoryReflectionLog 或 None
+        """
+        return self.db.query(MemoryReflectionLog).filter(
+            MemoryReflectionLog.id == uuid.UUID(log_id)
+        ).first()
+
+
+    def get_stats(self, end_user_id: str) -> Dict[str, Any]:
+        """统计查询：按子问题和状态分组计数
+
+        Args:
+            end_user_id: 终端用户 ID
+
+        Returns:
+            {
+                "total": int,
+                "sub_problem": {"entity_dedup": 28, ...},
+                "status": {"resolved": 42, "recorded": 5},
+                "resolve_rate": 0.89
+            }
+        """
+        base = self.db.query(MemoryReflectionLog).filter(
+            MemoryReflectionLog.end_user_id == uuid.UUID(end_user_id)
+        )
+
+        total = base.count()
+
+        # 按 sub_problem 分组计数
+        sub_counts = dict(
+            base.with_entities(
+                MemoryReflectionLog.sub_problem,
+                func.count()
+            ).group_by(MemoryReflectionLog.sub_problem).all()
+        )
+
+        # 按 status 分组计数
+        status_counts = dict(
+            base.with_entities(
+                MemoryReflectionLog.status,
+                func.count()
+            ).group_by(MemoryReflectionLog.status).all()
+        )
+
+        # 补全所有枚举值（确保前端拿到完整结构）
+        from app.schemas.memory_reflection_schemas import SubProblemEnum
+        all_sub_problems = [e.value for e in SubProblemEnum]
+        sub_problem = {sp: sub_counts.get(sp, 0) for sp in all_sub_problems}
+        status = {
+            "resolved": status_counts.get("resolved", 0),
+            "recorded": status_counts.get("recorded", 0),
+        }
+
+        resolve_rate = round(status["resolved"] / total, 2) if total > 0 else 0.0
+
+        return {
+            "total": total,
+            "sub_problem": sub_problem,
+            "status": status,
+            "resolve_rate": resolve_rate,
+        }

--- a/api/app/schemas/memory_reflection_schemas.py
+++ b/api/app/schemas/memory_reflection_schemas.py
@@ -1,7 +1,8 @@
 import uuid
+from datetime import datetime
 
-from pydantic import BaseModel, Field
-from typing import Optional, Union
+from pydantic import BaseModel, Field, ConfigDict, field_serializer
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 from enum import Enum
 
@@ -11,6 +12,69 @@ class OptimizationStrategy(str, Enum):
     SPEED_FIRST = "speed_first"
     ACCURACY_FIRST = "accuracy_first"
     BALANCED = "balanced"
+
+class SubProblemEnum(str, Enum):
+    """反思引擎子问题类型枚举"""
+    ENTITY_DEDUP = "entity_dedup"
+    DESCRIPTION_MERGE = "description_merge"
+    STALE_DETECTION = "stale_detection"
+    FACT_CONTRADICTION = "fact_contradiction"
+    METADATA_VALIDATION = "metadata_validation"
+    UNRESOLVED_ENTITY = "unresolved_entity"
+
+class TriggerTypeEnum(str, Enum):
+    """触发方式枚举"""
+    SCHEDULED = "scheduled"
+    CONVERSATION = "conversation"
+
+class LogStatusEnum(str, Enum):
+    """日志状态枚举"""
+    RESOLVED = "resolved"
+    RECORDED = "recorded"
+
+class ReflectionLogListItem(BaseModel):
+    """列表页单条日志（轻量字段，不含 JSONB 详情）"""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    sub_problem: str
+    trigger_type: str
+    baseline: Optional[str] = None
+    strategy: Optional[str] = None
+    confidence: Optional[float] = None
+    status: str
+    summary_text: Optional[str] = None
+    created_at: datetime
+
+    @field_serializer("created_at", when_used="json")
+    def _serialize_created_at(self, dt: datetime):
+        return int(dt.timestamp() * 1000) if dt else None
+
+class ReflectionLogDetail(BaseModel):
+    """详情页完整日志（含 JSONB 字段）"""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    end_user_id: uuid.UUID
+    sub_problem: str
+    trigger_type: str
+    baseline: Optional[str] = None
+    strategy: Optional[str] = None
+    confidence: Optional[float] = None
+    status: str
+    summary_text: Optional[str] = None
+    entity_ids: Optional[List[str]] = None
+    statement_ids: Optional[List[str]] = None
+    trigger_detail: Optional[Dict[str, Any]] = None
+    solution_detail: Optional[Dict[str, Any]] = None
+    execution_detail: Optional[Dict[str, Any]] = None
+    created_at: datetime
+
+    @field_serializer("created_at", when_used="json")
+    def _serialize_created_at(self, dt: datetime):
+        return int(dt.timestamp() * 1000) if dt else None
+
+
 class Memory_Reflection(BaseModel):
     config_id:  Union[uuid.UUID, int, str]  = None
     reflection_enabled: bool


### PR DESCRIPTION
Add 3 endpoints for reflection log display:
- GET /reflection/logs/stats: statistics overview
- GET /reflection/logs/{log_id}: single log detail
- GET /reflection/logs: paginated list with filters

## Summary by Sourcery

为终端用户添加用于查询和展示记忆反思日志的 API，以及配套的仓储和数据结构。

New Features:
- 暴露统计接口，用于获取指定终端用户的聚合反思日志指标。
- 暴露详情接口，用于获取单条反思日志的完整 JSON 详情。
- 暴露分页列表接口，用于浏览反思日志，并支持按子问题、状态和触发类型进行筛选。

Enhancements:
- 扩展反思日志仓储，新增用于分页查询、单条日志获取以及聚合统计计算的方法。
- 引入用于反思日志列表项和详细记录的枚举和视图模型，并对时间戳进行序列化以便前端使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add APIs and supporting repository and schema structures to query and present memory reflection logs for end users.

New Features:
- Expose a statistics endpoint to retrieve aggregated reflection log metrics for a given end user.
- Expose a detail endpoint to retrieve a single reflection log with full JSON details.
- Expose a paginated list endpoint to browse reflection logs with filtering by sub-problem, status, and trigger type.

Enhancements:
- Extend the reflection log repository with methods for paginated queries, single-log retrieval, and aggregated statistics computation.
- Introduce enums and view models for reflection log list items and detailed records, including timestamp serialization for frontend consumption.

</details>