### PR TITLE
fix(rag): fix document parsing hang, page limit rejection and task cancellation

### DIFF
--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -12,6 +12,7 @@ from app.celery_app import celery_app
 from app.controllers import file_controller
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
+from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
 from app.db import get_db
@@ -26,6 +27,12 @@ from app.services.file_storage_service import FileStorageService, get_file_stora
 
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
+
+# Redis keys for document parse task tracking
+_PARSE_TASK_KEY = "doc:{doc_id}:parse_task"
+_PARSE_CANCEL_KEY = "doc:{doc_id}:parse_cancel"
+_PARSE_TASK_TTL = 7200  # 2 hours
+_PARSE_CANCEL_TTL = 60  # 1 minute
 
 router = APIRouter(
     prefix="/documents",
@@ -281,15 +288,31 @@ async def delete_document(
         file_id = db_document.file_id
         kb_id = db_document.kb_id
 
-        # 2. Delete vector index (non-404 failures raise, caught by except below)
+        # 2. Cancel any running parse task via Redis
+        task_id = REDIS_CONN.get(_PARSE_TASK_KEY.format(doc_id=document_id))
+        if task_id:
+            api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
+            try:
+                celery_app.control.revoke(task_id, terminate=True)
+                api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
+            except NotImplementedError:
+                # ThreadPool does not support force termination; rely on Redis cancel marker
+                api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
+            except Exception as revoke_err:
+                api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
+        # Set cancellation marker and clean up task key
+        REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
+        REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
+
+        # 3. Delete vector index (non-404 failures raise, caught by except below)
         db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
         vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
         vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
 
-        # 3. Delete file (storage errors are swallowed internally)
+        # 4. Delete file (storage errors are swallowed internally)
         await file_controller._delete_file(db=db, file_id=file_id, current_user=current_user, storage_service=storage_service)
 
-        # 4. Delete document from DB (last — if DB fails, external resources are already cleaned)
+        # 5. Delete document from DB (last — if DB fails, external resources are already cleaned)
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
         db.delete(db_document)
         db.commit()
@@ -343,17 +366,37 @@ async def parse_documents(
                 detail="File has no storage key (legacy data not migrated)"
             )
 
-        # 4. Obtain knowledge base information
+        # 4. Atomically claim parse slot via Redis SET NX
+        redis_client = REDIS_CONN.REDIS
+        task_key = _PARSE_TASK_KEY.format(doc_id=document_id)
+        claimed = redis_client.set(task_key, "CLAIMED", ex=_PARSE_TASK_TTL, nx=True)
+        if not claimed:
+            existing_task_id = REDIS_CONN.get(task_key)
+            api_logger.info(f"Document is already being parsed: document_id={document_id}, task_id={existing_task_id}")
+            return success(data={"task_id": existing_task_id or "unknown"}, msg="Document is already being parsed.")
+
+        # 5. Obtain knowledge base information
         api_logger.info(f"Obtain details of the knowledge base: knowledge_id={db_document.kb_id}")
         db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
         if not db_knowledge:
+            # Rollback Redis claim on failure
+            REDIS_CONN.delete(task_key)
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Knowledge base not found")
 
-        # 5. Dispatch parse task with file_key (not file_path)
-        task = celery_app.send_task(
-            "app.core.rag.tasks.parse_document",
-            args=[db_file.file_key, document_id, db_file.file_name]
-        )
+        # 6. Dispatch parse task with file_key (not file_path)
+        try:
+            task = celery_app.send_task(
+                "app.core.rag.tasks.parse_document",
+                args=[db_file.file_key, document_id, db_file.file_name]
+            )
+        except Exception:
+            # Rollback Redis claim if Celery dispatch fails
+            REDIS_CONN.delete(task_key)
+            raise
+
+        # 7. Store real task_id in Redis (overwrite CLAIMED)
+        REDIS_CONN.set(task_key, task.id, exp=_PARSE_TASK_TTL)
+
         result = {
             "task_id": task.id
         }

--- a/api/app/core/rag/deepdoc/parser/mineru_parser.py
+++ b/api/app/core/rag/deepdoc/parser/mineru_parser.py
@@ -210,7 +210,7 @@ class MinerUParser(RAGPdfParser):
             self.logger.info(f"[MinerU] invoke api: {self.mineru_api}/file_parse")
             if callback:
                 callback(0.20, f"[MinerU] invoke api: {self.mineru_api}/file_parse")
-            response = requests.post(url=f"{self.mineru_api}/file_parse", files=files, data=data, headers=headers, timeout=1800)
+            response = requests.post(url=f"{self.mineru_api}/file_parse", files=files, data=data, headers=headers, timeout=300)
 
             response.raise_for_status()
             if response.headers.get("Content-Type") == "application/zip":

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -307,6 +307,10 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             return await storage_service.download_file(file_key)
 
         try:
+            # Early-exit check after download
+            if _should_abort(document_id):
+                _clear_redis_state(document_id)
+                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             file_binary = asyncio.run(_download())
         except RuntimeError:
             # If there's already a running loop (e.g. in some worker configurations)
@@ -318,11 +322,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         if not file_binary:
             raise IOError(f"Downloaded empty file from storage: {file_key}")
         logger.info(f"[ParseDoc] Downloaded {len(file_binary)} bytes from storage key: {file_key}")
-
-        # Early-exit check after download
-        if _should_abort(document_id):
-            _clear_redis_state(document_id)
-            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
 
         # 防线1：页数限制
         estimated_pages = _get_estimated_pages(file_name, file_binary)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -333,7 +333,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             logger.info(f"[ParseDoc] document={document_id} 页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}限制，跳过解析")
             db_document.progress = -1.0
             db_document.run = 0
-            db_document.progress_msg = f"文档页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}页限制，拒绝解析"
+            db_document.progress_msg = _progress_msg() + f"Page count ({estimated_pages}) exceeds limit ({MAX_DOCUMENT_PAGES}), parsing rejected\n"
             db.commit()
             return f"parse document '{file_name or document_id}' failed: page limit exceeded"
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -6,7 +6,7 @@ import shutil
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -22,6 +22,7 @@ from app.core.logging_config import get_logger
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
 from app.core.rag.graphrag.utils import get_llm_cache, set_llm_cache
+from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
 from app.core.rag.integrations.feishu.models import FileInfo
 from app.core.rag.integrations.yuque.client import YuqueAPIClient
@@ -64,6 +65,25 @@ EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "20"))
 EMBEDDING_MAX_WORKERS = int(os.getenv("EMBEDDING_MAX_WORKERS", "3"))
 # auto_questions LLM 并发调用的最大线程数
 AUTO_QUESTIONS_MAX_WORKERS = int(os.getenv("AUTO_QUESTIONS_MAX_WORKERS", "5"))
+# 文档解析页数上限
+MAX_DOCUMENT_PAGES = int(os.getenv("MAX_DOCUMENT_PAGES", "200"))
+
+
+def _get_estimated_pages(file_name: str, file_binary: bytes) -> int | None:
+    """快速获取 PDF 页数，失败返回 None（不阻断）"""
+    ext = os.path.splitext(file_name)[1].lower()
+    try:
+        if ext == ".pdf":
+            from app.core.rag.deepdoc.parser.pdf_parser import RAGPdfParser
+            return RAGPdfParser.total_page_number(binary=file_binary)
+    except Exception:
+        pass
+    return None
+
+
+# Redis keys for document parse task tracking
+_PARSE_TASK_KEY = "doc:{doc_id}:parse_task"
+_PARSE_CANCEL_KEY = "doc:{doc_id}:parse_cancel"
 
 # 模块级同步 Redis 连接池，供 Celery 任务共享使用
 # 连接 CELERY_BACKEND DB，与 write_message:last_done 时间戳写入保持一致
@@ -229,6 +249,28 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
     def _progress_msg() -> str:
         return "\n".join(progress_lines) + "\n"
 
+    def _should_abort(doc_id: uuid.UUID) -> bool:
+        """Check if the document has been deleted or marked for cancellation via Redis."""
+        cancel = REDIS_CONN.get(_PARSE_CANCEL_KEY.format(doc_id=doc_id))
+        if cancel:
+            logger.info(f"[ParseDoc] document={doc_id} cancelled via Redis -- aborting")
+            return True
+        # Fallback to DB check only when Redis is unavailable
+        if not REDIS_CONN.is_alive():
+            doc = db.query(Document).filter(Document.id == doc_id).first()
+            if doc is None:
+                logger.info(f"[ParseDoc] document={doc_id} deleted -- aborting")
+                return True
+        return False
+
+    def _clear_redis_state(doc_id: uuid.UUID):
+        """Clean up Redis tracking keys."""
+        try:
+            REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=doc_id))
+            REDIS_CONN.delete(_PARSE_CANCEL_KEY.format(doc_id=doc_id))
+        except Exception:
+            logger.warning(f"[ParseDoc] failed to clear Redis state for {doc_id}", exc_info=True)
+
     with get_db_context() as db:
       try:
         if not isinstance(document_id, uuid.UUID):
@@ -277,6 +319,18 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             raise IOError(f"Downloaded empty file from storage: {file_key}")
         logger.info(f"[ParseDoc] Downloaded {len(file_binary)} bytes from storage key: {file_key}")
 
+        # Early-exit check after download
+        if _should_abort(document_id):
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
+        # 防线1：页数限制
+        estimated_pages = _get_estimated_pages(file_name, file_binary)
+        if estimated_pages and estimated_pages > MAX_DOCUMENT_PAGES:
+            raise ValueError(
+                f"文档页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}页限制，拒绝解析"
+            )
+
         def progress_callback(prog=None, msg=None):
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} parse progress: {prog} msg: {msg}.")
 
@@ -315,6 +369,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         db.commit()
         db.refresh(db_document)
 
+        # Early-exit check after chunking
+        if _should_abort(document_id):
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
         # 2. Document vectorization and storage
         total_chunks = (len(child_res) + len(parent_res)) if parent_child_mode else len(res)
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
@@ -322,6 +381,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         if total_chunks == 0:
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} No chunks generated, skipping vectorization.")
         else:
+            # Early-exit check before vectorization
+            if _should_abort(document_id):
+                _clear_redis_state(document_id)
+                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
             total_batches = ceil(total_chunks / EMBEDDING_BATCH_SIZE)
             progress_per_batch = 0.2 / total_batches
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
@@ -563,6 +627,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             db.commit()
             db.refresh(db_document)
 
+        # Early-exit check after vectorization
+        if _should_abort(document_id):
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
         # Vectorization and data entry completed
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Indexing done.")
         db_document.chunk_num = total_chunks
@@ -575,19 +644,26 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # GraphRAG: 异步派发到独立队列，不阻塞文档解析流程
         if db_knowledge.parser_config and db_knowledge.parser_config.get("graphrag", {}).get("use_graphrag", False):
+            # Check again before dispatching GraphRAG
+            if _should_abort(document_id):
+                _clear_redis_state(document_id)
+                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
             db_document.progress_msg = _progress_msg()
             db.commit()
             build_graphrag_for_document.delay(str(document_id), str(db_knowledge.id))
 
+        _clear_redis_state(document_id)
         result = f"parse document '{db_document.file_name}' processed successfully."
         logger.info(f"[ParseDoc] document={document_id} file='{db_document.file_name}' done in {db_document.process_duration:.1f}s, chunks={total_chunks}")
         return result
       except Exception as e:
         logger.error(f"[ParseDoc] document={document_id} failed: {e}", exc_info=True)
+        _clear_redis_state(document_id)
         if db_document is not None:
             try:
                 db.rollback()
+                db_document.progress = -1.0
                 db_document.progress_msg = _progress_msg() + f"Failed to vectorize and import the parsed document:{str(e)}\n"
                 db_document.run = 0
                 db.commit()

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -326,7 +326,10 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # 防线1：页数限制
         estimated_pages = _get_estimated_pages(file_name, file_binary)
-        if estimated_pages and estimated_pages > MAX_DOCUMENT_PAGES:
+        logger.info(f"[ParseDoc] document={document_id} estimated_pages={estimated_pages}")
+        if estimated_pages is None:
+            raise ValueError("无法获取文档页数，拒绝解析")
+        if estimated_pages > MAX_DOCUMENT_PAGES:
             raise ValueError(
                 f"文档页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}页限制，拒绝解析"
             )
@@ -2297,7 +2300,7 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
     result["task_id"] = self.request.id
     logger.info(f"反思引擎Layer2 任务完成，耗时 {result['elapsed_time']:.1f}s")
     return result
-    
+
 @celery_app.task(
     name="app.tasks.layer2_dedup_full_scan_task",
     bind=True,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -328,12 +328,14 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         estimated_pages = _get_estimated_pages(file_name, file_binary)
         logger.info(f"[ParseDoc] document={document_id} estimated_pages={estimated_pages}")
         if estimated_pages is None:
-            logger.info(f"[ParseDoc] document={document_id} 无法获取页数，继续解析")
+            logger.info(f"[ParseDoc] document={document_id} not obtain page number, parse failed.")
+            progress_lines.append(datetime.now().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: not obtain page number")
         elif estimated_pages > MAX_DOCUMENT_PAGES:
-            logger.info(f"[ParseDoc] document={document_id} 页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}限制，跳过解析")
+            logger.info(f"[ParseDoc] document={document_id}, estimated page number:({estimated_pages}), exceeds {MAX_DOCUMENT_PAGES}")
+            progress_lines.append(datetime.now().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: page limit exceeded")
             db_document.progress = -1.0
             db_document.run = 0
-            db_document.progress_msg = _progress_msg() + f"Page count ({estimated_pages}) exceeds limit ({MAX_DOCUMENT_PAGES}), parsing rejected\n"
+            db_document.progress_msg = _progress_msg()
             db.commit()
             _clear_redis_state(document_id)
             return f"parse document '{file_name or document_id}' failed: page limit exceeded"

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -665,7 +665,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         _clear_redis_state(document_id)
         if db_document is not None:
             try:
-                db.rollback()
                 db_document.progress = -1.0
                 db_document.progress_msg = _progress_msg() + f"Failed to vectorize and import the parsed document:{str(e)}\n"
                 db_document.run = 0

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -335,6 +335,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             db_document.run = 0
             db_document.progress_msg = _progress_msg() + f"Page count ({estimated_pages}) exceeds limit ({MAX_DOCUMENT_PAGES}), parsing rejected\n"
             db.commit()
+            _clear_redis_state(document_id)
             return f"parse document '{file_name or document_id}' failed: page limit exceeded"
 
         def progress_callback(prog=None, msg=None):

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -349,6 +349,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         from app.core.rag.app.naive import chunk
         logger.info(f"[ParseDoc] file_binary size={len(file_binary)} bytes, type={type(file_binary).__name__}, bool={bool(file_binary)}")
 
+        # Early-exit check before chunking
+        if _should_abort(document_id):
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
         parent_child_mode = db_document.is_parent_child_mode
         if parent_child_mode:
             from app.core.rag.app.naive import chunk_parent_child
@@ -377,6 +382,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         db_document.progress_msg = _progress_msg()
         db.commit()
         db.refresh(db_document)
+
+        # Early-exit check before vectorization
+        if _should_abort(document_id):
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
 
         # 2. Document vectorization and storage
         total_chunks = (len(child_res) + len(parent_res)) if parent_child_mode else len(res)
@@ -638,6 +648,10 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # GraphRAG: 异步派发到独立队列，不阻塞文档解析流程
         if db_knowledge.parser_config and db_knowledge.parser_config.get("graphrag", {}).get("use_graphrag", False):
+            # Early-exit check before dispatching GraphRAG
+            if _should_abort(document_id):
+                _clear_redis_state(document_id)
+                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
             db_document.progress_msg = _progress_msg()
             db.commit()

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -75,7 +75,7 @@ def _get_estimated_pages(file_name: str, file_binary: bytes) -> int | None:
     try:
         if ext == ".pdf":
             from app.core.rag.deepdoc.parser.pdf_parser import RAGPdfParser
-            return RAGPdfParser.total_page_number(binary=file_binary)
+            return RAGPdfParser.total_page_number("", binary=file_binary)
     except Exception:
         pass
     return None

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -328,11 +328,14 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         estimated_pages = _get_estimated_pages(file_name, file_binary)
         logger.info(f"[ParseDoc] document={document_id} estimated_pages={estimated_pages}")
         if estimated_pages is None:
-            raise ValueError("无法获取文档页数，拒绝解析")
-        if estimated_pages > MAX_DOCUMENT_PAGES:
-            raise ValueError(
-                f"文档页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}页限制，拒绝解析"
-            )
+            logger.info(f"[ParseDoc] document={document_id} 无法获取页数，继续解析")
+        elif estimated_pages > MAX_DOCUMENT_PAGES:
+            logger.info(f"[ParseDoc] document={document_id} 页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}限制，跳过解析")
+            db_document.progress = -1.0
+            db_document.run = 0
+            db_document.progress_msg = f"文档页数({estimated_pages})超过{MAX_DOCUMENT_PAGES}页限制，拒绝解析"
+            db.commit()
+            return f"parse document '{file_name or document_id}' failed: page limit exceeded"
 
         def progress_callback(prog=None, msg=None):
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} parse progress: {prog} msg: {msg}.")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -378,11 +378,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         db.commit()
         db.refresh(db_document)
 
-        # Early-exit check after chunking
-        if _should_abort(document_id):
-            _clear_redis_state(document_id)
-            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
-
         # 2. Document vectorization and storage
         total_chunks = (len(child_res) + len(parent_res)) if parent_child_mode else len(res)
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
@@ -390,11 +385,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         if total_chunks == 0:
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} No chunks generated, skipping vectorization.")
         else:
-            # Early-exit check before vectorization
-            if _should_abort(document_id):
-                _clear_redis_state(document_id)
-                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
-
             total_batches = ceil(total_chunks / EMBEDDING_BATCH_SIZE)
             progress_per_batch = 0.2 / total_batches
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
@@ -636,11 +626,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             db.commit()
             db.refresh(db_document)
 
-        # Early-exit check after vectorization
-        if _should_abort(document_id):
-            _clear_redis_state(document_id)
-            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
-
         # Vectorization and data entry completed
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Indexing done.")
         db_document.chunk_num = total_chunks
@@ -653,10 +638,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # GraphRAG: 异步派发到独立队列，不阻塞文档解析流程
         if db_knowledge.parser_config and db_knowledge.parser_config.get("graphrag", {}).get("use_graphrag", False):
-            # Check again before dispatching GraphRAG
-            if _should_abort(document_id):
-                _clear_redis_state(document_id)
-                return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
             db_document.progress_msg = _progress_msg()
             db.commit()


### PR DESCRIPTION
## Summary

修复知识库文档解析任务卡死及状态异常问题，主要涉及以下改动：

1. **MinerU API 超时缩短**：将 `requests.post` 的 `timeout` 从 1800 秒缩短至 300 秒（5 分钟），解决 API 慢速流式响应导致 read timeout 计时器被不断重置、任务永久阻塞的问题。

2. **PDF 页数前置限制**：新增 `_get_estimated_pages()` 函数，解析前检测 PDF 页数，超过 `MAX_DOCUMENT_PAGES`（默认 200 页）直接拒绝并设置失败状态（`progress=-1.0`, `run=0`），避免大文档拖垮 worker。

3. **异常状态持久化**：去掉 `except` 块中的 `db.rollback()`，解决 rollback 后对象 detached 导致 `progress=-1.0` 等修改无法写入数据库的问题。

4. **删除文档时取消正在解析的任务**：在 `document_controller.py` 中新增 Redis 标记机制，删除文档时通知 worker 中断当前解析流程；`parse_document` 在关键节点（下载后、chunk 前、embedding 前、GraphRAG 前）检查中断标记。

5. **失败时清理 Redis 状态**：页数限制拒绝或异常退出时，确保 `_clear_redis_state` 被调用，避免残留 key 导致后续无法重新触发解析。

## Changes

\`\`\`
 api/app/controllers/document_controller.py       | 61 ++++++++++++++---
 api/app/core/rag/deepdoc/parser/mineru_parser.py |  2 +-
 api/app/tasks.py                                 | 84 +++++++++++++++++++++++-
\`\`\`

## Test Plan
- [ ] 上传超过 200 页的 PDF，确认被直接拒绝且状态显示为失败
- [ ] 上传正常 PDF 触发解析，删除文档确认 worker 中断并清理 Redis
- [ ] 确认 MinerU API 无响应时 5 分钟内超时失败

## Summary by Sourcery

通过基于 Redis 的任务追踪、页面数量上限以及更短的外部 API 超时时间，强制实施更安全、可取消的文档解析机制，以防止任务挂起和状态陈旧。

New Features:
- 引入基于 Redis 的追踪 key，用于声明、存储和取消文档解析任务，确保每个文档在任意时间只有一个活跃解析任务，并允许在文档被删除时触发取消。
- 新增可配置的 PDF 最大页数限制，并在解析前执行页数预检查，对于超出上限的文档提前拒绝并标记为失败状态。

Bug Fixes:
- 确保文档解析失败时，会正确地将进度和运行状态持久化到数据库中，而不是在事务回滚后丢失这些信息。
- 通过将 MinerU API 的 HTTP 超时时间从 30 分钟缩短到 5 分钟，防止文档解析无限期挂起。
- 保证当解析中止、超出限制或失败时，会清除 Redis 中的任务状态，避免取消标记或解析标记被卡住。

Enhancements:
- 在解析流水线的关键阶段（下载完成后、分块前、向量嵌入前以及 GraphRAG 分发前）增加提前中止检查，使 worker 能够及时停止已被取消或已删除的文档任务。
- 将文档删除操作与撤销正在执行的解析任务关联起来，并通过 Redis 将其标记为已取消，从而与 worker 端的中止检查协同工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce safer, cancellable document parsing with Redis-backed task tracking, page-count limits, and shorter external API timeouts to prevent hangs and stale states.

New Features:
- Introduce Redis-based tracking keys to claim, store, and cancel document parse tasks, ensuring only one active parse per document and allowing deletion-triggered cancellation.
- Add a configurable maximum page limit for PDFs and perform a pre-parse page count check to reject oversized documents early with a failed status.

Bug Fixes:
- Ensure document parse failures correctly persist progress and run status in the database instead of being rolled back and lost.
- Prevent document parsing from hanging indefinitely by reducing the MinerU API HTTP timeout from 30 minutes to 5 minutes.
- Guarantee Redis task state is cleared when parses abort, exceed limits, or fail, avoiding stuck cancellation/parse flags.

Enhancements:
- Add early-abort checks at key stages of the parse pipeline (post-download, pre-chunking, pre-embedding, and before GraphRAG dispatch) so workers can promptly stop cancelled or deleted document tasks.
- Wire document deletion to revoke any in-flight parse task and mark it as cancelled via Redis, coordinating with the worker-side abort checks.

</details>