### PR TITLE
fix(rag): support folder knowledge retrieval

### DIFF
--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -115,6 +115,18 @@ class Knowledge(Base):
     image2text = relationship("ModelConfig", foreign_keys=[image2text_id], uselist=False, backref="image2text")
 
     @property
+    def is_folder(self) -> bool:
+        return self.type == KnowledgeType.FOLDER
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == 1
+
+    @property
+    def is_retrievable_leaf(self) -> bool:
+        return self.is_active and not self.is_folder and (self.chunk_num or 0) > 0
+
+    @property
     def chunk_mode(self) -> int:
         """获取知识库是否已经使用父子分块模式"""
         # 1. None 还为设置模式

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -235,16 +235,15 @@ class KnowledgeRetrievalService:
             return [], []
 
         if current_user is None:
-            rows = (
-                db.query(knowledge_model.Knowledge.id, knowledge_model.Knowledge.workspace_id)
+            knowledges = (
+                db.query(knowledge_model.Knowledge)
                 .filter(
                     knowledge_model.Knowledge.id.in_(requested_kb_ids),
-                    knowledge_model.Knowledge.chunk_num > 0,
                     knowledge_model.Knowledge.status == 1,
                 )
                 .all()
             )
-            return [row[0] for row in rows], [row[1] for row in rows]
+            return cls._expand_knowledges_to_leaf_kbs(db=db, knowledges=knowledges)
 
         return cls._resolve_accessible_chunk_kbs(
             db=db,
@@ -257,42 +256,119 @@ class KnowledgeRetrievalService:
         return list(dict.fromkeys(values))
 
     @classmethod
+    def _expand_knowledges_to_leaf_kbs(
+            cls,
+            db: Session,
+            knowledges: list[Any],
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        knowledge_ids = []
+        workspace_ids = []
+        for knowledge in knowledges:
+            expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
+                db=db,
+                knowledge=knowledge,
+            )
+            knowledge_ids.extend(expanded_ids)
+            workspace_ids.extend(expanded_workspace_ids)
+        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
+
+    @classmethod
+    def _expand_folder_to_leaf_kbs(
+            cls,
+            db: Session,
+            knowledge: Any,
+            visited: set[uuid.UUID] | None = None,
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        if not knowledge or not knowledge.is_active:
+            return [], []
+        if knowledge.is_retrievable_leaf:
+            return [knowledge.id], [knowledge.workspace_id]
+        if not knowledge.is_folder:
+            return [], []
+
+        if visited is None:
+            visited = set()
+        if knowledge.id in visited:
+            logger.warning(
+                "Detected cyclic knowledge folder while expanding retrieval candidates: knowledge_id=%s",
+                knowledge.id,
+            )
+            return [], []
+        visited.add(knowledge.id)
+
+        knowledge_ids = []
+        workspace_ids = []
+        children = knowledge_repository.get_knowledges_by_parent_id(db=db, parent_id=knowledge.id)
+        for child in children:
+            if child.workspace_id != knowledge.workspace_id:
+                logger.warning(
+                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
+                    knowledge.id,
+                    child.id,
+                )
+                continue
+            expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
+                db=db,
+                knowledge=child,
+                visited=visited,
+            )
+            knowledge_ids.extend(expanded_ids)
+            workspace_ids.extend(expanded_workspace_ids)
+
+        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
+
+    @staticmethod
+    def _deduplicate_knowledge_pairs(
+            knowledge_ids: list[uuid.UUID],
+            workspace_ids: list[uuid.UUID],
+    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        seen = set()
+        deduplicated_ids = []
+        deduplicated_workspace_ids = []
+        for knowledge_id, workspace_id in zip(knowledge_ids, workspace_ids):
+            if knowledge_id in seen:
+                continue
+            seen.add(knowledge_id)
+            deduplicated_ids.append(knowledge_id)
+            deduplicated_workspace_ids.append(workspace_id)
+        return deduplicated_ids, deduplicated_workspace_ids
+
+    @classmethod
     def _resolve_accessible_chunk_kbs(
             cls,
             db: Session,
             kb_ids: list[uuid.UUID],
             current_user: Any,
     ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        filters = [
-            knowledge_model.Knowledge.id.in_(kb_ids),
-            knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-            knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
-            knowledge_model.Knowledge.chunk_num > 0,
-            knowledge_model.Knowledge.status == 1,
-        ]
-        private_items = knowledge_service.get_chunked_knowledgeids(
-            db=db,
-            filters=filters,
-            current_user=current_user,
+        private_targets = (
+            db.query(knowledge_model.Knowledge)
+            .filter(
+                knowledge_model.Knowledge.id.in_(kb_ids),
+                knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
+                knowledge_model.Knowledge.status == 1,
+            )
+            .all()
         )
-        knowledge_ids = [item[0] for item in private_items]
-        workspace_ids = [item[1] for item in private_items]
-
-        filters = [
-            knowledge_model.Knowledge.id.in_(kb_ids),
-            knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-            knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
-            knowledge_model.Knowledge.chunk_num > 0,
-            knowledge_model.Knowledge.status == 1,
-        ]
-        share_targets = knowledge_service.get_chunked_knowledgeids(
+        knowledge_ids, workspace_ids = cls._expand_knowledges_to_leaf_kbs(
             db=db,
-            filters=filters,
-            current_user=current_user,
+            knowledges=private_targets,
+        )
+
+        share_targets = (
+            db.query(knowledge_model.Knowledge)
+            .filter(
+                knowledge_model.Knowledge.id.in_(kb_ids),
+                knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
+                knowledge_model.Knowledge.status == 1,
+            )
+            .all()
         )
         if share_targets:
+            share_target_ids = [target.id for target in share_targets]
             filters = [
-                knowledgeshare_model.KnowledgeShare.target_kb_id.in_(kb_ids),
+                knowledgeshare_model.KnowledgeShare.target_kb_id.in_(share_target_ids),
                 knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
             ]
             share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
@@ -300,10 +376,19 @@ class KnowledgeRetrievalService:
                 filters=filters,
                 current_user=current_user,
             )
-            knowledge_ids.extend([item[0] for item in share_items])
-            workspace_ids.extend([item[1] for item in share_items])
+            for source_kb_id, _source_workspace_id in share_items:
+                source_knowledge = knowledge_repository.get_knowledge_by_id(
+                    db=db,
+                    knowledge_id=source_kb_id,
+                )
+                expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
+                    db=db,
+                    knowledge=source_knowledge,
+                )
+                knowledge_ids.extend(expanded_ids)
+                workspace_ids.extend(expanded_workspace_ids)
 
-        return knowledge_ids, workspace_ids
+        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
 
     @staticmethod
     def _get_first_knowledge(


### PR DESCRIPTION
## Summary
- Fix folder knowledge bases being filtered out before retrieval because folders do not carry chunks themselves.
- Expand selected folders into active, chunked leaf knowledge bases before the existing retrieval flow.
- Preserve the existing multi-KB retrieval behavior and request/response schema.

## Changes
- api/app/models/knowledge_model.py | 12 ++
- api/app/services/knowledge_retrieval_service.py | 149 +++++++++++++++++++-----

## Test Plan
- [x] `.venv/bin/python -m py_compile app/models/knowledge_model.py app/services/knowledge_retrieval_service.py`
- [x] `.venv/bin/python -m pytest tests/rag/test_knowledge_retrieval_entry.py -q` (20 passed)

## Scope / Risk
- No API schema changes.
- No frontend changes.
- External API-key routes are not directly changed; callers that reuse `KnowledgeRetrievalService.retrieve` receive folder expansion behavior.
- Folder children are expected to be regular knowledge bases; share mapping remains supported when the selected target is a shared knowledge base.

## 由 Sourcery 提供的总结

通过在检索时将知识文件夹目标扩展为活跃的叶子知识库，同时保持现有的多知识库行为和响应模式，以支持基于知识文件夹的检索。

错误修复：
- 通过在查询 chunks 之前解析文件夹型知识库的活跃、已分块的叶子后代，确保它们不再在检索过程中被过滤掉。

增强功能：
- 引入模型级别的辅助工具，用于将知识记录分类为文件夹、活跃条目和可检索叶子，并在检索逻辑中复用这些工具。
- 对展开后的知识库/工作区配对进行去重，并在文件夹展开过程中加入防护措施，以防止循环或跨工作区的文件夹层级结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support knowledge-folder targets in retrieval by expanding them to active leaf knowledge bases while preserving existing multi-KB behavior and response schema.

Bug Fixes:
- Ensure folder knowledge bases are no longer filtered out from retrieval by resolving their active, chunked leaf descendants before querying chunks.

Enhancements:
- Introduce model-level helpers to classify knowledge records as folders, active items, and retrievable leaves, and reuse them in retrieval logic.
- Deduplicate expanded knowledge/workspace pairs and add safeguards against cyclic or cross-workspace folder hierarchies during folder expansion.

</details>