### PR TITLE
fix(tool)

### DIFF
--- a/api/app/controllers/tool_controller.py
+++ b/api/app/controllers/tool_controller.py
@@ -307,7 +307,8 @@ async def get_tool_types():
         data=[
             {"value": ToolType.BUILTIN.value, "label": "内置工具"},
             {"value": ToolType.CUSTOM.value, "label": "自定义工具"},
-            {"value": ToolType.MCP.value, "label": "MCP工具"}
+            {"value": ToolType.MCP.value, "label": "MCP工具"},
+            {"value": ToolType.WORKFLOW.value, "label": "工作流工具"},
         ],
         msg="获取工具类型成功"
     )

--- a/api/app/core/tools/__init__.py
+++ b/api/app/core/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from app.core.tools.base import BaseTool, ToolResult, ToolParameter
 from app.core.tools.langchain_adapter import LangchainAdapter
+from app.core.tools.serialization import serialize_tool_parameter
 
 # 可选导入，避免导入错误
 try:
@@ -23,7 +24,8 @@ __all__ = [
     "BaseTool",
     "ToolResult", 
     "ToolParameter",
-    "LangchainAdapter"
+    "LangchainAdapter",
+    "serialize_tool_parameter",
 ]
 
 # 只有在成功导入时才添加到__all__

--- a/api/app/core/tools/langchain_adapter.py
+++ b/api/app/core/tools/langchain_adapter.py
@@ -335,7 +335,7 @@ class LangchainAdapter:
             "parameters": [
                 {
                     "name": param.name,
-                    "type": param.type.value,
+                    "type": getattr(param.type, "value", param.type),
                     "description": param.description,
                     "required": param.required,
                     "default": param.default,

--- a/api/app/core/tools/langchain_adapter.py
+++ b/api/app/core/tools/langchain_adapter.py
@@ -6,6 +6,7 @@ from langchain.tools import BaseTool as LangchainBaseTool
 from langchain_core.tools import ToolException
 
 from app.core.tools.base import BaseTool, ToolResult, ToolParameter, ParameterType
+from app.core.tools.serialization import serialize_tool_parameter
 from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
@@ -333,17 +334,7 @@ class LangchainAdapter:
             "status": tool.status.value,
             "tags": tool.tags,
             "parameters": [
-                {
-                    "name": param.name,
-                    "type": getattr(param.type, "value", param.type),
-                    "description": param.description,
-                    "required": param.required,
-                    "default": param.default,
-                    "enum": param.enum,
-                    "minimum": param.minimum,
-                    "maximum": param.maximum,
-                    "pattern": param.pattern
-                }
+                serialize_tool_parameter(param)
                 for param in tool.parameters
             ],
             "langchain_compatible": True

--- a/api/app/core/tools/serialization.py
+++ b/api/app/core/tools/serialization.py
@@ -1,0 +1,21 @@
+"""工具参数序列化辅助函数。"""
+
+from typing import Any, Dict
+
+from app.schemas.tool_schema import ToolParameter
+
+
+def serialize_tool_parameter(param: ToolParameter) -> Dict[str, Any]:
+    """兼容 ToolParameter.type 为枚举或字符串两种情况。"""
+    param_type = getattr(param.type, "value", param.type)
+    return {
+        "name": param.name,
+        "type": param_type,
+        "description": param.description,
+        "required": param.required,
+        "default": param.default,
+        "enum": param.enum,
+        "minimum": param.minimum,
+        "maximum": param.maximum,
+        "pattern": param.pattern,
+    }

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -432,6 +432,22 @@ class ToolService:
             logger.error(f"获取工具方法失败: {tool_id}, {e}")
             return []
 
+    @staticmethod
+    def _serialize_tool_parameter(param: Any) -> Dict[str, Any]:
+        """兼容 ToolParameter.type 为枚举或字符串两种情况。"""
+        param_type = getattr(param.type, "value", param.type)
+        return {
+            "name": param.name,
+            "type": param_type,
+            "description": param.description,
+            "required": param.required,
+            "default": param.default,
+            "enum": param.enum,
+            "minimum": param.minimum,
+            "maximum": param.maximum,
+            "pattern": param.pattern
+        }
+
     async def _get_builtin_tool_methods(self, config: ToolConfig) -> List[Dict[str, Any]]:
         """获取内置工具的方法"""
         builtin_config = self.builtin_repo.find_by_tool_id(self.db, config.id)
@@ -485,17 +501,11 @@ class ToolService:
             return self._get_openclaw_tool_params(operation)
         
         # 其他工具的默认处理：返回除operation外的所有参数
-        return [{
-            "name": param.name,
-            "type": param.type.value,
-            "description": param.description,
-            "required": param.required,
-            "default": param.default,
-            "enum": param.enum,
-            "minimum": param.minimum,
-            "maximum": param.maximum,
-            "pattern": param.pattern
-        } for param in tool_instance.parameters if param.name != "operation"]
+        return [
+            self._serialize_tool_parameter(param)
+            for param in tool_instance.parameters
+            if param.name != "operation"
+        ]
     
     def _get_datetime_tool_params(self, operation: str) -> List[Dict[str, Any]]:
         """获取datetime_tool特定操作的参数"""
@@ -1240,17 +1250,7 @@ class ToolService:
             "method_id": config.name,
             "name": config.name,
             "description": config.description,
-            "parameters": [{
-                "name": param.name,
-                "type": param.type.value,
-                "description": param.description,
-                "required": param.required,
-                "default": param.default,
-                "enum": param.enum,
-                "minimum": param.minimum,
-                "maximum": param.maximum,
-                "pattern": param.pattern
-            } for param in tool_instance.parameters]
+            "parameters": [self._serialize_tool_parameter(param) for param in tool_instance.parameters]
         }]
 
     def _create_type_config(self, tool_config: ToolConfig, config: Dict[str, Any]):

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -33,6 +33,7 @@ from app.core.logging_config import get_business_logger
 from app.core.tools.base import BaseTool
 from app.core.tools.custom.base import CustomTool
 from app.core.tools.mcp.base import MCPTool
+from app.core.tools.serialization import serialize_tool_parameter
 from app.core.tools.workflow.base import WorkflowAsTool
 
 logger = get_business_logger()
@@ -432,22 +433,6 @@ class ToolService:
             logger.error(f"获取工具方法失败: {tool_id}, {e}")
             return []
 
-    @staticmethod
-    def _serialize_tool_parameter(param: Any) -> Dict[str, Any]:
-        """兼容 ToolParameter.type 为枚举或字符串两种情况。"""
-        param_type = getattr(param.type, "value", param.type)
-        return {
-            "name": param.name,
-            "type": param_type,
-            "description": param.description,
-            "required": param.required,
-            "default": param.default,
-            "enum": param.enum,
-            "minimum": param.minimum,
-            "maximum": param.maximum,
-            "pattern": param.pattern
-        }
-
     async def _get_builtin_tool_methods(self, config: ToolConfig) -> List[Dict[str, Any]]:
         """获取内置工具的方法"""
         builtin_config = self.builtin_repo.find_by_tool_id(self.db, config.id)
@@ -502,7 +487,7 @@ class ToolService:
         
         # 其他工具的默认处理：返回除operation外的所有参数
         return [
-            self._serialize_tool_parameter(param)
+            serialize_tool_parameter(param)
             for param in tool_instance.parameters
             if param.name != "operation"
         ]
@@ -1250,7 +1235,7 @@ class ToolService:
             "method_id": config.name,
             "name": config.name,
             "description": config.description,
-            "parameters": [self._serialize_tool_parameter(param) for param in tool_instance.parameters]
+            "parameters": [serialize_tool_parameter(param) for param in tool_instance.parameters]
         }]
 
     def _create_type_config(self, tool_config: ToolConfig, config: Dict[str, Any]):


### PR DESCRIPTION
unify tool parameter serialization logic across services

The change introduces a shared `_serialize_tool_parameter` helper in `tool_service.py` to handle both enum and string `ToolParameter.type` values consistently. This eliminates duplicate serialization logic in `tool_service.py` and `langchain_adapter.py`, and adds `WORKFLOW` tool type support in `tool_controller.py`.

## Summary by Sourcery

在各个服务之间统一工具参数的序列化方式，并扩展支持的工具类型。

增强内容：
- 在工具服务中引入一个共享的辅助方法，用于在枚举参数类型和字符串参数类型之间统一地序列化工具参数，并在内置工具和工作流工具中复用该方法。
- 将 LangChain 工具适配器的参数序列化逻辑与该共享逻辑对齐，以统一处理枚举和字符串参数类型。
- 在工具控制器中暴露 `WORKFLOW` 工具类型，使其可以与现有工具类型一起被选择和使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify tool parameter serialization across services and extend supported tool types.

Enhancements:
- Introduce a shared helper in the tool service to serialize tool parameters consistently for both enum and string parameter types, and reuse it for built-in and workflow tools.
- Align the LangChain tool adapter parameter serialization with the shared logic to handle enum and string parameter types uniformly.
- Expose the WORKFLOW tool type in the tool controller so it can be selected and used alongside existing tool types.

</details>