### PR TITLE
refactor(workflow+llm): refactor LLM node and streaming logic, add multi-vendor adaptation

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -124,16 +124,30 @@ class RedBearModelFactory:
     }
 
     @staticmethod
-    def _extract_top_k_from_extra_params(extra_params: Dict[str, Any]) -> tuple[Dict[str, Any], Optional[int]]:
-        """从 extra_params 中分离 top_k 和 RedBearModelConfig 专有字段，返回 (过滤后的 extra_params, top_k 值)
+    def _extract_provider_specific_params(extra_params: Dict[str, Any]) -> tuple[Dict[str, Any], dict[str, Any]]:
+        """从 extra_params 中分离提供商特有参数和 RedBearModelConfig 专有字段，
+        返回 (过滤后的 extra_params, provider_specific dict)
 
-        deep_thinking, thinking_budget_tokens, streaming 等字段是 RedBearModelConfig 的配置字段，
-        不应该被展开到最终 LLM 类的构造参数中，否则 OpenAI SDK 等会报 unknown keyword argument。
+        provider_specific 包含需要按提供商路由的参数：
+        - top_k: 仅 Ollama/DashScope 支持，DashScope non-Omni 需通过 model_kwargs
+        - repetition_penalty: 仅 Ollama/DashScope 支持
+        - seed: 仅部分提供商支持，DashScope non-Omni 需通过 model_kwargs
+        - enable_search: 仅 DashScope 支持
+        - stop: 仅 OpenAI 兼容提供商支持顶级传递
+        - temperature: ChatTongyi 不接受顶级传递，需通过 model_kwargs
+        - max_tokens: ChatTongyi 不接受顶级传递，需通过 model_kwargs
+
+        config_only_keys 中的字段是 RedBearModelConfig 配置字段，
+        不应该被展开到最终 LLM 类的构造参数中。
         """
-        top_k_value = extra_params.get("top_k")
+        provider_specific_keys = ("top_k", "repetition_penalty", "seed", "enable_search", "stop", "temperature", "max_tokens")
         config_only_keys = RedBearModelFactory._CONFIG_ONLY_KEYS
-        filtered = {k: v for k, v in extra_params.items() if k not in config_only_keys and k != "top_k"}
-        return filtered, top_k_value
+        provider_specific = {}
+        for key in provider_specific_keys:
+            if key in extra_params:
+                provider_specific[key] = extra_params[key]
+        filtered = {k: v for k, v in extra_params.items() if k not in config_only_keys and k not in provider_specific_keys}
+        return filtered, provider_specific
 
     @classmethod
     def get_model_params(cls, config: RedBearModelConfig) -> Dict[str, Any]:
@@ -145,7 +159,7 @@ class RedBearModelFactory:
         logger = get_business_logger()
         logger.debug(f"获取模型参数 - Provider: {provider}, Model: {config.model_name}, is_omni: {config.is_omni}, deep_thinking: {config.deep_thinking}")
 
-        filtered_extra_params, top_k_value = cls._extract_top_k_from_extra_params(config.extra_params)
+        filtered_extra_params, provider_specific = cls._extract_provider_specific_params(config.extra_params)
         default_headers = config.extra_params.get("default_headers")
         if default_headers:
             logger.info(f"额外请求头已注入: {default_headers}")
@@ -187,6 +201,15 @@ class RedBearModelFactory:
                         extra_body["thinking_budget"] = config.thinking_budget_tokens
                 else:
                     extra_body["enable_thinking"] = False
+            # Omni uses OpenAI-compatible API: all provider-specific params
+            # are top-level args (temperature, max_tokens, seed, stop, etc.)
+            for key in ("temperature", "max_tokens", "seed", "stop", "repetition_penalty"):
+                if key in provider_specific and provider_specific[key] is not None:
+                    if key == "repetition_penalty":
+                        extra_body = params.setdefault("extra_body", {})
+                        extra_body[key] = provider_specific[key]
+                    else:
+                        params[key] = provider_specific[key]
             # JSON 输出模式
             # thinking（A类）模型启用深度思考时，response_format 与思考模式 API 冲突，跳过由调用方 prompt 注入兜底
             if config.json_output:
@@ -209,8 +232,11 @@ class RedBearModelFactory:
             # OllamaLLM 有 top_k 原生字段，可直接传入顶层；
             # ChatOpenAI/CompatibleChatOpenAI 不支持 top_k，OpenAI API 也无此参数，不能放入 model_kwargs
             # 否则会透传到 AsyncCompletions.create() 导致 unexpected keyword argument 错误
-            if provider == ModelProvider.OLLAMA and top_k_value is not None:
-                filtered_extra_params["top_k"] = top_k_value
+            if provider == ModelProvider.OLLAMA:
+                if "top_k" in provider_specific and provider_specific["top_k"] is not None:
+                    filtered_extra_params["top_k"] = provider_specific["top_k"]
+                if "repetition_penalty" in provider_specific and provider_specific["repetition_penalty"] is not None:
+                    filtered_extra_params["repetition_penalty"] = provider_specific["repetition_penalty"]
 
             params: Dict[str, Any] = {
                 "model": config.model_name,
@@ -220,6 +246,13 @@ class RedBearModelFactory:
                 "max_retries": config.max_retries,
                 **filtered_extra_params
             }
+
+            # OpenAI-compatible providers: temperature, max_tokens, seed, stop
+            # are top-level params. Other provider-specific params (top_k,
+            # repetition_penalty) are already handled above for Ollama.
+            for key in ("temperature", "max_tokens", "seed", "stop"):
+                if key in provider_specific and provider_specific[key] is not None:
+                    params[key] = provider_specific[key]
 
             if default_headers and provider != ModelProvider.OLLAMA:
                 params["default_headers"] = default_headers
@@ -265,9 +298,13 @@ class RedBearModelFactory:
                 "max_retries": config.max_retries,
                 **filtered_extra_params
             }
-            if top_k_value is not None:
-                model_kwargs = params.setdefault("model_kwargs", {})
-                model_kwargs["top_k"] = top_k_value
+            # ChatTongyi 不接受 temperature/max_tokens/seed/stop/enable_search
+            # 等参数作为顶级构造器参数，需通过 model_kwargs 传递
+            model_kwargs = params.setdefault("model_kwargs", {})
+            for key in ("top_k", "repetition_penalty", "seed", "enable_search",
+                        "stop", "temperature", "max_tokens"):
+                if key in provider_specific and provider_specific[key] is not None:
+                    model_kwargs[key] = provider_specific[key]
             # thinking 参数处理：
             # - thinking_only（B类）：不能传 enable_thinking，不做任何处理
             # - thinking（A类）：混合思考，流式和非流式均可开关，非流式也支持 thinking_budget
@@ -312,9 +349,19 @@ class RedBearModelFactory:
                 "config": boto_config,
                 **filtered_extra_params
             }
-            if top_k_value is not None:
-                model_kwargs = params.setdefault("model_kwargs", {})
-                model_kwargs["top_k"] = top_k_value
+            model_kwargs = params.setdefault("model_kwargs", {})
+            # Bedrock 专用参数路由：
+            # top_k, seed → model_kwargs 保持原名
+            # stop → model_kwargs 映射为 stop_sequences
+            # temperature, max_tokens → ChatBedrock 有顶级字段，直接传递
+            for key in ("top_k", "seed"):
+                if key in provider_specific and provider_specific[key] is not None:
+                    model_kwargs[key] = provider_specific[key]
+            if "stop" in provider_specific and provider_specific["stop"] is not None:
+                model_kwargs["stop_sequences"] = provider_specific["stop"]
+            for key in ("temperature", "max_tokens"):
+                if key in provider_specific and provider_specific[key] is not None:
+                    params[key] = provider_specific[key]
 
             # 解析 API key (格式: access_key_id:secret_access_key)
             if config.api_key and ":" in config.api_key:

--- a/api/app/core/workflow/engine/event_stream_handler.py
+++ b/api/app/core/workflow/engine/event_stream_handler.py
@@ -102,42 +102,68 @@ class EventStreamHandler:
           - If all segments are processed, deactivate the End node.
           - Otherwise, yield the current chunk as a streaming message.
 
+        Literal-text segments between variable segments are emitted automatically
+        so the cursor can advance past them during streaming without waiting for
+        emit_activate_chunk.
+
         Args:
             data (dict): Node chunk event data, expected keys:
                          - "node_id": ID of the node producing this chunk
                          - "chunk": Chunk of output text
                          - "done": Boolean indicating whether the node finished producing output
+                         - "field": Field name of the chunk (e.g. "output" or "reasoning_content")
 
         Yields:
             dict: Streaming message event in the format:
-                  {"event": "message", "data": {"chunk": ...}}
+                  {"event": "message", "data": {"content": ...}}
         """
         node_id = data.get("node_id")
-        if self.coordinator.activate_end:
-            end_info = self.coordinator.current_activate_end_info
-            if not end_info or end_info.cursor >= len(end_info.outputs):
-                return
-            current_output = end_info.outputs[end_info.cursor]
-            if current_output.is_variable and current_output.depends_on_scope(node_id):
-                # Field-level matching: route real-time chunks only to the segment
-                # that references the same field. Chunks carrying "reasoning_content"
-                # flow to {{node.reasoning_content}}, "output" to {{node.output}}.
-                chunk_field = data.get("field", "output")
-                segment_field = current_output.get_field() or "output"
-                if chunk_field != segment_field:
-                    return
+        if not self.coordinator.activate_end:
+            return
 
-                if data.get("done"):
-                    end_info.cursor += 1
-                    if end_info.cursor >= len(end_info.outputs):
-                        self.coordinator.pop_current_activate_end()
-                else:
-                    yield {
-                        "event": "message",
-                        "data": {
-                            "content": data.get("chunk")
-                        }
+        end_info = self.coordinator.current_activate_end_info
+        if not end_info or end_info.cursor >= len(end_info.outputs):
+            return
+
+        # Emit any activated literal-text segments before the target variable
+        # so the cursor can reach the next variable segment during streaming.
+        while end_info.cursor < len(end_info.outputs):
+            seg = end_info.outputs[end_info.cursor]
+            if seg.is_variable:
+                break
+            if not seg.activate and not end_info.force:
+                break
+            yield {
+                "event": "message",
+                "data": {"content": seg.literal}
+            }
+            end_info.cursor += 1
+
+        if end_info.cursor >= len(end_info.outputs):
+            self.coordinator.pop_current_activate_end()
+            return
+
+        current_output = end_info.outputs[end_info.cursor]
+        if current_output.is_variable and current_output.depends_on_scope(node_id):
+            # Field-level matching: route real-time chunks only to the segment
+            # that references the same field. Chunks carrying "reasoning_content"
+            # flow to {{node.reasoning_content}}, "output" to {{node.output}}.
+            chunk_field = data.get("field", "output")
+            segment_field = current_output.get_field() or "output"
+            if chunk_field != segment_field:
+                return
+
+            if data.get("done"):
+                end_info.cursor += 1
+                if end_info.cursor >= len(end_info.outputs):
+                    self.coordinator.pop_current_activate_end()
+            else:
+                yield {
+                    "event": "message",
+                    "data": {
+                        "content": data.get("chunk")
                     }
+                }
 
     @staticmethod
     async def handle_node_error_event(data: dict):

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -329,16 +329,100 @@ _PARAM_PROVIDER_SUPPORT: dict[str, frozenset[ModelProvider]] = {
     "seed": frozenset({
         ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
         ModelProvider.OLLAMA, ModelProvider.VOLCANO, ModelProvider.DASHSCOPE,
+        ModelProvider.BEDROCK,
     }),
-    "search": frozenset({ModelProvider.DASHSCOPE}),
+    "frequency_penalty": frozenset({
+        ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+        ModelProvider.VOLCANO, ModelProvider.DASHSCOPE,
+    }),
+    "presence_penalty": frozenset({
+        ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+        ModelProvider.VOLCANO, ModelProvider.DASHSCOPE,
+    }),
+    "enable_search": frozenset({ModelProvider.DASHSCOPE}),
 }
 
 _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
-    "top_k": "当前提供商不支持取样数量(top_k)参数，该参数不会生效",
-    "repetition_penalty": "当前提供商不支持重复惩罚参数，该参数不会生效",
-    "seed": "当前提供商不支持随机种子参数，该参数不会生效",
-    "search": "当前提供商不支持联网搜索参数，该参数不会生效",
+    "top_k": "当前提供商不支持取样数量(top_k)参数，该参数已自动剥离",
+    "repetition_penalty": "当前提供商不支持重复惩罚参数，该参数已自动剥离",
+    "seed": "当前提供商不支持随机种子参数，该参数已自动剥离",
+    "frequency_penalty": "当前提供商不支持频率惩罚参数，该参数已自动剥离",
+    "presence_penalty": "当前提供商不支持存在惩罚参数，该参数已自动剥离",
+    "enable_search": "当前提供商不支持联网搜索参数，该参数已自动剥离",
 }
+
+# Providers whose LLM chat class accepts OpenAI-style multimodal content
+# format: [{"type": "text", "text": "..."}], [{"type": "image_url", ...}] etc.
+# DashScope non-Omni (ChatTongyi) uses its own format and rejects OpenAI-style lists.
+_MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
+    ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+    ModelProvider.VOLCANO,
+    ModelProvider.OLLAMA,
+    ModelProvider.BEDROCK,
+})
+
+
+def strip_unsupported_llm_params(
+        extra_params: dict[str, Any],
+        provider: str,
+        is_omni: bool = False,
+) -> tuple[dict[str, Any], list[str]]:
+    """Strip provider-unsupported parameters from extra_params.
+
+    Parameters listed in _PARAM_PROVIDER_SUPPORT are only kept when the
+    provider (or, for DashScope, the Omni variant) is in the support set.
+    Other parameters (top_p, frequency_penalty, presence_penalty, etc.)
+    are kept by default — they'll be routed to model_kwargs or top-level
+    by RedBearModelFactory.get_model_params based on the provider.
+
+    Note: temperature, max_tokens, seed, stop, top_k, repetition_penalty,
+    enable_search are extracted from extra_params before reaching
+    RedBearModelFactory and then re-routed per provider. They are not
+    affected by this stripping step.
+
+    Returns:
+        (stripped_params, warnings): filtered params and warning messages
+        for each stripped parameter.
+    """
+    warnings: list[str] = []
+    provider_lower = provider.lower() if provider else ""
+
+    try:
+        provider_enum = ModelProvider(provider_lower)
+    except ValueError:
+        return extra_params, warnings
+
+    # DashScope Omni is OpenAI-compatible; non-Omni (ChatTongyi) is not.
+    # frequency_penalty / presence_penalty are only safe for Omni.
+    # Other params (top_k, seed, enable_search, repetition_penalty) are
+    # supported by ChatTongyi via model_kwargs routing in RedBearModelFactory.
+    effective_provider = provider_enum
+    if provider_enum == ModelProvider.DASHSCOPE and not is_omni:
+        # Map DashScope non-Omni to a virtual "dashscope_native" so that
+        # OpenAI-only params (frequency_penalty, presence_penalty) are
+        # stripped while DashScope-native params (top_k, seed,
+        # enable_search, repetition_penalty via model_kwargs) remain.
+        _DASHSCOPE_NATIVE_SUPPORT: dict[str, bool] = {
+            "top_k": True,
+            "repetition_penalty": True,
+            "seed": True,
+            "frequency_penalty": False,
+            "presence_penalty": False,
+            "enable_search": True,
+        }
+        for param_key, supported in _DASHSCOPE_NATIVE_SUPPORT.items():
+            if param_key in extra_params and not supported:
+                warnings.append(_PARAM_PROVIDER_WARNINGS.get(param_key, f"参数 {param_key} 已自动剥离"))
+                extra_params.pop(param_key, None)
+        return extra_params, warnings
+
+    # General case: check _PARAM_PROVIDER_SUPPORT
+    for param_key, supported_providers in _PARAM_PROVIDER_SUPPORT.items():
+        if param_key in extra_params and provider_enum not in supported_providers:
+            warnings.append(_PARAM_PROVIDER_WARNINGS.get(param_key, f"参数 {param_key} 已自动剥离"))
+            extra_params.pop(param_key, None)
+
+    return extra_params, warnings
 
 
 def validate_llm_param_constraints(
@@ -407,15 +491,25 @@ def validate_llm_param_constraints(
         if provider_enum not in supported:
             warnings.append(_PARAM_PROVIDER_WARNINGS["repetition_penalty"])
 
+    if config.frequency_penalty.enable:
+        supported = _PARAM_PROVIDER_SUPPORT["frequency_penalty"]
+        if provider_enum not in supported:
+            warnings.append(_PARAM_PROVIDER_WARNINGS["frequency_penalty"])
+
+    if config.presence_penalty.enable:
+        supported = _PARAM_PROVIDER_SUPPORT["presence_penalty"]
+        if provider_enum not in supported:
+            warnings.append(_PARAM_PROVIDER_WARNINGS["presence_penalty"])
+
     if config.seed.enable:
         supported = _PARAM_PROVIDER_SUPPORT["seed"]
         if provider_enum not in supported:
             warnings.append(_PARAM_PROVIDER_WARNINGS["seed"])
 
     if config.search:
-        supported = _PARAM_PROVIDER_SUPPORT["search"]
+        supported = _PARAM_PROVIDER_SUPPORT["enable_search"]
         if provider_enum not in supported:
-            warnings.append(_PARAM_PROVIDER_WARNINGS["search"])
+            warnings.append(_PARAM_PROVIDER_WARNINGS["enable_search"])
 
     return warnings
 

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -17,7 +17,7 @@ from app.core.workflow.engine.state_manager import WorkflowState
 from app.core.workflow.engine.variable_pool import VariablePool
 from app.core.workflow.nodes.base_node import BaseNode
 from app.core.workflow.nodes.enums import HttpErrorHandle
-from app.core.workflow.nodes.llm.config import LLMNodeConfig, validate_llm_param_constraints
+from app.core.workflow.nodes.llm.config import LLMNodeConfig, validate_llm_param_constraints, strip_unsupported_llm_params, _MULTIMODAL_COMPATIBLE_PROVIDERS
 from app.core.workflow.variable.base_variable import VariableType
 from app.db import get_db_context
 from app.models import ModelType
@@ -219,6 +219,13 @@ class LLMNode(BaseNode):
         if self.typed_config.response_format.enable and self.typed_config.response_format.value == "text":
             json_output = False
 
+        # If the model lacks JSON_OUTPUT capability, disable json_output entirely
+        # so neither API-level response_format nor prompt injection is applied.
+        # The warning is already produced by validate_llm_param_constraints.
+        capability_set = set(model_info.capability or [])
+        if json_output and ModelCapability.JSON_OUTPUT not in capability_set:
+            json_output = False
+
         if self.typed_config.extra_headers.enable and self.typed_config.extra_headers.value:
             try:
                 import json
@@ -226,6 +233,34 @@ class LLMNode(BaseNode):
                 extra_params["default_headers"] = extra_headers_dict
             except json.JSONDecodeError as e:
                 logger.warning(f"节点 {self.node_id}: 额外请求头 JSON 解析失败: {e}")
+
+        # Strip provider-unsupported parameters so they never reach the API call
+        extra_params, strip_warnings = strip_unsupported_llm_params(
+            extra_params, model_info.provider or "", model_info.is_omni
+        )
+        if strip_warnings:
+            for w in strip_warnings:
+                logger.warning(f"节点 {self.node_id} 参数安全剥离: {w} (模型={model_info.model_name}, 提供商={model_info.provider})")
+            self._param_warnings = (self._param_warnings or []) + strip_warnings
+
+        # Vision: only enable for providers whose LLM class accepts
+        # OpenAI-style multimodal content format ([{type: text, text: ...}]).
+        # DashScope non-Omni (ChatTongyi) rejects this format.
+        effective_vision = self.typed_config.vision
+        if effective_vision:
+            try:
+                provider_enum = ModelProvider(model_info.provider.lower())
+            except ValueError:
+                provider_enum = None
+            is_compatible = (
+                provider_enum in _MULTIMODAL_COMPATIBLE_PROVIDERS
+                or (provider_enum == ModelProvider.DASHSCOPE and model_info.is_omni)
+            )
+            if not is_compatible:
+                effective_vision = False
+                logger.warning(
+                    f"节点 {self.node_id}: 模型提供商 {model_info.provider} 不支持 "
+                    f"OpenAI 多模态内容格式，已自动关闭 vision")
 
         llm = RedBearLLM(
             RedBearModelConfig(
@@ -262,31 +297,31 @@ class LLMNode(BaseNode):
                         "content": await self.process_message(
                             model_info,
                             content,
-                            self.typed_config.vision,
+                            effective_vision,
                         )
                     })
                 elif role in ["user", "human"]:
                     messages.append({
                         "role": "user",
-                        "content": await self.process_message(model_info, content, self.typed_config.vision)
+                        "content": await self.process_message(model_info, content, effective_vision)
                     })
                 elif role in ["ai", "assistant"]:
                     messages.append({
                         "role": "assistant",
-                        "content": await self.process_message(model_info, content, self.typed_config.vision)
+                        "content": await self.process_message(model_info, content, effective_vision)
                     })
                 else:
                     logger.warning(f"未知的消息角色: {role}，默认使用 user")
                     messages.append({
                         "role": "user",
-                        "content": await self.process_message(model_info, content, self.typed_config.vision)
+                        "content": await self.process_message(model_info, content, effective_vision)
                     })
 
-            if self.typed_config.vision_input and self.typed_config.vision:
+            if self.typed_config.vision_input and effective_vision:
                 file_content = []
                 files = variable_pool.get_instance(self.typed_config.vision_input)
                 for file in files.value:
-                    content = await self.process_message(model_info, file.value, self.typed_config.vision)
+                    content = await self.process_message(model_info, file.value, effective_vision)
                     if content:
                         file_content.extend(content)
                 if messages and messages[-1]["role"] == 'user':
@@ -301,7 +336,7 @@ class LLMNode(BaseNode):
                     if isinstance(message["content"], list):
                         file_content = []
                         for file in message["content"]:
-                            content = await self.process_message(model_info, file, self.typed_config.vision)
+                            content = await self.process_message(model_info, file, effective_vision)
                             if content:
                                 file_content.extend(content)
                         history_message.append(
@@ -311,7 +346,7 @@ class LLMNode(BaseNode):
                         message["content"] = await self.process_message(
                             model_info,
                             message["content"],
-                            self.typed_config.vision
+                            effective_vision
                         )
                         history_message.append(message)
                 messages = messages[:-1] + history_message + messages[-1:]
@@ -324,11 +359,21 @@ class LLMNode(BaseNode):
 
         # 所有 provider 统一注入 JSON prompt 兜底，确保即使 API 层 response_format 未生效也能引导 JSON 输出
         if json_output:
+            json_prompt_suffix = "\n请以JSON格式输出。"
             system_msg = next((m for m in self.messages if m["role"] == "system"), None)
             if system_msg:
-                system_msg["content"] += "\n请以JSON格式输出。"
+                if isinstance(system_msg["content"], list):
+                    # Multimodal format: append suffix to the last text object
+                    for item in reversed(system_msg["content"]):
+                        if isinstance(item, dict) and item.get("type") == "text":
+                            item["text"] += json_prompt_suffix
+                            break
+                    else:
+                        system_msg["content"].append({"type": "text", "text": json_prompt_suffix})
+                else:
+                    system_msg["content"] += json_prompt_suffix
             else:
-                self.messages.insert(0, {"role": "system", "content": "请以JSON格式输出。"})
+                self.messages.insert(0, {"role": "system", "content": json_prompt_suffix})
 
         return llm
 
@@ -589,13 +634,20 @@ class LLMNode(BaseNode):
                         chunk_count += 1
                         buffered_chunks.append(content)
 
+                # Signal that reasoning_content streaming is complete so the
+                # stream-output cursor can advance past {{node.reasoning_content}}
+                # segments before output chunks arrive.
+                if self.typed_config.enable_reasoning_content_extraction:
+                    yield {"__final__": False, "chunk": "", "done": True, "field": "reasoning_content"}
+
                 for c in buffered_chunks:
-                    yield {"__final__": False, "chunk": c}
+                    yield {"__final__": False, "chunk": c, "field": "output"}
 
                 yield {
                     "__final__": False,
                     "chunk": "",
-                    "done": True
+                    "done": True,
+                    "field": "output"
                 }
 
                 reasoning_content = ""

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     proxy: {
       // 主要API代理，支持 /api 和 /api/* 格式
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://localhost:5173',
         changeOrigin: true,
 
         // 匹配所有以/api开头的请求，包括/api/token

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     proxy: {
       // 主要API代理，支持 /api 和 /api/* 格式
       '/api': {
-        target: 'http://localhost:5173',
+        target: 'http://localhost:8000',
         changeOrigin: true,
 
         // 匹配所有以/api开头的请求，包括/api/token


### PR DESCRIPTION
- Update the web proxy port to 8000.
- Refactor the event stream processor to optimize variable chunk streaming logic and automatically send literal text chunks.
- Add a parameter stripping utility function to filter out unsupported LLM parameters by vendor.
- Refactor RedBearModelFactory to separate vendor-specific parameter handling logic.
- Add multi-modal compatible vendor support to automatically adapt formats for non-Omni versions of Qwen.
- Optimize JSON output handling logic to be compatible with multi-modal message formats.
- Improve streaming chunk markers for reasoning content and output content.

## Summary by Sourcery

优化 LLM 节点配置、提供商适配以及流式行为，以便能够根据不同厂商安全地路由模型参数，稳健处理多模态和 JSON 输出，并改进终端节点的流式语义，同时更新 Web 开发代理目标地址。

New Features:
- 引入「感知提供商」的参数剥离工具，在发起 API 调用前移除各厂商不支持的 LLM 参数，并对被剥离的参数发出警告。
- 增加多模态兼容性处理机制，可根据不同提供商的能力和模型变体启用或禁用视觉能力。
- 扩展流式事件，增加字段级标记，使推理片段与输出片段能够独立流式传输与单独完成。

Enhancements:
- 扩展各提供商特定的参数支持映射（包括 frequency penalty 和 presence penalty），并优化被剥离参数的警告信息描述。
- 重构 `RedBearModelFactory` 中的模型参数提取逻辑，将提供商特定的路由（OpenAI-compatible、DashScope、Ollama、Bedrock）集中处理，涵盖顶层字段和 `model_kwargs` 字段。
- 改进 JSON 输出处理，使 JSON 提示在文本与多模态消息格式中都能正确工作，并对不具备 JSON 输出能力的模型自动禁用此特性。
- 调整事件流处理逻辑，自动发出变量之间的字面文本片段，并在流式传输过程中更精确地管理光标前进位置。

Build:
- 将前端开发服务器的代理目标从端口 5173 修改为指向运行在 8000 端口的后端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine LLM node configuration, provider adaptation, and streaming behavior to safely route model parameters per vendor, handle multimodal and JSON output robustly across providers, and improve end-node streaming semantics, while updating the web dev proxy target.

New Features:
- Introduce a provider-aware parameter stripping utility to remove unsupported LLM parameters before API calls and surface warnings.
- Add multimodal compatibility handling to enable or disable vision features based on provider capabilities and model variants.
- Extend streaming events with field-level markers so reasoning and output segments can be streamed and finalized independently.

Enhancements:
- Expand provider-specific parameter support mappings (including frequency and presence penalties) and clarify warning messages for stripped parameters.
- Refactor model parameter extraction in RedBearModelFactory to centralize provider-specific routing (OpenAI-compatible, DashScope, Ollama, Bedrock) for top-level and model_kwargs fields.
- Improve JSON output handling so JSON prompting works correctly with both text and multimodal message formats and is disabled for models without JSON output capability.
- Adjust event stream handling to automatically emit literal text segments between variables and better manage cursor advancement during streaming.

Build:
- Update the frontend dev server proxy to target the backend on port 8000 instead of 5173.

</details>