### PR TITLE
fix(rag): add kb_id validation in chunk batch creation and filter empty retrieval results

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -642,7 +642,10 @@ async def create_chunks_batch(
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The knowledge base does not exist or access is denied")
 
-    db_document = db.query(Document).filter(Document.id == document_id).first()
+    db_document = db.query(Document).filter(
+        Document.id == document_id,
+        Document.kb_id == kb_id
+    ).first()
     if not db_document:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The document does not exist or you do not have permission to access it")
 
@@ -1050,6 +1053,6 @@ async def retrieve_chunks(
                     base_url=emb_key.api_base
                 )
                 doc = kg_retriever.retrieval(question=retrieve_data.query, workspace_ids=workspace_ids, kb_ids=kb_ids, emb_mdl=embedding_model, llm=chat_model)
-                if doc:
+                if doc['page_content'].strip() != "":
                     rs.insert(0, doc)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")


### PR DESCRIPTION
## Summary

This PR addresses two issues in the chunk controller:

1. **Security validation in batch chunk creation**: Added `kb_id` check when querying the document in `create_chunks_batch`, preventing cross-knowledge-base document manipulation using arbitrary document IDs.

2. **Empty content filtering in retrieval**: Changed the condition from `if doc` to `if doc['page_content'].strip() != \"\"` in `retrieve_chunks`, ensuring empty retrieval results are not inserted into the response.

## Changes

- `api/app/controllers/chunk_controller.py`

## Test Plan
- [ ] Verify that creating chunks with a document ID from a different knowledge base returns 404
- [ ] Verify that empty retrieval results are correctly filtered out

## Summary by Sourcery

收紧分块操作的校验逻辑，并过滤掉空的检索结果。

Bug 修复：
- 确保批量创建分块时只访问属于指定知识库的文档，防止通过文档 ID 跨知识库访问文档。
- 避免将空的检索结果插入到响应中，只包含在去除首尾空白后页面内容非空的分块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten chunk operations validation and filter out empty retrieval results.

Bug Fixes:
- Ensure batch chunk creation only accesses documents belonging to the specified knowledge base, preventing cross-knowledge-base document access by ID.
- Avoid inserting empty retrieval results into the response by only including chunks whose page content is non-empty after trimming.

</details>