### PR TITLE
refactor(llm node): initialize buffered_chunks variable properly

### DIFF
--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -588,6 +588,7 @@ class LLMNode(BaseNode):
                 full_reasoning_content = ""
                 stop_sequences = self.typed_config.stop.value[:4] if (self.typed_config.stop.enable and self.typed_config.stop.value) else None
                 need_buffer = bool(stop_sequences)
+                buffered_chunks = [] if need_buffer else None
                 reasoning_done_sent = False
 
                 last_meta_data = {}


### PR DESCRIPTION
add buffered_chunks initialization for llm node when need_buffer is set

## Summary by Sourcery

错误修复：
- 当在流式响应中处理停止序列（stop-sequence）且需要缓冲时，确保 LLM 节点会初始化 `buffered_chunks`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the LLM node initializes buffered_chunks when buffering is required for stop-sequence handling during streaming responses.

</details>