### PR TITLE
feat(api): add edge groups aggregation and blank content filtering for graph data

### DIFF
--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -73,6 +73,32 @@ class GraphStatistics(BaseModel):
     )
 
 
+class GraphEdgeGroup(BaseModel):
+    """同一对节点之间的多边聚合（含双向）。
+
+    仅当两个节点间存在 ``>= 2`` 条边（无论方向）时，才会出现在响应的
+    ``edge_groups`` 数组中。``node_a`` / ``node_b`` 取两端 elementId 的字典序
+    升序，保证同一对节点对应唯一的分组——不论 Cypher 返回顺序如何，前端
+    都能用 ``(node_a, node_b)`` 作为稳定 key。
+
+    自环（``source == target``）不会构成分组。
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    node_a: str = Field(..., description="按 elementId 字典序较小的端点")
+    node_b: str = Field(..., description="按 elementId 字典序较大的端点")
+    total: int = Field(..., ge=2, description="本组涵盖的边总数（双向合计），最少 2")
+    a_to_b: List[str] = Field(
+        default_factory=list,
+        description="source=node_a, target=node_b 的边 id 列表；按 edges 中出现顺序",
+    )
+    b_to_a: List[str] = Field(
+        default_factory=list,
+        description="source=node_b, target=node_a 的边 id 列表；按 edges 中出现顺序",
+    )
+
+
 class GraphDataResponse(BaseModel):
     """``analytics_graph_data`` 的返回结构。controller 仍包一层 ApiResponse。"""
 
@@ -80,6 +106,13 @@ class GraphDataResponse(BaseModel):
 
     nodes: List[GraphNode] = Field(default_factory=list)
     edges: List[GraphEdge] = Field(default_factory=list)
+    edge_groups: List[GraphEdgeGroup] = Field(
+        default_factory=list,
+        description=(
+            "同一对节点之间存在多条边（双向合计 >= 2）的聚合视图。"
+            "便于前端在重边场景渲染聚合标签或多边弧线。"
+        ),
+    )
     statistics: GraphStatistics = Field(
         default_factory=GraphStatistics,
         description="节点/边统计信息，包含旧字段与新增 per_type",

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -42,6 +42,7 @@ __all__ = [
     "compute_stat_types",
     "assemble_per_type_stat",
     "assemble_center_per_type_stat",
+    "build_edge_groups",
     # Neo4j 查询封装
     "query_nodes_by_type_limits",
     "query_rel_count_batch",
@@ -438,6 +439,79 @@ def assemble_center_per_type_stat(
             "truncated": truncated,
         }
     return per_type_stat
+
+
+def build_edge_groups(
+    edges: Iterable[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """聚合「同一对节点之间的多条边」并按方向分桶（纯逻辑）。
+
+    业务背景：``EXTRACTED_RELATIONSHIP`` 等关系常常出现在同一对实体之间多次，
+    例如 (A)-[:关联于 {predicate_surface: 女朋友}]->(B) 与
+    (A)-[:关联于 {predicate_surface: 给…过生日}]->(B)。这些边在顶层 ``edges``
+    数组中是平铺的；前端如果想呈现「重边」效果，需要自己做一次 O(N) 聚合。
+    本函数把这部分逻辑下沉到后端，输出与方向无关的稳定分组。
+    
+    Args:
+        edges: 已经装配好的响应边列表。每项至少含 ``id`` / ``source`` /
+            ``target`` 三个字符串键；其它字段（type / properties / caption）
+            本函数不读取，由调用方维护。
+
+    Returns:
+        ``edge_groups`` 字段对应的列表。每个元素形如::
+
+            {
+                "node_a": "A",
+                "node_b": "B",
+                "total": 3,
+                "a_to_b": ["e1", "e3"],
+                "b_to_a": ["e2"],
+            }
+
+        当不存在任何重边对时返回 ``[]``。
+    """
+    # 用 dict 收口，键 = (node_a, node_b) 元组（已字典序排序）。
+    # 值同时记录两个方向的边 id 列表，避免二次遍历。
+    groups: Dict[Tuple[str, str], Dict[str, List[str]]] = {}
+
+    for edge in edges:
+        edge_id = edge.get("id")
+        source = edge.get("source")
+        target = edge.get("target")
+        if not edge_id or not source or not target:
+            continue
+        if source == target:
+            # 自环不属于「双向重边」语义，跳过。
+            continue
+
+        if source < target:
+            node_a, node_b = source, target
+            direction = "a_to_b"
+        else:
+            node_a, node_b = target, source
+            # source > target 时，原边实际是 b_to_a 方向。
+            direction = "b_to_a"
+
+        bucket = groups.get((node_a, node_b))
+        if bucket is None:
+            bucket = {"a_to_b": [], "b_to_a": []}
+            groups[(node_a, node_b)] = bucket
+        bucket[direction].append(edge_id)
+
+    result: List[Dict[str, Any]] = []
+    for (node_a, node_b), bucket in sorted(groups.items()):
+        total = len(bucket["a_to_b"]) + len(bucket["b_to_a"])
+        if total < 2:
+            # 单边对不进 edge_groups；它已经在顶层 edges 中，前端无需再聚合。
+            continue
+        result.append({
+            "node_a": node_a,
+            "node_b": node_b,
+            "total": total,
+            "a_to_b": bucket["a_to_b"],
+            "b_to_a": bucket["b_to_a"],
+        })
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -2307,6 +2307,11 @@ _NODE_FIELD_VALUE_MAPPERS: Dict[str, Callable[[Any], Any]] = {
     "entity_type": lambda v: type_mapping.get(v, ""),
     "emotion_type": lambda v: EmotionType.EMOTION_MAPPING.get(v),
     "emotion_subject": lambda v: EmotionSubject.SUBJECT_MAPPING.get(v),
+    # description 存储为分号分隔的字符串，API 返回时拆分为数组
+    "description": lambda v: (
+        [d.strip() for d in v.replace("；", ";").split(";") if d.strip()]
+        if isinstance(v, str) else (v if isinstance(v, list) else [])
+    ),
 }
 
 

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from collections import Counter
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -29,6 +29,7 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services._graph_data_helpers import (
     assemble_per_type_stat,
     assemble_center_per_type_stat,
+    build_edge_groups,
     compute_stat_types,
     resolve_mode_and_type_limits,
     _query_nodes_by_type_limits,
@@ -1729,7 +1730,9 @@ async def analytics_graph_data(
 
     Returns:
         ``GraphDataResponse.model_dump()`` 后的字典，顶层键为
-        ``nodes / edges / statistics``，必要时附带 ``message``。
+        ``nodes / edges / edge_groups / statistics``，必要时附带 ``message``。
+        ``edge_groups`` 把同一对节点之间的多条边按方向分桶（仅当某对节点的
+        总边数 ≥ 2 时才出现），便于前端做重边聚合渲染。
     """
     try:
         # 1. 用户校验
@@ -1760,6 +1763,9 @@ async def analytics_graph_data(
         # 6. Q3 边查询（try/except 降级，Requirement 8.4）
         edges, edge_type_counts = await _format_edges(node_ids)
 
+        # 6.1 同对节点重边聚合（双向分桶）。仅依赖 edges 列表，纯逻辑无 IO。
+        edge_groups = build_edge_groups(edges)
+
         # 7. Q4 全量计数 + statistics.per_type 装配
         per_type_stat = await _build_per_type_stat(
             mode=mode,
@@ -1785,7 +1791,8 @@ async def analytics_graph_data(
         )
         logger.info(
             f"图数据查询: end_user_id={end_user_id} mode={mode} "
-            f"nodes={len(nodes)} edges={len(edges)} per_type=[{per_type_log}]"
+            f"nodes={len(nodes)} edges={len(edges)} "
+            f"edge_groups={len(edge_groups)} per_type=[{per_type_log}]"
         )
 
         # 通过 GraphDataResponse 装配响应：拿到 ge=0 / 必填字段校验与向后兼容契约，
@@ -1793,6 +1800,7 @@ async def analytics_graph_data(
         response = GraphDataResponse(
             nodes=nodes,
             edges=edges,
+            edge_groups=edge_groups,
             statistics=statistics,
         )
         return response.model_dump(exclude_none=True)
@@ -2203,6 +2211,42 @@ async def analytics_community_graph_data(
         raise
 
 
+def _is_blank_content(value: Any) -> bool:
+    """判定一个属性值是否视作「空内容」。
+
+    业务规则（仅用于 ``ExtractedEntity`` 的 ``description`` /
+    ``description_summary``）：``None`` / 空字符串 / 仅空白的字符串 / 空列表
+    / 元素全为空白字符串的列表 —— 均视为「无内容」，不应在响应中暴露。
+
+    Args:
+        value: 属性原始值（``_clean_neo4j_value`` 之前的形态即可，本判定仅看
+            字符串与列表的「空」语义）。
+
+    Returns:
+        ``True`` 表示该字段无展示意义，调用方应跳过写入。
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, list):
+        if not value:
+            return True
+        return all(
+            isinstance(item, str) and item.strip() == ""
+            for item in value
+        )
+    return False
+
+
+# ``ExtractedEntity`` 节点中需要做「内容存在性」过滤的字段集合。
+# 命中本集合的字段，若值为空（参见 :func:`_is_blank_content`）将不会写入响应。
+_ENTITY_CONTENT_GATED_FIELDS: FrozenSet[str] = frozenset({
+    "description",
+    "description_summary",
+})
+
+
 def _extract_node_properties(
     label: str,
     properties: Dict[str, Any],
@@ -2218,6 +2262,11 @@ def _extract_node_properties(
 
     保留 ``entity_type`` / ``emotion_type`` / ``emotion_subject`` 三个字段
     的枚举映射逻辑，以维持响应字段的中文化展示。
+
+    业务过滤：当 ``label == "ExtractedEntity"`` 时，``description`` 与
+    ``description_summary`` 仅在「有内容」时才写入响应——空字符串、纯空白、
+    空列表、全空白元素列表均视为无内容（参见 :func:`_is_blank_content`）。
+    其余字段不受影响，节点本身始终返回。
 
     Args:
         label: 节点类型标签（``labels(n)[0]``）。
@@ -2235,6 +2284,15 @@ def _extract_node_properties(
         if field not in properties:
             continue
         value = properties[field]
+        # ExtractedEntity 的 description / description_summary 字段：
+        # 仅在原始值有内容时才纳入响应。判定基于「清洗前」的原始值，避免
+        # _clean_neo4j_value 把空字符串包装成其它形态后再判空。
+        if (
+            label == "ExtractedEntity"
+            and field in _ENTITY_CONTENT_GATED_FIELDS
+            and _is_blank_content(value)
+        ):
+            continue
         mapper = _NODE_FIELD_VALUE_MAPPERS.get(field)
         if mapper is not None:
             value = mapper(value)


### PR DESCRIPTION
## Summary by Sourcery

在图分析响应中添加边聚合（edge aggregation）元数据，并从节点属性中过滤空的实体描述。

新功能：
- 在图分析响应中暴露 `edge_groups` 聚合，用于按照方向将同一节点对之间的多条边分组。

增强内容：
- 在后端基于现有的边列表计算 `edge_groups`，以支持前端对多重边的渲染，而无需额外处理。
- 扩展 `GraphDataResponse` 模式和日志以包含 `edge_groups` 计数。
- 基于内容感知的空值检查，从 `ExtractedEntity` 节点中过滤空的 `description` 和 `description_summary` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add edge aggregation metadata to graph analytics responses and filter blank entity descriptions from node properties.

New Features:
- Expose an edge_groups aggregation in graph analytics responses to group multiple edges between the same node pair by direction.

Enhancements:
- Compute edge_groups on the backend from the existing edges list to support front-end multi-edge rendering without extra processing.
- Extend GraphDataResponse schema and logging to include edge_groups counts.
- Filter out empty description and description_summary values from ExtractedEntity nodes based on content-aware blank checks.

</details>