### PR TITLE
feat(rag): unify knowledge retrieval entry

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -9,28 +9,21 @@ from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.core.exceptions import BusinessException
-from app.core.error_codes import BizCode
 from app.core.logging_config import get_api_logger
-from app.core.rag.common.settings import kg_retriever
-from app.core.rag.llm.chat_model import Base
 from app.core.rag.llm.cv_model import QWenCV
-from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
-from app.core.rag.metadata.filter_engine import MetadataFilterEngine, FilterCondition, FilterGroup
-from app.services.knowledge_metadata_service import KnowledgeMetadataService
 from app.core.response_utils import success
 from app.db import get_db
 from app.dependencies import get_current_user
-from app.models import knowledge_model, knowledgeshare_model
 from app.models.document_model import Document
 from app.models.user_model import User
 from app.schemas import chunk_schema
+from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.schemas.response_schema import ApiResponse
-from app.services import knowledge_service, document_service, file_service, knowledgeshare_service
+from app.services import knowledge_service, document_service, file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service, generate_kb_file_key
-from app.services.model_service import ModelApiKeyService
+from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied, KnowledgeRetrievalService
 from app.core.rag.utils.preview_utils import _build_preview_hierarchy
 from app.core.utils.datetime_utils import to_timestamp_ms
 
@@ -936,6 +929,31 @@ def get_retrieve_types():
     return success(msg="Successfully obtained the retrieval type", data=list(chunk_schema.RetrieveType))
 
 
+def _build_knowledge_retrieval_request(
+        retrieve_data: chunk_schema.ChunkRetrieve,
+) -> KnowledgeRetrievalRequest:
+    return KnowledgeRetrievalRequest(
+        query=retrieve_data.query,
+        kb_ids=retrieve_data.kb_ids or [],
+        ex_ids=retrieve_data.ex_ids or [],
+        similarity_threshold=(
+            retrieve_data.similarity_threshold
+            if retrieve_data.similarity_threshold is not None
+            else 0.3
+        ),
+        vector_similarity_weight=(
+            retrieve_data.vector_similarity_weight
+            if retrieve_data.vector_similarity_weight is not None
+            else 0.3
+        ),
+        top_k=retrieve_data.top_k if retrieve_data.top_k is not None else 100,
+        retrieve_type=retrieve_data.retrieve_type or chunk_schema.RetrieveType.HYBRID,
+        rerank_score_threshold=retrieve_data.rerank_score_threshold,
+        metadata_filters=retrieve_data.metadata_filters or [],
+        metadata_filter_mode=retrieve_data.metadata_filter_mode,
+    )
+
+
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
@@ -947,209 +965,18 @@ async def retrieve_chunks(
     """
     api_logger.info(f"retrieve chunk: query={retrieve_data.query}, username: {current_user.username}")
 
-    # Resolve ex_ids to kb_ids and merge (union)
-    kb_ids = list(retrieve_data.kb_ids)
-    if retrieve_data.ex_ids:
-        resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
+    try:
+        request = _build_knowledge_retrieval_request(retrieve_data)
+        api_logger.info(f"retrieve chunk: request={request}")
+        result = KnowledgeRetrievalService.retrieve(
             db=db,
-            external_ids=retrieve_data.ex_ids,
-            workspace_id=current_user.current_workspace_id,
-            current_user=current_user
+            request=request,
+            current_user=current_user,
         )
-        kb_ids = list(set(kb_ids + resolved_ids))
-
-    filters = [
-        knowledge_model.Knowledge.id.in_(kb_ids),
-        knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-        knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
-        knowledge_model.Knowledge.chunk_num > 0,
-        knowledge_model.Knowledge.status == 1
-    ]
-    private_items = knowledge_service.get_chunked_knowledgeids(
-        db=db,
-        filters=filters,
-        current_user=current_user
-    )
-    private_kb_ids = [item[0] for item in private_items]
-    private_workspace_ids = [item[1] for item in private_items]
-    filters = [
-        knowledge_model.Knowledge.id.in_(kb_ids),
-        knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-        knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
-        knowledge_model.Knowledge.chunk_num > 0,
-        knowledge_model.Knowledge.status == 1
-    ]
-    items = knowledge_service.get_chunked_knowledgeids(
-        db=db,
-        filters=filters,
-        current_user=current_user
-    )
-    if items:
-        filters = [
-            knowledgeshare_model.KnowledgeShare.target_kb_id.in_(kb_ids),
-            knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
-        ]
-        share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
-            db=db,
-            filters=filters,
-            current_user=current_user
-        )
-        share_kb_ids = [item[0] for item in share_items]
-        share_workspace_ids = [item[1] for item in share_items]
-        private_kb_ids.extend(share_kb_ids)
-        private_workspace_ids.extend(share_workspace_ids)
-    if not private_kb_ids:
-        return success(data=[], msg="retrieval successful")
-    kb_id = private_kb_ids[0]
-    uuid_strs = [f"Vector_index_{kb_id}_Node".lower() for kb_id in private_kb_ids]
-    indices = ",".join(uuid_strs)
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
-    if not db_knowledge:
+    except KnowledgeRetrievalAccessDenied as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="The knowledge base does not exist or access is denied"
-        )
+            detail=str(exc),
+        ) from exc
 
-    # === 元数据过滤 ===
-    document_ids_filter = None
-    if retrieve_data.metadata_filters:
-        # 1) auto 模式拒绝
-        if retrieve_data.metadata_filter_mode.value != "manual":
-            raise BusinessException(
-                "metadata_filter_mode 暂仅支持 'manual'",
-                code=BizCode.INVALID_PARAMETER,
-            )
-
-        # 2) 收集所有库的字段定义
-        all_metadata_defs: dict[uuid.UUID, dict[str, dict]] = {}
-        for pk_kb_id in private_kb_ids:
-            all_metadata_defs[pk_kb_id] = KnowledgeMetadataService.get_metadata_defs_for_filtering(db, pk_kb_id)
-
-        # 3) 找出公共字段（所有库都有 + 类型一致）
-        # 先取所有字段名的交集
-        all_field_names = set()
-        for defs in all_metadata_defs.values():
-            all_field_names.update(defs.keys())
-
-        common_fields = set()
-        for field_name in all_field_names:
-            field_types = set()
-            all_have = True
-            for defs in all_metadata_defs.values():
-                if field_name not in defs:
-                    all_have = False
-                    break
-                field_types.add(defs[field_name]["type"])
-            if all_have and len(field_types) == 1:
-                common_fields.add(field_name)
-
-        # 4) 过滤条件中只保留公共字段，非公共字段忽略+打日志
-        filtered_groups = []
-        for group in retrieve_data.metadata_filters:
-            filtered_conditions = []
-            for cond in group.conditions:
-                if cond.field in common_fields:
-                    filtered_conditions.append(cond)
-                else:
-                    api_logger.warning(
-                        f"[MetadataFilter] 字段 '{cond.field}' 不是公共字段（不是所有知识库都有或类型不一致），已忽略"
-                    )
-            if filtered_conditions:
-                filtered_groups.append((group.logic, filtered_conditions))
-
-        if not filtered_groups:
-            api_logger.warning("[MetadataFilter] 过滤条件中无公共字段，跳过元数据过滤")
-        else:
-            all_document_ids = set()
-            for pk_kb_id in private_kb_ids:
-                metadata_defs = all_metadata_defs[pk_kb_id]
-
-                engine = MetadataFilterEngine(db)
-                filter_groups = [
-                    FilterGroup(
-                        conditions=[
-                            FilterCondition(field=c.field, operator=c.operator, value=c.value)
-                            for c in conditions
-                        ],
-                        logic=logic,
-                    )
-                    for logic, conditions in filtered_groups
-                ]
-
-                api_logger.info(
-                    f"[MetadataFilter] executing filter for kb_id={pk_kb_id}, "
-                    f"conditions={[{'field': c.field, 'op': c.operator, 'val': c.value} for g in filter_groups for c in g.conditions]}"
-                )
-                document_ids = engine.execute(
-                    knowledge_id=pk_kb_id,
-                    filter_groups=filter_groups,
-                    metadata_defs=metadata_defs,
-                )
-                api_logger.info(
-                    f"[MetadataFilter] kb_id={pk_kb_id}, "
-                    f"filtered_count={len(document_ids)}, "
-                    f"filtered_document_ids={sorted(str(d) for d in document_ids)}"
-                )
-                all_document_ids.update(document_ids)
-
-            document_ids_filter = [str(d) for d in all_document_ids]
-            api_logger.info(f"[MetadataFilter] final filter list: {document_ids_filter}")
-
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-
-    # default value is topk
-    topn = retrieve_data.top_k
-
-    # Helper: exclude documents in document_ids_filter (blacklist)
-    exclude_ids = set(document_ids_filter) if document_ids_filter else set()
-    def _exclude_filtered(docs):
-        if not exclude_ids:
-            return docs
-        filtered = [d for d in docs if d.metadata.get("document_id") not in exclude_ids]
-        api_logger.info(f"[MetadataFilter] post-filter: total={len(docs)}, excluded={len(docs) - len(filtered)}, remaining={len(filtered)}")
-        return filtered
-
-    # 1 participle search, 2 semantic search, 3 hybrid search
-    match retrieve_data.retrieve_type:
-        case chunk_schema.RetrieveType.PARTICIPLE:
-            rs = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
-            rs = _exclude_filtered(rs)
-            return success(data=jsonable_encoder(rs), msg="retrieval successful")
-        case chunk_schema.RetrieveType.SEMANTIC:
-            rs = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
-            rs = _exclude_filtered(rs)
-            return success(data=jsonable_encoder(rs), msg="retrieval successful")
-        case _:
-            rs1 = vector_service.search_by_vector(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.vector_similarity_weight, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
-            rs2 = vector_service.search_by_full_text(query=retrieve_data.query, top_k=topn, indices=indices, score_threshold=retrieve_data.similarity_threshold, file_names_filter=retrieve_data.file_names_filter, document_ids_filter=document_ids_filter)
-            # Efficient deduplication
-            seen_ids = set()
-            unique_rs = []
-            for doc in rs1 + rs2:
-                if doc.metadata["doc_id"] not in seen_ids:
-                    seen_ids.add(doc.metadata["doc_id"])
-                    unique_rs.append(doc)
-            rs = vector_service.rerank(query=retrieve_data.query, docs=unique_rs, top_k=retrieve_data.top_k) if unique_rs else []
-            rerank_threshold = retrieve_data.rerank_score_threshold if retrieve_data.rerank_score_threshold is not None else (retrieve_data.vector_similarity_weight if retrieve_data.vector_similarity_weight is not None else 0.1)
-            rs = [doc for doc in rs if doc.metadata.get("score", 0) > rerank_threshold]
-            if retrieve_data.retrieve_type == chunk_schema.RetrieveType.Graph:
-                kb_ids = [str(kb_id) for kb_id in private_kb_ids]
-                workspace_ids = [str(workspace_id) for workspace_id in private_workspace_ids]
-                llm_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.llm_id)
-                emb_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.embedding_id)
-                # Prepare to configure chat_mdl、embedding_model、vision_model information
-                chat_model = Base(
-                    key=llm_key.api_key,
-                    model_name=llm_key.model_name,
-                    base_url=llm_key.api_base
-                )
-                embedding_model = OpenAIEmbed(
-                    key=emb_key.api_key,
-                    model_name=emb_key.model_name,
-                    base_url=emb_key.api_base
-                )
-                doc = kg_retriever.retrieval(question=retrieve_data.query, workspace_ids=workspace_ids, kb_ids=kb_ids, emb_mdl=embedding_model, llm=chat_model)
-                if doc and doc['page_content'].strip() != '':
-                    rs.insert(0, doc)
-            rs = _exclude_filtered(rs)
-            return success(data=jsonable_encoder(rs), msg="retrieval successful")
+    return success(data=jsonable_encoder(result.chunks), msg="retrieval successful")

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -929,31 +929,6 @@ def get_retrieve_types():
     return success(msg="Successfully obtained the retrieval type", data=list(chunk_schema.RetrieveType))
 
 
-def _build_knowledge_retrieval_request(
-        retrieve_data: chunk_schema.ChunkRetrieve,
-) -> KnowledgeRetrievalRequest:
-    return KnowledgeRetrievalRequest(
-        query=retrieve_data.query,
-        kb_ids=retrieve_data.kb_ids or [],
-        ex_ids=retrieve_data.ex_ids or [],
-        similarity_threshold=(
-            retrieve_data.similarity_threshold
-            if retrieve_data.similarity_threshold is not None
-            else 0.3
-        ),
-        vector_similarity_weight=(
-            retrieve_data.vector_similarity_weight
-            if retrieve_data.vector_similarity_weight is not None
-            else 0.3
-        ),
-        top_k=retrieve_data.top_k if retrieve_data.top_k is not None else 100,
-        retrieve_type=retrieve_data.retrieve_type or chunk_schema.RetrieveType.HYBRID,
-        rerank_score_threshold=retrieve_data.rerank_score_threshold,
-        metadata_filters=retrieve_data.metadata_filters or [],
-        metadata_filter_mode=retrieve_data.metadata_filter_mode,
-    )
-
-
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
@@ -966,7 +941,7 @@ async def retrieve_chunks(
     api_logger.info(f"retrieve chunk: query={retrieve_data.query}, username: {current_user.username}")
 
     try:
-        request = _build_knowledge_retrieval_request(retrieve_data)
+        request = KnowledgeRetrievalRequest(**retrieve_data.model_dump(exclude_none=True))
         api_logger.info(f"retrieve chunk: request={request}")
         result = KnowledgeRetrievalService.retrieve(
             db=db,

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -789,7 +789,7 @@ class ElasticSearchVector(BaseVector):
             result = []
             for item in reranked_docs[:top_k]:
                 for doc in docs:
-                    if doc.page_content == item.page_content:
+                    if doc.metadata["doc_id"] == item.metadata['doc_id']:
                         doc.metadata["score"] = item.metadata["relevance_score"]
                         result.append(doc)
             return result

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -98,10 +98,8 @@ class ChunkRetrieve(BaseModel):
     top_k: int | None = Field(100, ge=1, le=100)
     retrieve_type: RetrieveType | None = Field(None)
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
-
-    # === 新增：元数据过滤 ===
-    metadata_filters: list[FilterGroup] | None = Field(None, description="元数据过滤条件")
-    metadata_filter_mode: MetadataFilterMode = Field(MetadataFilterMode.MANUAL, description="过滤模式")
+    metadata_filters: list[FilterGroup] | None = Field(None, description="filter condition groups")
+    metadata_filter_mode: MetadataFilterMode = Field(MetadataFilterMode.MANUAL, description="filter mode")
 
 
 class ChunkBatchCreate(BaseModel):

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -1,0 +1,43 @@
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.chunk_schema import RetrieveType
+from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
+
+
+class KnowledgeRetrievalRequest(BaseModel):
+    query: str
+    kb_ids: list[UUID] = Field(default_factory=list)
+    ex_ids: list[str] = Field(default_factory=list)
+    similarity_threshold: float = Field(default=0.3, ge=0, le=1)
+    vector_similarity_weight: float = Field(default=0.3, ge=0, le=1)
+    top_k: int = Field(default=100, ge=1, le=100)
+    retrieve_type: RetrieveType = RetrieveType.HYBRID
+    rerank_id: UUID | None = None
+    rerank_score_threshold: float | None = Field(default=None, ge=0, le=1)
+    metadata_filters: list[FilterGroup] = Field(default_factory=list)
+    metadata_filter_mode: MetadataFilterMode = MetadataFilterMode.MANUAL
+
+    @field_validator("query")
+    @classmethod
+    def validate_query(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("query must not be empty")
+        return stripped
+
+    @model_validator(mode="after")
+    def validate_knowledge_ids(self) -> "KnowledgeRetrievalRequest":
+        if not self.kb_ids and not self.ex_ids:
+            raise ValueError("kb_ids and ex_ids cannot both be empty")
+        if self.rerank_score_threshold is None:
+            self.rerank_score_threshold = self.vector_similarity_weight
+        return self
+
+
+class KnowledgeRetrievalResult(BaseModel):
+    chunks: list[Any] = Field(default_factory=list)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -11,6 +11,7 @@ class KnowledgeRetrievalRequest(BaseModel):
     query: str
     kb_ids: list[UUID] = Field(default_factory=list)
     ex_ids: list[str] = Field(default_factory=list)
+    file_names_filter: list[str] = Field(default_factory=list)
     similarity_threshold: float = Field(default=0.3, ge=0, le=1)
     vector_similarity_weight: float = Field(default=0.3, ge=0, le=1)
     top_k: int = Field(default=100, ge=1, le=100)

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -17,7 +17,10 @@ from app.core.rag.metadata.filter_engine import (
     MetadataFilterEngine,
 )
 from app.core.rag.models.chunk import DocumentChunk
-from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
+    ElasticSearchVector,
+    ElasticSearchVectorFactory,
+)
 from app.models import knowledge_model, knowledgeshare_model
 from app.models.models_model import ModelApiKey
 from app.repositories import knowledge_repository
@@ -100,6 +103,7 @@ class KnowledgeRetrievalService:
         vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_filter)
         full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_filter)
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+        logger.debug(f"Retrieved {len(unique_chunks)} chunks")
         if not unique_chunks:
             chunks = []
         else:
@@ -120,7 +124,7 @@ class KnowledgeRetrievalService:
 
     @staticmethod
     def _search_vector(
-            vector_service: Any,
+            vector_service: ElasticSearchVector,
             request: KnowledgeRetrievalRequest,
             indices: str,
             document_ids_filter: list[str] | None,
@@ -131,12 +135,13 @@ class KnowledgeRetrievalService:
             indices=indices,
             score_threshold=request.vector_similarity_weight,
             document_ids_filter=document_ids_filter,
+            file_names_filter=request.file_names_filter,
             resolve_parents=True,
         )
 
     @staticmethod
     def _search_full_text(
-            vector_service: Any,
+            vector_service: ElasticSearchVector,
             request: KnowledgeRetrievalRequest,
             indices: str,
             document_ids_filter: list[str] | None,
@@ -147,6 +152,7 @@ class KnowledgeRetrievalService:
             indices=indices,
             score_threshold=request.similarity_threshold,
             document_ids_filter=document_ids_filter,
+            file_names_filter=request.file_names_filter,
             resolve_parents=True,
         )
 
@@ -155,7 +161,7 @@ class KnowledgeRetrievalService:
             cls,
             db: Session,
             request: KnowledgeRetrievalRequest,
-            vector_service: Any,
+            vector_service: ElasticSearchVector,
             chunks: list[DocumentChunk],
     ) -> list[DocumentChunk]:
         if request.rerank_id:
@@ -172,6 +178,8 @@ class KnowledgeRetrievalService:
                 docs=chunks,
                 top_k=request.top_k,
             )
+
+        logger.debug(f"[rerank]rerank_id:{request.rerank_id}, returned {len(reranked_chunks)} docs")
 
         rerank_score_threshold = request.rerank_score_threshold or request.vector_similarity_weight or 0.1
 
@@ -454,7 +462,7 @@ class KnowledgeRetrievalService:
                 )
                 for doc in docs
             ]
-            reranked_docs = list(reranker.compress_documents(documents, query))
+            reranked_docs = list(reranker.compress_documents(documents, query, top_k))
             reranked_docs.sort(
                 key=lambda item: item.metadata.get("relevance_score", 0),
                 reverse=True,

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -462,7 +462,7 @@ class KnowledgeRetrievalService:
                 )
                 for doc in docs
             ]
-            reranked_docs = list(reranker.compress_documents(documents, query, top_k))
+            reranked_docs = list(reranker.compress_documents(documents, query, topn=top_k))
             reranked_docs.sort(
                 key=lambda item: item.metadata.get("relevance_score", 0),
                 reverse=True,

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1,0 +1,474 @@
+import logging
+import uuid
+from typing import Any
+
+from langchain_core.documents import Document
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
+from app.core.models import RedBearRerank
+from app.core.models.base import RedBearModelConfig
+from app.core.rag.llm.chat_model import Base
+from app.core.rag.llm.embedding_model import OpenAIEmbed
+from app.core.rag.metadata.filter_engine import (
+    FilterCondition as EngineFilterCondition,
+    FilterGroup as EngineFilterGroup,
+    MetadataFilterEngine,
+)
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
+from app.models import knowledge_model, knowledgeshare_model
+from app.models.models_model import ModelApiKey
+from app.repositories import knowledge_repository
+from app.schemas.chunk_schema import RetrieveType
+from app.schemas.knowledge_metadata_schema import MetadataFilterMode
+from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest, KnowledgeRetrievalResult
+from app.services import knowledge_service, knowledgeshare_service
+from app.services.knowledge_metadata_service import KnowledgeMetadataService
+from app.services.model_service import ModelApiKeyService, ModelConfigService
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeRetrievalAccessDenied(Exception):
+    pass
+
+
+class KnowledgeRetrievalConfigError(Exception):
+    pass
+
+
+class KnowledgeRetrievalService:
+    @classmethod
+    def retrieve(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> KnowledgeRetrievalResult:
+        knowledge_ids, workspace_ids = cls._resolve_retrievable_knowledge_ids(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not knowledge_ids:
+            return KnowledgeRetrievalResult(chunks=[])
+
+        db_knowledge = cls._get_first_knowledge(
+            db=db,
+            knowledge_id=knowledge_ids[0],
+            current_user=current_user,
+        )
+        if not db_knowledge:
+            raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
+
+        document_ids_filter = cls._build_metadata_document_filter(
+            db=db,
+            request=request,
+            knowledge_ids=knowledge_ids,
+        )
+        chunks = cls._retrieve_by_type(
+            db=db,
+            request=request,
+            knowledge_ids=knowledge_ids,
+            workspace_ids=workspace_ids,
+            db_knowledge=db_knowledge,
+            document_ids_filter=document_ids_filter,
+        )
+        chunks = cls._exclude_document_ids(chunks, document_ids_filter)
+        return KnowledgeRetrievalResult(chunks=chunks)
+
+    @classmethod
+    def _retrieve_by_type(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            workspace_ids: list[uuid.UUID],
+            db_knowledge: Any,
+            document_ids_filter: list[str] | None,
+    ) -> list[Any]:
+        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+        indices = ",".join(f"Vector_index_{knowledge_id}_Node".lower() for knowledge_id in knowledge_ids)
+
+        if request.retrieve_type == RetrieveType.PARTICIPLE:
+            return cls._search_full_text(vector_service, request, indices, document_ids_filter)
+        if request.retrieve_type == RetrieveType.SEMANTIC:
+            return cls._search_vector(vector_service, request, indices, document_ids_filter)
+
+        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_filter)
+        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_filter)
+        unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+        if not unique_chunks:
+            chunks = []
+        else:
+            chunks = cls._rerank_hybrid_chunks(db, request, vector_service, unique_chunks)
+
+        if request.retrieve_type == RetrieveType.Graph:
+            graph_doc = cls._retrieve_graph(
+                db=db,
+                request=request,
+                knowledge_ids=knowledge_ids,
+                workspace_ids=workspace_ids,
+                db_knowledge=db_knowledge,
+            )
+            if graph_doc:
+                chunks.insert(0, graph_doc)
+
+        return chunks
+
+    @staticmethod
+    def _search_vector(
+            vector_service: Any,
+            request: KnowledgeRetrievalRequest,
+            indices: str,
+            document_ids_filter: list[str] | None,
+    ) -> list[DocumentChunk]:
+        return vector_service.search_by_vector(
+            query=request.query,
+            top_k=request.top_k,
+            indices=indices,
+            score_threshold=request.vector_similarity_weight,
+            document_ids_filter=document_ids_filter,
+            resolve_parents=True,
+        )
+
+    @staticmethod
+    def _search_full_text(
+            vector_service: Any,
+            request: KnowledgeRetrievalRequest,
+            indices: str,
+            document_ids_filter: list[str] | None,
+    ) -> list[DocumentChunk]:
+        return vector_service.search_by_full_text(
+            query=request.query,
+            top_k=request.top_k,
+            indices=indices,
+            score_threshold=request.similarity_threshold,
+            document_ids_filter=document_ids_filter,
+            resolve_parents=True,
+        )
+
+    @classmethod
+    def _rerank_hybrid_chunks(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            vector_service: Any,
+            chunks: list[DocumentChunk],
+    ) -> list[DocumentChunk]:
+        if request.rerank_id:
+            reranked_chunks = cls.rerank_documents(
+                db=db,
+                rerank_id=request.rerank_id,
+                query=request.query,
+                docs=chunks,
+                top_k=request.top_k,
+            )
+        else:
+            reranked_chunks = vector_service.rerank(
+                query=request.query,
+                docs=chunks,
+                top_k=request.top_k,
+            )
+
+        rerank_score_threshold = request.rerank_score_threshold or request.vector_similarity_weight or 0.1
+
+        return [
+            chunk
+            for chunk in reranked_chunks
+            if (chunk.metadata or {}).get("score", 0) > rerank_score_threshold
+        ]
+
+    @staticmethod
+    def _retrieve_graph(
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            workspace_ids: list[uuid.UUID],
+            db_knowledge: Any,
+    ) -> Any | None:
+        from app.core.rag.common.settings import kg_retriever
+
+        llm_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.llm_id)
+        emb_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.embedding_id)
+        doc = kg_retriever.retrieval(
+            question=request.query,
+            workspace_ids=[str(workspace_id) for workspace_id in workspace_ids],
+            kb_ids=[str(knowledge_id) for knowledge_id in knowledge_ids],
+            emb_mdl=KnowledgeRetrievalService._build_embedding_model(emb_key),
+            llm=KnowledgeRetrievalService._build_chat_model(llm_key),
+        )
+        if doc and str(doc.get("page_content", "")).strip():
+            return doc
+        return None
+
+    @classmethod
+    def _resolve_retrievable_knowledge_ids(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        requested_kb_ids = cls._unique_ids(request.kb_ids)
+        if request.ex_ids:
+            if current_user is None:
+                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
+            resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
+                db=db,
+                external_ids=request.ex_ids,
+                workspace_id=current_user.current_workspace_id,
+                current_user=current_user,
+            )
+            requested_kb_ids = cls._unique_ids(requested_kb_ids + resolved_ids)
+
+        if not requested_kb_ids:
+            return [], []
+
+        if current_user is None:
+            rows = (
+                db.query(knowledge_model.Knowledge.id, knowledge_model.Knowledge.workspace_id)
+                .filter(
+                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
+                    knowledge_model.Knowledge.chunk_num > 0,
+                    knowledge_model.Knowledge.status == 1,
+                )
+                .all()
+            )
+            return [row[0] for row in rows], [row[1] for row in rows]
+
+        return cls._resolve_accessible_chunk_kbs(
+            db=db,
+            kb_ids=requested_kb_ids,
+            current_user=current_user,
+        )
+
+    @staticmethod
+    def _unique_ids(values: list[uuid.UUID]) -> list[uuid.UUID]:
+        return list(dict.fromkeys(values))
+
+    @classmethod
+    def _resolve_accessible_chunk_kbs(
+            cls,
+            db: Session,
+            kb_ids: list[uuid.UUID],
+            current_user: Any,
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        filters = [
+            knowledge_model.Knowledge.id.in_(kb_ids),
+            knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+            knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
+            knowledge_model.Knowledge.chunk_num > 0,
+            knowledge_model.Knowledge.status == 1,
+        ]
+        private_items = knowledge_service.get_chunked_knowledgeids(
+            db=db,
+            filters=filters,
+            current_user=current_user,
+        )
+        knowledge_ids = [item[0] for item in private_items]
+        workspace_ids = [item[1] for item in private_items]
+
+        filters = [
+            knowledge_model.Knowledge.id.in_(kb_ids),
+            knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+            knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
+            knowledge_model.Knowledge.chunk_num > 0,
+            knowledge_model.Knowledge.status == 1,
+        ]
+        share_targets = knowledge_service.get_chunked_knowledgeids(
+            db=db,
+            filters=filters,
+            current_user=current_user,
+        )
+        if share_targets:
+            filters = [
+                knowledgeshare_model.KnowledgeShare.target_kb_id.in_(kb_ids),
+                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
+            ]
+            share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
+                db=db,
+                filters=filters,
+                current_user=current_user,
+            )
+            knowledge_ids.extend([item[0] for item in share_items])
+            workspace_ids.extend([item[1] for item in share_items])
+
+        return knowledge_ids, workspace_ids
+
+    @staticmethod
+    def _get_first_knowledge(
+            db: Session,
+            knowledge_id: uuid.UUID,
+            current_user: Any = None,
+    ) -> Any:
+        if current_user is not None:
+            return knowledge_service.get_knowledge_by_id(
+                db=db,
+                knowledge_id=knowledge_id,
+                current_user=current_user,
+            )
+        return knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
+
+    @classmethod
+    def _build_metadata_document_filter(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+    ) -> list[str] | None:
+        if not request.metadata_filters:
+            return None
+
+        if request.metadata_filter_mode != MetadataFilterMode.MANUAL:
+            raise BusinessException(
+                "metadata_filter_mode 暂仅支持 'manual'",
+                code=BizCode.INVALID_PARAMETER,
+            )
+
+        metadata_defs_by_kb = {
+            knowledge_id: KnowledgeMetadataService.get_metadata_defs_for_filtering(db, knowledge_id)
+            for knowledge_id in knowledge_ids
+        }
+        common_fields = cls._get_common_metadata_fields(metadata_defs_by_kb)
+        filter_groups = cls._build_common_filter_groups(request.metadata_filters, common_fields)
+        if not filter_groups:
+            logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
+            return None
+
+        document_ids = set()
+        engine = MetadataFilterEngine(db)
+        for knowledge_id in knowledge_ids:
+            matched_ids = engine.execute(
+                knowledge_id=knowledge_id,
+                filter_groups=filter_groups,
+                metadata_defs=metadata_defs_by_kb[knowledge_id],
+            )
+            document_ids.update(matched_ids)
+        return [str(document_id) for document_id in document_ids]
+
+    @staticmethod
+    def _get_common_metadata_fields(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> set[str]:
+        field_names = set()
+        for metadata_defs in metadata_defs_by_kb.values():
+            field_names.update(metadata_defs.keys())
+
+        common_fields = set()
+        for field_name in field_names:
+            field_types = set()
+            all_have_field = True
+            for metadata_defs in metadata_defs_by_kb.values():
+                if field_name not in metadata_defs:
+                    all_have_field = False
+                    break
+                field_types.add(metadata_defs[field_name]["type"])
+            if all_have_field and len(field_types) == 1:
+                common_fields.add(field_name)
+        return common_fields
+
+    @staticmethod
+    def _build_common_filter_groups(metadata_filters: list[Any], common_fields: set[str]) -> list[EngineFilterGroup]:
+        filter_groups = []
+        for group in metadata_filters:
+            conditions = [
+                EngineFilterCondition(field=condition.field, operator=condition.operator, value=condition.value)
+                for condition in group.conditions
+                if condition.field in common_fields
+            ]
+            if conditions:
+                filter_groups.append(EngineFilterGroup(conditions=conditions, logic=group.logic))
+        return filter_groups
+
+    @staticmethod
+    def _deduplicate_chunks(chunks: list[DocumentChunk]) -> list[DocumentChunk]:
+        seen_doc_ids = set()
+        result = []
+        for chunk in chunks:
+            doc_id = chunk.metadata["doc_id"]
+            if doc_id in seen_doc_ids:
+                continue
+            seen_doc_ids.add(doc_id)
+            result.append(chunk)
+        return result
+
+    @staticmethod
+    def _exclude_document_ids(
+            chunks: list[Any],
+            document_ids_filter: list[str] | None,
+    ) -> list[Any]:
+        if not document_ids_filter:
+            return chunks
+        exclude_ids = set(document_ids_filter)
+        return [
+            chunk
+            for chunk in chunks
+            if chunk.metadata.get("document_id") not in exclude_ids
+        ]
+
+    @staticmethod
+    def _build_chat_model(api_key: ModelApiKey) -> Base:
+        return Base(
+            key=api_key.api_key,
+            model_name=api_key.model_name,
+            base_url=api_key.api_base,
+        )
+
+    @staticmethod
+    def _build_embedding_model(api_key: ModelApiKey) -> OpenAIEmbed:
+        return OpenAIEmbed(
+            key=api_key.api_key,
+            model_name=api_key.model_name,
+            base_url=api_key.api_base,
+        )
+
+    @staticmethod
+    def rerank_documents(
+            db: Session,
+            rerank_id: uuid.UUID,
+            query: str,
+            docs: list[DocumentChunk],
+            top_k: int,
+    ) -> list[DocumentChunk]:
+        if not rerank_id:
+            raise ValueError("rerank_id cannot be empty")
+        if not docs:
+            raise ValueError("retrieval chunks cannot be empty")
+        if top_k <= 0:
+            raise ValueError("top_k must be a positive integer")
+        try:
+            config = ModelConfigService.get_model_by_id(db=db, model_id=rerank_id)
+            api_config: ModelApiKey = config.api_keys[0]
+            reranker = RedBearRerank(
+                RedBearModelConfig(
+                    model_name=api_config.model_name,
+                    provider=api_config.provider,
+                    api_key=api_config.api_key,
+                    base_url=api_config.api_base,
+                )
+            )
+            documents = [
+                Document(
+                    page_content=doc.page_content,
+                    metadata=doc.metadata or {},
+                )
+                for doc in docs
+            ]
+            reranked_docs = list(reranker.compress_documents(documents, query))
+            reranked_docs.sort(
+                key=lambda item: item.metadata.get("relevance_score", 0),
+                reverse=True,
+            )
+            result = []
+            for item in reranked_docs[:top_k]:
+                for doc in docs:
+                    if doc.page_content == item.page_content:
+                        doc.metadata["score"] = item.metadata["relevance_score"]
+                        result.append(doc)
+            return result
+        except Exception as exc:
+            logger.warning(f"Rerank failed, falling back to original results: {str(exc)}")
+            for doc in docs[:top_k]:
+                if doc.metadata is not None and "score" not in doc.metadata:
+                    doc.metadata["score"] = 0.5
+            return docs[:top_k]


### PR DESCRIPTION
## Summary
- Add a lightweight `KnowledgeRetrievalRequest` and `KnowledgeRetrievalService` as the unified RAG retrieval entry.
- Switch the internal chunk retrieval controller to build the unified request directly from compatible payload fields.
- Preserve existing filename filtering by passing `file_names_filter` through vector and full-text Elasticsearch retrieval.
- Align custom rerank `top_k` handling and rerank result matching.

## Changes
```text
api/app/controllers/chunk_controller.py            | 224 +---------
api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py  |   2 +-
api/app/schemas/chunk_schema.py                    |   6 +-
api/app/schemas/knowledge_retrieval_schema.py      |  44 ++
api/app/services/knowledge_retrieval_service.py    | 482 +++++++++++++++++++++
5 files changed, 542 insertions(+), 216 deletions(-)
```

## API Impact
- Internal chunk retrieval endpoint is temporarily routed through the unified retrieval service for testing.
- No external API Key controller under `app/controllers/service/rag_api_*_controller.py` is changed in this PR.
- Request compatibility keeps existing chunk retrieval fields, including `file_names_filter`.

## Test Plan
- [x] `cd api && PYTHONPATH=. .venv/bin/pytest tests/rag/test_knowledge_retrieval_entry.py -q`
- [x] `cd api && PYTHONPATH=. .venv/bin/python -m py_compile app/controllers/chunk_controller.py app/schemas/chunk_schema.py app/schemas/knowledge_retrieval_schema.py app/services/knowledge_retrieval_service.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py`

## Summary by Sourcery

引入统一的知识检索服务和模式(schema)，并通过该服务路由内部的分块(chunk)检索，同时保持现有行为不变。

新功能：
- 添加 `KnowledgeRetrievalRequest` 和 `KnowledgeRetrievalResult` 模式，作为知识/分块检索的统一入口。
- 实现 `KnowledgeRetrievalService`，用于编排知识 ID 解析、基于元数据的文档过滤、混合搜索、可选的图检索以及重排序(reranking)。

增强改进：
- 重构分块检索控制器，将检索逻辑委托给新的 `KnowledgeRetrievalService`，同时保持对外 API 合约兼容。
- 统一重排序行为：在基于 Elasticsearch 的重排序结果中通过 `doc_id` 匹配文档，并在服务中集中处理重排序分数阈值。
- 明确元数据过滤字段，并在不同检索类型之间复用通用的过滤流水线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified knowledge retrieval service and schema and route internal chunk retrieval through it while preserving existing behavior.

New Features:
- Add KnowledgeRetrievalRequest and KnowledgeRetrievalResult schemas as a unified entry point for knowledge/chunk retrieval.
- Implement KnowledgeRetrievalService to orchestrate knowledge ID resolution, metadata-based document filtering, hybrid search, optional graph retrieval, and reranking.

Enhancements:
- Refactor the chunk retrieval controller to delegate retrieval logic to the new KnowledgeRetrievalService while keeping the external API contract compatible.
- Align reranking behavior by matching documents via doc_id in Elasticsearch-based rerank results and by centralizing rerank score threshold handling in the service.
- Clarify metadata filter fields and reuse a common filtering pipeline across retrieval types.

</details>