### PR TITLE
fix(rag): cancel running parse task when document is deleted

### DIFF
--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -293,7 +293,7 @@ async def delete_document(
         if task_id:
             api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
             try:
-                celery_app.control.revoke(task_id, terminate=True)
+                celery_app.control.revoke(task_id)
                 api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
             except NotImplementedError:
                 # ThreadPool does not support force termination; rely on Redis cancel marker

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -311,6 +311,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             # Early-exit check after download
             if _should_abort(document_id):
                 _clear_redis_state(document_id)
+                logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped")
                 return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             file_binary = asyncio.run(_download())
         except RuntimeError:
@@ -352,6 +353,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         # Early-exit check before chunking
         if _should_abort(document_id):
             _clear_redis_state(document_id)
+            logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped")
             return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
 
         parent_child_mode = db_document.is_parent_child_mode
@@ -386,6 +388,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         # Early-exit check before vectorization
         if _should_abort(document_id):
             _clear_redis_state(document_id)
+            logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped")
             return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
 
         # 2. Document vectorization and storage
@@ -644,6 +647,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             logger.info(f"[ParseDoc] document={document_id} deleted after data write -- rolling back vectors")
             vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
             _clear_redis_state(document_id)
+            logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped and es data deleted")
             return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
 
         db_document.chunk_num = total_chunks
@@ -659,6 +663,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             # Early-exit check before dispatching GraphRAG
             if _should_abort(document_id):
                 _clear_redis_state(document_id)
+                logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped")
                 return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
             progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
             db_document.progress_msg = _progress_msg()


### PR DESCRIPTION
## Summary
- When a document is deleted during parsing, cancel the running Celery task via Redis revoke
- Add Redis-based duplicate prevention (SET NX) for parse task submission
- Add checkpoint-based early-exit in parse_document task

## Changes
- `api/app/controllers/document_controller.py`: delete_document revoke + parse_documents SET NX
- `api/app/tasks.py`: _should_abort + _clear_redis_state + 5 checkpoints

## Summary by Sourcery

在文档被删除时处理进行中的文档解析的取消，并改进基于 Redis 的在解析检查点的中止行为的可观测性。

Bug 修复：
- 确保在发生删除操作时，正在运行的文档解析任务能够被干净地取消，而无需强制终止 worker 进程。

增强功能：
- 在多个解析检查点添加一致的日志记录，当基于 Redis 的取消中止文档处理时提供日志，以帮助调试和监控。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle cancellation of in-progress document parsing when a document is deleted and improve observability of Redis-based aborts during parse checkpoints.

Bug Fixes:
- Ensure running document parse tasks are cleanly cancelled when deletion occurs without forcing termination of the worker process.

Enhancements:
- Add consistent logging at multiple parse checkpoints when Redis-based cancellation aborts document processing to aid debugging and monitoring.

</details>