### PR TITLE
Feat/graph data per type limit

### DIFF
--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -19,6 +19,7 @@ from app.services.user_memory_service import (
     analytics_graph_data,
     analytics_community_graph_data,
 )
+from app.services._graph_data_helpers import parse_per_type_limits
 from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
 from app.schemas.response_schema import ApiResponse
 from app.schemas.memory_storage_schema import GenerateCacheRequest
@@ -248,6 +249,7 @@ async def get_graph_data_api(
         limit: int = 100,
         depth: int = 1,
         center_node_id: Optional[str] = None,
+        per_type_limits: Optional[str] = None,
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
 ) -> dict:
@@ -272,9 +274,24 @@ async def get_graph_data_api(
     if node_types:
         node_types_list = [t.strip() for t in node_types.split(",") if t.strip()]
 
+    # 解析 per_type_limits 参数；失败 → INVALID_PARAMETER
+    try:
+        per_type_limits_map = parse_per_type_limits(per_type_limits, api_logger)
+    except ValueError as e:
+        api_logger.warning(f"per_type_limits 参数解析失败: raw={per_type_limits!r}, error={e}")
+        return fail(BizCode.INVALID_PARAMETER, "per_type_limits 参数格式错误", str(e))
+
+    # 同时传 center_node_id 与 node_types：按设计优先 Center_Mode 并忽略 node_types
+    if center_node_id and node_types_list:
+        api_logger.info(
+            "同时传入 center_node_id 与 node_types，按设计优先 Center_Mode，"
+            f"node_types={node_types_list} 将被忽略"
+        )
+
     api_logger.info(
         f"图数据查询请求: end_user_id={end_user_id}, user={current_user.username}, "
-        f"workspace={workspace_id}, node_types={node_types_list}, limit={limit}, depth={depth}"
+        f"workspace={workspace_id}, node_types={node_types_list}, limit={limit}, depth={depth}, "
+        f"center_node_id={center_node_id}, per_type_limits={per_type_limits_map}"
     )
 
     try:
@@ -284,7 +301,8 @@ async def get_graph_data_api(
             node_types=node_types_list,
             limit=limit,
             depth=depth,
-            center_node_id=center_node_id
+            center_node_id=center_node_id,
+            per_type_limits=per_type_limits_map,
         )
         # 检查是否有错误消息
         if "message" in result and result["statistics"]["total_nodes"] == 0:

--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -20,6 +20,10 @@ from app.services.user_memory_service import (
     analytics_community_graph_data,
 )
 from app.services._graph_data_helpers import parse_per_type_limits
+from app.core.memory.constants.graph_data_constants import (
+    CENTER_MODE_LIMIT_HARD_MAX,
+    DEPTH_HARD_MAX,
+)
 from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
 from app.schemas.response_schema import ApiResponse
 from app.schemas.memory_storage_schema import GenerateCacheRequest
@@ -261,13 +265,13 @@ async def get_graph_data_api(
         return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
 
     # 参数验证
-    if limit > 1000:
-        limit = 1000
-        api_logger.warning("limit 参数超过最大值，已调整为 1000")
+    if limit > CENTER_MODE_LIMIT_HARD_MAX:
+        limit = CENTER_MODE_LIMIT_HARD_MAX
+        api_logger.warning(f"limit 参数超过最大值，已调整为 {CENTER_MODE_LIMIT_HARD_MAX}")
 
-    if depth > 3:
-        depth = 3
-        api_logger.warning("depth 参数超过最大值，已调整为 3")
+    if depth > DEPTH_HARD_MAX:
+        depth = DEPTH_HARD_MAX
+        api_logger.warning(f"depth 参数超过最大值，已调整为 {DEPTH_HARD_MAX}")
 
     # 解析 node_types 参数
     node_types_list = None

--- a/api/app/core/memory/constants/__init__.py
+++ b/api/app/core/memory/constants/__init__.py
@@ -1,0 +1,1 @@
+"""Memory subsystem constants."""

--- a/api/app/core/memory/constants/graph_data_constants.py
+++ b/api/app/core/memory/constants/graph_data_constants.py
@@ -1,0 +1,93 @@
+"""图数据可视化接口的常量定义。
+
+修改本文件即可扩展支持的节点类型 / 调整默认上限，无需改动控制器与服务层签名。
+
+注意：``Community`` 节点不在本接口的查询范围内 —— 社区数据由独立的
+``GET /api/memory-storage/analytics/community_graph`` 接口（service 层
+``analytics_community_graph_data``）专门暴露。本接口默认仅返回除 Community
+之外的 8 种节点类型，避免与社区接口的语义重叠。
+"""
+from typing import Dict, FrozenSet, List
+
+# 受支持的节点类型集合（与 Cypher labels(n)[0] 对齐，区分大小写）
+# 注意：``Community`` 节点交由 ``/analytics/community_graph`` 接口处理，
+# 故不出现在本集合中。
+SUPPORTED_NODE_TYPES: FrozenSet[str] = frozenset({
+    "Dialogue",
+    "Chunk",
+    "AssistantOriginal",
+    "AssistantPruned",
+    "Statement",
+    "ExtractedEntity",
+    "MemorySummary",
+    "Perceptual",
+})
+
+# 每种节点类型的默认 Per_Type_Limit
+DEFAULT_PER_TYPE_LIMIT_MAP: Dict[str, int] = {
+    "Dialogue": 20,
+    "Chunk": 30,
+    "AssistantOriginal": 20,
+    "AssistantPruned": 20,
+    "Statement": 50,
+    "ExtractedEntity": 50,
+    "MemorySummary": 20,
+    "Perceptual": 20,
+}
+
+# 单类型 Per_Type_Limit 硬上限（Requirement 2.8）
+SINGLE_TYPE_LIMIT_HARD_MAX: int = 500
+
+# 节点总量保护上限（Requirement 8.1）
+TOTAL_NODES_CAP: int = 2000
+
+# Center_Mode 下单一 limit 的硬上限（与控制器现有逻辑保持一致）
+CENTER_MODE_LIMIT_HARD_MAX: int = 1000
+
+# 节点属性白名单：未在表中的类型 fallback 到 _DEFAULT_FIELDS（Requirement 7.6）
+_DEFAULT_FIELDS: List[str] = ["caption"]
+
+NODE_PROPERTY_WHITELIST: Dict[str, List[str]] = {
+    "Dialogue": ["content", "created_at"],
+    "Chunk": ["content", "created_at"],
+    "Statement": [
+        "temporal_info",
+        "stmt_type",
+        "statement",
+        "valid_at",
+        "created_at",
+        "caption",
+        "emotion_keywords",
+        "emotion_type",
+        "emotion_subject",
+    ],
+    "ExtractedEntity": [
+        "description",
+        "name",
+        "entity_type",
+        "created_at",
+        "caption",
+        "aliases",
+        "connect_strength",
+    ],
+    "MemorySummary": ["summary", "content", "created_at", "caption"],
+    "Perceptual": [
+        "file_name",
+        "file_path",
+        "file_type",
+        "domain",
+        "topic",
+        "keywords",
+        "summary",
+    ],
+    # 助手回复节点 — 实际写入字段名为 ``text``（参见
+    # ``api/app/core/memory/models/graph_models.py`` 的
+    # ``AssistantOriginalNode`` / ``AssistantPrunedNode``），因此白名单也使用
+    # ``text``。前端按 ``properties.text`` 取节点正文内容。
+    "AssistantOriginal": ["text", "created_at"],
+    "AssistantPruned": ["text", "memory_type", "created_at"],
+    # 注意：Community 由 /analytics/community_graph 接口独立处理，
+    # 不出现在 SUPPORTED_NODE_TYPES 中。但保留白名单以支持其它流程
+    # （如 Center_Mode 中心节点扩展碰巧命中 Community 邻居）的属性裁剪。
+    "Community": ["name", "summary", "caption", "created_at"],
+}

--- a/api/app/core/memory/constants/graph_data_constants.py
+++ b/api/app/core/memory/constants/graph_data_constants.py
@@ -44,6 +44,9 @@ TOTAL_NODES_CAP: int = 2000
 # Center_Mode 下单一 limit 的硬上限（与控制器现有逻辑保持一致）
 CENTER_MODE_LIMIT_HARD_MAX: int = 1000
 
+# Center_Mode 下 ``depth`` 参数的硬上限（与控制器现有逻辑保持一致）
+DEPTH_HARD_MAX: int = 3
+
 # 节点属性白名单：未在表中的类型 fallback 到 _DEFAULT_FIELDS（Requirement 7.6）
 _DEFAULT_FIELDS: List[str] = ["caption"]
 

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -156,14 +156,46 @@ async def create_vector_indexes():
         await connector.close()
 
 
-async def create_user_indexes():
+async def create_end_user_id_indexes():
+    """为受 graph_data 接口查询的 8 类节点建立 ``end_user_id`` 范围索引。
+
+    所有 graph_data 系列查询（Q1 / Q4）都按 ``n.end_user_id = $end_user_id AND
+    labels(n)[0] = $label`` 过滤；如果不建索引，对每个类型都要全表扫描，
+    在大库下会成为性能瓶颈。
+
+    本函数对全部 8 类受支持节点统一建立单字段范围索引（``IF NOT EXISTS``
+    保证幂等）；首次创建时 Neo4j 会异步在后台填充索引，不阻塞在线查询。
+    """
     connector = Neo4jConnector()
-    await connector.execute_query(
-        """
-        CREATE INDEX user_perceptual IF NOT EXISTS
-        FOR (p:Perceptual) ON (p.end_user_id);
-        """
-    )
+    try:
+        for label, idx_name in [
+            ("Dialogue",          "user_dialogue"),
+            ("Chunk",             "user_chunk"),
+            ("Statement",         "user_statement"),
+            ("ExtractedEntity",   "user_extracted_entity"),
+            ("MemorySummary",     "user_memory_summary"),
+            ("Perceptual",        "user_perceptual"),
+            ("AssistantOriginal", "user_assistant_original"),
+            ("AssistantPruned",   "user_assistant_pruned"),
+        ]:
+            await connector.execute_query(
+                f"""
+                CREATE INDEX {idx_name} IF NOT EXISTS
+                FOR (n:{label}) ON (n.end_user_id);
+                """
+            )
+    finally:
+        await connector.close()
+
+
+async def create_user_indexes():
+    """Deprecated: 历史保留入口；新代码请直接调用 :func:`create_end_user_id_indexes`。
+
+    早期版本只建了 ``Perceptual.end_user_id`` 一条；本函数现已并入到
+    :func:`create_end_user_id_indexes`，统一覆盖 8 类受支持节点。保留本函数
+    名是为了避免破坏外部调用方（如运维脚本）。
+    """
+    await create_end_user_id_indexes()
 
 
 async def create_unique_constraints():
@@ -220,4 +252,5 @@ async def create_all_indexes():
     """Create all indexes and constraints in one go."""
     await create_fulltext_indexes()
     await create_vector_indexes()
+    await create_end_user_id_indexes()
     await create_unique_constraints()

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1,3 +1,4 @@
+from app.core.memory.constants.graph_data_constants import SUPPORTED_NODE_TYPES
 from app.core.memory.enums import Neo4jNodeType
 
 DIALOGUE_NODE_SAVE = """
@@ -1062,26 +1063,45 @@ RETURN DISTINCT
 # ============================================================
 # graph_data 接口的参数化 Cypher 查询（spec: graph-data-per-type-limit）
 # ============================================================
-# 以下三段 Cypher 用于支撑 GET /api/memory-storage/analytics/graph_data 的
-# 「按类型独立 LIMIT + 批量关联计数 + 全量计数」流水线，文本与设计文档
-# `Cypher Queries` 一节保持完全一致（参见
+# 以下查询用于支撑 GET /api/memory-storage/analytics/graph_data 的
+# 「按类型独立 LIMIT + 批量关联计数 + 全量计数」流水线（参见
 # .kiro/specs/graph-data-per-type-limit/design.md）。
+#
+# 索引命中的关键约束（Neo4j 5.x）：
+#   `end_user_id` 范围索引是 label-property 索引（``FOR (n:Label) ON (n.end_user_id)``），
+#   规划器只有在 **label 出现在 MATCH 模式里**（``MATCH (n:Label)``）时才会用
+#   NodeIndexSeek。若把 label 放进 WHERE 用 ``labels(n)[0] = $node_type``，
+#   规划器无法绑定具体 label 索引，只能 AllNodesScan 全表扫描。动态 label
+#   (``MATCH (n:$($node_type))``, Neo4j 5.26+) 同样无法稳定命中索引。
+#   因此 Q1/Q4 改为「把白名单内的 label 字面量内联进 MATCH 模式」的 builder 形式。
+#   label 取自 :data:`SUPPORTED_NODE_TYPES`（已 ``isidentifier`` 校验 + 白名单过滤），
+#   字面量内联不存在注入风险。
 
-# Q1：按单个 Node_Type 与对应 Per_Type_Limit 检索节点。
-#
-# 注意：Neo4j 不允许 ``LIMIT`` 引用运行期变量（``Neo.ClientError.Statement.SyntaxError
-# 50N42 — It is not allowed to refer to variables in LIMIT``），因此本查询采用
-# 「单类型 + 静态 ``$limit`` 参数」的形式；service 层 helper
-# (:func:`app.services._graph_data_helpers._query_nodes_by_type_limits`) 在 Python
-# 侧对每个非零 ``Per_Type_Limit`` 类型循环下发一次本查询并合并结果，整体调用次数
-# 仍与节点总数 N 无关（最多 = 类型数，常数级），符合 Requirement 6.4 的语义。
-#
-# 参数：$end_user_id (STRING), $node_type (STRING), $limit (INTEGER, 静态)
-GRAPH_NODES_BY_TYPE_LIMITS = """
-// GRAPH_NODES_BY_TYPE_LIMITS
-MATCH (n)
+
+def build_graph_nodes_by_type_query(node_type: str) -> str:
+    """构建「按单个 Node_Type 检索节点」的 Cypher（Q1），label 字面量内联以命中索引。
+
+    Neo4j 不允许 ``LIMIT`` 引用运行期变量，故 ``$limit`` 仍以静态参数下发；
+    service 层 helper 对每个非零 ``Per_Type_Limit`` 类型循环调用一次本 builder，
+    整体调用次数与节点总数 N 无关（最多 = 类型数，常数级），符合 Requirement 6.4。
+
+    Args:
+        node_type: 节点 label，必须属于 :data:`SUPPORTED_NODE_TYPES`。
+
+    Returns:
+        把 ``node_type`` 内联进 ``MATCH (n:<label>)`` 后的 Cypher 字符串；
+        运行期参数为 ``$end_user_id`` (STRING) 与 ``$limit`` (INTEGER)。
+
+    Raises:
+        ValueError: 当 ``node_type`` 不在 :data:`SUPPORTED_NODE_TYPES` 中时
+            （防止任何未经白名单校验的字符串被内联进 Cypher）。
+    """
+    if node_type not in SUPPORTED_NODE_TYPES:
+        raise ValueError(f"不支持的 Node_Type，拒绝内联进 Cypher: {node_type!r}")
+    return f"""
+// GRAPH_NODES_BY_TYPE_LIMITS({node_type})
+MATCH (n:{node_type})
 WHERE n.end_user_id = $end_user_id
-  AND labels(n)[0] = $node_type
 RETURN
     elementId(n)        AS id,
     labels(n)           AS labels,
@@ -1089,7 +1109,36 @@ RETURN
 LIMIT $limit
 """
 
+
+def build_graph_total_count_by_type_query(node_type: str) -> str:
+    """构建「单个 Node_Type 全量计数」的 Cypher（Q4），label 字面量内联以命中索引。
+
+    取代旧版「``MATCH (n) WHERE labels(n)[0] IN $supported_types``」单查询——
+    后者无 label 在模式里，会对全库做 AllNodesScan。改为按类型 NodeIndexSeek，
+    service 层循环调用并合并为 ``{label: total}``（调用次数 = 类型数，常数级）。
+
+    Args:
+        node_type: 节点 label，必须属于 :data:`SUPPORTED_NODE_TYPES`。
+
+    Returns:
+        把 ``node_type`` 内联进 ``MATCH (n:<label>)`` 后的计数 Cypher；
+        运行期参数为 ``$end_user_id`` (STRING)。
+
+    Raises:
+        ValueError: 当 ``node_type`` 不在 :data:`SUPPORTED_NODE_TYPES` 中时。
+    """
+    if node_type not in SUPPORTED_NODE_TYPES:
+        raise ValueError(f"不支持的 Node_Type，拒绝内联进 Cypher: {node_type!r}")
+    return f"""
+// GRAPH_NODES_TOTAL_COUNT_BY_TYPE({node_type})
+MATCH (n:{node_type})
+WHERE n.end_user_id = $end_user_id
+RETURN count(n) AS total
+"""
+
+
 # Q2：批量查询若干节点的关联边总数，取代旧实现里每节点一次的 N+1 子查询。
+# Q2 按 ``elementId(n)`` 直接定位节点，无需 label，不涉及上面的索引命中问题。
 #
 # 注意：Neo4j 5 已移除 ``size((n)--())`` 这种「pattern expression in size()」用法，
 # 必须改用 ``COUNT { (n)--() }`` 子查询表达式（见
@@ -1106,19 +1155,9 @@ MATCH (n) WHERE elementId(n) = nid
 RETURN nid AS id, COUNT { (n)--() } AS rel_count
 """
 
-# Q4：按支持类型聚合 end_user 下的节点全量总数，用于 statistics.per_type 元数据。
-# 参数：$end_user_id (STRING), $supported_types (LIST<STRING>)
-GRAPH_NODES_TOTAL_COUNT_BY_TYPE = """
-// GRAPH_NODES_TOTAL_COUNT_BY_TYPE
-MATCH (n)
-WHERE n.end_user_id = $end_user_id
-  AND labels(n)[0] IN $supported_types
-RETURN labels(n)[0] AS label, count(n) AS total
-"""
-
-# DEPRECATED: Graph_Node_query 已被新版 GRAPH_NODES_BY_TYPE_LIMITS 取代，
-# 后者通过参数化 $type_limits 支持任意 Node_Type 与独立 Per_Type_Limit。
-# 此常量仅保留以避免破坏式改动；新代码不应再使用，等迁移完成后再行清理。
+# DEPRECATED: Graph_Node_query 已被 build_graph_nodes_by_type_query() 取代，
+# 后者按 SUPPORTED_NODE_TYPES 内联 label 字面量，可命中 end_user_id 索引并支持
+# 独立 Per_Type_Limit。此常量仅保留以避免破坏式改动；新代码不应再使用。
 Graph_Node_query = """
 MATCH (n:MemorySummary)
 WHERE n.end_user_id = $end_user_id

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1059,6 +1059,66 @@ RETURN DISTINCT
  x.statement as statement,x.created_at as created_at
 """
 
+# ============================================================
+# graph_data 接口的参数化 Cypher 查询（spec: graph-data-per-type-limit）
+# ============================================================
+# 以下三段 Cypher 用于支撑 GET /api/memory-storage/analytics/graph_data 的
+# 「按类型独立 LIMIT + 批量关联计数 + 全量计数」流水线，文本与设计文档
+# `Cypher Queries` 一节保持完全一致（参见
+# .kiro/specs/graph-data-per-type-limit/design.md）。
+
+# Q1：按单个 Node_Type 与对应 Per_Type_Limit 检索节点。
+#
+# 注意：Neo4j 不允许 ``LIMIT`` 引用运行期变量（``Neo.ClientError.Statement.SyntaxError
+# 50N42 — It is not allowed to refer to variables in LIMIT``），因此本查询采用
+# 「单类型 + 静态 ``$limit`` 参数」的形式；service 层 helper
+# (:func:`app.services._graph_data_helpers._query_nodes_by_type_limits`) 在 Python
+# 侧对每个非零 ``Per_Type_Limit`` 类型循环下发一次本查询并合并结果，整体调用次数
+# 仍与节点总数 N 无关（最多 = 类型数，常数级），符合 Requirement 6.4 的语义。
+#
+# 参数：$end_user_id (STRING), $node_type (STRING), $limit (INTEGER, 静态)
+GRAPH_NODES_BY_TYPE_LIMITS = """
+// GRAPH_NODES_BY_TYPE_LIMITS
+MATCH (n)
+WHERE n.end_user_id = $end_user_id
+  AND labels(n)[0] = $node_type
+RETURN
+    elementId(n)        AS id,
+    labels(n)           AS labels,
+    properties(n)       AS properties
+LIMIT $limit
+"""
+
+# Q2：批量查询若干节点的关联边总数，取代旧实现里每节点一次的 N+1 子查询。
+#
+# 注意：Neo4j 5 已移除 ``size((n)--())`` 这种「pattern expression in size()」用法，
+# 必须改用 ``COUNT { (n)--() }`` 子查询表达式（见
+# ``Neo.ClientError.Statement.SyntaxError 50N42 — A pattern expression should
+# only be used in order to test the existence of a pattern. It can no longer be
+# used inside the function size(), an alternative is to replace size() with
+# COUNT {}.``）。
+#
+# 参数：$node_ids (LIST<STRING>)
+GRAPH_NODES_REL_COUNT_BATCH = """
+// GRAPH_NODES_REL_COUNT_BATCH
+UNWIND $node_ids AS nid
+MATCH (n) WHERE elementId(n) = nid
+RETURN nid AS id, COUNT { (n)--() } AS rel_count
+"""
+
+# Q4：按支持类型聚合 end_user 下的节点全量总数，用于 statistics.per_type 元数据。
+# 参数：$end_user_id (STRING), $supported_types (LIST<STRING>)
+GRAPH_NODES_TOTAL_COUNT_BY_TYPE = """
+// GRAPH_NODES_TOTAL_COUNT_BY_TYPE
+MATCH (n)
+WHERE n.end_user_id = $end_user_id
+  AND labels(n)[0] IN $supported_types
+RETURN labels(n)[0] AS label, count(n) AS total
+"""
+
+# DEPRECATED: Graph_Node_query 已被新版 GRAPH_NODES_BY_TYPE_LIMITS 取代，
+# 后者通过参数化 $type_limits 支持任意 Node_Type 与独立 Per_Type_Limit。
+# 此常量仅保留以避免破坏式改动；新代码不应再使用，等迁移完成后再行清理。
 Graph_Node_query = """
 MATCH (n:MemorySummary)
 WHERE n.end_user_id = $end_user_id

--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -43,7 +43,13 @@ class PerTypeStat(BaseModel):
     returned: int = Field(..., ge=0, description="本次响应中该类型的节点数量")
     total: int = Field(..., ge=0, description="end_user 下该类型的全量节点总数")
     limit: int = Field(..., ge=0, description="本次请求该类型实际生效的 Per_Type_Limit")
-    truncated: bool = Field(..., description="total > returned 即为 True")
+    truncated: bool = Field(
+        ...,
+        description=(
+            "是否因 Per_Type_Limit 限制而截断：limit>0 且 total>returned 时为 True。"
+            "limit==0（主动跳过该类型）时恒为 False。"
+        ),
+    )
 
 
 class GraphStatistics(BaseModel):

--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -1,0 +1,84 @@
+"""GET /api/memory-storage/analytics/graph_data 响应模型。
+
+所有模型均为 Pydantic v2，统一使用 ``ConfigDict(extra="ignore")`` 静默丢弃多余字段，
+以保证后端在装配响应或前端在反序列化时都能向后兼容（Requirement 3.1 / 7.4）。
+"""
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GraphNode(BaseModel):
+    """单个节点的展示形态。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., description="Neo4j elementId")
+    label: str = Field(..., description="节点 label，对应 Supported_Node_Types 之一")
+    properties: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="按 NODE_PROPERTY_WHITELIST 过滤后的属性 + associative_memory 计数",
+    )
+    caption: str = Field(..., description="前端展示文案；优先取 properties.caption，否则取 label")
+
+
+class GraphEdge(BaseModel):
+    """单条边的展示形态。两端节点必定都在响应 nodes 数组中。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., description="Neo4j 关系 elementId")
+    source: str = Field(..., description="起点节点 elementId")
+    target: str = Field(..., description="终点节点 elementId")
+    type: str = Field(..., description="关系类型（type(r)）")
+    properties: Dict[str, Any] = Field(default_factory=dict, description="关系属性")
+    caption: str = Field(..., description="前端展示文案，缺省时由 service 层填充关系类型")
+
+
+class PerTypeStat(BaseModel):
+    """单一 Node_Type 的截断元数据（Requirement 3）。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    returned: int = Field(..., ge=0, description="本次响应中该类型的节点数量")
+    total: int = Field(..., ge=0, description="end_user 下该类型的全量节点总数")
+    limit: int = Field(..., ge=0, description="本次请求该类型实际生效的 Per_Type_Limit")
+    truncated: bool = Field(..., description="total > returned 即为 True")
+
+
+class GraphStatistics(BaseModel):
+    """统计字段。同时保留旧字段以维持向后兼容（Requirement 3.6 / 7.4）。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    total_nodes: int = Field(0, ge=0, description="本次响应中节点总数")
+    total_edges: int = Field(0, ge=0, description="本次响应中边总数")
+    node_types: Dict[str, int] = Field(
+        default_factory=dict,
+        description="兼容字段：返回数量按 Node_Type 聚合（不含 total）",
+    )
+    edge_types: Dict[str, int] = Field(
+        default_factory=dict,
+        description="兼容字段：返回数量按关系类型聚合",
+    )
+    per_type: Dict[str, PerTypeStat] = Field(
+        default_factory=dict,
+        description="新增：每种 Node_Type 的 returned/total/limit/truncated",
+    )
+
+
+class GraphDataResponse(BaseModel):
+    """``analytics_graph_data`` 的返回结构。controller 仍包一层 ApiResponse。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    nodes: List[GraphNode] = Field(default_factory=list)
+    edges: List[GraphEdge] = Field(default_factory=list)
+    statistics: GraphStatistics = Field(
+        default_factory=GraphStatistics,
+        description="节点/边统计信息，包含旧字段与新增 per_type",
+    )
+    message: Optional[str] = Field(
+        default=None,
+        description="仅在用户不存在 / 参数无效等空结果场景出现，与现有行为兼容",
+    )

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -4,12 +4,13 @@
 本模块集中放置不依赖 Neo4j / 数据库的可单测纯逻辑，便于 controller 与 service
 层共享。任何与 Cypher 直接交互的封装均不应放在此处。
 
-Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 7.3, 8.2
+Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 6.1, 6.3, 6.4,
+            7.3, 8.2
 """
 import logging
 import math
 from logging import Logger
-from typing import Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from app.core.memory.constants.graph_data_constants import (
     DEFAULT_PER_TYPE_LIMIT_MAP,
@@ -17,6 +18,12 @@ from app.core.memory.constants.graph_data_constants import (
     SUPPORTED_NODE_TYPES,
     TOTAL_NODES_CAP,
 )
+from app.repositories.neo4j.cypher_queries import (
+    GRAPH_NODES_BY_TYPE_LIMITS,
+    GRAPH_NODES_REL_COUNT_BATCH,
+    GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
+)
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 
 _LOGGER: Logger = logging.getLogger(__name__)
@@ -50,10 +57,7 @@ def parse_per_type_limits(raw: Optional[str], logger: Logger) -> Dict[str, int]:
     Raises:
         ValueError: 当 ``raw`` 中存在格式非法的条目（缺冒号 / 非整数 / 负数）时。
     """
-    if raw is None:
-        return {}
-
-    if raw.strip() == "":
+    if not raw or not raw.strip():
         return {}
 
     result: Dict[str, int] = {}
@@ -241,14 +245,6 @@ def _apply_total_cap_shrink(
 # 3. 输入为空时短路返回空容器，避免向 Neo4j 发起无意义的查询（Requirement 6.3）。
 #
 # Validates: Requirements 6.1, 6.3, 6.4
-from typing import Any, List
-
-from app.repositories.neo4j.cypher_queries import (
-    GRAPH_NODES_BY_TYPE_LIMITS,
-    GRAPH_NODES_REL_COUNT_BATCH,
-    GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
-)
-from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 
 async def _query_nodes_by_type_limits(

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -1,0 +1,375 @@
+# -*- coding: UTF-8 -*-
+"""图数据可视化接口的纯函数 helper。
+
+本模块集中放置不依赖 Neo4j / 数据库的可单测纯逻辑，便于 controller 与 service
+层共享。任何与 Cypher 直接交互的封装均不应放在此处。
+
+Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 7.3, 8.2
+"""
+import logging
+import math
+from logging import Logger
+from typing import Dict, Iterable, Optional
+
+from app.core.memory.constants.graph_data_constants import (
+    DEFAULT_PER_TYPE_LIMIT_MAP,
+    SINGLE_TYPE_LIMIT_HARD_MAX,
+    SUPPORTED_NODE_TYPES,
+    TOTAL_NODES_CAP,
+)
+
+
+_LOGGER: Logger = logging.getLogger(__name__)
+
+
+def parse_per_type_limits(raw: Optional[str], logger: Logger) -> Dict[str, int]:
+    """解析 ``per_type_limits`` 查询字符串为 ``{Type: int}`` 映射。
+
+    输入示例: ``"Statement:100,MemorySummary:5"``。
+
+    解析规则（严格遵循 design ``Algorithm 1``）:
+
+    - ``raw`` 为 ``None`` 或仅含空白 → 返回 ``{}``。
+    - 每个条目必须形如 ``Identifier:non-negative-int``：
+        - 缺少冒号 → ``ValueError``。
+        - ``Type`` 不是合法 Python identifier → ``ValueError``。
+        - ``Limit`` 不是整数 → ``ValueError``。
+        - ``Limit`` 为负数 → ``ValueError``。
+    - ``Type`` 不在 :data:`SUPPORTED_NODE_TYPES` → 记录 warning 并跳过该条目。
+    - ``Limit`` 超过 :data:`SINGLE_TYPE_LIMIT_HARD_MAX` → 截断并记录 warning。
+    - 同一 ``Type`` 重复出现 → 记录 warning 并取最后一次值（与 querystring 习惯一致）。
+    - ``Limit`` 等于 0 → 保留 0，调用方可据此跳过对应类型的查询（Requirement 2.9）。
+
+    Args:
+        raw: 原始查询字符串；可为 ``None`` 或空串。
+        logger: 用于输出 warning 的 logger（由 controller 注入，便于上下文化）。
+
+    Returns:
+        合法且支持的 ``{Type: limit}`` 字典；若 ``raw`` 为空则为空字典。
+
+    Raises:
+        ValueError: 当 ``raw`` 中存在格式非法的条目（缺冒号 / 非整数 / 负数）时。
+    """
+    if raw is None:
+        return {}
+
+    if raw.strip() == "":
+        return {}
+
+    result: Dict[str, int] = {}
+
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if entry == "":
+            continue
+
+        if ":" not in entry:
+            raise ValueError(
+                f"非法 per_type_limits 条目 '{entry}'，期望格式 'Type:Limit'"
+            )
+
+        type_part, limit_part = entry.split(":", 1)
+        type_part = type_part.strip()
+        limit_part = limit_part.strip()
+
+        if not type_part.isidentifier():
+            raise ValueError(f"非法 Node_Type '{type_part}'，必须为合法标识符")
+
+        try:
+            limit_val = int(limit_part)
+        except ValueError as exc:
+            raise ValueError(
+                f"per_type_limits 中 {type_part} 的 limit 必须为整数: '{limit_part}'"
+            ) from exc
+
+        if limit_val < 0:
+            raise ValueError(
+                f"per_type_limits 中 {type_part} 的 limit 必须为非负整数: '{limit_part}'"
+            )
+
+        if type_part not in SUPPORTED_NODE_TYPES:
+            logger.warning(
+                "per_type_limits 包含未支持的 Node_Type，已忽略: %s",
+                type_part,
+            )
+            continue
+
+        if limit_val > SINGLE_TYPE_LIMIT_HARD_MAX:
+            logger.warning(
+                "per_type_limits 中 %s 的 limit=%d 超过单值上限 %d，已截断",
+                type_part,
+                limit_val,
+                SINGLE_TYPE_LIMIT_HARD_MAX,
+            )
+            limit_val = SINGLE_TYPE_LIMIT_HARD_MAX
+
+        if type_part in result:
+            logger.warning(
+                "per_type_limits 中 %s 重复出现，使用最后一次值 %d",
+                type_part,
+                limit_val,
+            )
+
+        result[type_part] = limit_val
+
+    return result
+
+
+def _resolve_per_type_limits(
+    target_types: Iterable[str],
+    user_overrides: Dict[str, int],
+    fallback_default: int,
+) -> Dict[str, int]:
+    """合并用户显式 ``per_type_limits`` 与内置默认值，得到最终的 Per_Type_Limit 映射。
+
+    严格遵循 design ``Algorithm 2`` 的优先级:
+
+    1. 用户显式指定（``user_overrides[t]``）—— 最高优先级。
+    2. 内置默认值（:data:`DEFAULT_PER_TYPE_LIMIT_MAP[t]`）。
+    3. ``fallback_default``（来自 controller 透传的 ``limit`` 参数），并以
+       :data:`SINGLE_TYPE_LIMIT_HARD_MAX` 钳制（Requirement 7.3）。
+
+    Args:
+        target_types: 本次需要解析 limit 的 Node_Type 集合。Default_Mode 下为
+            :data:`SUPPORTED_NODE_TYPES`，Filter_Mode 下为 ``node_types`` 与
+            :data:`SUPPORTED_NODE_TYPES` 的交集（由调用方先做过滤）。
+        user_overrides: :func:`parse_per_type_limits` 的输出。键已经过
+            :data:`SUPPORTED_NODE_TYPES` 过滤、值已被 :data:`SINGLE_TYPE_LIMIT_HARD_MAX`
+            钳制；本函数不再重复校验。
+        fallback_default: controller 透传的 ``limit`` 参数，作为「未在
+            ``user_overrides`` 显式指定，且未在 :data:`DEFAULT_PER_TYPE_LIMIT_MAP`
+            内置默认」时的兜底值。
+
+    Returns:
+        ``{Node_Type: Per_Type_Limit}`` 映射；键集合等于 ``target_types``。
+    """
+    final: Dict[str, int] = {}
+    for t in target_types:
+        if t in user_overrides:
+            final[t] = user_overrides[t]
+        elif t in DEFAULT_PER_TYPE_LIMIT_MAP:
+            final[t] = DEFAULT_PER_TYPE_LIMIT_MAP[t]
+        else:
+            final[t] = min(fallback_default, SINGLE_TYPE_LIMIT_HARD_MAX)
+    return final
+
+
+def _apply_total_cap_shrink(
+    limits: Dict[str, int],
+    cap: int = TOTAL_NODES_CAP,
+    logger: Optional[Logger] = None,
+) -> Dict[str, int]:
+    """当 ``limits`` 合计超过 ``cap`` 时，按默认值比例等比缩减各 Per_Type_Limit。
+
+    严格遵循 design ``Algorithm 3``:
+
+    - ``S = sum(limits.values())``。``S <= cap`` → 原样返回（不复制，与现有调用方约定一致；
+      调用方需视为只读）。
+    - 否则以 :data:`DEFAULT_PER_TYPE_LIMIT_MAP` 中各类型默认值的相对比例作为权重：
+        - ``share_t = cap * default_weight_t / Σ default_weight``
+        - ``floored_t = min(floor(share_t), 用户原值 limits[t])``——后者用于防止
+          某类型用户原值小于按比例分配时上溢。
+    - 余数 ``cap - Σ floored`` 按「分数部分降序、类型字典序升序」逐个 +1 分配，
+      但每个类型不超过其用户原值（已达原值则跳过，保留确定性）。
+    - 缩减发生时记录 warning 日志（Requirement 8.2）。
+    - 类型不在 :data:`DEFAULT_PER_TYPE_LIMIT_MAP` 中时按权重 0 处理；若全部权重均为 0，
+      则原样返回（极端兜底，调用方在常规路径上不会触发）。
+
+    Args:
+        limits: 经过 :func:`_resolve_per_type_limits` 解析后得到的初始 Per_Type_Limit
+            映射；其中可能存在 0（``Limit==0`` 表示跳过查询）。
+        cap: 总量上限，默认取 :data:`TOTAL_NODES_CAP`。
+        logger: 可选的 logger；为 ``None`` 时使用模块 logger。便于上层注入带上下文
+            的 logger 做日志聚合。
+
+    Returns:
+        缩减后的 ``{Node_Type: Per_Type_Limit}`` 映射；键集合等于 ``limits``。
+        当未触发缩减时直接返回入参对象本身。
+    """
+    log = logger or _LOGGER
+
+    total = sum(limits.values())
+    if total <= cap:
+        return limits
+
+    weight_sum = sum(
+        DEFAULT_PER_TYPE_LIMIT_MAP.get(t, 0) for t in limits
+    )
+    if weight_sum == 0:
+        # 极端兜底：所有类型都不在 DEFAULT_PER_TYPE_LIMIT_MAP 中，无法按比例缩减。
+        return limits
+
+    floored: Dict[str, int] = {}
+    fractions: Dict[str, float] = {}
+    for t, user_value in limits.items():
+        weight = DEFAULT_PER_TYPE_LIMIT_MAP.get(t, 0)
+        share = cap * (weight / weight_sum)
+        share_floor = int(math.floor(share))
+        # 防上溢：缩减后不应大于用户原值。
+        floored[t] = min(share_floor, user_value)
+        fractions[t] = share - share_floor
+
+    remaining = cap - sum(floored.values())
+    if remaining > 0:
+        # 余数大的优先 +1；同余数按 type 字典序升序保证确定性。
+        for t, _frac in sorted(
+            fractions.items(),
+            key=lambda kv: (-kv[1], kv[0]),
+        ):
+            if remaining <= 0:
+                break
+            if floored[t] < limits[t]:
+                floored[t] += 1
+                remaining -= 1
+
+    log.warning(
+        "per_type_limits 合计 %d 超过 TOTAL_NODES_CAP=%d，已等比缩减为 %s",
+        total,
+        cap,
+        floored,
+    )
+    return floored
+
+
+# ---------------------------------------------------------------------------
+# Neo4j 查询 helper（封装 graph_data 接口的 Q1/Q2/Q4）
+# ---------------------------------------------------------------------------
+#
+# 三个 helper 把 Cypher 文本与结果整形从 service 主流程中抽离，便于：
+# 1. 单元测试通过 mock ``Neo4jConnector.execute_query`` 验证传参；
+# 2. 服务层主流程聚焦在「类型解析 → cap 缩减 → 结果装配」的业务逻辑；
+# 3. 输入为空时短路返回空容器，避免向 Neo4j 发起无意义的查询（Requirement 6.3）。
+#
+# Validates: Requirements 6.1, 6.3, 6.4
+from typing import Any, List
+
+from app.repositories.neo4j.cypher_queries import (
+    GRAPH_NODES_BY_TYPE_LIMITS,
+    GRAPH_NODES_REL_COUNT_BATCH,
+    GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
+)
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+
+async def _query_nodes_by_type_limits(
+    connector: Neo4jConnector,
+    end_user_id: str,
+    type_limits: Dict[str, int],
+) -> List[Dict[str, Any]]:
+    """按 ``{Node_Type: Per_Type_Limit}`` 检索节点（封装 Q1）。
+
+    实现方式（必须为「单类型 + 静态 ``$limit``」循环）::
+
+        for node_type, limit in type_limits.items():
+            if limit <= 0:                  # 0 表示跳过该类型
+                continue
+            rows = await connector.execute_query(
+                GRAPH_NODES_BY_TYPE_LIMITS,
+                end_user_id=end_user_id,
+                node_type=node_type,
+                limit=int(limit),
+            )
+
+    背景：Neo4j 不允许 ``LIMIT`` 引用运行期变量（``Neo.ClientError.Statement.SyntaxError
+    50N42``），因此不能用 ``UNWIND $type_limits AS spec ... LIMIT spec.limit`` 写法。
+    单类型循环把 ``$limit`` 作为静态参数下发，对每个非零 limit 类型发起一次查询，
+    调用次数 ``= 非零 limit 类型数``（最多 = ``len(SUPPORTED_NODE_TYPES)`` 个常量），
+    与节点数 N 无关，仍符合 Requirement 6.4「总查询次数与 N 无关」的语义。
+
+    Args:
+        connector: 由调用方注入的 :class:`Neo4jConnector` 实例，便于在测试中 mock。
+        end_user_id: 终端用户 UUID 字符串。
+        type_limits: ``{Node_Type: Per_Type_Limit}`` 映射。``Per_Type_Limit==0`` 的
+            条目会被本函数自动过滤（保留 0 会触发无意义的 ``LIMIT 0`` 查询）。
+
+    Returns:
+        合并后的 Cypher 行列表，每项包含 ``id`` / ``labels`` / ``properties`` 三个键。
+        当 ``type_limits`` 为空、或所有值 ≤ 0 时直接返回 ``[]``，不发起查询
+        （Requirement 6.3）。返回顺序为 ``type_limits`` 字典的迭代顺序（Python 3.7+
+        保留插入顺序）。
+    """
+    if not type_limits:
+        return []
+
+    merged_rows: List[Dict[str, Any]] = []
+    for node_type, limit in type_limits.items():
+        limit_int = int(limit)
+        if limit_int <= 0:
+            continue
+        rows = await connector.execute_query(
+            GRAPH_NODES_BY_TYPE_LIMITS,
+            end_user_id=end_user_id,
+            node_type=node_type,
+            limit=limit_int,
+        )
+        if rows:
+            merged_rows.extend(rows)
+
+    return merged_rows
+
+
+async def _query_rel_count_batch(
+    connector: Neo4jConnector,
+    node_ids: List[str],
+) -> Dict[str, int]:
+    """批量查询若干节点的关联边总数（封装 Q2，消除 N+1）。
+
+    Args:
+        connector: :class:`Neo4jConnector` 实例。
+        node_ids: 节点 ``elementId`` 列表。
+
+    Returns:
+        ``{element_id: rel_count}`` 字典。当 ``node_ids`` 为空时返回 ``{}`` 且
+        不发起查询（Requirement 6.3）。结果中缺失的节点会被调用方按 0 处理。
+    """
+    if not node_ids:
+        return {}
+
+    rows = await connector.execute_query(
+        GRAPH_NODES_REL_COUNT_BATCH,
+        node_ids=list(node_ids),
+    )
+
+    result: Dict[str, int] = {}
+    for row in rows:
+        node_id = row.get("id")
+        if node_id is None:
+            continue
+        result[node_id] = int(row.get("rel_count", 0) or 0)
+    return result
+
+
+async def _query_total_count_by_type(
+    connector: Neo4jConnector,
+    end_user_id: str,
+    supported_types: List[str],
+) -> Dict[str, int]:
+    """按 label 聚合 end_user 下的全量节点总数（封装 Q4）。
+
+    Args:
+        connector: :class:`Neo4jConnector` 实例。
+        end_user_id: 终端用户 UUID 字符串。
+        supported_types: 需要计数的 Node_Type 列表（一般为
+            :data:`SUPPORTED_NODE_TYPES`，或 Filter_Mode 下的过滤后类型）。
+
+    Returns:
+        ``{label: total}`` 字典。当 ``supported_types`` 为空时返回 ``{}`` 且
+        不发起查询。结果中缺失的类型由调用方在装配 ``statistics.per_type``
+        时按 0 处理。
+    """
+    if not supported_types:
+        return {}
+
+    rows = await connector.execute_query(
+        GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
+        end_user_id=end_user_id,
+        supported_types=list(supported_types),
+    )
+
+    result: Dict[str, int] = {}
+    for row in rows:
+        label = row.get("label")
+        if not label:
+            continue
+        result[label] = int(row.get("total", 0) or 0)
+    return result

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -19,9 +19,9 @@ from app.core.memory.constants.graph_data_constants import (
     TOTAL_NODES_CAP,
 )
 from app.repositories.neo4j.cypher_queries import (
-    GRAPH_NODES_BY_TYPE_LIMITS,
     GRAPH_NODES_REL_COUNT_BATCH,
-    GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
+    build_graph_nodes_by_type_query,
+    build_graph_total_count_by_type_query,
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -41,6 +41,7 @@ __all__ = [
     "resolve_mode_and_type_limits",
     "compute_stat_types",
     "assemble_per_type_stat",
+    "assemble_center_per_type_stat",
     # Neo4j 查询封装
     "query_nodes_by_type_limits",
     "query_rel_count_batch",
@@ -386,6 +387,59 @@ def assemble_per_type_stat(
     return per_type_stat
 
 
+def assemble_center_per_type_stat(
+    stat_types: Iterable[str],
+    node_type_counts: Dict[str, int],
+    total_by_type: Dict[str, int],
+    *,
+    global_limit: int,
+    total_returned: int,
+) -> Dict[str, Dict[str, Any]]:
+    """装配 Center_Mode 下的 ``statistics.per_type`` 元数据（纯逻辑）。
+
+    Center_Mode 不做按类型限流，而是用一个**全局** ``limit`` 控制中心节点
+    1..depth 跳邻居的**总**返回量。因此「截断」是全局概念，无法精确归因到
+    某一类型：只要本次返回的节点总数达到了 ``global_limit``，就说明可能有更多
+    邻居因全局上限被丢弃。
+
+    本函数据此装配：
+
+    - 每个类型的 ``limit`` 统一填全局 ``global_limit``（表达「本次受此上限约束」），
+      而非 :func:`assemble_per_type_stat` 里那种逐类型独立的 Per_Type_Limit；
+    - ``truncated``：仅当全局发生截断（``total_returned >= global_limit`` 且
+      该类型 ``total > returned``）时才为 True——既反映全局上限触顶，又避免给
+      「该类型其实已全量返回」的类型误标截断；
+    - ``returned`` / ``total`` 语义与 :func:`assemble_per_type_stat` 一致。
+
+    Args:
+        stat_types: 需要装配的 Node_Type 集合（Center_Mode 下一般为全部
+            :data:`SUPPORTED_NODE_TYPES`，以呈现「全量 vs 当前」对照）。
+        node_type_counts: 本次响应中按类型聚合的返回数量 ``{label: returned}``。
+        total_by_type: Q4 全量计数结果 ``{label: total}``。
+        global_limit: Center_Mode 实际生效的全局节点上限（已被控制器钳制
+            ≤ :data:`CENTER_MODE_LIMIT_HARD_MAX`）。
+        total_returned: 本次响应中的节点总数（所有类型 returned 之和）。
+
+    Returns:
+        ``{Node_Type: {returned, total, limit, truncated}}`` 映射。
+    """
+    limit_int = int(global_limit)
+    global_truncated = limit_int > 0 and int(total_returned) >= limit_int
+
+    per_type_stat: Dict[str, Dict[str, Any]] = {}
+    for node_type in stat_types:
+        returned = node_type_counts.get(node_type, 0)
+        total = int(total_by_type.get(node_type, 0))
+        truncated = global_truncated and total > returned
+        per_type_stat[node_type] = {
+            "returned": returned,
+            "total": total,
+            "limit": limit_int,
+            "truncated": truncated,
+        }
+    return per_type_stat
+
+
 # ---------------------------------------------------------------------------
 # Neo4j 查询 helper（封装 graph_data 接口的 Q1/Q2/Q4）
 # ---------------------------------------------------------------------------
@@ -405,23 +459,30 @@ async def _query_nodes_by_type_limits(
 ) -> List[Dict[str, Any]]:
     """按 ``{Node_Type: Per_Type_Limit}`` 检索节点（封装 Q1）。
 
-    实现方式（必须为「单类型 + 静态 ``$limit``」循环）::
+    实现方式（单类型循环 + label 字面量内联）::
 
         for node_type, limit in type_limits.items():
             if limit <= 0:                  # 0 表示跳过该类型
                 continue
             rows = await connector.execute_query(
-                GRAPH_NODES_BY_TYPE_LIMITS,
+                build_graph_nodes_by_type_query(node_type),
                 end_user_id=end_user_id,
-                node_type=node_type,
                 limit=int(limit),
             )
 
-    背景：Neo4j 不允许 ``LIMIT`` 引用运行期变量（``Neo.ClientError.Statement.SyntaxError
-    50N42``），因此不能用 ``UNWIND $type_limits AS spec ... LIMIT spec.limit`` 写法。
-    单类型循环把 ``$limit`` 作为静态参数下发，对每个非零 limit 类型发起一次查询，
-    调用次数 ``= 非零 limit 类型数``（最多 = ``len(SUPPORTED_NODE_TYPES)`` 个常量），
-    与节点数 N 无关，仍符合 Requirement 6.4「总查询次数与 N 无关」的语义。
+    两点背景：
+
+    1. Neo4j 不允许 ``LIMIT`` 引用运行期变量（``Neo.ClientError.Statement.SyntaxError
+       50N42``），因此不能用 ``UNWIND $type_limits AS spec ... LIMIT spec.limit`` 写法，
+       只能对每个类型单独下发静态 ``$limit``。
+    2. ``end_user_id`` 范围索引是 label-property 索引，规划器只有在 label 出现在
+       MATCH 模式里（``MATCH (n:Statement)``）时才会走 NodeIndexSeek；把 label 放进
+       WHERE 用 ``labels(n)[0] = $node_type``（或动态 label ``MATCH (n:$($node_type))``）
+       都无法稳定命中索引、退化为 AllNodesScan。因此这里改用
+       :func:`build_graph_nodes_by_type_query` 把白名单内的 label 字面量内联进模式。
+
+    对每个非零 limit 类型发起一次查询，调用次数 ``= 非零 limit 类型数``（最多
+    = ``len(SUPPORTED_NODE_TYPES)`` 个常量），与节点数 N 无关，符合 Requirement 6.4。
 
     Args:
         connector: 由调用方注入的 :class:`Neo4jConnector` 实例，便于在测试中 mock。
@@ -444,9 +505,8 @@ async def _query_nodes_by_type_limits(
         if limit_int <= 0:
             continue
         rows = await connector.execute_query(
-            GRAPH_NODES_BY_TYPE_LIMITS,
+            build_graph_nodes_by_type_query(node_type),
             end_user_id=end_user_id,
-            node_type=node_type,
             limit=limit_int,
         )
         if rows:
@@ -493,6 +553,13 @@ async def _query_total_count_by_type(
 ) -> Dict[str, int]:
     """按 label 聚合 end_user 下的全量节点总数（封装 Q4）。
 
+    与 Q1 同理：为命中 ``end_user_id`` 范围索引（label-property 索引），
+    必须把 label 字面量内联进 MATCH 模式。旧版「``MATCH (n) WHERE labels(n)[0]
+    IN $supported_types``」单查询缺少模式内 label，会对全库 AllNodesScan；
+    这里改为对每个类型调用 :func:`build_graph_total_count_by_type_query`
+    单独 NodeIndexSeek 计数，再合并为 ``{label: total}``。调用次数 = 类型数
+    （最多 = ``len(SUPPORTED_NODE_TYPES)``，常数级），与节点数 N 无关。
+
     Args:
         connector: :class:`Neo4jConnector` 实例。
         end_user_id: 终端用户 UUID 字符串。
@@ -507,18 +574,16 @@ async def _query_total_count_by_type(
     if not supported_types:
         return {}
 
-    rows = await connector.execute_query(
-        GRAPH_NODES_TOTAL_COUNT_BY_TYPE,
-        end_user_id=end_user_id,
-        supported_types=list(supported_types),
-    )
-
     result: Dict[str, int] = {}
-    for row in rows:
-        label = row.get("label")
-        if not label:
-            continue
-        result[label] = int(row.get("total", 0) or 0)
+    for node_type in supported_types:
+        rows = await connector.execute_query(
+            build_graph_total_count_by_type_query(node_type),
+            end_user_id=end_user_id,
+        )
+        total = 0
+        if rows:
+            total = int(rows[0].get("total", 0) or 0)
+        result[node_type] = total
     return result
 
 

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -10,7 +10,7 @@ Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 6.1, 6.3, 6.4,
 import logging
 import math
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from app.core.memory.constants.graph_data_constants import (
     DEFAULT_PER_TYPE_LIMIT_MAP,
@@ -27,6 +27,25 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 
 _LOGGER: Logger = logging.getLogger(__name__)
+
+
+# 受支持的「公开」接口。带下划线前缀的函数历史上已被同功能域的 service 与测试
+# 直接引用；为明确表达它们是受支持的图数据编排接口，这里通过 ``__all__`` 公开，
+# 并为跨模块稳定使用的函数提供无下划线别名（旧名保留以维持向后兼容）。
+__all__ = [
+    # 查询字符串解析 / 类型解析 / 总量缩减
+    "parse_per_type_limits",
+    "resolve_per_type_limits",
+    "apply_total_cap_shrink",
+    # 编排纯逻辑
+    "resolve_mode_and_type_limits",
+    "compute_stat_types",
+    "assemble_per_type_stat",
+    # Neo4j 查询封装
+    "query_nodes_by_type_limits",
+    "query_rel_count_batch",
+    "query_total_count_by_type",
+]
 
 
 def parse_per_type_limits(raw: Optional[str], logger: Logger) -> Dict[str, int]:
@@ -177,7 +196,9 @@ def _apply_total_cap_shrink(
       但每个类型不超过其用户原值（已达原值则跳过，保留确定性）。
     - 缩减发生时记录 warning 日志（Requirement 8.2）。
     - 类型不在 :data:`DEFAULT_PER_TYPE_LIMIT_MAP` 中时按权重 0 处理；若全部权重均为 0，
-      则原样返回（极端兜底，调用方在常规路径上不会触发）。
+      则退化为「非零 limit 类型权重相等」的均匀分布（零 limit 类型不占用 cap），
+      复用同一套等比缩减算法，确保 TOTAL_NODES_CAP 约束仍然生效；
+      若全部 limit 均为 0，则原样返回。
 
     Args:
         limits: 经过 :func:`_resolve_per_type_limits` 解析后得到的初始 Per_Type_Limit
@@ -196,18 +217,29 @@ def _apply_total_cap_shrink(
     if total <= cap:
         return limits
 
-    weight_sum = sum(
-        DEFAULT_PER_TYPE_LIMIT_MAP.get(t, 0) for t in limits
-    )
+    # 计算各类型权重。常规路径直接取 DEFAULT_PER_TYPE_LIMIT_MAP 中的默认值；
+    # 当所有类型都无默认权重（weight_sum == 0）时，退化为「非零 limit 类型权重=1」
+    # 的均匀分布。均匀分布本质上是等比分布的特例，因此下方复用同一套缩减算法，
+    # 避免逻辑重复并保持 tie-break 行为一致。
+    weights: Dict[str, int] = {
+        t: DEFAULT_PER_TYPE_LIMIT_MAP.get(t, 0) for t in limits
+    }
+    weight_sum = sum(weights.values())
+    uniform_fallback = False
     if weight_sum == 0:
-        # 极端兜底：所有类型都不在 DEFAULT_PER_TYPE_LIMIT_MAP 中，无法按比例缩减。
-        return limits
+        # 极端兜底：所有类型都不在 DEFAULT_PER_TYPE_LIMIT_MAP 中。
+        # 对非零 limit 类型赋予均匀权重（零 limit 表示跳过，不占用 cap）。
+        weights = {t: (1 if v > 0 else 0) for t, v in limits.items()}
+        weight_sum = sum(weights.values())
+        uniform_fallback = True
+        if weight_sum == 0:
+            # 所有类型 limit 均为 0，无可分配份额，原样返回。
+            return limits
 
     floored: Dict[str, int] = {}
     fractions: Dict[str, float] = {}
     for t, user_value in limits.items():
-        weight = DEFAULT_PER_TYPE_LIMIT_MAP.get(t, 0)
-        share = cap * (weight / weight_sum)
+        share = cap * (weights[t] / weight_sum)
         share_floor = int(math.floor(share))
         # 防上溢：缩减后不应大于用户原值。
         floored[t] = min(share_floor, user_value)
@@ -226,13 +258,132 @@ def _apply_total_cap_shrink(
                 floored[t] += 1
                 remaining -= 1
 
-    log.warning(
-        "per_type_limits 合计 %d 超过 TOTAL_NODES_CAP=%d，已等比缩减为 %s",
-        total,
-        cap,
-        floored,
-    )
+    if uniform_fallback:
+        log.warning(
+            "per_type_limits 合计 %d 超过 TOTAL_NODES_CAP=%d，"
+            "且所有类型均无默认权重，已按均匀分布缩减为 %s",
+            total,
+            cap,
+            floored,
+        )
+    else:
+        log.warning(
+            "per_type_limits 合计 %d 超过 TOTAL_NODES_CAP=%d，已等比缩减为 %s",
+            total,
+            cap,
+            floored,
+        )
     return floored
+
+
+# ---------------------------------------------------------------------------
+# 编排纯逻辑（模式分派 / 统计装配）—— 不触碰 Neo4j，便于单测
+# ---------------------------------------------------------------------------
+#
+# 这几个函数从 service 层 ``analytics_graph_data`` 的编排流程中抽离出「不依赖
+# Neo4j」的决策与装配逻辑，使其可脱离数据库直接单测：
+#
+# - :func:`resolve_mode_and_type_limits` —— Filter/Default 模式分派 + Per_Type_Limit
+#   解析 + 总量上限缩减（不含 Center_Mode，后者直接走邻居查询无需类型解析）。
+# - :func:`compute_stat_types` —— 依据模式推导 ``statistics.per_type`` 应覆盖的
+#   Node_Type 集合。
+# - :func:`assemble_per_type_stat` —— 依据 returned/total/limit 装配每类型的截断元数据。
+#
+# Validates: Requirements 1.3, 1.4, 2.9, 3.1, 3.7, 7.3, 8.2
+
+
+def resolve_mode_and_type_limits(
+    node_types: Optional[List[str]],
+    limit: int,
+    per_type_limits: Optional[Dict[str, int]],
+) -> Tuple[str, Dict[str, int]]:
+    """Filter/Default 模式分派 + Per_Type_Limit 解析 + 总量上限缩减（纯逻辑）。
+
+    本函数不涉及 Center_Mode（中心节点查询不需要按类型解析 limit），仅处理
+    ``analytics_graph_data`` 在非 Center 路径下的类型决策，便于脱离 Neo4j 单测。
+
+    Args:
+        node_types: 可选的 Node_Type 过滤列表。非空 → Filter_Mode（取与
+            :data:`SUPPORTED_NODE_TYPES` 的交集）；空 → Default_Mode（覆盖全部
+            :data:`SUPPORTED_NODE_TYPES`）。
+        limit: 兜底 Per_Type_Limit，透传给 :func:`_resolve_per_type_limits`。
+        per_type_limits: 用户显式指定的 ``{Node_Type: Per_Type_Limit}`` 映射，
+            可为 ``None``。
+
+    Returns:
+        ``(mode, type_limits)`` —— ``mode`` ∈ ``{"Filter", "Default"}``；
+        ``type_limits`` 为经 cap 缩减后的 ``{Node_Type: Per_Type_Limit}`` 映射。
+    """
+    if node_types:
+        target_types = [t for t in node_types if t in SUPPORTED_NODE_TYPES]
+        mode = "Filter"
+    else:
+        target_types = sorted(SUPPORTED_NODE_TYPES)
+        mode = "Default"
+
+    type_limits = _resolve_per_type_limits(
+        target_types=target_types,
+        user_overrides=dict(per_type_limits or {}),
+        fallback_default=limit,
+    )
+    type_limits = _apply_total_cap_shrink(type_limits)
+    return mode, type_limits
+
+
+def compute_stat_types(mode: str, type_limits: Dict[str, int]) -> List[str]:
+    """推导 ``statistics.per_type`` 应覆盖的 Node_Type 集合（纯逻辑）。
+
+    - Filter_Mode 收敛到 ``type_limits`` 的键集合（用户显式关心的类型）。
+    - 其余模式（Default / Center）使用全部 :data:`SUPPORTED_NODE_TYPES`，
+      以呈现「全量 vs 当前」对照。
+
+    Args:
+        mode: ``{"Filter", "Default", "Center"}`` 之一。
+        type_limits: 本次生效的 ``{Node_Type: Per_Type_Limit}`` 映射。
+
+    Returns:
+        排序后的 Node_Type 列表（字典序，保证确定性）。
+    """
+    if mode == "Filter":
+        return sorted(type_limits.keys())
+    return sorted(SUPPORTED_NODE_TYPES)
+
+
+def assemble_per_type_stat(
+    stat_types: Iterable[str],
+    type_limits: Dict[str, int],
+    node_type_counts: Dict[str, int],
+    total_by_type: Dict[str, int],
+) -> Dict[str, Dict[str, Any]]:
+    """装配 ``statistics.per_type`` 的 returned/total/limit/truncated 元数据（纯逻辑）。
+
+    截断语义：``limit==0`` 表示调用方主动跳过该类型的节点查询（Requirement 2.9），
+    此时 ``returned`` 必为 0 属于预期行为，不应标记为「截断」；否则客户端会把
+    「主动跳过」误解为「后端因容量限制截断」。仅当 ``limit>0`` 且 ``total>returned``
+    时才认为发生了真正的截断。
+
+    Args:
+        stat_types: 需要装配的 Node_Type 集合（一般来自 :func:`compute_stat_types`）。
+        type_limits: 本次生效的 ``{Node_Type: Per_Type_Limit}`` 映射。
+        node_type_counts: 本次响应中按类型聚合的返回数量 ``{label: returned}``。
+        total_by_type: Q4 全量计数结果 ``{label: total}``。
+
+    Returns:
+        ``{Node_Type: {returned, total, limit, truncated}}`` 映射。
+    """
+    per_type_stat: Dict[str, Dict[str, Any]] = {}
+    for node_type in stat_types:
+        returned = node_type_counts.get(node_type, 0)
+        total = int(total_by_type.get(node_type, 0))
+        type_limit = int(type_limits.get(node_type, 0))
+        truncated = type_limit > 0 and total > returned
+        per_type_stat[node_type] = {
+            "returned": returned,
+            "total": total,
+            "limit": type_limit,
+            "truncated": truncated,
+        }
+    return per_type_stat
 
 
 # ---------------------------------------------------------------------------
@@ -369,3 +520,17 @@ async def _query_total_count_by_type(
             continue
         result[label] = int(row.get("total", 0) or 0)
     return result
+
+
+# ---------------------------------------------------------------------------
+# 无下划线公开别名
+# ---------------------------------------------------------------------------
+#
+# 以下函数历史上以 ``_`` 前缀定义并被同功能域的 service/测试直接引用。为对外
+# 明确表达「这是受支持的图数据编排接口」，提供无下划线别名；下划线旧名保留，
+# 以维持既有 import 的向后兼容，避免一次性大规模重命名。
+resolve_per_type_limits = _resolve_per_type_limits
+apply_total_cap_shrink = _apply_total_cap_shrink
+query_nodes_by_type_limits = _query_nodes_by_type_limits
+query_rel_count_batch = _query_rel_count_batch
+query_total_count_by_type = _query_total_count_by_type

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -8,13 +8,14 @@ import os
 import uuid
 from collections import Counter
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_logger
 from app.core.memory.constants.graph_data_constants import (
+    DEPTH_HARD_MAX,
     NODE_PROPERTY_WHITELIST,
     SUPPORTED_NODE_TYPES,
     _DEFAULT_FIELDS,
@@ -1674,7 +1675,7 @@ async def analytics_graph_data(
     db: Session,
     end_user_id: str,
     node_types: Optional[List[str]] = None,
-    limit: int = 130,
+    limit: int = 100,
     depth: int = 1,
     center_node_id: Optional[str] = None,
     per_type_limits: Optional[Dict[str, int]] = None,
@@ -1717,150 +1718,34 @@ async def analytics_graph_data(
             logger.error(f"无效的 end_user_id 格式: {end_user_id}")
             return _empty_graph_response("无效的用户ID格式")
 
-        repo = EndUserRepository(db)
-        end_user = repo.get_by_id(user_uuid)
+        end_user = EndUserRepository(db).get_by_id(user_uuid)
         if not end_user:
             logger.warning(f"未找到 end_user_id 为 {end_user_id} 的用户")
             return _empty_graph_response("用户不存在")
 
-        user_overrides: Dict[str, int] = dict(per_type_limits or {})
-
-        # 2. 模式分派 + Per_Type_Limit 解析
-        if center_node_id:
-            mode = "Center"
-            type_limits: Dict[str, int] = {}
-            node_rows = await _query_center_node_neighbors(
-                end_user_id=end_user_id,
-                center_node_id=center_node_id,
-                depth=depth,
-                limit=limit,
-            )
-        else:
-            if node_types:
-                target_types = [t for t in node_types if t in SUPPORTED_NODE_TYPES]
-                mode = "Filter"
-            else:
-                target_types = sorted(SUPPORTED_NODE_TYPES)
-                mode = "Default"
-
-            type_limits = _resolve_per_type_limits(
-                target_types=target_types,
-                user_overrides=user_overrides,
-                fallback_default=limit,
-            )
-            type_limits = _apply_total_cap_shrink(type_limits)
-
-            non_zero_limits = {t: v for t, v in type_limits.items() if v > 0}
-            if non_zero_limits:
-                node_rows = await _query_nodes_by_type_limits(
-                    _neo4j_connector,
-                    end_user_id=end_user_id,
-                    type_limits=non_zero_limits,
-                )
-            else:
-                node_rows = []
-
-        # 3. 节点 ID 收集（Q2 / Q3 都需要）
-        node_ids: List[str] = []
-        node_records: List[Tuple[str, str, Dict[str, Any]]] = []
-        for record in node_rows:
-            node_id = record.get("id")
-            if not node_id:
-                continue
-            labels_value = record.get("labels") or []
-            node_label = labels_value[0] if labels_value else "Unknown"
-            node_props = record.get("properties") or {}
-            node_ids.append(node_id)
-            node_records.append((node_id, node_label, node_props))
-
-        # 4. Q2 批量关联计数（消除 N+1）
-        rel_count_map = await _query_rel_count_batch(_neo4j_connector, node_ids)
-
-        # 5. 节点格式化
-        nodes: List[Dict[str, Any]] = []
-        node_type_counts: Dict[str, int] = {}
-        for node_id, node_label, node_props in node_records:
-            rel_count = int(rel_count_map.get(node_id, 0))
-            filtered_props = _extract_node_properties(
-                node_label, node_props, rel_count=rel_count
-            )
-            caption = filtered_props.get("caption", node_label)
-            nodes.append({
-                "id": node_id,
-                "label": node_label,
-                "properties": filtered_props,
-                "caption": caption,
-            })
-            node_type_counts[node_label] = node_type_counts.get(node_label, 0) + 1
-
-        # 6. Q3 边查询（try/except 降级，Requirement 8.4）
-        edges: List[Dict[str, Any]] = []
-        edge_type_counts: Dict[str, int] = {}
-        if node_ids:
-            try:
-                edge_rows = await _query_edges_among_nodes(node_ids)
-            except Exception as e:
-                logger.error(f"边查询失败，降级为空边: {e}", exc_info=True)
-                edge_rows = []
-
-            node_id_set = set(node_ids)
-            for record in edge_rows:
-                source = record.get("source")
-                target = record.get("target")
-                # 防御性双端过滤：Cypher 已过滤悬空边，这里保险起见再校验一次
-                if source not in node_id_set or target not in node_id_set:
-                    continue
-                edge_id = record.get("id")
-                rel_type = record.get("rel_type")
-                edge_props = record.get("properties") or {}
-                cleaned_edge_props = {
-                    key: _clean_neo4j_value(value)
-                    for key, value in edge_props.items()
-                }
-                # caption 取值优先级：
-                #   1. properties.caption（写入端显式提供）
-                #   2. EXTRACTED_RELATIONSHIP 边走 properties.predicate（实体—实体语义关系）
-                #   3. 回落到 rel_type（字面量关系类型）
-                caption = cleaned_edge_props.get("caption")
-                if not caption and rel_type == "EXTRACTED_RELATIONSHIP":
-                    caption = cleaned_edge_props.get("predicate") or rel_type
-                if not caption:
-                    caption = rel_type
-                edges.append({
-                    "id": edge_id,
-                    "source": source,
-                    "target": target,
-                    "type": rel_type,
-                    "properties": cleaned_edge_props,
-                    "caption": caption,
-                })
-                edge_type_counts[rel_type] = edge_type_counts.get(rel_type, 0) + 1
-
-        # 7. Q4 全量计数 + statistics.per_type 装配
-        # Default_Mode 用全部 Supported_Node_Types；Filter_Mode 收敛到 type_limits
-        # 的键集合；Center_Mode 用全部 Supported_Node_Types 以呈现「全量 vs 当前」。
-        if mode == "Filter":
-            stat_types = sorted(type_limits.keys())
-        else:
-            stat_types = sorted(SUPPORTED_NODE_TYPES)
-
-        total_by_type = await _query_total_count_by_type(
-            _neo4j_connector,
+        # 2. 模式分派 + Q1 节点查询
+        mode, type_limits, node_rows = await _collect_node_query(
             end_user_id=end_user_id,
-            supported_types=stat_types,
+            node_types=node_types,
+            limit=limit,
+            depth=depth,
+            center_node_id=center_node_id,
+            per_type_limits=per_type_limits,
         )
 
-        per_type_stat: Dict[str, Dict[str, Any]] = {}
-        for node_type in stat_types:
-            returned = node_type_counts.get(node_type, 0)
-            total = int(total_by_type.get(node_type, 0))
-            type_limit = int(type_limits.get(node_type, 0))
-            per_type_stat[node_type] = {
-                "returned": returned,
-                "total": total,
-                "limit": type_limit,
-                "truncated": total > returned,
-            }
+        # 3+4+5. Q2 批量关联计数 → 节点装配
+        nodes, node_type_counts, node_ids = await _format_nodes(node_rows)
+
+        # 6. Q3 边查询（try/except 降级，Requirement 8.4）
+        edges, edge_type_counts = await _format_edges(node_ids)
+
+        # 7. Q4 全量计数 + statistics.per_type 装配
+        per_type_stat = await _build_per_type_stat(
+            mode=mode,
+            end_user_id=end_user_id,
+            type_limits=type_limits,
+            node_type_counts=node_type_counts,
+        )
 
         statistics = {
             "total_nodes": len(nodes),
@@ -1891,6 +1776,187 @@ async def analytics_graph_data(
         raise
 
 
+# ---------------------------------------------------------------------------
+# analytics_graph_data 的内部装配 helper
+# ---------------------------------------------------------------------------
+
+
+async def _collect_node_query(
+    *,
+    end_user_id: str,
+    node_types: Optional[List[str]],
+    limit: int,
+    depth: int,
+    center_node_id: Optional[str],
+    per_type_limits: Optional[Dict[str, int]],
+) -> Tuple[str, Dict[str, int], List[Dict[str, Any]]]:
+    """模式分派 + Per_Type_Limit 解析 + Q1 节点查询。
+
+    Returns:
+        ``(mode, type_limits, node_rows)`` —— ``mode`` ∈ ``{"Center","Filter","Default"}``；
+        ``type_limits`` 为本次实际生效的 ``{Node_Type: Per_Type_Limit}`` 映射，Center_Mode
+        下为空 dict；``node_rows`` 为 Q1 返回的节点行列表（按字典顺序合并）。
+    """
+    if center_node_id:
+        node_rows = await _query_center_node_neighbors(
+            end_user_id=end_user_id,
+            center_node_id=center_node_id,
+            depth=depth,
+            limit=limit,
+        )
+        return "Center", {}, node_rows
+
+    if node_types:
+        target_types = [t for t in node_types if t in SUPPORTED_NODE_TYPES]
+        mode = "Filter"
+    else:
+        target_types = sorted(SUPPORTED_NODE_TYPES)
+        mode = "Default"
+
+    type_limits = _resolve_per_type_limits(
+        target_types=target_types,
+        user_overrides=dict(per_type_limits or {}),
+        fallback_default=limit,
+    )
+    type_limits = _apply_total_cap_shrink(type_limits)
+
+    non_zero_limits = {t: v for t, v in type_limits.items() if v > 0}
+    if not non_zero_limits:
+        return mode, type_limits, []
+
+    node_rows = await _query_nodes_by_type_limits(
+        _neo4j_connector,
+        end_user_id=end_user_id,
+        type_limits=non_zero_limits,
+    )
+    return mode, type_limits, node_rows
+
+
+async def _format_nodes(
+    node_rows: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], Dict[str, int], List[str]]:
+    """Q2 批量关联计数 → 装配节点列表。
+
+    Returns:
+        ``(nodes, node_type_counts, node_ids)`` —— ``nodes`` 是装配后的响应列表；
+        ``node_type_counts`` 为 ``{label: count}``；``node_ids`` 为本批节点的
+        elementId 列表（顺序与 ``nodes`` 一致），供后续边查询/双端校验使用。
+    """
+    node_records: List[Tuple[str, str, Dict[str, Any]]] = []
+    node_ids: List[str] = []
+    for record in node_rows:
+        node_id = record.get("id")
+        if not node_id:
+            continue
+        labels_value = record.get("labels") or []
+        node_label = labels_value[0] if labels_value else "Unknown"
+        node_props = record.get("properties") or {}
+        node_records.append((node_id, node_label, node_props))
+        node_ids.append(node_id)
+
+    rel_count_map = await _query_rel_count_batch(_neo4j_connector, node_ids)
+
+    nodes: List[Dict[str, Any]] = []
+    node_type_counts: Dict[str, int] = {}
+    for node_id, node_label, node_props in node_records:
+        rel_count = int(rel_count_map.get(node_id, 0))
+        filtered_props = _extract_node_properties(
+            node_label, node_props, rel_count=rel_count
+        )
+        nodes.append({
+            "id": node_id,
+            "label": node_label,
+            "properties": filtered_props,
+            "caption": filtered_props.get("caption", node_label),
+        })
+        node_type_counts[node_label] = node_type_counts.get(node_label, 0) + 1
+
+    return nodes, node_type_counts, node_ids
+
+
+async def _format_edges(
+    node_ids: List[str],
+) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+    """Q3 边查询 + 装配边列表（Requirement 8.4：异常时降级为空边）。
+
+    Returns:
+        ``(edges, edge_type_counts)`` —— ``edges`` 为装配后的响应边列表，仅保留两端都
+        在 ``node_ids`` 中的边；``edge_type_counts`` 为 ``{rel_type: count}``。
+        当 ``node_ids`` 为空时直接返回 ``([], {})``，不发起查询。
+    """
+    if not node_ids:
+        return [], {}
+
+    try:
+        edge_rows = await _query_edges_among_nodes(node_ids)
+    except Exception as e:
+        logger.error(f"边查询失败，降级为空边: {e}", exc_info=True)
+        edge_rows = []
+
+    node_id_set = set(node_ids)
+    edges: List[Dict[str, Any]] = []
+    edge_type_counts: Dict[str, int] = {}
+    for record in edge_rows:
+        source = record.get("source")
+        target = record.get("target")
+        # 防御性双端过滤：Cypher 已过滤悬空边，这里保险起见再校验一次
+        if source not in node_id_set or target not in node_id_set:
+            continue
+        rel_type = record.get("rel_type")
+        cleaned_edge_props = {
+            key: _clean_neo4j_value(value)
+            for key, value in (record.get("properties") or {}).items()
+        }
+        edges.append({
+            "id": record.get("id"),
+            "source": source,
+            "target": target,
+            "type": rel_type,
+            "properties": cleaned_edge_props,
+            "caption": _resolve_edge_caption(rel_type, cleaned_edge_props),
+        })
+        edge_type_counts[rel_type] = edge_type_counts.get(rel_type, 0) + 1
+
+    return edges, edge_type_counts
+
+
+async def _build_per_type_stat(
+    *,
+    mode: str,
+    end_user_id: str,
+    type_limits: Dict[str, int],
+    node_type_counts: Dict[str, int],
+) -> Dict[str, Dict[str, Any]]:
+    """Q4 全量计数 + 装配 ``statistics.per_type`` 截断元数据。
+
+    Default_Mode / Center_Mode 用全部 :data:`SUPPORTED_NODE_TYPES` 以呈现「全量 vs
+    当前」；Filter_Mode 收敛到 ``type_limits`` 的键集合。
+    """
+    if mode == "Filter":
+        stat_types = sorted(type_limits.keys())
+    else:
+        stat_types = sorted(SUPPORTED_NODE_TYPES)
+
+    total_by_type = await _query_total_count_by_type(
+        _neo4j_connector,
+        end_user_id=end_user_id,
+        supported_types=stat_types,
+    )
+
+    per_type_stat: Dict[str, Dict[str, Any]] = {}
+    for node_type in stat_types:
+        returned = node_type_counts.get(node_type, 0)
+        total = int(total_by_type.get(node_type, 0))
+        type_limit = int(type_limits.get(node_type, 0))
+        per_type_stat[node_type] = {
+            "returned": returned,
+            "total": total,
+            "limit": type_limit,
+            "truncated": total > returned,
+        }
+    return per_type_stat
+
+
 def _empty_graph_response(message: str) -> Dict[str, Any]:
     """构造空响应结构（用户不存在 / UUID 非法等场景）。"""
     return {
@@ -1919,7 +1985,7 @@ async def _query_center_node_neighbors(
     Cypher 不允许直接参数化变长路径长度（``[*1..n]``），因此需要将 ``depth``
     安全拼入字符串；调用方需保证 ``depth`` 已被钳制为 ≤ 3。
     """
-    safe_depth = max(1, min(int(depth), 3))
+    safe_depth = max(1, min(int(depth), DEPTH_HARD_MAX))
     cypher = f"""
     MATCH path = (center)-[*1..{safe_depth}]-(connected)
     WHERE center.end_user_id = $end_user_id
@@ -2133,17 +2199,52 @@ def _extract_node_properties(
 
     filtered_props: Dict[str, Any] = {}
     for field in allowed_fields:
-        if field in properties:
-            value = properties[field]
-            if str(field) == 'entity_type':
-                value = type_mapping.get(value, '')
-            if str(field) == "emotion_type":
-                value = EmotionType.EMOTION_MAPPING.get(value)
-            if str(field) == "emotion_subject":
-                value = EmotionSubject.SUBJECT_MAPPING.get(value)
-            filtered_props[field] = _clean_neo4j_value(value)
-    filtered_props['associative_memory'] = rel_count
+        if field not in properties:
+            continue
+        value = properties[field]
+        mapper = _NODE_FIELD_VALUE_MAPPERS.get(field)
+        if mapper is not None:
+            value = mapper(value)
+        filtered_props[field] = _clean_neo4j_value(value)
+    filtered_props["associative_memory"] = rel_count
     return filtered_props
+
+
+# 节点 ``properties`` 中需要做枚举/字典映射的字段。
+# 修改本表即可扩展新的字段映射规则，无需触碰 ``_extract_node_properties`` 主体。
+_NODE_FIELD_VALUE_MAPPERS: Dict[str, Callable[[Any], Any]] = {
+    "entity_type": lambda v: type_mapping.get(v, ""),
+    "emotion_type": lambda v: EmotionType.EMOTION_MAPPING.get(v),
+    "emotion_subject": lambda v: EmotionSubject.SUBJECT_MAPPING.get(v),
+}
+
+
+def _resolve_edge_caption(
+    rel_type: Optional[str],
+    edge_props: Dict[str, Any],
+) -> Optional[str]:
+    """派生边的展示文案 ``caption``。
+
+    取值优先级（与 docs/api/graph-data-quickref.md 描述一致）::
+
+        1. ``edge_props.caption`` —— 写入端显式提供
+        2. ``rel_type == "EXTRACTED_RELATIONSHIP"`` 时取 ``edge_props.predicate`` —— 实体—实体语义关系
+        3. 回落到 ``rel_type`` 字面量
+
+    Args:
+        rel_type: Cypher ``type(r)`` 返回的关系类型字符串。
+        edge_props: ``properties(r)`` 经过 ``_clean_neo4j_value`` 清洗后的关系属性。
+
+    Returns:
+        最终用于响应的 ``caption`` 字符串；若 ``rel_type`` 与 ``edge_props.caption``
+        都缺失则返回 ``None``（实际场景下不会发生，因为 Cypher 必返回 ``rel_type``）。
+    """
+    explicit = edge_props.get("caption")
+    if explicit:
+        return explicit
+    if rel_type == "EXTRACTED_RELATIONSHIP":
+        return edge_props.get("predicate") or rel_type
+    return rel_type
 
 
 def _clean_neo4j_value(value: Any) -> Any:

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -17,7 +17,6 @@ from app.core.logging_config import get_logger
 from app.core.memory.constants.graph_data_constants import (
     DEPTH_HARD_MAX,
     NODE_PROPERTY_WHITELIST,
-    SUPPORTED_NODE_TYPES,
     _DEFAULT_FIELDS,
 )
 from app.core.memory.storage_services.extraction_engine.deduplication.deduped_and_disamb import _USER_PLACEHOLDER_NAMES
@@ -28,11 +27,12 @@ from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.neo4j.cypher_queries import Graph_Node_query
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services._graph_data_helpers import (
-    _apply_total_cap_shrink,
+    assemble_per_type_stat,
+    compute_stat_types,
+    resolve_mode_and_type_limits,
     _query_nodes_by_type_limits,
     _query_rel_count_batch,
     _query_total_count_by_type,
-    _resolve_per_type_limits,
 )
 from app.schemas.memory_episodic_schema import EmotionSubject, EmotionType, type_mapping
 from app.services.memory_base_service import MemoryBaseService, MIN_MEMORY_SUMMARY_COUNT
@@ -1806,19 +1806,11 @@ async def _collect_node_query(
         )
         return "Center", {}, node_rows
 
-    if node_types:
-        target_types = [t for t in node_types if t in SUPPORTED_NODE_TYPES]
-        mode = "Filter"
-    else:
-        target_types = sorted(SUPPORTED_NODE_TYPES)
-        mode = "Default"
-
-    type_limits = _resolve_per_type_limits(
-        target_types=target_types,
-        user_overrides=dict(per_type_limits or {}),
-        fallback_default=limit,
+    mode, type_limits = resolve_mode_and_type_limits(
+        node_types=node_types,
+        limit=limit,
+        per_type_limits=per_type_limits,
     )
-    type_limits = _apply_total_cap_shrink(type_limits)
 
     non_zero_limits = {t: v for t, v in type_limits.items() if v > 0}
     if not non_zero_limits:
@@ -1932,10 +1924,7 @@ async def _build_per_type_stat(
     Default_Mode / Center_Mode 用全部 :data:`SUPPORTED_NODE_TYPES` 以呈现「全量 vs
     当前」；Filter_Mode 收敛到 ``type_limits`` 的键集合。
     """
-    if mode == "Filter":
-        stat_types = sorted(type_limits.keys())
-    else:
-        stat_types = sorted(SUPPORTED_NODE_TYPES)
+    stat_types = compute_stat_types(mode, type_limits)
 
     total_by_type = await _query_total_count_by_type(
         _neo4j_connector,
@@ -1943,18 +1932,12 @@ async def _build_per_type_stat(
         supported_types=stat_types,
     )
 
-    per_type_stat: Dict[str, Dict[str, Any]] = {}
-    for node_type in stat_types:
-        returned = node_type_counts.get(node_type, 0)
-        total = int(total_by_type.get(node_type, 0))
-        type_limit = int(type_limits.get(node_type, 0))
-        per_type_stat[node_type] = {
-            "returned": returned,
-            "total": total,
-            "limit": type_limit,
-            "truncated": total > returned,
-        }
-    return per_type_stat
+    return assemble_per_type_stat(
+        stat_types=stat_types,
+        type_limits=type_limits,
+        node_type_counts=node_type_counts,
+        total_by_type=total_by_type,
+    )
 
 
 def _empty_graph_response(message: str) -> Dict[str, Any]:

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -24,10 +24,10 @@ from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.db import get_db_context
 from app.repositories.conversation_repository import ConversationRepository
 from app.repositories.end_user_repository import EndUserRepository
-from app.repositories.neo4j.cypher_queries import Graph_Node_query
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services._graph_data_helpers import (
     assemble_per_type_stat,
+    assemble_center_per_type_stat,
     compute_stat_types,
     resolve_mode_and_type_limits,
     _query_nodes_by_type_limits,
@@ -35,6 +35,7 @@ from app.services._graph_data_helpers import (
     _query_total_count_by_type,
 )
 from app.schemas.memory_episodic_schema import EmotionSubject, EmotionType, type_mapping
+from app.schemas.graph_data_schema import GraphDataResponse
 from app.services.memory_base_service import MemoryBaseService, MIN_MEMORY_SUMMARY_COUNT
 from app.services.memory_config_service import MemoryConfigService
 from app.services.memory_perceptual_service import MemoryPerceptualService
@@ -1690,9 +1691,12 @@ async def analytics_graph_data(
     3. 调用 ``_resolve_per_type_limits`` + ``_apply_total_cap_shrink`` 得到最终
        生效的 ``{Node_Type: Per_Type_Limit}`` 映射；
     4. 顺序执行 Q1（节点）→ Q2（批量关联计数）→ Q3（边，try/except 降级）→
-       Q4（按 label 全量计数）四次 Cypher，整体调用次数与节点数 N 无关；
-    5. 通过 :class:`GraphDataResponse` 装配响应，``statistics.per_type`` 包含
-       本次配置内全部 Node_Type 的 ``returned/total/limit/truncated`` 元数据。
+       Q4（按 label 全量计数）四类 Cypher。其中 Q1/Q4 为命中 ``end_user_id``
+       label-property 索引，按 :data:`SUPPORTED_NODE_TYPES` 逐类型下发（每类一次
+       NodeIndexSeek），总查询次数 ``≤ 2*类型数 + 2``，与节点数 N 无关；
+    5. 通过 :class:`GraphDataResponse` 装配响应（``model_dump(exclude_none=True)``），
+       ``statistics.per_type`` 包含本次配置内全部 Node_Type 的
+       ``returned/total/limit/truncated`` 元数据。
 
     Args:
         db: SQLAlchemy 会话，用于校验 end_user 是否存在。
@@ -1745,6 +1749,8 @@ async def analytics_graph_data(
             end_user_id=end_user_id,
             type_limits=type_limits,
             node_type_counts=node_type_counts,
+            center_limit=limit,
+            total_returned=len(nodes),
         )
 
         statistics = {
@@ -1765,11 +1771,14 @@ async def analytics_graph_data(
             f"nodes={len(nodes)} edges={len(edges)} per_type=[{per_type_log}]"
         )
 
-        return {
-            "nodes": nodes,
-            "edges": edges,
-            "statistics": statistics,
-        }
+        # 通过 GraphDataResponse 装配响应：拿到 ge=0 / 必填字段校验与向后兼容契约，
+        # 再 model_dump() 回 dict 以维持 controller 接口形态。无 message 时不输出该键。
+        response = GraphDataResponse(
+            nodes=nodes,
+            edges=edges,
+            statistics=statistics,
+        )
+        return response.model_dump(exclude_none=True)
 
     except Exception as e:
         logger.error(f"获取图数据失败: {str(e)}", exc_info=True)
@@ -1918,11 +1927,26 @@ async def _build_per_type_stat(
     end_user_id: str,
     type_limits: Dict[str, int],
     node_type_counts: Dict[str, int],
+    center_limit: int,
+    total_returned: int,
 ) -> Dict[str, Dict[str, Any]]:
     """Q4 全量计数 + 装配 ``statistics.per_type`` 截断元数据。
 
     Default_Mode / Center_Mode 用全部 :data:`SUPPORTED_NODE_TYPES` 以呈现「全量 vs
     当前」；Filter_Mode 收敛到 ``type_limits`` 的键集合。
+
+    Center_Mode 走专用装配（:func:`assemble_center_per_type_stat`）：该模式由单一
+    全局 ``center_limit`` 控制邻居总量，``type_limits`` 为空，逐类型 Per_Type_Limit
+    语义不适用。专用装配把每类 ``limit`` 填全局上限、并按「全局触顶」判定截断，
+    避免 ``truncated`` 恒为 False 误导前端。
+
+    Args:
+        mode: ``{"Center", "Filter", "Default"}`` 之一。
+        end_user_id: 终端用户 UUID 字符串。
+        type_limits: 本次生效的 ``{Node_Type: Per_Type_Limit}``（Center_Mode 下为空）。
+        node_type_counts: 本次响应中按类型聚合的返回数量。
+        center_limit: Center_Mode 实际生效的全局节点上限（已被控制器钳制）。
+        total_returned: 本次响应中的节点总数，用于 Center_Mode 的全局截断判定。
     """
     stat_types = compute_stat_types(mode, type_limits)
 
@@ -1931,6 +1955,15 @@ async def _build_per_type_stat(
         end_user_id=end_user_id,
         supported_types=stat_types,
     )
+
+    if mode == "Center":
+        return assemble_center_per_type_stat(
+            stat_types=stat_types,
+            node_type_counts=node_type_counts,
+            total_by_type=total_by_type,
+            global_limit=center_limit,
+            total_returned=total_returned,
+        )
 
     return assemble_per_type_stat(
         stat_types=stat_types,

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -7,7 +7,7 @@ User Memory Service
 import os
 import uuid
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
@@ -2247,6 +2247,23 @@ def _resolve_edge_caption(
     return rel_type
 
 
+def _format_datetime_naive_iso(dt: datetime) -> str:
+    """将 ``datetime`` 序列化为不带时区后缀的 ISO 字符串。
+
+    Neo4j 节点写入端历史上既有用 naive ``datetime`` 的（``Statement`` / ``Chunk`` /
+    ``MemorySummary`` 等），也有用 tz-aware ``datetime`` 的（``AssistantOriginal`` /
+    ``AssistantPruned``）。直接 ``isoformat()`` 会让响应里两类节点的 ``created_at``
+    一会儿带 ``+00:00`` 一会儿不带，前端体验不一致。
+
+    本函数对 tz-aware 的 ``datetime`` 先转换为 UTC，再剥掉 ``tzinfo``，最后调用
+    ``isoformat()``；naive 的 ``datetime`` 直接 ``isoformat()``。结果格式统一为
+    形如 ``"2026-05-28T06:35:16.910751"``。
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt.isoformat()
+
+
 def _clean_neo4j_value(value: Any) -> Any:
     """
     清理单个值的 Neo4j 特殊类型
@@ -2267,13 +2284,12 @@ def _clean_neo4j_value(value: Any) -> Any:
     # 处理字典
     if isinstance(value, dict):
         return {k: _clean_neo4j_value(v) for k, v in value.items()}
-    
     # 处理 Neo4j DateTime 类型
     if hasattr(value, '__class__') and 'neo4j.time' in str(type(value)):
         try:
             if hasattr(value, 'to_native'):
                 native_dt = value.to_native()
-                return native_dt.isoformat()
+                return _format_datetime_naive_iso(native_dt)
             return str(value)
         except Exception:
             return str(value)

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -14,6 +14,11 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_logger
+from app.core.memory.constants.graph_data_constants import (
+    NODE_PROPERTY_WHITELIST,
+    SUPPORTED_NODE_TYPES,
+    _DEFAULT_FIELDS,
+)
 from app.core.memory.storage_services.extraction_engine.deduplication.deduped_and_disamb import _USER_PLACEHOLDER_NAMES
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.db import get_db_context
@@ -21,6 +26,13 @@ from app.repositories.conversation_repository import ConversationRepository
 from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.neo4j.cypher_queries import Graph_Node_query
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.services._graph_data_helpers import (
+    _apply_total_cap_shrink,
+    _query_nodes_by_type_limits,
+    _query_rel_count_batch,
+    _query_total_count_by_type,
+    _resolve_per_type_limits,
+)
 from app.schemas.memory_episodic_schema import EmotionSubject, EmotionType, type_mapping
 from app.services.memory_base_service import MemoryBaseService, MIN_MEMORY_SUMMARY_COUNT
 from app.services.memory_config_service import MemoryConfigService
@@ -1664,201 +1676,286 @@ async def analytics_graph_data(
     node_types: Optional[List[str]] = None,
     limit: int = 130,
     depth: int = 1,
-    center_node_id: Optional[str] = None
+    center_node_id: Optional[str] = None,
+    per_type_limits: Optional[Dict[str, int]] = None,
 ) -> Dict[str, Any]:
-    """
-    获取 Neo4j 图数据，用于前端可视化
-    
+    """获取 Neo4j 图数据，用于前端可视化（按 Per_Type_Limit 精细化控制）。
+
+    本函数严格遵循 design ``Algorithm 4``：
+
+    1. 校验 ``end_user_id`` 合法性与用户存在性，失败返回结构化空响应；
+    2. 按 ``center_node_id`` / ``node_types`` 分派 Center_Mode / Filter_Mode /
+       Default_Mode 三条路径，统一使用 ``Per_Type_Limit`` 控制每种类型的返回数量；
+    3. 调用 ``_resolve_per_type_limits`` + ``_apply_total_cap_shrink`` 得到最终
+       生效的 ``{Node_Type: Per_Type_Limit}`` 映射；
+    4. 顺序执行 Q1（节点）→ Q2（批量关联计数）→ Q3（边，try/except 降级）→
+       Q4（按 label 全量计数）四次 Cypher，整体调用次数与节点数 N 无关；
+    5. 通过 :class:`GraphDataResponse` 装配响应，``statistics.per_type`` 包含
+       本次配置内全部 Node_Type 的 ``returned/total/limit/truncated`` 元数据。
+
     Args:
-        db: 数据库会话
-        end_user_id: 终端用户ID
-        node_types: 可选的节点类型列表
-        limit: 返回节点数量限制
-        depth: 图遍历深度
-        center_node_id: 可选的中心节点ID
-        
+        db: SQLAlchemy 会话，用于校验 end_user 是否存在。
+        end_user_id: 终端用户 UUID 字符串。
+        node_types: 可选的 Node_Type 过滤列表。非空 → Filter_Mode；空 →
+            Default_Mode（覆盖全部 :data:`SUPPORTED_NODE_TYPES`）。
+        limit: 兜底 Per_Type_Limit；同时也作为 Center_Mode 下的单一节点上限。
+        depth: 仅在 Center_Mode 下生效，控制邻居跳数。
+        center_node_id: 中心节点 elementId；非空时进入 Center_Mode 并忽略
+            ``node_types`` / ``per_type_limits`` 中的类型过滤语义。
+        per_type_limits: 由 controller 解析得到的 ``{Node_Type: Per_Type_Limit}``
+            映射；本函数不再做格式校验。
+
     Returns:
-        包含节点、边和统计信息的字典
+        ``GraphDataResponse.model_dump()`` 后的字典，顶层键为
+        ``nodes / edges / statistics``，必要时附带 ``message``。
     """
     try:
-        # 1. 获取 end_user_id
-        user_uuid = uuid.UUID(end_user_id)
+        # 1. 用户校验
+        try:
+            user_uuid = uuid.UUID(end_user_id)
+        except (ValueError, TypeError):
+            logger.error(f"无效的 end_user_id 格式: {end_user_id}")
+            return _empty_graph_response("无效的用户ID格式")
+
         repo = EndUserRepository(db)
         end_user = repo.get_by_id(user_uuid)
         if not end_user:
             logger.warning(f"未找到 end_user_id 为 {end_user_id} 的用户")
-            return {
-                "nodes": [],
-                "edges": [],
-                "statistics": {
-                    "total_nodes": 0,
-                    "total_edges": 0,
-                    "node_types": {},
-                    "edge_types": {}
-                },
-                "message": "用户不存在"
-            }
-        
-        # 2. 构建节点查询
+            return _empty_graph_response("用户不存在")
+
+        user_overrides: Dict[str, int] = dict(per_type_limits or {})
+
+        # 2. 模式分派 + Per_Type_Limit 解析
         if center_node_id:
-            # 基于中心节点的扩展查询
-            node_query = f"""
-            MATCH path = (center)-[*1..{depth}]-(connected)
-            WHERE center.end_user_id = $end_user_id
-              AND elementId(center) = $center_node_id
-            WITH collect(DISTINCT center) + collect(DISTINCT connected) as all_nodes
-            UNWIND all_nodes as n
-            RETURN DISTINCT 
-                elementId(n) as id,
-                labels(n)[0] as label,
-                properties(n) as properties
-            LIMIT $limit
-            """
-            node_params = {
-                "end_user_id": end_user_id,
-                "center_node_id": center_node_id,
-                "limit": limit
-            }
-        elif node_types:
-            # 按节点类型过滤查询
-            node_query = """
-            MATCH (n)
-            WHERE n.end_user_id = $end_user_id
-              AND labels(n)[0] IN $node_types
-            RETURN 
-                elementId(n) as id,
-                labels(n)[0] as label,
-                properties(n) as properties
-            LIMIT $limit
-            """
-            node_params = {
-                "end_user_id": end_user_id,
-                "node_types": node_types,
-                "limit": limit
-            }
+            mode = "Center"
+            type_limits: Dict[str, int] = {}
+            node_rows = await _query_center_node_neighbors(
+                end_user_id=end_user_id,
+                center_node_id=center_node_id,
+                depth=depth,
+                limit=limit,
+            )
         else:
-            # 查询所有节点
-            node_query=Graph_Node_query
-            node_params = {
-                "end_user_id": end_user_id,
-                "limit": limit
-            }
-        # 执行节点查询
-        node_results = await _neo4j_connector.execute_query(node_query, **node_params)
-        
-        # 3. 格式化节点数据
-        nodes = []
-        node_ids = []
-        node_type_counts = {}
-        
-        for record in node_results:
-            node_id = record["id"]
-            node_labels = record.get("labels", [])
-            node_label = node_labels[0] if node_labels else "Unknown"
-            node_props = record["properties"]
-            # 根据节点类型提取需要的属性字段
-            filtered_props = await _extract_node_properties(node_label, node_props,node_id)
-            
-            # 直接使用数据库中的 caption，如果没有则使用节点类型作为默认值
+            if node_types:
+                target_types = [t for t in node_types if t in SUPPORTED_NODE_TYPES]
+                mode = "Filter"
+            else:
+                target_types = sorted(SUPPORTED_NODE_TYPES)
+                mode = "Default"
+
+            type_limits = _resolve_per_type_limits(
+                target_types=target_types,
+                user_overrides=user_overrides,
+                fallback_default=limit,
+            )
+            type_limits = _apply_total_cap_shrink(type_limits)
+
+            non_zero_limits = {t: v for t, v in type_limits.items() if v > 0}
+            if non_zero_limits:
+                node_rows = await _query_nodes_by_type_limits(
+                    _neo4j_connector,
+                    end_user_id=end_user_id,
+                    type_limits=non_zero_limits,
+                )
+            else:
+                node_rows = []
+
+        # 3. 节点 ID 收集（Q2 / Q3 都需要）
+        node_ids: List[str] = []
+        node_records: List[Tuple[str, str, Dict[str, Any]]] = []
+        for record in node_rows:
+            node_id = record.get("id")
+            if not node_id:
+                continue
+            labels_value = record.get("labels") or []
+            node_label = labels_value[0] if labels_value else "Unknown"
+            node_props = record.get("properties") or {}
+            node_ids.append(node_id)
+            node_records.append((node_id, node_label, node_props))
+
+        # 4. Q2 批量关联计数（消除 N+1）
+        rel_count_map = await _query_rel_count_batch(_neo4j_connector, node_ids)
+
+        # 5. 节点格式化
+        nodes: List[Dict[str, Any]] = []
+        node_type_counts: Dict[str, int] = {}
+        for node_id, node_label, node_props in node_records:
+            rel_count = int(rel_count_map.get(node_id, 0))
+            filtered_props = _extract_node_properties(
+                node_label, node_props, rel_count=rel_count
+            )
             caption = filtered_props.get("caption", node_label)
-            
             nodes.append({
                 "id": node_id,
                 "label": node_label,
                 "properties": filtered_props,
-                "caption": caption
+                "caption": caption,
             })
-            
-            node_ids.append(node_id)
             node_type_counts[node_label] = node_type_counts.get(node_label, 0) + 1
-        
-        # 4. 查询节点之间的关系
-        if len(node_ids) > 0:
-            edge_query = """
-            MATCH (n)-[r]->(m)
-            WHERE elementId(n) IN $node_ids 
-              AND elementId(m) IN $node_ids
-            RETURN 
-                elementId(r) as id,
-                elementId(n) as source,
-                elementId(m) as target,
-                type(r) as rel_type,
-                properties(r) as properties
-            """
-            edge_results = await _neo4j_connector.execute_query(
-                edge_query,
-                node_ids=node_ids
-            )
+
+        # 6. Q3 边查询（try/except 降级，Requirement 8.4）
+        edges: List[Dict[str, Any]] = []
+        edge_type_counts: Dict[str, int] = {}
+        if node_ids:
+            try:
+                edge_rows = await _query_edges_among_nodes(node_ids)
+            except Exception as e:
+                logger.error(f"边查询失败，降级为空边: {e}", exc_info=True)
+                edge_rows = []
+
+            node_id_set = set(node_ids)
+            for record in edge_rows:
+                source = record.get("source")
+                target = record.get("target")
+                # 防御性双端过滤：Cypher 已过滤悬空边，这里保险起见再校验一次
+                if source not in node_id_set or target not in node_id_set:
+                    continue
+                edge_id = record.get("id")
+                rel_type = record.get("rel_type")
+                edge_props = record.get("properties") or {}
+                cleaned_edge_props = {
+                    key: _clean_neo4j_value(value)
+                    for key, value in edge_props.items()
+                }
+                # caption 取值优先级：
+                #   1. properties.caption（写入端显式提供）
+                #   2. EXTRACTED_RELATIONSHIP 边走 properties.predicate（实体—实体语义关系）
+                #   3. 回落到 rel_type（字面量关系类型）
+                caption = cleaned_edge_props.get("caption")
+                if not caption and rel_type == "EXTRACTED_RELATIONSHIP":
+                    caption = cleaned_edge_props.get("predicate") or rel_type
+                if not caption:
+                    caption = rel_type
+                edges.append({
+                    "id": edge_id,
+                    "source": source,
+                    "target": target,
+                    "type": rel_type,
+                    "properties": cleaned_edge_props,
+                    "caption": caption,
+                })
+                edge_type_counts[rel_type] = edge_type_counts.get(rel_type, 0) + 1
+
+        # 7. Q4 全量计数 + statistics.per_type 装配
+        # Default_Mode 用全部 Supported_Node_Types；Filter_Mode 收敛到 type_limits
+        # 的键集合；Center_Mode 用全部 Supported_Node_Types 以呈现「全量 vs 当前」。
+        if mode == "Filter":
+            stat_types = sorted(type_limits.keys())
         else:
-            edge_results = []
-        
-        # 5. 格式化边数据
-        edges = []
-        edge_type_counts = {}
-        
-        for record in edge_results:
-            edge_id = record["id"]
-            source = record["source"]
-            target = record["target"]
-            rel_type = record["rel_type"]
-            edge_props = record["properties"]
-            
-            # 清理边属性中的 Neo4j 特殊类型
-            # 对于边，我们保留所有属性，但清理特殊类型
-            cleaned_edge_props = {}
-            if edge_props:
-                for key, value in edge_props.items():
-                    cleaned_edge_props[key] = _clean_neo4j_value(value)
-            
-            # 直接使用关系类型作为 caption，如果 properties 中有 caption 则使用它
-            caption = cleaned_edge_props.get("caption", rel_type)
-            
-            edges.append({
-                "id": edge_id,
-                "source": source,
-                "target": target,
-                "type": rel_type,
-                "properties": cleaned_edge_props,
-                "caption": caption
-            })
-            
-            edge_type_counts[rel_type] = edge_type_counts.get(rel_type, 0) + 1
-        
-        # 6. 构建统计信息
+            stat_types = sorted(SUPPORTED_NODE_TYPES)
+
+        total_by_type = await _query_total_count_by_type(
+            _neo4j_connector,
+            end_user_id=end_user_id,
+            supported_types=stat_types,
+        )
+
+        per_type_stat: Dict[str, Dict[str, Any]] = {}
+        for node_type in stat_types:
+            returned = node_type_counts.get(node_type, 0)
+            total = int(total_by_type.get(node_type, 0))
+            type_limit = int(type_limits.get(node_type, 0))
+            per_type_stat[node_type] = {
+                "returned": returned,
+                "total": total,
+                "limit": type_limit,
+                "truncated": total > returned,
+            }
+
         statistics = {
             "total_nodes": len(nodes),
             "total_edges": len(edges),
             "node_types": node_type_counts,
-            "edge_types": edge_type_counts
+            "edge_types": edge_type_counts,
+            "per_type": per_type_stat,
         }
-        
+
+        # 8. 日志输出 returned/total/limit 三元组（Requirement 8.5）
+        per_type_log = ", ".join(
+            f"{t}:returned={v['returned']}/total={v['total']}/limit={v['limit']}"
+            for t, v in per_type_stat.items()
+        )
         logger.info(
-            f"成功获取图数据: end_user_id={end_user_id}, "
-            f"nodes={len(nodes)}, edges={len(edges)}"
+            f"图数据查询: end_user_id={end_user_id} mode={mode} "
+            f"nodes={len(nodes)} edges={len(edges)} per_type=[{per_type_log}]"
         )
 
         return {
             "nodes": nodes,
             "edges": edges,
-            "statistics": statistics
+            "statistics": statistics,
         }
-        
-    except ValueError:
-        logger.error(f"无效的 end_user_id 格式: {end_user_id}")
-        return {
-            "nodes": [],
-            "edges": [],
-            "statistics": {
-                "total_nodes": 0,
-                "total_edges": 0,
-                "node_types": {},
-                "edge_types": {}
-            },
-            "message": "无效的用户ID格式"
-        }
+
     except Exception as e:
         logger.error(f"获取图数据失败: {str(e)}", exc_info=True)
         raise
+
+
+def _empty_graph_response(message: str) -> Dict[str, Any]:
+    """构造空响应结构（用户不存在 / UUID 非法等场景）。"""
+    return {
+        "nodes": [],
+        "edges": [],
+        "statistics": {
+            "total_nodes": 0,
+            "total_edges": 0,
+            "node_types": {},
+            "edge_types": {},
+            "per_type": {},
+        },
+        "message": message,
+    }
+
+
+async def _query_center_node_neighbors(
+    *,
+    end_user_id: str,
+    center_node_id: str,
+    depth: int,
+    limit: int,
+) -> List[Dict[str, Any]]:
+    """以中心节点为起点的 1..depth 跳邻居查询（Center_Mode）。
+
+    Cypher 不允许直接参数化变长路径长度（``[*1..n]``），因此需要将 ``depth``
+    安全拼入字符串；调用方需保证 ``depth`` 已被钳制为 ≤ 3。
+    """
+    safe_depth = max(1, min(int(depth), 3))
+    cypher = f"""
+    MATCH path = (center)-[*1..{safe_depth}]-(connected)
+    WHERE center.end_user_id = $end_user_id
+      AND elementId(center) = $center_node_id
+    WITH collect(DISTINCT center) + collect(DISTINCT connected) as all_nodes
+    UNWIND all_nodes as n
+    RETURN DISTINCT
+        elementId(n) as id,
+        labels(n) as labels,
+        properties(n) as properties
+    LIMIT $limit
+    """
+    rows = await _neo4j_connector.execute_query(
+        cypher,
+        end_user_id=end_user_id,
+        center_node_id=center_node_id,
+        limit=int(limit),
+    )
+    return list(rows)
+
+
+async def _query_edges_among_nodes(node_ids: List[str]) -> List[Dict[str, Any]]:
+    """查询若干节点之间的有向关系（Q3）。Cypher 已过滤悬空边。"""
+    cypher = """
+    MATCH (n)-[r]->(m)
+    WHERE elementId(n) IN $node_ids
+      AND elementId(m) IN $node_ids
+    RETURN
+        elementId(r) as id,
+        elementId(n) as source,
+        elementId(m) as target,
+        type(r) as rel_type,
+        properties(r) as properties
+    """
+    rows = await _neo4j_connector.execute_query(cypher, node_ids=list(node_ids))
+    return list(rows)
 
 
 # 辅助函数
@@ -2007,45 +2104,45 @@ async def analytics_community_graph_data(
         raise
 
 
-async  def _extract_node_properties(label: str, properties: Dict[str, Any],node_id: str) -> Dict[str, Any]:
-    """
-    根据节点类型提取需要的属性字段
-    
-    Args:
-        label: 节点类型标签
-        properties: 节点的所有属性
-        
-    Returns:
-        过滤后的属性字典
-    """
-    # 定义每种节点类型需要的字段（白名单）
-    field_whitelist = {
-        "Dialogue": ["content", "created_at"],
-        "Chunk": ["content", "created_at"],
-        "Statement": ["temporal_info", "stmt_type", "statement", "valid_at", "created_at", "caption","emotion_keywords","emotion_type","emotion_subject"],
-        "ExtractedEntity": ["description", "name", "entity_type", "created_at", "caption","aliases","connect_strength"],
-        "MemorySummary": ["summary", "content", "created_at", "caption"],  # 添加 content 字段
-        "Perceptual": ["file_name", "file_path", "file_type", "domain", "topic", "keywords", "summary"]
-    }
-    
-    # 获取该节点类型的白名单字段
-    allowed_fields = field_whitelist.get(label, [])
+def _extract_node_properties(
+    label: str,
+    properties: Dict[str, Any],
+    *,
+    rel_count: int,
+) -> Dict[str, Any]:
+    """根据节点类型从 ``properties`` 中提取受白名单约束的字段。
 
-    count_neo4j=f"""MATCH (n)-[r]-(m) WHERE elementId(n) ="{node_id}" RETURN count(r) AS rel_count;"""
-    node_results = await (_neo4j_connector.execute_query(count_neo4j))
-    # 提取白名单中的字段
-    filtered_props = {}
+    白名单读取自 :data:`NODE_PROPERTY_WHITELIST`；当 ``label`` 未在白名单中
+    时回落到 :data:`_DEFAULT_FIELDS`（仅 ``caption``）。``associative_memory``
+    由调用方通过 ``rel_count`` 关键字参数注入，本函数不再发起 Cypher 查询，
+    用于消除原先 ``count(r)`` 子查询造成的 N+1。
+
+    保留 ``entity_type`` / ``emotion_type`` / ``emotion_subject`` 三个字段
+    的枚举映射逻辑，以维持响应字段的中文化展示。
+
+    Args:
+        label: 节点类型标签（``labels(n)[0]``）。
+        properties: 节点的全部属性。
+        rel_count: 节点的关联边数量；由调用方批量计数后注入，写入返回字典的
+            ``associative_memory`` 字段。
+
+    Returns:
+        过滤后的属性字典，至少包含 ``associative_memory`` 字段。
+    """
+    allowed_fields = NODE_PROPERTY_WHITELIST.get(label, _DEFAULT_FIELDS)
+
+    filtered_props: Dict[str, Any] = {}
     for field in allowed_fields:
         if field in properties:
             value = properties[field]
-            if  str(field) == 'entity_type':
-                value=type_mapping.get(value,'')
-            if str(field)=="emotion_type":
-                value=EmotionType.EMOTION_MAPPING.get(value)
-            if  str(field)=="emotion_subject":
-                value=EmotionSubject.SUBJECT_MAPPING.get(value)
+            if str(field) == 'entity_type':
+                value = type_mapping.get(value, '')
+            if str(field) == "emotion_type":
+                value = EmotionType.EMOTION_MAPPING.get(value)
+            if str(field) == "emotion_subject":
+                value = EmotionSubject.SUBJECT_MAPPING.get(value)
             filtered_props[field] = _clean_neo4j_value(value)
-    filtered_props['associative_memory']=[i['rel_count'] for i in node_results][0]
+    filtered_props['associative_memory'] = rel_count
     return filtered_props
 
 


### PR DESCRIPTION
## Summary by Sourcery

为分析图数据 API 实现按节点类型的限制、统计以及性能优化。

New Features:
- 通过 `per_type_limits` 参数为图数据查询指定按类型的节点上限，并在默认模式、过滤模式和中心模式中一致地强制执行这些限制。
- 在图数据响应中暴露详细的按类型统计信息，包括返回数量、总数、限制值以及截断标记，并提供正式的 Pydantic 响应模式。

Enhancements:
- 将图数据检索重构为辅助函数，以支持按类型限制、批量关系计数、健壮的边查询以及结构化的空响应。
- 将来自 Neo4j 的 datetime 序列化标准化为无时区的 ISO 字符串，以便客户端一致展示。
- 添加可配置的整体节点数量上限、按类型上限以及遍历深度上限，以保护图查询免受过载影响。
- 扩展边注释解析逻辑，以更好地支持语义关系及回退方案。

Build:
- 引入参数化的 Cypher 查询及辅助包装器，用于在图数据处理管道中按类型限制获取节点、批量获取关系计数以及按类型获取总数。

Chores:
- 添加图数据专用常量，并将内存子系统常量重组到专用模块中。
- 扩展 Neo4j 索引以覆盖所有受支持节点标签上的 `end_user_id`，并相应更新全局索引创建流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement per-node-type limits, statistics, and performance optimizations for the analytics graph data API.

New Features:
- Allow specifying per-type node limits for graph data queries via a per_type_limits parameter and enforce them consistently across default, filter, and center modes.
- Expose detailed per-type statistics in graph data responses, including returned, total, limit, and truncation flags, with a formal Pydantic response schema.

Enhancements:
- Refactor graph data retrieval into helper functions to support per-type limiting, batched relationship counting, robust edge querying, and structured empty responses.
- Standardize datetime serialization from Neo4j to timezone-naive ISO strings for consistent client display.
- Add configurable caps for overall node count, per-type limits, and traversal depth to protect graph queries from excessive load.
- Extend edge caption resolution to better support semantic relationships and fallbacks.

Build:
- Introduce parameterized Cypher queries and helper wrappers to fetch nodes by type limits, batch relationship counts, and total counts by type for the graph data pipeline.

Chores:
- Add graph data–specific constants and reorganize memory subsystem constants into a dedicated module.
- Expand Neo4j indexing to cover end_user_id across all supported node labels and update the global index creation routine accordingly.

</details>