### PR TITLE
feat(reflection): improve unresolved-reference resolve log display

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -660,6 +660,30 @@ class Layer2Inspector:
 
         # Step 5: 写反思日志（仅 resolved=true 时）
         if validated.resolved:
+            # 过滤掉"用户"实体（与 Step 4 写入逻辑一致：用户节点不是被消解出的新实体）
+            resolved_entities = [
+                e for e in validated.entities if e.name.strip() != "用户"
+            ]
+
+            # 列表页摘要：消解指代: <首个实体> 等 N 个实体
+            if resolved_entities:
+                summary_text = (
+                    f"消解指代: {resolved_entities[0].name} "
+                    f"等 {len(resolved_entities)} 个实体"
+                )
+            else:
+                summary_text = "消解指代: 无新增实体"
+
+            # 详情页变更项：按实体逐行展示，附带实体类型
+            changes = [
+                {
+                    "field": "识别实体",
+                    "old": "未识别",
+                    "new": f"{e.name}（{e.type}）",
+                }
+                for e in resolved_entities
+            ]
+
             log_repo = self.log_repo_factory()
             log_repo.create(
                 end_user_id=end_user_id,
@@ -669,22 +693,16 @@ class Layer2Inspector:
                 strategy="RESOLVE",
                 confidence=None,
                 status="resolved",
-                summary_text=f"消解为: {', '.join(e.name for e in validated.entities[:3])}",
+                summary_text=summary_text[:256],
                 entity_ids=created_entity_ids,
                 statement_ids=[stmt["statement_id"]],
                 trigger_detail={
                     "statement_id": stmt["statement_id"],
-                    "statement_text": stmt["statement_text"],
+                    "statement_text": f"未识别语句：{stmt['statement_text']}",
                 },
                 solution_detail={
                     "title": "RESOLVE — 指代消解成功",
-                    "changes": [
-                        {
-                            "field": "unresolved_reference",
-                            "old": "未识别",
-                            "new": ", ".join(e.name for e in validated.entities),
-                        }
-                    ],
+                    "changes": changes,
                 },
                 execution_detail=tracker.to_dict(),
             )

--- a/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
@@ -519,7 +519,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `predicate` 只能使用上方预定义的中文关系类型。
 - `predicate_id` 必须只由 `predicate` 决定，并严格使用“本体 ID 映射”中的整数。
 - `predicate_surface` 用于记录当前陈述中更贴近原文的关系表达；它可以比 `predicate` 更自然或更细，但不得改变 `predicate_id` 和 `predicate` 的 canonical 判断。
-- 如果没有任何预定义关系适用，返回 `triplets: []`。
+
 - 不要为了保留一句抽象判断或泛因果命题，而强行构造“用户-拥有-努力”“努力-导致-回报”这类低价值 triplet。
 - `关联于` 不用于补救无法成立的关系，也不用于连接“努力”“回报”“成功”“意义”这类抽象概念。
 - `偏好` 只用于具体、明确、用户特异且值得保留的对象或目标；如果相关内容过于抽象或空泛，不要抽取 `偏好`，应改写进相关实体的 `description`。
@@ -531,7 +531,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `predicate` must use one of the predefined Chinese relation labels above.
 - `predicate_id` must be determined only by `predicate` and must strictly use the integer from the ontology ID mapping.
 - `predicate_surface` records the relation expression closer to the source statement; it may be more natural or specific than `predicate`, but it must not change the canonical `predicate_id` or `predicate`.
-- If no predefined relation fits, return `triplets: []`.
+
 - Do not force low-value triplets such as "user-has-effort" or "effort-causes-reward" just to preserve a generic causal belief or slogan-like proposition.
 - Do not use `关联于` as a rescue relation when no real relation exists, and do not connect abstract concepts such as "effort", "reward", "success", or "meaning" with it.
 - Use `偏好` only for concrete, specific, user-grounded objects or goals worth retaining; if the relevant content is too abstract or generic, do not extract `偏好` and instead rewrite it into the relevant entity `description`.

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2366,15 +2366,17 @@ FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
 )
 WITH keeper, loser
 OPTIONAL MATCH (loser)-[r:EXTRACTED_RELATIONSHIP]->(target)
-WHERE target <> keeper AND NOT (keeper)-[:EXTRACTED_RELATIONSHIP]->(target)
+WHERE target <> keeper
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
-  CREATE (keeper)-[:EXTRACTED_RELATIONSHIP {relation_type: r.relation_type}]->(target)
+  MERGE (keeper)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(target)
+  SET nr += properties(r)
 )
 WITH keeper, loser
 OPTIONAL MATCH (source)-[r:EXTRACTED_RELATIONSHIP]->(loser)
-WHERE source <> keeper AND NOT (source)-[:EXTRACTED_RELATIONSHIP]->(keeper)
+WHERE source <> keeper
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
-  CREATE (source)-[:EXTRACTED_RELATIONSHIP {relation_type: r.relation_type}]->(keeper)
+  MERGE (source)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(keeper)
+  SET nr += properties(r)
 )
 WITH keeper, loser
 DETACH DELETE loser


### PR DESCRIPTION
Refine the RESOLVE reflection log for unresolved-reference resolution: exclude the 用户 entity, summarize as 消解指代: <first> 等 N 个实体 (capped 256), list entities with type, and prefix trigger statement. Also drop the redundant triplets:[] line in resolve_unresolved_triplet prompt.

## Summary by Sourcery

改进未解析引用（unresolved-reference）解析过程中的反射日志和提示，使实体解析结果更清晰、冗余更少。

新功能：
- 在日志中新增汇总型未解析引用解析条目，用受限长度且可读性良好的摘要字符串描述已解析的实体。
- 在解析日志详情中为每个实体加入变更条目，并包含实体类型信息。

增强点：
- 在已解析实体日志中排除通用的 用户 实体，使日志与存储的实体保持一致。
- 在解析日志中为触发语句文本添加前缀，以明确其之前是未被识别的内容。
- 从未解析三元组解析提示中删除关于返回空三元组列表的冗余说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reflection logs and prompts for unresolved-reference resolution to make entity resolution results clearer and less redundant.

New Features:
- Add summarized unresolved-reference resolution log entries that describe resolved entities with a capped, human-readable summary string.
- Include per-entity change entries with entity type information in the resolution log details.

Enhancements:
- Exclude the generic 用户 entity from resolved-entity logging to align logs with stored entities.
- Prefix the trigger statement text in resolution logs to clarify that it was previously unrecognized.
- Remove redundant instructions about returning an empty triplets list from the unresolved triplet resolution prompt.

</details>