### PR TITLE
feat(memory): add deterministic alias merger for entity deduplication

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
@@ -1,0 +1,101 @@
+"""反思阶段 · 别名归并（"别名属于" 关系处理）
+
+将 (A)-[:EXTRACTED_RELATIONSHIP {predicate:'别名属于'}]->(B) 的别名节点 A
+归并进规范实体 B：A.name 进 B.aliases、A.description 拼入 B.description，
+A 上其它边重定向到 B，最后删除 A 节点。
+
+三步均为确定性 Cypher，不涉及 LLM / embedding。
+逻辑迁移自原写入后处理任务 post_store_dedup_and_alias_merge。
+"""
+import logging
+from typing import Any, Dict
+
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.repositories.neo4j.cypher_queries import (
+    MERGE_ALIAS_BELONGS_TO,
+    REDIRECT_ALIAS_EDGES,
+    DELETE_ALIAS_NODES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def merge_alias_belongs_to(
+    connector: Neo4jConnector,
+    end_user_id: str,
+) -> Dict[str, Any]:
+    """按 end_user_id 全量处理 "别名属于" 关系。
+
+    顺序执行三步，每步独立异常隔离：
+      1. 别名归并：source.name → target.aliases，source.description → target.description
+      2. 边重定向：别名节点其它边 → 规范实体
+      3. 删除别名节点：DETACH DELETE
+
+    Args:
+        connector: Neo4j 连接器
+        end_user_id: 终端用户 ID
+
+    Returns:
+        统计字典：alias_merged / edges_redirected / alias_nodes_deleted / errors
+    """
+    result: Dict[str, Any] = {
+        "alias_merged": 0,
+        "edges_redirected": 0,
+        "alias_nodes_deleted": 0,
+        "errors": {},
+    }
+
+    # ── 1. 别名归并（name 进 aliases，description 拼接） ──
+    try:
+        records = await connector.execute_query(
+            MERGE_ALIAS_BELONGS_TO,
+            end_user_id=end_user_id,
+        )
+        result["alias_merged"] = len(records) if records else 0
+        logger.info(
+            f"[AliasMerge] 别名归并完成 end_user_id={end_user_id}, "
+            f"影响 target={result['alias_merged']}"
+        )
+    except Exception as e:
+        logger.warning(f"[AliasMerge] 别名归并失败 end_user_id={end_user_id}: {e}")
+        result["errors"]["merge"] = str(e)
+
+    # ── 2. 边重定向（别名节点其它边 → 规范实体） ──
+    try:
+        redirect_records = await connector.execute_query(
+            REDIRECT_ALIAS_EDGES,
+            end_user_id=end_user_id,
+        )
+        if redirect_records:
+            row = redirect_records[0]
+            result["edges_redirected"] = (
+                (row.get("redirected_incoming") or 0)
+                + (row.get("redirected_outgoing") or 0)
+                + (row.get("redirected_stmt") or 0)
+            )
+        logger.info(
+            f"[AliasMerge] 边重定向完成 end_user_id={end_user_id}, "
+            f"汇总={result['edges_redirected']}"
+        )
+    except Exception as e:
+        logger.warning(f"[AliasMerge] 边重定向失败 end_user_id={end_user_id}: {e}")
+        result["errors"]["redirect"] = str(e)
+
+    # ── 3. 删除别名节点（DETACH DELETE） ──
+    try:
+        delete_records = await connector.execute_query(
+            DELETE_ALIAS_NODES,
+            end_user_id=end_user_id,
+        )
+        result["alias_nodes_deleted"] = (
+            delete_records[0].get("deleted_count", 0) if delete_records else 0
+        )
+        logger.info(
+            f"[AliasMerge] 别名节点删除完成 end_user_id={end_user_id}, "
+            f"删除={result['alias_nodes_deleted']}"
+        )
+    except Exception as e:
+        logger.warning(f"[AliasMerge] 别名节点删除失败 end_user_id={end_user_id}: {e}")
+        result["errors"]["delete"] = str(e)
+
+    return result

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -161,6 +161,10 @@ class Layer2Inspector:
             end_user_id, baseline, language
         )
 
+        # 别名归并 — 处理 "别名属于" 关系（确定性 Cypher，无 LLM）
+        # 放在 unresolved 之后、entity_dedup 之前：先清理别名节点，
+        results["alias_merge"] = await self._run_alias_merge(end_user_id)
+
         # 子问题 3 — 复杂去重消歧（entity_dedup）
         results["entity_dedup"] = await self._run_entity_dedup(end_user_id, baseline)
 
@@ -172,6 +176,20 @@ class Layer2Inspector:
         # TODO: 子问题 4 — 本体 Metadata 校验（metadata_validation）
 
         return results
+
+    async def _run_alias_merge(self, end_user_id: str) -> Dict[str, Any]:
+        """别名归并：处理 "别名属于" 关系（确定性 Cypher，无 LLM）
+
+        将别名节点的 name/description 归并进规范实体，重定向其它边，
+        最后删除别名节点。逻辑迁移自原写入后处理任务。
+        """
+        from .deterministic.alias_merger import merge_alias_belongs_to
+
+        try:
+            return await merge_alias_belongs_to(self.connector, end_user_id)
+        except Exception as e:
+            logger.warning(f"[AliasMerge] 执行失败 end_user_id={end_user_id}: {e}")
+            return {"status": "error", "error": str(e)}
 
     async def _run_entity_dedup(self, end_user_id: str, baseline: str) -> Dict[str, Any]:
         """子问题 3 复杂去重 方案A：高频两路召回去重"""

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2359,3 +2359,107 @@ MATCH (s:Statement {id: $statement_id})
 SET s.has_unsolved_reference = false
 RETURN s.id AS statement_id
 """
+
+# ============================================================================
+# 反思阶段 · 别名归并（"别名属于" 关系处理）
+# 由 Layer2Inspector 确定性步骤调用，按 end_user_id 全量扫描 "别名属于" 边：
+#   1. MERGE_ALIAS_BELONGS_TO：将 source.name 并入 target.aliases，
+#      source.description 追加到 target.description
+#   2. REDIRECT_ALIAS_EDGES：将别名节点(source)上其它边重定向到 target
+#   3. DELETE_ALIAS_NODES：DETACH DELETE 别名节点（连同 "别名属于" 边）
+# ============================================================================
+
+# 别名归并：将 predicate="别名属于" 的 EXTRACTED_RELATIONSHIP 边的 source.name
+# 合并进 target.aliases（去重），并将 source.description 追加到 target.description（分号分隔）
+MERGE_ALIAS_BELONGS_TO = """
+// 先按 target 分组，将所有 source.name 和 source.description 聚合，
+// 再一次性 SET，避免多条 别名属于 边对同一 target 反复覆盖。
+MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
+WHERE r.predicate = '别名属于'
+WITH target,
+     coalesce(target.aliases, []) AS existing_aliases,
+     coalesce(target.description, '') AS tgt_desc,
+     collect(DISTINCT source.name) AS source_names,
+     collect(DISTINCT coalesce(source.description, '')) AS source_descs
+
+// 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值）
+WITH target, tgt_desc, source_names, source_descs, existing_aliases,
+     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT n IN existing_aliases] AS new_aliases
+
+// 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
+WITH target, new_aliases, existing_aliases, source_descs,
+     reduce(desc = tgt_desc, src IN source_descs |
+         CASE
+             WHEN src <> '' AND NOT desc CONTAINS src
+             THEN CASE WHEN desc = '' THEN src ELSE desc + '；' + src END
+             ELSE desc
+         END
+     ) AS new_description
+
+SET target.aliases = new_aliases,
+    target.description = new_description
+
+RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_aliases) - size(existing_aliases) AS added_count
+"""
+
+# 边重定向：将指向别名节点（"别名属于"关系的 source）的所有其他边，重定向到用户节点（target）。
+# 处理两类边：
+#   1. EXTRACTED_RELATIONSHIP：其他实体 → 别名节点 或 别名节点 → 其他实体
+#   2. STATEMENT_ENTITY：陈述句 → 别名节点
+# 对于每条需要重定向的边，创建一条指向用户节点的新边（复制所有属性），然后删除旧边。
+REDIRECT_ALIAS_EDGES = """
+// 找到所有 别名→用户 的映射
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
+WHERE ar.predicate = '别名属于'
+WITH collect({alias_id: elementId(alias), user_id: elementId(user), alias_eid: alias.id, user_eid: user.id}) AS mappings
+
+// 1. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 target 的情况
+UNWIND mappings AS m
+MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias:ExtractedEntity {end_user_id: $end_user_id})
+WHERE alias.id = m.alias_eid
+  AND r.predicate <> '别名属于'
+  AND other.id <> m.user_eid
+WITH m, other, r, alias
+MATCH (user:ExtractedEntity {id: m.user_eid, end_user_id: $end_user_id})
+CREATE (other)-[nr:EXTRACTED_RELATIONSHIP]->(user)
+SET nr = properties(r)
+DELETE r
+WITH count(*) AS redirected_incoming
+
+// 2. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 source 的情况
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
+WHERE ar2.predicate = '别名属于'
+WITH alias, user2, redirected_incoming
+MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
+WHERE r.predicate <> '别名属于'
+  AND other.id <> user2.id
+WITH user2, other, r, redirected_incoming
+CREATE (user2)-[nr:EXTRACTED_RELATIONSHIP]->(other)
+SET nr = properties(r)
+DELETE r
+WITH redirected_incoming, count(*) AS redirected_outgoing
+
+// 3. 重定向 STATEMENT_ENTITY 边：陈述句 → 别名节点
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
+WHERE ar3.predicate = '别名属于'
+WITH alias, user3, redirected_incoming, redirected_outgoing
+MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
+WITH user3, stmt, r, redirected_incoming, redirected_outgoing
+CREATE (stmt)-[nr:STATEMENT_ENTITY]->(user3)
+SET nr = properties(r)
+DELETE r
+
+RETURN redirected_incoming, redirected_outgoing, count(*) AS redirected_stmt
+"""
+
+# 删除别名节点：在别名归并和边重定向完成后，删除所有 predicate="别名属于" 关系的 source 节点。
+# 此时这些节点的其他边已被 REDIRECT_ALIAS_EDGES 重定向完毕，
+# 唯一剩余的边就是 (alias)-[:EXTRACTED_RELATIONSHIP {predicate:'别名属于'}]->(user)，
+# 使用 DETACH DELETE 一并删除节点和该关系。
+DELETE_ALIAS_NODES = """
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
+WHERE r.predicate = '别名属于'
+WITH alias, count(r) AS rel_count
+DETACH DELETE alias
+RETURN count(alias) AS deleted_count
+"""


### PR DESCRIPTION
- Add alias_merger.py module to handle "别名属于" (alias-belongs-to) relationship processing
- Merge alias node names into target entity aliases array and consolidate descriptions
- Redirect edges from alias nodes to canonical entities before deletion
- Integrate merge_alias_belongs_to into Layer2Inspector reflection engine workflow
- Add three new Cypher queries (MERGE_ALIAS_BELONGS_TO, REDIRECT_ALIAS_EDGES, DELETE_ALIAS_NODES) for deterministic alias processing
- Execute alias merge after unresolved entity extraction and before entity deduplication
- Provides complete audit trail with counts for merged aliases, redirected edges, and deleted nodes

## Summary by Sourcery

在反射引擎中新增一个确定性的别名合并步骤，用于在实体去重之前，将别名实体规范化为规范实体。

新功能：
- 引入 Cypher 查询，将别名实体合并到目标别名和描述中，重定向相关边，并为指定终端用户删除别名节点。
- 在 Layer2Inspector 反射引擎中添加一个确定性的别名合并工作流，并在运行流水线中暴露其结果。
- 提供一个 `alias_merger` 工具，用于编排别名合并、边重定向以及别名节点删除，并汇总审计统计信息。

改进：
- 记录详细的别名合并、边重定向和删除统计信息，并捕获错误，以提升对反射处理过程的可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a deterministic alias-merging step in the reflection engine to normalize alias entities into canonical entities before entity deduplication.

New Features:
- Introduce Cypher queries to merge alias entities into target aliases and descriptions, redirect related edges, and delete alias nodes for a given end user.
- Add a deterministic alias merge workflow to the Layer2Inspector reflection engine and expose its results in the run pipeline.
- Provide an alias_merger utility that orchestrates alias merging, edge redirection, and alias node deletion with aggregated audit statistics.

Enhancements:
- Log detailed alias merge, edge redirection, and deletion statistics with error capture for better observability of reflection processing.

</details>