### PR TITLE
fix(web): knowledge-retrieval output variable type

### DIFF
--- a/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
+++ b/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
@@ -72,7 +72,7 @@ const NODE_VARIABLES = {
   ],
   'jinja-render': [{ label: 'output', dataType: 'string', field: 'output' }],
   tool: [{ label: 'data', dataType: 'string', field: 'data' }],
-  'knowledge-retrieval': [{ label: 'output', dataType: 'array[object]', field: 'output' }],
+  'knowledge-retrieval': [{ label: 'output', dataType: 'array[string]', field: 'output' }],
   'parameter-extractor': [
     { label: '__is_success', dataType: 'number', field: '__is_success' },
     { label: '__reason', dataType: 'string', field: '__reason' }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 将变量列表配置中的知识检索节点输出变量类型，从 `array[object]` 更新为 `array[string]`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update the knowledge-retrieval node output variable type from array[object] to array[string] in the variable list configuration.

</details>