### PR TITLE
feat(rag): support auto metadata filters

### DIFF
--- a/api/app/controllers/knowledge_metadata_controller.py
+++ b/api/app/controllers/knowledge_metadata_controller.py
@@ -21,6 +21,86 @@ router = APIRouter(
 )
 
 
+def _format_builtin_fields(fields) -> list[schemas.KnowledgeMetadataResponse]:
+    return [
+        schemas.KnowledgeMetadataResponse(
+            id=None,
+            type=field.type,
+            name=field.name,
+            is_builtin=True,
+        )
+        for field in fields
+    ]
+
+
+def _format_metadata_fields_result(result: dict) -> dict:
+    custom_responses = [
+        schemas.KnowledgeMetadataResponse.model_validate(field)
+        for field in result["custom"]
+    ]
+    return {
+        "custom": custom_responses,
+        "builtin_enabled": result["builtin_enabled"],
+        "builtin_fields": _format_builtin_fields(result["builtin_fields"]),
+    }
+
+
+def _field_value(field, key: str):
+    if isinstance(field, dict):
+        return field.get(key)
+    return getattr(field, key)
+
+
+def _format_common_metadata_fields_result(result: dict) -> dict:
+    return {
+        "custom": [
+            {
+                "type": _field_value(field, "type"),
+                "name": _field_value(field, "name"),
+                "is_builtin": False,
+            }
+            for field in result["custom"]
+        ],
+        "builtin_enabled": result["builtin_enabled"],
+        "builtin_fields": [
+            {
+                "type": _field_value(field, "type"),
+                "name": _field_value(field, "name"),
+                "is_builtin": True,
+            }
+            for field in result["builtin_fields"]
+        ],
+    }
+
+
+@router.post("/metadata/fields", response_model=ApiResponse)
+async def list_common_metadata_fields(
+    data: schemas.KnowledgeMetadataFieldsRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List common metadata fields across knowledge bases."""
+    kb_ids = list(dict.fromkeys(data.kb_ids))
+    api_logger.info(f"List common metadata fields: kb_ids={kb_ids}, user={current_user.username}")
+
+    for kb_id in kb_ids:
+        db_knowledge = require_current_workspace_knowledge(
+            db=db,
+            knowledge_id=kb_id,
+            current_user=current_user,
+        )
+        if not db_knowledge:
+            raise ResourceNotFoundException("知识库", str(kb_id))
+
+    result = KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids(
+        db,
+        kb_ids,
+        include_counts=False,
+    )
+
+    return success(data=_format_common_metadata_fields_result(result))
+
+
 @router.get("/{kb_id}/metadata", response_model=ApiResponse)
 async def list_metadata_fields(
     kb_id: uuid.UUID,
@@ -41,26 +121,7 @@ async def list_metadata_fields(
 
     result = KnowledgeMetadataService.list_metadata_fields(db, kb_id)
 
-    custom_responses = [
-        schemas.KnowledgeMetadataResponse.model_validate(f) for f in result["custom"]
-    ]
-
-    # 内置字段转换为响应格式
-    builtin_responses = []
-    if result["builtin_enabled"]:
-        for bf in result["builtin_fields"]:
-            builtin_responses.append(schemas.KnowledgeMetadataResponse(
-                id=None,
-                type=bf.type,
-                name=bf.name,
-                is_builtin=True,
-            ))
-
-    return success(data={
-        "custom": custom_responses,
-        "builtin_enabled": result["builtin_enabled"],
-        "builtin_fields": builtin_responses,
-    })
+    return success(data=_format_metadata_fields_result(result))
 
 
 @router.post("/{kb_id}/metadata", response_model=ApiResponse)
@@ -171,18 +232,9 @@ async def get_builtin_metadata_fields(
 
     result = KnowledgeMetadataService.get_builtin_fields(db, kb_id)
 
-    field_responses = []
-    for bf in result["fields"]:
-        field_responses.append(schemas.KnowledgeMetadataResponse(
-            id=None,
-            type=bf.type,
-            name=bf.name,
-            is_builtin=True,
-        ))
-
     return success(data=schemas.BuiltinMetadataListResponse(
         enabled=result["enabled"],
-        fields=field_responses,
+        fields=_format_builtin_fields(result["fields"]),
     ))
 
 

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -522,15 +522,16 @@ class ElasticSearchVector(BaseVector):
                 }
             }
 
-        # If document_ids_filter is passed in, append to filter (blacklist: exclude these IDs)
-        document_ids_filter = kwargs.get("document_ids_filter")
-        if document_ids_filter:
+        document_ids_include = kwargs.get("document_ids_include")
+        if document_ids_include is None:
+            document_ids_include = kwargs.get("document_ids_filter")
+        if document_ids_include:
             query_str["bool"]["filter"].append({
-                "bool": {"must_not": {"terms": {"metadata.document_id": document_ids_filter}}}
+                "terms": {Field.DOCUMENT_ID.value: document_ids_include}
             })
-            logger.info(f"[ES search_by_vector] excluding document_ids: {document_ids_filter}")
+            logger.info(f"[ES search_by_vector] including document_ids: {document_ids_include}")
         else:
-            logger.info("[ES search_by_vector] no document_ids_filter")
+            logger.info("[ES search_by_vector] no document_ids_include")
 
         logger.debug(f"[ES search_by_vector] query DSL: {query_str}")
 
@@ -627,15 +628,16 @@ class ElasticSearchVector(BaseVector):
                 }
             }
 
-        # If document_ids_filter is passed in, append to filter (blacklist: exclude these IDs)
-        document_ids_filter = kwargs.get("document_ids_filter")
-        if document_ids_filter:
+        document_ids_include = kwargs.get("document_ids_include")
+        if document_ids_include is None:
+            document_ids_include = kwargs.get("document_ids_filter")
+        if document_ids_include:
             query_str["bool"]["filter"].append({
-                "bool": {"must_not": {"terms": {"metadata.document_id": document_ids_filter}}}
+                "terms": {Field.DOCUMENT_ID.value: document_ids_include}
             })
-            logger.info(f"[ES search_by_full_text] excluding document_ids: {document_ids_filter}")
+            logger.info(f"[ES search_by_full_text] including document_ids: {document_ids_include}")
         else:
-            logger.info("[ES search_by_full_text] no document_ids_filter")
+            logger.info("[ES search_by_full_text] no document_ids_include")
 
         logger.debug(f"[ES search_by_full_text] query DSL: {query_str}")
 
@@ -1062,7 +1064,6 @@ class ElasticSearchVectorIndexOps:
                 logger.info(f"Updated mapping for {index_name}: added {list(update_body['properties'].keys())}")
         except Exception as e:
             logger.warning(f"Failed to update mapping for {index_name}: {e}")
-
 
 class ElasticSearchVectorFactory:
     """Create full vector services that require configured model clients."""

--- a/api/app/repositories/knowledge_metadata_repository.py
+++ b/api/app/repositories/knowledge_metadata_repository.py
@@ -1,6 +1,6 @@
 import uuid
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, delete, update
+from sqlalchemy import and_, delete, update, func
 from app.models.knowledge_metadata_model import KnowledgeMetadata, KnowledgeMetadataBinding
 from app.core.logging_config import get_db_logger
 
@@ -25,6 +25,14 @@ class KnowledgeMetadataRepository:
     def get_by_knowledge_id(db: Session, knowledge_id: uuid.UUID) -> list[KnowledgeMetadata]:
         return db.query(KnowledgeMetadata).filter(
             KnowledgeMetadata.knowledge_id == knowledge_id
+        ).all()
+
+    @staticmethod
+    def get_by_knowledge_ids(db: Session, knowledge_ids: list[uuid.UUID]) -> list[KnowledgeMetadata]:
+        if not knowledge_ids:
+            return []
+        return db.query(KnowledgeMetadata).filter(
+            KnowledgeMetadata.knowledge_id.in_(knowledge_ids)
         ).all()
 
     @staticmethod
@@ -106,3 +114,28 @@ class KnowledgeMetadataRepository:
                 KnowledgeMetadataBinding.document_id == document_id,
             )
         ).first() is not None
+
+    @staticmethod
+    def count_active_bindings_by_metadata_ids(
+        db: Session,
+        metadata_ids: list[uuid.UUID],
+    ) -> dict[uuid.UUID, int]:
+        if not metadata_ids:
+            return {}
+
+        from app.models.document_model import Document
+
+        rows = (
+            db.query(
+                KnowledgeMetadataBinding.metadata_id,
+                func.count(KnowledgeMetadataBinding.document_id),
+            )
+            .join(Document, Document.id == KnowledgeMetadataBinding.document_id)
+            .filter(
+                KnowledgeMetadataBinding.metadata_id.in_(metadata_ids),
+                Document.status == 1,
+            )
+            .group_by(KnowledgeMetadataBinding.metadata_id)
+            .all()
+        )
+        return {metadata_id: int(count) for metadata_id, count in rows}

--- a/api/app/schemas/knowledge_metadata_schema.py
+++ b/api/app/schemas/knowledge_metadata_schema.py
@@ -53,6 +53,7 @@ class KnowledgeMetadataResponse(BaseModel):
     type: str = Field(..., description="字段类型")
     name: str = Field(..., description="字段名")
     is_builtin: bool = Field(False, description="是否内置字段")
+    count: int | None = Field(None, description="字段被有效文档使用的数量（仅自定义字段）")
     created_at: datetime.datetime | int | None = Field(None, description="创建时间戳(ms)")
     updated_at: datetime.datetime | int | None = Field(None, description="更新时间戳(ms)")
 
@@ -80,6 +81,10 @@ class BuiltinMetadataEnableRequest(BaseModel):
 class BuiltinMetadataListResponse(BaseModel):
     enabled: bool = Field(..., description="开关状态")
     fields: list[KnowledgeMetadataResponse] = Field(..., description="内置字段列表")
+
+
+class KnowledgeMetadataFieldsRequest(BaseModel):
+    kb_ids: list[uuid.UUID] = Field(..., min_length=1, description="知识库ID列表")
 
 
 # === Batch Update Document Metadata Schemas ===

--- a/api/app/services/knowledge_metadata_service.py
+++ b/api/app/services/knowledge_metadata_service.py
@@ -30,17 +30,126 @@ class KnowledgeMetadataService:
         获取知识库的所有元数据字段（自定义 + 内置）
         Returns: {"custom": [...], "builtin_enabled": bool, "builtin_fields": [...]}
         """
+        return KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids(
+            db=db,
+            knowledge_ids=[knowledge_id],
+            include_builtin_when_disabled=True,
+            preserve_single_ids=True,
+        )
+
+    @staticmethod
+    def list_metadata_fields_for_knowledge_ids(
+        db: Session,
+        knowledge_ids: list[uuid.UUID],
+        *,
+        include_builtin_when_disabled: bool = False,
+        preserve_single_ids: bool = False,
+        include_counts: bool = True,
+    ) -> dict:
+        """List common metadata fields across knowledge bases."""
         from app.models.knowledge_model import Knowledge
 
-        custom_fields = KnowledgeMetadataRepository.get_by_knowledge_id(db, knowledge_id)
+        unique_knowledge_ids = list(dict.fromkeys(knowledge_ids))
+        if not unique_knowledge_ids:
+            return {
+                "custom": [],
+                "builtin_enabled": False,
+                "builtin_fields": [],
+            }
 
-        knowledge = db.query(Knowledge).filter(Knowledge.id == knowledge_id).first()
-        builtin_enabled = knowledge.builtin_metadata_enabled == 1 if knowledge else False
+        custom_fields = KnowledgeMetadataRepository.get_by_knowledge_ids(db, unique_knowledge_ids)
+        fields_by_kb = {knowledge_id: [] for knowledge_id in unique_knowledge_ids}
+        for field in custom_fields:
+            fields_by_kb.setdefault(field.knowledge_id, []).append(field)
+
+        counts_by_metadata_id = {}
+        if include_counts:
+            metadata_ids = [field.id for field in custom_fields]
+            counts_by_metadata_id = KnowledgeMetadataRepository.count_active_bindings_by_metadata_ids(
+                db,
+                metadata_ids,
+            )
+
+        knowledge_rows = (
+            db.query(Knowledge.id, Knowledge.builtin_metadata_enabled)
+            .filter(Knowledge.id.in_(unique_knowledge_ids))
+            .all()
+        )
+        builtin_enabled_by_kb = {
+            row[0]: row[1] == 1
+            for row in knowledge_rows
+        }
+        for knowledge_id in unique_knowledge_ids:
+            builtin_enabled_by_kb.setdefault(knowledge_id, False)
+
+        return KnowledgeMetadataService._build_common_metadata_fields_response(
+            fields_by_kb=fields_by_kb,
+            builtin_enabled_by_kb=builtin_enabled_by_kb,
+            counts_by_metadata_id=counts_by_metadata_id,
+            include_builtin_when_disabled=include_builtin_when_disabled,
+            preserve_single_ids=preserve_single_ids,
+        )
+
+    @staticmethod
+    def _build_common_metadata_fields_response(
+        fields_by_kb: dict[uuid.UUID, list[KnowledgeMetadata]],
+        builtin_enabled_by_kb: dict[uuid.UUID, bool],
+        counts_by_metadata_id: dict[uuid.UUID, int],
+        *,
+        include_builtin_when_disabled: bool = False,
+        preserve_single_ids: bool = False,
+    ) -> dict:
+        knowledge_ids = list(fields_by_kb.keys())
+        common_keys: set[tuple[str, str]] | None = None
+        field_lookup_by_kb: dict[uuid.UUID, dict[tuple[str, str], KnowledgeMetadata]] = {}
+
+        for knowledge_id, fields in fields_by_kb.items():
+            lookup = {(field.name, field.type): field for field in fields}
+            field_lookup_by_kb[knowledge_id] = lookup
+            keys = set(lookup.keys())
+            common_keys = keys if common_keys is None else common_keys & keys
+
+        common_keys = common_keys or set()
+        first_kb_id = knowledge_ids[0] if knowledge_ids else None
+        first_kb_fields = fields_by_kb.get(first_kb_id, []) if first_kb_id else []
+        ordered_keys = [
+            (field.name, field.type)
+            for field in first_kb_fields
+            if (field.name, field.type) in common_keys
+        ]
+
+        single_kb = len(knowledge_ids) == 1
+        custom_fields = []
+        for key in ordered_keys:
+            fields = [
+                field_lookup_by_kb[knowledge_id][key]
+                for knowledge_id in knowledge_ids
+            ]
+            count = sum(counts_by_metadata_id.get(field.id, 0) for field in fields)
+            first_field = fields[0]
+            custom_field = {
+                "id": first_field.id if single_kb and preserve_single_ids else None,
+                "type": first_field.type,
+                "name": first_field.name,
+                "is_builtin": False,
+                "count": count,
+            }
+            if single_kb and preserve_single_ids:
+                custom_field["created_at"] = first_field.created_at
+                custom_field["updated_at"] = first_field.updated_at
+            custom_fields.append(custom_field)
+
+        builtin_enabled = all(
+            builtin_enabled_by_kb.get(knowledge_id, False)
+            for knowledge_id in knowledge_ids
+        ) if knowledge_ids else False
 
         return {
             "custom": custom_fields,
             "builtin_enabled": builtin_enabled,
-            "builtin_fields": BuiltinFieldResolver.get_all() if builtin_enabled else [],
+            "builtin_fields": BuiltinFieldResolver.get_all()
+            if builtin_enabled or include_builtin_when_disabled
+            else [],
         }
 
     @staticmethod
@@ -143,7 +252,7 @@ class KnowledgeMetadataService:
 
         return {
             "enabled": enabled,
-            "fields": BuiltinFieldResolver.get_all() if enabled else [],
+            "fields": BuiltinFieldResolver.get_all(),
         }
 
     @staticmethod

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -66,20 +66,23 @@ class KnowledgeRetrievalService:
         if not db_knowledge:
             raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
 
-        document_ids_filter = cls._build_metadata_document_filter(
+        document_ids_include = cls._build_metadata_document_filter(
             db=db,
             request=request,
             knowledge_ids=knowledge_ids,
         )
+        if document_ids_include == []:
+            return KnowledgeRetrievalResult(chunks=[])
+
         chunks = cls._retrieve_by_type(
             db=db,
             request=request,
             knowledge_ids=knowledge_ids,
             workspace_ids=workspace_ids,
             db_knowledge=db_knowledge,
-            document_ids_filter=document_ids_filter,
+            document_ids_include=document_ids_include,
         )
-        chunks = cls._exclude_document_ids(chunks, document_ids_filter)
+        chunks = cls._include_document_ids(chunks, document_ids_include)
         return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
@@ -90,18 +93,18 @@ class KnowledgeRetrievalService:
             knowledge_ids: list[uuid.UUID],
             workspace_ids: list[uuid.UUID],
             db_knowledge: Any,
-            document_ids_filter: list[str] | None,
+            document_ids_include: list[str] | None,
     ) -> list[Any]:
         vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
         indices = ",".join(f"Vector_index_{knowledge_id}_Node".lower() for knowledge_id in knowledge_ids)
 
         if request.retrieve_type == RetrieveType.PARTICIPLE:
-            return cls._search_full_text(vector_service, request, indices, document_ids_filter)
+            return cls._search_full_text(vector_service, request, indices, document_ids_include)
         if request.retrieve_type == RetrieveType.SEMANTIC:
-            return cls._search_vector(vector_service, request, indices, document_ids_filter)
+            return cls._search_vector(vector_service, request, indices, document_ids_include)
 
-        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_filter)
-        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_filter)
+        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_include)
+        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_include)
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         logger.debug(f"Retrieved {len(unique_chunks)} chunks")
         if not unique_chunks:
@@ -127,14 +130,14 @@ class KnowledgeRetrievalService:
             vector_service: ElasticSearchVector,
             request: KnowledgeRetrievalRequest,
             indices: str,
-            document_ids_filter: list[str] | None,
+            document_ids_include: list[str] | None,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_vector(
             query=request.query,
             top_k=request.top_k,
             indices=indices,
             score_threshold=request.vector_similarity_weight,
-            document_ids_filter=document_ids_filter,
+            document_ids_include=document_ids_include,
             file_names_filter=request.file_names_filter,
             resolve_parents=True,
         )
@@ -144,14 +147,14 @@ class KnowledgeRetrievalService:
             vector_service: ElasticSearchVector,
             request: KnowledgeRetrievalRequest,
             indices: str,
-            document_ids_filter: list[str] | None,
+            document_ids_include: list[str] | None,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_full_text(
             query=request.query,
             top_k=request.top_k,
             indices=indices,
             score_threshold=request.similarity_threshold,
-            document_ids_filter=document_ids_filter,
+            document_ids_include=document_ids_include,
             file_names_filter=request.file_names_filter,
             resolve_parents=True,
         )
@@ -486,18 +489,25 @@ class KnowledgeRetrievalService:
         return result
 
     @staticmethod
+    def _include_document_ids(
+            chunks: list[Any],
+            document_ids_include: list[str] | None,
+    ) -> list[Any]:
+        if document_ids_include is None:
+            return chunks
+        include_ids = set(document_ids_include)
+        return [
+            chunk
+            for chunk in chunks
+            if chunk.metadata.get("document_id") in include_ids
+        ]
+
+    @staticmethod
     def _exclude_document_ids(
             chunks: list[Any],
             document_ids_filter: list[str] | None,
     ) -> list[Any]:
-        if not document_ids_filter:
-            return chunks
-        exclude_ids = set(document_ids_filter)
-        return [
-            chunk
-            for chunk in chunks
-            if chunk.metadata.get("document_id") not in exclude_ids
-        ]
+        return KnowledgeRetrievalService._include_document_ids(chunks, document_ids_filter)
 
     @staticmethod
     def _build_chat_model(api_key: ModelApiKey) -> Base:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -29,6 +29,7 @@ from app.schemas.knowledge_metadata_schema import MetadataFilterMode
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest, KnowledgeRetrievalResult
 from app.services import knowledge_service, knowledgeshare_service
 from app.services.knowledge_metadata_service import KnowledgeMetadataService
+from app.services.metadata_auto_filter_service import MetadataAutoFilterService
 from app.services.model_service import ModelApiKeyService, ModelConfigService
 
 logger = logging.getLogger(__name__)
@@ -414,21 +415,20 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             knowledge_ids: list[uuid.UUID],
     ) -> list[str] | None:
-        if not request.metadata_filters:
+        if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
             return None
-
-        if request.metadata_filter_mode != MetadataFilterMode.MANUAL:
-            raise BusinessException(
-                "metadata_filter_mode 暂仅支持 'manual'",
-                code=BizCode.INVALID_PARAMETER,
-            )
 
         metadata_defs_by_kb = {
             knowledge_id: KnowledgeMetadataService.get_metadata_defs_for_filtering(db, knowledge_id)
             for knowledge_id in knowledge_ids
         }
-        common_fields = cls._get_common_metadata_fields(metadata_defs_by_kb)
-        filter_groups = cls._build_common_filter_groups(request.metadata_filters, common_fields)
+        common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
+        filter_groups = cls._build_metadata_filter_groups(
+            db=db,
+            request=request,
+            knowledge_ids=knowledge_ids,
+            common_metadata_defs=common_metadata_defs,
+        )
         if not filter_groups:
             logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
             return None
@@ -444,24 +444,86 @@ class KnowledgeRetrievalService:
             document_ids.update(matched_ids)
         return [str(document_id) for document_id in document_ids]
 
+    @classmethod
+    def _build_metadata_filter_groups(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            common_metadata_defs: dict[str, dict],
+    ) -> list[EngineFilterGroup]:
+        if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
+            if not request.metadata_filters:
+                return []
+            return cls._build_common_filter_groups(
+                request.metadata_filters,
+                set(common_metadata_defs.keys()),
+            )
+
+        if request.metadata_filter_mode == MetadataFilterMode.AUTO:
+            if not common_metadata_defs:
+                return []
+            llm = cls._build_metadata_auto_filter_llm(
+                db=db,
+                knowledge_id=knowledge_ids[0],
+            )
+            if not llm:
+                logger.warning("[MetadataAutoFilter] LLM is unavailable; skipping metadata filter")
+                return []
+            return MetadataAutoFilterService.generate_filter_groups(
+                query=request.query,
+                metadata_defs=common_metadata_defs,
+                llm=llm,
+            )
+
+        raise BusinessException(
+            f"metadata_filter_mode 不支持: {request.metadata_filter_mode}",
+            code=BizCode.INVALID_PARAMETER,
+        )
+
+    @classmethod
+    def _build_metadata_auto_filter_llm(
+            cls,
+            db: Session,
+            knowledge_id: uuid.UUID,
+    ) -> Base | None:
+        knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
+        if not knowledge or not knowledge.llm_id:
+            return None
+
+        api_key = ModelApiKeyService.get_available_api_key(db, knowledge.llm_id)
+        if not api_key:
+            return None
+        return cls._build_chat_model(api_key)
+
     @staticmethod
-    def _get_common_metadata_fields(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> set[str]:
+    def _get_common_metadata_defs(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> dict[str, dict]:
         field_names = set()
         for metadata_defs in metadata_defs_by_kb.values():
             field_names.update(metadata_defs.keys())
 
-        common_fields = set()
+        common_defs = {}
         for field_name in field_names:
-            field_types = set()
-            all_have_field = True
+            common_type = None
+            common_def = None
             for metadata_defs in metadata_defs_by_kb.values():
-                if field_name not in metadata_defs:
-                    all_have_field = False
+                field_def = metadata_defs.get(field_name)
+                if not field_def:
+                    common_def = None
                     break
-                field_types.add(metadata_defs[field_name]["type"])
-            if all_have_field and len(field_types) == 1:
-                common_fields.add(field_name)
-        return common_fields
+                if common_type is None:
+                    common_type = field_def["type"]
+                    common_def = field_def
+                elif common_type != field_def["type"]:
+                    common_def = None
+                    break
+            if common_def:
+                common_defs[field_name] = dict(common_def)
+        return common_defs
+
+    @staticmethod
+    def _get_common_metadata_fields(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> set[str]:
+        return set(KnowledgeRetrievalService._get_common_metadata_defs(metadata_defs_by_kb).keys())
 
     @staticmethod
     def _build_common_filter_groups(metadata_filters: list[Any], common_fields: set[str]) -> list[EngineFilterGroup]:

--- a/api/app/services/metadata_auto_filter_service.py
+++ b/api/app/services/metadata_auto_filter_service.py
@@ -1,0 +1,265 @@
+import json
+import logging
+from typing import Any
+
+import json_repair
+
+from app.core.rag.llm.chat_model import ERROR_PREFIX
+from app.core.rag.metadata.filter_engine import (
+    FilterCondition as EngineFilterCondition,
+    FilterGroup as EngineFilterGroup,
+)
+from app.core.utils.datetime_utils import parse_iso_to_utc_naive
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataAutoFilterService:
+    """Generate metadata filter groups from a user query with LLM assistance."""
+
+    _OPERATOR_ALIASES = {
+        "contains": "contains",
+        "not contains": "not_contains",
+        "not_contains": "not_contains",
+        "start with": "starts_with",
+        "starts with": "starts_with",
+        "starts_with": "starts_with",
+        "end with": "ends_with",
+        "ends with": "ends_with",
+        "ends_with": "ends_with",
+        "is": "eq",
+        "=": "eq",
+        "==": "eq",
+        "eq": "eq",
+        "is not": "ne",
+        "!=": "ne",
+        "≠": "ne",
+        "ne": "ne",
+        ">": "gt",
+        "gt": "gt",
+        "<": "lt",
+        "lt": "lt",
+        "≥": "gte",
+        ">=": "gte",
+        "gte": "gte",
+        "≤": "lte",
+        "<=": "lte",
+        "lte": "lte",
+        "before": "before",
+        "after": "after",
+        "empty": "is_empty",
+        "is empty": "is_empty",
+        "is_empty": "is_empty",
+        "not empty": "not_empty",
+        "is not empty": "not_empty",
+        "not_empty": "not_empty",
+    }
+    _SUPPORTED_OPERATORS = {
+        "string": {
+            "eq", "ne", "contains", "not_contains",
+            "starts_with", "ends_with", "is_empty", "not_empty",
+        },
+        "number": {"eq", "ne", "gt", "lt", "gte", "lte", "is_empty", "not_empty"},
+        "time": {"eq", "before", "after", "is_empty", "not_empty"},
+    }
+
+    @classmethod
+    def generate_filter_groups(
+        cls,
+        query: str,
+        metadata_defs: dict[str, dict],
+        llm: Any,
+    ) -> list[EngineFilterGroup]:
+        if not metadata_defs:
+            return []
+
+        raw_conditions = cls._extract_metadata_conditions(
+            query=query,
+            metadata_defs=metadata_defs,
+            llm=llm,
+        )
+        conditions = []
+        for raw_condition in raw_conditions:
+            condition = cls._normalize_condition(raw_condition, metadata_defs)
+            if condition:
+                conditions.append(condition)
+
+        logger.info(
+            "[MetadataAutoFilter] extracted %s valid conditions from %s candidates",
+            len(conditions),
+            len(raw_conditions),
+        )
+        if not conditions:
+            return []
+        return [EngineFilterGroup(conditions=conditions, logic="AND")]
+
+    @classmethod
+    def _extract_metadata_conditions(
+        cls,
+        query: str,
+        metadata_defs: dict[str, dict],
+        llm: Any,
+    ) -> list[dict[str, Any]]:
+        system_prompt = (
+            "You are a text metadata extract engine. Extract only metadata filters that are clearly "
+            "present in the user's input and only use fields from the provided metadata list."
+        )
+        history = [
+            {
+                "role": "user",
+                "content": cls._build_prompt(query=query, metadata_defs=metadata_defs),
+            }
+        ]
+        response = llm.chat(
+            system=system_prompt,
+            history=history,
+            gen_conf={"temperature": 0},
+        )
+        content = response[0] if isinstance(response, tuple) else response
+        if not content or str(content).startswith(ERROR_PREFIX):
+            logger.warning("[MetadataAutoFilter] LLM returned no usable content")
+            return []
+        return cls._parse_llm_response(str(content))
+
+    @staticmethod
+    def _build_prompt(query: str, metadata_defs: dict[str, dict]) -> str:
+        metadata_fields = [
+            {
+                "name": field_name,
+                "type": field_def.get("type"),
+            }
+            for field_name, field_def in metadata_defs.items()
+        ]
+        return (
+            "### Job Description\n"
+            "You are a text metadata extract engine that extracts text metadata based on user input.\n"
+            "### Task\n"
+            "Only extract metadata that exists in the input text from the provided metadata list. "
+            "Use one of these operators: [\"contains\", \"not contains\", \"start with\", "
+            "\"end with\", \"is\", \"is not\", \"empty\", \"not empty\", \"=\", \"≠\", "
+            "\">\", \"<\", \"≥\", \"≤\", \"before\", \"after\"].\n"
+            "### Format\n"
+            "Return a JSON object with key \"metadata_fields\". The value must be an array of objects. "
+            "Each object must contain \"metadata_field_name\", \"metadata_field_value\", "
+            "and \"comparison_operator\".\n"
+            "### Constraint\n"
+            "Do not include any field that is not in metadata_fields. "
+            "Do not include anything other than JSON in your response.\n\n"
+            f"input_text:\n{query}\n\n"
+            f"metadata_fields:\n{json.dumps(metadata_fields, ensure_ascii=False)}"
+        )
+
+    @staticmethod
+    def _parse_llm_response(content: str) -> list[dict[str, Any]]:
+        cleaned = content.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.strip("`").strip()
+            if cleaned.lower().startswith("json"):
+                cleaned = cleaned[4:].strip()
+        try:
+            parsed = json_repair.loads(cleaned)
+        except Exception:
+            logger.warning("[MetadataAutoFilter] Failed to parse LLM response as JSON")
+            return []
+
+        if isinstance(parsed, dict):
+            items = parsed.get("metadata_fields")
+        elif isinstance(parsed, list):
+            items = parsed
+        else:
+            return []
+
+        if not isinstance(items, list):
+            return []
+        return [item for item in items if isinstance(item, dict)]
+
+    @classmethod
+    def _normalize_condition(
+        cls,
+        raw_condition: dict[str, Any],
+        metadata_defs: dict[str, dict],
+    ) -> EngineFilterCondition | None:
+        field_name = cls._get_first_present(
+            raw_condition,
+            ("metadata_field_name", "field", "name"),
+        )
+        if not isinstance(field_name, str):
+            return None
+        field_name = field_name.strip()
+        field_def = metadata_defs.get(field_name)
+        if not field_def:
+            return None
+
+        operator = cls._normalize_operator(
+            cls._get_first_present(raw_condition, ("comparison_operator", "operator")),
+        )
+        field_type = field_def.get("type")
+        if operator not in cls._SUPPORTED_OPERATORS.get(field_type, set()):
+            return None
+
+        value = cls._get_first_present(raw_condition, ("metadata_field_value", "value"))
+        normalized_value = cls._normalize_value(
+            value=value,
+            field_type=field_type,
+            operator=operator,
+        )
+        if normalized_value is _InvalidValue:
+            return None
+
+        return EngineFilterCondition(
+            field=field_name,
+            operator=operator,
+            value=normalized_value,
+        )
+
+    @staticmethod
+    def _get_first_present(values: dict[str, Any], keys: tuple[str, ...]) -> Any:
+        for key in keys:
+            if key in values:
+                return values[key]
+        return None
+
+    @classmethod
+    def _normalize_operator(cls, operator: Any) -> str | None:
+        if not isinstance(operator, str):
+            return None
+        return cls._OPERATOR_ALIASES.get(" ".join(operator.strip().lower().split()))
+
+    @classmethod
+    def _normalize_value(cls, value: Any, field_type: str, operator: str) -> Any:
+        if operator in ("is_empty", "not_empty"):
+            return None
+        match field_type:
+            case "string":
+                if value is None:
+                    return _InvalidValue
+                return str(value)
+            case "number":
+                return cls._normalize_number(value)
+            case "time":
+                return cls._normalize_time(value)
+        return _InvalidValue
+
+    @staticmethod
+    def _normalize_number(value: Any) -> int | float | object:
+        if isinstance(value, bool) or value is None:
+            return _InvalidValue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return _InvalidValue
+        return int(number) if number.is_integer() else number
+
+    @staticmethod
+    def _normalize_time(value: Any) -> str | object:
+        if not isinstance(value, str) or not value.strip():
+            return _InvalidValue
+        try:
+            if parse_iso_to_utc_naive(value.strip()) is None:
+                return _InvalidValue
+        except ValueError:
+            return _InvalidValue
+        return value.strip()
+
+
+_InvalidValue = object()


### PR DESCRIPTION
## Summary
- feat(rag): support auto metadata filters
- fix(rag): adjust metadata filtering and fields

## Changes
```
 .../controllers/knowledge_metadata_controller.py   | 112 ++++++---
 .../rag/vdb/elasticsearch/elasticsearch_vector.py  |  27 ++-
 .../repositories/knowledge_metadata_repository.py  |  35 ++-
 api/app/schemas/knowledge_metadata_schema.py       |   5 +
 api/app/services/knowledge_metadata_service.py     | 119 ++++++++-
 api/app/services/knowledge_retrieval_service.py    | 144 ++++++++---
 api/app/services/metadata_auto_filter_service.py   | 265 +++++++++++++++++++++
 7 files changed, 622 insertions(+), 85 deletions(-)
```

## Test Plan
- [x] PYTHONPATH=. .venv/bin/pytest tests/rag/test_metadata_auto_filter_requirement.py tests/rag/test_metadata_filter_fields_requirement.py -q
- [x] PYTHONPATH=. .venv/bin/python -m py_compile app/schemas/knowledge_metadata_schema.py app/repositories/knowledge_metadata_repository.py app/services/knowledge_metadata_service.py app/controllers/knowledge_metadata_controller.py app/services/knowledge_retrieval_service.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py app/services/metadata_auto_filter_service.py
- [x] git diff --check origin/develop..HEAD

## External API Impact
- API Key /chunks/retrieval reuses the internal retrieval service, so metadata include behavior and metadata_filter_mode=auto are available there as well.
- No new external metadata field-list route was added.

## Summary by Sourcery

为知识检索添加基于 LLM 的自动元数据过滤功能，并增强跨一个或多个知识库的元数据字段列举能力。

New Features:
- 支持在知识检索中使用 LLM 生成的过滤分组，进行基于元数据的自动过滤。
- 提供 API，用于列出多个知识库之间的公共元数据字段。
- 在列出某个知识库的元数据时，返回自定义元数据字段的使用计数。

Bug Fixes:
- 通过在检索和 Elasticsearch 查询中从“文档排除过滤”改为“文档包含过滤”，修正元数据过滤语义。
- 确保内置元数据字段在内置字段 API 中始终被返回，而不受启用状态影响。

Enhancements:
- 优化元数据过滤分组的构建逻辑，在验证多个知识库间公共元数据定义的同时，支持手动模式和自动模式。
- 统一并简化元数据字段响应的格式，包括相关端点中内置字段的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add LLM-driven automatic metadata filtering to knowledge retrieval and enhance metadata field listing across one or more knowledge bases.

New Features:
- Support automatic metadata-based filtering in knowledge retrieval using LLM-generated filter groups.
- Expose an API to list common metadata fields across multiple knowledge bases.
- Return usage counts for custom metadata fields when listing metadata for a knowledge base.

Bug Fixes:
- Correct metadata filtering semantics by switching from document exclusion to inclusion filters in retrieval and Elasticsearch queries.
- Ensure builtin metadata fields are always returned from the builtin fields API regardless of enabled status.

Enhancements:
- Refine metadata filter group construction to support both manual and auto modes while validating common metadata definitions across knowledge bases.
- Unify and simplify formatting of metadata field responses, including builtin field formatting across related endpoints.

</details>