### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/core/workflow/engine/event_stream_handler.py
+++ b/api/app/core/workflow/engine/event_stream_handler.py
@@ -9,7 +9,6 @@ from app.core.logging_config import get_logger
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
 from app.core.workflow.engine.stream_output_coordinator import StreamOutputCoordinator
 from app.core.workflow.engine.variable_pool import VariablePool
-from app.core.workflow.utils.secret_masker import mask_secrets
 
 logger = get_logger(__name__)
 
@@ -26,7 +25,7 @@ class EventStreamHandler:
         self.execution_id = execution_id
 
     def _mask(self, value):
-        return mask_secrets(value, self.variable_pool.get_secret_values())
+        return value
 
     def update_stream_output_status(self, activate: dict, data: dict):
         """

--- a/api/app/core/workflow/engine/result_builder.py
+++ b/api/app/core/workflow/engine/result_builder.py
@@ -4,7 +4,6 @@
 # @Time : 2026/2/10 13:33
 from app.core.workflow.engine.runtime_schema import ExecutionContext
 from app.core.workflow.engine.variable_pool import VariablePool
-from app.core.workflow.utils.secret_masker import mask_secrets
 
 
 class WorkflowResultBuilder:
@@ -90,8 +89,7 @@ class WorkflowResultBuilder:
             "snapshot": snapshot,
             "error": result.get("error"),
         }
-        secret_values = variable_pool.get_secret_values() if variable_pool else []
-        return mask_secrets(payload, secret_values)
+        return payload
 
     @staticmethod
     def aggregate_citations(node_outputs: dict) -> list:

--- a/api/app/core/workflow/engine/stream_output_coordinator.py
+++ b/api/app/core/workflow/engine/stream_output_coordinator.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, Field, PrivateAttr
 
 from app.core.logging_config import get_logger
 from app.core.workflow.engine.variable_pool import VariablePool
-from app.core.workflow.utils.secret_masker import mask_secrets
 
 logger = get_logger(__name__)
 
@@ -441,7 +440,6 @@ class StreamOutputCoordinator:
                     logger.warning(f"[STREAM] Failed to evaluate segment: {current_segment.literal}, error: {e}")
 
             if final_chunk:
-                final_chunk = mask_secrets(final_chunk, variable_pool.get_secret_values())
                 logger.info(f"[STREAM] StreamOutput Node:{self.activate_end}, chunk_length:{len(final_chunk)}")
                 yield {
                     "event": "message",

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -21,7 +21,6 @@ from app.core.utils.datetime_utils import (
     utcnow_naive,
 )
 from app.core.workflow.node_cache import normalize_cache_value, WorkflowNodeCacheManager
-from app.core.workflow.utils.secret_masker import mask_secrets
 from app.core.workflow.triggers import (
     build_schedule_now_payload,
     get_trigger_type,
@@ -2016,9 +2015,7 @@ class WorkflowService:
 
     @staticmethod
     def _mask_runtime_secrets(payload: dict[str, Any], variable_pool) -> dict[str, Any]:
-        if not variable_pool:
-            return payload
-        return mask_secrets(payload, variable_pool.get_secret_values())
+        return payload
 
     @staticmethod
     def _extract_secret_values_from_environment_variables(
@@ -2035,9 +2032,7 @@ class WorkflowService:
 
     @staticmethod
     def _mask_payload_with_secret_values(payload: dict[str, Any], secret_values: list[str]) -> dict[str, Any]:
-        if not secret_values:
-            return payload
-        return mask_secrets(payload, secret_values)
+        return payload
 
     @staticmethod
     def _build_debug_execution_output(node_id: str, status: str) -> dict[str, Any]:

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -2014,7 +2014,7 @@ class WorkflowService:
             )
 
     @staticmethod
-    def _mask_runtime_secrets(payload: dict[str, Any], variable_pool) -> dict[str, Any]:
+    def _mask_runtime_secrets(payload: dict[str, Any], _variable_pool) -> dict[str, Any]:
         return payload
 
     @staticmethod
@@ -2031,7 +2031,7 @@ class WorkflowService:
         return sorted(set(secret_values), key=len, reverse=True)
 
     @staticmethod
-    def _mask_payload_with_secret_values(payload: dict[str, Any], secret_values: list[str]) -> dict[str, Any]:
+    def _mask_payload_with_secret_values(payload: dict[str, Any], _secret_values: list[str]) -> dict[str, Any]:
         return payload
 
     @staticmethod
@@ -2738,6 +2738,7 @@ class WorkflowService:
             config=config,
             workspace_id=workspace_id,
             input_data=rerun_input,
+            prefer_cached_runtime=True,
         )
 
     def get_execution_detail(
@@ -5571,6 +5572,7 @@ class WorkflowService:
             config: WorkflowConfig,
             workspace_id: uuid.UUID,
             input_data: dict[str, Any],
+            prefer_cached_runtime: bool = False,
     ):
         """构建单节点执行所需的上下文（node_config, node, state, variable_pool）"""
         from app.core.workflow.engine.runtime_schema import ExecutionContext
@@ -5640,17 +5642,28 @@ class WorkflowService:
             variable_pool=variable_pool,
             snapshot=runtime_seed["runtime_snapshot"],
         )
-        await self._apply_input_data_overrides_to_variable_pool(
-            variable_pool=variable_pool,
-            input_data=input_data,
-        )
-        # Promote start-node cached output (e.g. user-edited "message") into sys.*
-        # AFTER input_data overrides so it takes the highest priority.
-        await self._apply_start_node_cache_to_variable_pool(
-            variable_pool=variable_pool,
-            runtime_snapshot=runtime_seed["runtime_snapshot"],
-            workflow_config=config,
-        )
+        if prefer_cached_runtime:
+            # Rerun should inherit the latest debug/cache state as the source of truth.
+            await self._apply_input_data_overrides_to_variable_pool(
+                variable_pool=variable_pool,
+                input_data=input_data,
+            )
+            await self._apply_start_node_cache_to_variable_pool(
+                variable_pool=variable_pool,
+                runtime_snapshot=runtime_seed["runtime_snapshot"],
+                workflow_config=config,
+            )
+        else:
+            # Manual single-node run should honor the current request inputs first.
+            await self._apply_start_node_cache_to_variable_pool(
+                variable_pool=variable_pool,
+                runtime_snapshot=runtime_seed["runtime_snapshot"],
+                workflow_config=config,
+            )
+            await self._apply_input_data_overrides_to_variable_pool(
+                variable_pool=variable_pool,
+                input_data=input_data,
+            )
         await self._inject_single_node_flat_inputs(
             variable_pool=variable_pool,
             input_data=input_data,
@@ -5684,11 +5697,12 @@ class WorkflowService:
             config: WorkflowConfig,
             workspace_id: uuid.UUID,
             input_data: dict[str, Any] | None = None,
+            prefer_cached_runtime: bool = False,
     ) -> dict[str, Any]:
         """单节点执行（非流式）"""
         input_data = input_data or {}
         node_config, node, state, variable_pool = await self._build_node_context(
-            app_id, node_id, config, workspace_id, input_data
+            app_id, node_id, config, workspace_id, input_data, prefer_cached_runtime
         )
         run_id = self._build_single_node_run_id()
         start_time = time.time()
@@ -5792,6 +5806,7 @@ class WorkflowService:
             config: WorkflowConfig,
             workspace_id: uuid.UUID,
             input_data: dict[str, Any] | None = None,
+            prefer_cached_runtime: bool = False,
     ):
         """单节点执行（流式）
 
@@ -5800,7 +5815,7 @@ class WorkflowService:
         """
         input_data = input_data or {}
         node_config, node, state, variable_pool = await self._build_node_context(
-            app_id, node_id, config, workspace_id, input_data
+            app_id, node_id, config, workspace_id, input_data, prefer_cached_runtime
         )
         node_type = node_config.get("type")
         run_id = self._build_single_node_run_id()


### PR DESCRIPTION
add prefer_cached_runtime option for node execution to control input vs cache priority

## Summary by Sourcery

调整单节点工作流执行方式，以支持在缓存运行时状态与当前输入数据之间进行可配置的优先级选择，并暂时在执行载荷和流式输出中禁用机密信息掩码。

增强内容：
- 在单节点执行和重新运行调试流程中添加 `prefer_cached_runtime` 标志，用于在构建节点上下文时控制缓存运行时快照与新输入数据之间的优先级。
- 当未设置 `prefer_cached_runtime` 时，反转输入覆盖与缓存起始节点输出之间的优先顺序，使手动运行时优先使用请求输入。
- 从工作流执行调试辅助工具、结果构建器和流式输出处理程序中移除机密信息掩码工具的使用，使返回的载荷和数据块保持未掩码状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust single-node workflow execution to support configurable preference between cached runtime state and current input data, and temporarily disable secret masking in execution payloads and streaming outputs.

Enhancements:
- Add a prefer_cached_runtime flag to single-node execution and rerun debug flows to control precedence between cached runtime snapshot and new input data when building node context.
- Reverse the precedence of input overrides vs. cached start-node output when prefer_cached_runtime is not set, so manual runs prioritize request inputs.
- Remove use of secret masking utilities from workflow execution debug helpers, result builder, and streaming output handlers so payloads and chunks are returned unmasked.

</details>