### PR TITLE
perf(api): add partial indexes on end_users for workspace-memory queries

### DIFF
--- a/api/app/models/end_user_model.py
+++ b/api/app/models/end_user_model.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -11,6 +11,21 @@ from app.core.utils.datetime_utils import utcnow_naive
 
 class EndUser(Base):
     __tablename__ = "end_users"
+    __table_args__ = (
+        Index(
+            "ix_end_users_workspace_memory",
+            "workspace_id",
+            "memory_count",
+            postgresql_where="memory_count > 0",
+        ),
+        Index(
+            "ix_end_users_workspace_created_desc",
+            "workspace_id",
+            "created_at",
+            "id",
+            postgresql_where="memory_count > 0",
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False, index=True)
     app_id = Column(UUID(as_uuid=True), ForeignKey("apps.id"), nullable=True)


### PR DESCRIPTION
Add two partial PostgreSQL indexes filtered by memory_count > 0 to optimize end-user queries by workspace, covering both count-based and time-ordered lookups.

## Summary by Sourcery

在 `end_users` 上添加部分 PostgreSQL 索引，以优化针对具有非零 memory 计数的用户的工作区范围查询。

增强内容：
- 为 `memory_count` 大于零的 `end_users` 引入基于 `workspace_id` 和 `memory_count` 的部分索引。
- 为 `memory_count` 大于零的 `end_users` 引入基于 `workspace_id`、`created_at` 和 `id` 的部分索引，以加速按时间排序的查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add partial PostgreSQL indexes on end_users to optimize workspace-scoped queries for users with non-zero memory counts.

Enhancements:
- Introduce a partial index on workspace_id and memory_count for end_users with memory_count greater than zero.
- Introduce a partial index on workspace_id, created_at, and id for end_users with memory_count greater than zero to speed up time-ordered lookups.

</details>