### PR TITLE
fix(web): kb chunk ui

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -558,7 +558,9 @@ const CreateDataset = () => {
     if (!knowledgeBaseId) return
     knowledgesChunkPolicy(knowledgeBaseId)
       .then(res => {
-        setIsParentChildMode((res as { parent_child_mode: boolean | null }).parent_child_mode)
+        const response = res as { parent_child_mode: boolean; } || {}
+        setIsParentChildMode(response.parent_child_mode)
+        setProcessingMethod(response.parent_child_mode ? 'parentChildBlock' : 'directBlock')
       })
 
   }

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -356,7 +356,7 @@ const RecallTestResult = ({
                     return renderTextContent(formattedContent);
                   }
                   return children?.length > 0
-                    ? <div className="rb:max-h-12.5 rb:overflow-hidden">
+                    ? <div className="rb:line-clamp-3 rb:overflow-hidden">
                       {renderTextContent(item.page_content)}
                     </div>
                     : renderTextContent(item.page_content);


### PR DESCRIPTION
## Summary by Sourcery

调整知识库数据集创建行为，并微调召回测试结果文本的截断方式。

Bug Fixes:
- 确保在知识库父子模式下，对返回结果进行安全处理，并据此同时设置模式状态和处理方法。

Enhancements:
- 将召回测试结果文本的截断方式调整为：对溢出内容使用三行文本夹取（three-line clamp）显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust knowledge base dataset creation behavior and tweak recall test result text truncation.

Bug Fixes:
- Ensure knowledge base parent-child mode response is safely handled and used to set both mode state and processing method.

Enhancements:
- Change recall test result text truncation to use a three-line clamp for overflowing content.

</details>