### PR TITLE
fix(knowledge-node)

### DIFF
--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class KnowledgeRetrievalNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
-        self.typed_config: KnowledgeRetrievalNodeConfig | None = None
+        self.typed_config: KnowledgeRetrievalNodeConfig = KnowledgeRetrievalNodeConfig(**self.config)
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -326,7 +326,6 @@ class KnowledgeRetrievalNode(BaseNode):
         Raises:
             RuntimeError: If no valid knowledge base is found or access is denied.
         """
-        self.typed_config = KnowledgeRetrievalNodeConfig(**self.config)
         if not self.typed_config.knowledge_bases:
             return []
         query = self._render_template(self.typed_config.query, variable_pool)


### PR DESCRIPTION
initialize typed_config in constructor and remove redundant assignment

Removed redundant initialization of `typed_config` in the `run` method and moved it to the constructor for consistency and clarity.

## Summary by Sourcery

Enhancements:
- 将 `KnowledgeRetrievalNode` 类型化配置的初始化从 `execute` 方法移动到构造函数中，以确保配置只初始化一次并保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Move KnowledgeRetrievalNode typed configuration initialization from the execute method to the constructor to ensure a single, consistent configuration setup.

</details>