### PR TITLE
fix: prevent 'Event loop is closed' error during httpx client GC

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -1290,28 +1290,19 @@ class WritePipeline:
 
     async def _cleanup(self) -> None:
         """
-        清理资源：关闭 Neo4j 连接器和 HTTP 客户端。
-        在 run() 的 finally 块中调用，确保资源释放。
+        清理资源：关闭 Neo4j 连接器，断开客户端引用。
+
+        不再尝试反射关闭 httpx 内部 client——由 tasks.py 的
+        _shutdown_loop_gracefully 中 set_exception_handler 兜底，
+        抑制 GC 阶段 'Event loop is closed' 的噪音日志。
         """
-        # 关闭 Neo4j 连接器
         if self._neo4j_connector:
             try:
                 await self._neo4j_connector.close()
             except Exception as e:
                 logger.error(f"Error closing Neo4j connector: {e}")
 
-        # 关闭 LLM/Embedder 底层 httpx 客户端
-        # 防止 'RuntimeError: Event loop is closed' 在垃圾回收时触发
-        for client_obj in (self._llm_client, self._embedder_client):
-            try:
-                underlying = getattr(client_obj, "client", None) or getattr(
-                    client_obj, "model", None
-                )
-                if underlying is None:
-                    continue
-                inner = getattr(underlying, "_model", underlying)
-                http_client = getattr(inner, "async_client", None)
-                if http_client is not None and hasattr(http_client, "aclose"):
-                    await http_client.aclose()
-            except Exception:
-                pass
+        # 断开引用链，让 GC 尽早回收（减少 loop 关闭后残留对象的概率）
+        self._neo4j_connector = None
+        self._llm_client = None
+        self._embedder_client = None

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -169,27 +169,21 @@ def set_asyncio_event_loop():
 
 
 def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
-    """Gracefully shutdown pending async generators and tasks on the event loop.
+    """Cancel pending tasks but keep the loop open for reuse.
 
-    This prevents 'RuntimeError: Event loop is closed' from httpx.AsyncClient.__del__
-    by giving pending aclose() coroutines a chance to run before the loop is discarded.
-
-    Note: This only tears down the given loop. Callers that need a fresh event
-    loop afterwards should use ``set_asyncio_event_loop()`` explicitly.
+    Not closing the loop avoids 'Event loop is closed' from httpx AsyncClient.__del__ during GC.
     """
     try:
-        # Cancel and collect all remaining tasks
+        # Cancel remaining tasks to prevent leaks between Celery tasks
         all_tasks = asyncio.all_tasks(loop)
         if all_tasks:
             for task in all_tasks:
                 task.cancel()
             loop.run_until_complete(asyncio.gather(*all_tasks, return_exceptions=True))
-        # Shutdown async generators (triggers __aclose__ on httpx clients etc.)
-        loop.run_until_complete(loop.shutdown_asyncgens())
     except Exception:
         pass
-    finally:
-        loop.close()
+    # NOTE: Do NOT close the loop. It will be reused by set_asyncio_event_loop()
+    # for subsequent Celery tasks on the same thread.
 
 
 @celery_app.task(name="tasks.process_item")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -169,7 +169,7 @@ def set_asyncio_event_loop():
 
 
 def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
-    """Cancel pending tasks but keep the loop open for reuse.
+    """Cancel pending tasks and finalize async generators, but keep the loop open for reuse.
 
     Not closing the loop avoids 'Event loop is closed' from httpx AsyncClient.__del__ during GC.
     """
@@ -180,10 +180,11 @@ def _shutdown_loop_gracefully(loop: asyncio.AbstractEventLoop):
             for task in all_tasks:
                 task.cancel()
             loop.run_until_complete(asyncio.gather(*all_tasks, return_exceptions=True))
+        # Finalize async generators so network/client resources are properly cleaned up.
+        # This does NOT close the loop.
+        loop.run_until_complete(loop.shutdown_asyncgens())
     except Exception:
         pass
-    # NOTE: Do NOT close the loop. It will be reused by set_asyncio_event_loop()
-    # for subsequent Celery tasks on the same thread.
 
 
 @celery_app.task(name="tasks.process_item")


### PR DESCRIPTION
- Remove explicit httpx aclose() from WritePipeline._cleanup()
- Stop closing the event loop in _shutdown_loop_gracefully() so it remains reusable across Celery tasks on the same thread
- Let set_exception_handler suppress remaining GC noise on shutdown

## Summary by Sourcery

通过调整清理流程和事件循环的关闭行为，防止 httpx 异步客户端在垃圾回收时触发 “Event loop is closed” 错误。

Bug Fixes:
- 在写入流水线的清理过程中，停止显式关闭底层的 httpx 异步客户端，以避免在事件循环已关闭时延迟触发的 `aclose()` 调用。
- 在 Celery 任务关闭期间保持 asyncio 事件循环处于打开状态，同时仍然取消未完成任务，以防止在垃圾回收期间出现 “Event loop is closed” 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent httpx async client garbage collection from triggering 'Event loop is closed' errors by adjusting cleanup and event loop shutdown behavior.

Bug Fixes:
- Stop explicitly closing underlying httpx async clients in the write pipeline cleanup to avoid late aclose() calls on a closed loop.
- Keep the asyncio event loop open during Celery task shutdown while still cancelling pending tasks to prevent 'Event loop is closed' errors during GC.

</details>