### PR TITLE
feat(memory): add conversation_id filtering and improve search result formatting

### DIFF
--- a/api/app/controllers/service/mcp_memory.py
+++ b/api/app/controllers/service/mcp_memory.py
@@ -97,7 +97,7 @@ async def write_memory(
 @mcp.tool
 async def read_memory(
         message: str,
-        search_switch: str = "0",
+        search_switch: str = "2",
 ) -> dict:
     """检索与当前上下文相关的历史记忆。
 
@@ -111,8 +111,8 @@ async def read_memory(
     Args:
         message: 检索查询，用自然语言描述想查找什么。越具体效果越好。
                  例如："用户对咖啡有什么偏好"、"上次讨论的旅行计划"。
-        search_switch: 检索深度。"0"=深度检索+交叉验证（默认，适合复杂问题），
-                       "1"=深度检索（适合一般回忆），"2"=快速检索（适合简单查询）。
+        search_switch: 检索深度。"0"=深度检索+交叉验证（适合复杂问题），
+                       "1"=深度检索（适合一般回忆），"2"=快速检索（默认，适合简单查询）。
     """
     try:
         workspace_id, end_user_id, config_id, storage_type = _resolve_context()

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -68,6 +68,7 @@ class MemoryService:
             workspace_id: str | None = None,
             storage_type: str = "neo4j",
             user_rag_memory_id: str | None = None,
+            conversation_id: str | None = None,
             language: str = "zh",
     ):
         config_service = MemoryConfigService(db)
@@ -90,6 +91,7 @@ class MemoryService:
             storage_type=StorageType(storage_type),
             user_rag_memory_id=user_rag_memory_id,
             language=language,
+            conversation_id=conversation_id
         )
 
     async def write(

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -25,6 +25,7 @@ class MemoryContext(BaseModel):
     memory_config: MemoryConfig | None = None
     storage_type: StorageType = StorageType.NEO4J
     user_rag_memory_id: str | None = None
+    conversation_id: str | None = None
     language: str = "zh"
 
 

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -465,10 +465,11 @@ class HistorySearchService:
     async def run(self) -> MemorySearchResult:
         conversation: Conversation | None = self.db.scalar(
             select(Conversation).where(
-                Conversation.user_id == self.ctx.end_user_id
+                Conversation.user_id == self.ctx.end_user_id,
+                Conversation.id != self.ctx.conversation_id
             ).order_by(
                 Conversation.updated_at.desc()
-            ).offset(1).limit(1)
+            ).limit(1)
         )
 
         if conversation is None:

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -49,8 +49,8 @@ class ChunkBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</chunk>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</chunk>\n")
         return "".join(parts)
 
 
@@ -72,8 +72,8 @@ class StatementBuiler(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</statement>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</statement>\n")
         return "".join(parts)
 
 
@@ -97,8 +97,8 @@ class EntityBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</entity>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</entity>\n")
         return "".join(parts)
 
 
@@ -120,8 +120,8 @@ class SummaryBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</summary>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</summary>\n")
         return "".join(parts)
 
 
@@ -157,8 +157,8 @@ class PerceptualBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</history-file-input>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</history-file-input>\n")
         return "".join(parts)
 
 
@@ -180,8 +180,8 @@ class CommunityBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</community>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</community>\n")
         return "".join(parts)
 
 
@@ -207,10 +207,10 @@ class MetadataBuilder(BaseBuilder):
         parts = ["<user-info>"]
         fields = [
             # ("description", self.record.get("description", "")),
-            ("aliases_name", self.record.get("aliases", [])),
+            ("aliases-name", self.record.get("aliases", [])),
             ("anchors", self.record.get("anchors", [])),
-            ("beliefs_or_stances", self.record.get("beliefs_or_stances", [])),
-            ("core_facts", self.record.get("core_facts", [])),
+            ("beliefs-or-stances", self.record.get("beliefs_or_stances", [])),
+            ("core-facts", self.record.get("core_facts", [])),
             ("events", self.record.get("events", [])),
             ("goals", self.record.get("goals", [])),
             ("interests", self.record.get("interests", [])),
@@ -219,8 +219,8 @@ class MetadataBuilder(BaseBuilder):
         ]
         for tag, value in fields:
             if value:
-                parts.append(f"<{tag}>{value}</{tag}>")
-        parts.append("</user-info>")
+                parts.append(f"<{tag}>{value}</{tag}>\n")
+        parts.append("</user-info>\n")
         return "".join(parts)
 
 
@@ -252,6 +252,6 @@ def build_relation_content(rel: RelationMemory) -> str:
     ]
     for tag, value in fields:
         if value:
-            parts.append(f"<{tag}>{value}</{tag}>")
-    parts.append("</relationship>")
+            parts.append(f"<{tag}>{value}</{tag}>\n")
+    parts.append("</relationship>\n")
     return "".join(parts)

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -42,6 +42,7 @@ class MemoryReadNode(BaseNode):
                 config_id=str(self.typed_config.config_id),
                 end_user_id=end_user_id,
                 user_rag_memory_id=state["user_rag_memory_id"],
+                conversation_id=variable_pool.get_value("sys.conversation_id"),
             )
             query = self._render_template(self.typed_config.message, variable_pool)
             self._process = {"query": query, "config_id": str(self.typed_config.config_id)}


### PR DESCRIPTION
- Add conversation_id parameter to memory service and search context
- Exclude current conversation from content search results
- Add newline separators to XML-like search result tags
- Rename XML tags to use hyphens instead of underscores
- Change MCP memory tool default search_switch to "2"

## Summary by Sourcery

添加具备会话感知能力的记忆搜索行为，并调整搜索结果的格式和默认配置。

新功能：
- 在记忆上下文、服务以及工作流节点中添加 `conversation_id`，以支持基于会话范围的记忆操作。

增强改进：
- 在进行基于内容的记忆搜索时，从结果中排除当前会话。
- 调整搜索引擎结果构建器，在类似 XML 的标签之间插入换行分隔符，以提升可读性和可解析性。
- 重命名用户信息的类似 XML 字段标签，将下划线命名改为使用连字符命名。
- 将 MCP 记忆工具的默认搜索深度改为使用快速搜索模式（"2"）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add conversation-aware memory search behavior and adjust search result formatting and defaults.

New Features:
- Add conversation_id to memory context, service, and workflow node to support conversation-scoped memory operations.

Enhancements:
- Exclude the current conversation when selecting conversations for content-based memory search.
- Adjust search engine result builder to insert newline separators between XML-like tags for better readability and parsing.
- Rename user-info XML-like field tags to use hyphenated names instead of underscores.
- Change the MCP memory tool's default search depth to use the fast search mode ("2").

</details>