### PR TITLE
fix(web): kb document chunk total size

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -50,6 +50,7 @@ const DocumentDetails: FC = () => {
   const [infoItems, setInfoItems] = useState<InfoItem[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [total, setTotal] = useState(0);
   const [chunkLoading, setChunkLoading] = useState(false);
   const [keywords, setKeywords] = useState('');
   const [fileUrl, setFileUrl] = useState('');
@@ -219,6 +220,7 @@ const DocumentDetails: FC = () => {
       }
       
       setHasMore(response.page?.has_next ?? false);
+      setTotal(response.page?.total ?? 0);
     } catch (error) {
       console.error('Failed to fetch document details:', error);
       message.error(t('common.loadFailed') || '加载失败');
@@ -472,6 +474,7 @@ const DocumentDetails: FC = () => {
           <RecallTestResult 
             refresh={refreshChunks}
             data={chunkList} 
+            total={total}
             showEmpty={false}
             hasMore={hasMore}
             loadMore={loadMoreChunks}

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -23,6 +23,7 @@ interface RecallTestResultProps {
   data: RecallTestData[];
   showEmpty?: boolean;
   hasMore?: boolean;
+  total?: number;
   loadMore?: () => void;
   refresh?: () => void;
   loading?: boolean;
@@ -38,6 +39,7 @@ const RecallTestResult = ({
   data, 
   showEmpty = true,
   hasMore = false,
+  total = 0,
   loadMore,
   refresh,
   loading = false,
@@ -395,7 +397,7 @@ const RecallTestResult = ({
         <div className='rb:flex rb:items-center rb:justify-start rb:gap-2'>
           <span className='rb:text-lg rb:font-medium'>{t('knowledgeBase.recallResult')}</span>
           <span className='rb:text-gray-500 rb:text-xs rb:pt-0.5'>
-            (<span className='rb:text-[#155EEF]'>{data.length}</span> results)
+            (<span className='rb:text-[#155EEF]'>{total || data.length}</span> results)
           </span>
         </div>
         <InfiniteScroll


### PR DESCRIPTION
## Summary by Sourcery

在知识库文档详情和召回测试结果中，跟踪并展示后端返回的文档分片（chunks）总数。

New Features:
- 为召回测试结果暴露一个总数属性，用于显示与当前已加载列表无关的整体分片数量。

Bug Fixes:
- 确保召回结果计数反映的是后端报告的文档分片总数，而不仅仅是当前已加载页的数量。

Enhancements:
- 将分页元数据（总数）从文档详情中存储并传递到召回测试结果视图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and display the total number of document chunks returned by the backend in knowledge base document details and recall test results.

New Features:
- Expose a total count prop for recall test results to show the overall number of chunks independent of the currently loaded list.

Bug Fixes:
- Ensure the recall result count reflects the backend-reported total number of document chunks instead of just the currently loaded page.

Enhancements:
- Store and propagate pagination metadata (total count) from document details to the recall test results view.

</details>