### PR TITLE
feat(web): graph detail

### DIFF
--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -379,7 +379,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
 
                       {(selectedNode as Node).properties.associative_memory > 0 && <div>
                         <div className="rb:font-medium rb:leading-5">{t('userMemory.associative_memory')}</div>
-                        <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-1 rb:pb-4 rb:border-b rb:border-[#DFE4ED]">
+                        <div className="rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-1 rb:pb-4">
                           <span className="rb:text-[#155EEF] rb:font-medium">{(selectedNode as Node).properties.associative_memory}</span> {t('userMemory.unix')}{t('userMemory.associative_memory')}
                         </div>
                       </div>}
@@ -499,9 +499,13 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
                   </>}
               </div>
 
-              {activeTab !== 'communityNetwork' && <Flex align="center" justify="center" className="rb:absolute rb:bottom-3 rb:left-6 rb:right-6 rb:border rb:border-[#171719] rb:rounded-xl rb:h-11 rb:font-medium rb:leading-5 rb:cursor-pointer" onClick={handleViewAll}>
-                {t('userMemory.completeMemory')}
-              </Flex>}
+              {activeTab !== 'communityNetwork' && selectedNode.label === 'ExtractedEntity' &&
+                <>
+                  <Flex align="center" justify="center" className="rb:absolute rb:bottom-3 rb:left-6 rb:right-6 rb:border rb:border-[#171719] rb:rounded-xl rb:h-11 rb:font-medium rb:leading-5 rb:cursor-pointer" onClick={handleViewAll}>
+                    {t('userMemory.completeMemory')}
+                  </Flex>
+                </>
+              }
             </>
           }
         </RbCard>

--- a/web/src/views/UserMemoryDetail/pages/GraphDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/GraphDetail.tsx
@@ -107,7 +107,8 @@ const GraphDetail = forwardRef<GraphDetailRef>((_props, ref) => {
   return (
     <>
       <PageHeader
-        title={vo?.label === 'ExtractedEntity' ? undefined : vo?.name}
+        // title={vo?.label === 'ExtractedEntity' ? undefined : vo?.name}
+        title={vo?.name}
         extra={
           <Space size={12}>
             <Button
@@ -120,9 +121,10 @@ const GraphDetail = forwardRef<GraphDetailRef>((_props, ref) => {
           </Space>
         }
       />
-      {vo?.label === 'ExtractedEntity'
+      {/* {vo?.label === 'ExtractedEntity'
         ? <ExtractedEntityGraphDetail />
-        : <Row gutter={12} wrap={false} className="rb:p-3! rb:pr-0! rb:h-[calc(100vh-64px)] rb:w-full! rb:flex-nowrap! rb:overflow-hidden!">
+        : */}
+        <Row gutter={12} wrap={false} className="rb:p-3! rb:pr-0! rb:h-[calc(100vh-64px)] rb:w-full! rb:flex-nowrap! rb:overflow-hidden!">
           <Col flex="480px" className="rb:h-full!">
             <RbCard
               title={t('userMemory.relationshipEvolution')}
@@ -178,7 +180,7 @@ const GraphDetail = forwardRef<GraphDetailRef>((_props, ref) => {
             </RbCard>
           </Col>
         </Row>
-      }
+      {/* } */}
     </>
   )
 })

--- a/web/src/views/Workflow/components/SingleNodeRun/index.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/index.tsx
@@ -165,6 +165,7 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
     })
       .then(res => {
         setResult(res as RunResult)
+        refreshCache()
       })
       .catch(err => {
         setResult({ status: 'failed', error: err.message })
@@ -204,6 +205,7 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
     })
       .then(res => {
         setResult(res as RunResult)
+        refreshCache()
       })
       .catch(err => {
         setResult({ status: 'failed', error: err.message })


### PR DESCRIPTION
## Summary by Sourcery

更新图谱详情和关系网络的行为，并确保在工作流单节点运行后，能够刷新执行后的缓存数据。

Bug Fixes:
- 将关系网络中的“complete memory”（完整记忆）操作限制为仅可对已抽取实体节点执行。

Enhancements:
- 始终在页面标题中以实体名称展示图谱详情布局，移除仅针对 ExtractedEntity 的特殊视图。
- 调整联想记忆（associative memory）区域的样式，移除底部边框以获得更简洁的展示效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update graph detail and relationship network behavior and ensure workflow single-node runs refresh cached data after execution.

Bug Fixes:
- Restrict the 'complete memory' action in the relationship network to extracted entity nodes only.

Enhancements:
- Always show the graph detail layout with the entity name in the page header, removing the special ExtractedEntity-only view.
- Adjust associative memory section styling by removing the bottom border for cleaner presentation.

</details>