### PR TITLE
fix(conversation_share)

### DIFF
--- a/api/app/services/conversation_share_service.py
+++ b/api/app/services/conversation_share_service.py
@@ -126,7 +126,8 @@ class ConversationShareService:
         # 获取会话消息（排除已删除的）
         messages = self.db.query(Message).filter(
             Message.conversation_id == share.conversation_id,
-            Message.is_deleted == False,
+            Message.is_deleted.is_(False),
+            Message.is_current.is_(True)
         ).order_by(Message.created_at).all()
 
         logger.info(


### PR DESCRIPTION
filter out non-current messages in shared conversation

## Summary by Sourcery

错误修复：
- 将非当前消息从共享会话中排除，同时继续忽略已删除的消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Exclude non-current messages from shared conversations while continuing to ignore deleted messages.

</details>