### PR TITLE
fix(rag): handle missing API keys and set default top_k value

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -988,10 +988,8 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
-            # api_logger.debug(f"Rerank result before: {rs}")
             rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
             rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
-            # api_logger.debug(f"Rerank result  after: {rs}")
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -966,17 +966,20 @@ async def retrieve_chunks(
 
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
+    # default value is topk
+    topn = retrieve_data.top_k
+
     # 1 participle search, 2 semantic search, 3 hybrid search
     match retrieve_data.retrieve_type:
         case chunk_schema.RetrieveType.PARTICIPLE:
-            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
+            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case chunk_schema.RetrieveType.SEMANTIC:
-            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
+            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case _:
-            rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
-            rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
+            rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter)
+            rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter)
             # Efficient deduplication
             seen_ids = set()
             unique_rs = []
@@ -985,8 +988,10 @@ async def retrieve_chunks(
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
+            # api_logger.debug(f"Rerank result before: {rs}")
             rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
             rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
+            # api_logger.debug(f"Rerank result  after: {rs}")
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -934,13 +934,11 @@ class ElasticSearchVectorFactory:
             raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
         if knowledge.reranker is None:
             raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
-        embedding_config = ""
-        if knowledge.embedding.api_keys:
-            embedding_config = knowledge.embedding.api_keys[0]
+        embedding_config = knowledge.embedding.api_keys[0] if knowledge.embedding.api_keys else None
+        if not knowledge.embedding.api_keys:
             logger.warning(f"No embedding api key found for knowledge {knowledge.id}")
-        reranker_config = ""
-        if knowledge.reranker.api_keys:
-            reranker_config = knowledge.reranker.api_keys[0]
+        reranker_config = knowledge.reranker.api_keys[0] if knowledge.reranker.api_keys else None
+        if not knowledge.reranker.api_keys:
             logger.warning(f"No reranker api key found for knowledge {knowledge.id}")
 
         return ElasticSearchVector(

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -554,6 +554,7 @@ class ElasticSearchVector(BaseVector):
 
             docs_and_scores.append((DocumentChunk(page_content=page_content, metadata=metadata), score))
 
+        # docs = [doc for doc, score in docs_and_scores]
         docs = []
         for doc, score in docs_and_scores:
             # check score threshold
@@ -648,7 +649,8 @@ class ElasticSearchVector(BaseVector):
             # Normalize the score to the [0,1] interval
             normalized_score = res["_score"] / max_score
             docs_and_scores.append((DocumentChunk(page_content=page_content, metadata=metadata), normalized_score))
-        
+
+        # docs = [doc for doc, score in docs_and_scores]
         docs = []
         for doc, score in docs_and_scores:
             # check score threshold
@@ -740,43 +742,29 @@ class ElasticSearchVector(BaseVector):
 
     def rerank(self, query: str, docs: list[DocumentChunk], top_k: int) -> list[DocumentChunk]:
         """
-        Reorder the list of document blocks and return the top_k results most relevant to the query
-        Args:
-            query: query string
-            docs: List of document chunk to be rearranged
-            top_k: The number of top-level documents returned
-
-        Returns:
-            Rearranged document chunk list (sorted in descending order of relevance)
-
-        Raises:
-            ValueError: If the input document list is empty or top_k is invalid
+        Reorder the list of document blocks and return the top_k results most relevant to the query.
+        Falls back to the original docs (truncated to top_k) if reranking fails.
         """
-        # parameter validation
         if not docs:
             raise ValueError("retrieval chunks be empty")
         if top_k <= 0:
             raise ValueError("top_k must be a positive integer")
         try:
-            # Convert to LangChain Document object
             documents = [
                 Document(
-                    page_content=doc.page_content,  # Ensure that DocumentChunk possesses this attribute
-                    metadata=doc.metadata or {}  # Deal with possible None metadata
+                    page_content=doc.page_content,
+                    metadata=doc.metadata or {}
                 )
                 for doc in docs
             ]
 
-            # Perform reordering (compress_documents will automatically handle relevance scores and indexing)
             reranked_docs = list(self.reranker.compress_documents(documents, query))
             print(reranked_docs)
 
-            # Sort in descending order based on relevance score
             reranked_docs.sort(
                 key=lambda x: x.metadata.get("relevance_score", 0),
                 reverse=True
             )
-            # Convert back to a list of DocumentChunk, and save the relevance_score to metadata["score"]
             result = []
             for item in reranked_docs[:top_k]:
                 for doc in docs:
@@ -785,7 +773,11 @@ class ElasticSearchVector(BaseVector):
                         result.append(doc)
             return result
         except Exception as e:
-            raise RuntimeError(f"Failed to rerank documents: {str(e)}") from e
+            logger.warning(f"Rerank failed, falling back to original results: {str(e)}")
+            for doc in docs[:top_k]:
+                if doc.metadata is not None and "score" not in doc.metadata:
+                    doc.metadata["score"] = 0.5
+            return docs[:top_k]
 
     def create_collection(
         self,

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -30,7 +30,7 @@ class ElasticSearchVector(BaseVector):
     def __init__(self, index_name: str, client: Elasticsearch,
                  embedding_config: ModelApiKey, reranker_config: ModelApiKey):
         super().__init__(index_name.lower())
-        
+
         # 初始化 Embedding 模型（自动支持火山引擎多模态）
         self.embeddings = RedBearEmbeddings(RedBearModelConfig(
             model_name=embedding_config.model_name,
@@ -39,7 +39,7 @@ class ElasticSearchVector(BaseVector):
             base_url=embedding_config.api_base
         ))
         self.is_multimodal_embedding = self.embeddings.is_multimodal_supported()
-        
+
         self.reranker = RedBearRerank(RedBearModelConfig(
             model_name=reranker_config.model_name,
             provider=reranker_config.provider,
@@ -625,7 +625,7 @@ class ElasticSearchVector(BaseVector):
             query=query_str,
         )
         # logger.info(result)
-        
+
         if "errors" in result:
             raise ValueError(f"Error during query: {result['errors']}")
 
@@ -934,12 +934,20 @@ class ElasticSearchVectorFactory:
             raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
         if knowledge.reranker is None:
             raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
+        embedding_config = ""
+        if knowledge.embedding.api_keys:
+            embedding_config = knowledge.embedding.api_keys[0]
+            logger.warning(f"No embedding api key found for knowledge {knowledge.id}")
+        reranker_config = ""
+        if knowledge.reranker.api_keys:
+            reranker_config = knowledge.reranker.api_keys[0]
+            logger.warning(f"No reranker api key found for knowledge {knowledge.id}")
 
         return ElasticSearchVector(
             index_name=collection_name,
             client=client,
-            embedding_config=knowledge.embedding.api_keys[0],
-            reranker_config=knowledge.reranker.api_keys[0],
+            embedding_config=embedding_config,
+            reranker_config=reranker_config,
         )
 
     @classmethod

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -76,7 +76,7 @@ class ChunkRetrieve(BaseModel):
     file_names_filter: list[str] | None = Field(None)
     similarity_threshold: float | None = Field(None)
     vector_similarity_weight: float | None = Field(None)
-    top_k: int | None = Field(None)
+    top_k: int | None = Field(100, ge=1, le=100)
     retrieve_type: RetrieveType | None = Field(None)
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
 


### PR DESCRIPTION
## Summary
- fix(rerank): graceful fallback when reranker fails — return original docs instead of raising RuntimeError
- fix(rerank): remove redundant logs
- fix(rerank): fix ES instance when invalidation model config
- fix(rag): handle missing API keys and set default top_k value

## Changes
 api/app/controllers/chunk_controller.py            |  11 +-
 .../rag/vdb/elasticsearch/elasticsearch_vector.py  |  48 +++--
 api/app/schemas/chunk_schema.py                    |   2 +-
 3 files changed, 31 insertions(+), 30 deletions(-)

## Test Plan
- [ ] 验证 rerank 失败时是否降级返回原始结果
- [ ] 验证 top_k 默认值是否正确生效
- [ ] 验证缺失 API key 时是否正确处理

## Summary by Sourcery

通过添加安全的重排回退机制、处理缺失的模型 API 密钥，并引入默认的 `top_k` 限制来提升 RAG 检索的健壮性。

Bug 修复：
- 当重排失败时，不再抛出错误，而是返回原始检索到的内容片段（截断为 `top_k` 条）。
- 在初始化 Elasticsearch 向量后端时，如果缺少嵌入或重排模型的 API 密钥，改为记录警告日志而不是导致程序崩溃。
- 为内容片段检索请求应用一个经过验证的默认 `top_k` 值，以避免无效或未设置的限制。

增强：
- 在全文、向量和混合搜索路径中统一检索处理逻辑对 `top_k` 参数的使用方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RAG retrieval robustness by adding safe reranking fallback, handling missing model API keys, and introducing a default top_k limit.

Bug Fixes:
- Return original retrieved chunks (truncated to top_k) when reranking fails instead of raising an error.
- Handle missing embedding and reranker API keys when initializing the Elasticsearch vector backend, logging warnings instead of crashing.
- Apply a validated default top_k value for chunk retrieval requests to avoid invalid or unset limits.

Enhancements:
- Normalize retrieval handler usage of the top_k parameter across full-text, vector, and hybrid search paths.

</details>