### PR TITLE
fix(web): kb share recall test

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/Share.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/Share.tsx
@@ -28,7 +28,6 @@ const Share: FC = () => {
   const recallTestRef = useRef<RecallTestDrawerRef>(null);
   const [infoItems, setInfoItems] = useState<InfoItem[]>([]);
   const [knowledgeBaseFolderPath, setKnowledgeBaseFolderPath] = useState<BreadcrumbItem[]>([]);
-  const [viewInfo,setViewInfo] = useState<boolean>(false);
   const { updateBreadcrumbs } = useBreadcrumbManager({
     breadcrumbType: 'detail'
   });
@@ -39,11 +38,18 @@ const Share: FC = () => {
     
     if (knowledgeBaseId) {
       fetchKnowledgeBaseDetail(knowledgeBaseId);
-      // Open recall test component
-      setTimeout(() => {
-        console.log('Share.tsx - calling handleOpen with:', knowledgeBaseId);
-        recallTestRef.current?.handleOpen(knowledgeBaseId);
-      }, 100);
+      // Use callback ref to ensure recall test is ready before calling methods
+      const tryOpen = (retries = 5) => {
+        if (recallTestRef.current) {
+          recallTestRef.current.handleOpen(knowledgeBaseId);
+        } else if (retries > 0) {
+          // Retry with a short delay until the ref is ready
+          setTimeout(() => tryOpen(retries - 1), 50);
+        } else {
+          console.warn('Share.tsx - recallTestRef is still null after retries');
+        }
+      };
+      tryOpen();
     } else {
       console.warn('Share.tsx - knowledgeBaseId is undefined or empty');
     }
@@ -161,7 +167,7 @@ const Share: FC = () => {
           <span className='rb:text-gray-500 rb:text-sm rb:ml-2 rb:font-normal'>(ID: {knowledgeBase.id})</span></h1>
         
         {/* <p className="rb:text-gray-600 rb:mt-2">{knowledgeBase.description || t('knowledgeBase.noDescription')}</p> */}
-        <span className='rb:text-white rb:text-xs rb:bg-blue-500 rb:px-1 rb:py-[2px] rb:rounded'>{knowledgeBase.permission_id}</span>
+        <span className='rb:text-white rb:text-xs rb:bg-blue-500 rb:px-1 rb:py-0.5 rb:rounded'>{knowledgeBase.permission_id}</span>
         <Popover
           content={<InfoPanel title={t('knowledgeBase.knowledgeBaseInfo')} items={infoItems} />}
           trigger="hover"
@@ -169,7 +175,7 @@ const Share: FC = () => {
           arrow={false}
         >
           <span 
-            className='rb:border rb:border-[#171719] rb:px-1 rb:py-[2px] rb:rounded rb:text-gray-900 rb:text-xs rb:cursor-pointer'
+            className='rb:border rb:border-[#171719] rb:px-1 rb:py-0.5 rb:rounded rb:text-gray-900 rb:text-xs rb:cursor-pointer'
           >{t('knowledgeBase.viewBasicInfo')}</span>
         </Popover>
       </div>
@@ -181,7 +187,7 @@ const Share: FC = () => {
       </div>
       <div className="rb:flex rb:flex-1 rb:gap-4 rb:min-h-0">
         <div className="rb:flex-1 rb:p-4 rb:border rb:flex rb:flex-col rb:border-[#DFE4ED] rb:bg-white rb:rounded-xl rb:overflow-hidden">
-          <div className='rb:flex rb:flex-col rb:txt-left rb:mb-5 rb:gap-2 rb:flex-shrink-0'>
+          <div className='rb:flex rb:flex-col rb:txt-left rb:mb-5 rb:gap-2 rb:shrink-0'>
             <h1 className="rb:text-lg rb:font-bold">{t('knowledgeBase.knowledgeBase')} {t('knowledgeBase.recallTest')}</h1>
             <span className='rb:text-gray-500 rb:text-xs'>{t('knowledgeBase.recallTestDescription')}</span>
           </div>

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -6,7 +6,6 @@ import type { RecallTestDrawerRef, RecallTestData, RecallTestParams } from '@/vi
 // import refreshIcon from '@/assets/images/knowledgeBase/refresh-blue.png';
 import RecallTestResult from './RecallTestResult';
 import { reChunks, getRetrievalModeType } from '@/api/knowledgeBase';
-import { hybrid } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
 const { TextArea } = Input;
 
@@ -27,6 +26,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
         { label: t('knowledgeBase.vector'), value: false },
     ]);
 
+    console.log('RecallTest - knowledgeBaseId:', knowledgeBaseId);
     // Get retrieval mode options
     useEffect(() => {
         fetchRetrievalModeOptions();
@@ -100,7 +100,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
     }));
   return (
     <div className='rb:w-full rb:h-full rb:flex rb:flex-col rb:overflow-hidden'>
-      <div className='rb:flex-shrink-0'>
+      <div className='rb:shrink-0'>
         <div className='rb:flexx rb:mb-2 rb:items-center rb:justify-between'>
           <span className='rb:font-medium'>{ t('knowledgeBase.testQuestion')}</span>
           {/* <div className='rb:flex rb:items-center rb:justify-end'>

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -72,6 +72,7 @@ export interface RecallTestParams {
   top_k?: number;
   hybrid?: boolean; // 是否混合检索
   hybrid_weight?: string;
+  retrieve_type?: string; //
 }
 // 文件夹 
 export interface FolderFormData {


### PR DESCRIPTION
## Summary by Sourcery

确保知识库回忆测试面板可以在分享视图中可靠初始化，并对相关的 UI 和类型定义进行更新以保持一致。

Bug Fixes:
- 通过将调用延迟到 `ref` 就绪后执行，修复从知识库分享页面打开回忆测试抽屉时偶发无法打开的问题。

Enhancements:
- 调整 `RecallTest` 布局以及相关分享视图元素，使用一致的收缩（shrink）和内边距（padding）工具类，以提高 UI 渲染的稳定性。
- 为 `RecallTestParams` 扩展 `retrieve_type` 字段，以支持更多检索配置。
- 从回忆测试组件和分享视图中移除未使用的导入和状态，并添加有针对性的日志以帮助调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the knowledge base recall test panel initializes reliably from the Share view and align related UI and typing updates.

Bug Fixes:
- Fix intermittent failure to open the recall test drawer from the knowledge base Share page by deferring calls until the ref is ready.

Enhancements:
- Adjust RecallTest layout and related Share view elements to use consistent shrink and padding utilities for more stable UI rendering.
- Extend RecallTestParams with a retrieve_type field to support additional retrieval configuration.
- Remove unused imports and state from recall test components and Share view, and add targeted logging to aid debugging.

</details>