### PR TITLE
fix(reflection): add write lock and consistent user accounting 

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2394,6 +2394,9 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
                                             logger.warning(
                                                 f"反思引擎Layer2 获取锁超时，跳过用户 {user['id']}"
                                             )
+                                            # 锁超时的用户仍计入处理列表，保证与低频任务的用户口径一致
+                                            processed_users += 1
+                                            processed_user_ids.append(str(user['id']))
                                             continue
 
                                     try:
@@ -2430,6 +2433,14 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
                                             await asyncio.to_thread(write_lock.release)
                                 except Exception as e:
                                     logger.error(f"反思引擎Layer2 巡检失败 user={user['id']}: {e}")
+                                    # 回滚失败事务，避免污染后续用户的查询
+                                    try:
+                                        db.rollback()
+                                    except Exception:
+                                        pass
+                                    # 失败用户仍计入处理列表，保证与低频任务的用户口径一致
+                                    processed_users += 1
+                                    processed_user_ids.append(str(user['id']))
 
                 logger.info(
                     f"反思引擎Layer2 巡检遍历完成: 处理 {processed_users} 个用户, "
@@ -2506,6 +2517,7 @@ def layer2_dedup_full_scan_task(self) -> Dict[str, Any]:
             skipped_configs = 0
             skipped_inactive = 0
             total_merged = 0
+            redis_client = get_sync_redis_client()
 
             for workspace in workspaces:
                 service = WorkspaceAppService(db)
@@ -2531,25 +2543,56 @@ def layer2_dedup_full_scan_task(self) -> Dict[str, Any]:
                                     skipped_inactive += 1
                                     continue
 
-                                memory_service = MemoryService(
-                                    db=db,
-                                    config_id=config_id,
-                                    end_user_id=str(user['id']),
-                                    workspace_id=str(workspace.id),
-                                )
-                                r = await memory_service.run_dedup_full_scan()
-                                processed_users += 1
-                                processed_user_ids.append(str(user['id']))
-                                merged = r.get("merged_count", 0)
-                                total_merged += merged
-                                if merged > 0:
-                                    logger.info(
-                                        f"方案B全量扫描 用户 {user['id']} "
-                                        f"扫描类型 {r.get('scanned_types', 0)}, "
-                                        f"合并 {merged} 对"
+                                # 获取 Redis 锁，和写入 pipeline 互斥
+                                write_lock = None
+                                if redis_client is not None:
+                                    write_lock = RedisFairLock(
+                                        key=f"memory_write:{user['id']}",
+                                        redis_client=redis_client,
+                                        expire=600,
+                                        timeout=30,
+                                        auto_renewal=True,
                                     )
+                                    if not await asyncio.to_thread(write_lock.acquire):
+                                        logger.warning(
+                                            f"方案B全量扫描 获取锁超时，跳过用户 {user['id']}"
+                                        )
+                                        # 锁超时的用户仍计入处理列表，保证与高频任务的用户口径一致
+                                        processed_users += 1
+                                        processed_user_ids.append(str(user['id']))
+                                        continue
+
+                                try:
+                                    memory_service = MemoryService(
+                                        db=db,
+                                        config_id=config_id,
+                                        end_user_id=str(user['id']),
+                                        workspace_id=str(workspace.id),
+                                    )
+                                    r = await memory_service.run_dedup_full_scan()
+                                    processed_users += 1
+                                    processed_user_ids.append(str(user['id']))
+                                    merged = r.get("merged_count", 0)
+                                    total_merged += merged
+                                    if merged > 0:
+                                        logger.info(
+                                            f"方案B全量扫描 用户 {user['id']} "
+                                            f"扫描类型 {r.get('scanned_types', 0)}, "
+                                            f"合并 {merged} 对"
+                                        )
+                                finally:
+                                    if write_lock is not None:
+                                        await asyncio.to_thread(write_lock.release)
                             except Exception as e:
                                 logger.error(f"方案B全量扫描失败 user={user['id']}: {e}")
+                                # 回滚失败事务，避免污染后续用户的查询
+                                try:
+                                    db.rollback()
+                                except Exception:
+                                    pass
+                                # 失败用户仍计入处理列表，保证与高频任务的用户口径一致
+                                processed_users += 1
+                                processed_user_ids.append(str(user['id']))
 
             logger.info(
                 f"方案B全量扫描完成: 处理 {processed_users} 用户, "


### PR DESCRIPTION
- Acquire shared memory_write:{end_user_id} lock around dedup full scan, matching layer2_reflection_task, to avoid concurrent graph edits on the same user.
- Count lock-timeout and per-user failure cases into processed_user_ids in both layer2 tasks so the two tasks report a consistent user set.
- Roll back the shared db session on per-user failure to prevent an aborted transaction from breaking subsequent users' queries.

## Summary by Sourcery

通过写锁同步第二层反射任务（reflection layer2 tasks），并在高频和低频任务之间统一按用户的计费与错误处理逻辑。

Bug Fixes:
- 在反射任务中，当某个用户处理失败时，回滚共享数据库会话，以防止已中止的事务影响后续用户。
- 将发生锁超时或按用户失败的用户纳入已处理用户指标中，使两个第二层反射任务在上报用户集合时保持一致。
- 在低频反射任务中，对全量去重扫描操作获取按用户的写锁，防止在执行完整去重扫描期间对内存图进行并发修改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize reflection layer2 tasks with write locking and align per-user accounting and error handling between the high- and low-frequency jobs.

Bug Fixes:
- Rollback the shared database session after per-user failures in reflection tasks to prevent aborted transactions from impacting subsequent users.
- Include users that hit lock timeouts or per-user failures in the processed user metrics so both layer2 reflection tasks report a consistent user set.
- Prevent concurrent memory graph modifications during full deduplication scans by acquiring a per-user write lock around the scan operation in the low-frequency reflection task.

</details>