### PR TITLE
Fix/v0.3.7 zy

### DIFF
--- a/web/src/views/KnowledgeBase/components/MetadataDrawer.tsx
+++ b/web/src/views/KnowledgeBase/components/MetadataDrawer.tsx
@@ -142,9 +142,9 @@ const MetadataDrawer = forwardRef<MetadataDrawerRef>((_props, ref) => {
                       <span className="rb:font-medium">{item.name}</span>
                       <Tag color="blue">{item.type}</Tag>
                     </div>
-                    <span className="rb:text-[12px] rb:text-[#5B6167]">
+                    {/* <span className="rb:text-[12px] rb:text-[#5B6167]">
                       {item.count || 0} {t('knowledgeBase.metadata.valueCount')}
-                    </span>
+                    </span> */}
                     <Space size={8} className="rb:absolute rb:right-0 rb:hidden! rb:group-hover:inline-flex! rb:bg-white rb:p-2! rb:rounded-tr-lg rb:rounded-br-lg">
                       <div
                         className="rb:size-4.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/common/edit.svg')]"
@@ -192,12 +192,7 @@ const MetadataDrawer = forwardRef<MetadataDrawerRef>((_props, ref) => {
                       <span className="rb:font-medium">{item.name}</span>
                       <Tag color="blue">{item.type}</Tag>
                     </div>
-                    {builtinEnabled
-                      ? <span className="rb:text-[12px] rb:text-[#5B6167]">
-                        {item.count || 0} {t('knowledgeBase.metadata.valueCount')}
-                      </span>
-                      : t('knowledgeBase.metadata.builtinDisabled')
-                    }
+                    {!builtinEnabled && t('knowledgeBase.metadata.builtinDisabled')}
                   </Flex>
                 ))}
               </Flex>

--- a/web/src/views/Workflow/components/CanvasToolbar.tsx
+++ b/web/src/views/Workflow/components/CanvasToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, forwardRef, useImperativeHandle } from 'react';
+import { useState, forwardRef, useImperativeHandle, useRef } from 'react';
 import { Select, Divider, Tooltip } from 'antd';
 import { PlusOutlined, MinusOutlined, FileAddOutlined } from '@ant-design/icons'
 import clsx from 'clsx'
@@ -6,7 +6,7 @@ import { Node } from '@antv/x6';
 import { useTranslation } from 'react-i18next'
 
 import type { GraphRef, WorkflowConfig } from '../types'
-import VariableInspector from './VariableInspector'
+import VariableInspector, { type VariableInspectorRef } from './VariableInspector'
 
 interface CanvasToolbarProps {
   selectedNode: Node | null;
@@ -26,6 +26,7 @@ interface CanvasToolbarProps {
 }
 export interface CanvasToolbarRef {
   setIsVariableInspectorVisible: (visible: boolean) => void;
+  refreshCache: () => void;
 }
 
 const CanvasToolbar = forwardRef<CanvasToolbarRef, CanvasToolbarProps>(({
@@ -46,9 +47,14 @@ const CanvasToolbar = forwardRef<CanvasToolbarRef, CanvasToolbarProps>(({
 }, ref) => {
   const { t } = useTranslation()
   const [isVariableInspectorVisible, setIsVariableInspectorVisible] = useState(false)
+  const variableInspectorRef = useRef<VariableInspectorRef>(null)
 
+  const refreshCache = () => {
+    variableInspectorRef.current?.refresh()
+  }
   useImperativeHandle(ref, () => ({
     setIsVariableInspectorVisible,
+    refreshCache,
   }))
 
   return (
@@ -156,6 +162,7 @@ const CanvasToolbar = forwardRef<CanvasToolbarRef, CanvasToolbarProps>(({
       {/* 变量检查面板 */}
       {isVariableInspectorVisible &&
         <VariableInspector 
+          ref={variableInspectorRef}
           selectedNode={selectedNode}
           config={config}
           onClose={() => setIsVariableInspectorVisible(false)}

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -59,9 +59,10 @@ interface ChatProps {
   onOpenChange: (open: boolean) => void;
   /** Function to save workflow configuration */
   handleSave: (flag?: boolean) => Promise<unknown>;
+  refreshCache: () => void;
 }
 const Chat = forwardRef<ChatRef, ChatProps>(({
-  appId, graphRef, features, appType, open, onOpenChange, handleSave
+  appId, graphRef, features, appType, open, onOpenChange, handleSave, refreshCache
 }, ref) => {
   const { t } = useTranslation()
   const { message: messageApi } = App.useApp()
@@ -651,6 +652,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
       }).finally(() => {
         setLoading(false)
         setStreamLoading(false)
+        refreshCache()
       })
   }
 

--- a/web/src/views/Workflow/components/Properties/Trigger/Webhook.tsx
+++ b/web/src/views/Workflow/components/Properties/Trigger/Webhook.tsx
@@ -59,7 +59,7 @@ const Webhook: FC<{ selectedNode?: any; graphRef?: any; }> = () => {
 
   const path = useMemo(() => {
     return values?.route_key
-      ? `${window.location.origin}/workflows/triggers/webhook/${values.route_key}`
+      ? `${window.location.origin}/api/workflows/triggers/webhook/${values.route_key}`
       : undefined
   }, [values?.route_key])
 

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { Graph, Node } from '@antv/x6';
 import { Form, Input, Select, InputNumber, Switch, Flex, Space, Dropdown, type MenuProps, Button, App, Popover, Tabs } from 'antd';
 
-import type { NodeConfig, NodeProperties, ChatVariable, EnvVariable } from '../../types'
+import type { NodeConfig, ChatVariable, EnvVariable } from '../../types'
 import CustomSelect from "@/components/CustomSelect";
 import MessageEditor from './MessageEditor'
 import Knowledge from './Knowledge/Knowledge';
@@ -84,6 +84,8 @@ interface PropertiesProps {
   nodeClick: ({ node }: { node: Node }) => void;
   /** Application type */
   appType?: Application['type'];
+  /** Function to refresh cache */
+  refreshCache: () => void;
 }
 
 /**
@@ -102,6 +104,7 @@ const Properties: FC<PropertiesProps> = ({
   handleSave,
   nodeClick,
   appType,
+  refreshCache,
 }) => {
   const { t } = useTranslation()
   const { message } = App.useApp()
@@ -182,18 +185,6 @@ const Properties: FC<PropertiesProps> = ({
       }, { deep: false })
     }
   }, [values, selectedNode, form])
-
-  /**
-   * Update node label in graph
-   * @param newLabel - New label text
-   */
-  const updateNodeLabel = (newLabel: string) => {
-    if (selectedNode && form) {
-      const nodeData = selectedNode.getData() as NodeProperties;
-      selectedNode.setAttrByPath('text/text', `${nodeData.icon} ${newLabel}`);
-      selectedNode.setData({ ...selectedNode.getData(), name: newLabel });
-    }
-  };
   /**
    * Get filtered variable list based on node type and config key
    * @param nodeType - Type of the node
@@ -1245,6 +1236,7 @@ const Properties: FC<PropertiesProps> = ({
           selectedNode={selectedNode}
           appId={appId || config?.app_id || ''}
           variableList={variableList}
+          refreshCache={refreshCache}
         />
       )}
     </div>

--- a/web/src/views/Workflow/components/SingleNodeRun/index.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/index.tsx
@@ -44,9 +44,10 @@ interface SingleNodeRunProps {
   selectedNode: Node
   appId: string
   variableList: Suggestion[]
+  refreshCache: () => void;
 }
 
-const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, appId, variableList }) => {
+const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, appId, variableList, refreshCache }) => {
   const { t } = useTranslation()
   const [form] = Form.useForm()
   const [loading, setLoading] = useState(false)
@@ -146,6 +147,7 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
         nodeRun(appId, nodeData.id, { inputs: params, stream: false })
           .then(res => {
             setResult(res as RunResult)
+            refreshCache()
           })
           .catch(err => {
             setResult({ status: 'failed', error: err.message })

--- a/web/src/views/Workflow/components/VariableInspector.tsx
+++ b/web/src/views/Workflow/components/VariableInspector.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useImperativeHandle, forwardRef } from 'react';
 import { Collapse, Flex, Input, InputNumber, Select, Checkbox, Button, Form, message } from 'antd';
 import { CodeOutlined } from '@ant-design/icons';
 import clsx from 'clsx';
@@ -35,6 +35,11 @@ interface VariableInspectorProps {
   runOpen: boolean;
 }
 
+export interface VariableInspectorRef {
+  refresh: () => void;
+  clearCache: () => void;
+}
+
 interface VariableData {
   name: string;
   value: any;
@@ -42,13 +47,13 @@ interface VariableData {
   nodeKey?: string;
 }
 
-const VariableInspector: FC<VariableInspectorProps> = ({ 
+const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProps>(({ 
   selectedNode,
   config,
   onClose,
   collapsed,
   runOpen,
- }) => {
+ }, ref) => {
   const { t } = useTranslation();
   const { id } = useParams()
   const [form] = Form.useForm()
@@ -96,6 +101,11 @@ const VariableInspector: FC<VariableInspectorProps> = ({
     getVariables()
   }, [id])
 
+  useImperativeHandle(ref, () => ({
+    refresh: getVariables,
+    clearCache: handleClearCache,
+  }))
+
   const getVariables = () => {
     if (!id) return
     getWorkflowDebugState(id)
@@ -122,8 +132,6 @@ const VariableInspector: FC<VariableInspectorProps> = ({
           })
         })
         setVariables(newVariables);
-
-        console.log('VariableInspector allVariables', newVariables, flattenVariables(newVariables))
         
         if (selectedVariable) {
           const updatedVariable = flattenVariables(newVariables).find(
@@ -131,6 +139,7 @@ const VariableInspector: FC<VariableInspectorProps> = ({
                  v.nodeKey === selectedVariable.nodeKey
           );
           if (updatedVariable) {
+            form.setFieldValue([updatedVariable.nodeKey, updatedVariable.name], updatedVariable.value);
             setSelectedVariable(updatedVariable);
           }
         }
@@ -243,28 +252,39 @@ const VariableInspector: FC<VariableInspectorProps> = ({
     );
   };
 
-  const getNodeIcon = (nodeKey: string): string | null => {
+  const getNodeIcon = (nodeKey: string): {
+    icon: string | null;
+    name: string;
+  } | null => {
     const nodeInConfig = config?.nodes.find(n => n.id === nodeKey);
+    const nodeInfo: {
+      icon: string | null;
+      name: string;
+    } = {
+      icon: null,
+      name: nodeInConfig?.name || nodeKey,
+    }
     if (!nodeInConfig) return null;
     for (const category of nodeLibrary) {
       const nodeInLib = category.nodes.find(n => n.type === nodeInConfig.type);
-      if (nodeInLib?.icon) return nodeInLib.icon;
+      if (nodeInLib?.icon) nodeInfo.icon = nodeInLib.icon;
     }
-    return null;
+    return nodeInfo;
   };
 
   const renderNodeGroup = (nodeKey: string) => {
     const items = variables[nodeKey] || [];
     
     if (!Object.keys(items).length) return null;
-    const nodeIcon = getNodeIcon(nodeKey);
+    const nodeInfo = getNodeIcon(nodeKey);
 
+    if (!nodeInfo) return null;
     return (
       <Collapse.Panel
         header={
           <div className="rb:flex rb:items-center rb:gap-2">
-            {nodeIcon && <div className={clsx("rb:size-5 rb:bg-cover", nodeIcon)} />}
-            <span className="rb:text-sm rb:text-[#1D2129]">{nodeKey}</span>
+            {nodeInfo.icon && <div className={clsx("rb:size-5 rb:bg-cover", nodeInfo.icon)} />}
+            <span className="rb:text-sm rb:text-[#1D2129]">{nodeInfo.name}</span>
           </div>
         }
         key={nodeKey}
@@ -328,9 +348,9 @@ const VariableInspector: FC<VariableInspectorProps> = ({
                       {selectedVariable.nodeKey && (
                         <>
                           {getNodeIcon(selectedVariable.nodeKey) && (
-                            <div className={clsx("rb:size-3.5 rb:bg-cover", getNodeIcon(selectedVariable.nodeKey))} />
+                            <div className={clsx("rb:size-3.5 rb:bg-cover", getNodeIcon(selectedVariable.nodeKey)?.icon)} />
                           )}
-                          {selectedVariable.nodeKey} /
+                          {getNodeIcon(selectedVariable.nodeKey)?.name} /
                         </>
                       )}
                       <span className="rb:text-sm rb:font-medium rb:text-[#1D2129]">{selectedVariable.name}</span>
@@ -352,14 +372,22 @@ const VariableInspector: FC<VariableInspectorProps> = ({
                 </Flex>
               </Form>
             ) : (
-              <div className="rb:h-full rb:flex rb:flex-col rb:items-center rb:justify-center rb:text-center">
-                <div className="rb:w-12 rb:h-12 rb:bg-[#F0F1F5] rb:rounded-full rb:flex rb:items-center rb:justify-center rb:mb-3">
-                  <CodeOutlined className="rb:text-[#BBBFC4] rb:text-xl" />
-                </div>
-                <div className="rb:text-xs rb:text-[#BBBFC4]">
-                  {t('workflow.selectVariable')}
-                </div>
-              </div>
+              <Flex vertical justify="center" className="rb:h-full!">
+                <Flex justify="end">
+                  <div className="rb:cursor-pointer rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/close_grey.svg')]"
+                    onClick={onClose}
+                  ></div>
+                </Flex>
+
+                <Flex vertical align="center" justify="center" className="rb:flex-1 rb:text-center">
+                  <div className="rb:w-12 rb:h-12 rb:bg-[#F0F1F5] rb:rounded-full rb:flex rb:items-center rb:justify-center rb:mb-3">
+                    <CodeOutlined className="rb:text-[#BBBFC4] rb:text-xl" />
+                  </div>
+                  <div className="rb:text-xs rb:text-[#BBBFC4]">
+                    {t('workflow.selectVariable')}
+                  </div>
+                </Flex>
+              </Flex>
             )}
           </div>
         </Flex>
@@ -376,6 +404,6 @@ const VariableInspector: FC<VariableInspectorProps> = ({
       }
     </div>
   );
-};
+});
 
 export default VariableInspector;

--- a/web/src/views/Workflow/index.tsx
+++ b/web/src/views/Workflow/index.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 
 import NodeLibrary from './components/NodeLibrary'
 import Properties from './components/Properties';
-import CanvasToolbar from './components/CanvasToolbar';
+import CanvasToolbar, { type CanvasToolbarRef } from './components/CanvasToolbar';
 import PortClickHandler from './components/PortClickHandler';
 import { useWorkflowGraph } from './hooks/useWorkflowGraph';
 import type { WorkflowRef, FeaturesConfigForm, FeaturesConfigModalRef } from '@/views/ApplicationConfig/types'
@@ -23,6 +23,7 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
   const miniMapRef = useRef<HTMLDivElement>(null);
   const addChatVariableRef = useRef<AddChatVariableRef>(null)
   const addEnvVariableRef = useRef<AddEnvVariableRef>(null)
+  const canvasToolbarRef = useRef<CanvasToolbarRef>(null)
 
   const chatRef = useRef<ChatRef>(null)
   const [collapsed, setCollapsed] = useState(false)
@@ -73,6 +74,9 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
   const addEnvVariable = () => {
     addEnvVariableRef.current?.handleOpen()
   }
+  const refreshCache = () => {
+    canvasToolbarRef.current?.refreshCache()
+  }
 
   // Ref used to imperatively open the config modal
   const funConfigModalRef = useRef<FeaturesConfigModalRef>(null)
@@ -115,6 +119,7 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
         <div ref={containerRef} className="rb:w-full rb:h-full" />
         {/* 地图工具栏 */}
         <CanvasToolbar
+          ref={canvasToolbarRef}
           selectedNode={selectedNode}
           miniMapRef={miniMapRef}
           graphRef={graphRef}
@@ -148,6 +153,7 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
           handleSave={handleSave}
           nodeClick={nodeClick}
           appType={appType}
+          refreshCache={refreshCache}
         />
       }
       <Chat
@@ -160,6 +166,7 @@ const Workflow = forwardRef<WorkflowRef, WorkflowProps>(({ onFeaturesLoad, appTy
         open={runOpen}
         onOpenChange={setRunOpen}
         handleSave={handleSave}
+        refreshCache={refreshCache}
       />
       <PortClickHandler
         graph={graphRef.current}


### PR DESCRIPTION
## Summary by Sourcery

通过 refs 暴露 workflow 变量检查器，并在节点或聊天运行后刷新，同时改进节点标注和检查器 UI。

增强内容：
- 通过 ref 暴露 VariableInspector 方法，并从 Workflow 传递 refreshCache 回调，经由 CanvasToolbar、Properties、Chat 和 SingleNodeRun，使变量数据在执行后保持最新。
- 增强 VariableInspector 显示效果：在变量分组和表头中展示带图标的节点显示名称，在刷新时更新所选变量表单的值，并优化空状态布局，引入关闭操作入口。
- 调整知识库元数据抽屉，默认隐藏数值计数详情，并简化内置元数据状态消息。
- 更新 webhook 触发器 URL 生成逻辑，改为使用 `/api/workflows/triggers/webhook` 路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose workflow variable inspector via refs and refresh it after node or chat runs while improving node labeling and inspector UI.

Enhancements:
- Expose VariableInspector methods through a ref and thread a refreshCache callback from Workflow through CanvasToolbar, Properties, Chat, and SingleNodeRun to keep variable data up to date after executions.
- Enhance VariableInspector display by showing node display names with icons in variable groups and headers, updating selected variable form values on refresh, and refining the empty-state layout with a close affordance.
- Adjust knowledge base metadata drawer to hide value count details by default and simplify builtin metadata status messaging.
- Update webhook trigger URL generation to use the /api/workflows/triggers/webhook path.

</details>