### PR TITLE
fix(app_dsl_service)

### DIFF
--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -428,11 +428,10 @@ class AppDslService:
             for w in result.warnings:
                 warnings.append(f"[节点警告] {w.node_name or w.node_id}: {w.detail}")
             wf_service = WorkflowService(self.db)
-            if self._has_secret_environment_variables([v.model_dump() for v in result.environment_variables]):
+            raw_env_vars = [v.model_dump() for v in result.environment_variables]
+            if self._has_secret_environment_variables(raw_env_vars):
                 warnings.append("检测到 secret 类型环境变量，导入时其值已清空，请在导入后重新配置。")
-            environment_variables = self._clear_imported_secret_environment_variables(
-                [v.model_dump() for v in result.environment_variables]
-            )
+            environment_variables = self._clear_imported_secret_environment_variables(raw_env_vars)
             if create:
                 wf_service.create_workflow_config(
                     app_id=app_id,

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -228,6 +228,20 @@ class AppDslService:
                 result.append(item)
         return result
 
+    @staticmethod
+    def _clear_imported_secret_environment_variables(environment_variables: list[dict] | None) -> list[dict]:
+        result = []
+        for item in environment_variables or []:
+            if item.get("value_type") == "secret":
+                result.append({**item, "value": None})
+            else:
+                result.append(item)
+        return result
+
+    @staticmethod
+    def _has_secret_environment_variables(environment_variables: list[dict] | None) -> bool:
+        return any(item.get("value_type") == "secret" for item in (environment_variables or []))
+
     def _skill_ref(self, skill_id) -> Optional[dict]:
         if not skill_id:
             return None
@@ -414,13 +428,18 @@ class AppDslService:
             for w in result.warnings:
                 warnings.append(f"[节点警告] {w.node_name or w.node_id}: {w.detail}")
             wf_service = WorkflowService(self.db)
+            if self._has_secret_environment_variables([v.model_dump() for v in result.environment_variables]):
+                warnings.append("检测到 secret 类型环境变量，导入时其值已清空，请在导入后重新配置。")
+            environment_variables = self._clear_imported_secret_environment_variables(
+                [v.model_dump() for v in result.environment_variables]
+            )
             if create:
                 wf_service.create_workflow_config(
                     app_id=app_id,
                     nodes=[n.model_dump() for n in result.nodes],
                     edges=[e.model_dump() for e in result.edges],
                     variables=[v.model_dump() for v in result.variables],
-                    environment_variables=[v.model_dump() for v in result.environment_variables],
+                    environment_variables=environment_variables,
                     execution_config=raw_wf.get("execution_config", {}),
                     features=raw_wf.get("features", {}),
                     triggers=raw_wf.get("triggers", []),
@@ -432,7 +451,7 @@ class AppDslService:
                     existing.nodes = [n.model_dump() for n in result.nodes]
                     existing.edges = [e.model_dump() for e in result.edges]
                     existing.variables = [v.model_dump() for v in result.variables]
-                    existing.environment_variables = [v.model_dump() for v in result.environment_variables]
+                    existing.environment_variables = environment_variables
                     existing.execution_config = raw_wf.get("execution_config", {})
                     existing.features = raw_wf.get("features", {})
                     existing.triggers = raw_wf.get("triggers", [])
@@ -443,7 +462,7 @@ class AppDslService:
                         nodes=[n.model_dump() for n in result.nodes],
                         edges=[e.model_dump() for e in result.edges],
                         variables=[v.model_dump() for v in result.variables],
-                        environment_variables=[v.model_dump() for v in result.environment_variables],
+                        environment_variables=environment_variables,
                         execution_config=raw_wf.get("execution_config", {}),
                         features=raw_wf.get("features", {}),
                         triggers=raw_wf.get("triggers", []),

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -2579,10 +2579,17 @@ class WorkflowService:
         )
         latest_cache = manager.get_latest_cache(include_inactive=False)
         next_result_data = self._sanitize_cache_result_data(result_data or {})
+        if patches:
+            if latest_cache:
+                patch_base = latest_cache.get("result_data") or {}
+            else:
+                debug_state = self._read_workflow_debug_state(
+                    app_id=app_id, workflow_config=config
+                )
+                debug_nodes = (debug_state.get("snapshot") or {}).get("nodes") or {}
+                patch_base = self._unwrap_typed_group(debug_nodes.get(node_id) or {})
+            next_result_data = self._apply_cache_result_patches(patch_base, patches)
         if not latest_cache:
-            # No existing cache record — create one on-the-fly so that nodes
-            # which are not normally cached (e.g. "start") can still have their
-            # debug output persisted when the user edits it in the UI.
             cache_key = manager.build_cache_key(next_result_data)
             updated = manager.save_cache(
                 cache_key=cache_key,
@@ -2592,25 +2599,31 @@ class WorkflowService:
                 ttl_seconds=None,
             )
         else:
-            if patches:
-                next_result_data = self._apply_cache_result_patches(
-                    latest_cache.get("result_data") or {},
-                    patches,
-                )
             updated = manager.update_latest_cache(
                 result_data=next_result_data,
             )
         if not updated:
             return None
         node_type_maps = self._build_snapshot_type_maps(config)["nodes"]
+        # Build the new snapshot for this node from the patched result_data.
+        # Then merge it with the existing snapshot so fields not covered by
+        # the patch (e.g. user_id, workspace_id on the start node) are kept.
+        new_node_snapshot = self._build_public_node_snapshot_from_cache_result(
+            next_result_data,
+            type_map=node_type_maps.get(node_id),
+        )
+        existing_debug_state = self._read_workflow_debug_state(
+            app_id=app_id, workflow_config=config
+        )
+        existing_node_snapshot = (
+            existing_debug_state.get("snapshot") or {}
+        ).get("nodes", {}).get(node_id) or {}
+        merged_node_snapshot = self._merge_typed_group(existing_node_snapshot, new_node_snapshot)
         self._sync_workflow_debug_state_node(
             app_id=app_id,
             workflow_config=config,
             node_id=node_id,
-            node_snapshot=self._build_public_node_snapshot_from_cache_result(
-            next_result_data,
-            type_map=node_type_maps.get(node_id),
-            ),
+            node_snapshot=merged_node_snapshot,
             source="cache_update",
         )
         serialized = self._serialize_node_cache(updated)


### PR DESCRIPTION
clear secret environment variables during workflow import and add warning

## Summary by Sourcery

确保在导入工作流时清除密钥类型的环境变量，并向用户发出警告，以防止意外重复使用密钥值。

Bug Fixes:
- 在工作流导入期间将密钥类型环境变量的值重置为 null，以避免保留之前的密钥。

Enhancements:
- 在导入过程中，当工作流包含密钥类型环境变量时，添加检测和警告信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure secret-type environment variables are cleared and users are warned when importing workflows to prevent accidental reuse of secret values.

Bug Fixes:
- Reset secret-type environment variable values to null during workflow import to avoid persisting previous secrets.

Enhancements:
- Add detection and warning messaging when workflows contain secret-type environment variables during import.

</details>