### PR TITLE
feat(web): workflow next step

### DIFF
--- a/web/src/components/MoreDropdown/index.tsx
+++ b/web/src/components/MoreDropdown/index.tsx
@@ -1,24 +1,35 @@
 import { type FC, type MouseEvent } from 'react';
-import { Dropdown } from 'antd';
+import { Dropdown, Flex } from 'antd';
 import type { MenuProps } from 'antd';
 
 interface MoreDropdownProps {
   items: NonNullable<MenuProps['items']>;
   placement?: 'bottomRight' | 'bottomLeft' | 'topRight' | 'topLeft';
   onClick?: (e: MouseEvent) => void;
+  iconClassName?: string;
+  variant?: 'outline' | 'borderless';
 }
 
 /**
  * Dropdown triggered by a "more" icon button.
  * Used in card headers across ApiKeyManagement, Ontology, KnowledgeBase, etc.
  */
-const MoreDropdown: FC<MoreDropdownProps> = ({ items, placement = 'bottomRight', onClick }) => {
+const MoreDropdown: FC<MoreDropdownProps> = ({ items, placement = 'bottomRight', onClick, iconClassName = '', variant = 'borderless' }) => {
   return (
     <Dropdown menu={{ items }} placement={placement}>
-      <div
-        onClick={(e) => { e.stopPropagation(); onClick?.(e); }}
-        className="rb:cursor-pointer rb:size-5.5 rb:bg-[url('@/assets/images/common/more.svg')] rb:hover:bg-[url('@/assets/images/common/more_hover.svg')]"
-      />
+      {variant === 'outline'
+        ? <Flex align="center" justify="center" className="rb:cursor-pointer rb:border rb:border-[#EBEBEB] rb:rounded-lg rb:size-6! rb:hover:border-[#171719]">
+          <div
+            onClick={(e) => { e.stopPropagation(); onClick?.(e); }}
+            className={`rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/more.svg')]`}
+          />
+        </Flex>
+        : 
+          <div
+            onClick={(e) => { e.stopPropagation(); onClick?.(e); }}
+            className={`rb:cursor-pointer rb:size-5.5 rb:bg-cover rb:bg-[url('@/assets/images/common/more.svg')] rb:hover:bg-[url('@/assets/images/common/more_hover.svg')] ${iconClassName}`}
+          />
+      }
     </Dropdown>
   );
 };

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2622,6 +2622,10 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
         addVariable: 'Add Variables',
         outputVariable: 'Output Variable',
         duplicateName: 'Variable name cannot be duplicated',
+        times: 'times',
+        ms: 'ms',
+        setting: 'Setting',
+        lastRun: 'Last Run',
       },
 
       clear: 'Clear',
@@ -2708,6 +2712,15 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       variableSelect: {
         empty: 'No variables available',
       },
+      singleRun: 'Run this node',
+      nextStep: 'Next Step',
+      nextStepTip: 'Add the next node in the workflow',
+      addParallelNode: 'Add Parallel Node',
+      chooseNextNode: 'Choose Next Node',
+      disconnect: 'Disconnect',
+      delete: 'Delete',
+      jumpToNode: 'Jump to Node',
+      errorBranch: 'Error Branch',
     },
     emotionEngine: {
       emotionEngineConfig: 'Emotion Engine Configuration',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2606,6 +2606,8 @@ export const zh = {
         duplicateName: '变量名不能重复',
         times: '次',
         ms: '毫秒',
+        setting: '设置',
+        lastRun: '上次运行',
       },
 
       clear: '清空',
@@ -2693,6 +2695,14 @@ export const zh = {
         empty: '暂无变量',
       },
       singleRun: '运行此节点',
+      nextStep: '下一步',
+      nextStepTip: '添加此工作流程中的下一个节点',
+      addParallelNode: '添加并行节点',
+      chooseNextNode: '选择下一个节点',
+      disconnect: '断开连接',
+      delete: '删除',
+      jumpToNode: '跳转到节点',
+      errorBranch: '异常时',
     },
     emotionEngine: {
       emotionEngineConfig: '情感引擎配置',

--- a/web/src/views/Workflow/components/PortClickHandler.tsx
+++ b/web/src/views/Workflow/components/PortClickHandler.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:30:28 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-07 18:38:06
+ * @Last Modified time: 2026-05-27 10:14:48
  */
 import { useEffect, useState } from 'react';
 import { Flex, Popover } from 'antd';
@@ -46,9 +46,10 @@ export const adjustCycleContainerSize = (graph: any, cycleId: string) => {
 
 interface PortClickHandlerProps {
   graph: any;
+  nodeClick: ({ node }: { node: any }) => void;
 }
 
-const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
+const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph, nodeClick }) => {
   const { t } = useTranslation();
   const [popoverVisible, setPopoverVisible] = useState(false);
   const [sourceNode, setSourceNode] = useState<any>(null);
@@ -332,6 +333,8 @@ const PortClickHandler: React.FC<PortClickHandlerProps> = ({ graph }) => {
     } else {
       addedCells.forEach(c => { if (c.isNode?.()) c.toFront(); });
     }
+
+    nodeClick({ node: newNode });
 
     // Re-enable history and manually push one batch frame for all added cells
     graph.enableHistory();

--- a/web/src/views/Workflow/components/Properties/NextStep/index.tsx
+++ b/web/src/views/Workflow/components/Properties/NextStep/index.tsx
@@ -1,0 +1,223 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-05-26 18:30:00 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-05-27 12:19:26
+ */
+import { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Graph, Node } from '@antv/x6';
+import { Flex, Button, type MenuProps } from 'antd';
+import clsx from 'clsx';
+
+import MoreDropdown from '@/components/MoreDropdown';
+
+interface NextStepProps {
+  selectedNode: Node;
+  graphRef: React.MutableRefObject<Graph | undefined>;
+  onAddNode: (e: React.MouseEvent, portId?: string) => void;
+  onNodeClick: (params: { node: Node }) => void;
+  nodeData: any;
+}
+
+const prevEdgeHeight = 40;
+const rightGap = 4;
+const targetYInit = 18;
+const NextStep: FC<NextStepProps> = ({
+  selectedNode,
+  graphRef,
+  onAddNode,
+  onNodeClick,
+  nodeData,
+}) => {
+  const { t } = useTranslation();
+
+  const renderNextNodes = () => {
+    const graph = graphRef.current;
+    if (!graph) return null;
+
+    const rightPorts = selectedNode.getPorts().filter((p: any) => p.group === 'right');
+
+    if (!rightPorts || rightPorts.length === 0) {
+      return null;
+    }
+
+    const portEdgeCounts = rightPorts.map((port) => {
+      const edges = graph.getOutgoingEdges(selectedNode)?.filter((edge) => {
+        return edge.getSourcePortId() === port.id;
+      });
+      return (edges?.length || 0);
+    });
+
+    const initHeight = nodeData.type === 'if-else' || nodeData.type === 'question-classifier' ? 64 : 42;
+    const svgHeight = rightPorts.reduce((maxY, _port, index) => {
+      if (index === 0) return 22;
+      const prevEdgeCount = portEdgeCounts.slice(0, index).reduce((sum, count) => sum + count, 0);
+      const totalHeight = initHeight * (index + 1) + prevEdgeCount * prevEdgeHeight + index * rightGap;
+      const targetY = targetYInit + totalHeight;
+      return Math.max(maxY, targetY + 2);
+    }, 22);
+
+    return (
+      <Flex className="rb:w-full!">
+        <div className="rb:w-6 rb:relative">
+          <svg className="rb:w-6" viewBox={`0 0 24 ${svgHeight}`} preserveAspectRatio="none">
+            <g>
+              <path d="M0,18 L24,18" stroke-width="1" fill="none" className="rb:stroke-[#EBEBEB]"></path>
+              <rect x="0" y="16" width="1" height="4" className="rb:fill-[#171719]"></rect>
+              <rect x="23" y="16" width="1" height="4" className="rb:fill-[#171719]"></rect>
+            </g>
+            {rightPorts.length > 1 && rightPorts.slice(1).map((port, i) => {
+              const prevEdgeCount = portEdgeCounts.slice(0, i + 1).reduce((sum, count) => sum + count, 0);
+              const totalHeight = initHeight * (i + 1) + prevEdgeCount * prevEdgeHeight + i * rightGap;
+              const targetY = targetYInit + totalHeight;
+              return (
+                <g key={port.id}>
+                  <path d={`M0,18 Q12,18 12,28 L12,${targetY - 10} Q12,${targetY} 24,${targetY}`} strokeWidth="1" fill="none" className="rb:stroke-[#EBEBEB]"></path>
+                  <rect x="23" y={targetY - 2} width="1" height="4" className="rb:fill-[#171719]"></rect>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+        <Flex vertical gap={4} className="rb:flex-1!">
+          {rightPorts.map((port, index) => {
+            const portId = port.id;
+            const portLabel = portId === 'ERROR'
+              ? t('workflow.errorBranch')
+              : nodeData.type === 'if-else' && index === rightPorts.length - 1
+              ? 'ELSE'
+              : nodeData.type === 'if-else'
+              ? `CASE ${index}`
+              : nodeData.type === 'question-classifier'
+              ? `分类 ${index + 1}`
+              : port.label;
+            
+            const outgoingEdges = graph.getOutgoingEdges(selectedNode)?.filter((edge) => {
+              const sourcePort = edge.getSourcePortId();
+              return sourcePort === portId;
+            });
+
+            return (
+              <div key={portId}
+                className={clsx("rb:w-full rb:bg-[#F6F6F6] rb:p-1 rb:rounded-md", {
+                  'rb:bg-[rgba(255,93,52,0.08)]': portId === 'ERROR',
+                })}
+              >
+                {portLabel && typeof portLabel === 'string' &&
+                  <div className={clsx("rb:text-[#5B6167] rb:text-[10px] rb:font-medium rb:pl-1 rb:mb-1", {
+                    'rb:text-[#FF5D34]': portId === 'ERROR',
+                  })}>{portLabel}</div>
+                }
+                <Flex vertical gap={4}>
+                  {outgoingEdges && outgoingEdges.length > 0 ? (
+                    <Flex vertical gap={4}>
+                      {outgoingEdges.map((edge, index) => {
+                        const targetNode = edge.getTargetCell();
+                        if (!targetNode || !targetNode.isNode()) return null;
+
+                        const targetData = targetNode.getData();
+
+                        const menuItems: MenuProps['items'] = [
+                          {
+                            key: 'disconnect',
+                            label: t('workflow.disconnect'),
+                            onClick: () => {
+                              graph.removeEdge(edge);
+                            }
+                          },
+                          {
+                            key: 'delete',
+                            label: t('workflow.delete'),
+                            onClick: () => {
+                              graph.removeNode(targetNode);
+                            }
+                          },
+                        ];
+
+                        return (
+                          <Flex
+                            key={index}
+                            gap={8}
+                            align="center"
+                            className="rb:bg-[#FFFFFF] rb:rounded-md rb:px-2! rb:py-1.5! rb:h-9 rb:group"
+                          >
+                            <div className={`rb:size-4 rb:bg-cover ${targetData.icon}`} />
+                            <span className="rb:text-xs rb:text-[#212332] rb:truncate rb:flex-1">
+                              {targetData?.name || targetData?.label || t('workflow.unnamedNode')}
+                            </span>
+                            <Flex align="center" gap={8} className="rb:hidden! rb:group-hover:inline-flex!">
+                              <Button size="small" className="rb:text-[12px]!"
+                                onClick={() => onNodeClick({ node: targetNode })}
+                              >
+                                {t('workflow.jumpToNode')}
+                              </Button>
+                              <MoreDropdown
+                                items={menuItems}
+                                placement="bottomRight"
+                                variant="outline"
+                              />
+                            </Flex>
+                          </Flex>
+                        );
+                      })}
+                      <Flex
+                        align="center"
+                        gap={8}
+                        className="rb:rounded-md rb:px-2! rb:py-1.5! rb:border rb:border-dashed rb:border-[#DFE4ED] rb:cursor-pointer"
+                        onClick={(e) => onAddNode(e, portId)}
+                      >
+                        <Flex align="center" justify="center" className="rb:size-5 rb:rounded-md rb-border rb:bg-[#DFE4ED] rb:text-[#5B6167]">
+                          +
+                        </Flex>
+                        <div className="rb:text-[#5B6167]">{t('workflow.addParallelNode')}</div>
+                      </Flex>
+                    </Flex>
+                  ) : (
+                    <Flex
+                      align="center"
+                      gap={8}
+                      className="rb:rounded-md rb:px-2! rb:py-1.5! rb:border rb:border-dashed rb:border-[#DFE4ED] rb:cursor-pointer"
+                      onClick={(e) => onAddNode(e, portId)}
+                    >
+                      <Flex align="center" justify="center" className="rb:size-5 rb:rounded-md rb-border rb:bg-[#DFE4ED] rb:text-[#5B6167]">
+                        +
+                      </Flex>
+                      <div className="rb:text-[#5B6167]">{t('workflow.chooseNextNode')}</div>
+                    </Flex>
+                  )}
+                </Flex>
+              </div>
+            );
+          })}
+        </Flex>
+      </Flex>
+    );
+  };
+
+  if (!nodeData || nodeData.type === 'output') return null;
+
+  return (
+    <div className="rb:text-[12px] rb:leading-4.5 rb-border-t rb:mt-3 rb:px-3 rb:pt-3">
+      <div className="rb:font-medium">
+        {t('workflow.nextStep')}
+      </div>
+      <div className="rb:text-[#5B6167] rb:mt-1">{t('workflow.nextStepTip')}</div>
+
+      <div className="rb:mt-3">
+        <Flex gap={0} align="start" className="rb:w-full!">
+          <div className="rb:relative">
+            <Flex align="center" justify="center" className="rb:size-7 rb:rounded-md rb-border">
+              <div className={`rb:size-4 rb:bg-cover ${nodeData.icon}`} />
+            </Flex>
+          </div>
+          <div className="rb:flex-1">
+            {renderNextNodes()}
+          </div>
+        </Flex>
+      </div>
+    </div>
+  );
+};
+
+export default NextStep;

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -2,15 +2,15 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:39:59 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-22 15:14:47
+ * @Last Modified time: 2026-05-27 13:46:08
  */
 import { type FC, useEffect, useState, useMemo } from "react";
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { Graph, Node } from '@antv/x6';
-import { Form, Input, Select, InputNumber, Switch, Flex, Space, Dropdown, type MenuProps, Button, App, Popover } from 'antd';
+import { Form, Input, Select, InputNumber, Switch, Flex, Space, Dropdown, type MenuProps, Button, App, Popover, Tabs } from 'antd';
 
-import type { NodeConfig, NodeProperties, ChatVariable } from '../../types'
+import type { NodeConfig, ChatVariable } from '../../types'
 import CustomSelect from "@/components/CustomSelect";
 import MessageEditor from './MessageEditor'
 import Knowledge from './Knowledge/Knowledge';
@@ -46,6 +46,8 @@ import { cannotRunNodes } from '../../constant'
 import RadioGroupBtn from './RadioGroupBtn'
 import type { Model } from '@/views/ModelManagement/types';
 import Retry from './Retry'
+import NextStep from './NextStep'
+import RunResultDisplay, { type RunResult } from '../SingleNodeRun/RunResultDisplay'
 
 /**
  * Props for Properties component
@@ -71,6 +73,8 @@ interface PropertiesProps {
   chatVariables: ChatVariable[];
   /** Function to save workflow configuration */
   handleSave: (flag?: boolean) => Promise<unknown>;
+  /** Handler for node click */
+  nodeClick: ({ node }: { node: Node }) => void;
 }
 
 /**
@@ -86,6 +90,7 @@ const Properties: FC<PropertiesProps> = ({
   config,
   appId,
   handleSave,
+  nodeClick,
 }) => {
   const { t } = useTranslation()
   const { message } = App.useApp()
@@ -94,11 +99,13 @@ const Properties: FC<PropertiesProps> = ({
   const values = Form.useWatch([], form);
   const variableList = useVariableList(selectedNode, graphRef, chatVariables)
   const data = selectedNode.getData() || {}
+  console.log('data', data)
 
   useEffect(() => {
     if (selectedNode?.getData()?.id) {
       setOutputCollapsed(true)
       setAdvancedSettingsCollapsed(false)
+      setActiveKey('setting');
     }
     form.resetFields()
   }, [selectedNode?.getData()?.id])
@@ -124,18 +131,6 @@ const Properties: FC<PropertiesProps> = ({
       form.resetFields()
     }
   }, [selectedNode, form])
-
-  /**
-   * Update node label in graph
-   * @param newLabel - New label text
-   */
-  const updateNodeLabel = (newLabel: string) => {
-    if (selectedNode && form) {
-      const nodeData = selectedNode.getData() as NodeProperties;
-      selectedNode.setAttrByPath('text/text', `${nodeData.icon} ${newLabel}`);
-      selectedNode.setData({ ...selectedNode.getData(), name: newLabel });
-    }
-  };
 
   useEffect(() => {
     if (values && selectedNode) {
@@ -568,519 +563,603 @@ const Properties: FC<PropertiesProps> = ({
     }
   }
 
+  const handleAddNode = (e: React.MouseEvent, portId?: string) => {
+    const graph = graphRef.current;
+    if (!graph) return;
+
+    let sourcePortId = portId;
+    if (!sourcePortId) {
+      const sourceNodePort = selectedNode.getPorts().find((p: any) => p.group === 'right');
+      sourcePortId = sourceNodePort?.id || 'right';
+    }
+
+    const tempElement = document.createElement('div');
+    tempElement.style.cssText = 'position: fixed; width: 1px; height: 1px; z-index: 9999;';
+    
+    tempElement.style.left = `${e.clientX}px`;
+    tempElement.style.top = `${e.clientY}px`;
+    
+    document.body.appendChild(tempElement);
+
+    const event = new CustomEvent('port:click', {
+      detail: {
+        node: selectedNode,
+        port: sourcePortId,
+        element: tempElement,
+        edgeInsertion: null,
+      },
+    });
+    window.dispatchEvent(event);
+  }
+
+  const [nameHover, setNameHover] = useState(false)
+  const [activeKey, setActiveKey] = useState('setting')
+
+  const [result, setResult] = useState<RunResult | null>(null)
+  const [resultLoading, setResultLoading] = useState(false)
+
+  useEffect(() => {
+    if (activeKey === 'setting') {
+      setResult(null)
+      setResultLoading(false)
+    } else {
+      // Run result display
+    }
+  }, [activeKey])
   return (
-    <>
     <div className={clsx("rb:h-[calc(100vh-88px)] rb:w-90 rb:fixed rb:right-2.5 rb:top-18.5 rb:bottom-2.5 rb:z-1000", styles.properties)}>
-      <RbCard
-        title={t('workflow.nodeProperties')}
-        extra={<Space>
-          {!cannotRunNodes.includes(selectedNode?.data?.type) && <Popover content={t('workflow.singleRun')} classNames={{ body: 'rb:py-0.5! rb:px-1! rb:rounded-[6px]! rb:text-[12px]!' }}>
-            <div
-              className="rb:cursor-pointer rb:size-4 rb:hover:bg-[#F6F6F6] rb:rounded-sm rb:bg-cover rb:bg-[url('@/assets/images/workflow/run.svg')]"
-              onClick={handleRun}
-            ></div>
-          </Popover>}
-          <Dropdown
-            menu={{
-              items: [
-                { key: 'delete', icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/delete_dark.svg')]"></div>, label: <Flex>{t('common.delete')}</Flex> },
-                // { key: 'copy', icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/copy_dark.svg')]"></div>, label: t('common.copy') }
-              ],
-              onClick: handleClick
-            }}
-          >
-            <div className="rb:cursor-pointer rb:size-4 rb:hover:bg-[#F6F6F6] rb:rounded-sm rb:bg-cover rb:bg-[url(@/assets/images/common/dash.svg)]">
-            </div>
-          </Dropdown>
-          <div className="rb:size-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/close.svg')]" onClick={blankClick}></div>
-        </Space>}
-        headerType="borderless"
-        headerClassName={clsx("rb:font-[MiSans-Bold] rb:font-bold rb:min-h-[48px]!")}
-        className="rb:h-full! rb:hover:shadow-none!"
-        bodyClassName={clsx('rb:overflow-y-auto! rb:h-[calc(100%-48px)]! rb:px-3! rb:pt-0! rb:pb-3!')}
-      >
-        <Form key={selectedNode?.getData()?.id} form={form} size="small" layout="vertical">
-          <Form.Item name="name" label={t('workflow.nodeName')}>
-            <Input
-              placeholder={t('common.pleaseEnter')}
-              onChange={(e) => {
-                updateNodeLabel(e.target.value);
-              }}
-            />
-          </Form.Item>
-          <Form.Item name="id" label="ID">
-            <Input disabled />
-          </Form.Item>
-          {selectedNode?.data?.type === 'list-operator'
-            ? <ListOperator
-              options={variableList}
-              selectedNode={selectedNode} 
-            />
-            : selectedNode?.data?.type === 'unknown'
-            ? <>
-              <Form.Item name="replaceNode" label={t('workflow.config.unknown.replaceNodeType')}>
-                <Select
-                  options={nodeLibrary.map(category => ({
-                    label: t(`workflow.${category.category}`),
-                    options: category.nodes.filter(item => !['cycle-start', 'break'].includes(item.type)).map(node => ({
-                      label: <div className="rb:flex rb:items-center rb:gap-2 rb:flex-1">
-                        <div className={`rb:size-3.5 rb:bg-cover ${node.icon}`} />
-                        <div className="rb:wrap-break-word rb:line-clamp-1">{t(`workflow.${node.type}`)}</div>
-                      </div>,
-                      value: node.type
-                    }))
-                  }))}
-                  placeholder={t('common.pleaseSelect')}
-                  allowClear
+      <Form key={selectedNode?.getData()?.id} form={form} size="small" layout="vertical" className="rb:h-full!">
+        <RbCard
+          title={() => (
+            <Flex gap={4} align="center">
+              <div className={clsx("rb:size-6 rb:bg-cover rb:shrink-0", data.icon)}></div>
+              <Form.Item name="name" noStyle>
+                <Input
+                  placeholder={t('common.pleaseEnter')}
+                  variant="underlined"
+                  size="large"
+                  onFocus={() => setNameHover(true)}
+                  onBlur={() => setNameHover(false)}
+                  className={clsx('rb:px-1! rb:py-0!', {
+                    'rb:border-b-[#FFFFFF]!': !nameHover,
+                    'rb:border-b-[#EBEBEB]!': nameHover
+                  })}
                 />
               </Form.Item>
-              <Button type="primary" size="small" className="rb:text-[12px]!" onClick={handleSureReplace}>{t('workflow.sureReplace')}</Button>
-            </>
-            : selectedNode?.data?.type === 'http-request'
-              ? <HttpRequest
-                options={variableList}
-                selectedNode={selectedNode}
-                graphRef={graphRef}
-              />
-              : selectedNode?.data?.type === 'tool'
-                ? <ToolConfig options={variableList} />
-                : selectedNode?.data?.type === 'jinja-render'
-                  ? <JinjaRender
-                    selectedNode={selectedNode}
-                    options={getFilteredVariableList(selectedNode?.data?.type, 'mapping')}
-                    templateOptions={getFilteredVariableList(selectedNode?.data?.type, 'template')}
-                  />
-                  : selectedNode?.data?.type === 'code'
-                    ? <CodeExecution
-                      selectedNode={selectedNode}
-                      options={getFilteredVariableList(selectedNode?.data?.type, 'mapping')}
+            </Flex>
+          )}
+          extra={<Space>
+            {!cannotRunNodes.includes(selectedNode?.data?.type) && <Popover content={t('workflow.singleRun')} classNames={{ body: 'rb:py-0.5! rb:px-1! rb:rounded-[6px]! rb:text-[12px]!' }}>
+              <div
+                className="rb:cursor-pointer rb:size-4 rb:hover:bg-[#F6F6F6] rb:rounded-sm rb:bg-cover rb:bg-[url('@/assets/images/workflow/run.svg')]"
+                onClick={handleRun}
+              ></div>
+            </Popover>}
+            <Dropdown
+              menu={{
+                items: [
+                  { key: 'delete', icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/delete_dark.svg')]"></div>, label: <Flex>{t('common.delete')}</Flex> },
+                  // { key: 'copy', icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/copy_dark.svg')]"></div>, label: t('common.copy') }
+                ],
+                onClick: handleClick
+              }}
+            >
+              <div className="rb:cursor-pointer rb:size-4 rb:hover:bg-[#F6F6F6] rb:rounded-sm rb:bg-cover rb:bg-[url(@/assets/images/common/dash.svg)]">
+              </div>
+            </Dropdown>
+            <div className="rb:size-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/close.svg')]" onClick={blankClick}></div>
+          </Space>}
+          headerType="borderless"
+          headerClassName={clsx("rb:font-[MiSans-Bold] rb:font-bold rb:min-h-[48px]!")}
+          className="rb:h-full! rb:hover:shadow-none!"
+          bodyClassName={clsx('rb:overflow-hidden! rb:h-[calc(100%-48px)]! rb:px-0! rb:pt-0! rb:pb-3!')}
+        >
+          {/* <Tabs
+            items={[
+              { key: 'setting', label: t('workflow.config.setting') },
+              { key: 'lastRun', label: t('workflow.config.lastRun') },
+            ]}
+            activeKey={activeKey}
+            onChange={setActiveKey}
+            size="small"
+            className={styles.tabs}
+          /> */}
+          {/* <div className="rb:h-[calc(100%-52px)] rb:overflow-y-auto!"> */}
+          <div className="rb:h-full rb:overflow-y-auto!">
+            {activeKey === 'setting' &&
+              <>
+                <div className="rb:px-3!">
+                  <Form.Item name="id" label="ID">
+                    <Input disabled />
+                  </Form.Item>
+                  {selectedNode?.data?.type === 'list-operator'
+                    ? <ListOperator
+                      options={variableList}
+                      selectedNode={selectedNode} 
                     />
-                    : configs && Object.keys(configs).length > 0 && Object.keys(configs).map((key) => {
-                      const config = configs[key] || {}
-
-                      if (config.dependsOn && (values as any)?.[config.dependsOn as string] !== config.dependsOnValue) {
-                        return null
-                      }
-
-                      if (selectedNode?.data?.type === 'start' && key === 'variables' && config.type === 'define') {
-                        return (
-                          <Form.Item key={key} name={key} className="rb:mb-0!">
-                            <VariableList
-                              parentName={key}
-                              selectedNode={selectedNode}
-                              config={config}
-                            />
-                          </Form.Item>
-                        )
-                      }
-
-                      if (key === 'model_id' && selectedNode?.data?.type === 'llm') {
-                        return <ModelConfig key={key} variableOptions={getFilteredVariableList(selectedNode?.data?.type)} />
-                      }
-                      if (selectedNode?.data?.type === 'llm' && key === 'messages' && config.type === 'define') {
-                        // 为llm节点且isArray=true时添加context变量支持
-                        let contextVariableList = [...getFilteredVariableList('llm')];
-                        const isArrayMode = config.isArray !== false; // 默认为true
-
-                        if (isArrayMode) {
-                          const contextKey = `${selectedNode.id}_context`;
-                          const hasContextVariable = contextVariableList.some(v => v.key === contextKey);
-
-                          if (!hasContextVariable) {
-                            contextVariableList.unshift({
-                              key: contextKey,
-                              label: 'context',
-                              type: 'variable',
-                              dataType: 'string',
-                              value: `context`,
-                              nodeData: selectedNode.getData(),
-                              isContext: true,
-                            });
-                          }
-                        }
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <MessageEditor
-                              key={key}
-                              options={contextVariableList.filter(variable => variable.nodeData?.type !== 'knowledge-retrieval')}
-                              parentName={key}
-                              placeholder={t(config.placeholder || 'common.pleaseSelect')}
-                              size="small"
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (selectedNode?.data?.type === 'iteration' && key === 'output_type') {
-                        return (<Form.Item key={key} name={key} hidden />)
-                      }
-                      if (key === 'inference_mode') {
-                        const modelCapability: string[] = modelOptions.find((item) => item.id === values?.model_id)?.capability || []
-                        const options = modelCapability.includes('function_call') && config.options
-                          ? [...config.options]
-                          : config.options
-                          ? config.options.filter((item) => item.value !== 'function_calling')
-                          : []
-
-                        return (
-                          <div key={key} className="rb:text-[12px] rb:leading-4.5">
-                            <Flex align="center" className="rb:font-medium rb:cursor-pointer rb:mb-2!" onClick={() => setAdvancedSettingsCollapsed(!advancedSettingsCollapsed)}>
-                              {t('workflow.config.parameter-extractor.advanced_settings')}
-                              <div
-                                className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/caret_right_outlined.svg')]", {
-                                  'rb:rotate-90': !advancedSettingsCollapsed
-                                })}
-                              ></div>
-                            </Flex>
-                            <Form.Item
-                              name="inference_mode"
-                              label={t('workflow.config.parameter-extractor.inference_mode')}
-                              hidden={!advancedSettingsCollapsed}
-                              tooltip={t('workflow.config.parameter-extractor.inference_mode_tip')}
-                            >
-                              <RadioGroupBtn
-                                options={options.map((item) => ({
-                                  ...item,
-                                  label: t(item.label)
-                                }))}
-                                type="outer"
-                              />
-                            </Form.Item>
-                          </div>
-                        )
-                      }
-                      if (config.type === 'define') {
-                        return null
-                      }
-
-                      if (config.type === 'retry') {
-                        return (
-                          <Retry key={key} />
-                        )
-                      }
-                      if (config.type === 'knowledge') {
-                        return (
-                          <Form.Item
-                            key={key}
-                            name={key}
-                          >
-                            <Knowledge />
-                          </Form.Item>
-                        )
-                      }
-
-                      if (config.type === 'messageEditor') {
-                        return (
-                          <Form.Item key={key} name={key} required={config.required} label={selectedNode?.data?.type === 'memory-write' ? t(`workflow.config.${selectedNode?.data?.type}.${key}`) : undefined}>
-                            <MessageEditor
-                              title={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
-                              placeholder={t(config.placeholder || 'common.pleaseEnter')}
-                              isArray={!!config.isArray}
-                              parentName={key}
-                              language={config.language as LexicalEditorProps['language']}
-                              options={getFilteredVariableList(selectedNode?.data?.type, key)}
-                              titleVariant={config.titleVariant}
-                              size="small"
-                            />
-                          </Form.Item>
-                        )
-                      }
-
-                      if (config.type === 'paramList') {
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <ParamsList
-                              label={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'groupVariableList') {
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <GroupVariableList
-                              name={key}
-                              options={getFilteredVariableList(selectedNode?.data?.type, key)}
-                              isCanAdd={!!(values as any)?.group}
-                              size="small"
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'caseList') {
-                        return (
-                          <Form.Item key={key} name={key} noStyle>
-                            <CaseList
-                              name={key}
-                              options={getFilteredVariableList(selectedNode?.data?.type, key)}
-                              selectedNode={selectedNode}
-                              graphRef={graphRef}
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'cycleVarsList') {
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <CycleVarsList
-                              size="small"
-                              parentName={key}
-                              options={getFilteredVariableList(selectedNode?.data?.type, key)}
-                              selectedNode={selectedNode}
-                              graphRef={graphRef}
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'assignmentList') {
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <AssignmentList
-                              parentName={key}
-                              options={(() => {
-                                if (config.filterLoopIterationVars) {
-                                  const loopIterationVars: Suggestion[] = [];
-
-                                  return [...getFilteredVariableList(selectedNode?.data?.type, key), ...loopIterationVars];
-                                }
-                                return getFilteredVariableList(selectedNode?.data?.type, key);
-                              })()
-                              }
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'memoryConfig') {
-                        return (
-                          <Form.Item
-                            key={key}
-                            name={key}
-                            noStyle
-                          >
-                            <MemoryConfig
-                              parentName={key}
-                              options={getFilteredVariableList('llm')}
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'conditionList') {
-                        return (
-                          <Form.Item
-                            key={key}
-                            name={key}
-                            noStyle
-                          >
-                            <ConditionList
-                              parentName={key}
-                              options={(() => {
-                                const cycleVars = values?.cycle_vars || [];
-                                const cycleVarSuggestions: Suggestion[] = cycleVars.filter(vo => vo.name && vo.name.trim() !== '').map((cycleVar: any) => ({
-                                  key: `${selectedNode.id}_cycle_${cycleVar.name}`,
-                                  label: cycleVar.name,
-                                  type: 'variable',
-                                  dataType: cycleVar.type || 'string',
-                                  value: `${selectedNode.getData().id}.${cycleVar.name}`,
-                                  nodeData: selectedNode.getData(),
-                                }));
-
-                                return [...getFilteredVariableList(selectedNode?.data?.type, key), ...cycleVarSuggestions];
-                              })()}
-                              selectedNode={selectedNode}
-                              graphRef={graphRef}
-                              addBtnText={t('workflow.config.addCase')}
-                            />
-                          </Form.Item>
-                        )
-                      }
-                      if (config.type === 'mappingList') {
-                        return <MappingList
-                          key={key}
-                          label={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
-                          name={key}
-                          options={variableList}
-                          isNeedType={config.isNeedType as boolean}
+                    : selectedNode?.data?.type === 'unknown'
+                    ? <>
+                      <Form.Item name="replaceNode" label={t('workflow.config.unknown.replaceNodeType')}>
+                        <Select
+                          options={nodeLibrary.map(category => ({
+                            label: t(`workflow.${category.category}`),
+                            options: category.nodes.filter(item => !['cycle-start', 'break'].includes(item.type)).map(node => ({
+                              label: <div className="rb:flex rb:items-center rb:gap-2 rb:flex-1">
+                                <div className={`rb:size-3.5 rb:bg-cover ${node.icon}`} />
+                                <div className="rb:wrap-break-word rb:line-clamp-1">{t(`workflow.${node.type}`)}</div>
+                              </div>,
+                              value: node.type
+                            }))
+                          }))}
+                          placeholder={t('common.pleaseSelect')}
+                          allowClear
                         />
-                      }
-                      if (config.type === 'errorHandle') {
-                        return (
-                          <Form.Item key={key} name={key}>
-                            <ErrorHandle
+                      </Form.Item>
+                      <Button type="primary" size="small" className="rb:text-[12px]!" onClick={handleSureReplace}>{t('workflow.sureReplace')}</Button>
+                    </>
+                    : selectedNode?.data?.type === 'http-request'
+                      ? <HttpRequest
+                        options={variableList}
+                        selectedNode={selectedNode}
+                        graphRef={graphRef}
+                      />
+                      : selectedNode?.data?.type === 'tool'
+                        ? <ToolConfig options={variableList} />
+                        : selectedNode?.data?.type === 'jinja-render'
+                          ? <JinjaRender
+                            selectedNode={selectedNode}
+                            options={getFilteredVariableList(selectedNode?.data?.type, 'mapping')}
+                            templateOptions={getFilteredVariableList(selectedNode?.data?.type, 'template')}
+                          />
+                          : selectedNode?.data?.type === 'code'
+                            ? <CodeExecution
                               selectedNode={selectedNode}
-                              graphRef={graphRef}
+                              options={getFilteredVariableList(selectedNode?.data?.type, 'mapping')}
                             />
-                          </Form.Item>
-                        )
-                      }
+                            : configs && Object.keys(configs).length > 0 && Object.keys(configs).map((key) => {
+                              const config = configs[key] || {}
 
-                      if (key === 'vision_input' && !values?.vision) {
-                        return null
-                      }
+                              if (config.dependsOn && (values as any)?.[config.dependsOn as string] !== config.dependsOnValue) {
+                                return null
+                              }
 
-                      return (
-                        <Form.Item
-                          key={key}
-                          name={key}
-                          label={key === 'vision_input'
-                            ? undefined : key === 'parallel_count'
-                              ? <span className="rb:text-[10px] rb:text-[#5B6167] rb:leading-3.5 rb:-mb-1!">{t(`workflow.config.${selectedNode?.data?.type}.${key}`)}</span>
-                              : t(`workflow.config.${selectedNode?.data?.type}.${key}`)
-                          }
-                          tooltip={config.tip ? t(config.tip) : undefined}
-                          layout={config.type === 'switch' ? 'horizontal' : 'vertical'}
-                          className={
-                            key === 'parallel' && values?.parallel
-                              ? 'rb:mb-1!'
-                              : key === 'vision' && values?.vision
-                                ? 'rb:mb-2!'
-                                : key === 'group' && values?.group
-                                  ? 'rb:mb-3!'
-                                  : ''
-                          }
-                          hidden={Boolean(config.hidden)}
-                          required={config.required}
-                        >
-                          {config.type === 'input'
-                            ? <Input placeholder={t('common.pleaseEnter')} />
-                            : config.type === 'textarea'
-                              ? <Input.TextArea placeholder={t('common.pleaseEnter')} />
-                              : config.type === 'select'
-                                ? <Select
-                                  options={config.needTranslation ? (config.options || []).map(vo => ({ ...vo, label: t(vo.label) })) : config.options}
-                                  placeholder={t('common.pleaseSelect')}
-                                />
-                                : config.type === 'inputNumber'
-                                  ? <InputNumber
-                                    placeholder={t('common.pleaseEnter')}
-                                    className="rb:w-full!"
-                                    onChange={(value) => form.setFieldValue(key, value)}
-                                  />
-                                  : config.type === 'slider'
-                                    ? <RbSlider
-                                      min={config.min}
-                                      max={config.max}
-                                      step={config.step || 0.01}
-                                      isInput={true}
+                              if (selectedNode?.data?.type === 'start' && key === 'variables' && config.type === 'define') {
+                                return (
+                                  <Form.Item key={key} name={key} className="rb:mb-0!">
+                                    <VariableList
+                                      parentName={key}
+                                      selectedNode={selectedNode}
+                                      config={config}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+
+                              if (key === 'model_id' && selectedNode?.data?.type === 'llm') {
+                                return <ModelConfig key={key} variableOptions={getFilteredVariableList(selectedNode?.data?.type)} />
+                              }
+                              if (selectedNode?.data?.type === 'llm' && key === 'messages' && config.type === 'define') {
+                                // 为llm节点且isArray=true时添加context变量支持
+                                let contextVariableList = [...getFilteredVariableList('llm')];
+                                const isArrayMode = config.isArray !== false; // 默认为true
+
+                                if (isArrayMode) {
+                                  const contextKey = `${selectedNode.id}_context`;
+                                  const hasContextVariable = contextVariableList.some(v => v.key === contextKey);
+
+                                  if (!hasContextVariable) {
+                                    contextVariableList.unshift({
+                                      key: contextKey,
+                                      label: 'context',
+                                      type: 'variable',
+                                      dataType: 'string',
+                                      value: `context`,
+                                      nodeData: selectedNode.getData(),
+                                      isContext: true,
+                                    });
+                                  }
+                                }
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <MessageEditor
+                                      key={key}
+                                      options={contextVariableList.filter(variable => variable.nodeData?.type !== 'knowledge-retrieval')}
+                                      parentName={key}
+                                      placeholder={t(config.placeholder || 'common.pleaseSelect')}
                                       size="small"
                                     />
-                                    : config.type === 'modelSelect'
-                                      ? <ModelSelect
-                                        placeholder={t('common.pleaseSelect')}
-                                        params={config.params}
-                                        size="small"
-                                        className="rb:w-full!"
-                                        updateOptions={setModelOptions}
-                                        onChange={handleChangeModel}
+                                  </Form.Item>
+                                )
+                              }
+                              if (selectedNode?.data?.type === 'iteration' && key === 'output_type') {
+                                return (<Form.Item key={key} name={key} hidden />)
+                              }
+                              if (key === 'inference_mode') {
+                                const modelCapability: string[] = modelOptions.find((item) => item.id === values?.model_id)?.capability || []
+                                const options = modelCapability.includes('function_call') && config.options
+                                  ? [...config.options]
+                                  : config.options
+                                  ? config.options.filter((item) => item.value !== 'function_calling')
+                                  : []
+
+                                return (
+                                  <div key={key} className="rb:text-[12px] rb:leading-4.5">
+                                    <Flex align="center" className="rb:font-medium rb:cursor-pointer rb:mb-2!" onClick={() => setAdvancedSettingsCollapsed(!advancedSettingsCollapsed)}>
+                                      {t('workflow.config.parameter-extractor.advanced_settings')}
+                                      <div
+                                        className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/caret_right_outlined.svg')]", {
+                                          'rb:rotate-90': !advancedSettingsCollapsed
+                                        })}
+                                      ></div>
+                                    </Flex>
+                                    <Form.Item
+                                      name="inference_mode"
+                                      label={t('workflow.config.parameter-extractor.inference_mode')}
+                                      hidden={!advancedSettingsCollapsed}
+                                      tooltip={t('workflow.config.parameter-extractor.inference_mode_tip')}
+                                    >
+                                      <RadioGroupBtn
+                                        options={options.map((item) => ({
+                                          ...item,
+                                          label: t(item.label)
+                                        }))}
+                                        type="outer"
                                       />
-                                      : config.type === 'customSelect'
-                                        ? <CustomSelect
+                                    </Form.Item>
+                                  </div>
+                                )
+                              }
+                              if (config.type === 'define') {
+                                return null
+                              }
+
+                              if (config.type === 'retry') {
+                                return (
+                                  <Retry key={key} />
+                                )
+                              }
+                              if (config.type === 'knowledge') {
+                                return (
+                                  <Form.Item
+                                    key={key}
+                                    name={key}
+                                  >
+                                    <Knowledge />
+                                  </Form.Item>
+                                )
+                              }
+
+                              if (config.type === 'messageEditor') {
+                                return (
+                                  <Form.Item key={key} name={key} required={config.required} label={selectedNode?.data?.type === 'memory-write' ? t(`workflow.config.${selectedNode?.data?.type}.${key}`) : undefined}>
+                                    <MessageEditor
+                                      title={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
+                                      placeholder={t(config.placeholder || 'common.pleaseEnter')}
+                                      isArray={!!config.isArray}
+                                      parentName={key}
+                                      language={config.language as LexicalEditorProps['language']}
+                                      options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                      titleVariant={config.titleVariant}
+                                      size="small"
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+
+                              if (config.type === 'paramList') {
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <ParamsList
+                                      label={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'groupVariableList') {
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <GroupVariableList
+                                      name={key}
+                                      options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                      isCanAdd={!!(values as any)?.group}
+                                      size="small"
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'caseList') {
+                                return (
+                                  <Form.Item key={key} name={key} noStyle>
+                                    <CaseList
+                                      name={key}
+                                      options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                      selectedNode={selectedNode}
+                                      graphRef={graphRef}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'cycleVarsList') {
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <CycleVarsList
+                                      size="small"
+                                      parentName={key}
+                                      options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                      selectedNode={selectedNode}
+                                      graphRef={graphRef}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'assignmentList') {
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <AssignmentList
+                                      parentName={key}
+                                      options={(() => {
+                                        if (config.filterLoopIterationVars) {
+                                          const loopIterationVars: Suggestion[] = [];
+
+                                          return [...getFilteredVariableList(selectedNode?.data?.type, key), ...loopIterationVars];
+                                        }
+                                        return getFilteredVariableList(selectedNode?.data?.type, key);
+                                      })()
+                                      }
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'memoryConfig') {
+                                return (
+                                  <Form.Item
+                                    key={key}
+                                    name={key}
+                                    noStyle
+                                  >
+                                    <MemoryConfig
+                                      parentName={key}
+                                      options={getFilteredVariableList('llm')}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'conditionList') {
+                                return (
+                                  <Form.Item
+                                    key={key}
+                                    name={key}
+                                    noStyle
+                                  >
+                                    <ConditionList
+                                      parentName={key}
+                                      options={(() => {
+                                        const cycleVars = values?.cycle_vars || [];
+                                        const cycleVarSuggestions: Suggestion[] = cycleVars.filter(vo => vo.name && vo.name.trim() !== '').map((cycleVar: any) => ({
+                                          key: `${selectedNode.id}_cycle_${cycleVar.name}`,
+                                          label: cycleVar.name,
+                                          type: 'variable',
+                                          dataType: cycleVar.type || 'string',
+                                          value: `${selectedNode.getData().id}.${cycleVar.name}`,
+                                          nodeData: selectedNode.getData(),
+                                        }));
+
+                                        return [...getFilteredVariableList(selectedNode?.data?.type, key), ...cycleVarSuggestions];
+                                      })()}
+                                      selectedNode={selectedNode}
+                                      graphRef={graphRef}
+                                      addBtnText={t('workflow.config.addCase')}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+                              if (config.type === 'mappingList') {
+                                return <MappingList
+                                  key={key}
+                                  label={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
+                                  name={key}
+                                  options={variableList}
+                                  isNeedType={config.isNeedType as boolean}
+                                />
+                              }
+                              if (config.type === 'errorHandle') {
+                                return (
+                                  <Form.Item key={key} name={key}>
+                                    <ErrorHandle
+                                      selectedNode={selectedNode}
+                                      graphRef={graphRef}
+                                    />
+                                  </Form.Item>
+                                )
+                              }
+
+                              if (key === 'vision_input' && !values?.vision) {
+                                return null
+                              }
+
+                              return (
+                                <Form.Item
+                                  key={key}
+                                  name={key}
+                                  label={key === 'vision_input'
+                                    ? undefined : key === 'parallel_count'
+                                      ? <span className="rb:text-[10px] rb:text-[#5B6167] rb:leading-3.5 rb:-mb-1!">{t(`workflow.config.${selectedNode?.data?.type}.${key}`)}</span>
+                                      : t(`workflow.config.${selectedNode?.data?.type}.${key}`)
+                                  }
+                                  tooltip={config.tip ? t(config.tip) : undefined}
+                                  layout={config.type === 'switch' ? 'horizontal' : 'vertical'}
+                                  className={
+                                    key === 'parallel' && values?.parallel
+                                      ? 'rb:mb-1!'
+                                      : key === 'vision' && values?.vision
+                                        ? 'rb:mb-2!'
+                                        : key === 'group' && values?.group
+                                          ? 'rb:mb-3!'
+                                          : ''
+                                  }
+                                  hidden={Boolean(config.hidden)}
+                                  required={config.required}
+                                >
+                                  {config.type === 'input'
+                                    ? <Input placeholder={t('common.pleaseEnter')} />
+                                    : config.type === 'textarea'
+                                      ? <Input.TextArea placeholder={t('common.pleaseEnter')} />
+                                      : config.type === 'select'
+                                        ? <Select
+                                          options={config.needTranslation ? (config.options || []).map(vo => ({ ...vo, label: t(vo.label) })) : config.options}
                                           placeholder={t('common.pleaseSelect')}
-                                          url={config.url as string}
-                                          params={config.params}
-                                          hasAll={false}
-                                          valueKey={config.valueKey}
-                                          labelKey={config.labelKey}
-                                          size="small"
                                         />
-                                        : config.type === 'variableList'
-                                          ? <VariableSelect
-                                            placeholder={t(config.placeholder || 'common.pleaseSelect')}
-                                            options={(() => {
-                                              const baseVariableList = getFilteredVariableList(selectedNode?.data?.type, key);
-                                              // Apply filtering if specified in config
-                                              if (config.filterNodeTypes) {
-                                                return baseVariableList.filter(variable => {
-                                                  const nodeTypeMatch = !config.filterNodeTypes ||
-                                                    (Array.isArray(config.filterNodeTypes) && config.filterNodeTypes.includes(variable.nodeData?.type));
-                                                  return nodeTypeMatch;
-                                                });
-                                              }
-                                              if (config.onFilterVariableType) {
-                                                const types = config.onFilterVariableType as string[];
-                                                let list: Suggestion[] = []
-                                                baseVariableList.forEach((variable) => {
-                                                  if (variable.children?.length) {
-                                                    const filteredChildren = variable.children.filter((c: Suggestion) => types.includes(c.dataType));
-                                                    console.log('filteredChildren', filteredChildren)
-                                                    if (filteredChildren.length > 0) {
-                                                      list.push({ ...variable, children: filteredChildren });
-                                                    } else if (types.includes(variable.dataType)) {
-                                                      list.push({ ...variable, children: [] });
-                                                    }
-                                                  } else if (types.includes(variable.dataType)) {
-                                                    list.push(variable);
-                                                  }
-                                                });
-
-                                                return list
-                                              }
-                                              // Filter child nodes for iteration output
-                                              if (config.filterChildNodes && selectedNode) {
-                                                const graph = graphRef.current;
-                                                if (!graph) return [];
-
-                                                const nodes = graph.getNodes();
-
-                                                // Find child nodes whose cycle field equals parent node's ID
-                                                const childNodes = nodes.filter(node => {
-                                                  const nodeData = node.getData();
-                                                  return nodeData?.cycle === selectedNode.id;
-                                                });
-
-                                                return baseVariableList.filter(variable =>
-                                                  childNodes.some(node => node.id === variable.nodeData?.id) || selectedNode?.data?.type === 'iteration' && key === 'output' && variable.value.includes('sys.')
-                                                );
-                                              }
-                                              return baseVariableList;
-                                            })()}
-                                            onChange={(value, option) => handleChangeVariableList(value as string, option, key)}
-                                            size="small"
+                                        : config.type === 'inputNumber'
+                                          ? <InputNumber
+                                            placeholder={t('common.pleaseEnter')}
+                                            className="rb:w-full!"
+                                            onChange={(value) => form.setFieldValue(key, value)}
                                           />
-                                          : config.type === 'switch'
-                                            ? <Switch onChange={
-                                              key === 'group'
-                                                ? () => { form.setFieldValue('group_variables', []) }
-                                                : key === 'vision'
-                                                  ? () => { form.setFieldValue('vision_input', undefined) }
-                                                  : undefined
-                                            } />
-                                            : config.type === 'categoryList'
-                                              ? <CategoryList
-                                                parentName={key}
-                                                selectedNode={selectedNode}
-                                                graphRef={graphRef}
-                                                options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                          : config.type === 'slider'
+                                            ? <RbSlider
+                                              min={config.min}
+                                              max={config.max}
+                                              step={config.step || 0.01}
+                                              isInput={true}
+                                              size="small"
+                                            />
+                                            : config.type === 'modelSelect'
+                                              ? <ModelSelect
+                                                placeholder={t('common.pleaseSelect')}
+                                                params={config.params}
+                                                size="small"
+                                                className="rb:w-full!"
+                                                updateOptions={setModelOptions}
+                                                onChange={handleChangeModel}
                                               />
-                                              : config.type === 'editor'
-                                                ? <Editor options={getFilteredVariableList(selectedNode?.data?.type, key)} variant="outlined" size="small" placeholder={config.placeholder || t('common.pleaseEnter')} />
-                                                : null
-                          }
-                        </Form.Item>
-                      )
-                    })
-          }
-        </Form>
+                                              : config.type === 'customSelect'
+                                                ? <CustomSelect
+                                                  placeholder={t('common.pleaseSelect')}
+                                                  url={config.url as string}
+                                                  params={config.params}
+                                                  hasAll={false}
+                                                  valueKey={config.valueKey}
+                                                  labelKey={config.labelKey}
+                                                  size="small"
+                                                />
+                                                : config.type === 'variableList'
+                                                  ? <VariableSelect
+                                                    placeholder={t(config.placeholder || 'common.pleaseSelect')}
+                                                    options={(() => {
+                                                      const baseVariableList = getFilteredVariableList(selectedNode?.data?.type, key);
+                                                      // Apply filtering if specified in config
+                                                      if (config.filterNodeTypes) {
+                                                        return baseVariableList.filter(variable => {
+                                                          const nodeTypeMatch = !config.filterNodeTypes ||
+                                                            (Array.isArray(config.filterNodeTypes) && config.filterNodeTypes.includes(variable.nodeData?.type));
+                                                          return nodeTypeMatch;
+                                                        });
+                                                      }
+                                                      if (config.onFilterVariableType) {
+                                                        const types = config.onFilterVariableType as string[];
+                                                        let list: Suggestion[] = []
+                                                        baseVariableList.forEach((variable) => {
+                                                          if (variable.children?.length) {
+                                                            const filteredChildren = variable.children.filter((c: Suggestion) => types.includes(c.dataType));
+                                                            console.log('filteredChildren', filteredChildren)
+                                                            if (filteredChildren.length > 0) {
+                                                              list.push({ ...variable, children: filteredChildren });
+                                                            } else if (types.includes(variable.dataType)) {
+                                                              list.push({ ...variable, children: [] });
+                                                            }
+                                                          } else if (types.includes(variable.dataType)) {
+                                                            list.push(variable);
+                                                          }
+                                                        });
 
-        {currentNodeVariables.length > 0 && !(!values?.group && selectedNode.getData().type === 'var-aggregator') &&
-          <div className="rb:text-[12px] rb:leading-4.5">
-            <Flex gap={8} vertical>
-              <Flex align="center" className="rb:font-medium rb:cursor-pointer" onClick={handleToggle}>
-                {t('workflow.config.outputVariable')}
-                <div
-                  className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/caret_right_outlined.svg')]", {
-                    'rb:rotate-90': !outputCollapsed
-                  })}
-                ></div>
-              </Flex>
-              {!outputCollapsed && currentNodeVariables.map(vo => (
-                <Flex key={vo.value} gap={4}>
-                  <span className="rb:font-medium">{vo.label}</span>
-                  <span className="rb:text-[#212332]">{vo.dataType}</span>
-                </Flex>
-              ))}
-            </Flex>
+                                                        return list
+                                                      }
+                                                      // Filter child nodes for iteration output
+                                                      if (config.filterChildNodes && selectedNode) {
+                                                        const graph = graphRef.current;
+                                                        if (!graph) return [];
+
+                                                        const nodes = graph.getNodes();
+
+                                                        // Find child nodes whose cycle field equals parent node's ID
+                                                        const childNodes = nodes.filter(node => {
+                                                          const nodeData = node.getData();
+                                                          return nodeData?.cycle === selectedNode.id;
+                                                        });
+
+                                                        return baseVariableList.filter(variable =>
+                                                          childNodes.some(node => node.id === variable.nodeData?.id) || selectedNode?.data?.type === 'iteration' && key === 'output' && variable.value.includes('sys.')
+                                                        );
+                                                      }
+                                                      return baseVariableList;
+                                                    })()}
+                                                    onChange={(value, option) => handleChangeVariableList(value as string, option, key)}
+                                                    size="small"
+                                                  />
+                                                  : config.type === 'switch'
+                                                    ? <Switch onChange={
+                                                      key === 'group'
+                                                        ? () => { form.setFieldValue('group_variables', []) }
+                                                        : key === 'vision'
+                                                          ? () => { form.setFieldValue('vision_input', undefined) }
+                                                          : undefined
+                                                    } />
+                                                    : config.type === 'categoryList'
+                                                      ? <CategoryList
+                                                        parentName={key}
+                                                        selectedNode={selectedNode}
+                                                        graphRef={graphRef}
+                                                        options={getFilteredVariableList(selectedNode?.data?.type, key)}
+                                                      />
+                                                      : config.type === 'editor'
+                                                        ? <Editor options={getFilteredVariableList(selectedNode?.data?.type, key)} variant="outlined" size="small" placeholder={config.placeholder || t('common.pleaseEnter')} />
+                                                        : null
+                                  }
+                                </Form.Item>
+                              )
+                            })
+                  }
+
+                {currentNodeVariables.length > 0 && !(!values?.group && selectedNode.getData().type === 'var-aggregator') &&
+                  <div className="rb:text-[12px] rb:leading-4.5">
+                    <Flex gap={8} vertical>
+                      <Flex align="center" className="rb:font-medium rb:cursor-pointer" onClick={handleToggle}>
+                        {t('workflow.config.outputVariable')}
+                        <div
+                          className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/caret_right_outlined.svg')]", {
+                            'rb:rotate-90': !outputCollapsed
+                          })}
+                        ></div>
+                      </Flex>
+                      {!outputCollapsed && currentNodeVariables.map(vo => (
+                        <Flex key={vo.value} gap={4}>
+                          <span className="rb:font-medium">{vo.label}</span>
+                          <span className="rb:text-[#212332]">{vo.dataType}</span>
+                        </Flex>
+                      ))}
+                    </Flex>
+                  </div>
+                }
+                </div>
+                <NextStep
+                  selectedNode={selectedNode}
+                  graphRef={graphRef}
+                  onAddNode={handleAddNode}
+                  onNodeClick={nodeClick}
+                  nodeData={data}
+                />
+              </>
+            }
+            {activeKey === 'lastRun' &&
+              <RunResultDisplay
+                result={result}
+                loading={resultLoading}
+                nodeData={data}
+              />
+            }
           </div>
-        }
-      </RbCard>
+        </RbCard>
+      </Form>
 
       {isRun && (
         <SingleNodeRun
@@ -1092,7 +1171,6 @@ const Properties: FC<PropertiesProps> = ({
         />
       )}
     </div>
-    </>
   );
 };
 export default Properties;

--- a/web/src/views/Workflow/components/Properties/properties.module.css
+++ b/web/src/views/Workflow/components/Properties/properties.module.css
@@ -166,3 +166,13 @@
 .properties :global(.ant-input-number-affix-wrapper) {
   font-size: 12px;
 }
+.properties .tabs:global(.ant-tabs >.ant-tabs-nav .ant-tabs-nav-wrap),
+.properties .tabs:global(.ant-tabs >div>.ant-tabs-nav .ant-tabs-nav-wrap) {
+  padding: 0 12px;
+}
+.properties .tabs:global(.ant-tabs .ant-tabs-tab-btn) {
+  font-size: 13px;
+}
+.properties .tabs:global(.ant-tabs .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn) {
+  font-weight: 500;
+}

--- a/web/src/views/Workflow/components/SingleNodeRun/RunResultDisplay.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/RunResultDisplay.tsx
@@ -1,0 +1,118 @@
+import { type FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button, Flex, Skeleton } from 'antd'
+import copy from 'copy-to-clipboard'
+import { App } from 'antd'
+
+import CodeBlock from '@/components/Markdown/CodeBlock'
+import Markdown from '@/components/Markdown'
+import RbAlert from '@/components/RbAlert'
+import { hasProcessNodes } from '../../constant'
+
+export interface RunResult {
+  status: 'completed' | 'failed' | 'running';
+  node_id?: string;
+  node_type?: string;
+  inputs?: Record<string, any>;
+  outputs?: any;
+  token_usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+  process?: any;
+  elapsed_time?: number;
+  error?: string | null;
+}
+
+interface RunResultDisplayProps {
+  result: RunResult | null
+  loading: boolean
+  nodeData: any
+}
+
+const RunResultDisplay: FC<RunResultDisplayProps> = ({ result, loading, nodeData }) => {
+  const { t } = useTranslation()
+  const { message } = App.useApp()
+
+  const handleCopy = (val: string) => {
+    copy(val)
+    message.success(t('common.copySuccess'))
+  }
+
+  const statusColor = result?.status === 'completed' ? '#369F21' : result?.status === 'failed' ? '#FF5D34' : '#5B6167'
+
+  if (!result) return null
+
+  return (
+    <>
+      <div className="rb:rounded-lg rb:border rb:border-[#E8E8E8] rb:p-3 rb:bg-[#F6FFF4]">
+        <Flex justify="space-between" align="start">
+          <Flex vertical align="start" gap={2}>
+            <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.status')}</span>
+            <span className="rb:font-medium rb:text-[13px]" style={{ color: statusColor }}>
+              {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : result.status?.toUpperCase()}
+            </span>
+          </Flex>
+          <Flex vertical align="start" gap={2}>
+            <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.elapsedTime')}</span>
+            {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : result.elapsed_time != null && <span className="rb:font-medium rb:text-[13px]">{result.elapsed_time?.toFixed(3)}ms</span>}
+          </Flex>
+          <Flex vertical gap={2} align="start">
+            <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.totalTokens')}</span>
+            {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : <span className="rb:font-medium rb:text-[13px]">{ result?.token_usage?.total_tokens || 0} Tokens</span>}
+          </Flex>
+        </Flex>
+      </div>
+
+      {(['inputs', 'process', 'outputs'] as const).map(key => {
+        if (!hasProcessNodes.includes(nodeData.type) && key === 'process') return null
+        const content = typeof result[key as keyof RunResult] === 'object' && result[key as keyof RunResult] ? JSON.stringify(result[key as keyof RunResult], null, 2) : result[key as keyof RunResult] ? result[key as keyof RunResult] : '{}'
+        return (
+          <div key={key} className="rb:bg-[#EBEBEB] rb:rounded-lg">
+            <div className="rb:py-2 rb:px-3 rb:flex rb:justify-between rb:items-center rb:text-[12px]">
+              {t(`workflow.${key}_result`)}
+              {!loading &&
+                <Button
+                  className="rb:py-0! rb:px-1! rb:text-[12px]!"
+                  size="small"
+                  onClick={() => handleCopy(content)}
+                >{t('common.copy')}</Button>
+              }
+            </div>
+            <div className="rb:max-h-40 rb:overflow-auto">
+              {loading
+                ? <Skeleton active title={false} className="rb:m-3! rb:w-[calc(100%-24px)]!" />
+                : <CodeBlock
+                    size="small"
+                    value={content}
+                    needCopy={false}
+                    showLineNumbers={true}
+                    background="#EBEBEB"
+                  />
+              }
+            </div>
+          </div>
+        )
+      })}
+
+      {result?.error && (
+        <RbAlert color="orange" className="rb:pb-0!">
+          <Flex vertical className="rb:w-full!">
+            <Flex align="center" justify="space-between">
+              {t(`workflow.error`)}
+              <Button
+                className="rb:py-0! rb:px-1! rb:text-[12px]!"
+                size="small"
+                onClick={() => handleCopy(result?.error || '')}
+              >{t('common.copy')}</Button>
+            </Flex>
+            <Markdown className="rb:wrap-break-word!" content={result?.error || ''} />
+          </Flex>
+        </RbAlert>
+      )}
+    </>
+  )
+}
+
+export default RunResultDisplay

--- a/web/src/views/Workflow/components/SingleNodeRun/index.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/index.tsx
@@ -2,25 +2,21 @@
  * @Author: ZhaoYing 
  * @Date: 2026-05-07 18:37:31 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-20 14:41:28
+ * @Last Modified time: 2026-05-27 11:39:38
  */
 import { type FC, useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button, Flex, Form, Input, InputNumber, Select, App, Checkbox, Skeleton } from 'antd'
+import { Button, Flex, Form, Input, InputNumber, Select, Checkbox } from 'antd'
 import { Node } from '@antv/x6'
-import copy from 'copy-to-clipboard'
 import clsx from 'clsx'
 
 import { nodeRun } from '@/api/application'
-import CodeBlock from '@/components/Markdown/CodeBlock'
 import RbCard from '@/components/RbCard/Card'
 import styles from '../Properties/properties.module.css'
 import ContextList from './ContextList'
 import FileVarInput from './FileVarInput'
+import RunResultDisplay from './RunResultDisplay'
 import type { Suggestion } from '../Editor/plugin/AutocompletePlugin'
-import Markdown from '@/components/Markdown'
-import RbAlert from '@/components/RbAlert'
-import { hasProcessNodes } from '../../constant'
 import type { Variable } from '../Properties/VariableList/types'
 import CodeMirrorEditor from '@/components/CodeMirrorEditor';
 
@@ -50,7 +46,6 @@ interface SingleNodeRunProps {
 
 const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, appId, variableList }) => {
   const { t } = useTranslation()
-  const { message } = App.useApp()
   const [form] = Form.useForm()
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<RunResult | null>(null)
@@ -143,13 +138,6 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
           .finally(() => setLoading(false))
       })
   }
-
-  const handleCopy = (val: string) => {
-    copy(val)
-    message.success(t('common.copySuccess'))
-  }
-
-  const statusColor = result?.status === 'completed' ? '#369F21' : result?.status === 'failed' ? '#FF5D34' : '#5B6167'
 
   useEffect(() => {
     if (open) {
@@ -296,76 +284,7 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
                 </Button>
               }
 
-              {/* Status row */}
-              {result && (
-                <div className="rb:rounded-lg rb:border rb:border-[#E8E8E8] rb:p-3 rb:bg-[#F6FFF4]">
-                  <Flex justify="space-between" align="start">
-                    <Flex vertical align="start" gap={2}>
-                      <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.status')}</span>
-                      <span className="rb:font-medium rb:text-[13px]" style={{ color: statusColor }}>
-                        {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : result.status?.toUpperCase()}
-                      </span>
-                    </Flex>
-                    <Flex vertical align="start" gap={2}>
-                      <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.elapsedTime')}</span>
-                      {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : result.elapsed_time != null && <span className="rb:font-medium rb:text-[13px]">{result.elapsed_time?.toFixed(3)}ms</span>}
-                    </Flex>
-                    <Flex vertical gap={2} align="start">
-                      <span className="rb:text-[11px] rb:text-[#5B6167]">{t('workflow.totalTokens')}</span>
-                      {loading ? <Skeleton active paragraph={false} className="rb:w-20!" /> : <span className="rb:font-medium rb:text-[13px]">{ result?.token_usage?.total_tokens || 0} Tokens</span>}
-                    </Flex>
-                  </Flex>
-                </div>
-              )}
-
-              {/* Input / Output code blocks */}
-              {result && (['inputs', 'process', 'outputs'] as const).map(key => {
-                if (!hasProcessNodes.includes(nodeData.type) && key === 'process') return null
-                const content = typeof result[key as keyof RunResult] === 'object' && result[key as keyof RunResult] ? JSON.stringify(result[key as keyof RunResult], null, 2) : result[key as keyof RunResult] ? result[key as keyof RunResult] : '{}'
-                return (
-                  <div key={key} className="rb:bg-[#EBEBEB] rb:rounded-lg">
-                    <div className="rb:py-2 rb:px-3 rb:flex rb:justify-between rb:items-center rb:text-[12px]">
-                      {t(`workflow.${key}_result`)}
-                      {!loading &&
-                        <Button
-                          className="rb:py-0! rb:px-1! rb:text-[12px]!"
-                          size="small"
-                          onClick={() => handleCopy(content)}
-                        >{t('common.copy')}</Button>
-                      }
-                    </div>
-                    <div className="rb:max-h-40 rb:overflow-auto">
-                      {loading
-                        ? <Skeleton active title={false} className="rb:m-3! rb:w-[calc(100%-24px)]!" />
-                        : <CodeBlock
-                            size="small"
-                            value={content}
-                            needCopy={false}
-                            showLineNumbers={true}
-                            background="#EBEBEB"
-                          />
-                      }
-                    </div>
-                  </div>
-                )
-              })}
-
-              {/* Error */}
-              {result?.error && (
-                <RbAlert color="orange" className="rb:pb-0!">
-                  <Flex vertical className="rb:w-full!">
-                    <Flex align="center" justify="space-between">
-                      {t(`workflow.error`)}
-                      <Button
-                        className="rb:py-0! rb:px-1! rb:text-[12px]!"
-                        size="small"
-                        onClick={() => handleCopy(result?.error || '')}
-                      >{t('common.copy')}</Button>
-                    </Flex>
-                    <Markdown className="rb:wrap-break-word!" content={result?.error || ''} />
-                  </Flex>
-                </RbAlert>
-              )}
+              <RunResultDisplay result={result} loading={loading} nodeData={nodeData} />
             </Flex>
           </Form>
         </RbCard>

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,9 +2,11 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-19 15:16:10
+ * @Last Modified time: 2026-05-27 13:47:18
  */
-import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, History, Selection, type Edge } from '@antv/x6';
+import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, History, Selection,
+  // Scroller,
+type Edge } from '@antv/x6';
 import { register as registerReactShape } from '@antv/x6-react-shape';
 import type { PortMetadata } from '@antv/x6/lib/model/port';
 import { App } from 'antd';
@@ -694,6 +696,13 @@ export const useWorkflowGraph = ({
         padding: 5,
       }),
     );
+    // graphRef.current.use(
+    //   new Scroller({
+    //     enabled: true,
+    //     pannable: false,
+    //     autoResize: true,
+    //   }),
+    // );
     graphRef.current.use(
       new Snapline({
         enabled: true,

--- a/web/src/views/Workflow/index.tsx
+++ b/web/src/views/Workflow/index.tsx
@@ -120,6 +120,7 @@ const Workflow = forwardRef<WorkflowRef, { onFeaturesLoad?: (features: FeaturesC
           chatVariables={chatVariables}
           appId={config?.app_id}
           handleSave={handleSave}
+          nodeClick={nodeClick}
         />
       }
       <Chat
@@ -129,7 +130,10 @@ const Workflow = forwardRef<WorkflowRef, { onFeaturesLoad?: (features: FeaturesC
         graphRef={graphRef}
         appId={config?.app_id as string}
       />
-      <PortClickHandler graph={graphRef.current} />
+      <PortClickHandler
+        graph={graphRef.current}
+        nodeClick={nodeClick}
+      />
 
       <AddChatVariable
         ref={addChatVariableRef}


### PR DESCRIPTION
## Summary by Sourcery

添加工作流节点“Next Step”管理界面，统一单节点运行结果渲染，并增强下拉菜单/按钮及国际化（i18n）支持。

新特性：
- 在工作流属性面板中引入 NextStep 组件，用于可视化并管理下游节点，包括添加、跳转到、断开连接以及删除下一步节点。
- 在工作流图中通过端口点击进行连接时，新增支持在连接到新创建节点后跳转到该节点。
- 为属性面板中的“节点设置”和“上次运行结果”视图切换增加标签页状态和（已注释的）脚手架结构。

缺陷修复：
- 当在节点间切换时，将工作流属性面板默认切换到“设置”标签页，并适当地清除上次运行状态。
- 通过委托给新的共享展示组件，清理 SingleNodeRun 中重复的运行结果 UI 和未使用的代码。

改进：
- 优化工作流属性头部，将节点名称编辑内联到图标旁，并改进布局和滚动行为。
- 抽取可复用的 RunResultDisplay 组件，用于显示节点运行状态、耗时、tokens、输入输出及错误信息，在属性面板和单节点运行对话框之间共享。
- 扩展通用 MoreDropdown 组件，增加描边（outline）变体和可自定义图标样式，以便在卡片和菜单中更丰富地使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add workflow node "Next Step" management UI, unify single-node run result rendering, and enhance dropdown/button and i18n support.

New Features:
- Introduce a NextStep component in the workflow properties panel to visualize and manage downstream nodes, including adding, jumping to, disconnecting, and deleting next-step nodes.
- Add support for jumping to a newly created node when connecting via port clicks in the workflow graph.
- Add tab state and (commented) scaffolding for switching between node settings and last run results in the properties panel.

Bug Fixes:
- Default the workflow properties panel to the settings tab when switching nodes and clear last run state appropriately.
- Clean up duplicated run result UI and unused code in SingleNodeRun by delegating to the new shared display component.

Enhancements:
- Refine the workflow properties header to inline node name editing with icon and improve layout and scrolling behavior.
- Extract reusable RunResultDisplay component for showing node run status, timings, tokens, IO and errors, shared between the properties panel and single-node run dialog.
- Extend the generic MoreDropdown component with outline variant and customizable icon styling for richer usage in cards and menus.

</details>