### PR TITLE
fix(llm node): optimize reasoning content and output stream handling logic

### DIFF
--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -587,7 +587,8 @@ class LLMNode(BaseNode):
                 chunk_count = 0
                 full_reasoning_content = ""
                 stop_sequences = self.typed_config.stop.value[:4] if (self.typed_config.stop.enable and self.typed_config.stop.value) else None
-                buffered_chunks = []
+                need_buffer = bool(stop_sequences)
+                reasoning_done_sent = False
 
                 last_meta_data = {}
                 last_usage_metadata = {}
@@ -600,6 +601,7 @@ class LLMNode(BaseNode):
                         last_meta_data = chunk.response_metadata
                     if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
                         last_usage_metadata = chunk.usage_metadata
+                    reasoning_chunk = ""
                     if self.typed_config.enable_reasoning_content_extraction:
                         additional_kwargs = getattr(chunk, 'additional_kwargs', None) or {}
                         reasoning_chunk = additional_kwargs.get("reasoning_content") or additional_kwargs.get("reasoning", "")
@@ -608,6 +610,17 @@ class LLMNode(BaseNode):
                             yield {"__final__": False, "chunk": reasoning_chunk, "field": "reasoning_content"}
 
                     if content:
+                        # When reasoning_content has been received but current chunk
+                        # has no new reasoning, reasoning is complete. Emit the done
+                        # signal now so the stream-output cursor advances past the
+                        # reasoning_content segment before output chunks arrive.
+                        if self.typed_config.enable_reasoning_content_extraction \
+                                and full_reasoning_content \
+                                and not reasoning_done_sent \
+                                and not reasoning_chunk:
+                            reasoning_done_sent = True
+                            yield {"__final__": False, "chunk": "", "done": True, "field": "reasoning_content"}
+
                         full_response += content
 
                         if stop_sequences:
@@ -632,16 +645,20 @@ class LLMNode(BaseNode):
                                 break
 
                         chunk_count += 1
-                        buffered_chunks.append(content)
+                        if need_buffer:
+                            buffered_chunks.append(content)
+                        else:
+                            yield {"__final__": False, "chunk": content, "field": "output"}
 
-                # Signal that reasoning_content streaming is complete so the
-                # stream-output cursor can advance past {{node.reasoning_content}}
-                # segments before output chunks arrive.
-                if self.typed_config.enable_reasoning_content_extraction:
+                # Emit reasoning_content done signal if it wasn't sent
+                # during the loop (e.g. model had no reasoning, or every
+                # chunk contained reasoning_content).
+                if self.typed_config.enable_reasoning_content_extraction and not reasoning_done_sent:
                     yield {"__final__": False, "chunk": "", "done": True, "field": "reasoning_content"}
 
-                for c in buffered_chunks:
-                    yield {"__final__": False, "chunk": c, "field": "output"}
+                if need_buffer:
+                    for c in buffered_chunks:
+                        yield {"__final__": False, "chunk": c, "field": "output"}
 
                 yield {
                     "__final__": False,


### PR DESCRIPTION
- Introduce `need_buffer` and `reasoning_done_sent` state variables to precisely control stream buffering logic.
- Send the reasoning completion signal early when reasoning content is not updated, advancing the streaming cursor ahead of time.
- Adjust the timing of the reasoning completion signal to cover scenarios with no reasoning content and full reasoning chunks.
- Optimize the logic for directly sending the output stream when no stop sequences are present.

## Summary by Sourcery

优化 LLM 在处理推理内容和输出分片时的流式行为。

Bug 修复：
- 确保在推理内容结束或不存在时，在正确的时间发出推理完成信号，防止流式游标错位。

增强功能：
- 仅在配置了停止序列时有条件地缓冲输出分片；当不存在停止序列时，允许直接流式输出。
- 改进推理流与输出流之间的协调，更好地处理推理内容为部分、完整或缺失的各种情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize LLM streaming behavior for reasoning content and output chunks.

Bug Fixes:
- Ensure the reasoning completion signal is emitted at the correct time when reasoning content stops or is absent, preventing misaligned stream cursors.

Enhancements:
- Conditionally buffer output chunks only when stop sequences are configured, allowing direct streaming of output when no stop sequences are present.
- Improve reasoning and output stream coordination to better handle cases with partial, full, or missing reasoning content.

</details>