### PR TITLE
fix(web): conversationId clear

### DIFF
--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-06 21:10:56 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-01 15:39:33
+ * @Last Modified time: 2026-06-02 15:41:46
  */
 /**
  * Workflow Chat Component
@@ -137,6 +137,7 @@ const Chat = forwardRef<ChatRef, { appId: string; appType?: Application['type'];
     setChatList([])
     setVariables([])
     setExecutionId(null)
+    setConversationId(null)
     executionIdRef.current = 'draft'
     setMessage(undefined)
     toolbarRef.current?.setFiles([])


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在清除工作流聊天时，连同其他聊天状态一起重置已存储的会话 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reset the stored conversation ID alongside other chat state when clearing the workflow chat.

</details>