### PR TITLE
fix(workflow node): improve compatibility logic for manual intervention node configuration

### DIFF
--- a/api/app/core/workflow/nodes/human_intervention/config.py
+++ b/api/app/core/workflow/nodes/human_intervention/config.py
@@ -87,12 +87,15 @@ class HumanInterventionNodeConfig(BaseNodeConfig):
     @field_validator("delivery_method", mode="before")
     @classmethod
     def coerce_delivery_method(cls, v):
-        """兼容旧版配置：delivery_method 为字符串时转换为 DeliveryMethodConfig"""
+        """兼容旧版配置：delivery_method 为字符串或非法类型时转换为 DeliveryMethodConfig"""
         if isinstance(v, str):
             # 旧格式: "webapp" / "email" — 转换为对应的嵌套配置
             if v == "email":
                 return {"webapp": {"enabled": False}, "email": {"enabled": True}}
             # 默认视为 webapp
+            return {"webapp": {"enabled": True}, "email": {"enabled": False}}
+        # 兼容空列表等非 dict 类型（旧配置或前端未发送该字段）
+        if not isinstance(v, dict):
             return {"webapp": {"enabled": True}, "email": {"enabled": False}}
         return v
     content: str = Field(


### PR DESCRIPTION
Expand the backward compatibility scope for legacy configurations to handle scenarios where `delivery_method` is an invalid type (neither a dictionary nor a string). In such cases, uniformly return the default configuration with web notifications enabled.

## Summary by Sourcery

Bug Fixes:
- 通过回退到默认的网页通知配置来处理非字典、非字符串类型的 `delivery_method` 值，以防止无效配置导致错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle non-dict, non-string delivery_method values by falling back to a default web notification configuration to prevent invalid configs from causing errors.

</details>