### PR TITLE
fix(rag): fix callback error[rerank, repeat]

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -1,3 +1,4 @@
+import json
 import os
 import csv
 import io
@@ -1121,7 +1122,9 @@ async def retrieve_chunks(
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case _:
             rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
+            api_logger.debug(f"[HybridSearch] vector search result: {json.dumps(jsonable_encoder(rs1), ensure_ascii=False)}")
             rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
+            api_logger.debug(f"[HybridSearch] text search result: {json.dumps(jsonable_encoder(rs2), ensure_ascii=False)}")
             # Efficient deduplication
             seen_ids = set()
             unique_rs = []
@@ -1129,9 +1132,12 @@ async def retrieve_chunks(
                 if doc.metadata["doc_id"] not in seen_ids:
                     seen_ids.add(doc.metadata["doc_id"])
                     unique_rs.append(doc)
+            api_logger.debug(f"[HybridSearch] unique result: {json.dumps(jsonable_encoder(unique_rs), ensure_ascii=False)}")
             rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
+            api_logger.debug(f"[HybridSearch] reranked result: {json.dumps(jsonable_encoder(rs), ensure_ascii=False)}")
             rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
             rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
+            api_logger.debug(f"[HybridSearch] rerank_threshold result: {json.dumps(jsonable_encoder(rs), ensure_ascii=False)}")
             if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
                 kb_ids = [str(kb_id) for kb_id in private_kb_ids]
                 workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]

--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -30,6 +30,7 @@ class RedBearRerank(BaseDocumentCompressor):
             self,
             documents: Sequence[Document],
             query: str,
+            topn: Optional[int] = 100,
             callbacks: Optional[Callbacks] = None,
     ) -> Sequence[Document]:
         """
@@ -44,7 +45,7 @@ class RedBearRerank(BaseDocumentCompressor):
             A sequence of compressed documents.
         """
         compressed = []
-        for res in self.rerank(documents, query):
+        for res in self.rerank(documents, query, top_n=topn):
             doc = documents[res["index"]]
             doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
             doc_copy.metadata["relevance_score"] = res["relevance_score"]

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -779,7 +779,7 @@ class ElasticSearchVector(BaseVector):
                 for doc in docs
             ]
 
-            reranked_docs = list(self.reranker.compress_documents(documents, query))
+            reranked_docs = list(self.reranker.compress_documents(documents, query, top_k))
             logger.debug(f"[rerank] returned {len(reranked_docs)} docs")
 
             reranked_docs.sort(
@@ -789,9 +789,10 @@ class ElasticSearchVector(BaseVector):
             result = []
             for item in reranked_docs[:top_k]:
                 for doc in docs:
-                    if doc.page_content == item.page_content:
+                    if doc.page_content == item.page_content and doc.metadata['doc_id'] == item.metadata['doc_id']:
                         doc.metadata["score"] = item.metadata["relevance_score"]
                         result.append(doc)
+                        break
             return result
         except Exception as e:
             logger.warning(f"Rerank failed, falling back to original results: {str(e)}")


### PR DESCRIPTION
## Summary
- Fix rerank callback handling and duplicate result mapping for RAG chunk retrieval.

## Changes
```
api/app/controllers/chunk_controller.py                    | 6 ++++++
api/app/core/models/rerank.py                              | 3 ++-
api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py | 5 +++--
3 files changed, 11 insertions(+), 3 deletions(-)
```

## Test Plan
- [ ] Not run; branch was cherry-picked and pushed for review only.

## External API Impact
- The `/chunks/retrieval` service API reuses the internal chunk controller, so rerank behavior changes apply to API key callers as well.

## Summary by Sourcery

改进 RAG 混合检索的重排序处理和日志记录，以优化分块检索。

Bug 修复：
- 确保 reranker 中的 `compress_documents` 在对文档进行重排序时遵守可配置的 top-n 限制。
- 修复重排序后文档的映射逻辑，通过同时匹配页面内容和文档 ID，并在首次匹配后立即中断，以避免重复。
- 将 `top_k` 传递给 Elasticsearch reranker，使其与回调的预期保持一致，并防止在重排序处理过程中出现错误。

增强：
- 为混合搜索的向量结果、文本结果、去重结果、重排序结果以及阈值过滤结果添加详细的调试日志，以便更好地排查 RAG 检索问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RAG hybrid retrieval rerank handling and logging for chunk retrieval.

Bug Fixes:
- Ensure reranker compress_documents respects a configurable top-n limit when reranking documents.
- Fix reranked document mapping to avoid duplicates by matching both page content and document ID and breaking after the first match.
- Pass top_k through to the Elasticsearch reranker to align callback expectations and prevent errors in rerank processing.

Enhancements:
- Add detailed debug logging for hybrid search vector, text, deduplicated, reranked, and threshold-filtered results to aid troubleshooting of RAG retrieval.

</details>