### PR TITLE
fix(web): human-intervention check list

### DIFF
--- a/web/src/views/Workflow/components/CheckList/index.tsx
+++ b/web/src/views/Workflow/components/CheckList/index.tsx
@@ -90,7 +90,8 @@ const specialValidators: Record<string, (val: any) => boolean> = {
   // jinja-render.mapping: if non-empty, every item must have a name
   'jinja-render.mapping': (val: any[]) => Array.isArray(val) && val.length > 0 && val.some(v => !v?.name || !v?.value),
   'agent.model': (val: any) => !val?.model_id,
-  'human-intervention.actions': (val: any[]) => Array.isArray(val) && val.length > 0 && val.some(v => !v?.id || !v?.label),
+  'human-intervention.actions': (val: any[]) => !Array.isArray(val) || !val.length || val.some(v => !v?.id || !v?.label),
+  'human-intervention.delivery_method': (val: Record<string, { enabled: boolean; }>) => Object.values(val).every(v => !v.enabled),
 }
 
 function isEmpty(val: any): boolean {


### PR DESCRIPTION
## Summary by Sourcery

调整工作流检查清单中与人工干预配置相关的校验逻辑。

Bug 修复：
- 在工作流检查清单中，将空的或非数组类型的 `human-intervention` 动作视为无效。
- 在工作流检查清单中验证 `human-intervention` 的投递方式，要求至少启用一个选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust workflow checklist validation for human intervention configuration.

Bug Fixes:
- Treat empty or non-array human-intervention actions as invalid in the workflow checklist.
- Validate human-intervention delivery methods to require at least one enabled option in the workflow checklist.

</details>