### PR TITLE
Fix/v0.3.6 supporting context direction

### DIFF
--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -31,8 +31,10 @@ async def get_chunked_dialogs(
 
     Returns:
         List of DialogData objects with generated chunks. When context_before or context_after is provided,
-        dialog_data.metadata["supporting_context"] will contain a List[MessageItem] in
-        [upstream messages..., downstream messages...] order.
+        dialog_data.metadata["supporting_context"] will contain a dict with two keys
+        ``{"before_msgs": List[MessageItem], "after_msgs": List[MessageItem]}``,
+        directly mirroring the SupportingContext schema. The target message itself is
+        NEVER placed in either list — its position is implied by the field names.
     """
     from app.core.logging_config import get_agent_logger
     logger = get_agent_logger(__name__)
@@ -157,13 +159,23 @@ async def get_chunked_dialogs(
 # step4: 注入结构化上下文（滑动窗口写入场景）
     if context_before or context_after:
         from app.core.memory.storage_services.extraction_engine.steps.schema.extraction_step_schema import MessageItem
-        supporting_msgs = []
-        for msg in (context_before or []):
-            supporting_msgs.append(MessageItem(role=msg["role"], msg=msg["content"]))
-        for msg in (context_after or []):
-            supporting_msgs.append(MessageItem(role=msg["role"], msg=msg["content"]))
-        dialog_data.metadata["supporting_context"] = supporting_msgs
-        logger.info(f"[SupportingContext] 注入 {len(supporting_msgs)} 条上下文消息 "
-                    f"(before={len(context_before or [])}, after={len(context_after or [])})")
+        before_msgs = [
+            MessageItem(role=msg["role"], msg=msg["content"])
+            for msg in (context_before or [])
+        ]
+        after_msgs = [
+            MessageItem(role=msg["role"], msg=msg["content"])
+            for msg in (context_after or [])
+        ]
+        # 直接用方向化字段，让 target_content 在结构上夹在 before_msgs 与 after_msgs 之间，
+        # LLM 通过字段名而非额外提示理解位置关系。
+        dialog_data.metadata["supporting_context"] = {
+            "before_msgs": before_msgs,
+            "after_msgs": after_msgs,
+        }
+        logger.info(
+            f"[SupportingContext] 注入上下文消息: "
+            f"before={len(before_msgs)}, after={len(after_msgs)}"
+        )
 
     return [dialog_data]

--- a/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
+++ b/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
@@ -212,21 +212,29 @@ class NewExtractionOrchestrator:
         Priority:
             1. If ``dialog.metadata["supporting_context"]`` exists (injected by
                the sliding-window write path via ``get_chunked_dialogs``), use
-               the structured ``List[MessageItem]`` directly.
+               the structured ``{"before_msgs": [...], "after_msgs": [...]}``
+               payload directly.
             2. Otherwise fall back to wrapping ``dialog.content`` as a single
-               ``MessageItem(role="context", ...)`` for backward compatibility
-               with non-sliding-window call paths.
+               ``MessageItem(role="context", ...)`` placed in ``before_msgs``
+               for backward compatibility with non-sliding-window call paths.
+               (Using ``before_msgs`` is semantically accurate: the legacy
+               full-dialogue string represents content that has already
+               occurred relative to any chunk being processed.)
         """
         # Prefer structured context injected by the sliding-window write path
         if dialog.metadata and "supporting_context" in dialog.metadata:
-            return SupportingContext(msgs=dialog.metadata["supporting_context"])
+            payload = dialog.metadata["supporting_context"]
+            return SupportingContext(
+                before_msgs=payload.get("before_msgs", []),
+                after_msgs=payload.get("after_msgs", []),
+            )
 
         # Fallback: legacy string-concatenation path
-        msgs: List[MessageItem] = []
+        before_msgs: List[MessageItem] = []
         if hasattr(dialog, "content") and dialog.content:
             # dialog.content is the raw conversation string; wrap as single msg
-            msgs.append(MessageItem(role="context", msg=dialog.content))
-        return SupportingContext(msgs=msgs)
+            before_msgs.append(MessageItem(role="context", msg=dialog.content))
+        return SupportingContext(before_msgs=before_msgs, after_msgs=[])
     
     @staticmethod
     def _convert_to_triplet_input(

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/statement_extraction.py
@@ -125,9 +125,10 @@ class StatementExtractor:
                 "target_content": chunk_content,
                 "target_message_date": datetime.now().isoformat(),
                 "supporting_context": {
-                    "msgs": [
+                    "before_msgs": [
                         {"role": "context", "msg": dialogue_content}
-                    ] if dialogue_content else []
+                    ] if dialogue_content else [],
+                    "after_msgs": [],
                 },
             },
         )

--- a/api/app/core/memory/storage_services/extraction_engine/steps/schema/extraction_step_schema.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/schema/extraction_step_schema.py
@@ -21,9 +21,18 @@ class MessageItem(BaseModel):
 
 
 class SupportingContext(BaseModel):
-    """Dialogue context window (used for pronoun resolution, etc.)."""
+    """Dialogue context window split by direction relative to the target.
 
-    msgs: List[MessageItem] = Field(default_factory=list)
+    ``before_msgs`` are messages that occurred before the target chunk;
+    ``after_msgs`` are messages that occurred after it. The target content
+    itself is **never** placed in either list — it is carried separately in
+    ``StatementStepInput.target_content`` / ``TripletStepInput.statement_text``.
+    Modeling direction at the schema level lets the LLM see the temporal
+    relationship structurally instead of relying on an inline separator hint.
+    """
+
+    before_msgs: List[MessageItem] = Field(default_factory=list)
+    after_msgs: List[MessageItem] = Field(default_factory=list)
 
 
 # ── Statement extraction ──

--- a/api/app/core/memory/storage_services/extraction_engine/steps/statement_temporal_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/statement_temporal_step.py
@@ -97,12 +97,25 @@ class StatementTemporalExtractionStep(ExtractionStep[StatementStepInput, List[St
     # ── Lifecycle ──
 
     async def render_prompt(self, input_data: StatementStepInput) -> str:
-        # Build optional dialogue context from supporting_context messages
+        ctx = input_data.supporting_context
+        has_any_ctx = bool(ctx.before_msgs or ctx.after_msgs)
+
+        # Build optional dialogue context — kept for prompts that use the
+        # legacy ``dialogue_context`` flag; preserves before → after order so
+        # the LLM sees the natural temporal flow with target_content sitting
+        # logically in between the two halves.
         dialogue_content = None
-        if self.include_dialogue_context and input_data.supporting_context.msgs:
-            dialogue_content = "\n".join(
-                f"{m.role}: {m.msg}" for m in input_data.supporting_context.msgs
-            )
+        if self.include_dialogue_context and has_any_ctx:
+            parts: List[str] = []
+            if ctx.before_msgs:
+                parts.append(
+                    "\n".join(f"{m.role}: {m.msg}" for m in ctx.before_msgs)
+                )
+            if ctx.after_msgs:
+                parts.append(
+                    "\n".join(f"{m.role}: {m.msg}" for m in ctx.after_msgs)
+                )
+            dialogue_content = "\n---\n".join(parts)
 
         input_json = {
             "chunk_id": input_data.chunk_id,
@@ -111,10 +124,12 @@ class StatementTemporalExtractionStep(ExtractionStep[StatementStepInput, List[St
             "target_content": input_data.target_content,
             "target_message_date": input_data.target_message_date,
             "supporting_context": {
-                "msgs": [
-                    {"role": m.role, "msg": m.msg}
-                    for m in input_data.supporting_context.msgs
-                ]
+                "before_msgs": [
+                    {"role": m.role, "msg": m.msg} for m in ctx.before_msgs
+                ],
+                "after_msgs": [
+                    {"role": m.role, "msg": m.msg} for m in ctx.after_msgs
+                ],
             },
         }
 

--- a/api/app/core/memory/storage_services/extraction_engine/steps/triplet_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/triplet_step.py
@@ -51,10 +51,20 @@ class TripletExtractionStep(ExtractionStep[TripletStepInput, TripletStepOutput])
     # ── Lifecycle ──
 
     async def render_prompt(self, input_data: TripletStepInput) -> str:
-        # Build chunk_content from supporting_context for pronoun resolution
-        chunk_content = "\n".join(
-            f"{m.role}: {m.msg}" for m in input_data.supporting_context.msgs
-        ) if input_data.supporting_context.msgs else ""
+        ctx = input_data.supporting_context
+        # Build chunk_content from supporting_context for pronoun resolution.
+        # Preserve before → after ordering so the LLM sees the natural temporal
+        # flow with the statement_text sitting logically between the two halves.
+        chunk_parts: list[str] = []
+        if ctx.before_msgs:
+            chunk_parts.append(
+                "\n".join(f"{m.role}: {m.msg}" for m in ctx.before_msgs)
+            )
+        if ctx.after_msgs:
+            chunk_parts.append(
+                "\n".join(f"{m.role}: {m.msg}" for m in ctx.after_msgs)
+            )
+        chunk_content = "\n---\n".join(chunk_parts)
 
         input_json = {
             "statement_id": input_data.statement_id,
@@ -62,10 +72,12 @@ class TripletExtractionStep(ExtractionStep[TripletStepInput, TripletStepOutput])
             "statement_type": input_data.statement_type,
             "temporal_type": input_data.temporal_type,
             "supporting_context": {
-                "msgs": [
-                    {"role": m.role, "msg": m.msg}
-                    for m in input_data.supporting_context.msgs
-                ]
+                "before_msgs": [
+                    {"role": m.role, "msg": m.msg} for m in ctx.before_msgs
+                ],
+                "after_msgs": [
+                    {"role": m.role, "msg": m.msg} for m in ctx.after_msgs
+                ],
             },
             "speaker": input_data.speaker,
             "dialog_at": input_data.dialog_at or "",

--- a/api/app/core/memory/utils/debug/write_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/write_snapshot_recorder.py
@@ -213,7 +213,7 @@ class WriteSnapshotRecorder:
         - dialog_id / chunk_id：定位信息
         - input：本次 extract_statement 注入给 LLM 的上下文
             （target_content / target_message_date / dialog_at /
-             supporting_context.msgs）
+             supporting_context.before_msgs / supporting_context.after_msgs）
         - outputs：LLM 抽取出来的 statement 列表
         便于人工核对每个 chunk 的输入是否正确、输出是否合理。
         """

--- a/api/app/core/memory/utils/debug/write_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/write_snapshot_recorder.py
@@ -226,12 +226,27 @@ class WriteSnapshotRecorder:
                 input_dump: Optional[Dict[str, Any]] = None
                 if step_input is not None and hasattr(step_input, "model_dump"):
                     full = step_input.model_dump()
-                    # 仅保留与 extract_statement 提示词相关的字段，避免冗余
+                    ctx = full.get("supporting_context") or {}
+                    before_msgs = ctx.get("before_msgs") or []
+                    after_msgs = ctx.get("after_msgs") or []
+                    # 与 StatementTemporalExtractionStep.render_prompt 中构建 input_json
+                    # 完全一致的结构，保证快照展示的就是实际传入 extract_statement 的内容。
                     input_dump = {
+                        "chunk_id": full.get("chunk_id"),
+                        "end_user_id": full.get("end_user_id"),
+                        "dialog_at": full.get("dialog_at") or "",
                         "target_content": full.get("target_content"),
                         "target_message_date": full.get("target_message_date"),
-                        "dialog_at": full.get("dialog_at"),
-                        "supporting_context": full.get("supporting_context"),
+                        "supporting_context": {
+                            "before_msgs": [
+                                {"role": m.get("role", ""), "msg": m.get("msg", "")}
+                                for m in before_msgs
+                            ],
+                            "after_msgs": [
+                                {"role": m.get("role", ""), "msg": m.get("msg", "")}
+                                for m in after_msgs
+                            ],
+                        },
                     }
                 snapshot_data.append(
                     {

--- a/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
@@ -45,7 +45,9 @@ Each output item should be a structured candidate memory statement.
 - target_content: 当前要处理的对话片段文本，也是唯一允许被抽取的目标文本
 - target_message_date: 目标文本对应的时间，可作为辅助时间背景；当与 dialog_at 同时存在时，优先使用 dialog_at 解析相对时间表达
 - supporting_context: 完整对话上下文，仅用于辅助理解 target_content，不能单独贡献新的可抽取事实
-- supporting_context.msgs: 按顺序提供的上下文消息，可包含 User 和 Assistant
+- supporting_context.before_msgs: 发生在 target_content **之前**的上下文消息列表（按时间升序），可包含 User 和 Assistant
+- supporting_context.after_msgs: 发生在 target_content **之后**的上下文消息列表（按时间升序），可包含 User 和 Assistant
+- 注意：target_content 在结构上夹在 before_msgs 与 after_msgs 之间，但与两侧消息**不一定直接相邻**，中间可能存在被剪枝或省略的消息
   {% else %}
 - chunk_id: unique chunk identifier
 - end_user_id: end-user identifier
@@ -53,24 +55,26 @@ Each output item should be a structured candidate memory statement.
 - target_content: the current dialogue fragment to process, and the only text span that may be extracted from
 - target_message_date: the time associated with the target content and may serve as supporting temporal context; when both exist, prefer `dialog_at` for resolving relative expressions
 - supporting_context: full dialogue context used only to help interpret target_content and must not independently contribute new extractable facts
-- supporting_context.msgs: ordered contextual messages, which may include User and Assistant messages
+- supporting_context.before_msgs: ordered list of messages that occurred **before** target_content (chronological), may include User and Assistant
+- supporting_context.after_msgs: ordered list of messages that occurred **after** target_content (chronological), may include User and Assistant
+- Note: target_content sits structurally between before_msgs and after_msgs, but is **not necessarily directly adjacent** to either side — pruned or omitted messages may exist in between
   {% endif %}
 
 === Scope ===
 {% if language == "zh" %}
 
 - 只从 `target_content` 中提取陈述句。
-- `supporting_context.msgs` 只用于解释 `target_content` 中的代词、省略、主体、时间和语义背景。
-- 不要从 `supporting_context.msgs` 中单独提取任何陈述句。
-- 如果某条信息没有出现在 `target_content` 中，即使它出现在 `supporting_context.msgs` 中，也不能把它作为独立 statement 输出。
-- 如果 Assistant 在 `supporting_context.msgs` 中提供了总结、猜测、解释或改写，这些内容只能作为理解辅助，不能被当作事实直接提取。
+- `supporting_context.before_msgs` 与 `supporting_context.after_msgs` 只用于解释 `target_content` 中的代词、省略、主体、时间和语义背景。
+- 不要从 `before_msgs` 或 `after_msgs` 中单独提取任何陈述句。
+- 如果某条信息没有出现在 `target_content` 中，即使它出现在 `before_msgs` 或 `after_msgs` 中，也不能把它作为独立 statement 输出。
+- 如果 Assistant 在 `before_msgs` 或 `after_msgs` 中提供了总结、猜测、解释或改写，这些内容只能作为理解辅助，不能被当作事实直接提取。
 - 每条输出的 statement 都必须能够在 `target_content` 中找到直接对应的表达依据。
   {% else %}
 - Extract statements only from `target_content`.
-- `supporting_context.msgs` is used only to interpret references, ellipsis, subjects, temporal expressions, and semantic background in `target_content`.
-- Do not extract any standalone statement from `supporting_context.msgs`.
-- If a piece of information does not appear in `target_content`, it must not be output as an independent statement even if it appears in `supporting_context.msgs`.
-- If the Assistant in `supporting_context.msgs` provides a summary, guess, interpretation, or rephrasing, treat it only as interpretive support and never as a direct factual source for extraction.
+- `supporting_context.before_msgs` and `supporting_context.after_msgs` are used only to interpret references, ellipsis, subjects, temporal expressions, and semantic background in `target_content`.
+- Do not extract any standalone statement from `before_msgs` or `after_msgs`.
+- If a piece of information does not appear in `target_content`, it must not be output as an independent statement even if it appears in `before_msgs` or `after_msgs`.
+- If the Assistant in `before_msgs` or `after_msgs` provides a summary, guess, interpretation, or rephrasing, treat it only as interpretive support and never as a direct factual source for extraction.
 - Every output statement must be directly grounded in wording from `target_content`.
   {% endif %}
 
@@ -324,7 +328,7 @@ Rewrite boundary:
   "target_content": "老李这学期要求还是一如既往地严，不过他讲课确实清晰透彻，而且每节课的结构都特别清楚。就是气场实在太吓人了，我每次被他点名都有点发怵。",
   "target_message_date": "2023-09-04T18:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
         "msg": "今天是九月第一周的星期一，上了本学期第一节数据库课。作为班长，我帮李教授发了教学大纲。老李宣布的期末项目考核标准特别严，看了一眼大纲上的作业量，我感觉这学期恐怕要脱层皮。不过老李讲课确实清晰透彻，就是气场实在太吓人了。"
@@ -333,7 +337,8 @@ Rewrite boundary:
         "role": "Assistant",
         "msg": "听起来你对这门课既佩服又有点压力，李教授应该是很有气场的老师。"
       }
-    ]
+    ],
+    "after_msgs": []
   }
 }
 
@@ -386,7 +391,7 @@ Rewrite boundary:
   "target_content": "我最近在学Python，每天晚上都会练一个小时。这周还打算先把基础语法和函数部分过一遍。",
   "target_message_date": "2026-04-01T00:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
         "msg": "我最近在学Python。"
@@ -395,7 +400,8 @@ Rewrite boundary:
         "role": "Assistant",
         "msg": "Python 是一个很实用的语言。"
       }
-    ]
+    ],
+    "after_msgs": []
   }
 }
 
@@ -448,11 +454,17 @@ Rewrite boundary:
   "target_content": "去年冬天老师布置的那两个项目我一直觉得有点难，而且我昨晚看了半天还是没太搞明白。要是这周末再弄不出来，我可能就得去问助教了。",
   "target_message_date": "2026-04-01T00:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
-        "msg": "去年冬天老师布置的那两个项目我一直觉得有点难，而且我昨晚看了半天还是没太搞明白。要是这周末再弄不出来，我可能就得去问助教了。"
+        "msg": "上次跟你说的那两个项目我还卡着。"
       },
+      {
+        "role": "Assistant",
+        "msg": "嗯，是去年冬天老师布置的那两个项目，是吧？"
+      }
+    ],
+    "after_msgs": [
       {
         "role": "Assistant",
         "msg": "听起来你卡在老师去年冬天布置的那两个项目上了，如果这周末还没进展，再去问助教也可以。"
@@ -510,7 +522,7 @@ Example Input: {
   "target_content": "Old Li is just as strict as ever this semester, but he really explains things clearly and the structure of every class is extremely clear. His presence is honestly kind of intimidating, and I get nervous every time he calls on me.",
   "target_message_date": "2023-09-04T18:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
         "msg": "Today was the Monday of the first week of September, and I had the first database class of the semester. As class monitor, I helped Professor Li distribute the syllabus. Professor Li said the grading criteria for the final project would be very strict. Old Li is just as strict as ever this semester, but he really explains things clearly and the structure of every class is extremely clear. His presence is honestly kind of intimidating."
@@ -519,7 +531,8 @@ Example Input: {
         "role": "Assistant",
         "msg": "It sounds like you admire the teaching but also feel pressured by Professor Li."
       }
-    ]
+    ],
+    "after_msgs": []
   }
 }
 
@@ -572,7 +585,7 @@ Example Input: {
   "target_content": "I've been learning Python recently, and I practice for an hour every night. This week I also plan to review basic syntax and functions first.",
   "target_message_date": "2026-04-01T00:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
         "msg": "I've been learning Python recently."
@@ -581,7 +594,8 @@ Example Input: {
         "role": "Assistant",
         "msg": "Python is a very practical language."
       }
-    ]
+    ],
+    "after_msgs": []
   }
 }
 
@@ -634,11 +648,17 @@ Example Input: {
   "target_content": "The two projects the teacher assigned last winter seem difficult to me, and even after looking at them for a long time last night I still didn't really understand them. If I still can't finish them by this weekend, I may have to ask the TA.",
   "target_message_date": "2026-04-01T00:00:00",
   "supporting_context": {
-    "msgs": [
+    "before_msgs": [
       {
         "role": "User",
-        "msg": "The two projects the teacher assigned last winter seem difficult to me, and even after looking at them for a long time last night I still didn't really understand them. If I still can't finish them by this weekend, I may have to ask the TA."
+        "msg": "I'm still stuck on those two projects I told you about."
       },
+      {
+        "role": "Assistant",
+        "msg": "You mean the two projects the teacher assigned last winter, right?"
+      }
+    ],
+    "after_msgs": [
       {
         "role": "Assistant",
         "msg": "It sounds like you're stuck on the two projects assigned last winter, and asking the TA would make sense if there is still no progress by this weekend."

--- a/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
@@ -651,12 +651,8 @@ Example Input: {
     "before_msgs": [
       {
         "role": "User",
-        "msg": "I'm still stuck on those two projects I told you about."
+        "msg": "The two projects the teacher assigned last winter seem difficult to me, and even after looking at them for a long time last night I still didn't really understand them. If I still can't finish them by this weekend, I may have to ask the TA."
       },
-      {
-        "role": "Assistant",
-        "msg": "You mean the two projects the teacher assigned last winter, right?"
-      }
     ],
     "after_msgs": [
       {

--- a/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
@@ -51,9 +51,11 @@ Extract entities and knowledge triplets from the given statement.
 - `statement_type`: 上游提供的陈述类别，例如 `FACT` / `OPINION` / `OTHER`
 - `temporal_type`: 上游提供的时间类别，例如 `STATIC` / `DYNAMIC` / `ATEMPORAL`
 - `supporting_context`: 原始对话上下文
-- `supporting_context.msgs`: 上下文消息列表
-- `supporting_context.msgs[].role`: `User` / `Assistant`
-- `supporting_context.msgs[].msg`: 消息文本
+- `supporting_context.before_msgs`: 发生在 `statement_text` 来源消息**之前**的上下文消息列表（按时间升序）
+- `supporting_context.after_msgs`: 发生在 `statement_text` 来源消息**之后**的上下文消息列表（按时间升序）
+- `supporting_context.before_msgs[].role` / `supporting_context.after_msgs[].role`: `User` / `Assistant`
+- `supporting_context.before_msgs[].msg` / `supporting_context.after_msgs[].msg`: 消息文本
+- 注意：`statement_text` 在结构上夹在 `before_msgs` 与 `after_msgs` 之间，但与两侧消息**不一定直接相邻**
 - `speaker`: `user` / `assistant`
 - `dialog_at`: 会话时间，ISO 8601 时间点；每个实体 `description` 必须复制该值作为开头时间戳
 - `valid_at`: ISO 8601 时间点，或 `NULL`
@@ -66,9 +68,11 @@ Extract entities and knowledge triplets from the given statement.
 - `statement_type`: upstream statement category such as `FACT` / `OPINION` / `OTHER`
 - `temporal_type`: upstream temporal category such as `STATIC` / `DYNAMIC` / `ATEMPORAL`
 - `supporting_context`: original conversation context
-- `supporting_context.msgs`: context message list
-- `supporting_context.msgs[].role`: `User` / `Assistant`
-- `supporting_context.msgs[].msg`: message text
+- `supporting_context.before_msgs`: ordered list of messages that occurred **before** the source of `statement_text` (chronological)
+- `supporting_context.after_msgs`: ordered list of messages that occurred **after** the source of `statement_text` (chronological)
+- `supporting_context.before_msgs[].role` / `supporting_context.after_msgs[].role`: `User` / `Assistant`
+- `supporting_context.before_msgs[].msg` / `supporting_context.after_msgs[].msg`: message text
+- Note: `statement_text` sits structurally between `before_msgs` and `after_msgs`, but is **not necessarily directly adjacent** to either side
 - `speaker`: `user` / `assistant`
 - `dialog_at`: session time as an ISO 8601 timestamp; every entity `description` must copy this value as its leading timestamp
 - `valid_at`: ISO 8601 timestamp or `NULL`
@@ -126,10 +130,10 @@ Primary statement to analyze:
 {% if language == "zh" %}
 
 - 只把 `statement_text` 作为直接抽取目标。
-- `supporting_context.msgs` 只能用于解释 `statement_text` 中的代词、省略、主体身份和必要背景。
-- 不要从 `supporting_context.msgs` 中单独抽取实体或关系。
-- 如果某条信息只出现在 `supporting_context.msgs` 中，而没有出现在 `statement_text` 中，就不要输出它。
-- 如果 `supporting_context.msgs` 中的 Assistant 消息包含总结、猜测、解释或改写，这些内容只能作为理解辅助，不能直接作为抽取来源。
+- `supporting_context.before_msgs` 与 `supporting_context.after_msgs` 只能用于解释 `statement_text` 中的代词、省略、主体身份和必要背景。
+- 不要从 `before_msgs` 或 `after_msgs` 中单独抽取实体或关系。
+- 如果某条信息只出现在 `before_msgs` 或 `after_msgs` 中，而没有出现在 `statement_text` 中，就不要输出它。
+- 如果 `before_msgs` 或 `after_msgs` 中的 Assistant 消息包含总结、猜测、解释或改写，这些内容只能作为理解辅助，不能直接作为抽取来源。
 - `statement_type`、`temporal_type` 是辅助理解字段，不是抽取目标。
 - `dialog_at` 是辅助时间上下文字段，不是抽取目标。
 - `valid_at`、`invalid_at` 不用于决定是否创建实体或关系，但如果产生 triplet，必须原样复制到每个 triplet 的同名字段中。
@@ -138,10 +142,10 @@ Primary statement to analyze:
 - 对命名关系中新出现的称呼、别名、昵称、产品名，不要因为上下文可推断其所指而直接改写，它们应保持原样作为实体名。
   {% else %}
 - Treat `statement_text` as the only direct extraction target.
-- Use `supporting_context.msgs` only to interpret references, ellipsis, subject identity, and necessary background in `statement_text`.
-- Do not extract any standalone entity or relation from `supporting_context.msgs`.
-- If some information appears only in `supporting_context.msgs` but not in `statement_text`, do not include it in the output.
-- If Assistant messages in `supporting_context.msgs` contain summary, guess, interpretation, or rephrasing, use them only as interpretive support and never as a direct extraction source.
+- Use `supporting_context.before_msgs` and `supporting_context.after_msgs` only to interpret references, ellipsis, subject identity, and necessary background in `statement_text`.
+- Do not extract any standalone entity or relation from `before_msgs` or `after_msgs`.
+- If some information appears only in `before_msgs` or `after_msgs` but not in `statement_text`, do not include it in the output.
+- If Assistant messages in `before_msgs` or `after_msgs` contain summary, guess, interpretation, or rephrasing, use them only as interpretive support and never as a direct extraction source.
 - Treat `statement_type` and `temporal_type` as auxiliary context, not extraction targets.
 - Treat `dialog_at` as auxiliary session-time context, not an extraction target.
 - Do not use `valid_at` or `invalid_at` to decide whether to create entities or relations, but if any triplet is produced, copy them verbatim into every triplet field with the same names.


### PR DESCRIPTION
## Summary by Sourcery

为记忆抽取流水线引入“方向感知”的支撑对话上下文，并更新所有相关的提示词、模式(schema)、编排逻辑和调试工具，使其使用独立的 before/after 消息列表，而不是单一的扁平上下文列表。

增强内容：
- 优化时间和三元组抽取提示词，将 supporting_context 描述为 before_msgs 和 after_msgs，在中英文中都明确其位置语义和使用约束。
- 扩展 SupportingContext 模式，将消息拆分为 before_msgs 和 after_msgs，确保目标内容在结构上处于二者之间，且绝不被包含在任一列表中。
- 更新陈述和三元组抽取步骤，在保留时间顺序并添加分隔符的前提下，使用新的“方向感知” before/after 消息结构来渲染提示词和上下文字符串。
- 调整对话分块 (get_chunked_dialogs) 和编排逻辑 (_build_supporting_context)，以构造并传递“方向感知”的 supporting_context 负载，同时为旧版的完整对话字符串提供向后兼容支持。
- 使陈述抽取快照和调试工具与新的 supporting_context 结构保持一致，确保记录的输入与实际发送给 LLM 的负载相匹配。

文档：
- 修订行内文档和提示词示例，解释新的方向感知 supporting_context.before_msgs/after_msgs 约定，并澄清不得直接从上下文消息中抽取事实。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce direction-aware supporting dialogue context for memory extraction pipelines and update all related prompts, schemas, orchestration, and debugging utilities to use separate before/after message lists instead of a single flat context list.

Enhancements:
- Refine temporal and triplet extraction prompts to describe supporting_context as before_msgs and after_msgs with clear positional semantics and usage constraints in both Chinese and English.
- Extend SupportingContext schema to split messages into before_msgs and after_msgs, ensuring the target content is structurally between them and never included in either list.
- Update statement and triplet extraction steps to render prompts and context strings using the new direction-aware before/after message structure while preserving chronological order and adding separators.
- Adjust dialog chunking (get_chunked_dialogs) and orchestration (_build_supporting_context) to construct and pass through direction-aware supporting_context payloads, including backward compatibility for legacy full-dialogue strings.
- Align statement extraction snapshots and debug tooling with the new supporting_context shape so recorded inputs match the actual payload sent to LLMs.

Documentation:
- Revise inline documentation and prompt examples to explain the new direction-aware supporting_context.before_msgs/after_msgs contract and clarify that no facts may be extracted directly from context messages.

</details>