### PR TITLE
fix(alias-merger): sync merged aliases to postgresql after merge

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
@@ -7,14 +7,16 @@ A 上其它边重定向到 B，最后删除 A 节点。
 三步均为确定性 Cypher，不涉及 LLM / embedding。
 逻辑迁移自原写入后处理任务 post_store_dedup_and_alias_merge。
 """
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.repositories.neo4j.cypher_queries import (
     MERGE_ALIAS_BELONGS_TO,
     REDIRECT_ALIAS_EDGES,
     DELETE_ALIAS_NODES,
+    GET_USER_ENTITY_ALIASES,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,17 +33,21 @@ async def merge_alias_belongs_to(
       2. 边重定向：别名节点其它边 → 规范实体
       3. 删除别名节点：DETACH DELETE
 
+    归并完成后，再将用户实体的最新 aliases 同步回 PostgreSQL end_user_info
+    （aliases 增量合并、other_name 为空时取 aliases[0]、同步 end_user.other_name）。
+
     Args:
         connector: Neo4j 连接器
         end_user_id: 终端用户 ID
 
     Returns:
-        统计字典：alias_merged / edges_redirected / alias_nodes_deleted / errors
+        统计字典：alias_merged / edges_redirected / alias_nodes_deleted / pg_synced / errors
     """
     result: Dict[str, Any] = {
         "alias_merged": 0,
         "edges_redirected": 0,
         "alias_nodes_deleted": 0,
+        "pg_synced": False,
         "errors": {},
     }
 
@@ -98,4 +104,87 @@ async def merge_alias_belongs_to(
         logger.warning(f"[AliasMerge] 别名节点删除失败 end_user_id={end_user_id}: {e}")
         result["errors"]["delete"] = str(e)
 
+    # ── 4. 同步用户实体最新 aliases 到 PostgreSQL end_user_info ──
+    try:
+        records = await connector.execute_query(
+            GET_USER_ENTITY_ALIASES,
+            end_user_id=end_user_id,
+        )
+        # 汇总所有用户实体节点的 aliases（去重，忽略大小写），交给 PG 增量合并
+        merged_aliases: List[str] = []
+        seen_lower = set()
+        for rec in records or []:
+            for alias in rec.get("aliases") or []:
+                alias = (alias or "").strip()
+                if alias and alias.lower() not in seen_lower:
+                    merged_aliases.append(alias)
+                    seen_lower.add(alias.lower())
+
+        if merged_aliases:
+            # PG 为同步 session，放到线程池执行，避免阻塞反思的 event loop
+            await asyncio.to_thread(
+                _sync_user_aliases_to_pg, end_user_id, merged_aliases
+            )
+            result["pg_synced"] = True
+            logger.info(
+                f"[AliasMerge] aliases 同步 PostgreSQL 完成 end_user_id={end_user_id}, "
+                f"aliases_count={len(merged_aliases)}"
+            )
+        else:
+            logger.debug(
+                f"[AliasMerge] 用户实体无 aliases，跳过 PG 同步 end_user_id={end_user_id}"
+            )
+    except Exception as e:
+        logger.warning(f"[AliasMerge] aliases 同步 PostgreSQL 失败 end_user_id={end_user_id}: {e}")
+        result["errors"]["pg_sync"] = str(e)
+
     return result
+
+
+def _sync_user_aliases_to_pg(end_user_id: str, aliases: List[str]) -> None:
+    """将别名归并后的用户 aliases 增量同步到 PostgreSQL end_user_info。
+
+    与写入阶段 tasks._sync_end_user_info_pg 行为一致：
+      - aliases 合并到 end_user_info.aliases（去重，忽略大小写）
+      - end_user_info.other_name 为空时取 aliases[0]
+      - end_user.other_name 与 end_user_info.other_name 保持同步（仅当 end_user 为空）
+
+    失败只记日志，不抛异常，不影响反思主流程。
+    """
+    import uuid as _uuid
+
+    from app.db import get_db_context
+    from app.repositories.end_user_info_repository import EndUserInfoRepository
+    from app.repositories.end_user_repository import EndUserRepository
+
+    try:
+        eu_uuid = _uuid.UUID(end_user_id)
+    except (ValueError, TypeError):
+        logger.warning(f"[AliasMerge] 非法 end_user_id，跳过 PG 同步: {end_user_id}")
+        return
+
+    with get_db_context() as db:
+        info_repo = EndUserInfoRepository(db)
+        info = info_repo.update_aliases_and_metadata(
+            end_user_id=eu_uuid,
+            new_aliases=aliases,
+            new_metadata=None,
+        )
+        if info is None:
+            logger.warning(
+                f"[AliasMerge] end_user_info 记录不存在，跳过 PG 同步: end_user_id={end_user_id}"
+            )
+            return
+
+        # 同步 end_user.other_name（仅当 end_user 侧为空）
+        new_other_name = (info.other_name or "").strip()
+        if new_other_name:
+            eu_repo = EndUserRepository(db)
+            end_user = eu_repo.get_end_user_by_id(eu_uuid)
+            if end_user and not (end_user.other_name or "").strip():
+                end_user.other_name = new_other_name
+                db.commit()
+                logger.info(
+                    f"[AliasMerge] 同步 end_user.other_name={new_other_name}: "
+                    f"end_user_id={end_user_id}"
+                )

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2316,3 +2316,14 @@ WITH alias, count(r) AS rel_count
 DETACH DELETE alias
 RETURN count(alias) AS deleted_count
 """
+
+
+# 查询用户实体节点的最新 aliases：用于别名归并完成后，将归并结果同步回 PostgreSQL
+# end_user_info.aliases / other_name。判定用户实体的口径与 metadata_extractor.is_user_entity
+# 保持一致：name 命中常见用户称呼，或 entity_type 为 '用户'。
+GET_USER_ENTITY_ALIASES = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE toLower(e.name) IN ['用户', '我', 'user', 'i']
+   OR e.entity_type = '用户'
+RETURN e.id AS entity_id, e.name AS name, coalesce(e.aliases, []) AS aliases
+"""


### PR DESCRIPTION
- Add asyncio import and List type hint for async/threading support
- Import GET_USER_ENTITY_ALIASES cypher query for fetching user entity aliases
- Add pg_synced flag to result dictionary to track PostgreSQL synchronization status
- Implement alias collection logic that deduplicates and normalizes aliases (case-insensitive)
- Use asyncio.to_thread to execute PostgreSQL sync in thread pool, preventing event loop blocking
- Add _sync_user_aliases_to_pg helper function to incrementally merge aliases into end_user_info
- Sync end_user.other_name when end_user_info.other_name is set and end_user side is empty
- Add GET_USER_ENTITY_ALIASES cypher query to retrieve user entity nodes and their aliases
- Update function docstring to document new PostgreSQL synchronization step and result fields

## Sourcery 总结

在别名合并后，将来自 Neo4j 的已合并用户实体别名同步回 PostgreSQL 的 `end_user_info`。

新功能：
- 通过 `GET_USER_ENTITY_ALIASES` Cypher 查询从 Neo4j 获取用户实体别名。
- 在别名合并后，将已合并的别名和 `other_name` 增量同步到 PostgreSQL 的 `end_user_info` 和 `end_user` 记录中。

增强内容：
- 在别名合并结果中增加 `pg_synced` 标志以及用于 PostgreSQL 同步的错误跟踪。
- 在后台线程中执行 PostgreSQL 同步，以避免阻塞异步事件循环。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize merged user entity aliases from Neo4j back to PostgreSQL end_user_info after alias merge.

New Features:
- Add retrieval of user entity aliases from Neo4j via the GET_USER_ENTITY_ALIASES Cypher query.
- Introduce incremental synchronization of merged aliases and other_name to PostgreSQL end_user_info and end_user records after alias merging.

Enhancements:
- Extend alias merge results with a pg_synced flag and error tracking for PostgreSQL synchronization.
- Perform PostgreSQL synchronization in a background thread to avoid blocking the async event loop.

</details>