### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/core/workflow/adapters/base_adapter.py
+++ b/api/app/core/workflow/adapters/base_adapter.py
@@ -14,6 +14,7 @@ from app.schemas.workflow_schema import (
     EdgeDefinition,
     NodeDefinition,
     VariableDefinition,
+    EnvironmentVariableDefinition,
     ExecutionConfig,
     TriggerConfig
 )
@@ -41,6 +42,7 @@ class WorkflowParserResult(BaseModel):
     edges: list[EdgeDefinition] = Field(default_factory=list)
     nodes: list[NodeDefinition] = Field(default_factory=list)
     variables: list[VariableDefinition] = Field(default_factory=list)
+    environment_variables: list[EnvironmentVariableDefinition] = Field(default_factory=list)
     features: dict[str, Any] = Field(default_factory=dict)
     warnings: list[ExceptionDefinition] = Field(default_factory=list)
     errors: list[ExceptionDefinition] = Field(default_factory=list)
@@ -54,6 +56,7 @@ class WorkflowImportResult(BaseModel):
     edges: list[EdgeDefinition] = Field(default_factory=list)
     nodes: list[NodeDefinition] = Field(default_factory=list)
     variables: list[VariableDefinition] = Field(default_factory=list)
+    environment_variables: list[EnvironmentVariableDefinition] = Field(default_factory=list)
     features: dict[str, Any] = Field(default_factory=dict)
     warnings: list[ExceptionDefinition] = Field(default_factory=list)
     errors: list[ExceptionDefinition] = Field(default_factory=list)
@@ -65,6 +68,7 @@ class BasePlatformAdapter(ABC):
         self.nodes: list[NodeDefinition] = []
         self.edges: list[EdgeDefinition] = []
         self.conv_variables: list[VariableDefinition] = []
+        self.env_variables: list[EnvironmentVariableDefinition] = []
 
         self.errors = []
         self.warnings = []

--- a/api/app/core/workflow/adapters/dify/converter.py
+++ b/api/app/core/workflow/adapters/dify/converter.py
@@ -36,13 +36,15 @@ from app.core.workflow.nodes.configs import (
     ListOperatorNodeConfig,
     DocExtractorNodeConfig,
 )
-from app.schemas.workflow_schema import VariableDefinition as SchemaVariableDefinition
+from app.schemas.workflow_schema import (
+    VariableDefinition as SchemaVariableDefinition,
+    EnvironmentVariableDefinition,
+)
 from app.core.workflow.nodes.cycle_graph.config import (
     ConditionDetail as LoopConditionDetail,
     ConditionsConfig,
     CycleVariable
 )
-from app.core.workflow.nodes.list_operator.config import FilterCondition
 from app.core.workflow.nodes.enums import (
     ValueInputType,
     ComparisonOperator,
@@ -218,6 +220,26 @@ class DifyConverter(BaseConverter):
                     return origin_value
         except:
             raise Exception(f"convert variable failed: {target_type}")
+
+    def convert_environment_variable(self, variable: dict[str, Any]) -> EnvironmentVariableDefinition:
+        name = variable.get("name") or variable.get("variable") or variable.get("key")
+        value_type = variable.get("value_type") or variable.get("type") or "string"
+        if value_type not in {"string", "number", "secret"}:
+            raise Exception(f"unsupported environment variable type: {value_type}")
+
+        value = variable.get("value")
+        if value_type == "number" and value is not None:
+            value = self._convert_number(value)
+        elif value is not None:
+            value = self._convert_string(value)
+
+        return EnvironmentVariableDefinition(
+            name=name,
+            value_type=value_type,
+            required=variable.get("required", False),
+            value=value,
+            description=variable.get("description") or variable.get("label"),
+        )
 
     @staticmethod
     def convert_compare_operator(operator):

--- a/api/app/core/workflow/adapters/dify/dify_adapter.py
+++ b/api/app/core/workflow/adapters/dify/dify_adapter.py
@@ -18,6 +18,7 @@ from app.schemas.workflow_schema import (
     NodeDefinition,
     EdgeDefinition,
     VariableDefinition,
+    EnvironmentVariableDefinition,
     TriggerConfig,
     ExecutionConfig
 )
@@ -120,6 +121,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             target_workflow_type = mode
         
         conv_variables = self.config.get("workflow").get("conversation_variables") or []
+        environment_variables = self.config.get("workflow").get("environment_variables") or []
         # 纯工作流没有会话变量
         if target_workflow_type == "pure_workflow":
             conv_variables = []
@@ -130,6 +132,17 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
 
         # 开始节点的文件变量合并到会话变量
         self.conv_variables.extend(self._file_vars_to_conv)
+
+        for variable in environment_variables:
+            try:
+                env_var: EnvironmentVariableDefinition = self.convert_environment_variable(variable)
+                self.env_variables.append(env_var)
+            except Exception as e:
+                self.warnings.append(ExceptionDefinition(
+                    type=ExceptionType.VARIABLE,
+                    name=variable.get("name") or variable.get("variable"),
+                    detail=f"convert environment variable error - {e}"
+                ))
 
         features = self.convert_features(
             self.config.get("workflow", {}).get("features", {})
@@ -148,6 +161,7 @@ class DifyAdapter(BasePlatformAdapter, DifyConverter):
             edges=self.edges,
             nodes=self.nodes,
             variables=self.conv_variables,
+            environment_variables=self.env_variables,
             features=features,
             warnings=self.warnings,
             errors=self.errors

--- a/api/app/core/workflow/adapters/memory_bear/memory_bear_adapter.py
+++ b/api/app/core/workflow/adapters/memory_bear/memory_bear_adapter.py
@@ -14,7 +14,13 @@ from app.core.workflow.adapters.base_adapter import (
 from app.core.workflow.adapters.errors import ExceptionDefinition, ExceptionType, UnsupportedNodeType
 from app.core.workflow.adapters.memory_bear.memory_bear_converter import MemoryBearConverter
 from app.core.workflow.nodes.enums import NodeType
-from app.schemas.workflow_schema import ExecutionConfig, NodeDefinition, EdgeDefinition, VariableDefinition
+from app.schemas.workflow_schema import (
+    ExecutionConfig,
+    NodeDefinition,
+    EdgeDefinition,
+    VariableDefinition,
+    EnvironmentVariableDefinition,
+)
 
 logger = get_logger()
 
@@ -39,6 +45,10 @@ class MemoryBearAdapter(BasePlatformAdapter, MemoryBearConverter):
     @property
     def origin_variables(self):
         return self.config.get("workflow").get("variables") or []
+
+    @property
+    def origin_environment_variables(self):
+        return self.config.get("workflow").get("environment_variables") or []
 
     def get_metadata(self) -> PlatformMetadata:
         return PlatformMetadata(
@@ -123,6 +133,18 @@ class MemoryBearAdapter(BasePlatformAdapter, MemoryBearConverter):
             logger.debug(f"MemoryBear convert variable error - {e}", exc_info=True)
             return None
 
+    def _convert_environment_variable(self, variable: dict[str, Any]) -> EnvironmentVariableDefinition | None:
+        try:
+            return EnvironmentVariableDefinition(**variable)
+        except Exception as e:
+            self.warnings.append(ExceptionDefinition(
+                type=ExceptionType.VARIABLE,
+                name=variable.get("name"),
+                detail=f"convert environment variable error - {e}"
+            ))
+            logger.debug(f"MemoryBear convert environment variable error - {e}", exc_info=True)
+            return None
+
     def parse_workflow(self) -> WorkflowParserResult:
         for node in self.origin_nodes:
             converted = self._convert_node(node)
@@ -141,6 +163,11 @@ class MemoryBearAdapter(BasePlatformAdapter, MemoryBearConverter):
             if converted:
                 self.conv_variables.append(converted)
 
+        for variable in self.origin_environment_variables:
+            converted = self._convert_environment_variable(variable)
+            if converted:
+                self.env_variables.append(converted)
+
         return WorkflowParserResult(
             success=not self.errors and not self.warnings,
             platform=self.get_metadata(),
@@ -150,6 +177,7 @@ class MemoryBearAdapter(BasePlatformAdapter, MemoryBearConverter):
             edges=self.edges,
             nodes=self.nodes,
             variables=self.conv_variables,
+            environment_variables=self.env_variables,
             warnings=self.warnings,
             errors=self.errors,
         )

--- a/api/app/core/workflow/engine/event_stream_handler.py
+++ b/api/app/core/workflow/engine/event_stream_handler.py
@@ -2,8 +2,6 @@
 # Author: Eternity
 # @Email: 1533512157@qq.com
 # @Time : 2026/2/10 13:33
-import datetime
-
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
@@ -11,6 +9,7 @@ from app.core.logging_config import get_logger
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
 from app.core.workflow.engine.stream_output_coordinator import StreamOutputCoordinator
 from app.core.workflow.engine.variable_pool import VariablePool
+from app.core.workflow.utils.secret_masker import mask_secrets
 
 logger = get_logger(__name__)
 
@@ -25,6 +24,9 @@ class EventStreamHandler:
         self.coordinator = output_coordinator
         self.variable_pool = variable_pool
         self.execution_id = execution_id
+
+    def _mask(self, value):
+        return mask_secrets(value, self.variable_pool.get_secret_values())
 
     def update_stream_output_status(self, activate: dict, data: dict):
         """
@@ -142,7 +144,7 @@ class EventStreamHandler:
                 break
             yield {
                 "event": "message",
-                "data": {"content": seg.literal}
+                "data": {"content": self._mask(seg.literal)}
             }
             end_info.cursor += 1
 
@@ -168,12 +170,11 @@ class EventStreamHandler:
                 yield {
                     "event": "message",
                     "data": {
-                        "content": data.get("chunk")
+                        "content": self._mask(data.get("chunk"))
                     }
                 }
 
-    @staticmethod
-    async def handle_node_error_event(data: dict):
+    async def handle_node_error_event(self, data: dict):
         """
         Handle node error events ("node_error") during workflow execution.
 
@@ -202,7 +203,7 @@ class EventStreamHandler:
                   }
         """
         node_id = data.get("node_id")
-        yield {
+        payload = {
             "event": "node_error",
             "data": {
                 "node_id": node_id,
@@ -214,6 +215,7 @@ class EventStreamHandler:
                 "error": data.get("error")
             }
         }
+        yield self._mask(payload)
 
     async def handle_debug_event(self, data: dict, input_data: dict):
         """
@@ -295,7 +297,7 @@ class EventStreamHandler:
             logger.info(
                 f"[NODE-END] Node '{node_name}' execution completed - execution_id: {self.execution_id}")
 
-            yield {
+            payload = {
                 "event": "node_end",
                 "data": {
                     "node_id": node_name,
@@ -309,11 +311,10 @@ class EventStreamHandler:
                     "token_usage": result.get("node_outputs", {}).get(node_name, {}).get("token_usage")
                 }
             }
+            yield self._mask(payload)
 
-    @staticmethod
-    async def handle_cycle_item_event(data: dict):
-        yield {
+    async def handle_cycle_item_event(self, data: dict):
+        yield self._mask({
             "event": "cycle_item",
             "data": data.get("data")
-        }
-
+        })

--- a/api/app/core/workflow/engine/graph_builder.py
+++ b/api/app/core/workflow/engine/graph_builder.py
@@ -468,9 +468,10 @@ class GraphBuilder:
                     for label, branch in unique_branch.items():
                         if node_output and evaluate_condition(
                                 branch["condition"],
-                                {},
-                                {src: node_output},
-                                {}
+                                variable_pool.lazy_namespace("conv"),
+                                {**variable_pool.lazy_all_node_outputs(), src: node_output},
+                                variable_pool.lazy_namespace("sys"),
+                                variable_pool.lazy_namespace("env"),
                         ):
                             logger.debug(f"Conditional routing {src}: selected branch {label}")
                             new_state["activate"][branch["node"]["name"]] = True

--- a/api/app/core/workflow/engine/result_builder.py
+++ b/api/app/core/workflow/engine/result_builder.py
@@ -4,6 +4,7 @@
 # @Time : 2026/2/10 13:33
 from app.core.workflow.engine.runtime_schema import ExecutionContext
 from app.core.workflow.engine.variable_pool import VariablePool
+from app.core.workflow.utils.secret_masker import mask_secrets
 
 
 class WorkflowResultBuilder:
@@ -68,7 +69,7 @@ class WorkflowResultBuilder:
         # 汇总所有 knowledge 节点的 citations
         citations = self.aggregate_citations(node_outputs)
 
-        return {
+        payload = {
             "status": "completed" if success else "failed",
             "output": final_output,
             "variables": {
@@ -84,6 +85,8 @@ class WorkflowResultBuilder:
             "snapshot": snapshot,
             "error": result.get("error"),
         }
+        secret_values = variable_pool.get_secret_values() if variable_pool else []
+        return mask_secrets(payload, secret_values)
 
     @staticmethod
     def aggregate_citations(node_outputs: dict) -> list:

--- a/api/app/core/workflow/engine/stream_output_coordinator.py
+++ b/api/app/core/workflow/engine/stream_output_coordinator.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 from app.core.logging_config import get_logger
 from app.core.workflow.engine.variable_pool import VariablePool
+from app.core.workflow.utils.secret_masker import mask_secrets
 
 logger = get_logger(__name__)
 
@@ -378,6 +379,7 @@ class StreamOutputCoordinator:
                     logger.warning(f"[STREAM] Failed to evaluate segment: {current_segment.literal}, error: {e}")
 
             if final_chunk:
+                final_chunk = mask_secrets(final_chunk, variable_pool.get_secret_values())
                 logger.info(f"[STREAM] StreamOutput Node:{self.activate_end}, chunk_length:{len(final_chunk)}")
                 yield {
                     "event": "message",

--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -146,6 +146,8 @@ class VariablePool:
             user_id, conversation_id).
         - ``conv.*``:
             Conversation-level variables that persist across multiple turns.
+        - ``env.*``:
+            Workflow-level environment variables. Read-only at runtime.
         - ``<node_id>.*``:
             Variables produced by workflow nodes.
     """
@@ -161,7 +163,8 @@ class VariablePool:
                 Storage for all variables managed by the pool.
         """
         self.locks = defaultdict(Lock)
-        self.variables: dict[str, dict[str, VariableStruct[Any]]] = {"sys": {}, "conv": {}}
+        self.variables: dict[str, dict[str, VariableStruct[Any]]] = {"sys": {}, "conv": {}, "env": {}}
+        self.secret_values: set[str] = set()
 
     @staticmethod
     def transform_selector(selector):
@@ -382,7 +385,7 @@ class VariablePool:
         return {
             ns: LazyVariableDict(vars_dict, literal)
             for ns, vars_dict in self.variables.items()
-            if ns not in ("sys", "conv")
+            if ns not in ("sys", "conv", "env")
         }
 
     def get_all_system_vars(self, literal=False) -> dict[str, Any]:
@@ -407,6 +410,21 @@ class VariablePool:
             return {k: v.instance.to_literal() for k, v in conv_namespace.items()}
         return {k: v.instance.get_value() for k, v in conv_namespace.items()}
 
+    def get_all_environment_vars(self, literal=False) -> dict[str, Any]:
+        """获取所有环境变量"""
+        env_namespace = self.variables.get("env", {})
+        if literal:
+            return {k: v.instance.to_literal() for k, v in env_namespace.items()}
+        return {k: v.instance.get_value() for k, v in env_namespace.items()}
+
+    def register_secret_value(self, value: Any) -> None:
+        if value in (None, "", "__SECRET__"):
+            return
+        self.secret_values.add(str(value))
+
+    def get_secret_values(self) -> list[str]:
+        return sorted(self.secret_values, key=len, reverse=True)
+
     def get_all_node_outputs(self, literal=False) -> dict[str, Any]:
         """获取所有节点输出（运行时变量）
         
@@ -420,7 +438,7 @@ class VariablePool:
                     for k, v in vars_dict.items()
                 }
                 for namespace, vars_dict in self.variables.items()
-                if namespace not in ("sys", "conv")
+                if namespace not in ("sys", "conv", "env")
             }
         else:
             runtime_vars = {
@@ -429,7 +447,7 @@ class VariablePool:
                     for k, v in vars_dict.items()
                 }
                 for namespace, vars_dict in self.variables.items()
-                if namespace not in ("sys", "conv")
+                if namespace not in ("sys", "conv", "env")
             }
         return runtime_vars
 
@@ -502,6 +520,7 @@ class VariablePoolInitializer:
             execution_context: ExecutionContext
     ) -> None:
         await self._init_conversation_vars(variable_pool, input_data)
+        await self._init_environment_vars(variable_pool)
         await self._init_system_vars(variable_pool, input_data, execution_context)
 
     async def _init_conversation_vars(
@@ -545,6 +564,36 @@ class VariablePoolInitializer:
                     var_type=var_type,
                     mut=True
                 )
+
+    async def _init_environment_vars(
+            self,
+            variable_pool: VariablePool,
+    ):
+        init_env_vars: list[dict] = self.workflow_config.get("environment_variables") or []
+
+        for var_def in init_env_vars:
+            var_name = var_def.get("name")
+            value_type = var_def.get("value_type")
+            var_value = var_def.get("value")
+            required = bool(var_def.get("required"))
+            if not var_name:
+                continue
+
+            runtime_type = VariableType.NUMBER if value_type == "number" else VariableType.STRING
+            if var_value is None:
+                var_value = DEFAULT_VALUE(runtime_type)
+            if required and (var_value in ("", None) or (value_type == "secret" and var_value == "__SECRET__")):
+                raise ValueError(f"必填环境变量 '{var_name}' 尚未配置")
+            if value_type == "secret":
+                variable_pool.register_secret_value(var_value)
+
+            await variable_pool.new(
+                namespace="env",
+                key=var_name,
+                value=var_value,
+                var_type=runtime_type,
+                mut=False
+            )
 
     @staticmethod
     async def _resolve_file_default(file_def: dict) -> dict | None:

--- a/api/app/core/workflow/nodes/assigner/node.py
+++ b/api/app/core/workflow/nodes/assigner/node.py
@@ -59,6 +59,9 @@ class AssignerNode(BaseNode):
             variable_selector = assignment.variable_selector
             namespace = re.sub(pattern, r"\1", variable_selector).split('.')[0]
 
+            if namespace == "env":
+                raise ValueError(f"Environment variables are read-only and cannot be assigned. - {variable_selector}")
+
             # Only conversation variables ('conv') are allowed
             if namespace != 'conv' and namespace not in state["cycle_nodes"]:
                 raise ValueError(f"Only conversation or cycle variables can be assigned. - {variable_selector}")

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -593,6 +593,7 @@ class BaseNode(ABC):
           - sys.xxx: System variables (e.g., message, execution_id, workspace_id,
             user_id, conversation_id)
           - conv.xxx: Conversation variables (persist across multiple turns)
+          - env.xxx: Environment variables (workflow-level, read-only)
           - node_id.xxx: Node outputs
 
         Args:
@@ -612,6 +613,7 @@ class BaseNode(ABC):
             conv_vars=variable_pool.lazy_namespace("conv", literal=True),
             node_outputs=variable_pool.lazy_all_node_outputs(literal=True),
             system_vars=variable_pool.lazy_namespace("sys", literal=True),
+            env_vars=variable_pool.lazy_namespace("env", literal=True),
             strict=strict
         )
 
@@ -622,6 +624,7 @@ class BaseNode(ABC):
         Supported variable namespaces:
           - sys.xxx: System variables
           - conv.xxx: Conversation variables
+          - env.xxx: Environment variables
           - node_id.xxx: Node outputs
 
         Args:
@@ -638,7 +641,8 @@ class BaseNode(ABC):
             expression=expression,
             conv_var=variable_pool.lazy_namespace("conv"),
             node_outputs=variable_pool.lazy_all_node_outputs(),
-            system_vars=variable_pool.lazy_namespace("sys")
+            system_vars=variable_pool.lazy_namespace("sys"),
+            env_vars=variable_pool.lazy_namespace("env"),
         )
 
     @staticmethod

--- a/api/app/core/workflow/utils/expression_evaluator.py
+++ b/api/app/core/workflow/utils/expression_evaluator.py
@@ -15,7 +15,7 @@ class ExpressionEvaluator:
     """Safe expression evaluator for workflow variables and node outputs."""
 
     # Reserved namespaces
-    RESERVED_NAMESPACES = {"var", "node", "sys", "nodes"}
+    RESERVED_NAMESPACES = {"var", "node", "sys", "nodes", "env", "conv"}
 
     @classmethod
     def normalize_template(cls, template: str) -> str:
@@ -30,7 +30,8 @@ class ExpressionEvaluator:
             expression: str,
             conv_vars: dict[str, Any],
             node_outputs: dict[str, Any],
-            system_vars: dict[str, Any] | None = None
+            system_vars: dict[str, Any] | None = None,
+            env_vars: dict[str, Any] | None = None,
     ) -> Any:
         """
         Safely evaluate an expression using workflow variables.
@@ -57,6 +58,7 @@ class ExpressionEvaluator:
             "conv": conv_vars,  # conversation variables
             "node": node_outputs,  # node outputs
             "sys": system_vars or {},  # system variables
+            "env": env_vars or {},  # environment variables
         }
 
         # context.update(conv_vars)
@@ -90,7 +92,8 @@ class ExpressionEvaluator:
             expression: str,
             conv_var: dict[str, Any],
             node_outputs: dict[str, Any],
-            system_vars: dict[str, Any] | None = None
+            system_vars: dict[str, Any] | None = None,
+            env_vars: dict[str, Any] | None = None,
     ) -> bool:
         """
         Evaluate a boolean expression (for conditions).
@@ -105,7 +108,7 @@ class ExpressionEvaluator:
             bool: Boolean result
         """
         result = ExpressionEvaluator.evaluate(
-            expression, conv_var, node_outputs, system_vars
+            expression, conv_var, node_outputs, system_vars, env_vars
         )
         return bool(result)
 
@@ -143,11 +146,12 @@ def evaluate_expression(
         expression: str,
         conv_var: dict[str, Any] | LazyVariableDict,
         node_outputs: dict[str, dict[str, Any] | LazyVariableDict],
-        system_vars: dict[str, Any] | LazyVariableDict
+        system_vars: dict[str, Any] | LazyVariableDict,
+        env_vars: dict[str, Any] | LazyVariableDict | None = None,
 ) -> Any:
     """Evaluate an expression (convenience function)."""
     return ExpressionEvaluator.evaluate(
-        expression, conv_var, node_outputs, system_vars
+        expression, conv_var, node_outputs, system_vars, env_vars
     )
 
 
@@ -155,9 +159,10 @@ def evaluate_condition(
         expression: str,
         conv_var: dict[str, Any] | LazyVariableDict,
         node_outputs: dict[str, dict[str, Any] | LazyVariableDict],
-        system_vars: dict[str, Any] | LazyVariableDict
+        system_vars: dict[str, Any] | LazyVariableDict,
+        env_vars: dict[str, Any] | LazyVariableDict | None = None,
 ) -> Any:
     """Evaluate a boolean condition expression (convenience function)."""
     return ExpressionEvaluator.evaluate_bool(
-        expression, conv_var, node_outputs, system_vars
+        expression, conv_var, node_outputs, system_vars, env_vars
     )

--- a/api/app/core/workflow/utils/secret_masker.py
+++ b/api/app/core/workflow/utils/secret_masker.py
@@ -1,0 +1,49 @@
+from typing import Any, Iterable
+
+MASKED_SECRET_VALUE = "__SECRET__"
+
+
+def normalize_secret_values(secret_values: Iterable[str] | None) -> list[str]:
+    """Normalize runtime secret values for deterministic masking."""
+    if not secret_values:
+        return []
+
+    normalized = {
+        str(value)
+        for value in secret_values
+        if value not in (None, "", MASKED_SECRET_VALUE)
+    }
+    return sorted(normalized, key=len, reverse=True)
+
+
+def mask_secret_text(text: str, secret_values: Iterable[str] | None) -> str:
+    """Replace secret substrings in text with a placeholder."""
+    if not text:
+        return text
+
+    masked = text
+    for secret in normalize_secret_values(secret_values):
+        if secret in masked:
+            masked = masked.replace(secret, MASKED_SECRET_VALUE)
+    return masked
+
+
+def mask_secrets(value: Any, secret_values: Iterable[str] | None) -> Any:
+    """Recursively mask runtime secrets in common JSON-like structures."""
+    secrets = normalize_secret_values(secret_values)
+    if not secrets:
+        return value
+
+    return _mask_secrets(value, secrets)
+
+
+def _mask_secrets(value: Any, secret_values: list[str]) -> Any:
+    if isinstance(value, str):
+        return mask_secret_text(value, secret_values)
+    if isinstance(value, dict):
+        return {key: _mask_secrets(item, secret_values) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_mask_secrets(item, secret_values) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_mask_secrets(item, secret_values) for item in value)
+    return value

--- a/api/app/core/workflow/utils/template_renderer.py
+++ b/api/app/core/workflow/utils/template_renderer.py
@@ -64,7 +64,8 @@ class TemplateRenderer:
             template: str,
             conv_vars: dict[str, Any] | LazyVariableDict,
             node_outputs: dict[str, Any] | dict[str, LazyVariableDict],
-            system_vars: dict[str, Any] | LazyVariableDict | None = None
+            system_vars: dict[str, Any] | LazyVariableDict | None = None,
+            env_vars: dict[str, Any] | LazyVariableDict | None = None,
     ) -> str:
         """Render template
 
@@ -103,6 +104,7 @@ class TemplateRenderer:
             "conv": conv_vars,  # Conversation variables: {{conv.user_name}}
             "node": node_outputs,  # Node outputs: {{node.node_1.output}}
             "sys": system_vars,  # System variables: {{sys.execution_id}}
+            "env": env_vars,  # Environment variables: {{env.OPENAI_API_KEY}}
         }
 
         # Allow direct access to node outputs by node ID: {{llm_qa.output}}
@@ -168,6 +170,7 @@ def render_template(
         conv_vars: dict[str, Any] | LazyVariableDict,
         node_outputs: dict[str, Any] | dict[str, LazyVariableDict],
         system_vars: dict[str, Any] | LazyVariableDict,
+        env_vars: dict[str, Any] | LazyVariableDict | None = None,
         strict: bool = True
 ) -> str:
     """Render template (convenience function)
@@ -192,7 +195,7 @@ def render_template(
         'Analyze: This is a text'
     """
     renderer = _strict_renderer if strict else _lenient_renderer
-    return renderer.render(template, conv_vars, node_outputs, system_vars)
+    return renderer.render(template, conv_vars, node_outputs, system_vars, env_vars)
 
 
 def validate_template(template: str) -> list[str]:

--- a/api/app/core/workflow/validator.py
+++ b/api/app/core/workflow/validator.py
@@ -6,6 +6,7 @@
 
 import copy
 import logging
+import re
 from collections import defaultdict, deque
 from typing import Any, Union, TYPE_CHECKING
 
@@ -20,6 +21,9 @@ logger = logging.getLogger(__name__)
 
 class WorkflowValidator:
     """工作流配置验证器"""
+
+    ENV_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+    ENV_ALLOWED_TYPES = {"string", "number", "secret"}
 
     @classmethod
     def pure_cycle_graph(cls, workflow_config: Union[dict[str, Any], Any], node_id) -> tuple[list, list]:
@@ -119,10 +123,20 @@ class WorkflowValidator:
         """
         workflow_config = copy.deepcopy(workflow_config)
         errors = []
+        workflow_type = workflow_config.get("workflow_type", "workflow") if isinstance(workflow_config, dict) \
+            else getattr(workflow_config, "workflow_type", "workflow")
+        environment_variables = workflow_config.get("environment_variables", []) if isinstance(workflow_config, dict) \
+            else getattr(workflow_config, "environment_variables", [])
         trigger_nodes_prepared = (
             isinstance(workflow_config, dict)
             and workflow_config.get(TRIGGER_NODES_PREPARED_FLAG) is True
         )
+
+        if workflow_type == "pure_workflow" and (workflow_config.get("variables", []) if isinstance(workflow_config, dict)
+                                                 else getattr(workflow_config, "variables", [])):
+            errors.append("pure_workflow 不支持会话变量 variables，请改用开始节点输入变量或 environment_variables")
+
+        errors.extend(cls._validate_environment_variables(environment_variables, publish=publish))
 
         graphs = cls.get_subgraph(workflow_config)
         for index, graph in enumerate(graphs):
@@ -226,6 +240,51 @@ class WorkflowValidator:
                             )
 
         return len(errors) == 0, errors
+
+    @classmethod
+    def _validate_environment_variables(
+        cls,
+        environment_variables: list[dict[str, Any]] | None,
+        *,
+        publish: bool = False,
+    ) -> list[str]:
+        errors: list[str] = []
+        names: set[str] = set()
+
+        for item in environment_variables or []:
+            name = item.get("name", "")
+            value_type = item.get("value_type")
+            value = item.get("value")
+            required = bool(item.get("required"))
+
+            if not name:
+                errors.append("environment_variables 中存在缺少 name 的变量")
+                continue
+            if name in names:
+                errors.append(f"environment variable '{name}' 重复定义")
+            names.add(name)
+
+            if not cls.ENV_NAME_PATTERN.match(name):
+                errors.append(f"environment variable '{name}' 名称不合法，建议使用大写字母、数字和下划线")
+
+            if value_type not in cls.ENV_ALLOWED_TYPES:
+                errors.append(
+                    f"environment variable '{name}' 的 value_type '{value_type}' 不支持，仅支持 string、number、secret"
+                )
+                continue
+
+            if value_type in {"string", "secret"} and value is not None and not isinstance(value, str):
+                errors.append(f"environment variable '{name}' 的值必须是字符串")
+            if value_type == "number" and value is not None and not isinstance(value, (int, float)):
+                errors.append(f"environment variable '{name}' 的值必须是数字")
+
+            if publish and required:
+                if value in (None, ""):
+                    errors.append(f"必填环境变量 '{name}' 尚未配置")
+                elif value_type == "secret" and value == "__SECRET__":
+                    errors.append(f"必填 secret 环境变量 '{name}' 仍为占位值，请先补全")
+
+        return errors
 
     @staticmethod
     def get_reachable_nodes(start_id: str, edges: list[dict]) -> set[str]:

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -2,9 +2,8 @@
 工作流相关数据模型
 """
 
-import datetime
 import uuid
-from sqlalchemy import Column, String, Boolean, DateTime, Integer, Float, ForeignKey, Text
+from sqlalchemy import Column, String, Boolean, DateTime, Integer, Float, ForeignKey, Text, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.db import Base
@@ -36,6 +35,7 @@ class WorkflowConfig(Base):
     
     # 全局变量定义
     variables = Column(JSONB, default=list)
+    environment_variables = Column(JSONB, default=list, server_default=text("'[]'::jsonb"))
     
     # 执行配置
     execution_config = Column(JSONB, nullable=False, default=dict)

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -48,6 +48,7 @@ class WorkflowConfigRepository:
         nodes: list[dict[str, Any]],
         edges: list[dict[str, Any]],
         variables: list[dict[str, Any]] | None = None,
+        environment_variables: list[dict[str, Any]] | None = None,
         execution_config: dict[str, Any] | None = None,
         features: dict[str, Any] | None = None,
         triggers: list[dict[str, Any]] | None = None,
@@ -59,7 +60,8 @@ class WorkflowConfigRepository:
             app_id: 应用 ID
             nodes: 节点列表
             edges: 边列表
-            variables: 变量列表
+            variables: 会话变量列表
+            environment_variables: 环境变量列表
             execution_config: 执行配置
             features: 功能特性
             triggers: 触发器列表
@@ -78,6 +80,8 @@ class WorkflowConfigRepository:
             existing.workflow_type = workflow_type
             if variables is not None:
                 existing.variables = variables
+            if environment_variables is not None:
+                existing.environment_variables = environment_variables
             if execution_config is not None:
                 existing.execution_config = execution_config
             if triggers is not None:
@@ -94,6 +98,7 @@ class WorkflowConfigRepository:
                 nodes=nodes,
                 edges=edges,
                 variables=variables or [],
+                environment_variables=environment_variables or [],
                 execution_config=execution_config or {},
                 features=features or {},
                 triggers=triggers or [],

--- a/api/app/schemas/workflow_schema.py
+++ b/api/app/schemas/workflow_schema.py
@@ -4,7 +4,7 @@
 
 import datetime
 import uuid
-from typing import Any
+from typing import Any, Literal
 from pydantic import BaseModel, Field, ConfigDict, field_serializer
 
 from app.core.utils.datetime_utils import to_timestamp_ms
@@ -57,6 +57,19 @@ class VariableDefinition(BaseModel):
     max_file_size_mb: float | None = Field(default=None, description="单文件最大大小(MB)，仅 file/file-list-upload 时有效")
 
 
+class EnvironmentVariableDefinition(BaseModel):
+    """环境变量定义"""
+
+    name: str = Field(..., description="环境变量名称，运行时通过 env.NAME 访问")
+    value_type: Literal["string", "number", "secret"] = Field(
+        ...,
+        description="环境变量类型: string, number, secret"
+    )
+    required: bool = Field(default=False, description="是否必填")
+    value: str | int | float | None = Field(default=None, description="变量值")
+    description: str | None = Field(default=None, description="变量描述")
+
+
 class ExecutionConfig(BaseModel):
     """执行配置"""
     max_iterations: int = Field(default=100, ge=1, le=1000, description="最大迭代次数")
@@ -93,6 +106,7 @@ class WorkflowConfigCreate(BaseModel):
     nodes: list[NodeDefinition] = Field(default_factory=list, description="节点列表")
     edges: list[EdgeDefinition] = Field(default_factory=list, description="边列表")
     variables: list[VariableDefinition] = Field(default_factory=list, description="变量列表")
+    environment_variables: list[EnvironmentVariableDefinition] = Field(default_factory=list, description="环境变量列表")
     execution_config: ExecutionConfig = Field(default_factory=ExecutionConfig, description="执行配置")
     triggers: list[TriggerConfig] = Field(default_factory=list, description="触发器列表")
     features: dict = Field(default_factory=dict, description="功能特性配置")
@@ -104,6 +118,7 @@ class WorkflowConfigUpdate(BaseModel):
     nodes: list[NodeDefinition] | None = None
     edges: list[EdgeDefinition] | None = None
     variables: list[VariableDefinition] | None = None
+    environment_variables: list[EnvironmentVariableDefinition] | None = None
     features: dict | None = None
     execution_config: ExecutionConfig | None = None
     triggers: list[TriggerConfig] | None = None
@@ -119,6 +134,7 @@ class WorkflowConfig(BaseModel):
     nodes: list[dict[str, Any]]
     edges: list[dict[str, Any]]
     variables: list[dict[str, Any]]
+    environment_variables: list[dict[str, Any]]
     execution_config: dict[str, Any]
     triggers: list[dict[str, Any]]
     features: dict | None

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -108,6 +108,8 @@ class AppDslService:
             enriched = {**cfg}
             if "nodes" in cfg:
                 enriched["nodes"] = self._enrich_workflow_nodes(cfg["nodes"])
+            if "environment_variables" in cfg:
+                enriched["environment_variables"] = self._mask_environment_variables(cfg["environment_variables"])
             return enriched
         return cfg
 
@@ -116,6 +118,7 @@ class AppDslService:
             config = self.db.query(WorkflowConfig).filter(WorkflowConfig.app_id == app.id).first()
             config_data = {
                 "variables": config.variables if config else [],
+                "environment_variables": self._mask_environment_variables(config.environment_variables) if config else [],
                 "edges": config.edges if config else [],
                 "nodes": self._enrich_workflow_nodes(config.nodes) if config else [],
                 "features": config.features if config else {},
@@ -214,6 +217,16 @@ class AppDslService:
             
             enriched_nodes.append({**node, "config": config})
         return enriched_nodes
+
+    @staticmethod
+    def _mask_environment_variables(environment_variables: list[dict] | None) -> list[dict]:
+        result = []
+        for item in environment_variables or []:
+            if item.get("value_type") == "secret":
+                result.append({**item, "value": "__SECRET__"})
+            else:
+                result.append(item)
+        return result
 
     def _skill_ref(self, skill_id) -> Optional[dict]:
         if not skill_id:
@@ -407,6 +420,7 @@ class AppDslService:
                     nodes=[n.model_dump() for n in result.nodes],
                     edges=[e.model_dump() for e in result.edges],
                     variables=[v.model_dump() for v in result.variables],
+                    environment_variables=[v.model_dump() for v in result.environment_variables],
                     execution_config=raw_wf.get("execution_config", {}),
                     features=raw_wf.get("features", {}),
                     triggers=raw_wf.get("triggers", []),
@@ -418,6 +432,7 @@ class AppDslService:
                     existing.nodes = [n.model_dump() for n in result.nodes]
                     existing.edges = [e.model_dump() for e in result.edges]
                     existing.variables = [v.model_dump() for v in result.variables]
+                    existing.environment_variables = [v.model_dump() for v in result.environment_variables]
                     existing.execution_config = raw_wf.get("execution_config", {})
                     existing.features = raw_wf.get("features", {})
                     existing.triggers = raw_wf.get("triggers", [])
@@ -428,6 +443,7 @@ class AppDslService:
                         nodes=[n.model_dump() for n in result.nodes],
                         edges=[e.model_dump() for e in result.edges],
                         variables=[v.model_dump() for v in result.variables],
+                        environment_variables=[v.model_dump() for v in result.environment_variables],
                         execution_config=raw_wf.get("execution_config", {}),
                         features=raw_wf.get("features", {}),
                         triggers=raw_wf.get("triggers", []),

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -13,7 +13,7 @@ import uuid
 from typing import Annotated, Any, Dict, List, Optional, Tuple
 
 from fastapi import Depends
-from sqlalchemy import and_, column, delete, exists, func, or_, select, update as sa_update
+from sqlalchemy import and_, column, exists, func, or_, select, update as sa_update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
@@ -419,6 +419,7 @@ class AppService:
             nodes=[node.model_dump() for node in data.nodes] if data.nodes else [],
             edges=[edge.model_dump() for edge in data.edges] if data.edges else [],
             variables=[var.model_dump() for var in data.variables] if data.variables else [],
+            environment_variables=[var.model_dump() for var in data.environment_variables] if getattr(data, "environment_variables", None) else [],
             execution_config=data.execution_config.model_dump() if data.execution_config else {},
             features=data.features if data.features else {},
             triggers=[trigger.model_dump() for trigger in data.triggers] if data.triggers else [],
@@ -430,6 +431,7 @@ class AppService:
             nodes=config_dict["nodes"],
             edges=config_dict["edges"],
             variables=config_dict["variables"],
+            environment_variables=config_dict["environment_variables"],
             execution_config=config_dict["execution_config"],
             features=config_dict["features"],
             triggers=config_dict["triggers"],
@@ -957,6 +959,8 @@ class AppService:
                         nodes=copy.deepcopy(source_config.nodes) if source_config.nodes else [],
                         edges=copy.deepcopy(source_config.edges) if source_config.edges else [],
                         variables=copy.deepcopy(source_config.variables) if source_config.variables else [],
+                        environment_variables=copy.deepcopy(source_config.environment_variables)
+                        if source_config.environment_variables else [],
                         execution_config=copy.deepcopy(source_config.execution_config) if source_config.execution_config else {},
                         features=copy.deepcopy(source_config.features) if source_config.features else {},
                         triggers=copy.deepcopy(source_config.triggers) if source_config.triggers else [],
@@ -1657,6 +1661,7 @@ class AppService:
             nodes=[node.model_dump() for node in data.nodes] if data.nodes else [],
             edges=[edge.model_dump() for edge in data.edges] if data.edges else [],
             variables=[var.model_dump() for var in data.variables] if data.variables else [],
+            environment_variables=[var.model_dump() for var in data.environment_variables] if data.environment_variables else [],
             execution_config=data.execution_config.model_dump() if data.execution_config else {},
             features=features,
             triggers=[trigger.model_dump() for trigger in data.triggers] if data.triggers else [],
@@ -1677,6 +1682,7 @@ class AppService:
                 nodes=config_dict["nodes"],
                 edges=config_dict["edges"],
                 variables=config_dict["variables"],
+                environment_variables=config_dict["environment_variables"],
                 execution_config=config_dict["execution_config"],
                 triggers=config_dict["triggers"],
                 features=config_dict["features"],
@@ -1692,6 +1698,7 @@ class AppService:
             workflow_cfg.nodes = config_dict["nodes"]
             workflow_cfg.edges = config_dict["edges"]
             workflow_cfg.variables = config_dict["variables"]
+            workflow_cfg.environment_variables = config_dict["environment_variables"]
             workflow_cfg.execution_config = config_dict["execution_config"]
             workflow_cfg.triggers = config_dict["triggers"]
             workflow_cfg.features = config_dict["features"]
@@ -1741,6 +1748,7 @@ class AppService:
                         {"source": "start", "target": "output_node"}
                     ],
                     "variables": [],
+                    "environment_variables": [],
                     "execution_config": {
                         "max_execution_time": 300,
                         "max_iterations": 10,
@@ -1757,6 +1765,7 @@ class AppService:
                         {'source': 'start', 'target': 'end'}
                     ],
                     'variables': [],
+                    'environment_variables': [],
                     'execution_config': {
                         'max_execution_time': 300,
                         'max_iterations': 10
@@ -1771,6 +1780,7 @@ class AppService:
             nodes=template_data.get('nodes', []),
             edges=template_data.get('edges', []),
             variables=template_data.get('variables', []),
+            environment_variables=template_data.get('environment_variables', []),
             execution_config=template_data.get('execution_config', {}),
             triggers=template_data.get('triggers', []),
             workflow_type=normalized_workflow_type,

--- a/api/app/services/workflow_import_service.py
+++ b/api/app/services/workflow_import_service.py
@@ -70,6 +70,7 @@ class WorkflowImportService:
             edges=workflow_config.edges,
             nodes=workflow_config.nodes,
             variables=workflow_config.variables,
+            environment_variables=workflow_config.environment_variables,
             features=workflow_config.features,
             warnings=workflow_config.warnings,
             errors=workflow_config.errors
@@ -101,6 +102,7 @@ class WorkflowImportService:
                     nodes=config["nodes"],
                     edges=config["edges"],
                     variables=config["variables"],
+                    environment_variables=config.get("environment_variables", []),
                     features=config.get("features", {}),
                     workflow_type=config.get("workflow_type", "workflow")
                 )

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -12,6 +12,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+from app.core.workflow.utils.secret_masker import mask_secrets
 from app.core.workflow.triggers import (
     build_schedule_now_payload,
     get_trigger_type,
@@ -73,6 +74,7 @@ class WorkflowService:
             nodes=normalized_nodes,
             edges=cfg.get("edges", []),
             variables=cfg.get("variables", []),
+            environment_variables=cfg.get("environment_variables", []),
             execution_config=cfg.get("execution_config", {}),
             triggers=cfg.get("triggers", []),
             features=cfg.get("features", {}),
@@ -107,6 +109,7 @@ class WorkflowService:
         nodes: list[dict[str, Any]] | None,
         edges: list[dict[str, Any]] | None,
         variables: list[dict[str, Any]] | None,
+        environment_variables: list[dict[str, Any]] | None,
         execution_config: dict[str, Any] | None,
         features: dict[str, Any] | None,
         triggers: list[dict[str, Any]] | None,
@@ -118,6 +121,7 @@ class WorkflowService:
             "nodes": normalized_nodes,
             "edges": edges or [],
             "variables": variables or [],
+            "environment_variables": environment_variables or [],
             "execution_config": execution_config or {},
             "features": features or {},
             "triggers": normalized_triggers,
@@ -574,6 +578,7 @@ class WorkflowService:
             nodes: list[dict[str, Any]],
             edges: list[dict[str, Any]],
             variables: list[dict[str, Any]] | None = None,
+            environment_variables: list[dict[str, Any]] | None = None,
             execution_config: dict[str, Any] | None = None,
             features: dict[str, Any] | None = None,
             triggers: list[dict[str, Any]] | None = None,
@@ -603,6 +608,7 @@ class WorkflowService:
             nodes=nodes,
             edges=edges,
             variables=variables,
+            environment_variables=environment_variables,
             execution_config=execution_config,
             features=features,
             triggers=triggers,
@@ -627,6 +633,7 @@ class WorkflowService:
             nodes=normalized_nodes,
             edges=edges,
             variables=variables,
+            environment_variables=environment_variables,
             execution_config=execution_config,
             features=features,
             triggers=normalized_triggers,
@@ -653,6 +660,7 @@ class WorkflowService:
             nodes: list[dict[str, Any]] | None = None,
             edges: list[dict[str, Any]] | None = None,
             variables: list[dict[str, Any]] | None = None,
+            environment_variables: list[dict[str, Any]] | None = None,
             execution_config: dict[str, Any] | None = None,
             features: dict[str, Any] | None = None,
             triggers: list[dict[str, Any]] | None = None,
@@ -691,6 +699,7 @@ class WorkflowService:
             nodes=nodes if nodes is not None else config.nodes,
             edges=edges if edges is not None else config.edges,
             variables=variables if variables is not None else config.variables,
+            environment_variables=environment_variables if environment_variables is not None else config.environment_variables,
             execution_config=execution_config if execution_config is not None else config.execution_config,
             features=features if features is not None else config.features,
             triggers=triggers if triggers is not None else config.triggers,
@@ -699,6 +708,7 @@ class WorkflowService:
         updated_nodes = config_dict["nodes"]
         updated_edges = config_dict["edges"]
         updated_variables = config_dict["variables"]
+        updated_environment_variables = config_dict["environment_variables"]
         updated_execution_config = config_dict["execution_config"]
         updated_features = config_dict["features"]
         updated_triggers = config_dict["triggers"]
@@ -720,6 +730,7 @@ class WorkflowService:
             nodes=updated_nodes,
             edges=updated_edges,
             variables=updated_variables,
+            environment_variables=updated_environment_variables,
             execution_config=updated_execution_config,
             features=updated_features,
             triggers=updated_triggers,
@@ -792,6 +803,7 @@ class WorkflowService:
             nodes=config.nodes,
             edges=config.edges,
             variables=config.variables,
+            environment_variables=config.environment_variables,
             execution_config=config.execution_config,
             features=config.features,
             triggers=config.triggers,
@@ -834,6 +846,7 @@ class WorkflowService:
             nodes=config.nodes,
             edges=config.edges,
             variables=config.variables,
+            environment_variables=config.environment_variables,
             execution_config=config.execution_config,
             features=config.features,
             triggers=config.triggers,
@@ -912,6 +925,12 @@ class WorkflowService:
         if isinstance(value, list):
             return [WorkflowService._serialize_execution_value(item) for item in value]
         return value
+
+    @staticmethod
+    def _mask_runtime_secrets(payload: dict[str, Any], variable_pool) -> dict[str, Any]:
+        if not variable_pool:
+            return payload
+        return mask_secrets(payload, variable_pool.get_secret_values())
 
     def get_execution_detail(self, execution_id: str) -> dict[str, Any] | None:
         execution = self.get_execution(execution_id)
@@ -1657,6 +1676,7 @@ class WorkflowService:
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables,
+            "environment_variables": config.environment_variables,
             "execution_config": config.execution_config,
             "features": feature_configs
         }
@@ -2118,6 +2138,7 @@ class WorkflowService:
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables,
+            "environment_variables": config.environment_variables,
             "execution_config": config.execution_config,
             "features": feature_configs
         }
@@ -2375,6 +2396,7 @@ class WorkflowService:
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables or [],
+            "environment_variables": config.environment_variables or [],
             "execution_config": config.execution_config or {},
             "features": config.features or {},
         }
@@ -2450,7 +2472,7 @@ class WorkflowService:
         try:
             result = await node.execute(state, variable_pool)
             elapsed = (time.time() - start_time) * 1000
-            return {
+            payload = {
                 "status": "completed",
                 "node_id": node_id,
                 "node_type": node_config.get("type"),
@@ -2461,10 +2483,11 @@ class WorkflowService:
                 "elapsed_time": elapsed,
                 "error": None,
             }
+            return self._mask_runtime_secrets(payload, variable_pool)
         except Exception as e:
             elapsed = (time.time() - start_time) * 1000
             logger.error(f"单节点执行失败: node_id={node_id}, error={e}", exc_info=True)
-            return {
+            payload = {
                 "status": "failed",
                 "node_id": node_id,
                 "node_type": node_config.get("type"),
@@ -2474,6 +2497,7 @@ class WorkflowService:
                 "elapsed_time": elapsed,
                 "error": str(e),
             }
+            return self._mask_runtime_secrets(payload, variable_pool)
 
     async def run_single_node_stream(
             self,
@@ -2505,10 +2529,13 @@ class WorkflowService:
                 else:
                     chunk = item.get("chunk", "")
                     if chunk:
-                        yield {"event": "node_chunk", "data": {"node_id": node_id, "chunk": chunk}}
+                        yield self._mask_runtime_secrets(
+                            {"event": "node_chunk", "data": {"node_id": node_id, "chunk": chunk}},
+                            variable_pool
+                        )
 
             elapsed = (time.time() - start_time) * 1000
-            yield {
+            yield self._mask_runtime_secrets({
                 "event": "node_end",
                 "data": {
                     "node_id": node_id,
@@ -2521,11 +2548,11 @@ class WorkflowService:
                     "elapsed_time": elapsed,
                     "error": None,
                 }
-            }
+            }, variable_pool)
         except Exception as e:
             elapsed = (time.time() - start_time) * 1000
             logger.error(f"单节点流式执行失败: node_id={node_id}, error={e}", exc_info=True)
-            yield {
+            yield self._mask_runtime_secrets({
                 "event": "node_error",
                 "data": {
                     "node_id": node_id,
@@ -2534,7 +2561,7 @@ class WorkflowService:
                     "elapsed_time": elapsed,
                     "error": str(e),
                 }
-            }
+            }, variable_pool)
 
     @staticmethod
     def get_start_node_variables(config: dict) -> list:

--- a/api/app/utils/app_config_utils.py
+++ b/api/app/utils/app_config_utils.py
@@ -153,6 +153,7 @@ def workflow_config_4_app_release(release: AppRelease) -> WorkflowConfig:
         nodes=config_dict.get("nodes", []),
         edges=config_dict.get("edges", []),
         variables=config_dict.get("variables", []),
+        environment_variables=config_dict.get("environment_variables", []),
         execution_config=config_dict.get("execution_config", {}),
         triggers=config_dict.get("triggers", []),
         features=config_dict.get("features", {})
@@ -280,6 +281,7 @@ def dict_to_workflow_config(config_dict: Dict[str, Any], app_id: Optional[uuid.U
         nodes=config_dict.get("nodes", []),
         edges=config_dict.get("edges", []),
         variables=config_dict.get("variables", []),
+        environment_variables=config_dict.get("environment_variables", []),
         execution_config=config_dict.get("execution_config", {}),
         triggers=config_dict.get("triggers", []),
         is_active=config_dict.get("is_active", True),


### PR DESCRIPTION
add secret masking for workflow stream outputs and environment variables support

## Summary by Sourcery

添加一等公民的工作流环境变量，并将其贯穿于校验、存储、导入/导出、适配器和执行流程中，包括在表达式/模板求值和默认配置中的支持，同时在运行时强制其为只读，并禁止在纯工作流中使用会话变量。

New Features:
- 引入工作流级环境变量定义，支持 schema、仓库持久化，以及在创建、更新、复制、导入、导出和默认工作流配置中的 API 接入。
- 将环境变量以专用只读 `env` 命名空间的形式暴露在变量池中，用于模板、表达式、路由条件和节点执行，并包含对 Dify 和 MemoryBear 格式的适配器支持。

Bug Fixes:
- 阻止纯工作流配置使用会话变量，提示用户改用起始节点输入或环境变量。

Enhancements:
- 增加对环境变量的校验，包括命名规则、字符串/数字/密钥类型的约束、重复检查以及发布时的必填检查。
- 引入集中式密钥脱敏工具，并将其集成到工作流流式输出、节点执行响应、调试输出和最终结果中，避免在运行时泄露密钥值。
- 将环境变量排除在节点输出列表之外，并阻止赋值节点修改 env 变量，以强制其不可变性。
- 在导出或富化工作流配置时对密钥类型的环境变量进行脱敏处理，使存储的定义使用占位符而非原始密钥值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add first-class workflow environment variables and wire them through validation, storage, import/export, adapters, and execution, including support in expression/template evaluation and default configs, while enforcing them as read-only at runtime and disallowing conversation variables in pure workflows.

New Features:
- Introduce workflow-level environment variable definitions with schema support, repository persistence, and API wiring for create, update, copy, import, export, and default workflow configs.
- Expose environment variables as a dedicated read-only `env` namespace in the variable pool for use in templates, expressions, routing conditions, and node execution, including adapter support for Dify and MemoryBear formats.

Bug Fixes:
- Prevent pure workflow configurations from using conversation variables, guiding users to start-node inputs or environment variables instead.

Enhancements:
- Add validation for environment variables, including naming rules, type constraints for string/number/secret values, duplication checks, and publish-time required checks.
- Introduce centralized secret masking utilities and integrate them into workflow streaming, node execution responses, debug outputs, and final results to avoid leaking runtime secret values.
- Exclude environment variables from node outputs listings and prevent assignment nodes from mutating env variables, enforcing their immutability.
- Mask secret-type environment variables when exporting or enriching workflow configs so that stored definitions use placeholders instead of raw secrets.

</details>