### PR TITLE
feat(api): add has_unsolved_reference field and enforce event-time in entity descriptions

### DIFF
--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -284,6 +284,12 @@ class StatementNode(Node):
     invalid_at: Optional[datetime] = Field(None, description="Temporal validity end")
     dialog_at: Optional[datetime] = Field(None, description="Absolute timestamp of the conversation this statement belongs to")
 
+    # Reference resolution
+    has_unsolved_reference: bool = Field(
+        False,
+        description="Whether the statement has unresolved references (used by reflection engine layer 2)"
+    )
+
     # Embedding and other fields
     statement_embedding: Optional[List[float]] = Field(None, description="Statement embedding vector")
     chunk_embedding: Optional[List[float]] = Field(None, description="Chunk embedding vector")

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -233,6 +233,7 @@ async def build_graph_nodes_and_edges(
                     created_at=dialog_data.created_at,
                     dialog_at=getattr(statement, "dialog_at", None),
                     config_id=dialog_data.config_id if hasattr(dialog_data, "config_id") else None,
+                    has_unsolved_reference=getattr(statement, "has_unsolved_reference", False),
                     emotion_type=getattr(statement, "emotion_type", None),
                     emotion_intensity=getattr(statement, "emotion_intensity", None),
                     emotion_keywords=getattr(statement, "emotion_keywords", None),

--- a/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
@@ -14,6 +14,7 @@ Extract entities and knowledge triplets from the given statement.
 - 命名关系中新出现的称呼、别名、昵称、产品名保持原样，不做替换。
 - `description` 必须使用中文。
 - 每个实体的 `description` 必须以输入中的 `dialog_at` 时间戳开头，格式为 `[dialog_at] 描述文本`；如果输入中 `dialog_at` 为空或不存在，则使用 `[NULL]`。
+- 如果 `statement_text` 表达已发生或正在发生的事件，且上游已经把相对时间解析进 `statement_text` 或 `valid_at`/`invalid_at`，实体 `description` 的正文必须保留这个事件时间；不要只写 `[dialog_at]` 后接无时间描述。
 - `type`、`predicate` 必须使用上方预定义的中文标签。
 - 每个实体必须输出 `type_id`，并且必须与 `type` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_id`，并且必须与 `predicate` 对应的本体 ID 完全一致。
@@ -32,6 +33,7 @@ Extract entities and knowledge triplets from the given statement.
 - Newly introduced names in naming or alias expressions must stay in their original form.
 - Generate `description` in English.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
+- If `statement_text` describes an event that has happened or is happening, and upstream has resolved the relative time into `statement_text` or `valid_at`/`invalid_at`, the entity `description` body MUST preserve that event time; do not write only a `[dialog_at]` prefix followed by a timeless description.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
 - Every entity MUST include `type_id`, and it MUST exactly match the ontology ID for `type`.
 - Every triplet MUST include `predicate_id`, and it MUST exactly match the ontology ID for `predicate`.
@@ -497,7 +499,12 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 优先描述实体在当前陈述和必要上下文中的身份、作用、关系、归属和限定信息；在不引入额外推断的前提下，尽量包含与该实体直接相关的上下文限定。
 - 对账号、用户名、编号、邮箱等识别联系信息，`description` 应尽量写清它属于哪个实体、哪个账号/平台或哪种联系方式，例如 `用户的 GitHub 账号的用户名`，不要只写成泛泛的 `用户名`。
 - `description` 只保留适合长期附着在该实体上的描述，例如稳定身份、稳定关系、长期偏好/兴趣/习惯、较稳定认知倾向或可用于区分实体的持久特征。
-- 不要把短期状态、一次性事件、临时计划、当前情绪、具体时间锚点，或只在当前句子里短暂成立的信息写进 `description`。
+- 不要把短期状态、临时计划、当前情绪，或只在当前句子里短暂成立且没有长期记忆价值的信息写进 `description`。
+- 例外：如果 `statement_text` 本身表达的是值得保留的事件、经历、变化或里程碑，且输入 `temporal_type` 是 `DYNAMIC` 或 `statement_text` 已经包含明确事件时间，则相关实体的 `description` 正文必须保留该事件时间和核心动作。
+- 事件时间优先来源：先使用 `statement_text` 中已经写明的时间表达；如果正文没有时间但 `valid_at` / `invalid_at` 不是 `NULL`，则用这些字段对应的时间边界改写成自然语言时间。
+- 不要把 `dialog_at` 当作事件发生时间。`[dialog_at]` 只是溯源前缀；真正的事件时间必须出现在 `description` 正文里。
+- 正确示例：`[2026-05-20T14:00:00+08:00] 用户在2026年5月19日从上海搬到深圳`。
+- 错误示例：`[2026-05-20T14:00:00+08:00] 从上海搬到深圳的说话者`。
 - 如果实体应保留，但当前 statement 中没有适合长期附着在该实体上的稳定描述，则 `description` 仍必须保留时间戳前缀，可写为 `[dialog_at]` 或 `[NULL]`，不要输出空字符串。
   {% else %}
 - `description` MUST start with `[dialog_at]`, where `dialog_at` is copied directly from the input `dialog_at` field (ISO 8601 timestamp); if `dialog_at` is empty or absent, write `[NULL]`. Format example: `[2025-03-15T10:00:00Z] The speaker who lives in Paris`.
@@ -505,7 +512,12 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - Prefer describing the entity's role, identity, relation, ownership, and qualifiers in the current statement and necessary supporting context; include directly related contextual qualifiers as much as possible without adding unsupported inference.
 - For identification/contact information such as accounts, usernames, IDs, emails, or phone numbers, `description` should specify which entity, account/platform, or contact method it belongs to, such as `the username of the user's GitHub account`, rather than a generic `username`.
 - `description` should keep only information suitable to remain attached to the entity over time, such as stable identity, stable relations, long-term preferences/interests/habits, relatively stable beliefs, or persistent distinguishing traits.
-- Do not put short-lived states, one-off events, temporary plans, current emotions, concrete time anchors, or information that only briefly holds in the current sentence into `description`.
+- Do not put short-lived states, temporary plans, current emotions, or information that only briefly holds in the current sentence and has no long-term memory value into `description`.
+- Exception: if `statement_text` itself expresses a worthwhile event, experience, change, or milestone, and the input `temporal_type` is `DYNAMIC` or `statement_text` already contains a clear event time, the relevant entity `description` body MUST preserve that event time and the core action.
+- Event time source priority: first use the time expression already written in `statement_text`; if the text has no time but `valid_at` / `invalid_at` is not `NULL`, rewrite those temporal bounds into a natural-language time expression.
+- Do not treat `dialog_at` as the event time. `[dialog_at]` is only a provenance prefix; the true event time must appear in the `description` body.
+- Correct example: `[2026-05-20T14:00:00+08:00] The user moved from Shanghai to Shenzhen on May 19, 2026`.
+- Incorrect example: `[2026-05-20T14:00:00+08:00] The speaker who moved from Shanghai to Shenzhen`.
 - If an entity should be retained but the current statement does not provide any suitable stable description for it, `description` must still keep the timestamp prefix and may be `[dialog_at]` or `[NULL]`; do not output an empty string.
   {% endif %}
 
@@ -872,6 +884,7 @@ JSON 要求：
 - 字符串值中不要换行
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，但用户自指必须规范成 `用户`，可稳定解析的其他代词必须替换为具体指代实体名
 - `description` 必须使用中文，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
+- 如果 statement 是有长期记忆价值的事件、经历、变化或里程碑，`description` 正文必须保留已解析事件时间，不能只依赖 `[dialog_at]` 前缀表达时间
 - `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用中文说明
 - 每个 entity 都必须包含 `type_id`，且必须与 `type` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_id`，且必须与 `predicate` 的本体 ID 一致
@@ -888,6 +901,7 @@ JSON 要求：
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
 - `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
+- If the statement is a long-term-memory-worthy event, experience, change, or milestone, the `description` body must preserve the resolved event time and must not rely only on the `[dialog_at]` prefix for time
 - `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
 - Every entity must include `type_id`, exactly matching the ontology ID for `type`
 - Every triplet must include `predicate_id`, exactly matching the ontology ID for `predicate`

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -115,6 +115,7 @@ async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jC
                 "last_access_time": statement.last_access_time,
                 "access_count": statement.access_count,
                 "dialog_at": statement.dialog_at.isoformat() if statement.dialog_at else None,
+                "has_unsolved_reference": getattr(statement, "has_unsolved_reference", False),
             }
             flattened_statements.append(flattened_statement)
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -41,7 +41,8 @@ SET s += {
     access_history: statement.access_history,
     last_access_time: statement.last_access_time,
     access_count: statement.access_count,
-    dialog_at: statement.dialog_at
+    dialog_at: statement.dialog_at,
+    has_unsolved_reference: statement.has_unsolved_reference
 }
 RETURN s.id AS uuid
 """


### PR DESCRIPTION
- Add has_unsolved_reference boolean field to StatementNode for reflection engine layer 2 reference resolution tracking
- Propagate the field through graph build step, Neo4j add_nodes, and cypher merge queries
- Update extract_triplet.jinja2 prompts to require entity descriptions to preserve resolved event time when temporal_type is DYNAMIC or the statement expresses a long-term-memory-worthy event/change/milestone
- Clarify that [dialog_at] is only a provenance prefix and must not be used as a substitute for the actual event time in description body
- Add correct/incorrect examples for event-time handling in prompts
- Remove over-broad exclusion of one-off events and time anchors from stable description rules when the event has lasting memory value

## Summary by Sourcery

为语句添加未解析引用的追踪，并收紧提示规则，使实体描述保留真实事件时间，而不是依赖对话时间戳。

新特性：
- 在语句上引入 `has_unsolved_reference` 标志，用于下游的反思和图处理。

增强：
- 在图构建、Neo4j 节点创建以及 cypher 合并查询中传递 `has_unsolved_reference` 字段。
- 优化 `extract_triplet` 提示，要求实体描述在处理值得长期记忆的事件时必须包含已解析的事件时间，并澄清 `dialog_at` 的角色仅作为溯源信息。
- 添加具体的正确和错误示例，以指导在实体描述中的事件时间处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add tracking for unresolved references on statements and tighten prompting rules so entity descriptions preserve true event times rather than relying on dialog timestamps.

New Features:
- Introduce a has_unsolved_reference flag on statements for downstream reflection and graph processing.

Enhancements:
- Propagate the has_unsolved_reference field through graph building, Neo4j node creation, and cypher merge queries.
- Refine extract_triplet prompts to require entity descriptions to include resolved event times for long-term-memory-worthy events and clarify the role of dialog_at as provenance only.
- Add concrete correct and incorrect examples to guide event-time handling in entity descriptions.

</details>