### PR TITLE
fix(tasks): tighten layer2 reflection inactivity filter to 36h

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2254,14 +2254,14 @@ def post_store_dedup_and_alias_merge_task(
         if loop:
             _shutdown_loop_gracefully(loop)
 
-def _should_skip_reflection_by_inactivity(db, end_user_id: str, inactive_days: int = 3) -> bool:
-    """反思任务前置过滤：用户最近一次会话更新距今 >= inactive_days 天则跳过。
+def _should_skip_reflection_by_inactivity(db, end_user_id: str, inactive_hours: int = 36) -> bool:
+    """反思任务前置过滤：用户最近一次会话更新距今 >= inactive_hours 小时则跳过。
 
     通过 conversations.user_id（存的是 end_user_id 的 UUID 字符串）取该用户所有会话
     的最新 updated_at（最后写入时间），与当前 UTC 时间比较。
 
     Returns:
-        True  -> 跳过反思（无会话记录，或最近更新已超过 inactive_days 天）
+        True  -> 跳过反思（无会话记录，或最近更新已超过 inactive_hours 小时）
         False -> 正常执行反思
     """
     from sqlalchemy import func
@@ -2286,7 +2286,7 @@ def _should_skip_reflection_by_inactivity(db, end_user_id: str, inactive_days: i
     now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
     if last_updated.tzinfo is not None:
         last_updated = last_updated.astimezone(timezone.utc).replace(tzinfo=None)
-    return (now_utc - last_updated) >= timedelta(days=inactive_days)
+    return (now_utc - last_updated) >= timedelta(hours=inactive_hours)
 
 
 @celery_app.task(
@@ -2379,7 +2379,7 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
 
                             for user in end_users:
                                 try:
-                                    # 前置过滤：最近一次会话更新距今 >= 3 天则跳过（仅对活跃用户反思）
+                                    # 前置过滤：最近一次会话更新距今 >= 36 小时则跳过（仅对活跃用户反思）
                                     if _should_skip_reflection_by_inactivity(db, str(user['id'])):
                                         skipped_inactive += 1
                                         continue
@@ -2449,7 +2449,7 @@ def layer2_reflection_task(self) -> Dict[str, Any]:
                 logger.info(
                     f"反思引擎Layer2 巡检遍历完成: 处理 {processed_users} 个用户, "
                     f"跳过 {skipped_configs} 个未启用反思的配置, "
-                    f"跳过 {skipped_inactive} 个 3 天内无会话更新的用户"
+                    f"跳过 {skipped_inactive} 个 36 小时内无会话更新的用户"
                 )
 
                 return {
@@ -2572,7 +2572,7 @@ def layer2_dedup_full_scan_task(self) -> Dict[str, Any]:
 
                         for user in end_users:
                             try:
-                                # 前置过滤：最近一次会话更新距今 >= 3 天则跳过
+                                # 前置过滤：最近一次会话更新距今 >= 36 小时则跳过
                                 if _should_skip_reflection_by_inactivity(db, str(user['id'])):
                                     skipped_inactive += 1
                                     continue
@@ -2631,7 +2631,7 @@ def layer2_dedup_full_scan_task(self) -> Dict[str, Any]:
             logger.info(
                 f"方案B全量扫描完成: 处理 {processed_users} 用户, "
                 f"跳过 {skipped_configs} 个未启用配置, "
-                f"跳过 {skipped_inactive} 个 3 天内无会话更新的用户, "
+                f"跳过 {skipped_inactive} 个 36 小时内无会话更新的用户, "
                 f"总合并 {total_merged} 对"
             )
             return {


### PR DESCRIPTION
## Summary by Sourcery

将基于不活跃状态的 layer2 反射任务预过滤阈值，从原来的 3 天收紧为 36 小时，并相应更新相关日志和文档字符串。

Enhancements:
- 将反射不活跃检查从基于天数的阈值改为基于小时的阈值，使用 36 小时替代原来的 3 天阈值来决定是否跳过用户。
- 更新相关注释和日志消息，使其引用新的 36 小时不活跃时间窗口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the inactivity-based prefilter for layer2 reflection tasks from a 3-day threshold to a 36-hour threshold and update related logging and documentation strings accordingly.

Enhancements:
- Change the reflection inactivity check to use an hours-based threshold set to 36 hours instead of a 3-day threshold for determining whether to skip users.
- Update associated comments and log messages to reference the new 36-hour inactivity window.

</details>