### PR TITLE
refactor(llm node): optimize template rendering logic and adjust parameter whitelist

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -118,7 +118,7 @@ class RedBearModelFactory:
     """模型工厂类"""
 
     _CONFIG_ONLY_KEYS = {
-        "deep_thinking", "thinking_budget_tokens", "streaming",
+        "deep_thinking", "thinking_budget_tokens",
         "enable_search", "enable_thinking", "response_format", "json_output",
         "default_headers",
     }

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -77,6 +77,7 @@ class LLMNode(BaseNode):
         self.typed_config: LLMNodeConfig | None = None
         self.messages = []
         self.model_info: ModelInfo | None = None
+        self._param_warnings: list[str] = []
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -88,7 +89,7 @@ class LLMNode(BaseNode):
         }
 
     def _render_context(self, message: str, variable_pool: VariablePool):
-        context = f"<context>{self._render_template(self.typed_config.context, variable_pool)}</context>"
+        context = f"<context>{self._render_template(self.typed_config.context, variable_pool, strict=False)}</context>"
         return message.replace("{{context}}", context)
 
     def _extract_reasoning_content(self, content: str) -> tuple[str, str]:
@@ -178,7 +179,7 @@ class LLMNode(BaseNode):
         if param_warnings:
             for w in param_warnings:
                 logger.warning(f"节点 {self.node_id} 参数限制警告: {w} (模型={model_info.model_name}, 提供商={model_info.provider})")
-            self._param_warnings = param_warnings
+            self._param_warnings.extend(param_warnings)
 
         # 4. 创建 LLM 实例（使用已提取的数据）
         # 注意：对于流式输出，需要在模型初始化时设置 streaming=True
@@ -289,7 +290,7 @@ class LLMNode(BaseNode):
                 role = msg_config.role.lower()
                 content_template = msg_config.content
                 content_template = self._render_context(content_template, variable_pool)
-                content = self._render_template(content_template, variable_pool)
+                content = self._render_template(content_template, variable_pool, strict=False)
                 # 根据角色创建对应的消息对象
                 if role == "system":
                     messages.append({
@@ -354,7 +355,7 @@ class LLMNode(BaseNode):
         else:
             # 使用简单的 prompt 格式（向后兼容）——包装为标准消息列表以兼容所有 provider
             prompt_template = self.config.get("prompt", "")
-            rendered = self._render_template(prompt_template, variable_pool)
+            rendered = self._render_template(prompt_template, variable_pool, strict=False)
             self.messages = [{"role": "user", "content": rendered}]
 
         # 所有 provider 统一注入 JSON prompt 兜底，确保即使 API 层 response_format 未生效也能引导 JSON 输出


### PR DESCRIPTION
- Remove the `streaming` parameter from `_CONFIG_ONLY_KEYS`.
- Add the `strict=False` parameter to the template rendering method to relax rendering validation.
- Fix the assignment method of `_param_warnings` to use `extend` instead of overwriting.

## 由 Sourcery 提供的总结

放宽 LLM 节点模板渲染限制，并调整模型配置参数的处理方式。

错误修复：
- 通过追加新警告而不是覆盖列表，保留已累积的 LLM 参数警告信息。

增强改进：
- 在 LLM 节点上初始化并跟踪参数警告，以提升日志记录和诊断的清晰度。
- 通过对上下文、消息和提示模板禁用严格校验，放宽 LLM 模板渲染，对变量不一致情况更具容错性。
- 在模型工厂中将 `streaming` 标志视为运行时参数，而不是仅限配置的键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax LLM node template rendering and adjust model configuration parameter handling.

Bug Fixes:
- Preserve accumulated LLM parameter warning messages by appending new warnings instead of overwriting the list.

Enhancements:
- Initialize and track parameter warnings on LLM nodes for clearer logging and diagnostics.
- Relax LLM template rendering by disabling strict validation for context, message, and prompt templates to be more tolerant of variable inconsistencies.
- Treat the `streaming` flag as a runtime parameter instead of a config-only key in the model factory.

</details>