### PR TITLE
feat(memory): add episodic memory summarization step to write pipeline

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -1151,7 +1151,7 @@ class WritePipeline:
                     language=self.language,
                 )
 
-                async with bear.step(1, 5, "剪枝", "构建 Pruned_Context") as s:
+                async with bear.step(1, 6, "剪枝", "构建 Pruned_Context") as s:
                     pruning_records: list = []
                     _before = context_before or []
                     _after = context_after or []
@@ -1196,7 +1196,7 @@ class WritePipeline:
                     pruning_pipeline=pruning_pipeline,
                 )
 
-                async with bear.step(2, 5, "预处理", "消息分块") as s:
+                async with bear.step(2, 6, "预处理", "消息分块") as s:
                     from app.core.memory.agent.utils.get_dialogs import get_chunked_dialogs
                     recorder = getattr(self, "_recorder", None)
                     snapshot = recorder.snapshot if recorder else None
@@ -1213,7 +1213,7 @@ class WritePipeline:
                     )
                     s.metadata(chunks=sum(len(d.chunks) for d in chunked_dialogs))
 
-                async with bear.step(3, 5, "萃取", "知识提取") as s:
+                async with bear.step(3, 6, "萃取", "知识提取") as s:
                     extraction_result = await self._extract(chunked_dialogs, is_pilot_run=False)
                     self._merge_alias_in_memory(extraction_result)
                     stats = extraction_result.stats
@@ -1223,14 +1223,18 @@ class WritePipeline:
                         relations=stats["relation_count"],
                     )
 
-                async with bear.step(4, 5, "存储", "写入 Neo4j"):
+                async with bear.step(4, 6, "存储", "写入 Neo4j"):
                     await self._store(extraction_result)
 
                 await self._post_store_async_tasks(extraction_result)
 
-                async with bear.step(5, 5, "聚类", "增量更新社区") as s:
+                async with bear.step(5, 6, "聚类", "增量更新社区") as s:
                     await self._cluster(extraction_result)
                     s.metadata(mode="async")
+
+                # Step 6: 摘要 - 生成情景记忆摘要
+                async with bear.step(6, 6, "摘要", "生成情景记忆"):
+                    await self._summarize(chunked_dialogs)
 
                 await self._advance_write_cursor(
                     conversation_id=conversation_id,

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -37,7 +37,6 @@ from app.core.memory.agent.utils.messages_tools import (
 )
 from app.core.memory.agent.utils.type_classifier import status_typle
 from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
-from app.core.memory.memory_service import MemoryService
 from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
 from app.core.memory.utils.log.audit_logger import audit_logger
 from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
@@ -639,32 +638,7 @@ class MemoryAgentService:
             enforce_window=False,  # API 同步路径，详见 execute_pending_from_pool docstring
         )
 
-    async def _write_neo4j(
-            self,
-            end_user_id: str,
-            messages: list[MessageItem] | list[dict],
-            memory_config,
-            language: Language | str,
-            db: Session,
-    ) -> None:
-        """使用新流水线（MemoryService → WritePipeline）写入 Neo4j。"""
-        messages_dict = [
-            msg if isinstance(msg, dict) else msg.model_dump(exclude_none=True)
-            for msg in messages
-        ]
-        service = MemoryService(
-            db=db,
-            config_id=memory_config.config_id,
-            end_user_id=end_user_id,
-        )
-        result = await service.write(
-            messages=messages_dict, language=language, ref_id='',
-        )
-        logger.info(
-            f"[WritePipeline] 完成: status={result.status}, "
-            f"elapsed={result.elapsed_seconds:.2f}s, "
-            f"extraction={result.extraction}"
-        )
+
 
     async def _invalidate_interest_cache(self, end_user_id: str) -> None:
         """写入完成后失效兴趣分布缓存。"""


### PR DESCRIPTION
- Extend WritePipeline from 5 to 6 steps, adding a new summarization step that calls _summarize() to generate episodic memory summaries
- Remove unused _write_neo4j method and MemoryService import from MemoryAgentService

## 由 Sourcery 提供的摘要

为内存写入流水线扩展一个额外的总结步骤，并从内存代理服务中移除已废弃的 Neo4j 写入管道。

新功能：
- 在内存写入流水线中添加第六步，用于从分块对话中生成情节式记忆摘要。

改进：
- 更新流水线进度元数据，以反映新的六步写入流程。
- 从 MemoryAgentService 中移除未使用的 Neo4j 写入辅助工具及其关联的 MemoryService 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the memory write pipeline with an additional summarization step and remove obsolete Neo4j write plumbing from the memory agent service.

New Features:
- Add a sixth step to the memory write pipeline to generate episodic memory summaries from chunked dialogs.

Enhancements:
- Update pipeline progress metadata to reflect the new six-step write flow.
- Remove the unused Neo4j write helper and its associated MemoryService dependency from MemoryAgentService.

</details>