### PR TITLE
fix(rerank)

### DIFF
--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -19,8 +19,12 @@ class RedBearRerank(BaseDocumentCompressor):
         """创建内部模型实例"""
         model_class = get_provider_rerank_class(config.provider)
         model_params = RedBearModelFactory.get_rerank_model_params(config)
-        print(model_params)
-        return model_class(**model_params)
+        instance = model_class(**model_params)
+        # DashScopeRerank.validate_environment always overwrites `model` with the
+        # default gte_rerank — restore the user-specified model name here.
+        if config.provider.lower() == ModelProvider.DASHSCOPE and hasattr(instance, "model"):
+            instance.model = config.model_name
+        return instance
 
     def compress_documents(
             self,


### PR DESCRIPTION
restore user-specified model name for DashScopeRerank

## Summary by Sourcery

Bug Fixes:
- 为 DashScopeRerank 实例恢复使用已配置的模型名称，而不是始终使用默认的重排模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the configured model name for DashScopeRerank instances instead of always using the default rerank model.

</details>