### PR TITLE
fix(web): human-intervention node run

### DIFF
--- a/web/src/views/Workflow/components/SingleNodeRun/index.tsx
+++ b/web/src/views/Workflow/components/SingleNodeRun/index.tsx
@@ -219,7 +219,6 @@ const SingleNodeRun: FC<SingleNodeRunProps> = ({ open, onClose, selectedNode, ap
       if (nodeData?.type === 'iteration' || inputVars.length < 1 && !hasContext && !(isLlm && nodeData?.config?.vision?.defaultValue)) {
         if (nodeData?.type === 'human-intervention') {
           setStep(1)
-          setIsAutoRun(nodeData?.config?.content?.defaultValue?.trim() === '')
           setRenderedContent(nodeData?.config?.content?.defaultValue)
         } else {
           setIsAutoRun(true)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 防止在触发单节点运行时，仅因默认内容为空而自动运行需要人工干预的节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent human-intervention nodes from being auto-run based solely on empty default content when triggering a single-node run.

</details>