### PR TITLE
feat(memory): add hot memory tags cache refresh task

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -139,6 +139,7 @@ celery_app.conf.update(
         'app.tasks.init_implicit_emotions_for_users': {'queue': 'periodic_tasks'},
         'app.tasks.init_interest_distribution_for_users': {'queue': 'periodic_tasks'},
         'app.tasks.init_community_clustering_for_users': {'queue': 'periodic_tasks'},
+        'app.tasks.refresh_hot_memory_tags_cache': {'queue': 'periodic_tasks'},
 
         # Sliding window write tasks → memory_tasks queue (IO-bound async tasks)
         'app.tasks.sliding_window_write': {'queue': 'memory_tasks'},
@@ -184,6 +185,7 @@ implicit_emotions_update_schedule = crontab(
 )
 layer2_reflection_schedule = timedelta(minutes=settings.LAYER2_REFLECTION_INTERVAL_MINUTES)
 layer2_dedup_full_scan_schedule = crontab(hour=settings.LAYER2_DEDUP_FULL_SCAN_HOUR, minute=0)
+hot_memory_tags_refresh_schedule = crontab(hour=settings.HOT_MEMORY_TAGS_REFRESH_HOUR, minute=0)
 # 构建定时任务配置
 beat_schedule_config = {
     # "run-workspace-reflection": {
@@ -221,6 +223,11 @@ beat_schedule_config = {
     "run-layer2-dedup-full-scan": {
         "task": "app.tasks.layer2_dedup_full_scan_task",
         "schedule": layer2_dedup_full_scan_schedule,
+        "args": (),
+    },
+    "refresh-hot-memory-tags-cache": {
+        "task": "app.tasks.refresh_hot_memory_tags_cache",
+        "schedule": hot_memory_tags_refresh_schedule,
         "args": (),
     },
     # "scan-idle-conversations": {

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -461,9 +461,9 @@ async def get_hot_memory_tags_api(
     
     缓存策略：
     - 缓存键：workspace_id + limit
-    - 过期时间：5分钟（300秒）
+    - 过期时间：28小时（HOT_MEMORY_TAGS_CACHE_EXPIRE），由每日定时任务预热刷新
     - 缓存命中：~50ms
-    - 缓存未命中：~600-800ms（取决于LLM速度）
+    - 缓存未命中：~600-800ms（取决于LLM速度），实时查询后回写缓存作为兜底
     """
     workspace_id = current_user.current_workspace_id
 

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -21,6 +21,7 @@ from app.schemas.memory_storage_schema import (
 )
 from app.schemas.response_schema import ApiResponse
 from app.services.memory_storage_service import (
+    HOT_MEMORY_TAGS_CACHE_EXPIRE,
     DataConfigService,
     MemoryStorageService,
     analytics_hot_memory_tags,
@@ -490,11 +491,11 @@ async def get_hot_memory_tags_api(
         api_logger.info(f"Cache miss for key: {cache_key}, executing query")
         result = await analytics_hot_memory_tags(db, current_user, limit)
 
-        # 写入缓存（过期时间：5分钟）
+        # 写入缓存（过期时间：28小时）
         # 注意：result是列表，需要转换为JSON字符串
         try:
             cache_data = json.dumps(result, ensure_ascii=False)
-            await aio_redis_set(cache_key, cache_data, expire=300)
+            await aio_redis_set(cache_key, cache_data, expire=HOT_MEMORY_TAGS_CACHE_EXPIRE)
             api_logger.info(f"Cached result for key: {cache_key}")
         except Exception as cache_error:
             # 缓存写入失败不影响主流程

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -275,6 +275,10 @@ class Settings:
     LAYER2_DEDUP_FULL_SCAN_HOUR: int = TypeAdapter(
         Annotated[int, Field(ge=0, le=23, description="Layer 2 dedup full scan hour, must be 0-23")]
     ).validate_python(int(os.getenv("LAYER2_DEDUP_FULL_SCAN_HOUR", "3")))
+    # 热门记忆标签缓存预热时间（UTC 小时，0-23）。19 = 北京时间 03:00
+    HOT_MEMORY_TAGS_REFRESH_HOUR: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=23, description="Hot memory tags cache refresh hour (UTC), 0-23. 19=Beijing 03:00")]
+    ).validate_python(int(os.getenv("HOT_MEMORY_TAGS_REFRESH_HOUR", "19")))
     # Memory Module Configuration (internal)
     
     MEMORY_OUTPUT_DIR: str = os.getenv("MEMORY_OUTPUT_DIR", "logs/memory-output")

--- a/api/app/core/memory/analytics/hot_memory_tags.py
+++ b/api/app/core/memory/analytics/hot_memory_tags.py
@@ -92,8 +92,9 @@ async def filter_tags_with_llm(tags: List[str], end_user_id: str) -> List[str]:
         return structured_response.meaningful_tags
 
     except Exception as e:
-        logger.error(f"LLM筛选过程中发生错误: {e}", exc_info=True)
-        # 在LLM失败时返回原始标签，确保流程继续
+        # LLM 不可用/不支持结构化输出时降级：不打印堆栈，仅一条简洁告警，
+        # 返回原始标签确保流程继续（标签未经 LLM 精筛，但功能可用）
+        logger.warning(f"LLM筛选不可用，降级使用原始标签: {e}")
         return tags
 
 async def filter_interests_with_llm(tags: List[str], end_user_id: str, language: str = "zh") -> List[str]:

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -592,78 +592,72 @@ async def search_all_batch(end_user_ids: List[str]) -> Dict[str, int]:
     return data
 
 
+# 热门记忆标签缓存 key 前缀（与 controller、清缓存接口保持一致）
+HOT_MEMORY_TAGS_CACHE_PREFIX = "hot_memory_tags"
+# 缓存过期：28 小时（= 24h 预热周期 + 4h 安全余量，避免次日预热前空窗）
+HOT_MEMORY_TAGS_CACHE_EXPIRE = 100800
+
+
+async def compute_hot_memory_tags(
+        workspace_id: str,
+        limit: int = 10,
+) -> List[Dict[str, Any]]:
+    """计算指定 workspace 的热门记忆标签（不依赖 current_user）。
+
+    供接口实时查询与定时预热任务共用。
+
+    策略：
+        1. 按 workspace_id 取所有 end_user_id
+        2. 单次批量 Cypher 聚合标签频率（get_raw_tags_batch）
+        3. 调用一次 LLM 筛选（filter_tags_with_llm）
+        4. 按频率/顺序过滤后返回前 limit 个
+    """
+    raw_limit = limit * 4
+
+    from app.db import SessionLocal
+    from app.models.end_user_model import EndUser
+
+    def _get_end_user_ids_in_thread() -> List[str]:
+        """独立线程独立 session，避免跨线程共享连接。"""
+        with SessionLocal() as thread_db:
+            rows = thread_db.query(EndUser.id).filter(
+                EndUser.workspace_id == workspace_id
+            ).distinct().all()
+            return [str(eid) for (eid,) in rows]
+
+    end_user_ids = await asyncio.to_thread(_get_end_user_ids_in_thread)
+    if not end_user_ids:
+        return []
+
+    connector = Neo4jConnector()
+    try:
+        sorted_tags = await get_raw_tags_batch(connector, end_user_ids, limit=raw_limit)
+        if not sorted_tags:
+            return []
+
+        tag_names = [tag for tag, _ in sorted_tags]
+        first_end_user_id = end_user_ids[0]
+        filtered_tag_names = await filter_tags_with_llm(tag_names, first_end_user_id)
+
+        filtered_set = set(filtered_tag_names)
+        final_tags = [(tag, freq) for tag, freq in sorted_tags if tag in filtered_set]
+        top_tags = final_tags[:limit]
+        return [{"name": t, "frequency": f} for t, f in top_tags]
+    finally:
+        await connector.close()
+
 async def analytics_hot_memory_tags(
         db: Session,
         current_user: User,
         limit: int = 10
 ) -> List[Dict[str, Any]]:
-    """
-    获取热门记忆标签，按数量排序并返回前N个
-    
-    原方案的策略：
+    """获取热门记忆标签（接口入口）。
 
-        1.获取 workspace 下所有 end_user
-        2.逐个用户串行查询 Neo4j，每人取 top 40 标签
-        3.应用层合并所有结果，相同标签频率累加
-        4.排序取 top 40
-        5.调用一次 LLM 筛选
-        6. 返回前 limit 个
-
-    优化策略：
-        1. 获取 workspace 下所有 end_user_id
-        2. 单次批量 Cypher 查询聚合所有用户的标签频率（替代 N 次串行查询）
-        3. 调用一次 LLM 进行筛选
-        4. 返回前 limit 个
-    
-    性能对比：
-    - 优化前：N 次 Neo4j 往返 + 应用层聚合 → ~600-1600ms（N=20）
-    - 优化后：1 次 Neo4j 往返（数据库侧聚合）→ ~30-80ms
+    从 current_user 取 workspace 后委托 compute_hot_memory_tags。
+    签名保持不变（db / current_user 仍保留），controller 调用方零改动。
     """
     workspace_id = current_user.current_workspace_id
-    raw_limit = limit * 4
-
-    from app.db import SessionLocal
-    from app.services.memory_dashboard_service import get_workspace_end_users
-
-    def _get_end_users_in_thread():
-        """在独立线程中使用独立 session，避免跨线程共享连接"""
-        with SessionLocal() as thread_db:
-            return get_workspace_end_users(thread_db, workspace_id, current_user)
-
-    end_users = await asyncio.to_thread(_get_end_users_in_thread)
-
-    if not end_users:
-        return []
-
-    # 收集所有 end_user_id
-    end_user_ids = [str(eu.id) for eu in end_users]
-
-    connector = Neo4jConnector()
-    try:
-        # 单次批量查询：在 Neo4j 侧完成聚合 + 排序 + 截断
-        sorted_tags = await get_raw_tags_batch(
-            connector,
-            end_user_ids,
-            limit=raw_limit
-        )
-
-        if not sorted_tags:
-            return []
-
-        # LLM 筛选
-        tag_names = [tag for tag, _ in sorted_tags]
-        first_end_user_id = end_user_ids[0]
-        filtered_tag_names = await filter_tags_with_llm(tag_names, first_end_user_id)
-
-        # 根据 LLM 结果过滤，保留频率和顺序
-        filtered_set = set(filtered_tag_names)
-        final_tags = [(tag, freq) for tag, freq in sorted_tags if tag in filtered_set]
-        top_tags = final_tags[:limit]
-
-        return [{"name": t, "frequency": f} for t, f in top_tags]
-
-    finally:
-        await connector.close()
+    return await compute_hot_memory_tags(str(workspace_id), limit)
 
 
 async def analytics_recent_activity_stats(workspace_id: Optional[str] = None) -> Dict[str, Any]:

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -612,6 +612,10 @@ async def compute_hot_memory_tags(
         3. 调用一次 LLM 筛选（filter_tags_with_llm）
         4. 按频率/顺序过滤后返回前 limit 个
     """
+    # 防护：limit 可能来自 API 查询参数，非正值会导致 raw_limit 无效（Cypher LIMIT 无意义），
+    # 回退到默认值 10
+    if limit <= 0:
+        limit = 10
     raw_limit = limit * 4
 
     from app.db import SessionLocal

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3964,6 +3964,104 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
         }
 
 
+@celery_app.task(
+    name="app.tasks.refresh_hot_memory_tags_cache",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+    time_limit=3600,
+    soft_time_limit=3300,
+)
+def refresh_hot_memory_tags_cache(self) -> Dict[str, Any]:
+    """定时任务：为所有活跃 workspace 预热热门记忆标签缓存（limit=10）。
+
+    每天北京 03:00（UTC 19:00）执行，缓存过期 28h，使白天请求全程命中缓存。
+    """
+    start_time = time.time()
+
+    async def _run() -> Dict[str, Any]:
+        import json as _json
+
+        from app.aioRedis import aio_redis_get, aio_redis_set
+        from app.models.workspace_model import Workspace
+        from app.services.memory_storage_service import (
+            HOT_MEMORY_TAGS_CACHE_EXPIRE,
+            HOT_MEMORY_TAGS_CACHE_PREFIX,
+            compute_hot_memory_tags,
+        )
+
+        limit = 10  # 前端首页固定 limit
+
+        # 1. 取全量启用（is_active=True）的 workspace id（短事务，取完即出）
+        #    与 write_all_workspaces_memory_task 一致，仅排除已停用/软删除的 workspace
+        with get_db_context() as db:
+            workspace_ids = [
+                str(wid) for (wid,) in db.query(Workspace.id).filter(
+                    Workspace.is_active.is_(True)
+                ).all()
+            ]
+
+        if not workspace_ids:
+            return {"status": "SUCCESS", "message": "无活跃工作空间", "total": 0}
+
+        logger.info(f"[HotTagsRefresh] 开始预热 {len(workspace_ids)} 个 workspace 的热门标签缓存")
+
+        refreshed = 0
+        empty = 0
+        failed = 0
+
+        # 2. 逐个 workspace 计算并写缓存（串行，避免 LLM 并发压力）
+        for workspace_id in workspace_ids:
+            try:
+                result = await compute_hot_memory_tags(workspace_id, limit)
+                if not result:
+                    empty += 1
+                cache_key = f"{HOT_MEMORY_TAGS_CACHE_PREFIX}:{workspace_id}:{limit}"
+                cache_data = _json.dumps(result, ensure_ascii=False)
+                await aio_redis_set(cache_key, cache_data, expire=HOT_MEMORY_TAGS_CACHE_EXPIRE)
+
+                # aio_redis_set 内部吞异常（写失败仅记日志、不抛），这里写后读回校验，
+                # 确保 refreshed 计数真实反映「缓存确实写入」，而非虚报成功
+                verify = await aio_redis_get(cache_key)
+                if verify is None:
+                    failed += 1
+                    logger.error(f"[HotTagsRefresh] 缓存写入校验失败（读回为空） key={cache_key}")
+                    continue
+
+                refreshed += 1
+                logger.info(
+                    f"[HotTagsRefresh] 缓存写入成功 key={cache_key} "
+                    f"tags={len(result)} expire={HOT_MEMORY_TAGS_CACHE_EXPIRE}s"
+                )
+            except Exception as e:
+                failed += 1
+                logger.error(f"[HotTagsRefresh] workspace={workspace_id} 预热失败: {e}", exc_info=True)
+
+        logger.info(f"[HotTagsRefresh] 预热完成: refreshed={refreshed}, empty={empty}, failed={failed}")
+        return {
+            "status": "SUCCESS",
+            "total": len(workspace_ids),
+            "refreshed": refreshed,
+            "empty": empty,
+            "failed": failed,
+        }
+
+    try:
+        loop = set_asyncio_event_loop()
+        result = loop.run_until_complete(_run())
+        result["elapsed_time"] = time.time() - start_time
+        result["task_id"] = self.request.id
+        return result
+    except Exception as e:
+        return {
+            "status": "FAILURE",
+            "error": str(e),
+            "elapsed_time": time.time() - start_time,
+            "task_id": self.request.id,
+        }
+
+
 # =============================================================================
 # 社区聚类补全任务（触发型）
 # =============================================================================

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3976,7 +3976,8 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
 def refresh_hot_memory_tags_cache(self) -> Dict[str, Any]:
     """定时任务：为所有活跃 workspace 预热热门记忆标签缓存（limit=10）。
 
-    每天北京 03:00（UTC 19:00）执行，缓存过期 28h，使白天请求全程命中缓存。
+    执行时间由 settings.HOT_MEMORY_TAGS_REFRESH_HOUR（UTC 小时）决定，
+    默认 19（= 北京时间 03:00）。缓存过期 28h，使白天请求全程命中缓存。
     """
     start_time = time.time()
 


### PR DESCRIPTION
- Add periodic task to refresh hot memory tags cache on schedule
- Extend cache expiration from 5 minutes to 28 hours (100800 seconds)
- Configure refresh schedule via HOT_MEMORY_TAGS_REFRESH_HOUR setting (default: 19 UTC)
- Refactor analytics_hot_memory_tags into compute_hot_memory_tags for shared use by API and scheduler
- Optimize tag computation with single batch Neo4j query instead of per-user serial queries
- Improve LLM filter error handling with graceful degradation (warning log, return raw tags)
- Update hot memory tags cache key and expiration constants for consistency across codebase

## Summary by Sourcery

添加一个定时 Celery 任务，为所有活跃工作区预热“热门记忆标签”缓存，并在 API 与调度器之间共享标签计算逻辑。

New Features:
- 引入一个周期性 Celery 任务，根据可配置的 UTC 小时设定，为所有活跃工作区刷新热门记忆标签缓存。
- 暴露一个工作区级别的热门记忆标签计算函数，可被 API 端点和后台调度器复用。

Enhancements:
- 将热门记忆标签缓存过期时间从 5 分钟延长到 28 小时，并将缓存键/TTL 常量集中管理以保证使用一致性。
- 优化热门记忆标签的聚合方式，将“按用户串行执行的 Neo4j 查询”替换为“针对工作区所有终端用户的一次批量查询”。
- 放宽 LLM 标签过滤失败时的处理方式，通过记录警告并返回原始标签来实现优雅降级，而不是将其视为错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a scheduled Celery task to prewarm hot memory tags cache for all active workspaces and share the tag computation logic between the API and scheduler.

New Features:
- Introduce a periodic Celery task that refreshes hot memory tags cache for all active workspaces based on a configurable UTC hour setting.
- Expose a workspace-level hot memory tags computation function reusable by both the API endpoint and background scheduler.

Enhancements:
- Extend hot memory tags cache expiration from 5 minutes to 28 hours and centralize cache key/TTL constants for consistent usage.
- Optimize hot memory tags aggregation by replacing per-user serial Neo4j queries with a single batch query over all end users in a workspace.
- Relax LLM tag-filtering failure handling to degrade gracefully by logging a warning and returning raw tags instead of treating it as an error.

</details>