### PR TITLE
fix(celery_app): adjust scan-idle-conversations schedule from 60s to 3600s

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -204,9 +204,10 @@ beat_schedule_config = {
     },
     "scan-idle-conversations": {
         "task": "app.tasks.scan_idle_conversations",
-        "schedule": 60.0,
+        "schedule": 3600.0,
         "options": {"queue": "periodic_tasks"},
     },
+    # FIXME: Infinite task accumulation
 }
 
 celery_app.conf.beat_schedule = beat_schedule_config


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 降低 `scan-idle-conversations` Celery 定时任务的执行频率，以防止任务过度堆积。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reduce the frequency of the scan-idle-conversations Celery beat task to prevent excessive task accumulation.

</details>