### PR TITLE
fix(conversation_model)

### DIFF
--- a/api/app/models/conversation_model.py
+++ b/api/app/models/conversation_model.py
@@ -89,17 +89,17 @@ class Message(Base):
     content = Column(Text, nullable=False, comment="消息内容")
 
     # === 版本化支持（重新生成功能） ===
-    version = Column(Integer, default=1, comment="版本号（重新生成时递增）")
-    is_current = Column(Boolean, default=True, comment="是否为当前展示版本")
+    version = Column(Integer, server_default="1", comment="版本号（重新生成时递增）")
+    is_current = Column(Boolean, server_default="true", comment="是否为当前展示版本")
     parent_message_id = Column(UUID(as_uuid=True), comment="父消息ID（用于重新生成时关联原用户消息）")
 
     # === 逻辑删除 ===
-    is_deleted = Column(Boolean, default=False, comment="逻辑删除标记")
+    is_deleted = Column(Boolean, server_default="false", comment="逻辑删除标记")
 
     # === 统计字段（冗余，便于查询） ===
-    like_count = Column(Integer, default=0, comment="点赞数")
-    dislike_count = Column(Integer, default=0, comment="点踩数")
-    report_count = Column(Integer, default=0, comment="举报数")
+    like_count = Column(Integer, server_default="0", comment="点赞数")
+    dislike_count = Column(Integer, server_default="0", comment="点踩数")
+    report_count = Column(Integer, server_default="0", comment="举报数")
 
     # 元数据（避免使用 metadata 保留字）
     meta_data = Column(JSON, comment="消息元数据（如模型、token使用等）")

--- a/api/app/models/conversation_model.py
+++ b/api/app/models/conversation_model.py
@@ -89,17 +89,17 @@ class Message(Base):
     content = Column(Text, nullable=False, comment="消息内容")
 
     # === 版本化支持（重新生成功能） ===
-    version = Column(Integer, server_default="1", comment="版本号（重新生成时递增）")
-    is_current = Column(Boolean, server_default="true", comment="是否为当前展示版本")
+    version = Column(Integer, server_default="1", default=1, comment="版本号（重新生成时递增）")
+    is_current = Column(Boolean, server_default="true", default=True, comment="是否为当前展示版本")
     parent_message_id = Column(UUID(as_uuid=True), comment="父消息ID（用于重新生成时关联原用户消息）")
 
     # === 逻辑删除 ===
-    is_deleted = Column(Boolean, server_default="false", comment="逻辑删除标记")
+    is_deleted = Column(Boolean, server_default="false", default=False, comment="逻辑删除标记")
 
     # === 统计字段（冗余，便于查询） ===
-    like_count = Column(Integer, server_default="0", comment="点赞数")
-    dislike_count = Column(Integer, server_default="0", comment="点踩数")
-    report_count = Column(Integer, server_default="0", comment="举报数")
+    like_count = Column(Integer, server_default="0", default=0, comment="点赞数")
+    dislike_count = Column(Integer, server_default="0", default=0, comment="点踩数")
+    report_count = Column(Integer, server_default="0", default=0, comment="举报数")
 
     # 元数据（避免使用 metadata 保留字）
     meta_data = Column(JSON, comment="消息元数据（如模型、token使用等）")


### PR DESCRIPTION
use server_default for Boolean and Integer columns

## Summary by Sourcery

增强内容：
- 将整型和布尔型消息字段切换为使用服务端默认值，用于版本号、当前标志、删除标志以及点赞/点踩/举报计数器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Switch Integer and Boolean message fields to use server-side default values for version, current flag, deletion flag, and like/dislike/report counters.

</details>