### PR TITLE
feat(web): memory info

### DIFF
--- a/web/src/components/Charts/GraphNetworkChart.tsx
+++ b/web/src/components/Charts/GraphNetworkChart.tsx
@@ -47,6 +47,7 @@ export interface Edge {
   caption: string;
   value: number;
   weight: number;
+  properties?: Record<string, any>;
 }
 
 export interface EdgeClickData extends Edge {
@@ -140,7 +141,8 @@ const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
         target: l.target,
         caption: l.caption,
         type: l.type,
-        label: l.type === 'EXTRACTED_RELATIONSHIP' ? (l as any).properties?.predicate || undefined : undefined,
+        label: l.type === 'EXTRACTED_RELATIONSHIP' ? (l as any).properties?.predicate_surface || undefined : undefined,
+        properties: l.properties
       }))
     return { nodes: d3Nodes, links: d3Links }
   }, [nodes, links, colors])
@@ -297,9 +299,21 @@ const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
       .attr('font-size', '12px')
       .attr('fill', '#5B6167')
       .attr('dy', -5)
-      .style('pointer-events', 'none')
+      .style('cursor', 'pointer')
       .style('user-select', 'none')
       .style('display', 'none')
+      .on('click', (_event, d) => {
+        const sourceId = typeof d.source === 'string' ? d.source : d.source.id
+        const targetId = typeof d.target === 'string' ? d.target : d.target.id
+        onNodeClick?.(selectedNodeId === d.id ? null : {
+          ...d,
+          id: d.id,
+          source: sourceId,
+          target: targetId,
+          label: d.label || '',
+          type: 'edge',
+        } as any)
+      })
     linkLabelSelRef.current = linkLabelSel
 
     const nodeSel = g.append('g').selectAll<SVGGElement, D3Node>('g')
@@ -545,8 +559,22 @@ const GraphNetworkChart: FC<GraphNetworkChartProps> = ({
 
     simulation.on('tick', () => {
       linkSel
-        .attr('x1', d => (d.source as D3Node).x ?? 0)
-        .attr('y1', d => (d.source as D3Node).y ?? 0)
+        .attr('x1', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          const dx = (target.x ?? 0) - (source.x ?? 0)
+          const dy = (target.y ?? 0) - (source.y ?? 0)
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1
+          return (source.x ?? 0) + (dx / dist) * (source.symbolSize + 2)
+        })
+        .attr('y1', d => {
+          const source = d.source as D3Node
+          const target = d.target as D3Node
+          const dx = (target.x ?? 0) - (source.x ?? 0)
+          const dy = (target.y ?? 0) - (source.y ?? 0)
+          const dist = Math.sqrt(dx * dx + dy * dy) || 1
+          return (source.y ?? 0) + (dy / dist) * (source.symbolSize + 2)
+        })
         .attr('x2', d => {
           const source = d.source as D3Node
           const target = d.target as D3Node

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1717,10 +1717,14 @@ export const en = {
       created_at: 'Created At',
       updated_at: 'Last Updated',
       fullScreen: 'Full Screen',
+      alias: 'Alias',
+      relations: 'Relations',
       goals: 'Goals',
-      traits: 'Traits',
-      interests: 'Interests',
       core_facts: 'Core Facts',
+      interests: 'Interests',
+      traits: 'Traits',
+      beliefs_or_stances: 'Belief',
+      anchors: 'Anchors',
 
       memoryWindow: "{{name}}'s Memory Overview",
       memory_insight: 'Overall Overview',
@@ -1742,6 +1746,7 @@ export const en = {
       ExtractedEntity_aliases: 'Aliases',
       ExtractedEntity_connect_strngth: 'Connection Strength',
       ExtractedEntity_importance_score: 'Importance Score',
+      ExtractedEntity_description_summary: 'Description Summary',
 
       AssistantPruned_memory_type: 'Memory Type',
 
@@ -1851,7 +1856,7 @@ export const en = {
       manual: 'Manual',
       solution_detail_noChanges: 'No changes',
       resetView: 'Reset View',
-      relationshipType: 'Relationship Type',
+      predicate: 'Predicate',
       sourceNode: 'Source Node',
       targetNode: 'Target Node',
       totalCategoryStats: 'Total events',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1682,10 +1682,14 @@ export const zh = {
       created_at: '创建时间',
       updated_at: '最后更新时间',
       fullScreen: '全屏',
+      alias: '别名',
+      relations: '关系',
       goals: '目标',
-      traits: '性格特点',
-      interests: '兴趣爱好',
       core_facts: '核心事实',
+      interests: '兴趣爱好',
+      traits: '性格特点',
+      beliefs_or_stances: '价值观',
+      anchors: '锚点',
 
       memoryWindow: "{{name}} 的记忆之窗",
       memory_insight: '总体概述',
@@ -1707,6 +1711,7 @@ export const zh = {
       ExtractedEntity_aliases: '别名',
       ExtractedEntity_connect_strngth: '连接强度',
       ExtractedEntity_importance_score: '重要性评分',
+      ExtractedEntity_description_summary: '摘要',
 
       AssistantPruned_memory_type: '记忆类型',
 
@@ -1816,7 +1821,7 @@ export const zh = {
       manual: '手动',
       solution_detail_noChanges: '无变更',
       resetView: '重置视图',
-      relationshipType: '关系类型',
+      predicate: '关系父类',
       sourceNode: '源节点',
       targetNode: '目标节点',
       totalCategoryStats: '总事件数',

--- a/web/src/views/UserMemoryDetail/components/EndUserProfile.tsx
+++ b/web/src/views/UserMemoryDetail/components/EndUserProfile.tsx
@@ -84,7 +84,7 @@ const EndUserProfile = forwardRef<EndUserProfileRef, EndUserProfileProps>(({ cla
         ></div>
       }
       headerClassName="rb:min-h-[46px]!! rb:font-medium!"
-      className={clsx("rb:bg-[#FFFFFF]! rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.13)]! rb:absolute! rb:w-80 rb:top-29 rb:left-26", className)}
+      className={clsx("rb:bg-[#FFFFFF]! rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.13)]! rb:absolute! rb:w-100 rb:top-29 rb:left-26", className)}
       bodyClassName="rb:px-5! rb:pb-5! rb:pt-3.75! rb:max-h-[calc(100vh-186px)] rb:overflow-auto"
     >
       {loading
@@ -94,30 +94,15 @@ const EndUserProfile = forwardRef<EndUserProfileRef, EndUserProfileProps>(({ cla
             <div className="rb:text-[#7B8085]">{t('userMemory.other_name')}</div>
             <div className="rb:mt-0.5">{data?.other_name || '-'}</div>
           </div>
-          {data?.meta_data?.goals && data?.meta_data?.goals.length > 0 &&
-            <div>
-              <div className="rb:text-[#7B8085]">{t('userMemory.goals')}</div>
-              <div className="rb:mt-0.5">{formatValue(data?.meta_data?.goals?.join(' | ') || '-')}</div>
-            </div>
-          }
-          {data?.meta_data?.traits && data?.meta_data?.traits.length > 0 &&
-            <div>
-              <div className="rb:text-[#7B8085]">{t('userMemory.traits')}</div>
-              <div className="rb:mt-0.5">{formatValue(data?.meta_data?.traits?.join(' | ') || '-')}</div>
-            </div>
-          }
-          {data?.meta_data?.core_facts && data?.meta_data?.core_facts.length > 0 &&
-            <div>
-              <div className="rb:text-[#7B8085]">{t('userMemory.core_facts')}</div>
-              <div className="rb:mt-0.5">{formatValue(data?.meta_data?.core_facts?.join(' | ') || '-')}</div>
-            </div>
-          }
-          {data?.meta_data?.interests && data?.meta_data?.interests.length > 0 &&
-            <div>
-              <div className="rb:text-[#7B8085]">{t('userMemory.interests')}</div>
-              <div className="rb:mt-0.5">{formatValue(data?.meta_data?.interests?.join(' | ') || '-')}</div>
-            </div>
-          }
+          {(['alias', 'relations', 'goals', 'core_facts', 'interests', 'traits', 'beliefs_or_stances', 'anchors'] as (keyof EndUser['meta_data'])[]).map((key) => {
+            if (!data?.meta_data?.[key] || (Array.isArray(data?.meta_data?.[key]) && data?.meta_data?.[key].length < 1)) return null
+            return(
+              <div key={key}>
+                <div className="rb:text-[#7B8085]">{t(`userMemory.${key}`)}</div>
+                <div className="rb:mt-0.5">{formatValue(data?.meta_data?.[key])}</div>
+              </div>
+            )
+          })}
 
           <div className="rb:text-[#7B8085] rb:text-[12px] rb:leading-4.5">
             {t('userMemory.updated_at')}: {data?.updated_at ? dayjs(data?.updated_at).format('YYYY/MM/DD HH:mm:ss') : ''}

--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -292,29 +292,28 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
               const targetNode = nodes.find(n => n.id === (selectedNode as EdgeClickData).target)
               return (
                 <Flex vertical gap={12}>
-                {/* <div> */}
-                  {selectedNode.label && <Tag>{selectedNode.label}</Tag>}
-                {/* </div> */}
-                <div className="rb:font-medium rb:text-[#212332] rb:text-[16px] rb:leading-5.5">
-                  {(selectedNode as EdgeClickData).label}
-                </div>
-                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.relationshipType')}</div>
-                <div className="rb:font-medium">
-                  {(selectedNode as Edge).caption}
-                </div>
+                  {(selectedNode as EdgeClickData).properties?.predicate_surface &&
+                    <div className="rb:text-[#212332]">
+                      {(selectedNode as EdgeClickData).properties?.predicate_surface}
+                    </div>
+                  }
+                  <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.predicate')}</div>
+                  <div className="rb:font-medium">
+                    {(selectedNode as EdgeClickData).properties?.predicate}
+                  </div>
 
-                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.sourceNode')}</div>
-                <div className="rb:font-medium">
-                  {sourceNode?.name || (selectedNode as EdgeClickData).source}
-                  {sourceNode?.caption && ` (${sourceNode!.caption})`}
-                </div>
+                  <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.sourceNode')}</div>
+                  <div className="rb:font-medium">
+                    {sourceNode?.name || (selectedNode as EdgeClickData).source}
+                    {sourceNode?.caption && ` (${sourceNode!.caption})`}
+                  </div>
 
-                <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.targetNode')}</div>
-                <div className="rb:font-medium">
-                  {targetNode?.name || (selectedNode as EdgeClickData).target}
-                  {targetNode?.caption && ` (${targetNode!.caption})`}
-                </div>
-              </Flex>
+                  <div className="rb:text-[#5B6167] rb:font-regular">{t('userMemory.targetNode')}</div>
+                  <div className="rb:font-medium">
+                    {targetNode?.name || (selectedNode as EdgeClickData).target}
+                    {targetNode?.caption && ` (${targetNode!.caption})`}
+                  </div>
+                </Flex>
               )
             })()
             : <>
@@ -386,7 +385,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
 
 
                       {selectedNode.label === 'ExtractedEntity' && <>
-                        {(['entity_type', 'aliases'] as const).map(key => {
+                        {(['description_summary', 'entity_type', 'aliases'] as const).map(key => {
                           const p = (selectedNode as Node).properties as ExtractedEntityNodeProperties
                           if (p[key]) {
                             return (

--- a/web/src/views/UserMemoryDetail/types.ts
+++ b/web/src/views/UserMemoryDetail/types.ts
@@ -94,6 +94,7 @@ export interface ExtractedEntityNodeProperties {
   aliases: string[];
   connect_strength: string;
   associative_memory: number;
+  description_summary?: string;
 }
 export interface PerceptualNodeProperties {
   file_name: string;
@@ -206,6 +207,9 @@ export interface EndUser {
     traits: string[];
     interests: string[];
     core_facts: string[];
+    alias: string[];
+    beliefs_or_stances: string[];
+    anchors: string[];
   };
   created_at: number;
   updated_at: number;


### PR DESCRIPTION
## Summary by Sourcery

增强用户记忆详情视图和图形网络图表，在 UI 中呈现更丰富的谓词和用户画像元数据。

新功能：
- 当在关系网络中选择一个抽取出的关系边时，显示关系谓词的表面文本和谓词详情。
- 在终端用户画像面板中展示更多终端用户元数据字段（别名、关系、信念或立场、锚点），并支持对抽取实体的描述摘要。

改进：
- 允许点击图形网络图表中的边标签来选择边并显示其详情，并调整边的渲染方式，使其从节点边缘开始，以改善视觉效果。
- 将边属性传播到图形网络图表的数据模型中，并更新标签以使用谓词表面文本而不是原始谓词。
- 将终端用户画像元数据渲染重构为通用的映射布局，并加宽画像面板以提升可读性。

文档：
- 为新的用户记忆元数据字段和抽取实体描述摘要添加 i18n 文本，并在英文和中文语言环境中将关系类型标签重命名为谓词术语。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the user memory detail views and graph network chart to surface richer predicate and profile metadata in the UI.

New Features:
- Display relationship predicate surface text and predicate details when an extracted relationship edge is selected in the relationship network.
- Expose additional end-user metadata fields (alias, relations, beliefs or stances, anchors) in the end user profile panel and support description summaries on extracted entities.

Enhancements:
- Allow clicking on edge labels in the graph network chart to select edges and show their details, and adjust edge rendering to start from the node perimeter for improved visuals.
- Propagate edge properties into the graph network chart data model and update labels to use predicate surface text instead of the raw predicate.
- Refactor end user profile metadata rendering to a generic, mapped layout and widen the profile panel for better readability.

Documentation:
- Add i18n strings for new user memory metadata fields and extracted entity description summaries, and rename relationship type labels to predicate terminology in both English and Chinese locales.

</details>