### PR TITLE
feat(metadata): introduce add/delete/update patch operations for meta…

### DIFF
--- a/api/app/aioRedis.py
+++ b/api/app/aioRedis.py
@@ -43,19 +43,29 @@ def get_thread_safe_redis() -> redis.StrictRedis:
       ``_shutdown_loop_gracefully`` which closes the loop after each run)
     """
     current_pid = os.getpid()
+    # 用 get_running_loop()：仅返回"当前正在运行"的 loop，
+    # 避免 get_event_loop() 在线程里隐式创建一个无关的新 loop。
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
+
     cached_loop = getattr(_thread_local, "loop", None)
-    loop_stale = cached_loop is not None and cached_loop.is_closed()
+    # 只要 running loop 与 cached loop 不是同一个对象（包含 cached loop 已关闭），
+    # 就必须重建连接池，否则池里的 socket 仍然绑在旧 loop 上，
+    # 在新 loop 里 await 会抛 "Future attached to a different loop"。
+    loop_changed = (
+        running_loop is not None and cached_loop is not running_loop
+    ) or (cached_loop is not None and cached_loop.is_closed())
 
     if not hasattr(_thread_local, "pool") \
             or getattr(_thread_local, "pid", None) != current_pid \
-            or loop_stale:
+            or loop_changed:
+        # 旧池由 GC 回收即可：ConnectionPool.disconnect() 是协程，
+        # 在这个同步函数里既不能 await，也不应在已离开的旧 loop 上调度，
+        # 否则会抛 "coroutine was never awaited"。
         _thread_local.pid = current_pid
-        # Python 3.10+: get_event_loop() raises RuntimeError in threads
-        # where no loop has been set yet (e.g. Celery --pool=threads).
-        try:
-            _thread_local.loop = asyncio.get_event_loop()
-        except RuntimeError:
-            _thread_local.loop = None
+        _thread_local.loop = running_loop
         _thread_local.pool = ConnectionPool.from_url(
             _REDIS_URL,
             db=settings.REDIS_DB,

--- a/api/app/core/memory/models/__init__.py
+++ b/api/app/core/memory/models/__init__.py
@@ -61,6 +61,7 @@ from app.core.memory.models.triplet_models import (
 # User metadata models
 from app.core.memory.models.metadata_models import (
     MetadataExtractionResponse,
+    MetadataOperation,
 )
 
 # Ontology scenario models (LLM extracted from scenarios)
@@ -130,6 +131,7 @@ __all__ = [
     "Triplet",
     "TripletExtractionResponse",
     "MetadataExtractionResponse",
+    "MetadataOperation",
     # Ontology models
     "OntologyClass",
     "OntologyExtractionResponse",

--- a/api/app/core/memory/models/metadata_models.py
+++ b/api/app/core/memory/models/metadata_models.py
@@ -5,76 +5,143 @@ standalone metadata extraction pipeline (post-dedup async Celery task).
 
 The field definitions align with the Jinja2 prompt template
 ``extract_user_metadata.jinja2``.
+
+Output schema: ``operations`` patch list, where each item is one of
+``add`` / ``delete`` / ``update`` against one of 8 metadata fields.
+
+The 9th field ``aliases`` referenced by the prompt template is intentionally
+filtered out at runtime — alias merging is handled by the reflection-engine
+``alias_merger`` pipeline and stays decoupled from this metadata patch flow.
 """
 
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# ── Fields managed by metadata patch ──
+# NOTE: ``aliases`` is intentionally excluded; see module docstring.
+ALLOWED_METADATA_FIELDS: tuple[str, ...] = (
+    "core_facts",
+    "traits",
+    "relations",
+    "goals",
+    "interests",
+    "beliefs_or_stances",
+    "anchors",
+    "events",
+)
+
+# Fields the prompt template documents but the runtime intentionally rejects.
+# Used to give a clearer error than "unknown field" when LLM honors the prompt
+# but ignores the runtime whitelist.
+FILTERED_METADATA_FIELDS: tuple[str, ...] = ("aliases",)
+
+OperationLiteral = Literal["add", "delete", "update"]
+
+
+class MetadataOperation(BaseModel):
+    """Single patch operation produced by the LLM.
+
+    Per the prompt template, exactly one of the following layouts is valid:
+
+    - ``add``    : ``op``, ``field``, ``value``
+    - ``delete`` : ``op``, ``field``, ``old_value``
+    - ``update`` : ``op``, ``field``, ``old_value``, ``new_value``
+
+    Validation is permissive on extra keys (LLM noise is dropped) but strict
+    on required keys per ``op``.
+
+    The ``op`` field is typed as ``Literal["add","delete","update"]`` so that
+    Pydantic / mypy reject unknown ops up-front; ``_validate_shape`` only
+    handles ``field`` whitelisting and per-op required-key combinations.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    op: OperationLiteral
+    field: str
+    value: Optional[str] = None
+    old_value: Optional[str] = None
+    new_value: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "MetadataOperation":
+        field = (self.field or "").strip()
+        if field in FILTERED_METADATA_FIELDS:
+            raise ValueError(
+                f"field {self.field!r} is filtered at runtime "
+                f"(handled by a separate pipeline)"
+            )
+        if field not in ALLOWED_METADATA_FIELDS:
+            raise ValueError(f"unknown field: {self.field!r}")
+        self.field = field
+
+        if self.op == "add":
+            v = (self.value or "").strip()
+            if not v:
+                raise ValueError("`add` operation requires non-empty `value`")
+            self.value = v
+        elif self.op == "delete":
+            ov = (self.old_value or "").strip()
+            if not ov:
+                raise ValueError("`delete` operation requires non-empty `old_value`")
+            self.old_value = ov
+        else:  # update
+            ov = (self.old_value or "").strip()
+            nv = (self.new_value or "").strip()
+            if not ov or not nv:
+                raise ValueError(
+                    "`update` operation requires both `old_value` and `new_value`"
+                )
+            self.old_value = ov
+            self.new_value = nv
+        return self
 
 
 class MetadataExtractionResponse(BaseModel):
     """LLM 元数据提取响应结构。
 
-    字段与 extract_user_metadata.jinja2 模板的输出 JSON 一一对应。
-    每个字段都是字符串数组，表示本次新增的元数据条目。
+    仅保留 ``operations`` 一个顶层字段；任何不合法或越界的 op 在
+    ``model_validator(mode="before")`` 阶段通过尝试构造 :class:`MetadataOperation`
+    静默丢弃，校验逻辑只在 ``MetadataOperation._validate_shape`` 一处。
+
+    Pydantic v2 默认 ``revalidate_instances="never"``，因此 before-validator
+    构造好的实例不会再被外层字段重新校验，没有双重校验开销。
     """
 
     model_config = ConfigDict(extra="ignore")
 
-    aliases: List[str] = Field(
+    operations: List[MetadataOperation] = Field(
         default_factory=list,
-        description="用户别名、昵称、称呼",
-    )
-    core_facts: List[str] = Field(
-        default_factory=list,
-        description="用户稳定的基础事实（身份、年龄、国籍、所在地等）",
-    )
-    traits: List[str] = Field(
-        default_factory=list,
-        description="用户稳定的人格特质、风格、行为倾向",
-    )
-    relations: List[str] = Field(
-        default_factory=list,
-        description="用户与他人/群体/宠物/重要对象之间的长期关系",
-    )
-    goals: List[str] = Field(
-        default_factory=list,
-        description="用户明确、稳定的长期目标或计划",
-    )
-    interests: List[str] = Field(
-        default_factory=list,
-        description="用户稳定的兴趣、偏好、长期爱好",
-    )
-    beliefs_or_stances: List[str] = Field(
-        default_factory=list,
-        description="用户稳定的信念、价值立场",
-    )
-    anchors: List[str] = Field(
-        default_factory=list,
-        description="对用户有长期意义的物品、收藏、纪念物",
-    )
-    events: List[str] = Field(
-        default_factory=list,
-        description="对用户画像有长期价值的个人经历、事件、里程碑",
+        description="LLM 输出的元数据 patch 操作列表",
     )
 
-    # ── 便捷属性 ──
+    @model_validator(mode="before")
+    @classmethod
+    def _filter_operations(cls, data: object) -> object:
+        """通过 try/except 静默丢弃 LLM 输出的无效 / 越界 op。
 
-    METADATA_FIELDS: List[str] = [
-        "core_facts", "traits", "relations", "goals",
-        "interests", "beliefs_or_stances", "anchors", "events",
-    ]
+        被静默丢弃的情形（均由 ``MetadataOperation._validate_shape`` 决定）：
+            - 非 dict、未知 op、未知或被白名单过滤的 field（如 ``aliases``）
+            - shape 不符（例如 ``add`` 缺 ``value``、``update`` 缺 ``new_value``）
 
-    def has_any_metadata(self) -> bool:
-        """是否提取到了任何元数据（不含 aliases）。"""
-        return any(
-            bool(getattr(self, field, []))
-            for field in self.METADATA_FIELDS
-        )
+        丢弃计数写入 ``data["_dropped_ops_count"]``，供上层 task 记日志。
+        由于 ``model_config = ConfigDict(extra="ignore")``，该 key 不会
+        出现在最终模型实例上（Pydantic 自动忽略）。
+        """
+        if not isinstance(data, dict):
+            return data
+        raw_ops = data.get("operations")
+        if not isinstance(raw_ops, list):
+            return data
 
-    def to_metadata_dict(self) -> dict:
-        """返回 8 个元数据字段的字典（不含 aliases），用于 Neo4j 回写。"""
-        return {
-            field: getattr(self, field, [])
-            for field in self.METADATA_FIELDS
-        }
+        cleaned: List[MetadataOperation] = []
+        dropped = 0
+        for item in raw_ops:
+            try:
+                cleaned.append(MetadataOperation.model_validate(item))
+            except Exception:
+                dropped += 1
+                continue
+        return {**data, "operations": cleaned, "_dropped_ops_count": dropped}

--- a/api/app/core/memory/models/metadata_models.py
+++ b/api/app/core/memory/models/metadata_models.py
@@ -14,9 +14,12 @@ filtered out at runtime — alias merging is handled by the reflection-engine
 ``alias_merger`` pipeline and stays decoupled from this metadata patch flow.
 """
 
+import logging
 from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 # ── Fields managed by metadata patch ──
@@ -138,10 +141,22 @@ class MetadataExtractionResponse(BaseModel):
 
         cleaned: List[MetadataOperation] = []
         dropped = 0
+        dropped_details: List[str] = []
         for item in raw_ops:
             try:
                 cleaned.append(MetadataOperation.model_validate(item))
-            except Exception:
+            except Exception as e:
                 dropped += 1
+                dropped_details.append(
+                    f"item={item!r}, reason={e}"
+                )
                 continue
+
+        if dropped > 0:
+            logger.warning(
+                f"[Metadata] MetadataExtractionResponse 丢弃了 {dropped}/{len(raw_ops)} 条无效 op: "
+                + "; ".join(dropped_details[:5])
+                + ("..." if dropped > 5 else "")
+            )
+
         return {**data, "operations": cleaned, "_dropped_ops_count": dropped}

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/metadata_extractor.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/metadata_extractor.py
@@ -57,7 +57,6 @@ def collect_user_entities_for_metadata(
                 "entity_id": entity.id,
                 "entity_name": entity.name,
                 "descriptions": descriptions,
-                "aliases": list(entity.aliases or []),
                 "end_user_id": entity.end_user_id,
             })
 

--- a/api/app/core/memory/storage_services/extraction_engine/steps/metadata_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/metadata_step.py
@@ -75,12 +75,23 @@ class MetadataExtractionStep(ExtractionStep[MetadataStepInput, MetadataStepOutpu
 
         仅识别新 schema 的 ``operations``。无效输出统一返回空结果，由
         上层日志告警，不再尝试任何旧 schema 的兼容回退。
+
+        ``dropped_ops_count`` 从 ``MetadataExtractionResponse`` 的 before-validator
+        传递到输出，使调用方可在日志/快照中追踪被丢弃的无效 op。
         """
         if raw_response is None:
             return self.get_default_output()
 
         operations = list(getattr(raw_response, "operations", []) or [])
-        return MetadataStepOutput(operations=operations)
+
+        # _dropped_ops_count 由 MetadataExtractionResponse._filter_operations 写入
+        # data dict；由于 extra="ignore" 不会成为实例属性，此处用 getattr 安全取值。
+        dropped_ops_count = getattr(raw_response, "_dropped_ops_count", 0) or 0
+
+        return MetadataStepOutput(
+            operations=operations,
+            dropped_ops_count=dropped_ops_count,
+        )
 
     def get_default_output(self) -> MetadataStepOutput:
         return MetadataStepOutput(operations=[])

--- a/api/app/core/memory/storage_services/extraction_engine/steps/metadata_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/metadata_step.py
@@ -1,7 +1,8 @@
 """MetadataExtractionStep — 用户实体元数据提取 step。
 
 从用户实体的 description 中提取结构化元数据（core_facts、traits、relations 等），
-通过 Celery 异步任务在去重消歧完成后执行，结果回写到 Neo4j ExtractedEntity 节点。
+通过 Celery 异步任务在去重消歧完成后执行，结果以 patch operations 的形式回写到
+Neo4j ExtractedEntity 节点。
 
 不注册为 SidecarStepFactory 的自动旁路（因为它在去重后异步执行，不在主萃取流程中），
 而是由 Celery 任务直接实例化调用。
@@ -70,20 +71,16 @@ class MetadataExtractionStep(ExtractionStep[MetadataStepInput, MetadataStepOutpu
     async def parse_response(
         self, raw_response: Any, input_data: MetadataStepInput
     ) -> MetadataStepOutput:
-        """将 LLM 响应解析为 MetadataStepOutput。"""
+        """将 LLM 响应解析为 MetadataStepOutput。
+
+        仅识别新 schema 的 ``operations``。无效输出统一返回空结果，由
+        上层日志告警，不再尝试任何旧 schema 的兼容回退。
+        """
         if raw_response is None:
             return self.get_default_output()
 
-        return MetadataStepOutput(
-            core_facts=getattr(raw_response, "core_facts", []) or [],
-            traits=getattr(raw_response, "traits", []) or [],
-            relations=getattr(raw_response, "relations", []) or [],
-            goals=getattr(raw_response, "goals", []) or [],
-            interests=getattr(raw_response, "interests", []) or [],
-            beliefs_or_stances=getattr(raw_response, "beliefs_or_stances", []) or [],
-            anchors=getattr(raw_response, "anchors", []) or [],
-            events=getattr(raw_response, "events", []) or [],
-        )
+        operations = list(getattr(raw_response, "operations", []) or [])
+        return MetadataStepOutput(operations=operations)
 
     def get_default_output(self) -> MetadataStepOutput:
-        return MetadataStepOutput()
+        return MetadataStepOutput(operations=[])

--- a/api/app/core/memory/storage_services/extraction_engine/steps/schema/sidecar_step_schema.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/schema/sidecar_step_schema.py
@@ -5,8 +5,14 @@ Sidecar steps are non-critical (is_critical=False) modules registered via
 extraction pipeline.  Failures degrade gracefully to default outputs.
 """
 
-from typing import List
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar
+
 from pydantic import BaseModel, Field
+
+from app.core.memory.models.metadata_models import (
+    ALLOWED_METADATA_FIELDS,
+    MetadataOperation,
+)
 
 
 # ── Emotion extraction (sidecar) ──
@@ -38,25 +44,62 @@ class MetadataStepInput(BaseModel):
     )
     existing_metadata: dict = Field(
         default_factory=dict,
-        description="Neo4j 中已有的元数据，用于增量去重",
+        description="Neo4j 中已有的元数据，用于增量去重 / patch old_value 校验",
     )
 
 
-class MetadataStepOutput(BaseModel):
-    """Output of MetadataExtractionStep."""
+_TItem = TypeVar("_TItem")
 
-    core_facts: List[str] = Field(default_factory=list)
-    traits: List[str] = Field(default_factory=list)
-    relations: List[str] = Field(default_factory=list)
-    goals: List[str] = Field(default_factory=list)
-    interests: List[str] = Field(default_factory=list)
-    beliefs_or_stances: List[str] = Field(default_factory=list)
-    anchors: List[str] = Field(default_factory=list)
-    events: List[str] = Field(default_factory=list)
+
+class MetadataStepOutput(BaseModel):
+    """Output of MetadataExtractionStep.
+
+    The new contract is a flat list of patch operations. Helpers below group
+    them by field for the Cypher patch query.
+    """
+
+    operations: List[MetadataOperation] = Field(default_factory=list)
 
     def has_any(self) -> bool:
-        """是否提取到了任何元数据。"""
-        return any([
-            self.core_facts, self.traits, self.relations, self.goals,
-            self.interests, self.beliefs_or_stances, self.anchors, self.events,
-        ])
+        return bool(self.operations)
+
+    def _group_by_field(
+        self,
+        op_kind: str,
+        extractor: Callable[[MetadataOperation], Optional[_TItem]],
+    ) -> Dict[str, List[_TItem]]:
+        """按 ``op.field`` 分组指定 ``op_kind`` 的 operations。
+
+        ``extractor`` 用于把 op 转成桶内元素；返回 ``None`` 视为该 op 跳过。
+        所有白名单字段都会出现在结果中（空 list），方便上层一次性拼参。
+        """
+        out: Dict[str, List[_TItem]] = {f: [] for f in ALLOWED_METADATA_FIELDS}
+        for op in self.operations:
+            if op.op != op_kind:
+                continue
+            item = extractor(op)
+            if item is None:
+                continue
+            out[op.field].append(item)
+        return out
+
+    def adds_by_field(self) -> Dict[str, List[str]]:
+        return self._group_by_field("add", lambda op: op.value or None)
+
+    def deletes_by_field(self) -> Dict[str, List[str]]:
+        return self._group_by_field("delete", lambda op: op.old_value or None)
+
+    def updates_by_field(self) -> Dict[str, List[Tuple[str, str]]]:
+        def _pair(op: MetadataOperation) -> Optional[Tuple[str, str]]:
+            if not op.old_value or not op.new_value:
+                return None
+            return op.old_value, op.new_value
+
+        return self._group_by_field("update", _pair)
+
+    def counts(self) -> Dict[str, int]:
+        result = {"add": 0, "delete": 0, "update": 0}
+        for op in self.operations:
+            if op.op in result:
+                result[op.op] += 1
+        return result

--- a/api/app/core/memory/storage_services/extraction_engine/steps/schema/sidecar_step_schema.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/schema/sidecar_step_schema.py
@@ -59,6 +59,10 @@ class MetadataStepOutput(BaseModel):
     """
 
     operations: List[MetadataOperation] = Field(default_factory=list)
+    dropped_ops_count: int = Field(
+        default=0,
+        description="被 LLM 响应校验阶段静默丢弃的无效 op 数量（格式错误/字段越界等）",
+    )
 
     def has_any(self) -> bool:
         return bool(self.operations)

--- a/api/app/core/memory/utils/prompt/prompts/extract_user_metadata.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_user_metadata.jinja2
@@ -1,32 +1,34 @@
 ===Task===
 {% if language == "zh" %}
-你是一个用户画像 metadata 增量提取助手。你的任务是根据输入的用户 `description` 列表，提取值得长期保留、适合挂在“用户节点”下的新增 metadata。
+你是一个用户画像 metadata patch 生成助手。你的任务是根据输入的用户 `description` 列表和已有 `existing_metadata`，输出可用于更新用户节点 metadata 数组属性的操作列表。
 
 你会同时收到：
 
 - `description`: 一组待分析的描述字符串
 - `existing_metadata`: 用户当前已经存在的 metadata
 
-你的目标不是重建完整 metadata，而是只输出“新增内容”：
+你的目标不是重建完整 metadata，而是只输出需要执行的 patch operations：
 
-- 只能输出从 `description` 中能够支持的新增 metadata
-- 不要重复输出已经出现在 `existing_metadata` 里的内容
-- 不允许修改、重写、删除或纠正已有 metadata
-- 所有字段一律输出为字符串数组
+- `add`: 新增一条长期有价值、且 existing_metadata 中不存在的 metadata
+- `delete`: 删除一条被 description 明确否定、撤销或取消的已有 metadata
+- `update`: 用 description 明确支持的新值替换一条已有 metadata
+- 不要输出完整 metadata
+- 不要输出没有明确证据支持的删除或修改
   {% else %}
-  You are an assistant for incremental user metadata extraction. Your task is to extract durable, user-node-level new metadata from the input `description` list.
+  You are an assistant for generating user metadata patches. Your task is to read the input `description` list and `existing_metadata`, then output operations that can update user-node metadata array properties.
 
 You will receive:
 
 - `description`: a list of descriptions to analyze
 - `existing_metadata`: the user's existing metadata
 
-Your goal is not to rebuild the full metadata. You must output only new metadata:
+Your goal is not to rebuild the full metadata. Output only patch operations:
 
-- Output only metadata supported by `description`
-- Do not repeat anything already present in `existing_metadata`
-- Do not modify, rewrite, delete, or correct existing metadata
-- Every field must be an array of strings
+- `add`: add durable metadata that is supported by `description` and not already present in `existing_metadata`
+- `delete`: delete existing metadata that is explicitly negated, revoked, or cancelled by `description`
+- `update`: replace an existing metadata item with a new value explicitly supported by `description`
+- Do not output full metadata
+- Do not output delete or update operations without clear evidence
   {% endif %}
 
 ===Inputs===
@@ -35,7 +37,6 @@ Your goal is not to rebuild the full metadata. You must output only new metadata
 
 - `description`: 字符串数组，表示关于用户的一组描述
 - `existing_metadata`: 现有 metadata 对象，字段固定为：
-  - `aliases`
   - `core_facts`
   - `traits`
   - `relations`
@@ -44,11 +45,13 @@ Your goal is not to rebuild the full metadata. You must output only new metadata
   - `beliefs_or_stances`
   - `anchors`
   - `events`
+
+注意：`aliases` 不属于本任务管辖范围，由独立的别名合并链路处理。即便 description 中
+出现了别名信息，也不要为 `aliases` 输出任何 operation。
     {% else %}
     The input JSON contains:
 - `description`: an array of strings describing the user
 - `existing_metadata`: an existing metadata object with these fixed fields:
-  - `aliases`
   - `core_facts`
   - `traits`
   - `relations`
@@ -57,6 +60,10 @@ Your goal is not to rebuild the full metadata. You must output only new metadata
   - `beliefs_or_stances`
   - `anchors`
   - `events`
+
+Note: `aliases` is out of scope for this task and is handled by a separate
+alias-merging pipeline. Even if `description` mentions alias-like information,
+do not emit any operation for `aliases`.
     {% endif %}
 
 Input JSON:
@@ -68,7 +75,7 @@ Input JSON:
 ===Field Definitions===
 {% if language == "zh" %}
 
-- `aliases`
+- `aliases` *（不在本任务管辖，列在此仅用于解释 existing_metadata，不要输出 operation）*
   - 用户的别名、昵称、称呼、英文名、稳定使用的另一个名字
 - `core_facts`
   - 用户相对稳定的基础事实，如身份、年龄、来源地、所在地、关系状态、家庭状态、长期背景
@@ -90,7 +97,7 @@ Input JSON:
   - 对用户画像有长期价值的个人经历、事件、里程碑
   - 保持字符串格式，可包含多个片段，常见格式如 `事件 | 时间 | 补充说明`
     {% else %}
-- `aliases`
+- `aliases` *(out of scope for this task; listed only to explain `existing_metadata`. Do not emit operations for it.)*
   - aliases, nicknames, stable alternative names, English names, or regular forms of address
 - `core_facts`
   - stable basic facts such as identity, age, origin, residence, relationship status, family status, or long-term background
@@ -116,26 +123,19 @@ Input JSON:
 ===Core Principles===
 {% if language == "zh" %}
 
-1. 只提取新增内容
+1. 输出 patch，不输出完整 metadata
 
-- 如果某条信息已经在 `existing_metadata` 中出现，不能再次输出
-- 即使 `description` 只是换了一种说法表达已有信息，也不要重复输出
-- 如果只是轻微改写、近义改写、语序调整，也视为重复
+- 只输出 `operations` 数组
+- 如果没有任何需要执行的操作，输出 `{"operations": []}`
+- 不要按 8 个字段分别输出数组
 
-2. 不修改已有内容
-
-- 不要纠正已有 metadata 的措辞
-- 不要补全已有 metadata 的结构
-- 不要把已有 metadata 中的短字符串改写成更长版本后再输出
-- 不要因为 `description` 出现了更精确表达，就把已有内容升级后重新输出
-
-3. 只保留对用户画像有长期价值的信息
+2. 只保留对用户画像有长期价值的信息
 
 - 优先提取稳定身份、长期偏好、重要关系、重大目标、长期立场、重要锚点、关键事件
 - 不要提取纯闲聊、瞬时感受、一次性很弱的细节
 - 短暂情绪通常不单独提取，除非它是某个重要事件说明的一部分
 
-4. 最小语义完整单元
+3. 最小语义完整单元
 
 - 每个 metadata 条目都应尽量保留“最小但语义完整”的信息
 - 不要退化成脱离上下文后意义不足的裸名词、裸地名、裸主题词、裸事件名
@@ -144,46 +144,40 @@ Input JSON:
 - 优先保留类似 `在上海工作`、`来自湖南长沙`、`申请领养机构`、`参加 pride parade | 3 July 2023` 这样的形式
 - 避免输出类似 `上海`、`湖南长沙`、`家庭`、`pride parade` 这种信息残缺的条目
 
-5. 所有字段都必须是字符串数组
+4. 操作值保持字符串形式
 
-- 不允许输出对象数组
-- 不允许输出嵌套结构
+- `value`、`old_value`、`new_value` 都必须是字符串
+- 不允许输出对象值、嵌套结构或数组值
 - 不允许把 `events` 拆成 event/time/note 对象
 - 不允许把 `relations` 拆成结构化对象
 
-6. 可以保留多段信息在一个字符串里
+5. 可以保留多段信息在一个字符串里
 
 - `relations`、`anchors`、`events` 可以使用 `|` 连接多个片段
 - 只有在确实有助于保留结构时才这样做
 - 不必强行补满固定片段数，宁可简洁准确
 
-7. 证据边界
+6. 证据边界
 
-- 只能依据 `description` 提取新增 metadata
-- `existing_metadata` 只用于去重和分类参考，不是新增内容来源
+- 只能依据 `description` 决定是否新增、删除或修改 metadata
+- `existing_metadata` 用于去重、分类参考，以及为 `delete/update` 精确定位旧值
 - 不要从常识、推测或世界知识补充额外信息
 - 但允许从复合表述中识别并提取属于字段定义范围内的蕴含事实。例如 `single parent` 蕴含了关系状态和家庭状态，可以提取为 core_fact。但仅限于该蕴含信息本身属于某个字段的定义范围且具有长期画像价值。不要泛化提取所有修饰词或临时状态
   {% else %}
 
-1. Extract only new content
+1. Output patches, not full metadata
 
-- If something already appears in `existing_metadata`, do not output it again
-- If a description merely paraphrases existing metadata, do not output it
-- Minor wording changes, synonym swaps, or reordered phrasing still count as duplicates
+- Output only the `operations` array
+- If there are no operations to perform, output `{"operations": []}`
+- Do not output separate arrays for the 8 metadata fields
 
-2. Do not modify existing content
-
-- Do not correct wording in existing metadata
-- Do not expand existing metadata and re-output it
-- Do not upgrade an existing item into a more detailed version and emit it as new
-
-3. Keep only durable user-profile information
+2. Keep only durable user-profile information
 
 - Prioritize stable identity, long-term preferences, important relationships, major goals, durable stances, meaningful anchors, and key events
 - Exclude casual chatter, fleeting states, and weak one-off details
 - Temporary emotions should usually not be extracted unless they are part of an important event description
 
-4. Minimal Semantically Complete Unit
+3. Minimal Semantically Complete Unit
 
 - Each metadata item should preserve the smallest semantically complete unit
 - Do not reduce items to bare nouns, bare place names, bare topic labels, or bare event names when that loses key meaning
@@ -192,32 +186,46 @@ Input JSON:
 - Prefer forms like `works in Shanghai`, `from Hunan Changsha`, `applied to adoption agencies`, or `attended pride parade | 3 July 2023`
 - Avoid low-information items like `Shanghai`, `Hunan Changsha`, `family`, or `pride parade` when they are semantically incomplete
 
-5. Every field must be an array of strings
+4. Operation values remain strings
 
-- No object arrays
-- No nested structure
+- `value`, `old_value`, and `new_value` must be strings
+- Do not output object values, nested structures, or array values
 - Do not split `events` into event/time/note objects
 - Do not split `relations` into structured objects
 
-6. Multi-part strings are allowed
+5. Multi-part strings are allowed
 
 - `relations`, `anchors`, and `events` may use `|` to join parts
 - Do this only when it helps preserve useful structure
 - Do not force a fixed number of parts
 
-7. Evidence boundary
+6. Evidence boundary
 
-- Extract new metadata only from `description`
-- Use `existing_metadata` only for deduplication and category reference
+- Use only `description` to decide whether to add, delete, or update metadata
+- Use `existing_metadata` for deduplication, category reference, and exact old-value targeting for `delete/update`
 - Do not add unsupported information from world knowledge or inference beyond the text
 - However, you may extract implied facts from compound expressions when they fall within a field's defined scope. For example, `single parent` implies relationship status and family status, and may be extracted as a core_fact. This is allowed only when the implied information belongs to a field's definition and has durable profile value. Do not over-extract every modifier or transient state
   {% endif %}
 
-===Deduplication Rules===
+===Operation Rules===
 {% if language == "zh" %}
 
+- `add`
+  - 当 description 支持一条新的长期画像 metadata，且 existing_metadata 中没有等价内容时输出
+  - 如果某条信息已经存在、近义存在、或只是轻微改写，不要 add
+- `delete`
+  - 只有当 description 明确否定、撤销、取消、结束或声明某条已有 metadata 不再成立时才输出
+  - `old_value` 必须从 `existing_metadata[field]` 中原样复制，不得改写
+  - 如果无法唯一定位旧值，不要输出 delete
+- `update`
+  - 只有当 description 明确表达某条已有 metadata 被新事实替代时才输出
+  - `old_value` 必须从 `existing_metadata[field]` 中原样复制，不得改写
+  - `new_value` 必须是 description 支持的最小语义完整字符串
+  - 如果只是更精确表达、轻微补写、风格改写，且不构成明确替代，不要 update
+- 临时、短期、旅行、出差、暂住、最近几天/几周等信息，不得覆盖长期画像
+- 不确定是否应该 delete/update 时，不要输出 delete/update
 - 先理解 `description` 想表达的含义，再与 `existing_metadata` 做语义去重
-- 若以下任一情况成立，则视为已存在，不要输出：
+- 对 add 来说，若以下任一情况成立，则视为已存在，不要输出：
   - 完全相同
   - 近义表达
   - 更长或更短但语义相同
@@ -225,8 +233,22 @@ Input JSON:
   - 只是把已有事件或关系中的时间或备注略作改写
 - 去重标准以“是否新增了值得保留的新事实”为准，而不是字面是否完全一致
   {% else %}
+- `add`
+  - Output when `description` supports a new durable metadata item and no equivalent item exists in `existing_metadata`
+  - Do not add if the item already exists, exists as a paraphrase, or is only a light rewording
+- `delete`
+  - Output only when `description` explicitly negates, revokes, cancels, ends, or says an existing metadata item is no longer true
+  - `old_value` must be copied exactly from `existing_metadata[field]`; do not rewrite it
+  - If the old item cannot be uniquely located, do not output delete
+- `update`
+  - Output only when `description` clearly says an existing metadata item has been replaced by a new fact
+  - `old_value` must be copied exactly from `existing_metadata[field]`; do not rewrite it
+  - `new_value` must be a minimal semantically complete string supported by `description`
+  - Do not update for mere precision improvements, light expansions, or style rewrites unless they are a clear replacement
+- Temporary, short-term, travel, business-trip, short-stay, or recent-days/weeks information must not overwrite durable profile metadata
+- If unsure whether to delete or update, do not output delete/update
 - First understand the meaning of the description, then deduplicate semantically against `existing_metadata`
-- Treat an item as already existing if any of these holds:
+- For add operations, treat an item as already existing if any of these holds:
   - exact match
   - close paraphrase
   - longer or shorter wording with the same meaning
@@ -277,6 +299,9 @@ Input JSON:
 
 - 只收稳定兴趣
 - 短期尝试一次某事，通常不算 interest
+- 不要把带有稳定行为的信息退化成裸主题词
+- 如果 description 表达的是持续学习、稳定训练、长期参与、经常创作等行为，应保留最小完整行为短语
+- 例如 `稳定参加攀岩训练` 好于 `攀岩`，`长期学习混音` 好于 `混音`
 
 `beliefs_or_stances`
 
@@ -340,6 +365,9 @@ Input JSON:
 
 - only stable interests
 - a one-time attempt usually does not qualify
+- Do not reduce stable activity information to a bare topic label
+- If `description` expresses ongoing learning, stable training, long-term participation, frequent creation, or similar behavior, preserve the smallest complete activity phrase
+- For example, `regularly attends climbing training` is better than `climbing`, and `long-term learning music mixing` is better than `music mixing`
 
 `beliefs_or_stances`
 
@@ -367,27 +395,39 @@ Input JSON:
 ===Output Hard Constraints===
 {% if language == "zh" %}
 
-- 只输出新增 metadata，不要输出完整 metadata
-- 结果必须包含全部 9 个字段
-- 每个字段都必须是数组
-- 即使某字段没有新增内容，也必须输出空数组
-- 每个数组元素必须是字符串
+- 只输出 metadata patch operations，不要输出完整 metadata
+- 结果必须只包含一个顶层键：`operations`
+- `operations` 必须是数组
+- 如果没有任何操作，输出空数组
+- 每个 operation 必须是对象
+- 每个 operation 的 `op` 只能是 `"add"`、`"delete"`、`"update"`
+- 每个 operation 的 `field` 必须是 8 个固定字段之一（不包含 `aliases`）
+- `add` operation 必须包含且只包含：`op`、`field`、`value`
+- `delete` operation 必须包含且只包含：`op`、`field`、`old_value`
+- `update` operation 必须包含且只包含：`op`、`field`、`old_value`、`new_value`
+- `old_value` 必须从对应的 `existing_metadata[field]` 中原样复制
+- `value`、`old_value`、`new_value` 都必须是字符串
 - 不要输出 `null`
 - 不要输出解释文字
 - 不要输出 markdown code fence
-- 不要输出字段之外的任何额外键
-- 如果没有任何新增 metadata，也必须返回所有字段都为空数组的 JSON
+- 不要输出任何额外键
   {% else %}
-- Output only new metadata, not the full metadata
-- The result must include all 9 fields
-- Every field must be an array
-- Use empty arrays when there is no new content
-- Every array element must be a string
+- Output only metadata patch operations, not the full metadata
+- The result must contain exactly one top-level key: `operations`
+- `operations` must be an array
+- Use an empty array when there are no operations
+- Each operation must be an object
+- Each operation's `op` must be exactly one of `"add"`, `"delete"`, or `"update"`
+- Each operation's `field` must be one of the 8 fixed metadata fields (not `aliases`)
+- An `add` operation must contain exactly: `op`, `field`, `value`
+- A `delete` operation must contain exactly: `op`, `field`, `old_value`
+- An `update` operation must contain exactly: `op`, `field`, `old_value`, `new_value`
+- `old_value` must be copied exactly from the corresponding `existing_metadata[field]`
+- `value`, `old_value`, and `new_value` must be strings
 - Do not output `null`
 - Do not output explanation text
 - Do not wrap the result in markdown code fences
-- Do not output any keys beyond the required fields
-- If there is no new metadata, still return the full JSON shape with empty arrays
+- Do not output any extra keys
   {% endif %}
 
 ===Examples===
@@ -402,16 +442,12 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": [
-    "started volunteering for a trans youth hotline"
+  "operations": [
+    {
+      "op": "add",
+      "field": "events",
+      "value": "started volunteering for a trans youth hotline"
+    }
   ]
 }
 
@@ -426,15 +462,7 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": []
 }
 
 示例 3
@@ -447,17 +475,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [
-    "Mia | sister"
-  ],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "relations",
+      "value": "Mia | sister"
+    }
+  ]
 }
 
 示例 4
@@ -470,17 +494,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [
-    "journal | from first year after moving"
-  ],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "anchors",
+      "value": "journal | from first year after moving"
+    }
+  ]
 }
 
 示例 5
@@ -493,16 +513,12 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": [
-    "attended workshop on trauma-informed care | last month | clarified future direction"
+  "operations": [
+    {
+      "op": "add",
+      "field": "events",
+      "value": "attended workshop on trauma-informed care | last month | clarified future direction"
+    }
   ]
 }
 
@@ -516,17 +532,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [
-    "在上海工作"
-  ],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "core_facts",
+      "value": "在上海工作"
+    }
+  ]
 }
 
 示例 7
@@ -539,17 +551,65 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [
-    "来自湖南长沙"
-  ],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "core_facts",
+      "value": "来自湖南长沙"
+    }
+  ]
+}
+
+示例 8
+Input:
+
+- description:
+  - "用户明确说自己已经不再申请英国研究生。"
+- existing_metadata:
+  - goals: ["申请英国研究生"]
+
+Output:
+{
+  "operations": [
+    {
+      "op": "delete",
+      "field": "goals",
+      "old_value": "申请英国研究生"
+    }
+  ]
+}
+
+示例 9
+Input:
+
+- description:
+  - "用户已经搬到上海长期居住。"
+- existing_metadata:
+  - core_facts: ["住在北京"]
+
+Output:
+{
+  "operations": [
+    {
+      "op": "update",
+      "field": "core_facts",
+      "old_value": "住在北京",
+      "new_value": "长期住在上海"
+    }
+  ]
+}
+
+示例 10
+Input:
+
+- description:
+  - "用户这两周临时住在上海。"
+- existing_metadata:
+  - core_facts: ["住在北京"]
+
+Output:
+{
+  "operations": []
 }
 {% else %}
 Example 1
@@ -562,16 +622,12 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": [
-    "started volunteering for a trans youth hotline"
+  "operations": [
+    {
+      "op": "add",
+      "field": "events",
+      "value": "started volunteering for a trans youth hotline"
+    }
   ]
 }
 
@@ -586,15 +642,7 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": []
 }
 
 Example 3
@@ -607,17 +655,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [
-    "Mia | sister"
-  ],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "relations",
+      "value": "Mia | sister"
+    }
+  ]
 }
 
 Example 4
@@ -630,17 +674,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [
-    "journal | from first year after moving"
-  ],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "anchors",
+      "value": "journal | from first year after moving"
+    }
+  ]
 }
 
 Example 5
@@ -653,16 +693,12 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": [
-    "attended workshop on trauma-informed care | last month | clarified future direction"
+  "operations": [
+    {
+      "op": "add",
+      "field": "events",
+      "value": "attended workshop on trauma-informed care | last month | clarified future direction"
+    }
   ]
 }
 
@@ -676,17 +712,13 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [
-    "works in Shanghai"
-  ],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "core_facts",
+      "value": "works in Shanghai"
+    }
+  ]
 }
 
 Example 7
@@ -699,17 +731,65 @@ Input:
 
 Output:
 {
-  "aliases": [],
-  "core_facts": [
-    "from Hunan Changsha"
-  ],
-  "traits": [],
-  "relations": [],
-  "goals": [],
-  "interests": [],
-  "beliefs_or_stances": [],
-  "anchors": [],
-  "events": []
+  "operations": [
+    {
+      "op": "add",
+      "field": "core_facts",
+      "value": "from Hunan Changsha"
+    }
+  ]
+}
+
+Example 8
+Input:
+
+- description:
+  - "The user explicitly said they are no longer applying to UK graduate schools."
+- existing_metadata:
+  - goals: ["apply to UK graduate schools"]
+
+Output:
+{
+  "operations": [
+    {
+      "op": "delete",
+      "field": "goals",
+      "old_value": "apply to UK graduate schools"
+    }
+  ]
+}
+
+Example 9
+Input:
+
+- description:
+  - "The user has moved to Shanghai and now lives there long-term."
+- existing_metadata:
+  - core_facts: ["lives in Beijing"]
+
+Output:
+{
+  "operations": [
+    {
+      "op": "update",
+      "field": "core_facts",
+      "old_value": "lives in Beijing",
+      "new_value": "lives in Shanghai long-term"
+    }
+  ]
+}
+
+Example 10
+Input:
+
+- description:
+  - "The user is temporarily staying in Shanghai for two weeks."
+- existing_metadata:
+  - core_facts: ["lives in Beijing"]
+
+Output:
+{
+  "operations": []
 }
 {% endif %}
 
@@ -738,15 +818,24 @@ Return a strict JSON object with this exact structure:
 
 ```json
 {
-  "aliases": ["string"],
-  "core_facts": ["string"],
-  "traits": ["string"],
-  "relations": ["string"],
-  "goals": ["string"],
-  "interests": ["string"],
-  "beliefs_or_stances": ["string"],
-  "anchors": ["string"],
-  "events": ["string"]
+  "operations": [
+    {
+      "op": "add",
+      "field": "core_facts",
+      "value": "string"
+    },
+    {
+      "op": "delete",
+      "field": "goals",
+      "old_value": "string"
+    },
+    {
+      "op": "update",
+      "field": "core_facts",
+      "old_value": "string",
+      "new_value": "string"
+    }
+  ]
 }
 ```
 
@@ -757,7 +846,7 @@ JSON 要求：
 - 不要使用中文引号
 - 不要在 JSON 外输出任何文字
 - 字符串内如果包含双引号，必须转义为 `\"`
-- 不要遗漏字段
+- 顶层只允许输出 `operations`
 - 不要输出尾逗号
 - metadata 字符串语言必须与输入 `description` 的主要语言一致
   {% else %}
@@ -766,7 +855,7 @@ JSON 要求：
 - No smart quotes
 - Output JSON only
 - Escape internal quotes as `\"`
-- Do not omit any field
+- Output only the top-level `operations` key
 - Do not emit trailing commas
 - Metadata string language must match the primary language of the input `description`
   {% endif %}

--- a/api/app/repositories/end_user_info_repository.py
+++ b/api/app/repositories/end_user_info_repository.py
@@ -70,76 +70,62 @@ class EndUserInfoRepository:
         logger.info(f"删除用户所有信息记录: end_user_id={end_user_id}, count={count}")
         return count
 
-    def update_aliases_and_metadata(
+    def replace_metadata_fields(
         self,
         end_user_id: uuid.UUID,
-        new_aliases: Optional[List[str]] = None,
-        new_metadata: Optional[dict] = None,
-    ) -> Optional[EndUserInfo]:
-        """增量更新用户别名列表和元数据。
+        metadata: Dict[str, List[str]],
+    ) -> Optional["EndUserInfo"]:
+        """以 Neo4j 为权威源，覆盖 ``meta_data`` 中指定字段。
 
-        - aliases：将 new_aliases 合并到现有列表（去重，忽略大小写），不覆盖
-        - meta_data：将 new_metadata 的各字段列表合并到现有 meta_data（去重），不覆盖
-        - other_name：若当前为空且 aliases 非空，则取 aliases[0] 作为 other_name
+        语义：
+            - 只覆盖 ``metadata`` 中显式提供的 key；其他 key 原样保留
+              （避免误伤未管理字段或别的链路写入的内容）
+            - ``aliases`` 与 ``other_name`` 不在本方法管辖范围内，原值保留
+            - 入参 dict 的 value 必须是 list；非 list 类型会被忽略
 
         Args:
             end_user_id: 终端用户 ID
-            new_aliases: 本次新增的别名列表
-            new_metadata: 本次提取的 extracted_metadata 字典
+            metadata: 要覆盖的字段字典，例如
+                {"core_facts": [...], "traits": [...], ...}
 
         Returns:
-            更新后的 EndUserInfo，若记录不存在则返回 None
+            更新后的 EndUserInfo；记录不存在时返回 None
         """
+        if not metadata:
+            return self.get_by_end_user_id(end_user_id)
+
         end_user_info = self.get_by_end_user_id(end_user_id)
         if not end_user_info:
-            logger.warning(f"[EndUserInfo] 记录不存在，跳过更新: end_user_id={end_user_id}")
+            logger.warning(
+                f"[EndUserInfo] 记录不存在，跳过 metadata 覆盖: end_user_id={end_user_id}"
+            )
             return None
 
+        existing_meta = dict(end_user_info.meta_data or {})
         changed = False
-
-        # ── 合并 aliases（去重，忽略大小写）──
-        if new_aliases:
-            existing = list(end_user_info.aliases or [])
-            existing_lower = {a.lower() for a in existing}
-            for alias in new_aliases:
-                alias = alias.strip()
-                if alias and alias.lower() not in existing_lower:
-                    existing.append(alias)
-                    existing_lower.add(alias.lower())
-            end_user_info.aliases = existing
+        for field, values in metadata.items():
+            if not isinstance(values, list):
+                logger.warning(
+                    f"[EndUserInfo] meta_data.{field} 期望 list，实际为 "
+                    f"{type(values).__name__}，已跳过该字段: end_user_id={end_user_id}"
+                )
+                continue
+            existing_meta[field] = list(values)
             changed = True
 
-        # ── 同步 other_name：取 aliases[0]（若当前为空）──
-        if end_user_info.aliases and not (end_user_info.other_name or "").strip():
-            end_user_info.other_name = end_user_info.aliases[0]
-            changed = True
+        if not changed:
+            return end_user_info
 
-        # ── 合并 meta_data（各字段列表去重追加）──
-        if new_metadata:
-            existing_meta = dict(end_user_info.meta_data or {})
-            for field, values in new_metadata.items():
-                if not isinstance(values, list):
-                    continue
-                existing_list = list(existing_meta.get(field) or [])
-                existing_set = {str(v).lower() for v in existing_list}
-                for v in values:
-                    if str(v).lower() not in existing_set:
-                        existing_list.append(v)
-                        existing_set.add(str(v).lower())
-                existing_meta[field] = existing_list
-            end_user_info.meta_data = existing_meta
-            changed = True
-
-        if changed:
-            self.db.commit()
-            self.db.refresh(end_user_info)
-            logger.info(
-                f"[EndUserInfo] 更新完成: end_user_id={end_user_id}, "
-                f"aliases_count={len(end_user_info.aliases or [])}"
-            )
+        end_user_info.meta_data = existing_meta
+        self.db.commit()
+        self.db.refresh(end_user_info)
+        logger.info(
+            f"[EndUserInfo] meta_data 字段覆盖完成: end_user_id={end_user_id}, "
+            f"fields={list(metadata.keys())}"
+        )
         return end_user_info
 
-    def remove_aliases(
+    def remove_aliases( # NOTE：刘淼 别名移除
         self,
         end_user_id: uuid.UUID,
         aliases_to_remove: List[str],

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -135,56 +135,108 @@ SET e.name = CASE WHEN entity.name IS NOT NULL AND entity.name <> '' THEN entity
 RETURN e.id AS uuid
 """
 
-# ── 元数据增量回写：将 LLM 提取的元数据追加到用户实体节点 ──
-ENTITY_METADATA_UPDATE = """
-MATCH (e:ExtractedEntity {id: $entity_id})
-SET e.core_facts = CASE
-        WHEN $core_facts IS NOT NULL AND size($core_facts) > 0
-        THEN reduce(acc = coalesce(e.core_facts, []), item IN $core_facts |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.core_facts, []) END,
-    e.traits = CASE
-        WHEN $traits IS NOT NULL AND size($traits) > 0
-        THEN reduce(acc = coalesce(e.traits, []), item IN $traits |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.traits, []) END,
-    e.relations = CASE
-        WHEN $relations IS NOT NULL AND size($relations) > 0
-        THEN reduce(acc = coalesce(e.relations, []), item IN $relations |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.relations, []) END,
-    e.goals = CASE
-        WHEN $goals IS NOT NULL AND size($goals) > 0
-        THEN reduce(acc = coalesce(e.goals, []), item IN $goals |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.goals, []) END,
-    e.interests = CASE
-        WHEN $interests IS NOT NULL AND size($interests) > 0
-        THEN reduce(acc = coalesce(e.interests, []), item IN $interests |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.interests, []) END,
-    e.beliefs_or_stances = CASE
-        WHEN $beliefs_or_stances IS NOT NULL AND size($beliefs_or_stances) > 0
-        THEN reduce(acc = coalesce(e.beliefs_or_stances, []), item IN $beliefs_or_stances |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.beliefs_or_stances, []) END,
-    e.anchors = CASE
-        WHEN $anchors IS NOT NULL AND size($anchors) > 0
-        THEN reduce(acc = coalesce(e.anchors, []), item IN $anchors |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.anchors, []) END,
-    e.events = CASE
-        WHEN $events IS NOT NULL AND size($events) > 0
-        THEN reduce(acc = coalesce(e.events, []), item IN $events |
-            CASE WHEN item IN acc THEN acc ELSE acc + item END)
-        ELSE coalesce(e.events, []) END
-RETURN e.id AS uuid
-"""
-
 # ── 查询用户实体已有的元数据（供增量提取时去重） ──
 ENTITY_METADATA_QUERY = """
 MATCH (e:ExtractedEntity {id: $entity_id})
 RETURN e.core_facts AS core_facts,
+       e.traits AS traits,
+       e.relations AS relations,
+       e.goals AS goals,
+       e.interests AS interests,
+       e.beliefs_or_stances AS beliefs_or_stances,
+       e.anchors AS anchors,
+       e.events AS events
+"""
+
+# ── 元数据 patch 回写：对 8 字段统一应用 delete / update / add 三段操作 ──
+# 设计要点：
+#   1. 8 个字段一次原子 SET，纯 Cypher（不依赖 APOC），无 race 风险
+#   2. delete: [x IN list WHERE NOT x IN $field_delete] —— 仅精确剔除被指名项
+#   3. update: [x IN list | CASE WHEN x = pair.old THEN pair.new ELSE x END]
+#              对每个 (old, new) pair 顺序应用一次，匹配不到则保持原值
+#   4. add:    reduce 去重追加，原值不会丢失
+#   5. 输入参数（每字段三类）：
+#        $<field>_delete : List[str]
+#        $<field>_update : List[{old: str, new: str}]
+#        $<field>_add    : List[str]
+#      上层调用方对未变更字段传空数组即可，避免 Cypher 内部出现 NULL 分支。
+ENTITY_METADATA_PATCH = """
+MATCH (e:ExtractedEntity {id: $entity_id})
+
+// ── core_facts ──
+WITH e,
+     [x IN coalesce(e.core_facts, []) WHERE NOT x IN $core_facts_delete] AS cf0
+WITH e, reduce(acc = cf0, pair IN $core_facts_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS cf1
+WITH e, reduce(acc = cf1, item IN $core_facts_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS cf2
+SET e.core_facts = cf2
+
+// ── traits ──
+WITH e,
+     [x IN coalesce(e.traits, []) WHERE NOT x IN $traits_delete] AS tr0
+WITH e, reduce(acc = tr0, pair IN $traits_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS tr1
+WITH e, reduce(acc = tr1, item IN $traits_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS tr2
+SET e.traits = tr2
+
+// ── relations ──
+WITH e,
+     [x IN coalesce(e.relations, []) WHERE NOT x IN $relations_delete] AS re0
+WITH e, reduce(acc = re0, pair IN $relations_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS re1
+WITH e, reduce(acc = re1, item IN $relations_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS re2
+SET e.relations = re2
+
+// ── goals ──
+WITH e,
+     [x IN coalesce(e.goals, []) WHERE NOT x IN $goals_delete] AS go0
+WITH e, reduce(acc = go0, pair IN $goals_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS go1
+WITH e, reduce(acc = go1, item IN $goals_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS go2
+SET e.goals = go2
+
+// ── interests ──
+WITH e,
+     [x IN coalesce(e.interests, []) WHERE NOT x IN $interests_delete] AS in0
+WITH e, reduce(acc = in0, pair IN $interests_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS in1
+WITH e, reduce(acc = in1, item IN $interests_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS in2
+SET e.interests = in2
+
+// ── beliefs_or_stances ──
+WITH e,
+     [x IN coalesce(e.beliefs_or_stances, []) WHERE NOT x IN $beliefs_or_stances_delete] AS be0
+WITH e, reduce(acc = be0, pair IN $beliefs_or_stances_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS be1
+WITH e, reduce(acc = be1, item IN $beliefs_or_stances_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS be2
+SET e.beliefs_or_stances = be2
+
+// ── anchors ──
+WITH e,
+     [x IN coalesce(e.anchors, []) WHERE NOT x IN $anchors_delete] AS an0
+WITH e, reduce(acc = an0, pair IN $anchors_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS an1
+WITH e, reduce(acc = an1, item IN $anchors_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS an2
+SET e.anchors = an2
+
+// ── events ──
+WITH e,
+     [x IN coalesce(e.events, []) WHERE NOT x IN $events_delete] AS ev0
+WITH e, reduce(acc = ev0, pair IN $events_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS ev1
+WITH e, reduce(acc = ev1, item IN $events_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS ev2
+SET e.events = ev2
+
+RETURN e.id AS uuid,
+       e.core_facts AS core_facts,
        e.traits AS traits,
        e.relations AS relations,
        e.goals AS goals,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2491,61 +2491,55 @@ def layer2_dedup_full_scan_task(self) -> Dict[str, Any]:
     logger.info(f"反思引擎去重消岐全量扫描任务完成，耗时 {result['elapsed_time']:.1f}s")
     return result
 
-def _sync_end_user_info_pg(
+def _sync_metadata_to_pg(
     end_user_id: str,
-    aliases: List[str],
-    extracted_metadata: Optional[Dict[str, Any]],
+    metadata: Dict[str, List[str]],
 ) -> None:
-    """将别名和元数据增量同步到 PostgreSQL end_user_info 表。
+    """以 Neo4j patch 后的最新值覆盖 PG end_user_info.meta_data 中对应 key。
 
-    - aliases 合并到 end_user_info.aliases（去重）
-    - end_user_info.other_name 若为空则取 aliases[0]
-    - end_user.other_name 与 end_user_info.other_name 保持同步
-    - extracted_metadata 各字段列表合并到 end_user_info.meta_data（去重）
+    此函数仅处理 8 个被 metadata patch 管理的字段（core_facts、traits、
+    relations、goals、interests、beliefs_or_stances、anchors、events）。
+    `aliases` 和 `other_name` 不在本函数管辖范围内（保持原有别名同步链路）。
 
-    失败只记日志，不抛异常，不影响主流程。
+    覆盖语义但不丢失历史的两道保护：
+        1. 入参 metadata 来自 Neo4j patch 后的最新读回值——它已经叠加了历史
+        2. 仅覆盖 metadata 中显式提供的 key，`meta_data` 里其它 key 原样保留
+
+    早返回与副作用：
+        - 当 ``metadata`` 为空 dict 时直接返回，不读取也不更新 PG，
+          因此不会刷新 ``end_user_info`` 的 ``updated_at``。下游若依赖该
+          时间戳判断"上次同步时间"，需要自行处理"零变更"场景。
+        - 失败只记日志，不抛异常，不影响主流程。
     """
+    if not metadata:
+        return
     try:
         import uuid as _uuid
         from app.db import get_db_context
         from app.repositories.end_user_info_repository import EndUserInfoRepository
-        from app.repositories.end_user_repository import EndUserRepository
 
         eu_uuid = _uuid.UUID(end_user_id)
 
         with get_db_context() as db:
             info_repo = EndUserInfoRepository(db)
-            info = info_repo.update_aliases_and_metadata(
+            info = info_repo.replace_metadata_fields(
                 end_user_id=eu_uuid,
-                new_aliases=aliases or [],
-                new_metadata=extracted_metadata,
+                metadata=metadata,
             )
             if info is None:
                 logger.warning(
-                    f"[Metadata][PG] end_user_info 记录不存在，跳过同步: end_user_id={end_user_id}"
+                    f"[Metadata][PG] end_user_info 记录不存在，跳过 metadata 覆盖: "
+                    f"end_user_id={end_user_id}"
                 )
                 return
 
-            # 同步 end_user.other_name（与 end_user_info.other_name 保持一致）
-            new_other_name = (info.other_name or "").strip()
-            if new_other_name:
-                eu_repo = EndUserRepository(db)
-                end_user = eu_repo.get_end_user_by_id(eu_uuid)
-                if end_user and not (end_user.other_name or "").strip():
-                    end_user.other_name = new_other_name
-                    db.commit()
-                    logger.info(
-                        f"[Metadata][PG] 同步 end_user.other_name={new_other_name}: "
-                        f"end_user_id={end_user_id}"
-                    )
-
         logger.info(
-            f"[Metadata][PG] end_user_info 同步完成: end_user_id={end_user_id}, "
-            f"aliases_count={len(aliases or [])}"
+            f"[Metadata][PG] end_user_info.meta_data 覆盖完成: "
+            f"end_user_id={end_user_id}, fields={list(metadata.keys())}"
         )
     except Exception as e:
         logger.warning(
-            f"[Metadata][PG] 同步 end_user_info 失败（不影响主流程）: "
+            f"[Metadata][PG] 覆盖 end_user_info.meta_data 失败（不影响主流程）: "
             f"end_user_id={end_user_id}, error={e}",
             exc_info=True,
         )
@@ -2556,6 +2550,8 @@ def _sync_end_user_info_pg(
     name="app.tasks.extract_metadata_batch",
     max_retries=2,
     default_retry_delay=30,
+    soft_time_limit=90,
+    time_limit=120,
 )
 def extract_metadata_batch_task(
     self,
@@ -2568,15 +2564,20 @@ def extract_metadata_batch_task(
 
     在主写入流水线完成后异步执行。从用户实体的 description 中提取
     结构化元数据（core_facts、traits、relations 等），增量回写到 Neo4j，
-    同时将 aliases 和 extracted_metadata 同步到 PostgreSQL end_user_info 表。
+    随后以 Neo4j 为权威源覆盖 PostgreSQL end_user_info.meta_data 中
+    对应的 8 个字段。aliases / other_name 由反思阶段的 alias_merger
+    单独承接，本任务不再触发别名同步。
 
     Args:
-        user_entities: 用户实体列表，每项包含:
+        user_entities: 用户实体列表，每项预期包含:
             - entity_id: 实体 ID
             - entity_name: 实体名称
             - descriptions: description 文本列表
-            - aliases: 实体别名列表（来自 "别名属于" 关系归并后的结果）
             - end_user_id: 终端用户 ID（用于写入 PostgreSQL）
+
+            注：上游 collector（``collect_user_entities_for_metadata``）当前
+            还会附带 ``aliases`` 字段，本任务**显式忽略**该字段。别名同步由
+            reflection 阶段的 ``alias_merger`` 单独承接。
         llm_model_id: LLM 模型 UUID 字符串
         language: 语言 ("zh" / "en")
         snapshot_dir: 可选的快照目录路径（调试模式下使用）
@@ -2594,16 +2595,27 @@ def extract_metadata_batch_task(
         return {"status": "SUCCESS", "total": 0, "extracted": 0, "failed": 0, "task_id": task_id}
 
     async def _run() -> Dict[str, Any]:
+        from app.core.memory.models.metadata_models import ALLOWED_METADATA_FIELDS
         from app.core.memory.models.variate_config import ExtractionPipelineConfig
         from app.core.memory.storage_services.extraction_engine.steps.base import StepContext
         from app.core.memory.storage_services.extraction_engine.steps.metadata_step import MetadataExtractionStep
         from app.core.memory.storage_services.extraction_engine.steps.schema import (
             MetadataStepInput,
+            MetadataStepOutput,
         )
         from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
         from app.db import get_db_context
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-        from app.repositories.neo4j.cypher_queries import ENTITY_METADATA_UPDATE, ENTITY_METADATA_QUERY
+        from app.repositories.neo4j.cypher_queries import (
+            ENTITY_METADATA_PATCH,
+            ENTITY_METADATA_QUERY,
+        )
+
+        # ── 边界保护常量 ──
+        # 单实体 LLM 单次返回的 op 数量硬上限（超出截断并告警）
+        MAX_OPS_PER_ENTITY = 50
+        # 单字段（Neo4j 列表属性）允许的最大长度；add 时若已超此值，跳过并告警
+        MAX_LIST_LEN_PER_FIELD = 200
 
         # Build LLM client
         with get_db_context() as db:
@@ -2622,36 +2634,149 @@ def extract_metadata_batch_task(
         failed = 0
         snapshot_outputs: Dict[str, Any] = {} if snapshot_dir else None  # type: ignore[assignment]
 
+        # ── 内联 helpers：保持闭包，便于复用 connector / step / extracted 计数 ──
+
+        async def _load_existing_metadata(entity_id: str) -> Dict[str, List[str]]:
+            """读取 Neo4j 当前 8 字段值作为 LLM 增量去重 + old_value 校验的输入。"""
+            existing: Dict[str, List[str]] = {f: [] for f in ALLOWED_METADATA_FIELDS}
+            try:
+                records = await connector.execute_query(
+                    ENTITY_METADATA_QUERY, entity_id=entity_id
+                )
+            except Exception as e:
+                logger.warning(f"[Metadata] 查询已有元数据失败: {e}")
+                return existing
+            if not records:
+                return existing
+            rec = records[0]
+            for field in ALLOWED_METADATA_FIELDS:
+                val = rec.get(field)
+                existing[field] = list(val) if val else []
+            return existing
+
+        def _filter_invalid_old_values(
+            result: MetadataStepOutput,
+            existing_metadata: Dict[str, List[str]],
+            entity_name: str,
+            entity_id: str,
+        ) -> int:
+            """就地过滤 result.operations 中 old_value 不在 Neo4j 当前列表的 op。
+
+            防止 Cypher 列表推导静默失败：``[x | CASE WHEN x = old THEN new ELSE x END]``
+            匹配不到 old_value 时不会报错，但也不会改值。
+
+            Returns:
+                被丢弃的 op 数量，仅用于审计日志。
+            """
+            valid_ops: List[Any] = []
+            skipped = 0
+            for op in result.operations:
+                if op.op in ("delete", "update"):
+                    cur_list = existing_metadata.get(op.field) or []
+                    if op.old_value not in cur_list:
+                        skipped += 1
+                        logger.warning(
+                            f"[Metadata] 实体 {entity_name}({entity_id}) "
+                            f"丢弃 {op.op} op：old_value 在当前 {op.field} 中不存在: "
+                            f"old_value={op.old_value!r}"
+                        )
+                        continue
+                valid_ops.append(op)
+            result.operations = valid_ops
+            return skipped
+
+        def _build_patch_params(
+            result: MetadataStepOutput, entity_id: str,
+            existing_metadata: Dict[str, List[str]],
+            entity_name: str,
+        ) -> Dict[str, Any]:
+            """按字段把 add / delete / update 拼成 ENTITY_METADATA_PATCH 的参数。
+
+            对 add 路径做长度保护：若该字段当前长度 + 即将 add 的数量 >
+            ``MAX_LIST_LEN_PER_FIELD``，只保留能容纳的部分，其余截断并告警。
+            """
+            adds = result.adds_by_field()
+            deletes = result.deletes_by_field()
+            updates = result.updates_by_field()
+            params: Dict[str, Any] = {"entity_id": entity_id}
+            for field in ALLOWED_METADATA_FIELDS:
+                # delete 和 update 不增加长度，无需限制
+                params[f"{field}_delete"] = deletes.get(field, [])
+                params[f"{field}_update"] = [
+                    {"old": old, "new": new}
+                    for (old, new) in updates.get(field, [])
+                ]
+                # add 路径做长度保护
+                field_adds = adds.get(field, [])
+                current_len = len(existing_metadata.get(field) or [])
+                capacity = max(0, MAX_LIST_LEN_PER_FIELD - current_len)
+                if len(field_adds) > capacity:
+                    overflow = len(field_adds) - capacity
+                    field_adds = field_adds[:capacity]
+                    logger.warning(
+                        f"[Metadata] 实体 {entity_name}({entity_id}) "
+                        f"字段 {field} 长度将超上限({MAX_LIST_LEN_PER_FIELD})，"
+                        f"截断 {overflow} 条 add"
+                    )
+                params[f"{field}_add"] = field_adds
+            return params
+
+        def _extract_post_state(patch_records: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+            """从 patch RETURN 中取出权威的 8 字段值用于覆盖式同步到 PG。"""
+            if not patch_records:
+                return {}
+            rec = patch_records[0]
+            return {
+                field: list(rec.get(field) or [])
+                for field in ALLOWED_METADATA_FIELDS
+            }
+
         connector = Neo4jConnector()
         try:
             for entity_dict in user_entities:
                 entity_id = entity_dict["entity_id"]
                 entity_name = entity_dict.get("entity_name", "")
                 descriptions = entity_dict.get("descriptions", [])
-                aliases = entity_dict.get("aliases", [])
                 end_user_id = entity_dict.get("end_user_id", "")
 
                 if not descriptions:
                     logger.debug(f"[Metadata] 跳过无 description 的实体: {entity_id}")
                     continue
 
+                post_state: Dict[str, List[str]] = {}
                 try:
-                    # 查询已有元数据用于增量去重
-                    existing_metadata = {}
+                    # ── 分布式锁：同一 entity_id 的 patch 操作串行化 ──
+                    # 防止并发 patch 导致 Lost Update（Neo4j WITH-SET 非原子读改写）。
+                    # TTL 30s 足够覆盖一次 LLM 调用 + patch + PG 同步；
+                    # 锁超时后自动释放，不会永久阻塞。
+                    # 锁竞争时本次跳过该实体：数据不丢失——下一轮 write_pipeline
+                    # 仍会触发新的 metadata 任务，此时描述已在 Neo4j 中累积。
+                    lock_key = f"metadata:patch:{entity_id}"
+                    lock_value = f"{task_id}:{entity_id}"
+                    lock_acquired = False
+                    _lock_redis = None
                     try:
-                        records = await connector.execute_query(
-                            ENTITY_METADATA_QUERY, entity_id=entity_id
+                        from app.aioRedis import get_thread_safe_redis
+                        _lock_redis = get_thread_safe_redis()
+                        lock_acquired = bool(
+                            _lock_redis.set(lock_key, lock_value, nx=True, ex=30)
                         )
-                        if records:
-                            rec = records[0]
-                            for field in (
-                                "core_facts", "traits", "relations", "goals",
-                                "interests", "beliefs_or_stances", "anchors", "events",
-                            ):
-                                val = rec.get(field)
-                                existing_metadata[field] = val if val else []
-                    except Exception as e:
-                        logger.warning(f"[Metadata] 查询已有元数据失败: {e}")
+                    except Exception as lock_err:
+                        # Redis 不可用时退化为无锁模式（打 warning 继续执行）
+                        logger.warning(
+                            f"[Metadata] 获取分布式锁失败，退化为无锁模式: "
+                            f"entity_id={entity_id}, error={lock_err}"
+                        )
+                        lock_acquired = True  # 继续执行，不因锁组件故障卡死
+
+                    if not lock_acquired:
+                        logger.info(
+                            f"[Metadata] 实体 {entity_name}({entity_id}) 已被其他任务锁定，"
+                            f"本次跳过（下一轮 write 仍会触发 metadata 提取）"
+                        )
+                        continue
+
+                    existing_metadata = await _load_existing_metadata(entity_id)
 
                     inp = MetadataStepInput(
                         entity_id=entity_id,
@@ -2661,50 +2786,69 @@ def extract_metadata_batch_task(
                     )
                     result = await step.run(inp)
 
-                    if result.has_any():
-                        # 回写 Neo4j
-                        await connector.execute_query(
-                            ENTITY_METADATA_UPDATE,
-                            entity_id=entity_id,
-                            core_facts=result.core_facts,
-                            traits=result.traits,
-                            relations=result.relations,
-                            goals=result.goals,
-                            interests=result.interests,
-                            beliefs_or_stances=result.beliefs_or_stances,
-                            anchors=result.anchors,
-                            events=result.events,
-                        )
-                        extracted += 1
-                        logger.info(
-                            f"[Metadata] 实体 {entity_name}({entity_id}) 元数据提取并回写成功"
+                    # ── 边界保护：单实体 op 数量硬截断 ──
+                    if len(result.operations) > MAX_OPS_PER_ENTITY:
+                        truncated_count = len(result.operations) - MAX_OPS_PER_ENTITY
+                        result.operations = result.operations[:MAX_OPS_PER_ENTITY]
+                        logger.warning(
+                            f"[Metadata] 实体 {entity_name}({entity_id}) LLM 返回 op 数"
+                            f"超过上限({MAX_OPS_PER_ENTITY})，已截断 {truncated_count} 条"
                         )
 
-                        # 同步写入 PostgreSQL end_user_info
-                        if end_user_id:
-                            _sync_end_user_info_pg(
+                    if result.has_any():
+                        skipped_ops_count = _filter_invalid_old_values(
+                            result, existing_metadata, entity_name, entity_id
+                        )
+
+                        if not result.has_any():
+                            logger.info(
+                                f"[Metadata] 实体 {entity_name}({entity_id}) 所有 op 均被过滤，跳过 patch"
+                            )
+                            if snapshot_outputs is not None:
+                                snapshot_outputs[entity_id] = {
+                                    "entity_name": entity_name,
+                                    "descriptions": descriptions,
+                                    "operations": [],
+                                    "skipped_ops": skipped_ops_count,
+                                }
+                            continue
+
+                        # 单语句原子 patch，并直接拿到 Neo4j 上 patch 后的最新 8 字段值
+                        patch_records = await connector.execute_query(
+                            ENTITY_METADATA_PATCH,
+                            **_build_patch_params(result, entity_id, existing_metadata, entity_name),
+                        )
+
+                        counts = result.counts()
+                        logger.info(
+                            f"[Metadata] 实体 {entity_name}({entity_id}) patch 完成: "
+                            f"add={counts['add']}, delete={counts['delete']}, "
+                            f"update={counts['update']}, skipped={skipped_ops_count}"
+                        )
+                        extracted += 1
+
+                        post_state = _extract_post_state(patch_records)
+
+                        # 同步写入 PostgreSQL end_user_info：metadata 8 字段以 Neo4j 为准覆盖
+                        if end_user_id and post_state:
+                            _sync_metadata_to_pg(
                                 end_user_id=end_user_id,
-                                aliases=aliases,
-                                extracted_metadata=result.model_dump(),
+                                metadata=post_state,
                             )
                     else:
-                        # 即使无新增元数据，也同步 aliases 到 PostgreSQL
-                        if end_user_id and aliases:
-                            _sync_end_user_info_pg(
-                                end_user_id=end_user_id,
-                                aliases=aliases,
-                                extracted_metadata=None,
-                            )
                         logger.debug(
                             f"[Metadata] 实体 {entity_name}({entity_id}) 无新增元数据"
                         )
 
                     if snapshot_outputs is not None:
-                        snapshot_outputs[entity_id] = {
+                        snap_entry: Dict[str, Any] = {
                             "entity_name": entity_name,
                             "descriptions": descriptions,
-                            "extracted_metadata": result.model_dump(),
+                            "operations": [op.model_dump() for op in result.operations],
                         }
+                        if post_state:
+                            snap_entry["post_state"] = post_state
+                        snapshot_outputs[entity_id] = snap_entry
 
                 except Exception as e:
                     failed += 1
@@ -2713,6 +2857,18 @@ def extract_metadata_batch_task(
                     logger.warning(
                         f"[Metadata] 实体 {entity_id} 元数据提取失败: {e}"
                     )
+                finally:
+                    # 释放分布式锁（仅当前 task 持有时删除）
+                    if lock_acquired and _lock_redis is not None:
+                        try:
+                            stored = _lock_redis.get(lock_key)
+                            if stored and (
+                                stored == lock_value
+                                or stored == lock_value.encode()
+                            ):
+                                _lock_redis.delete(lock_key)
+                        except Exception:
+                            pass  # 锁超时自动释放即可，不影响主流程
         finally:
             await connector.close()
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2747,8 +2747,8 @@ def extract_metadata_batch_task(
                 try:
                     # ── 分布式锁：同一 entity_id 的 patch 操作串行化 ──
                     # 防止并发 patch 导致 Lost Update（Neo4j WITH-SET 非原子读改写）。
-                    # TTL 30s 足够覆盖一次 LLM 调用 + patch + PG 同步；
-                    # 锁超时后自动释放，不会永久阻塞。
+                    # TTL 与 soft_time_limit 对齐（90s），确保在 Celery 收回任务前锁
+                    # 不会意外过期；正常执行路径在 finally 块主动释放，不会占满 TTL。
                     # 锁竞争时本次跳过该实体：数据不丢失——下一轮 write_pipeline
                     # 仍会触发新的 metadata 任务，此时描述已在 Neo4j 中累积。
                     lock_key = f"metadata:patch:{entity_id}"
@@ -2759,7 +2759,7 @@ def extract_metadata_batch_task(
                         from app.aioRedis import get_thread_safe_redis
                         _lock_redis = get_thread_safe_redis()
                         lock_acquired = bool(
-                            _lock_redis.set(lock_key, lock_value, nx=True, ex=30)
+                            _lock_redis.set(lock_key, lock_value, nx=True, ex=90)
                         )
                     except Exception as lock_err:
                         # Redis 不可用时退化为无锁模式（打 warning 继续执行）
@@ -2810,6 +2810,7 @@ def extract_metadata_batch_task(
                                     "descriptions": descriptions,
                                     "operations": [],
                                     "skipped_ops": skipped_ops_count,
+                                    "dropped_ops_count": result.dropped_ops_count,
                                 }
                             continue
 
@@ -2823,7 +2824,8 @@ def extract_metadata_batch_task(
                         logger.info(
                             f"[Metadata] 实体 {entity_name}({entity_id}) patch 完成: "
                             f"add={counts['add']}, delete={counts['delete']}, "
-                            f"update={counts['update']}, skipped={skipped_ops_count}"
+                            f"update={counts['update']}, skipped={skipped_ops_count}, "
+                            f"dropped_by_validator={result.dropped_ops_count}"
                         )
                         extracted += 1
 
@@ -2845,6 +2847,7 @@ def extract_metadata_batch_task(
                             "entity_name": entity_name,
                             "descriptions": descriptions,
                             "operations": [op.model_dump() for op in result.operations],
+                            "dropped_ops_count": result.dropped_ops_count,
                         }
                         if post_state:
                             snap_entry["post_state"] = post_state


### PR DESCRIPTION
…data extraction pipeline

## Summary by Sourcery

将用户元数据的提取切换为生成结构化的补丁（patch）操作，并以原子方式同时应用到 Neo4j 和 PostgreSQL，从而解耦别名处理，并加强校验与并发控制。

New Features:
- 为用户元数据字段引入 add/delete/update 补丁操作，并更新 prompt、响应 schema 和提取流水线以使用这些操作。
- 返回 Neo4j 应用补丁后的元数据状态，并将其作为权威来源，用于覆盖 PostgreSQL 中 end_user_info.meta_data 的对应字段。

Enhancements:
- 将别名处理从元数据提取流水线中解耦，把 aliases 和 other_name 留给专门的别名合并流程处理。
- 增加对元数据操作的健壮校验和分组，包括字段白名单、逐操作结构检查，以及用于构建 Cypher 参数的辅助方法。
- 用原子级字段补丁查询替换之前只能追加的 Neo4j 元数据写入方式，使其支持删除和更新，并返回更新后的列表。
- 引入基于 Redis 的按实体分布式锁，以及对操作数与列表大小的安全限制，以避免竞态条件和无界增长。
- 优化 Redis 连接池管理，以跟踪当前运行的事件循环，并避免在多线程环境中跨事件循环复用连接的问题。
- 将元数据 LLM 响应解析简化为新的操作 schema，并移除对传统 schema 的处理。
- 调整 end_user_info 仓储逻辑，从增量合并改为按键替换元数据字段。

Documentation:
- 更新 extract_user_metadata 的 prompt（中/英文），描述新的补丁操作约定、字段范围、操作规则以及输出 JSON 结构，并包含 add、delete 和 update 的示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch user metadata extraction to produce structured patch operations and apply them atomically to Neo4j and PostgreSQL, decoupling alias handling and tightening validation and concurrency controls.

New Features:
- Introduce add/delete/update patch operations for user metadata fields and update the prompt, response schema, and extraction pipeline to use them.
- Return Neo4j post-patch metadata state and use it as the authoritative source to overwrite corresponding fields in PostgreSQL end_user_info.meta_data.

Enhancements:
- Decouple alias handling from the metadata extraction pipeline, leaving aliases and other_name to a dedicated alias-merging flow.
- Add robust validation and grouping of metadata operations, including field whitelisting, per-op shape checks, and helper methods to build Cypher parameters.
- Replace the previous append-only Neo4j metadata write with an atomic field-level patch query that supports deletes and updates and returns the updated lists.
- Introduce Redis-based per-entity distributed locking and safety limits on operations and list sizes to avoid race conditions and unbounded growth.
- Refine Redis connection pooling to track the currently running event loop and avoid cross-loop reuse issues in threaded contexts.
- Simplify metadata LLM response parsing to the new operations schema and drop legacy schema handling.
- Adjust end_user_info repository logic to perform keyed metadata field replacement instead of incremental merging.

Documentation:
- Update the extract_user_metadata prompt (both zh/en) to describe the new patch-operation contract, field scope, operation rules, and output JSON shape, including examples for add, delete, and update.

</details>