### PR TITLE
fix(workflow): optimize content moderation logic and terminate streaming immediately upon trigger

### DIFF
--- a/api/app/core/moderation/output_moderation.py
+++ b/api/app/core/moderation/output_moderation.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class OutputModeration:
-    CHECK_INTERVAL = 200
+    CHECK_INTERVAL = 1
 
     def __init__(
         self,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -2160,6 +2160,7 @@ class WorkflowService:
 
 
             moderation_flagged = False
+            active_llm_nodes: set[str] = set()  # 已 node_start 但尚未 node_end 的 LLM 节点
 
             async for event in execute_workflow_stream(
                     workflow_config=workflow_config_dict,
@@ -2226,6 +2227,23 @@ class WorkflowService:
                             "completed",
                             output_data=workflow_output_data,
                         )
+                        # 合成 LLM node_end 事件：只为当前正在执行的 LLM 节点补发
+                        import datetime as _dt
+                        for llm_node_id in active_llm_nodes:
+                            node_end_event = {
+                                "event": "node_end",
+                                "data": {
+                                    "node_id": llm_node_id,
+                                    "conversation_id": str(conversation_id_uuid) if conversation_id_uuid else None,
+                                    "execution_id": execution.execution_id,
+                                    "timestamp": int(_dt.datetime.now().timestamp() * 1000),
+                                    "output": preset_response,
+                                    "elapsed_time": 0,
+                                }
+                            }
+                            node_end_mapped = self._emit(public, node_end_event)
+                            if node_end_mapped:
+                                yield node_end_mapped
                         # 合成 workflow_end 事件并退出，不再等待 LLM 静默执行完成
                         end_internal_event = {
                             "event": "workflow_end",
@@ -2350,6 +2368,11 @@ class WorkflowService:
                         self.db.commit()
                 elif event.get("event") == "workflow_start":
                     event["data"]["message_id"] = str(message_id)
+                # 记录活跃 LLM 节点：node_start 加入，node_end 移除，合成时只为活跃节点补发
+                if event_type == "node_start" and event_data.get("node_id") in llm_node_ids:
+                    active_llm_nodes.add(event_data.get("node_id"))
+                if event_type == "node_end" and event_data.get("node_id") in llm_node_ids:
+                    active_llm_nodes.discard(event_data.get("node_id"))
                 event = self._emit(public, event)
                 if event:
                     yield event

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -2159,6 +2159,8 @@ class WorkflowService:
                             llm_node_ids.add(node.get("id", ""))
 
 
+            moderation_flagged = False
+
             async for event in execute_workflow_stream(
                     workflow_config=workflow_config_dict,
                     input_data=input_data,
@@ -2170,6 +2172,77 @@ class WorkflowService:
             ):
                 event_type = event.get("event")
                 event_data = event.get("data", {})
+
+                # 审查触发后，跳过所有后续 message 事件（不再向客户端输出模型流式文本）
+                if moderation_flagged and event_type == "message":
+                    continue
+
+                # message 事件：先审查再 yield，检测到关键词立即触发 message_replace 并结束流式
+                if event_type == "message" and output_moderation and not moderation_flagged:
+                    chunk = event_data.get("content", "")
+                    if output_moderation.accumulate(chunk):
+                        moderation_flagged = True
+                        yield {"event": "message_replace",
+                               "data": {"content": output_moderation.preset_response}}
+
+                        # 审查触发后，立即保存对话、更新执行状态，合成结束事件并退出循环
+                        preset_response = output_moderation.preset_response
+                        human_message, human_meta = self._extract_human_message_and_meta(
+                            [], payload.message or "", files
+                        )
+                        if conversation_id_uuid:
+                            self.conversation_service.add_message(
+                                conversation_id=conversation_id_uuid,
+                                role="user",
+                                content=human_message,
+                                meta_data=human_meta,
+                                sync_memory=False,
+                            )
+                            self.conversation_service.add_message(
+                                message_id=message_id,
+                                conversation_id=conversation_id_uuid,
+                                role="assistant",
+                                content=preset_response,
+                                meta_data={"usage": {}, "audio_url": None, "moderation_flagged": True},
+                                sync_memory=False,
+                            )
+                        # 更新执行状态为完成，标记审查触发
+                        workflow_output_data = {
+                            "moderation_flagged": True,
+                            "preset_response": preset_response,
+                        }
+                        if _cycle_items and execution.output_data:
+                            import copy
+                            new_output_data = copy.deepcopy(execution.output_data)
+                            node_outputs = new_output_data.setdefault("node_outputs", {})
+                            for cycle_node_id, items in _cycle_items.items():
+                                if cycle_node_id in node_outputs:
+                                    node_outputs[cycle_node_id]["cycle_items"] = items
+                                else:
+                                    node_outputs[cycle_node_id] = {"cycle_items": items}
+                            workflow_output_data.update(new_output_data)
+                        self.update_execution_status(
+                            execution.execution_id,
+                            "completed",
+                            output_data=workflow_output_data,
+                        )
+                        # 合成 workflow_end 事件并退出，不再等待 LLM 静默执行完成
+                        end_internal_event = {
+                            "event": "workflow_end",
+                            "data": {
+                                "conversation_id": str(conversation_id_uuid) if conversation_id_uuid else None,
+                                "output": preset_response,
+                                "usage": {},
+                                "elapsed_time": 0,
+                                "status": "completed",
+                                "error": "",
+                                "moderation_flagged": True,
+                            }
+                        }
+                        end_event = self._emit(public, end_internal_event)
+                        if end_event:
+                            yield end_event
+                        break
 
                 if event_type == "cycle_item":
                     cycle_id = event_data.get("cycle_id")
@@ -2280,15 +2353,6 @@ class WorkflowService:
                 event = self._emit(public, event)
                 if event:
                     yield event
-
-                if event_type == "message" and output_moderation:
-                    chunk = event_data.get("content", "")
-                    output_moderation.accumulate(chunk)
-
-                if event_type == "node_end" and output_moderation \
-                        and event_data.get("node_id") in llm_node_ids \
-                        and output_moderation.check_final():
-                    yield {"event": "message_replace", "data": {"content": output_moderation.preset_response}}
 
         except Exception as e:
             logger.error(


### PR DESCRIPTION
- Adjust the check interval from 200 to 1 to improve moderation real-time performance.
- Introduce a moderation flag variable to skip all subsequent message events once triggered.
- Refactor the moderation trigger timing to directly replace the message and end the stream upon detecting violations.
- Remove the legacy moderation logic at node completion to unify the streaming moderation process.

## Summary by Sourcery

优化工作流流式输出的审核机制，一旦出现违规内容立即触发审核，并用预设响应终止流式输出。

New Features:
- 在流式输出过程中，一旦触发审核，立即用审核预设消息替换原本的输出并终止当前工作流。

Bug Fixes:
- 在触发审核后，不再继续流式发送模型消息，通过跳过后续的消息事件来避免继续输出。

Enhancements:
- 使用标志位追踪审核状态，以集中管理并简化流式输出的审核流程。
- 在触发审核时，将预设的审核响应和执行状态持久化为已完成，并将对应输出标记为 `moderation_flagged`。
- 缩短输出审核检查的时间间隔，以提升对违规内容的实时检测能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize workflow streaming output moderation to trigger immediately on violating content and terminate the stream with a preset response.

New Features:
- Add immediate moderation-triggered message replacement and workflow termination during streaming output.

Bug Fixes:
- Prevent further streaming of model messages after moderation is triggered by skipping subsequent message events.

Enhancements:
- Track moderation state with a flag to centralize and simplify streaming moderation flow.
- Persist moderated preset responses and execution status as completed when moderation is triggered, including marking outputs as moderation_flagged.
- Reduce output moderation check interval to improve real-time detection of violating content.

</details>