### PR TITLE
fix(llm node)

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -118,7 +118,7 @@ class RedBearModelFactory:
     """模型工厂类"""
 
     _CONFIG_ONLY_KEYS = {
-        "deep_thinking", "thinking_budget_tokens", "streaming",
+        "deep_thinking", "thinking_budget_tokens",
         "enable_search", "enable_thinking", "response_format", "json_output",
         "default_headers",
     }

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -5,6 +5,7 @@ LLM 节点实现
 """
 
 import logging
+import json
 from copy import deepcopy
 from typing import Any
 
@@ -228,7 +229,6 @@ class LLMNode(BaseNode):
 
         if self.typed_config.extra_headers.enable and self.typed_config.extra_headers.value:
             try:
-                import json
                 extra_headers_dict = json.loads(self.typed_config.extra_headers.value)
                 extra_params["default_headers"] = extra_headers_dict
             except json.JSONDecodeError as e:


### PR DESCRIPTION
remove redundant json import and update model config keys

## Summary by Sourcery

在 LLM 工作流节点中调整模型配置的处理方式，并清理冗余的导入。

改进内容：
- 从模型工厂的仅配置键中移除已弃用或未使用的 `streaming` 键。
- 在解析额外请求头时，依赖现有的 JSON 工具函数，移除 LLM 工作流节点中冗余的内联 `json` 导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust model configuration handling and clean up redundant imports in the LLM workflow node.

Enhancements:
- Remove the deprecated or unused `streaming` key from the model factory configuration-only keys.
- Rely on existing JSON utilities by removing a redundant inline `json` import from the LLM workflow node when parsing extra headers.

</details>