### PR TITLE
fix(web): workflow tool name

### DIFF
--- a/web/src/views/ApplicationConfig/components/ToolList/ToolList.tsx
+++ b/web/src/views/ApplicationConfig/components/ToolList/ToolList.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:26:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-19 21:22:53
+ * @Last Modified time: 2026-06-03 23:04:15
  */
 /**
  * Tool List Component
@@ -45,18 +45,18 @@ const ToolList: FC<{ value?: ToolOption[]; onChange?: (config: ToolOption[]) => 
 
             switch ((toolDetail as any).tool_type) {
               case 'mcp':
+              case 'workflow':
                 const mcpFilterItem = (methods as any[]).find(vo => vo.name === item.operation)
                 return {
                   ...item,
                   is_active: (toolDetail as any).is_active,
-                  label: mcpFilterItem?.description,
+                  label: (toolDetail as any).tool_type === 'workflow' ? mcpFilterItem?.name ||mcpFilterItem?.description : mcpFilterItem?.description,
                   method_id: mcpFilterItem?.method_id,
                   value: mcpFilterItem?.name,
                   description: mcpFilterItem?.description,
                   parameters: mcpFilterItem?.parameters
                 }
               case 'builtin':
-              case 'workflow':
                 if ((methods as any[]).length > 1) {
                   const builtinFilterItem = (methods as any[]).find(vo => vo.name === item.operation)
                   return {
@@ -83,7 +83,7 @@ const ToolList: FC<{ value?: ToolOption[]; onChange?: (config: ToolOption[]) => 
                 return {
                   ...item,
                   is_active: (toolDetail as any).is_active,
-                  label: customFilterItem?.name,
+                  label: (toolDetail as any).tool_type === 'workflow' ? customFilterItem?.name ||customFilterItem?.description : customFilterItem?.name,
                   method_id: customFilterItem?.method_id,
                   value: customFilterItem?.name,
                   description: customFilterItem?.description,

--- a/web/src/views/ApplicationConfig/components/ToolList/ToolModal.tsx
+++ b/web/src/views/ApplicationConfig/components/ToolList/ToolModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:26:06 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-02 18:20:03
+ * @Last Modified time: 2026-06-03 23:03:21
  */
 /**
  * Tool Selection Modal
@@ -66,7 +66,10 @@ const ToolModal = forwardRef<ToolModalRef, ToolModalProps>(({
     form.validateFields().then(() => {
       setLoading(false)
       let operation: any = undefined
-      if (selectdTools[0].value === 'mcp' || (selectdTools[0].value === 'builtin' && selectdTools[1]?.children && selectdTools[1].children.length > 1)) {
+      if (selectdTools[0].value === 'mcp'
+        || selectdTools[0].value === 'workflow'
+        || (selectdTools[0].value === 'builtin' && selectdTools[1]?.children && selectdTools[1].children.length > 1)
+      ) {
         operation = selectdTools[2].value
       } else if (selectdTools[0].value === 'custom') {
         operation = selectdTools[2].method_id

--- a/web/src/views/Skills/components/ToolList/ToolList.tsx
+++ b/web/src/views/Skills/components/ToolList/ToolList.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:26:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-02-05 10:51:22
+ * @Last Modified time: 2026-06-03 23:04:12
  */
 /**
  * Tool List Component
@@ -58,12 +58,13 @@ const ToolList: FC<ToolListProps> = ({value, onChange}) => {
             // Process based on tool type
             switch ((toolDetail as any).tool_type) {
               case 'mcp':
+              case 'workflow':
                 // MCP tools: Find method by operation name
                 const mcpFilterItem = (methods as any[]).find(vo => vo.name === item.operation)
                 return {
                   ...item,
                   is_active: (toolDetail as any).is_active,
-                  label: mcpFilterItem?.description,
+                  label: (toolDetail as any).tool_type === 'workflow' ? mcpFilterItem?.name ||mcpFilterItem?.description : mcpFilterItem?.description,
                   method_id: mcpFilterItem?.method_id,
                   value: mcpFilterItem?.name,
                   description: mcpFilterItem?.description,
@@ -71,7 +72,6 @@ const ToolList: FC<ToolListProps> = ({value, onChange}) => {
                 }
                 break
               case 'builtin':
-              case 'workflow':
                 // Builtin tools: Handle single or multiple methods
                 if ((methods as any[]).length > 1) {
                   const builtinFilterItem = (methods as any[]).find(vo => vo.name === item.operation)

--- a/web/src/views/Skills/components/ToolList/ToolModal.tsx
+++ b/web/src/views/Skills/components/ToolList/ToolModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:26:06 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-02 18:21:05
+ * @Last Modified time: 2026-06-03 23:03:09
  */
 /**
  * Tool Selection Modal
@@ -87,10 +87,12 @@ const ToolModal = forwardRef<ToolModalRef, ToolModalProps>(({
       let operation: any = undefined
 
       // Determine operation based on tool type
-      if (selectdTools[0].value === 'mcp' || 
-          (selectdTools[0].value === 'builtin' && 
-           selectdTools[1]?.children && 
-           selectdTools[1].children.length > 1)) {
+      if (selectdTools[0].value === 'mcp'
+        || selectdTools[0].value === 'workflow'
+        || (selectdTools[0].value === 'builtin' && 
+          selectdTools[1]?.children && 
+          selectdTools[1].children.length > 1)
+        ) {
         // MCP or builtin with multiple methods: use method name
         operation = selectdTools[2].value
       } else if (selectdTools[0].value === 'custom') {
@@ -102,7 +104,7 @@ const ToolModal = forwardRef<ToolModalRef, ToolModalProps>(({
       const tool = {
         ...selectdTools[2],
         // Custom tools use label, others use description
-        label: selectdTools[0].value === 'custom' ? selectdTools[2].label : selectdTools[2].description,
+        label: ['custom', 'workflow'].includes(selectdTools[0].value as string) ? selectdTools[2].label : selectdTools[2].description,
         tool_id: selectdTools[1].value as string,
         enabled: true
       }


### PR DESCRIPTION
## Summary by Sourcery

在技能和应用配置中，对工作流工具的处理方式进行统一，对工具选择和列表展示进行对齐。

Bug 修复：
- 确保在工具弹窗中选择工作流工具时，使用正确的 operation 字段。
- 修复工作流工具在工具列表中的显示标签，使其优先使用方法名（method name），若无则回退为描述（description）。

功能增强：
- 在选择和配置流程中，将工作流工具与 MCP 工具和自定义工具进行一致化处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align workflow tools handling across skills and application configuration tool selection and listing.

Bug Fixes:
- Ensure workflow tools use the correct operation field when selected in tool modals.
- Fix display labels for workflow tools in tool lists to prefer method name and fall back to description.

Enhancements:
- Treat workflow tools consistently with MCP and custom tools in selection and configuration flows.

</details>