### PR TITLE
Fix/v0.3.6 zy

### DIFF
--- a/web/src/views/ApplicationConfig/ReleasePage.tsx
+++ b/web/src/views/ApplicationConfig/ReleasePage.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:41 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-28 15:10:39
+ * @Last Modified time: 2026-06-01 12:14:43
  */
 import { type FC, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -149,7 +149,7 @@ const ReleasePage: FC<{data: Application; refresh: () => void}> = ({data, refres
               {selectedVersion && <>
                 {data?.type !== 'multi_agent' && <RbButton onClick={handleExport}>{t('common.export')}</RbButton>}
                 {data.current_release_id !== selectedVersion.id && <RbButton onClick={handleRollback}>{t('application.willRollToThisVersion')}</RbButton>}
-                {data?.type === 'workflow' && <>
+                {data?.type !== 'pure_workflow' && <>
                   <RbButton type="primary" ghost onClick={() => releaseShareModalRef.current?.handleOpen()}>{t('application.share')}</RbButton>
                   <RbButton type="primary" ghost onClick={() => embedWebsiteModalRef.current?.handleOpen()}>{t('application.embedWebsite')}</RbButton>
                 </>}

--- a/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ModelConfigModal.tsx
@@ -42,7 +42,7 @@ interface ModelConfigModalProps {
  */
 const configFields = [
   { key: 'temperature', max: 2, min: 0, step: 0.1, defaultValue: 0.7 },
-  { key: 'max_tokens', max: 32000, min: 256, step: 1, defaultValue: 2000 },
+  { key: 'max_tokens', max: 32000, min: 256, step: 1, defaultValue: 8000 },
   { key: 'top_p', max: 1, min: 0, step: 0.1, defaultValue: 1.0 },
   { key: 'frequency_penalty', max: 2.0, min: -2.0, step: 0.1, defaultValue: 0.0 },
   { key: 'presence_penalty', max: 2.0, min: -2.0, step: 0.1, defaultValue: 0.0 },

--- a/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
@@ -47,7 +47,7 @@ export const fieldConfigs: Record<string, any> = {
     max: 32000, 
     min: 256, 
     step: 1, 
-    defaultValue: 2000 
+    defaultValue: 8000 
   },
   json_output: {
     type: 'switch',

--- a/web/src/views/Workflow/constant.ts
+++ b/web/src/views/Workflow/constant.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:06:18 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-29 19:46:16
+ * @Last Modified time: 2026-06-01 12:17:51
  */
 import type { ReactShapeConfig } from '@antv/x6-react-shape';
 import type { GroupMetadata, PortMetadata } from '@antv/x6/lib/model/port';
@@ -128,7 +128,7 @@ export const nodeLibrary: NodeLibrary[] = [
           },
           max_tokens: { 
             type: 'define',
-            defaultValue: 2000 
+            defaultValue: 8000 
           },
           json_output: {
             type: 'define',


### PR DESCRIPTION
## Summary by Sourcery

调整发布页面操作，并提高模型配置中的默认最大 token 限制。

增强内容：
- 对除纯工作流外的所有应用类型显示分享和嵌入网站的操作。
- 将应用和工作流的模型配置设置中的默认 `max_tokens` 值从 2000 提升到 8000。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust release page actions and increase default max token limits for model configuration.

Enhancements:
- Show share and embed website actions for all application types except pure workflow.
- Increase the default max_tokens value from 2000 to 8000 across application and workflow model configuration settings.

</details>