### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -840,7 +840,8 @@ async def draft_run(
                         payload=payload,
                         config=config,
                         workspace_id=current_user.current_workspace_id,
-                        source=source
+                        source=source,
+                        trigger_payload=payload.trigger_payload
                 ):
                     # 提取事件类型和数据
                     event_type = event.get("event", "message")
@@ -871,7 +872,7 @@ async def draft_run(
         )
 
         source = HitLogSource.EXTERNAL if is_shared else HitLogSource.CONSOLE
-        result = await workflow_service.run(app_id, payload, config, current_user.current_workspace_id, source=source)
+        result = await workflow_service.run(app_id, payload, config, current_user.current_workspace_id, source=source, trigger_payload=payload.trigger_payload)
 
         logger.debug(
             "工作流试运行返回结果",
@@ -1111,6 +1112,7 @@ async def run_single_workflow_node(
         "message": raw_inputs.pop("sys.message", ""),
         "files": raw_inputs.pop("sys.files", []),
         "user_id": raw_inputs.pop("sys.user_id", str(current_user.id)),
+        "trigger_payload": raw_inputs.pop("trigger_payload", None),
         "inputs": raw_inputs,
         "conversation_id": "",
         "conv_messages": [],

--- a/api/app/controllers/workflow_trigger_controller.py
+++ b/api/app/controllers/workflow_trigger_controller.py
@@ -50,7 +50,7 @@ async def _read_request_body(request: Request) -> Any:
         return raw.hex()
 
 
-@router.api_route("/webhook/{route_key}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+@router.api_route("/webhook/{route_key}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"])
 async def trigger_webhook(
     route_key: str,
     request: Request,

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -650,6 +650,7 @@ class DraftRunRequest(BaseModel):
     variables: Optional[Dict[str, Any]] = Field(default=None, description="自定义变量参数值")
     stream: bool = Field(default=False, description="是否流式返回")
     files: Optional[List[FileInput]] = Field(default_factory=list, description="附件列表（支持多文件）")
+    trigger_payload: Optional[Dict[str, Any]] = Field(default=None, description="触发器 payload，webhook 试运行时传入")
 
 
 class SuggestedQuestion(BaseModel):

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -198,6 +198,8 @@ class WorkflowService:
                     "meta": {
                         "trigger_type": "webhook",
                         "source": "debug",
+                        "method": str(config.get("method", "POST")).upper(),
+                        "route_key": config.get("route_key", ""),
                     },
                 },
             )
@@ -241,10 +243,30 @@ class WorkflowService:
         *,
         preferred_node_id: str | None = None,
     ) -> dict[str, Any]:
+        trigger_node = self._find_debug_trigger_node(nodes, preferred_node_id=preferred_node_id)
+
         if input_data.get("trigger_payload") is not None:
+            # trigger_payload 已有，只补全缺失的 trigger / meta
+            if trigger_node and get_trigger_type(trigger_node) == "webhook":
+                cfg = trigger_node.get("config") or {}
+                merged = dict(input_data)
+                payload = dict(input_data["trigger_payload"])
+                if not payload.get("meta"):
+                    payload["meta"] = {
+                        "trigger_type": "webhook",
+                        "method": str(cfg.get("method", "POST")).upper(),
+                        "route_key": cfg.get("route_key", ""),
+                    }
+                    merged["trigger_payload"] = payload
+                if not merged.get("trigger"):
+                    merged["trigger"] = {
+                        "type": "webhook",
+                        "id": trigger_node.get("id"),
+                        "meta": {"source": "debug", "mode": "test_run"},
+                    }
+                return merged
             return input_data
 
-        trigger_node = self._find_debug_trigger_node(nodes, preferred_node_id=preferred_node_id)
         if not trigger_node:
             return input_data
 


### PR DESCRIPTION
support trigger_payload for webhook debug runs and extend HTTP methods

## Summary by Sourcery

支持在 webhook 调试运行中传递和扩展触发器负载，并扩展 webhook 触发器的功能。

新功能：
- 允许草稿和调试工作流运行在基于 webhook 的触发器中接受可选的 `trigger_payload`。
- 在 webhook 调试触发上下文和负载中包含 HTTP 方法和 `route_key` 元数据。
- 在 webhook 触发端点上支持 `HEAD` 请求。

增强：
- 当提供 `trigger_payload` 时，确保调试 webhook 运行会自动补全缺失的触发器和元信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support passing and enriching trigger payloads for webhook debug runs and extend webhook trigger capabilities.

New Features:
- Allow draft and debug workflow runs to accept an optional trigger_payload for webhook-based triggers.
- Include HTTP method and route_key metadata in webhook debug trigger contexts and payloads.
- Support HEAD requests on the webhook trigger endpoint.

Enhancements:
- Ensure debug webhook runs auto-populate missing trigger and meta information when a trigger_payload is provided.

</details>