### PR TITLE
feat(web): unresolved_entity reflect log

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1816,7 +1816,7 @@ export const en = {
       expired_detection: 'Expired Detection',
       factual_contradiction: 'Contradiction',
       ontology_verification: 'Ontology Verification',
-      unrecognized_entity: 'Unrecognized Entity',
+      unresolved_entity: 'Unrecognized Entity',
       to_be_implemented: 'To be Implemented',
       allStatus: 'All Status',
       resolved: 'Resolved',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1780,7 +1780,7 @@ export const zh = {
       expired_detection: '过期检测',
       factual_contradiction: '事实矛盾',
       ontology_verification: '本体校验',
-      unrecognized_entity: '未识别实体',
+      unresolved_entity: '未识别实体',
       to_be_implemented: '待实现',
       allStatus: '全部状态',
       resolved: '已处理',

--- a/web/src/views/UserMemoryDetail/components/ReflectLogDetail.tsx
+++ b/web/src/views/UserMemoryDetail/components/ReflectLogDetail.tsx
@@ -44,6 +44,10 @@ interface DescriptionMerge {
   fragment_count?: number;
   original_description?: string;
 }
+interface UnresolvedEntity {
+  statement_id: string;
+  statement_text: string;
+}
 interface SolutionDetailChange {
   field: string;
   old: string;
@@ -79,7 +83,7 @@ interface DetailData {
   entity_ids: string[];
   statement_ids: string[] | null;
 
-  trigger_detail: EntityData | DescriptionMerge;
+  trigger_detail: EntityData | DescriptionMerge | UnresolvedEntity;
   solution_detail: {
     title: string;
     changes: SolutionDetailChange[];
@@ -235,6 +239,17 @@ const ReflectLogDetail = forwardRef<ReflectLogDetailRef>((_, ref) => {
                         </div>
                         <div className="rb:bg-[#F6F6F6] rb:rounded-xl rb:p-3 rb:text-[12px]">
                           {trigger_detail.original_description}
+                        </div>
+                      </>
+                    })()}
+                  </>}
+
+                  {data.sub_problem === 'unresolved_entity' && <>
+                    {(() => {
+                      const trigger_detail = data.trigger_detail as UnresolvedEntity
+                      return <>
+                        <div className="rb:text-[12px] rb:bg-[#F6F6F6] rb:rounded-xl rb:p-3!">
+                          {trigger_detail.statement_text}
                         </div>
                       </>
                     })()}

--- a/web/src/views/UserMemoryDetail/pages/ReflectLogs.tsx
+++ b/web/src/views/UserMemoryDetail/pages/ReflectLogs.tsx
@@ -22,10 +22,10 @@ import Tag from '@/components/Tag'
 const subTypeObj: Record<string, boolean> = {
   entity_dedup: true,
   description_merge: true,
+  unresolved_entity: true,
   expired_detection: false,
   factual_contradiction: false,
   ontology_verification: false,
-  unrecognized_entity: false,
 }
 
 const queryInitialValues = {


### PR DESCRIPTION
## Summary by Sourcery

支持在用户记忆详情中展示未解析实体的反思日志，并将 i18n key 与新的子问题类型对齐。

New Features:
- 在 ReflectLogDetail 中新增对未解析实体触发详情的处理，用于展示相关的原始语句文本。

Enhancements:
- 更新反思日志子类型配置，将 `unresolved_entity` 视为实体相关的子类型。
- 将中英文语言环境中的 i18n key 从 `unrecognized_entity` 重命名为 `unresolved_entity`，以与后端子问题命名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support display of unresolved entity reflect logs in user memory detail and align i18n keys with the new sub-problem type.

New Features:
- Add handling of unresolved entity trigger details in ReflectLogDetail to display the related statement text.

Enhancements:
- Update reflect log subtype configuration to treat unresolved_entity as an entity-related subtype.
- Rename i18n keys from unrecognized_entity to unresolved_entity in both English and Chinese locales to match backend sub-problem naming.

</details>