### PR TITLE
fix(llm node): optimize reasoning content and output stream handling logic

### DIFF
--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -587,7 +587,8 @@ class LLMNode(BaseNode):
                 chunk_count = 0
                 full_reasoning_content = ""
                 stop_sequences = self.typed_config.stop.value[:4] if (self.typed_config.stop.enable and self.typed_config.stop.value) else None
-                buffered_chunks = []
+                need_buffer = bool(stop_sequences)
+                reasoning_done_sent = False
 
                 last_meta_data = {}
                 last_usage_metadata = {}
@@ -600,6 +601,7 @@ class LLMNode(BaseNode):
                         last_meta_data = chunk.response_metadata
                     if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
                         last_usage_metadata = chunk.usage_metadata
+                    reasoning_chunk = ""
                     if self.typed_config.enable_reasoning_content_extraction:
                         additional_kwargs = getattr(chunk, 'additional_kwargs', None) or {}
                         reasoning_chunk = additional_kwargs.get("reasoning_content") or additional_kwargs.get("reasoning", "")
@@ -608,6 +610,17 @@ class LLMNode(BaseNode):
                             yield {"__final__": False, "chunk": reasoning_chunk, "field": "reasoning_content"}
 
                     if content:
+                        # When reasoning_content has been received but current chunk
+                        # has no new reasoning, reasoning is complete. Emit the done
+                        # signal now so the stream-output cursor advances past the
+                        # reasoning_content segment before output chunks arrive.
+                        if self.typed_config.enable_reasoning_content_extraction \
+                                and full_reasoning_content \
+                                and not reasoning_done_sent \
+                                and not reasoning_chunk:
+                            reasoning_done_sent = True
+                            yield {"__final__": False, "chunk": "", "done": True, "field": "reasoning_content"}
+
                         full_response += content
 
                         if stop_sequences:
@@ -632,16 +645,20 @@ class LLMNode(BaseNode):
                                 break
 
                         chunk_count += 1
-                        buffered_chunks.append(content)
+                        if need_buffer:
+                            buffered_chunks.append(content)
+                        else:
+                            yield {"__final__": False, "chunk": content, "field": "output"}
 
-                # Signal that reasoning_content streaming is complete so the
-                # stream-output cursor can advance past {{node.reasoning_content}}
-                # segments before output chunks arrive.
-                if self.typed_config.enable_reasoning_content_extraction:
+                # Emit reasoning_content done signal if it wasn't sent
+                # during the loop (e.g. model had no reasoning, or every
+                # chunk contained reasoning_content).
+                if self.typed_config.enable_reasoning_content_extraction and not reasoning_done_sent:
                     yield {"__final__": False, "chunk": "", "done": True, "field": "reasoning_content"}
 
-                for c in buffered_chunks:
-                    yield {"__final__": False, "chunk": c, "field": "output"}
+                if need_buffer:
+                    for c in buffered_chunks:
+                        yield {"__final__": False, "chunk": c, "field": "output"}
 
                 yield {
                     "__final__": False,


### PR DESCRIPTION
- Introduce `need_buffer` and `reasoning_done_sent` state variables to precisely control stream buffering logic.
- Send the reasoning completion signal early when reasoning content is not updated, advancing the streaming cursor ahead of time.
- Adjust the timing of the reasoning completion signal to cover scenarios with no reasoning content and full reasoning chunks.
- Optimize the logic for directly sending the output stream when no stop sequences are present.

## Summary by Sourcery

优化 LLM 节点在推理内容和输出分块上的流式行为，以改进光标对齐以及对停止序列的处理。

Bug Fixes:
- 确保推理完成信号在正确的时间发出，包括在没有新的推理内容，或所有推理内容都已在较早分块中的情况。
- 在未配置停止序列时，防止输出分块被不必要地阻塞或延迟。

Enhancements:
- 引入显式状态标志，用于在 LLM 响应过程中控制何时缓冲输出分块以及何时直接将其流式输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine LLM node streaming behavior for reasoning content and output chunks to improve cursor alignment and handling of stop sequences.

Bug Fixes:
- Ensure the reasoning completion signal is emitted at the correct time, including cases with no new reasoning content or with all reasoning in earlier chunks.
- Prevent output chunks from being blocked or delayed unnecessarily when no stop sequences are configured.

Enhancements:
- Introduce explicit state flags to control when to buffer output chunks versus streaming them directly during LLM responses.

</details>