### PR TITLE
feat(memory): add dialog_at field and wire entity name embeddings

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -1089,7 +1089,8 @@ class WritePipeline:
             logger.info(f"[LanguageDetect][run_with_window] detected={detected}, language={self.language}, text_len={len(user_content)}")
 
         _dialog_at = (
-            dispatch_at
+            target_message.get("dialog_at")
+            or dispatch_at
             or target_message.get("created_at", "")
             or ""
         )

--- a/api/app/core/memory/sliding_window/window_utils.py
+++ b/api/app/core/memory/sliding_window/window_utils.py
@@ -200,6 +200,7 @@ def message_to_dict(message: MemoryMessage) -> dict:
             if message.created_at is not None
             else None
         ),
+        "dialog_at": message.dialog_at,
         "files": message.files,
     }
 
@@ -453,6 +454,7 @@ async def write_batch_to_memory_messages(
                 message_seq=next_seq,
                 should_memorize=True,
                 created_at=datetime.now(timezone.utc),
+                dialog_at=(msg.get("dialog_at") or None),
                 files=msg.get("files"),
             )
             db.add(mm)

--- a/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
+++ b/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
@@ -834,6 +834,10 @@ class NewExtractionOrchestrator:
         assigned_stmt_emb = 0
         assigned_chunk_emb = 0
         assigned_dialog_emb = 0
+        assigned_entity_emb = 0
+
+        # Embedding lookup table (key: f"{entity_idx}_{name}" — matches _build_entity_embedding_input)
+        entity_emb_map = embedding_output.entity_embeddings if embedding_output else {}
 
         for dialog in dialog_data_list:
             dialog_stmts = all_stmt_results.get(dialog.id, {})
@@ -876,9 +880,11 @@ class NewExtractionOrchestrator:
                                 type_description=getattr(e, "type_description", ""),
                                 description=e.description,
                                 is_explicit_memory=e.is_explicit_memory,
+                                name_embedding=entity_emb_map.get(f"{e.entity_idx}_{e.name}"),
                             )
                             for e in triplet_out.entities
                         ]
+                        assigned_entity_emb += sum(1 for e in entities if e.name_embedding)
                         triplets = [
                             TripletRelation(
                                 subject_name=t.subject_name,
@@ -942,11 +948,12 @@ class NewExtractionOrchestrator:
 
         logger.info(
             "Data assignment complete — statements: %d, triplets: %d, "
-            "emotions: %d, stmt_emb: %d, chunk_emb: %d, dialog_emb: %d",
+            "emotions: %d, stmt_emb: %d, chunk_emb: %d, dialog_emb: %d, entity_emb: %d",
             total_stmts,
             assigned_triplets,
             assigned_emotions,
             assigned_stmt_emb,
             assigned_chunk_emb,
             assigned_dialog_emb,
+            assigned_entity_emb,
         )

--- a/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
+++ b/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
@@ -884,7 +884,7 @@ class NewExtractionOrchestrator:
                             )
                             for e in triplet_out.entities
                         ]
-                        assigned_entity_emb += sum(1 for e in entities if e.name_embedding)
+                        assigned_entity_emb += sum(1 for e in entities if e.name_embedding is not None)
                         triplets = [
                             TripletRelation(
                                 subject_name=t.subject_name,

--- a/api/app/models/memory_message_model.py
+++ b/api/app/models/memory_message_model.py
@@ -66,6 +66,15 @@ class MemoryMessage(Base):
     # 多模态文件信息（工作流 MemoryWriteNode 传入）
     files = Column(JSON, nullable=True, comment="文件信息列表，FileInput.model_dump(mode='json')")
 
+    # 业务侧会话发生时间（ISO 8601 字符串），由 API 调用方提供。
+    # 与 created_at 的区别：created_at 是入库时刻，dialog_at 是会话真正发生的时刻。
+    # 用于温度衰减、时间相关萃取（dialog_at 进入 jinja2 prompt 锚定相对时间）。
+    dialog_at = Column(
+        String(64),
+        nullable=True,
+        comment="业务侧会话发生时间（ISO 8601），调用方未提供时为 NULL",
+    )
+
     # 时间戳
     created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
 


### PR DESCRIPTION
Add dialog_at column to MemoryMessage for business-side conversation timestamps, wired through serialization, write pipeline resolution, and batch creation. Wire entity name embeddings into extraction pipeline orchestrator with embedding lookup and assignment tracking.

## Summary by Sourcery

为记忆消息添加业务侧对话时间戳支持，并将实体名称向量嵌入集成到抽取管线的结果中。

新功能：
- 在记忆消息上存储业务侧的 `dialog_at` 时间戳，将其在序列化和批次创建流程中向下传递，并在写入管线中将其作为对话时间的主要来源。
- 在抽取管线的编排器中，将预先计算好的实体名称向量嵌入附加到抽取出的实体上，并在日志中跟踪相关的分配指标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for business-side dialog timestamps on memory messages and wire entity name embeddings into the extraction pipeline results.

New Features:
- Store a business-side dialog_at timestamp on memory messages, propagate it through serialization and batch creation, and use it as the primary source for dialog time in the write pipeline.
- Attach precomputed entity name embeddings to extracted entities in the extraction pipeline orchestrator and track assignment metrics in logging.

</details>