### PR TITLE
fix(memory-reflection): support workflow apps in memory config extract

### DIFF
--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -88,7 +88,7 @@ class WorkspaceAppService:
         processed_configs: Set[str] = set()
         
         for release in app_releases:
-            memory_content = self._extract_memory_content(release.config)
+            memory_content = self._extract_memory_content(release.config, app.type)
             if memory_content and memory_content in processed_configs:
                 continue
 
@@ -107,12 +107,38 @@ class WorkspaceAppService:
 
             app_info["releases"].append(release_info)
 
-    def _extract_memory_content(self, config: Any) -> str:
-        """Extract memory_config_id from config (兼容新旧字段名)"""
-        if not config or not isinstance(config, dict):
+    def _extract_memory_content(self, release_config: Any, app_type: Optional[str] = None) -> Optional[str]:
+        """Extract memory_config_id from release config（类型感知）
+
+        - agent 应用：读取顶层 release_config.memory.memory_config_id
+        - workflow / pure_workflow 应用：扫描 release_config.nodes 中的记忆节点
+
+        复用 MemoryConfigService.extract_memory_config_id，按 app_type 分派；
+        若 app_type 缺失或解析失败，回退到旧的 agent 顶层 memory 结构。
+
+        Args:
+            release_config: 发布配置字典（app_releases.config）
+            app_type: 应用类型（agent / workflow / pure_workflow / multi_agent）
+
+        Returns:
+            memory_config_id 字符串，不存在时返回 None
+        """
+        if not release_config or not isinstance(release_config, dict):
             return None
 
-        memory_obj = config.get('memory')
+        if app_type:
+            from app.services.memory_config_service import MemoryConfigService
+            try:
+                config_id, _is_legacy = MemoryConfigService(self.db).extract_memory_config_id(app_type, release_config)
+                if config_id:
+                    return str(config_id)
+            except Exception as e:
+                api_logger.warning(
+                    f"提取 memory_config_id 失败，app_type: {app_type}, 错误: {str(e)}"
+                )
+
+        # 回退：兼容旧 agent 结构（顶层 memory 对象）
+        memory_obj = release_config.get('memory')
         if memory_obj and isinstance(memory_obj, dict):
             # 兼容新旧字段名：优先使用 memory_config_id，回退到 memory_content
             return memory_obj.get('memory_config_id') or memory_obj.get('memory_content')


### PR DESCRIPTION
Extract memory_config_id based on app type so workflow/pure_workflow apps stored in workflow nodes are also picked up by reflection tasks. Previously only agent apps with top-level memory config were detected.

## Summary by Sourcery

更新内存反射逻辑，以便根据发布配置为更多类型的应用检测内存配置 ID。

Bug Fixes:
- 确保在工作流节点中定义了内存配置的 `workflow` 和 `pure_workflow` 类型应用，能够被内存反射正确识别。

Enhancements:
- 当应用类型缺失或解析失败时回退到旧版的顶层内存提取方式，从而提升内存配置检测的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update memory reflection to detect memory configuration IDs for additional app types based on release configuration.

Bug Fixes:
- Ensure workflow and pure_workflow apps with memory configs defined in workflow nodes are correctly picked up by memory reflection.

Enhancements:
- Fallback to legacy top-level memory extraction when app type is missing or parsing fails, improving robustness of memory config detection.

</details>