### PR TITLE
fix(web): chat open

### DIFF
--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -101,6 +101,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
     } else {
       handleClose(false)
     }
+    getVariables()
   }, [open])
 
   useEffect(() => {
@@ -164,6 +165,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
         }
       })
     }
+    console.log('startNodes', allVariables)
     setVariables([...allVariables])
     toolbarRef.current?.setVariables([...allVariables])
   }
@@ -746,7 +748,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
         extra={<div className="rb:size-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/close.svg')]" onClick={() => handleClose()}></div>}
         headerType="borderless"
         headerClassName={clsx("rb:font-[MiSans-Bold] rb:font-bold rb:min-h-[48px]!")}
-        className="rb:h-full! rb:hover:shadow-none!"
+        className="rb:h-full!"
         bodyClassName={clsx('rb:overflow-hidden! rb:h-[calc(100%-48px)]! rb:px-0! rb:pt-0! rb:pb-3!')}
     >
       <ChatContent


### PR DESCRIPTION
## Summary by Sourcery

确保在打开聊天抽屉时刷新聊天变量，并简化聊天卡片样式。

改进内容：
- 当聊天面板的打开状态发生变化时触发变量重新加载，以保持聊天上下文为最新。
- 移除聊天容器卡片的悬停阴影样式，以统一其外观。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure chat variables are refreshed when the chat drawer opens and simplify the chat card styling.

Enhancements:
- Trigger variable reloading when the chat panel open state changes to keep chat context up to date.
- Remove hover shadow styling from the chat container card to standardize its appearance.

</details>