### PR TITLE
fix(web): form field node

### DIFF
--- a/web/src/views/Workflow/components/Editor/nodes/FormFieldEditModal.tsx
+++ b/web/src/views/Workflow/components/Editor/nodes/FormFieldEditModal.tsx
@@ -62,6 +62,8 @@ const FormFieldEditModal = forwardRef<FormFieldEditModalRef, FormFieldEditModalP
       .then(values => {
         const id = values.id || ''
         if (!id.trim()) return
+
+        console.log('values', values)
         
         if (prefillMode === 'static') {
           onSave(id.trim(), values.default_value || undefined, undefined)

--- a/web/src/views/Workflow/components/Editor/nodes/FormFieldNode.tsx
+++ b/web/src/views/Workflow/components/Editor/nodes/FormFieldNode.tsx
@@ -44,8 +44,8 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
   const { updateFormFields, formFields, options } = useFormFieldContext();
   const modalRef = useRef<FormFieldEditModalRef>(null);
   const [displayId, setDisplayId] = useState(initialId);
-  const [displayDefaultValue, setDisplayDefaultValue] = useState(initialDefaultValue);
-  // const [isDragging, setIsDragging] = useState(false);
+
+  console.log('initialDefaultValue', initialDefaultValue, initialVariableRef)
 
   const handleDelete = () => {
     editor.update(() => {
@@ -72,7 +72,7 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
   };
 
   const handleEdit = () => {
-    modalRef.current?.open(displayId, displayDefaultValue || '', initialVariableRef || '');
+    modalRef.current?.open(displayId, initialDefaultValue, initialVariableRef);
   };
 
   // const handleDragStart = (e: React.DragEvent) => {
@@ -97,7 +97,6 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
     });
     
     setDisplayId(id);
-    setDisplayDefaultValue(defaultValue || '');
   }
 
   return (
@@ -121,7 +120,9 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
           <span className="rb:text-gray-700 rb:font-medium">{displayId}</span>
         </Space>
         
-        <div className="rb:flex-1 rb:min-w-0 rb:text-[12px] rb:overflow-hidden rb:text-ellipsis rb:whitespace-nowrap rb:text-gray-500">{displayDefaultValue}</div>
+        <div className="rb:flex-1 rb:min-w-0 rb:text-[12px] rb:overflow-hidden rb:text-ellipsis rb:whitespace-nowrap rb:text-gray-500">
+          {initialVariableRef || initialDefaultValue}
+        </div>
         <Flex align="center" gap={8} className="rb:flex rb:gap-0 rb:shrink-0">
           <div
             className="rb:size-4.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/common/edit.svg')]"

--- a/web/src/views/Workflow/components/Editor/plugin/InsertFormFieldPlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InsertFormFieldPlugin.tsx
@@ -87,6 +87,7 @@ const InsertFormFieldPlugin = ({ formFields = [], updateFormFields, options = []
       }
     });
 
+    console.log('fieldData', fieldData)
     if (!filteredField) {
       updateFormFields([...formFields, fieldData]);
     }


### PR DESCRIPTION
## Summary by Sourcery

修复表单字段节点在显示和编辑默认值及变量引用时的行为，并为表单字段数据添加临时调试输出。

Bug Fixes:
- 确保表单字段编辑模态框接收到正确的默认值和变量引用，而不是依赖组件本地状态。
- 在工作流编辑器节点中，为表单字段显示正确的变量引用或默认值。

Chores:
- 在初始表单字段值、模态框表单提交值以及插入的字段数据周围添加调试日志，以便排查表单字段相关问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix how form field nodes display and edit default values and variable references, adding temporary debugging output for form field data.

Bug Fixes:
- Ensure the form field edit modal receives the correct default value and variable reference instead of relying on component-local state.
- Display the appropriate variable reference or default value for a form field in the workflow editor node.

Chores:
- Add debugging logs around initial form field values, modal form submission values, and inserted field data to aid investigation of form field issues.

</details>