### PR TITLE
refactor(workflow)

### DIFF
--- a/api/app/core/workflow/nodes/code/node.py
+++ b/api/app/core/workflow/nodes/code/node.py
@@ -63,10 +63,15 @@ class CodeNode(BaseNode):
     def _extract_extra_fields(self, business_result: Any) -> dict:
         return {"process": {"language": self._language, "code": self._executed_code}}
 
+    def _get_typed_config(self) -> CodeNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = CodeNodeConfig(**self.config)
+        return self.typed_config
+
     def _output_types(self) -> dict[str, VariableType]:
         output_dict = {}
-        for output in self.config.get("output_variables", []):
-            output_dict[output["name"]] = VariableType(output["type"])
+        for output in self._get_typed_config().output_variables:
+            output_dict[output.name] = output.type
         output_dict["branch_signal"] = VariableType.STRING
         return output_dict
 
@@ -112,7 +117,7 @@ class CodeNode(BaseNode):
             raise RuntimeError("The output of main must be a dictionary")
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
-        self.typed_config = CodeNodeConfig(**self.config)
+        self.typed_config = self._get_typed_config()
         input_variable_dict = {}
         for input_variable in self.typed_config.input_variables:
             input_variable_dict[input_variable.name] = self.get_variable(input_variable.variable, variable_pool)

--- a/api/app/core/workflow/nodes/if_else/node.py
+++ b/api/app/core/workflow/nodes/if_else/node.py
@@ -27,9 +27,14 @@ class IfElseNode(BaseNode):
             "output": VariableType.STRING
         }
 
+    def _get_typed_config(self) -> IfElseNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = IfElseNodeConfig(**self.config)
+        return self.typed_config
+
     def _extract_input(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
         result = []
-        for case in self.typed_config.cases:
+        for case in self._get_typed_config().cases:
             expressions = []
             for expression in case.expressions:
                 expressions.append({
@@ -96,7 +101,7 @@ class IfElseNode(BaseNode):
         """
         conditions = []
 
-        for case_branch in self.typed_config.cases:
+        for case_branch in self._get_typed_config().cases:
             branch_result = []
             for expression in case_branch.expressions:
                 pattern = r"\{\{\s*(.*?)\s*\}\}"
@@ -145,7 +150,7 @@ class IfElseNode(BaseNode):
         Returns:
             str: The matched branch identifier, e.g., 'CASE1', 'CASE2', ..., used for node transitions.
         """
-        self.typed_config = IfElseNodeConfig(**self.config)
+        self.typed_config = self._get_typed_config()
         expressions = self.evaluate_conditional_edge_expressions(variable_pool)
         self._condition_results = [
             {"case": f"CASE{i+1}", "result": v} for i, v in enumerate(expressions[:-1])

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -29,7 +29,12 @@ logger = logging.getLogger(__name__)
 class KnowledgeRetrievalNode(BaseNode):
     def __init__(self, node_config: dict[str, Any], workflow_config: dict[str, Any], down_stream_nodes: list[str]):
         super().__init__(node_config, workflow_config, down_stream_nodes)
-        self.typed_config: KnowledgeRetrievalNodeConfig = KnowledgeRetrievalNodeConfig(**self.config)
+        self.typed_config: KnowledgeRetrievalNodeConfig | None = None
+
+    def _get_typed_config(self) -> KnowledgeRetrievalNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = KnowledgeRetrievalNodeConfig(**self.config)
+        return self.typed_config
 
     def _output_types(self) -> dict[str, VariableType]:
         return {
@@ -56,9 +61,10 @@ class KnowledgeRetrievalNode(BaseNode):
         return {"citations": citations, "process": process}
 
     def _extract_input(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
+        cfg = self._get_typed_config()
         return {
-            "query": self._render_template(self.typed_config.query, variable_pool),
-            "knowledge_bases": [kb_config.model_dump(mode="json") for kb_config in self.typed_config.knowledge_bases],
+            "query": self._render_template(cfg.query, variable_pool),
+            "knowledge_bases": [kb_config.model_dump(mode="json") for kb_config in cfg.knowledge_bases],
         }
 
     @staticmethod
@@ -326,6 +332,7 @@ class KnowledgeRetrievalNode(BaseNode):
         Raises:
             RuntimeError: If no valid knowledge base is found or access is denied.
         """
+        self.typed_config = self._get_typed_config()
         if not self.typed_config.knowledge_bases:
             return []
         query = self._render_template(self.typed_config.query, variable_pool)

--- a/api/app/core/workflow/nodes/parameter_extractor/node.py
+++ b/api/app/core/workflow/nodes/parameter_extractor/node.py
@@ -40,13 +40,19 @@ class ParameterExtractorNode(BaseNode):
                 }
         return None
 
+    def _get_typed_config(self) -> ParameterExtractorNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = ParameterExtractorNodeConfig(**self.config)
+        return self.typed_config
+
     def _extract_input(self, state: WorkflowState, variable_pool: VariablePool) -> dict[str, Any]:
+        cfg = self._get_typed_config()
         return {
-            "text": self._render_template(self.typed_config.text, variable_pool),
-            "prompt": self._render_template(self.typed_config.prompt, variable_pool),
-            "params": [param.model_dump(mode="json") for param in self.typed_config.params],
-            "model_id": str(self.typed_config.model_id),
-            "inference_mode": self.typed_config.inference_mode,
+            "text": self._render_template(cfg.text, variable_pool),
+            "prompt": self._render_template(cfg.prompt, variable_pool),
+            "params": [param.model_dump(mode="json") for param in cfg.params],
+            "model_id": str(cfg.model_id),
+            "inference_mode": cfg.inference_mode,
         }
 
     def _extract_extra_fields(self, business_result: Any) -> dict:
@@ -277,7 +283,7 @@ class ParameterExtractorNode(BaseNode):
         return result
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
-        self.typed_config = ParameterExtractorNodeConfig(**self.config)
+        self.typed_config = self._get_typed_config()
         llm = self._get_llm_instance()
 
         actual_mode = self._resolve_inference_mode()

--- a/api/app/core/workflow/nodes/question_classifier/node.py
+++ b/api/app/core/workflow/nodes/question_classifier/node.py
@@ -31,11 +31,16 @@ class QuestionClassifierNode(BaseNode):
         self._last_messages: list = []
         self._classification_result: str = ""
 
+    def _get_typed_config(self) -> QuestionClassifierNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = QuestionClassifierNodeConfig(**self.config)
+        return self.typed_config
+
     def _extract_extra_fields(self, business_result: Any) -> dict:
         return {"process": {
             "messages": self._last_messages,
             "classification_result": self._classification_result,
-            "model_id": str(self.typed_config.model_id) if self.typed_config else None,
+            "model_id": str(self._get_typed_config().model_id),
         }}
 
     def _extract_token_usage(self, business_result: Any) -> dict[str, int] | None:
@@ -153,7 +158,7 @@ class QuestionClassifierNode(BaseNode):
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> dict:
         """执行问题分类"""
-        self.typed_config = QuestionClassifierNodeConfig(**self.config)
+        self.typed_config = self._get_typed_config()
         self.category_to_case_map = self._build_category_case_map()
         question = self.typed_config.input_variable
         supplement_prompt = self.typed_config.user_supplement_prompt or ""

--- a/api/app/core/workflow/nodes/variable_aggregator/node.py
+++ b/api/app/core/workflow/nodes/variable_aggregator/node.py
@@ -16,8 +16,13 @@ class VariableAggregatorNode(BaseNode):
         super().__init__(node_config, workflow_config, down_stream_nodes)
         self.typed_config: VariableAggregatorNodeConfig | None = None
 
+    def _get_typed_config(self) -> VariableAggregatorNodeConfig:
+        if self.typed_config is None:
+            self.typed_config = VariableAggregatorNodeConfig(**self.config)
+        return self.typed_config
+
     def _output_types(self) -> dict[str, VariableType]:
-        config = VariableAggregatorNodeConfig(**self.config)
+        config = self._get_typed_config()
         output = {}
         if not config.group_type:
             for group_name in config.group_variables.keys():
@@ -50,7 +55,7 @@ class VariableAggregatorNode(BaseNode):
             - str: In non-group mode, returns the first non-None variable value.
             - dict: In group mode, returns a mapping of group_name -> first non-None variable value.
         """
-        self.typed_config = VariableAggregatorNodeConfig(**self.config)
+        self.typed_config = self._get_typed_config()
         if not self.typed_config.group:
             # --------------------------
             # Non-group mode


### PR DESCRIPTION
lazy-initialize typed config across all node types

## Summary by Sourcery

在多个工作流节点类型中对已类型化的节点配置对象进行延迟初始化，以避免重复构建并集中管理访问。

增强内容：
- 为工作流节点引入共享的 `_get_typed_config` 帮助方法，用于缓存和复用已解析的节点配置。
- 更新节点逻辑，以依赖惰性求值的 `typed_config` 实例，而不是在每次执行或调用处重新构建配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Lazy-initialize typed node configuration objects across multiple workflow node types to avoid repeated construction and centralize access.

Enhancements:
- Introduce shared _get_typed_config helpers for workflow nodes to cache and reuse parsed node configuration.
- Update node logic to rely on lazily evaluated typed_config instances instead of constructing configs at each execution or call site.

</details>