### PR TITLE
feat(workflow)

### DIFF
--- a/api/app/controllers/model_controller.py
+++ b/api/app/controllers/model_controller.py
@@ -86,7 +86,7 @@ def get_model_list(
             unique_flat_capability = list(dict.fromkeys(flat_capability))
             capability_list = unique_flat_capability
 
-        api_logger.error(f"获取模型type_list: {type_list}")
+        api_logger.info(f"获取模型type_list: {type_list}")
         query = model_schema.ModelConfigQuery(
             type=type_list,
             provider=provider,

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -13,7 +13,7 @@ from langgraph.config import get_stream_writer
 from langgraph.errors import GraphInterrupt
 
 from app.core.config import settings
-from app.core.workflow.node_cache import WorkflowNodeCacheManager
+from app.core.workflow.node_cache import DEFAULT_CACHEABLE_NODE_TYPES, WorkflowNodeCacheManager
 from app.core.workflow.engine.state_manager import WorkflowState
 from app.core.workflow.engine.variable_pool import VariablePool
 from app.core.workflow.nodes.enums import BRANCH_NODES
@@ -230,8 +230,6 @@ class BaseNode(ABC):
         return self._get_runtime_options().get("cache_source", "workflow_execution")
 
     def _is_cache_enabled(self) -> bool:
-        from app.core.workflow.node_cache import DEFAULT_CACHEABLE_NODE_TYPES
-
         if self._get_runtime_options().get("bypass_node_cache"):
             return False
         execution_config = self.workflow_config.get("execution_config") or {}

--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -13,7 +13,7 @@ from langgraph.config import get_stream_writer
 from langgraph.errors import GraphInterrupt
 
 from app.core.config import settings
-from app.core.workflow.node_cache import DEFAULT_CACHEABLE_NODE_TYPES, WorkflowNodeCacheManager
+from app.core.workflow.node_cache import WorkflowNodeCacheManager
 from app.core.workflow.engine.state_manager import WorkflowState
 from app.core.workflow.engine.variable_pool import VariablePool
 from app.core.workflow.nodes.enums import BRANCH_NODES
@@ -230,6 +230,8 @@ class BaseNode(ABC):
         return self._get_runtime_options().get("cache_source", "workflow_execution")
 
     def _is_cache_enabled(self) -> bool:
+        from app.core.workflow.node_cache import DEFAULT_CACHEABLE_NODE_TYPES
+
         if self._get_runtime_options().get("bypass_node_cache"):
             return False
         execution_config = self.workflow_config.get("execution_config") or {}

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -122,8 +122,8 @@ class WorkflowConfigRepository:
 
         nodes = list(config.nodes or [])
         updated = False
+        from app.core.workflow.nodes.enums import NodeType
         for node in nodes:
-            from app.core.workflow.nodes.enums import NodeType
             if node.get("type") == NodeType.TRIGGER and node.get("id") == trigger_id:
                 node["runtime"] = runtime
                 updated = True

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy import desc, select, delete
 from fastapi import Depends
 
-from app.core.workflow.nodes.enums import NodeType
 from app.models.workflow_model import (
     WorkflowConfig,
     WorkflowExecution,
@@ -124,6 +123,7 @@ class WorkflowConfigRepository:
         nodes = list(config.nodes or [])
         updated = False
         for node in nodes:
+            from app.core.workflow.nodes.enums import NodeType
             if node.get("type") == NodeType.TRIGGER and node.get("id") == trigger_id:
                 node["runtime"] = runtime
                 updated = True

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1896,6 +1896,44 @@ class WorkflowService:
                 mut=mut,
             )
 
+    async def _apply_start_node_cache_to_variable_pool(
+            self,
+            *,
+            variable_pool,
+            runtime_snapshot: dict[str, Any] | None,
+            workflow_config: WorkflowConfig | None,
+    ) -> None:
+        """Promote start-node cached output fields into sys.* variables.
+
+        When the user edits the start node's output in the debug panel
+        (e.g. changes 'message' to '你是谁'), the value is stored in
+        debug_snapshot.nodes[start_node_id].  This method reads that snapshot
+        and writes the relevant fields back to sys.* so that rerun of any
+        downstream node sees the overridden values.
+        """
+        if not isinstance(runtime_snapshot, dict):
+            return
+        nodes_snapshot = runtime_snapshot.get("nodes") or {}
+        if not isinstance(nodes_snapshot, dict) or not nodes_snapshot:
+            return
+        # Find the start node id from workflow config
+        start_node_id = next(
+            (n.get("id") for n in (getattr(workflow_config, "nodes", None) or []) if n.get("type") == NodeType.START),
+            None,
+        )
+        if not start_node_id or start_node_id not in nodes_snapshot:
+            return
+        start_output = self._unwrap_typed_group(nodes_snapshot[start_node_id])
+        if not isinstance(start_output, dict):
+            return
+        sys_field_map = {
+            "message": VariableType.STRING,
+            "files": VariableType.ARRAY_FILE,
+        }
+        for field, var_type in sys_field_map.items():
+            if field in start_output and start_output[field] is not None:
+                await variable_pool.new("sys", field, start_output[field], var_type, mut=False)
+
     async def _restore_variable_pool_from_snapshot(
             self,
             *,
@@ -2545,17 +2583,28 @@ class WorkflowService:
             node_name=node.get("name"),
         )
         latest_cache = manager.get_latest_cache(include_inactive=False)
-        if not latest_cache:
-            return None
         next_result_data = self._sanitize_cache_result_data(result_data or {})
-        if patches:
-            next_result_data = self._apply_cache_result_patches(
-                latest_cache.get("result_data") or {},
-                patches,
+        if not latest_cache:
+            # No existing cache record — create one on-the-fly so that nodes
+            # which are not normally cached (e.g. "start") can still have their
+            # debug output persisted when the user edits it in the UI.
+            cache_key = manager.build_cache_key(next_result_data)
+            updated = manager.save_cache(
+                cache_key=cache_key,
+                input_data={},
+                result_data=next_result_data,
+                source="manual",
+                ttl_seconds=None,
             )
-        updated = manager.update_latest_cache(
-            result_data=next_result_data,
-        )
+        else:
+            if patches:
+                next_result_data = self._apply_cache_result_patches(
+                    latest_cache.get("result_data") or {},
+                    patches,
+                )
+            updated = manager.update_latest_cache(
+                result_data=next_result_data,
+            )
         if not updated:
             return None
         node_type_maps = self._build_snapshot_type_maps(config)["nodes"]
@@ -5599,6 +5648,13 @@ class WorkflowService:
         await self._apply_input_data_overrides_to_variable_pool(
             variable_pool=variable_pool,
             input_data=input_data,
+        )
+        # Promote start-node cached output (e.g. user-edited "message") into sys.*
+        # AFTER input_data overrides so it takes the highest priority.
+        await self._apply_start_node_cache_to_variable_pool(
+            variable_pool=variable_pool,
+            runtime_snapshot=runtime_seed["runtime_snapshot"],
+            workflow_config=config,
         )
         await self._inject_single_node_flat_inputs(
             variable_pool=variable_pool,


### PR DESCRIPTION
support start node debug edits propagation to sys.* variables and enable manual cache for non-cacheable nodes

The changes introduce two key enhancements to the workflow system: (1) `_apply_start_node_cache_to_variable_pool` promotes user-edited start node outputs (e.g., "message", "files") from debug snapshots into `sys.*` variables, ensuring downstream nodes see overridden values during rerun; (2) cache persistence is extended to non-cacheable nodes (e.g., start node) by creating on-the-fly cache records when no prior cache exists. Additionally, removed unused `DEFAULT_CACHEABLE_NODE_TYPES` import from `base_node.py` and downgraded a log level from error to info in `model_controller.py`.

## Summary by Sourcery

通过将已编辑的起始节点输出传播到系统变量，并在此前不可缓存的节点上持久化手动缓存更新，改进工作流调试行为。

New Features:
- 将用户在调试中编辑的起始节点输出值传播到对应的 `sys.*` 变量中，以便在重新运行时，下游节点能够看到被覆盖后的值。
- 允许为此前没有缓存记录的节点创建并持久化手动缓存条目，包括像起始节点这样的非可缓存节点。

Enhancements:
- 将冗余的模型列表日志级别从 error 降级为 info，以减少不必要的错误日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve workflow debug behavior by propagating edited start-node outputs into system variables and persisting manual cache updates even for previously non-cacheable nodes.

New Features:
- Propagate user-edited start node debug outputs into corresponding sys.* variables so downstream nodes see overridden values on reruns.
- Allow creation and persistence of manual cache entries for nodes that did not previously have cache records, including non-cacheable nodes like the start node.

Enhancements:
- Downgrade noisy model list logging from error to info to reduce unnecessary error logs.

</details>