### PR TITLE
refactor(core)

### DIFF
--- a/api/app/cache/memory/activity_stats_cache.py
+++ b/api/app/cache/memory/activity_stats_cache.py
@@ -11,6 +11,7 @@ from typing import Optional, Dict, Any
 from datetime import datetime
 
 from app.aioRedis import get_thread_safe_redis
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class ActivityStatsCache:
             key = cls._get_key(workspace_id)
             payload = {
                 "stats": stats,
-                "generated_at": datetime.now().isoformat(),
+                "generated_at": to_iso_z(utcnow_naive()),
                 "workspace_id": workspace_id,
                 "cached": True,
             }

--- a/api/app/cache/memory/interest_memory.py
+++ b/api/app/cache/memory/interest_memory.py
@@ -7,9 +7,9 @@ Interest Distribution Cache
 import json
 import logging
 from typing import Optional, List, Dict, Any
-from datetime import datetime
 
 from app.aioRedis import get_thread_safe_redis
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ class InterestMemoryCache:
             key = cls._get_key(end_user_id, language)
             payload = {
                 "data": data,
-                "generated_at": datetime.now().isoformat(),
+                "generated_at": to_iso_z(utcnow_naive()),
                 "cached": True,
             }
             value = json.dumps(payload, ensure_ascii=False)

--- a/api/app/controllers/auth_controller.py
+++ b/api/app/controllers/auth_controller.py
@@ -3,6 +3,7 @@ from typing import Callable
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.response_utils import success
 from app.db import get_db
 from app.schemas.response_schema import ApiResponse
@@ -149,8 +150,8 @@ async def refresh_token(
     new_refresh_token, new_refresh_token_id = security.create_refresh_token(subject=user.id)
     
     # 计算过期时间
-    access_expires_at = datetime.now() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    refresh_expires_at = datetime.now() + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    access_expires_at = utcnow_naive() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    refresh_expires_at = utcnow_naive() + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
     
     # 单点登录会话管理
     if settings.ENABLE_SINGLE_SESSION:

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -28,6 +28,7 @@ from app.services import knowledge_service, document_service, file_service, know
 from app.services.file_storage_service import FileStorageService, get_file_storage_service, generate_kb_file_key
 from app.services.model_service import ModelApiKeyService
 from app.core.rag.utils.preview_utils import _build_preview_hierarchy
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
@@ -139,7 +140,7 @@ async def get_preview_chunks(
                 "doc_id": pid,
                 "file_id": str(db_document.file_id),
                 "file_name": db_document.file_name,
-                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "file_created_at": to_timestamp_ms(db_document.created_at),
                 "document_id": str(db_document.id),
                 "knowledge_id": str(db_document.kb_id),
                 "sort_id": idx,
@@ -153,7 +154,7 @@ async def get_preview_chunks(
                 "doc_id": uuid.uuid4().hex,
                 "file_id": str(db_document.file_id),
                 "file_name": db_document.file_name,
-                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "file_created_at": to_timestamp_ms(db_document.created_at),
                 "document_id": str(db_document.id),
                 "knowledge_id": str(db_document.kb_id),
                 "sort_id": idx,
@@ -187,7 +188,7 @@ async def get_preview_chunks(
                 "doc_id": uuid.uuid4().hex,
                 "file_id": str(db_document.file_id),
                 "file_name": db_document.file_name,
-                "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                "file_created_at": to_timestamp_ms(db_document.created_at),
                 "document_id": str(db_document.id),
                 "knowledge_id": str(db_document.kb_id),
                 "sort_id": idx,
@@ -598,7 +599,7 @@ async def create_chunk(
         "doc_id": doc_id,
         "file_id": str(db_document.file_id),
         "file_name": db_document.file_name,
-        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+        "file_created_at": to_timestamp_ms(db_document.created_at),
         "document_id": str(document_id),
         "knowledge_id": str(kb_id),
         "sort_id": sort_id,
@@ -683,7 +684,7 @@ async def create_chunks_batch(
             "doc_id": doc_id,
             "file_id": str(db_document.file_id),
             "file_name": db_document.file_name,
-            "file_created_at": int(db_document.created_at.timestamp() * 1000),
+            "file_created_at": to_timestamp_ms(db_document.created_at),
             "document_id": str(document_id),
             "knowledge_id": str(kb_id),
             "sort_id": sort_id,

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -8,6 +8,7 @@ from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
 from app.controllers import file_controller
 from app.core.config import settings
@@ -243,7 +244,7 @@ async def update_document(
     if updated_fields:
         api_logger.debug(f"updated fields: {', '.join(updated_fields)}")
 
-    db_document.updated_at = datetime.datetime.now()
+    db_document.updated_at = utcnow_naive()
 
     # 4. Save to database
     try:

--- a/api/app/controllers/i18n_controller.py
+++ b/api/app/controllers/i18n_controller.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from typing import Callable, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import success
 from app.db import get_db
@@ -789,7 +790,7 @@ def export_missing_translations(
     translation_logger = translation_service.translation_logger
     
     # Generate filename with timestamp
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = utcnow_naive().strftime("%Y%m%d_%H%M%S")
     locale_suffix = f"_{locale}" if locale else "_all"
     output_file = f"logs/i18n/missing_translations{locale_suffix}_{timestamp}.json"
     

--- a/api/app/controllers/implicit_memory_controller.py
+++ b/api/app/controllers/implicit_memory_controller.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import fail, success
@@ -104,7 +105,7 @@ def validate_date_range(start_date: Optional[datetime], end_date: Optional[datet
     if start_date and end_date and start_date >= end_date:
         raise ValueError("start_date must be before end_date")
     
-    if start_date and start_date > datetime.now():
+    if start_date and start_date > utcnow_naive():
         raise ValueError("start_date cannot be in the future")
 
 

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -9,6 +9,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
@@ -400,7 +401,7 @@ async def _update_knowledge(
         if updated_fields:
             api_logger.debug(f"updated fields: {', '.join(updated_fields)}")
 
-        db_knowledge.updated_at = datetime.datetime.now()
+        db_knowledge.updated_at = utcnow_naive()
 
         # 3. Save to database
         db.commit()
@@ -446,7 +447,7 @@ async def delete_knowledge(
         # 2. Soft-delete knowledge base
         api_logger.debug(f"Perform a soft delete: {db_knowledge.name} (ID: {knowledge_id})")
         db_knowledge.status = 2
-        db_knowledge.updated_at = datetime.datetime.now()
+        db_knowledge.updated_at = utcnow_naive()
         db.commit()
         api_logger.info(f"The knowledge base has been successfully deleted: {db_knowledge.name} (ID: {knowledge_id})")
         return success(msg="The knowledge base has been successfully deleted")

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from typing import Optional
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.response_utils import success
 from app.db import get_db
 from app.dependencies import get_current_user
@@ -570,10 +571,10 @@ async def dashboard_data(
     # 如果没有提供时间范围，默认使用最近30天
     if start_date is None or end_date is None:
         from datetime import datetime, timedelta
-        end_dt = datetime.now()
+        end_dt = utcnow_naive()
         start_dt = end_dt - timedelta(days=30)
-        end_date = int(end_dt.timestamp() * 1000)
-        start_date = int(start_dt.timestamp() * 1000)
+        end_date = to_timestamp_ms(end_dt)
+        start_date = to_timestamp_ms(start_dt)
         api_logger.info(f"使用默认时间范围: {start_dt} 到 {end_dt}")
     
     # 获取 storage_type，如果为 None 则使用默认值

--- a/api/app/controllers/message_interaction_controller.py
+++ b/api/app/controllers/message_interaction_controller.py
@@ -23,6 +23,7 @@ from app.services.conversation_share_service import ConversationShareService
 from app.services.draft_run_service import AgentRunService
 from app.services.app_service import AppService
 from app.models import ModelConfig
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 router = APIRouter(prefix="/apps", tags=["Message Interaction"])
 
@@ -355,7 +356,7 @@ async def get_reports_for_review(
             "selected_text": r.selected_text,
             "text_start_offset": r.text_start_offset,
             "text_end_offset": r.text_end_offset,
-            "created_at": int(r.created_at.timestamp() * 1000) if r.created_at else None,
+            "created_at": to_timestamp_ms(r.created_at),
         }
         for r in reports
     ]

--- a/api/app/controllers/model_controller.py
+++ b/api/app/controllers/model_controller.py
@@ -98,7 +98,7 @@ def get_model_list(
             pagesize=pagesize
         )
 
-        api_logger.debug(f"开始获取模型配置列表: {query.dict()}")
+        api_logger.debug(f"开始获取模型配置列表: {query.model_dump()}")
         result_orm = ModelConfigService.get_model_list(db=db, query=query, tenant_id=current_user.tenant_id)
         result = PageData.model_validate(result_orm)
         api_logger.info(f"模型配置列表获取成功: 总数={result.page.total}, 当前页={len(result.items)}")

--- a/api/app/controllers/tenant_subscription_controller.py
+++ b/api/app/controllers/tenant_subscription_controller.py
@@ -1,7 +1,6 @@
 """
 租户套餐查询接口（普通用户可访问）
 """
-import datetime
 from typing import Callable, Optional
 
 from fastapi import APIRouter, Depends
@@ -15,6 +14,7 @@ from app.dependencies import get_current_user
 from app.i18n.dependencies import get_translator
 from app.models.user_model import User
 from app.schemas.response_schema import ApiResponse
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 
 logger = get_api_logger()
 
@@ -47,6 +47,7 @@ async def get_my_tenant_subscription(
             free_plan = svc.plan_repo.get_free_plan()
             if not free_plan:
                 return success(data=None, msg="暂无有效套餐")
+            current_time_ms = to_timestamp_ms(utcnow_naive())
             return success(data={
                 "subscription_id": None,
                 "tenant_id": str(tenant_id),
@@ -75,8 +76,8 @@ async def get_my_tenant_subscription(
                 "expired_at": None,
                 "status": "active",
                 "quotas": free_plan.quotas or {},
-                "created_at": int(datetime.datetime.utcnow().timestamp() * 1000),
-                "updated_at": int(datetime.datetime.utcnow().timestamp() * 1000),
+                "created_at": current_time_ms,
+                "updated_at": current_time_ms,
             }, msg="免费套餐")
 
         return success(data=svc.build_response(sub))
@@ -89,6 +90,7 @@ async def get_my_tenant_subscription(
         from app.config.default_free_plan import DEFAULT_FREE_PLAN
 
         plan = DEFAULT_FREE_PLAN
+        current_time_ms = to_timestamp_ms(utcnow_naive())
         response_data = {
             "subscription_id": None,
             "tenant_id": str(current_user.tenant.id),
@@ -117,8 +119,8 @@ async def get_my_tenant_subscription(
             "expired_at": None,
             "status": "active",
             "quotas": plan["quotas"],
-            "created_at": int(datetime.datetime.utcnow().timestamp() * 1000),
-            "updated_at": int(datetime.datetime.utcnow().timestamp() * 1000),
+            "created_at": current_time_ms,
+            "updated_at": current_time_ms,
         }
         return success(data=response_data, msg="社区版免费套餐")
 

--- a/api/app/core/api_key_auth.py
+++ b/api/app/core/api_key_auth.py
@@ -3,13 +3,13 @@ import time
 import uuid
 from functools import wraps
 from typing import Optional, List
-from datetime import datetime
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.core.api_key_utils import add_rate_limit_headers
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.exceptions import (
     BusinessException,
     RateLimitException,
@@ -199,7 +199,7 @@ async def log_api_key_usage(
             "status_code": response.status_code if hasattr(response, "status_code") else None,
             "response_time": round(response_time),
             "tokens_used": None,
-            "created_at": datetime.now()
+            "created_at": utcnow_naive()
         }
 
         ApiKeyLogRepository.create(db, log_data)

--- a/api/app/core/api_key_utils.py
+++ b/api/app/core/api_key_utils.py
@@ -1,8 +1,8 @@
 """API Key 工具函数"""
 import secrets
 import uuid as _uuid
-from typing import Optional, Union
 from datetime import datetime
+from typing import Optional, Union
 
 from sqlalchemy.orm import Session as _Session
 from app.core.error_codes import BizCode as _BizCode
@@ -11,6 +11,7 @@ from app.models.end_user_model import EndUser as _EndUser
 from app.repositories.end_user_repository import EndUserRepository as _EndUserRepository
 
 from app.models.api_key_model import ApiKeyType
+from app.core.utils.datetime_utils import parse_timestamp_to_utc_naive, to_timestamp_ms
 from fastapi import Response
 from fastapi.responses import JSONResponse
 
@@ -56,22 +57,12 @@ def add_rate_limit_headers(response, headers: dict):
 
 def timestamp_to_datetime(timestamp: Optional[Union[int, float]]) -> Optional[datetime]:
     """将时间戳转换为datetime对象"""
-    if timestamp is None:
-        return None
-
-    # 处理毫秒级时间戳
-    if timestamp > 1e10:
-        timestamp = timestamp / 1000
-
-    return datetime.fromtimestamp(timestamp)
+    return parse_timestamp_to_utc_naive(timestamp)
 
 
 def datetime_to_timestamp(dt: Optional[datetime]) -> Optional[int]:
     """将datetime对象转换为时间戳（毫秒）"""
-    if dt is None:
-        return None
-
-    return int(dt.timestamp() * 1000)
+    return to_timestamp_ms(dt)
 
 
 def get_current_user_from_api_key(db: _Session, api_key_auth):

--- a/api/app/core/logging_config.py
+++ b/api/app/core/logging_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.core.config import settings
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.sensitive_filter import SensitiveDataFilter
 
 
@@ -274,8 +275,7 @@ def get_prompt_logger() -> logging.Logger:
     logger.propagate = False  # Don't propagate to root logger (no console output)
     
     # Create timestamped log file
-    from datetime import datetime
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = utcnow_naive().strftime("%Y%m%d-%H%M%S")
     log_file = Path("logs/prompts/") / f"prompt_logs-{timestamp}.log"
     
     # Ensure log directory exists
@@ -514,10 +514,8 @@ def log_time(step_name: str, duration: float, log_file: str = "logs/time.log") -
         >>> log_time("Database Query", 0.15, "logs/custom_time.log")
         # Logs to custom file and console
     """
-    from datetime import datetime
-    
     # Format timestamp
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = utcnow_naive().strftime("%Y-%m-%d %H:%M:%S")
     
     # Format timing entry for file
     log_entry = f"[{timestamp}] {step_name}: {duration:.2f} seconds\n"

--- a/api/app/core/memory/agent/langgraph_graph/tools/tool.py
+++ b/api/app/core/memory/agent/langgraph_graph/tools/tool.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from langchain.tools import tool
 from pydantic import BaseModel, Field
@@ -9,6 +9,7 @@ from app.core.memory.src.search import (
     search_by_temporal,
     search_by_keyword_temporal,
 )
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 
 
 def extract_tool_message_content(response):
@@ -151,8 +152,9 @@ def create_time_retrieval_tool(end_user_id: str):
         async def _async_search():
             # Use passed parameters or default values
             actual_end_user_id = end_user_id_param or end_user_id
-            actual_end_date = end_date or datetime.now().strftime("%Y-%m-%d")
-            actual_start_date = start_date or (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+            current_date = utcnow_naive()
+            actual_end_date = end_date or current_date.strftime("%Y-%m-%d")
+            actual_start_date = start_date or (current_date - timedelta(days=7)).strftime("%Y-%m-%d")
             
             # Basic time search
             results = await search_by_temporal(
@@ -195,8 +197,9 @@ def create_time_retrieval_tool(end_user_id: str):
         """
 
         async def _async_search():
-            actual_end_date = end_date or datetime.now().strftime("%Y-%m-%d")
-            actual_start_date = start_date or (datetime.now() - timedelta(days=days_back)).strftime("%Y-%m-%d")
+            current_date = utcnow_naive()
+            actual_end_date = end_date or current_date.strftime("%Y-%m-%d")
+            actual_start_date = start_date or (current_date - timedelta(days=days_back)).strftime("%Y-%m-%d")
 
             # Keyword time search
             results = await search_by_keyword_temporal(
@@ -342,7 +345,7 @@ def create_hybrid_retrieval_tool_async(memory_config, **search_params):
                 "error": f"混合检索失败: {str(e)}",
                 "search_query": context,
                 "search_type": search_type,
-                "timestamp": datetime.now().isoformat()
+                "timestamp": to_iso_z(utcnow_naive())
             }
             return json.dumps(error_result, ensure_ascii=False, indent=2)
 

--- a/api/app/core/memory/agent/utils/redis_base.py
+++ b/api/app/core/memory/agent/utils/redis_base.py
@@ -1,7 +1,8 @@
 import json
-from typing import Any, List, Dict, Optional
-from datetime import datetime, timedelta
+from typing import Any, List, Dict
+from datetime import timedelta
 
+from app.core.utils.datetime_utils import utcnow_naive
 
 def serialize_messages(messages: Any) -> str:
     """
@@ -112,7 +113,7 @@ def filter_by_time_range(items: List[Dict], minutes: int) -> List[Dict]:
     Returns:
         List[Dict]: 过滤后的数据列表
     """
-    time_threshold = datetime.now() - timedelta(minutes=minutes)
+    time_threshold = utcnow_naive() - timedelta(minutes=minutes)
     time_threshold_str = time_threshold.strftime("%Y-%m-%d %H:%M:%S")
     
     filtered_items = []
@@ -183,4 +184,4 @@ def get_current_timestamp() -> str:
     Returns:
         str: 格式化的时间字符串 "YYYY-MM-DD HH:MM:SS"
     """
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return utcnow_naive().strftime("%Y-%m-%d %H:%M:%S")

--- a/api/app/core/memory/analytics/implicit_memory/analyzers/dimension_analyzer.py
+++ b/api/app/core/memory/analytics/implicit_memory/analyzers/dimension_analyzer.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.analytics.implicit_memory.llm_client import ImplicitMemoryLLMClient
 from app.core.memory.llm_tools.llm_client import LLMClientException
 from app.schemas.implicit_memory_schema import (
@@ -87,7 +88,7 @@ class DimensionAnalyzer:
             
             # Create dimension scores
             dimension_scores = {}
-            current_time = datetime.now()
+            current_time = utcnow_naive()
             
             for dimension_name in self.DIMENSIONS:
                 # Handle response as dictionary
@@ -224,7 +225,7 @@ class DimensionAnalyzer:
         Returns:
             Empty DimensionPortrait
         """
-        current_time = datetime.now()
+        current_time = utcnow_naive()
         
         return DimensionPortrait(
             creativity=self._create_default_dimension_score("creativity"),
@@ -253,7 +254,7 @@ class DimensionAnalyzer:
         
         # Create trend entry from existing portrait
         trend_entry = {
-            "timestamp": existing_portrait.analysis_timestamp.isoformat(),
+            "timestamp": to_iso_z(existing_portrait.analysis_timestamp),
             "creativity": existing_portrait.creativity.percentage,
             "aesthetic": existing_portrait.aesthetic.percentage,
             "technology": existing_portrait.technology.percentage,

--- a/api/app/core/memory/analytics/implicit_memory/analyzers/habit_analyzer.py
+++ b/api/app/core/memory/analytics/implicit_memory/analyzers/habit_analyzer.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.analytics.implicit_memory.llm_client import ImplicitMemoryLLMClient
 from app.core.memory.llm_tools.llm_client import LLMClientException
 from app.schemas.implicit_memory_schema import (
@@ -292,7 +293,7 @@ class HabitAnalyzer:
             Consolidated list of habits
         """
         consolidated = existing_habits.copy()
-        current_time = datetime.now()
+        current_time = utcnow_naive()
         
         for new_habit in new_habits:
             # Find similar existing habit
@@ -448,7 +449,7 @@ class HabitAnalyzer:
             confidence_score = habit.confidence_level
             
             # Recency score (more recent = higher score)
-            days_since_last = (datetime.now() - habit.last_observed).days
+            days_since_last = (utcnow_naive() - habit.last_observed).days
             recency_score = max(0, 365 - days_since_last)  # Max 365 days
             
             # Current habit bonus

--- a/api/app/core/memory/analytics/implicit_memory/analyzers/interest_analyzer.py
+++ b/api/app/core/memory/analytics/implicit_memory/analyzers/interest_analyzer.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.analytics.implicit_memory.llm_client import ImplicitMemoryLLMClient
 from app.core.memory.llm_tools.llm_client import LLMClientException
 from app.schemas.implicit_memory_schema import (
@@ -86,7 +87,7 @@ class InterestAnalyzer:
             
             # Create interest categories
             interest_categories = {}
-            current_time = datetime.now()
+            current_time = utcnow_naive()
             
             # Extract interest_distribution from response dict
             interest_distribution = response.get("interest_distribution", {})
@@ -255,7 +256,7 @@ class InterestAnalyzer:
         Returns:
             Empty InterestAreaDistribution with equal percentages
         """
-        current_time = datetime.now()
+        current_time = utcnow_naive()
         equal_percentage = 25.0  # 100% / 4 categories
         
         def default_category(name: str) -> InterestCategory:

--- a/api/app/core/memory/analytics/implicit_memory/analyzers/preference_analyzer.py
+++ b/api/app/core/memory/analytics/implicit_memory/analyzers/preference_analyzer.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.analytics.implicit_memory.llm_client import ImplicitMemoryLLMClient
 from app.core.memory.llm_tools.llm_client import LLMClientException
 from app.schemas.implicit_memory_schema import (
@@ -75,7 +76,7 @@ class PreferenceAnalyzer:
             
             # Convert to PreferenceTag objects
             preference_tags = []
-            current_time = datetime.now()
+            current_time = utcnow_naive()
             
             for pref_data in response.get("preferences", []):
                 try:
@@ -168,7 +169,7 @@ class PreferenceAnalyzer:
             Consolidated list of preferences
         """
         consolidated = existing_preferences.copy()
-        current_time = datetime.now()
+        current_time = utcnow_naive()
         
         for new_pref in new_preferences:
             # Find similar existing preference

--- a/api/app/core/memory/analytics/implicit_memory/data_source.py
+++ b/api/app/core/memory/analytics/implicit_memory/data_source.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.repositories.neo4j.memory_summary_repository import MemorySummaryRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.schemas.implicit_memory_schema import TimeRange, UserMemorySummary
@@ -33,7 +34,7 @@ class MemoryDataSource:
         if isinstance(timestamp, str):
             return datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
         elif timestamp is None:
-            return datetime.now()
+            return utcnow_naive()
         return timestamp
     
     def _dict_to_user_summary(self, summary_dict: Dict, user_id: str) -> Optional[UserMemorySummary]:

--- a/api/app/core/memory/analytics/implicit_memory/habit_detector.py
+++ b/api/app/core/memory/analytics/implicit_memory/habit_detector.py
@@ -10,6 +10,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import List, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.analytics.implicit_memory.analyzers.habit_analyzer import (
     HabitAnalyzer,
 )
@@ -119,7 +120,7 @@ class HabitDetector:
             confidence_score = habit.confidence_level / 100.0
             
             # Recency score (0.0-1.0)
-            current_time = datetime.now()
+            current_time = utcnow_naive()
             days_since_last = (current_time - habit.last_observed).days
             
             # Exponential decay for recency (habits lose relevance over time)
@@ -183,7 +184,7 @@ class HabitDetector:
         if not habits:
             return []
         
-        current_time = datetime.now()
+        current_time = utcnow_naive()
         cutoff_date = current_time - timedelta(days=current_threshold_days)
         
         current_habits = []

--- a/api/app/core/memory/analytics/implicit_memory/llm_client.py
+++ b/api/app/core/memory/analytics/implicit_memory/llm_client.py
@@ -8,6 +8,7 @@ extraction, personality dimension analysis, interest categorization, and habit d
 import logging
 from typing import Any, Dict, List, Optional
 
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.memory.analytics.implicit_memory.prompts import (
     get_dimension_analysis_prompt,
     get_habit_analysis_prompt,
@@ -105,7 +106,7 @@ class ImplicitMemoryLLMClient:
             formatted_summary = {
                 'summary_id': summary.summary_id,
                 'user_content': summary.user_content,
-                'timestamp': summary.timestamp.isoformat(),
+                'timestamp': to_iso_z(summary.timestamp),
                 'summary_type': summary.summary_type,
                 'confidence_score': summary.confidence_score
             }

--- a/api/app/core/memory/models/message_models.py
+++ b/api/app/core/memory/models/message_models.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 from uuid import uuid4
 from datetime import datetime
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.utils.data.ontology import StatementType, TemporalInfo, RelevenceInfo
 from app.core.memory.models.triplet_models import TripletExtractionResponse, Triplet
 
@@ -186,7 +187,7 @@ class DialogData(BaseModel):
     ref_id: str = Field(..., description="Refer to external dialog id. This is used to link to the original dialog.")
     end_user_id: str = Field(default=..., description="End user ID of dialogue data")
     run_id: str = Field(default_factory=lambda: uuid4().hex, description="Unique identifier for this pipeline run.")
-    created_at: datetime = Field(default_factory=datetime.now, description="The timestamp when the dialog was created.")
+    created_at: datetime = Field(default_factory=utcnow_naive, description="The timestamp when the dialog was created.")
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata for the dialog.")
     chunks: List[Chunk] = Field(default_factory=list, description="A list of chunks from the conversation context.")
     config_id: Optional[int | str] = Field(None, description="Configuration ID used to process this dialog (integer or string)")

--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
+from app.core.utils.datetime_utils import to_iso_z
+
 if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
 
@@ -351,7 +353,7 @@ class PruningPipeline:
                 "pair_id": pruned_edge.pair_id,
                 "end_user_id": pruned_edge.end_user_id,
                 "run_id": pruned_edge.run_id,
-                "created_at": pruned_edge.created_at.isoformat(),
+                "created_at": to_iso_z(pruned_edge.created_at),
             }]
             result = await tx.run(ASSISTANT_PRUNED_EDGE_SAVE, edges=edge_data)
             await result.consume()

--- a/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
+++ b/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from datetime import datetime
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.prompt import prompt_manager
 from app.core.memory.utils.llm.llm_utils import StructResponse
 from app.core.models import RedBearLLM
@@ -17,14 +17,14 @@ class QueryPreprocessor:
         if not text:
             return text
 
-        text = re.sub(rf"{"|".join(AgentMemoryDataset.PRONOUN)}", AgentMemoryDataset.NAME, text)
+        text = re.sub(rf'{"|".join(AgentMemoryDataset.PRONOUN)}', AgentMemoryDataset.NAME, text)
         return text
 
     @staticmethod
     async def split(query: str, history: list, llm_client: RedBearLLM):
         system_prompt = prompt_manager.render(
             name="problem_split",
-            datetime=datetime.now().strftime("%Y-%m-%d"),
+            datetime=utcnow_naive().strftime("%Y-%m-%d"),
         )
         messages = [
             {"role": "system", "content": system_prompt},

--- a/api/app/core/memory/sliding_window/window_utils.py
+++ b/api/app/core/memory/sliding_window/window_utils.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 import logging
 import uuid
 from bisect import bisect_right
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import List
 
 from sqlalchemy import func, select, update
 
 from app.db import get_db_context
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.models.conversation_model import Conversation
 from app.models.memory_message_model import MemoryMessage
 
@@ -195,11 +196,7 @@ def message_to_dict(message: MemoryMessage) -> dict:
         "content": message.content,
         "message_seq": message.message_seq,
         "should_memorize": message.should_memorize,
-        "created_at": (
-            message.created_at.isoformat()
-            if message.created_at is not None
-            else None
-        ),
+        "created_at": to_iso_z(message.created_at),
         "dialog_at": message.dialog_at,
         "files": message.files,
     }
@@ -453,7 +450,7 @@ async def write_batch_to_memory_messages(
                 content=content,
                 message_seq=next_seq,
                 should_memorize=True,
-                created_at=datetime.now(timezone.utc),
+                created_at=utcnow_naive(),
                 dialog_at=(msg.get("dialog_at") or None),
                 files=msg.get("files"),
             )

--- a/api/app/core/memory/src/search.py
+++ b/api/app/core/memory/src/search.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
 
 from app.core.logging_config import get_memory_logger
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.llm_tools.openai_embedder import OpenAIEmbedderClient
 from app.core.memory.models.config_models import TemporalSearchParams
 from app.core.memory.models.variate_config import ForgettingEngineConfig
@@ -237,7 +238,7 @@ def rerank_with_activation(
     engine = None
     if forgetting_config:
         engine = ForgettingEngine(forgetting_config)
-    now_dt = now or datetime.now()
+    now_dt = now or utcnow_naive()
 
     reranked: Dict[str, List[Dict[str, Any]]] = {}
 
@@ -728,7 +729,7 @@ async def run_hybrid_search(
                 "total_embedding_results": 0,
                 "total_reranked_results": 0,
                 "search_query": "",
-                "search_timestamp": datetime.now().isoformat(),
+                "search_timestamp": to_iso_z(utcnow_naive()),
                 "error": "Empty query"
             }
         }
@@ -827,7 +828,7 @@ async def run_hybrid_search(
                 "total_embedding_results": sum(
                     len(v) if isinstance(v, list) else 0 for v in embedding_results.values()),
                 "search_query": query_text,
-                "search_timestamp": datetime.now().isoformat()
+                "search_timestamp": to_iso_z(utcnow_naive())
             }
 
             # Apply two-stage reranking with ACTR activation calculation
@@ -885,7 +886,7 @@ async def run_hybrid_search(
                     len(v) if isinstance(v, list) else 0 for v in embedding_results.values()),
                 "total_reranked_results": sum(len(v) if isinstance(v, list) else 0 for v in reranked_results.values()),
                 "search_query": query_text,
-                "search_timestamp": datetime.now().isoformat(),
+                "search_timestamp": to_iso_z(utcnow_naive()),
                 "reranking_alpha": rerank_alpha,
                 "activation_boost_factor": activation_boost_factor,
                 "forgetting_rerank": use_forgetting_rerank,

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_preprocessor.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_preprocessor.py
@@ -16,9 +16,9 @@ import os
 
 from typing import List, Dict, Any, Optional, Union
 from pathlib import Path
-from datetime import datetime
 
 from app.core.memory.models.message_models import DialogData, ConversationContext, ConversationMessage
+from app.core.utils.datetime_utils import to_iso_z
 
 
 class DataPreprocessor:
@@ -724,7 +724,7 @@ class DataPreprocessor:
             serializable_data.append({
                 'id': dialog.id,
                 'ref_id': dialog.ref_id,
-                'created_at': dialog.created_at.isoformat(),
+                'created_at': to_iso_z(dialog.created_at),
                 'context': {
                     'msgs': [{'role': msg.role, 'msg': msg.msg} for msg in dialog.context.msgs]
                 },

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.models.message_models import (
     DialogData,
     ConversationMessage,
@@ -279,7 +280,7 @@ class SemanticPruner:
                     original_text=asst_msg.msg,
                     pruned_text=result.assistant_memory_hint,
                     memory_type=result.assistant_memory_type,
-                    created_at=datetime.now().isoformat(),
+                    created_at=to_iso_z(utcnow_naive()),
                 ))
 
                 if result.assistant_memory_hint == "NULL":

--- a/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
+++ b/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
@@ -7,9 +7,9 @@ import importlib
 import logging
 import os
 import re
-from datetime import datetime
 from typing import Any, Dict, List, Tuple
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.models.graph_models import (
     EntityEntityEdge,
     ExtractedEntityNode,
@@ -1048,7 +1048,7 @@ def _write_dedup_fusion_report(
         out_path = settings.get_memory_output_path("dedup_entity_output.txt")
         report_lines: List[str] = []
         if not append:
-            report_lines.append(f"去重融合报告 - {datetime.now().isoformat()}")
+            report_lines.append(f"去重融合报告 - {to_iso_z(utcnow_naive())}")
             report_lines.append("")
         if stage_label:
             # 追加写入时，在阶段标题前增加一个空行以增强分隔

--- a/api/app/core/memory/storage_services/extraction_engine/deduplication/second_layer_dedup.py
+++ b/api/app/core/memory/storage_services/extraction_engine/deduplication/second_layer_dedup.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Tuple
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.models.graph_models import (
     EntityEntityEdge,
     ExtractedEntityNode,
@@ -48,7 +49,7 @@ def _parse_dt(val: Any) -> datetime: # 定义内部辅助函数_parse_dt，用�
         except Exception:
             pass
     # Fallback: now; upstream should provide real times
-    return datetime.now()
+    return utcnow_naive()
 
 
 def _row_to_entity(row: Dict[str, Any]) -> ExtractedEntityNode:

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/memory_summary.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/memory_summary.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple
 from uuid import uuid4
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_memory_logger
 from app.core.memory.llm_tools.openai_embedder import OpenAIEmbedderClient
 from app.core.memory.models.base_response import RobustLLMResponse
@@ -216,7 +217,7 @@ async def _process_chunk_summary(
             user_id=dialog.end_user_id,
             apply_id=dialog.end_user_id,
             run_id=dialog.run_id,  # 使用 dialog 的 run_id
-            created_at=datetime.now(),
+            created_at=utcnow_naive(),
             dialog_id=dialog.id,
             chunk_ids=[chunk.id],
             content=summary_text,

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.models.message_models import DialogData, Statement
 from app.core.memory.models.variate_config import StatementExtractionConfig
 from app.core.memory.utils.data.ontology import (
@@ -123,7 +124,7 @@ class StatementExtractor:
                 "chunk_id": getattr(chunk, "id", ""),
                 "end_user_id": end_user_id or "",
                 "target_content": chunk_content,
-                "target_message_date": datetime.now().isoformat(),
+                "target_message_date": to_iso_z(utcnow_naive()),
                 "supporting_context": {
                     "msgs": [
                         {"role": "context", "msg": dialogue_content}
@@ -252,7 +253,7 @@ class StatementExtractor:
                 f.write(f"Content: {statement.statement}\n")
                 f.write(f"Type: {statement.stmt_type.value}\n")
                 f.write(f"Temporal Info: {statement.temporal_info.value}\n")
-                f.write(f"Created At: {datetime.now()}\n")
+                f.write(f"Created At: {to_iso_z(utcnow_naive())}\n")
                 f.write(f"Expired At: {None}\n")
                 f.write(f"Valid At: {statement.temporal_validity.valid_at if statement.temporal_validity else None}\n")
                 f.write(f"Invalid At: {statement.temporal_validity.invalid_at if statement.temporal_validity else None}\n")

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/temporal_extraction.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/temporal_extraction.py
@@ -1,6 +1,5 @@
 import os
 import asyncio
-from datetime import datetime
 from typing import Any, Optional
 from pydantic import BaseModel, Field
 from app.core.memory.llm_tools.openai_client import OpenAIClient
@@ -8,6 +7,7 @@ from app.core.memory.models.message_models import DialogData, Statement, Tempora
 from app.core.memory.utils.prompt.prompt_utils import render_temporal_extraction_prompt
 from app.core.memory.utils.data.ontology import LABEL_DEFINITIONS, TemporalInfo
 from app.core.memory.utils.log.logging_utils import prompt_logger
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class RawTemporalRange(BaseModel):
@@ -49,7 +49,7 @@ class TemporalExtractor:
             TemporalValidityRange: The extracted temporal validity range.
         """
         if not ref_dates:
-            ref_dates = {"today": datetime.now().strftime("%Y-%m-%d")}
+            ref_dates = {"today": utcnow_naive().strftime("%Y-%m-%d")}
 
         if statement.temporal_info == TemporalInfo.ATEMPORAL:
             return TemporalValidityRange(valid_at=None, invalid_at=None)

--- a/api/app/core/memory/storage_services/extraction_engine/pipeline_help.py
+++ b/api/app/core/memory/storage_services/extraction_engine/pipeline_help.py
@@ -22,6 +22,8 @@ import json
 from datetime import datetime
 from collections import defaultdict
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+
 
 def _parse_triplets_from_file(filepath):
     """解析三元组文件，返回三元组列表"""
@@ -302,7 +304,7 @@ def _write_extracted_result_summary(
     # 构建 JSON 结构（字段顺序按用户需求组织：先“实体去重的影响”，后“实体消歧的效果”）
     readable_path = os.path.join(pipeline_output_dir, "extracted_result_readable.txt")
     summary_json = {
-        "generated_at": datetime.now().isoformat(),
+        "generated_at": to_iso_z(utcnow_naive()),
         "entities": {
             "extracted_count": extracted_entity_count,
         },
@@ -392,7 +394,7 @@ def _write_extracted_result_summary(
 
     # 额外生成可读版文本，模块顺序调整
     lines: list[str] = []
-    lines.append(f"结果汇总 - {datetime.now().isoformat()}")
+    lines.append(f"结果汇总 - {to_iso_z(utcnow_naive())}")
     lines.append("")
     # 提取实体数模块
     lines.append("提取实体数：")
@@ -494,7 +496,7 @@ def export_test_input_doc(
             d = m.model_dump()
             for k, v in list(d.items()):
                 if isinstance(v, datetime):
-                    d[k] = v.isoformat()
+                    d[k] = to_iso_z(v)
             return d
 
         def _entity_to_dict(e):
@@ -506,7 +508,7 @@ def export_test_input_doc(
             }
 
         with open(out_path, "w", encoding="utf-8") as f:
-            header_time = entity_nodes[0].created_at.isoformat()
+            header_time = to_iso_z(entity_nodes[0].created_at)
             f.write(
                 f"=== TEST EXTRACTED ENTITIES === (created_at: {header_time})\n"
             )

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.memory.models.graph_models import (
     ChunkNode,
     DialogueNode,
@@ -187,7 +188,7 @@ async def build_graph_nodes_and_edges(
                     keywords=content_meta.get("keywords", []),
                     topic=content_meta.get("topic", ""),
                     domain=content_meta.get("domain", ""),
-                    created_at=p.created_time.isoformat() if p.created_time else None,
+                    created_at=to_iso_z(p.created_time),
                     file_type=file_type,
                     summary_embedding=summary_embedding,
                 )

--- a/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/access_history_manager.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.storage_services.forgetting_engine.actr_calculator import (
     ACTRCalculator,
 )
@@ -95,9 +96,9 @@ class AccessHistoryManager:
             RuntimeError: 如果更新失败
         """
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
         
-        current_time_iso = current_time.isoformat()
+        current_time_iso = to_iso_z(current_time)
         
         # 验证节点标签
         valid_labels = ["Statement", "ExtractedEntity", "MemorySummary"]
@@ -173,7 +174,7 @@ class AccessHistoryManager:
         batch_start = time.time()
         
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
         
         # 合并同一节点的访问次数，避免对同一节点并发写入
         access_count_map: Dict[str, int] = {}
@@ -372,7 +373,7 @@ class AccessHistoryManager:
             repair_data['access_count'] = len(access_history)
             
             if access_history:
-                current_time = datetime.now()
+                current_time = utcnow_naive()
                 last_access_dt = datetime.fromisoformat(access_history[-1])
                 access_history_dt = [
                     datetime.fromisoformat(ts) for ts in access_history

--- a/api/app/core/memory/storage_services/forgetting_engine/forgetting_engine.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forgetting_engine.py
@@ -17,6 +17,8 @@ R(t, S) = offset + (1 - offset) * exp(-λ_time * t / (λ_mem * S))
 import math
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
+
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.models.variate_config import ForgettingEngineConfig
 
 
@@ -245,7 +247,7 @@ class ForgettingEngine:
             经过的天数（浮点数）
         """
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
 
         time_diff = current_time - created_at
         return time_diff.total_seconds() / (24 * 3600)
@@ -265,7 +267,7 @@ class ForgettingEngine:
             经过的小时数（浮点数）
         """
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
 
         time_diff = current_time - created_at
         return time_diff.total_seconds() / 3600

--- a/api/app/core/memory/storage_services/forgetting_engine/forgetting_scheduler.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forgetting_scheduler.py
@@ -17,8 +17,8 @@ Classes:
 import logging
 from typing import Dict, Any, Optional
 from uuid import UUID
-from datetime import datetime
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.memory.storage_services.forgetting_engine.forgetting_strategy import ForgettingStrategy
 from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -105,8 +105,8 @@ class ForgettingScheduler:
             raise RuntimeError("遗忘周期已在运行中，请等待当前周期完成")
         
         self.is_running = True
-        start_time = datetime.now()
-        start_time_iso = start_time.isoformat()
+        start_time = utcnow_naive()
+        start_time_iso = to_iso_z(start_time)
         
         logger.info(
             f"开始遗忘周期: end_user_id={end_user_id}, "
@@ -130,7 +130,7 @@ class ForgettingScheduler:
             
             if total_forgettable == 0:
                 logger.info("没有可遗忘的节点对，遗忘周期结束")
-                end_time = datetime.now()
+                end_time = utcnow_naive()
                 duration = (end_time - start_time).total_seconds()
                 
                 report = {
@@ -140,7 +140,7 @@ class ForgettingScheduler:
                     'reduction_rate': 0.0,
                     'duration_seconds': duration,
                     'start_time': start_time_iso,
-                    'end_time': end_time.isoformat(),
+                    'end_time': to_iso_z(end_time),
                     'failed_count': 0,
                     'success_rate': 1.0
                 }
@@ -283,7 +283,7 @@ class ForgettingScheduler:
             logger.info(f"遗忘后节点总数: {nodes_after}")
             
             # 步骤7：生成遗忘报告
-            end_time = datetime.now()
+            end_time = utcnow_naive()
             duration = (end_time - start_time).total_seconds()
             
             # 计算节点减少率
@@ -305,7 +305,7 @@ class ForgettingScheduler:
                 'reduction_rate': reduction_rate,
                 'duration_seconds': duration,
                 'start_time': start_time_iso,
-                'end_time': end_time.isoformat(),
+                'end_time': to_iso_z(end_time),
                 'failed_count': failed_count,
                 'success_rate': success_rate
             }

--- a/api/app/core/memory/storage_services/forgetting_engine/forgetting_strategy.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forgetting_strategy.py
@@ -16,6 +16,7 @@ from typing import List, Dict, Any, Optional
 from uuid import UUID
 from datetime import datetime, timedelta
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.core.memory.storage_services.forgetting_engine.actr_calculator import ACTRCalculator
 
@@ -122,8 +123,8 @@ class ForgettingStrategy:
                 - avg_activation: 平均激活值（用于排序）
         """
         # 计算时间阈值
-        cutoff_time = datetime.now() - timedelta(days=min_days_since_access)
-        cutoff_time_iso = cutoff_time.isoformat()
+        cutoff_time = utcnow_naive() - timedelta(days=min_days_since_access)
+        cutoff_time_iso = to_iso_z(cutoff_time)
         
         # 构建查询
         query = """
@@ -293,8 +294,8 @@ class ForgettingStrategy:
         inherited_importance = max(statement_importance, entity_importance)
         
         # 创建 MemorySummary 节点
-        current_time = datetime.now()
-        current_time_iso = current_time.isoformat()
+        current_time = utcnow_naive()
+        current_time_iso = to_iso_z(current_time)
         
         # 生成新的 MemorySummary ID
         import uuid
@@ -641,4 +642,3 @@ class ForgettingStrategy:
             summary = f"{summary[:197]}..."
         
         return summary
-

--- a/api/app/core/memory/storage_services/forgetting_engine/memory_strength.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/memory_strength.py
@@ -19,6 +19,7 @@ import math
 from typing import List, Optional
 from datetime import datetime, timedelta
 
+from app.core.utils.datetime_utils import utcnow_naive
 
 class MemoryStrengthCalculator:
     """
@@ -66,7 +67,7 @@ class MemoryStrengthCalculator:
             raise ValueError("access_times cannot be empty")
 
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
 
         # Calculate time differences in specified units
         time_diffs = []
@@ -180,7 +181,7 @@ class MemoryStrengthCalculator:
             tuple: (should_retain: bool, retention_probability: float, activation: float)
         """
         if current_time is None:
-            current_time = datetime.now()
+            current_time = utcnow_naive()
 
         activation = self.calculate_activation(access_times, current_time)
 
@@ -241,7 +242,7 @@ def calculate_retention(
     activation = calculator.calculate_activation(access_times, current_time)
 
     if current_time is None:
-        current_time = datetime.now()
+        current_time = utcnow_naive()
 
     last_access = max(access_times)
     time_since_last = (current_time - last_access).total_seconds()

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/full_scan_dedup.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/full_scan_dedup.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.aioRedis import get_redis_connection
+from app.core.utils.datetime_utils import to_iso_z, utcnow
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ async def get_last_scan_time(end_user_id: str, entity_type: str) -> Optional[str
 async def update_scan_time(end_user_id: str, entity_type: str) -> None:
     """更新扫描时间为当前时间（永久保留，不设TTL）"""
     redis = await get_redis_connection()
-    now = datetime.now(timezone.utc).isoformat()
+    now = to_iso_z(utcnow())
     await redis.set(_scan_time_key(end_user_id, entity_type), now)
 
 

--- a/api/app/core/memory/utils/debug/pipeline_snapshot.py
+++ b/api/app/core/memory/utils/debug/pipeline_snapshot.py
@@ -31,8 +31,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import datetime
 from typing import Any, Dict, Optional
+
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +148,7 @@ class PipelineSnapshot:
         self._oss_prefix: Optional[str] = None
 
         if self.enabled:
-            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            ts = utcnow_naive().strftime("%Y%m%d_%H%M%S")
             if conversation_id:
                 # 滑动窗口路径：按 user / conversation / seq_xxx_时间戳 三级组织
                 seq_part = (
@@ -194,7 +195,7 @@ class PipelineSnapshot:
             "end_user_id": self.end_user_id,
             "conversation_id": self.conversation_id,
             "message_seq": self.message_seq,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": to_iso_z(utcnow_naive()),
             "stats": stats,
         }
         if self.extra_metadata:

--- a/api/app/core/rag/crawler/__main__.py
+++ b/api/app/core/rag/crawler/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import sys
 from app.core.rag.crawler.web_crawler import WebCrawler
+from app.core.utils.datetime_utils import to_iso_z
 
 
 def setup_logging(verbose: bool = False):
@@ -49,7 +50,7 @@ def main(entry_url: str,
                 'title': doc.title,
                 'content': doc.content,
                 'content_length': doc.content_length,
-                'crawl_timestamp': doc.crawl_timestamp.isoformat(),
+                'crawl_timestamp': to_iso_z(doc.crawl_timestamp),
                 'http_status': doc.http_status,
                 'metadata': doc.metadata
             })

--- a/api/app/core/rag/crawler/web_crawler.py
+++ b/api/app/core/rag/crawler/web_crawler.py
@@ -6,6 +6,7 @@ from typing import Iterator, Optional, List, Set
 from urllib.parse import urlparse
 import logging
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.rag.crawler.url_normalizer import URLNormalizer
 from app.core.rag.crawler.robots_parser import RobotsParser
 from app.core.rag.crawler.rate_limiter import RateLimiter
@@ -86,7 +87,7 @@ class WebCrawler:
             CrawledDocument: Structured document with extracted content
         """
         logger.info(f"Starting crawl from {self.entry_url} (max_pages: {self.max_pages})")
-        self.start_time = datetime.now()
+        self.start_time = utcnow_naive()
         
         # Add entry URL to queue
         normalized_entry = self.url_normalizer.normalize(self.entry_url)
@@ -151,7 +152,7 @@ class WebCrawler:
                     title=extracted.title,
                     content=extracted.text,
                     content_length=len(extracted.text),
-                    crawl_timestamp=datetime.now(),
+                    crawl_timestamp=utcnow_naive(),
                     http_status=fetch_result.status_code,
                     metadata={
                         'word_count': extracted.word_count,
@@ -179,7 +180,7 @@ class WebCrawler:
                 self._record_error(f"Processing error: {str(e)}")
                 continue
         
-        self.end_time = datetime.now()
+        self.end_time = utcnow_naive()
         logger.info(f"Crawl completed. Processed {self.pages_processed} pages.")
     
     def get_summary(self) -> CrawlSummary:
@@ -190,9 +191,9 @@ class WebCrawler:
             CrawlSummary: Statistics including success/error/skip counts
         """
         if not self.start_time:
-            self.start_time = datetime.now()
+            self.start_time = utcnow_naive()
         if not self.end_time:
-            self.end_time = datetime.now()
+            self.end_time = utcnow_naive()
         
         duration = (self.end_time - self.start_time).total_seconds()
         

--- a/api/app/core/rag/prompts/generator.py
+++ b/api/app/core/rag/prompts/generator.py
@@ -12,6 +12,7 @@ from app.core.rag.nlp import rag_tokenizer
 from .template import load_prompt
 from app.core.rag.common.constants import TAG_FLD
 from app.core.rag.common.token_utils import encoder, num_tokens_from_string
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 STOP_TOKEN="<|STOP|>"
@@ -201,9 +202,10 @@ def full_question(messages=[], language=None, chat_mdl=None):
             continue
         conv.append("{}: {}".format(m["role"].upper(), m["content"]))
     conversation = "\n".join(conv)
-    today = datetime.date.today().isoformat()
-    yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
-    tomorrow = (datetime.date.today() + datetime.timedelta(days=1)).isoformat()
+    current_date = utcnow_naive().date()
+    today = current_date.isoformat()
+    yesterday = (current_date - datetime.timedelta(days=1)).isoformat()
+    tomorrow = (current_date + datetime.timedelta(days=1)).isoformat()
 
     template = PROMPT_JINJA_ENV.from_string(FULL_QUESTION_PROMPT_TEMPLATE)
     rendered_prompt = template.render(
@@ -347,7 +349,7 @@ def next_step(chat_mdl, history:list, tools_description: list[dict], task_desc, 
         hist[-1]["content"] += user_prompt
     else:
         hist.append({"role": "user", "content": user_prompt})
-    json_str = chat_mdl.chat(template.render(task_analysis=task_desc, desc=desc, today=datetime.datetime.now().strftime("%Y-%m-%d")),
+    json_str = chat_mdl.chat(template.render(task_analysis=task_desc, desc=desc, today=utcnow_naive().strftime("%Y-%m-%d")),
                              hist[1:], stop=["<|stop|>"])
     tk_cnt = num_tokens_from_string(json_str)
     json_str = re.sub(r"^.*</think>", "", json_str, flags=re.DOTALL)
@@ -407,7 +409,7 @@ def rank_memories(chat_mdl, goal:str, sub_goal:str, tool_call_summaries: list[st
 
 def gen_meta_filter(chat_mdl, meta_data:dict, query: str) -> list:
     sys_prompt = PROMPT_JINJA_ENV.from_string(META_FILTER).render(
-        current_date=datetime.datetime.today().strftime('%Y-%m-%d'),
+        current_date=utcnow_naive().strftime('%Y-%m-%d'),
         metadata_keys=json.dumps(meta_data),
         user_question=query
     )

--- a/api/app/core/tools/mcp/service_manager.py
+++ b/api/app/core/tools/mcp/service_manager.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, List, Optional, Tuple
 from datetime import datetime
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.tool_model import MCPToolConfig, ToolConfig, ToolType, ToolStatus
 from app.core.logging_config import get_business_logger
 from app.core.tools.mcp.base import MCPToolManager
@@ -66,7 +67,7 @@ class MCPServiceManager:
                 connection_config=connection_config,
                 available_tools=[tool_name],
                 health_status="unknown",
-                last_health_check=datetime.now()
+                last_health_check=utcnow_naive()
             )
             
             self.db.add(mcp_config)

--- a/api/app/core/utils/__init__.py
+++ b/api/app/core/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Core utility helpers."""

--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -1,0 +1,70 @@
+"""Unified datetime helpers.
+
+Project convention:
+- Database stores naive UTC datetime.
+- Runtime calculations may use aware UTC datetime.
+- Any naive datetime loaded from DB is interpreted as UTC.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+
+
+def utcnow() -> datetime:
+    """Return an aware UTC datetime."""
+    return datetime.now(UTC)
+
+
+def utcnow_naive() -> datetime:
+    """Return a naive UTC datetime for DB storage."""
+    return utcnow().replace(tzinfo=None)
+
+
+def as_utc_aware(dt: datetime | None) -> datetime | None:
+    """Interpret a datetime as UTC-aware.
+
+    Naive datetime are treated as UTC by project convention.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def to_timestamp_ms(dt: datetime | None) -> int | None:
+    """Serialize a datetime to a UTC millisecond timestamp."""
+    aware_dt = as_utc_aware(dt)
+    if aware_dt is None:
+        return None
+    return int(aware_dt.timestamp() * 1000)
+
+
+def to_iso_z(dt: datetime | None) -> str | None:
+    """Serialize a datetime to an ISO-8601 UTC string with Z suffix."""
+    aware_dt = as_utc_aware(dt)
+    if aware_dt is None:
+        return None
+    return aware_dt.isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp_to_utc_naive(timestamp: int | float | None) -> datetime | None:
+    """Convert a second/millisecond timestamp to naive UTC datetime."""
+    if timestamp is None:
+        return None
+    if timestamp > 1e10:
+        timestamp = timestamp / 1000
+    return datetime.fromtimestamp(timestamp, UTC).replace(tzinfo=None)
+
+
+def parse_iso_to_utc_naive(value: str | None) -> datetime | None:
+    """Parse an ISO datetime and normalize it to naive UTC."""
+    if not value:
+        return None
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(UTC).replace(tzinfo=None)

--- a/api/app/core/workflow/engine/event_stream_handler.py
+++ b/api/app/core/workflow/engine/event_stream_handler.py
@@ -8,6 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
 from app.core.logging_config import get_logger
+from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
 from app.core.workflow.engine.stream_output_coordinator import StreamOutputCoordinator
 from app.core.workflow.engine.variable_pool import VariablePool
 
@@ -282,9 +283,7 @@ class EventStreamHandler:
                     "node_id": node_name,
                     "conversation_id": conversation_id,
                     "execution_id": self.execution_id,
-                    "timestamp": int(datetime.datetime.fromisoformat(
-                        data.get("timestamp")
-                    ).timestamp() * 1000),
+                    "timestamp": to_timestamp_ms(parse_iso_to_utc_naive(data.get("timestamp"))),
                 }
             }
         elif event_type == "task_result":
@@ -302,9 +301,7 @@ class EventStreamHandler:
                     "node_id": node_name,
                     "conversation_id": conversation_id,
                     "execution_id": self.execution_id,
-                    "timestamp": int(datetime.datetime.fromisoformat(
-                        data.get("timestamp")
-                    ).timestamp() * 1000),
+                    "timestamp": to_timestamp_ms(parse_iso_to_utc_naive(data.get("timestamp"))),
                     "input": result.get("node_outputs", {}).get(node_name, {}).get("input"),
                     "output": result.get("node_outputs", {}).get(node_name, {}).get("output"),
                     "process": result.get("node_outputs", {}).get(node_name, {}).get("process"),
@@ -319,5 +316,4 @@ class EventStreamHandler:
             "event": "cycle_item",
             "data": data.get("data")
         }
-
 

--- a/api/app/core/workflow/executor.py
+++ b/api/app/core/workflow/executor.py
@@ -2,7 +2,6 @@
 # Author: Eternity
 # @Email: 1533512157@qq.com
 # @Time : 2026/2/9 13:51
-import datetime
 import time
 import logging
 from typing import Any
@@ -17,6 +16,7 @@ from app.core.workflow.engine.state_manager import WorkflowStateManager
 from app.core.workflow.engine.stream_output_coordinator import StreamOutputCoordinator
 from app.core.workflow.engine.variable_pool import VariablePool, VariablePoolInitializer
 from app.core.workflow.nodes.base_node import NodeExecutionError
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +133,7 @@ class WorkflowExecutor:
                   - token_usage: aggregated token usage if available
                   - error: error message if any
         """
-        start = datetime.datetime.now()
+        start = utcnow_naive()
         async for event in self.execute_stream(input_data):
             if event.get("event") == "workflow_end":
                 return event.get("data")
@@ -141,7 +141,7 @@ class WorkflowExecutor:
             {"error": "Workflow execution did not end as expected"},
             self.execution_context,
             self.variable_pool,
-            (datetime.datetime.now() - start).total_seconds(),
+            (utcnow_naive() - start).total_seconds(),
             "",
             success=False
         )
@@ -171,7 +171,7 @@ class WorkflowExecutor:
         """
         logger.info(f"Starting workflow execution (streaming): execution_id={self.execution_context.execution_id}")
 
-        start_time = datetime.datetime.now()
+        start_time = utcnow_naive()
 
         yield {
             "event": "workflow_start",
@@ -179,7 +179,7 @@ class WorkflowExecutor:
                 "execution_id": self.execution_context.execution_id,
                 "workspace_id": self.execution_context.workspace_id,
                 "conversation_id": self.execution_context.conversation_id,
-                "timestamp": int(start_time.timestamp() * 1000)
+                "timestamp": to_timestamp_ms(start_time)
             }
         }
         result = None
@@ -256,7 +256,7 @@ class WorkflowExecutor:
                 yield msg_event
 
             result = graph.get_state(self.execution_context.checkpoint_config).values
-            end_time = datetime.datetime.now()
+            end_time = utcnow_naive()
             elapsed_time = (end_time - start_time).total_seconds()
 
             # For output nodes, collect structured results from variable_pool and serialize to JSON
@@ -322,7 +322,7 @@ class WorkflowExecutor:
             }
 
         except Exception as e:
-            end_time = datetime.datetime.now()
+            end_time = utcnow_naive()
             elapsed_time = (end_time - start_time).total_seconds()
 
             logger.error(f"Workflow execution failed: execution_id={self.execution_context.execution_id}, error={e}",

--- a/api/app/i18n/logger.py
+++ b/api/app/i18n/logger.py
@@ -10,12 +10,12 @@ This module provides:
 
 import logging
 from typing import Dict, List, Optional, Set
-from datetime import datetime
 from collections import defaultdict
 from pathlib import Path
 import json
 
 from app.core.logging_config import get_logger
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 
 logger = get_logger(__name__)
 
@@ -88,7 +88,7 @@ class TranslationLogger:
         
         # Create context entry
         entry = {
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": to_iso_z(utcnow_naive()),
             "key": key,
             "locale": locale,
             "context": context or {}
@@ -130,7 +130,7 @@ class TranslationLogger:
             "key": key,
             "locale": locale,
             "context": context or {},
-            "timestamp": datetime.now().isoformat()
+            "timestamp": to_iso_z(utcnow_naive())
         }
         
         self._logger.error(
@@ -223,7 +223,7 @@ class TranslationLogger:
         missing = self.get_missing_translations(locale)
         
         report = {
-            "generated_at": datetime.now().isoformat(),
+            "generated_at": to_iso_z(utcnow_naive()),
             "total_missing": sum(len(keys) for keys in missing.values()),
             "missing_by_locale": {
                 loc: {
@@ -301,7 +301,7 @@ class TranslationLogger:
             output_file: Output file path
         """
         data = {
-            "exported_at": datetime.now().isoformat(),
+            "exported_at": to_iso_z(utcnow_naive()),
             "missing_translations": self.get_missing_translations(),
             "statistics": self.get_statistics(),
             "recent_context": self.get_missing_with_context(limit=1000)

--- a/api/app/i18n/metrics.py
+++ b/api/app/i18n/metrics.py
@@ -14,7 +14,8 @@ import time
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 from collections import defaultdict
-from datetime import datetime
+
+from app.core.utils.datetime_utils import utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class TranslationMetrics:
         self._error_counts: Dict[str, int] = defaultdict(int)
         
         # Start time
-        self._start_time = datetime.now()
+        self._start_time = utcnow_naive()
         
         logger.info("TranslationMetrics initialized")
     
@@ -125,7 +126,7 @@ class TranslationMetrics:
         timing_stats = self._calculate_timing_stats()
         
         # Calculate uptime
-        uptime_seconds = (datetime.now() - self._start_time).total_seconds()
+        uptime_seconds = (utcnow_naive() - self._start_time).total_seconds()
         
         return {
             "uptime_seconds": round(uptime_seconds, 2),
@@ -207,7 +208,7 @@ class TranslationMetrics:
         self._locale_usage.clear()
         self._namespace_usage.clear()
         self._error_counts.clear()
-        self._start_time = datetime.now()
+        self._start_time = utcnow_naive()
         logger.info("Metrics reset")
     
     def export_prometheus(self) -> str:

--- a/api/app/models/agent_app_config_model.py
+++ b/api/app/models/agent_app_config_model.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import relationship
 
 from app.base.type import PydanticType
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from app.schemas.app_schema import ModelParameters
 
 
@@ -41,8 +42,8 @@ class AgentConfig(Base):
 
     # 状态与时间戳
     is_active = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 关系
     app = relationship("App", back_populates="agent_config")

--- a/api/app/models/agent_execution_model.py
+++ b/api/app/models/agent_execution_model.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class AgentExecution(Base):
@@ -88,14 +89,14 @@ class AgentExecution(Base):
     error_message = Column(Text, nullable=True)
 
     # 性能指标
-    started_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     completed_at = Column(DateTime, nullable=True)
     elapsed_time = Column(Float, nullable=True, comment="总耗时（秒）")
 
     # Token 使用
     token_usage = Column(JSONB, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
 
     # 扩展元数据（模型名称、provider 等运行时信息）
     meta_data = Column(JSONB, nullable=True, default=dict, comment="扩展元数据")

--- a/api/app/models/annotation_model.py
+++ b/api/app/models/annotation_model.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, String, DateTime, ForeignKey, Float, Integer, Tex
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class HitLogSource(StrEnum):
@@ -32,8 +33,8 @@ class AppAnnotation(Base):
     hit_count = Column(Integer, default=0, nullable=False, comment="命中次数")
 
     is_active = Column(Integer, default=1, nullable=False, comment="是否激活: 1=是, 0=否")
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, nullable=False, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False, comment="更新时间")
 
     # 复合索引：加速按应用ID查询
     __table_args__ = (
@@ -60,8 +61,8 @@ class AppAnnotationSetting(Base):
     # 是否启用标注功能
     enabled = Column(Integer, default=0, nullable=False, comment="是否启用: 1=是, 0=否")
 
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, nullable=False, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False, comment="更新时间")
 
     def __repr__(self):
         return f"<AppAnnotationSetting(app_id={self.app_id}, threshold={self.similarity_threshold}, enabled={self.enabled})>"
@@ -79,7 +80,7 @@ class AppAnnotationHitLog(Base):
     matched_question = Column(Text, nullable=False, comment="匹配到的标注问题")
     answer = Column(Text, nullable=False, comment="返回的标注答案")
     similarity = Column(Float, nullable=False, comment="相似度分数")
-    hit_at = Column(DateTime, default=datetime.datetime.now, nullable=False, comment="命中时间")
+    hit_at = Column(DateTime, default=utcnow_naive, nullable=False, comment="命中时间")
 
     __table_args__ = (
         Index("idx_hit_log_annotation", "annotation_id", "hit_at"),

--- a/api/app/models/api_key_model.py
+++ b/api/app/models/api_key_model.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import relationship
 from enum import StrEnum
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ApiKeyType(StrEnum):
@@ -55,8 +56,8 @@ class ApiKey(Base):
 
     # 审计
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, comment="创建者")
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, nullable=False, default=datetime.datetime.now, onupdate=datetime.datetime.now,
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, nullable=False, default=utcnow_naive, onupdate=utcnow_naive,
                         comment="更新时间")
 
     # 关系
@@ -88,7 +89,7 @@ class ApiKeyLog(Base):
     tokens_used = Column(Integer, comment="使用的 Token 数")
 
     # 时间
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now, index=True, comment="创建时间")
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive, index=True, comment="创建时间")
 
     # 关系
     api_key = relationship("ApiKey", back_populates="logs")

--- a/api/app/models/app_model.py
+++ b/api/app/models/app_model.py
@@ -6,6 +6,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, JSON
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class IconType(StrEnum):
     """图标类型枚举"""
@@ -69,8 +70,8 @@ class App(Base):
     )
 
     is_active = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 一对一：Agent 配置（仅当 type=agent 时有效）
     agent_config = relationship(

--- a/api/app/models/app_release_model.py
+++ b/api/app/models/app_release_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, Integer, ForeignKey, U
 from sqlalchemy.dialects.postgresql import UUID, JSON
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.app_model import IconType
 
 
@@ -39,11 +40,11 @@ class AppRelease(Base):
 
     # 发布信息
     published_by = Column(UUID(as_uuid=True), nullable=False, comment="users.id")
-    published_at = Column(DateTime, default=datetime.datetime.now)
+    published_at = Column(DateTime, default=utcnow_naive)
 
     is_active = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 关系: 指定外键，避免与 App.current_release_id 引起歧义
     app = relationship("App", back_populates="releases", foreign_keys=[app_id])

--- a/api/app/models/appshare_model.py
+++ b/api/app/models/appshare_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from sqlalchemy.orm import relationship
 
 
@@ -20,8 +21,8 @@ class AppShare(Base):
     shared_by = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False, comment="分享者用户ID")
     permission = Column(String, default="readonly", nullable=False, comment="权限模式: readonly | editable")
     is_active = Column(Boolean, default=True, server_default='true', nullable=False, comment="是否有效，False 表示逻辑删除")
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive)
 
     # Relationships
     source_app = relationship("App", foreign_keys=[source_app_id], backref="shares")

--- a/api/app/models/conversation_model.py
+++ b/api/app/models/conversation_model.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class Conversation(Base):
@@ -52,8 +53,8 @@ class Conversation(Base):
     is_active = Column(Boolean, default=True, nullable=False, comment="是否活跃")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
 
     # 关联关系
     app = relationship("App", back_populates="conversations")
@@ -108,7 +109,7 @@ class Message(Base):
     status = Column(String(20), nullable=False, server_default="completed", comment="消息状态: completed/failed")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
 
     # 关联关系
     conversation = relationship("Conversation", back_populates="messages")

--- a/api/app/models/conversation_share_model.py
+++ b/api/app/models/conversation_share_model.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ConversationShare(Base):
@@ -33,7 +34,7 @@ class ConversationShare(Base):
     view_count = Column(Integer, default=0, comment="访问次数")
 
     is_active = Column(Boolean, default=True, nullable=False, comment="是否有效")
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
 
     # 关联关系
     conversation = relationship("Conversation", back_populates="shares")

--- a/api/app/models/document_model.py
+++ b/api/app/models/document_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey, Float
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class Document(Base):
     __tablename__ = "documents"
@@ -45,12 +46,12 @@ class Document(Base):
     chunk_num = Column(Integer, default=0, comment="chunk num")
     progress = Column(Float, default=0)
     progress_msg = Column(String, default="", comment="process message")
-    process_begin_at = Column(DateTime, default=datetime.datetime.now)
+    process_begin_at = Column(DateTime, default=utcnow_naive)
     process_duration = Column(Float, default=0)
     run = Column(Integer, default=0, comment="start to run processing or cancel.(1: run it; 2: cancel)")
     status = Column(Integer, default=1, comment="is it validate(0: wasted, 1: validate)")
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive)
 
     @property
     def is_parent_child_mode(self) -> bool:

--- a/api/app/models/end_user_info_model.py
+++ b/api/app/models/end_user_info_model.py
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class EndUserInfo(Base):
@@ -17,8 +18,8 @@ class EndUserInfo(Base):
     other_name = Column(String, nullable=False, comment="关联的用户名称")
     aliases = Column(ARRAY(String), nullable=True, comment="用户别名列表（字符串数组）")
     meta_data = Column(JSONB, nullable=True, comment="用户相关的扩展信息（JSON格式）")
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
 
     # 与 EndUser 的关系
     end_user = relationship("EndUser", back_populates="info")

--- a/api/app/models/end_user_model.py
+++ b/api/app/models/end_user_model.py
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class EndUser(Base):
@@ -19,8 +20,8 @@ class EndUser(Base):
     other_name = Column(String, default="", nullable=False)
     other_address = Column(String, default="", nullable=False)
     reflection_time = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
     
     # 用户档案字段 - User Profile Fields
     position = Column(String, nullable=True, comment="职位")

--- a/api/app/models/file_metadata_model.py
+++ b/api/app/models/file_metadata_model.py
@@ -12,6 +12,7 @@ from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class FileMetadata(Base):
@@ -42,4 +43,4 @@ class FileMetadata(Base):
     file_size = Column(Integer, nullable=False, default=0, comment="File size in bytes")
     content_type = Column(String(128), nullable=True, comment="MIME content type")
     status = Column(String(16), nullable=False, default="pending", comment="Upload status: pending, completed, failed")
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)

--- a/api/app/models/file_model.py
+++ b/api/app/models/file_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class File(Base):
     __tablename__ = "files"
@@ -16,4 +17,4 @@ class File(Base):
     file_size = Column(Integer, default=0, comment="file size(byte)")
     file_url = Column(String, index=True, nullable=True, comment="file comes from a website url")
     file_key = Column(String(512), nullable=True, index=True, comment="storage file key for FileStorageService")
-    created_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)

--- a/api/app/models/forgetting_cycle_history_model.py
+++ b/api/app/models/forgetting_cycle_history_model.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from sqlalchemy import Column, Integer, String, Float, DateTime, Index
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ForgettingCycleHistory(Base):
@@ -18,7 +19,7 @@ class ForgettingCycleHistory(Base):
     
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False, index=True, comment="主键ID")
     end_user_id = Column(String(255), nullable=False, comment="终端用户ID")
-    execution_time = Column(DateTime, nullable=False, default=datetime.now, comment="执行时间")
+    execution_time = Column(DateTime, nullable=False, default=utcnow_naive, comment="执行时间")
     merged_count = Column(Integer, default=0, comment="本次成功融合的节点对数")
     failed_count = Column(Integer, default=0, comment="本次融合失败的节点对数")
     average_activation_value = Column(Float, nullable=True, comment="平均激活值")

--- a/api/app/models/generic_file_model.py
+++ b/api/app/models/generic_file_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, Index, JSON
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class GenericFile(Base):
@@ -40,8 +41,8 @@ class GenericFile(Base):
     reference_count = Column(Integer, default=0, comment="引用计数")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
     deleted_at = Column(DateTime, nullable=True, comment="删除时间（软删除）")
 
     # 复合索引

--- a/api/app/models/implicit_emotions_storage_model.py
+++ b/api/app/models/implicit_emotions_storage_model.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from sqlalchemy import Column, String, Text, DateTime, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ImplicitEmotionsStorage(Base):
@@ -29,8 +30,8 @@ class ImplicitEmotionsStorage(Base):
     emotion_suggestions = Column(JSONB, nullable=True, comment="情绪个性化建议数据")
     
     # 时间戳
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow, comment="创建时间")
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow, comment="更新时间")
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, nullable=False, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
     
     # 数据生成时间（用于业务逻辑）
     implicit_generated_at = Column(DateTime, nullable=True, comment="隐性记忆画像生成时间")

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -4,6 +4,7 @@ import enum
 from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from sqlalchemy.orm import relationship
 
 
@@ -101,8 +102,8 @@ class Knowledge(Base):
                            },
                            comment="default parser config")
     status = Column(Integer, index=True, default=1, comment="is it validate(0: disable, 1: enable, 2:Soft-delete)")
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive)
 
     # Relationships
     created_user = relationship("User", backref="created_user")

--- a/api/app/models/knowledgeshare_model.py
+++ b/api/app/models/knowledgeshare_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from sqlalchemy.orm import relationship
 
 
@@ -15,8 +16,8 @@ class KnowledgeShare(Base):
     target_kb_id = Column(UUID(as_uuid=True), ForeignKey('knowledges.id'), nullable=False, comment="target knowledges.id")
     target_workspace_id = Column(UUID(as_uuid=True), ForeignKey('workspaces.id'), nullable=False, comment="target workspaces.id")
     shared_by = Column(UUID(as_uuid=True), ForeignKey('users.id'), nullable=False, comment="shared users.id")
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive)
 
     # Relationships
     target_kb = relationship("Knowledge", backref="target_kb")

--- a/api/app/models/mcp_market_config_model.py
+++ b/api/app/models/mcp_market_config_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class McpMarketConfig(Base):
     __tablename__ = "mcp_market_configs"
@@ -13,4 +14,4 @@ class McpMarketConfig(Base):
     status = Column(Integer, default=0, comment="connect status(0: Not connected, 1: connected)")
     tenant_id = Column(UUID(as_uuid=True), nullable=False, comment="tenant.id")
     created_by = Column(UUID(as_uuid=True), nullable=False, comment="users.id")
-    created_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)

--- a/api/app/models/mcp_market_model.py
+++ b/api/app/models/mcp_market_model.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class McpMarket(Base):
     __tablename__ = "mcp_markets"
@@ -15,4 +16,4 @@ class McpMarket(Base):
     url = Column(String, index=True, nullable=False, comment="mcp market url")
     category = Column(String, index=True, nullable=False, comment="category")
     created_by = Column(UUID(as_uuid=True), nullable=False, comment="users.id")
-    created_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)

--- a/api/app/models/memory_config_model.py
+++ b/api/app/models/memory_config_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class MemoryConfig(Base):
@@ -90,8 +91,8 @@ class MemoryConfig(Base):
     emotion_enable_subject = Column(Boolean, default=True, comment="是否启用主体分类")
     
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
 
     def __repr__(self):
         return f"<MemoryConfig(config_id={self.config_id}, config_name={self.config_name})>"

--- a/api/app/models/memory_increment_model.py
+++ b/api/app/models/memory_increment_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, ForeignKey, Integer, Date, DateTime
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class MemoryIncrement(Base):
     __tablename__ = "memory_increments"
@@ -11,8 +12,8 @@ class MemoryIncrement(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), index=True, nullable=False)
     total_num = Column(Integer, default=0, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 与 App 的关系（指向映射类名，而非表名）
     workspace = relationship("Workspace", back_populates="memory_increments")

--- a/api/app/models/memory_message_model.py
+++ b/api/app/models/memory_message_model.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.postgresql import UUID, JSON
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class MemoryMessage(Base):
@@ -76,7 +77,7 @@ class MemoryMessage(Base):
     )
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
 
     # 关联关系
     conversation = relationship(

--- a/api/app/models/memory_perceptual_model.py
+++ b/api/app/models/memory_perceptual_model.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects.postgresql import JSONB
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from app.schemas.app_schema import FileType
 
 
@@ -48,4 +49,4 @@ class MemoryPerceptualModel(Base):
     summary = Column(String, comment="摘要")
     meta_data = Column(JSONB, comment="元信息")
 
-    created_time = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    created_time = Column(DateTime, default=utcnow_naive, comment="创建时间")

--- a/api/app/models/memory_short_model.py
+++ b/api/app/models/memory_short_model.py
@@ -7,6 +7,7 @@ from sqlalchemy import Column, String, DateTime, Text, JSON
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ShortTermMemory(Base):
@@ -32,7 +33,7 @@ class ShortTermMemory(Base):
     retrieved_content = Column(JSON, nullable=True, default=list, comment="检索到的相关内容，格式为[{}, {}]")
     
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, index=True, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, index=True, comment="创建时间")
     
     def __repr__(self):
         return f"<ShortTermMemory(id={self.id}, end_user_id={self.end_user_id}, created_at={self.created_at})>"
@@ -54,7 +55,7 @@ class LongTermMemory(Base):
     retrieved_content = Column(JSON, nullable=True, default=list, comment="检索到的相关内容，格式为[{}, {}]")
     
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, index=True, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, index=True, comment="创建时间")
     
     def __repr__(self):
         return f"<LongTermMemory(id={self.id}, end_user_id={self.end_user_id}, created_at={self.created_at})>"

--- a/api/app/models/message_feedback_model.py
+++ b/api/app/models/message_feedback_model.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class MessageFeedback(Base):
@@ -31,7 +32,7 @@ class MessageFeedback(Base):
     feedback_type = Column(String(20), nullable=False, comment="反馈类型: like/dislike")
     feedback_content = Column(Text, comment="反馈原因（点踩时填写）")
 
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
 
     # 联合唯一约束：一个用户对一条消息只能有一条反馈
     __table_args__ = (

--- a/api/app/models/message_report_model.py
+++ b/api/app/models/message_report_model.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class MessageReportType(StrEnum):
@@ -76,8 +77,8 @@ class MessageReport(Base):
     # 处理结果
     action_taken = Column(String(50), comment="处理措施: warning/content_removed/user_banned/no_action")
 
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
 
     # 关联关系
     message = relationship("Message", back_populates="reports")

--- a/api/app/models/models_model.py
+++ b/api/app/models/models_model.py
@@ -8,14 +8,15 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class BaseModel(Base):
     """基础模型（抽象类，提取公共字段）"""
     __abstract__ = True  # 标记为抽象类，不生成表
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
     is_active = Column(Boolean, default=True, nullable=False, comment="是否激活")
 
 
@@ -73,7 +74,7 @@ model_config_api_key_association = Table(
     Base.metadata,
     Column('model_config_id', UUID(as_uuid=True), ForeignKey('model_configs.id'), primary_key=True),
     Column('api_key_id', UUID(as_uuid=True), ForeignKey('model_api_keys.id'), primary_key=True),
-    Column('created_at', DateTime, default=datetime.datetime.now)
+    Column('created_at', DateTime, default=utcnow_naive)
 )
 
 
@@ -175,7 +176,7 @@ class ModelBase(Base):
     is_official = Column(Boolean, default=True, comment="是否供应商官方模型（区分自定义）")
     tags = Column(ARRAY(String), default=list, nullable=False, comment="模型标签（如['聊天', '创作']）")
     add_count = Column(Integer, default=0, nullable=False, comment="模型被用户添加的次数")
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间", server_default=func.now())
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间", )
     capability = Column(ARRAY(String), default=list, nullable=False, server_default=text("'{}'::varchar[]"),
                         comment="模型能力列表（如['vision', 'audio', 'video']）")
     is_omni = Column(Boolean, default=False, nullable=False, server_default="false", comment="是否为Omni模型（使用特殊API调用）")

--- a/api/app/models/multi_agent_model.py
+++ b/api/app/models/multi_agent_model.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import relationship
 
 from app.base.type import PydanticType
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 from app.schemas.app_schema import ModelParameters
 
 
@@ -102,8 +103,8 @@ class MultiAgentConfig(Base):
 
     # 状态
     is_active = Column(Boolean, default=True, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 关系
     app = relationship("App")
@@ -164,7 +165,7 @@ class AgentInvocation(Base):
     error_message = Column(Text, comment="错误信息")
 
     # 性能指标
-    started_at = Column(DateTime, nullable=False, default=datetime.datetime.now, index=True)
+    started_at = Column(DateTime, nullable=False, default=utcnow_naive, index=True)
     completed_at = Column(DateTime)
     elapsed_time = Column(Float, comment="耗时（秒）")
     token_usage = Column(JSON, comment="Token 使用情况")
@@ -172,7 +173,7 @@ class AgentInvocation(Base):
     # 元数据
     meta_data = Column(JSON, comment="额外元数据")
 
-    created_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
 
     # 关系
     caller = relationship("AgentConfig", foreign_keys=[caller_agent_id])

--- a/api/app/models/ontology_class.py
+++ b/api/app/models/ontology_class.py
@@ -13,6 +13,7 @@ from sqlalchemy import Column, String, DateTime, Text, ForeignKey, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class OntologyClass(Base):
@@ -33,8 +34,8 @@ class OntologyClass(Base):
     scene_id = Column(UUID(as_uuid=True), ForeignKey("ontology_scene.scene_id", ondelete="CASCADE"), nullable=False, index=True, comment="所属场景ID")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, nullable=False, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False, comment="更新时间")
 
     # 关系：类型属于某个场景
     scene = relationship("OntologyScene", back_populates="classes")

--- a/api/app/models/ontology_scene.py
+++ b/api/app/models/ontology_scene.py
@@ -13,6 +13,7 @@ from sqlalchemy import Column, String, DateTime, Integer, Text, ForeignKey, Uniq
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class OntologyScene(Base):
@@ -36,8 +37,8 @@ class OntologyScene(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True, comment="所属工作空间ID")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, nullable=False, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False, comment="更新时间")
 
     # 关系：一个场景可以有多个类型
     classes = relationship("OntologyClass", back_populates="scene", cascade="all, delete-orphan")

--- a/api/app/models/prompt_optimizer_model.py
+++ b/api/app/models/prompt_optimizer_model.py
@@ -6,6 +6,7 @@ from sqlalchemy import Column, ForeignKey, Text, DateTime, String, Index, Boolea
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class RoleType(StrEnum):
@@ -65,7 +66,7 @@ class PromptOptimizerSession(Base):
     # app_id = Column(UUID(as_uuid=True), ForeignKey("apps.id"), nullable=False, comment="Application ID")
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, comment="User ID")
 
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="Creation Time", index=True)
+    created_at = Column(DateTime, default=utcnow_naive, comment="Creation Time", index=True)
 
 
 class PromptOptimizerSessionHistory(Base):
@@ -132,7 +133,7 @@ class PromptOptimizerSessionHistory(Base):
     content = Column(Text, nullable=False, comment="Message Content")
     # prompt = Column(Text, nullable=False, comment="Prompt")
 
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="Creation Time", index=True)
+    created_at = Column(DateTime, default=utcnow_naive, comment="Creation Time", index=True)
 
 
 class PromptHistory(Base):
@@ -149,5 +150,5 @@ class PromptHistory(Base):
     )
     title = Column(String, nullable=False, comment="Title")
     prompt = Column(Text, nullable=False, comment="Prompt")
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="Creation Time", index=True)
+    created_at = Column(DateTime, default=utcnow_naive, comment="Creation Time", index=True)
     is_delete = Column(Boolean, default=False, comment="Delete")

--- a/api/app/models/reflection_log_model.py
+++ b/api/app/models/reflection_log_model.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, DateTime, Float, String, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class MemoryReflectionLog(Base):
@@ -29,4 +30,4 @@ class MemoryReflectionLog(Base):
     solution_detail = Column(JSONB, nullable=True)
     execution_detail = Column(JSONB, nullable=True)
 
-    created_at = Column(DateTime, default=datetime.datetime.now, nullable=False)
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False)

--- a/api/app/models/release_share_model.py
+++ b/api/app/models/release_share_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, Integer, ForeignKey, U
 from sqlalchemy.dialects.postgresql import UUID, JSON
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ReleaseShare(Base):
@@ -35,8 +36,8 @@ class ReleaseShare(Base):
     
     # 元数据
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, comment="创建者")
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 
     # 关系
     release = relationship("AppRelease", backref="share")

--- a/api/app/models/retrieval_info.py
+++ b/api/app/models/retrieval_info.py
@@ -3,6 +3,7 @@ import uuid
 from sqlalchemy import Column, DateTime, Text
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class RetrievalInfo(Base):
     __tablename__ = "retrieval_info"
@@ -10,4 +11,4 @@ class RetrievalInfo(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False, index=True)
     host_id = Column(UUID(as_uuid=True), nullable=False)
     retrieve_info = Column(Text, default="", nullable=True)
-    created_at = Column(DateTime, default=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)

--- a/api/app/models/skill_model.py
+++ b/api/app/models/skill_model.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, Text, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, JSON
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class Skill(Base):
@@ -30,8 +31,8 @@ class Skill(Base):
     is_public = Column(Boolean, default=False, nullable=False, comment="是否公开到市场")
     
     # 时间戳
-    created_at = Column(DateTime, default=datetime.datetime.now, comment="创建时间")
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now, comment="更新时间")
+    created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, comment="更新时间")
 
     def __repr__(self):
         return f"<Skill(id={self.id}, name={self.name})>"

--- a/api/app/models/tenant_model.py
+++ b/api/app/models/tenant_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, DateTime, Boolean, text
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class Tenants(Base):
@@ -12,8 +13,8 @@ class Tenants(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     name = Column(String, index=True, nullable=False)
     description = Column(String, nullable=True)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
     is_active = Column(Boolean, default=True)
     
     # SSO 外部关联字段

--- a/api/app/models/tool_model.py
+++ b/api/app/models/tool_model.py
@@ -8,6 +8,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class ToolType(StrEnum):
@@ -116,8 +117,8 @@ class ToolConfig(Base):
     is_active = Column(Boolean, default=True, server_default='true', nullable=False, index=True, comment="是否可用，False表示已删除")
 
     # 时间戳
-    created_at = Column(DateTime, default=datetime.now, nullable=False)
-    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, nullable=False)
+    created_at = Column(DateTime, default=utcnow_naive, nullable=False)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive, nullable=False)
     
     # 关联关系
     tenant = relationship("Tenants", back_populates="tool_configs")
@@ -257,7 +258,7 @@ class ToolExecution(Base):
 #     version_constraint = Column(String(100))  # 版本约束，如 ">=1.0.0"
 #
 #     # 时间戳
-#     created_at = Column(DateTime, default=datetime.now, nullable=False)
+#     created_at = Column(DateTime, default=utcnow_naive, nullable=False)
 #
 #     # 关联关系
 #     tool = relationship("ToolConfig", foreign_keys=[tool_id])

--- a/api/app/models/user_model.py
+++ b/api/app/models/user_model.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class User(Base):
     __tablename__ = "users"
@@ -14,8 +15,8 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean, default=True, nullable=False)
     is_superuser = Column(Boolean, default=False, nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
     last_login_at = Column(DateTime, nullable=True)  # 最后登录时间，可为空
     
     # SSO 外部关联字段

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -8,6 +8,7 @@ from sqlalchemy import Column, String, Boolean, DateTime, Integer, Float, Foreig
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 class WorkflowConfig(Base):
@@ -45,12 +46,12 @@ class WorkflowConfig(Base):
     
     # 状态
     is_active = Column(Boolean, nullable=False, default=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=datetime.datetime.now,
-        onupdate=datetime.datetime.now
+        default=utcnow_naive,
+        onupdate=utcnow_naive
     )
     
     # 关系
@@ -122,7 +123,7 @@ class WorkflowExecution(Base):
     error_node_id = Column(String(100))
     
     # 性能指标
-    started_at = Column(DateTime, nullable=False, default=datetime.datetime.now, index=True)
+    started_at = Column(DateTime, nullable=False, default=utcnow_naive, index=True)
     completed_at = Column(DateTime)
     elapsed_time = Column(Float)  # 耗时（秒）
     
@@ -132,7 +133,7 @@ class WorkflowExecution(Base):
     # 元数据（使用 meta_data 避免与 SQLAlchemy 保留字 metadata 冲突）
     meta_data = Column(JSONB, default=dict)
     
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
     
     # 关系
     workflow_config = relationship("WorkflowConfig", back_populates="executions")
@@ -185,7 +186,7 @@ class WorkflowNodeExecution(Base):
     error_message = Column(Text)
     
     # 性能指标
-    started_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    started_at = Column(DateTime, nullable=False, default=utcnow_naive)
     completed_at = Column(DateTime)
     elapsed_time = Column(Float)  # 耗时（秒）
     
@@ -199,7 +200,7 @@ class WorkflowNodeExecution(Base):
     # 元数据（使用 meta_data 避免与 SQLAlchemy 保留字 metadata 冲突）
     meta_data = Column(JSONB, default=dict)
     
-    created_at = Column(DateTime, nullable=False, default=datetime.datetime.now)
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
     
     # 关系
     execution = relationship("WorkflowExecution", back_populates="node_executions")

--- a/api/app/models/workspace_model.py
+++ b/api/app/models/workspace_model.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.db import Base
+from app.core.utils.datetime_utils import utcnow_naive
 
 class WorkspaceRole(StrEnum):
     manager = "manager"
@@ -29,8 +30,8 @@ class Workspace(Base):
     llm = Column(String, nullable=True)
     embedding = Column(String, nullable=True)
     rerank = Column(String, nullable=True)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
     is_active = Column(Boolean, default=True)
     
     # Relationships
@@ -63,8 +64,8 @@ class WorkspaceInvite(Base):
     expires_at = Column(DateTime, nullable=False)
     accepted_at = Column(DateTime, nullable=True)
     created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.datetime.now)
-    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+    created_at = Column(DateTime, default=utcnow_naive)
+    updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
     
     # Relationships
     workspace = relationship("Workspace")

--- a/api/app/repositories/agent_execution_repository.py
+++ b/api/app/repositories/agent_execution_repository.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.agent_execution_model import AgentExecution
 
 
@@ -33,12 +34,10 @@ class AgentExecutionRepository:
         message_id: Optional[uuid.UUID] = None,
     ) -> None:
         """更新执行记录为完成状态"""
-        import datetime as dt
-
         updates = {
             "steps": steps,
             "status": status,
-            "completed_at": completed_at or dt.datetime.now(),
+            "completed_at": completed_at or utcnow_naive(),
         }
         if elapsed_time is not None:
             updates["elapsed_time"] = elapsed_time

--- a/api/app/repositories/api_key_repository.py
+++ b/api/app/repositories/api_key_repository.py
@@ -6,6 +6,7 @@ from typing import Optional, List, Tuple
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func, and_
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.api_key_model import ApiKey, ApiKeyLog
 from app.schemas import api_key_schema
 
@@ -92,7 +93,7 @@ class ApiKeyRepository:
         if api_key:
             api_key.usage_count += 1
             api_key.quota_used += 1
-            api_key.last_used_at = datetime.datetime.now()
+            api_key.last_used_at = utcnow_naive()
             db.flush()
             return True
         return False
@@ -105,7 +106,7 @@ class ApiKeyRepository:
             return {}
 
         # 今日请求数
-        today_start = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_start = utcnow_naive().replace(hour=0, minute=0, second=0, microsecond=0)
         today_count_stmt = select(func.count()).select_from(ApiKeyLog).where(
             and_(
                 ApiKeyLog.api_key_id == api_key_id,

--- a/api/app/repositories/document_repository.py
+++ b/api/app/repositories/document_repository.py
@@ -1,6 +1,7 @@
 import uuid
 import datetime
 from sqlalchemy.orm import Session
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.document_model import Document
 from app.schemas import document_schema
 from app.core.logging_config import get_db_logger
@@ -108,7 +109,7 @@ def reset_documents_progress_by_kb_id(db: Session, kb_id: uuid.UUID) -> int:
             Document.progress_msg: "Pending",
             Document.process_duration: 0,
             Document.run: 0,  # Reset run status
-            Document.updated_at: datetime.datetime.now()
+            Document.updated_at: utcnow_naive()
         }
 
         # Perform batch update

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_db_logger
 from app.models.app_model import App
 from app.models.end_user_model import EndUser
@@ -274,7 +275,7 @@ class EndUserRepository:
                         EndUser.behavior_pattern: behavior_pattern,
                         EndUser.key_findings: key_findings,
                         EndUser.growth_trajectory: growth_trajectory,
-                        EndUser.memory_insight_updated_at: datetime.datetime.now()
+                        EndUser.memory_insight_updated_at: utcnow_naive()
                     },
                     synchronize_session=False
                 )
@@ -324,7 +325,7 @@ class EndUserRepository:
                         EndUser.personality_traits: personality,
                         EndUser.core_values: core_values,
                         EndUser.one_sentence_summary: one_sentence,
-                        EndUser.user_summary_updated_at: datetime.datetime.now()
+                        EndUser.user_summary_updated_at: utcnow_naive()
                     },
                     synchronize_session=False
                 )
@@ -371,7 +372,7 @@ class EndUserRepository:
                         EndUser.user_summary: user_summary,
                         EndUser.rag_tags: rag_tags,
                         EndUser.rag_personas: rag_personas,
-                        EndUser.rag_summary_updated_at: datetime.datetime.now(),
+                        EndUser.rag_summary_updated_at: utcnow_naive(),
                     },
                     synchronize_session=False
                 )
@@ -409,7 +410,7 @@ class EndUserRepository:
                 .update(
                     {
                         EndUser.memory_insight: memory_insight,
-                        EndUser.memory_insight_updated_at: datetime.datetime.now(),
+                        EndUser.memory_insight_updated_at: utcnow_naive(),
                     },
                     synchronize_session=False
                 )

--- a/api/app/repositories/generic_file_repository.py
+++ b/api/app/repositories/generic_file_repository.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, or_, func
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.generic_file_model import GenericFile
 from app.core.upload_enums import UploadContext
 from app.core.logging_config import get_db_logger
@@ -102,7 +103,7 @@ class GenericFileRepository:
                     setattr(file, field, value)
             
             # Update timestamp
-            file.updated_at = datetime.now()
+            file.updated_at = utcnow_naive()
             
             self.db.flush()
             db_logger.info(f"File updated successfully: {file.file_name} (ID: {file_id})")
@@ -130,9 +131,9 @@ class GenericFileRepository:
                 return False
             
             # Soft delete by setting deleted_at
-            file.deleted_at = datetime.now()
+            file.deleted_at = utcnow_naive()
             file.status = "deleted"
-            file.updated_at = datetime.now()
+            file.updated_at = utcnow_naive()
             
             self.db.flush()
             db_logger.info(f"File soft deleted successfully: {file.file_name} (ID: {file_id})")

--- a/api/app/repositories/home_page_repository.py
+++ b/api/app/repositories/home_page_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy import func, Table, MetaData
 from uuid import UUID
 from typing import Dict, Optional, Any
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models.end_user_model import EndUser
 from app.models.user_model import User
 from app.models.workspace_model import Workspace, WorkspaceMember
@@ -84,7 +85,7 @@ class HomePageRepository:
         workspace_ids = db.query(Workspace.id).filter(
             Workspace.tenant_id == tenant_id,
             Workspace.is_active.is_(True)
-        ).subquery()
+        ).scalar_subquery()
 
         total_users = db.query(EndUser).join(
             App,
@@ -124,7 +125,7 @@ class HomePageRepository:
         workspace_ids = db.query(Workspace.id).filter(
             Workspace.tenant_id == tenant_id,
             Workspace.is_active.is_(True)
-        ).subquery()
+        ).scalar_subquery()
         
         running_apps = db.query(App).filter(
             App.workspace_id.in_(workspace_ids),
@@ -226,13 +227,13 @@ class HomePageRepository:
             version_info = {
                 "introduction": {
                     "codeName": note.code_name or "",
-                    "releaseDate": int(datetime.combine(note.release_date, time()).timestamp() * 1000) if note.release_date else 0,
+                    "releaseDate": to_timestamp_ms(datetime.combine(note.release_date, time())) if note.release_date else 0,
                     "upgradePosition": note.upgrade_position or "",
                     "coreUpgrades": note.core_upgrades or []
                 },
                 "introduction_en": {
                     "codeName": note.code_name_en or note.code_name or "",
-                    "releaseDate": int(datetime.combine(note.release_date, time()).timestamp() * 1000) if note.release_date else 0,
+                    "releaseDate": to_timestamp_ms(datetime.combine(note.release_date, time())) if note.release_date else 0,
                     "upgradePosition": note.upgrade_position_en or note.upgrade_position or "",
                     "coreUpgrades": note.core_upgrades_en or []
                 }
@@ -274,13 +275,13 @@ class HomePageRepository:
             return {
                 "introduction": {
                     "codeName": note.code_name or "",
-                    "releaseDate": int(datetime.combine(note.release_date, time()).timestamp() * 1000) if note.release_date else 0,
+                    "releaseDate": to_timestamp_ms(datetime.combine(note.release_date, time())) if note.release_date else 0,
                     "upgradePosition": note.upgrade_position or "",
                     "coreUpgrades": note.core_upgrades or []
                 },
                 "introduction_en": {
                     "codeName": note.code_name_en or note.code_name or "",
-                    "releaseDate": int(datetime.combine(note.release_date, time()).timestamp() * 1000) if note.release_date else 0,
+                    "releaseDate": to_timestamp_ms(datetime.combine(note.release_date, time())) if note.release_date else 0,
                     "upgradePosition": note.upgrade_position_en or note.upgrade_position or "",
                     "coreUpgrades": note.core_upgrades_en or []
                 }

--- a/api/app/repositories/implicit_emotions_storage_repository.py
+++ b/api/app/repositories/implicit_emotions_storage_repository.py
@@ -12,6 +12,7 @@ import redis
 from sqlalchemy import exists, not_, select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.end_user_model import EndUser
 from app.models.implicit_emotions_storage_model import ImplicitEmotionsStorage
 
@@ -46,8 +47,8 @@ class ImplicitEmotionsStorageRepository:
         """创建新的存储记录（事务由调用方提交）"""
         storage = ImplicitEmotionsStorage(
             end_user_id=end_user_id,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow()
+            created_at=utcnow_naive(),
+            updated_at=utcnow_naive()
         )
         self.db.add(storage)
         self.db.flush()
@@ -66,8 +67,8 @@ class ImplicitEmotionsStorageRepository:
             storage = self.create(end_user_id)
 
         storage.implicit_profile = profile_data
-        storage.implicit_generated_at = datetime.utcnow()
-        storage.updated_at = datetime.utcnow()
+        storage.implicit_generated_at = utcnow_naive()
+        storage.updated_at = utcnow_naive()
 
         self.db.flush()
         self.db.refresh(storage)
@@ -85,8 +86,8 @@ class ImplicitEmotionsStorageRepository:
             storage = self.create(end_user_id)
 
         storage.emotion_suggestions = suggestions_data
-        storage.emotion_generated_at = datetime.utcnow()
-        storage.updated_at = datetime.utcnow()
+        storage.emotion_generated_at = utcnow_naive()
+        storage.updated_at = utcnow_naive()
 
         self.db.flush()
         self.db.refresh(storage)
@@ -216,7 +217,7 @@ class ImplicitEmotionsStorageRepository:
         """
         from sqlalchemy import String as SAString
         from sqlalchemy import cast
-        today_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_start = utcnow_naive().replace(hour=0, minute=0, second=0, microsecond=0)
         tomorrow_start = today_start + timedelta(days=1)
         offset = 0
         while True:

--- a/api/app/repositories/memory_increment_repository.py
+++ b/api/app/repositories/memory_increment_repository.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import uuid
 import datetime
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.memory_increment_model import MemoryIncrement
 
 from app.core.logging_config import get_db_logger
@@ -85,8 +86,8 @@ class MemoryIncrementRepository:
             memory_increment = MemoryIncrement(
                 workspace_id=workspace_id,
                 total_num=total_num,
-                created_at=datetime.datetime.now(),
-                updated_at=datetime.datetime.now()
+                created_at=utcnow_naive(),
+                updated_at=utcnow_naive()
             )
             self.db.add(memory_increment)
             self.db.commit()

--- a/api/app/repositories/memory_perceptual_repository.py
+++ b/api/app/repositories/memory_perceptual_repository.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Optional
 from sqlalchemy import and_, desc, select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_db_logger
 from app.models.memory_perceptual_model import MemoryPerceptualModel, PerceptualType, FileStorageService
 from app.schemas.memory_perceptual_schema import PerceptualQuerySchema
@@ -47,7 +48,7 @@ class MemoryPerceptualRepository:
                 file_ext=file_ext,
                 summary=summary,
                 meta_data=meta_data,
-                created_time=datetime.now()
+                created_time=utcnow_naive()
             )
 
             self.db.add(perceptual_memory)

--- a/api/app/repositories/memory_short_repository.py
+++ b/api/app/repositories/memory_short_repository.py
@@ -7,6 +7,7 @@ import uuid
 import datetime
 
 from app.models.memory_short_model import ShortTermMemory, LongTermMemory
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_db_logger
 
 # 获取数据库专用日志器
@@ -117,7 +118,7 @@ class ShortTermMemoryRepository:
             List[ShortTermMemory]: 记忆记录列表，按创建时间倒序
         """
         try:
-            cutoff_time = datetime.datetime.now() - datetime.timedelta(hours=hours)
+            cutoff_time = utcnow_naive() - datetime.timedelta(hours=hours)
             
             # 使用复合索引 ix_memory_short_term_user_time 优化查询
             memories = (
@@ -178,7 +179,7 @@ class ShortTermMemoryRepository:
             int: 删除的记录数
         """
         try:
-            cutoff_time = datetime.datetime.now() - datetime.timedelta(days=days)
+            cutoff_time = utcnow_naive() - datetime.timedelta(days=days)
             
             deleted_count = (
                 self.db.query(ShortTermMemory)
@@ -499,5 +500,4 @@ class LongTermMemoryRepository:
             self.db.rollback()
             db_logger.error(f"创建或更新长期记忆记录时出错: {str(e)}")
             raise
-
 

--- a/api/app/repositories/model_repository.py
+++ b/api/app/repositories/model_repository.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Dict, Any, Tuple
 from sqlalchemy import and_, or_, func, desc
 from sqlalchemy.orm import Session, joinedload
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_db_logger
 from app.models.models_model import ModelConfig, ModelApiKey, ModelType, ModelBase, model_config_api_key_association
 from app.schemas.model_schema import (
@@ -111,7 +112,7 @@ class ModelConfigRepository:
     @staticmethod
     def get_list(db: Session, query: ModelConfigQuery, tenant_id: uuid.UUID | None = None) -> Tuple[List[ModelConfig], int]:
         """获取模型配置列表"""
-        db_logger.debug(f"查询模型配置列表: {query.dict()}, tenant_id={tenant_id}")
+        db_logger.debug(f"查询模型配置列表: {query.model_dump()}, tenant_id={tenant_id}")
 
         try:
             # 构建查询条件
@@ -587,7 +588,7 @@ class ModelApiKeyRepository:
             # 更新使用次数和最后使用时间
             current_count = int(db_api_key.usage_count or "0")
             db_api_key.usage_count = str(current_count + 1)
-            db_api_key.last_used_at = func.now()
+            db_api_key.last_used_at = utcnow_naive()
             
             db.flush()
             db_logger.debug(f"API Key使用统计更新成功: api_key_id={api_key_id}")

--- a/api/app/repositories/neo4j/add_edges.py
+++ b/api/app/repositories/neo4j/add_edges.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 import hashlib
 from datetime import datetime
 from uuid import uuid4
+from app.core.utils.datetime_utils import to_iso_z
 from app.repositories.neo4j.cypher_queries import CHUNK_STATEMENT_EDGE_SAVE, MEMORY_SUMMARY_STATEMENT_EDGE_SAVE
 from app.core.memory.models.message_models import Chunk
 # 使用新的仓储层
@@ -85,7 +86,7 @@ async def add_memory_summary_statement_edges(summaries: List[MemorySummaryNode],
                     "chunk_id": chunk_id,
                     "end_user_id": s.end_user_id,
                     "run_id": s.run_id,
-                    "created_at": s.created_at.isoformat() if s.created_at else None,
+                    "created_at": to_iso_z(s.created_at),
                 })
 
         if not edges:

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Optional
 
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.memory.models.graph_models import DialogueNode, StatementNode, ChunkNode, MemorySummaryNode
 from app.repositories.neo4j.cypher_queries import DIALOGUE_NODE_SAVE, STATEMENT_NODE_SAVE, CHUNK_NODE_SAVE, \
     MEMORY_SUMMARY_NODE_SAVE
@@ -41,7 +42,7 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
                 "run_id": dialogue.run_id,
                 "ref_id": dialogue.ref_id,
                 "name": dialogue.name,
-                "created_at": dialogue.created_at.isoformat() if dialogue.created_at else None,
+                "created_at": to_iso_z(dialogue.created_at),
                 "content": dialogue.content,
                 "dialog_embedding": dialogue.dialog_embedding
             })
@@ -85,7 +86,7 @@ async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jC
                 "run_id": statement.run_id,
                 "chunk_id": statement.chunk_id,
                 # "created_at": statement.created_at.isoformat(),
-                "created_at": statement.created_at.isoformat() if statement.created_at else None,
+                "created_at": to_iso_z(statement.created_at),
                 "stmt_type": statement.stmt_type,
                 "temporal_info": statement.temporal_info.value,
                 "statement": statement.statement,
@@ -93,8 +94,8 @@ async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jC
                 "chunk_embedding": statement.chunk_embedding if statement.chunk_embedding else None,
                 # "temporal_validity_valid_at": statement.temporal_validity_valid_at.isoformat() if statement.temporal_validity_valid_at else None,
                 # "temporal_validity_invalid_at": statement.temporal_validity_invalid_at.isoformat() if statement.temporal_validity_invalid_at else None,
-                "valid_at": statement.valid_at.isoformat() if statement.valid_at else None,
-                "invalid_at": statement.invalid_at.isoformat() if statement.invalid_at else None,
+                "valid_at": to_iso_z(statement.valid_at),
+                "invalid_at": to_iso_z(statement.invalid_at),
                 # "triplet_extraction_info": json.dumps({
                 #     "triplets": [triplet.model_dump() for triplet in statement.triplet_extraction_info.triplets] if statement.triplet_extraction_info else [],
                 #     "entities": [entity.model_dump() for entity in statement.triplet_extraction_info.entities] if statement.triplet_extraction_info else []
@@ -114,7 +115,7 @@ async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jC
                 "access_history": statement.access_history if statement.access_history else [],
                 "last_access_time": statement.last_access_time,
                 "access_count": statement.access_count,
-                "dialog_at": statement.dialog_at.isoformat() if statement.dialog_at else None,
+                "dialog_at": to_iso_z(statement.dialog_at),
             }
             flattened_statements.append(flattened_statement)
 
@@ -157,7 +158,7 @@ async def add_chunk_nodes(chunks: List[ChunkNode], connector: Neo4jConnector) ->
                 "name": chunk.name,
                 "end_user_id": chunk.end_user_id,
                 "run_id": chunk.run_id,
-                "created_at": chunk.created_at.isoformat() if chunk.created_at else None,
+                "created_at": to_iso_z(chunk.created_at),
                 "dialog_id": chunk.dialog_id,
                 "content": chunk.content,
                 "chunk_embedding": chunk.chunk_embedding if chunk.chunk_embedding else None,
@@ -208,7 +209,7 @@ async def add_memory_summary_nodes(
                 "name": s.name,
                 "end_user_id": s.end_user_id,
                 "run_id": s.run_id,
-                "created_at": s.created_at.isoformat() if s.created_at else None,
+                "created_at": to_iso_z(s.created_at),
                 "dialog_id": s.dialog_id,
                 "chunk_ids": s.chunk_ids,
                 "content": s.content,

--- a/api/app/repositories/neo4j/emotion_repository.py
+++ b/api/app/repositories/neo4j/emotion_repository.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 import json
 
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
@@ -209,7 +210,7 @@ class EmotionRepository:
         days = days_map.get(time_range, 30)
         
         # 计算起始日期（使用字符串比较，避免时区问题）
-        start_date = (datetime.now() - timedelta(days=days)).isoformat()
+        start_date = to_iso_z(utcnow_naive() - timedelta(days=days))
         
         # 使用 datetime() 函数进行时间比较，与其他查询保持一致
         query = """
@@ -236,7 +237,7 @@ class EmotionRepository:
                     "statement_id": record["statement_id"],
                     "emotion_type": record["emotion_type"],
                     "emotion_intensity": record["emotion_intensity"],
-                    "created_at": record["created_at"].isoformat() if hasattr(record["created_at"], "isoformat") else str(record["created_at"])
+                    "created_at": to_iso_z(record["created_at"]) if hasattr(record["created_at"], "isoformat") else str(record["created_at"])
                 }
                 for record in results
             ]

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -29,6 +29,7 @@ from app.core.memory.models.graph_models import (
     AssistantPrunedEdge,
     AssistantDialogEdge,
 )
+from app.core.utils.datetime_utils import to_iso_z
 import logging
 
 logger = logging.getLogger(__name__)
@@ -54,9 +55,9 @@ async def save_entities_and_relationships(
             'statement_id': edge.source_statement_id,
             'value': edge.relation_value,
             'statement': edge.statement,
-            'valid_at': edge.valid_at.isoformat() if edge.valid_at else None,
-            'invalid_at': edge.invalid_at.isoformat() if edge.invalid_at else None,
-            'created_at': edge.created_at.isoformat() if edge.created_at else None,
+            'valid_at': to_iso_z(edge.valid_at),
+            'invalid_at': to_iso_z(edge.invalid_at),
+            'created_at': to_iso_z(edge.created_at),
             'run_id': edge.run_id,
             'end_user_id': edge.end_user_id,
         }
@@ -115,7 +116,7 @@ async def save_statement_chunk_edges(
             "target": edge.target,
             "end_user_id": edge.end_user_id,
             "run_id": edge.run_id,
-            "created_at": edge.created_at.isoformat() if edge.created_at else None,
+            "created_at": to_iso_z(edge.created_at),
         })
 
     try:
@@ -144,7 +145,7 @@ async def save_statement_entity_edges(
             "end_user_id": edge.end_user_id,
             "run_id": edge.run_id,
             "connect_strength": edge.connect_strength,
-            "created_at": edge.created_at.isoformat() if edge.created_at else None,
+            "created_at": to_iso_z(edge.created_at),
         }
         all_se_edges.append(edge_data)
 
@@ -311,9 +312,9 @@ async def save_dialog_and_statements_to_neo4j(
                     'statement_id': edge.source_statement_id,
                     'value': edge.relation_value,
                     'statement': edge.statement,
-                    'valid_at': edge.valid_at.isoformat() if edge.valid_at else None,
-                    'invalid_at': edge.invalid_at.isoformat() if edge.invalid_at else None,
-                    'created_at': edge.created_at.isoformat() if edge.created_at else None,
+                    'valid_at': to_iso_z(edge.valid_at),
+                    'invalid_at': to_iso_z(edge.invalid_at),
+                    'created_at': to_iso_z(edge.created_at),
                     'run_id': edge.run_id,
                     'end_user_id': edge.end_user_id,
                 })
@@ -331,7 +332,7 @@ async def save_dialog_and_statements_to_neo4j(
                     "id": edge.id,
                     "source": edge.source,
                     "target": edge.target,
-                    "created_at": edge.created_at.isoformat() if edge.created_at else None,
+                    "created_at": to_iso_z(edge.created_at),
                     "run_id": edge.run_id,
                     "end_user_id": edge.end_user_id,
                 })
@@ -348,7 +349,7 @@ async def save_dialog_and_statements_to_neo4j(
                 se_edge_data.append({
                     "source": edge.source,
                     "target": edge.target,
-                    "created_at": edge.created_at.isoformat() if edge.created_at else None,
+                    "created_at": to_iso_z(edge.created_at),
                     "run_id": edge.run_id,
                     "end_user_id": edge.end_user_id,
                     "connect_strength": getattr(edge, "connect_strength", "strong"),
@@ -367,7 +368,7 @@ async def save_dialog_and_statements_to_neo4j(
                     "perceptual_id": edge.source,
                     "chunk_id": edge.target,
                     "end_user_id": edge.end_user_id,
-                    "created_at": edge.created_at.isoformat() if edge.created_at else None,
+                    "created_at": to_iso_z(edge.created_at),
                 })
             result = await tx.run(PERCEPTUAL_CHUNK_EDGE_SAVE, edges=perceptual_edge_data)
             perceptual_edges_uuids = [record["uuid"] async for record in result]
@@ -401,7 +402,7 @@ async def save_dialog_and_statements_to_neo4j(
                 "pair_id": edge.pair_id,
                 "end_user_id": edge.end_user_id,
                 "run_id": edge.run_id,
-                "created_at": edge.created_at.isoformat() if edge.created_at else None,
+                "created_at": to_iso_z(edge.created_at),
             } for edge in assistant_pruned_edges]
             result = await tx.run(ASSISTANT_PRUNED_EDGE_SAVE, edges=edge_data)
             pruned_edge_uuids = [record["uuid"] async for record in result]
@@ -416,7 +417,7 @@ async def save_dialog_and_statements_to_neo4j(
                 "target": edge.target,
                 "end_user_id": edge.end_user_id,
                 "run_id": edge.run_id,
-                "created_at": edge.created_at.isoformat() if edge.created_at else None,
+                "created_at": to_iso_z(edge.created_at),
             } for edge in assistant_dialog_edges]
             result = await tx.run(ASSISTANT_DIALOG_EDGE_SAVE, edges=edge_data)
             dialog_edge_uuids = [record["uuid"] async for record in result]

--- a/api/app/repositories/neo4j/neo4j_connector.py
+++ b/api/app/repositories/neo4j/neo4j_connector.py
@@ -14,12 +14,13 @@ from neo4j import AsyncGraphDatabase, basic_auth
 from neo4j.time import DateTime as Neo4jDateTime, Date as Neo4jDate, Time as Neo4jTime, Duration as Neo4jDuration
 
 from app.core.config import settings
+from app.core.utils.datetime_utils import to_iso_z
 
 
 def _convert_neo4j_types(value: Any) -> Any:
     """递归将 neo4j 原生时间类型转为 Python 原生类型 / ISO 字符串，确保可被 json.dumps 序列化。"""
     if isinstance(value, Neo4jDateTime):
-        return value.to_native().isoformat() if value.tzinfo else value.iso_format()
+        return to_iso_z(value.to_native()) if value.tzinfo else value.iso_format()
     if isinstance(value, Neo4jDate):
         return value.iso_format()
     if isinstance(value, Neo4jTime):

--- a/api/app/repositories/release_share_repository.py
+++ b/api/app/repositories/release_share_repository.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import select
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models import ReleaseShare
 
 
@@ -50,10 +51,9 @@ class ReleaseShareRepository:
     
     def increment_view_count(self, share_id: uuid.UUID) -> None:
         """增加访问次数（异步更新，不阻塞）"""
-        from datetime import datetime
         stmt = select(ReleaseShare).where(ReleaseShare.id == share_id)
         share = self.db.scalars(stmt).first()
         if share:
             share.view_count += 1
-            share.last_accessed_at = datetime.now()
+            share.last_accessed_at = utcnow_naive()
             self.db.commit()

--- a/api/app/repositories/workspace_invite_repository.py
+++ b/api/app/repositories/workspace_invite_repository.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import datetime
 import uuid
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.workspace_model import WorkspaceInvite, InviteStatus
 from app.schemas.workspace_schema import WorkspaceInviteCreate
 
@@ -20,7 +21,7 @@ class WorkspaceInviteRepository:
         created_by_user_id: uuid.UUID
     ) -> WorkspaceInvite:
         """创建工作空间邀请"""
-        expires_at = datetime.datetime.now() + datetime.timedelta(days=invite_data.expires_in_days)
+        expires_at = utcnow_naive() + datetime.timedelta(days=invite_data.expires_in_days)
         
         db_invite = WorkspaceInvite(
             workspace_id=workspace_id,
@@ -92,7 +93,7 @@ class WorkspaceInviteRepository:
             invite.status = status
             if accepted_at:
                 invite.accepted_at = accepted_at
-            invite.updated_at = datetime.datetime.now()
+            invite.updated_at = utcnow_naive()
             self.db.commit()
             self.db.refresh(invite)
         return invite
@@ -103,7 +104,7 @@ class WorkspaceInviteRepository:
 
     def expire_old_invites(self) -> int:
         """将过期的邀请标记为已过期"""
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         expired_count = self.db.query(WorkspaceInvite).filter(
             and_(
                 WorkspaceInvite.status == InviteStatus.pending,

--- a/api/app/schemas/annotation_schema.py
+++ b/api/app/schemas/annotation_schema.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from typing import Optional, List
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 # ==================== Input Schemas ====================
@@ -44,11 +45,11 @@ class Annotation(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class AnnotationListItem(BaseModel):
@@ -64,11 +65,11 @@ class AnnotationListItem(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class AnnotationSettingResponse(BaseModel):
@@ -124,4 +125,4 @@ class AnnotationHitLogItem(BaseModel):
 
     @field_serializer("hit_at", when_used="json")
     def _serialize_hit_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -4,6 +4,7 @@ import uuid
 from pydantic import BaseModel, Field, ConfigDict, field_validator, field_serializer, computed_field, model_validator
 from typing import Optional, List
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.api_key_model import ApiKeyType
 from app.core.api_key_utils import timestamp_to_datetime, datetime_to_timestamp
 
@@ -26,7 +27,7 @@ class ApiKeyCreate(BaseModel):
         """检查API Key是否已过期"""
         if not self.expires_at:
             return False
-        return datetime.datetime.now() > self.expires_at
+        return utcnow_naive() > self.expires_at
 
     @field_validator('expires_at', mode='before')
     @classmethod
@@ -78,7 +79,7 @@ class ApiKeyUpdate(BaseModel):
         """检查API Key是否已过期"""
         if not self.expires_at:
             return False
-        return datetime.datetime.now() > self.expires_at
+        return utcnow_naive() > self.expires_at
 
     @field_validator('expires_at', mode='before')
     @classmethod
@@ -125,7 +126,7 @@ class ApiKeyResponse(BaseModel):
         """检查API Key是否已过期"""
         if not self.expires_at:
             return False
-        return datetime.datetime.now() > self.expires_at
+        return utcnow_naive() > self.expires_at
 
     @field_serializer('expires_at', 'created_at')
     @classmethod
@@ -164,7 +165,7 @@ class ApiKey(BaseModel):
         """检查API Key是否已过期"""
         if not self.expires_at:
             return False
-        return datetime.datetime.now() > self.expires_at
+        return utcnow_naive() > self.expires_at
 
     @field_serializer('expires_at', 'last_used_at', 'created_at', 'updated_at')
     def serialize_datetime(self, v: Optional[datetime.datetime]) -> Optional[int]:

--- a/api/app/schemas/app_log_schema.py
+++ b/api/app/schemas/app_log_schema.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict, Any, List
 
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 class LogFileInfo(BaseModel):
     """日志中用户上传的文件信息"""
@@ -30,7 +31,7 @@ class AppLogMessage(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("meta_data", when_used="json")
     def _serialize_meta_data(self, data: Optional[Dict[str, Any]]):
@@ -52,11 +53,11 @@ class AppLogConversation(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class AppLogNodeExecution(BaseModel):

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -5,6 +5,7 @@ from enum import Enum, StrEnum
 
 from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator, model_serializer
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.schemas.workflow_schema import WorkflowConfigCreate
 
 
@@ -417,15 +418,15 @@ class App(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("shared_at", when_used="json")
     def _serialize_shared_at(self, dt: Optional[datetime.datetime]):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class AgentConfig(BaseModel):
@@ -504,11 +505,11 @@ class AgentConfig(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class PublishRequest(BaseModel):
@@ -554,15 +555,15 @@ class AppRelease(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("published_at", when_used="json")
     def _serialize_published_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # ---------- App Copy Schema ----------
@@ -622,11 +623,11 @@ class AppShare(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # ---------- Draft Run Schemas ----------

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Optional, Dict, Any, List
 from pydantic import BaseModel, Field, ConfigDict, field_serializer, model_serializer
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 # 导入 FileInput（用于体验运行）
 from app.schemas.app_schema import FileInput
 
@@ -58,7 +59,7 @@ class Message(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("meta_data", when_used="json")
     def _serialize_meta_data(self, data: Optional[Dict[str, Any]]):
@@ -83,11 +84,11 @@ class Conversation(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class ConversationWithMessages(Conversation):

--- a/api/app/schemas/document_schema.py
+++ b/api/app/schemas/document_schema.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, field_serializer, ConfigDict
 import datetime
 import uuid
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class DocumentBase(BaseModel):
@@ -50,14 +51,14 @@ class Document(DocumentBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     model_config = ConfigDict(from_attributes=True)
 
     @field_serializer("process_begin_at", when_used="json")
     def _serialize_process_begin_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/end_user_schema.py
+++ b/api/app/schemas/end_user_schema.py
@@ -1,8 +1,10 @@
 import uuid
 import datetime
-from typing import Optional, List
+from typing import Optional
 from pydantic import BaseModel, Field
 from pydantic import ConfigDict
+
+from app.core.utils.datetime_utils import utcnow_naive
 
 class EndUser(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -13,9 +15,9 @@ class EndUser(BaseModel):
     other_id: Optional[str] = Field(description="第三方ID", default=None)
     other_name: Optional[str] = Field(description="其他名称", default="")
     other_address: Optional[str] = Field(description="其他地址", default="")
-    reflection_time: Optional[datetime.datetime] = Field(description="反思时间", default_factory=datetime.datetime.now)
-    created_at: datetime.datetime = Field(description="创建时间", default_factory=datetime.datetime.now)
-    updated_at: datetime.datetime = Field(description="更新时间", default_factory=datetime.datetime.now)
+    reflection_time: Optional[datetime.datetime] = Field(description="反思时间", default_factory=utcnow_naive)
+    created_at: datetime.datetime = Field(description="创建时间", default_factory=utcnow_naive)
+    updated_at: datetime.datetime = Field(description="更新时间", default_factory=utcnow_naive)
     
     # 用户摘要和洞察更新时间
     user_summary_updated_at: Optional[datetime.datetime] = Field(description="用户摘要最后更新时间", default=None)

--- a/api/app/schemas/file_schema.py
+++ b/api/app/schemas/file_schema.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, field_serializer, ConfigDict
 import datetime
 import uuid
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class BatchDownloadRequest(BaseModel):
@@ -62,4 +63,4 @@ class File(FileBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/implicit_memory_schema.py
+++ b/api/app/schemas/implicit_memory_schema.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class FrequencyPattern(str, Enum):
@@ -36,11 +37,11 @@ class TimeRange(BaseModel):
 
     @field_serializer("start_date", when_used="json")
     def _serialize_start_date(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("end_date", when_used="json")
     def _serialize_end_date(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class DateRange(BaseModel):
@@ -57,11 +58,11 @@ class DateRange(BaseModel):
 
     @field_serializer("start_date", when_used="json")
     def _serialize_start_date(self, dt: Optional[datetime.datetime]):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("end_date", when_used="json")
     def _serialize_end_date(self, dt: Optional[datetime.datetime]):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class AnalysisConfig(BaseModel):
@@ -90,11 +91,11 @@ class PreferenceTagResponse(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class DimensionScoreResponse(BaseModel):
@@ -122,7 +123,7 @@ class DimensionPortraitResponse(BaseModel):
 
     @field_serializer("analysis_timestamp", when_used="json")
     def _serialize_analysis_timestamp(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class InterestCategoryResponse(BaseModel):
@@ -153,7 +154,7 @@ class InterestAreaDistributionResponse(BaseModel):
 
     @field_serializer("analysis_timestamp", when_used="json")
     def _serialize_analysis_timestamp(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class BehaviorHabitResponse(BaseModel):
@@ -171,11 +172,11 @@ class BehaviorHabitResponse(BaseModel):
 
     @field_serializer("first_observed", when_used="json")
     def _serialize_first_observed(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("last_observed", when_used="json")
     def _serialize_last_observed(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class UserProfileResponse(BaseModel):
@@ -194,11 +195,11 @@ class UserProfileResponse(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # Internal/Business Logic Schemas
@@ -215,7 +216,7 @@ class MemorySummary(BaseModel):
 
     @field_serializer("timestamp", when_used="json")
     def _serialize_timestamp(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class UserMemorySummary(BaseModel):
@@ -230,7 +231,7 @@ class UserMemorySummary(BaseModel):
 
     @field_serializer("timestamp", when_used="json")
     def _serialize_timestamp(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class SummaryAnalysisResult(BaseModel):
@@ -246,7 +247,7 @@ class SummaryAnalysisResult(BaseModel):
 
     @field_serializer("analysis_timestamp", when_used="json")
     def _serialize_analysis_timestamp(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # Aliases for backward compatibility with existing code
@@ -277,4 +278,4 @@ class CompleteProfileResponse(BaseModel):
     
     @field_serializer("generated_at", when_used="json")
     def _serialize_generated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/knowledge_schema.py
+++ b/api/app/schemas/knowledge_schema.py
@@ -4,6 +4,7 @@ import uuid
 from .user_schema import User
 from .model_schema import ModelConfig
 from typing import Optional
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models.knowledge_model import KnowledgeType, PermissionType
 
 
@@ -63,8 +64,8 @@ class Knowledge(KnowledgeBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/knowledgeshare_schema.py
+++ b/api/app/schemas/knowledgeshare_schema.py
@@ -4,6 +4,7 @@ import uuid
 from .knowledge_schema import Knowledge
 from .workspace_schema import Workspace
 from .user_schema import User
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class KnowledgeShareBase(BaseModel):
@@ -28,10 +29,10 @@ class KnowledgeShare(KnowledgeShareBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     model_config = ConfigDict(from_attributes=True)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/mcp_market_config_schema.py
+++ b/api/app/schemas/mcp_market_config_schema.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, field_serializer, ConfigDict
 import datetime
 import uuid
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class McpMarketConfigBase(BaseModel):
@@ -28,4 +29,4 @@ class McpMarketConfig(McpMarketConfigBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/mcp_market_schema.py
+++ b/api/app/schemas/mcp_market_schema.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, field_serializer, ConfigDict
 import datetime
 import uuid
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class McpMarketBase(BaseModel):
@@ -34,4 +35,4 @@ class McpMarket(McpMarketBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)

--- a/api/app/schemas/memory_increment_schema.py
+++ b/api/app/schemas/memory_increment_schema.py
@@ -1,16 +1,17 @@
 import uuid
 import datetime
-from typing import Optional
 from pydantic import BaseModel, Field, field_serializer
 from pydantic import ConfigDict
+
+from app.core.utils.datetime_utils import utcnow_naive
 
 class MemoryIncrement(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     workspace_id: uuid.UUID = Field(description="工作空间ID")
     total_num: int = Field(description="增量总数")    
-    created_at: datetime.datetime = Field(description="创建时间", default_factory=datetime.datetime.now())
-    updated_at: datetime.datetime = Field(description="更新时间", default_factory=datetime.datetime.now())
+    created_at: datetime.datetime = Field(description="创建时间", default_factory=utcnow_naive)
+    updated_at: datetime.datetime = Field(description="更新时间", default_factory=utcnow_naive)
 
     @field_serializer('created_at', 'updated_at')
     def serialize_datetime(self, dt: datetime.datetime, _info) -> str:

--- a/api/app/schemas/memory_reflection_schemas.py
+++ b/api/app/schemas/memory_reflection_schemas.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field, ConfigDict, field_serializer
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 from enum import Enum
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 class OptimizationStrategy(str, Enum):
@@ -49,7 +50,7 @@ class ReflectionLogListItem(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 class ReflectionLogDetail(BaseModel):
     """详情页完整日志（含 JSONB 字段）"""
@@ -73,7 +74,7 @@ class ReflectionLogDetail(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class Memory_Reflection(BaseModel):

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -7,6 +7,8 @@ import time
 import uuid
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+
 
 # ============================================================================
 # 从 json_schema.py 迁移的 Schema
@@ -35,8 +37,7 @@ class BaseDataSchema(BaseModel):
     def _set_default_created_at(cls, v):
         """Set default created_at if missing"""
         if isinstance(v, dict) and v.get("created_at") is None:
-            from datetime import datetime
-            v["created_at"] = datetime.now().isoformat()
+            v["created_at"] = to_iso_z(utcnow_naive())
         return v
 
 

--- a/api/app/schemas/model_schema.py
+++ b/api/app/schemas/model_schema.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Dict, Any
 import datetime
 import uuid
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models.models_model import ModelProvider, ModelType, LoadBalanceStrategy
 from app.core.logging_config import get_business_logger
 
@@ -94,7 +95,7 @@ class ModelConfig(ModelConfigBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime | None):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("api_keys", when_used="json")
     def _serialize_api_keys(self, api_keys: List["ModelApiKey"]):
@@ -107,7 +108,7 @@ class ModelConfig(ModelConfigBase):
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # ModelApiKey Schemas
@@ -210,15 +211,15 @@ class ModelApiKey(ModelApiKeyBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("last_used_at", when_used="json")
     def _serialize_last_used_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class ModelConfigQuery(BaseModel):

--- a/api/app/schemas/multi_agent_schema.py
+++ b/api/app/schemas/multi_agent_schema.py
@@ -4,6 +4,7 @@ import datetime
 from typing import Optional, List, Dict, Any, Union
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.schemas.app_schema import ModelParameters
 
 
@@ -128,11 +129,11 @@ class MultiAgentConfigSchema(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # ==================== 多 Agent 运行 ====================

--- a/api/app/schemas/ontology_schemas.py
+++ b/api/app/schemas/ontology_schemas.py
@@ -24,6 +24,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer, ConfigDict
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.memory.models.ontology_scenario_models import OntologyClass
 
 
@@ -158,7 +159,7 @@ class OntologyResultResponse(BaseModel):
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
         """将创建时间序列化为毫秒时间戳"""
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     class Config:
         from_attributes = True
@@ -246,12 +247,12 @@ class SceneResponse(BaseModel):
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
         """将创建时间序列化为毫秒时间戳"""
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
         """将更新时间序列化为毫秒时间戳"""
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     model_config = ConfigDict(from_attributes=True)
 
@@ -400,12 +401,12 @@ class ClassResponse(BaseModel):
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
         """将创建时间序列化为毫秒时间戳"""
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
         """将更新时间序列化为毫秒时间戳"""
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/app/schemas/release_share_schema.py
+++ b/api/app/schemas/release_share_schema.py
@@ -2,6 +2,7 @@ import uuid
 import datetime
 from typing import Optional, List, Dict, Any
 from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 
 # ---------- Input Schemas ----------
@@ -57,15 +58,15 @@ class ReleaseShare(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
     @field_serializer("last_accessed_at", when_used="json")
     def _serialize_last_accessed_at(self, dt: Optional[datetime.datetime]):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class SharedReleaseInfo(BaseModel):

--- a/api/app/schemas/retrieval_info_schema.py
+++ b/api/app/schemas/retrieval_info_schema.py
@@ -4,10 +4,12 @@ from typing import Optional, Text
 from pydantic import BaseModel, Field
 from pydantic import ConfigDict
 
+from app.core.utils.datetime_utils import utcnow_naive
+
 class Host(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID = Field(description="宿主ID")
     host_id: uuid.UUID = Field(description="其他ID")
     retrieve_info: Optional[Text] = Field(description="检索信息")
-    created_at: datetime.datetime = Field(description="创建时间", default_factory=datetime.datetime.now)
+    created_at: datetime.datetime = Field(description="创建时间", default_factory=utcnow_naive)

--- a/api/app/schemas/skill_schema.py
+++ b/api/app/schemas/skill_schema.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, Field, field_serializer
 import uuid
 from datetime import datetime
 
+from app.core.utils.datetime_utils import to_timestamp_ms
+
 
 class SkillBase(BaseModel):
     """Skill 基础 Schema"""
@@ -49,7 +51,7 @@ class Skill(BaseModel):
     @field_serializer('created_at', 'updated_at')
     def serialize_datetime_to_timestamp(self, value: datetime) -> int:
         """（毫秒级）时间戳"""
-        return int(value.timestamp() * 1000)
+        return to_timestamp_ms(value)
 
     class Config:
         from_attributes = True

--- a/api/app/schemas/token_schema.py
+++ b/api/app/schemas/token_schema.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, EmailStr, field_serializer
 from typing import Optional
 import datetime
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 class Token(BaseModel):
     access_token: str
@@ -11,11 +12,11 @@ class Token(BaseModel):
 
     @field_serializer("expires_at", when_used="json")
     def _serialize_expires_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("refresh_expires_at", when_used="json")
     def _serialize_refresh_expires_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 class TokenData(BaseModel):
     userId: Optional[str] = None

--- a/api/app/schemas/user_schema.py
+++ b/api/app/schemas/user_schema.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 import datetime
 import uuid
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models import Workspace
 from app.models.workspace_model import WorkspaceRole
 
@@ -94,7 +95,7 @@ class User(UserBase):
     @classmethod
     def _created_at_to_ms(cls, v):
         if isinstance(v, datetime.datetime):
-            return int(v.timestamp() * 1000)
+            return to_timestamp_ms(v)
         if isinstance(v, (int, float)):
             return int(v)
         return v
@@ -108,7 +109,7 @@ class User(UserBase):
         if v is None:
             return None
         if isinstance(v, datetime.datetime):
-            return int(v.timestamp() * 1000)
+            return to_timestamp_ms(v)
         if isinstance(v, (int, float)):
             return int(v)
         return v

--- a/api/app/schemas/workflow_schema.py
+++ b/api/app/schemas/workflow_schema.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Any
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 
 # ==================== 节点和边定义 ====================
 
@@ -128,11 +129,11 @@ class WorkflowConfig(BaseModel):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("updated_at", when_used="json")
     def _serialize_updated_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("features", when_used="json")
     def _serialize_features(self, features: dict | None):
@@ -194,15 +195,15 @@ class WorkflowExecution(BaseModel):
 
     @field_serializer("started_at", when_used="json")
     def _serialize_started_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("completed_at", when_used="json")
     def _serialize_completed_at(self, dt: datetime.datetime | None):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class WorkflowNodeExecution(BaseModel):
@@ -231,15 +232,15 @@ class WorkflowNodeExecution(BaseModel):
 
     @field_serializer("started_at", when_used="json")
     def _serialize_started_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("completed_at", when_used="json")
     def _serialize_completed_at(self, dt: datetime.datetime | None):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 # ==================== 验证响应 ====================

--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -3,6 +3,7 @@ import email
 import uuid
 from typing import Literal, Optional
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models.workspace_model import InviteStatus, WorkspaceRole
 from pydantic import (
     BaseModel,
@@ -50,7 +51,7 @@ class Workspace(WorkspaceBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class WorkspaceResponse(WorkspaceBase):
@@ -63,7 +64,7 @@ class WorkspaceResponse(WorkspaceBase):
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp()) if dt else None
+        return to_timestamp_ms(dt)
 
 
 class WorkspaceMemberBase(BaseModel):
@@ -125,7 +126,7 @@ class WorkspaceMemberItem(BaseModel):
     # 将最后登录时间序列化为毫秒时间戳，便于前端统一格式化
     @field_serializer("last_login_at", when_used="json")
     def _serialize_last_login(self, dt: datetime.datetime | None):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     # # 动态计算角色中文标签
     # @computed_field
@@ -154,17 +155,17 @@ class WorkspaceInviteResponse(BaseModel):
 
     @field_serializer("expires_at", when_used="json")
     def _serialize_expires_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     @field_serializer("created_at", when_used="json")
     def _serialize_created_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
 
     model_config = ConfigDict(from_attributes=True)
 
     @field_serializer("accepted_at", when_used="json")
     def _serialize_accepted_at(self, dt: datetime.datetime):
-        return int(dt.timestamp() * 1000) if dt else None
+        return to_timestamp_ms(dt)
     
 
 class InviteValidateResponse(BaseModel):

--- a/api/app/services/agent_handoff.py
+++ b/api/app/services/agent_handoff.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, Optional, List
 from datetime import datetime
 from pydantic import BaseModel, Field
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
@@ -21,13 +22,13 @@ class HandoffContext(BaseModel):
     from_agent_id: str = Field(..., description="源 Agent ID")
     to_agent_id: str = Field(..., description="目标 Agent ID")
     reason: str = Field(..., description="切换原因")
-    timestamp: datetime = Field(default_factory=datetime.now)
+    timestamp: datetime = Field(default_factory=utcnow_naive)
     user_message: Optional[str] = Field(None, description="触发切换的用户消息")
     context_summary: Optional[str] = Field(None, description="上下文摘要")
     
     class Config:
         json_encoders = {
-            datetime: lambda v: v.isoformat()
+            datetime: lambda v: to_iso_z(v)
         }
 
 
@@ -70,14 +71,14 @@ class HandoffState(BaseModel):
     current_agent_id: str = Field(..., description="当前活跃的 Agent ID")
     handoff_history: List[HandoffContext] = Field(default_factory=list, description="切换历史")
     context_data: Dict[str, Any] = Field(default_factory=dict, description="共享上下文数据")
-    created_at: datetime = Field(default_factory=datetime.now)
-    updated_at: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=utcnow_naive)
+    updated_at: datetime = Field(default_factory=utcnow_naive)
     
     def add_handoff(self, context: HandoffContext):
         """添加 handoff 记录"""
         self.handoff_history.append(context)
         self.current_agent_id = context.to_agent_id
-        self.updated_at = datetime.now()
+        self.updated_at = utcnow_naive()
         
         logger.info(
             "Agent handoff 记录",
@@ -99,7 +100,7 @@ class HandoffState(BaseModel):
     
     class Config:
         json_encoders = {
-            datetime: lambda v: v.isoformat()
+            datetime: lambda v: to_iso_z(v)
         }
 
 

--- a/api/app/services/agent_tools.py
+++ b/api/app/services/agent_tools.py
@@ -7,6 +7,7 @@ from langchain.tools import tool
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models import AgentConfig, ModelConfig, AgentInvocation
 from app.services.agent_registry import AgentRegistry
 from app.core.exceptions import BusinessException, ResourceNotFoundException
@@ -243,7 +244,7 @@ def create_agent_invocation_tool(
                 input_message=message,
                 context=context,
                 status="running",
-                started_at=datetime.datetime.now()
+                started_at=utcnow_naive()
             )
             db.add(invocation)
             db.commit()
@@ -281,7 +282,7 @@ def create_agent_invocation_tool(
                 # 10. 更新调用记录
                 invocation.status = "completed"
                 invocation.output_message = result["message"]
-                invocation.completed_at = datetime.datetime.now()
+                invocation.completed_at = utcnow_naive()
                 invocation.elapsed_time = elapsed_time
                 invocation.token_usage = result.get("usage", {})
                 db.commit()
@@ -302,7 +303,7 @@ def create_agent_invocation_tool(
                 # 更新调用记录为失败
                 invocation.status = "failed"
                 invocation.error_message = str(e)
-                invocation.completed_at = datetime.datetime.now()
+                invocation.completed_at = utcnow_naive()
                 invocation.elapsed_time = time.time() - start_time
                 db.commit()
                 

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -3,11 +3,12 @@ import time
 import uuid
 import math
 from typing import Optional, Tuple
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from sqlalchemy.orm import Session
 from sqlalchemy import select
 
+from app.core.utils.datetime_utils import as_utc_aware, utcnow_naive
 from app.aioRedis import aio_redis
 from app.models.api_key_model import ApiKey, ApiKeyType
 from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
@@ -340,15 +341,15 @@ class RateLimiterService:
         """检查日调用量限制。
         使用原子 INCR，先写后判断，极低概率下允许轻微超限（并发场景下可接受）。
         """
-        today = datetime.now().strftime("%Y%m%d")
+        today = utcnow_naive().strftime("%Y%m%d")
         key = f"rate_limit:daily:{api_key_id}:{today}"
 
-        now = datetime.now()
+        now = utcnow_naive()
         tomorrow_0 = (now + timedelta(days=1)).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         expire_seconds = int((tomorrow_0 - now).total_seconds())
-        reset_time = int(tomorrow_0.timestamp())
+        reset_time = int(as_utc_aware(tomorrow_0).timestamp())
 
         async with self.redis.pipeline() as pipe:
             pipe.incr(key)
@@ -467,7 +468,7 @@ class ApiKeyAuthService:
         if not api_key_obj.is_active:
             return None
 
-        if api_key_obj.expires_at and datetime.now() > api_key_obj.expires_at:
+        if api_key_obj.expires_at and utcnow_naive() > api_key_obj.expires_at:
             return None
 
         if api_key_obj.quota_limit and api_key_obj.quota_used >= api_key_obj.quota_limit:

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -6,6 +6,7 @@ from typing import Optional
 import yaml
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.config import settings
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException, ResourceNotFoundException
@@ -41,7 +42,7 @@ class AppDslService:
         meta = {
             "version": settings.SYSTEM_VERSION,
             "platform": "MemoryBear",
-            "exported_at": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+            "exported_at": to_iso_z(utcnow_naive()),
         }
         app_meta = {
             "name": app.name,
@@ -264,7 +265,7 @@ class AppDslService:
             raise BusinessException(f"不支持的应用类型: {app_type}", BizCode.BAD_REQUEST)
 
         warnings: list[str] = []
-        now = datetime.datetime.now()
+        now = utcnow_naive()
 
         if app_id is not None:
             return self._overwrite_dsl(dsl, app_id, app_type, workspace_id, tenant_id, warnings, now)

--- a/api/app/services/app_log_service.py
+++ b/api/app/services/app_log_service.py
@@ -6,6 +6,7 @@ from typing import Optional, Tuple
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_business_logger
 from app.models.app_model import AppType
 from app.models.conversation_model import Conversation, Message
@@ -194,7 +195,7 @@ class AppLogService:
                 ))
 
         for execution in executions:
-            started_at = execution.started_at or dt.datetime.now()
+            started_at = execution.started_at or dt.utcnow_naive()
             completed_at = execution.completed_at or started_at
 
             # assistant message 的 id，同时作为 node_executions_map 的 key

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import and_, column, delete, exists, func, or_, select, update a
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.exceptions import (
     BusinessException,
@@ -690,7 +691,7 @@ class AppService:
             raise BusinessException(message="已存在同名应用", code=BizCode.RESOURCE_ALREADY_EXISTS)
 
         try:
-            now = datetime.datetime.now()
+            now = utcnow_naive()
 
             app = App(
                 id=uuid.uuid4(),
@@ -769,7 +770,7 @@ class AppService:
                 changed = True
 
         if changed:
-            app.updated_at = datetime.datetime.now()
+            app.updated_at = utcnow_naive()
             self.db.commit()
             self.db.refresh(app)
             logger.info("应用更新成功", extra={"app_id": str(app_id)})
@@ -808,7 +809,7 @@ class AppService:
             AppShare.is_active.is_(True)
         ).values(
             is_active=False,
-            updated_at=datetime.datetime.now()
+            updated_at=utcnow_naive()
         )
         self.db.execute(stmt)
         
@@ -861,7 +862,7 @@ class AppService:
                 new_name = f"{source_app.name} - 副本"
             new_name = self._unique_app_name(new_name, target_workspace_id, source_app.type)
 
-            now = datetime.datetime.now()
+            now = utcnow_naive()
 
             # 创建新应用（复制基础信息）
             new_app = App(
@@ -1338,7 +1339,7 @@ class AppService:
         stmt = select(AgentConfig).where(AgentConfig.app_id == app_id, AgentConfig.is_active.is_(True)).order_by(
             AgentConfig.updated_at.desc())
         agent_cfg: Optional[AgentConfig] = self.db.scalars(stmt).first()
-        now = datetime.datetime.now()
+        now = utcnow_naive()
 
         if not agent_cfg:
             agent_cfg = AgentConfig(
@@ -1383,7 +1384,7 @@ class AppService:
     def _agent_config_from_release(self, release: "AppRelease") -> "AgentConfig":
         """从发布版本快照重建 AgentConfig 对象（不入库，仅用于运行）"""
         cfg = release.config or {}
-        now = release.created_at or datetime.datetime.now()
+        now = release.created_at or utcnow_naive()
         agent_cfg = AgentConfig(
             id=uuid.uuid4(),
             app_id=release.app_id,
@@ -1405,7 +1406,7 @@ class AppService:
     def _workflow_config_from_release(self, release: "AppRelease") -> "WorkflowConfig":
         """从发布版本快照重建 WorkflowConfig 对象（不入库，仅用于运行）"""
         cfg = release.config or {}
-        now = release.created_at or datetime.datetime.now()
+        now = release.created_at or utcnow_naive()
         from app.models.workflow_model import WorkflowConfig as WorkflowConfigModel
         # 查出源应用真实的 WorkflowConfig id，供 workflow_executions 外键使用
         real_config = WorkflowConfigRepository(self.db).get_by_app_id(release.app_id)
@@ -1523,7 +1524,7 @@ class AppService:
         Returns:
             AgentConfig: 默认配置对象
         """
-        now = datetime.datetime.now()
+        now = utcnow_naive()
 
         # 创建一个临时的配置对象，不添加到数据库
         default_config = AgentConfig(
@@ -1642,7 +1643,7 @@ class AppService:
         # 获取现有配置
         repo = WorkflowConfigRepository(self.db)
         workflow_cfg = repo.get_by_app_id(app_id)
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         workflow_service = WorkflowService(self.db)
         features = data.features or {}
         workflow_type = self._normalize_workflow_type(
@@ -1716,7 +1717,7 @@ class AppService:
         """
         from app.core.workflow.template_loader import load_workflow_template
 
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         normalized_workflow_type = self._normalize_workflow_type(workflow_type)
 
         template_id = "pure_workflow_simple_qa" \
@@ -1985,7 +1986,7 @@ class AppService:
                 "应用发布配置准备完成"
             )
 
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         version = self._get_next_version(app_id)
 
         release = AppRelease(
@@ -2170,7 +2171,7 @@ class AppService:
             )
 
         app.current_release_id = release.id
-        app.updated_at = datetime.datetime.now()
+        app.updated_at = utcnow_naive()
 
         self.db.commit()
         self.db.refresh(release)
@@ -2243,7 +2244,7 @@ class AppService:
                 )
 
         # 3. 创建分享记录
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         shares = []
 
         for target_ws_id in target_workspace_ids:
@@ -2587,7 +2588,7 @@ class AppService:
             )
 
         share.permission = permission
-        share.updated_at = datetime.datetime.now()
+        share.updated_at = utcnow_naive()
         self.db.commit()
         self.db.refresh(share)
 

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -10,6 +10,7 @@ from jinja2 import Template
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.exceptions import ResourceNotFoundException
@@ -673,7 +674,7 @@ class ConversationService:
                 "version": v.version,
                 "is_current": v.is_current,
                 "content": v.content,
-                "created_at": int(v.created_at.timestamp() * 1000),
+                "created_at": to_timestamp_ms(v.created_at),
             }
             for v in versions
         ]
@@ -783,7 +784,7 @@ class ConversationService:
             raise BusinessException("Conversation not found", BizCode.INVALID_CONVERSATION)
         is_stable = (
                 conversation.updated_at
-                and datetime.now() - conversation.updated_at > timedelta(days=1)
+                and utcnow_naive() - conversation.updated_at > timedelta(days=1)
         )
         if conversation_detail and is_stable:
             logger.info(f"Conversation detail found in repository for conversation_id={conversation_id}")

--- a/api/app/services/conversation_share_service.py
+++ b/api/app/services/conversation_share_service.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional, List
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
@@ -55,7 +56,7 @@ class ConversationShareService:
 
         expire_at = None
         if expire_hours:
-            expire_at = datetime.now() + timedelta(hours=expire_hours)
+            expire_at = utcnow_naive() + timedelta(hours=expire_hours)
 
         share = ConversationShare(
             conversation_id=conversation_id,
@@ -85,7 +86,7 @@ class ConversationShareService:
             "share_id": str(share.id),
             "share_uuid": share_uuid,
             "share_url": share_url,
-            "expire_at": int(expire_at.timestamp() * 1000) if expire_at else None,
+            "expire_at": to_timestamp_ms(expire_at),
             "has_password": bool(password),
         }
 
@@ -112,7 +113,7 @@ class ConversationShareService:
             raise BusinessException("分享链接不存在或已失效", BizCode.NOT_FOUND)
 
         # 检查过期
-        if share.expire_at and share.expire_at < datetime.now():
+        if share.expire_at and share.expire_at < utcnow_naive():
             raise BusinessException("分享链接已过期", BizCode.FORBIDDEN)
 
         # 检查密码
@@ -145,7 +146,7 @@ class ConversationShareService:
                     "id": str(msg.id),
                     "role": msg.role,
                     "content": msg.content,
-                    "created_at": int(msg.created_at.timestamp() * 1000),
+                    "created_at": to_timestamp_ms(msg.created_at),
                     "meta_data": msg.meta_data,
                     "feedback_type": msg.feedbacks[0].feedback_type if msg.feedbacks else None,
                     "feedback_content": msg.feedbacks[0].feedback_content if msg.feedbacks else None
@@ -212,10 +213,10 @@ class ConversationShareService:
                 "share_uuid": s.share_uuid,
                 "share_url": f"{settings.FILE_LOCAL_SERVER_URL}/share/{s.share_uuid}",
                 "view_count": s.view_count,
-                "expire_at": int(s.expire_at.timestamp() * 1000) if s.expire_at else None,
+                "expire_at": to_timestamp_ms(s.expire_at),
                 "has_password": bool(s.password),
                 "allow_copy": s.allow_copy,
-                "created_at": int(s.created_at.timestamp() * 1000),
+                "created_at": to_timestamp_ms(s.created_at),
             }
             for s in shares
         ]

--- a/api/app/services/conversation_state_manager.py
+++ b/api/app/services/conversation_state_manager.py
@@ -2,6 +2,7 @@
 import json
 from typing import Optional, Dict, Any, List
 from datetime import datetime
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
@@ -89,7 +90,7 @@ class ConversationStateManager:
         state["current_agent_id"] = agent_id
         state["last_message"] = message
         state["last_topic"] = topic
-        state["updated_at"] = datetime.now().isoformat()
+        state["updated_at"] = to_iso_z(utcnow_naive())
         
         # 添加到历史
         history_item = {
@@ -98,7 +99,7 @@ class ConversationStateManager:
             "topic": topic,
             "confidence": confidence,
             "agent_changed": agent_changed,
-            "timestamp": datetime.now().isoformat()
+            "timestamp": to_iso_z(utcnow_naive())
         }
         state["routing_history"].append(history_item)
         
@@ -196,8 +197,8 @@ class ConversationStateManager:
             "last_topic": None,
             "switch_count": 0,
             "same_agent_turns": 0,
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat()
+            "created_at": to_iso_z(utcnow_naive()),
+            "updated_at": to_iso_z(utcnow_naive())
         }
         
         # 保存初始状态

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.agent.agent_middleware import AgentMiddleware
 from app.core.agent.langchain_agent import LangChainAgent
 from app.core.config import settings
@@ -1799,7 +1800,7 @@ class AgentRunService:
             "加载指定时间前的历史消息",
             extra={
                 "conversation_id": str(conversation_id),
-                "before_time": before_time.isoformat(),
+                "before_time": to_iso_z(before_time),
                 "max_history": max_history,
                 "loaded_count": len(filtered_history)
             }
@@ -1981,7 +1982,7 @@ class AgentRunService:
                     "provider": model_config.provider if model_config else None,
                     "type": model_config.type if model_config else None
                 } if model_config else None,
-                "snapshot_time": datetime.datetime.now().isoformat()
+                "snapshot_time": to_iso_z(utcnow_naive())
             }
 
             return snapshot

--- a/api/app/services/home_page_service.py
+++ b/api/app/services/home_page_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import Dict, Any
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.repositories.home_page_repository import HomePageRepository
 from app.schemas.home_page_schema import HomeStatistics, WorkspaceInfo
 
@@ -32,7 +33,7 @@ class HomePageService:
     def get_home_statistics(db: Session, tenant_id: UUID) -> HomeStatistics:
         """获取首页统计数据"""
         # 计算时间范围
-        now = datetime.now()
+        now = utcnow_naive()
         week_start = now - timedelta(days=now.weekday())
         week_start = week_start.replace(hour=0, minute=0, second=0, microsecond=0)
         

--- a/api/app/services/implicit_memory_service.py
+++ b/api/app/services/implicit_memory_service.py
@@ -11,6 +11,7 @@ import asyncio
 from datetime import datetime
 from typing import List, Optional
 
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.memory.analytics.implicit_memory.analyzers.dimension_analyzer import (
     DimensionAnalyzer,
 )
@@ -168,7 +169,7 @@ class ImplicitMemoryService:
             if date_range:
                 time_range = TimeRange(
                     start_date=date_range.start_date or datetime.min,
-                    end_date=date_range.end_date or datetime.now()
+                    end_date=date_range.end_date or utcnow_naive()
                 )
             
             user_summaries = await self.extract_user_summaries(
@@ -382,7 +383,7 @@ class ImplicitMemoryService:
 
     def _build_empty_profile(self) -> dict:
         """构建 MemorySummary 不足时返回的固定空白画像数据"""
-        now_ms = int(datetime.utcnow().timestamp() * 1000)
+        now_ms = to_timestamp_ms(utcnow_naive())
         insufficient = "Insufficient data for analysis"
 
         def _empty_dimension(name: str) -> dict:

--- a/api/app/services/memory_api_service.py
+++ b/api/app/services/memory_api_service.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy.orm import Session
 
 from app.celery_task_scheduler import scheduler
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException, ResourceNotFoundException
 from app.core.logging_config import get_logger
@@ -474,8 +475,8 @@ class MemoryAPIService:
                     "config_desc": config.config_desc,
                     "is_default": config.is_default or False,
                     "scene_name": scene_name,
-                    "created_at": config.created_at.isoformat() if config.created_at else None,
-                    "updated_at": config.updated_at.isoformat() if config.updated_at else None,
+                    "created_at": to_iso_z(config.created_at),
+                    "updated_at": to_iso_z(config.updated_at),
                 })
 
             logger.info(f"Found {len(configs)} memory configs for workspace {workspace_id}")

--- a/api/app/services/memory_base_service.py
+++ b/api/app/services/memory_base_service.py
@@ -8,6 +8,7 @@ import re
 from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.logging_config import get_logger
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services.emotion_analytics_service import EmotionAnalyticsService
@@ -332,20 +333,20 @@ class MemoryBaseService:
             # 处理 Neo4j DateTime 对象
             if hasattr(timestamp_value, 'to_native'):
                 dt_object = timestamp_value.to_native()
-                return int(dt_object.timestamp() * 1000)
+                return to_timestamp_ms(dt_object)
             
             # 处理 Python datetime 对象
             if isinstance(timestamp_value, datetime):
-                return int(timestamp_value.timestamp() * 1000)
+                return to_timestamp_ms(timestamp_value)
             
             # 处理字符串格式
             if isinstance(timestamp_value, str):
                 dt_object = datetime.fromisoformat(timestamp_value.replace("Z", "+00:00"))
-                return int(dt_object.timestamp() * 1000)
+                return to_timestamp_ms(dt_object)
             
             # 其他情况尝试转换为字符串再解析
             dt_object = datetime.fromisoformat(str(timestamp_value).replace("Z", "+00:00"))
-            return int(dt_object.timestamp() * 1000)
+            return to_timestamp_ms(dt_object)
             
         except (ValueError, TypeError, AttributeError) as e:
             logger.warning(f"无法解析时间戳: {timestamp_value}, error={str(e)}")

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_config_logger, get_logger
 from app.core.validators.memory_config_validators import (
     validate_and_resolve_model_id,
@@ -391,7 +392,7 @@ class MemoryConfigService:
                 reflexion_iteration_period=int(memory_config.iteration_period or "3"),
                 reflexion_range=memory_config.reflexion_range or "partial",
                 reflexion_baseline=memory_config.baseline or "Time",
-                loaded_at=datetime.now(),
+                loaded_at=utcnow_naive(),
                 # Pipeline config: Deduplication
                 enable_llm_dedup_blockwise=bool(
                     memory_config.enable_llm_dedup_blockwise) if memory_config.enable_llm_dedup_blockwise is not None else False,

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Dict, Any
 import uuid
 from fastapi import HTTPException
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.user_model import User
 from app.models.app_model import App
 from app.models.end_user_model import EndUser, EndUser as EndUserModel
@@ -632,7 +633,7 @@ def get_dashboard_yesterday_changes(
 
     business_logger.info(f"计算昨日对比百分比: workspace_id={workspace_id}, storage_type={storage_type}")
 
-    now_local = datetime.now()
+    now_local = utcnow_naive()
     today_start = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
 
     changes = {

--- a/api/app/services/memory_episodic_service.py
+++ b/api/app/services/memory_episodic_service.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytz
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.logging_config import get_logger
 from app.services.memory_base_service import MemoryBaseService
 
@@ -187,7 +188,7 @@ class MemoryEpisodicService(MemoryBaseService):
             return None
         
         # 返回ISO格式字符串
-        return start_time.isoformat()
+        return to_iso_z(start_time)
     
     async def get_episodic_memory_overview(
         self,

--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -16,6 +16,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.logging_config import get_api_logger
 from app.core.memory.storage_services.forgetting_engine.actr_calculator import ACTRCalculator
 from app.core.memory.storage_services.forgetting_engine.forgetting_strategy import ForgettingStrategy
@@ -306,7 +307,7 @@ class MemoryForgetService:
             if last_access_dt:
                 if last_access_dt.tzinfo is None:
                     last_access_dt = last_access_dt.replace(tzinfo=timezone.utc)
-                last_access_timestamp = int(last_access_dt.timestamp() * 1000)
+                last_access_timestamp = to_timestamp_ms(last_access_dt)
             else:
                 last_access_timestamp = 0
 
@@ -365,7 +366,7 @@ class MemoryForgetService:
             min_days_since_access = config.get('min_days_since_access', 30)
         
         # 记录执行开始时间
-        execution_time = datetime.now()
+        execution_time = utcnow_naive()
         
         # 运行遗忘周期（LLM 客户端将在需要时由 forgetting_strategy 内部获取）
         report = await forgetting_scheduler.run_forgetting_cycle(
@@ -570,7 +571,7 @@ class MemoryForgetService:
                 'average_activation_value': round(result['average_activation'], 2) if result['average_activation'] is not None else None,
                 'low_activation_nodes': result['low_activation_nodes'] or 0,
                 'forgetting_threshold': forgetting_threshold,
-                'timestamp': int(datetime.now().timestamp() * 1000)
+                'timestamp': to_timestamp_ms(utcnow_naive())
             }
         else:
             activation_metrics = {
@@ -580,7 +581,7 @@ class MemoryForgetService:
                 'average_activation_value': None,
                 'low_activation_nodes': 0,
                 'forgetting_threshold': forgetting_threshold,
-                'timestamp': int(datetime.now().timestamp() * 1000)
+                'timestamp': to_timestamp_ms(utcnow_naive())
             }
         
         # 收集节点类型分布
@@ -670,7 +671,7 @@ class MemoryForgetService:
                         'merged_count': record.merged_count,
                         'average_activation': round(record.average_activation_value, 2) if record.average_activation_value is not None else None,
                         'total_nodes': record.total_nodes,
-                        'execution_time': int(record.execution_time.timestamp() * 1000)
+                        'execution_time': to_timestamp_ms(record.execution_time)
                     })
                 
                 api_logger.info(f"成功获取最近 {len(recent_trends)} 个日期的历史趋势数据")
@@ -709,7 +710,7 @@ class MemoryForgetService:
             'activation_metrics': activation_metrics,
             'node_distribution': node_distribution,
             'recent_trends': recent_trends,
-            'timestamp': int(datetime.now().timestamp() * 1000)
+            'timestamp': to_timestamp_ms(utcnow_naive())
         }
 
         api_logger.info(
@@ -801,7 +802,7 @@ class MemoryForgetService:
         actr_calculator, _, _, config = await self._get_forgetting_components(db, config_id)
         
         # 生成遗忘曲线数据
-        initial_time = datetime.now()
+        initial_time = utcnow_naive()
         curve_data = actr_calculator.get_forgetting_curve(
             initial_time=initial_time,
             importance_score=importance_score,

--- a/api/app/services/memory_konwledges_server.py
+++ b/api/app/services/memory_konwledges_server.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
+from app.core.utils.datetime_utils import to_iso_z, to_timestamp_ms
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
@@ -257,7 +258,7 @@ def find_documents_by_kb_id(
                 "file_name": doc.file_name,
                 "file_ext": doc.file_ext,
                 "file_size": doc.file_size,
-                "created_at": doc.created_at.isoformat() if doc.created_at else None,
+                "created_at": to_iso_z(doc.created_at),
                 "status": getattr(doc, 'status', None)
             })
         return result
@@ -417,7 +418,7 @@ async def create_document_chunk(
         "doc_id": doc_id,
         "file_id": str(db_document.file_id),
         "file_name": db_document.file_name,
-        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+        "file_created_at": to_timestamp_ms(db_document.created_at),
         "document_id": str(document_id),
         "knowledge_id": str(kb_id),
         "sort_id": sort_id,

--- a/api/app/services/memory_perceptual_service.py
+++ b/api/app/services/memory_perceptual_service.py
@@ -8,6 +8,7 @@ import langid
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
@@ -113,7 +114,7 @@ class MemoryPerceptualService:
                 "keywords": content.keywords,
                 "topic": content.topic,
                 "domain": content.domain,
-                "created_time": int(memory.created_time.timestamp() * 1000),
+                "created_time": to_timestamp_ms(memory.created_time),
                 **detail
             }
 
@@ -176,7 +177,7 @@ class MemoryPerceptualService:
                     topic=topic,
                     domain=domain,
                     keywords=keywords,
-                    created_time=int(memory.created_time.timestamp() * 1000),
+                    created_time=to_timestamp_ms(memory.created_time),
                     storage_service=FileStorageService(memory.storage_service),
                 )
                 memory_items.append(memory_item)

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -9,6 +9,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.db import get_db
 from app.core.logging_config import get_api_logger
 from app.core.memory.storage_services.reflection_engine import ReflectionConfig, ReflectionEngine
@@ -71,8 +72,8 @@ class WorkspaceAppService:
             "type": app.type,
             "status": app.status,
             "visibility": app.visibility,
-            "created_at": app.created_at.isoformat() if app.created_at else None,
-            "updated_at": app.updated_at.isoformat() if app.updated_at else None,
+            "created_at": to_iso_z(app.created_at),
+            "updated_at": to_iso_z(app.updated_at),
             "releases": [],
             "memory_configs": [],
             "end_users": []
@@ -197,7 +198,7 @@ class WorkspaceAppService:
 
             end_user = self.db.query(EndUser).filter(EndUser.id == end_user_id).first()
             if end_user:
-                end_user.reflection_time = datetime.now()
+                end_user.reflection_time = utcnow_naive()
                 self.db.commit()
                 api_logger.info(f"成功更新用户反思时间，end_user_id: {end_user_id}")
                 return True
@@ -308,7 +309,7 @@ class MemoryReflectionService:
                         else:
                             reflection_time = current_reflection_time
 
-                        current_time = datetime.now()
+                        current_time = utcnow_naive()
                         time_diff = current_time - reflection_time
                         hours_diff = int(time_diff.total_seconds() / 3600)
 

--- a/api/app/services/message_feedback_service.py
+++ b/api/app/services/message_feedback_service.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
@@ -170,5 +171,5 @@ class FeedbackService:
         return {
             "feedback_type": feedback.feedback_type,
             "feedback_content": feedback.feedback_content,
-            "created_at": int(feedback.created_at.timestamp() * 1000),
+            "created_at": to_timestamp_ms(feedback.created_at),
         }

--- a/api/app/services/message_report_service.py
+++ b/api/app/services/message_report_service.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional, List, Tuple
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
@@ -163,7 +164,7 @@ class ReportService:
         report.action_taken = action_taken
         report.reviewer_id = reviewer_id
         report.review_note = review_note
-        report.reviewed_at = datetime.now()
+        report.reviewed_at = utcnow_naive()
 
         # 根据处理措施执行相应操作
         if action_taken == "content_removed":

--- a/api/app/services/multi_agent_handoffs_integration.py
+++ b/api/app/services/multi_agent_handoffs_integration.py
@@ -12,6 +12,7 @@ from app.services.collaborative_orchestrator import CollaborativeOrchestrator
 from app.schemas.multi_agent_schema import MultiAgentRunRequest
 from app.core.logging_config import get_business_logger
 from app.core.exceptions import BusinessException
+from app.core.utils.datetime_utils import to_iso_z
 from app.core.error_codes import BizCode
 from app.services.multi_agent_service import MultiAgentService
 
@@ -184,14 +185,14 @@ class MultiAgentHandoffsService:
                     "from_agent": h.from_agent_id,
                     "to_agent": h.to_agent_id,
                     "reason": h.reason,
-                    "timestamp": h.timestamp.isoformat(),
+                    "timestamp": to_iso_z(h.timestamp),
                     "user_message": h.user_message,
                     "context_summary": h.context_summary
                 }
                 for h in state.handoff_history
             ],
-            "created_at": state.created_at.isoformat(),
-            "updated_at": state.updated_at.isoformat()
+            "created_at": to_iso_z(state.created_at),
+            "updated_at": to_iso_z(state.updated_at)
         }
 
     def clear_handoff_state(self, conversation_id: str):

--- a/api/app/services/pilot_run_service.py
+++ b/api/app/services/pilot_run_service.py
@@ -15,6 +15,7 @@ import time
 from datetime import datetime
 from typing import Awaitable, Callable, Optional
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.config import settings
 from app.core.logging_config import get_memory_logger, log_time
 from app.core.memory.models.message_models import (
@@ -91,7 +92,7 @@ async def run_pilot_extraction(
     """
     log_file = "logs/time.log"
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = utcnow_naive().strftime("%Y-%m-%d %H:%M:%S")
     with open(log_file, "a", encoding="utf-8") as f:
         f.write(f"\n=== Pilot Run Started: {timestamp} ===\n")
 
@@ -274,5 +275,5 @@ async def run_pilot_extraction(
     total_time = time.time() - pipeline_start
     log_time("TOTAL PILOT RUN TIME", total_time, log_file)
     with open(log_file, "a", encoding="utf-8") as f:
-        f.write(f"=== Pilot Run Completed: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ===\n\n")
+        f.write(f"=== Pilot Run Completed: {utcnow_naive().strftime('%Y-%m-%d %H:%M:%S')} ===\n\n")
     logger.info(f"Pilot run complete. Total time: {total_time:.2f}s")

--- a/api/app/services/prompt_optimizer_service.py
+++ b/api/app/services/prompt_optimizer_service.py
@@ -5,6 +5,7 @@ import langid
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
@@ -451,7 +452,7 @@ class PromptOptimizerService:
             "session_id": prompt_obj.session_id,
             "title": prompt_obj.title,
             "prompt": prompt_obj.prompt,
-            "created_at": int(prompt_obj.created_at.timestamp() * 1000)
+            "created_at": to_timestamp_ms(prompt_obj.created_at)
         }
 
     def delete_prompt(
@@ -535,7 +536,7 @@ class PromptOptimizerService:
                 "id": release.id,
                 "title": release.title,
                 "prompt": release.prompt,
-                "created_at": int(release.created_at.timestamp() * 1000),
+                "created_at": to_timestamp_ms(release.created_at),
                 "first_message": first_message
             })
 

--- a/api/app/services/release_share_service.py
+++ b/api/app/services/release_share_service.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy import select
 
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models import ReleaseShare, AppRelease, App, AgentConfig
 from app.repositories.release_share_repository import ReleaseShareRepository
 from app.core.share_utils import (
@@ -295,7 +296,7 @@ class ReleaseShareService:
                     app_type=release.type,
                     version=release.version,
                     release_notes=release.release_notes,
-                    published_at=int(release.published_at.timestamp() * 1000),
+                    published_at=to_timestamp_ms(release.published_at),
                     config={},
                     require_password=True,
                     is_password_verified=False,
@@ -327,7 +328,7 @@ class ReleaseShareService:
             app_type=release.type,
             version=release.version,
             release_notes=release.release_notes,
-            published_at=int(release.published_at.timestamp() * 1000),
+            published_at=to_timestamp_ms(release.published_at),
             config=release.config or {},
             require_password=share.require_password,
             is_password_verified=is_password_verified,

--- a/api/app/services/session_service.py
+++ b/api/app/services/session_service.py
@@ -1,9 +1,10 @@
 from typing import Optional
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
 from app.aioRedis import aio_redis_set, aio_redis_get, aio_redis_delete
 from app.core.config import settings
+from app.core.utils.datetime_utils import to_iso_z, utcnow
 
 
 class SessionService:
@@ -32,14 +33,15 @@ class SessionService:
             return
             
         session_key = SessionService._get_user_session_key(username)
+        current_time = utcnow()
         session_data = {
             "token_id": token_id,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "expires_at": expires_at.isoformat()
+            "created_at": to_iso_z(current_time),
+            "expires_at": to_iso_z(expires_at)
         }
         
         # 计算过期时间（秒）
-        expire_seconds = int((expires_at - datetime.now(timezone.utc)).total_seconds())
+        expire_seconds = int((expires_at - current_time).total_seconds())
         if expire_seconds > 0:
             await aio_redis_set(session_key, session_data, expire=expire_seconds)
     
@@ -139,7 +141,7 @@ class SessionService:
             user_id: 用户ID
         """
         invalidation_key = f"user_token_invalidation:{user_id}"
-        current_time = datetime.now(timezone.utc).isoformat()
+        current_time = to_iso_z(utcnow())
         
         # 设置失效时间戳，过期时间为 refresh token 的最大有效期
         expire_seconds = settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.tools.mcp import MCPToolManager, SimpleMCPClient
@@ -1107,7 +1108,7 @@ class ToolService:
                         available_tools_display.append(str(tool_item))
 
                 config_data.update({
-                    "last_health_check": int(mcp_config.last_health_check.timestamp() * 1000) if mcp_config.last_health_check else None,
+                    "last_health_check": to_timestamp_ms(mcp_config.last_health_check),
                     "health_status": mcp_config.health_status,
                     "available_tools": available_tools_display,
                     "source_channel": mcp_config.source_channel,
@@ -1446,7 +1447,7 @@ class ToolService:
                 tool_config_id=uuid.UUID(tool_id),
                 status=ExecutionStatus.RUNNING.value,
                 input_data=parameters,
-                started_at=datetime.now(),
+                started_at=utcnow_naive(),
                 user_id=user_id,
                 workspace_id=workspace_id
             )
@@ -1466,7 +1467,7 @@ class ToolService:
                 execution.status = ExecutionStatus.COMPLETED.value if result.success else ExecutionStatus.FAILED.value
                 execution.output_data = result.data if result.success else None
                 execution.error_message = result.error if not result.success else None
-                execution.completed_at = datetime.now()
+                execution.completed_at = utcnow_naive()
                 execution.execution_time = result.execution_time
                 execution.token_usage = result.token_usage
                 self.db.commit()
@@ -1542,7 +1543,7 @@ class ToolService:
 
                     # 更新数据库
                     mcp_config.available_tools = tool_list
-                    mcp_config.last_health_check = datetime.now()
+                    mcp_config.last_health_check = utcnow_naive()
                     mcp_config.health_status = "healthy"
                     mcp_config.error_message = None
                     config.status = ToolStatus.AVAILABLE.value
@@ -1562,7 +1563,7 @@ class ToolService:
                     return {"success": False, "message": f"同步工具失败: {error}"}
             else:
                 # 更新错误状态
-                mcp_config.last_health_check = datetime.now()
+                mcp_config.last_health_check = utcnow_naive()
                 mcp_config.health_status = "error"
                 mcp_config.error_message = test_result.get("error", "连接失败")
                 config.status = ToolStatus.ERROR.value
@@ -1648,7 +1649,7 @@ class ToolService:
 
                 # 更新数据库
                 mcp_config.available_tools = tool_list
-                mcp_config.last_health_check = datetime.now()
+                mcp_config.last_health_check = utcnow_naive()
                 mcp_config.health_status = "healthy"
                 mcp_config.error_message = None
 
@@ -1669,7 +1670,7 @@ class ToolService:
             try:
                 mcp_config = self.mcp_repo.find_by_tool_id(self.db, config.id)
                 if mcp_config:
-                    mcp_config.last_health_check = datetime.now()
+                    mcp_config.last_health_check = utcnow_naive()
                     mcp_config.health_status = "error"
                     mcp_config.error_message = str(e)
                     config.status = ToolStatus.ERROR.value

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_iso_z, to_timestamp_ms, utcnow_naive
 from app.core.logging_config import get_logger
 from app.core.memory.constants.graph_data_constants import (
     DEPTH_HARD_MAX,
@@ -351,11 +352,7 @@ class UserMemoryService:
     @staticmethod
     def _datetime_to_timestamp(dt: Optional[Any]) -> Optional[int]:
         """将 DateTime 对象转换为时间戳（毫秒）"""
-        if dt is None:
-            return None
-        if hasattr(dt, 'timestamp'):
-            return int(dt.timestamp() * 1000)
-        return None
+        return to_timestamp_ms(dt) if hasattr(dt, 'timestamp') else None
     
     @staticmethod
     def convert_profile_to_dict_with_timestamp(profile_data: Any) -> dict:
@@ -519,14 +516,14 @@ class UserMemoryService:
                     setattr(end_user_info_record, field, value)
             
             # 更新时间戳
-            end_user_info_record.updated_at = datetime.now()
+            end_user_info_record.updated_at = utcnow_naive()
             
             # 如果 other_name 被更新，同步更新 end_user 表
             if other_name_updated:
                 end_user_record = EndUserRepository(db).get_by_id(user_uuid)
                 if end_user_record:
                     end_user_record.other_name = update_data['other_name']
-                    end_user_record.updated_at = datetime.now()
+                    end_user_record.updated_at = utcnow_naive()
                     logger.info(f"同步更新 end_user 表的 other_name: end_user_id={end_user_id}, other_name={update_data['other_name']}")
                 else:
                     logger.warning(f"未找到对应的 end_user 记录: end_user_id={end_user_id}")
@@ -2264,20 +2261,17 @@ def _resolve_edge_caption(
 
 
 def _format_datetime_naive_iso(dt: datetime) -> str:
-    """将 ``datetime`` 序列化为不带时区后缀的 ISO 字符串。
+    """将 ``datetime`` 序列化为带 ``Z`` 后缀的 UTC ISO 字符串。
 
     Neo4j 节点写入端历史上既有用 naive ``datetime`` 的（``Statement`` / ``Chunk`` /
     ``MemorySummary`` 等），也有用 tz-aware ``datetime`` 的（``AssistantOriginal`` /
     ``AssistantPruned``）。直接 ``isoformat()`` 会让响应里两类节点的 ``created_at``
     一会儿带 ``+00:00`` 一会儿不带，前端体验不一致。
 
-    本函数对 tz-aware 的 ``datetime`` 先转换为 UTC，再剥掉 ``tzinfo``，最后调用
-    ``isoformat()``；naive 的 ``datetime`` 直接 ``isoformat()``。结果格式统一为
-    形如 ``"2026-05-28T06:35:16.910751"``。
+    本函数统一将 ``datetime`` 解释为 UTC，并输出显式带时区的 ISO 字符串，
+    形如 ``"2026-05-28T06:35:16.910751Z"``。
     """
-    if dt.tzinfo is not None:
-        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-    return dt.isoformat()
+    return to_iso_z(dt)
 
 
 def _clean_neo4j_value(value: Any) -> Any:

--- a/api/app/services/user_service.py
+++ b/api/app/services/user_service.py
@@ -7,6 +7,7 @@ from pydantic import EmailStr
 from sqlalchemy.orm import Session
 import uuid
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.aioRedis import aio_redis_set, aio_redis_get, aio_redis_delete
 from app.models import Workspace
 from app.models.user_model import User
@@ -395,7 +396,7 @@ def update_last_login_time(db: Session, user_id: uuid.UUID) -> User:
             raise BusinessException("用户不存在", code=BizCode.USER_NOT_FOUND)
         
         # 更新最后登录时间
-        db_user.last_login_at = datetime.datetime.now()
+        db_user.last_login_at = utcnow_naive()
         db.commit()
         db.refresh(db_user)
         

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -11,6 +11,7 @@ import yaml
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.core.workflow.triggers import (
     build_schedule_now_payload,
     get_trigger_type,
@@ -64,7 +65,7 @@ class WorkflowService:
     ) -> WorkflowConfig:
         """从发布版本快照重建运行时 WorkflowConfig。"""
         cfg = release.config or {}
-        now = release.created_at or datetime.datetime.now()
+        now = release.created_at or utcnow_naive()
         normalized_nodes = WorkflowService._prepare_nodes(cfg.get("nodes", []))
         return WorkflowConfig(
             id=real_config_id or cfg.get("id") or uuid.uuid4(),
@@ -170,7 +171,7 @@ class WorkflowService:
         trigger_id = trigger_node.get("id")
         config = trigger_node.get("config") or {}
         current_time = datetime.datetime.now(datetime.timezone.utc)
-        generated_at = current_time.isoformat()
+        generated_at = to_iso_z(current_time)
 
         if trigger_type == "schedule":
             return (
@@ -504,7 +505,7 @@ class WorkflowService:
             release_id=release.id,
             trigger_type="schedule",
             trigger_id=trigger.get("id"),
-            trigger_meta={"source": "schedule", "run_at": current_time.isoformat()},
+            trigger_meta={"source": "schedule", "run_at": to_iso_z(current_time)},
             trigger_payload=schedule_event,
             source="schedule",
         )
@@ -905,7 +906,7 @@ class WorkflowService:
         if isinstance(value, uuid.UUID):
             return str(value)
         if isinstance(value, datetime.datetime):
-            return value.isoformat()
+            return to_iso_z(value)
         if isinstance(value, dict):
             return {k: WorkflowService._serialize_execution_value(v) for k, v in value.items()}
         if isinstance(value, list):
@@ -940,8 +941,8 @@ class WorkflowService:
             "meta_data": meta_data,
             "error_message": execution.error_message,
             "error_node_id": execution.error_node_id,
-            "started_at": execution.started_at.isoformat() if execution.started_at else None,
-            "completed_at": execution.completed_at.isoformat() if execution.completed_at else None,
+            "started_at": to_iso_z(execution.started_at),
+            "completed_at": to_iso_z(execution.completed_at),
             "elapsed_time": execution.elapsed_time,
             "token_usage": self._serialize_execution_value(execution.token_usage),
             "node_executions": [
@@ -955,8 +956,8 @@ class WorkflowService:
                     "input_data": self._serialize_execution_value(node_execution.input_data or {}),
                     "output_data": self._serialize_execution_value(node_execution.output_data or {}),
                     "error_message": node_execution.error_message,
-                    "started_at": node_execution.started_at.isoformat() if node_execution.started_at else None,
-                    "completed_at": node_execution.completed_at.isoformat() if node_execution.completed_at else None,
+                    "started_at": to_iso_z(node_execution.started_at),
+                    "completed_at": to_iso_z(node_execution.completed_at),
                     "elapsed_time": node_execution.elapsed_time,
                     "token_usage": self._serialize_execution_value(node_execution.token_usage),
                     "cache_hit": node_execution.cache_hit,
@@ -1030,7 +1031,7 @@ class WorkflowService:
         # 如果是完成状态，计算耗时
         if status in ["completed", "failed", "cancelled", "timeout"]:
             if not execution.completed_at:
-                execution.completed_at = datetime.datetime.now()
+                execution.completed_at = utcnow_naive()
                 elapsed = (execution.completed_at - execution.started_at).total_seconds()
                 execution.elapsed_time = elapsed
 
@@ -1564,7 +1565,7 @@ class WorkflowService:
             }
             execution.token_usage = {}
             execution.elapsed_time = 0
-            execution.completed_at = datetime.datetime.now()
+            execution.completed_at = utcnow_naive()
             self.db.commit()
 
             return {
@@ -1622,7 +1623,7 @@ class WorkflowService:
                 execution.status = "completed"
                 execution.output_data = {"answer": preset_response, "moderation_flagged": True}
                 execution.elapsed_time = 0
-                execution.completed_at = datetime.datetime.now()
+                execution.completed_at = utcnow_naive()
                 self.db.commit()
                 return {
                     "execution_id": execution.execution_id,
@@ -1975,7 +1976,7 @@ class WorkflowService:
             }
             execution.token_usage = {}
             execution.elapsed_time = 0
-            execution.completed_at = datetime.datetime.now()
+            execution.completed_at = utcnow_naive()
             self.db.commit()
 
             start_internal_event = {
@@ -2060,7 +2061,7 @@ class WorkflowService:
                 execution.status = "completed"
                 execution.output_data = {"answer": preset_response, "moderation_flagged": True}
                 execution.elapsed_time = 0
-                execution.completed_at = datetime.datetime.now()
+                execution.completed_at = utcnow_naive()
                 self.db.commit()
 
                 start_internal_event = {

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.config.default_ontology_initializer import DefaultOntologyInitializer
 from app.core.config import settings
 from app.core.error_codes import BizCode
@@ -529,7 +530,7 @@ def create_workspace_invite(
             # 生成新的邀请链接（重新生成令牌）
             token, token_hash = _generate_invite_token()
             existing_invite.token_hash = token_hash
-            existing_invite.updated_at = datetime.datetime.now()
+            existing_invite.updated_at = utcnow_naive()
             db.commit()
             db.refresh(existing_invite)
             invite_token = token
@@ -610,7 +611,7 @@ def validate_invite_token(db: Session, token: str) -> InviteValidateResponse:
         raise BusinessException("邀请令牌无效", BizCode.WORKSPACE_INVITE_NOT_FOUND)
 
     # 检查邀请状态和过期时间
-    now = datetime.datetime.now()
+    now = utcnow_naive()
     is_expired = invite.expires_at < now or invite.status != InviteStatus.pending
     is_valid = not is_expired
 
@@ -657,7 +658,7 @@ def accept_workspace_invite(
             raise BusinessException(f"邀请已被{invite.status}", BizCode.WORKSPACE_INVITE_INVALID)
 
         # 检查过期时间
-        now = datetime.datetime.now()
+        now = utcnow_naive()
         if invite.expires_at < now:
             business_logger.warning("邀请已过期")
             # 标记为过期

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -6,7 +6,7 @@ import shutil
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -16,6 +16,14 @@ from redis.exceptions import RedisError
 from fastapi.encoders import jsonable_encoder
 
 # Import a unified Celery instance
+from app.core.utils.datetime_utils import (
+    as_utc_aware,
+    parse_iso_to_utc_naive,
+    to_iso_z,
+    to_timestamp_ms,
+    utcnow,
+    utcnow_naive,
+)
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
@@ -32,7 +40,7 @@ from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.llm.sequence2txt_model import QWenSeq2txt
 from app.core.rag.models.chunk import DocumentChunk
-from app.core.rag.prompts.generator import question_proposal, qa_proposal
+from app.core.rag.prompts.generator import qa_proposal
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
 )
@@ -244,7 +252,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
     """
 
     db_document = None
-    progress_lines: list[str] = [f"{datetime.now().strftime('%H:%M:%S')} Task has been received."]
+    progress_lines: list[str] = [f"{utcnow_naive().strftime('%H:%M:%S')} Task has been received."]
 
     def _progress_msg() -> str:
         return "\n".join(progress_lines) + "\n"
@@ -288,11 +296,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             file_name = db_document.file_name
 
         # 1. Download file from storage backend
-        progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Start to parse.")
+        progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} Start to parse.")
         start_time = time.time()
         db_document.progress = 0.0
         db_document.progress_msg = _progress_msg()
-        db_document.process_begin_at = datetime.now(tz=timezone.utc)
+        db_document.process_begin_at = utcnow_naive()
         db_document.process_duration = 0.0
         db_document.run = 1
         db.commit()
@@ -328,10 +336,10 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         logger.info(f"[ParseDoc] document={document_id} estimated_pages={estimated_pages}")
         if estimated_pages is None:
             logger.info(f"[ParseDoc] document={document_id} not obtain page number, parse failed.")
-            progress_lines.append(datetime.now().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: not obtain page number")
+            progress_lines.append(utcnow_naive().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: not obtain page number")
         elif estimated_pages > MAX_DOCUMENT_PAGES:
             logger.info(f"[ParseDoc] document={document_id}, estimated page number:({estimated_pages}), exceeds {MAX_DOCUMENT_PAGES}")
-            progress_lines.append(datetime.now().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: page limit exceeded")
+            progress_lines.append(utcnow_naive().strftime('%H:%M:%S') + f" parse document '{file_name or document_id}' failed: page limit exceeded")
             db_document.progress = -1.0
             db_document.run = 0
             db_document.progress_msg = _progress_msg()
@@ -340,7 +348,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             return f"parse document '{file_name or document_id}' failed: page limit exceeded"
 
         def progress_callback(prog=None, msg=None):
-            progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} parse progress: {prog} msg: {msg}.")
+            progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} parse progress: {prog} msg: {msg}.")
 
         # Prepare vision_model for parsing
         vision_model = _build_vision_model(file_name, db_knowledge)
@@ -376,7 +384,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         parser_config=db_document.parser_config,
                         is_root=False)
 
-        progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Finish parsing.")
+        progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} Finish parsing.")
         db_document.progress = 0.8
         db_document.progress_msg = _progress_msg()
         db.commit()
@@ -389,10 +397,10 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         # 2. Document vectorization and storage
         total_chunks = (len(child_res) + len(parent_res)) if parent_child_mode else len(res)
-        progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
+        progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} Generate {total_chunks} chunks.")
 
         if total_chunks == 0:
-            progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} No chunks generated, skipping vectorization.")
+            progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} No chunks generated, skipping vectorization.")
         else:
             total_batches = ceil(total_chunks / EMBEDDING_BATCH_SIZE)
             progress_per_batch = 0.2 / total_batches
@@ -428,7 +436,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         "doc_id": parent_doc_id,
                         "file_id": str(db_document.file_id),
                         "file_name": db_document.file_name,
-                        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                        "file_created_at": to_timestamp_ms(db_document.created_at),
                         "document_id": str(db_document.id),
                         "knowledge_id": str(db_document.kb_id),
                         "sort_id": idx,
@@ -446,7 +454,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         "doc_id": uuid.uuid4().hex,
                         "file_id": str(db_document.file_id),
                         "file_name": db_document.file_name,
-                        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                        "file_created_at": to_timestamp_ms(db_document.created_at),
                         "document_id": str(db_document.id),
                         "knowledge_id": str(db_document.kb_id),
                         "sort_id": idx,
@@ -463,7 +471,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     all_batch_chunks.append(all_chunks[batch_start:batch_end])
 
                 progress_lines.append(
-                    f"{datetime.now().strftime('%H:%M:%S')} Parent-child mode: {len(parent_chunks_list)} parent chunks + "
+                    f"{utcnow_naive().strftime('%H:%M:%S')} Parent-child mode: {len(parent_chunks_list)} parent chunks + "
                     f"{len(child_chunks_list)} child chunks prepared.")
 
             elif auto_questions_topn:
@@ -518,7 +526,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         qa_map[global_idx] = pairs
 
                 progress_lines.append(
-                    f"{datetime.now().strftime('%H:%M:%S')} QA pairs generated for {total_chunks} chunks "
+                    f"{utcnow_naive().strftime('%H:%M:%S')} QA pairs generated for {total_chunks} chunks "
                     f"(workers={AUTO_QUESTIONS_MAX_WORKERS}).")
 
                 # 组装 chunks：source chunks + qa chunks
@@ -535,7 +543,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         "doc_id": source_chunk_id,
                         "file_id": str(db_document.file_id),
                         "file_name": db_document.file_name,
-                        "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                        "file_created_at": to_timestamp_ms(db_document.created_at),
                         "document_id": str(db_document.id),
                         "knowledge_id": str(db_document.kb_id),
                         "sort_id": global_idx,
@@ -552,7 +560,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                             "doc_id": uuid.uuid4().hex,
                             "file_id": str(db_document.file_id),
                             "file_name": db_document.file_name,
-                            "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                            "file_created_at": to_timestamp_ms(db_document.created_at),
                             "document_id": str(db_document.id),
                             "knowledge_id": str(db_document.kb_id),
                             "sort_id": qa_sort_id,
@@ -574,7 +582,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     all_batch_chunks.append(all_chunks[batch_start:batch_end])
 
                 progress_lines.append(
-                    f"{datetime.now().strftime('%H:%M:%S')} QA mode: {len(source_chunks)} source chunks + "
+                    f"{utcnow_naive().strftime('%H:%M:%S')} QA mode: {len(source_chunks)} source chunks + "
                     f"{len(qa_chunks)} QA chunks prepared.")
             else:
                 # 无 auto_questions：直接构建 chunks
@@ -587,7 +595,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                             "doc_id": uuid.uuid4().hex,
                             "file_id": str(db_document.file_id),
                             "file_name": db_document.file_name,
-                            "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                            "file_created_at": to_timestamp_ms(db_document.created_at),
                             "document_id": str(db_document.id),
                             "knowledge_id": str(db_document.kb_id),
                             "sort_id": global_idx,
@@ -628,7 +636,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
             # 所有 batch 完成后一次性更新进度
             db_document.progress = 0.8 + 0.2  # 直接到 1.0 前的状态
-            progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} All {total_batches} batches embedded (workers={EMBEDDING_MAX_WORKERS}).")
+            progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} All {total_batches} batches embedded (workers={EMBEDDING_MAX_WORKERS}).")
             db_document.progress_msg = _progress_msg()
             db_document.process_duration = time.time() - start_time
             db_document.run = 0
@@ -636,11 +644,11 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             db.refresh(db_document)
 
         # Vectorization and data entry completed
-        progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Indexing done.")
+        progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} Indexing done.")
         db_document.chunk_num = total_chunks
         db_document.progress = 1.0
         db_document.process_duration = time.time() - start_time
-        progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} Task done ({db_document.process_duration}s).")
+        progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} Task done ({db_document.process_duration}s).")
         db_document.progress_msg = _progress_msg()
         db_document.run = 0
         db.commit()
@@ -651,7 +659,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             if _should_abort(document_id):
                 _clear_redis_state(document_id)
                 return f"parse document '{file_name or document_id}' aborted (deleted or cancelled)."
-            progress_lines.append(f"{datetime.now().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
+            progress_lines.append(f"{utcnow_naive().strftime('%H:%M:%S')} GraphRAG enabled, dispatching async task.")
             db_document.progress_msg = _progress_msg()
             db.commit()
             build_graphrag_for_document.delay(str(document_id), str(db_knowledge.id))
@@ -834,7 +842,7 @@ def build_graphrag_for_document(document_id: str, knowledge_id: str):
 
             # 更新文档进度信息
             db_document.progress_msg = (db_document.progress_msg or "") + \
-                f"{datetime.now().strftime('%H:%M:%S')} Knowledge Graph done ({duration:.1f}s)\n"
+                f"{utcnow_naive().strftime('%H:%M:%S')} Knowledge Graph done ({duration:.1f}s)\n"
             db.commit()
 
             return f"build_graphrag_for_document '{document_id}' processed successfully."
@@ -931,7 +939,7 @@ def import_qa_chunks(kb_id: str, document_id: str, filename: str, contents: byte
                     "doc_id": doc_id,
                     "file_id": str(db_document.file_id),
                     "file_name": db_document.file_name,
-                    "file_created_at": int(db_document.created_at.timestamp() * 1000),
+                    "file_created_at": to_timestamp_ms(db_document.created_at),
                     "document_id": document_id,
                     "knowledge_id": kb_id,
                     "sort_id": sort_id,
@@ -1045,7 +1053,7 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
                                         db_document.file_name = db_file.file_name
                                         db_document.file_ext = db_file.file_ext
                                         db_document.file_size = db_file.file_size
-                                        db_document.updated_at = datetime.now()
+                                        db_document.updated_at = utcnow_naive()
                                         db.commit()
                                         db.refresh(db_document)
                                         # 3. Document parsing, vectorization, and storage
@@ -1195,7 +1203,7 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
                                         db_document.file_ext = db_file.file_ext
                                         db_document.file_size = db_file.file_size
                                         db_document.created_at = db_file.created_at
-                                        db_document.updated_at = datetime.now()
+                                        db_document.updated_at = utcnow_naive()
                                         db.commit()
                                         db.refresh(db_document)
                                         # 3. Document parsing, vectorization, and storage
@@ -1357,7 +1365,7 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
                                         db_document.file_ext = db_file.file_ext
                                         db_document.file_size = db_file.file_size
                                         db_document.created_at = db_file.created_at
-                                        db_document.updated_at = datetime.now()
+                                        db_document.updated_at = utcnow_naive()
                                         db.commit()
                                         db.refresh(db_document)
                                         # 3. Document parsing, vectorization, and storage
@@ -1646,8 +1654,7 @@ def write_message_task(
                 f"[CELERY WRITE] Executing MemoryAgentService.write_memory "
                 f"with config_id = {actual_config_id} (type: {type(actual_config_id).__name__}), language={language}")
 
-            from datetime import datetime, timezone
-            _default_dialog_at = datetime.now(timezone.utc).isoformat()
+            _default_dialog_at = to_iso_z(utcnow_naive())
             for msg in message:
                 if isinstance(msg, dict) and not msg.get("dialog_at"):
                     msg["dialog_at"] = _default_dialog_at
@@ -1709,7 +1716,7 @@ def write_message_task(
             _r = redis_client
             if _r is not None:
                 from datetime import timezone as _tz
-                _now_utc = datetime.now(_tz.utc).isoformat()
+                _now_utc = to_iso_z(datetime.now(_tz.utc))
                 _r.set(
                     f"write_message:last_done:{end_user_id}",
                     _now_utc,
@@ -2772,7 +2779,7 @@ def write_total_memory_task(workspace_id: str) -> Dict[str, Any]:
                         "total_num": 0,
                         "end_user_count": 0,
                         "memory_increment_id": str(memory_increment.id),
-                        "created_at": memory_increment.created_at.isoformat(),
+                        "created_at": to_iso_z(memory_increment.created_at),
                     }
 
                 # 2. 查询所有app下的end_user_id（去重）
@@ -2805,7 +2812,7 @@ def write_total_memory_task(workspace_id: str) -> Dict[str, Any]:
                     "end_user_count": len(end_users),
                     "end_user_details": end_user_details,
                     "memory_increment_id": str(memory_increment.id),
-                    "created_at": memory_increment.created_at.isoformat(),
+                    "created_at": to_iso_z(memory_increment.created_at),
                 }
             except Exception as e:
                 raise e
@@ -2899,7 +2906,7 @@ def write_all_workspaces_memory_task(self) -> Dict[str, Any]:
                                 "total_num": 0,
                                 "end_user_count": 0,
                                 "memory_increment_id": str(memory_increment.id),
-                                "created_at": memory_increment.created_at.isoformat(),
+                                "created_at": to_iso_z(memory_increment.created_at),
                             })
                             logger.info(f"工作空间 {workspace.name} 没有应用，记录总量为0")
                             continue
@@ -2935,7 +2942,7 @@ def write_all_workspaces_memory_task(self) -> Dict[str, Any]:
                             "end_user_count": len(end_users),
                             "end_user_details": end_user_details,
                             "memory_increment_id": str(memory_increment.id),
-                            "created_at": memory_increment.created_at.isoformat(),
+                            "created_at": to_iso_z(memory_increment.created_at),
                         })
 
                         logger.info(
@@ -4553,7 +4560,7 @@ def scan_workflow_schedule_triggers():
     """扫描并派发已发布工作流中的定时触发器。"""
     from app.services.workflow_service import WorkflowService
 
-    now = datetime.now(timezone.utc)
+    now = utcnow()
     triggered = 0
 
     with get_db_context() as db:
@@ -4569,15 +4576,15 @@ def scan_workflow_schedule_triggers():
                         "app_id": str(app.id),
                         "release_id": str(release.id),
                         "trigger_id": trigger_id,
-                        "scheduled_at": now.isoformat(),
+                        "scheduled_at": to_iso_z(now),
                     },
                     queue="workflow_trigger_tasks",
                 )
                 runtime = {
                     **(trigger.get("runtime") or {}),
                     "dispatch_status": "queued",
-                    "last_dispatched_at": now.isoformat(),
-                    "last_scheduled_at": now.isoformat(),
+                    "last_dispatched_at": to_iso_z(now),
+                    "last_scheduled_at": to_iso_z(now),
                     "last_error": None,
                 }
                 service.update_release_trigger_runtime_state(release.id, trigger_id, runtime)
@@ -4592,7 +4599,7 @@ def scan_workflow_schedule_triggers():
                     exc_info=True,
                 )
 
-    return {"triggered": triggered, "scanned_at": now.isoformat()}
+    return {"triggered": triggered, "scanned_at": to_iso_z(now)}
 
 
 @celery_app.task(name="app.tasks.run_workflow_schedule_trigger", queue="workflow_trigger_tasks")
@@ -4600,7 +4607,7 @@ def run_workflow_schedule_trigger(app_id: str, release_id: str, trigger_id: str,
     """执行单个已发布的 schedule trigger。"""
     from app.services.workflow_service import WorkflowService
 
-    run_at = datetime.fromisoformat(scheduled_at) if scheduled_at else datetime.now(timezone.utc)
+    run_at = as_utc_aware(parse_iso_to_utc_naive(scheduled_at)) if scheduled_at else utcnow()
     with get_db_context() as db:
         service = WorkflowService(db)
         app = db.get(App, uuid.UUID(app_id))
@@ -4632,8 +4639,8 @@ def run_workflow_schedule_trigger(app_id: str, release_id: str, trigger_id: str,
         running_runtime = {
             **runtime,
             "dispatch_status": "running",
-            "last_started_at": datetime.now(timezone.utc).isoformat(),
-            "last_scheduled_at": run_at.isoformat(),
+            "last_started_at": to_iso_z(utcnow()),
+            "last_scheduled_at": to_iso_z(run_at),
             "last_error": None,
         }
         service.update_release_trigger_runtime_state(release.id, trigger_id, running_runtime)
@@ -4652,18 +4659,18 @@ def run_workflow_schedule_trigger(app_id: str, release_id: str, trigger_id: str,
             completed_runtime = {
                 **running_runtime,
                 "dispatch_status": "completed",
-                "last_triggered_at": run_at.isoformat(),
-                "last_completed_at": datetime.now(timezone.utc).isoformat(),
+                "last_triggered_at": to_iso_z(run_at),
+                "last_completed_at": to_iso_z(utcnow()),
                 "last_error": None,
             }
             service.update_release_trigger_runtime_state(release.id, trigger_id, completed_runtime)
             service.update_trigger_runtime_state(app.id, trigger_id, completed_runtime)
-            return {"status": "completed", "trigger_id": trigger_id, "scheduled_at": run_at.isoformat()}
+            return {"status": "completed", "trigger_id": trigger_id, "scheduled_at": to_iso_z(run_at)}
         except Exception as exc:
             failed_runtime = {
                 **running_runtime,
                 "dispatch_status": "failed",
-                "last_failed_at": datetime.now(timezone.utc).isoformat(),
+                "last_failed_at": to_iso_z(utcnow()),
                 "last_error": str(exc),
             }
             service.update_release_trigger_runtime_state(release.id, trigger_id, failed_runtime)

--- a/api/app/utils/app_config_utils.py
+++ b/api/app/utils/app_config_utils.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional, Union
 from datetime import datetime
 
 from app.db import get_db_read
+from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
 from app.models import AppRelease, WorkflowConfig
 from app.models.agent_app_config_model import AgentConfig
 from app.models.multi_agent_model import MultiAgentConfig
@@ -218,8 +219,8 @@ def dict_to_multi_agent_config(config_dict: Dict[str, Any], app_id: Optional[uui
         execution_config=config_dict.get("execution_config", {}),
         aggregation_strategy=config_dict.get("aggregation_strategy", "merge"),
         is_active=config_dict.get("is_active", True),
-        created_at=config_dict.get("created_at", datetime.now()),
-        updated_at=config_dict.get("updated_at", datetime.now())
+        created_at=config_dict.get("created_at", utcnow_naive()),
+        updated_at=config_dict.get("updated_at", utcnow_naive())
     )
 
     return multi_agent_config
@@ -282,8 +283,8 @@ def dict_to_workflow_config(config_dict: Dict[str, Any], app_id: Optional[uuid.U
         execution_config=config_dict.get("execution_config", {}),
         triggers=config_dict.get("triggers", []),
         is_active=config_dict.get("is_active", True),
-        created_at=config_dict.get("created_at", datetime.now()),
-        updated_at=config_dict.get("updated_at", datetime.now())
+        created_at=config_dict.get("created_at", utcnow_naive()),
+        updated_at=config_dict.get("updated_at", utcnow_naive())
     )
 
     return workflow_config
@@ -314,8 +315,8 @@ def agent_config_to_dict(agent_config) -> Dict[str, Any]:
         "parent_agent_id": str(agent_config.parent_agent_id) if agent_config.parent_agent_id else None,
         "capabilities": agent_config.capabilities,
         "is_active": agent_config.is_active,
-        "created_at": agent_config.created_at.isoformat() if agent_config.created_at else None,
-        "updated_at": agent_config.updated_at.isoformat() if agent_config.updated_at else None
+        "created_at": to_iso_z(agent_config.created_at),
+        "updated_at": to_iso_z(agent_config.updated_at)
     }
 
 
@@ -339,8 +340,8 @@ def multi_agent_config_to_dict(multi_agent_config) -> Dict[str, Any]:
         "execution_config": multi_agent_config.execution_config,
         "aggregation_strategy": multi_agent_config.aggregation_strategy,
         "is_active": multi_agent_config.is_active,
-        "created_at": multi_agent_config.created_at.isoformat() if multi_agent_config.created_at else None,
-        "updated_at": multi_agent_config.updated_at.isoformat() if multi_agent_config.updated_at else None
+        "created_at": to_iso_z(multi_agent_config.created_at),
+        "updated_at": to_iso_z(multi_agent_config.updated_at)
     }
 
 
@@ -362,6 +363,6 @@ def workflow_config_to_dict(workflow_config) -> Dict[str, Any]:
         "execution_config": workflow_config.execution_config,
         "triggers": workflow_config.triggers,
         "is_active": workflow_config.is_active,
-        "created_at": workflow_config.created_at.isoformat() if workflow_config.created_at else None,
-        "updated_at": workflow_config.updated_at.isoformat() if workflow_config.updated_at else None
+        "created_at": to_iso_z(workflow_config.created_at),
+        "updated_at": to_iso_z(workflow_config.updated_at)
     }

--- a/api/app/utils/volc_asr.py
+++ b/api/app/utils/volc_asr.py
@@ -3,8 +3,8 @@ import json
 import uuid
 import os
 import time
-from datetime import datetime
 from app.core.config import settings
+from app.core.utils.datetime_utils import utcnow_naive
 
 
 # 火山的ASR
@@ -78,7 +78,7 @@ def main():
     try:
         # 提交任务
         print("提交语音识别任务...")
-        task_id, status_code = asr_client.submit_task(audio_url)
+        task_id, _status_code = asr_client.submit_task(audio_url)
         if not task_id:
             raise Exception("提交任务失败，未获取到任务ID")
 
@@ -89,7 +89,7 @@ def main():
         result = asr_client.query_result(task_id)
 
         # 保存结果
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = utcnow_naive().strftime("%Y%m%d_%H%M%S")
         output_file = os.path.join(output_dir, f"result_{timestamp}.json")
 
         with open(output_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
replace datetime.now with centralized datetime utilities

Introduce and use `app.core.utils.datetime_utils` (utcnow_naive, to_iso_z, to_timestamp_ms) across multiple modules to standardize datetime handling, improve testability, and ensure consistent timezone-naive UTC behavior. Removes scattered `datetime.*` imports and direct calls.