### PR TITLE
fix(rag): avoid model client init for index cleanup

### DIFF
--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -14,7 +14,10 @@ from app.controllers import file_controller
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
 from app.core.rag.utils.redis_conn import REDIS_CONN
-from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
+    ElasticSearchVectorFactory,
+    ElasticSearchVectorIndexOps,
+)
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
 from app.core.response_utils import success
@@ -232,8 +235,10 @@ async def update_document(
     if "status" in update_dict:
         new_status = update_dict["status"]
         if new_status != db_document.status:
-            vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-            vector_service.change_status_by_document_id(document_id=str(document_id), status=new_status)
+            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).change_document_status(
+                document_id=str(document_id),
+                status=new_status,
+            )
 
     # 3.2 Update fields (only update non-null fields)
     api_logger.debug(f"Start updating the document fields: {document_id}")
@@ -312,8 +317,10 @@ async def delete_document(
 
         # 3. Delete vector index (non-404 failures raise, caught by except below)
         db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
-        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-        vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
+        ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field(
+            key="document_id",
+            value=str(document_id),
+        )
 
         # 4. Delete file (storage errors are swallowed internally)
         await file_controller._delete_file(db=db, file_id=file_id, current_user=current_user, storage_service=storage_service)

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -21,7 +21,10 @@ from app.core.rag.llm.chat_model import Base
 from app.core.rag.nlp import rag_tokenizer, search
 from app.core.rag.prompts.generator import graph_entity_types
 from app.core.rag.utils.redis_conn import REDIS_CONN
-from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
+    ElasticSearchVectorFactory,
+    ElasticSearchVectorIndexOps,
+)
 from app.core.response_utils import success, fail
 from app.db import get_db
 from app.dependencies import get_current_user
@@ -475,8 +478,7 @@ async def _update_knowledge(
             if embedding_id != db_knowledge.embedding_id:
                 embedding_changed = True
                 if db_knowledge.embedding_id and db_knowledge.reranker_id:
-                    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-                    vector_service.delete()
+                    ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_index()
                 document_service.reset_documents_progress_by_kb_id(db, kb_id=db_knowledge.id, current_user=current_user)
 
         # 2. Update fields (only update non-null fields)

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -54,7 +54,7 @@ class ElasticSearchVector(BaseVector):
 
     def add_chunks(self, chunks: list[DocumentChunk], **kwargs):
         # 仅在写入时检查并补充字段映射，避免每次检索都做冗余检查
-        # ElasticSearchVectorFactory._ensure_parent_id_mapping(self._client, self._collection_name)
+        # ElasticSearchVectorIndexOps.ensure_parent_id_mapping(self._client, self._collection_name)
 
         # QA chunks: embedding 只对 question 字段做；source/parent chunks: 不做 embedding
         texts_for_embedding = []
@@ -877,16 +877,15 @@ class ElasticSearchVector(BaseVector):
             self._client.indices.create(index=self._collection_name, body=index_mapping)
 
 
-class ElasticSearchVectorFactory:
-    """ES 向量服务工厂 - 单例共享连接"""
-
+class ElasticSearchVectorClientProvider:
+    """Shared Elasticsearch client provider."""
     _client: Elasticsearch | None = None
     _lock = threading.Lock()
     _version_checked = False
 
     @classmethod
-    def _get_shared_client(cls) -> Elasticsearch:
-        """获取共享的 ES 客户端（线程安全的懒加载单例）"""
+    def get_shared_client(cls) -> Elasticsearch:
+        """Get a thread-safe shared Elasticsearch client."""
         if cls._client is not None:
             return cls._client
 
@@ -945,33 +944,96 @@ class ElasticSearchVectorFactory:
 
         return cls._client
 
+
+class ElasticSearchVectorIndexOps:
+    """Lightweight Elasticsearch index operations that do not initialize model clients."""
+
+    def __init__(self, collection_name: str, client: Elasticsearch):
+        self._collection_name = collection_name
+        self._client = client
+
+    @staticmethod
+    def collection_name_for_knowledge(knowledge_id: Any) -> str:
+        return f"Vector_index_{knowledge_id}_Node".lower()
+
     @classmethod
-    def init_vector(cls, knowledge: Knowledge) -> ElasticSearchVector:
-        """创建向量服务实例（共享 ES 连接）"""
-        client = cls._get_shared_client()
-        collection_name = f"Vector_index_{knowledge.id}_Node"
+    def _get_shared_client(cls) -> Elasticsearch:
+        return ElasticSearchVectorClientProvider.get_shared_client()
 
-        if knowledge.embedding is None:
-            raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
-        if knowledge.reranker is None:
-            raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
-        embedding_config = knowledge.embedding.api_keys[0] if knowledge.embedding.api_keys else None
-        if not knowledge.embedding.api_keys:
-            logger.warning(f"No embedding api key found for knowledge {knowledge.id}")
-        reranker_config = knowledge.reranker.api_keys[0] if knowledge.reranker.api_keys else None
-        if not knowledge.reranker.api_keys:
-            logger.warning(f"No reranker api key found for knowledge {knowledge.id}")
-
-        return ElasticSearchVector(
-            index_name=collection_name,
-            client=client,
-            embedding_config=embedding_config,
-            reranker_config=reranker_config,
+    @classmethod
+    def for_knowledge(cls, knowledge_id: Any) -> "ElasticSearchVectorIndexOps":
+        return cls(
+            collection_name=cls.collection_name_for_knowledge(knowledge_id),
+            client=cls._get_shared_client(),
         )
 
+    def delete_index(self) -> None:
+        if self._client.indices.exists(index=self._collection_name):
+            self._client.indices.delete(index=self._collection_name, ignore=[400, 404])
+
+    def _get_ids_by_metadata_field(self, key: str, value: str) -> list[str] | None:
+        query = {"query": {"term": {f"{Field.METADATA_KEY.value}.{key}": value}}}
+        response = self._client.search(index=self._collection_name, body=query, size=10000)
+        if response["hits"]["hits"]:
+            return [hit["_id"] for hit in response["hits"]["hits"]]
+        return None
+
+    def delete_by_metadata_field(
+            self,
+            key: str,
+            value: str,
+            *,
+            refresh: bool = False,
+    ) -> bool:
+        if not self._client.indices.exists(index=self._collection_name):
+            return False
+
+        actual_ids = self._get_ids_by_metadata_field(key, value)
+        if not actual_ids:
+            return True
+
+        actions = [{"_op_type": "delete", "_index": self._collection_name, "_id": es_id} for es_id in actual_ids]
+        try:
+            helpers.bulk(self._client, actions)
+            if refresh:
+                self._client.indices.refresh(index=self._collection_name)
+        except BulkIndexError as e:
+            for error in e.errors:
+                delete_error = error.get("delete", {})
+                status = delete_error.get("status")
+                doc_id = delete_error.get("_id")
+
+                if status == 404:
+                    logger.warning(f"Document not found for deletion: {doc_id}")
+                else:
+                    logger.error(f"Error deleting document: {error}")
+                    raise
+
+        return True
+
+    def change_document_status(self, document_id: str, status: int) -> int:
+        body = {
+            "script": {
+                "source": "ctx._source.metadata.status = params.new_status",
+                "params": {
+                    "new_status": status
+                }
+            },
+            "query": {
+                "term": {
+                    Field.DOCUMENT_ID.value: document_id
+                }
+            }
+        }
+        result = self._client.update_by_query(
+            index=self._collection_name,
+            body=body,
+        )
+        return result["updated"]
+
     @classmethod
-    def _ensure_parent_id_mapping(cls, client: Elasticsearch, index_name: str):
-        """为已有索引补充缺失的字段映射（仅追加，非破坏性）"""
+    def ensure_parent_id_mapping(cls, client: Elasticsearch, index_name: str):
+        """Add missing parent/QA mapping fields to an existing index."""
         if not client.indices.exists(index=index_name):
             return
         try:
@@ -981,21 +1043,17 @@ class ElasticSearchVectorFactory:
 
             update_body: dict[str, Any] = {"properties": {}}
 
-            # metadata.parent_id
             if metadata_props.get("parent_id", {}).get("type") != "keyword":
                 update_body["properties"]["metadata"] = {
                     "properties": {"parent_id": {"type": "keyword"}}
                 }
 
-            # top-level parent_id
             if props.get(Field.PARENT_ID.value, {}).get("type") != "keyword":
                 update_body["properties"][Field.PARENT_ID.value] = {"type": "keyword"}
 
-            # top-level chunk_type
             if Field.CHUNK_TYPE.value not in props:
                 update_body["properties"][Field.CHUNK_TYPE.value] = {"type": "keyword"}
 
-            # source_chunk_id
             if Field.SOURCE_CHUNK_ID.value not in props:
                 update_body["properties"][Field.SOURCE_CHUNK_ID.value] = {"type": "keyword"}
 
@@ -1006,3 +1064,29 @@ class ElasticSearchVectorFactory:
             logger.warning(f"Failed to update mapping for {index_name}: {e}")
 
 
+class ElasticSearchVectorFactory:
+    """Create full vector services that require configured model clients."""
+
+    @classmethod
+    def init_vector(cls, knowledge: Knowledge) -> ElasticSearchVector:
+        """Create a full vector service with configured model clients."""
+        client = ElasticSearchVectorClientProvider.get_shared_client()
+        collection_name = ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id)
+
+        if knowledge.embedding is None:
+            raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
+        if knowledge.reranker is None:
+            raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
+        if not knowledge.embedding.api_keys:
+            raise ValueError(f"No embedding api key found for knowledge {knowledge.id}")
+        if not knowledge.reranker.api_keys:
+            raise ValueError(f"No reranker api key found for knowledge {knowledge.id}")
+        embedding_config = knowledge.embedding.api_keys[0]
+        reranker_config = knowledge.reranker.api_keys[0]
+
+        return ElasticSearchVector(
+            index_name=collection_name,
+            client=client,
+            embedding_config=embedding_config,
+            reranker_config=reranker_config,
+        )


### PR DESCRIPTION
## Summary
- Avoid initializing embedding and reranker model clients for Elasticsearch index cleanup operations.
- Add lightweight Elasticsearch index operations for knowledge/document cleanup paths.

## Changes
```
 api/app/controllers/document_controller.py         |  17 ++-
 api/app/controllers/knowledge_controller.py        |   8 +-
 .../rag/vdb/elasticsearch/elasticsearch_vector.py  | 146 ++++++++++++++++-----
 3 files changed, 132 insertions(+), 39 deletions(-)
```

## Test Plan
- [x] /Users/codingx/Documents/Projects/红熊智能/MemoryBear/api/.venv/bin/python -m py_compile app/controllers/knowledge_controller.py app/controllers/document_controller.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
- [x] /Users/codingx/Documents/Projects/红熊智能/MemoryBear/api/.venv/bin/python -m pytest tests/controllers/test_knowledge_update_missing_model_key.py tests/rag/test_knowledge_retrieval_entry.py -q

## Summary by Sourcery

将轻量级的 Elasticsearch 索引操作从完整的向量服务初始化中分离出来，从而在清理路径中避免不必要的模型客户端初始化。

Bug Fixes:
- 确保文档状态更新以及文档/知识清理可以直接在 Elasticsearch 索引上运行，而无需有效的模型 API 密钥。

Enhancements:
- 引入 `ElasticSearchVectorClientProvider` 和 `ElasticSearchVectorIndexOps`，以在不初始化 embedding 或 reranker 客户端的情况下执行索引级操作。
- 优化 `ElasticSearchVectorFactory.init_vector`，严格校验模型配置，并依赖共享的客户端提供者。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate lightweight Elasticsearch index operations from full vector service initialization to avoid unnecessary model client setup during cleanup paths.

Bug Fixes:
- Ensure document status updates and document/knowledge cleanup operate directly on Elasticsearch indexes without requiring valid model API keys.

Enhancements:
- Introduce ElasticSearchVectorClientProvider and ElasticSearchVectorIndexOps to perform index-level operations without initializing embedding or reranker clients.
- Refine ElasticSearchVectorFactory.init_vector to validate model configurations strictly and rely on shared client provider.

</details>