### PR TITLE
perf(dashboard): defer Celery tasks to background threads and optimize batch queries

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -171,52 +171,34 @@ def get_workspace_end_users(
         }
     }
 
-    # Redis 节流 + Celery 任务分发放到后台线程，不阻塞接口响应
-    import threading
+    # Redis 节流 + Celery 任务派发（同步内联，操作极轻量，无需开线程）
+    try:
+        from app.tasks import get_sync_redis_client
+        from app.celery_app import celery_app as _celery_app
 
-    def _fire_and_forget_tasks(_end_user_ids, _workspace_id):
-        """后台线程：执行 Redis 节流判断 + Celery 任务派发"""
-        try:
-            from app.tasks import get_sync_redis_client
-
-            _redis = get_sync_redis_client()
-            if _redis is None:
-                api_logger.warning("后台任务 Redis 不可用，跳过")
-                return
-        except Exception as _e:
-            api_logger.warning(f"后台任务 Redis 不可用，跳过: {_e}")
-            return
-
-        try:
-            from app.celery_app import celery_app as _celery_app
-
+        _redis = get_sync_redis_client()
+        if _redis is not None:
             # 按需初始化任务（节流 60s）
-            _throttle_key = f"dashboard:init_tasks:throttle:{_workspace_id}"
+            _throttle_key = f"dashboard:init_tasks:throttle:{workspace_id}"
             if _redis.set(_throttle_key, "1", nx=True, ex=60):
                 _celery_app.send_task(
                     "app.tasks.init_implicit_emotions_for_users",
-                    kwargs={"end_user_ids": _end_user_ids},
+                    kwargs={"end_user_ids": end_user_ids},
                 )
                 _celery_app.send_task(
                     "app.tasks.init_interest_distribution_for_users",
-                    kwargs={"end_user_ids": _end_user_ids},
+                    kwargs={"end_user_ids": end_user_ids},
                 )
 
             # 社区聚类补全任务（节流 60s）
-            _cluster_key = f"dashboard:cluster_task:throttle:{_workspace_id}"
+            _cluster_key = f"dashboard:cluster_task:throttle:{workspace_id}"
             if _redis.set(_cluster_key, "1", nx=True, ex=60):
                 _celery_app.send_task(
                     "app.tasks.init_community_clustering_for_users",
-                    kwargs={"end_user_ids": _end_user_ids, "workspace_id": str(_workspace_id)},
+                    kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
                 )
-        except Exception as _e:
-            api_logger.warning(f"后台任务派发失败（不影响已返回响应）: {_e}")
-
-    threading.Thread(
-        target=_fire_and_forget_tasks,
-        args=(end_user_ids, workspace_id),
-        daemon=True,
-    ).start()
+    except Exception as _e:
+        api_logger.warning(f"后台任务派发失败（不影响已返回响应）: {_e}")
 
     api_logger.info(f"成功获取 {len(end_users)} 个宿主记录，总计 {total} 条")
     return success(data=result, msg="宿主列表获取成功")

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -86,8 +86,10 @@ def get_workspace_end_users(
     # 如果未提供 workspace_id，使用当前用户的工作空间
     if workspace_id is None:
         workspace_id = current_user.current_workspace_id
+
     # 获取当前空间类型
     current_workspace_type = memory_dashboard_service.get_current_workspace_type(db, workspace_id, current_user)
+
     api_logger.info(f"用户 {current_user.username} 请求获取工作空间 {workspace_id} 的宿主列表, 类型: {current_workspace_type}")
 
     if current_workspace_type == "rag":
@@ -135,35 +137,7 @@ def get_workspace_end_users(
         api_logger.error(f"批量获取记忆配置失败: {str(e)}")
         memory_configs_map = {}
 
-    # 共享 Redis 客户端：用于两个节流块（按需初始化 + 社区聚类补全）
-    # 复用 app.tasks 模块级连接池，避免在请求路径上重复创建客户端；
-    # Redis 不可用时返回 None，下游节流块直接跳过，避免 UnboundLocalError
-    from app.tasks import get_sync_redis_client
-    _throttle_redis = get_sync_redis_client()
-    if _throttle_redis is None:
-        api_logger.warning("节流 Redis 客户端不可用，本次节流任务跳过")
-
-    # 触发按需初始化：为 implicit_emotions_storage / interest_distribution 中没有记录的用户异步生成数据
-    # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次，避免刷新页面导致重复提交
-    if _throttle_redis is not None:
-        try:
-            _throttle_key = f"dashboard:init_tasks:throttle:{workspace_id}"
-            if _throttle_redis.set(_throttle_key, "1", nx=True, ex=60):
-                from app.celery_app import celery_app as _celery_app
-                _celery_app.send_task(
-                    "app.tasks.init_implicit_emotions_for_users",
-                    kwargs={"end_user_ids": end_user_ids},
-                )
-                _celery_app.send_task(
-                    "app.tasks.init_interest_distribution_for_users",
-                    kwargs={"end_user_ids": end_user_ids},
-                )
-                api_logger.info(f"已触发按需初始化任务，候选用户数: {len(end_user_ids)}")
-            else:
-                api_logger.info(f"按需初始化任务节流中，跳过: workspace_id={workspace_id}")
-        except Exception as e:
-            api_logger.warning(f"触发按需初始化任务失败（不影响主流程）: {e}")
-
+    # 构建响应数据（先返回给用户，Redis/Celery 操作放后台）
     items = []
     for index, end_user in enumerate(end_users):
         user_id = str(end_user.id)
@@ -186,23 +160,6 @@ def get_workspace_end_users(
             },
         })
 
-    # 触发社区聚类补全任务（异步，不阻塞接口响应）
-    # 使用 Redis SET NX 节流：同一 workspace 60秒内只触发一次
-    if _throttle_redis is not None:
-        try:
-            _cluster_throttle_key = f"dashboard:cluster_task:throttle:{workspace_id}"
-            if _throttle_redis.set(_cluster_throttle_key, "1", nx=True, ex=60):
-                from app.celery_app import celery_app as _celery_app
-                _celery_app.send_task(
-                    "app.tasks.init_community_clustering_for_users",
-                    kwargs={"end_user_ids": end_user_ids, "workspace_id": str(workspace_id)},
-                )
-                api_logger.info(f"已触发社区聚类补全任务，候选用户数: {len(end_user_ids)}")
-            else:
-                api_logger.info(f"社区聚类补全任务节流中，跳过: workspace_id={workspace_id}")
-        except Exception as e:
-            api_logger.warning(f"触发社区聚类补全任务失败（不影响主流程）: {str(e)}")
-
     # 构建分页响应
     result = {
         "items": items,
@@ -213,6 +170,62 @@ def get_workspace_end_users(
             "hasnext": (page * pagesize) < total
         }
     }
+
+    # Redis 节流 + Celery 任务分发放到后台线程，不阻塞接口响应
+    import threading
+
+    def _fire_and_forget_tasks(_end_user_ids, _workspace_id):
+        """后台线程：执行 Redis 节流判断 + Celery 任务派发"""
+        try:
+            import redis
+            from app.core.config import settings as _settings
+
+            _pool = redis.ConnectionPool(
+                host=_settings.REDIS_HOST,
+                port=_settings.REDIS_PORT,
+                db=_settings.REDIS_DB_CELERY_BACKEND,
+                password=_settings.REDIS_PASSWORD,
+                decode_responses=True,
+                max_connections=10,
+                socket_connect_timeout=3,
+                socket_timeout=5,
+            )
+            _redis = redis.StrictRedis(connection_pool=_pool)
+            _redis.ping()
+        except Exception as _e:
+            api_logger.warning(f"后台任务 Redis 不可用，跳过: {_e}")
+            return
+
+        try:
+            from app.celery_app import celery_app as _celery_app
+
+            # 按需初始化任务（节流 60s）
+            _throttle_key = f"dashboard:init_tasks:throttle:{_workspace_id}"
+            if _redis.set(_throttle_key, "1", nx=True, ex=60):
+                _celery_app.send_task(
+                    "app.tasks.init_implicit_emotions_for_users",
+                    kwargs={"end_user_ids": _end_user_ids},
+                )
+                _celery_app.send_task(
+                    "app.tasks.init_interest_distribution_for_users",
+                    kwargs={"end_user_ids": _end_user_ids},
+                )
+
+            # 社区聚类补全任务（节流 60s）
+            _cluster_key = f"dashboard:cluster_task:throttle:{_workspace_id}"
+            if _redis.set(_cluster_key, "1", nx=True, ex=60):
+                _celery_app.send_task(
+                    "app.tasks.init_community_clustering_for_users",
+                    kwargs={"end_user_ids": _end_user_ids, "workspace_id": str(_workspace_id)},
+                )
+        except Exception as _e:
+            api_logger.warning(f"后台任务派发失败（不影响已返回响应）: {_e}")
+
+    threading.Thread(
+        target=_fire_and_forget_tasks,
+        args=(end_user_ids, workspace_id),
+        daemon=True,
+    ).start()
 
     api_logger.info(f"成功获取 {len(end_users)} 个宿主记录，总计 {total} 条")
     return success(data=result, msg="宿主列表获取成功")

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -177,21 +177,12 @@ def get_workspace_end_users(
     def _fire_and_forget_tasks(_end_user_ids, _workspace_id):
         """后台线程：执行 Redis 节流判断 + Celery 任务派发"""
         try:
-            import redis
-            from app.core.config import settings as _settings
+            from app.tasks import get_sync_redis_client
 
-            _pool = redis.ConnectionPool(
-                host=_settings.REDIS_HOST,
-                port=_settings.REDIS_PORT,
-                db=_settings.REDIS_DB_CELERY_BACKEND,
-                password=_settings.REDIS_PASSWORD,
-                decode_responses=True,
-                max_connections=10,
-                socket_connect_timeout=3,
-                socket_timeout=5,
-            )
-            _redis = redis.StrictRedis(connection_pool=_pool)
-            _redis.ping()
+            _redis = get_sync_redis_client()
+            if _redis is None:
+                api_logger.warning("后台任务 Redis 不可用，跳过")
+                return
         except Exception as _e:
             api_logger.warning(f"后台任务 Redis 不可用，跳过: {_e}")
             return

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -1530,12 +1530,11 @@ def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, An
 
 def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) -> Dict[str, Dict[str, Any]]:
     """
-    批量获取多个终端用户关联的记忆配置（优化版本，减少数据库查询次数）
+    批量获取多个终端用户关联的记忆配置。
 
-    使用与 get_end_user_connected_config 相同的逻辑：
+    逻辑：
     1. 优先使用 end_user.memory_config_id
-    2. 如果没有，尝试从 AppRelease.config 提取并回填
-    3. 如果仍然没有，回退到工作空间默认配置
+    2. 如果没有，回退到工作空间默认配置
 
     Args:
         end_user_ids: 终端用户ID列表
@@ -1543,154 +1542,51 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
 
     Returns:
         字典，key 为 end_user_id，value 为包含 memory_config_id 和 memory_config_name 的字典
-        格式: {
-            "user_id_1": {"memory_config_id": "xxx", "memory_config_name": "xxx"},
-            "user_id_2": {"memory_config_id": None, "memory_config_name": None},
-            ...
-        }
     """
-    import json as json_module
-
-    from sqlalchemy import select
+    from sqlalchemy.orm import load_only
 
     from app.models.app_model import App
-    from app.models.app_release_model import AppRelease
     from app.models.end_user_model import EndUser
     from app.models.memory_config_model import MemoryConfig
-    from app.services.memory_config_service import MemoryConfigService
 
     logger.info(f"Batch getting connected configs for {len(end_user_ids)} end_users")
 
-    result = {}
+    result: Dict[str, Dict[str, Any]] = {}
 
     if not end_user_ids:
         return result
 
-    # 1. 批量查询所有 end_user 及其 app_id 和 memory_config_id
-    end_users = db.query(EndUser).filter(EndUser.id.in_(end_user_ids)).all()
+    # 1. 批量查询所有 end_user，只加载需要的列
+    end_users = (
+        db.query(EndUser)
+        .options(load_only(EndUser.id, EndUser.app_id, EndUser.memory_config_id))
+        .filter(EndUser.id.in_(end_user_ids))
+        .all()
+    )
 
-    # 创建映射 - 保留 EndUser 对象引用以便回填
-    end_user_map = {str(eu.id): eu for eu in end_users}
     user_data = {str(eu.id): {"app_id": eu.app_id, "memory_config_id": eu.memory_config_id} for eu in end_users}
 
     # 记录未找到的用户
-    found_user_ids = set(user_data.keys())
-    missing_user_ids = set(end_user_ids) - found_user_ids
-    if missing_user_ids:
-        logger.warning(f"End users not found: {missing_user_ids}")
-        for user_id in missing_user_ids:
-            result[user_id] = {"memory_config_id": None, "memory_config_name": None}
+    missing_user_ids = set(end_user_ids) - set(user_data.keys())
+    for user_id in missing_user_ids:
+        result[user_id] = {"memory_config_id": None, "memory_config_name": None}
 
-    # 2. 批量获取所有相关应用以获取 workspace_id 和 type
-    app_ids = list(set(data["app_id"] for data in user_data.values()))
+    # 2. 批量获取所有相关应用的 workspace_id
+    app_ids = list(set(data["app_id"] for data in user_data.values() if data["app_id"]))
     if not app_ids:
+        for user_id in user_data:
+            result[user_id] = {"memory_config_id": None, "memory_config_name": None}
         return result
 
-    apps = db.query(App).filter(App.id.in_(app_ids)).all()
-    app_map = {app.id: app for app in apps}
+    apps = (
+        db.query(App)
+        .options(load_only(App.id, App.workspace_id))
+        .filter(App.id.in_(app_ids))
+        .all()
+    )
     app_to_workspace = {app.id: app.workspace_id for app in apps}
 
-    # 3. 对于没有 memory_config_id 的用户，尝试从 AppRelease.config 提取
-    users_needing_migration = [
-        (end_user_id, data["app_id"])
-        for end_user_id, data in user_data.items()
-        if not data["memory_config_id"]
-    ]
-
-    if users_needing_migration:
-        # 批量获取相关应用的最新发布版本
-        migration_app_ids = list(set(app_id for _, app_id in users_needing_migration))
-
-        # 查询每个应用的最新活跃发布版本
-        app_latest_releases = {}
-        for app_id in migration_app_ids:
-            stmt = (
-                select(AppRelease)
-                .where(AppRelease.app_id == app_id, AppRelease.is_active.is_(True))
-                .order_by(AppRelease.version.desc())
-                .limit(1)
-            )
-            latest_release = db.scalars(stmt).first()
-            if latest_release:
-                app_latest_releases[app_id] = latest_release
-
-        # 为每个需要迁移的用户提取 memory_config_id
-        config_service = MemoryConfigService(db)
-        users_to_backfill = []  # [(end_user, memory_config_id), ...]
-
-        for end_user_id, app_id in users_needing_migration:
-            latest_release = app_latest_releases.get(app_id)
-            if not latest_release:
-                continue
-
-            config = latest_release.config or {}
-
-            # 如果 config 是字符串，解析为字典
-            if isinstance(config, str):
-                try:
-                    config = json_module.loads(config)
-                except json_module.JSONDecodeError:
-                    logger.warning(f"Failed to parse config JSON for release {latest_release.id}")
-                    continue
-
-            # 使用 MemoryConfigService 的提取方法
-            app = app_map.get(app_id)
-            if not app:
-                continue
-
-            legacy_config_id, is_legacy_int = config_service.extract_memory_config_id(
-                app_type=app.type,
-                config=config
-            )
-
-            if legacy_config_id:
-                # 更新 user_data 中的 memory_config_id
-                user_data[end_user_id]["memory_config_id"] = legacy_config_id
-
-                # 记录需要回填的用户（稍后验证配置存在后再回填）
-                end_user = end_user_map.get(end_user_id)
-                if end_user:
-                    users_to_backfill.append((end_user, legacy_config_id))
-            elif is_legacy_int:
-                logger.info(
-                    f"Legacy int config detected for end_user {end_user_id}, will use workspace default"
-                )
-
-        # 验证提取的 config_id 是否存在于数据库中
-        if users_to_backfill:
-            config_ids_to_validate = list(set(cid for _, cid in users_to_backfill))
-            existing_configs = db.query(MemoryConfig).filter(
-                MemoryConfig.config_id.in_(config_ids_to_validate)
-            ).all()
-            valid_config_ids = {mc.config_id for mc in existing_configs}
-
-            # 只回填存在的配置
-            valid_backfills = [
-                (eu, cid) for eu, cid in users_to_backfill
-                if cid in valid_config_ids
-            ]
-            invalid_backfills = [
-                (eu, cid) for eu, cid in users_to_backfill
-                if cid not in valid_config_ids
-            ]
-
-            if invalid_backfills:
-                invalid_ids = [str(cid) for _, cid in invalid_backfills]
-                logger.warning(
-                    f"Skipping backfill for non-existent memory_config_ids: {invalid_ids}"
-                )
-                # 清除 user_data 中无效的 config_id
-                for eu, cid in invalid_backfills:
-                    user_data[str(eu.id)]["memory_config_id"] = None
-
-            # 批量回填 end_user.memory_config_id
-            if valid_backfills:
-                for end_user, memory_config_id in valid_backfills:
-                    end_user.memory_config_id = memory_config_id
-                db.commit()
-                logger.info(f"Migrated memory_config_id for {len(valid_backfills)} end_users")
-
-    # 4. 收集需要查询的 memory_config_id 和需要回退的 workspace_id
+    # 3. 分类：有直接配置的 vs 需要回退到工作空间默认的
     direct_config_ids = []
     workspace_fallback_users = []  # [(end_user_id, workspace_id), ...]
 
@@ -1702,32 +1598,41 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
             if workspace_id:
                 workspace_fallback_users.append((end_user_id, workspace_id))
 
-    # 5. 批量查询直接分配的配置
+    # 4. 批量查询直接分配的配置
     config_id_to_config = {}
     if direct_config_ids:
-        configs = db.query(MemoryConfig).filter(MemoryConfig.config_id.in_(direct_config_ids)).all()
+        configs = (
+            db.query(MemoryConfig)
+            .options(load_only(MemoryConfig.config_id, MemoryConfig.config_name))
+            .filter(MemoryConfig.config_id.in_(direct_config_ids))
+            .all()
+        )
         config_id_to_config = {mc.config_id: mc for mc in configs}
 
-    # 6. 获取工作空间默认配置（需要逐个查询，因为 get_workspace_default_config 有复杂逻辑）
-    workspace_default_configs = {}
+    # 5. 批量获取工作空间默认配置
+    workspace_default_configs: Dict[Any, Any] = {}
     unique_workspace_ids = list(set(ws_id for _, ws_id in workspace_fallback_users))
 
     if unique_workspace_ids:
-        config_service = MemoryConfigService(db)
-        for workspace_id in unique_workspace_ids:
-            default_config = config_service.get_workspace_default_config(workspace_id)
-            if default_config:
-                workspace_default_configs[workspace_id] = default_config
+        default_configs = (
+            db.query(MemoryConfig)
+            .options(load_only(MemoryConfig.config_id, MemoryConfig.config_name, MemoryConfig.workspace_id))
+            .filter(
+                MemoryConfig.workspace_id.in_(unique_workspace_ids),
+                MemoryConfig.is_default.is_(True),
+                MemoryConfig.state.is_(True),
+            )
+            .all()
+        )
+        workspace_default_configs = {mc.workspace_id: mc for mc in default_configs}
 
-    # 7. 构建最终结果
+    # 6. 构建最终结果
     for end_user_id, data in user_data.items():
         memory_config = None
 
-        # 优先使用 end_user 直接分配的配置
         if data["memory_config_id"]:
             memory_config = config_id_to_config.get(data["memory_config_id"])
 
-        # 回退到工作空间默认配置
         if not memory_config:
             workspace_id = app_to_workspace.get(data["app_id"])
             if workspace_id:

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, load_only
 from sqlalchemy import desc, nullslast, or_, cast, String, func
 from typing import List, Optional, Dict, Any
 import uuid
@@ -120,8 +120,17 @@ def get_workspace_end_users_paginated(
     business_logger.info(f"获取工作空间宿主列表（分页）: workspace_id={workspace_id}, keyword={keyword}, page={page}, pagesize={pagesize}, 操作者: {current_user.username}")
 
     try:
-        # 构建基础查询
-        base_query = db.query(EndUserModel).filter(
+        # 构建基础查询 — 只加载接口需要的列，避免加载大 Text 字段
+        _dashboard_columns = load_only(
+            EndUserModel.id,
+            EndUserModel.other_name,
+            EndUserModel.memory_count,
+            EndUserModel.app_id,
+            EndUserModel.memory_config_id,
+            EndUserModel.created_at,
+            EndUserModel.workspace_id,
+        )
+        base_query = db.query(EndUserModel).options(_dashboard_columns).filter(
             EndUserModel.workspace_id == workspace_id,
             EndUserModel.memory_count > 0 , # 只查询有记忆的宿主
         )
@@ -153,11 +162,9 @@ def get_workspace_end_users_paginated(
             desc(EndUserModel.id)
         ).offset((page - 1) * pagesize).limit(pagesize).all()
 
-        # 转换为 Pydantic 模型
-        end_users = [EndUserSchema.model_validate(eu) for eu in end_users_orm]
-
-        business_logger.info(f"成功获取 {len(end_users)} 个宿主记录，总计 {total} 条")
-        return {"items": end_users, "total": total}
+        # 直接返回 ORM 对象，controller 只需要 id/other_name/memory_count
+        business_logger.info(f"成功获取 {len(end_users_orm)} 个宿主记录，总计 {total} 条")
+        return {"items": end_users_orm, "total": total}
 
     except HTTPException:
         raise
@@ -210,6 +217,15 @@ def get_workspace_end_users_paginated_rag(
                 EndUserModel,
                 chunk_subquery.c.memory_count.label("memory_count"),
             )
+            .options(load_only(
+                EndUserModel.id,
+                EndUserModel.other_name,
+                EndUserModel.memory_count,
+                EndUserModel.app_id,
+                EndUserModel.memory_config_id,
+                EndUserModel.created_at,
+                EndUserModel.workspace_id,
+            ))
             .join(
                 chunk_subquery,
                 chunk_subquery.c.file_name == func.concat(cast(EndUserModel.id, String), ".txt"),
@@ -243,7 +259,7 @@ def get_workspace_end_users_paginated_rag(
         items = []
         for end_user_orm, memory_count in rows:
             items.append({
-                "end_user": EndUserSchema.model_validate(end_user_orm),
+                "end_user": end_user_orm,
                 "memory_count": int(memory_count or 0),
             })
 


### PR DESCRIPTION
- Move Redis throttling and Celery task dispatching to background thread in get_workspace_end_users so the API response returns immediately
- Simplify get_end_users_connected_configs_batch by removing AppRelease.config backfill logic, using direct config_id or workspace default only
- Add load_only to all dashboard queries to avoid loading unused Text columns

## Summary by Sourcery

优化内存仪表盘工作区终端用户列表的性能，以及相关任务的后台处理。

增强内容：
- 简化终端用户内存配置的批量获取逻辑，只使用直接配置 ID 或工作区默认值，移除基于 AppRelease 的回填逻辑。
- 将用于仪表盘初始化和聚类任务的 Redis 限流与 Celery 任务派发延迟到后台线程中执行，使 API 响应可以立即返回。
- 将仪表盘终端用户列表的 ORM 查询限制为控制器所需的字段，并直接返回 ORM 对象而非 Pydantic 模型，以降低开销。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize memory dashboard workspace end-user listing performance and background processing of related tasks.

Enhancements:
- Simplify batch retrieval of end-user memory configs to use only direct config IDs or workspace defaults, removing AppRelease-based backfill logic.
- Defer Redis throttling and Celery task dispatch for dashboard initialization and clustering tasks to a background thread so the API response can return immediately.
- Restrict ORM queries for dashboard end-user lists to only the columns needed by the controller and return ORM objects directly instead of Pydantic models to reduce overhead.

</details>