### PR TITLE
feat(app_controller)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -4,7 +4,7 @@ import json
 from typing import Optional, Annotated
 
 import yaml
-from fastapi import APIRouter, Depends, Path, Form, UploadFile, File
+from fastapi import APIRouter, Depends, Path, Form, UploadFile, File, Query
 from fastapi.responses import StreamingResponse, Response
 from sqlalchemy.orm import Session
 from urllib.parse import quote
@@ -20,7 +20,7 @@ from app.models.annotation_model import HitLogSource
 from app.models.app_model import AppType
 from app.repositories import knowledge_repository
 from app.repositories.end_user_repository import EndUserRepository
-from app.schemas import app_schema
+from app.schemas import app_schema, tool_schema
 from app.schemas.response_schema import PageData, PageMeta
 from app.schemas.workflow_schema import WorkflowConfig as WorkflowConfigSchema
 from app.schemas.workflow_schema import WorkflowConfigUpdate, WorkflowImportSave
@@ -319,7 +319,7 @@ def get_opening(
     # 根据应用类型获取 features
     from app.models.app_model import App as AppModel
     app = db.get(AppModel, app_id)
-    if app and app.type == "workflow":
+    if app and app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         cfg = app_service.get_workflow_config(db=db, app_id=app_id, workspace_id=workspace_id)
         features = cfg.features or {}
     else:
@@ -587,8 +587,11 @@ async def draft_run(
 
     # 1. 验证应用
     app = service._get_app_or_404(app_id)
-    if app.type != AppType.AGENT and app.type != AppType.MULTI_AGENT and app.type != AppType.WORKFLOW:
+    if app.type not in (AppType.AGENT, AppType.MULTI_AGENT, AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         raise BusinessException("只有 Agent , Workflow 类型应用支持试运行", BizCode.APP_TYPE_NOT_SUPPORTED)
+
+    if app.type != AppType.PURE_WORKFLOW and not payload.message:
+        raise BusinessException("当前应用类型要求必须传入 message", BizCode.INVALID_PARAMETER)
 
     # 只读操作，允许访问共享应用
     service._validate_app_accessible(app, workspace_id)
@@ -603,14 +606,15 @@ async def draft_run(
         )
         payload.user_id = str(new_end_user.id)
 
-    # 处理会话ID（创建或验证）
-    conversation_id = await draft_service._ensure_conversation(
-        conversation_id=payload.conversation_id,
-        app_id=app_id,
-        workspace_id=workspace_id,
-        user_id=payload.user_id
-    )
-    payload.conversation_id = conversation_id
+    # pure_workflow 不强制会话；其他类型仍沿用会话逻辑。
+    if app.type != AppType.PURE_WORKFLOW or payload.conversation_id:
+        conversation_id = await draft_service._ensure_conversation(
+            conversation_id=payload.conversation_id,
+            app_id=app_id,
+            workspace_id=workspace_id,
+            user_id=payload.user_id
+        )
+        payload.conversation_id = conversation_id
 
     if app.type == AppType.AGENT:
         service._check_agent_config(app_id)
@@ -675,7 +679,7 @@ async def draft_run(
             "开始非流式试运行",
             extra={
                 "app_id": str(app_id),
-                "message_length": len(payload.message),
+                "message_length": len(payload.message or ""),
                 "has_conversation_id": bool(payload.conversation_id),
                 "has_variables": bool(payload.variables),
                 "has_files": bool(payload.files)
@@ -743,7 +747,7 @@ async def draft_run(
                 "开始多智能体流式试运行",
                 extra={
                     "app_id": str(app_id),
-                    "message_length": len(payload.message),
+                    "message_length": len(payload.message or ""),
                     "has_conversation_id": bool(payload.conversation_id)
                 }
             )
@@ -777,7 +781,7 @@ async def draft_run(
             "开始多智能体非流式试运行",
             extra={
                 "app_id": str(app_id),
-                "message_length": len(payload.message),
+                "message_length": len(payload.message or ""),
                 "has_conversation_id": bool(payload.conversation_id)
             }
         )
@@ -797,7 +801,7 @@ async def draft_run(
             data=result,
             msg="多 Agent 任务执行成功"
         )
-    elif app.type == AppType.WORKFLOW:  # 工作流
+    elif app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):  # 工作流 / 对话流
         # 共享应用：从最新发布版本读配置快照，而非草稿
         is_shared = app.workspace_id != workspace_id
         if is_shared:
@@ -815,7 +819,7 @@ async def draft_run(
                 "开始工作流流式试运行",
                 extra={
                     "app_id": str(app_id),
-                    "message_length": len(payload.message),
+                    "message_length": len(payload.message or ""),
                     "has_conversation_id": bool(payload.conversation_id)
                 }
             )
@@ -861,7 +865,7 @@ async def draft_run(
             "开始非流式试运行",
             extra={
                 "app_id": str(app_id),
-                "message_length": len(payload.message),
+                "message_length": len(payload.message or ""),
                 "has_conversation_id": bool(payload.conversation_id)
             }
         )
@@ -1369,6 +1373,53 @@ async def import_app(
         data={"app": app_schema.App.model_validate(result_app), "warnings": warnings},
         msg="应用导入成功" + ("，但部分资源需手动配置" if warnings else "")
     )
+
+
+@router.post("/{app_id}/publish_tool", summary="发布工作流为工具")
+@cur_workspace_access_guard()
+async def publish_workflow_as_tool(
+        app_id: uuid.UUID,
+        payload: tool_schema.WorkflowToolCreateRequest,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
+):
+    from app.services.workflow_tool_publish_service import WorkflowToolPublishService
+    from app.services.tool_service import ToolService
+
+    service = WorkflowToolPublishService(db)
+    tool_config = service.publish_workflow_as_tool(
+        workflow_app_id=app_id,
+        tool_name=payload.name,
+        tool_description=payload.description or "",
+        tenant_id=current_user.tenant_id,
+        workspace_id=current_user.current_workspace_id,
+        created_by=current_user.id,
+        icon=payload.icon,
+        timeout=payload.timeout,
+        tags=payload.tags,
+        release_id=uuid.UUID(payload.release_id) if payload.release_id else None,
+    )
+
+    detail = ToolService(db).get_tool_detail(str(tool_config.id), current_user.tenant_id)
+    return success(data=detail or tool_schema.ToolDetailSchema.model_validate(tool_config))
+
+
+@router.get("/{app_id}/publish_tool/preview", summary="预览工作流发布为工具的入参和出参")
+@cur_workspace_access_guard()
+async def preview_workflow_tool_publish(
+        app_id: uuid.UUID,
+        release_id: uuid.UUID | None = Query(None, description="指定工作流发布版本ID，不传则使用当前发布版本"),
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user),
+):
+    from app.services.workflow_tool_publish_service import WorkflowToolPublishService
+
+    preview = WorkflowToolPublishService(db).get_publish_preview(
+        workflow_app_id=app_id,
+        workspace_id=current_user.current_workspace_id,
+        release_id=release_id,
+    )
+    return success(data=preview)
 
 
 @router.get("/citations/{document_id}/download", summary="下载引用文档原始文件")

--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -506,26 +506,31 @@ async def chat(
             config = release.config or {}
             if not config.get("sub_agents"):
                 raise BusinessException("多 Agent 应用未配置子 Agent", BizCode.AGENT_CONFIG_MISSING)
-        elif app_type == AppType.WORKFLOW:
+        elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             # Multi-Agent 类型：验证多 Agent 配置
             pass
         else:
             raise BusinessException(f"不支持的应用类型: {app_type}", BizCode.APP_TYPE_NOT_SUPPORTED)
 
-        # 获取或创建会话（提前验证）
-        conversation = service.create_or_get_conversation(
-            share_token=share_data.share_token,
-            conversation_id=payload.conversation_id,
-            user_id=str(new_end_user.id),  # 转换为字符串
-            password=password
-        )
+        if app_type != AppType.PURE_WORKFLOW and not payload.message:
+            raise BusinessException("当前应用类型要求必须传入 message", BizCode.INVALID_PARAMETER)
+
+        # pure_workflow 无需自动创建会话；传入 conversation_id 时仍允许沿用原会话。
+        conversation = None
+        if app_type != AppType.PURE_WORKFLOW or payload.conversation_id:
+            conversation = service.create_or_get_conversation(
+                share_token=share_data.share_token,
+                conversation_id=payload.conversation_id,
+                user_id=str(new_end_user.id),  # 转换为字符串
+                password=password
+            )
 
         logger.debug(
             "参数验证完成",
             extra={
                 "share_token": share_token,
                 "app_type": app_type,
-                "conversation_id": str(conversation.id),
+                "conversation_id": str(conversation.id) if conversation else None,
                 "stream": payload.stream
             }
         )
@@ -630,7 +635,7 @@ async def chat(
         )
 
         return success(data=conversation_schema.ChatResponse(**result).model_dump(mode="json"))
-    elif app_type == AppType.WORKFLOW:
+    elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         config = workflow_config_4_app_release(release)
         if not config.id:
             with get_db_read() as db:
@@ -642,7 +647,7 @@ async def chat(
             async def event_generator():
                 async for event in app_chat_service.workflow_chat_stream(
                         message=payload.message,
-                        conversation_id=conversation.id,  # 使用已创建的会话 ID
+                        conversation_id=conversation.id if conversation else None,
                         user_id=end_user_id,  # 转换为字符串
                         variables=payload.variables,
                         files=payload.files,
@@ -678,7 +683,7 @@ async def chat(
         source = HitLogSource.EXTERNAL
         result = await app_chat_service.workflow_chat(
             message=payload.message,
-            conversation_id=conversation.id,  # 使用已创建的会话 ID
+            conversation_id=conversation.id if conversation else None,
             user_id=end_user_id,  # 转换为字符串
             variables=payload.variables,
             files=payload.files,
@@ -718,7 +723,7 @@ async def config_query(
     share_service = SharedChatService(db)
     share_token = share_data.share_token
     share, release = share_service.get_release_by_share_token(share_token, password)
-    if release.app.type == AppType.WORKFLOW:
+    if release.app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         workflow_service = WorkflowService(db)
         content = {
             "app_name": release.app.name,
@@ -1063,5 +1068,4 @@ async def switch_message_version(
     )
 
     return success(data=result)
-
 

--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -12,7 +12,6 @@ from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.response_utils import success
 from app.db import get_db
-from app.models.app_model import App
 from app.models.app_model import AppType
 from app.models.app_release_model import AppRelease
 from app.repositories import knowledge_repository
@@ -69,7 +68,7 @@ def _checkAppConfig(release: AppRelease):
     elif release.type == AppType.MULTI_AGENT:
         if not release.config:
             raise BusinessException("Multi-Agent 应用未配置模型", BizCode.AGENT_CONFIG_MISSING)
-    elif release.type == AppType.WORKFLOW:
+    elif release.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         if not release.config:
             raise BusinessException("工作流应用未配置模型", BizCode.AGENT_CONFIG_MISSING)
     else:
@@ -85,7 +84,7 @@ async def chat(
         conversation_service: Annotated[ConversationService, Depends(get_conversation_service)] = None,
         app_chat_service: Annotated[AppChatService, Depends(get_app_chat_service)] = None,
         app_service: Annotated[AppService, Depends(get_app_service)] = None,
-        message: str = Body(..., description="聊天消息内容"),
+        message: str | None = Body(None, description="聊天消息内容"),
 ):
     """
     Agent/Workflow 聊天接口
@@ -152,14 +151,19 @@ async def chat(
     # check app config
     _checkAppConfig(active_release)
 
-    # 获取或创建会话（提前验证）
-    conversation = conversation_service.create_or_get_conversation(
-        app_id=app.id,
-        workspace_id=workspace_id,
-        user_id=end_user_id,
-        is_draft=False,
-        conversation_id=payload.conversation_id
-    )
+    if app_type != AppType.PURE_WORKFLOW and not payload.message:
+        raise BusinessException("当前应用类型要求必须传入 message", BizCode.INVALID_PARAMETER)
+
+    # pure_workflow 不强制创建会话；传入 conversation_id 时仍支持复用。
+    conversation = None
+    if app_type != AppType.PURE_WORKFLOW or payload.conversation_id:
+        conversation = conversation_service.create_or_get_conversation(
+            app_id=app.id,
+            workspace_id=workspace_id,
+            user_id=end_user_id,
+            is_draft=False,
+            conversation_id=payload.conversation_id
+        )
 
     if app_type == AppType.AGENT:
 
@@ -177,7 +181,7 @@ async def chat(
             async def event_generator():
                 async for event in app_chat_service.agent_chat_stream(
                         message=payload.message,
-                        conversation_id=conversation.id,  # 使用已创建的会话 ID
+                        conversation_id=conversation.id if conversation else None,
                         user_id=end_user_id,  # 转换为字符串
                         variables=payload.variables,
                         web_search=web_search,
@@ -258,7 +262,7 @@ async def chat(
         )
 
         return success(data=conversation_schema.ChatResponse(**result).model_dump(mode="json"))
-    elif app_type == AppType.WORKFLOW:
+    elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
         # 多 Agent 流式返回
         config = workflow_config_4_app_release(active_release)
         if payload.stream:
@@ -300,7 +304,7 @@ async def chat(
         result = await app_chat_service.workflow_chat(
 
             message=payload.message,
-            conversation_id=conversation.id,  # 使用已创建的会话 ID
+            conversation_id=conversation.id if conversation else None,
             user_id=end_user_id,  # 转换为字符串
             variables=payload.variables,
             config=config,

--- a/api/app/controllers/tool_controller.py
+++ b/api/app/controllers/tool_controller.py
@@ -89,7 +89,7 @@ async def get_tool(
         service: ToolService = Depends(get_tool_service)
 ):
     """获取工具详情"""
-    tool = service.get_tool_info(tool_id, current_user.tenant_id)
+    tool = service.get_tool_detail(tool_id, current_user.tenant_id)
     if not tool:
         raise HTTPException(status_code=404, detail="工具不存在")
     return success(data=tool, msg="获取工具详情成功")

--- a/api/app/core/agent/agent_middleware.py
+++ b/api/app/core/agent/agent_middleware.py
@@ -75,7 +75,13 @@ class AgentMiddleware:
         
         return filtered_tools, activated_skill_ids
     
-    def load_skill_tools(self, db, tenant_id: uuid.UUID, base_tools: List = None) -> tuple[List, Dict[str, Any], Dict[str, str]]:
+    def load_skill_tools(
+        self,
+        db,
+        tenant_id: uuid.UUID,
+        base_tools: List = None,
+        runtime_context: Optional[Dict[str, Any]] = None,
+    ) -> tuple[List, Dict[str, Any], Dict[str, str]]:
         """
         加载技能关联的工具
         
@@ -83,6 +89,7 @@ class AgentMiddleware:
             db: 数据库会话
             tenant_id: 租户id
             base_tools: 基础工具列表
+            runtime_context: 运行时上下文, 含非业务参数
         
         Returns:
             (工具列表, 技能配置字典, 工具到技能的映射 {tool_name: skill_id})
@@ -121,7 +128,12 @@ class AgentMiddleware:
                     continue
             
             # 加载技能工具并获取映射关系
-            skill_tools, skill_tool_map = SkillService.load_skill_tools(db, skill_ids_to_load, tenant_id)
+            skill_tools, skill_tool_map = SkillService.load_skill_tools(
+                db,
+                skill_ids_to_load,
+                tenant_id,
+                runtime_context=runtime_context,
+            )
             
             # 只添加不冲突的 skill_tools
             for tool in skill_tools:

--- a/api/app/core/tools/__init__.py
+++ b/api/app/core/tools/__init__.py
@@ -14,6 +14,11 @@ try:
 except ImportError:
     MCPTool = None
 
+try:
+    from .workflow.base import WorkflowAsTool
+except ImportError:
+    WorkflowAsTool = None
+
 __all__ = [
     "BaseTool",
     "ToolResult", 
@@ -27,3 +32,6 @@ if CustomTool:
 
 if MCPTool:
     __all__.append("MCPTool")
+
+if WorkflowAsTool:
+    __all__.append("WorkflowAsTool")

--- a/api/app/core/tools/base.py
+++ b/api/app/core/tools/base.py
@@ -20,6 +20,7 @@ class BaseTool(ABC):
         self.tool_id = tool_id
         self.config = config
         self._status = ToolStatus.AVAILABLE
+        self._runtime_context: Dict[str, Any] = {}
     
     @property
     @abstractmethod
@@ -64,6 +65,16 @@ class BaseTool(ABC):
     def tags(self) -> List[str]:
         """工具标签"""
         return self.config.get("tags", [])
+
+    def set_runtime_context(self, **context: Any):
+        """设置运行时上下文，用于传递非业务参数。"""
+        self._runtime_context.update({k: v for k, v in context.items() if v is not None})
+
+    def get_runtime_context(self, key: Optional[str] = None, default: Any = None) -> Any:
+        """获取运行时上下文。"""
+        if key is None:
+            return dict(self._runtime_context)
+        return self._runtime_context.get(key, default)
     
     def validate_parameters(self, parameters: Dict[str, Any]) -> Dict[str, str]:
         """验证参数

--- a/api/app/core/tools/workflow/__init__.py
+++ b/api/app/core/tools/workflow/__init__.py
@@ -1,0 +1,3 @@
+from .base import WorkflowAsTool
+
+__all__ = ["WorkflowAsTool"]

--- a/api/app/core/tools/workflow/base.py
+++ b/api/app/core/tools/workflow/base.py
@@ -1,0 +1,173 @@
+import json
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.tools.base import BaseTool
+from app.models.app_model import App
+from app.models.tool_model import ToolType
+from app.schemas import DraftRunRequest
+from app.schemas.tool_schema import ParameterType, ToolParameter, ToolResult
+
+
+class WorkflowAsTool(BaseTool):
+    """将纯工作流包装为可执行工具。"""
+
+    def __init__(
+        self,
+        db: Session,
+        tool_id: str,
+        workflow_app_id: uuid.UUID,
+        release_id: Optional[uuid.UUID],
+        tool_name: str,
+        tool_description: str,
+        input_parameters: List[Dict[str, Any]],
+        output_schema: Optional[Dict[str, Any]] = None,
+        timeout: int = 300,
+    ):
+        config = {
+            "workflow_app_id": str(workflow_app_id),
+            "version": "1.0.0",
+            "tags": ["workflow"],
+            "timeout": timeout,
+        }
+        super().__init__(tool_id=tool_id, config=config)
+
+        self.db = db
+        self.workflow_app_id = workflow_app_id
+        self.release_id = release_id
+        self._name = tool_name
+        self._description = tool_description
+        self._input_parameters = input_parameters
+        self._output_schema = output_schema
+        self.workflow_service = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def tool_type(self) -> ToolType:
+        return ToolType.WORKFLOW
+
+    @property
+    def parameters(self) -> List[ToolParameter]:
+        params = []
+        for p in self._input_parameters:
+            type_str = p.get("type", "string")
+            param_type = ParameterType.STRING
+            if type_str == "integer":
+                param_type = ParameterType.INTEGER
+            elif type_str == "number":
+                param_type = ParameterType.NUMBER
+            elif type_str == "boolean":
+                param_type = ParameterType.BOOLEAN
+            elif type_str == "array":
+                param_type = ParameterType.ARRAY
+            elif type_str == "object":
+                param_type = ParameterType.OBJECT
+
+            params.append(
+                ToolParameter(
+                    name=p.get("name"),
+                    type=param_type,
+                    description=p.get("description", ""),
+                    required=p.get("required", False),
+                )
+            )
+        return params
+
+    def _normalize_output(self, result: Dict[str, Any]) -> Any:
+        """优先提取结构化输出，兼容 workflow_service.run 的返回格式。"""
+        structured_output = result.get("output_data")
+        if structured_output:
+            return structured_output
+
+        structured_output = result.get("output")
+        if isinstance(structured_output, str):
+            text = structured_output.strip()
+            if text.startswith("{") or text.startswith("["):
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return structured_output
+        return structured_output
+
+    async def execute(self, **kwargs) -> ToolResult:
+        start_time = time.time()
+        try:
+            if self.workflow_service is None:
+                from app.services.workflow_service import WorkflowService
+                self.workflow_service = WorkflowService(self.db)
+
+            workspace_id = self._resolve_workspace_id()
+            user_id = self.get_runtime_context("user_id")
+            workflow_config = None
+            if self.release_id:
+                from app.services.app_service import AppService
+                app_service = AppService(self.db)
+                release = app_service.get_release_by_id(self.workflow_app_id, self.release_id)
+                workflow_config = app_service._workflow_config_from_release(release)
+
+            payload = DraftRunRequest(
+                user_id=str(user_id) if user_id else None,
+                variables=kwargs,
+                stream=False,
+            )
+
+            result = await self.workflow_service.run(
+                app_id=self.workflow_app_id,
+                payload=payload,
+                config=workflow_config,
+                workspace_id=workspace_id,
+                release_id=self.release_id,
+                source="tool",
+            )
+
+            execution_time = time.time() - start_time
+            structured_output = self._normalize_output(result)
+            final_output = {}
+            if self._output_schema and "properties" in self._output_schema:
+                if isinstance(structured_output, dict):
+                    for key in self._output_schema["properties"]:
+                        if key in structured_output:
+                            final_output[key] = structured_output[key]
+                elif structured_output is not None:
+                    output_keys = list(self._output_schema["properties"].keys())
+                    if len(output_keys) == 1:
+                        final_output[output_keys[0]] = structured_output
+            else:
+                final_output = structured_output if structured_output is not None else {}
+
+            return ToolResult.success_result(
+                data=final_output,
+                execution_time=execution_time,
+                token_usage=result.get("token_usage"),
+            )
+        except Exception as e:
+            execution_time = time.time() - start_time
+            return ToolResult.error_result(
+                error=str(e),
+                error_code="WORKFLOW_EXECUTION_ERROR",
+                execution_time=execution_time,
+            )
+
+    def _resolve_workspace_id(self) -> uuid.UUID:
+        """优先使用运行时上下文中的 workspace_id，缺失时回退到工作流所属应用。"""
+        workspace_id = self.get_runtime_context("workspace_id")
+        if isinstance(workspace_id, uuid.UUID):
+            return workspace_id
+        if isinstance(workspace_id, str) and workspace_id:
+            return uuid.UUID(workspace_id)
+
+        app = self.db.get(App, self.workflow_app_id)
+        if app and getattr(app, "workspace_id", None):
+            return app.workspace_id
+
+        raise ValueError("workflow tool execution requires workspace_id")

--- a/api/app/core/workflow/adapters/base_adapter.py
+++ b/api/app/core/workflow/adapters/base_adapter.py
@@ -37,6 +37,7 @@ class WorkflowParserResult(BaseModel):
     execution_config: ExecutionConfig
     origin_config: dict[str, Any]
     trigger: TriggerConfig | None
+    workflow_type: str = Field(default="workflow", description="target workflow type")
     edges: list[EdgeDefinition] = Field(default_factory=list)
     nodes: list[NodeDefinition] = Field(default_factory=list)
     variables: list[VariableDefinition] = Field(default_factory=list)
@@ -49,6 +50,7 @@ class WorkflowImportResult(BaseModel):
     success: bool
     temp_id: str | None = Field(..., description="cache id")
     workflow_id: str | None = Field(..., description="workflow id")
+    workflow_type: str = Field(default="workflow", description="target workflow type")
     edges: list[EdgeDefinition] = Field(default_factory=list)
     nodes: list[NodeDefinition] = Field(default_factory=list)
     variables: list[VariableDefinition] = Field(default_factory=list)

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -109,8 +109,18 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
                 self.edges.append(edge)
 
         mode = self.config.get("app", {}).get("mode", "advanced-chat")
+        
+        # 确定目标工作流类型
+        if mode == "advanced-chat":
+            target_workflow_type = "workflow"
+        elif mode == "workflow":
+            target_workflow_type = "pure_workflow"
+        else:
+            target_workflow_type = mode
+        
         conv_variables = self.config.get("workflow").get("conversation_variables") or []
-        if mode == "workflow":
+        # 纯工作流没有会话变量
+        if target_workflow_type == "pure_workflow":
             conv_variables = []
         for variable in conv_variables:
             con_var = self._convert_variable(variable)
@@ -133,6 +143,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             execution_config=execution_config,
             origin_config=self.config,
             trigger=trigger,
+            workflow_type=target_workflow_type,
             edges=self.edges,
             nodes=self.nodes,
             variables=self.conv_variables,

--- a/api/app/core/workflow/engine/result_builder.py
+++ b/api/app/core/workflow/engine/result_builder.py
@@ -71,7 +71,7 @@ class WorkflowResultBuilder:
             },
             "node_outputs": node_outputs,
             "messages": result.get("messages", []),
-            "conversation_id": execution_context.conversation_id,
+            "conversation_id": execution_context.conversation_id or None,
             "elapsed_time": elapsed_time,
             "token_usage": token_usage,
             "citations": citations,

--- a/api/app/core/workflow/engine/runtime_schema.py
+++ b/api/app/core/workflow/engine/runtime_schema.py
@@ -22,16 +22,16 @@ class ExecutionContext(BaseModel):
             cls,
             execution_id: str,
             workspace_id: str,
-            user_id: str,
-            conversation_id: str,
+            user_id: str | None,
+            conversation_id: str | None,
             memory_storage_type: str,
             user_rag_memory_id: str
     ):
         return cls(
             execution_id=execution_id,
             workspace_id=workspace_id,
-            user_id=user_id,
-            conversation_id=conversation_id,
+            user_id=user_id or "",
+            conversation_id=conversation_id or "",
             memory_storage_type=memory_storage_type,
             user_rag_memory_id=user_rag_memory_id,
 
@@ -41,4 +41,3 @@ class ExecutionContext(BaseModel):
                 }
             )
         )
-

--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -563,22 +563,22 @@ class VariablePoolInitializer:
             input_data: dict,
             context: ExecutionContext
     ):
-        user_message = input_data.get("message") or ""
         user_files = input_data.get("files") or []
         conversations = input_data.get("conv_messages", [])
         conversation_index = len(conversations) // 2
 
         input_variables = input_data.get("variables") or {}
         sys_vars = {
-            "message": (user_message, VariableType.STRING),
             "conversation_index": (conversation_index, VariableType.NUMBER),
-            "conversation_id": (input_data.get("conversation_id"), VariableType.STRING),
+            "conversation_id": (input_data.get("conversation_id") or "", VariableType.STRING),
             "execution_id": (context.execution_id, VariableType.STRING),
             "workspace_id": (context.workspace_id, VariableType.STRING),
             "user_id": (context.user_id, VariableType.STRING),
             "input_variables": (input_variables, VariableType.OBJECT),
             "files": (user_files, VariableType.ARRAY_FILE)
         }
+        if "message" in input_data and input_data.get("message") is not None:
+            sys_vars["message"] = (input_data.get("message"), VariableType.STRING)
         for key, var_def in sys_vars.items():
             value = var_def[0]
             var_type = var_def[1]

--- a/api/app/core/workflow/nodes/start/node.py
+++ b/api/app/core/workflow/nodes/start/node.py
@@ -60,16 +60,18 @@ class StartNode(BaseNode):
 
         # 处理自定义变量（传入 pool 避免重复创建）
         custom_vars = self._process_custom_variables(variable_pool)
+        user_message = variable_pool.get_value("sys.message", default=None, strict=False)
 
         # 返回业务数据（包含自定义变量）
         result = {
-            "message": variable_pool.get_value("sys.message"),
             "execution_id": variable_pool.get_value("sys.execution_id"),
             "conversation_id": variable_pool.get_value("sys.conversation_id"),
             "workspace_id": variable_pool.get_value("sys.workspace_id"),
             "user_id": variable_pool.get_value("sys.user_id"),
             **custom_vars  # 自定义变量作为节点输出的一部分
         }
+        if user_message is not None:
+            result["message"] = user_message
 
         logger.debug(
             f"Node {self.node_id} (Start) execution completed, "
@@ -183,10 +185,13 @@ class StartNode(BaseNode):
             输入数据字典
         """
         input_variables = variable_pool.get_value("sys.input_variables", default={}, strict=False)
-        return {
+        result = {
             "execution_id": variable_pool.get_value("sys.execution_id"),
             "conversation_id": variable_pool.get_value("sys.conversation_id"),
-            "message": variable_pool.get_value("sys.message"),
             "conversation_vars": variable_pool.get_all_conversation_vars(),
             "input_variables": input_variables,
         }
+        user_message = variable_pool.get_value("sys.message", default=None, strict=False)
+        if user_message is not None:
+            result["message"] = user_message
+        return result

--- a/api/app/models/api_key_model.py
+++ b/api/app/models/api_key_model.py
@@ -14,7 +14,8 @@ class ApiKeyType(StrEnum):
     """API Key 类型"""
     AGENT = "agent"  # 智能体
     CLUSTER = "multi_agent"  # 集群
-    WORKFLOW = "workflow"  # 工作流
+    WORKFLOW = "workflow"  # 工作流(对话式)
+    PURE_WORKFLOW = "pure_workflow" # 纯工作流
     SERVICE = "service"  # 服务
 
 

--- a/api/app/models/app_model.py
+++ b/api/app/models/app_model.py
@@ -19,11 +19,12 @@ class AppVisibility(StrEnum):
     WORKSPACE = "workspace"
     PUBLIC = "public"
 
-# 应用类型：agent | workflow | multi_agent
+# 应用类型：agent | workflow | pure_workflow | multi_agent
 class AppType(StrEnum):
     """应用类型枚举"""
     AGENT = "agent"
     WORKFLOW = "workflow"
+    PURE_WORKFLOW = "pure_workflow"
     MULTI_AGENT = "multi_agent"
 
 

--- a/api/app/models/tool_model.py
+++ b/api/app/models/tool_model.py
@@ -15,6 +15,7 @@ class ToolType(StrEnum):
     BUILTIN = "builtin"
     CUSTOM = "custom"
     MCP = "mcp"
+    WORKFLOW = "workflow"
 
 
 class ToolStatus(StrEnum):
@@ -296,5 +297,20 @@ class ToolExecution(Base):
 #     updated_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
 #     last_loaded_at = Column(DateTime)
 #
-#     def __repr__(self):
-#         return f"<PluginConfig(id={self.id}, name={self.name}, version={self.version})>"
+class WorkflowToolConfig(Base):
+    """工作流工具配置模型"""
+    __tablename__ = "workflow_tool_configs"
+
+    id = Column(UUID(as_uuid=True), ForeignKey("tool_configs.id"), primary_key=True)
+    app_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    workflow_config_id = Column(UUID(as_uuid=True), nullable=False)
+    release_id = Column(UUID(as_uuid=True), ForeignKey("app_releases.id"), nullable=True, index=True)
+    input_parameters = Column(JSON, default=list)
+    output_schema = Column(JSON, default=dict)
+    timeout = Column(Integer, default=300)
+
+    # 关联关系
+    base_config = relationship("ToolConfig", foreign_keys=[id])
+    
+    def __repr__(self):
+        return f"<WorkflowToolConfig(id={self.id}, app_id={self.app_id})>"

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -26,6 +26,9 @@ class WorkflowConfig(Base):
         index=True
     )
     
+    # 工作流类型:pure_workflow(纯工作流) | workflow(对话式工作流)
+    workflow_type = Column(String(20), nullable=False, server_default="workflow", index=True)
+    
     # 节点和边的定义（JSON 格式）
     nodes = Column(JSONB, nullable=False, default=list)
     edges = Column(JSONB, nullable=False, default=list)

--- a/api/app/repositories/tool_repository.py
+++ b/api/app/repositories/tool_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy import func
 
 from app.models.tool_model import (
     ToolConfig, BuiltinToolConfig, CustomToolConfig, MCPToolConfig,
-    ToolExecution, ToolType, ToolStatus
+    WorkflowToolConfig, ToolExecution, ToolType, ToolStatus
 )
 
 
@@ -200,6 +200,17 @@ class MCPToolRepository:
         return db.query(MCPToolConfig).filter(
             MCPToolConfig.connection_status == "error"
         ).all()
+
+
+class WorkflowToolRepository:
+    """工作流工具仓储类"""
+
+    @staticmethod
+    def find_by_tool_id(db: Session, tool_id: uuid.UUID) -> Optional[WorkflowToolConfig]:
+        """根据工具ID查找工作流工具配置"""
+        return db.query(WorkflowToolConfig).filter(
+            WorkflowToolConfig.id == tool_id
+        ).first()
 
 
 class ToolExecutionRepository:

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -44,7 +44,8 @@ class WorkflowConfigRepository:
         variables: list[dict[str, Any]] | None = None,
         execution_config: dict[str, Any] | None = None,
         features: dict[str, Any] | None = None,
-        triggers: list[dict[str, Any]] | None = None
+        triggers: list[dict[str, Any]] | None = None,
+        workflow_type: str = "workflow"
     ) -> WorkflowConfig:
         """创建或更新工作流配置
         
@@ -56,6 +57,7 @@ class WorkflowConfigRepository:
             execution_config: 执行配置
             features: 功能特性
             triggers: 触发器列表
+            workflow_type: 工作流类型
         
         Returns:
             工作流配置
@@ -67,12 +69,15 @@ class WorkflowConfigRepository:
             # 更新现有配置
             existing.nodes = nodes
             existing.edges = edges
+            existing.workflow_type = workflow_type
             if variables is not None:
                 existing.variables = variables
             if execution_config is not None:
                 existing.execution_config = execution_config
             if triggers is not None:
                 existing.triggers = triggers
+            if features is not None:
+                existing.features = features
             self.db.commit()
             self.db.refresh(existing)
             return existing
@@ -85,7 +90,8 @@ class WorkflowConfigRepository:
                 variables=variables or [],
                 execution_config=execution_config or {},
                 features=features or {},
-                triggers=triggers or []
+                triggers=triggers or [],
+                workflow_type=workflow_type
             )
             self.db.add(config)
             self.db.commit()

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -329,7 +329,7 @@ class AppCreate(BaseModel):
     description: Optional[str] = None
     icon: Optional[str] = None
     icon_type: Optional[str] = None
-    type: str = Field(pattern=r"^(agent|workflow|multi_agent)$")
+    type: str = Field(pattern=r"^(agent|workflow|pure_workflow|multi_agent)$")
     visibility: Optional[str] = None
     status: Optional[str] = None
     tags: Optional[List[str]] = Field(default_factory=list)
@@ -632,7 +632,7 @@ class AppShare(BaseModel):
 # ---------- Draft Run Schemas ----------
 
 class AppChatRequest(BaseModel):
-    message: str = Field(..., description="用户消息")
+    message: Optional[str] = Field(default=None, description="用户消息，pure_workflow 可不传")
     conversation_id: Optional[str] = Field(default=None, description="会话ID（用于多轮对话）")
     user_id: Optional[str] = Field(default=None, description="用户ID（用于会话管理）")
     variables: Optional[Dict[str, Any]] = Field(default=None, description="自定义变量参数值")
@@ -644,7 +644,7 @@ class AppChatRequest(BaseModel):
 
 class DraftRunRequest(BaseModel):
     """试运行请求"""
-    message: str = Field(..., description="用户消息")
+    message: Optional[str] = Field(default=None, description="用户消息，pure_workflow 可不传")
     conversation_id: Optional[str] = Field(default=None, description="会话ID（用于多轮对话）")
     user_id: Optional[str] = Field(default=None, description="用户ID（用于会话管理）")
     variables: Optional[Dict[str, Any]] = Field(default=None, description="自定义变量参数值")

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -24,7 +24,7 @@ class MessageCreate(BaseModel):
 
 class ChatRequest(BaseModel):
     """聊天请求（基于 share_token）"""
-    message: str = Field(..., description="用户消息")
+    message: Optional[str] = Field(default=None, description="用户消息，pure_workflow 可不传")
     conversation_id: Optional[uuid.UUID] = Field(None, description="会话ID（多轮对话）")
     user_id: Optional[str] = Field(None, description="用户ID（外部系统）")
     variables: Optional[Dict[str, Any]] = Field(None, description="变量参数")

--- a/api/app/schemas/tool_schema.py
+++ b/api/app/schemas/tool_schema.py
@@ -117,6 +117,7 @@ class ToolConfigSchema(BaseModel):
     version: str = "1.0.0"
     tags: List[str] = Field(default_factory=list)
     tenant_id: str
+    is_active: bool = Field(True, description="是否可用（False 表示已删除）")
     created_at: datetime
     updated_at: datetime
 
@@ -165,11 +166,24 @@ class MCPToolConfigSchema(BaseModel):
         from_attributes = True
 
 
+class WorkflowToolConfigSchema(BaseModel):
+    """工作流工具配置模式"""
+    app_id: str = Field(..., description="关联的应用ID")
+    workflow_config_id: str = Field(..., description="工作流配置ID")
+    release_id: Optional[str] = Field(None, description="绑定的工作流发布版本ID")
+    input_parameters: List[Dict[str, Any]] = Field(default_factory=list, description="输入参数定义")
+    output_schema: Dict[str, Any] = Field(default_factory=dict, description="输出结构定义")
+    timeout: int = Field(300, description="超时时间（秒）")
+
+    class Config:
+        from_attributes = True
+
 class ToolDetailSchema(ToolConfigSchema):
     """工具详情模式（包含类型特定配置）"""
     builtin_config: Optional[BuiltinToolConfigSchema] = None
     custom_config: Optional[CustomToolConfigSchema] = None
     mcp_config: Optional[MCPToolConfigSchema] = None
+    workflow_config: Optional[WorkflowToolConfigSchema] = None
 
 
 class ToolExecutionSchema(BaseModel):
@@ -273,3 +287,23 @@ class CustomToolTestRequest(BaseModel):
     method: str = Field(..., description="HTTP方法")
     path: str = Field(..., description="API路径")
     parameters: Dict[str, Any] = Field(default_factory=dict, description="请求参数")
+
+
+class WorkflowToolCreateRequest(BaseModel):
+    """创建工作流工具请求"""
+    name: str = Field(..., min_length=1, max_length=255, description="工具名称")
+    description: Optional[str] = Field(None, max_length=1000, description="工具描述")
+    icon: Optional[str] = Field(None, max_length=255, description="工具图标")
+    release_id: Optional[str] = Field(None, description="工作流发布版本ID，不传则使用当前发布版本")
+    timeout: int = Field(300, ge=10, le=600, description="超时时间（秒）")
+    tags: List[str] = Field(default_factory=list, description="工具标签")
+
+
+class WorkflowToolPublishPreviewSchema(BaseModel):
+    """工作流发布为工具前的预览信息"""
+    app_id: str = Field(..., description="应用ID")
+    release_id: str = Field(..., description="发布版本ID")
+    release_version: int = Field(..., description="发布版本号")
+    release_version_name: str = Field(..., description="发布版本名称")
+    input_parameters: List[Dict[str, Any]] = Field(default_factory=list, description="输入参数定义")
+    output_schema: Dict[str, Any] = Field(default_factory=dict, description="输出结构定义")

--- a/api/app/schemas/workflow_schema.py
+++ b/api/app/schemas/workflow_schema.py
@@ -87,6 +87,7 @@ class WorkflowConfigCreate(BaseModel):
     execution_config: ExecutionConfig = Field(default_factory=ExecutionConfig, description="执行配置")
     triggers: list[TriggerConfig] = Field(default_factory=list, description="触发器列表")
     features: dict = Field(default_factory=dict, description="功能特性配置")
+    workflow_type: str = Field(default="workflow", description="工作流类型: pure_workflow 或 workflow")
 
 
 class WorkflowConfigUpdate(BaseModel):
@@ -97,6 +98,7 @@ class WorkflowConfigUpdate(BaseModel):
     features: dict | None = None
     execution_config: ExecutionConfig | None = None
     triggers: list[TriggerConfig] | None = None
+    workflow_type: str | None = None
 
 
 class WorkflowConfig(BaseModel):
@@ -111,6 +113,7 @@ class WorkflowConfig(BaseModel):
     execution_config: dict[str, Any]
     triggers: list[dict[str, Any]]
     features: dict | None
+    workflow_type: str
     is_active: bool
     created_at: datetime.datetime
     updated_at: datetime.datetime

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -82,6 +82,7 @@ class ApiKeyService:
                     ApiKeyType.AGENT.value: AppType.AGENT.value,
                     ApiKeyType.CLUSTER.value: AppType.MULTI_AGENT.value,
                     ApiKeyType.WORKFLOW.value: AppType.WORKFLOW.value,
+                    ApiKeyType.PURE_WORKFLOW.value: AppType.PURE_WORKFLOW.value,
                 }
                 expected_app_type = type_app_type_map.get(data.type)
 

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -192,8 +192,8 @@ class AppChatService:
         # 获取工具服务
         tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(workspace_id))
 
-        tools.extend(self.agent_service.load_tools_config(config.tools, web_search, tenant_id))
-        skill_tools, skill_prompts = self.agent_service.load_skill_config(config.skills, message, tenant_id)
+        tools.extend(self.agent_service.load_tools_config(config.tools, web_search, tenant_id, user_id, workspace_id))
+        skill_tools, skill_prompts = self.agent_service.load_skill_config(config.skills, message, tenant_id, user_id, workspace_id)
         tools.extend(skill_tools)
         if skill_prompts:
             system_prompt = f"{system_prompt}\n\n{skill_prompts}"
@@ -583,9 +583,9 @@ class AppChatService:
             # 获取工具服务
             tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(workspace_id))
 
-            tools.extend(self.agent_service.load_tools_config(config.tools, web_search, tenant_id))
+            tools.extend(self.agent_service.load_tools_config(config.tools, web_search, tenant_id, user_id, workspace_id))
 
-            skill_tools, skill_prompts = self.agent_service.load_skill_config(config.skills, message, tenant_id)
+            skill_tools, skill_prompts = self.agent_service.load_skill_config(config.skills, message, tenant_id, user_id, workspace_id)
             tools.extend(skill_tools)
             if skill_prompts:
                 system_prompt = f"{system_prompt}\n\n{skill_prompts}"
@@ -1144,8 +1144,8 @@ class AppChatService:
 
     async def workflow_chat(
             self,
-            message: str,
-            conversation_id: uuid.UUID,
+            message: Optional[str],
+            conversation_id: Optional[uuid.UUID],
             config: WorkflowConfig,
             app_id: uuid.UUID,
             release_id: uuid.UUID,
@@ -1163,7 +1163,7 @@ class AppChatService:
         payload = DraftRunRequest(
             message=message,
             variables=variables,
-            conversation_id=str(conversation_id),
+            conversation_id=str(conversation_id) if conversation_id else None,
             stream=True,
             user_id=user_id,
             files=files
@@ -1179,8 +1179,8 @@ class AppChatService:
 
     async def workflow_chat_stream(
             self,
-            message: str,
-            conversation_id: uuid.UUID,
+            message: Optional[str],
+            conversation_id: Optional[uuid.UUID],
             config: WorkflowConfig,
             app_id: uuid.UUID,
             release_id: uuid.UUID,
@@ -1200,7 +1200,7 @@ class AppChatService:
         payload = DraftRunRequest(
             message=message,
             variables=variables,
-            conversation_id=str(conversation_id),
+            conversation_id=str(conversation_id) if conversation_id else None,
             stream=True,
             user_id=user_id,
             files=files

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -73,7 +73,8 @@ class AppDslService:
         config_key = {
             AppType.AGENT: "agent_config",
             AppType.MULTI_AGENT: "multi_agent_config",
-            AppType.WORKFLOW: "workflow"
+            AppType.WORKFLOW: "workflow",
+            AppType.PURE_WORKFLOW: "workflow"
         }.get(app.type, "config")
         config_data = self._enrich_release_config(app.type, release.config or {}, release.default_model_config_id)
         dsl = {**meta, "app": app_meta, config_key: config_data}
@@ -102,7 +103,7 @@ class AppDslService:
                     {**r, "_ref": self._agent_ref(r.get("target_agent_id"))} for r in (cfg["routing_rules"] or [])
                 ]
             return enriched
-        if app_type == AppType.WORKFLOW:
+        if app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             enriched = {**cfg}
             if "nodes" in cfg:
                 enriched["nodes"] = self._enrich_workflow_nodes(cfg["nodes"])
@@ -110,7 +111,7 @@ class AppDslService:
         return cfg
 
     def _export_draft(self, app: App, meta: dict, app_meta: dict) -> tuple[str, str]:
-        if app.type == AppType.WORKFLOW:
+        if app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             config = self.db.query(WorkflowConfig).filter(WorkflowConfig.app_id == app.id).first()
             config_data = {
                 "variables": config.variables if config else [],
@@ -119,6 +120,7 @@ class AppDslService:
                 "features": config.features if config else {},
                 "execution_config": config.execution_config if config else {},
                 "triggers": config.triggers if config else [],
+                "workflow_type": config.workflow_type if config else AppType.WORKFLOW,
             } if config else {}
             dsl = {**meta, "app": app_meta, "workflow": config_data}
 
@@ -258,7 +260,7 @@ class AppDslService:
         """
         app_meta = dsl.get("app", {})
         app_type = app_meta.get("type")
-        if app_type not in (AppType.AGENT, AppType.MULTI_AGENT, AppType.WORKFLOW):
+        if app_type not in (AppType.AGENT, AppType.MULTI_AGENT, AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             raise BusinessException(f"不支持的应用类型: {app_type}", BizCode.BAD_REQUEST)
 
         warnings: list[str] = []
@@ -382,8 +384,10 @@ class AppDslService:
                 else:
                     self.db.add(MultiAgentConfig(id=uuid.uuid4(), app_id=app_id, is_active=True, created_at=now, **fields))
 
-        elif app_type == AppType.WORKFLOW:
-            raw_wf = dsl.get("workflow") or {}
+        elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
+            raw_wf = dsl.get("workflow")
+            if not raw_wf:
+                raise BusinessException("工作流配置缺失", BizCode.BAD_REQUEST)
             raw_nodes = raw_wf.get("nodes") or []
             resolved_nodes = self._resolve_workflow_nodes(raw_nodes, tenant_id, workspace_id, warnings)
             resolved_dsl = {**dsl, "workflow": {**raw_wf, "nodes": resolved_nodes}}
@@ -715,7 +719,7 @@ class AppDslService:
             ).first()
             if not exists:
                 warnings.append(f"记忆配置 '{config_id}' 未匹配，已置空，请导入后手动配置")
-                return {**memory, "memory_config_id": None, "enabled": True}
+                return {**memory, "memory_config_id": None, "enabled": memory.get("enabled", True)}
             return memory
         exists = self.db.query(MemoryConfigModel).filter(
             MemoryConfigModel.config_id == config_uuid,
@@ -723,7 +727,7 @@ class AppDslService:
         ).first()
         if not exists:
             warnings.append(f"记忆配置 '{config_id}' 未匹配，已置空，请导入后手动配置")
-            return {**memory, "memory_config_id": None, "enabled": True}
+            return {**memory, "memory_config_id": None, "enabled": memory.get("enabled", True)}
         return memory
 
     def _resolve_workflow_memory(self, memory_config_id: str, workspace_id: uuid.UUID) -> Optional[str]:

--- a/api/app/services/app_log_service.py
+++ b/api/app/services/app_log_service.py
@@ -110,7 +110,7 @@ class AppLogService:
             workspace_id=workspace_id
         )
 
-        if app_type == AppType.WORKFLOW:
+        if app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             messages, node_executions_map = self._get_workflow_messages_and_nodes(conversation_id)
         else:
             messages = self.message_repository.get_messages_by_conversation(

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -63,6 +63,14 @@ class AppService:
         self.db = db
         self.app_repo = AppRepository(self.db)
 
+    def _normalize_workflow_type(self, workflow_type: Any, default: str = AppType.WORKFLOW.value) -> str:
+        """将 workflow_type 归一化为字符串，兼容 None/枚举/普通字符串。"""
+        if workflow_type is None:
+            return default
+        if hasattr(workflow_type, "value"):
+            return str(workflow_type.value)
+        return str(workflow_type)
+
     # ==================== 私有辅助方法 ====================
 
     def _validate_workspace_access(self, app: App, workspace_id: Optional[uuid.UUID]) -> None:
@@ -701,7 +709,7 @@ class AppService:
             if app.type == "multi_agent" and data.multi_agent_config:
                 self._create_multi_agent_config(app.id, data.multi_agent_config, now)
 
-            if app.type == "workflow" and data.workflow_config:
+            if app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW) and data.workflow_config:
                 from app.schemas.workflow_schema import WorkflowConfigCreate
                 wf_data = WorkflowConfigCreate(**data.workflow_config) if isinstance(data.workflow_config, dict) else data.workflow_config
                 self._create_workflow_config(app.id, wf_data, now)
@@ -926,7 +934,7 @@ class AppService:
                     )
                     self.db.add(new_config)
 
-            elif source_app.type == AppType.WORKFLOW:
+            elif source_app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
                 source_config = self.db.query(WorkflowConfig).filter(
                     WorkflowConfig.app_id == source_app.id
                 ).first()
@@ -941,6 +949,7 @@ class AppService:
                         execution_config=copy.deepcopy(source_config.execution_config) if source_config.execution_config else {},
                         features=copy.deepcopy(source_config.features) if source_config.features else {},
                         triggers=copy.deepcopy(source_config.triggers) if source_config.triggers else [],
+                        workflow_type=source_config.workflow_type,
                         is_active=True,
                         created_at=now,
                         updated_at=now,
@@ -1361,7 +1370,7 @@ class AppService:
         logger.info("Agent 配置更新成功", extra={"app_id": str(app_id)})
         return agent_cfg
 
-    def _agent_config_from_release(self, release: "AppRelease") -> "AgentConfig":
+    def _agent_config_from_release(self, release: "type[AppRelease]") -> "AgentConfig":
         """从发布版本快照重建 AgentConfig 对象（不入库，仅用于运行）"""
         cfg = release.config or {}
         now = release.created_at or datetime.datetime.now()
@@ -1400,6 +1409,7 @@ class AppService:
             execution_config=cfg.get("execution_config", {}),
             triggers=cfg.get("triggers", []),
             features=cfg.get("features", {}),
+            workflow_type=self._normalize_workflow_type(cfg.get("workflow_type")),
             is_active=True,
             created_at=now,
             updated_at=now,
@@ -1565,8 +1575,8 @@ class AppService:
 
         app = self._get_app_or_404(app_id)
 
-        if app.type != AppType.WORKFLOW:
-            raise BusinessException("只有 Workflow 类型应用支持 Workflow 配置", BizCode.APP_TYPE_NOT_SUPPORTED)
+        if app.type not in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
+            raise BusinessException("只有 Workflow 或 Pure_Workflow 类型应用支持 Workflow 配置", BizCode.APP_TYPE_NOT_SUPPORTED)
 
         # 只读操作，允许访问共享应用
         self._validate_app_accessible(app, workspace_id)
@@ -1587,7 +1597,7 @@ class AppService:
 
         # 返回默认配置模板（不保存到数据库）
         logger.debug("配置不存在，返回默认模板", extra={"app_id": str(app_id)})
-        return self._create_default_workflow_config(app_id)
+        return self._create_default_workflow_config(app_id, app.type)
 
     def update_workflow_config(
             self,
@@ -1614,8 +1624,8 @@ class AppService:
 
         app = self._get_app_or_404(app_id)
 
-        if app.type != AppType.WORKFLOW:
-            raise BusinessException("只有 Workflow 类型应用支持 Workflow 配置", BizCode.APP_TYPE_NOT_SUPPORTED)
+        if app.type not in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
+            raise BusinessException("只有 Workflow 或 Pure_Workflow 类型应用支持 Workflow 配置", BizCode.APP_TYPE_NOT_SUPPORTED)
 
         self._validate_app_writable(app, workspace_id)
 
@@ -1635,6 +1645,7 @@ class AppService:
                 execution_config=data.execution_config.model_dump() if data.execution_config else {},
                 triggers=[trigger.model_dump() for trigger in data.triggers] if data.triggers else [],
                 features=data.features or {},
+                workflow_type=self._normalize_workflow_type(data.workflow_type, self._normalize_workflow_type(app.type)),
                 is_active=True,
                 created_at=now,
                 updated_at=now
@@ -1649,6 +1660,10 @@ class AppService:
             workflow_cfg.execution_config = data.execution_config.model_dump() if data.execution_config else {}
             workflow_cfg.triggers = [trigger.model_dump() for trigger in data.triggers] if data.triggers else []
             workflow_cfg.features = data.features or {}
+            workflow_cfg.workflow_type = self._normalize_workflow_type(
+                data.workflow_type,
+                self._normalize_workflow_type(workflow_cfg.workflow_type, self._normalize_workflow_type(app.type))
+            )
             workflow_cfg.updated_at = now
 
         self.db.commit()
@@ -1657,7 +1672,7 @@ class AppService:
         logger.info("Workflow 配置更新成功", extra={"app_id": str(app_id)})
         return workflow_cfg
 
-    def _create_default_workflow_config(self, app_id: uuid.UUID) -> WorkflowConfig:
+    def _create_default_workflow_config(self, app_id: uuid.UUID, workflow_type: Any = AppType.WORKFLOW.value) -> WorkflowConfig:
         """创建默认的 workflow 配置模板（不保存到数据库）
 
         使用 template_loader 加载 simple_qa 模板作为默认配置
@@ -1706,6 +1721,7 @@ class AppService:
             variables=template_data.get('variables', []),
             execution_config=template_data.get('execution_config', {}),
             triggers=template_data.get('triggers', []),
+            workflow_type=self._normalize_workflow_type(workflow_type),
             is_active=True,
             created_at=now,
             updated_at=now
@@ -1894,7 +1910,7 @@ class AppService:
                     "orchestration_mode": multi_agent_cfg.orchestration_mode
                 }
             )
-        elif app.type == AppType.WORKFLOW:
+        elif app.type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             service = WorkflowService(self.db)
             workflow_cfg = service.get_workflow_config(app_id)
             if not workflow_cfg:
@@ -1907,6 +1923,7 @@ class AppService:
                 "variables": workflow_cfg.variables,
                 "execution_config": workflow_cfg.execution_config,
                 "triggers": workflow_cfg.triggers,
+                "workflow_type": workflow_cfg.workflow_type,
                 "features": workflow_cfg.features or {}
             }
 

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -376,7 +376,7 @@ class AgentRunService:
                 raise ValueError(f"The required parameter '{variable.get('name')}' was not provided")
         return input_vars
 
-    def load_tools_config(self, tools_config, web_search, tenant_id) -> list:
+    def load_tools_config(self, tools_config, web_search, tenant_id, user_id=None, workspace_id=None) -> list:
         """加载工具配置"""
         tools = []
         if web_search:
@@ -392,6 +392,7 @@ class AgentRunService:
                     # 根据工具名称查找工具实例
                     tool_instance = tool_service.get_tool_instance(tool_config.get("tool_id", ""), tenant_id)
                     if tool_instance:
+                        tool_instance.set_runtime_context(user_id=user_id, workspace_id=workspace_id)
                         # 转换为LangChain工具
                         langchain_tool = tool_instance.to_langchain_tool(tool_config.get("operation", None))
                         tools.append(langchain_tool)
@@ -406,7 +407,10 @@ class AgentRunService:
     def load_skill_config(
             self,
             skills_config: dict | None,
-            message: str, tenant_id
+            message: str,
+            tenant_id,
+            user_id=None,
+            workspace_id=None,
     ) -> tuple[list, str]:
         if not skills_config:
             return [], ""
@@ -416,7 +420,11 @@ class AgentRunService:
         skill_enable = skills_config.get("enabled", False)
         if skill_enable:
             middleware = AgentMiddleware(skills=skills_config)
-            skill_tools, skill_configs, tool_to_skill_map = middleware.load_skill_tools(self.db, tenant_id)
+            skill_tools, skill_configs, tool_to_skill_map = middleware.load_skill_tools(
+                self.db,
+                tenant_id,
+                runtime_context={"user_id": user_id, "workspace_id": workspace_id},
+            )
 
             # 给技能工具挂载元数据（技能名称）
             for t in skill_tools:
@@ -732,8 +740,8 @@ class AgentRunService:
             tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(workspace_id))
 
             # 从配置中获取启用的工具
-            tools.extend(self.load_tools_config(tools_config, web_search, tenant_id))
-            skill_tools, skill_prompts = self.load_skill_config(skills_config, message, tenant_id)
+            tools.extend(self.load_tools_config(tools_config, web_search, tenant_id, user_id, workspace_id))
+            skill_tools, skill_prompts = self.load_skill_config(skills_config, message, tenant_id, user_id, workspace_id)
             tools.extend(skill_tools)
             if skill_prompts:
                 system_prompt = f"{system_prompt}\n\n{skill_prompts}"
@@ -1120,8 +1128,8 @@ class AgentRunService:
             tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(workspace_id))
 
             # 从配置中获取启用的工具
-            tools.extend(self.load_tools_config(tools_config, web_search, tenant_id))
-            skill_tools, skill_prompts = self.load_skill_config(skills_config, message, tenant_id)
+            tools.extend(self.load_tools_config(tools_config, web_search, tenant_id, user_id, workspace_id))
+            skill_tools, skill_prompts = self.load_skill_config(skills_config, message, tenant_id, user_id, workspace_id)
             tools.extend(skill_tools)
             if skill_prompts:
                 system_prompt = f"{system_prompt}\n\n{skill_prompts}"

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -18,6 +18,7 @@ from app.core.logging_config import get_config_logger, get_logger
 from app.core.validators.memory_config_validators import (
     validate_and_resolve_model_id,
 )
+from app.models.app_model import AppType
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.schemas.memory_config_schema import (
     ConfigurationError,
@@ -854,11 +855,11 @@ class MemoryConfigService:
                 - memory_config_id: 提取的配置ID，如果不存在或为旧格式则返回 None
                 - is_legacy_int: 是否检测到旧格式 int 数据，需要回退到工作空间默认配置
         """
-        if app_type == "agent":
+        if app_type == AppType.AGENT:
             return self._extract_memory_config_id_from_agent(config)
-        elif app_type == "workflow":
+        elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
             return self._extract_memory_config_id_from_workflow(config)
-        elif app_type == "multi_agent":
+        elif app_type == AppType.MULTI_AGENT:
             # Multi-agent 暂不支持记忆配置提取
             logger.debug(f"多智能体应用暂不支持记忆配置提取: app_type={app_type}")
             return None, False

--- a/api/app/services/skill_service.py
+++ b/api/app/services/skill_service.py
@@ -46,7 +46,7 @@ class SkillService:
             for tool_config in skill.tools:
                 tool_id = tool_config.get("tool_id")
                 if tool_id:
-                    tool_info = tool_service.get_tool_info(tool_id, tenant_id)
+                    tool_info = tool_service.get_tool_summary(tool_id, tenant_id)
                     if tool_info:
                         enriched_tool = {
                             "tool_id": tool_id,
@@ -105,7 +105,12 @@ class SkillService:
             raise e
 
     @staticmethod
-    def load_skill_tools(db: Session, skill_ids: List[str], tenant_id: uuid.UUID) -> tuple[List, dict[str, str]]:
+    def load_skill_tools(
+        db: Session,
+        skill_ids: List[str],
+        tenant_id: uuid.UUID,
+        runtime_context: dict | None = None,
+    ) -> tuple[List, dict[str, str]]:
         """加载技能关联的工具
         
         Returns:
@@ -123,6 +128,8 @@ class SkillService:
                     for tool_config in skill.tools:
                         tool = tool_service.get_tool_instance(tool_config.get("tool_id", ""), tenant_id)
                         if tool:
+                            if runtime_context:
+                                tool.set_runtime_context(**runtime_context)
                             langchain_tool = tool.to_langchain_tool(tool_config.get("operation", None))
                             tools.append(langchain_tool)
                             # 建立工具到技能的映射

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -13,18 +13,27 @@ from app.core.exceptions import BusinessException
 from app.core.tools.mcp import MCPToolManager, SimpleMCPClient
 from app.repositories.tool_repository import (
     ToolRepository, BuiltinToolRepository, CustomToolRepository,
-    MCPToolRepository, ToolExecutionRepository
+    MCPToolRepository, WorkflowToolRepository, ToolExecutionRepository
 )
 
 from app.models.tool_model import (
     ToolConfig, BuiltinToolConfig, CustomToolConfig, MCPToolConfig,
     ToolExecution, ToolType, ToolStatus, ExecutionStatus, AuthType
 )
-from app.schemas.tool_schema import ToolInfo, ToolResult
+from app.schemas.tool_schema import (
+    ToolInfo,
+    ToolResult,
+    ToolDetailSchema,
+    BuiltinToolConfigSchema,
+    CustomToolConfigSchema,
+    MCPToolConfigSchema,
+    WorkflowToolConfigSchema,
+)
 from app.core.logging_config import get_business_logger
 from app.core.tools.base import BaseTool
 from app.core.tools.custom.base import CustomTool
 from app.core.tools.mcp.base import MCPTool
+from app.core.tools.workflow.base import WorkflowAsTool
 
 logger = get_business_logger()
 
@@ -54,6 +63,7 @@ class ToolService:
         self.builtin_repo = BuiltinToolRepository()
         self.custom_repo = CustomToolRepository()
         self.mcp_repo = MCPToolRepository()
+        self.workflow_repo = WorkflowToolRepository()
         self.execution_repo = ToolExecutionRepository()
 
     def list_tools(
@@ -77,10 +87,15 @@ class ToolService:
             logger.error(f"获取工具列表失败: {e}")
             return []
 
-    def get_tool_info(self, tool_id: str, tenant_id: uuid.UUID) -> Optional[ToolInfo]:
-        """获取工具详情"""
+    def get_tool_summary(self, tool_id: str, tenant_id: uuid.UUID) -> Optional[ToolInfo]:
+        """获取工具基础信息"""
         config = self.tool_repo.find_by_id_and_tenant_all(self.db, uuid.UUID(tool_id), tenant_id)
         return self._config_to_info(config) if config else None
+
+    def get_tool_detail(self, tool_id: str, tenant_id: uuid.UUID) -> Optional[ToolDetailSchema]:
+        """获取工具详情（包含类型特定配置）"""
+        config = self.tool_repo.find_by_id_and_tenant_all(self.db, uuid.UUID(tool_id), tenant_id)
+        return self._config_to_detail(config) if config else None
 
     def _check_name_duplicate(self, name: str, tool_type: ToolType, tenant_id: uuid.UUID, exclude_id: Optional[uuid.UUID] = None):
         """检查工具名称是否重复"""
@@ -305,6 +320,7 @@ class ToolService:
             )
 
             # 执行工具
+            tool.set_runtime_context(user_id=user_id, workspace_id=workspace_id)
             result = await tool.safe_execute(**parameters)
 
             # 记录执行完成
@@ -334,6 +350,8 @@ class ToolService:
                 return await self._test_custom_connection(config)
             elif config.tool_type == ToolType.BUILTIN.value:
                 return await self._test_builtin_connection(config)
+            elif config.tool_type == ToolType.WORKFLOW.value:
+                return {"success": True, "message": "工作流工具无需额外连接测试"}
             else:
                 return {"success": True, "message": "未知工具类型"}
 
@@ -405,6 +423,8 @@ class ToolService:
                 return await self._get_custom_tool_methods(config)
             elif config.tool_type == ToolType.MCP.value:
                 return await self._get_mcp_tool_methods(config)
+            elif config.tool_type == ToolType.WORKFLOW.value:
+                return await self._get_workflow_tool_methods(config)
             else:
                 return []
                 
@@ -992,6 +1012,8 @@ class ToolService:
             return self._create_custom_instance(config)
         elif config.tool_type == ToolType.MCP.value:
             return self._create_mcp_instance(config)
+        elif config.tool_type == ToolType.WORKFLOW.value:
+            return self._create_workflow_instance(config)
         return None
 
     def _create_builtin_instance(self, config: ToolConfig) -> Optional[BaseTool]:
@@ -1049,6 +1071,25 @@ class ToolService:
 
         return MCPTool(str(config.id), tool_config)
 
+    def _create_workflow_instance(self, config: ToolConfig) -> Optional[WorkflowAsTool]:
+        """创建工作流工具实例"""
+        workflow_config = self.workflow_repo.find_by_tool_id(self.db, config.id)
+
+        if not workflow_config:
+            return None
+
+        return WorkflowAsTool(
+            db=self.db,
+            tool_id=str(config.id),
+            workflow_app_id=workflow_config.app_id,
+            release_id=workflow_config.release_id,
+            tool_name=config.name,
+            tool_description=config.description or "",
+            input_parameters=workflow_config.input_parameters or [],
+            output_schema=workflow_config.output_schema or {},
+            timeout=workflow_config.timeout or 300,
+        )
+
     def _config_to_info(self, config: ToolConfig) -> ToolInfo:
         """配置转换为信息对象"""
         config_data = config.config_data or {}
@@ -1074,6 +1115,17 @@ class ToolService:
                     "market_config_id": mcp_config.market_config_id,
                     "mcp_service_id": mcp_config.mcp_service_id
                 })
+        elif config.tool_type == ToolType.WORKFLOW.value:
+            workflow_config = self.workflow_repo.find_by_tool_id(self.db, config.id)
+            if workflow_config:
+                config_data.update({
+                    "app_id": str(workflow_config.app_id),
+                    "workflow_config_id": str(workflow_config.workflow_config_id),
+                    "release_id": str(workflow_config.release_id) if workflow_config.release_id else None,
+                    "input_parameters": workflow_config.input_parameters or [],
+                    "output_schema": workflow_config.output_schema or {},
+                    "timeout": workflow_config.timeout or 300,
+                })
         
         return ToolInfo(
             id=str(config.id),
@@ -1089,6 +1141,111 @@ class ToolService:
             is_active=config.is_active,
             created_at=config.created_at
         )
+
+    def _config_to_detail(self, config: ToolConfig) -> ToolDetailSchema:
+        """配置转换为详情对象。"""
+        info = self._config_to_info(config)
+        detail_data = info.model_dump()
+        detail_data["updated_at"] = config.updated_at or config.created_at
+
+        builtin_config = None
+        custom_config = None
+        mcp_config = None
+        workflow_config = None
+
+        if config.tool_type == ToolType.BUILTIN.value:
+            cfg = self.builtin_repo.find_by_tool_id(self.db, config.id)
+            if cfg:
+                builtin_config = BuiltinToolConfigSchema.model_validate(cfg)
+        elif config.tool_type == ToolType.CUSTOM.value:
+            cfg = self.custom_repo.find_by_tool_id(self.db, config.id)
+            if cfg:
+                custom_config = CustomToolConfigSchema.model_validate(cfg)
+        elif config.tool_type == ToolType.MCP.value:
+            cfg = self.mcp_repo.find_by_tool_id(self.db, config.id)
+            if cfg:
+                mcp_config = MCPToolConfigSchema.model_validate({
+                    "server_url": cfg.server_url,
+                    "connection_config": cfg.connection_config or {},
+                    "last_health_check": cfg.last_health_check,
+                    "health_status": cfg.health_status,
+                    "error_message": cfg.error_message,
+                    "available_tools": cfg.available_tools or [],
+                    "source_channel": cfg.source_channel,
+                    "market_id": str(cfg.market_id) if cfg.market_id else None,
+                    "market_config_id": str(cfg.market_config_id) if cfg.market_config_id else None,
+                    "mcp_service_id": cfg.mcp_service_id,
+                })
+        elif config.tool_type == ToolType.WORKFLOW.value:
+            cfg = self.workflow_repo.find_by_tool_id(self.db, config.id)
+            if cfg:
+                workflow_config = WorkflowToolConfigSchema.model_validate({
+                    "app_id": str(cfg.app_id),
+                    "workflow_config_id": str(cfg.workflow_config_id),
+                    "release_id": str(cfg.release_id) if cfg.release_id else None,
+                    "input_parameters": cfg.input_parameters or [],
+                    "output_schema": cfg.output_schema or {},
+                    "timeout": cfg.timeout or 300,
+                })
+
+        detail_data.update({
+            "builtin_config": builtin_config,
+            "custom_config": custom_config,
+            "mcp_config": mcp_config,
+            "workflow_config": workflow_config,
+        })
+        detail_data["config_data"] = self._strip_type_specific_config_data_for_detail(
+            config.tool_type,
+            detail_data.get("config_data", {}),
+        )
+        return ToolDetailSchema.model_validate(detail_data)
+
+    @staticmethod
+    def _strip_type_specific_config_data_for_detail(
+        tool_type: str,
+        config_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """在详情返回中去掉已由类型配置承载的重复字段。"""
+        if not config_data:
+            return {}
+
+        duplicate_fields_map = {
+            ToolType.BUILTIN.value: {"tool_class", "requires_config", "is_enabled", "parameters"},
+            ToolType.CUSTOM.value: {"base_url", "auth_type", "auth_config", "timeout", "schema_content", "schema_url"},
+            ToolType.MCP.value: {
+                "last_health_check", "health_status", "available_tools",
+                "source_channel", "market_id", "market_config_id", "mcp_service_id",
+                "server_url", "connection_config", "error_message",
+            },
+            ToolType.WORKFLOW.value: {
+                "app_id", "workflow_config_id", "release_id", "input_parameters", "output_schema", "timeout",
+            },
+        }
+        duplicate_fields = duplicate_fields_map.get(tool_type, set())
+        return {k: v for k, v in config_data.items() if k not in duplicate_fields}
+
+    async def _get_workflow_tool_methods(self, config: ToolConfig) -> List[Dict[str, Any]]:
+        """获取工作流工具的方法列表。"""
+        tool_instance = self.get_tool_instance(str(config.id), config.tenant_id)
+        if not tool_instance:
+            return []
+
+        return [{
+            "method_id": config.name,
+            "name": config.name,
+            "description": config.description,
+            "parameters": [{
+                "name": param.name,
+                "type": param.type.value,
+                "description": param.description,
+                "required": param.required,
+                "default": param.default,
+                "enum": param.enum,
+                "minimum": param.minimum,
+                "maximum": param.maximum,
+                "pattern": param.pattern
+            } for param in tool_instance.parameters]
+        }]
 
     def _create_type_config(self, tool_config: ToolConfig, config: Dict[str, Any]):
         """创建类型特定配置"""

--- a/api/app/services/workflow_import_service.py
+++ b/api/app/services/workflow_import_service.py
@@ -87,20 +87,24 @@ class WorkflowImportService:
         if config is None:
             raise BusinessException("Configuration import timed out. Please try again.")
         config = json.loads(config)
-        unique_name = self.app_service._unique_app_name(name, workspace_id, AppType.WORKFLOW)
+        unique_name = self.app_service._unique_app_name(
+            name, workspace_id, config.get("workflow_type", AppType.WORKFLOW)
+        )
         app = self.app_service.create_app(
             user_id=user_id,
             workspace_id=workspace_id,
             data=AppCreate(
                 name=unique_name,
                 description=description,
-                type="workflow",
+                type=config.get("workflow_type", AppType.WORKFLOW),
                 workflow_config=WorkflowConfigCreate(
                     nodes=config["nodes"],
                     edges=config["edges"],
                     variables=config["variables"],
-                    features=config.get("features", {})
+                    features=config.get("features", {}),
+                    workflow_type=config.get("workflow_type", "workflow")
                 )
             )
         )
+
         return app

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -19,7 +19,7 @@ from app.core.workflow.nodes.enums import NodeType
 from app.core.workflow.validator import validate_workflow_config
 from app.db import get_db
 from app.models import App
-from app.models.workflow_model import WorkflowConfig, WorkflowExecution, WorkflowNodeExecution
+from app.models.workflow_model import WorkflowConfig, WorkflowExecution
 from app.repositories import knowledge_repository
 from app.repositories.workflow_repository import (
     WorkflowConfigRepository,
@@ -116,6 +116,7 @@ class WorkflowService:
             execution_config: dict[str, Any] | None = None,
             features: dict[str, Any] | None = None,
             triggers: list[dict[str, Any]] | None = None,
+            workflow_type: str = "workflow",
             validate: bool = True
     ) -> WorkflowConfig:
         """创建工作流配置
@@ -128,6 +129,7 @@ class WorkflowService:
             execution_config: 执行配置
             features: 功能特性
             triggers: 触发器列表
+            workflow_type: 工作流类型
             validate: 是否验证配置
 
         Returns:
@@ -143,7 +145,8 @@ class WorkflowService:
             "variables": variables or [],
             "execution_config": execution_config or {},
             "features": features or {},
-            "triggers": triggers or []
+            "triggers": triggers or [],
+            "workflow_type": workflow_type
         }
 
         # 验证配置
@@ -164,7 +167,8 @@ class WorkflowService:
             variables=variables,
             execution_config=execution_config,
             features=features,
-            triggers=triggers
+            triggers=triggers,
+            workflow_type=workflow_type
         )
 
         logger.info(f"创建工作流配置成功: app_id={app_id}, config_id={config.id}")
@@ -188,7 +192,9 @@ class WorkflowService:
             edges: list[dict[str, Any]] | None = None,
             variables: list[dict[str, Any]] | None = None,
             execution_config: dict[str, Any] | None = None,
+            features: dict[str, Any] | None = None,
             triggers: list[dict[str, Any]] | None = None,
+            workflow_type: str | None = None,
             validate: bool = True
     ) -> WorkflowConfig:
         """更新工作流配置
@@ -199,7 +205,9 @@ class WorkflowService:
             edges: 边列表
             variables: 变量列表
             execution_config: 执行配置
+            features: 功能特性
             triggers: 触发器列表
+            workflow_type: 工作流类型
             validate: 是否验证配置
 
         Returns:
@@ -221,7 +229,9 @@ class WorkflowService:
         updated_edges = edges if edges is not None else config.edges
         updated_variables = variables if variables is not None else config.variables
         updated_execution_config = execution_config if execution_config is not None else config.execution_config
+        updated_features = features if features is not None else config.features
         updated_triggers = triggers if triggers is not None else config.triggers
+        updated_workflow_type = workflow_type if workflow_type is not None else config.workflow_type
 
         # 构建配置字典
         config_dict = {
@@ -229,7 +239,9 @@ class WorkflowService:
             "edges": updated_edges,
             "variables": updated_variables,
             "execution_config": updated_execution_config,
-            "triggers": updated_triggers
+            "features": updated_features,
+            "triggers": updated_triggers,
+            "workflow_type": updated_workflow_type
         }
 
         # 验证配置
@@ -249,7 +261,9 @@ class WorkflowService:
             edges=updated_edges,
             variables=updated_variables,
             execution_config=updated_execution_config,
-            triggers=updated_triggers
+            features=updated_features,
+            triggers=updated_triggers,
+            workflow_type=updated_workflow_type
         )
 
         logger.info(f"更新工作流配置成功: app_id={app_id}, config_id={config.id}")
@@ -796,6 +810,8 @@ class WorkflowService:
             error: str,
     ) -> None:
         """将失败时的用户消息和助手错误消息写入会话。"""
+        if not conversation_id:
+            return
         self.conversation_service.add_message(
             conversation_id=conversation_id,
             role="user",
@@ -811,6 +827,40 @@ class WorkflowService:
             meta_data={"error": error},
             sync_memory=False,
         )
+
+    @staticmethod
+    def _supports_conversation(config: WorkflowConfig) -> bool:
+        return getattr(config, "workflow_type", "workflow") == "workflow"
+
+    def _ensure_conversation(
+            self,
+            *,
+            app_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+            user_id: str | None,
+            conversation_id: uuid.UUID | None,
+            enable_conversation: bool,
+    ) -> uuid.UUID | None:
+        if not enable_conversation:
+            return conversation_id
+        if conversation_id:
+            return conversation_id
+
+        from app.models import Conversation as ConversationModel
+
+        conversation_id = uuid.uuid4()
+        new_conversation = ConversationModel(
+            id=conversation_id,
+            app_id=app_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            is_draft=True,
+            title="草稿会话",
+        )
+        self.db.add(new_conversation)
+        self.db.commit()
+        self.db.refresh(new_conversation)
+        return conversation_id
 
     def _get_history_info(self, conversation_id: uuid.UUID) -> tuple[dict, list] | None:
         executions = self.execution_repo.get_by_conversation_id(
@@ -877,6 +927,8 @@ class WorkflowService:
                 message=f"工作流配置不存在: app_id={app_id}"
             )
 
+        supports_conversation = self._supports_conversation(config)
+
         feature_configs = config.features or {}
         self._validate_file_upload(feature_configs, payload.files)
 
@@ -887,36 +939,37 @@ class WorkflowService:
         )
 
         input_data = {
-            "message": payload.message, "variables": resolved_variables,
-            "conversation_id": payload.conversation_id,
+            "variables": resolved_variables,
             "files": [file.model_dump(mode='json') for file in payload.files]
         }
+        if payload.message is not None:
+            input_data["message"] = payload.message
+        if payload.conversation_id:
+            input_data["conversation_id"] = payload.conversation_id
 
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
+        conversation_id_uuid = self._ensure_conversation(
+            app_id=app_id,
+            workspace_id=workspace_id,
+            user_id=payload.user_id,
+            conversation_id=conversation_id_uuid,
+            enable_conversation=supports_conversation,
+        )
+        if conversation_id_uuid:
+            payload.conversation_id = str(conversation_id_uuid)
+            input_data["conversation_id"] = str(conversation_id_uuid)
 
         # 检查标注命中 — 在创建工作流执行之前，命中则直接返回跳过整个工作流
-        annotation_match = self._check_annotation_match(app_id, payload.message,
-                                                        source=source or HitLogSource.CONSOLE)
+        annotation_match = None
+        if supports_conversation and payload.message:
+            annotation_match = self._check_annotation_match(
+                app_id, payload.message, source=source or HitLogSource.CONSOLE
+            )
         if annotation_match:
-            if not conversation_id_uuid:
-                conversation_id_uuid = uuid.uuid4()
-                from app.models import Conversation as ConversationModel
-                new_conversation = ConversationModel(
-                    id=conversation_id_uuid,
-                    app_id=app_id,
-                    workspace_id=workspace_id,
-                    user_id=payload.user_id,
-                    is_draft=True,
-                    title="草稿会话",
-                )
-                self.db.add(new_conversation)
-                self.db.commit()
-                self.db.refresh(new_conversation)
-
             message_id = uuid.uuid4()
             prev_messages = []
-            history = self._get_history_info(conversation_id_uuid)
+            history = self._get_history_info(conversation_id_uuid) if conversation_id_uuid else None
             if history:
                 _, prev_messages = history
             self.conversation_service.add_message(
@@ -1007,7 +1060,7 @@ class WorkflowService:
             # 更新状态为运行中
             self.update_execution_status(execution.execution_id, "running")
 
-            history = self._get_history_info(conversation_id_uuid)
+            history = self._get_history_info(conversation_id_uuid) if conversation_id_uuid else None
             if history:
                 conv_vars, conv_messages = history
                 input_data["conv"] = conv_vars
@@ -1018,7 +1071,12 @@ class WorkflowService:
             is_new_conversation = init_message_length == 0
             if is_new_conversation:
                 opening_cfg = feature_configs.get("opening_statement", {})
-                if isinstance(opening_cfg, dict) and opening_cfg.get("enabled") and opening_cfg.get("statement"):
+                if (
+                        conversation_id_uuid
+                        and isinstance(opening_cfg, dict)
+                        and opening_cfg.get("enabled")
+                        and opening_cfg.get("statement")
+                ):
                     statement = opening_cfg["statement"]
                     suggested_questions = opening_cfg.get("suggested_questions", [])
                     if payload.variables:
@@ -1069,13 +1127,14 @@ class WorkflowService:
                                 })
                     if message["role"] == "assistant":
                         assistant_message = message["content"]
-                self.conversation_service.add_message(
-                    conversation_id=conversation_id_uuid,
-                    role="user",
-                    content=human_message,
-                    meta_data=human_meta,
-                    sync_memory=False,
-                )
+                if conversation_id_uuid:
+                    self.conversation_service.add_message(
+                        conversation_id=conversation_id_uuid,
+                        role="user",
+                        content=human_message,
+                        meta_data=human_meta,
+                        sync_memory=False,
+                    )
                 # 过滤 citations
                 citations = result.get("citations", [])
                 citation_cfg = feature_configs.get("citation", {})
@@ -1092,14 +1151,15 @@ class WorkflowService:
                 assistant_meta = {"usage": token_usage, "audio_url": None}
                 if filtered_citations:
                     assistant_meta["citations"] = filtered_citations
-                self.conversation_service.add_message(
-                    message_id=message_id,
-                    conversation_id=conversation_id_uuid,
-                    role="assistant",
-                    content=assistant_message,
-                    meta_data=assistant_meta,
-                    sync_memory=False,
-                )
+                if conversation_id_uuid:
+                    self.conversation_service.add_message(
+                        message_id=message_id,
+                        conversation_id=conversation_id_uuid,
+                        role="assistant",
+                        content=assistant_message,
+                        meta_data=assistant_meta,
+                        sync_memory=False,
+                    )
                 self.update_execution_status(
                     execution.execution_id,
                     "completed",
@@ -1136,7 +1196,7 @@ class WorkflowService:
                 "message": result.get("output"),  # 最终输出（字符串）
                 "message_id": str(message_id),
                 # "output_data": result.get("node_outputs", {}),  # 所有节点输出（详细数据）
-                "conversation_id": result.get("conversation_id"),  # 所有节点输出（详细数据）payload.,  # 会话 ID
+                "conversation_id": result.get("conversation_id") or (str(conversation_id_uuid) if conversation_id_uuid else None),
                 "error_message": result.get("error"),
                 "elapsed_time": result.get("elapsed_time"),
                 "token_usage": result.get("token_usage"),
@@ -1187,6 +1247,7 @@ class WorkflowService:
                 code=BizCode.CONFIG_MISSING,
                 message=f"工作流配置不存在: app_id={app_id}"
             )
+        supports_conversation = self._supports_conversation(config)
         feature_configs = config.features or {}
         self._validate_file_upload(feature_configs, payload.files)
 
@@ -1197,37 +1258,37 @@ class WorkflowService:
         )
 
         input_data = {
-            "message": payload.message, "variables": resolved_variables,
-            "conversation_id": payload.conversation_id,
+            "variables": resolved_variables,
             "files": [file.model_dump(mode='json') for file in payload.files]
         }
+        if payload.message is not None:
+            input_data["message"] = payload.message
+        if payload.conversation_id:
+            input_data["conversation_id"] = payload.conversation_id
 
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
+        conversation_id_uuid = self._ensure_conversation(
+            app_id=app_id,
+            workspace_id=workspace_id,
+            user_id=payload.user_id,
+            conversation_id=conversation_id_uuid,
+            enable_conversation=supports_conversation,
+        )
+        if conversation_id_uuid:
+            payload.conversation_id = str(conversation_id_uuid)
+            input_data["conversation_id"] = str(conversation_id_uuid)
 
         # 检查标注命中 — 在创建工作流执行之前，命中则直接返回跳过整个工作流
-        annotation_match = self._check_annotation_match(app_id, payload.message,
-                                                        source=source or HitLogSource.CONSOLE)
+        annotation_match = None
+        if supports_conversation and payload.message:
+            annotation_match = self._check_annotation_match(
+                app_id, payload.message, source=source or HitLogSource.CONSOLE
+            )
         if annotation_match:
-            if not conversation_id_uuid:
-                from app.models import Conversation as ConversationModel
-                conversation_id_uuid = uuid.uuid4()
-                new_conversation = ConversationModel(
-                    id=conversation_id_uuid,
-                    app_id=app_id,
-                    workspace_id=workspace_id,
-                    user_id=payload.user_id,
-                    is_draft=True,
-                    title="草稿会话",
-                )
-                self.db.add(new_conversation)
-                self.db.commit()
-                self.db.refresh(new_conversation)
-                payload.conversation_id = str(conversation_id_uuid)
-
             message_id = uuid.uuid4()
             prev_messages = []
-            history = self._get_history_info(conversation_id_uuid)
+            history = self._get_history_info(conversation_id_uuid) if conversation_id_uuid else None
             if history:
                 _, prev_messages = history
             self.conversation_service.add_message(
@@ -1342,7 +1403,7 @@ class WorkflowService:
             execution.input_data = input_data
             self.db.commit()
             self.update_execution_status(execution.execution_id, "running")
-            history = self._get_history_info(conversation_id_uuid)
+            history = self._get_history_info(conversation_id_uuid) if conversation_id_uuid else None
             if history:
                 conv_vars, conv_messages = history
                 input_data["conv"] = conv_vars
@@ -1355,7 +1416,12 @@ class WorkflowService:
             is_new_conversation = init_message_length == 0
             if is_new_conversation:
                 opening_cfg = feature_configs.get("opening_statement", {})
-                if isinstance(opening_cfg, dict) and opening_cfg.get("enabled") and opening_cfg.get("statement"):
+                if (
+                        conversation_id_uuid
+                        and isinstance(opening_cfg, dict)
+                        and opening_cfg.get("enabled")
+                        and opening_cfg.get("statement")
+                ):
                     statement = opening_cfg["statement"]
                     suggested_questions = opening_cfg.get("suggested_questions", [])
                     if payload.variables:
@@ -1415,13 +1481,14 @@ class WorkflowService:
                                         })
                             if message["role"] == "assistant":
                                 assistant_message = message["content"]
-                        self.conversation_service.add_message(
-                            conversation_id=conversation_id_uuid,
-                            role="user",
-                            content=human_message,
-                            meta_data=human_meta,
-                            sync_memory=False,
-                        )
+                        if conversation_id_uuid:
+                            self.conversation_service.add_message(
+                                conversation_id=conversation_id_uuid,
+                                role="user",
+                                content=human_message,
+                                meta_data=human_meta,
+                                sync_memory=False,
+                            )
                         # 过滤 citations
                         citations = event.get("data", {}).get("citations", [])
                         citation_cfg = feature_configs.get("citation", {})
@@ -1438,14 +1505,15 @@ class WorkflowService:
                         assistant_meta = {"usage": token_usage, "audio_url": None}
                         if filtered_citations:
                             assistant_meta["citations"] = filtered_citations
-                        self.conversation_service.add_message(
-                            message_id=message_id,
-                            conversation_id=conversation_id_uuid,
-                            role="assistant",
-                            content=assistant_message,
-                            meta_data=assistant_meta,
-                            sync_memory=False,
-                        )
+                        if conversation_id_uuid:
+                            self.conversation_service.add_message(
+                                message_id=message_id,
+                                conversation_id=conversation_id_uuid,
+                                role="assistant",
+                                content=assistant_message,
+                                meta_data=assistant_meta,
+                                sync_memory=False,
+                            )
                         self.update_execution_status(
                             execution.execution_id,
                             "completed",

--- a/api/app/services/workflow_tool_publish_service.py
+++ b/api/app/services/workflow_tool_publish_service.py
@@ -1,0 +1,226 @@
+import uuid
+import logging
+from typing import Any, Dict, List, Optional
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import BusinessException
+from app.core.error_codes import BizCode
+from app.models.app_model import App, AppType
+from app.models.app_release_model import AppRelease
+from app.models.tool_model import ToolConfig, WorkflowToolConfig, ToolStatus, ToolType
+from app.models.workflow_model import WorkflowConfig
+from app.schemas.tool_schema import WorkflowToolPublishPreviewSchema
+
+logger = logging.getLogger(__name__)
+
+class WorkflowToolPublishService:
+    """工作流工具发布服务"""
+    
+    def __init__(self, db: Session):
+        self.db = db
+
+    def _validate_workflow_app(self, app_id: uuid.UUID, workspace_id: uuid.UUID) -> type[App]:
+        app = self.db.query(App).filter(
+            App.id == app_id,
+            App.workspace_id == workspace_id,
+            App.is_active.is_(True)
+        ).first()
+        
+        if not app:
+            raise BusinessException(f"应用不存在或无权访问: {app_id}", BizCode.NOT_FOUND)
+        
+        if app.type != AppType.PURE_WORKFLOW:
+            raise BusinessException(
+                f"只有 Workflow(纯工作流) 类型可以发布为工具，当前类型: {app.type}。",
+                BizCode.INVALID_PARAMETER
+            )
+        return app
+
+    def _get_workflow_config(self, app_id: uuid.UUID) -> type[WorkflowConfig]:
+        config = self.db.query(WorkflowConfig).filter(
+            WorkflowConfig.app_id == app_id,
+            WorkflowConfig.is_active.is_(True)
+        ).first()
+        
+        if not config:
+            raise BusinessException("工作流配置不存在", BizCode.NOT_FOUND)
+        return config
+
+    def _get_release(self, app: type[App], release_id: Optional[uuid.UUID]) -> AppRelease:
+        resolved_release_id = release_id or app.current_release_id
+        if not resolved_release_id:
+            raise BusinessException("请先发布工作流，再将其发布为工具", BizCode.CONFIG_MISSING)
+
+        release = self.db.query(AppRelease).filter(
+            AppRelease.id == resolved_release_id,
+            AppRelease.app_id == app.id,
+            AppRelease.is_active.is_(True),
+        ).first()
+        if not release:
+            raise BusinessException("工作流发布版本不存在", BizCode.NOT_FOUND)
+        return release
+
+    @staticmethod
+    def _get_nodes(workflow_source: Any) -> List[Dict[str, Any]]:
+        if isinstance(workflow_source, dict):
+            nodes = workflow_source.get("nodes", [])
+        else:
+            nodes = getattr(workflow_source, "nodes", [])
+        return nodes if isinstance(nodes, list) else []
+
+    @staticmethod
+    def _get_node_config(node: Dict[str, Any]) -> Dict[str, Any]:
+        config = node.get("config")
+        return config if isinstance(config, dict) else {}
+
+    @staticmethod
+    def _map_to_json_type(var_type: Any) -> str:
+        type_str = str(var_type or "string").lower()
+        if type_str in {"int", "integer"}:
+            return "integer"
+        if type_str in {"number", "float", "double"}:
+            return "number"
+        if type_str in {"bool", "boolean"}:
+            return "boolean"
+        if type_str.startswith("array[") or type_str == "array":
+            return "array"
+        if type_str in {"object", "json"}:
+            return "object"
+        if type_str in {"file", "array[file]"}:
+            return "string"
+        return "string"
+
+    @staticmethod
+    def _extract_input_parameters(workflow_source: Any) -> List[Dict[str, Any]]:
+        parameters = []
+        for node in WorkflowToolPublishService._get_nodes(workflow_source):
+            if node.get("type") == "start":
+                node_config = WorkflowToolPublishService._get_node_config(node)
+                variables = node_config.get("variables")
+                if not isinstance(variables, list):
+                    variables = node.get("variables", [])
+                for var in variables:
+                    if not isinstance(var, dict):
+                        continue
+                    parameters.append({
+                        "name": var.get("name"),
+                        "type": WorkflowToolPublishService._map_to_json_type(var.get("type")),
+                        "description": var.get("description", ""),
+                        "required": var.get("required", False)
+                    })
+                break
+        return parameters
+
+    @staticmethod
+    def _extract_output_schema(workflow_source: Any) -> Dict[str, Any]:
+        schema = {"type": "object", "properties": {}}
+        for node in WorkflowToolPublishService._get_nodes(workflow_source):
+            if node.get("type") == "output":
+                node_config = WorkflowToolPublishService._get_node_config(node)
+                outputs = node_config.get("outputs")
+                if not isinstance(outputs, list):
+                    outputs = node.get("outputs", [])
+                for out in outputs:
+                    if not isinstance(out, dict):
+                        continue
+                    name = out.get("name")
+                    if name:
+                        schema["properties"][name] = {
+                            "type": WorkflowToolPublishService._map_to_json_type(out.get("type"))
+                        }
+                break
+        return schema
+
+    def get_publish_preview(
+            self,
+            workflow_app_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+            release_id: Optional[uuid.UUID] = None,
+    ) -> WorkflowToolPublishPreviewSchema:
+        app = self._validate_workflow_app(workflow_app_id, workspace_id)
+        release = self._get_release(app, release_id)
+        release_config = release.config or {}
+
+        return WorkflowToolPublishPreviewSchema(
+            app_id=str(workflow_app_id),
+            release_id=str(release.id),
+            release_version=release.version,
+            release_version_name=release.version_name,
+            input_parameters=self._extract_input_parameters(release_config),
+            output_schema=self._extract_output_schema(release_config),
+        )
+
+    def publish_workflow_as_tool(
+        self,
+        workflow_app_id: uuid.UUID,
+        tool_name: str,
+        tool_description: str,
+        tenant_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        created_by: uuid.UUID,
+        icon: Optional[str] = None,
+        timeout: int = 300,
+        tags: Optional[List[str]] = None,
+        release_id: Optional[uuid.UUID] = None,
+    ) -> type[ToolConfig] | None:
+        _ = created_by
+        app = self._validate_workflow_app(workflow_app_id, workspace_id)
+        release = self._get_release(app, release_id)
+        workflow_config = self._get_workflow_config(workflow_app_id)
+        release_config = release.config or {}
+
+        input_parameters = self._extract_input_parameters(release_config)
+        output_schema = self._extract_output_schema(release_config)
+
+        # Check if already published
+        existing_tool = self.db.query(WorkflowToolConfig).filter(
+            WorkflowToolConfig.app_id == workflow_app_id
+        ).first()
+
+        if existing_tool:
+            # Update existing tool
+            tool_config = self.db.query(ToolConfig).filter(ToolConfig.id == existing_tool.id).first()
+            tool_config.name = tool_name
+            tool_config.description = tool_description
+            tool_config.icon = icon
+            if tags is not None:
+                tool_config.tags = tags
+
+            existing_tool.input_parameters = input_parameters
+            existing_tool.output_schema = output_schema
+            existing_tool.timeout = timeout
+            existing_tool.workflow_config_id = workflow_config.id
+            existing_tool.release_id = release.id
+            
+            self.db.commit()
+            self.db.refresh(tool_config)
+            return tool_config
+
+        # Create new tool
+        tool_id = uuid.uuid4()
+        tool_config = ToolConfig(
+            id=tool_id,
+            name=tool_name,
+            description=tool_description,
+            icon=icon,
+            tool_type=ToolType.WORKFLOW,
+            status=ToolStatus.AVAILABLE,
+            tags=tags or ["workflow"],
+            tenant_id=tenant_id
+        )
+        self.db.add(tool_config)
+
+        workflow_tool_config = WorkflowToolConfig(
+            id=tool_id,
+            app_id=workflow_app_id,
+            workflow_config_id=workflow_config.id,
+            release_id=release.id,
+            input_parameters=input_parameters,
+            output_schema=output_schema,
+            timeout=timeout
+        )
+        self.db.add(workflow_tool_config)
+        
+        self.db.commit()
+        self.db.refresh(tool_config)
+        return tool_config


### PR DESCRIPTION
support PURE_WORKFLOW app type and add workflow tool publishing endpoints

## Summary by Sourcery

为新的 PURE_WORKFLOW 应用类型提供支持，启用将纯工作流发布为可复用工具，并在聊天、草稿运行和分享相关 API 中放宽对纯工作流的消息/会话要求。

New Features:
- 引入 PURE_WORKFLOW 应用类型，并在工作流配置、模型、DSL 导入/导出、版本发布以及内存配置中传递 `workflow_type`。
- 允许纯工作流应用在没有必需消息或自动创建会话的情况下运行，同时在提供会话时仍然支持会话能力。
- 添加“工作流即工具”的能力，包括工作流工具类型、模型、仓库、运行时封装器以及用于预览和发布工作流为工具的端点。
- 扩展工具详情 API 和模式，以返回特定类型的配置，包括工作流工具的元数据和配置。

Bug Fixes:
- 在不存在 `conversation_id` 时避免保存失败的会话，并仅在会话存在时才进行工作流历史、开场白和消息的写入。
- 在 DSL 导入中解决缺失的内存配置时，保留已有的内存启用标志，而不是强制将其设为启用。
- 将空的工作流引擎会话 ID 在最终输出中规范化为 `None`，以避免泄露空字符串。

Enhancements:
- 将运行时上下文（`user_id`、`workspace_id`）向下传入工具和技能工具，使执行能够具备租户和用户感知能力。
- 优化工具测试、方法发现和实例创建，以支持工作流工具，并在不需要连接测试的场景下简化连接测试流程。
- 在应用聊天、草稿运行和分享聊天的模式与控制器中将消息字段改为可选，并增加校验以确保只有会话型应用类型才需要消息。
- 调整日志和导出/导入辅助工具，使 PURE_WORKFLOW 在 DSL 导出键选择和配置校验等方面与 WORKFLOW 及其他应用类型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a new PURE_WORKFLOW app type, enable publishing pure workflows as reusable tools, and relax message/conversation requirements for pure workflows across chat, draft-run, and sharing APIs.

New Features:
- Introduce PURE_WORKFLOW app type and propagate workflow_type through workflow configs, models, DSL import/export, releases, and memory configuration.
- Allow pure workflow apps to run without a required message or automatically created conversation, while still supporting conversations when provided.
- Add workflow-as-tool capability including workflow tool type, models, repositories, runtime wrapper, and endpoints to preview and publish workflows as tools.
- Extend tool detail APIs and schemas to return type-specific configurations, including workflow tool metadata and configuration.

Bug Fixes:
- Avoid saving failed conversations when no conversation_id exists and guard workflow history, opening statement, and message writes on conversation presence.
- Preserve existing memory enabled flags when resolving missing memory configurations in DSL import, instead of forcing them enabled.
- Normalize empty workflow engine conversation IDs to None in final outputs to avoid leaking empty strings.

Enhancements:
- Propagate runtime context (user_id, workspace_id) into tools and skill tools so executions can be tenant- and user-aware.
- Refine tool testing, method discovery, and instance creation to handle workflow tools and simplify connection testing where not needed.
- Make message fields optional in app chat, draft run, and share chat schemas and controllers, with validation that only conversational app types require a message.
- Adjust logging and export/import helpers to treat PURE_WORKFLOW consistently alongside WORKFLOW and other app types, including DSL export key selection and config validation.

</details>