### PR TITLE
Fix/v0.3.6 zy

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -154,6 +154,7 @@ const DocumentDetails: FC = () => {
     ].filter((item) => item.value !== null && item.value !== undefined && item.value !== '');
   };
 
+  const [isParentChildMode, setIsParentChildMode] = useState<string | boolean>('false');
   const fetchDocumentDetail = async () => {
     if (!documentId) return;
     setLoading(true);
@@ -163,7 +164,10 @@ const DocumentDetails: FC = () => {
       setInfoItems(formatDocumentInfo(response));
       const url = `${window.location.origin}/api/files/${response.file_id}`;
       setFileUrl(url);
-      setParserMode(response?.parser_config?.auto_questions || 0)
+      const auto_questions = response?.parser_config?.auto_questions || 0
+      const parent_chunk_mode = response?.parser_config?.parent_chunk_mode || false
+      setParserMode(auto_questions)
+      setIsParentChildMode(auto_questions === 0 && parent_chunk_mode)
       // ChunkList will be called automatically in useEffect based on document.progress
     } catch (error) {
       console.error('Failed to fetch document details:', error);
@@ -492,6 +496,7 @@ const DocumentDetails: FC = () => {
       {/* Insert content modal */}
       <InsertModal 
         ref={insertModalRef}
+        isParentChildMode={isParentChildMode}
         onInsert={handleInsertContent}
         onSuccess={handleInsertSuccess}
       />

--- a/web/src/views/KnowledgeBase/components/InsertModal.tsx
+++ b/web/src/views/KnowledgeBase/components/InsertModal.tsx
@@ -13,9 +13,10 @@ export interface InsertModalRef {
 interface InsertModalProps {
   onInsert?: (documentId: string, content: string | Record<string, string>, chunkId?: string, parentChunkId?: string) => Promise<boolean>;
   onSuccess?: () => void;
+  isParentChildMode?: boolean | string;
 }
 
-const InsertModal = forwardRef<InsertModalRef, InsertModalProps>(({ onInsert, onSuccess }, ref) => {
+const InsertModal = forwardRef<InsertModalRef, InsertModalProps>(({ onInsert, onSuccess, isParentChildMode }, ref) => {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -177,7 +178,7 @@ const InsertModal = forwardRef<InsertModalRef, InsertModalProps>(({ onInsert, on
     {
       key: 'qaMode',
       label: t('knowledgeBase.qaMode'),
-      disabled: !parentChunkId,
+      disabled: isParentChildMode || !parentChunkId,
       children: (
         // QA 模式的编辑界面
         <div className='rb:flex rb:flex-col rb:gap-4'>

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -84,7 +84,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                 kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [],
                 similarity_threshold: values.similarity_threshold || 0.2,
                 vector_similarity_weight: values.vector_similarity_weight || 0.3,
-                top_k: values.top_k || 1024,
+                top_k: values.top_k || 100,
                 // hybrid: values.retrieve_type !== hybrid ? true : false,
                 retrieve_type: retrieveType,
             };


### PR DESCRIPTION
## Summary by Sourcery

调整文档详情和插入模态框在父子解析模式下的行为，并微调召回测试默认值。

Bug Fixes:
- 将父子解析器配置从文档详情传递到插入模态框，当启用父级分块时，正确禁用 QA 模式。
- 将召回测试中的默认 `top_k` 值从 1024 降低到 100，以避免默认情况下结果集过大。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust document detail and insert modal behavior for parent-child parsing mode and tune recall test defaults.

Bug Fixes:
- Propagate parent-child parser configuration from document details to the insert modal to correctly disable QA mode when parent chunks are enforced.
- Reduce the default top_k value in recall tests from 1024 to 100 to avoid overly large result sets by default.

</details>