### PR TITLE
feat(workflow-tool)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -1393,7 +1393,6 @@ async def publish_workflow_as_tool(
         tool_description=payload.description or "",
         tenant_id=current_user.tenant_id,
         workspace_id=current_user.current_workspace_id,
-        created_by=current_user.id,
         icon=payload.icon,
         timeout=payload.timeout,
         tags=payload.tags,

--- a/api/app/core/tools/workflow/base.py
+++ b/api/app/core/tools/workflow/base.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.core.tools.base import BaseTool
 from app.models.app_model import App
 from app.models.tool_model import ToolType
-from app.schemas import DraftRunRequest
+from app.schemas.app_schema import DraftRunRequest
 from app.schemas.tool_schema import ParameterType, ToolParameter, ToolResult
 
 

--- a/api/app/schemas/tool_schema.py
+++ b/api/app/schemas/tool_schema.py
@@ -175,7 +175,6 @@ class WorkflowToolConfigSchema(BaseModel):
     output_schema: Dict[str, Any] = Field(default_factory=dict, description="输出结构定义")
     timeout: int = Field(300, description="超时时间（秒）")
     workspace_id: Optional[str] = Field(None, description="所属空间ID")
-    workspace_name: Optional[str] = Field(None, description="所属空间名称")
 
     class Config:
         from_attributes = True

--- a/api/app/schemas/tool_schema.py
+++ b/api/app/schemas/tool_schema.py
@@ -174,6 +174,8 @@ class WorkflowToolConfigSchema(BaseModel):
     input_parameters: List[Dict[str, Any]] = Field(default_factory=list, description="输入参数定义")
     output_schema: Dict[str, Any] = Field(default_factory=dict, description="输出结构定义")
     timeout: int = Field(300, description="超时时间（秒）")
+    workspace_id: Optional[str] = Field(None, description="所属空间ID")
+    workspace_name: Optional[str] = Field(None, description="所属空间名称")
 
     class Config:
         from_attributes = True

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1370,7 +1370,7 @@ class AppService:
         logger.info("Agent 配置更新成功", extra={"app_id": str(app_id)})
         return agent_cfg
 
-    def _agent_config_from_release(self, release: "type[AppRelease]") -> "AgentConfig":
+    def _agent_config_from_release(self, release: "AppRelease") -> "AgentConfig":
         """从发布版本快照重建 AgentConfig 对象（不入库，仅用于运行）"""
         cfg = release.config or {}
         now = release.created_at or datetime.datetime.now()

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -1179,6 +1179,11 @@ class ToolService:
         elif config.tool_type == ToolType.WORKFLOW.value:
             cfg = self.workflow_repo.find_by_tool_id(self.db, config.id)
             if cfg:
+                from app.models.app_model import App
+                workspace_id = None
+                app = self.db.query(App).filter(App.id == cfg.app_id).first()
+                if app:
+                    workspace_id = str(app.workspace_id)
                 workflow_config = WorkflowToolConfigSchema.model_validate({
                     "app_id": str(cfg.app_id),
                     "workflow_config_id": str(cfg.workflow_config_id),
@@ -1186,6 +1191,7 @@ class ToolService:
                     "input_parameters": cfg.input_parameters or [],
                     "output_schema": cfg.output_schema or {},
                     "timeout": cfg.timeout or 300,
+                    "workspace_id": workspace_id,
                 })
 
         detail_data.update({
@@ -1219,6 +1225,7 @@ class ToolService:
             },
             ToolType.WORKFLOW.value: {
                 "app_id", "workflow_config_id", "release_id", "input_parameters", "output_schema", "timeout",
+                "workspace_id"
             },
         }
         duplicate_fields = duplicate_fields_map.get(tool_type, set())

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -15,7 +15,7 @@ from app.repositories.tool_repository import (
     ToolRepository, BuiltinToolRepository, CustomToolRepository,
     MCPToolRepository, WorkflowToolRepository, ToolExecutionRepository
 )
-
+from app.models.app_model import App
 from app.models.tool_model import (
     ToolConfig, BuiltinToolConfig, CustomToolConfig, MCPToolConfig,
     ToolExecution, ToolType, ToolStatus, ExecutionStatus, AuthType
@@ -1179,7 +1179,6 @@ class ToolService:
         elif config.tool_type == ToolType.WORKFLOW.value:
             cfg = self.workflow_repo.find_by_tool_id(self.db, config.id)
             if cfg:
-                from app.models.app_model import App
                 workspace_id = None
                 app = self.db.query(App).filter(App.id == cfg.app_id).first()
                 if app:

--- a/api/app/services/workflow_tool_publish_service.py
+++ b/api/app/services/workflow_tool_publish_service.py
@@ -19,7 +19,7 @@ class WorkflowToolPublishService:
     def __init__(self, db: Session):
         self.db = db
 
-    def _validate_workflow_app(self, app_id: uuid.UUID, workspace_id: uuid.UUID) -> type[App]:
+    def _validate_workflow_app(self, app_id: uuid.UUID, workspace_id: uuid.UUID) -> App:
         app = self.db.query(App).filter(
             App.id == app_id,
             App.workspace_id == workspace_id,
@@ -36,7 +36,7 @@ class WorkflowToolPublishService:
             )
         return app
 
-    def _get_workflow_config(self, app_id: uuid.UUID) -> type[WorkflowConfig]:
+    def _get_workflow_config(self, app_id: uuid.UUID) -> WorkflowConfig:
         config = self.db.query(WorkflowConfig).filter(
             WorkflowConfig.app_id == app_id,
             WorkflowConfig.is_active.is_(True)
@@ -46,7 +46,7 @@ class WorkflowToolPublishService:
             raise BusinessException("工作流配置不存在", BizCode.NOT_FOUND)
         return config
 
-    def _get_release(self, app: type[App], release_id: Optional[uuid.UUID]) -> AppRelease:
+    def _get_release(self, app: App, release_id: Optional[uuid.UUID]) -> AppRelease:
         resolved_release_id = release_id or app.current_release_id
         if not resolved_release_id:
             raise BusinessException("请先发布工作流，再将其发布为工具", BizCode.CONFIG_MISSING)
@@ -157,13 +157,11 @@ class WorkflowToolPublishService:
         tool_description: str,
         tenant_id: uuid.UUID,
         workspace_id: uuid.UUID,
-        created_by: uuid.UUID,
         icon: Optional[str] = None,
         timeout: int = 300,
         tags: Optional[List[str]] = None,
         release_id: Optional[uuid.UUID] = None,
-    ) -> type[ToolConfig] | None:
-        _ = created_by
+    ) -> ToolConfig | None:
         app = self._validate_workflow_app(workflow_app_id, workspace_id)
         release = self._get_release(app, release_id)
         workflow_config = self._get_workflow_config(workflow_app_id)
@@ -182,6 +180,7 @@ class WorkflowToolPublishService:
             tool_config = self.db.query(ToolConfig).filter(ToolConfig.id == existing_tool.id).first()
             tool_config.name = tool_name
             tool_config.description = tool_description
+            tool_config.is_active = True
             tool_config.icon = icon
             if tags is not None:
                 tool_config.tags = tags


### PR DESCRIPTION
expose workspace_id in workflow tool config and improve type hints

## Summary by Sourcery

通过工具配置和详情响应对外暴露工作流工作区元数据，并在与工作流和智能体相关的服务中收紧类型注解。

新功能：
- 在工作流工具配置模式中加入 `workspace_id` 和 `workspace_name` 字段，并在工作流工具详情响应中暴露 `workspace_id`。

改进：
- 在更新已有工具配置时，确保基于工作流的工具会被重新激活。
- 通过移除未使用的 `created_by` 参数，简化工作流工具发布 API。
- 修正应用、工作流配置、版本发布以及智能体配置辅助函数的类型注解，使其引用具体的模型类，而不是类型对象。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose workflow workspace metadata through tool configuration and detail responses while tightening type hints in workflow- and agent-related services.

New Features:
- Include workspace_id and workspace_name fields in the workflow tool configuration schema and expose workspace_id in workflow tool detail responses.

Enhancements:
- Ensure workflow-based tools are reactivated when updating an existing tool configuration.
- Simplify workflow tool publishing API by removing an unused created_by parameter.
- Correct type hints for app, workflow config, release, and agent configuration helpers to reference concrete model classes instead of type objects.

</details>