### PR TITLE
fix(memory): suppress default callbacks in LLM invocations

### DIFF
--- a/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
+++ b/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
@@ -31,7 +31,9 @@ class QueryPreprocessor:
             {"role": "user", "content": f"<history>{history}</history><query>{query}</query>"},
         ]
         try:
-            sub_queries = await llm_client.ainvoke(messages) | StructResponse(mode='json')
+            sub_queries = await llm_client.ainvoke(messages, config={
+                "callbacks": []
+            }) | StructResponse(mode='json')
             queries = sub_queries["questions"]
         except Exception as e:
             logger.error(f"[QueryPreprocessor] Sub-question segmentation failed - {e}")

--- a/api/app/core/memory/read_services/generate_engine/retrieval_summary.py
+++ b/api/app/core/memory/read_services/generate_engine/retrieval_summary.py
@@ -20,7 +20,10 @@ class RetrievalSummaryProcessor:
                         f"<content>{content}{memory_l0_str}</content>"},
         ]
         try:
-            summary = await llm_client.ainvoke(messages) | StructResponse(mode='str')
+            summary = await llm_client.ainvoke(
+                messages,
+                config={"callbacks": []}
+            ) | StructResponse(mode='str')
             return summary
         except:
             logger.error("Failed to generate reply summary, returning original content", exc_info=True)

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -216,7 +216,12 @@ class Neo4jSearchService:
         ]
 
         for _ in range(RELATIONSHIP_LOOP_LIMIT):
-            response: AIMessage = await llm_with_tools.ainvoke(messages)
+            response: AIMessage = await llm_with_tools.ainvoke(
+                messages,
+                config={
+                    "callbacks": [],
+                }
+            )
             messages.append(response)
 
             if not response.tool_calls:


### PR DESCRIPTION
## Summary by Sourcery

在内容搜索和生成流程中调用 LLM 时，禁用默认的内存回调，以避免产生非预期的副作用。

Bug 修复：
- 在关系搜索中调用 LLM 工具时禁用默认回调，以防止出现不必要的内存处理。
- 在基于 LLM 的检索摘要中禁用默认回调，以防止非预期的回调执行。
- 在基于 LLM 的查询预处理流程中禁用默认回调，以避免来自全局或默认回调的副作用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Suppress default memory callbacks when invoking LLMs in content search and generation flows to avoid unintended side effects.

Bug Fixes:
- Disable default callbacks for LLM tool invocation in relation search to prevent unwanted memory handling.
- Disable default callbacks for LLM-based retrieval summarization to prevent unintended callback execution.
- Disable default callbacks for LLM-based query preprocessing to avoid side effects from global or default callbacks.

</details>