### PR TITLE
fix(web): neo4j icon click

### DIFF
--- a/web/src/views/UserMemoryDetail/Neo4j.tsx
+++ b/web/src/views/UserMemoryDetail/Neo4j.tsx
@@ -95,7 +95,6 @@ const Neo4j: FC = () => {
     e.stopPropagation();
     setSelectedKey(type)
     if (type !== 'Brain') {
-      setSelectedKey(null);
       setBrainMemories([]);
       setRegionId(null);
     }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在点击非 Brain 的 Neo4j 条目类型时，停止清除已选中的键，同时仍然重置相关的 brain 内存状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop clearing the selected key when clicking on non-Brain Neo4j item types while still resetting related brain memory state.

</details>