### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -1109,13 +1109,14 @@ async def run_single_workflow_node(
 
     raw_inputs = payload.inputs or {}
     input_data = {
-        "message": raw_inputs.pop("sys.message", ""),
-        "files": raw_inputs.pop("sys.files", []),
+        "message": raw_inputs.pop("sys.message", None),
+        "files": raw_inputs.pop("sys.files", None),
         "user_id": raw_inputs.pop("sys.user_id", str(current_user.id)),
         "trigger_payload": raw_inputs.pop("trigger_payload", None),
         "inputs": raw_inputs,
         "conversation_id": "",
         "conv_messages": [],
+        "base_execution_id": payload.base_execution_id,
     }
 
     if payload.stream:
@@ -1167,6 +1168,79 @@ async def get_workflow_node_last_run(
     return success(data=result)
 
 
+@router.put("/{app_id}/workflow/nodes/{node_id}/cache", summary="更新节点缓存")
+@cur_workspace_access_guard()
+async def update_workflow_node_cache(
+        app_id: uuid.UUID,
+        node_id: str,
+        payload: app_schema.NodeCacheUpdateRequest,
+        db: Annotated[Session, Depends(get_db)] = None,
+        current_user: Annotated[User, Depends(get_current_user)] = None,
+        workflow_service: Annotated[WorkflowService, Depends(get_workflow_service)] = None,
+):
+    workspace_id = current_user.current_workspace_id
+    service = AppService(db)
+    app = service._get_app_or_404(app_id)
+    service._validate_app_accessible(app, workspace_id)
+    result = workflow_service.update_node_cache(
+        app_id=app_id,
+        node_id=node_id,
+        result_data=payload.result_data,
+        patches=[item.model_dump() for item in payload.patches],
+    )
+    if not result:
+        raise BusinessException("节点缓存不存在", BizCode.NOT_FOUND)
+    return success(data=result)
+
+
+@router.delete("/{app_id}/workflow/nodes/{node_id}/cache", summary="失效节点缓存")
+@cur_workspace_access_guard()
+async def invalidate_workflow_node_cache(
+        app_id: uuid.UUID,
+        node_id: str,
+        db: Annotated[Session, Depends(get_db)] = None,
+        current_user: Annotated[User, Depends(get_current_user)] = None,
+        workflow_service: Annotated[WorkflowService, Depends(get_workflow_service)] = None,
+):
+    workspace_id = current_user.current_workspace_id
+    service = AppService(db)
+    app = service._get_app_or_404(app_id)
+    service._validate_app_accessible(app, workspace_id)
+    affected = workflow_service.invalidate_node_cache(app_id=app_id, node_id=node_id)
+    if affected <= 0:
+        raise BusinessException("节点缓存不存在", BizCode.NOT_FOUND)
+    return success(data={"affected": affected})
+
+
+@router.post("/{app_id}/workflow/nodes/{node_id}/rerun", summary="基于最近一次单节点调试输入重跑")
+@cur_workspace_access_guard()
+async def rerun_workflow_node(
+        app_id: uuid.UUID,
+        node_id: str,
+        payload: app_schema.NodeRerunRequest,
+        db: Annotated[Session, Depends(get_db)] = None,
+        current_user: Annotated[User, Depends(get_current_user)] = None,
+        workflow_service: Annotated[WorkflowService, Depends(get_workflow_service)] = None,
+):
+    workspace_id = current_user.current_workspace_id
+    service = AppService(db)
+    app = service._get_app_or_404(app_id)
+    service._validate_app_accessible(app, workspace_id)
+    config = workflow_service.get_workflow_config(app_id)
+    if not config:
+        raise BusinessException("工作流配置不存在，无法运行", BizCode.CONFIG_MISSING)
+    result = await workflow_service.rerun_node_from_last_debug(
+        app_id=app_id,
+        node_id=node_id,
+        config=config,
+        workspace_id=workspace_id,
+        invalidate_cache=payload.invalidate_cache,
+        bypass_cache=payload.bypass_cache,
+        base_execution_id=payload.base_execution_id,
+    )
+    return success(data=result)
+
+
 @router.get("/{app_id}/workflow")
 @cur_workspace_access_guard()
 async def get_workflow_config(
@@ -1200,8 +1274,8 @@ async def get_workflow_execution_detail(
     app = service._get_app_or_404(app_id)
     service._validate_app_accessible(app, workspace_id)
 
-    execution_detail = workflow_service.get_execution_detail(execution_id)
-    if not execution_detail or execution_detail.get("app_id") != str(app_id):
+    execution_detail = workflow_service.get_execution_detail(execution_id=execution_id, app_id=app_id)
+    if not execution_detail:
         raise BusinessException("执行记录不存在", BizCode.NOT_FOUND)
 
     return success(data=execution_detail)

--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -1012,7 +1012,7 @@ models:
   type: rerank
   provider: dashscope
   description: gte-rerank-v2重排序模型，4000上下文窗口
-  is_deprecated: false
+  is_deprecated: true
   is_official: true
   capability: []
   is_omni: false
@@ -1023,7 +1023,7 @@ models:
   type: rerank
   provider: dashscope
   description: gte-rerank重排序模型，4000上下文窗口
-  is_deprecated: false
+  is_deprecated: true
   is_official: true
   capability: []
   is_omni: false

--- a/api/app/core/workflow/engine/result_builder.py
+++ b/api/app/core/workflow/engine/result_builder.py
@@ -55,15 +55,18 @@ class WorkflowResultBuilder:
         token_usage = self.aggregate_token_usage(node_outputs)
         conversation_vars = {}
         sys_vars = {}
+        env_vars = {}
         snapshot = {
             "system": {},
             "conversation": {},
+            "environment": {},
             "nodes": {},
         }
 
         if variable_pool:
             conversation_vars = variable_pool.get_all_conversation_vars()
             sys_vars = variable_pool.get_all_system_vars()
+            env_vars = variable_pool.get_all_environment_vars()
             snapshot = variable_pool.to_dict()
 
         # 汇总所有 knowledge 节点的 citations
@@ -71,10 +74,12 @@ class WorkflowResultBuilder:
 
         payload = {
             "status": "completed" if success else "failed",
+            "execution_id": execution_context.execution_id,
             "output": final_output,
             "variables": {
                 "conv": conversation_vars,
-                "sys": sys_vars
+                "sys": sys_vars,
+                "env": env_vars,
             },
             "node_outputs": node_outputs,
             "messages": result.get("messages", []),

--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -492,6 +492,7 @@ class VariablePool:
         return {
             "system": self.get_all_system_vars(),
             "conversation": self.get_all_conversation_vars(),
+            "environment": self.get_all_environment_vars(),
             "nodes": self.get_all_node_outputs()  # 从 runtime_vars 读取
         }
 

--- a/api/app/core/workflow/node_cache.py
+++ b/api/app/core/workflow/node_cache.py
@@ -1,0 +1,242 @@
+import datetime
+import hashlib
+import json
+import uuid
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.core.utils.datetime_utils import utcnow_naive
+from app.db import get_db_context
+from app.repositories.workflow_repository import WorkflowNodeCacheRepository
+
+
+DEFAULT_CACHEABLE_NODE_TYPES = {
+    "llm",
+    "code",
+    "knowledge-retrieval",
+    "jinja-render",
+    "parameter-extractor",
+    "question-classifier",
+    "var-aggregator",
+}
+
+
+def normalize_cache_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    if isinstance(value, datetime.date):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, BaseModel):
+        return normalize_cache_value(value.model_dump())
+    if isinstance(value, dict):
+        return {str(k): normalize_cache_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [normalize_cache_value(item) for item in value]
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        return normalize_cache_value(value.model_dump())
+    if hasattr(value, "dict") and callable(value.dict):
+        return normalize_cache_value(value.dict())
+    return str(value)
+
+
+class WorkflowNodeCacheManager:
+    def __init__(
+            self,
+            *,
+            app_id: str | uuid.UUID | None,
+            workflow_config_id: str | uuid.UUID | None,
+            node_id: str,
+            node_type: str,
+            node_name: str | None,
+    ):
+        self.app_id = self._parse_uuid(app_id)
+        self.workflow_config_id = self._parse_uuid(workflow_config_id)
+        self.node_id = node_id
+        self.node_type = node_type
+        self.node_name = node_name
+
+    @staticmethod
+    def _parse_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
+        if not value:
+            return None
+        if isinstance(value, uuid.UUID):
+            return value
+        try:
+            return uuid.UUID(str(value))
+        except (ValueError, TypeError):
+            return None
+
+    def is_available(self) -> bool:
+        return self.app_id is not None
+
+    def build_cache_key(self, input_data: Any) -> str:
+        payload = {
+            "node_id": self.node_id,
+            "node_type": self.node_type,
+            "input_data": normalize_cache_value(input_data),
+        }
+        content = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def serialize(cache) -> dict[str, Any]:
+        return {
+            "id": cache.id,
+            "app_id": cache.app_id,
+            "workflow_config_id": cache.workflow_config_id,
+            "node_id": cache.node_id,
+            "node_type": cache.node_type,
+            "node_name": cache.node_name,
+            "cache_key": cache.cache_key,
+            "source": cache.source,
+            "status": cache.status,
+            "input_data": cache.input_data,
+            "result_data": cache.result_data,
+            "hit_count": cache.hit_count,
+            "last_hit_at": cache.last_hit_at,
+            "expires_at": cache.expires_at,
+            "invalidated_at": cache.invalidated_at,
+            "meta_data": cache.meta_data or {},
+            "created_at": cache.created_at,
+            "updated_at": cache.updated_at,
+        }
+
+    def get_active_cache(self, cache_key: str) -> dict[str, Any] | None:
+        if not self.app_id:
+            return None
+
+        now = utcnow_naive()
+        with get_db_context() as db:
+            repo = WorkflowNodeCacheRepository(db)
+            cache = repo.get_active_by_key(self.app_id, self.node_id, cache_key)
+            if not cache:
+                return None
+
+            if cache.expires_at and cache.expires_at <= now:
+                cache.status = "expired"
+                cache.invalidated_at = now
+                db.commit()
+                return None
+
+            cache.hit_count = int(cache.hit_count or 0) + 1
+            cache.last_hit_at = now
+            db.commit()
+            db.refresh(cache)
+            return self.serialize(cache)
+
+    def get_latest_cache(self, include_inactive: bool = False) -> dict[str, Any] | None:
+        if not self.app_id:
+            return None
+
+        now = utcnow_naive()
+        with get_db_context() as db:
+            repo = WorkflowNodeCacheRepository(db)
+            repo.invalidate_expired(now)
+            db.commit()
+            cache = repo.get_latest_by_node(self.app_id, self.node_id, include_inactive=include_inactive)
+            if not cache:
+                return None
+            return self.serialize(cache)
+
+    def save_cache(
+            self,
+            *,
+            cache_key: str,
+            input_data: Any,
+            result_data: dict[str, Any],
+            source: str,
+            ttl_seconds: int | None,
+            meta_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if not self.app_id:
+            return None
+
+        now = utcnow_naive()
+        expires_at = now + datetime.timedelta(seconds=ttl_seconds) if ttl_seconds else None
+        normalized_input = normalize_cache_value(input_data)
+        normalized_result = normalize_cache_value(result_data)
+        normalized_meta = normalize_cache_value(meta_data or {})
+
+        with get_db_context() as db:
+            repo = WorkflowNodeCacheRepository(db)
+            cache = repo.get_active_by_key(self.app_id, self.node_id, cache_key)
+            if cache and cache.expires_at and cache.expires_at <= now:
+                cache.status = "expired"
+                cache.invalidated_at = now
+                cache = None
+
+            if cache is None:
+                cache = repo.create(
+                    app_id=self.app_id,
+                    workflow_config_id=self.workflow_config_id,
+                    node_id=self.node_id,
+                    node_type=self.node_type,
+                    node_name=self.node_name,
+                    cache_key=cache_key,
+                    source=source,
+                    status="active",
+                    input_data=normalized_input,
+                    result_data=normalized_result,
+                    hit_count=0,
+                    last_hit_at=None,
+                    expires_at=expires_at,
+                    invalidated_at=None,
+                    meta_data=normalized_meta,
+                )
+            else:
+                cache.workflow_config_id = self.workflow_config_id
+                cache.node_type = self.node_type
+                cache.node_name = self.node_name
+                cache.source = source
+                cache.status = "active"
+                cache.input_data = normalized_input
+                cache.result_data = normalized_result
+                cache.expires_at = expires_at
+                cache.invalidated_at = None
+                cache.meta_data = normalized_meta
+
+            db.commit()
+            db.refresh(cache)
+            return self.serialize(cache)
+
+    def update_latest_cache(
+            self,
+            *,
+            result_data: dict[str, Any],
+            meta_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        if not self.app_id:
+            return None
+
+        with get_db_context() as db:
+            repo = WorkflowNodeCacheRepository(db)
+            cache = repo.get_latest_by_node(self.app_id, self.node_id, include_inactive=False)
+            if not cache:
+                return None
+            cache.result_data = normalize_cache_value(result_data)
+            if meta_data is not None:
+                cache.meta_data = normalize_cache_value(meta_data)
+            db.commit()
+            db.refresh(cache)
+            return self.serialize(cache)
+
+    def invalidate_latest_cache(self) -> int:
+        if not self.app_id:
+            return 0
+
+        now = utcnow_naive()
+        with get_db_context() as db:
+            repo = WorkflowNodeCacheRepository(db)
+            affected = repo.invalidate_by_node(self.app_id, self.node_id, invalidated_at=now)
+            db.commit()
+            return affected

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncGenerator
 from langgraph.config import get_stream_writer
 
 from app.core.config import settings
+from app.core.workflow.node_cache import DEFAULT_CACHEABLE_NODE_TYPES, WorkflowNodeCacheManager
 from app.core.workflow.engine.state_manager import WorkflowState
 from app.core.workflow.engine.variable_pool import VariablePool
 from app.core.workflow.nodes.enums import BRANCH_NODES
@@ -64,6 +65,7 @@ class BaseNode(ABC):
         # 使用 or 运算符处理 None 值
         self.config = node_config.get("config") or {}
         self.error_handling = node_config.get("error_handling") or {}
+        self.cache_config = node_config.get("cache") or {}
 
         self.variable_change_able = False
 
@@ -188,6 +190,144 @@ class BaseNode(ABC):
         """
         return settings.WORKFLOW_NODE_TIMEOUT
 
+    def _get_cache_manager(self) -> WorkflowNodeCacheManager:
+        return WorkflowNodeCacheManager(
+            app_id=self.workflow_config.get("app_id"),
+            workflow_config_id=self.workflow_config.get("workflow_config_id"),
+            node_id=self.node_id,
+            node_type=self.node_type,
+            node_name=self.node_name,
+        )
+
+    def _get_runtime_options(self) -> dict[str, Any]:
+        return self.workflow_config.get("runtime_options") or {}
+
+    def _get_cache_source(self) -> str:
+        return self._get_runtime_options().get("cache_source", "workflow_execution")
+
+    def _is_cache_enabled(self) -> bool:
+        if self._get_runtime_options().get("bypass_node_cache"):
+            return False
+        execution_config = self.workflow_config.get("execution_config") or {}
+        if not execution_config.get("enable_cache", True):
+            return False
+        explicit = self.cache_config.get("enabled")
+        if explicit is not None:
+            return bool(explicit)
+        return self.node_type in DEFAULT_CACHEABLE_NODE_TYPES
+
+    def _get_cache_ttl_seconds(self) -> int | None:
+        raw_value = (
+            self.cache_config.get("ttl_seconds")
+            if "ttl_seconds" in self.cache_config
+            else self.cache_config.get("ttl")
+        )
+        if raw_value in (None, "", False):
+            return None
+        try:
+            ttl_seconds = int(raw_value)
+        except (TypeError, ValueError):
+            return None
+        return ttl_seconds if ttl_seconds > 0 else None
+
+    async def _store_runtime_variables(self, extracted_output: Any, variable_pool: VariablePool) -> None:
+        if extracted_output is None:
+            return
+        runtime_vars = extracted_output
+        if not isinstance(extracted_output, dict):
+            runtime_vars = {"output": extracted_output}
+        for key, value in runtime_vars.items():
+            if key not in self.output_types:
+                continue
+            await variable_pool.new(self.node_id, key, value, self.output_types[key], mut=self.variable_change_able)
+
+    def _build_cache_input_snapshot(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
+        return self._extract_input(state, variable_pool)
+
+    def _build_state_update_from_cache(
+            self,
+            *,
+            cache_entry: dict[str, Any],
+            state: WorkflowState,
+            lookup_started_at: float,
+    ) -> dict[str, Any]:
+        cached_result = dict(cache_entry.get("result_data") or {})
+        original_elapsed = cached_result.get("elapsed_time")
+        cached_result["status"] = "completed"
+        cached_result["error"] = None
+        cached_result["elapsed_time"] = (time.time() - lookup_started_at) * 1000
+        cached_result["execution_order"] = time.monotonic_ns()
+        cached_result["cache_hit"] = True
+        cached_result["cache_key"] = cache_entry.get("cache_key")
+        cached_result["cache_id"] = str(cache_entry.get("id")) if cache_entry.get("id") else None
+        cached_result["cache_status"] = cache_entry.get("status")
+        cached_result["cache_hit_count"] = cache_entry.get("hit_count", 0)
+        if original_elapsed is not None:
+            cached_result["cache_origin_elapsed_time"] = original_elapsed
+        return {
+            "node_outputs": {
+                self.node_id: cached_result
+            },
+            "looping": state["looping"],
+        } | self.trans_activate(state)
+
+    async def _try_use_cache(
+            self,
+            state: WorkflowState,
+            variable_pool: VariablePool,
+            lookup_started_at: float,
+    ) -> dict[str, Any] | None:
+        if not self._is_cache_enabled():
+            return None
+        manager = self._get_cache_manager()
+        if not manager.is_available():
+            return None
+        cache_input = self._build_cache_input_snapshot(state, variable_pool)
+        cache_key = manager.build_cache_key(cache_input)
+        cache_entry = manager.get_active_cache(cache_key)
+        if not cache_entry:
+            return None
+        await self._store_runtime_variables((cache_entry.get("result_data") or {}).get("output"), variable_pool)
+        return self._build_state_update_from_cache(
+            cache_entry=cache_entry,
+            state=state,
+            lookup_started_at=lookup_started_at,
+        )
+
+    def _save_cache(
+            self,
+            *,
+            state: WorkflowState,
+            variable_pool: VariablePool,
+            node_output: dict[str, Any],
+    ) -> None:
+        if not self._is_cache_enabled():
+            return
+        if not isinstance(node_output, dict) or node_output.get("status") != "completed":
+            return
+        manager = self._get_cache_manager()
+        if not manager.is_available():
+            return
+        cache_input = self._build_cache_input_snapshot(state, variable_pool)
+        cache_key = manager.build_cache_key(cache_input)
+        cache_payload = dict(node_output)
+        cache_payload.pop("execution_order", None)
+        cache_payload.pop("cache_hit", None)
+        cache_payload.pop("cache_id", None)
+        cache_payload.pop("cache_status", None)
+        cache_payload.pop("cache_hit_count", None)
+        cache_payload.pop("cache_origin_elapsed_time", None)
+        manager.save_cache(
+            cache_key=cache_key,
+            input_data=cache_input,
+            result_data=cache_payload,
+            source=self._get_cache_source(),
+            ttl_seconds=self._get_cache_ttl_seconds(),
+            meta_data={
+                "execution_id": state.get("execution_id"),
+            },
+        )
+
     async def run(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
         """Runs the node with error handling and output wrapping (non-streaming).
 
@@ -207,9 +347,10 @@ class BaseNode(ABC):
         if not self.check_activate(state):
             return self.trans_activate(state)
 
-        import time
-
         start_time = time.time()
+        cached_state_update = await self._try_use_cache(state, variable_pool, start_time)
+        if cached_state_update:
+            return cached_state_update
 
         timeout = self.get_timeout()
 
@@ -230,17 +371,19 @@ class BaseNode(ABC):
 
             # Store extracted outputs as runtime variables for downstream nodes.
             if extracted_output is not None:
-                runtime_vars = extracted_output
-                if not isinstance(extracted_output, dict):
-                    runtime_vars = {"output": extracted_output}
-                for k, v in runtime_vars.items():
-                    await variable_pool.new(self.node_id, k, v, self.output_types[k], mut=self.variable_change_able)
+                await self._store_runtime_variables(extracted_output, variable_pool)
 
             # Return the wrapped output along with activation state updates.
-            return {
+            state_update = {
                 **wrapped_output,
                 "looping": state["looping"]
             } | self.trans_activate(state)
+            self._save_cache(
+                state=state,
+                variable_pool=variable_pool,
+                node_output=wrapped_output.get("node_outputs", {}).get(self.node_id, {}),
+            )
+            return state_update
 
         except TimeoutError:
             elapsed_time = (time.time() - start_time) * 1000
@@ -288,9 +431,11 @@ class BaseNode(ABC):
             logger.debug(f"jump node: {self.node_id}")
             return
 
-        import time
-
         start_time = time.time()
+        cached_state_update = await self._try_use_cache(state, variable_pool, start_time)
+        if cached_state_update:
+            yield cached_state_update
+            return
 
         timeout = self.get_timeout()
 
@@ -346,17 +491,18 @@ class BaseNode(ABC):
 
             # Store extracted output in runtime variables (for quick access by subsequent nodes)
             if extracted_output is not None:
-                runtime_vars = extracted_output
-                if not isinstance(extracted_output, dict):
-                    runtime_vars = {"output": extracted_output}
-                for k, v in runtime_vars.items():
-                    await variable_pool.new(self.node_id, k, v, self.output_types[k], mut=self.variable_change_able)
+                await self._store_runtime_variables(extracted_output, variable_pool)
 
             # Build complete state update (including node_outputs, runtime_vars, and final streaming buffer)
             state_update = {
                 **final_output,
                 "looping": state["looping"]
             }
+            self._save_cache(
+                state=state,
+                variable_pool=variable_pool,
+                node_output=final_output.get("node_outputs", {}).get(self.node_id, {}),
+            )
 
             # Finally yield state update
             # LangGraph will merge this into state

--- a/api/app/core/workflow/nodes/start/node.py
+++ b/api/app/core/workflow/nodes/start/node.py
@@ -169,6 +169,10 @@ class StartNode(BaseNode):
                 processed[var_name] = var_def.default
                 logger.debug(f"变量 '{var_name}' 使用默认值: {var_def.default}")
             else:
+                # file 类型未传值时不生成空占位，避免后续被当成无效 FileObject 写入变量池
+                if var_type == VariableType.FILE:
+                    self.output_var_types[var_name] = var_type
+                    continue
                 processed[var_name] = DEFAULT_VALUE(var_type)
             self.output_var_types[var_name] = var_type
 

--- a/api/app/core/workflow/variable/base_variable.py
+++ b/api/app/core/workflow/variable/base_variable.py
@@ -26,6 +26,16 @@ class VariableType(StrEnum):
 
     ANY = 'any'
 
+    @staticmethod
+    def _is_file_like_dict(var: Any) -> bool:
+        return isinstance(var, dict) and (
+            var.get("is_file") is True
+            or (
+                any(key in var for key in ("file_id", "upload_file_id", "url"))
+                and any(key in var for key in ("type", "origin_file_type", "transfer_method"))
+            )
+        )
+
     @classmethod
     def type_map(cls, var: Any) -> "VariableType":
         """Maps a Python value to a corresponding VariableType.
@@ -45,7 +55,7 @@ class VariableType(StrEnum):
             return cls.BOOLEAN
         elif isinstance(var, (int, float)):
             return cls.NUMBER
-        elif isinstance(var, FileObject) or (isinstance(var, dict) and var.get('is_file')):
+        elif isinstance(var, FileObject) or cls._is_file_like_dict(var):
             return cls.FILE
         elif isinstance(var, dict):
             return cls.OBJECT
@@ -53,7 +63,12 @@ class VariableType(StrEnum):
             if len(var) == 0:
                 return cls.ARRAY_STRING
             else:
-                child_type = type(var[0])
+                first_item = next((item for item in var if item is not None), None)
+                if first_item is None:
+                    return cls.ARRAY_STRING
+                if isinstance(first_item, FileObject) or cls._is_file_like_dict(first_item):
+                    return cls.ARRAY_FILE
+                child_type = type(first_item)
                 if child_type == str:
                     return cls.ARRAY_STRING
                 elif child_type == int or child_type == float:

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -24,7 +24,7 @@ from .conversation_model import Conversation, Message
 from .api_key_model import ApiKey, ApiKeyLog, ApiKeyType
 from .memory_config_model import MemoryConfig
 from .multi_agent_model import MultiAgentConfig, AgentInvocation
-from .workflow_model import WorkflowConfig, WorkflowExecution, WorkflowNodeExecution
+from .workflow_model import WorkflowConfig, WorkflowExecution, WorkflowNodeExecution, WorkflowNodeCache
 from .agent_execution_model import AgentExecution
 from .retrieval_info import RetrievalInfo
 from .prompt_optimizer_model import PromptOptimizerSession, PromptOptimizerSessionHistory
@@ -87,6 +87,7 @@ __all__ = [
     "WorkflowConfig",
     "WorkflowExecution",
     "WorkflowNodeExecution",
+    "WorkflowNodeCache",
     "AgentExecution",
     "RetrievalInfo",
     "PromptOptimizerSession",

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -3,7 +3,7 @@
 """
 
 import uuid
-from sqlalchemy import Column, String, Boolean, DateTime, Integer, Float, ForeignKey, Text, text
+from sqlalchemy import Column, String, Boolean, DateTime, Integer, BigInteger, Float, ForeignKey, Text, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.db import Base
@@ -172,7 +172,7 @@ class WorkflowNodeExecution(Base):
     node_name = Column(String(100))
     
     # 执行顺序
-    execution_order = Column(Integer, nullable=False)
+    execution_order = Column(BigInteger, nullable=False)
     retry_count = Column(Integer, nullable=False, default=0)
     
     # 输入输出
@@ -207,3 +207,53 @@ class WorkflowNodeExecution(Base):
     
     def __repr__(self):
         return f"<WorkflowNodeExecution(id={self.id}, node_id={self.node_id}, status={self.status})>"
+
+
+class WorkflowNodeCache(Base):
+    """工作流节点缓存表"""
+
+    __tablename__ = "workflow_node_caches"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+
+    app_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("apps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    workflow_config_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workflow_configs.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+
+    node_id = Column(String(100), nullable=False, index=True)
+    node_type = Column(String(50), nullable=False)
+    node_name = Column(String(100))
+    cache_key = Column(String(64), nullable=False, index=True)
+    source = Column(String(32), nullable=False, default="workflow_execution")
+
+    status = Column(String(20), nullable=False, default="active", index=True)
+    input_data = Column(JSONB)
+    result_data = Column(JSONB)
+    hit_count = Column(Integer, nullable=False, default=0)
+    last_hit_at = Column(DateTime)
+    expires_at = Column(DateTime)
+    invalidated_at = Column(DateTime)
+    meta_data = Column(JSONB, default=dict)
+
+    created_at = Column(DateTime, nullable=False, default=utcnow_naive)
+    updated_at = Column(
+        DateTime,
+        nullable=False,
+        default=utcnow_naive,
+        onupdate=utcnow_naive
+    )
+
+    app = relationship("App")
+    workflow_config = relationship("WorkflowConfig")
+
+    def __repr__(self):
+        return f"<WorkflowNodeCache(id={self.id}, node_id={self.node_id}, status={self.status})>"

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -12,7 +12,8 @@ from app.core.workflow.nodes.enums import NodeType
 from app.models.workflow_model import (
     WorkflowConfig,
     WorkflowExecution,
-    WorkflowNodeExecution
+    WorkflowNodeExecution,
+    WorkflowNodeCache,
 )
 from app.db import get_db
 
@@ -329,6 +330,86 @@ class WorkflowNodeExecutionRepository:
         return self.db.execute(stmt).scalars().first()
 
 
+class WorkflowNodeCacheRepository:
+    """工作流节点缓存仓储"""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(self, **kwargs) -> WorkflowNodeCache:
+        cache = WorkflowNodeCache(**kwargs)
+        self.db.add(cache)
+        return cache
+
+    def get_active_by_key(
+            self,
+            app_id: uuid.UUID,
+            node_id: str,
+            cache_key: str,
+    ) -> WorkflowNodeCache | None:
+        stmt = (
+            select(WorkflowNodeCache)
+            .where(
+                WorkflowNodeCache.app_id == app_id,
+                WorkflowNodeCache.node_id == node_id,
+                WorkflowNodeCache.cache_key == cache_key,
+                WorkflowNodeCache.status == "active",
+            )
+            .order_by(desc(WorkflowNodeCache.updated_at), desc(WorkflowNodeCache.created_at))
+            .limit(1)
+        )
+        return self.db.execute(stmt).scalars().first()
+
+    def get_latest_by_node(
+            self,
+            app_id: uuid.UUID,
+            node_id: str,
+            include_inactive: bool = False,
+    ) -> WorkflowNodeCache | None:
+        stmt = select(WorkflowNodeCache).where(
+            WorkflowNodeCache.app_id == app_id,
+            WorkflowNodeCache.node_id == node_id,
+        )
+        if not include_inactive:
+            stmt = stmt.where(WorkflowNodeCache.status == "active")
+        stmt = stmt.order_by(desc(WorkflowNodeCache.updated_at), desc(WorkflowNodeCache.created_at)).limit(1)
+        return self.db.execute(stmt).scalars().first()
+
+    def invalidate_by_node(
+            self,
+            app_id: uuid.UUID,
+            node_id: str,
+            *,
+            invalidated_at,
+            statuses: tuple[str, ...] = ("active", "expired"),
+    ) -> int:
+        stmt = (
+            select(WorkflowNodeCache)
+            .where(
+                WorkflowNodeCache.app_id == app_id,
+                WorkflowNodeCache.node_id == node_id,
+                WorkflowNodeCache.status.in_(statuses),
+            )
+        )
+        items = list(self.db.execute(stmt).scalars())
+        for item in items:
+            item.status = "invalidated"
+            item.invalidated_at = invalidated_at
+        return len(items)
+
+    def invalidate_expired(self, now) -> int:
+        stmt = select(WorkflowNodeCache).where(
+            WorkflowNodeCache.status == "active",
+            WorkflowNodeCache.expires_at.is_not(None),
+            WorkflowNodeCache.expires_at <= now,
+        )
+        items = list(self.db.execute(stmt).scalars())
+        for item in items:
+            item.status = "expired"
+            item.invalidated_at = now
+        return len(items)
+
+
 # ==================== 依赖注入函数 ====================
 
 def get_workflow_config_repository(
@@ -350,3 +431,10 @@ def get_workflow_node_execution_repository(
 ) -> WorkflowNodeExecutionRepository:
     """获取工作流节点执行记录仓储（依赖注入）"""
     return WorkflowNodeExecutionRepository(db)
+
+
+def get_workflow_node_cache_repository(
+    db: Annotated[Session, Depends(get_db)]
+) -> WorkflowNodeCacheRepository:
+    """获取工作流节点缓存仓储（依赖注入）"""
+    return WorkflowNodeCacheRepository(db)

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Optional, Any, List, Dict, Union
 from enum import Enum, StrEnum
 
-from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator, model_serializer
+from pydantic import BaseModel, Field, ConfigDict, field_serializer, field_validator, model_serializer, model_validator
 
 from app.core.utils.datetime_utils import to_timestamp_ms
 from app.schemas.workflow_schema import WorkflowConfigCreate
@@ -735,6 +735,72 @@ class NodeRunRequest(BaseModel):
         }]
     )
     stream: bool = Field(default=False, description="是否流式返回")
+    base_execution_id: Optional[str] = Field(
+        default=None,
+        description="基准执行 ID，用于基于某次整图执行快照恢复上下文后再单节点运行",
+    )
+
+
+class NodeCacheUpdateRequest(BaseModel):
+    """更新节点缓存内容"""
+    result_data: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="兼容旧模式：直接提交完整的缓存结果数据",
+    )
+    patches: List["NodeCacheVariablePatch"] = Field(
+        default_factory=list,
+        description="新模式：按变量 patch 缓存内容，只修改指定字段",
+    )
+
+    @model_validator(mode="after")
+    def validate_payload(self):
+        if self.result_data is None and not self.patches:
+            raise ValueError("result_data 和 patches 至少需要传一个")
+        if self.result_data is not None and self.patches:
+            raise ValueError("result_data 和 patches 不能同时传")
+        return self
+
+
+class NodeCacheVariablePatch(BaseModel):
+    """按变量 patch 节点缓存内容"""
+    scope: str = Field(
+        default="output",
+        description="修改范围，只支持 output/input/process",
+    )
+    path: Optional[str] = Field(
+        default=None,
+        description="变量路径，支持 dot notation，例如 output 或 metadata.answer",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        description="变量名，等价于 path 的简写",
+    )
+    value: Any = Field(
+        ...,
+        description="变量新值",
+    )
+    type: Optional[str] = Field(
+        default=None,
+        description="变量类型，仅作为前端透传和调试信息，后端以 value 为准",
+    )
+
+    @model_validator(mode="after")
+    def validate_patch(self):
+        if self.scope not in {"output", "input", "process"}:
+            raise ValueError("scope 只支持 output、input、process")
+        if bool(self.path) == bool(self.name):
+            raise ValueError("path 和 name 必须二选一")
+        return self
+
+
+class NodeRerunRequest(BaseModel):
+    """基于最近一次单节点调试输入重跑"""
+    invalidate_cache: bool = Field(default=False, description="重跑前是否先失效当前缓存")
+    bypass_cache: bool = Field(default=False, description="重跑时是否跳过缓存直接真实执行")
+    base_execution_id: Optional[str] = Field(
+        default=None,
+        description="可选，覆盖最近一次单节点调试绑定的基准执行 ID",
+    )
 
 
 class DraftRunCompareRequest(BaseModel):

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -12,6 +12,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+from app.core.workflow.node_cache import normalize_cache_value, WorkflowNodeCacheManager
 from app.core.workflow.utils.secret_masker import mask_secrets
 from app.core.workflow.triggers import (
     build_schedule_now_payload,
@@ -27,6 +28,7 @@ from app.core.exceptions import BusinessException
 from app.core.workflow.adapters.registry import PlatformAdapterRegistry
 from app.core.workflow.executor import execute_workflow, execute_workflow_stream
 from app.core.workflow.nodes.enums import NodeType
+from app.core.workflow.variable.base_variable import VariableType, DEFAULT_VALUE
 from app.core.workflow.validator import validate_workflow_config
 from app.db import get_db
 from app.models import App, AppRelease
@@ -35,7 +37,8 @@ from app.repositories import knowledge_repository
 from app.repositories.workflow_repository import (
     WorkflowConfigRepository,
     WorkflowExecutionRepository,
-    WorkflowNodeExecutionRepository
+    WorkflowNodeExecutionRepository,
+    WorkflowNodeCacheRepository,
 )
 from app.schemas import DraftRunRequest, FileInput, FileType
 from app.services.annotation_service import AnnotationService
@@ -54,6 +57,7 @@ class WorkflowService:
         self.config_repo = WorkflowConfigRepository(db)
         self.execution_repo = WorkflowExecutionRepository(db)
         self.node_execution_repo = WorkflowNodeExecutionRepository(db)
+        self.node_cache_repo = WorkflowNodeCacheRepository(db)
         self.conversation_service = ConversationService(db)
         self.multimodal_service = MultimodalService(db)
 
@@ -927,6 +931,516 @@ class WorkflowService:
         return value
 
     @staticmethod
+    def _normalize_variable_type_name(var_type: Any) -> str:
+        if isinstance(var_type, VariableType):
+            return var_type.value
+        if isinstance(var_type, str) and var_type:
+            if var_type == "secret":
+                return VariableType.STRING.value
+            return var_type
+        return VariableType.ANY.value
+
+    @staticmethod
+    def _infer_variable_type_name(value: Any) -> str:
+        try:
+            return VariableType.type_map(value).value
+        except Exception:
+            return VariableType.ANY.value
+
+    @classmethod
+    def _build_typed_variable(cls, value: Any, var_type: Any = None) -> dict[str, Any]:
+        serialized_value = cls._serialize_execution_value(value)
+        type_name = cls._normalize_variable_type_name(var_type)
+        if type_name == VariableType.ANY.value:
+            type_name = cls._infer_variable_type_name(serialized_value)
+        return {
+            "type": type_name,
+            "value": serialized_value,
+        }
+
+    @staticmethod
+    def _is_typed_variable_payload(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and "type" in value
+            and "value" in value
+            and isinstance(value.get("type"), str)
+            and value["type"] in {item.value for item in VariableType}
+        )
+
+    @classmethod
+    def _normalize_typed_group(
+            cls,
+            raw_group: Any,
+            *,
+            type_map: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if not isinstance(raw_group, dict):
+            return {}
+        normalized: dict[str, Any] = {}
+        for name, value in raw_group.items():
+            if cls._is_typed_variable_payload(value):
+                normalized[name] = cls._build_typed_variable(
+                    value=value.get("value"),
+                    var_type=value.get("type"),
+                )
+                continue
+            normalized[name] = cls._build_typed_variable(
+                value=value,
+                var_type=(type_map or {}).get(name),
+            )
+        return normalized
+
+    @classmethod
+    def _unwrap_typed_variable(cls, value: Any) -> Any:
+        if cls._is_typed_variable_payload(value):
+            return cls._serialize_execution_value(value.get("value"))
+        return cls._serialize_execution_value(value)
+
+    @classmethod
+    def _unwrap_typed_group(cls, raw_group: Any) -> dict[str, Any]:
+        if not isinstance(raw_group, dict):
+            return {}
+        return {
+            name: cls._unwrap_typed_variable(value)
+            for name, value in raw_group.items()
+        }
+
+    @classmethod
+    def _merge_typed_group(cls, base_group: Any, overlay_group: Any) -> dict[str, Any]:
+        merged = dict(base_group or {}) if isinstance(base_group, dict) else {}
+        if isinstance(overlay_group, dict):
+            for name, value in overlay_group.items():
+                merged[name] = value
+        return merged
+
+    @classmethod
+    def _merge_execution_snapshots(
+            cls,
+            base_snapshot: dict[str, Any],
+            overlay_snapshot: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged_nodes = dict(base_snapshot.get("nodes") or {})
+        for node_id, node_group in (overlay_snapshot.get("nodes") or {}).items():
+            merged_nodes[node_id] = cls._merge_typed_group(merged_nodes.get(node_id), node_group)
+
+        return {
+            "system": cls._merge_typed_group(
+                base_snapshot.get("system"),
+                overlay_snapshot.get("system"),
+            ),
+            "conversation": cls._merge_typed_group(
+                base_snapshot.get("conversation"),
+                overlay_snapshot.get("conversation"),
+            ),
+            "environment": cls._merge_typed_group(
+                base_snapshot.get("environment"),
+                overlay_snapshot.get("environment"),
+            ),
+            "nodes": merged_nodes,
+        }
+
+    @staticmethod
+    def _get_execution_source(execution: WorkflowExecution | None) -> str:
+        if not execution:
+            return "workflow_execution"
+        meta_data = execution.meta_data or {}
+        return meta_data.get("source", "workflow_execution")
+
+    def _find_latest_base_execution(
+            self,
+            app_id: uuid.UUID,
+            *,
+            exclude_execution_id: str | None = None,
+    ) -> WorkflowExecution | None:
+        executions = self.execution_repo.get_by_app_id(app_id, limit=50, offset=0)
+        for execution in executions:
+            if exclude_execution_id and execution.execution_id == exclude_execution_id:
+                continue
+            if self._get_execution_source(execution) == "single_node_debug":
+                continue
+            if not isinstance(execution.output_data, dict):
+                continue
+            return execution
+        return None
+
+    def _resolve_base_execution(
+            self,
+            *,
+            app_id: uuid.UUID,
+            explicit_execution_id: str | None = None,
+            debug_execution: WorkflowExecution | None = None,
+    ) -> WorkflowExecution | None:
+        candidate: WorkflowExecution | None = None
+        if explicit_execution_id:
+            candidate = self.get_execution(explicit_execution_id)
+            if not candidate or candidate.app_id != app_id:
+                raise BusinessException("基准执行不存在", BizCode.NOT_FOUND)
+        elif debug_execution:
+            stored_execution_id = (debug_execution.meta_data or {}).get("base_execution_id")
+            if stored_execution_id:
+                candidate = self.get_execution(stored_execution_id)
+                if candidate and candidate.app_id != app_id:
+                    candidate = None
+
+        if candidate and self._get_execution_source(candidate) == "single_node_debug":
+            nested_execution_id = (candidate.meta_data or {}).get("base_execution_id")
+            if nested_execution_id and nested_execution_id != candidate.execution_id:
+                nested_execution = self.get_execution(nested_execution_id)
+                if nested_execution and nested_execution.app_id == app_id:
+                    candidate = nested_execution
+
+        if candidate:
+            return candidate
+
+        return self._find_latest_base_execution(
+            app_id,
+            exclude_execution_id=debug_execution.execution_id if debug_execution else None,
+        )
+
+    @staticmethod
+    def _coerce_variable_type(var_type: Any, value: Any = None) -> VariableType:
+        if isinstance(var_type, VariableType):
+            return var_type
+        if isinstance(var_type, str):
+            try:
+                return VariableType(var_type)
+            except ValueError:
+                pass
+        try:
+            return VariableType.type_map(value)
+        except Exception:
+            return VariableType.ANY
+
+    @staticmethod
+    def _build_conversation_variable_type_map(variables: list[dict[str, Any]] | None) -> dict[str, str]:
+        return {
+            item.get("name"): item.get("type", VariableType.STRING.value)
+            for item in (variables or [])
+            if item.get("name")
+        }
+
+    @staticmethod
+    def _build_system_variable_type_map() -> dict[str, str]:
+        return {
+            "conversation_index": VariableType.NUMBER.value,
+            "conversation_id": VariableType.STRING.value,
+            "execution_id": VariableType.STRING.value,
+            "workspace_id": VariableType.STRING.value,
+            "user_id": VariableType.STRING.value,
+            "input_variables": VariableType.OBJECT.value,
+            "files": VariableType.ARRAY_FILE.value,
+            "trigger": VariableType.OBJECT.value,
+            "trigger_payload": VariableType.OBJECT.value,
+            "message": VariableType.STRING.value,
+        }
+
+    @classmethod
+    def _build_missing_typed_variable(cls, var_type: Any) -> dict[str, Any]:
+        type_name = cls._normalize_variable_type_name(var_type)
+        if type_name == VariableType.FILE.value:
+            default_value = None
+        elif type_name == VariableType.ANY.value:
+            default_value = None
+        else:
+            default_value = cls._serialize_execution_value(DEFAULT_VALUE(VariableType(type_name)))
+        return {
+            "type": type_name,
+            "value": default_value,
+        }
+
+    @classmethod
+    def _build_node_variable_type_maps(
+            cls,
+            nodes: list[dict[str, Any]] | None,
+    ) -> dict[str, dict[str, str]]:
+        result: dict[str, dict[str, str]] = {}
+        for node in nodes or []:
+            node_id = node.get("id")
+            if not node_id:
+                continue
+            if node.get("type") != NodeType.START.value:
+                continue
+            config = node.get("config") or {}
+            type_map = {
+                "message": VariableType.STRING.value,
+                "execution_id": VariableType.STRING.value,
+                "conversation_id": VariableType.STRING.value,
+                "workspace_id": VariableType.STRING.value,
+                "user_id": VariableType.STRING.value,
+            }
+            for item in config.get("variables") or []:
+                name = item.get("name")
+                if not name:
+                    continue
+                type_map[name] = cls._normalize_variable_type_name(item.get("type"))
+            result[node_id] = type_map
+        return result
+
+    @staticmethod
+    def _build_environment_variable_type_map(environment_variables: list[dict[str, Any]] | None) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for item in environment_variables or []:
+            name = item.get("name")
+            if not name:
+                continue
+            value_type = item.get("value_type", VariableType.STRING.value)
+            result[name] = VariableType.NUMBER.value if value_type == "number" else VariableType.STRING.value
+        return result
+
+    @staticmethod
+    def _build_environment_snapshot(environment_variables: list[dict[str, Any]] | None) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for item in environment_variables or []:
+            name = item.get("name")
+            if not name:
+                continue
+            result[name] = item.get("value")
+        return WorkflowService._serialize_execution_value(result)
+
+    def _build_execution_snapshot(
+            self,
+            *,
+            execution: WorkflowExecution,
+            node_executions: list[WorkflowNodeExecution],
+            output_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        conversation_type_map = self._build_conversation_variable_type_map(
+            workflow_config.variables if workflow_config else []
+        )
+        system_type_map = self._build_system_variable_type_map()
+        node_type_maps = self._build_node_variable_type_maps(
+            workflow_config.nodes if workflow_config else []
+        )
+        environment_type_map = self._build_environment_variable_type_map(
+            workflow_config.environment_variables if workflow_config else []
+        )
+        snapshot_data = output_data.get("snapshot") if isinstance(output_data, dict) else {}
+        variables_data = output_data.get("variables") if isinstance(output_data, dict) else {}
+
+        raw_system_vars = snapshot_data.get("system") if isinstance(snapshot_data, dict) else {}
+        raw_conversation_vars = snapshot_data.get("conversation") if isinstance(snapshot_data, dict) else {}
+        raw_environment_vars = snapshot_data.get("environment") if isinstance(snapshot_data, dict) else {}
+        raw_node_vars = snapshot_data.get("nodes") if isinstance(snapshot_data, dict) else {}
+
+        if not raw_system_vars and isinstance(variables_data, dict):
+            raw_system_vars = variables_data.get("sys") or {}
+        if not raw_conversation_vars and isinstance(variables_data, dict):
+            raw_conversation_vars = variables_data.get("conv") or {}
+        if not raw_environment_vars and isinstance(variables_data, dict):
+            raw_environment_vars = variables_data.get("env") or {}
+        if not raw_environment_vars:
+            raw_environment_vars = self._build_environment_snapshot(
+                workflow_config.environment_variables if workflow_config else []
+            )
+
+        ordered_node_vars: dict[str, Any] = {}
+        serialized_raw_node_vars = self._serialize_execution_value(raw_node_vars or {})
+        for node_execution in node_executions:
+            node_id = node_execution.node_id
+            node_type_map = node_type_maps.get(node_id)
+            if node_id in ordered_node_vars:
+                continue
+            if isinstance(serialized_raw_node_vars, dict) and node_id in serialized_raw_node_vars:
+                ordered_node_vars[node_id] = self._normalize_typed_group(
+                    serialized_raw_node_vars[node_id],
+                    type_map=node_type_map,
+                )
+                continue
+            serialized_output = self._serialize_execution_value(node_execution.output_data or {})
+            if isinstance(serialized_output, dict) and "output" in serialized_output:
+                node_value = serialized_output.get("output")
+                if isinstance(node_value, dict):
+                    ordered_node_vars[node_id] = self._normalize_typed_group(
+                        node_value,
+                        type_map=node_type_map,
+                    )
+                else:
+                    ordered_node_vars[node_id] = {
+                        "output": self._build_typed_variable(
+                            node_value,
+                            node_type_map.get("output") if node_type_map else None,
+                        )
+                    }
+            else:
+                if isinstance(serialized_output, dict):
+                    ordered_node_vars[node_id] = self._normalize_typed_group(
+                        serialized_output,
+                        type_map=node_type_map,
+                    )
+                else:
+                    ordered_node_vars[node_id] = {
+                        "output": self._build_typed_variable(
+                            serialized_output,
+                            node_type_map.get("output") if node_type_map else None,
+                        )
+                    }
+
+        if isinstance(serialized_raw_node_vars, dict):
+            for node_id, node_value in serialized_raw_node_vars.items():
+                if node_id not in ordered_node_vars:
+                    ordered_node_vars[node_id] = self._normalize_typed_group(
+                        node_value,
+                        type_map=node_type_maps.get(node_id),
+                    )
+
+        for node_id, type_map in node_type_maps.items():
+            node_vars = ordered_node_vars.setdefault(node_id, {})
+            for var_name, var_type in type_map.items():
+                if var_name not in node_vars:
+                    node_vars[var_name] = self._build_missing_typed_variable(var_type)
+
+        return {
+            "system": self._normalize_typed_group(
+                raw_system_vars or {},
+                type_map=system_type_map,
+            ),
+            "conversation": self._normalize_typed_group(
+                raw_conversation_vars or {},
+                type_map=conversation_type_map,
+            ),
+            "environment": self._normalize_typed_group(
+                raw_environment_vars or {},
+                type_map=environment_type_map,
+            ),
+            "nodes": ordered_node_vars,
+        }
+
+    def _build_execution_snapshot_from_record(self, execution: WorkflowExecution) -> dict[str, Any]:
+        node_executions = self.node_execution_repo.get_by_execution_id(execution.id)
+        output_data = self._serialize_execution_value(execution.output_data or {})
+        return self._build_execution_snapshot(
+            execution=execution,
+            node_executions=node_executions,
+            output_data=output_data if isinstance(output_data, dict) else {},
+        )
+
+    def _extract_execution_messages(self, execution: WorkflowExecution | None) -> list[dict[str, Any]]:
+        if not execution or not isinstance(execution.output_data, dict):
+            return []
+        messages = self._serialize_execution_value(execution.output_data.get("messages") or [])
+        return messages if isinstance(messages, list) else []
+
+    def _extract_execution_node_outputs(self, execution: WorkflowExecution | None) -> dict[str, Any]:
+        if not execution or not isinstance(execution.output_data, dict):
+            return {}
+        node_outputs = self._serialize_execution_value(execution.output_data.get("node_outputs") or {})
+        return node_outputs if isinstance(node_outputs, dict) else {}
+
+    async def _restore_snapshot_group_to_variable_pool(
+            self,
+            *,
+            variable_pool,
+            namespace: str,
+            raw_group: Any,
+            mut: bool,
+            skip_keys: set[str] | None = None,
+    ) -> None:
+        if not isinstance(raw_group, dict):
+            return
+        for name, typed_value in raw_group.items():
+            if skip_keys and name in skip_keys:
+                continue
+            resolved_type = self._coerce_variable_type(
+                typed_value.get("type") if self._is_typed_variable_payload(typed_value) else None,
+                self._unwrap_typed_variable(typed_value),
+            )
+            resolved_value = self._unwrap_typed_variable(typed_value)
+            if resolved_value is None:
+                if resolved_type == VariableType.FILE:
+                    continue
+                if resolved_type != VariableType.ANY:
+                    resolved_value = DEFAULT_VALUE(resolved_type)
+            await variable_pool.new(
+                namespace=namespace,
+                key=name,
+                value=resolved_value,
+                var_type=resolved_type,
+                mut=mut,
+            )
+
+    async def _restore_variable_pool_from_snapshot(
+            self,
+            *,
+            variable_pool,
+            snapshot: dict[str, Any] | None,
+    ) -> None:
+        if not isinstance(snapshot, dict):
+            return
+        await self._restore_snapshot_group_to_variable_pool(
+            variable_pool=variable_pool,
+            namespace="sys",
+            raw_group=snapshot.get("system"),
+            mut=False,
+            skip_keys={"execution_id", "workspace_id", "user_id"},
+        )
+        await self._restore_snapshot_group_to_variable_pool(
+            variable_pool=variable_pool,
+            namespace="conv",
+            raw_group=snapshot.get("conversation"),
+            mut=True,
+        )
+        await self._restore_snapshot_group_to_variable_pool(
+            variable_pool=variable_pool,
+            namespace="env",
+            raw_group=snapshot.get("environment"),
+            mut=False,
+        )
+        for node_id, group in (snapshot.get("nodes") or {}).items():
+            await self._restore_snapshot_group_to_variable_pool(
+                variable_pool=variable_pool,
+                namespace=node_id,
+                raw_group=group,
+                mut=False,
+            )
+
+    async def _apply_input_data_overrides_to_variable_pool(
+            self,
+            *,
+            variable_pool,
+            input_data: dict[str, Any],
+    ) -> None:
+        if input_data.get("message") is not None:
+            await variable_pool.new("sys", "message", input_data.get("message"), VariableType.STRING, mut=False)
+        if input_data.get("files") is not None:
+            await variable_pool.new("sys", "files", input_data.get("files"), VariableType.ARRAY_FILE, mut=False)
+        if input_data.get("trigger") is not None:
+            await variable_pool.new("sys", "trigger", input_data.get("trigger"), VariableType.OBJECT, mut=False)
+        if input_data.get("trigger_payload") is not None:
+            await variable_pool.new(
+                "sys",
+                "trigger_payload",
+                input_data.get("trigger_payload"),
+                VariableType.OBJECT,
+                mut=False,
+            )
+        if input_data.get("conversation_id"):
+            await variable_pool.new(
+                "sys",
+                "conversation_id",
+                input_data.get("conversation_id"),
+                VariableType.STRING,
+                mut=False,
+            )
+        if input_data.get("variables") is not None:
+            await variable_pool.new(
+                "sys",
+                "input_variables",
+                input_data.get("variables") or {},
+                VariableType.OBJECT,
+                mut=False,
+            )
+        for key, value in (input_data.get("conv") or {}).items():
+            await variable_pool.new(
+                "conv",
+                key,
+                value,
+                self._coerce_variable_type(None, value),
+                mut=True,
+            )
+
+    @staticmethod
     def _mask_runtime_secrets(payload: dict[str, Any], variable_pool) -> dict[str, Any]:
         if not variable_pool:
             return payload
@@ -974,6 +1488,33 @@ class WorkflowService:
             "error": payload.get("error"),
             "execution_order": 1,
             "retry_count": 0,
+        }
+
+    @staticmethod
+    def _build_single_node_payload_from_node_output(
+            node_id: str,
+            node_type: str | None,
+            node_output: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "status": node_output.get("status", "completed"),
+            "node_id": node_id,
+            "node_type": node_type,
+            "inputs": node_output.get("input"),
+            "outputs": node_output.get("output"),
+            "process": node_output.get("process"),
+            "token_usage": node_output.get("token_usage"),
+            "elapsed_time": node_output.get("elapsed_time"),
+            "error": node_output.get("error"),
+            "cache_hit": bool(node_output.get("cache_hit", False)),
+            "cache_key": node_output.get("cache_key"),
+        }
+
+    @staticmethod
+    def _attach_debug_execution_id(payload: dict[str, Any], execution_id: str) -> dict[str, Any]:
+        return {
+            **(payload or {}),
+            "execution_id": execution_id,
         }
 
     @staticmethod
@@ -1077,6 +1618,7 @@ class WorkflowService:
             workflow_config: WorkflowConfig,
             node_id: str,
             input_data: dict[str, Any],
+            base_execution_id: str | None = None,
     ) -> WorkflowExecution:
         conversation_id = input_data.get("conversation_id")
         conversation_id_uuid = uuid.UUID(conversation_id) if conversation_id else None
@@ -1093,6 +1635,7 @@ class WorkflowService:
             "debug": True,
             "source": "single_node_debug",
             "node_id": node_id,
+            "base_execution_id": base_execution_id,
         }
         self.db.commit()
         self.db.refresh(execution)
@@ -1140,6 +1683,7 @@ class WorkflowService:
             "token_usage": node_execution.token_usage,
             "retry_count": node_execution.retry_count,
             "cache_hit": node_execution.cache_hit,
+            "cache_key": node_execution.cache_key,
             "started_at": node_execution.started_at,
             "completed_at": node_execution.completed_at,
         }
@@ -1159,62 +1703,257 @@ class WorkflowService:
             config.environment_variables if config else []
         )
         payload = self._serialize_last_node_execution(node_execution)
+        payload["cache"] = self.get_node_cache(app_id=app_id, node_id=node_id)
+        payload["can_rerun_from_last_debug"] = self._has_single_node_debug_input(app_id, node_id)
         return self._mask_payload_with_secret_values(payload, secret_values)
 
-    def get_execution_detail(self, execution_id: str) -> dict[str, Any] | None:
+    @staticmethod
+    def _build_node_cache_manager(
+            *,
+            app_id: uuid.UUID,
+            workflow_config_id: uuid.UUID | None,
+            node_id: str,
+            node_type: str | None,
+            node_name: str | None,
+    ) -> WorkflowNodeCacheManager:
+        return WorkflowNodeCacheManager(
+            app_id=app_id,
+            workflow_config_id=workflow_config_id,
+            node_id=node_id,
+            node_type=node_type or "unknown",
+            node_name=node_name,
+        )
+
+    @staticmethod
+    def _sanitize_cache_result_data(result_data: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(result_data or {})
+        for transient_key in (
+            "cache_hit",
+            "cache_key",
+            "cache_id",
+            "cache_status",
+            "cache_hit_count",
+            "cache_origin_elapsed_time",
+        ):
+            normalized.pop(transient_key, None)
+        normalized.pop("execution_order", None)
+        return normalize_cache_value(normalized)
+
+    @staticmethod
+    def _set_nested_patch_value(target: dict[str, Any], path: str, value: Any) -> None:
+        keys = [item for item in path.split(".") if item]
+        if not keys:
+            raise ValueError("patch path 不能为空")
+        current = target
+        for key in keys[:-1]:
+            nested = current.get(key)
+            if not isinstance(nested, dict):
+                nested = {}
+                current[key] = nested
+            current = nested
+        current[keys[-1]] = normalize_cache_value(value)
+
+    @classmethod
+    def _apply_cache_result_patches(
+            cls,
+            result_data: dict[str, Any],
+            patches: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        merged = cls._sanitize_cache_result_data(result_data)
+        for patch in patches or []:
+            scope = patch.get("scope", "output")
+            selector = patch.get("path") or patch.get("name")
+            if not selector:
+                continue
+            scope_value = merged.get(scope)
+            if selector == "output" and not isinstance(scope_value, dict):
+                merged[scope] = normalize_cache_value(patch.get("value"))
+                continue
+            if not isinstance(scope_value, dict):
+                scope_value = {}
+                merged[scope] = scope_value
+            cls._set_nested_patch_value(scope_value, selector, patch.get("value"))
+        return merged
+
+    @staticmethod
+    def _serialize_node_cache(cache: dict[str, Any] | None) -> dict[str, Any] | None:
+        if not cache:
+            return None
+        return {
+            "id": str(cache["id"]) if cache.get("id") else None,
+            "node_id": cache.get("node_id"),
+            "node_type": cache.get("node_type"),
+            "node_name": cache.get("node_name"),
+            "cache_key": cache.get("cache_key"),
+            "source": cache.get("source"),
+            "status": cache.get("status"),
+            "input_data": cache.get("input_data"),
+            "result_data": cache.get("result_data"),
+            "hit_count": cache.get("hit_count", 0),
+            "last_hit_at": cache.get("last_hit_at"),
+            "expires_at": cache.get("expires_at"),
+            "invalidated_at": cache.get("invalidated_at"),
+            "created_at": cache.get("created_at"),
+            "updated_at": cache.get("updated_at"),
+            "meta_data": cache.get("meta_data") or {},
+        }
+
+    def get_node_cache(self, app_id: uuid.UUID, node_id: str) -> dict[str, Any] | None:
+        config = self.get_workflow_config(app_id)
+        node_name = self._get_node_name_from_config(config, node_id)
+        node_type = next((node.get("type") for node in (config.nodes if config else []) if node.get("id") == node_id), None)
+        manager = self._build_node_cache_manager(
+            app_id=app_id,
+            workflow_config_id=config.id if config else None,
+            node_id=node_id,
+            node_type=node_type,
+            node_name=node_name,
+        )
+        cache = manager.get_latest_cache(include_inactive=False)
+        secret_values = self._extract_secret_values_from_environment_variables(
+            config.environment_variables if config else []
+        )
+        serialized = self._serialize_node_cache(cache)
+        return self._mask_payload_with_secret_values(serialized, secret_values) if serialized else None
+
+    def update_node_cache(
+            self,
+            *,
+            app_id: uuid.UUID,
+            node_id: str,
+            result_data: dict[str, Any] | None = None,
+            patches: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any] | None:
+        config = self.get_workflow_config(app_id)
+        if not config:
+            return None
+        node = next((item for item in config.nodes or [] if item.get("id") == node_id), None)
+        if not node:
+            return None
+        manager = self._build_node_cache_manager(
+            app_id=app_id,
+            workflow_config_id=config.id,
+            node_id=node_id,
+            node_type=node.get("type"),
+            node_name=node.get("name"),
+        )
+        latest_cache = manager.get_latest_cache(include_inactive=False)
+        if not latest_cache:
+            return None
+        next_result_data = self._sanitize_cache_result_data(result_data or {})
+        if patches:
+            next_result_data = self._apply_cache_result_patches(
+                latest_cache.get("result_data") or {},
+                patches,
+            )
+        updated = manager.update_latest_cache(
+            result_data=next_result_data,
+        )
+        if not updated:
+            return None
+        serialized = self._serialize_node_cache(updated)
+        secret_values = self._extract_secret_values_from_environment_variables(config.environment_variables)
+        return self._mask_payload_with_secret_values(serialized, secret_values)
+
+    def invalidate_node_cache(self, *, app_id: uuid.UUID, node_id: str) -> int:
+        config = self.get_workflow_config(app_id)
+        node = next((item for item in (config.nodes if config else []) or [] if item.get("id") == node_id), None)
+        manager = self._build_node_cache_manager(
+            app_id=app_id,
+            workflow_config_id=config.id if config else None,
+            node_id=node_id,
+            node_type=node.get("type") if node else None,
+            node_name=node.get("name") if node else None,
+        )
+        return manager.invalidate_latest_cache()
+
+    def _has_single_node_debug_input(self, app_id: uuid.UUID, node_id: str) -> bool:
+        node_execution = self.node_execution_repo.get_latest_by_app_node(
+            app_id=app_id,
+            node_id=node_id,
+            source="single_node_debug",
+        )
+        if not node_execution:
+            return False
+        execution = node_execution.execution or self.db.get(WorkflowExecution, node_execution.execution_id)
+        return bool(execution and isinstance(execution.input_data, dict))
+
+    async def rerun_node_from_last_debug(
+            self,
+            *,
+            app_id: uuid.UUID,
+            node_id: str,
+            config: WorkflowConfig,
+            workspace_id: uuid.UUID,
+            invalidate_cache: bool = False,
+            bypass_cache: bool = False,
+            base_execution_id: str | None = None,
+    ) -> dict[str, Any]:
+        node_execution = self.node_execution_repo.get_latest_by_app_node(
+            app_id=app_id,
+            node_id=node_id,
+            source="single_node_debug",
+        )
+        if not node_execution:
+            raise BusinessException("没有可用于重跑的单节点调试输入", BizCode.NOT_FOUND)
+        execution = node_execution.execution or self.db.get(WorkflowExecution, node_execution.execution_id)
+        if not execution or not isinstance(execution.input_data, dict):
+            raise BusinessException("未找到可复用的单节点调试输入", BizCode.NOT_FOUND)
+        if invalidate_cache:
+            self.invalidate_node_cache(app_id=app_id, node_id=node_id)
+        rerun_input = dict(execution.input_data or {})
+        rerun_input["bypass_cache"] = bypass_cache
+        rerun_input["base_execution_id"] = (
+            base_execution_id
+            or rerun_input.get("base_execution_id")
+            or (execution.meta_data or {}).get("base_execution_id")
+        )
+        return await self.run_single_node(
+            app_id=app_id,
+            node_id=node_id,
+            config=config,
+            workspace_id=workspace_id,
+            input_data=rerun_input,
+        )
+
+    def get_execution_detail(
+            self,
+            execution_id: str,
+            app_id: uuid.UUID | None = None,
+    ) -> dict[str, Any] | None:
         execution = self.get_execution(execution_id)
         if not execution:
             return None
+        if app_id and execution.app_id != app_id:
+            return None
 
-        node_executions = self.node_execution_repo.get_by_execution_id(execution.id)
-        output_data = self._serialize_execution_value(execution.output_data or {})
-        input_data = self._serialize_execution_value(execution.input_data or {})
-        meta_data = self._serialize_execution_value(execution.meta_data or {})
-        snapshot = {}
-        if isinstance(output_data, dict):
-            snapshot = output_data.get("snapshot") or {}
-
-        return {
+        snapshot = self._build_execution_snapshot_from_record(execution)
+        if self._get_execution_source(execution) == "single_node_debug":
+            base_execution = self._resolve_base_execution(
+                app_id=execution.app_id,
+                debug_execution=execution,
+            )
+            if base_execution and base_execution.execution_id != execution.execution_id:
+                snapshot = self._merge_execution_snapshots(
+                    self._build_execution_snapshot_from_record(base_execution),
+                    snapshot,
+                )
+        payload = {
             "execution_id": execution.execution_id,
             "app_id": str(execution.app_id),
-            "workflow_config_id": str(execution.workflow_config_id),
-            "release_id": str(execution.release_id) if execution.release_id else None,
-            "conversation_id": str(execution.conversation_id) if execution.conversation_id else None,
-            "trigger_type": execution.trigger_type,
             "status": execution.status,
-            "input_data": input_data,
-            "output_data": output_data,
             "snapshot": snapshot,
-            "context": self._serialize_execution_value(execution.context or {}),
-            "meta_data": meta_data,
             "error_message": execution.error_message,
             "error_node_id": execution.error_node_id,
             "started_at": to_iso_z(execution.started_at),
             "completed_at": to_iso_z(execution.completed_at),
             "elapsed_time": execution.elapsed_time,
-            "token_usage": self._serialize_execution_value(execution.token_usage),
-            "node_executions": [
-                {
-                    "node_id": node_execution.node_id,
-                    "node_type": node_execution.node_type,
-                    "node_name": node_execution.node_name,
-                    "execution_order": node_execution.execution_order,
-                    "retry_count": node_execution.retry_count,
-                    "status": node_execution.status,
-                    "input_data": self._serialize_execution_value(node_execution.input_data or {}),
-                    "output_data": self._serialize_execution_value(node_execution.output_data or {}),
-                    "error_message": node_execution.error_message,
-                    "started_at": to_iso_z(node_execution.started_at),
-                    "completed_at": to_iso_z(node_execution.completed_at),
-                    "elapsed_time": node_execution.elapsed_time,
-                    "token_usage": self._serialize_execution_value(node_execution.token_usage),
-                    "cache_hit": node_execution.cache_hit,
-                    "cache_key": node_execution.cache_key,
-                    "meta_data": self._serialize_execution_value(node_execution.meta_data or {}),
-                }
-                for node_execution in node_executions
-            ],
         }
+        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        secret_values = self._extract_secret_values_from_environment_variables(
+            workflow_config.environment_variables if workflow_config else []
+        )
+        return self._mask_payload_with_secret_values(payload, secret_values)
 
     def get_executions_by_app(
             self,
@@ -1902,12 +2641,15 @@ class WorkflowService:
 
         # 3. 构建工作流配置字典
         workflow_config_dict = {
+            "app_id": str(app_id),
+            "workflow_config_id": str(config.id),
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables,
             "environment_variables": config.environment_variables,
             "execution_config": config.execution_config,
-            "features": feature_configs
+            "features": feature_configs,
+            "runtime_options": {},
         }
 
         try:
@@ -2255,6 +2997,7 @@ class WorkflowService:
             end_internal_event = {
                 "event": "workflow_end",
                 "data": {
+                    "execution_id": execution.execution_id,
                     "conversation_id": str(conversation_id_uuid),
                     "output": answer,
                     "usage": {},
@@ -2339,6 +3082,7 @@ class WorkflowService:
                 end_internal_event = {
                     "event": "workflow_end",
                     "data": {
+                        "execution_id": execution.execution_id,
                         "conversation_id": str(conversation_id_uuid),
                         "output": preset_response,
                         "usage": {},
@@ -2368,12 +3112,15 @@ class WorkflowService:
 
         # 3. 构建工作流配置字典
         workflow_config_dict = {
+            "app_id": str(app_id),
+            "workflow_config_id": str(config.id),
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables,
             "environment_variables": config.environment_variables,
             "execution_config": config.execution_config,
-            "features": feature_configs
+            "features": feature_configs,
+            "runtime_options": {},
         }
 
         try:
@@ -2592,7 +3339,6 @@ class WorkflowService:
         from app.core.workflow.engine.variable_pool import VariablePool, VariablePoolInitializer
         from app.core.workflow.engine.state_manager import WorkflowState
         from app.core.workflow.nodes.node_factory import NodeFactory
-        from app.core.workflow.variable.base_variable import VariableType
 
         if not config:
             config = self.get_workflow_config(app_id)
@@ -2608,6 +3354,13 @@ class WorkflowService:
         node_config = next((n for n in config.nodes if n.get("id") == node_id), None)
         if not node_config:
             raise BusinessException(code=BizCode.NOT_FOUND, message=f"节点不存在: node_id={node_id}")
+
+        base_execution = self._resolve_base_execution(
+            app_id=app_id,
+            explicit_execution_id=input_data.get("base_execution_id"),
+        )
+        if base_execution:
+            input_data["base_execution_id"] = base_execution.execution_id
 
         # 如果目标节点是开始节点，将 inputs 中的变量值注入到 variables（sys.input_variables）
         if node_config.get("type") == NodeType.START:
@@ -2628,12 +3381,18 @@ class WorkflowService:
             input_data["variables"] = variables
 
         workflow_config_dict = {
+            "app_id": str(app_id),
+            "workflow_config_id": str(config.id),
             "nodes": config.nodes,
             "edges": config.edges,
             "variables": config.variables or [],
             "environment_variables": config.environment_variables or [],
             "execution_config": config.execution_config or {},
             "features": config.features or {},
+            "runtime_options": {
+                "bypass_node_cache": bool(input_data.get("bypass_cache")),
+                "cache_source": "single_node_debug",
+            },
         }
 
         storage_type, user_rag_memory_id = self._get_memory_store_info(workspace_id)
@@ -2660,6 +3419,15 @@ class WorkflowService:
 
         variable_pool = VariablePool()
         await VariablePoolInitializer(workflow_config_dict).initialize(variable_pool, input_data, execution_context)
+        if base_execution:
+            await self._restore_variable_pool_from_snapshot(
+                variable_pool=variable_pool,
+                snapshot=self._build_execution_snapshot_from_record(base_execution),
+            )
+        await self._apply_input_data_overrides_to_variable_pool(
+            variable_pool=variable_pool,
+            input_data=input_data,
+        )
 
         # 注入节点输入变量，支持扁平格式 {"node_id.var": value}
         for key, value in (input_data.get("inputs") or {}).items():
@@ -2672,9 +3440,11 @@ class WorkflowService:
             n.get("id") for n in workflow_config_dict.get("nodes", [])
             if n.get("type") in [NodeType.LOOP, NodeType.ITERATION]
         ]
+        base_messages = self._extract_execution_messages(base_execution)
+        base_node_outputs = self._extract_execution_node_outputs(base_execution)
         state = WorkflowState(
-            messages=input_data.get("conv_messages", []),
-            node_outputs={},
+            messages=input_data.get("conv_messages") or base_messages,
+            node_outputs=base_node_outputs,
             execution_id=execution_id,
             workspace_id=str(workspace_id),
             user_id=input_data.get("user_id", ""),
@@ -2708,22 +3478,17 @@ class WorkflowService:
             workflow_config=config,
             node_id=node_id,
             input_data=input_data,
+            base_execution_id=input_data.get("base_execution_id"),
         )
-        start_time = time.time()
         try:
-            result = await node.execute(state, variable_pool)
-            elapsed = (time.time() - start_time) * 1000
-            payload = {
-                "status": "completed",
-                "node_id": node_id,
-                "node_type": node_config.get("type"),
-                "inputs": node._extract_input(state, variable_pool),
-                "outputs": node._extract_output(result),
-                "process": node._extract_extra_fields(result).get("process"),
-                "token_usage": node._extract_token_usage(result),
-                "elapsed_time": elapsed,
-                "error": None,
-            }
+            state_update = await node.run(state, variable_pool)
+            node_output = (state_update.get("node_outputs") or {}).get(node_id) or {}
+            payload = self._build_single_node_payload_from_node_output(
+                node_id=node_id,
+                node_type=node_config.get("type"),
+                node_output=node_output,
+            )
+            payload = self._attach_debug_execution_id(payload, debug_execution.execution_id)
             self.update_execution_status(
                 debug_execution.execution_id,
                 "completed",
@@ -2740,16 +3505,16 @@ class WorkflowService:
             )
             return self._mask_runtime_secrets(payload, variable_pool)
         except Exception as e:
-            elapsed = (time.time() - start_time) * 1000
             logger.error(f"单节点执行失败: node_id={node_id}, error={e}", exc_info=True)
             payload = {
                 "status": "failed",
+                "execution_id": debug_execution.execution_id,
                 "node_id": node_id,
                 "node_type": node_config.get("type"),
                 "inputs": node._extract_input(state, variable_pool),
                 "outputs": None,
                 "token_usage": None,
-                "elapsed_time": elapsed,
+                "elapsed_time": None,
                 "error": str(e),
             }
             self.update_execution_status(
@@ -2792,13 +3557,52 @@ class WorkflowService:
             workflow_config=config,
             node_id=node_id,
             input_data=input_data,
+            base_execution_id=input_data.get("base_execution_id"),
         )
         start_time = time.time()
 
-        yield {"event": "node_start", "data": {"node_id": node_id, "node_type": node_type}}
+        yield {
+            "event": "node_start",
+            "data": {
+                "node_id": node_id,
+                "node_type": node_type,
+                "execution_id": debug_execution.execution_id,
+            }
+        }
 
         final_result = None
         try:
+            cached_state_update = await node._try_use_cache(state, variable_pool, start_time)
+            if cached_state_update:
+                node_output = (cached_state_update.get("node_outputs") or {}).get(node_id) or {}
+                event_payload = {
+                    "event": "node_end",
+                    "data": self._attach_debug_execution_id(
+                        self._build_single_node_payload_from_node_output(
+                            node_id=node_id,
+                            node_type=node_type,
+                            node_output=node_output,
+                        ),
+                        debug_execution.execution_id,
+                    )
+                }
+                self.update_execution_status(
+                    debug_execution.execution_id,
+                    "completed",
+                    token_usage=(event_payload["data"].get("token_usage") or {}).get("total_tokens"),
+                    output_data=self._build_debug_execution_output(node_id, "completed"),
+                )
+                debug_execution = self.get_execution(debug_execution.execution_id)
+                self._persist_single_node_execution(
+                    execution=debug_execution,
+                    node_id=node_id,
+                    node_type=node_type,
+                    node_name=node_config.get("name"),
+                    payload=event_payload["data"],
+                )
+                yield self._mask_runtime_secrets(event_payload, variable_pool)
+                return
+
             async for item in node.execute_stream(state, variable_pool):
                 if item.get("__final__"):
                     final_result = item["result"]
@@ -2806,25 +3610,41 @@ class WorkflowService:
                     chunk = item.get("chunk", "")
                     if chunk:
                         yield self._mask_runtime_secrets(
-                            {"event": "node_chunk", "data": {"node_id": node_id, "chunk": chunk}},
+                            {
+                                "event": "node_chunk",
+                                "data": {
+                                    "node_id": node_id,
+                                    "chunk": chunk,
+                                    "execution_id": debug_execution.execution_id,
+                                }
+                            },
                             variable_pool
                         )
 
             elapsed = (time.time() - start_time) * 1000
             event_payload = {
                 "event": "node_end",
-                "data": {
-                    "node_id": node_id,
-                    "node_type": node_type,
-                    "status": "succeeded",
-                    "inputs": node._extract_input(state, variable_pool),
-                    "outputs": node._extract_output(final_result),
-                    "process": node._extract_extra_fields(final_result).get("process"),
-                    "token_usage": node._extract_token_usage(final_result),
-                    "elapsed_time": elapsed,
-                    "error": None,
-                }
+                "data": self._attach_debug_execution_id(
+                    {
+                        "status": "completed",
+                        "node_id": node_id,
+                        "node_type": node_type,
+                        "inputs": node._extract_input(state, variable_pool),
+                        "outputs": node._extract_output(final_result),
+                        "process": node._extract_extra_fields(final_result).get("process"),
+                        "token_usage": node._extract_token_usage(final_result),
+                        "elapsed_time": elapsed,
+                        "error": None,
+                    },
+                    debug_execution.execution_id,
+                )
             }
+            node_output = self._normalize_single_node_payload(node_type, node_config.get("name"), event_payload["data"])
+            node._save_cache(
+                state=state,
+                variable_pool=variable_pool,
+                node_output=node_output,
+            )
             self.update_execution_status(
                 debug_execution.execution_id,
                 "completed",
@@ -2846,6 +3666,7 @@ class WorkflowService:
             event_payload = {
                 "event": "node_error",
                 "data": {
+                    "execution_id": debug_execution.execution_id,
                     "node_id": node_id,
                     "node_type": node_type,
                     "inputs": node._extract_input(state, variable_pool),


### PR DESCRIPTION
add node caching support with typed variable handling and cache update APIs

## Summary by Sourcery

为工作流节点添加带类型变量快照的缓存机制，并支持从调试执行中重新运行节点。

新功能：
- 为工作流节点引入按节点管理的缓存，使用数据库存储、TTL，以及缓存键生成。
- 新增用于获取、更新、失效和检查节点缓存条目的 API，包括补丁式缓存更新和缓存元数据暴露。
- 支持使用最近一次单节点调试输入重新运行某个工作流节点，并可选择复用或绕过缓存，以及附加到基础执行快照。
- 捕获带类型的执行快照（系统、会话、环境以及按节点划分的变量），并在单节点运行和执行详情视图中将其恢复到变量池中。

错误修复：
- 在启动节点没有提供文件输入时，避免创建占位的文件变量，从而防止产生无效的 `FileObject` 条目。

增强改进：
- 在节点输出、流式事件和最终工作流结果中传递执行和节点缓存元数据（命中缓存与否、缓存键、`execution_id`）。
- 改进变量类型处理和环境管理，包括文件 / 文件数组的检测，以及对缺失变量的默认值处理。
- 优化执行详情响应，使其聚焦于合并后的带类型快照，并在单节点调试运行时进行基础执行合并。
- 在配置中弃用部分 DashScope 排序（rerank）模型，并将 `WorkflowNodeExecution.execution_order` 扩展为 `BigInteger` 以提供更高精度的排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add workflow node caching with typed variable snapshots and support for rerunning nodes from debug executions.

New Features:
- Introduce per-node cache management with database-backed storage, TTL, and cache key generation for workflow nodes.
- Add APIs to fetch, update, invalidate, and inspect node cache entries, including patch-style cache updates and cache metadata exposure.
- Support rerunning a workflow node using the most recent single-node debug input, with options to reuse or bypass cache and attach to a base execution snapshot.
- Capture typed execution snapshots (system, conversation, environment, and per-node variables) and restore them into the variable pool for single-node runs and execution detail views.

Bug Fixes:
- Avoid creating placeholder file variables when no file input is provided in start nodes, preventing invalid FileObject entries.

Enhancements:
- Propagate execution and node cache metadata (cache hit, cache key, execution_id) through node outputs, streaming events, and final workflow results.
- Improve variable typing and environment handling, including file/array-of-file detection and default value handling for missing variables.
- Refine execution detail responses to focus on merged typed snapshots, with base execution merging for single-node debug runs.
- Deprecate select DashScope rerank models in configuration and widen WorkflowNodeExecution.execution_order to BigInteger for higher resolution ordering.

</details>