### PR TITLE
fix(rag): align QA import and cancel status handling

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -19,6 +19,7 @@ from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.rag.metadata.filter_engine import MetadataFilterEngine, FilterCondition, FilterGroup
+from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.services.knowledge_metadata_service import KnowledgeMetadataService
 from app.core.response_utils import success
 from app.db import get_db
@@ -37,11 +38,39 @@ from app.core.utils.datetime_utils import to_timestamp_ms
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
 
+# Redis keys for document processing task tracking.
+_PARSE_TASK_KEY = "doc:{doc_id}:parse_task"
+_PARSE_TASK_TTL = 7200  # 2 hours
+_QA_IMPORT_TASK_NAME = "app.core.rag.tasks.import_qa_chunks"
+
 router = APIRouter(
     prefix="/chunks",
     tags=["chunks"],
     dependencies=[Depends(get_current_user)]  # Apply auth to all routes in this controller
 )
+
+
+def _dispatch_qa_import_task(kb_id: uuid.UUID, document_id: uuid.UUID, filename: str, contents: bytes) -> tuple[str, bool]:
+    task_key = _PARSE_TASK_KEY.format(doc_id=document_id)
+    claimed = REDIS_CONN.REDIS.set(task_key, "CLAIMED", ex=_PARSE_TASK_TTL, nx=True)
+    if not claimed:
+        existing_task_id = REDIS_CONN.get(task_key)
+        api_logger.info(f"Document is already being processed: document_id={document_id}, task_id={existing_task_id}")
+        return existing_task_id or "unknown", False
+
+    from app.celery_app import celery_app
+    try:
+        task = celery_app.send_task(
+            _QA_IMPORT_TASK_NAME,
+            args=[str(kb_id), str(document_id), filename, contents],
+            queue="qa_import"
+        )
+    except Exception:
+        REDIS_CONN.delete(task_key)
+        raise
+
+    REDIS_CONN.set(task_key, task.id, exp=_PARSE_TASK_TTL)
+    return task.id, True
 
 
 @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
@@ -766,15 +795,16 @@ async def import_qa_new_doc(
     api_logger.info(f"Created doc for QA import: file_id={db_file.id}, document_id={db_document.id}, file_key={file_key}")
 
     # 7. 派发异步任务
-    from app.celery_app import celery_app
-    task = celery_app.send_task(
-        "app.core.rag.tasks.import_qa_chunks",
-        args=[str(kb_id), str(db_document.id), filename, contents],
-        queue="qa_import"
-    )
+    task_id, claimed = _dispatch_qa_import_task(kb_id=kb_id, document_id=db_document.id, filename=filename, contents=contents)
+    if not claimed:
+        return success(data={
+            "task_id": task_id,
+            "document_id": str(db_document.id),
+            "file_id": str(db_file.id),
+        }, msg="Document is already being processed.")
 
     return success(data={
-        "task_id": task.id,
+        "task_id": task_id,
         "document_id": str(db_document.id),
         "file_id": str(db_file.id),
     }, msg="QA 导入任务已提交，后台处理中")
@@ -810,14 +840,11 @@ async def import_qa_chunks(
     # 3. 读取文件内容，派发异步任务
     contents = await file.read()
 
-    from app.celery_app import celery_app
-    task = celery_app.send_task(
-        "app.core.rag.tasks.import_qa_chunks",
-        args=[str(kb_id), str(document_id), filename, contents],
-        queue="qa_import"
-    )
+    task_id, claimed = _dispatch_qa_import_task(kb_id=kb_id, document_id=document_id, filename=filename, contents=contents)
+    if not claimed:
+        return success(data={"task_id": task_id}, msg="Document is already being processed.")
 
-    return success(data={"task_id": task.id}, msg="QA 导入任务已提交，后台处理中")
+    return success(data={"task_id": task_id}, msg="QA 导入任务已提交，后台处理中")
 
 
 @router.get("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -38,7 +38,7 @@ api_logger = get_api_logger()
 _PARSE_TASK_KEY = "doc:{doc_id}:parse_task"
 _PARSE_CANCEL_KEY = "doc:{doc_id}:parse_cancel"
 _PARSE_TASK_TTL = 7200  # 2 hours
-_PARSE_CANCEL_TTL = 60  # 1 minute
+_PARSE_CANCEL_TTL = 300  # 5 minutes
 
 router = APIRouter(
     prefix="/documents",
@@ -306,8 +306,11 @@ async def delete_document(
                 api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
             except Exception as revoke_err:
                 api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
-        # Set cancellation marker and clean up task key
-        REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
+        # Set cancellation marker only for tasks that have already entered execution.
+        if db_document.run == 1:
+            REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
+        else:
+            api_logger.info(f"[DELETE] Skip cancel marker for non-running document: document_id={document_id}, run={db_document.run}")
         REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
 
         # 3. Delete vector index (non-404 failures raise, caught by except below)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -861,15 +861,57 @@ def import_qa_chunks(kb_id: str, document_id: str, filename: str, contents: byte
     import csv as csv_module
     import io
 
-    db = None
+    document_uuid = None
+
+    def _clear_redis_state():
+        if document_uuid is None:
+            return
+        try:
+            REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_uuid))
+            REDIS_CONN.delete(_PARSE_CANCEL_KEY.format(doc_id=document_uuid))
+        except Exception:
+            logger.warning(f"[ImportQA] failed to clear Redis state for {document_uuid}", exc_info=True)
+
+    def _should_abort() -> bool:
+        if document_uuid is None:
+            return False
+        cancel = REDIS_CONN.get(_PARSE_CANCEL_KEY.format(doc_id=document_uuid))
+        if cancel:
+            logger.info(f"[ImportQA] document={document_uuid} cancelled via Redis -- aborting")
+            return True
+        return False
+
+    def _mark_failed(doc: Document, message: str):
+        doc.progress = -1.0
+        doc.run = 0
+        doc.progress_msg = f"QA 导入失败: {message[:200]}"
+
+    def _mark_aborted(doc: Document):
+        doc.run = 0
+        doc.progress_msg = "QA 导入已取消"
+
     try:
+        document_uuid = uuid.UUID(str(document_id))
         from app.db import get_db_context
         with get_db_context() as db:
-            db_document = db.query(Document).filter(Document.id == uuid.UUID(document_id)).first()
+            db_document = db.query(Document).filter(Document.id == document_uuid).first()
             db_knowledge = db.query(Knowledge).filter(Knowledge.id == uuid.UUID(kb_id)).first()
             if not db_document or not db_knowledge:
                 logger.error(f"[ImportQA] document={document_id} or knowledge={kb_id} not found")
+                if db_document:
+                    _mark_failed(db_document, "Knowledge base not found")
+                    db.commit()
                 return {"error": "document or knowledge not found", "imported": 0}
+
+            if _should_abort():
+                _mark_aborted(db_document)
+                db.commit()
+                return {"error": "task cancelled", "imported": 0}
+
+            db_document.run = 1
+            db_document.progress = 0.0
+            db_document.progress_msg = "QA 导入处理中..."
+            db.commit()
 
             # 1. 解析文件
             qa_pairs = []
@@ -915,13 +957,22 @@ def import_qa_chunks(kb_id: str, document_id: str, filename: str, contents: byte
                     wb.close()
                 except Exception as e:
                     logger.error(f"[ImportQA] Excel parse failed: {e}")
+                    _mark_failed(db_document, f"Excel parse failed: {e}")
+                    db.commit()
                     return {"error": f"Excel parse failed: {e}", "imported": 0}
 
             if not qa_pairs:
                 logger.warning(f"[ImportQA] No valid QA pairs found in {filename}")
+                _mark_failed(db_document, "No valid QA pairs found")
+                db.commit()
                 return {"error": "No valid QA pairs found", "imported": 0}
 
             logger.info(f"[ImportQA] Parsed {len(qa_pairs)} QA pairs from {filename}, failed_rows={failed_rows}")
+
+            if _should_abort():
+                _mark_aborted(db_document)
+                db.commit()
+                return {"error": "task cancelled", "imported": 0}
 
             # 2. 写入 ES
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
@@ -951,13 +1002,27 @@ def import_qa_chunks(kb_id: str, document_id: str, filename: str, contents: byte
                 chunks.append(DocumentChunk(page_content=pair["question"], metadata=metadata))
 
             batch_size = 50
+            cancelled = False
             for i in range(0, len(chunks), batch_size):
+                if _should_abort():
+                    cancelled = True
+                    break
                 batch = chunks[i:i + batch_size]
                 vector_service.add_chunks(batch)
+                if _should_abort():
+                    cancelled = True
+                    break
+
+            if cancelled:
+                vector_service.delete_by_metadata_field(key="document_id", value=document_id)
+                _mark_aborted(db_document)
+                db.commit()
+                return {"error": "task cancelled", "imported": 0}
 
             # 3. 更新 chunk_num 和 progress
             db_document.chunk_num += len(chunks)
             db_document.progress = 1.0
+            db_document.run = 0
             db_document.progress_msg = f"QA 导入完成: {len(chunks)} 条"
             db.commit()
 
@@ -967,18 +1032,21 @@ def import_qa_chunks(kb_id: str, document_id: str, filename: str, contents: byte
 
     except Exception as e:
         logger.error(f"[ImportQA] Failed: {e}", exc_info=True)
-        # 尝试更新文档状态为失败
+        # Best effort: persist the failure state even if the main session failed.
         try:
             from app.db import get_db_context
             with get_db_context() as err_db:
                 doc = err_db.query(Document).filter(Document.id == uuid.UUID(document_id)).first()
                 if doc:
                     doc.progress = -1.0
+                    doc.run = 0
                     doc.progress_msg = f"QA 导入失败: {str(e)[:200]}"
                     err_db.commit()
         except Exception:
             pass
         return {"error": str(e), "imported": 0}
+    finally:
+        _clear_redis_state()
 
 
 @celery_app.task(name="app.core.rag.tasks.sync_knowledge_for_kb")


### PR DESCRIPTION
## Summary
- Align QA import task status handling with document parsing using `run` and `progress` state values.
- Add Redis-based two-hour deduplication for QA import dispatches on the same document.
- Limit document deletion cancel markers to running tasks, extend the cancel marker window to five minutes, and clean QA-imported ES data after cancellation.

## Changes
```
 api/app/controllers/chunk_controller.py    | 55 ++++++++++++++++------
 api/app/controllers/document_controller.py |  9 ++--
 api/app/tasks.py                           | 74 ++++++++++++++++++++++++++++--
 3 files changed, 118 insertions(+), 20 deletions(-)
```

## Test Plan
- [x] `api/.venv/bin/python -m py_compile api/app/controllers/chunk_controller.py api/app/controllers/document_controller.py api/app/tasks.py`
- [x] `git diff --check origin/develop..HEAD -- api/app/controllers/chunk_controller.py api/app/controllers/document_controller.py api/app/tasks.py`
- [x] Verified QA import dispatch, document delete cancel marker, and cancelled ES cleanup paths with `rg`.

## External API Impact
- Internal and API Key RAG document delete routes share `document_controller.delete_document`, so the cancel-marker behavior applies to both.
- API Key QA import-new-doc route reuses the internal QA import controller, so QA import deduplication/status behavior applies there as well.

## Summary by Sourcery

使 QA 导入的后台任务处理方式与现有的文档解析工作流保持一致，包括基于 Redis 的任务跟踪、取消机制以及状态更新。

新功能：
- 为每个文档的 QA 导入任务引入基于 Redis 的去重机制，时间窗口为两小时。

错误修复：
- 确保 QA 导入任务遵循文档删除的取消标记，并在任务被取消时清理任何已部分索引到 ES 的数据。
- 在 QA 导入文档上持久化一致的运行/进度状态，覆盖成功、失败和取消等路径。
- 避免为当前未在运行的文档设置取消标记，从而防止出现误取消情况。

增强改进：
- 重构 QA 导入分发逻辑为可复用的辅助方法，由内部端点和 API Key 端点共享使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align QA import background task handling with existing document parsing workflow, including Redis-based task tracking, cancellation, and status updates.

New Features:
- Introduce Redis-backed deduplication for QA import tasks per document with a two-hour window.

Bug Fixes:
- Ensure QA import tasks respect document deletion cancel markers and clean up any partially indexed ES data when cancelled.
- Persist consistent run/progress status on QA import documents for success, failure, and cancellation paths.
- Avoid setting cancel markers for documents that are not currently running, preventing spurious cancellations.

Enhancements:
- Refactor QA import dispatch logic into a reusable helper shared by internal and API key endpoints.

</details>