### PR TITLE
feat(web): release info

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1311,6 +1311,7 @@ export const en = {
       versionDescription: 'Version Description',
       versionDescriptionTip: 'Please describe the feature updates, bug fixes, and optimizations included in this release.',
       customTitle: 'Custom Title',
+      noIcon: 'No icon set',
       customTitlePlaceholder: 'Custom title (optional)',
       customTitleTip: 'Title will be displayed on the version card and shared page',
       customIcon: 'Custom Icon',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -694,6 +694,7 @@ export const zh = {
       versionDescription: '版本描述',
       versionDescriptionTip: '建议说明本次发布的功能更新、错误修复和优化项',
       customTitle: '自定义标题',
+      noIcon: '未设置图标',
       customTitlePlaceholder: '请输入版本展示标题 (选填)',
       customTitleTip: '标题将展示在版本卡片与对外分享页面，不填则使用应用名称',
       customIcon: '自定义图标',

--- a/web/src/views/ApplicationConfig/ReleasePage.tsx
+++ b/web/src/views/ApplicationConfig/ReleasePage.tsx
@@ -2,12 +2,12 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:29:41 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 16:19:04
+ * @Last Modified time: 2026-06-11 12:08:16
  */
 import { type FC, useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { Space, Input, Form, App, Flex, Dropdown } from 'antd';
+import { Space, Input, Form, App, Flex, Dropdown, Image } from 'antd';
 import copy from 'copy-to-clipboard';
 
 import Tag, { type TagProps } from './components/Tag'
@@ -208,6 +208,19 @@ const ReleasePage: FC<{data: Application; refresh: () => void}> = ({data, refres
                   </Form.Item>
                   <Form.Item label={t('application.editor')} className="rb:mb-0!">
                     <Input value={selectedVersion.publisher_name} disabled />
+                  </Form.Item>
+                  <Form.Item label={t('application.customTitle')} className="rb:mb-0!">
+                    <Input value={selectedVersion.name || '-'} disabled />
+                  </Form.Item>
+                  <Form.Item label={t('application.customIcon')} className="rb:mb-0!">
+                    {selectedVersion.icon
+                      ? <Image
+                        src={selectedVersion.icon}
+                        alt={selectedVersion.name || '-'}
+                        height={32}
+                      />
+                      : <Input value={t('application.noIcon')} disabled />
+                    }
                   </Form.Item>
                 </div>
               </RbCard>


### PR DESCRIPTION
## Summary by Sourcery

在应用发布页面中显示更多发布元数据，包括自定义标题和图标，并进行相应的国际化（i18n）更新。

新功能：
- 在发布详情面板中显示发布的自定义标题。
- 在发布详情面板中显示发布的自定义图标；当未设置图标时，显示本地化的占位符。

文档：
- 为发布配置中缺失的“无图标”占位文本新增英文和中文的 i18n 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display additional release metadata in the application release page, including custom title and icon, with corresponding i18n updates.

New Features:
- Show the release's custom title in the release details panel.
- Show the release's custom icon in the release details panel, or a localized placeholder when no icon is set.

Documentation:
- Add English and Chinese i18n strings for the missing "no icon" placeholder text in release configuration.

</details>