### PR TITLE
chore(reflection): remove debug print statements in _process_end_users

### DIFF
--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -160,8 +160,8 @@ class WorkspaceAppService:
                 "app_id": str(end_user.app_id)
             }
             app_info["end_users"].append(end_user_info)
-        print(100*'-')
-        print(app_info)
+        # print(100*'-')
+        # print(app_info)
 
     def get_end_user_reflection_time(self, end_user_id: str) -> Optional[Any]:
         """


### PR DESCRIPTION
Removed leftover print(100*'-') and print(app_info) that dumped full app and end-user details to stdout on every app during reflection task runs, causing noisy logs and potential user data exposure.

## Summary by Sourcery

从内存反射服务中移除冗长的终端用户反射日志，以减少日志噪音和潜在的数据暴露风险。

Bug 修复：
- 在反射运行过程中停止记录详细的应用和终端用户信息，以避免产生嘈杂日志并防止敏感用户数据泄露。

增强：
- 禁用内存反射服务在终端用户处理路径中遗留的调试打印语句。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove verbose end-user reflection logging from memory reflection service to reduce log noise and potential data exposure.

Bug Fixes:
- Stop logging detailed app and end-user information during reflection runs to avoid noisy logs and leaking sensitive user data.

Enhancements:
- Disable leftover debug print statements in the end-user processing path of the memory reflection service.

</details>