### PR TITLE
refactor: unify SSE event handling logic across the three chat services

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -781,11 +781,16 @@ class AppChatService:
                     yield f"event: tool_end\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'output': chunk.get('output'), 'meta': chunk.get('meta')}, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_error":
                     yield f"event: tool_error\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'error': chunk.get('error')}, ensure_ascii=False)}\n\n"
-                else:
+                elif isinstance(chunk, dict) and chunk.get("type") == "agent_log":
+                    yield f"event: agent_log\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+                elif isinstance(chunk, str):
                     full_content += chunk
                     yield f"event: message\ndata: {json.dumps({'content': chunk}, ensure_ascii=False)}\n\n"
                     if tts_task is not None:
                         await text_queue.put(chunk)
+                elif isinstance(chunk, dict):
+                    event_type = str(chunk.get("type") or "unknown")
+                    yield f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
             if tts_task is not None:
                 await text_queue.put(None)

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -1250,11 +1250,16 @@ class AgentRunService:
                     yield self._format_sse_event("tool_end", {"step_id": chunk.get("step_id"), "name": chunk["name"], "output": chunk.get("output"), "meta": chunk.get("meta")})
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_error":
                     yield self._format_sse_event("tool_error", {"step_id": chunk.get("step_id"), "name": chunk["name"], "error": chunk.get("error")})
-                else:
+                elif isinstance(chunk, dict) and chunk.get("type") == "agent_log":
+                    yield self._format_sse_event("agent_log", chunk)
+                elif isinstance(chunk, str):
                     full_content += chunk
                     yield self._format_sse_event("message", {"content": chunk})
                     if tts_task is not None:
                         await text_queue.put(chunk)
+                elif isinstance(chunk, dict):
+                    event_type = str(chunk.get("type") or "unknown")
+                    yield self._format_sse_event(event_type, chunk)
 
             # 文本结束，通知 TTS
             if tts_task is not None:

--- a/api/app/services/shared_chat_service.py
+++ b/api/app/services/shared_chat_service.py
@@ -516,10 +516,15 @@ class SharedChatService:
                     total_tokens = chunk
                 elif isinstance(chunk, dict) and chunk.get("type") == "reasoning":
                     yield f"event: reasoning\ndata: {json.dumps({'content': chunk['content']}, ensure_ascii=False)}\n\n"
-                else:
+                elif isinstance(chunk, dict) and chunk.get("type") == "agent_log":
+                    yield f"event: agent_log\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+                elif isinstance(chunk, str):
                     full_content += chunk
                     # 发送消息块事件
                     yield f"event: message\ndata: {json.dumps({'content': chunk}, ensure_ascii=False)}\n\n"
+                elif isinstance(chunk, dict):
+                    event_type = str(chunk.get("type") or "unknown")
+                    yield f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
             elapsed_time = time.time() - start_time
 


### PR DESCRIPTION
- Extract common SSE event dispatching logic.
- Add support for the `agent_log` event type.
- Ensure compatibility with unknown dictionary-type events.

## Summary by Sourcery

在与聊天相关的服务中统一 SSE 事件处理方式，并扩展对更多事件类型的支持。

新功能：
- 在 app、draft run 和 shared chat 流式端点中，为 `agent_log` 事件类型添加 SSE 支持。
- 为之前未处理的、基于字典的分片发出 SSE 事件，使用其 `type` 字段作为事件类型，若缺失则回退为 `unknown`。

改进：
- 对齐各处的流式处理分支，使字符串分片始终被视为 `message` 事件，而非字符串的字典分片则作为带类型的 SSE 事件进行分发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify SSE event handling across chat-related services and expand support for additional event types.

New Features:
- Add SSE support for the `agent_log` event type in app, draft run, and shared chat streaming endpoints.
- Emit SSE events for previously unhandled dictionary-based chunks using their `type` field or `unknown` as a fallback.

Enhancements:
- Align streaming branches so that string chunks are consistently treated as `message` events and non-string dictionary chunks are dispatched as typed SSE events.

</details>