### PR TITLE
fix(rag): add missing parent_id parameter to v1 import_qa endpoint

### DIFF
--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -257,6 +257,7 @@ async def import_qa_new_doc(
     request: Request,
     file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
     api_key_auth: ApiKeyAuth = None,
+    parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
     db: Session = Depends(get_db),
     storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
@@ -271,6 +272,7 @@ async def import_qa_new_doc(
         kb_id=kb_id,
         file=file,
         db=db,
+        parent_id=parent_id,
         current_user=current_user,
         storage_service=storage_service,
     )


### PR DESCRIPTION
## Summary

The v1 API endpoint `POST /api/v1/chunks/{kb_id}/import_qa` was missing the `parent_id` query parameter, causing all QA imported files to fall into the knowledge base root directory. Users could not specify a target folder for the imported document.

## Changes

- Added `parent_id: Optional[uuid.UUID] = Query(None)` parameter to `rag_api_chunk_controller.import_qa_new_doc`
- Passed `parent_id` through to `chunk_controller.import_qa_new_doc`

## Test Plan
- [ ] Call v1 import_qa with parent_id, verify file lands in correct folder
- [ ] Call v1 import_qa without parent_id, verify file falls back to kb root

## 由 Sourcery 提供的摘要

新功能：
- 允许 v1 QA 文档导入通过可选的 `parent_id` 参数指定目标父文件夹。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow v1 QA document imports to target a specific parent folder via an optional parent_id parameter.

</details>