### PR TITLE
fix(web): render form

### DIFF
--- a/web/src/components/Chat/InterventionList.tsx
+++ b/web/src/components/Chat/InterventionList.tsx
@@ -30,6 +30,8 @@ const InterventionItem: React.FC<InterventionItemProps> = ({
   editable
 }) => {
   const isEditable = !intervention?.resolved_action_id && editable
+  const isTimeout = intervention?.resolved_action_id === '__timeout__'
+
   // 不可编辑状态时默认收起，使用外部传入的展开状态
   const shouldExpand = isEditable || isExpanded
 
@@ -69,12 +71,16 @@ const InterventionItem: React.FC<InterventionItemProps> = ({
           <RenderedForm
             key={intervention.node_id || index}
             content={intervention.rendered_content || ''}
-            formFields={isEditable ? intervention.form_fields || [] : Object.entries(intervention.resolved_form_data || {}).map(([id, value]) => ({ id, default_value: value }))}
+            formFields={isEditable
+                ? intervention.form_fields || []
+                : Object.entries(intervention.resolved_form_data || {}).map(([id, value]) => ({ id, default_value: value }))
+            }
             actions={intervention.actions || []}
             resolved_action_id={intervention.resolved_action_id || ''}
             timeout_at={intervention.timeout_at}
             onActionClick={(actionId, fieldValues) => onActionClick(actionId, fieldValues, intervention.execution_id, intervention.node_id)}
             editable={isEditable}
+            isTimeout={isTimeout}
           />
         </div>
       }

--- a/web/src/components/Chat/RenderedForm.tsx
+++ b/web/src/components/Chat/RenderedForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Divider, Button, type ButtonProps } from 'antd'
+import { Divider, Button, Flex, type ButtonProps } from 'antd'
 import { useTranslation } from 'react-i18next'
 
 import Markdown from '@/components/Markdown'
@@ -26,6 +26,7 @@ interface RenderedFormProps {
   editable?: boolean;
   resolved_action_id?: string;
   timeout_at?: number;
+  isTimeout?: boolean;
 }
 
 // 渲染内容方法：处理 content、form_fields、actions 并替换变量
@@ -34,6 +35,7 @@ export const renderContent = (
   formFields: FormField[] = [],
   variables?: Record<string, any>,
   editable: boolean = true,
+  isTimeout: boolean = false
 ): string => {
 
   let renderedContent = content
@@ -50,9 +52,10 @@ export const renderContent = (
       if (editable && field) {
         // 可编辑状态：渲染表单元素
         return `<textarea id="${fieldId}" name="${fieldId}" default_value="${field.default_value || ''}" rows="4" class="rb:w-full rb:border rb:border-gray-200 rb:rounded-lg rb:p-2 rb:text-sm"></textarea>`
+      } else if (isTimeout) {
+        return `<textarea id="${fieldId}" name="${fieldId}" disabled default_value="${field?.default_value || ''}" rows="4" class="rb:w-full rb:border rb:border-gray-200 rb:rounded-lg rb:p-2 rb:text-sm"></textarea>`
       } else if (field) {
-        // 不可编辑状态：替换为 default_value
-        return field.default_value || ''
+        return field.default_value
       }
       return match
     }
@@ -77,16 +80,17 @@ const RenderedForm: React.FC<RenderedFormProps> = ({
   variables = {},
   editable = true,
   resolved_action_id,
-  timeout_at
+  timeout_at,
+  isTimeout = false
 }) => {
   const { t } = useTranslation()
   const [renderedContent, setRenderedContent] = useState<string | undefined>(undefined)
   const formRef = useRef<HTMLFormElement>(null)
 
   useEffect(() => {
-    const newRenderedContent = renderContent(content, formFields, variables, editable)
+    const newRenderedContent = renderContent(content, formFields, variables, editable, isTimeout)
     setRenderedContent(newRenderedContent)
-  }, [content, formFields, actions, variables, editable])
+  }, [content, formFields, actions, variables, editable, isTimeout])
 
   const handleButtonClick = (actionId: string) => {
     console.log('form', formRef.current)
@@ -121,7 +125,7 @@ const RenderedForm: React.FC<RenderedFormProps> = ({
     <form ref={formRef}>
       <Markdown content={renderedContent} />
       {editable && actions.length > 0 && (
-        <div className="rb:mt-2">
+        <Flex wrap gap={12} className="rb:mt-2!">
           {actions.map((action, index: number) => (
             <Button
               key={action.id || index}
@@ -131,7 +135,7 @@ const RenderedForm: React.FC<RenderedFormProps> = ({
               {action.label || `Action ${index + 1}`}
             </Button>
           ))}
-        </div>
+        </Flex>
       )}
     </form>
     {!resolved_action_id && timeout_at && <>

--- a/web/src/components/Chat/types.ts
+++ b/web/src/components/Chat/types.ts
@@ -5,6 +5,7 @@
  * @Last Modified time: 2026-06-05 20:01:24
  */
 import { type ReactNode } from 'react'
+import { type ButtonProps } from 'antd'
 
 /**
  * Chat message item interface
@@ -61,7 +62,7 @@ export interface Intervention {
   actions?: {
     id: string;
     label: string;
-    variant: string;
+    variant: ButtonProps['type'];
   }[];
   timeout_at?: number;
 

--- a/web/src/views/ApplicationConfig/TestChat/index.tsx
+++ b/web/src/views/ApplicationConfig/TestChat/index.tsx
@@ -6,7 +6,7 @@
  */
 import { type FC, useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { App } from 'antd'
+import { App, type ButtonProps } from 'antd'
 import clsx from 'clsx'
 import dayjs from 'dayjs'
 
@@ -80,7 +80,7 @@ interface NodeData {
   actions?: {
     id: string;
     label: string;
-    variant: string;
+    variant: ButtonProps['type'];
   }[];
   timeout_at?: number;
   agent_log?: any;

--- a/web/src/views/Conversation/index.tsx
+++ b/web/src/views/Conversation/index.tsx
@@ -14,7 +14,7 @@ import { type FC, useState, useEffect, useRef, useMemo } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import InfiniteScroll from 'react-infinite-scroll-component';
-import { Flex, Skeleton, App, Tooltip, Space } from 'antd'
+import { Flex, Skeleton, App, Tooltip, Space, type ButtonProps } from 'antd'
 import clsx from 'clsx'
 import dayjs from 'dayjs'
 
@@ -517,7 +517,7 @@ const Conversation: FC = () => {
           actions?: {
             id: string;
             label: string;
-            variant: string;
+            variant: ButtonProps['type'];
           }[];
           timeout_at?: number;
         }
@@ -765,6 +765,7 @@ const Conversation: FC = () => {
                   const filterIndex = lastAssistantMsg.interventions.findIndex(item => item.node_id === node_id)
                   lastAssistantMsg.interventions[filterIndex] = {
                     ...lastAssistantMsg.interventions[filterIndex],
+                    resolved_form_data: fieldValues,
                     resolved_action_id: actionId,
                   }
               
@@ -829,7 +830,7 @@ const Conversation: FC = () => {
             actions?: {
               id: string;
               label: string;
-              variant: string;
+              variant: ButtonProps['type'];
             }[];
             timeout_at?: number;
           }

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -23,7 +23,7 @@
  */
 import { forwardRef, useImperativeHandle, useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { App, Flex, Button } from 'antd'
+import { App, Flex, Button, type ButtonProps } from 'antd'
 import clsx from 'clsx'
 
 import ChatIcon from '@/assets/images/application/chat.png'
@@ -302,7 +302,7 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
           actions?: {
             id: string;
             label: string;
-            variant: string;
+            variant: ButtonProps['type'];
           }[];
           timeout_at?: number;
           agent_log?: Record<string, any>;

--- a/web/src/views/Workflow/components/Editor/nodes/FormFieldNode.tsx
+++ b/web/src/views/Workflow/components/Editor/nodes/FormFieldNode.tsx
@@ -12,12 +12,20 @@ import {
   DecoratorNode,
   $getNodeByKey,
   $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $createTextNode,
+  $createRangeSelection,
+  $setSelection,
+  $isTextNode,
+  $createParagraphNode,
 } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { Flex, Space } from 'antd';
 
 import { useFormFieldContext } from './FormFieldContext';
 import FormFieldEditModal, { type FormFieldEditModalRef } from './FormFieldEditModal';
+import { VariableComponent } from './VariableNode';
 
 export type SerializedFormFieldNode = Spread<
   {
@@ -45,7 +53,9 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
   const modalRef = useRef<FormFieldEditModalRef>(null);
   const [displayId, setDisplayId] = useState(initialId);
 
-  console.log('initialDefaultValue', initialDefaultValue, initialVariableRef)
+  const matchedVariable = initialVariableRef
+    ? options.find(opt => `{{${opt.value}}}` === initialVariableRef)
+    : undefined;
 
   const handleDelete = () => {
     editor.update(() => {
@@ -89,11 +99,75 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
     
     editor.update(() => {
       const node = $getNodeByKey(nodeKey) as FormFieldNode;
+      
       if (node) {
-        node.__id = id;
-        node.__default_value = defaultValue;
-        node.__variable_ref = variableRef;
+        // 编辑已有节点
+        const writableNode = node.getWritable();
+        writableNode.__id = id;
+        writableNode.__default_value = defaultValue;
+        writableNode.__variable_ref = variableRef;
+      } else {
+        // 新插入节点
+        const selection = $getSelection();
+        let anchorNode = null;
+        let anchorOffset = 0;
+
+        if (selection && $isRangeSelection(selection)) {
+          anchorNode = selection.anchor.getNode();
+          anchorOffset = selection.anchor.offset;
+        }
+
+        if (!anchorNode || !$isTextNode(anchorNode)) {
+          const root = $getRoot();
+          const children = root.getChildren();
+          
+          if (children.length > 0) {
+            const lastChild = children[children.length - 1];
+            const lastChildChildren = 'getChildren' in lastChild ? (lastChild as { getChildren(): any[] }).getChildren() : [];
+            if (lastChildChildren.length > 0) {
+              const lastTextNode = lastChildChildren[lastChildChildren.length - 1];
+              if ($isTextNode(lastTextNode)) {
+                anchorNode = lastTextNode;
+                anchorOffset = lastTextNode.getTextContent().length;
+              }
+            }
+          }
+        }
+
+        if ($isTextNode(anchorNode)) {
+          const nodeText = anchorNode.getTextContent();
+          const textBeforeCursor = nodeText.substring(0, anchorOffset);
+          const textAfterCursor = nodeText.substring(anchorOffset);
+
+          anchorNode.setTextContent(textBeforeCursor);
+
+          const newParagraph = $createParagraphNode();
+          const formFieldNode = $createFormFieldNode(id, defaultValue, variableRef);
+          const trailingSpace = $createTextNode('\n');
+          newParagraph.append(formFieldNode);
+          newParagraph.append(trailingSpace);
+          anchorNode.insertAfter(newParagraph);
+
+          if (textAfterCursor) {
+            const afterParagraph = $createParagraphNode();
+            afterParagraph.append($createTextNode(textAfterCursor));
+            trailingSpace.insertAfter(afterParagraph);
+          }
+
+          const newSelection = $createRangeSelection();
+          newSelection.anchor.set(trailingSpace.getKey(), 1, 'text');
+          newSelection.focus.set(trailingSpace.getKey(), 1, 'text');
+          $setSelection(newSelection);
+        } else {
+          const root = $getRoot();
+          const newParagraph = $createParagraphNode();
+          const formFieldNode = $createFormFieldNode(id, defaultValue, variableRef);
+          newParagraph.append(formFieldNode);
+          root.append(newParagraph);
+          root.append($createParagraphNode());
+        }
       }
+      modalRef.current?.close();
     });
     
     setDisplayId(id);
@@ -120,9 +194,16 @@ const FormFieldComponent: React.FC<{ nodeKey: NodeKey; id: string; default_value
           <span className="rb:text-gray-700 rb:font-medium">{displayId}</span>
         </Space>
         
-        <div className="rb:flex-1 rb:min-w-0 rb:text-[12px] rb:overflow-hidden rb:text-ellipsis rb:whitespace-nowrap rb:text-gray-500">
-          {initialVariableRef || initialDefaultValue}
-        </div>
+        {matchedVariable ? (
+          <VariableComponent
+            nodeKey={nodeKey}
+            data={matchedVariable}
+          />
+        ) : (
+          <div className="rb:flex-1 rb:min-w-0 rb:text-[12px] rb:overflow-hidden rb:text-ellipsis rb:whitespace-nowrap rb:text-gray-500">
+            {initialDefaultValue}
+          </div>
+        )}
         <Flex align="center" gap={8} className="rb:flex rb:gap-0 rb:shrink-0">
           <div
             className="rb:size-4.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/common/edit.svg')]"

--- a/web/src/views/Workflow/components/Editor/nodes/VariableNode.tsx
+++ b/web/src/views/Workflow/components/Editor/nodes/VariableNode.tsx
@@ -20,7 +20,7 @@ export type SerializedVariableNode = Spread<
   SerializedLexicalNode
 >;
 
-const VariableComponent: React.FC<{ nodeKey: NodeKey; data: Suggestion }> = ({
+export const VariableComponent: React.FC<{ nodeKey: NodeKey; data: Suggestion }> = ({
   nodeKey,
   data,
 }) => {


### PR DESCRIPTION
## Summary by Sourcery

更新表单字段节点渲染、干预（intervention）处理以及聊天表单在超时和基于变量字段情况下的行为。

New Features:
- 支持在编辑器中，将新的表单字段节点插入当前选区位置，或在不存在选区时插入到文档末尾。
- 使用共享的 `VariableComponent` 在表单字段节点中展示匹配到的变量引用。
- 在干预超时时，为表单字段渲染禁用状态的 `textarea`，同时保留默认值。

Bug Fixes:
- 确保编辑已有的表单字段节点时，使用可写实例以持久化 `id`、默认值和变量引用的更新。
- 在会话干预完成动作解析时，保留并存储解析后的表单数据，以便表单能够被一致地重新渲染。
- 通过拆分文本节点并重新排版内容，在插入表单字段节点时防止丢失结尾文本。

Enhancements:
- 使会话、干预、测试聊天和工作流聊天组件中的动作按钮变体与 `ButtonProps` 类型保持一致。
- 使用 `Flex` 布局动作按钮并通过 `InterventionList` 将超时状态传递到 `RenderedForm`，以优化渲染表单的布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update form field node rendering, intervention handling, and chat form behavior for timeouts and variable-based fields.

New Features:
- Support inserting new form field nodes into the editor at the current selection or document end when none exists.
- Display matched variable references in form field nodes using the shared VariableComponent.
- Render disabled textareas for form fields when interventions have timed out while preserving default values.

Bug Fixes:
- Ensure editing existing form field nodes uses writable instances to persist id, default value, and variable reference updates.
- Preserve and store resolved form data when conversation interventions resolve actions so forms can be re-rendered consistently.
- Prevent loss of trailing text when inserting form field nodes by splitting the text node and reflowing content.

Enhancements:
- Align action button variants across conversation, intervention, test chat, and workflow chat components with ButtonProps types.
- Refine rendered form layout by using Flex for action buttons and wiring timeout state through InterventionList into RenderedForm.

</details>