### PR TITLE
feat(web): network chart

### DIFF
--- a/web/src/components/Charts/GraphNetworkChart.tsx
+++ b/web/src/components/Charts/GraphNetworkChart.tsx
@@ -1,199 +1,718 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-10 14:06:09 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-10 14:06:09 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-05-29 14:12:04
  */
 /**
  * GraphNetworkChart Component
  * 
- * A force-directed graph visualization component built with ECharts.
+ * A force-directed graph visualization component built with D3.js.
  * Displays nodes and edges in an interactive network diagram with physics-based layout.
  * Supports zooming, panning, dragging nodes, and click interactions.
  */
-import { type FC, useEffect, useRef, type SetStateAction, type Dispatch } from 'react'
-import ReactEcharts from 'echarts-for-react';
-
+import { type FC, useEffect, useRef, type SetStateAction, type Dispatch, useMemo } from 'react'
+import * as d3 from 'd3'
 import PageEmpty from '@/components/Empty/PageEmpty'
 
-// Default color palette for node categories
-const Colors = ['#171719', '#155EEF', '#9C6FFF', '#FF8A4C']
+export const Colors = ['#155EEF', '#02AFD5', '#FF5D34', '#6473E9', '#369F21', '#4DA8FF', '#C86AFF', '#F7BA1E', '#5B6167']
 
-/**
- * Node interface representing a graph node/vertex
- */
 export interface Node {
-  id: string;              // Unique identifier for the node
-  label: string;           // Display label for the node
-  category: number;        // Category index for grouping and coloring
-  symbolSize: number;      // Size of the node symbol in pixels
-  name: string;            // Node name (used in ECharts)
-  itemStyle: {
-    color: string;         // Custom color for this node
+  id: string;
+  label: string;
+  category: number;
+  symbolSize: number;
+  name: string;
+  itemStyle?: {
+    color: string;
   }
-  caption: string;         // Additional description or caption
-  [key: string]: any;      // Allow additional custom properties
+  caption: string;
+  properties: Record<string, any>
+  x?: number;
+  y?: number;
+  fx?: number | null;
+  fy?: number | null;
+  vx?: number;
+  vy?: number;
+  [key: string]: any;
 }
 
-/**
- * Edge interface representing a connection between two nodes
- */
 export interface Edge {
-  id: string;              // Unique identifier for the edge
-  source: string;          // Source node ID
-  target: string;          // Target node ID
-  type: string;            // Type/category of the relationship
-  caption: string;         // Description of the relationship
-  value: number;           // Numeric value associated with the edge
-  weight: number;          // Weight/strength of the connection
+  id: string;
+  source: string;
+  target: string;
+  type: string;
+  caption: string;
+  value: number;
+  weight: number;
 }
 
-/**
- * Props for the GraphNetworkChart component
- */
+export interface EdgeClickData extends Edge {
+  id: string;
+  source: string;
+  target: string;
+  label: string;
+  type: 'edge';
+}
+
 interface GraphNetworkChartProps {
-  nodes: Node[];                                    // Array of nodes to display in the graph
-  links: Edge[];                                    // Array of edges connecting the nodes
-  categories: { name: string }[];                   // Category definitions for node grouping
-  colors?: string[];                                // Optional custom color palette (defaults to Colors)
-  onNodeClick: Dispatch<SetStateAction<Node | null>>;  // Callback when a node is clicked
+  nodes: Node[];
+  links: Edge[];
+  categories: { name: string }[];
+  colors?: string[];
+  onNodeClick: Dispatch<SetStateAction<Node | EdgeClickData | null>>;
+  selectedNodeId?: string | null;
+  selectedCategory?: string | null;
+}
+
+interface D3Node extends d3.SimulationNodeDatum {
+  id: string;
+  name: string;
+  category: number;
+  symbolSize: number;
+  color: string;
+  caption: string;
+}
+
+interface D3Link extends d3.SimulationLinkDatum<D3Node> {
+  id: string;
+  source: string | D3Node;
+  target: string | D3Node;
+  caption?: string;
+  type?: string;
+  label?: string;
 }
 
 const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
   nodes,
   links,
-  categories,
+  categories: _categories,
   colors = Colors,
   onNodeClick,
+  selectedNodeId,
+  selectedCategory,
 }) => {
-  // Reference to the ECharts instance for programmatic control
-  const chartRef = useRef<ReactEcharts>(null);
-  
-  // Flag to prevent multiple simultaneous resize operations (debouncing)
-  const resizeScheduledRef = useRef(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const resizeObserverRef = useRef<ResizeObserver | null>(null)
+  const nodeSelRef = useRef<d3.Selection<SVGGElement, D3Node, SVGGElement, unknown> | null>(null)
+  const linkSelRef = useRef<d3.Selection<SVGLineElement, D3Link, SVGGElement, unknown> | null>(null)
+  const linkLabelSelRef = useRef<d3.Selection<SVGTextElement, D3Link, SVGGElement, unknown> | null>(null)
+  const graphStateRef = useRef<{ nodes: D3Node[]; links: D3Link[] } | null>(null)
+  const zoomScaleRef = useRef<number>(1)
 
-  /**
-   * Effect: Handle responsive chart resizing
-   * 
-   * Uses ResizeObserver to detect container size changes and resize the chart accordingly.
-   * Implements requestAnimationFrame for smooth, debounced resize operations.
-   * Re-runs when nodes change to ensure proper sizing with new data.
-   */
+  const graphState = useMemo(() => {
+    if (!nodes || nodes.length === 0) return null
+    
+    const nodeMap = new Map(nodes.map(n => [n.id, n]))
+    const getColor = (i: number) => colors[i % colors.length]
+    
+    const d3Nodes: D3Node[] = nodes.map(n => ({
+      id: n.id,
+      name: n.name,
+      category: n.category,
+      symbolSize: n.symbolSize || 35,
+      color: n.itemStyle?.color || getColor(n.category),
+      caption: n.caption || ''
+    }))
+
+    const d3Links: D3Link[] = links
+      .filter(l => nodeMap.has(l.source) && nodeMap.has(l.target))
+      .map(l => ({
+        id: l.id,
+        source: l.source,
+        target: l.target,
+        caption: l.caption,
+        type: l.type,
+        label: l.type === 'EXTRACTED_RELATIONSHIP' ? (l as any).properties?.predicate || undefined : undefined,
+      }))
+    return { nodes: d3Nodes, links: d3Links }
+  }, [nodes, links, colors])
+
   useEffect(() => {
+    const container = containerRef.current
+    if (!container || !graphState) return
+    
+    graphStateRef.current = graphState
+
+    const width = container.clientWidth || 600
+    const height = container.clientHeight || 518
+
+    d3.select(container).selectAll('svg').remove()
+
+    const svg = d3.select(container).append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .style('width', '100%')
+      .style('height', '100%')
+
+    const g = svg.append('g')
+
+    const zoom = d3.zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.2, 4])
+      .on('zoom', e => {
+        g.attr('transform', e.transform)
+        zoomScaleRef.current = e.transform.k
+        const currentZoom = e.transform.k
+        g.selectAll<SVGTextElement, D3Node>('g text')
+          .style('display', d => {
+            if (!d.name) return 'none'
+            const textWidth = d.name.length * 6
+            return d.symbolSize * currentZoom >= textWidth / 2 ? 'block' : 'none'
+          })
+      })
+    svg.call(zoom)
+
+    const defaultZoom = graphState.nodes.length < 50 ? 3 : graphState.nodes.length < 100 ? 2 : 1
+    if (defaultZoom !== 1) {
+      svg.call(zoom.transform, d3.zoomIdentity
+        .translate(width / 2 * (1 - defaultZoom), height / 2 * (1 - defaultZoom))
+        .scale(defaultZoom)
+      )
+    }
+
+    const defs = svg.append('defs')
+    defs.append('marker')
+      .attr('id', 'arrow')
+      .attr('viewBox', '0 -3 6 6')
+      .attr('refX', 6).attr('refY', 0)
+      .attr('markerWidth', 4).attr('markerHeight', 4)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('d', 'M0,-3L6,0L0,3')
+      .attr('fill', 'rgba(91, 97, 103, 0.4)')
+
+    defs.append('marker')
+      .attr('id', 'arrow-highlight')
+      .attr('viewBox', '0 -3 6 6')
+      .attr('refX', 6).attr('refY', 0)
+      .attr('markerWidth', 4).attr('markerHeight', 4)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('d', 'M0,-3L6,0L0,3')
+      .attr('fill', 'rgba(91, 97, 103, 0.5)')
+
+    const simulation = d3.forceSimulation<D3Node>(graphState.nodes)
+      .force('link', d3.forceLink<D3Node, D3Link>(graphState.links).id(d => d.id).distance(80))
+      .force('charge', d3.forceManyBody().strength(-100))
+      .force('center', d3.forceCenter(width / 2, height / 2).strength(0.1))
+      .force('collision', d3.forceCollide<D3Node>(d => d.symbolSize + 15))
+
+    const linkSel = g.append('g').selectAll<SVGLineElement, D3Link>('line')
+      .data(graphState.links)
+      .enter()
+      .append('line')
+      .attr('stroke', '#A8ABB2')
+      .attr('stroke-opacity', 0.4)
+      .attr('stroke-width', 0.8)
+      .attr('marker-end', d => {
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        return (selectedNodeId && (sourceId === selectedNodeId || targetId === selectedNodeId)) 
+          ? 'url(#arrow-highlight)' 
+          : 'url(#arrow)'
+      })
+      .style('cursor', 'pointer')
+      .on('click', (_event, d) => {
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        onNodeClick?.(selectedNodeId === d.id ? null : {
+          ...d,
+          id: d.id,
+          source: sourceId,
+          target: targetId,
+          label: d.label || '',
+          type: 'edge',
+        } as any)
+      })
+    linkSelRef.current = linkSel
+
+    console.log('graphState', graphState.links.filter(l => l.label))
+    const linkLabelSel = g.append('g').selectAll<SVGTextElement, D3Link>('text')
+      .data(graphState.links.filter(l => l.label))
+      .enter()
+      .append('text')
+      .text(d => d.label || '')
+      .attr('text-anchor', 'middle')
+      .attr('font-size', '9px')
+      .attr('fill', '#5B6167')
+      .attr('dy', -5)
+      .style('pointer-events', 'none')
+      .style('user-select', 'none')
+      .style('display', 'none')
+    linkLabelSelRef.current = linkLabelSel
+
+    const nodeSel = g.append('g').selectAll<SVGGElement, D3Node>('g')
+      .data(graphState.nodes)
+      .enter()
+      .append('g')
+      .style('cursor', 'pointer')
+      .call(d3.drag<SVGGElement, D3Node>()
+        .on('start', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0.3).restart()
+          d.fx = d.x
+          d.fy = d.y
+        })
+        .on('drag', (event, d) => {
+          d.fx = event.x
+          d.fy = event.y
+        })
+        .on('end', (event, d) => {
+          if (!event.active) simulation.alphaTarget(0)
+          d.fx = null
+          d.fy = null
+        })
+      )
+    nodeSelRef.current = nodeSel
+
+    nodeSel.append('circle')
+      .attr('class', 'ring')
+      .attr('r', d => d.symbolSize * 1.35)
+      .attr('fill', 'none')
+      .attr('stroke', d => d.color)
+      .attr('stroke-width', 1)
+      .attr('stroke-opacity', 0.3)
+      .lower()
+
+    nodeSel.append('circle')
+      .attr('r', d => d.symbolSize)
+      .attr('fill', d => d.color)
+      .attr('fill-opacity', 0.85)
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 1.5)
+      .on('click', (_event: MouseEvent, d: D3Node) => {
+        const newSelectedId = selectedNodeId === d.id ? null : d.id
+        const originalNode = nodes.find(n => n.id === d.id)
+        if (originalNode) {
+          onNodeClick?.(newSelectedId ? originalNode : null as any)
+        }
+      })
+
+    nodeSel.append('text')
+      .text(d => d.name)
+      .attr('x', 0)
+      .attr('dy', 4)
+      .attr('text-anchor', 'middle')
+      .attr('font-size', '10px')
+      .attr('fill', '#171719')
+      .style('pointer-events', 'none')
+      .style('user-select', 'none')
+      .style('display', d => {
+        if (!d.name) return 'none'
+        const textWidth = d.name.length * 6
+        const currentZoom = defaultZoom
+        return d.symbolSize * currentZoom >= textWidth / 2 ? 'block' : 'none'
+      })
+
+    const highlightNodes = () => {
+      if (!selectedNodeId && !selectedCategory) {
+        nodeSel.selectAll<SVGCircleElement, D3Node>('circle')
+          .transition()
+          .duration(200)
+          .attr('r', d => d.symbolSize)
+          .attr('fill-opacity', 0.85)
+          .attr('stroke', '#fff')
+          .attr('stroke-width', 1.5)
+        nodeSel.selectAll<SVGCircleElement, D3Node>('circle.ring')
+          .transition()
+          .duration(200)
+          .attr('r', d => d.symbolSize * 1.35)
+          .attr('stroke-opacity', 0.3)
+        nodeSel.selectAll<SVGTextElement, D3Node>('text')
+          .attr('fill', '#171719')
+          .attr('font-weight', 'normal')
+          .style('display', d => {
+            if (!d.name) return 'none'
+            const textWidth = d.name.length * 6
+            return d.symbolSize * zoomScaleRef.current >= textWidth / 2 ? 'block' : 'none'
+          })
+        linkSel
+          .attr('stroke', '#A8ABB2')
+          .attr('stroke-opacity', 0.4)
+          .attr('stroke-width', 0.8)
+          .attr('marker-end', 'url(#arrow)')
+          .attr('stroke-dasharray', 'none')
+        linkLabelSel
+          .style('display', 'none')
+        return
+      }
+
+      const highlightedNodeIds = new Set<string>()
+      const highlightedLinkIds = new Set<string>()
+      
+      if (selectedNodeId) {
+        const isLink = graphState.links.some(link => link.id === selectedNodeId)
+        
+        if (isLink) {
+          highlightedLinkIds.add(selectedNodeId)
+        } else {
+          highlightedNodeIds.add(selectedNodeId)
+          graphState.links.forEach(link => {
+            const sourceId = typeof link.source === 'string' ? link.source : link.source.id
+            const targetId = typeof link.target === 'string' ? link.target : link.target.id
+            if (sourceId === selectedNodeId) highlightedNodeIds.add(targetId)
+            if (targetId === selectedNodeId) highlightedNodeIds.add(sourceId)
+          })
+        }
+      } else if (selectedCategory) {
+        graphState.nodes.forEach(node => {
+          if (node.caption === selectedCategory) {
+            highlightedNodeIds.add(node.id)
+          }
+        })
+      }
+
+      nodeSel.selectAll<SVGCircleElement, D3Node>('circle')
+        .transition()
+        .duration(200)
+        .attr('r', d => highlightedLinkIds.size ? d.symbolSize : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.2 : d.symbolSize * 0.8))
+        .attr('fill-opacity', d => highlightedLinkIds.size ? 0.85 : (highlightedNodeIds.has(d.id) ? 0.85 : 0.15))
+        .attr('stroke', d => highlightedLinkIds.size ? '#fff' : (highlightedNodeIds.has(d.id) ? '#fff' : '#ccc'))
+        .attr('stroke-width', d => highlightedLinkIds.size ? 1.5 : (highlightedNodeIds.has(d.id) ? 1.5 : 0.5))
+        .transition()
+        .duration(200)
+        .attr('r', d => highlightedLinkIds.size ? d.symbolSize : (highlightedNodeIds.has(d.id) ? d.symbolSize : d.symbolSize * 0.8))
+      
+      nodeSel.selectAll<SVGCircleElement, D3Node>('circle.ring')
+        .transition()
+        .duration(200)
+        .attr('r', d => highlightedLinkIds.size ? d.symbolSize * 1.35 : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 * 1.2 : d.symbolSize * 1.35 * 0.8))
+        .attr('stroke-opacity', d => highlightedLinkIds.size ? 0.3 : (highlightedNodeIds.has(d.id) ? 0.6 : 0.1))
+        .transition()
+        .duration(200)
+        .attr('r', d => highlightedLinkIds.size ? d.symbolSize * 1.35 : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 : d.symbolSize * 1.35 * 0.8))
+        .attr('stroke-opacity', d => highlightedLinkIds.size ? 0.3 : (highlightedNodeIds.has(d.id) ? 0.4 : 0.1))
+      
+      nodeSel.selectAll<SVGTextElement, D3Node>('text')
+        .attr('fill', d => highlightedLinkIds.size ? '#171719' : (highlightedNodeIds.has(d.id) ? '#171719' : '#bbb'))
+        .attr('font-weight', d => selectedNodeId && !highlightedLinkIds.size && d.id === selectedNodeId ? 'bold' : 'normal')
+        .style('display', d => {
+          if (!d.name) return 'none'
+          const textWidth = d.name.length * 6
+          const shouldShow = d.symbolSize * zoomScaleRef.current >= textWidth / 2
+          if (highlightedLinkIds.size) {
+            return shouldShow ? 'block' : 'none'
+          }
+          if (highlightedNodeIds.has(d.id)) return shouldShow ? 'block' : 'none'
+          return 'none'
+        })
+
+      linkSel
+        .attr('stroke', d => {
+          const linkId = d.id as string
+          if (highlightedLinkIds.has(linkId)) return '#A8ABB2'
+          const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+          const targetId = typeof d.target === 'string' ? d.target : d.target.id
+          return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? '#A8ABB2' : '#A8ABB2'
+        })
+        .attr('stroke-opacity', d => {
+          const linkId = d.id as string
+          if (highlightedLinkIds.has(linkId)) return 0.6
+          const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+          const targetId = typeof d.target === 'string' ? d.target : d.target.id
+          return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 0.6 : 0.15
+        })
+        .attr('stroke-width', d => {
+          const linkId = d.id as string
+          if (highlightedLinkIds.has(linkId)) return 1.5
+          const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+          const targetId = typeof d.target === 'string' ? d.target : d.target.id
+          return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 1.5 : 0.5
+        })
+        .attr('marker-end', d => {
+          const linkId = d.id as string
+          if (highlightedLinkIds.has(linkId)) return 'url(#arrow-highlight)'
+          const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+          const targetId = typeof d.target === 'string' ? d.target : d.target.id
+          return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 'url(#arrow-highlight)' : 'url(#arrow)'
+        })
+        .attr('stroke-dasharray', d => {
+          const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+          const targetId = typeof d.target === 'string' ? d.target : d.target.id
+          if (selectedNodeId && !highlightedLinkIds.size && sourceId === selectedNodeId) return '5,3'
+          if (selectedNodeId && !highlightedLinkIds.size && targetId === selectedNodeId) return 'none'
+          return 'none'
+        })
+        linkLabelSel
+          .style('display', d => {
+            const linkId = d.id as string
+            if (highlightedLinkIds.has(linkId)) return 'block'
+            if (!highlightedLinkIds.size) {
+              const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+              const targetId = typeof d.target === 'string' ? d.target : d.target.id
+              return (highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId)) ? 'block' : 'none'
+            }
+            return 'none'
+          })
+    }
+
+    highlightNodes()
+
+    simulation.on('tick', () => {
+      linkSel
+        .attr('x1', d => (d.source as D3Node).x ?? 0)
+        .attr('y1', d => (d.source as D3Node).y ?? 0)
+        .attr('x2', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          const dx = (target.x ?? 0) - (source.x ?? 0)
+          const dy = (target.y ?? 0) - (source.y ?? 0)
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1
+          return (target.x ?? 0) - (dx / dist) * (target.symbolSize + 2)
+        })
+        .attr('y2', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          const dx = (target.x ?? 0) - (source.x ?? 0)
+          const dy = (target.y ?? 0) - (source.y ?? 0)
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1
+          return (target.y ?? 0) - (dy / dist) * (target.symbolSize + 2)
+        })
+
+      nodeSel.attr('transform', d => `translate(${d.x ?? 0},${d.y ?? 0})`)
+
+      linkLabelSel
+        .attr('x', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          return ((source.x ?? 0) + (target.x ?? 0)) / 2
+        })
+        .attr('y', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          return ((source.y ?? 0) + (target.y ?? 0)) / 2 - 8
+        })
+        .attr('transform', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          const dx = (target.x ?? 0) - (source.x ?? 0)
+          const dy = (target.y ?? 0) - (source.y ?? 0)
+          const angle = Math.atan2(dy, dx) * 180 / Math.PI
+          const cx = ((source.x ?? 0) + (target.x ?? 0)) / 2
+          const cy = ((source.y ?? 0) + (target.y ?? 0)) / 2 - 8
+          const flipAngle = angle > 90 || angle < -90 ? angle + 180 : angle
+          return `rotate(${flipAngle}, ${cx}, ${cy})`
+        })
+    })
+
     const handleResize = () => {
-      if (chartRef.current && !resizeScheduledRef.current) {
-        resizeScheduledRef.current = true
-        // Use requestAnimationFrame for smooth, optimized resize
-        requestAnimationFrame(() => {
-          chartRef.current?.getEchartsInstance().resize();
-          resizeScheduledRef.current = false
-        });
+      if (!container) return
+      const newWidth = container.clientWidth
+      const newHeight = container.clientHeight
+      
+      svg.attr('width', newWidth).attr('height', newHeight)
+      
+      simulation.force('center', d3.forceCenter(newWidth / 2, newHeight / 2).strength(0.1))
+      simulation.alpha(0.3).restart()
+    }
+
+    resizeObserverRef.current = new ResizeObserver(handleResize)
+    resizeObserverRef.current.observe(container)
+
+    return () => {
+      simulation.stop()
+      resizeObserverRef.current?.disconnect()
+      d3.select(container).selectAll('svg').remove()
+    }
+  }, [graphState, nodes, onNodeClick])
+
+  useEffect(() => {
+    if (!selectedCategory || !nodeSelRef.current || !linkSelRef.current || !graphStateRef.current) return
+
+    const { nodes: graphNodes, links: graphLinks } = graphStateRef.current
+    
+    const highlightedNodeIds = new Set<string>()
+    const highlightedLinkIds = new Set<string>()
+
+    graphNodes.forEach(node => {
+      if (node.caption === selectedCategory) {
+        highlightedNodeIds.add(node.id)
+      }
+    })
+
+    graphLinks.forEach(link => {
+      const sourceId = typeof link.source === 'string' ? link.source : link.source.id
+      const targetId = typeof link.target === 'string' ? link.target : link.target.id
+      if (highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId)) {
+        highlightedLinkIds.add(link.id as string)
+      }
+    })
+
+    nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle')
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedNodeIds.has(d.id) ? d.symbolSize * 1.2 : d.symbolSize * 0.8)
+      .attr('fill-opacity', d => highlightedNodeIds.has(d.id) ? 0.85 : 0.15)
+      .attr('stroke', d => highlightedNodeIds.has(d.id) ? '#fff' : '#ccc')
+      .attr('stroke-width', d => highlightedNodeIds.has(d.id) ? 1.5 : 0.5)
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedNodeIds.has(d.id) ? d.symbolSize : d.symbolSize * 0.8)
+
+    nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle.ring')
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 * 1.2 : d.symbolSize * 1.35 * 0.8)
+      .attr('stroke-opacity', d => highlightedNodeIds.has(d.id) ? 0.6 : 0.1)
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 : d.symbolSize * 1.35 * 0.8)
+      .attr('stroke-opacity', d => highlightedNodeIds.has(d.id) ? 0.4 : 0.1)
+
+    nodeSelRef.current.selectAll<SVGTextElement, D3Node>('text')
+      .attr('fill', d => highlightedNodeIds.has(d.id) ? '#171719' : '#bbb')
+      .attr('font-weight', 'normal')
+      .style('display', d => {
+        if (!d.name) return 'none'
+        const textWidth = d.name.length * 6
+        const shouldShow = d.symbolSize * zoomScaleRef.current >= textWidth / 2
+        if (highlightedNodeIds.has(d.id)) return shouldShow ? 'block' : 'none'
+        return 'none'
+      })
+
+    linkSelRef.current
+      .attr('stroke', '#A8ABB2')
+      .attr('stroke-opacity', d => {
+        const linkId = d.id as string
+        return highlightedLinkIds.has(linkId) ? 0.6 : 0.15
+      })
+      .attr('stroke-width', d => {
+        const linkId = d.id as string
+        return highlightedLinkIds.has(linkId) ? 1.5 : 0.5
+      })
+      .attr('marker-end', d => {
+        const linkId = d.id as string
+        return highlightedLinkIds.has(linkId) ? 'url(#arrow-highlight)' : 'url(#arrow)'
+      })
+      .attr('stroke-dasharray', 'none')
+
+  }, [selectedCategory])
+
+  useEffect(() => {
+    if (!nodeSelRef.current || !linkSelRef.current || !graphStateRef.current) return
+
+    const { links: graphLinks } = graphStateRef.current
+    
+    const highlightedNodeIds = new Set<string>()
+    const highlightedLinkIds = new Set<string>()
+    
+    if (selectedNodeId) {
+      const isLink = graphLinks.some(link => link.id === selectedNodeId)
+      
+      if (isLink) {
+        highlightedLinkIds.add(selectedNodeId)
+      } else {
+        highlightedNodeIds.add(selectedNodeId)
+        graphLinks.forEach(link => {
+          const sourceId = typeof link.source === 'string' ? link.source : link.source.id
+          const targetId = typeof link.target === 'string' ? link.target : link.target.id
+          if (sourceId === selectedNodeId) highlightedNodeIds.add(targetId)
+          if (targetId === selectedNodeId) highlightedNodeIds.add(sourceId)
+        })
       }
     }
 
-    // Observe the chart container for size changes
-    const resizeObserver = new ResizeObserver(handleResize)
-    const chartElement = chartRef.current?.getEchartsInstance().getDom().parentElement
-    if (chartElement) {
-      resizeObserver.observe(chartElement)
+    if (!selectedNodeId && !selectedCategory) {
+      nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle')
+        .transition()
+        .duration(200)
+        .attr('r', d => d.symbolSize)
+        .attr('fill-opacity', 0.85)
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 1.5)
+      
+      nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle.ring')
+        .transition()
+        .duration(200)
+        .attr('r', d => d.symbolSize * 1.35)
+        .attr('stroke-opacity', 0.3)
+      
+      nodeSelRef.current.selectAll<SVGTextElement, D3Node>('text')
+        .attr('fill', '#171719')
+        .attr('font-weight', 'normal')
+        .style('display', d => {
+          if (!d.name) return 'none'
+          const textWidth = d.name.length * 6
+          return d.symbolSize * zoomScaleRef.current >= textWidth / 2 ? 'block' : 'none'
+        })
+      
+      linkSelRef.current
+        .attr('stroke', '#A8ABB2')
+        .attr('stroke-opacity', 0.4)
+        .attr('stroke-width', 0.8)
+        .attr('marker-end', 'url(#arrow)')
+        .attr('stroke-dasharray', 'none')
+      
+      return
     }
 
-    // Cleanup: disconnect observer when component unmounts
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [nodes])
+    nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle')
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedLinkIds.size ? d.symbolSize : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.2 : d.symbolSize * 0.8))
+      .attr('fill-opacity', d => highlightedLinkIds.size ? 0.85 : (highlightedNodeIds.has(d.id) ? 0.85 : 0.15))
+      .attr('stroke', d => highlightedLinkIds.size ? '#fff' : (highlightedNodeIds.has(d.id) ? '#fff' : '#ccc'))
+      .attr('stroke-width', d => highlightedLinkIds.size ? 1.5 : (highlightedNodeIds.has(d.id) ? 1.5 : 0.5))
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedLinkIds.size ? d.symbolSize : (highlightedNodeIds.has(d.id) ? d.symbolSize : d.symbolSize * 0.8))
+    
+    nodeSelRef.current.selectAll<SVGCircleElement, D3Node>('circle.ring')
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedLinkIds.size ? d.symbolSize * 1.35 : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 * 1.2 : d.symbolSize * 1.35 * 0.8))
+      .attr('stroke-opacity', d => highlightedLinkIds.size ? 0.3 : (highlightedNodeIds.has(d.id) ? 0.6 : 0.1))
+      .transition()
+      .duration(200)
+      .attr('r', d => highlightedLinkIds.size ? d.symbolSize * 1.35 : (highlightedNodeIds.has(d.id) ? d.symbolSize * 1.35 : d.symbolSize * 1.35 * 0.8))
+      .attr('stroke-opacity', d => highlightedLinkIds.size ? 0.3 : (highlightedNodeIds.has(d.id) ? 0.4 : 0.1))
+    
+    nodeSelRef.current.selectAll<SVGTextElement, D3Node>('text')
+      .attr('fill', d => highlightedLinkIds.size ? '#171719' : (highlightedNodeIds.has(d.id) ? '#171719' : '#bbb'))
+      .attr('font-weight', d => selectedNodeId && !highlightedLinkIds.size && d.id === selectedNodeId ? 'bold' : 'normal')
+      .style('display', d => {
+        if (!d.name) return 'none'
+        const textWidth = d.name.length * 6
+        const shouldShow = d.symbolSize * zoomScaleRef.current >= textWidth / 2
+        if (highlightedLinkIds.size) {
+          return shouldShow ? 'block' : 'none'
+        }
+        if (highlightedNodeIds.has(d.id)) return shouldShow ? 'block' : 'none'
+        return 'none'
+      })
+
+    linkSelRef.current
+      .attr('stroke', '#A8ABB2')
+      .attr('stroke-opacity', d => {
+        const linkId = d.id as string
+        if (highlightedLinkIds.has(linkId)) return 0.6
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 0.6 : 0.15
+      })
+      .attr('stroke-width', d => {
+        const linkId = d.id as string
+        if (highlightedLinkIds.has(linkId)) return 1.5
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 1.5 : 0.5
+      })
+      .attr('marker-end', d => {
+        const linkId = d.id as string
+        if (highlightedLinkIds.has(linkId)) return 'url(#arrow-highlight)'
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        return highlightedNodeIds.has(sourceId) || highlightedNodeIds.has(targetId) ? 'url(#arrow-highlight)' : 'url(#arrow)'
+      })
+      .attr('stroke-dasharray', 'none')
+
+  }, [selectedNodeId])
+
+  if (!nodes || nodes.length === 0) {
+    return <PageEmpty />
+  }
 
   return (
-    <div className="rb:w-full rb:h-full">
-      {/* Render chart only if nodes exist, otherwise show empty state */}
-      {nodes && nodes.length > 0
-        ? <ReactEcharts
-            ref={chartRef}
-            option={{
-              // Color palette for node categories
-              colors: colors,
-              
-              // Disable default tooltip (custom interaction via onNodeClick)
-              tooltip: {
-                show: false
-              },
-              
-              // Hide legend (categories not displayed in legend)
-              legend: {
-                show: false,
-                bottom: 12,
-              },
-              
-              series: [
-                {
-                  type: 'graph',              // Graph/network chart type
-                  layout: 'force',            // Force-directed layout algorithm
-                  data: nodes || [],          // Node data
-                  links: links || [],         // Edge data
-                  categories: categories,     // Category definitions
-                  roam: true,                 // Enable zoom and pan interactions
-                  
-                  // Dynamic zoom level based on node count for better initial view
-                  zoom: nodes.length < 50 ? 3 : nodes.length < 100 ? 2 : 1,
-                  
-                  // Node label configuration
-                  label: {
-                    show: true,               // Display labels
-                    position: 'right',        // Position label to the right of node
-                    formatter: '{b}',         // Use node name as label text
-                  },
-                  
-                  // Edge styling
-                  lineStyle: {
-                    color: '#5B6167',         // Gray color for edges
-                    curveness: 0.3            // Slight curve for better visibility
-                  },
-                  
-                  // Force-directed layout physics configuration
-                  force: {
-                    repulsion: 100,           // Repulsion force between nodes
-                    edgeLength: 80,           // Ideal distance between connected nodes
-                    gravity: 0.3,             // Gravity pulling nodes to center
-                    layoutAnimation: true,    // Animate layout changes
-                    preventOverlap: true,     // Prevent nodes from overlapping
-                    edgeSymbol: ['none', 'arrow'],  // Arrow on target end of edge
-                    edgeSymbolSize: [4, 10],  // Size of edge symbols
-                    initLayout: 'force'       // Use force-directed for initial layout
-                  },
-                  
-                  selectedMode: 'single',     // Allow selecting one node at a time
-                  draggable: true,            // Enable dragging nodes
-                  animationDurationUpdate: 0, // Disable animation on data update for performance
-                  
-                  // Styling for selected nodes
-                  select: {
-                    itemStyle: {
-                      borderWidth: 2,         // Thicker border when selected
-                      borderColor: '#ffffff', // White border for contrast
-                      shadowBlur: 10,         // Glow effect on selection
-                    }
-                  }
-                }
-              ]
-            }}
-            style={{ height: '100%', width: '100%' }}
-            notMerge={false}      // Merge options instead of replacing (better performance)
-            lazyUpdate={true}     // Batch updates for better performance
-            
-            // Event handlers
-            onEvents={{
-              click: (params: { dataType: string; data: Node; name: string }) => {
-                // Only trigger callback for node clicks (not edges or background)
-                if (params.dataType === 'node') {
-                  onNodeClick(params.data)
-                }
-              }
-            }}
-          />
-        : <PageEmpty />
-      }
-    </div>
+    <div ref={containerRef} className="rb:w-full rb:h-full" />
   )
 }
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1681,6 +1681,8 @@ export const en = {
       ExtractedEntity_connect_strngth: 'Connection Strength',
       ExtractedEntity_importance_score: 'Importance Score',
 
+      AssistantPruned_memory_type: 'Memory Type',
+
       associative_memory: 'Associative Memory',
       unix: 'items',
       completeMemory: 'Complete Memory',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1659,6 +1659,8 @@ export const zh = {
       ExtractedEntity_connect_strngth: '连接强度',
       ExtractedEntity_importance_score: '重要性评分',
 
+      AssistantPruned_memory_type: '记忆类型',
+
       associative_memory: '关联记忆',
       unix: '个',
       completeMemory: '完整记忆',
@@ -1760,6 +1762,10 @@ export const zh = {
       conversation: '对话',
       manual: '手动',
       solution_detail_noChanges: '无变更',
+      resetView: '重置视图',
+      relationshipType: '关系类型',
+      sourceNode: '源节点',
+      targetNode: '目标节点',
     },
     space: {
       createSpace: '创建空间',

--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 18:32:00 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-24 12:19:12
+ * @Last Modified time: 2026-05-29 20:02:38
  */
 /**
  * Relationship Network Component
@@ -13,30 +13,46 @@
 import React, { type FC, useEffect, useState, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Space, Flex, Divider, type SegmentedProps, Image } from 'antd'
+import { Space, Flex, Divider, type SegmentedProps, Image, Button } from 'antd'
 import dayjs from 'dayjs'
 import clsx from 'clsx'
 
 import RbCard from '@/components/RbCard/Card'
-import type { GraphData, StatementNodeProperties, ExtractedEntityNodeProperties } from '../types'
+import type { GraphData, Node as GraphNode, Edge as GraphEdge, PerceptualNodeProperties, StatementNodeProperties, ExtractedEntityNodeProperties, AssistantPrunedNodeProperties } from '../types'
 import type { RawCommunityNode } from '@/components/D3Graph/types'
 import {
   getMemorySearchEdges,
 } from '@/api/memory'
 import Tag from '@/components/Tag'
-import GraphNetworkChart, { type Node, type Edge } from '@/components/Charts/GraphNetworkChart'
+import GraphNetworkChart, { type Node, type Edge, type EdgeClickData, Colors } from '@/components/Charts/GraphNetworkChart'
 import CommunityNetwork from './CommunityNetwork'
 import PageTabs from '@/components/PageTabs'
 import AudioPlayer from './AudioPlayer'
 import VideoPlayer from './VideoPlayer'
 
+export const KEYS: Record<string, string[]> = {
+  image: ['summary', 'keywords', 'topic', 'domain', 'scene'],
+  video: ['summary', 'keywords', 'topic', 'domain', 'scene'],
+  audio: ['summary', 'keywords', 'topic', 'domain', 'speaker_count'],
+  last_text: ['summary', 'keywords', 'topic', 'domain', 'section_count'],
+}
+
+const getFileType = (fileType: string) => {
+  return fileType.includes('image')
+    ? 'image'
+    : fileType.includes('video')
+    ? 'video'
+    : fileType.includes('audio')
+    ? 'audio'
+    : 'last_text'
+}
 const RelationshipNetwork: FC = () => {
   const { t } = useTranslation()
   const { id } = useParams()
   const [nodes, setNodes] = useState<Node[]>([])
   const [links, setLinks] = useState<Edge[]>([])
-  const [categories, setCategories] = useState<{ name: string }[]>([])
-  const [selectedNode, setSelectedNode] = useState<Node | RawCommunityNode | null>(null)
+  const [categories, setCategories] = useState<{ name: string; value: number; }[]>([])
+  const [selectedNode, setSelectedNode] = useState<GraphNode | RawCommunityNode | EdgeClickData | null>(null)
   // const [fullScreen, setFullScreen] = useState<boolean>(false)
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState<SegmentedProps['value']>('relationshipNetwork')
@@ -46,25 +62,28 @@ const RelationshipNetwork: FC = () => {
 
   /** Fetch relationship network data */
   const getEdgeData = useCallback(() => {
+    console.log('getEdgeData')
     if (!id) return
     edgeAbortRef.current?.abort()
     edgeAbortRef.current = new AbortController()
     setSelectedNode(null)
     getMemorySearchEdges(id, { signal: edgeAbortRef.current.signal }).then((res) => {
+      console.log('API Response:', res)
       const { nodes, edges, statistics } = res as GraphData
+      console.log('GraphData - nodes:', nodes, 'edges:', edges, 'statistics:', statistics)
       const curNodes: Node[] = []
       const curEdges: Edge[] = []
-      const curNodeTypes = Object.keys(statistics.node_types).filter(vo => vo !== 'Dialogue')
+      const curNodeTypes = Object.keys(statistics.node_types)
 
       // Calculate connection count for each node
       const connectionCount: Record<string, number> = {}
-      edges.forEach(edge => {
+      edges.forEach((edge: GraphEdge) => {
         connectionCount[edge.source] = (connectionCount[edge.source] || 0) + 1
         connectionCount[edge.target] = (connectionCount[edge.target] || 0) + 1
       })
 
       // Process node data
-      nodes.filter(vo => vo.label !== 'Dialogue').forEach(node => {
+      nodes.forEach(node => {
         const connections = connectionCount[node.id] || 0
         const categoryIndex = curNodeTypes.indexOf(node.label)
 
@@ -75,7 +94,7 @@ const RelationshipNetwork: FC = () => {
           //   displayName = 'statement' in node.properties ? node.properties.statement?.slice(0, 5) || '' : ''
           //   break
           case 'ExtractedEntity':
-            displayName = 'name' in node.properties ? node.properties.name || '' : ''
+            displayName = 'name' in node.properties && typeof node.properties.name === 'string' ? node.properties.name || '' : ''
             break
           // default:
           //   displayName = 'content' in node.properties ? node.properties.content?.slice(0, 5) || '' : ''
@@ -108,17 +127,18 @@ const RelationshipNetwork: FC = () => {
         nodeIdToLabel[node.id] = node.label
       })
       // Process edge data
-      edges.forEach(edge => {
+      edges.forEach((edge: GraphEdge) => {
         curEdges.push({
           ...edge,
           source: edge.source,
           target: edge.target,
-          value: edge.weight || 1
+          value: edge.weight || 1,
+          caption: edge.caption || '',
         })
       })
 
       // Set categories
-      const curCategories = curNodeTypes.map(type => ({ name: type }))
+      const curCategories = Object.keys(statistics.node_types).map(type => ({ name: type, value: (statistics as GraphData['statistics']).node_types[type] || 0 }))
 
       setNodes(curNodes)
       setLinks(curEdges)
@@ -154,8 +174,12 @@ const RelationshipNetwork: FC = () => {
   const [fileSize, setFileSize] = useState<string>('')
   useEffect(() => {
     setFileSize('')
-    if (selectedNode && 'file_path' in selectedNode.properties && selectedNode.properties.file_path) {
-      fetch(selectedNode.properties.file_path, { method: 'HEAD' })
+    if (selectedNode) {
+      setSelectedCategory(null)
+    }
+    const properties: PerceptualNodeProperties = (selectedNode as GraphNode)?.properties as PerceptualNodeProperties || {}
+    if (selectedNode && (selectedNode as Node).type !== 'edge' && 'file_path' in properties && properties.file_path) {
+      fetch(properties.file_path, { method: 'HEAD' })
         .then(r => {
           const bytes = Number(r.headers.get('content-length'))
           if (!bytes) return
@@ -167,10 +191,16 @@ const RelationshipNetwork: FC = () => {
     }
   }, [selectedNode])
   const handleDownload = () => {
-    if (!selectedNode?.properties?.file_path) return
-    window.open(selectedNode?.properties?.file_path, '_blank')
+    if (!((selectedNode as GraphNode)?.properties as PerceptualNodeProperties)?.file_path) return
+    window.open(((selectedNode as GraphNode)?.properties as PerceptualNodeProperties)?.file_path, '_blank')
   }
 
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+  const handleClickCategory = (category: string | null) => {
+    setSelectedCategory(prev => category === prev ? null : category)
+    setSelectedNode(null)
+  }
+  console.log('selectedCategory', selectedCategory, selectedNode)
   return (
     <div className="rb:flex-1 rb:relative">
       <div className="rb:absolute rb:z-111 rb:bottom-10 rb:left-[calc(50%-96px)] rb:transition-transform-[translateX(-50%]">
@@ -186,14 +216,46 @@ const RelationshipNetwork: FC = () => {
       </div>
       {activeTab === 'communityNetwork'
         ? <CommunityNetwork onSelectCommunity={community => setSelectedNode(community)} />
-        : <GraphNetworkChart
-          nodes={nodes}
-          links={links}
-          categories={categories.map(vo => ({
-            name: t(`userMemory.${vo.name}`)
-          })) || []}
-          onNodeClick={(node) => setSelectedNode(node as Node)}
-        />
+        : <div>
+          {categories.length > 0 &&
+            <Flex gap={24} align="center" justify="space-between" wrap={false}
+              className={clsx('rb:absolute! rb:top-4 rb:left-0 rb:bg-[#FFFFFF] rb:rounded-xl rb:py-2! rb:px-3!', {
+                'rb:w-full': !selectedNode,
+                'rb:w-[calc(100%-412px)]': selectedNode,
+              })}
+            >
+              <Flex wrap gap={8}>
+                {categories.map((item, index) => (
+                  <Flex
+                    key={item.name}
+                    gap={4}
+                    align="center"
+                    className={clsx("rb:px-2! rb:py-1! rb:rounded-full rb:text-[12px] rb:leading-4 rb:text-[#000000]", {
+                      'rb:border rb:border-[#171719]': selectedCategory === item.name,
+                      'rb-border': selectedCategory !== item.name
+                    })}
+                    onClick={() => handleClickCategory(item.name)}
+                  >
+                    <div className={clsx(`rb:size-1.25 rb:rounded-full rb:mr-2`, `rb:bg-[${Colors[index]}]`)}></div>
+                    {item.name}
+                    <div className="rb:px-1 rb:rounded-full rb:bg-[#F6F6F6] rb:text-[10px] rb:h-3.5">{item.value}</div>
+                  </Flex>
+                ))}
+              </Flex>
+              <Button onClick={() => setSelectedCategory(null)}>{t('userMemory.resetView')}</Button>
+            </Flex>
+          }
+          <GraphNetworkChart
+            nodes={nodes}
+            links={links}
+            categories={categories.map(vo => ({
+              name: t(`userMemory.${vo.name}`)
+            })) || []}
+            onNodeClick={(node) => setSelectedNode(node as GraphNode)}
+            selectedNodeId={selectedNode?.id}
+            selectedCategory={selectedCategory}
+          />
+        </div>
       }
       {selectedNode &&
         <RbCard
@@ -207,139 +269,224 @@ const RelationshipNetwork: FC = () => {
           })}
           extra={<div className="rb:cursor-pointer rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/userMemory/close.svg')]" onClick={() => setSelectedNode(null)}></div>}
         >
-          <div className={clsx("rb:max-h-[calc(100vh-269px)] rb:overflow-auto", {
-            'rb:max-h-[calc(100vh-269px)]': activeTab !== 'communityNetwork',
-            'rb:max-h-[calc(100vh-205px)]': activeTab == 'communityNetwork',
-          })}>
-            {(selectedNode as RawCommunityNode).properties.community_id
-              ? <div>
-                  <div className="rb:font-medium rb:text-[#212332] rb:text-[16px] rb:leading-5.5 rb:pl-1">
-                    {(selectedNode as RawCommunityNode).properties.name || selectedNode.id}
-                  </div>
-                  {(selectedNode as RawCommunityNode).properties.summary && <>
-                    <div className="rb:mt-3 rb:font-medium rb:leading-5 rb:pl-1">{t('userMemory.summary')}</div>
-                    <div className="rb:bg-[#F6F6F6] rb:rounded-xl rb:px-3 rb:py-2.5 rb:mt-2">
-                      {(selectedNode as RawCommunityNode).properties.summary}
-                    </div>
-                  </>}
-                  <Flex align="center" justify="space-between" className="rb:mt-5!">
-                    <span className="rb:text-[#5B6167] rb:font-regular rb:pl-1">{t('userMemory.member_count')}</span>
-                    <span className="rb:font-medium">{(selectedNode as RawCommunityNode).properties.member_count}{t('userMemory.member_count_desc')}</span>
-                  </Flex>
-
-                  {(selectedNode as RawCommunityNode).properties.core_entities && <>
-                    <Divider className='rb:my-2.5!' />
-                    <div className="rb:font-medium rb:leading-5 rb:pl-1">{t('userMemory.core_entities')}</div>
-                    <ul className="rb:list-disc rb:pl-4 rb:text-[#5B6167] rb:mt-2">
-                      {(selectedNode as RawCommunityNode).properties.core_entities?.map((entity, index) => <li key={index}>{entity}</li>)}
-                    </ul>
-                  </>}
+          {selectedNode && 'type' in selectedNode && (selectedNode as EdgeClickData).type === 'edge'
+            ? (() => {
+              const sourceNode = nodes.find(n => n.id === (selectedNode as EdgeClickData).source)
+              const targetNode = nodes.find(n => n.id === (selectedNode as EdgeClickData).target)
+              return (
+                <Flex vertical gap={12}>
+                {/* <div> */}
+                  {selectedNode.label && <Tag>{selectedNode.label}</Tag>}
+                {/* </div> */}
+                <div className="rb:font-medium rb:text-[#212332] rb:text-[16px] rb:leading-5.5">
+                  {(selectedNode as EdgeClickData).label}
                 </div>
-              : <>
-                {(selectedNode as Node).name &&
-                  <div className="rb:font-medium rb:text-[16px] rb:text-[#212332] rb:leading-5.5 rb:mb-3">
-                    {(selectedNode as Node).name}
-                  </div>
-                }
-                <Flex vertical gap={24}>
-                  <div>
-                    <div className="rb:font-medium rb:leading-5">{t('userMemory.memoryContent')}</div>
-                    <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
-                      {['Chunk', 'Dialogue', 'MemorySummary'].includes(selectedNode.label) && 'content' in selectedNode.properties
-                        ? selectedNode.properties.content
-                        : selectedNode.label === 'ExtractedEntity' && 'description' in selectedNode.properties
-                          ? selectedNode.properties.description
-                          : selectedNode.label === 'Statement' && 'statement' in selectedNode.properties
-                            ? selectedNode.properties.statement
-                            : selectedNode.label === 'Perceptual' && 'summary' in selectedNode.properties
-                              ? selectedNode.properties.summary
-                            : ''
-                      }
-                    </div>
-                  </div>
+                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.relationshipType')}</div>
+                <div className="rb:font-medium">
+                  {(selectedNode as Edge).caption}
+                </div>
 
-                  <div>
-                    <div className="rb:font-medium rb:leading-5">{t('userMemory.created_at')}</div>
-                    <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
-                      {dayjs((selectedNode as Node).properties.created_at).format('YYYY-MM-DD HH:mm:ss')}
-                    </div>
-                  </div>
+                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.sourceNode')}</div>
+                <div className="rb:font-medium">
+                  {sourceNode?.name || (selectedNode as EdgeClickData).source}
+                  {sourceNode?.caption && ` (${sourceNode!.caption})`}
+                </div>
 
-                  {(selectedNode as Node).properties.associative_memory > 0 && <div>
-                    <div className="rb:font-medium rb:leading-5">{t('userMemory.associative_memory')}</div>
-                    <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-1 rb:pb-4 rb:border-b rb:border-[#DFE4ED]">
-                      <span className="rb:text-[#155EEF] rb:font-medium">{(selectedNode as Node).properties.associative_memory}</span> {t('userMemory.unix')}{t('userMemory.associative_memory')}
-                    </div>
-                  </div>}
-
-                  {selectedNode.label === 'Statement' && (<>
-                    {(['emotion_keywords', 'emotion_type', 'emotion_subject', 'importance_score'] as const).map(key => {
-                      const p = selectedNode.properties as StatementNodeProperties
-                      if ((key === 'emotion_keywords' && p[key]?.length > 0) || typeof p[key] === 'string') {
-                        return (
-                          <div key={key}>
-                            <div className="rb:font-medium rb:leading-5">{t(`userMemory.Statement_${key}`)}</div>
-                            <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
-                              {key === 'emotion_keywords'
-                                ? <Space>{p.emotion_keywords.map((v, i) => <Tag key={i}>{v}</Tag>)}</Space>
-                                : p[key]}
-                            </div>
-                          </div>
-                        )
-                      }
-                      return null
-                    })}
-                  </>)}
-
-                  {selectedNode.label === 'ExtractedEntity' && <>
-                    {(['name', 'entity_type', 'aliases', 'connect_strngth', 'importance_score'] as const).map(key => {
-                      const p = selectedNode.properties as ExtractedEntityNodeProperties
-                      if (p[key]) {
-                        return (
-                          <div key={key}>
-                            <div className="rb:font-medium rb:leading-5">{t(`userMemory.ExtractedEntity_${key}`)}</div>
-                            <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
-                              {Array.isArray(p[key]) && p[key].length > 0
-                                ? p[key].map((v, i) => <div key={i}>- {v}</div>)
-                                : p[key]}
-                            </div>
-                          </div>
-                        )
-                      }
-                      return null
-                    })}
-                  </>}
-                  {selectedNode.label === 'Perceptual' && <>
-                    {selectedNode.properties.file_type.includes('image')
-                      ? <Image src={selectedNode.properties.file_path} alt={selectedNode.properties.file_name} className="rb:rounded-xl rb:h-45! rb:w-full" />
-                      : selectedNode.properties.file_type.includes('video')
-                      ? <VideoPlayer src={selectedNode.properties.file_path} />
-                      : selectedNode.properties.file_type.includes('audio')
-                      ? <AudioPlayer src={selectedNode.properties.file_path} fileName={selectedNode.properties.file_name} fileSize={fileSize} />
-                      : <Flex gap={11} align="center" justify="space-between" className="rb:bg-[#F6F6F6] rb:min-h-15.5! rb:rounded-xl rb:p-3!">
-                        <Flex gap={12} align="center">
-                          <div className="rb:w-7.5 rb:h-9 rb:bg-cover rb:bg-[url('@/assets/images/userMemory/file.svg')]"></div>
-                          <div>
-                            <div className="rb:leading-5 rb:font-medium rb:mb-1">{selectedNode.properties.file_name}</div>
-                            <div className="rb:text-[#5B6167] rb:text-[12px] rb:leading-4.5">
-                              {fileSize || '-'}
-                            </div>
-                          </div>
-                        </Flex>
-                        <div
-                          className="rb:size-6 rb:bg-cover rb:cursor-pointer rb:bg-[url('@/assets/images/userMemory/download.svg')] rb:hover:bg-[url('@/assets/images/userMemory/download_hover.svg')]"
-                          onClick={handleDownload}
-                        ></div>
+                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.targetNode')}</div>
+                <div className="rb:font-medium">
+                  {targetNode?.name || (selectedNode as EdgeClickData).target}
+                  {targetNode?.caption && ` (${targetNode!.caption})`}
+                </div>
+              </Flex>
+              )
+            })()
+            : <>
+              <div className={clsx("rb:max-h-[calc(100vh-269px)] rb:overflow-auto", {
+                'rb:max-h-[calc(100vh-269px)]': activeTab !== 'communityNetwork',
+                'rb:max-h-[calc(100vh-205px)]': activeTab == 'communityNetwork',
+              })}>
+                {(selectedNode as RawCommunityNode).properties.community_id
+                  ? <div>
+                      <div className="rb:font-medium rb:text-[#212332] rb:text-[16px] rb:leading-5.5 rb:pl-1">
+                        {(selectedNode as RawCommunityNode).properties.name || selectedNode.id}
+                      </div>
+                      {(selectedNode as RawCommunityNode).properties.summary && <>
+                        <div className="rb:mt-3 rb:font-medium rb:leading-5 rb:pl-1">{t('userMemory.summary')}</div>
+                        <div className="rb:bg-[#F6F6F6] rb:rounded-xl rb:px-3 rb:py-2.5 rb:mt-2">
+                          {(selectedNode as RawCommunityNode).properties.summary}
+                        </div>
+                      </>}
+                      <Flex align="center" justify="space-between" className="rb:mt-5!">
+                        <span className="rb:text-[#5B6167] rb:font-regular rb:pl-1">{t('userMemory.member_count')}</span>
+                        <span className="rb:font-medium">{(selectedNode as RawCommunityNode).properties.member_count}{t('userMemory.member_count_desc')}</span>
                       </Flex>
-                    }
-                  </>}
-                </Flex>
-              </>}
-          </div>
 
-          {activeTab !== 'communityNetwork' && <Flex align="center" justify="center" className="rb:absolute rb:bottom-3 rb:left-6 rb:right-6 rb:border rb:border-[#171719] rb:rounded-xl rb:h-11 rb:font-medium rb:leading-5 rb:cursor-pointer" onClick={handleViewAll}>
-            {t('userMemory.completeMemory')}
-          </Flex>}
+                      {(selectedNode as RawCommunityNode).properties.core_entities && <>
+                        <Divider className='rb:my-2.5!' />
+                        <div className="rb:font-medium rb:leading-5 rb:pl-1">{t('userMemory.core_entities')}</div>
+                        <ul className="rb:list-disc rb:pl-4 rb:text-[#5B6167] rb:mt-2">
+                          {(selectedNode as RawCommunityNode).properties.core_entities?.map((entity, index) => <li key={index}>{entity}</li>)}
+                        </ul>
+                      </>}
+                    </div>
+                  : <>
+                    {(selectedNode as Node).name &&
+                      <div className="rb:font-medium rb:text-[16px] rb:text-[#212332] rb:leading-5.5 rb:mb-3">
+                        {(selectedNode as Node).name}
+                      </div>
+                    }
+                    <Flex vertical gap={24}>
+                      <div>
+                        <div className="rb:font-medium rb:leading-5">{t('userMemory.memoryContent')}</div>
+                        <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
+                          {['Chunk', 'Dialogue', 'MemorySummary', 'AssistantOriginal'].includes(selectedNode.label) && 'content' in ((selectedNode as GraphNode).properties as { content: string })
+                            ? ((selectedNode as GraphNode).properties as { content: string }).content
+                            : selectedNode.label === 'ExtractedEntity' && 'description' in ((selectedNode as GraphNode).properties as { description: string })
+                              ? ((selectedNode as GraphNode).properties as { description: string }).description
+                              : selectedNode.label === 'Statement' && 'statement' in ((selectedNode as GraphNode).properties as { statement: string })
+                                ? ((selectedNode as GraphNode).properties as { statement: string }).statement
+                                : selectedNode.label === 'Perceptual' && 'summary' in ((selectedNode as GraphNode).properties as { summary: string })
+                                  ? ((selectedNode as GraphNode).properties as { summary: string }).summary
+                                  : ['AssistantOriginal', 'AssistantPruned'].includes(selectedNode.label ) && 'text' in ((selectedNode as GraphNode).properties as { text: string })
+                                    ? ((selectedNode as GraphNode).properties as { text: string }).text
+                                    : ''
+                          }
+                        </div>
+                      </div>
+                      <div>
+                        <div className="rb:font-medium rb:leading-5">{t('userMemory.created_at')}</div>
+                        <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
+                          {dayjs((selectedNode as Node).properties.created_at).format('YYYY-MM-DD HH:mm:ss')}
+                        </div>
+                      </div>
+
+                      {(selectedNode as Node).properties.associative_memory > 0 && <div>
+                        <div className="rb:font-medium rb:leading-5">{t('userMemory.associative_memory')}</div>
+                        <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-1 rb:pb-4 rb:border-b rb:border-[#DFE4ED]">
+                          <span className="rb:text-[#155EEF] rb:font-medium">{(selectedNode as Node).properties.associative_memory}</span> {t('userMemory.unix')}{t('userMemory.associative_memory')}
+                        </div>
+                      </div>}
+
+
+                      {selectedNode.label === 'ExtractedEntity' && <>
+                        {(['entity_type', 'aliases'] as const).map(key => {
+                          const p = (selectedNode as Node).properties as ExtractedEntityNodeProperties
+                          if (p[key]) {
+                            return (
+                              <div key={key}>
+                                <div className="rb:font-medium rb:leading-5">{t(`userMemory.ExtractedEntity_${key}`)}</div>
+                                <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
+                                  {Array.isArray(p[key]) && p[key].length > 0
+                                    ? p[key].map((v, i) => <div key={i}>- {v}</div>)
+                                    : p[key]
+                                  }
+                                </div>
+                              </div>
+                            )
+                          }
+                          return null
+                        })}
+                      </>}
+                      {selectedNode.label === 'Perceptual' && <>
+                        <Flex vertical gap={16} className="rb:w-full!">
+                          {((selectedNode as GraphNode).properties as { file_path: string }).file_path
+                            ? <>
+                              {((selectedNode as GraphNode).properties as { file_type: string }).file_type.includes('image')
+                                ? <Image src={((selectedNode as GraphNode).properties as { file_path: string }).file_path} alt={((selectedNode as GraphNode).properties as { file_name: string }).file_name} width="100%" className="rb:rounded-xl rb:h-45!" />
+                                : ((selectedNode as GraphNode).properties as { file_type: string }).file_type.includes('video')
+                                ? <VideoPlayer src={((selectedNode as GraphNode).properties as { file_path: string }).file_path} />
+                                : ((selectedNode as GraphNode).properties as { file_type: string }).file_type.includes('audio')
+                                ? <AudioPlayer
+                                  src={((selectedNode as GraphNode).properties as { file_path: string }).file_path}
+                                  fileName={((selectedNode as GraphNode).properties as { file_name: string }).file_name}
+                                  fileSize={fileSize}
+                                />
+                                : <Flex gap={11} align="center" justify="space-between" className="rb:bg-[#F6F6F6] rb:min-h-15.5! rb:rounded-xl rb:p-3!">
+                                  <Flex gap={12} align="center">
+                                    <div className="rb:w-7.5 rb:h-9 rb:bg-cover rb:bg-[url('@/assets/images/userMemory/file.svg')]"></div>
+                                    <div>
+                                      <div className="rb:leading-5 rb:font-medium rb:mb-1 rb:wrap-break-word rb:line-clamp-1">
+                                        {((selectedNode as GraphNode).properties as { file_name: string }).file_name}
+                                      </div>
+                                      <div className="rb:text-[#5B6167] rb:text-[12px] rb:leading-4.5">
+                                        {fileSize || '-'}
+                                      </div>
+                                    </div>
+                                  </Flex>
+                                  <div
+                                    className="rb:size-6 rb:bg-cover rb:cursor-pointer rb:bg-[url('@/assets/images/userMemory/download.svg')] rb:hover:bg-[url('@/assets/images/userMemory/download_hover.svg')]"
+                                    onClick={handleDownload}
+                                  ></div>
+                                </Flex>
+                              }
+                            </>
+                            : null
+                          }
+                          {KEYS[getFileType(((selectedNode as GraphNode).properties as PerceptualNodeProperties).file_type)]?.map(key => {
+                            const value = ((selectedNode as GraphNode).properties as any)[key]
+                            return (
+                              <div key={key} className="rb:leading-5">
+                                <div className="rb:mb-1">{t(`perceptualDetail.${key}`)}</div>
+
+                                {typeof value === 'string'
+                                  ? <div className="rb:text-[#5B6167]">{value}</div>
+                                  : Array.isArray(value)
+                                  ? <Flex wrap gap={11}>
+                                      {value.map((vo, index) => <div key={index} className="rb:bg-[#F6F6F6] rb:rounded-[13px] rb:py-1 rb:px-2 rb:text-[12px] rb:font-medium rb:leading-4.5">{vo}</div>)}
+                                    </Flex>
+                                  : '-'
+                                }
+                              </div>
+                            )
+                          })}
+                        </Flex>
+                      </>}
+                      {selectedNode.label === 'Statement' && (<>
+                        {(['emotion_keywords'] as const).map(key => {
+                          const p = (selectedNode as GraphNode).properties as StatementNodeProperties
+                          if ((key === 'emotion_keywords' && p[key]?.length > 0) || typeof p[key] === 'string') {
+                            return (
+                              <div key={key}>
+                                <div className="rb:font-medium rb:leading-5">{t(`userMemory.Statement_${key}`)}</div>
+                                <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
+                                  {key === 'emotion_keywords'
+                                    ? <Space>{p.emotion_keywords.map((v, i) => <Tag key={i}>{v}</Tag>)}</Space>
+                                    : p[key]}
+                                </div>
+                              </div>
+                            )
+                          }
+                          return null
+                        })}
+                      </>)}
+
+                      {selectedNode.label === 'AssistantPruned' && <>
+                        {(['memory_type'] as const).map(key => {
+                          const p = (selectedNode as Node).properties as AssistantPrunedNodeProperties
+                          if (p[key]) {
+                            return (
+                              <div key={key}>
+                                <div className="rb:font-medium rb:leading-5">{t(`userMemory.AssistantPruned_${key}`)}</div>
+                                <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2">
+                                  {Array.isArray(p[key]) && p[key].length > 0
+                                    ? p[key].map((v, i) => <div key={i}>- {v}</div>)
+                                    : p[key]}
+                                </div>
+                              </div>
+                            )
+                          }
+                          return null
+                        })}
+                      </>}
+                    </Flex>
+                  </>}
+              </div>
+
+              {activeTab !== 'communityNetwork' && <Flex align="center" justify="center" className="rb:absolute rb:bottom-3 rb:left-6 rb:right-6 rb:border rb:border-[#171719] rb:rounded-xl rb:h-11 rb:font-medium rb:leading-5 rb:cursor-pointer" onClick={handleViewAll}>
+                {t('userMemory.completeMemory')}
+              </Flex>}
+            </>
+          }
         </RbCard>
       }
     </div>

--- a/web/src/views/UserMemoryDetail/types.ts
+++ b/web/src/views/UserMemoryDetail/types.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:57:15 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-19 17:52:22
+ * @Last Modified time: 2026-05-29 13:31:21
  */
 /**
  * User Memory Detail Types
@@ -61,6 +61,13 @@ export interface BaseProperties {
   created_at: number;
   associative_memory: number;
 }
+export interface AssistantOriginalNodeProperties extends BaseProperties {
+  text: string;
+}
+export interface AssistantPrunedNodeProperties extends BaseProperties {
+  text: string;
+  memory_type: string;
+}
 /**
  * Statement node properties
  */
@@ -71,9 +78,9 @@ export interface StatementNodeProperties {
   valid_at: string;
   created_at: number;
   emotion_keywords: string[];
-  emotion_type: string;
-  emotion_subject: string;
-  importance_score: number;
+  // emotion_type: string;
+  // emotion_subject: string;
+  // importance_score: number;
   associative_memory: number;
 }
 /**
@@ -84,11 +91,19 @@ export interface ExtractedEntityNodeProperties {
   name: string;
   entity_type: string;
   created_at: number;
-  aliases: string;
-  connect_strngth: string;
-  importance_score: number;
+  aliases: string[];
+  connect_strength: string;
   associative_memory: number;
-  community_name?: string;
+}
+export interface PerceptualNodeProperties {
+  file_name: string;
+  file_path: string;
+  file_type: string;
+  domain: string;
+  topic: string;
+  keywords: string[];
+  summary: string;
+  associative_memory: number;
 }
 /**
  * Memory summary node
@@ -109,21 +124,34 @@ export interface MemorySummaryNode {
   caption: string;
   associative_memory: number;
 }
-
 /**
  * Graph node
  */
 export interface Node {
   id: string;
-  label: 'Dialogue' | 'ExtractedEntity' | 'Chunk' | 'MemorySummary' | 'Statement';
+  label:  'AssistantOriginal' | 'AssistantPruned' | 'Chunk' | 'Dialogue' | 'ExtractedEntity' | 'Perceptual' | 'Statement';
   category: number;
   symbolSize: number;
   name: string;
   itemStyle: {
     color: string;
   }
-  properties: BaseProperties | StatementNodeProperties | ExtractedEntityNodeProperties
+  properties: BaseProperties | AssistantOriginalNodeProperties | StatementNodeProperties | ExtractedEntityNodeProperties | PerceptualNodeProperties
   caption: string;
+  type?: 'edge';
+}
+export interface ExtractedEdge {
+  statement: string;
+  run_id: string;
+  predicate: string;
+  end_user_id: string;
+  invalid_at: string;
+  valid_at: string;
+  predicate_description: string;
+  created_at: string | number;
+  predicate_id: number;
+  predicate_surface: string;
+  statement_id: string;
 }
 /**
  * Graph edge
@@ -132,16 +160,16 @@ export interface Edge {
   id: string;
   source: string;
   target: string;
-  type: string;
+  type: 'REFERENCES_ENTITY' | 'EXTRACTED_RELATIONSHIP';
   properties: {
     run_id: string;
-    group_id: string;
-    created_at: string;
-    expired_at: string;
-  }
+    end_user_id: string;
+    pair_id: string;
+    created_at: number | string;
+  } | ExtractedEdge
   caption: string;
-  value: number;
   weight: number;
+  value: number;
 }
 /**
  * Graph data structure


### PR DESCRIPTION
## Summary by Sourcery

将关系网络的 ECharts 图表替换为自定义的、基于 D3 的力导向网络可视化，并扩展内存详情以支持新的节点和边类型。

New Features:
- 引入基于 D3.js 的力导向 GraphNetworkChart，支持缩放、平移、拖拽以及丰富的节点/边高亮交互。
- 在关系网络中添加边选中功能，在侧边面板中展示关系元数据以及关联节点的详细信息。
- 支持更多内存节点类型（AssistantOriginal、AssistantPruned、Perceptual），并为其提供定制化的详情视图，包括媒体播放和元数据面板。
- 使用行内图例 UI，为关系网络节点添加基于类别的过滤和重置控制。

Enhancements:
- 优化节点和边的 schema，使其携带更丰富的属性，包括感知元数据和提取的关系详情。
- 通过基于 ResizeObserver 的 SVG 尺寸调整和缩放级别启发式算法，提升关系网络布局的响应性。
- 为新的关系网络标签提供本地化支持，比如内存类型、重置视图、关系类型以及源/目标节点字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the relationship network ECharts graph with a custom D3-based force-directed network visualization and extend memory detail support for new node and edge types.

New Features:
- Introduce a D3.js force-directed GraphNetworkChart with zoom, pan, drag, and rich node/edge highlighting interactions.
- Add edge selection support in the relationship network, showing relationship metadata and connected node details in a side panel.
- Support additional memory node types (AssistantOriginal, AssistantPruned, Perceptual) with tailored detail views including media playback and metadata panels.
- Add category-based filtering and reset controls for relationship network nodes using an inline legend UI.

Enhancements:
- Refine node and edge schemas to carry richer properties, including perceptual metadata and extracted relationship details.
- Improve layout responsiveness of the relationship network via ResizeObserver-driven SVG resizing and zoom-level heuristics.
- Localize new relationship network labels such as memory type, reset view, relationship type, and source/target node strings.

</details>