### PR TITLE
feat(memory): add unified entity timeline with source filtering 

### DIFF
--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -525,6 +525,38 @@ async def memory_space_entity_event_timeline(
     return success(data=result, msg="实体事件时间线")
 
 
+@router.get("/memory_space/entity_timeline", response_model=ApiResponse)
+async def memory_space_entity_timeline(
+        id: str,
+        type: str = Query("all", description="来源筛选：all/key_node/statement/memory_summary"),
+        page: int = Query(1, ge=1, description="页码，从1开始"),
+        pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+        current_user: User = Depends(get_current_user),
+):
+    """ExtractedEntity 合并记忆时间线（关键节点 / 情绪记忆 / 长期沉淀），分页 + 按来源筛选。
+
+    本接口仅服务 ExtractedEntity 节点（只有它才有「关键节点」来源）；
+    Statement / MemorySummary 节点仍走旧接口 timeline_memories。
+
+    Query 参数:
+        id: ExtractedEntity 节点的 Neo4j elementId
+        type: 来源筛选，all/key_node/statement/memory_summary，默认 all
+        page: 页码（从 1 开始）
+        pagesize: 每页条数（1~100）
+
+    total_count 与 type_stats 始终基于全量统计，不受 type 筛选影响。
+    """
+    allowed = {"all", "key_node", "statement", "memory_summary"}
+    if type not in allowed:
+        return fail(BizCode.INVALID_PARAMETER, "type 取值非法", f"type={type}")
+
+    memory_entity = MemoryEntityService(id, "ExtractedEntity")
+    result = await memory_entity.get_unified_timeline(
+        source_type=type, page=page, pagesize=pagesize
+    )
+    return success(data=result, msg="记忆时间线")
+
+
 @router.get("/memory_space/relationship_evolution", response_model=ApiResponse)
 async def memory_space_relationship_evolution(id: str, label: str,
                                               current_user: User = Depends(get_current_user),

--- a/api/app/core/memory/models/event_category_models.py
+++ b/api/app/core/memory/models/event_category_models.py
@@ -82,6 +82,14 @@ class EventCategory(Enum):
                 return member.label
         return None
 
+    @classmethod
+    def id_by_name(cls, name: Optional[str]) -> Optional[str]:
+        """根据中文分类名查 category_id；不存在返回 None"""
+        for member in cls:
+            if member.label == name:
+                return member.category_id
+        return None
+
 
 # 有序中文分类名（用于补全 / 排序兜底）
 EVENT_CATEGORY_NAMES: List[str] = EventCategory.names()
@@ -91,3 +99,6 @@ EVENT_CATEGORY_NAME_SET = frozenset(EVENT_CATEGORY_NAMES)
 
 # 有序 category_id
 EVENT_CATEGORY_IDS: List[str] = EventCategory.ids()
+
+# 中文分类名 → category_id（用于对外输出英文枚举）
+EVENT_CATEGORY_NAME_TO_ID = {member.label: member.category_id for member in EventCategory}

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from app.schemas.memory_episodic_schema import EmotionType
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
-from app.core.memory.models.event_category_models import EVENT_CATEGORY_NAMES
+from app.core.memory.models.event_category_models import EVENT_CATEGORY_NAMES, EVENT_CATEGORY_NAME_TO_ID
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +205,160 @@ class MemoryEntityService:
         # 排序：valid_at 降序（最新在前）
         events.sort(key=lambda e: e["valid_at"], reverse=True)
         return events
+
+    async def get_unified_timeline(self, source_type: str = "all", page: int = 1, pagesize: int = 10) -> dict:
+        """ExtractedEntity 合并时间线（关键节点 / 情绪记忆 / 长期沉淀），分页 + 按来源筛选。
+
+        本方法仅服务 ExtractedEntity 节点：
+        - 关键节点：读自身 event_timeline 结构化事件。
+        - 情绪记忆 / 长期沉淀：走图遍历查询，取关联 Statement / MemorySummary。
+        三类合并按 created_at 毫秒降序（时间未知排最后），再按 source_type 筛选 + 分页。
+        total_count / type_stats 始终基于全量，不受筛选影响。
+        """
+        # 1. 关键节点：读 ExtractedEntity 自身 event_timeline
+        entity_name = None
+        entity_type = None
+        description_summary = None
+        key_node_items = []
+        kn_results = await self.connector.execute_query(
+            Memory_Timeline_Entity_Events, id=self.id
+        )
+        if kn_results:
+            record = kn_results[0]
+            entity_name = record.get("entity_name")
+            entity_type = record.get("entity_type")
+            description_summary = record.get("description_summary")
+            events = self._parse_event_timeline(record.get("event_timeline") or "")
+            key_node_items = [
+                {
+                    "type": "key_node",
+                    "category": EVENT_CATEGORY_NAME_TO_ID.get(e.get("category")),
+                    "title": e.get("title"),
+                    "text": e.get("fact"),
+                    "created_at": e.get("valid_at"),
+                }
+                for e in events
+            ]
+
+        # 2. 情绪记忆 + 长期沉淀：走 ExtractedEntity 图遍历查询
+        graph_results = await self.connector.execute_query(
+            Memory_Timeline_ExtractedEntity, id=self.id
+        )
+
+        statement_items, summary_items = [], []
+        if graph_results and isinstance(graph_results, list):
+            for record in graph_results:
+                if not isinstance(record, dict):
+                    continue
+                statement_items.extend(
+                    self._collect_graph_source_items(record.get("statement"), "statement")
+                )
+                summary_items.extend(
+                    self._collect_graph_source_items(record.get("MemorySummary"), "memory_summary")
+                )
+            # 跨 record 再按 text 去重
+            statement_items = self._dedup_by_text(statement_items)
+            summary_items = self._dedup_by_text(summary_items)
+
+        # 3. type_stats（全量，不受筛选影响）；total_count 单独拎出
+        total_count = len(key_node_items) + len(statement_items) + len(summary_items)
+        type_stats = [
+            {"type": "key_node", "count": len(key_node_items)},
+            {"type": "statement", "count": len(statement_items)},
+            {"type": "memory_summary", "count": len(summary_items)},
+        ]
+
+        # 4. 合并 + 排序（created_at 均非空，按毫秒降序）
+        all_items = key_node_items + statement_items + summary_items
+        all_items.sort(key=lambda x: x["created_at"], reverse=True)
+        sorted_items = all_items
+
+        # 5. type 筛选（入参 type 即英文 key，直接比对）
+        if source_type != "all":
+            filtered = [i for i in sorted_items if i["type"] == source_type]
+        else:
+            filtered = sorted_items
+
+        # 6. 分页
+        total = len(filtered)
+        start = (page - 1) * pagesize
+        items = filtered[start:start + pagesize]
+        hasnext = page * pagesize < total
+
+        logger.info(
+            f"合并时间线: id={self.id}, type={source_type}, "
+            f"key_node={len(key_node_items)}, statement={len(statement_items)}, "
+            f"summary={len(summary_items)}, total={total}, page={page}, pagesize={pagesize}"
+        )
+
+        return {
+            "entity_name": entity_name,
+            "entity_type": entity_type,
+            "description_summary": description_summary,
+            "total_count": total_count,
+            "type_stats": type_stats,
+            "items": items,
+            "page": {"page": page, "pagesize": pagesize, "total": total, "hasnext": hasnext},
+        }
+
+    def _collect_graph_source_items(self, raw_value, source_type: str) -> list:
+        """把图遍历返回的 statement / MemorySummary 字段转为统一 item（created_at 毫秒）。
+
+        raw_value 可能是 collect 列表（ExtractedEntity / MemorySummary 查询）或单个对象
+        （Statement 查询的 statement 字段）；CASE 未匹配会产生 None，需过滤。
+        时间无法解析（created_at 为 None）的记录直接丢弃，保证每条都有有效时间。
+        """
+        items = []
+        candidates = raw_value if isinstance(raw_value, list) else [raw_value]
+        for c in candidates:
+            if not isinstance(c, dict):
+                continue
+            text = c.get("text")
+            if text is None or str(text).strip() == "" or "MemorySummaryChunk" in str(text):
+                continue
+            created_at = self._neo4j_dt_to_ms(c.get("created_at"))
+            if created_at is None:
+                continue
+            items.append({
+                "type": source_type,
+                "category": None,
+                "title": None,
+                "text": text,
+                "created_at": created_at,
+            })
+        return items
+
+    @staticmethod
+    def _dedup_by_text(items: list) -> list:
+        """按 text 去重，保留首次出现（保留其 created_at）。"""
+        seen = set()
+        result = []
+        for item in items:
+            text = item.get("text")
+            if text in seen:
+                continue
+            seen.add(text)
+            result.append(item)
+        return result
+
+    @staticmethod
+    def _neo4j_dt_to_ms(dt):
+        """Neo4j DateTime / ISO 字符串 → Unix 毫秒时间戳（UTC）；无法解析返回 None。
+
+        统一走项目 datetime_utils：先取 ISO 字符串，parse 为 naive UTC，再转毫秒。
+        """
+        if dt is None:
+            return None
+        try:
+            if hasattr(dt, "iso_format"):
+                iso = dt.iso_format()
+            elif isinstance(dt, str):
+                iso = dt
+            else:
+                iso = str(dt)
+            return to_timestamp_ms(parse_iso_to_utc_naive(iso))
+        except Exception:
+            return None
 
     async def get_timeline_memories_server(self,model_id, language_type):
         """


### PR DESCRIPTION
…agination

- Add memory_space_entity_timeline endpoint for ExtractedEntity nodes with combined timeline (key nodes/statements/memory summaries)
- Implement source_type filtering (all/key_node/statement/memory_summary) and pagination support
- Add get_unified_timeline method to merge and deduplicate timeline items across multiple sources
- Add id_by_name class method to EventCategory for looking up category_id by Chinese name
- Add EVENT_CATEGORY_NAME_TO_ID mapping dictionary for converting Chinese category names to English IDs
- Implement _collect_graph_source_items and _dedup_by_text helper methods for timeline aggregation
- Return entity metadata (name, type, description_summary) and type_stats in timeline response
- Total count and type statistics always reflect full dataset, unaffected by source_type filtering

## Summary by Sourcery

添加一个统一的分页时间线 API，用于抽取实体（extracted entities），将关键节点事件与相关陈述和记忆摘要合并在一起，并支持可选的来源过滤以及一致的全局统计信息。

New Features:
- 暴露新的 `/memory_space/entity_timeline` 端点，用于为 `ExtractedEntity` 节点获取组合后的记忆时间线，支持分页和按来源类型过滤。
- 在 `MemoryEntityService` 上提供 `get_unified_timeline` 方法，将关键节点事件、陈述和记忆摘要中的时间线项进行聚合与排序，整合为单一的统一时间流(feed)。

Enhancements:
- 引入辅助工具，用于将图查询结果规范化为统一的时间线条目，对文本进行去重，并将 Neo4j 的 datetime 值转换为毫秒级时间戳。
- 扩展事件类别模型，增加从中文类别名称到类别 ID 的反向查找，以及用于将中文类别名称转换为响应中使用的 `category_id` 值的映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a unified paginated timeline API for extracted entities that merges key node events with related statements and memory summaries, with optional source filtering and consistent global statistics.

New Features:
- Expose a new /memory_space/entity_timeline endpoint to fetch a combined memory timeline for ExtractedEntity nodes with pagination and source-type filtering.
- Provide a get_unified_timeline method on MemoryEntityService to aggregate and sort timeline items from key node events, statements, and memory summaries into a single unified feed.

Enhancements:
- Introduce helpers to normalize graph query results into unified timeline items, deduplicate entries by text, and convert Neo4j datetime values to millisecond timestamps.
- Extend event category models with a reverse lookup from Chinese category names to category IDs and a mapping for converting Chinese category names to category_id values used in responses.

</details>