### PR TITLE
feature(momery):entity timeline display lm

### DIFF
--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -5,7 +5,7 @@
 from typing import Optional
 import datetime
 from sqlalchemy.orm import Session
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Header, Query
 
 from app.db import get_db
 from app.core.language_utils import get_language_from_header
@@ -495,6 +495,34 @@ async def memory_space_timeline_of_shared_memories(
     timeline_memories_result = await MemoryEntity.get_timeline_memories_server(model_id, language)
 
     return success(data=timeline_memories_result, msg="共同记忆时间线")
+
+
+@router.get("/memory_space/entity_event_timeline", response_model=ApiResponse)
+async def memory_space_entity_event_timeline(
+        id: str,
+        label: str,
+        page: int = Query(1, ge=1, description="页码，从1开始"),
+        pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+        current_user: User = Depends(get_current_user),
+):
+    """ExtractedEntity 实体事件时间线（分页）
+
+    Query 参数:
+        id: 实体节点的 Neo4j elementId
+        label: 节点类型，仅支持 ExtractedEntity
+        page: 页码（从 1 开始）
+        pagesize: 每页条数（1~100）
+
+    实体基本信息（entity_name / description_summary 等）与 category_stats
+    始终基于全量事件计算，分页只影响返回的 items 列表。
+    """
+    # 仅支持 ExtractedEntity 节点
+    if label != 'ExtractedEntity':
+        return fail(BizCode.INVALID_PARAMETER, "该接口仅支持 ExtractedEntity 节点", f"label={label}")
+
+    memory_entity = MemoryEntityService(id, label)
+    result = await memory_entity.get_entity_event_timeline(page=page, pagesize=pagesize)
+    return success(data=result, msg="实体事件时间线")
 
 
 @router.get("/memory_space/relationship_evolution", response_model=ApiResponse)

--- a/api/app/core/memory/models/event_category_models.py
+++ b/api/app/core/memory/models/event_category_models.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""事件分类（event_timeline category）数据模型模块
+
+反思引擎事件时间线（event_timeline）中每条事件带一个分类，分类有稳定 ID
+（category_id，机读）与中文展示名（category，人读）两个维度，一一对应，共 13 类。
+
+本模块是该分类枚举的**唯一权威来源（Single Source of Truth）**，供以下场景复用：
+- 数据层写入兜底：校验 LLM 输出的 category 是否合法（``EVENT_CATEGORY_NAME_SET``）
+- 接口层统计补全：按固定顺序补全 category_stats（``EVENT_CATEGORY_NAMES``）
+- category_id ↔ category 的相互查询（``EventCategory``）
+
+注意：LLM prompt 中的「带语义描述的分类指引」仍维护在 prompt 模板内（描述用于
+辅助 LLM 分类，不适合机械注入），但其 13 个中文分类名必须与本模块保持一致。
+
+Classes:
+    EventCategory: 事件分类枚举，成员值为 category_id，附带中文展示名
+
+Module constants:
+    EVENT_CATEGORY_NAMES: 有序的中文分类名列表（用于补全 / 排序兜底）
+    EVENT_CATEGORY_NAME_SET: 中文分类名集合（用于合法性校验）
+    EVENT_CATEGORY_IDS: 有序的 category_id 列表
+"""
+
+from enum import Enum
+from typing import List, Optional
+
+
+class EventCategory(Enum):
+    """事件分类枚举
+
+    成员值为 ``category_id``（稳定机读 ID），``label`` 为中文展示名。
+    枚举定义顺序即业务固定顺序（与 prompt 分类池顺序一致），
+    用于 category_stats 在「无数据分类」补全时的排列。
+
+    Attributes:
+        label: 中文展示名，如「教育学习」
+    """
+
+    EDUCATION_LEARNING = ("education_learning", "教育学习")
+    CAREER_WORK = ("career_work", "职业工作")
+    PROJECT_MILESTONE = ("project_milestone", "项目里程碑")
+    RESIDENCE_RELOCATION = ("residence_relocation", "居住迁移")
+    RELATIONSHIP_FAMILY = ("relationship_family", "关系家庭")
+    PET_CARE = ("pet_care", "宠物照护")
+    HEALTH_MEDICAL = ("health_medical", "健康医疗")
+    TRAVEL_VISIT = ("travel_visit", "旅行到访")
+    PURCHASE_ASSET = ("purchase_asset", "购买资产")
+    CREATION_PUBLICATION = ("creation_publication", "创作发布")
+    ACHIEVEMENT_AWARD = ("achievement_award", "成就荣誉")
+    FINANCE_LEGAL_ADMIN = ("finance_legal_admin", "财务法务行政")
+    OTHER_LIFE_EVENT = ("other_life_event", "其他生活事件")
+
+    def __init__(self, category_id: str, label: str):
+        self._value_ = category_id
+        self.label = label
+
+    @property
+    def category_id(self) -> str:
+        """稳定机读 ID（等于枚举成员值）"""
+        return self._value_
+
+    @classmethod
+    def names(cls) -> List[str]:
+        """返回有序的中文分类名列表"""
+        return [member.label for member in cls]
+
+    @classmethod
+    def ids(cls) -> List[str]:
+        """返回有序的 category_id 列表"""
+        return [member.category_id for member in cls]
+
+    @classmethod
+    def is_valid_name(cls, name: Optional[str]) -> bool:
+        """判断中文分类名是否合法"""
+        return name in EVENT_CATEGORY_NAME_SET
+
+    @classmethod
+    def name_by_id(cls, category_id: Optional[str]) -> Optional[str]:
+        """根据 category_id 查中文分类名；不存在返回 None"""
+        for member in cls:
+            if member.category_id == category_id:
+                return member.label
+        return None
+
+
+# 有序中文分类名（用于补全 / 排序兜底）
+EVENT_CATEGORY_NAMES: List[str] = EventCategory.names()
+
+# 中文分类名集合（用于合法性校验）
+EVENT_CATEGORY_NAME_SET = frozenset(EVENT_CATEGORY_NAMES)
+
+# 有序 category_id
+EVENT_CATEGORY_IDS: List[str] = EventCategory.ids()

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -762,7 +762,7 @@ class Layer2Inspector:
 
         tracker.end_step(
             f"summary={len(result.description_summary)}字, "
-            f"events={len(result.new_events)}, "
+            f"events={len(result.events)}, "
             f"rename={result.should_rename_entity}"
         )
 
@@ -779,11 +779,16 @@ class Layer2Inspector:
 
         # Step 4: 过滤 events
         tracker.start_step("事件过滤", "decide")
-        valid_events = filter_events(result.new_events)
+        valid_events = filter_events(result.events)
 
         # 构建 event_timeline
+        # 单条格式：[valid_at|invalid_at] fact|title|category|category_id
+        # title / category / category_id 已在 filter_events 内兜底为合法值或 "NULL"
         if valid_events:
-            events_str = '；'.join(f'[{e.valid_at}|{e.invalid_at}] {e.fact}' for e in valid_events)
+            events_str = '；'.join(
+                f'[{e.valid_at}|{e.invalid_at}] {e.fact}|{e.title}|{e.category}|{e.category_id}'
+                for e in valid_events
+            )
             if existing_event_timeline:
                 event_timeline = existing_event_timeline + "；" + events_str
             else:
@@ -792,7 +797,7 @@ class Layer2Inspector:
             event_timeline = existing_event_timeline
 
         tracker.end_step(
-            f"有效事件 {len(valid_events)}/{len(result.new_events)}"
+            f"有效事件 {len(valid_events)}/{len(result.events)}"
         )
 
         # Step 5: 写入 Neo4j（summary + timeline + event_timeline + 清空 description）

--- a/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
@@ -89,12 +89,35 @@ class EventItem(BaseModel):
     valid_at: str
     invalid_at: str
     fact: str
+    title: str = "NULL"
+    category: str = "NULL"
+    category_id: str = "NULL"   # 稳定分类ID，按需求直接存、不做枚举校验
+
+
+# event_timeline category 固定枚举（13 类，单值）；仅校验 category，category_id 不校验
+_CATEGORY_ENUM = {
+    "教育学习", "职业工作", "项目里程碑", "居住迁移", "关系家庭",
+    "宠物照护", "健康医疗", "旅行到访", "购买资产", "创作发布",
+    "成就荣誉", "财务法务行政", "其他生活事件",
+}
+
+
+def _sanitize_field(value: str) -> str:
+    """清洗字段内的分隔符，防止破坏 [valid_at|invalid_at] fact|title|category|category_id 结构。
+
+    与现有 summary `；`->`，` 的清洗先例一致：
+    - `|`  -> `/`
+    - `；` -> `，`
+    """
+    if not value:
+        return ""
+    return value.replace('|', '/').replace('；', '，').strip()
 
 
 class SummarizeExtractRenameOutput(BaseModel):
     """LLM 输出：合并摘要 + 事件列表 + 更名判断"""
     description_summary: str
-    new_events: List[EventItem] = []
+    events: List[EventItem] = []
     should_rename_entity: bool = False
     suggested_entity_name: Optional[str] = None
 
@@ -120,12 +143,12 @@ def validate_summary_output(
 
 
 def filter_events(
-    new_events: List[EventItem],
+    events: List[EventItem],
 ) -> List[EventItem]:
     """过滤无效事件
 
     Args:
-        new_events: LLM 输出的新事件列表
+        events: LLM 输出的新事件列表
 
     Returns:
         过滤后的有效事件列表
@@ -133,7 +156,7 @@ def filter_events(
     valid_events = []
     seen_facts = set()
 
-    for event in new_events:
+    for event in events:
         # 过滤 fact 为空
         if not event.fact or not event.fact.strip():
             continue
@@ -147,6 +170,13 @@ def filter_events(
         if fact_lower in seen_facts:
             continue
         seen_facts.add(fact_lower)
+
+        # 写入前兜底：清洗分隔符 + category 枚举校验，保证拼接结构稳定
+        event.fact = _sanitize_field(event.fact)
+        event.title = _sanitize_field(event.title) if (event.title and event.title != "NULL") else "NULL"
+        event.category = event.category if event.category in _CATEGORY_ENUM else "NULL"
+        # category_id 不做枚举校验，仅清洗分隔符后原样透传（后续检索/聚合使用）
+        event.category_id = _sanitize_field(event.category_id) if (event.category_id and event.category_id != "NULL") else "NULL"
 
         valid_events.append(event)
 
@@ -202,7 +232,7 @@ async def summarize_extract_and_rename(
         elif isinstance(response, dict):
             result = SummarizeExtractRenameOutput(
                 description_summary=response.get("description_summary", ""),
-                new_events=[EventItem(**e) for e in response.get("new_events", [])],
+                events=[EventItem(**e) for e in response.get("events", [])],
                 should_rename_entity=response.get("should_rename_entity", False),
                 suggested_entity_name=response.get("suggested_entity_name"),
             )
@@ -210,7 +240,7 @@ async def summarize_extract_and_rename(
             data = response.model_dump()
             result = SummarizeExtractRenameOutput(
                 description_summary=data.get("description_summary", ""),
-                new_events=[EventItem(**e) for e in data.get("new_events", [])],
+                events=[EventItem(**e) for e in data.get("events", [])],
                 should_rename_entity=data.get("should_rename_entity", False),
                 suggested_entity_name=data.get("suggested_entity_name"),
             )

--- a/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
+from app.core.memory.models.event_category_models import EVENT_CATEGORY_NAME_SET
+
 logger = logging.getLogger(__name__)
 
 _prompt_dir = os.path.join(
@@ -94,14 +96,6 @@ class EventItem(BaseModel):
     category_id: str = "NULL"   # 稳定分类ID，按需求直接存、不做枚举校验
 
 
-# event_timeline category 固定枚举（13 类，单值）；仅校验 category，category_id 不校验
-_CATEGORY_ENUM = {
-    "教育学习", "职业工作", "项目里程碑", "居住迁移", "关系家庭",
-    "宠物照护", "健康医疗", "旅行到访", "购买资产", "创作发布",
-    "成就荣誉", "财务法务行政", "其他生活事件",
-}
-
-
 def _sanitize_field(value: str) -> str:
     """清洗字段内的分隔符，防止破坏 [valid_at|invalid_at] fact|title|category|category_id 结构。
 
@@ -174,7 +168,7 @@ def filter_events(
         # 写入前兜底：清洗分隔符 + category 枚举校验，保证拼接结构稳定
         event.fact = _sanitize_field(event.fact)
         event.title = _sanitize_field(event.title) if (event.title and event.title != "NULL") else "NULL"
-        event.category = event.category if event.category in _CATEGORY_ENUM else "NULL"
+        event.category = event.category if event.category in EVENT_CATEGORY_NAME_SET else "NULL"
         # category_id 不做枚举校验，仅清洗分隔符后原样透传（后续检索/聚合使用）
         event.category_id = _sanitize_field(event.category_id) if (event.category_id and event.category_id != "NULL") else "NULL"
 

--- a/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
@@ -3,7 +3,7 @@ You are an entity-level description reflection, event extraction, and rename-sug
 
 Your task has three parts:
 1. Merge new `description` fragments into the existing `description_summary`, and output a complete updated summary.
-2. Extract only new event candidates from the current `description`, and output them as `new_events`.
+2. Extract only new event candidates from the current `description`, and output them as `events`.
 3. Decide whether the entity should be renamed to a clearer, more specific, and more stable name.
 
 This is an entity-node reflection step. It is not raw-dialogue extraction.
@@ -12,7 +12,7 @@ This is an entity-node reflection step. It is not raw-dialogue extraction.
 
 你的任务有三部分：
 1. 将新的 `description` 碎片合并进已有 `description_summary`，输出完整的新摘要。
-2. 只从本轮 `description` 中提取新增事件候选，输出为 `new_events`。
+2. 只从本轮 `description` 中提取新增事件候选，输出为 `events`。
 3. 判断当前实体是否应该重命名为更清晰、更具体、更稳定的名字。
 
 这是实体节点级反思步骤，不是从原始对话重新抽取事实。
@@ -46,13 +46,13 @@ Input JSON:
 {% if language == "en" %}
 Return exactly four fields:
 - `description_summary`: the complete updated summary after merging existing summary and new fragments
-- `new_events`: only newly extracted event candidates from current `description`; do not output a full timeline
+- `events`: only newly extracted event candidates from current `description`; each event must include `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`; do not output a full timeline
 - `should_rename_entity`: whether the current entity should be renamed
 - `suggested_entity_name`: the suggested new name if renaming is needed; otherwise the string `"NULL"`
 {% else %}
 严格返回四个字段：
 - `description_summary`: 合并已有摘要和新增碎片后的完整新摘要
-- `new_events`: 只输出本轮从 `description` 中提取的新增事件候选，不要输出完整时间线
+- `events`: 只输出本轮从 `description` 中提取的新增事件候选；每个事件必须包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`；不要输出完整时间线
 - `should_rename_entity`: 是否建议重命名当前实体
 - `suggested_entity_name`: 如果需要重命名，输出建议的新实体名；如果不需要，输出字符串 `"NULL"`
 {% endif %}
@@ -78,7 +78,7 @@ Return exactly four fields:
 - Remove duplicates and low-value wording.
 - Remove source-like suffixes such as "the speaker", "mentioned by the user", or equivalent boilerplate.
 - Prefer concise natural prose over a timeline-like list.
-- Do not over-focus on one-off event details in the summary; event details should usually live in `new_events`.
+- Do not over-focus on one-off event details in the summary; event details should usually live in `events`.
 - Preserve useful stable facts even when they are not events.
 - For non-user entities, preserve the stable relationship between the entity and the user when supported by the input.
 - For non-user entities, if the input states a user relationship such as ownership, care, use, membership, study, attention, or dependence, the summary MUST keep that relationship explicitly.
@@ -88,7 +88,7 @@ Return exactly four fields:
 - 删除重复、空泛、低价值表述。
 - 删除“的说话者”“用户提到的对象”等来源性或模板化后缀。
 - 摘要应是简洁自然的描述，不要写成时间线列表。
-- 不要在摘要中过度堆叠一次性事件细节；事件细节通常进入 `new_events`。
+- 不要在摘要中过度堆叠一次性事件细节；事件细节通常进入 `events`。
 - 对重要稳定事实，即使不是事件，也应保留在摘要里。
 - 对非用户实体，如果输入支持，应在摘要中保留该实体与用户的稳定关系。
 - 对非用户实体，如果输入中出现用户拥有、照顾、使用、加入、学习、关注或依赖该实体等关系，摘要必须明确保留这种用户关系。
@@ -97,23 +97,25 @@ Return exactly four fields:
 
 ===New Event Extraction Rules===
 {% if language == "en" %}
-- Output only `new_events` extracted from the current `description`.
+- Output only `events` extracted from the current `description`.
 - Do not output the full existing event timeline.
 - Use `event_timeline` only for deduplication.
 - If a candidate event is semantically the same as an existing event, do not output it.
 - If a candidate event has the same core action and participants as an existing event, treat it as duplicate even if the new wording is more specific, has a fuller object name, or contains more detail.
 - If a new fragment only enriches an existing event, do not output it in this first version; it can be logged for later review.
-- A duplicate event must not appear in `new_events`.
+- A duplicate event must not appear in `events`.
 - If a candidate event is genuinely different from existing events, output it.
+- `title`, `category_id`, and `category` must be supported by the same evidence as `fact`; do not add unsupported details through them.
 {% else %}
-- 只输出从当前 `description` 中提取的 `new_events`。
+- 只输出从当前 `description` 中提取的 `events`。
 - 不要输出完整已有时间线。
 - `event_timeline` 只用于去重。
 - 如果候选事件与已有事件语义相同，不要输出。
 - 如果候选事件和已有事件的核心动作、参与者相同，即使新说法更具体、对象名称更完整、细节更多，也视为重复事件，不要输出。
 - 如果新碎片只是补充了已有事件的细节，第一版不要输出该事件；可以交给后端记录 review。
-- 重复事件绝不能进入 `new_events`。
-- 只有确实是不同事件时，才输出到 `new_events`。
+- 重复事件绝不能进入 `events`。
+- 只有确实是不同事件时，才输出到 `events`。
+- `title`、`category_id` 和 `category` 必须由 `fact` 的同一组证据支持；不要通过这两个字段加入无依据的新信息。
 {% endif %}
 
 ===What Counts As An Event===
@@ -123,20 +125,101 @@ An event is a concrete action, experience, change, or milestone that happened at
 Examples of event-like content:
 - entering school, graduating, joining a company, leaving a job, moving, marrying, breaking up, adopting, buying, finishing, attending, meeting, traveling, taking an exam, joining a competition, surgery, project milestone
 
-Do not add these to `new_events`:
+Do not add these to `events`:
 - attributes, identity labels, occupation, personality, preference, habit, long-term state, goal, wish, evaluation, abstract belief
 
 Important non-event information may still be merged into `description_summary`.
 {% else %}
 事件是发生在某个时间点或时间段的具体动作、经历、变化或里程碑。
 
-可以进入 `new_events` 的内容包括：
+可以进入 `events` 的内容包括：
 - 入学、毕业、入职、离职、搬家、结婚、分手、收养、购买、完成、参加、见面、旅行、考试、比赛、手术、项目节点等。
 
-不要进入 `new_events` 的内容包括：
+不要进入 `events` 的内容包括：
 - 属性、身份、职业、性格、偏好、习惯、长期状态、目标、愿望、评价、抽象观点。
 
 这些非事件信息如果重要，可以合并进 `description_summary`。
+{% endif %}
+
+===Event Title And Category Rules===
+{% if language == "en" %}
+Each `events` item must include:
+- `title`: a short event title for timeline display and retrieval snippets
+- `category_id`: exactly one stable event category id selected from the fixed category pool below
+- `category`: the Chinese display name that exactly matches the selected `category_id`
+
+`title` rules:
+- Make it short, concrete, and readable.
+- Chinese titles are usually 4 to 16 characters; English titles are usually 3 to 8 words.
+- Do not write a full sentence if a shorter title is enough.
+- Do not include dialogue-source boilerplate such as "the speaker", "mentioned by the user", or similar wording.
+- Do not repeat time expressions in `title`; time belongs in `valid_at` and `invalid_at`.
+- For non-user entities, if the user connection is essential, the title may explicitly include the user's action or relationship.
+- The title must be in the main language of the input descriptions.
+
+Fixed `category_id` to `category` pool:
+- `education_learning` -> `教育学习`: education, learning, school admission, graduation, exams, training, certification, study programs
+- `career_work` -> `职业工作`: employment, onboarding, resignation, job change, promotion, work responsibility changes
+- `project_milestone` -> `项目里程碑`: project start, completion, delivery, release, research or engineering milestone
+- `residence_relocation` -> `居住迁移`: moving, relocation, long-term residence or city changes
+- `relationship_family` -> `关系家庭`: marriage, breakup, family changes, friendship or colleague relationship changes
+- `pet_care` -> `宠物照护`: adopting, caring for, treating, training, or important changes involving a pet connected to the user
+- `health_medical` -> `健康医疗`: surgery, treatment, medical checkup, recovery, major health event
+- `travel_visit` -> `旅行到访`: travel, business trip, visit, meeting, going to a place
+- `purchase_asset` -> `购买资产`: buying, obtaining, selling, losing, or replacing important objects, devices, assets, or accounts
+- `creation_publication` -> `创作发布`: writing, creating, publishing, launching, or releasing a work
+- `achievement_award` -> `成就荣誉`: award, competition result, certificate earned, major personal achievement, completion of a difficult challenge
+- `finance_legal_admin` -> `财务法务行政`: contract, application, account opening, certificate, paperwork, legal, financial, or administrative milestone
+- `other_life_event` -> `其他生活事件`: a real event that cannot be reliably assigned to the categories above
+
+Category selection rules:
+- Choose exactly one primary `category_id`.
+- Output the exact Chinese `category` mapped to that `category_id`.
+- Prefer the `category_id` that best matches the user's likely retrieval intent.
+- Do not invent new `category_id` or `category` values.
+- If an event contains multiple aspects, choose the dominant aspect expressed by the evidence.
+- School, university, degree, study-abroad, doctoral, master's, exam, or certification applications should use `category_id: "education_learning"` and `category: "教育学习"`, not `finance_legal_admin`.
+- If the event is about a pet that the user owns, cares for, or depends on, prefer `category_id: "pet_care"` and `category: "宠物照护"`.
+- Use `other_life_event` / `其他生活事件` only when the event is concrete and useful but no listed category fits.
+{% else %}
+每个 `events` item 必须包含：
+- `title`: 用于时间线展示和检索结果摘要的短事件标题
+- `category_id`: 从下面固定类型池中选择的稳定事件类型 ID
+- `category`: 与 `category_id` 精确对应的中文展示名
+
+`title` 规则：
+- 标题要短、具体、可读。
+- 中文标题通常 4 到 16 个字；英文标题通常 3 到 8 个词。
+- 能用短标题表达时，不要写成长句。
+- 不要包含“的说话者”“用户提到的对象”等来源性或模板化表达。
+- 不要在 `title` 中重复时间表达；时间由 `valid_at` 和 `invalid_at` 承担。
+- 对非用户实体，如果用户关系对理解事件很关键，标题可以明确写出用户动作或用户关系。
+- 标题语言应跟随输入 description 的主要语言。
+
+固定 `category_id` 到 `category` 类型池：
+- `education_learning` -> `教育学习`: 教育、学习、入学、毕业、考试、培训、证书学习、学习项目
+- `career_work` -> `职业工作`: 入职、离职、转岗、升职、工作职责变化、职业工作节点
+- `project_milestone` -> `项目里程碑`: 项目启动、完成、交付、发布、研究或工程阶段节点
+- `residence_relocation` -> `居住迁移`: 搬家、迁居、长期居住地或城市变化
+- `relationship_family` -> `关系家庭`: 结婚、分手、家庭变化、朋友或同事关系变化
+- `pet_care` -> `宠物照护`: 用户拥有、照顾或依赖的宠物的收养、照护、治疗、训练或重要变化
+- `health_medical` -> `健康医疗`: 手术、治疗、体检、康复、明显健康事件
+- `travel_visit` -> `旅行到访`: 旅行、出差、参观、见面、到访地点
+- `purchase_asset` -> `购买资产`: 购买、获得、出售、遗失或更换重要物品、设备、资产或账号
+- `creation_publication` -> `创作发布`: 写作、创作、发布、上线或发表作品
+- `achievement_award` -> `成就荣誉`: 获奖、比赛结果、获得证书、重要成果、完成高难度挑战
+- `finance_legal_admin` -> `财务法务行政`: 合同、申请、开户、证件、手续、法律、财务或行政节点
+- `other_life_event` -> `其他生活事件`: 确实是事件且有记忆价值，但无法稳定归入以上类型
+
+`category_id` / `category` 选择规则：
+- 每个事件只能选择一个主类型。
+- `category` 必须与 `category_id` 在上表中的中文名精确一致。
+- 优先选择最符合用户未来检索意图的类型。
+- 不要创造类型池之外的新 `category_id` 或 `category` 值。
+- 如果一个事件包含多个方面，选择证据中最主要的事件方面。
+- 学校、学位、留学、博士、硕士、考试或证书相关申请，应选择 `category_id: "education_learning"` 和 `category: "教育学习"`，不要归入 `finance_legal_admin`。
+- 如果事件涉及用户拥有、照顾或依赖的宠物，优先选择 `category_id: "pet_care"` 和 `category: "宠物照护"`。
+- 只有当事件具体、有用、但确实无法归入其他类型时，才使用 `category_id: "other_life_event"` 和 `category: "其他生活事件"`。
 {% endif %}
 
 ===User-Centered Event Rule===
@@ -184,7 +267,8 @@ If `entity_name` is not the user node:
 {% if language == "en" %}
 - A bracketed timestamp at the beginning of a description fragment, such as `[2026-05-15T14:00:00+08:00]`, is the dialogue time, not necessarily the event time.
 - Use the bracketed timestamp as the reference time for relative phrases in that fragment when needed.
-- Every `new_events` item must include `valid_at`, `invalid_at`, and `fact`.
+- Every `events` item must include `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
+- `title`, `category_id`, `category`, and `fact` must be strings.
 - `valid_at` and `invalid_at` must be either `YYYY-MM-DD` or the string `"NULL"`.
 - Point event: set `valid_at` and `invalid_at` to the same date.
 - Explicit date: use that date directly.
@@ -202,7 +286,8 @@ If `entity_name` is not the user node:
 {% else %}
 - description 碎片开头的方括号时间戳，例如 `[2026-05-15T14:00:00+08:00]`，是对话时间，不一定是事件发生时间。
 - 对“昨天”“上个月”“三年前”等相对时间，必要时用该碎片开头的方括号时间戳作为参考时间。
-- 每个 `new_events` item 必须包含 `valid_at`、`invalid_at` 和 `fact`。
+- 每个 `events` item 必须包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- `title`、`category_id`、`category` 和 `fact` 必须是字符串。
 - `valid_at` 和 `invalid_at` 只能是 `YYYY-MM-DD` 或字符串 `"NULL"`。
 - 点事件：`valid_at` 和 `invalid_at` 填同一个日期。
 - 明确日期：直接使用该日期。
@@ -264,8 +349,10 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - Do not output extra keys.
 - Do not output JSON null.
 - If there is no summary, output an empty string for `description_summary`.
-- If there are no new events, output an empty array for `new_events`.
-- Every `new_events` item must include exactly `valid_at`, `invalid_at`, and `fact`.
+- If there are no new events, output an empty array for `events`.
+- Every `events` item must include exactly `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
+- `category_id` must be one of the fixed category ids listed in the prompt.
+- `category` must be the exact Chinese display name mapped to `category_id`.
 - `valid_at` and `invalid_at` must be strings, not JSON null.
 - `should_rename_entity` must be a JSON boolean.
 - If `should_rename_entity` is false, `suggested_entity_name` must be the string `"NULL"`.
@@ -280,8 +367,10 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - 不要输出额外字段。
 - 不要输出 JSON null。
 - 如果没有摘要，`description_summary` 输出空字符串。
-- 如果没有新增事件，`new_events` 输出空数组。
-- 每个 `new_events` item 必须且只能包含 `valid_at`、`invalid_at` 和 `fact`。
+- 如果没有新增事件，`events` 输出空数组。
+- 每个 `events` item 必须且只能包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- `category_id` 必须是 prompt 中固定类型池里的一个 ID。
+- `category` 必须是与 `category_id` 精确对应的中文展示名。
 - `valid_at` 和 `invalid_at` 必须是字符串，不能是 JSON null。
 - `should_rename_entity` 必须是 JSON boolean。
 - 如果 `should_rename_entity` 是 false，`suggested_entity_name` 必须是字符串 `"NULL"`。
@@ -298,8 +387,11 @@ Return exactly this JSON shape:
 {% endif %}
 {
   "description_summary": "string",
-  "new_events": [
+  "events": [
     {
+      "title": "string",
+      "category_id": "education_learning | career_work | project_milestone | residence_relocation | relationship_family | pet_care | health_medical | travel_visit | purchase_asset | creation_publication | achievement_award | finance_legal_admin | other_life_event",
+      "category": "教育学习 | 职业工作 | 项目里程碑 | 居住迁移 | 关系家庭 | 宠物照护 | 健康医疗 | 旅行到访 | 购买资产 | 创作发布 | 成就荣誉 | 财务法务行政 | 其他生活事件",
       "valid_at": "YYYY-MM-DD | NULL",
       "invalid_at": "YYYY-MM-DD | NULL",
       "fact": "string"

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -935,6 +935,16 @@ neo4j_query_all = """
                 other as entity2
                           """
 
+'''按 elementId 查询 ExtractedEntity 的事件时间线字段'''
+Memory_Timeline_Entity_Events = """
+MATCH (e:ExtractedEntity)
+WHERE elementId(e) = $id
+RETURN e.name AS entity_name,
+       e.entity_type AS entity_type,
+       e.description_summary AS description_summary,
+       e.event_timeline AS event_timeline
+"""
+
 '''针对当前节点下扩长的句子，实体和总结'''
 Memory_Timeline_ExtractedEntity = """
 MATCH (n)-[r1]-(e)-[r2]-(ms)

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -6,24 +6,219 @@ Memory_Timeline_Statement,
 Memory_Space_Emotion_Statement,
 Memory_Space_Emotion_MemorySummary,
 Memory_Space_Emotion_ExtractedEntity,
-Memory_Space_Associative,Memory_Space_User,Memory_Space_Entity
+Memory_Space_Associative,Memory_Space_User,Memory_Space_Entity,
+Memory_Timeline_Entity_Events,
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from typing import Dict, List, Any, Optional
 import logging
+import re
 from neo4j.time import DateTime as Neo4jDateTime
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app.schemas.memory_episodic_schema import EmotionType
 
 logger = logging.getLogger(__name__)
+
+# event_timeline category 固定顺序（13 类，与 prompt category_id→category 映射顺序一致）
+# 用于 category_stats 补全：有数据的按 count 降序在前，无数据的按此顺序补在后（count=0）
+_CATEGORY_ORDER = [
+    "教育学习", "职业工作", "项目里程碑", "居住迁移", "关系家庭",
+    "宠物照护", "健康医疗", "旅行到访", "购买资产", "创作发布",
+    "成就荣誉", "财务法务行政", "其他生活事件",
+]
+
 
 class MemoryEntityService:
     def __init__(self, id: str, table: str):
         self.id = id
         self.table = table
         self.connector = Neo4jConnector()
+
+    async def get_entity_event_timeline(self, page: int = 1, pagesize: int = 10) -> dict:
+        """获取 ExtractedEntity 的结构化事件时间线（分页）
+
+        从 Neo4j 读取实体的 event_timeline 属性，解析为结构化事件数组，
+        按 valid_at 降序排列，并统计各 category 的事件数量。
+
+        Args:
+            page: 页码（从 1 开始）
+            pagesize: 每页条数
+
+        Returns:
+            包含 entity_name, entity_type, description_summary, category_stats,
+            items（当前页事件）, page（分页信息）的字典。category_stats 始终基于
+            全量事件计算，分页只影响 items 列表。
+        """
+        results = await self.connector.execute_query(
+            Memory_Timeline_Entity_Events,
+            id=self.id,
+        )
+        if not results:
+            logger.warning(f"事件时间线查询无结果: elementId={self.id}")
+            return {
+                "entity_name": None,
+                "entity_type": None,
+                "description_summary": None,
+                "category_stats": [{"category": cat, "count": 0} for cat in _CATEGORY_ORDER],
+                "items": [],
+                "page": {"page": page, "pagesize": pagesize, "total": 0, "hasnext": False},
+            }
+
+        record = results[0]
+        entity_name = record.get("entity_name")
+        entity_type = record.get("entity_type")
+        description_summary = record.get("description_summary")
+        event_timeline_raw = record.get("event_timeline") or ""
+
+        # 解析 event_timeline 字符串（全量）
+        events = self._parse_event_timeline(event_timeline_raw)
+        total = len(events)
+
+        # 统计各 category 的事件数量；基于全量
+        # 13 类全部返回：有数据的按 count 降序在前，无数据的（count=0）按固定顺序补在后
+        category_counts = {}
+        for event in events:
+            cat = event.get("category")
+            if cat:
+                category_counts[cat] = category_counts.get(cat, 0) + 1
+        with_count = sorted(
+            [(cat, cnt) for cat, cnt in category_counts.items()],
+            key=lambda kv: kv[1], reverse=True
+        )
+        zero_count = [(cat, 0) for cat in _CATEGORY_ORDER if cat not in category_counts]
+        category_stats = [
+            {"category": cat, "count": cnt}
+            for cat, cnt in (with_count + zero_count)
+        ]
+
+        # 分页切片
+        start = (page - 1) * pagesize
+        items = events[start:start + pagesize]
+        hasnext = page * pagesize < total
+
+        logger.info(
+            f"事件时间线解析完成: entity={entity_name}, total={total}, "
+            f"returned={len(items)}, categories={len(category_stats)}, "
+            f"page={page}, pagesize={pagesize}"
+        )
+
+        return {
+            "entity_name": entity_name,
+            "entity_type": entity_type,
+            "description_summary": description_summary,
+            "category_stats": category_stats,
+            "items": items,
+            "page": {"page": page, "pagesize": pagesize, "total": total, "hasnext": hasnext},
+        }
+
+    @staticmethod
+    def _to_epoch_ms(value: str):
+        """把事件日期转为 Unix 毫秒时间戳（UTC）。
+
+        底层 event_timeline 只存日期（YYYY-MM-DD），按 UTC 当天 0 点换算为
+        毫秒时间戳，如 `2026-06-15` → `1781481600000`；兼容已带时分秒的历史值；
+        无法解析则返回 None。
+        """
+        if not value:
+            return None
+        value = value.strip()
+        # 依次尝试：纯日期 / 带时分秒（含 T 或空格分隔，允许末尾 Z）
+        fmts = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S")
+        v = value[:-1] if value.endswith("Z") else value
+        for fmt in fmts:
+            try:
+                d = datetime.strptime(v, fmt).replace(tzinfo=timezone.utc)
+                return int(d.timestamp() * 1000)
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
+    def _parse_event_timeline(event_timeline: str) -> list:
+        """解析 event_timeline 字符串为结构化事件列表，按 valid_at 降序排列
+
+        只展示新格式（4 段正文：fact|title|category|category_id）；旧格式（1 段，仅 fact）
+        字段残缺，直接跳过不返回。数据库中的 "NULL" 字符串统一转为 None；时间为空的事件不返回。
+
+        Args:
+            event_timeline: 原始 event_timeline 字符串
+
+        Returns:
+            结构化事件列表，按 valid_at 降序
+        """
+        if not event_timeline or not event_timeline.strip():
+            return []
+
+        events = []
+        for item in event_timeline.split('；'):
+            item = item.strip()
+            if not item:
+                continue
+
+            # 抠出 [valid_at|invalid_at]
+            m = re.match(r'^\[([^|]*)\|([^\]]*)\]\s*(.*)', item)
+            if m:
+                valid_at = m.group(1).strip() or None
+                invalid_at = m.group(2).strip() or None
+                body = m.group(3)
+            else:
+                valid_at = None
+                invalid_at = None
+                body = item
+
+            # "NULL" → None
+            if valid_at == "NULL":
+                valid_at = None
+            if invalid_at == "NULL":
+                invalid_at = None
+
+            # 按 | 切正文段（新格式为 4 段：fact|title|category|category_id）
+            parts = body.split('|')
+
+            # 旧格式（仅 fact，1 段）字段残缺，不展示给前端
+            if len(parts) < 4:
+                continue
+
+            fact = parts[0].strip()
+            title = parts[1].strip()
+            category = parts[2].strip()
+            category_id = parts[3].strip()
+
+            # "NULL" → None
+            if title == "NULL":
+                title = None
+            if category == "NULL":
+                category = None
+            if category_id == "NULL":
+                category_id = None
+
+            # fact 为空则跳过
+            if not fact:
+                continue
+
+            # 时间为空的事件不返回给前端
+            if not valid_at:
+                continue
+
+            # valid_at 转为 Unix 毫秒时间戳（UTC）；无法解析则跳过
+            valid_at_ms = MemoryEntityService._to_epoch_ms(valid_at)
+            if valid_at_ms is None:
+                continue
+
+            # 不返回 invalid_at / category_id（前端不需要）
+            events.append({
+                "title": title,
+                "fact": fact,
+                "category": category,
+                "valid_at": valid_at_ms,
+            })
+
+        # 排序：valid_at 降序（最新在前）
+        events.sort(key=lambda e: e["valid_at"], reverse=True)
+        return events
+
     async def get_timeline_memories_server(self,model_id, language_type):
         """
         获取时间线记忆数据

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -19,16 +19,9 @@ from datetime import datetime
 
 from app.schemas.memory_episodic_schema import EmotionType
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
+from app.core.memory.models.event_category_models import EVENT_CATEGORY_NAMES
 
 logger = logging.getLogger(__name__)
-
-# event_timeline category 固定顺序（13 类，与 prompt category_id→category 映射顺序一致）
-# 用于 category_stats 补全：有数据的按 count 降序在前，无数据的按此顺序补在后（count=0）
-_CATEGORY_ORDER = [
-    "教育学习", "职业工作", "项目里程碑", "居住迁移", "关系家庭",
-    "宠物照护", "健康医疗", "旅行到访", "购买资产", "创作发布",
-    "成就荣誉", "财务法务行政", "其他生活事件",
-]
 
 
 class MemoryEntityService:
@@ -62,7 +55,7 @@ class MemoryEntityService:
                 "entity_name": None,
                 "entity_type": None,
                 "description_summary": None,
-                "category_stats": [{"category": cat, "count": 0} for cat in _CATEGORY_ORDER],
+                "category_stats": [{"category": cat, "count": 0} for cat in EVENT_CATEGORY_NAMES],
                 "items": [],
                 "page": {"page": page, "pagesize": pagesize, "total": 0, "hasnext": False},
             }
@@ -88,7 +81,7 @@ class MemoryEntityService:
             [(cat, cnt) for cat, cnt in category_counts.items()],
             key=lambda kv: kv[1], reverse=True
         )
-        zero_count = [(cat, 0) for cat in _CATEGORY_ORDER if cat not in category_counts]
+        zero_count = [(cat, 0) for cat in EVENT_CATEGORY_NAMES if cat not in category_counts]
         category_stats = [
             {"category": cat, "count": cnt}
             for cat, cnt in (with_count + zero_count)

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -15,9 +15,10 @@ import logging
 import re
 from neo4j.time import DateTime as Neo4jDateTime
 import json
-from datetime import datetime, timezone
+from datetime import datetime
 
 from app.schemas.memory_episodic_schema import EmotionType
+from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
 
 logger = logging.getLogger(__name__)
 
@@ -117,23 +118,16 @@ class MemoryEntityService:
     def _to_epoch_ms(value: str):
         """把事件日期转为 Unix 毫秒时间戳（UTC）。
 
-        底层 event_timeline 只存日期（YYYY-MM-DD），按 UTC 当天 0 点换算为
-        毫秒时间戳，如 `2026-06-15` → `1781481600000`；兼容已带时分秒的历史值；
-        无法解析则返回 None。
+        底层 event_timeline 只存日期（YYYY-MM-DD），统一走 datetime_utils 解析为
+        naive UTC 再序列化为毫秒时间戳；无法解析则返回 None（调用方据此过滤）。
         """
         if not value:
             return None
-        value = value.strip()
-        # 依次尝试：纯日期 / 带时分秒（含 T 或空格分隔，允许末尾 Z）
-        fmts = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S")
-        v = value[:-1] if value.endswith("Z") else value
-        for fmt in fmts:
-            try:
-                d = datetime.strptime(v, fmt).replace(tzinfo=timezone.utc)
-                return int(d.timestamp() * 1000)
-            except ValueError:
-                continue
-        return None
+        try:
+            dt = parse_iso_to_utc_naive(value.strip())
+        except ValueError:
+            return None
+        return to_timestamp_ms(dt)
 
     @staticmethod
     def _parse_event_timeline(event_timeline: str) -> list:


### PR DESCRIPTION
## Summary by Sourcery

向记忆系统中添加带有分类和检索支持的结构化实体事件时间线。

新功能：
- 暴露一个分页 API 端点，用于检索某个 `ExtractedEntity` 节点的结构化事件时间线，并附带按类别统计数据。
- 在反思（reflection）输出中支持更丰富的事件元数据（title、category、category_id、timestamps、fact），并将其以可解析的时间线字符串形式持久化到 Neo4j 中。
- 引入集中化的事件类别模型，定义一组固定的事件类别及其标签，以便在提示词（prompts）、存储和 API 之间复用。

增强：
- 更新反思摘要时间线的提示词和解析流程，使用统一的 `events` 字段，并施加更严格的模式和分类要求。
- 在将事件写入事件时间线之前，对 LLM 生成的事件字段进行清洗，并验证事件类别，以保持序列化格式的稳定性。
- 添加辅助工具，用于解析和规范化存储的 `event_timeline` 字符串，将日期转换为 UTC 纪元毫秒，并对事件进行排序，以支持时间线视图。

文档：
- 扩展 LLM 提示词文档，描述事件标题和类别要求、可用的类别集合，以及新的 `events` 输出模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add structured entity event timelines with categorization and retrieval support to the memory system.

New Features:
- Expose a paginated API endpoint to retrieve an ExtractedEntity node's structured event timeline with per-category statistics.
- Support richer event metadata (title, category, category_id, timestamps, fact) in reflection outputs and persist them into Neo4j as a parseable timeline string.
- Introduce a centralized event category model defining the fixed set of event categories and their labels for reuse across prompts, storage, and APIs.

Enhancements:
- Update the reflection summary timeline prompt and parsing pipeline to use a unified `events` field with stricter schema and categorization requirements.
- Sanitize LLM-produced event fields and validate event categories before writing them into the event timeline to keep the serialized format stable.
- Add helpers to parse and normalize stored event_timeline strings, converting dates to UTC epoch milliseconds and sorting events for timeline views.

Documentation:
- Extend LLM prompt documentation to describe event title and category requirements, valid category pool, and the new `events` output schema.

</details>