### PR TITLE
fix(web): single run editor

### DIFF
--- a/web/src/views/Workflow/components/VariableInspector.tsx
+++ b/web/src/views/Workflow/components/VariableInspector.tsx
@@ -64,10 +64,15 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
   const handleUpdateCache = useCallback((values: Record<string, any>) => {
     if (!id || !selectedVariable || !selectedVariable?.nodeKey || !values || !Object.keys(values).length) return;
 
-    const lastValue = selectedVariable?.value;
-    const currentValue = values[selectedVariable.nodeKey][selectedVariable.name];
+    const { type } = selectedVariable;
+    const lastValue = !type?.includes('file') && typeof selectedVariable?.value === 'object'
+      ? JSON.stringify(selectedVariable?.value, null, 2)
+      : selectedVariable?.value;
+    const currentValue = !type?.includes('file') && typeof selectedVariable?.value === 'object'
+      ? JSON.parse(values[selectedVariable.nodeKey][selectedVariable.name])
+      : values[selectedVariable.nodeKey][selectedVariable.name]
 
-    if (lastValue === currentValue) return;
+    if (lastValue === values[selectedVariable.nodeKey][selectedVariable.name]) return;
     setSelectedVariable(prev => {
       if (prev?.value && prev.value !== currentValue) {
         return {
@@ -139,7 +144,7 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
                  v.nodeKey === selectedVariable.nodeKey
           );
           if (updatedVariable) {
-            form.setFieldValue([updatedVariable.nodeKey, updatedVariable.name], updatedVariable.value);
+            form.setFieldValue([updatedVariable.nodeKey, updatedVariable.name], !updatedVariable.type?.includes('file') && typeof updatedVariable.value === 'object' ? JSON.stringify(updatedVariable.value, null, 2) : updatedVariable.value);
             setSelectedVariable(updatedVariable);
           }
         }
@@ -184,6 +189,7 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
           />
           : dataType === 'object' || typeof value === 'object'
           ? <CodeMirrorEditor
+            key={fieldName as string}
             language="json"
             variant="borderless"
           />
@@ -219,9 +225,9 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
     setSelectedVariable(variable);
 
     setTimeout(() => {
-      const { value, name, nodeKey } = variable;
+      const { value, name, nodeKey, type } = variable;
       const fieldName = nodeKey ? [nodeKey, name] : name;
-      form.setFieldValue(fieldName, value);
+      form.setFieldValue(fieldName, !type?.includes('file') && typeof value === 'object' ? JSON.stringify(value, null, 2) : value);
     }, 0);
   };
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

调整变量检查器对对象和文件类型变量的处理方式，以保持单次运行编辑器中的值与表单同步。

增强内容：
- 在与表单同步时，将对象类型变量的值与 JSON 字符串之间进行规范化转换，以避免不必要的更新并支持编辑器。
- 通过使用字段名作为键，确保 CodeMirror 编辑器对 JSON 字段进行正确的重新渲染。
- 在更新表单值时，避免对文件类型变量应用 JSON 序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust variable inspector handling of object and file-type variables to keep single-run editor values in sync with the form.

Enhancements:
- Normalize object-typed variable values to and from JSON strings when syncing with the form to avoid unnecessary updates and support the editor.
- Ensure CodeMirror editor re-renders correctly for JSON fields by keying it with the field name.
- Avoid applying JSON serialization for file-type variables when updating form values.

</details>