### PR TITLE
fix(rag): expand hybrid retrieval before rerank

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -1099,7 +1099,8 @@ async def retrieve_chunks(
     vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
     # default value is topk
-    topn = retrieve_data.top_k
+    topn = 100
+    # topn = retrieve_data.top_k
 
     # Helper: exclude documents in document_ids_filter (blacklist)
     exclude_ids = set(document_ids_filter) if document_ids_filter else set()
@@ -1113,11 +1114,11 @@ async def retrieve_chunks(
     # 1 participle search, 2 semantic search, 3 hybrid search
     match retrieve_data.retrieve_type:
         case chunk_schema.RetrieveType.PARTICIPLE:
-            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
+            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
             rs = _exclude_filtered(rs)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case chunk_schema.RetrieveType.SEMANTIC:
-            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
+            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=retrieve_data.top_k, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
             rs = _exclude_filtered(rs)
             return success(data=jsonable_encoder(rs), msg="retrieval successful")
         case _:


### PR DESCRIPTION
## Summary
- Expand hybrid and graph retrieval candidate searches to 100 hits before reranking.
- Keep participle and semantic searches limited by the requested top_k.

## Changes
api/app/controllers/chunk_controller.py | 7 ++++---
1 file changed, 4 insertions(+), 3 deletions(-)

## Test Plan
- [x] `.venv/bin/python -m py_compile app/controllers/chunk_controller.py`
- [x] `git diff --check origin/release/v0.3.7..HEAD -- api/app/controllers/chunk_controller.py`

## Summary by Sourcery

在保持分词检索和语义检索受请求的 `top_k` 限制的前提下，增加混合检索的候选集合大小。

Bug Fixes:
- 确保分词检索和语义检索遵守用户指定的 `top_k`，而不是使用为混合检索扩展后的候选集合大小。

Enhancements:
- 将混合检索的候选文档池在重排序前扩展至 100 篇文档，以提升结果质量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase candidate size for hybrid retrieval while keeping participle and semantic retrieval constrained by requested top_k.

Bug Fixes:
- Ensure participle and semantic retrieval respect the user-specified top_k instead of the expanded candidate size used for hybrid retrieval.

Enhancements:
- Expand hybrid retrieval candidate pool to 100 documents before reranking to improve result quality.

</details>