### PR TITLE
feat(celery): support configuring subscription task scheduling intervals via environment variables

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -240,12 +240,19 @@ beat_schedule_config = {
 celery_app.conf.beat_schedule = beat_schedule_config
 
 # 企业版订阅任务调度配置（_HAS_SUBSCRIPTION_TASKS 在上方路由注册处探测完成）
+# 可通过环境变量调整频率（默认保持原行为）：
+#   SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES=N   → 状态变更主循环周期（默认 10；测试时可改成 1）
+#   SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES=N   → 邮件提醒周期（默认 60；测试时可改成 1）
+_SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES = int(os.getenv("SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES", "10"))
+_SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES = int(os.getenv("SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES", "60"))
+
+# 状态变更任务（默认每 10 分钟一次 + 每天 2 点兜底）
 if _HAS_SUBSCRIPTION_TASKS:
     celery_app.conf.beat_schedule.update({
-        # 主处理：每10分钟扫一次过期订阅（支持10万租户，concurrency=4可并行处理）
+        # 主处理：每 N 分钟扫一次过期订阅（支持10万租户，concurrency=4可并行处理）
         "process-expired-subscriptions": {
             "task": "subscription.process_expired_subscriptions",
-            "schedule": crontab(minute="*/10"),
+            "schedule": crontab(minute=f"*/{_SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES}"),
             "options": {"queue": "subscription_state_tasks"},
         },
         # 兜底修复：每天北京凌晨 2:00（= UTC 18:00）再全量扫一次，
@@ -255,10 +262,15 @@ if _HAS_SUBSCRIPTION_TASKS:
             "schedule": crontab(hour=18, minute=0),  # UTC 18:00 = CST 02:00
             "options": {"queue": "subscription_state_tasks"},
         },
-        # 到期提醒：每小时整点投递；旧扫描任务超过 1 小时未被消费则过期丢弃
+    })
+
+# 邮件提醒任务（默认每小时一次）
+if _HAS_SUBSCRIPTION_TASKS:
+    celery_app.conf.beat_schedule.update({
+        # 到期提醒：每 N 分钟投递一次；旧扫描任务超过 1 小时未被消费则过期丢弃
         "subscription-expiration-reminder": {
             "task": "subscription.expiration_reminder",
-            "schedule": crontab(minute=0),
+            "schedule": timedelta(minutes=_SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES),
             "options": {"queue": "subscription_email_tasks", "expires": 3600},
         },
     })


### PR DESCRIPTION
Update enterprise subscription task scheduling to replace fixed intervals with customizable environment variables:
1. Add `SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES` for state check interval (default: 10 minutes).
2. Add `SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES` for email reminder interval (default: 60 minutes).
3. Change email reminder task scheduling from crontab hourly execution to minute-based interval scheduling.

## Summary by Sourcery

允许企业订阅相关的 Celery 任务通过环境变量配置调度间隔，同时保留之前的默认值。

新功能：
- 引入 `SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES` 来控制订阅状态检查的时间间隔，默认值为 10 分钟。
- 引入 `SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES` 来控制订阅到期邮件提醒的时间间隔，默认值为 60 分钟。

增强：
- 将订阅状态处理从固定的 10 分钟 crontab 调度切换为可参数化的按分钟计算的 crontab 间隔。
- 将订阅到期提醒任务从按小时触发的 crontab 改为使用 `timedelta` 的可配置按分钟计算的时间间隔。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow enterprise subscription Celery tasks to have configurable scheduling intervals via environment variables while preserving previous defaults.

New Features:
- Introduce SUBSCRIPTION_STATE_BEAT_INTERVAL_MINUTES to control the subscription state check interval with a default of 10 minutes.
- Introduce SUBSCRIPTION_EMAIL_BEAT_INTERVAL_MINUTES to control the subscription expiration email reminder interval with a default of 60 minutes.

Enhancements:
- Switch subscription state processing from a fixed 10-minute crontab schedule to a parameterized minute-based crontab interval.
- Change the subscription expiration reminder task from an hourly crontab trigger to a configurable minute-based interval using timedelta.

</details>