### PR TITLE
fix(web): kb recall top_k max

### DIFF
--- a/web/src/components/Charts/GraphNetworkChart.tsx
+++ b/web/src/components/Charts/GraphNetworkChart.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-10 14:06:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-01 17:15:54
+ * @Last Modified time: 2026-06-02 10:35:00
  */
 /**
  * GraphNetworkChart Component
@@ -262,7 +262,6 @@ const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
       })
     linkSelRef.current = linkSel
 
-    console.log('graphState', graphState.links.filter(l => l.label))
     const linkLabelSel = g.append('g').selectAll<SVGTextElement, D3Link>('text')
       .data(graphState.links.filter(l => l.label))
       .enter()
@@ -324,19 +323,74 @@ const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
       })
 
     nodeSel.append('text')
-      .text(d => d.name)
       .attr('x', 0)
-      .attr('dy', 4)
+      .attr('y', 0)
       .attr('text-anchor', 'middle')
-      .attr('font-size', '10px')
+      .attr('dominant-baseline', 'middle')
+      .attr('font-size', d => {
+        const fontSize = Math.max(6, Math.min(12, d.symbolSize * 0.25))
+        return `${fontSize}px`
+      })
       .attr('fill', '#171719')
       .style('pointer-events', 'none')
       .style('user-select', 'none')
       .style('display', d => {
         if (!d.name) return 'none'
-        const textWidth = d.name.length * 6
         const currentZoom = defaultZoom
-        return d.symbolSize * currentZoom >= textWidth / 2 ? 'block' : 'none'
+        return d.symbolSize * currentZoom >= 20 ? 'block' : 'none'
+      })
+      .each(function(d) {
+        const text = d3.select(this)
+        const name = d.name || ''
+        const fontSize = Math.max(6, Math.min(12, d.symbolSize * 0.25))
+        const maxWidth = d.symbolSize * 1.2
+        const lineHeight = fontSize * 1.2
+        const maxLines = Math.floor((d.symbolSize * 1.2) / lineHeight) || 1
+        
+        const words = name.split('')
+        let line: string[] = []
+        let lines: string[] = []
+        let currentWidth = 0
+        const charWidth = fontSize * 0.55
+        
+        for (let i = 0; i < words.length; i++) {
+          const word = words[i]
+          const wordWidth = charWidth
+          if (currentWidth + wordWidth > maxWidth && line.length > 0) {
+            lines.push(line.join(''))
+            line = [word]
+            currentWidth = wordWidth
+          } else {
+            line.push(word)
+            currentWidth += wordWidth
+          }
+        }
+        if (line.length > 0) {
+          lines.push(line.join(''))
+        }
+        
+        if (lines.length > maxLines) {
+          lines = lines.slice(0, maxLines)
+          if (lines[maxLines - 1]) {
+            lines[maxLines - 1] = lines[maxLines - 1].slice(0, -1) + '...'
+          }
+        }
+        
+        text.selectAll('tspan').remove()
+        
+        if (lines.length === 1) {
+          text.text(lines[0])
+        } else {
+          const totalHeight = (lines.length - 1) * lineHeight
+          const startY = -totalHeight / 2
+          
+          lines.forEach((lineText, i) => {
+            text.append('tspan')
+              .attr('x', 0)
+              .attr('dy', i === 0 ? `${startY / fontSize}em` : `${lineHeight / fontSize}em`)
+              .text(lineText)
+          })
+        }
       })
 
     const highlightNodes = () => {

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -127,9 +127,9 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
               
               <Form.Item name="top_k" label={t('knowledgeBase.recallQuantity')}>
                   <InputNumber 
-                      placeholder='1 ~ 1024'
+                      placeholder='1 ~ 100'
                       min={1}
-                      max={1024}
+                      max={100}
                       style={{ width: '100%' }}
                   />
               </Form.Item>


### PR DESCRIPTION
## Summary by Sourcery

改进图形节点标签渲染，并收紧知识库召回参数限制。

Bug 修复：
- 将知识库召回的 `top_k` 输入最大值从 1024 限制为 100，以符合预期限制。

改进：
- 优化图网络节点标签样式：根据节点大小动态调整字体大小、居中对齐、支持多行换行，并在空间不足时使用省略号截断显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve graph node label rendering and tighten knowledge base recall parameter limits.

Bug Fixes:
- Restrict knowledge base recall top_k input to a maximum of 100 instead of 1024 to match intended limits.

Enhancements:
- Refine graph network node label styling with dynamic font sizing, centered alignment, multiline wrapping, and truncation with ellipsis based on node size.

</details>