### PR TITLE
fix(celery): increase layer2_reflection_task timeout from 540s to 1800s

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2255,8 +2255,8 @@ def post_store_dedup_and_alias_merge_task(
     ignore_result=False,
     max_retries=0,
     acks_late=False,
-    time_limit=600,
-    soft_time_limit=540,
+    time_limit=1860,
+    soft_time_limit=1800,
 )
 def layer2_reflection_task(self) -> Dict[str, Any]:
     """Layer 2 离线巡检（描述合并等）— 每 10 分钟


### PR DESCRIPTION
Task was hitting SoftTimeLimitExceeded when processing multiple users. Raised time_limit to 1860s and soft_time_limit to 1800s (30 min).

## 由 Sourcery 提供的摘要

错误修复：
- 提高 `layer2_reflection_task` Celery 任务的硬时间限制和软时间限制，以避免在处理多个用户时出现 `SoftTimeLimitExceeded` 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Raise the hard and soft time limits for the layer2_reflection_task Celery task to avoid SoftTimeLimitExceeded errors when processing multiple users.

</details>