### PR TITLE
fix(web): timeout default_value

### DIFF
--- a/web/src/components/Chat/InterventionList.tsx
+++ b/web/src/components/Chat/InterventionList.tsx
@@ -71,7 +71,7 @@ const InterventionItem: React.FC<InterventionItemProps> = ({
           <RenderedForm
             key={intervention.node_id || index}
             content={intervention.rendered_content || ''}
-            formFields={isEditable
+            formFields={(isEditable || isTimeout)
                 ? intervention.form_fields || []
                 : Object.entries(intervention.resolved_form_data || {}).map(([id, value]) => ({ id, default_value: value }))
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复干预表单渲染问题，使超时干预在其他情况下不可编辑时也能使用原始表单字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix intervention form rendering so timeout interventions use raw form fields even when not otherwise editable.

</details>