### PR TITLE
feat(memory): add Conversation hub node to cluster assistant nodes in graph

### DIFF
--- a/api/app/core/memory/constants/graph_data_constants.py
+++ b/api/app/core/memory/constants/graph_data_constants.py
@@ -17,6 +17,7 @@ SUPPORTED_NODE_TYPES: FrozenSet[str] = frozenset({
     "Chunk",
     "AssistantOriginal",
     "AssistantPruned",
+    "Conversation",
     "Statement",
     "ExtractedEntity",
     "MemorySummary",
@@ -29,6 +30,7 @@ DEFAULT_PER_TYPE_LIMIT_MAP: Dict[str, int] = {
     "Chunk": 30,
     "AssistantOriginal": 20,
     "AssistantPruned": 20,
+    "Conversation": 20,
     "Statement": 50,
     "ExtractedEntity": 50,
     "MemorySummary": 20,
@@ -89,6 +91,10 @@ NODE_PROPERTY_WHITELIST: Dict[str, List[str]] = {
     # ``text``。前端按 ``properties.text`` 取节点正文内容。
     "AssistantOriginal": ["text", "created_at"],
     "AssistantPruned": ["text", "memory_type", "created_at"],
+    # 会话级中心节点（参见 ``graph_models.py`` 的 ``ConversationNode``）。
+    # 用于把同一会话的 AssistantOriginal / AssistantPruned 聚成一个连通子图。
+    # 前端按 ``properties.conversation_id`` 识别会话，``caption`` 回落到 label。
+    "Conversation": ["conversation_id", "name", "created_at"],
     # 注意：Community 由 /analytics/community_graph 接口独立处理，
     # 不出现在 SUPPORTED_NODE_TYPES 中。但保留白名单以支持其它流程
     # （如 Center_Mode 中心节点扩展碰巧命中 Community 邻居）的属性裁剪。

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -632,3 +632,22 @@ class AssistantPrunedEdge(Edge):
 class AssistantDialogEdge(Edge):
     """Edge connecting an AssistantOriginal node to its parent Dialogue node (BELONGS_TO_DIALOG)."""
     pass
+
+
+class ConversationNode(Node):
+    """Hub node representing a conversation session.
+
+    Used to cluster all AssistantOriginal / AssistantPruned nodes that belong to
+    the same conversation into a single connected component in the graph.
+    The node id equals the conversation_id, so it is stable and reused
+    (via MERGE) across multiple sliding-window write tasks.
+
+    Attributes:
+        conversation_id: The conversation/session ID (equals node id)
+    """
+    conversation_id: str = Field(..., description="The conversation/session ID (equals node id)")
+
+
+class AssistantConversationEdge(Edge):
+    """Edge connecting an AssistantOriginal node to its Conversation hub node (BELONGS_TO_CONVERSATION)."""
+    pass

--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -265,15 +265,18 @@ class PruningPipeline:
         original_content: str,
         pruned_content: str,
     ) -> None:
-        """将剪枝结果写入 Neo4j（AssistantOriginal + AssistantPruned 节点）。
+        """将剪枝结果写入 Neo4j（AssistantOriginal + AssistantPruned + Conversation 中心节点）。
 
         创建：
+        - Conversation 中心节点：id == conversation_id，MERGE 幂等，跨写入复用
         - AssistantOriginal 节点：存储原始 assistant 消息
         - AssistantPruned 节点：存储剪枝后内容（A'）
         - PRUNED_TO 边：连接 Original → Pruned
+        - BELONGS_TO_CONVERSATION 边：连接 Original → Conversation 中心节点，
+          使同一会话的 assistant 剪枝节点聚成一个连通子图
 
         Args:
-            conversation_id: 对话 ID（用作 dialog_id）
+            conversation_id: 对话 ID（用作 dialog_id 和 Conversation 中心节点 id）
             message_seq: 消息序号（用于节点命名）
             original_content: assistant 消息原始内容
             pruned_content: 剪枝后内容（A'）
@@ -282,12 +285,16 @@ class PruningPipeline:
             AssistantOriginalNode,
             AssistantPrunedNode,
             AssistantPrunedEdge,
+            ConversationNode,
+            AssistantConversationEdge,
         )
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
         from app.repositories.neo4j.cypher_queries import (
             ASSISTANT_ORIGINAL_NODE_SAVE,
             ASSISTANT_PRUNED_NODE_SAVE,
             ASSISTANT_PRUNED_EDGE_SAVE,
+            CONVERSATION_NODE_SAVE,
+            ASSISTANT_CONVERSATION_EDGE_SAVE,
         )
 
         now = datetime.now(timezone.utc)
@@ -330,10 +337,42 @@ class PruningPipeline:
             pair_id=pair_id,
         )
 
+        # Conversation 中心节点：id == conversation_id，跨写入任务用 MERGE 复用。
+        # 所有 AssistantOriginal 通过 BELONGS_TO_CONVERSATION 挂到该节点，
+        # 使同一会话的 assistant 剪枝节点在图谱中聚成一个连通子图。
+        conversation_node = ConversationNode(
+            id=conversation_id,
+            name=f"Conversation_{conversation_id}",
+            end_user_id=self.end_user_id,
+            run_id=run_id,
+            created_at=now,
+            conversation_id=conversation_id,
+        )
+
+        conversation_edge = AssistantConversationEdge(
+            source=original_id,
+            target=conversation_id,
+            end_user_id=self.end_user_id,
+            run_id=run_id,
+            created_at=now,
+        )
+
         # 确保 Neo4j 连接器已初始化
         self._ensure_neo4j_connector()
 
         async def _write_in_transaction(tx):
+            # 写入 Conversation 中心节点（MERGE 幂等）
+            conversation_data = [{
+                "id": conversation_node.id,
+                "name": conversation_node.name,
+                "end_user_id": conversation_node.end_user_id,
+                "conversation_id": conversation_node.conversation_id,
+                "run_id": conversation_node.run_id,
+                "created_at": conversation_node.created_at.isoformat(),
+            }]
+            result = await tx.run(CONVERSATION_NODE_SAVE, conversations=conversation_data)
+            await result.consume()
+
             # 写入 AssistantOriginal 节点
             original_data = [original_node.model_dump()]
             result = await tx.run(ASSISTANT_ORIGINAL_NODE_SAVE, originals=original_data)
@@ -354,6 +393,18 @@ class PruningPipeline:
                 "created_at": pruned_edge.created_at.isoformat(),
             }]
             result = await tx.run(ASSISTANT_PRUNED_EDGE_SAVE, edges=edge_data)
+            await result.consume()
+
+            # 写入 BELONGS_TO_CONVERSATION 边（Original → Conversation 中心节点）
+            conv_edge_data = [{
+                "id": conversation_edge.id,
+                "source": conversation_edge.source,
+                "target": conversation_edge.target,
+                "end_user_id": conversation_edge.end_user_id,
+                "run_id": conversation_edge.run_id,
+                "created_at": conversation_edge.created_at.isoformat(),
+            }]
+            result = await tx.run(ASSISTANT_CONVERSATION_EDGE_SAVE, edges=conv_edge_data)
             await result.consume()
 
         await self._neo4j_connector.execute_write_transaction(_write_in_transaction)

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -177,6 +177,7 @@ async def create_end_user_id_indexes():
             ("Perceptual",        "user_perceptual"),
             ("AssistantOriginal", "user_assistant_original"),
             ("AssistantPruned",   "user_assistant_pruned"),
+            ("Conversation",      "user_conversation"),
         ]:
             await connector.execute_query(
                 f"""
@@ -241,6 +242,14 @@ async def create_unique_constraints():
             """
             CREATE CONSTRAINT assistant_pruned_id_unique IF NOT EXISTS
             FOR (p:AssistantPruned) REQUIRE p.id IS UNIQUE
+            """
+        )
+
+        # Conversation.id unique（会话级中心节点，MERGE 幂等的关键约束）
+        await connector.execute_query(
+            """
+            CREATE CONSTRAINT conversation_id_unique IF NOT EXISTS
+            FOR (c:Conversation) REQUIRE c.id IS UNIQUE
             """
         )
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2225,6 +2225,32 @@ ON CREATE SET r.id = edge.id,
     r.created_at = edge.created_at
 RETURN elementId(r) AS uuid
 """
+
+# Conversation hub node：会话级中心节点，用 MERGE 保证跨写入任务幂等复用。
+# 所有 AssistantOriginal 通过 BELONGS_TO_CONVERSATION 挂到该节点上，
+# 从而把同一会话的 assistant 剪枝节点聚成一个连通子图。
+CONVERSATION_NODE_SAVE = """
+UNWIND $conversations AS c
+MERGE (n:Conversation {id: c.id})
+ON CREATE SET n.name = c.name,
+    n.end_user_id = c.end_user_id,
+    n.conversation_id = c.conversation_id,
+    n.run_id = c.run_id,
+    n.created_at = c.created_at
+RETURN n.id AS uuid
+"""
+
+ASSISTANT_CONVERSATION_EDGE_SAVE = """
+UNWIND $edges AS edge
+MATCH (orig:AssistantOriginal {id: edge.source, end_user_id: edge.end_user_id})
+MATCH (conv:Conversation {id: edge.target})
+MERGE (orig)-[r:BELONGS_TO_CONVERSATION]->(conv)
+ON CREATE SET r.id = edge.id,
+    r.end_user_id = edge.end_user_id,
+    r.run_id = edge.run_id,
+    r.created_at = edge.created_at
+RETURN elementId(r) AS uuid
+"""
 # --- Reflection Engine Layer 2: Description Merge ---
 
 # Find entities whose description has accumulated >= min_fragments


### PR DESCRIPTION
Introduce a session-level Conversation hub node so that AssistantOriginal and AssistantPruned nodes from the same conversation form a single connected subgraph. The hub node id equals conversation_id and is reused idempotently via MERGE across sliding-window write tasks.

- Add Conversation to supported node types, per-type limits, and property whitelist
- Add ConversationNode and AssistantConversationEdge graph models
- Write Conversation node and BELONGS_TO_CONVERSATION edge in pruning pipeline
- Add CONVERSATION_NODE_SAVE and ASSISTANT_CONVERSATION_EDGE_SAVE cypher queries
- Add Conversation end_user_id index and id unique constraint

## 由 Sourcery 提供的摘要

在会话层级引入一个会话级 hub 节点，用于将同一会话中的助手裁剪节点分组为 Neo4j 中的一个连通子图。

新功能：
- 新增 Conversation hub 节点和 AssistantConversationEdge 图模型，用于表示会话级别的助手消息簇。
- 在裁剪流水线中使用新的 Cypher 查询持久化 Conversation 节点和 BELONGS_TO_CONVERSATION 边。

增强改进：
- 扩展支持的节点类型、按类型限制以及属性白名单，以包含 Conversation 节点。
- 在 Neo4j 中为 Conversation.id 添加索引和唯一约束，以支持滑动窗口写入中的幂等 MERGE 操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a conversation-level hub node to group assistant pruning nodes from the same session into a single connected subgraph in Neo4j.

New Features:
- Add Conversation hub node and AssistantConversationEdge graph models to represent session-level clusters of assistant messages.
- Persist Conversation nodes and BELONGS_TO_CONVERSATION edges in the pruning pipeline using new Cypher queries.

Enhancements:
- Extend supported node types, per-type limits, and property whitelists to include Conversation nodes.
- Add Neo4j indexes and a unique constraint on Conversation.id to support idempotent MERGE operations in sliding-window writes.

</details>