### PR TITLE
fix(rag): fix document parsing hang, page limit rejection and task cancellation

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -37,7 +37,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
 )
 from app.db import get_db_context
-from app.models import App, AppRelease, Document, File, Knowledge
+from app.models import Document, File, Knowledge
 from app.models.end_user_model import EndUser
 from app.schemas import document_schema, file_schema
 from app.services.memory_agent_service import MemoryAgentService, get_end_user_connected_config
@@ -637,6 +637,14 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # Vectorization and data entry completed
         progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Indexing done.")
+
+        # Early-exit check after data write: if doc deleted, remove written data
+        if _should_abort(document_id):
+            logger.info(f"[ParseDoc] document={document_id} deleted after data write -- rolling back vectors")
+            vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
+            _clear_redis_state(document_id)
+            return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
+
         db_document.chunk_num = total_chunks
         db_document.progress = 1.0
         db_document.process_duration = time.time() - start_time
@@ -2220,7 +2228,6 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
                 skipped_configs = 0
                 total_dedup_merged = 0
                 total_desc_merged = 0
-                redis_client = get_sync_redis_client()
 
                 for workspace in workspaces:
                     service = WorkspaceAppService(db)
@@ -2241,53 +2248,33 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
 
                             for user in end_users:
                                 try:
-                                    # 获取 Redis 锁，和写入 pipeline 互斥
-                                    write_lock = None
-                                    if redis_client is not None:
-                                        write_lock = RedisFairLock(
-                                            key=f"memory_write:{user['id']}",
-                                            redis_client=redis_client,
-                                            expire=600,
-                                            timeout=30,
-                                            auto_renewal=True,
+                                    memory_service = MemoryService(
+                                        db=db,
+                                        config_id=config_id,
+                                        end_user_id=str(user['id']),
+                                        workspace_id=str(workspace.id),
+                                    )
+                                    r = await memory_service.run_reflection_layer2(
+                                        baseline=baseline,
+                                    )
+                                    processed_users += 1
+                                    # 增量统计
+                                    dedup_info = r.get("entity_dedup", {})
+                                    merge_info = r.get("description_merge", {})
+                                    total_dedup_merged += dedup_info.get("merged_count", 0)
+                                    total_desc_merged += merge_info.get("merged_count", 0)
+                                    # 只在有实际合并时输出详细日志
+                                    if merge_info.get("merged_count", 0) > 0:
+                                        logger.info(
+                                            f"反思引擎Layer2 用户 {user['id']} 描述合并: "
+                                            f"候选 {merge_info['candidate_count']}, "
+                                            f"合并 {merge_info['merged_count']}"
                                         )
-                                        if not await asyncio.to_thread(write_lock.acquire):
-                                            logger.warning(
-                                                f"反思引擎Layer2 获取锁超时，跳过用户 {user['id']}"
-                                            )
-                                            continue
-
-                                    try:
-                                        memory_service = MemoryService(
-                                            db=db,
-                                            config_id=config_id,
-                                            end_user_id=str(user['id']),
-                                            workspace_id=str(workspace.id),
+                                    if dedup_info.get("merged_count", 0) > 0:
+                                        logger.info(
+                                            f"反思引擎Layer2 用户 {user['id']} 去重合并: "
+                                            f"合并 {dedup_info['merged_count']}"
                                         )
-                                        r = await memory_service.run_reflection_layer2(
-                                            baseline=baseline,
-                                        )
-                                        processed_users += 1
-                                        # 增量统计
-                                        dedup_info = r.get("entity_dedup", {})
-                                        merge_info = r.get("description_merge", {})
-                                        total_dedup_merged += dedup_info.get("merged_count", 0)
-                                        total_desc_merged += merge_info.get("merged_count", 0)
-                                        # 只在有实际合并时输出详细日志
-                                        if merge_info.get("merged_count", 0) > 0:
-                                            logger.info(
-                                                f"反思引擎Layer2 用户 {user['id']} 描述合并: "
-                                                f"候选 {merge_info['candidate_count']}, "
-                                                f"合并 {merge_info['merged_count']}"
-                                            )
-                                        if dedup_info.get("merged_count", 0) > 0:
-                                            logger.info(
-                                                f"反思引擎Layer2 用户 {user['id']} 去重合并: "
-                                                f"合并 {dedup_info['merged_count']}"
-                                            )
-                                    finally:
-                                        if write_lock is not None:
-                                            await asyncio.to_thread(write_lock.release)
                                 except Exception as e:
                                     logger.error(f"反思引擎Layer2 巡检失败 user={user['id']}: {e}")
 
@@ -4452,37 +4439,6 @@ def scan_idle_conversations_task() -> None:
 
         logger.info(f"[ScanIdle] 发现 {len(candidate_conv_ids)} 个对话存在未写入消息")
 
-        # 过滤：确保对话所属 app 已存在已发布版本（current_release_id IS NOT NULL）。
-        # 真正的 memory_config_id 解析（agent / workflow + legacy 兼容）由 FlushTask
-        # 内的 _resolve_release_memory_config_id 完成，这里只做粗筛避免每分钟空跑刷 WARN。
-        if candidate_conv_ids:
-            try:
-                from app.models.app_model import App
-
-                with get_db_context() as db:
-                    valid_conv_ids = [
-                        str(cid) for cid in db.execute(
-                            select(Conversation.id)
-                            .join(App, App.id == Conversation.app_id)
-                            .where(
-                                Conversation.id.in_(candidate_conv_ids),
-                                App.current_release_id.isnot(None),
-                            )
-                            .distinct()
-                        ).scalars().all()
-                    ]
-
-                skipped_no_release = len(candidate_conv_ids) - len(valid_conv_ids)
-                if skipped_no_release:
-                    logger.info(
-                        f"[ScanIdle] 跳过 {skipped_no_release} 个 app 未发布的对话"
-                    )
-                candidate_conv_ids = valid_conv_ids
-            except Exception as e:
-                logger.warning(
-                    f"[ScanIdle] 过滤未发布 app 失败，将走 FlushTask 兜底校验: err={e}"
-                )
-
         for conv_id_str in candidate_conv_ids:
             # 检查 conv_active key 是否存在（存在则对话仍活跃，跳过）
             # conv_active 写在 settings.REDIS_DB（DB 13），需要用专属 client 读取
@@ -4546,130 +4502,3 @@ def scan_idle_conversations_task() -> None:
     logger.info(
         f"[ScanIdle] 扫描完成: 派发={dispatched}, 跳过(活跃)={skipped_active}, 跳过(已锁)={skipped_locked}"
     )
-
-
-@celery_app.task(name="app.tasks.scan_workflow_schedule_triggers", queue="periodic_tasks")
-def scan_workflow_schedule_triggers():
-    """扫描并派发已发布工作流中的定时触发器。"""
-    from app.services.workflow_service import WorkflowService
-
-    now = datetime.now(timezone.utc)
-    triggered = 0
-
-    with get_db_context() as db:
-        service = WorkflowService(db)
-        due_triggers = service.get_due_schedule_triggers(now)
-        logger.info(f"[WorkflowSchedule] 扫描到 {len(due_triggers)} 个待执行触发器")
-
-        for app, release, _config, trigger in due_triggers:
-            trigger_id = trigger.get("id")
-            try:
-                run_workflow_schedule_trigger.apply_async(
-                    kwargs={
-                        "app_id": str(app.id),
-                        "release_id": str(release.id),
-                        "trigger_id": trigger_id,
-                        "scheduled_at": now.isoformat(),
-                    },
-                    queue="workflow_trigger_tasks",
-                )
-                runtime = {
-                    **(trigger.get("runtime") or {}),
-                    "dispatch_status": "queued",
-                    "last_dispatched_at": now.isoformat(),
-                    "last_scheduled_at": now.isoformat(),
-                    "last_error": None,
-                }
-                service.update_release_trigger_runtime_state(release.id, trigger_id, runtime)
-                service.update_trigger_runtime_state(app.id, trigger_id, runtime)
-                triggered += 1
-                logger.info(
-                    f"[WorkflowSchedule] 已派发: app_id={app.id}, release_id={release.id}, trigger_id={trigger_id}"
-                )
-            except Exception as exc:
-                logger.error(
-                    f"[WorkflowSchedule] 派发失败: app_id={app.id}, trigger_id={trigger_id}, error={exc}",
-                    exc_info=True,
-                )
-
-    return {"triggered": triggered, "scanned_at": now.isoformat()}
-
-
-@celery_app.task(name="app.tasks.run_workflow_schedule_trigger", queue="workflow_trigger_tasks")
-def run_workflow_schedule_trigger(app_id: str, release_id: str, trigger_id: str, scheduled_at: str | None = None):
-    """执行单个已发布的 schedule trigger。"""
-    from app.services.workflow_service import WorkflowService
-
-    run_at = datetime.fromisoformat(scheduled_at) if scheduled_at else datetime.now(timezone.utc)
-    with get_db_context() as db:
-        service = WorkflowService(db)
-        app = db.get(App, uuid.UUID(app_id))
-        release = db.get(AppRelease, uuid.UUID(release_id))
-        if not app or not release:
-            logger.warning(
-                f"[WorkflowSchedule] 跳过不存在的任务: app_id={app_id}, release_id={release_id}, trigger_id={trigger_id}"
-            )
-            return {"status": "skipped", "reason": "app_or_release_not_found"}
-
-        if app.current_release_id != release.id:
-            logger.info(
-                f"[WorkflowSchedule] 跳过过期发布版本任务: "
-                f"app_id={app_id}, queued_release_id={release_id}, current_release_id={app.current_release_id}, "
-                f"trigger_id={trigger_id}"
-            )
-            return {"status": "skipped", "reason": "stale_release"}
-
-        config = service._build_runtime_workflow_config_from_release(
-            release,
-            real_config_id=(app.workflow_config.id if app.workflow_config else None),
-        )
-        trigger = service._find_trigger_node(config.nodes, trigger_id=trigger_id, trigger_type="schedule")
-        if not trigger:
-            logger.warning(f"[WorkflowSchedule] 跳过不存在的 trigger: trigger_id={trigger_id}")
-            return {"status": "skipped", "reason": "trigger_not_found"}
-
-        runtime = trigger.get("runtime") or {}
-        running_runtime = {
-            **runtime,
-            "dispatch_status": "running",
-            "last_started_at": datetime.now(timezone.utc).isoformat(),
-            "last_scheduled_at": run_at.isoformat(),
-            "last_error": None,
-        }
-        service.update_release_trigger_runtime_state(release.id, trigger_id, running_runtime)
-        service.update_trigger_runtime_state(app.id, trigger_id, running_runtime)
-
-        try:
-            asyncio.run(
-                service.invoke_schedule_trigger(
-                    app=app,
-                    release=release,
-                    config=config,
-                    trigger=trigger,
-                    now=run_at,
-                )
-            )
-            completed_runtime = {
-                **running_runtime,
-                "dispatch_status": "completed",
-                "last_triggered_at": run_at.isoformat(),
-                "last_completed_at": datetime.now(timezone.utc).isoformat(),
-                "last_error": None,
-            }
-            service.update_release_trigger_runtime_state(release.id, trigger_id, completed_runtime)
-            service.update_trigger_runtime_state(app.id, trigger_id, completed_runtime)
-            return {"status": "completed", "trigger_id": trigger_id, "scheduled_at": run_at.isoformat()}
-        except Exception as exc:
-            failed_runtime = {
-                **running_runtime,
-                "dispatch_status": "failed",
-                "last_failed_at": datetime.now(timezone.utc).isoformat(),
-                "last_error": str(exc),
-            }
-            service.update_release_trigger_runtime_state(release.id, trigger_id, failed_runtime)
-            service.update_trigger_runtime_state(app.id, trigger_id, failed_runtime)
-            logger.error(
-                f"[WorkflowSchedule] 执行失败: app_id={app_id}, release_id={release_id}, trigger_id={trigger_id}, error={exc}",
-                exc_info=True,
-            )
-            raise


### PR DESCRIPTION
## Summary

修复知识库文档解析任务卡死及状态异常问题，主要涉及以下改动：

1. **MinerU API 超时缩短**：将 `requests.post` 的 `timeout` 从 1800 秒缩短至 300 秒（5 分钟），解决 API 慢速流式响应导致 read timeout 计时器被不断重置、任务永久阻塞的问题。

2. **PDF 页数前置限制**：新增 `_get_estimated_pages()` 函数，解析前检测 PDF 页数，超过 `MAX_DOCUMENT_PAGES`（默认 200 页）直接拒绝并设置失败状态（`progress=-1.0`, `run=0`），避免大文档拖垮 worker。

3. **异常状态持久化**：去掉 `except` 块中的 `db.rollback()`，解决 rollback 后对象 detached 导致 `progress=-1.0` 等修改无法写入数据库的问题。

4. **删除文档时取消正在解析的任务**：通过 Redis 标记机制，删除文档时通知 worker 中断当前解析流程；`parse_document` 在关键节点（下载后、chunk 前、embedding 前、GraphRAG 前）检查中断标记。

5. **数据写入后回滚**：如果文档在向量数据写入后被删除，清理已写入的向量数据。

## Changes

\`\`\`
 api/app/tasks.py | 34 insertions(+), 205 deletions(-)
\`\`\`

## Test Plan
- [ ] 上传超过 200 页的 PDF，确认被直接拒绝且状态显示为失败
- [ ] 上传正常 PDF 触发解析，删除文档确认 worker 中断并清理 Redis
- [ ] 确认 MinerU API 无响应时 5 分钟内超时失败

## Summary by Sourcery

优化文档解析、记忆反射、空闲会话扫描以及工作流调度等后台任务的行为。

增强点：
- 在向向量库写入后，如果源文档已被删除，则中止文档解析，并清理已写入的向量及 Redis 状态。
- 简化反射 Layer2 的周期任务，移除基于 Redis 的记忆处理写锁。
- 精简空闲会话扫描逻辑，移除基于应用发布状态的预过滤，将校验工作交由下游处理。
- 从任务模块中移除周期性工作流调度扫描以及触发执行的任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine background task behavior for document parsing, memory reflection, idle conversation scanning, and workflow scheduling.

Enhancements:
- Abort document parsing after vector write if the source document was deleted, and clean up written vectors and Redis state.
- Simplify the reflection Layer2 periodic task by removing the Redis-based write lock around memory processing.
- Streamline idle conversation scanning by dropping pre-filtering based on app release state, delegating validation to downstream processing.
- Remove the periodic workflow schedule scanning and trigger execution tasks from the task module.

</details>