### PR TITLE
fix(web): model add is_deprecated tag

### DIFF
--- a/web/src/components/ModelSelect/index.tsx
+++ b/web/src/components/ModelSelect/index.tsx
@@ -50,6 +50,7 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
       <Flex align="center" gap={8}>
         {logo && <img src={logo} className="rb:size-5 rb:rounded-md" alt={logo} />}
         <div className={`rb:flex-1 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap ${fontClassName}`}>{item.name}</div>
+        {item.is_deprecated && <Tag color="default">{t('modelNew.deprecated')}</Tag>}
       </Flex>
     );
   };
@@ -61,7 +62,7 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
   return (
     <Select
       placeholder={placeholder ?? t('common.pleaseSelect')}
-      options={[...options, ...initialData]}
+      options={[...options, ...initialData].map(item => ({ ...item, disabled: item.is_deprecated }))}
       fieldNames={{ label: 'name', value: 'id' }}
       allowClear
       // popupMatchSelectWidth={false}
@@ -75,6 +76,7 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
             <Flex align="center" gap={8}>
               {logo && <img src={logo} className="rb:size-5 rb:rounded-md" alt={logo} />}
               <span className="rb:wrap-break-word rb:line-clamp-1">{data.name as string}</span>
+              {data.is_deprecated && <Tag color="default">{t('modelNew.deprecated')}</Tag>}
             </Flex>
             {data.capability?.length > 0 && (
               <Flex gap={4} wrap>

--- a/web/src/views/KnowledgeBase/components/CreateModal.tsx
+++ b/web/src/views/KnowledgeBase/components/CreateModal.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
-import { Form, Input, Select, Modal, Tabs, Switch, Radio, Button, App } from 'antd';
+import { Form, Input, Select, Modal, Tabs, Switch, Radio, Button, App, Flex } from 'antd';
 import { useTranslation } from 'react-i18next';
 import type { KnowledgeBaseListItem, KnowledgeBaseFormData, CreateModalRef, CreateModalRefProps } from '@/views/KnowledgeBase/types';
 import { 
@@ -16,6 +16,7 @@ import {
 import RbModal from '@/components/RbModal'
 import SliderInput from '@/components/SliderInput'
 import { stringRegExp } from '@/utils/validator'
+import Tag from '@/components/Tag'
 const { TextArea } = Input;
 const { confirm } = Modal
 
@@ -176,7 +177,14 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
     typesToFetch.forEach((tp) => {
       const targetType = tp === 'image2text' ? 'chat' : tp;
       const filteredModels = (models?.items || []).filter((m: any) => m.type === targetType);
-      next[tp] = filteredModels.map((m: any) => ({ label: m.name, value: m.id }));
+      next[tp] = filteredModels.map((m: any) => ({
+        label: <Flex gap={4} align="center">
+          <span className="rb:wrap-break-word rb:line-clamp-1">{m.name}</span>
+          {m.is_deprecated && <Tag color="default">{t('modelNew.deprecated')}</Tag>}
+        </Flex>,
+        value: m.id,
+        disabled: m.is_deprecated
+      }));
     });
     
     setModelOptionsByType(next);

--- a/web/src/views/ModelManagement/types.ts
+++ b/web/src/views/ModelManagement/types.ts
@@ -346,4 +346,5 @@ export interface Model {
   created_at: number;
   updated_at: number;
   api_keys: ModelApiKey[];
+  is_deprecated: boolean;
 }


### PR DESCRIPTION
## Summary by Sourcery

在界面中标记已弃用模型，并在知识库创建和模型选择视图中阻止其被选中。

New Features:
- 在知识库创建和模型选择组件中，在已弃用模型旁显示 “deprecated” 标签。

Bug Fixes:
- 在知识库创建和模型选择下拉菜单中禁用已弃用模型的选择，以避免使用过时模型。

Enhancements:
- 扩展模型类型定义，加入前端使用的 `is_deprecated` 标志位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mark deprecated models in the UI and prevent their selection across knowledge base creation and model selection views.

New Features:
- Display a 'deprecated' tag next to deprecated models in knowledge base creation and model selection components.

Bug Fixes:
- Disable selection of deprecated models in knowledge base creation and model selection dropdowns to avoid using outdated models.

Enhancements:
- Extend the model type definition to include an `is_deprecated` flag used by the frontend.

</details>