### PR TITLE
feat(web): environment_variables; node last run result

### DIFF
--- a/web/src/api/application.ts
+++ b/web/src/api/application.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 13:59:45 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-29 17:54:08
+ * @Last Modified time: 2026-06-03 20:01:14
  */
 import { request } from '@/utils/request'
 import type { ApplicationModalData } from '@/views/ApplicationManagement/types'
@@ -301,4 +301,8 @@ export const workflowPublishAsTool = (app_id: string, data: WorkflowToolForm) =>
 // Get workflow execution details and variable snapshot
 export const getWorkflowExecutionDetail = (app_id: string, execution_id: string) => {
   return request.get(`/apps/${app_id}/workflow/executions/${execution_id}`)
+}
+// Get workflow node last run details
+export const getWorkflowNodeLastRunDetail = (app_id: string, node_id: string) => {
+  return request.get(`/apps/${app_id}/workflow/nodes/${node_id}/last_run`)
 }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2878,6 +2878,12 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       jumpToNode: 'Jump to Node',
       errorBranch: 'Error Branch',
       systemVariable: 'System Variables',
+      addEnvVariable: 'Environment Variable',
+      editEnvVariable: 'Edit Environment Variable',
+      'env-variable': {
+        value: 'Value',
+        secret: 'Secret',
+      },
     },
     emotionEngine: {
       emotionEngineConfig: 'Emotion Engine Configuration',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2844,6 +2844,12 @@ export const zh = {
       jumpToNode: '跳转到节点',
       errorBranch: '异常时',
       systemVariable: '系统变量',
+      addEnvVariable: '环境变量',
+      editEnvVariable: '编辑环境变量',
+      'env-variable': {
+        value: '值',
+        secret: 'Secret',
+      },
     },
     emotionEngine: {
       emotionEngineConfig: '情感引擎配置',

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-29 17:10:01
+ * @Last Modified time: 2026-06-03 17:52:34
  */
 import { type FC, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -168,6 +168,12 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
     workflowRef?.current?.addVariable()
   }
   /**
+   * Add environment variable to workflow
+   */
+  const addEnvVariable = () => {
+    workflowRef?.current?.addEnvVariable()
+  }
+  /**
    * Format dropdown menu items
    */
   const formatMenuItems = useMemo(() => {
@@ -244,6 +250,12 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
                 ></div>
               </Popover>
             }
+              <Popover content={t('workflow.addEnvVariable')} classNames={{ body: 'rb:py-0.5! rb:px-1! rb:rounded-[6px]! rb:text-[12px]!' }}>
+                <div
+                  className="rb:cursor-pointer rb:size-7.5 rb:border rb:border-[#EBEBEB] rb:hover:bg-[#F6F6F6] rb:rounded-[10px] rb:bg-[url('@/assets/images/workflow/variable.svg')] rb:bg-size-[16px_16px] rb:bg-center rb:bg-no-repeat"
+                  onClick={addEnvVariable}
+                ></div>
+              </Popover>
             <Popover content={t('workflow.run')} classNames={{ body: 'rb:py-0.5! rb:px-1! rb:rounded-[6px]! rb:text-[12px]!' }}>
               <div
                 className="rb:cursor-pointer rb:size-7.5 rb:border rb:border-[#EBEBEB] rb:hover:bg-[#F6F6F6] rb:rounded-[10px] rb:bg-[url('@/assets/images/workflow/run.svg')] rb:bg-size-[16px_16px] rb:bg-center rb:bg-no-repeat"

--- a/web/src/views/ApplicationConfig/types.ts
+++ b/web/src/views/ApplicationConfig/types.ts
@@ -2,13 +2,13 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:49 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-29 17:34:11
+ * @Last Modified time: 2026-06-03 17:51:18
  */
 import type { KnowledgeConfig } from './components/Knowledge/types'
 import type { Variable } from './components/VariableList/types'
 import type { ToolOption } from './components/ToolList/types'
 import type { ChatItem } from '@/components/Chat/types'
-import type { ChatVariable, GraphRef, WorkflowConfig } from '@/views/Workflow/types';
+import type { ChatVariable, GraphRef, WorkflowConfig, EnvVariable } from '@/views/Workflow/types';
 import type { ApiKey } from '@/views/ApiKeyManagement/types'
 import type { SkillConfigForm } from './components/Skill/types'
 import type { Capability } from '@/views/ModelManagement/types'
@@ -169,6 +169,8 @@ export interface WorkflowRef {
   /** Add variable */
   addVariable: () => void;
   chatVariables: ChatVariable[];
+  envVariables: EnvVariable[];
+  addEnvVariable: () => void;
   config: WorkflowConfig | null;
   features: WorkflowConfig['features'];
   handleFeaturesConfig?: () => void;

--- a/web/src/views/Workflow/components/AddEnvVariable/EnvVariableModal.tsx
+++ b/web/src/views/Workflow/components/AddEnvVariable/EnvVariableModal.tsx
@@ -1,0 +1,132 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-06-03 14:00:00 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-06-03 20:55:18
+ */
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Form, Input, Select, InputNumber } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import type { EnvVariableModalRef } from './types'
+import type { EnvVariable } from '../../types';
+import RbModal from '@/components/RbModal'
+
+const FormItem = Form.Item;
+
+interface EnvVariableModalProps {
+  refresh: (value: EnvVariable, editIndex?: number) => void;
+  variables?: EnvVariable[];
+}
+
+const EnvVariableModal = forwardRef<EnvVariableModalRef, EnvVariableModalProps>(({
+  refresh,
+  variables
+}, ref) => {
+  const { t } = useTranslation();
+
+  const [visible, setVisible] = useState(false);
+  const [form] = Form.useForm<EnvVariable>();
+  const [loading, setLoading] = useState(false);
+  const [editIndex, setEditIndex] = useState<number | undefined>(undefined);
+  const valueType = Form.useWatch('value_type', form);
+
+  const handleClose = () => {
+    setVisible(false);
+    form.resetFields();
+    setLoading(false);
+    setEditIndex(undefined);
+  };
+
+  const handleOpen = (variable?: EnvVariable, index?: number) => {
+    setVisible(true);
+    if (variable) {
+      form.setFieldsValue({
+        ...variable,
+        value: '********************'
+      });
+      setEditIndex(index);
+    } else {
+      form.resetFields();
+      setEditIndex(undefined);
+    }
+  };
+
+  const handleSave = () => {
+    form.validateFields().then((values) => {
+      refresh({ ...values, value_type: 'secret' as const }, editIndex);
+      handleClose();
+    });
+  };
+
+  useImperativeHandle(ref, () => ({ handleOpen }));
+
+  return (
+    <RbModal
+      title={editIndex !== undefined ? t('workflow.editEnvVariable') : t('workflow.addEnvVariable')}
+      open={visible}
+      onCancel={handleClose}
+      okText={t('common.save')}
+      onOk={handleSave}
+      confirmLoading={loading}
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        scrollToFirstError={{ behavior: 'instant', block: 'end', focus: true }}
+      >
+        <FormItem
+          label={t('workflow.config.parameter-extractor.type')}
+          name="value_type"
+          initialValue="secret"
+        >
+          <Select
+            options={['secret', 'string', 'number'].map((type) => ({
+              label: <span style={{ textTransform: 'capitalize' }}>{type}</span>,
+              value: type,
+            }))}
+          />
+        </FormItem>
+        <FormItem
+          name="name"
+          label={t('workflow.config.parameter-extractor.name')}
+          rules={[
+            { required: true, message: t('common.pleaseEnter') },
+            { pattern: /^[a-zA-Z_][a-zA-Z0-9_]*$/, message: t('workflow.config.parameter-extractor.invalidParamName') },
+            {
+              validator: (_, value) => {
+                const duplicate = variables?.some((v, i) => v.name === value && i !== editIndex);
+                return duplicate ? Promise.reject(t('workflow.config.duplicateName')) : Promise.resolve();
+              }
+            },
+          ]}
+        >
+          <Input placeholder={t('common.enter')} />
+        </FormItem>
+
+        <FormItem
+          name="required"
+          hidden={true}
+          initialValue={true}
+        />
+
+        <FormItem
+          name="value"
+          label={t('workflow.env-variable.value')}
+          rules={[{ required: true, message: t('common.pleaseEnter') }]}
+        >
+          {valueType === 'number'
+            ? <InputNumber placeholder={t('common.enter')} className="rb:w-full!" />
+            : <Input placeholder={t('common.enter')} />
+          }
+        </FormItem>
+
+        <FormItem name="description" label={t('workflow.config.parameter-extractor.desc')}>
+          <Input.TextArea placeholder={t('common.enter')} />
+        </FormItem>
+      </Form>
+    </RbModal>
+  );
+});
+
+export default EnvVariableModal;

--- a/web/src/views/Workflow/components/AddEnvVariable/index.tsx
+++ b/web/src/views/Workflow/components/AddEnvVariable/index.tsx
@@ -1,0 +1,121 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-06-03 19:53:01 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-06-03 19:53:01 
+ */
+import { useState, useImperativeHandle, forwardRef, useRef } from 'react';
+import { Button, List, Flex } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import type { EnvVariable, AddEnvVariableRef } from '../../types';
+import type { EnvVariableModalRef } from './types'
+import RbDrawer from '@/components/RbDrawer';
+import Empty from '@/components/Empty';
+import EnvVariableModal from './EnvVariableModal';
+
+interface AddEnvVariableProps {
+  variables?: EnvVariable[];
+  onChange?: (variables: EnvVariable[]) => void;
+  disabled?: boolean;
+  maxVariables?: number;
+}
+const AddEnvVariable = forwardRef<AddEnvVariableRef, AddEnvVariableProps>(({
+  variables = [],
+  onChange,
+}, ref) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const envVariableRef = useRef<EnvVariableModalRef>(null);
+
+  const handleAddVariable = () => {
+    envVariableRef.current?.handleOpen()
+  };
+
+  const handleEdit = (index: number) => {
+    envVariableRef.current?.handleOpen(variables[index], index)
+  }
+  const handleDelete = (index: number) => {
+    const list = [...variables]
+    list.splice(index, 1)
+    onChange && onChange(list)
+  }
+
+  const handleOpen = () => {
+    setOpen(true)
+  }
+  const handleSave = (value: EnvVariable, index?: number) => {
+    const list = [...variables]
+    if (typeof index === 'number' && index > -1) {
+      list[index] = value
+    } else {
+      list.push(value)
+    }
+    onChange && onChange(list)
+  }
+  useImperativeHandle(ref, () => ({
+      handleOpen,
+  }));
+
+  return (
+    <RbDrawer
+      title={t('workflow.addEnvVariable')}
+      open={open}
+      onClose={() => setOpen(false)}
+      width={480}
+    >
+      <div>
+        <Button
+          type="primary"
+          className="rb:mb-3"
+          onClick={handleAddVariable}
+        >
+          + {t('workflow.addEnvVariable')}
+        </Button>
+
+        {variables.length === 0
+          ? <Empty size={88} />
+          :
+          <List
+            grid={{ gutter: 12, column: 1 }}
+            dataSource={variables}
+            renderItem={(item, index) => (
+              <List.Item>
+                <div key={index} className="rb:relative rb:p-[12px_16px] rb:bg-[#FBFDFF] rb:cursor-pointer rb-border rb:rounded-lg">
+                  <Flex align="center" justify="space-between" className="rb:leading-4 rb:max-w-[calc(100%-60px)]">
+                    <div className="rb:flex-1 rb:font-medium rb:whitespace-break-spaces rb:wrap-break-word rb:line-clamp-1">{item.name}</div>
+                    <div className="rb:text-[12px] rb:text-[#5B6167] rb:font-regular">
+                      {item.required && <span className="rb:text-[#FF4D4F]">*</span>}
+                      ({t('workflow.env-variable.secret')})
+                    </div>
+                  </Flex>
+                  <div className="rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:wrap-break-word rb:line-clamp-1 rb:max-w-[calc(100%-60px)]">
+                    ********************
+                  </div>
+                  <Flex gap={12} className="rb:absolute rb:right-4 rb:top-[50%] rb:transform-[translateY(-50%)] rb:bg-white">
+                    <div
+                      className="rb:size-5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/editBorder.svg')] rb:hover:bg-[url('@/assets/images/editBg.svg')]"
+                      onClick={() => handleEdit(index)}
+                    ></div>
+                    <div
+                      className="rb:size-5 rb:cursor-pointer rb:bg-cover  rb:bg-[url('@/assets/images/deleteBorder.svg')] rb:hover:bg-[url('@/assets/images/deleteBg.svg')]"
+                      onClick={() => handleDelete(index)}
+                    ></div>
+                  </Flex>
+                </div>
+              </List.Item>
+            )}
+          />
+        }
+      </div>
+
+      <EnvVariableModal
+        ref={envVariableRef}
+        refresh={handleSave}
+        variables={variables}
+      />
+    </RbDrawer>
+  );
+});
+
+export default AddEnvVariable;

--- a/web/src/views/Workflow/components/AddEnvVariable/types.ts
+++ b/web/src/views/Workflow/components/AddEnvVariable/types.ts
@@ -1,0 +1,14 @@
+import type { EnvVariable } from '../../types';
+
+export interface AddEnvVariableProps {
+  variables?: EnvVariable[];
+  onChange?: (variables: EnvVariable[]) => void;
+  disabled?: boolean;
+  maxVariables?: number;
+}
+
+export type EnvVariableFormData = EnvVariable
+
+export interface EnvVariableModalRef {
+  handleOpen: (value?: EnvVariable, index?: number) => void;
+}

--- a/web/src/views/Workflow/components/Editor/nodes/VariableNode.tsx
+++ b/web/src/views/Workflow/components/Editor/nodes/VariableNode.tsx
@@ -50,13 +50,16 @@ const VariableComponent: React.FC<{ nodeKey: NodeKey; data: Suggestion }> = ({
       className="rb-border rb:rounded-md rb:bg-white rb:text-[10px] rb:text-[#212332] rb:h-5! rb:inline-flex rb:items-center rb:p-1 rb:mx-px rb:cursor-pointer"
       contentEditable={false}
     >
-      {!data.isContext && data.group !== 'CONVERSATION' && !data.value.includes('conv') && data.group !== 'SYSTEM' && !data.value.includes('sys')
+      {!data.isContext
+        && data.group !== 'CONVERSATION' && !data.value.includes('conv')
+        && data.group !== 'ENV' && !data.value.includes('env')
+        && data.group !== 'SYSTEM' && !data.value.includes('sys')
         ? <div className={`rb:size-3 rb:mr-1 rb:bg-cover ${data.nodeData?.icon}`} />
         : null
       }
       {!data.isContext && data.group !== 'CONVERSATION' && (
         <>
-          {!data.value.includes('conv') && !data.value.includes('sys') && <>
+          {!data.value.includes('conv') && !data.value.includes('env') && !data.value.includes('sys') && <>
             <span className="rb:wrap-break-word rb:line-clamp-1">{data.nodeData?.name}</span>
             <span style={{ color: '#DFE4ED', margin: '0 2px' }}>/</span>
           </>}

--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-28 13:48:02
+ * @Last Modified time: 2026-06-03 18:40:41
  */
 import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -74,6 +74,7 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
               const match = part.match(/^\{\{([^.]+)\.([^}]+)\}\}$/);
               const contextMatch = part.match(/^\{\{context\}\}$/);
               const conversationMatch = part.match(/^\{\{conv\.([^}]+)\}\}$/);
+              const envMatch = part.match(/^\{\{env\.([^}]+)\}\}$/);
               const systemMatch = part.match(/^\{\{sys\.([^}]+)\}\}$/);
 
               if (contextMatch) {
@@ -127,6 +128,29 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
                 }
                 if (systemSuggestion) {
                   paragraph.append($createVariableNode(systemSuggestion));
+                } else {
+                  paragraph.append($createTextNode(part));
+                }
+                return
+              }
+              if (envMatch) {
+                const [_, variableName] = envMatch;
+                const fullValue = `env.${variableName}`;
+                // First try direct match on top-level label
+                let envSuggestion = optionsRef.current.find(s =>
+                  s.group === 'ENV' && s.label === fullValue
+                );
+                // Then search children by value (e.g. env.api_key.url)
+                if (!envSuggestion) {
+                  for (const s of optionsRef.current) {
+                    if (s.group === 'ENV' && s.children) {
+                      const child = s.children.find(c => c.value === fullValue);
+                      if (child) { envSuggestion = child; break; }
+                    }
+                  }
+                }
+                if (envSuggestion) {
+                  paragraph.append($createVariableNode(envSuggestion));
                 } else {
                   paragraph.append($createTextNode(part));
                 }

--- a/web/src/views/Workflow/components/Nodes/ConditionNode.tsx
+++ b/web/src/views/Workflow/components/Nodes/ConditionNode.tsx
@@ -28,7 +28,7 @@ const ConditionNode: ReactShapeConfig['component'] = ({ node }) => {
   const data = node?.getData() || {};
   const { t } = useTranslation()
   const graphRef = useRef(node?.model?.graph)
-  const variableList = useVariableList(node ?? null, graphRef, data.chatVariables ?? [], data.appType ?? '')
+  const variableList = useVariableList(node ?? null, graphRef, data.chatVariables ?? [], data.envVariables ?? [], data.appType ?? '')
 
   const getLocaleField = (field: string, filedType: string) => {
     const key = filedType === 'boolean'

--- a/web/src/views/Workflow/components/Properties/HttpRequest/EditableTable.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/EditableTable.tsx
@@ -69,7 +69,7 @@ const EditableTable: FC<EditableTableProps> = ({
           ...vo,
           disabled: true
         })
-      } else if (vo.dataType !== 'array[file]') {
+      } else if (type !== 'file' && vo.dataType !== 'array[file]') {
         filterOptions.push(vo)
       }
     })

--- a/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:35:43 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-01 14:43:33
+ * @Last Modified time: 2026-06-03 19:07:11
  */
 import { type FC, useMemo, useRef, useState } from "react";
 import { useTranslation } from 'react-i18next'
@@ -86,7 +86,7 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
   const filterVariables = useMemo(() => {
     const filterList: Suggestion[] = []
     options.forEach(variable => {
-      if (['number', 'string'].includes(variable.dataType)) {
+      if (['number', 'string', 'secret'].includes(variable.dataType)) {
         filterList.push(variable)
       } else if (variable.dataType === 'file') {
         filterList.push({
@@ -102,7 +102,7 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
   const filterVariablesWithFile = useMemo(() => {
     const filterList: Suggestion[] = []
     options.forEach(variable => {
-      if (['number', 'string', 'file', 'array[file]'].includes(variable.dataType)) {
+      if (['number', 'string', 'file', 'array[file]', 'secret'].includes(variable.dataType)) {
         filterList.push(variable)
       }
     })
@@ -112,7 +112,7 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
   const jsonRawFilterVariables = useMemo(() => {
     const filterList: Suggestion[] = []
     options.forEach(variable => {
-      if (['number', 'string', 'array[string]', 'array[number]', 'object'].includes(variable.dataType)) {
+      if (['number', 'string', 'array[string]', 'array[number]', 'object', 'secret'].includes(variable.dataType)) {
         filterList.push(variable)
       } else if (variable.dataType === 'file') {
         filterList.push({

--- a/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
@@ -182,6 +182,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
         const childOptions = vo.children?.filter(child => child.dataType === type || (type === 'integer' && child.dataType === 'number'))
 
         if (vo.dataType === type
+          || (vo.dataType === 'secret' && type === 'string')
           || (type === 'integer' && vo.dataType === 'number')
           || (type === 'array' && vo.dataType.includes(type))
           || (type === 'object' && vo.dataType === 'object')
@@ -198,6 +199,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
           })
         }
       } else if (vo.dataType === type
+        || (vo.dataType === 'secret' && type === 'string')
         || (type === 'integer' && vo.dataType === 'number')
         || (type === 'array' && vo.dataType.includes(type))
         || (type === 'object' && vo.dataType === 'object')) {

--- a/web/src/views/Workflow/components/Properties/VariableSelect.tsx
+++ b/web/src/views/Workflow/components/Properties/VariableSelect.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:40:13 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-28 10:42:27
+ * @Last Modified time: 2026-06-03 18:52:25
  */
 import { useState, useRef, useEffect, useLayoutEffect, type FC } from 'react'
 import { createPortal } from 'react-dom'
@@ -281,9 +281,11 @@ const VariableSelect: FC<VariableSelectProps> = ({
   };
   const sep = <span className="rb:text-[#DFE4ED] rb:mx-0.5">/</span>;
   const isConversation = (parentOfSelected ?? selectedSuggestion)?.group === 'CONVERSATION' || 
-    (parentOfSelected ?? selectedSuggestion)?.group === 'SYSTEM'
+    (parentOfSelected ?? selectedSuggestion)?.group === 'SYSTEM' || 
+    (parentOfSelected ?? selectedSuggestion)?.group === 'ENV'
     || (selectedSuggestion?.group === 'CONVERSATION' && selectedSuggestion?.children?.some(c => `{{${c.value}}}` === value))
     || (selectedSuggestion?.group === 'SYSTEM' && selectedSuggestion?.children?.some(c => `{{${c.value}}}` === value))
+    || (selectedSuggestion?.group === 'ENV' && selectedSuggestion?.children?.some(c => `{{${c.value}}}` === value))
     || (selectedSuggestion ? filteredOptions.some(o => o.group === 'CONVERSATION' && o.children?.some(c => `{{${c.value}}}` === value)) : false);
   const nodeData = (parentOfSelected ?? selectedSuggestion)?.nodeData;
 

--- a/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
+++ b/web/src/views/Workflow/components/Properties/hooks/useVariableList.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-01-19 17:00:26 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-02 11:39:51
+ * @Last Modified time: 2026-06-03 18:53:06
  */
 /**
  * useVariableList Hook
@@ -17,7 +17,7 @@
 import { useMemo, useEffect, useState } from 'react';
 import { Graph, Node } from '@antv/x6';
 import type { Suggestion } from '../../Editor/plugin/AutocompletePlugin';
-import type { ChatVariable } from '../../../types';
+import type { ChatVariable, EnvVariable } from '../../../types';
 
 export const sysVariable = [
   { name: "message", type: "string",
@@ -411,12 +411,14 @@ export const getChildNodeVariables = (
  * @param {Node | null | undefined} selectedNode - Currently selected node
  * @param {React.MutableRefObject<Graph | undefined>} graphRef - Graph reference
  * @param {ChatVariable[]} chatVariables - List of chat variables
+ * @param {EnvVariable[]} envVariables - List of environment variables
  * @returns {Suggestion[]} List of available variables
  */
 export const useVariableList = (
   selectedNode: Node | null | undefined,
   graphRef: React.MutableRefObject<Graph | undefined>,
   chatVariables: ChatVariable[],
+  envVariables: EnvVariable[],
   appType?: string
 ) => {
   const [trigger, setTrigger] = useState(0);
@@ -466,11 +468,12 @@ export const useVariableList = (
     // Add system variables
     sysVariable.forEach((v: any) => {
         if (v?.name && !(appType === 'pure_workflow' && v.name === 'message')) {
-          addVariable(list, keys, `sys_${v.name}`, `sys.${v.name}`, v.type, `sys.${v.name}`, { type: 'SYSTEM', name: 'SYSTEM', icon: '' }, { group: 'SYSTEM' });
+          addVariable(list, keys, `sys_${v.name}`, `sys.${v.name}`, v.type, `sys.${v.name}`, { type: 'SYSTEM', name: 'SYSTEM', icon: '', id: 'SYSTEM' }, { group: 'SYSTEM' });
         }
       });
     // Add chat variables
-    chatVariables?.forEach(v => addVariable(list, keys, `CONVERSATION_${v.name}`, v.name, v.type, `conv.${v.name}`, { type: 'CONVERSATION', name: 'CONVERSATION', icon: '' }, { group: 'CONVERSATION' }, v.defaultValue ?? v.default));
+    chatVariables?.forEach(v => addVariable(list, keys, `CONVERSATION_${v.name}`, v.name, v.type, `conv.${v.name}`, { type: 'CONVERSATION', name: 'CONVERSATION', icon: '', id: 'ENV' }, { group: 'CONVERSATION' }, v.defaultValue ?? v.default));
+    envVariables?.forEach(v => addVariable(list, keys, `ENV_${v.name}`, v.name, v.value_type, `env.${v.name}`, { type: 'ENV', name: 'ENV', icon: '', id: 'ENV' }, { group: 'ENV' }));
 
     // Process each relevant node: deferred types last (they depend on prior variables)
     const deferredIds: string[] = [];
@@ -508,7 +511,7 @@ export const useVariableList = (
     }
 
     return list;
-  }, [selectedNode, graphRef, trigger, chatVariables, appType]);
+  }, [selectedNode, graphRef, trigger, chatVariables, envVariables, appType]);
 
   // Refresh variable list when graph changes
   useEffect(() => {

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -2,15 +2,15 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:39:59 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-02 17:08:35
+ * @Last Modified time: 2026-06-03 20:16:01
  */
 import { type FC, useEffect, useState, useMemo } from "react";
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { Graph, Node } from '@antv/x6';
-import { Form, Input, Select, InputNumber, Switch, Flex, Space, Dropdown, type MenuProps, Button, App, Popover } from 'antd';
+import { Form, Input, Select, InputNumber, Switch, Flex, Space, Dropdown, type MenuProps, Button, App, Popover, Tabs } from 'antd';
 
-import type { NodeConfig, ChatVariable } from '../../types'
+import type { NodeConfig, ChatVariable, EnvVariable } from '../../types'
 import CustomSelect from "@/components/CustomSelect";
 import MessageEditor from './MessageEditor'
 import Knowledge from './Knowledge/Knowledge';
@@ -50,6 +50,7 @@ import NextStep from './NextStep'
 import RunResultDisplay, { type RunResult } from '../SingleNodeRun/RunResultDisplay'
 import type { Application } from '@/views/ApplicationManagement/types'
 import Trigger from './Trigger'
+import { getWorkflowNodeLastRunDetail } from '@/api/application'
 
 /**
  * Props for Properties component
@@ -73,6 +74,8 @@ interface PropertiesProps {
   appId?: string;
   /** Chat variables */
   chatVariables: ChatVariable[];
+  /** Environment variables */
+  envVariables: EnvVariable[];
   /** Function to save workflow configuration */
   handleSave: (flag?: boolean) => Promise<unknown>;
   /** Handler for node click */
@@ -90,6 +93,7 @@ const Properties: FC<PropertiesProps> = ({
   selectedNode,
   graphRef,
   chatVariables,
+  envVariables,
   blankClick,
   config,
   appId,
@@ -102,7 +106,7 @@ const Properties: FC<PropertiesProps> = ({
   const [form] = Form.useForm<NodeConfig>();
   const [configs, setConfigs] = useState<Record<string, NodeConfig>>({} as Record<string, NodeConfig>)
   const values = Form.useWatch([], form);
-  const variableList = useVariableList(selectedNode, graphRef, chatVariables, appType)
+  const variableList = useVariableList(selectedNode, graphRef, chatVariables, envVariables, appType)
   const data = selectedNode.getData() || {}
   console.log('data', data)
 
@@ -459,6 +463,10 @@ const Properties: FC<PropertiesProps> = ({
       return filteredList
     }
 
+    if (nodeType === 'var-aggregator' || nodeType === 'assigner' || nodeType === 'jinja-render') {
+      return variableList.filter(variable => variable.dataType !== 'secret');
+    }
+
     // For all other node types, add parent iteration variables if applicable
     let baseList = variableList;
     return addParentIterationVars(baseList);
@@ -598,15 +606,33 @@ const Properties: FC<PropertiesProps> = ({
   const [nameHover, setNameHover] = useState(false)
   const [activeKey, setActiveKey] = useState('setting')
 
-  const [result, setResult] = useState<RunResult | null>(null)
+  const [result, setResult] = useState<RunResult>({} as RunResult)
   const [resultLoading, setResultLoading] = useState(false)
+
+  const getNodeLastRun = () => {
+    if (!appId || !data?.id) return
+    setResultLoading(true)
+    getWorkflowNodeLastRunDetail(appId, data?.id || '')
+      .then(res => {
+        setResult(res as RunResult)
+      })
+      .finally(() => {
+        setResultLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    if (!isRun) {
+      getNodeLastRun()
+    }
+  }, [isRun])
 
   useEffect(() => {
     if (activeKey === 'setting') {
-      setResult(null)
+      setResult({} as RunResult)
       setResultLoading(false)
     } else {
-      // Run result display
+      getNodeLastRun()
     }
   }, [activeKey])
   return (
@@ -657,7 +683,7 @@ const Properties: FC<PropertiesProps> = ({
           className="rb:h-full! rb:hover:shadow-none!"
           bodyClassName={clsx('rb:overflow-hidden! rb:h-[calc(100%-48px)]! rb:px-0! rb:pt-0! rb:pb-3!')}
         >
-          {/* <Tabs
+          <Tabs
             items={[
               { key: 'setting', label: t('workflow.config.setting') },
               { key: 'lastRun', label: t('workflow.config.lastRun') },
@@ -666,9 +692,8 @@ const Properties: FC<PropertiesProps> = ({
             onChange={setActiveKey}
             size="small"
             className={styles.tabs}
-          /> */}
-          {/* <div className="rb:h-[calc(100%-52px)] rb:overflow-y-auto!"> */}
-          <div className="rb:h-full rb:overflow-y-auto!">
+          />
+          <div className="rb:h-[calc(100%-52px)] rb:overflow-y-auto!">
             {activeKey === 'setting' &&
               <>
                 <div className="rb:px-3!">
@@ -967,7 +992,7 @@ const Properties: FC<PropertiesProps> = ({
                                   key={key}
                                   label={t(`workflow.config.${selectedNode?.data?.type}.${key}`)}
                                   name={key}
-                                  options={variableList}
+                                  options={getFilteredVariableList(selectedNode?.data?.type, key)}
                                   isNeedType={config.isNeedType as boolean}
                                 />
                               }
@@ -1160,11 +1185,13 @@ const Properties: FC<PropertiesProps> = ({
               </>
             }
             {activeKey === 'lastRun' &&
-              <RunResultDisplay
-                result={result}
-                loading={resultLoading}
-                nodeData={data}
-              />
+              <div className="rb:px-3!">
+                <RunResultDisplay
+                  result={result}
+                  loading={resultLoading}
+                  nodeData={data}
+                />
+              </div>
             }
           </div>
         </RbCard>

--- a/web/src/views/Workflow/components/SingleNodeRun/RunResultDisplay.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/RunResultDisplay.tsx
@@ -45,7 +45,7 @@ const RunResultDisplay: FC<RunResultDisplayProps> = ({ result, loading, nodeData
   if (!result) return null
 
   return (
-    <>
+    <Flex vertical gap={12}>
       <div className="rb:rounded-lg rb:border rb:border-[#E8E8E8] rb:p-3 rb:bg-[#F6FFF4]">
         <Flex justify="space-between" align="start">
           <Flex vertical align="start" gap={2}>
@@ -111,7 +111,7 @@ const RunResultDisplay: FC<RunResultDisplayProps> = ({ result, loading, nodeData
           </Flex>
         </RbAlert>
       )}
-    </>
+    </Flex>
   )
 }
 

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-29 18:50:18
+ * @Last Modified time: 2026-06-03 18:10:34
  */
 import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, History, Selection,
   // Scroller,
@@ -21,7 +21,7 @@ import { getWorkflowConfig, saveWorkflowConfig } from '@/api/application';
 import { useUser } from '@/store/user';
 import type { FeaturesConfigForm } from '@/views/ApplicationConfig/types';
 import { conditionNodeHeight, conditionNodeItemHeight, conditionNodePortItemArgsY, defaultAbsolutePortGroups, defaultPortItems, edgeAttrs, edgeHoverTool, edge_color, edge_selected_color, edge_width, graphNodeLibrary, nodeLibrary, nodeRegisterLibrary, nodeWidth, notesConfig, portAttrs, portItemArgsY, portMarkup, portTextAttrs, unknownNode } from '../constant';
-import type { ChatVariable, HistoryRecord, NodeProperties, WorkflowConfig } from '../types';
+import type { ChatVariable, EnvVariable, HistoryRecord, NodeProperties, WorkflowConfig } from '../types';
 import { calcConditionNodeTotalHeight, getConditionNodeCasePortY } from '../utils';
 import { useWorkflowStore } from '@/store/workflow';
 import type { Application } from '@/views/ApplicationManagement/types'
@@ -89,6 +89,9 @@ export interface UseWorkflowGraphReturn {
   /** Function to update chat variables */
   setChatVariables: Dispatch<SetStateAction<ChatVariable[]>>;
 
+  envVariables: EnvVariable[];
+  setEnvVariables: Dispatch<SetStateAction<EnvVariable[]>>;
+
   handleAddNotes: () => void;
   handleSaveFeaturesConfig: (value: FeaturesConfigForm) => void;
   features?: FeaturesConfigForm;
@@ -134,6 +137,7 @@ export const useWorkflowGraph = ({
   const isHandModeRef = useRef(true)
   const [config, setConfig] = useState<WorkflowConfig | null>(null);
   const [chatVariables, setChatVariables] = useState<ChatVariable[]>([])
+  const [envVariables, setEnvVariables] = useState<EnvVariable[]>([])
   const featuresRef = useRef<FeaturesConfigForm | undefined>(undefined)
   const [canUndo, setCanUndo] = useState(false)
   const [canRedo, setCanRedo] = useState(false)
@@ -146,10 +150,10 @@ export const useWorkflowGraph = ({
     graphRef.current.getNodes().forEach(node => {
       const data = node.getData()
       if (data?.type === 'if-else' || data?.type === 'question-classifier') {
-        node.setData({ ...data, chatVariables })
+        node.setData({ ...data, chatVariables, envVariables })
       }
     })
-  }, [chatVariables, graphRef.current])
+  }, [chatVariables, envVariables, graphRef.current])
 
   useEffect(() => {
     if (!appType || !graphRef.current) return
@@ -169,7 +173,7 @@ export const useWorkflowGraph = ({
     if (!id) return
     getWorkflowConfig(id)
       .then(res => {
-        const { variables, ...rest } = res as WorkflowConfig
+        const { variables, environment_variables, ...rest } = res as WorkflowConfig
         const initChatVariables = variables.map(v => {
           const { default: _, ...cleanV } = v
           return {
@@ -178,7 +182,8 @@ export const useWorkflowGraph = ({
           }
         })
         setChatVariables(initChatVariables)
-        setConfig({ ...rest, variables: initChatVariables })
+        setEnvVariables(environment_variables ?? [])
+        setConfig({ ...rest, variables: initChatVariables, environment_variables: environment_variables ?? [] })
         featuresRef.current = rest.features
         onFeaturesLoad?.(rest.features)
       })
@@ -281,7 +286,7 @@ export const useWorkflowGraph = ({
           id,
           type,
           name,
-          data: { ...node, ...nodeLibraryConfig, ...((type === 'if-else' || type === 'question-classifier') ? { chatVariables } : {}) },
+          data: { ...node, ...nodeLibraryConfig, ...((type === 'if-else' || type === 'question-classifier') ? { chatVariables, envVariables } : {}) },
           ...position,
         }
 
@@ -1668,6 +1673,7 @@ export const useWorkflowGraph = ({
             default: defaultValue ?? ''
           }
         }),
+        environment_variables: envVariables,
         nodes: nodes.map((node: Node) => {
           const data = node.getData();
           const position = node.getPosition();
@@ -2022,6 +2028,8 @@ export const useWorkflowGraph = ({
     handleSave,
     chatVariables,
     setChatVariables,
+    envVariables,
+    setEnvVariables,
     handleAddNotes,
     handleSaveFeaturesConfig,
     features: featuresRef.current,

--- a/web/src/views/Workflow/index.tsx
+++ b/web/src/views/Workflow/index.tsx
@@ -9,9 +9,10 @@ import { useWorkflowGraph } from './hooks/useWorkflowGraph';
 import type { WorkflowRef, FeaturesConfigForm, FeaturesConfigModalRef } from '@/views/ApplicationConfig/types'
 import type { Application } from '@/views/ApplicationManagement/types'
 import Chat from './components/Chat/Chat';
-import type { ChatRef, AddChatVariableRef } from './types'
+import type { ChatRef, AddChatVariableRef, AddEnvVariableRef } from './types'
 import AddChatVariable from './components/AddChatVariable';
 import FeaturesConfigModal from '@/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal'
+import AddEnvVariable from './components/AddEnvVariable';
 
 interface WorkflowProps {
   appType?: Application['type'];
@@ -21,6 +22,8 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
   const containerRef = useRef<HTMLDivElement>(null);
   const miniMapRef = useRef<HTMLDivElement>(null);
   const addChatVariableRef = useRef<AddChatVariableRef>(null)
+  const addEnvVariableRef = useRef<AddEnvVariableRef>(null)
+
   const chatRef = useRef<ChatRef>(null)
   const [collapsed, setCollapsed] = useState(false)
   // 使用自定义Hook初始化工作流图
@@ -40,6 +43,8 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
     handleSave,
     chatVariables,
     setChatVariables,
+    envVariables,
+    setEnvVariables,
     handleAddNotes,
     handleSaveFeaturesConfig,
     features,
@@ -63,6 +68,9 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
   const addVariable = () => {
     addChatVariableRef.current?.handleOpen()
   }
+  const addEnvVariable = () => {
+    addEnvVariableRef.current?.handleOpen()
+  }
 
   // Ref used to imperatively open the config modal
   const funConfigModalRef = useRef<FeaturesConfigModalRef>(null)
@@ -79,6 +87,8 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
     graphRef,
     addVariable,
     chatVariables,
+    addEnvVariable,
+    envVariables,
     config,
     features: features,
     handleFeaturesConfig,
@@ -131,6 +141,7 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
           parseEvent={parseEvent}
           config={config}
           chatVariables={chatVariables}
+          envVariables={envVariables}
           appId={config?.app_id}
           handleSave={handleSave}
           nodeClick={nodeClick}
@@ -155,6 +166,11 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
         ref={addChatVariableRef}
         variables={chatVariables}
         onChange={setChatVariables}
+      />
+      <AddEnvVariable
+        ref={addEnvVariableRef}
+        variables={envVariables}
+        onChange={setEnvVariables}
       />
       {/* Modal for editing feature settings; calls refresh on save */}
       <FeaturesConfigModal

--- a/web/src/views/Workflow/types.ts
+++ b/web/src/views/Workflow/types.ts
@@ -84,6 +84,7 @@ export interface WorkflowConfig {
     default?: string;
     defaultValue: string;
   }>,
+  environment_variables: EnvVariable[],
   execution_config: {
     max_execution_time: number;
     max_iterations: number;
@@ -114,6 +115,17 @@ export interface ChatVariable {
 }
 export interface AddChatVariableRef {
   handleOpen: (value?: ChatVariable) => void;
+}
+
+export interface EnvVariable {
+  name: string;
+  value_type: 'secret' | 'string' | 'number';
+  required: boolean;
+  value: string;
+  description: string;
+}
+export interface AddEnvVariableRef {
+  handleOpen: (value?: EnvVariable) => void;
 }
 
 export type HistoryActionType = 'add' | 'remove' | 'change' | 'undo' | 'redo' | 'batch'


### PR DESCRIPTION
## Sourcery 总结

在工作流中增加对环境变量的支持，并在属性面板中展示单节点最近一次运行的详细信息。

新功能：
- 在工作流配置中引入环境变量定义，并通过专用的抽屉和弹窗进行管理。
- 在整个工作流的变量选择器和编辑器自动补全中，将环境变量暴露为可选项，包括对 `env.*` 引用的支持。
- 在节点属性中提供 “Last Run” 标签页，用于获取并展示所选节点最近一次执行的结果。

缺陷修复：
- 调整 HTTP 请求和工具配置中的变量过滤逻辑，在合适的场景下接受密钥类型变量（secret-type variables）。
- 修复可编辑表格中的变量过滤问题，避免仅因类型为 `array[file]` 而错误排除非文件变量。

增强改进：
- 扩展变量过滤和选择逻辑，以支持密钥类型值，并在特定节点类型中隐藏密钥。
- 在工作流图的状态和条件节点中，与聊天变量一起传递环境变量。
- 改进单节点运行结果的布局，并将其集成到属性卡片的标签页中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for environment variables in workflows and expose single-node last run details in the properties panel.

New Features:
- Introduce environment variable definitions in workflow configuration and allow managing them via a dedicated drawer and modal.
- Expose environment variables as selectable options throughout workflow variable pickers and editor autocompletion, including env.* references.
- Provide a Last Run tab in node properties that fetches and displays the most recent execution result for the selected node.

Bug Fixes:
- Adjust HTTP request and tool configuration variable filters to accept secret-type variables where appropriate.
- Fix editable table variable filtering to avoid excluding non-file variables based solely on array[file] type.

Enhancements:
- Extend variable filtering and selection logic to handle secret-type values and hide secrets in certain node types.
- Propagate environment variables through workflow graph state and condition nodes alongside chat variables.
- Improve single-node run result layout and integrate it into the properties card tabs.

</details>