### PR TITLE
perf(memory): add Redis throttle to prevent duplicate async task triggers on refresh

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -134,31 +134,34 @@ def get_workspace_end_users(
         api_logger.error(f"批量获取记忆配置失败: {str(e)}")
         memory_configs_map = {}
 
+    # 共享 Redis 客户端：用于两个节流块（按需初始化 + 社区聚类补全）
+    # 复用 app.tasks 模块级连接池，避免在请求路径上重复创建客户端；
+    # Redis 不可用时返回 None，下游节流块直接跳过，避免 UnboundLocalError
+    from app.tasks import get_sync_redis_client
+    _throttle_redis = get_sync_redis_client()
+    if _throttle_redis is None:
+        api_logger.warning("节流 Redis 客户端不可用，本次节流任务跳过")
+
     # 触发按需初始化：为 implicit_emotions_storage / interest_distribution 中没有记录的用户异步生成数据
     # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次，避免刷新页面导致重复提交
-    try:
-        import redis as _sync_redis
-        from app.core.config import settings as _settings
-        _throttle_redis = _sync_redis.Redis(
-            host=_settings.REDIS_HOST, port=_settings.REDIS_PORT,
-            password=_settings.REDIS_PASSWORD, db=_settings.REDIS_DB,
-        )
-        _throttle_key = f"dashboard:init_tasks:throttle:{workspace_id}"
-        if _throttle_redis.set(_throttle_key, "1", nx=True, ex=60):
-            from app.celery_app import celery_app as _celery_app
-            _celery_app.send_task(
-                "app.tasks.init_implicit_emotions_for_users",
-                kwargs={"end_user_ids": end_user_ids},
-            )
-            _celery_app.send_task(
-                "app.tasks.init_interest_distribution_for_users",
-                kwargs={"end_user_ids": end_user_ids},
-            )
-            api_logger.info(f"已触发按需初始化任务，候选用户数: {len(end_user_ids)}")
-        else:
-            api_logger.info(f"按需初始化任务节流中，跳过: workspace_id={workspace_id}")
-    except Exception as e:
-        api_logger.warning(f"触发按需初始化任务失败（不影响主流程）: {e}")
+    if _throttle_redis is not None:
+        try:
+            _throttle_key = f"dashboard:init_tasks:throttle:{workspace_id}"
+            if _throttle_redis.set(_throttle_key, "1", nx=True, ex=60):
+                from app.celery_app import celery_app as _celery_app
+                _celery_app.send_task(
+                    "app.tasks.init_implicit_emotions_for_users",
+                    kwargs={"end_user_ids": end_user_ids},
+                )
+                _celery_app.send_task(
+                    "app.tasks.init_interest_distribution_for_users",
+                    kwargs={"end_user_ids": end_user_ids},
+                )
+                api_logger.info(f"已触发按需初始化任务，候选用户数: {len(end_user_ids)}")
+            else:
+                api_logger.info(f"按需初始化任务节流中，跳过: workspace_id={workspace_id}")
+        except Exception as e:
+            api_logger.warning(f"触发按需初始化任务失败（不影响主流程）: {e}")
 
     items = []
     for index, end_user in enumerate(end_users):
@@ -184,19 +187,20 @@ def get_workspace_end_users(
 
     # 触发社区聚类补全任务（异步，不阻塞接口响应）
     # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次
-    try:
-        _cluster_throttle_key = f"dashboard:cluster_task:throttle:{workspace_id}"
-        if _throttle_redis.set(_cluster_throttle_key, "1", nx=True, ex=60):
-            from app.celery_app import celery_app as _celery_app
-            _celery_app.send_task(
-                "app.tasks.init_community_clustering_for_users",
-                kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
-            )
-            api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
-        else:
-            api_logger.info(f"社区聚类补全任务节流中，跳过: workspace_id={workspace_id}")
-    except Exception as e:
-        api_logger.warning(f"触发社区聚类补全任务失败（不影响主流程）: {str(e)}")
+    if _throttle_redis is not None:
+        try:
+            _cluster_throttle_key = f"dashboard:cluster_task:throttle:{workspace_id}"
+            if _throttle_redis.set(_cluster_throttle_key, "1", nx=True, ex=60):
+                from app.celery_app import celery_app as _celery_app
+                _celery_app.send_task(
+                    "app.tasks.init_community_clustering_for_users",
+                    kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
+                )
+                api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
+            else:
+                api_logger.info(f"社区聚类补全任务节流中，跳过: workspace_id={workspace_id}")
+        except Exception as e:
+            api_logger.warning(f"触发社区聚类补全任务失败（不影响主流程）: {str(e)}")
 
     # 构建分页响应
     result = {

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -135,17 +135,28 @@ def get_workspace_end_users(
         memory_configs_map = {}
 
     # 触发按需初始化：为 implicit_emotions_storage / interest_distribution 中没有记录的用户异步生成数据
+    # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次，避免刷新页面导致重复提交
     try:
-        from app.celery_app import celery_app as _celery_app
-        _celery_app.send_task(
-            "app.tasks.init_implicit_emotions_for_users",
-            kwargs={"end_user_ids": end_user_ids},
+        import redis as _sync_redis
+        from app.core.config import settings as _settings
+        _throttle_redis = _sync_redis.Redis(
+            host=_settings.REDIS_HOST, port=_settings.REDIS_PORT,
+            password=_settings.REDIS_PASSWORD, db=_settings.REDIS_DB,
         )
-        _celery_app.send_task(
-            "app.tasks.init_interest_distribution_for_users",
-            kwargs={"end_user_ids": end_user_ids},
-        )
-        api_logger.info(f"已触发按需初始化任务，候选用户数: {len(end_user_ids)}")
+        _throttle_key = f"dashboard:init_tasks:throttle:{workspace_id}"
+        if _throttle_redis.set(_throttle_key, "1", nx=True, ex=60):
+            from app.celery_app import celery_app as _celery_app
+            _celery_app.send_task(
+                "app.tasks.init_implicit_emotions_for_users",
+                kwargs={"end_user_ids": end_user_ids},
+            )
+            _celery_app.send_task(
+                "app.tasks.init_interest_distribution_for_users",
+                kwargs={"end_user_ids": end_user_ids},
+            )
+            api_logger.info(f"已触发按需初始化任务，候选用户数: {len(end_user_ids)}")
+        else:
+            api_logger.info(f"按需初始化任务节流中，跳过: workspace_id={workspace_id}")
     except Exception as e:
         api_logger.warning(f"触发按需初始化任务失败（不影响主流程）: {e}")
 
@@ -172,13 +183,18 @@ def get_workspace_end_users(
         })
 
     # 触发社区聚类补全任务（异步，不阻塞接口响应）
+    # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次
     try:
-        from app.celery_app import celery_app as _celery_app
-        _celery_app.send_task(
-            "app.tasks.init_community_clustering_for_users",
-            kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
-        )
-        api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
+        _cluster_throttle_key = f"dashboard:cluster_task:throttle:{workspace_id}"
+        if _throttle_redis.set(_cluster_throttle_key, "1", nx=True, ex=60):
+            from app.celery_app import celery_app as _celery_app
+            _celery_app.send_task(
+                "app.tasks.init_community_clustering_for_users",
+                kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
+            )
+            api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
+        else:
+            api_logger.info(f"社区聚类补全任务节流中，跳过: workspace_id={workspace_id}")
     except Exception as e:
         api_logger.warning(f"触发社区聚类补全任务失败（不影响主流程）: {str(e)}")
 


### PR DESCRIPTION
## Summary by Sourcery

使用 Redis 为内存仪表板的后台初始化任务添加节流机制，以避免在频繁刷新时重复触发异步任务。

Enhancements:
- 为内存仪表板上的隐式情绪和兴趣分布初始化任务添加基于 Redis 的按工作区节流机制，防止重复执行。
- 为社区聚类完成任务添加基于 Redis 的按工作区节流机制，以限制执行频率并减少冗余工作。
- 改进与被节流和实际执行的后台任务相关的日志记录，以提升可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Throttle memory dashboard background initialization tasks using Redis to avoid duplicate async triggers on frequent refreshes.

Enhancements:
- Add per-workspace Redis-based throttling for implicit emotions and interest distribution initialization tasks on the memory dashboard.
- Add per-workspace Redis-based throttling for community clustering completion tasks to limit execution frequency and reduce redundant work.
- Improve logging around throttled and executed background tasks for better observability.

</details>