### PR TITLE
feat(web): pure_workflow app hide annotations

### DIFF
--- a/web/src/views/ApplicationConfig/Logs.tsx
+++ b/web/src/views/ApplicationConfig/Logs.tsx
@@ -203,7 +203,7 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
     },
   ]
   const isHasAnnotations = useMemo(() => {
-    return application.type !== 'multi_agent' && source !== 'sharing'
+    return ['multi_agent', 'pure_workflow'].includes(application?.type as string) && source !== 'sharing'
   }, [source, application.type])
   return (
     <div className="rb:bg-white rb:rounded-lg rb:pt-3 rb:px-3">

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -84,7 +84,7 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
    * Format tab items for display
    */
   const formatTabItems = useMemo(() => {
-    const isHasAnnotations = application?.type !== 'multi_agent' && source !== 'sharing'
+    const isHasAnnotations = ['multi_agent', 'pure_workflow'].includes(application?.type as string) && source !== 'sharing'
     return (source === 'sharing' ? sharingTabKeys : tabKeys).map(key => ({
       key,
       label: key === 'log' && isHasAnnotations ? t('application.logAnnotations') : t(`application.${key}`),


### PR DESCRIPTION
## Summary by Sourcery

根据应用类型调整应用日志视图，以控制何时提供注释功能。

新功能：
- 在应用配置视图中为 `pure_workflow` 应用启用日志注释。

改进：
- 统一日志和配置页头中的注释可见性逻辑，使其始终依赖于应用类型和共享来源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust application log views to control when annotations are available based on application type.

New Features:
- Enable log annotations for pure_workflow applications in the application configuration views.

Enhancements:
- Align annotation visibility logic across logs and configuration header to consistently depend on application type and sharing source.

</details>