### PR TITLE
refactor(api): integrate rerank model into memory search pipeline

### DIFF
--- a/api/app/core/memory/pipelines/base_pipeline.py
+++ b/api/app/core/memory/pipelines/base_pipeline.py
@@ -5,8 +5,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.core.memory.models.service_models import MemoryContext
-from app.core.models import RedBearModelConfig, RedBearLLM, RedBearEmbeddings
-from app.services.memory_config_service import MemoryConfigService
+from app.core.models import RedBearModelConfig, RedBearLLM, RedBearEmbeddings, RedBearRerank
 from app.services.model_service import ModelApiKeyService
 
 
@@ -26,14 +25,25 @@ class ModelClientMixin(ABC):
 
     @staticmethod
     def get_embedding_client(db: Session, model_id: uuid.UUID) -> RedBearEmbeddings:
-        config_service = MemoryConfigService(db)
-        embedder_client_config = config_service.get_embedder_config(str(model_id))
+        api_config = ModelApiKeyService.get_available_api_key(db, model_id)
         return RedBearEmbeddings(
             RedBearModelConfig(
-                model_name=embedder_client_config["model_name"],
-                provider=embedder_client_config["provider"],
-                api_key=embedder_client_config["api_key"],
-                base_url=embedder_client_config["base_url"],
+                model_name=api_config.model_name,
+                provider=api_config.provider,
+                api_key=api_config.api_key,
+                base_url=api_config.api_base,
+            )
+        )
+
+    @staticmethod
+    def get_rerank_client(db: Session, model_id: uuid.UUID) -> RedBearRerank:
+        api_config = ModelApiKeyService.get_available_api_key(db, model_id)
+        return RedBearRerank(
+            RedBearModelConfig(
+                model_name=api_config.model_name,
+                provider=api_config.provider,
+                api_key=api_config.api_key,
+                base_url=api_config.api_base,
             )
         )
 

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -21,7 +21,7 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
             includes=None
     ) -> MemorySearchResult:
         memory_l0 = None
-        if self.ctx.storage_type == StorageType.NEO4J:
+        if self.ctx.storage_type == StorageType.NEO4J:  
             memory_l0 = await self._get_search_service(includes).memory_l0()
 
         query = QueryPreprocessor.process(query)
@@ -45,6 +45,7 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
             return Neo4jSearchService(
                 self.ctx,
                 self.get_embedding_client(self.db, self.ctx.memory_config.embedding_model_id),
+                self.get_rerank_client(self.db, self.ctx.memory_config.rerank_model_id),
                 self.get_llm_client(self.db, self.ctx.memory_config.llm_model_id),
                 includes=includes,
             )

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -21,7 +21,7 @@ from app.core.memory.read_services.search_engine.result_builder import MetadataB
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
 from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool
 from app.core.memory.utils.llm.llm_utils import StructResponse
-from app.core.models import RedBearEmbeddings, RedBearLLM
+from app.core.models import RedBearEmbeddings, RedBearLLM, RedBearRerank
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.repositories import knowledge_repository
 from app.repositories.neo4j.graph_search import get_nodes_by_ids, get_relations_between_entity_pairs, search_graph, \
@@ -44,6 +44,7 @@ class Neo4jSearchService:
             self,
             ctx: MemoryContext,
             embedder: RedBearEmbeddings,
+            reranker: RedBearRerank,
             llm: RedBearLLM,
             includes: list[Neo4jNodeType] | None = None,
             alpha: float = DEFAULT_ALPHA,
@@ -58,6 +59,7 @@ class Neo4jSearchService:
         self.content_score_threshold = content_score_threshold
 
         self.embedder: RedBearEmbeddings = embedder
+        self.reranker: RedBearRerank = reranker
         self.llm: RedBearLLM = llm
         self.connector: Neo4jConnector | None = None
 
@@ -98,18 +100,17 @@ class Neo4jSearchService:
             include=self.includes
         )
 
-    def _rerank(
-            self,
+    @staticmethod
+    def _combine_score(
             keyword_results: list[dict],
             embedding_results: list[dict],
-            limit: int,
     ) -> list[dict]:
-        keyword_results = self._normalize_kw_scores(keyword_results)
+        # keyword_results = self._normalize_kw_scores(keyword_results)
 
         kw_norm_map = {}
         for item in keyword_results:
             item_id = item["id"]
-            kw_norm_map[item_id] = float(item.get("normalized_kw_score", 0))
+            kw_norm_map[item_id] = float(item.get("score", 0))
 
         emb_norm_map = {}
         for item in embedding_results:
@@ -132,24 +133,24 @@ class Neo4jSearchService:
                 combined[item_id]["kw_score"] = kw_norm_map.get(item_id, 0)
                 combined[item_id]["embedding_score"] = emb_norm_map.get(item_id, 0)
 
-        for item in combined.values():
-            item_id = item["id"]
-            kw = float(combined[item_id].get("kw_score", 0) or 0)
-            emb = float(combined[item_id].get("embedding_score", 0) or 0)
-            base = self.alpha * emb + (1 - self.alpha) * kw
-            combined[item_id]["content_score"] = base + min(1 - base, 0.1 * kw * emb)
-        results = sorted(combined.values(), key=lambda x: x["content_score"], reverse=True)
-        # results = [
-        #     res for res in results
-        #     if res["content_score"] > self.content_score_threshold
-        # ]
-        results = results[:limit]
-
-        logger.debug(
-            f"[MemorySearch] rerank: merged={len(combined)}, after_threshold={len(results)} "
-            f"(alpha={self.alpha})"
-        )
-        return results
+        # for item in combined.values():
+        #     item_id = item["id"]
+        #     kw = float(combined[item_id].get("kw_score", 0) or 0)
+        #     emb = float(combined[item_id].get("embedding_score", 0) or 0)
+        #     base = self.alpha * emb + (1 - self.alpha) * kw
+        #     combined[item_id]["content_score"] = base + min(1 - base, 0.1 * kw * emb)
+        # results = sorted(combined.values(), key=lambda x: x["content_score"], reverse=True)
+        # # results = [
+        # #     res for res in results
+        # #     if res["content_score"] > self.content_score_threshold
+        # # ]
+        # results = results[:limit]
+        #
+        # logger.debug(
+        #     f"[MemorySearch] rerank: merged={len(combined)}, after_threshold={len(results)} "
+        #     f"(alpha={self.alpha})"
+        # )
+        return list(combined.values())
 
     def _normalize_kw_scores(self, items: list[dict]) -> list[dict]:
         if not items:
@@ -179,23 +180,28 @@ class Neo4jSearchService:
 
         memories = []
         for node_type in self.includes:
-            reranked = self._rerank(
+            records = self._combine_score(
                 kw_results.get(node_type, []),
                 emb_results.get(node_type, []),
-                limit
             )
-            for record in reranked:
+            for record in records:
                 memory = data_builder_factory(node_type, record)
                 memories.append(Memory(
-                    score=memory.score,
+                    score=0,
                     content=memory.content,
                     data=memory.data,
                     source=node_type,
                     query=query,
                     id=memory.id
                 ))
-        memories.sort(key=lambda x: x.score, reverse=True)
-        return MemorySearchResult(memories=memories[:limit])
+        rerank_res = self.reranker.rerank(query=query, documents=[memory.content for memory in memories], top_n=limit)
+        reranked_memories = []
+        for rerank_record in rerank_res:
+            memory = memories[rerank_record["index"]]
+            memory.score = rerank_record["relevance_score"]
+            reranked_memories.append(memory)
+        # memories.sort(key=lambda x: x.score, reverse=True)
+        return MemorySearchResult(memories=reranked_memories[:limit])
 
     async def _run_relation_agent(self, query: str) -> RelationSearchResult:
         system_prompt = prompt_manager.render(


### PR DESCRIPTION
- Add `get_rerank_client` static method to `BasePipeline`
- Replace `_rerank` with `_combine_score` and external reranker call
- Inject `RedBearRerank` into `ContentSearchService`

## Summary by Sourcery

将外部重排序模型集成到内存搜索流水线中，并通过 Neo4j 内容搜索服务进行贯通。

New Features:
- 在基础内存流水线中新增一个重排序客户端工厂，并通过模型 API key 配置进行管理。
- 将 `RedBearRerank` 客户端注入 Neo4j 内容搜索服务，并使用它对混合搜索结果进行重排序。

Enhancements:
- 将内部的关键词/向量组合逻辑重构为可复用的分数合并辅助工具，用于为外部重排序模型提供输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an external rerank model into the memory search pipeline and wire it through the Neo4j content search service.

New Features:
- Add a rerank client factory to the base memory pipeline using model API key configuration.
- Inject a RedBearRerank client into the Neo4j content search service and use it to rerank hybrid search results.

Enhancements:
- Refactor the internal keyword/embedding combination logic into a reusable score-merging helper that feeds the external reranker.

</details>