### PR TITLE
feat(app)

### DIFF
--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -3,7 +3,7 @@ import json
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request, Body
+from fastapi import APIRouter, Depends, Request, Body, Query
 from sqlalchemy.orm import Session
 from starlette.responses import StreamingResponse
 
@@ -21,6 +21,7 @@ from app.repositories.end_user_repository import EndUserRepository
 from app.schemas import AppChatRequest, conversation_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.human_intervention_schema import HumanInterventionSubmitRequest
+from app.schemas.response_schema import PageData, PageMeta
 from app.services import workspace_service
 from app.services.app_chat_service import AppChatService, get_app_chat_service
 from app.services.app_service import get_app_service, AppService
@@ -334,6 +335,60 @@ async def chat(
         )
     else:
         raise BusinessException(f"不支持的应用类型: {app_type}", BizCode.APP_TYPE_NOT_SUPPORTED)
+
+
+@router.get("/conversations")
+@require_api_key(scopes=["app"])
+async def list_v1_conversations(
+        request: Request,
+        api_key_auth: ApiKeyAuth = None,
+        db: Session = Depends(get_db),
+        conversation_service: Annotated[ConversationService, Depends(get_conversation_service)] = None,
+        user_id: str = Query("", description="外部系统用户 ID"),
+        page: int = Query(1, description="页码，从 1 开始"),
+        page_size: int = Query(20, description="每页数量，最大 100"),
+):
+    """获取当前应用下指定外部用户的会话列表。"""
+    result = conversation_service.list_v1_conversations(
+        app_id=api_key_auth.resource_id,
+        workspace_id=api_key_auth.workspace_id,
+        external_user_id=user_id,
+        page=page,
+        page_size=page_size,
+    )
+    items = [
+        conversation_schema.V1ConversationListItem(**item)
+        for item in result["items"]
+    ]
+    page_meta = PageMeta(
+        page=result["page"],
+        pagesize=result["page_size"],
+        total=result["total"],
+        hasnext=result["hasnext"],
+    )
+    return success(data=PageData(page=page_meta, items=items).model_dump(mode="json"))
+
+
+@router.get("/conversations/{conversation_id}/messages")
+@require_api_key(scopes=["app"])
+async def list_v1_conversation_messages(
+        request: Request,
+        conversation_id: uuid.UUID,
+        api_key_auth: ApiKeyAuth = None,
+        db: Session = Depends(get_db),
+        conversation_service: Annotated[ConversationService, Depends(get_conversation_service)] = None,
+        user_id: str = Query("", description="外部系统用户 ID"),
+        limit: int = Query(20, description="返回消息数量，最大 200"),
+):
+    """获取当前应用下指定会话的历史消息。"""
+    result = conversation_service.list_v1_conversation_messages(
+        app_id=api_key_auth.resource_id,
+        workspace_id=api_key_auth.workspace_id,
+        external_user_id=user_id,
+        conversation_id=conversation_id,
+        limit=limit,
+    )
+    return success(data=conversation_schema.V1ConversationMessageListResponse(**result).model_dump(mode="json"))
 
 
 @router.post(

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -268,6 +268,47 @@ class ConversationRepository:
         )
         return conversations, total
 
+    def list_v1_conversations(
+            self,
+            *,
+            app_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+            internal_user_id: str,
+            page: int,
+            page_size: int,
+    ) -> tuple[list[Conversation], int]:
+        """查询 v1 对外服务某个终端用户的发布态会话列表。"""
+        stmt = select(Conversation).where(
+            Conversation.app_id == app_id,
+            Conversation.workspace_id == workspace_id,
+            Conversation.user_id == internal_user_id,
+            Conversation.is_active.is_(True),
+            Conversation.is_draft.is_(False),
+        )
+
+        total = int(
+            self.db.execute(
+                select(func.count()).select_from(stmt.subquery())
+            ).scalar_one()
+        )
+
+        stmt = stmt.order_by(desc(Conversation.updated_at))
+        stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+
+        conversations = list(self.db.scalars(stmt).all())
+
+        logger.info(
+            "Listed v1 conversations successfully",
+            extra={
+                "app_id": str(app_id),
+                "workspace_id": str(workspace_id),
+                "internal_user_id": internal_user_id,
+                "returned": len(conversations),
+                "total": total,
+            }
+        )
+        return conversations, total
+
     def get_conversation_for_app_log(
             self,
             conversation_id: uuid.UUID,

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -40,6 +40,9 @@ from .conversation_schema import (
     MessageCreate,
     ChatRequest,
     ChatResponse,
+    V1ConversationListItem,
+    V1ConversationMessageItem,
+    V1ConversationMessageListResponse,
 )
 from .multi_agent_schema import (
     SubAgentConfig,
@@ -115,6 +118,9 @@ __all__ = [
     "MessageCreate",
     "ChatRequest",
     "ChatResponse",
+    "V1ConversationListItem",
+    "V1ConversationMessageItem",
+    "V1ConversationMessageListResponse",
     # Multi-Agent Schemas
     "SubAgentConfig",
     "RoutingRule",

--- a/api/app/schemas/conversation_schema.py
+++ b/api/app/schemas/conversation_schema.py
@@ -117,6 +117,52 @@ class ChatResponse(BaseModel):
         return data
 
 
+class V1ConversationListItem(BaseModel):
+    """v1 应用对外服务的会话列表项"""
+    conversation_id: uuid.UUID
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    message_count: int = 0
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+    @field_serializer("created_at", when_used="json")
+    def _serialize_created_at_ms(self, dt: datetime.datetime):
+        return to_timestamp_ms(dt)
+
+    @field_serializer("updated_at", when_used="json")
+    def _serialize_updated_at_ms(self, dt: datetime.datetime):
+        return to_timestamp_ms(dt)
+
+
+class V1ConversationMessageItem(BaseModel):
+    """v1 应用对外服务的历史消息项"""
+    message_id: uuid.UUID
+    role: str
+    content: str
+    status: str
+    meta_data: Optional[Dict[str, Any]] = None
+    created_at: datetime.datetime
+    version: int = 1
+    is_current: bool = True
+    parent_message_id: Optional[uuid.UUID] = None
+
+    @field_serializer("created_at", when_used="json")
+    def _serialize_created_at_ms(self, dt: datetime.datetime):
+        return to_timestamp_ms(dt)
+
+    @field_serializer("meta_data", when_used="json")
+    def _serialize_meta_data(self, data: Optional[Dict[str, Any]]):
+        return data or {}
+
+
+class V1ConversationMessageListResponse(BaseModel):
+    """v1 应用对外服务的历史消息列表响应"""
+    conversation_id: uuid.UUID
+    items: List[V1ConversationMessageItem]
+    limit: int
+
+
 # ---------- Conversation Summary Schemas ----------
 class ConversationOut(BaseModel):
     theme: str

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,13 +1,11 @@
 """会话服务"""
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Annotated
 from typing import Optional, List, Tuple, Dict, Any
 
 import json_repair
 from fastapi import Depends
-from jinja2 import Template
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
@@ -21,8 +19,8 @@ from app.models import Conversation, Message, User, ModelType
 from app.models.conversation_model import ConversationDetail
 from app.models.prompt_optimizer_model import RoleType
 from app.repositories.conversation_repository import ConversationRepository, MessageRepository
+from app.repositories.end_user_repository import EndUserRepository
 from app.schemas.conversation_schema import ConversationOut
-from app.schemas.model_schema import ModelInfo
 from app.services import workspace_service
 from app.services.model_service import ModelConfigService
 from app.services.prompt import prompt_manager
@@ -41,6 +39,15 @@ class ConversationService:
         self.db = db
         self.conversation_repo = ConversationRepository(db)
         self.message_repo = MessageRepository(db)
+        self.end_user_repo = EndUserRepository(db)
+
+    _V1_MESSAGE_META_DATA_WHITELIST = {
+        "usage",
+        "citations",
+        "audio_url",
+        "audio_status",
+        "files",
+    }
 
     def create_conversation(
             self,
@@ -447,6 +454,187 @@ class ConversationService:
         )
 
         return messages
+
+    def _resolve_v1_internal_user_id(
+            self,
+            *,
+            workspace_id: uuid.UUID,
+            external_user_id: str,
+    ) -> str | None:
+        """将外部 user_id 解析为内部终端用户 ID，不存在时返回 None。"""
+        end_user = self.end_user_repo.get_end_user_by_other_id(
+            workspace_id=workspace_id,
+            other_id=external_user_id,
+        )
+        if not end_user:
+            return None
+        return str(end_user.id)
+
+    @classmethod
+    def _sanitize_v1_message_meta_data(cls, meta_data: Optional[dict]) -> dict:
+        """对外返回消息元数据时仅保留白名单字段。"""
+        if not isinstance(meta_data, dict):
+            return {}
+        return {
+            key: value
+            for key, value in meta_data.items()
+            if key in cls._V1_MESSAGE_META_DATA_WHITELIST
+        }
+
+    def list_v1_conversations(
+            self,
+            *,
+            app_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+            external_user_id: str,
+            page: int = 1,
+            page_size: int = 20,
+    ) -> dict:
+        """获取 v1 应用对外服务的会话列表。"""
+        if not external_user_id:
+            raise BusinessException("user_id 不能为空", BizCode.INVALID_PARAMETER)
+        if page < 1:
+            raise BusinessException("page 必须大于等于 1", BizCode.INVALID_PARAMETER)
+        if page_size < 1:
+            raise BusinessException("page_size 必须大于等于 1", BizCode.INVALID_PARAMETER)
+        if page_size > 100:
+            raise BusinessException("page_size 超过最大限制", BizCode.INVALID_PARAMETER)
+
+        internal_user_id = self._resolve_v1_internal_user_id(
+            workspace_id=workspace_id,
+            external_user_id=external_user_id,
+        )
+        if internal_user_id is None:
+            return {
+                "items": [],
+                "page": page,
+                "page_size": page_size,
+                "total": 0,
+                "hasnext": False,
+            }
+
+        try:
+            conversations, total = self.conversation_repo.list_v1_conversations(
+                app_id=app_id,
+                workspace_id=workspace_id,
+                internal_user_id=internal_user_id,
+                page=page,
+                page_size=page_size,
+            )
+        except BusinessException:
+            raise
+        except Exception as e:
+            logger.exception(
+                "查询 v1 会话列表失败",
+                extra={
+                    "app_id": str(app_id),
+                    "workspace_id": str(workspace_id),
+                    "external_user_id": external_user_id,
+                }
+            )
+            raise BusinessException("查询会话失败", BizCode.DB_ERROR, cause=e) from e
+
+        items = [
+            {
+                "conversation_id": conversation.id,
+                "title": conversation.title,
+                "summary": conversation.summary,
+                "message_count": conversation.message_count,
+                "created_at": conversation.created_at,
+                "updated_at": conversation.updated_at,
+            }
+            for conversation in conversations
+        ]
+
+        return {
+            "items": items,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "hasnext": (page * page_size) < total,
+        }
+
+    def list_v1_conversation_messages(
+            self,
+            *,
+            app_id: uuid.UUID,
+            workspace_id: uuid.UUID,
+            external_user_id: str,
+            conversation_id: uuid.UUID,
+            limit: int = 50,
+    ) -> dict:
+        """获取 v1 应用对外服务的会话历史消息。"""
+        if not external_user_id:
+            raise BusinessException("user_id 不能为空", BizCode.INVALID_PARAMETER)
+        if limit < 1:
+            raise BusinessException("limit 必须大于等于 1", BizCode.INVALID_PARAMETER)
+        if limit > 200:
+            raise BusinessException("limit 超过最大限制", BizCode.INVALID_PARAMETER)
+
+        internal_user_id = self._resolve_v1_internal_user_id(
+            workspace_id=workspace_id,
+            external_user_id=external_user_id,
+        )
+
+        try:
+            conversation = self.conversation_repo.get_conversation_by_conversation_id(conversation_id)
+        except ResourceNotFoundException as e:
+            raise BusinessException("会话不存在", BizCode.NOT_FOUND, cause=e) from e
+        except Exception as e:
+            logger.exception(
+                "查询 v1 会话详情失败",
+                extra={"conversation_id": str(conversation_id)}
+            )
+            raise BusinessException("查询会话失败", BizCode.DB_ERROR, cause=e) from e
+
+        if internal_user_id is None:
+            raise BusinessException("无权访问该会话", BizCode.FORBIDDEN)
+
+        if (
+            conversation.app_id != app_id
+            or conversation.workspace_id != workspace_id
+            or conversation.user_id != internal_user_id
+            or conversation.is_active is not True
+            or conversation.is_draft is not False
+        ):
+            raise BusinessException("无权访问该会话", BizCode.FORBIDDEN)
+
+        try:
+            messages = self.message_repo.get_message_by_conversation_id(
+                conversation_id,
+                limit=limit,
+                current_only=True,
+            )
+        except Exception as e:
+            logger.exception(
+                "查询 v1 会话消息失败",
+                extra={"conversation_id": str(conversation_id)}
+            )
+            raise BusinessException("查询会话失败", BizCode.DB_ERROR, cause=e) from e
+
+        items = []
+        for message in messages:
+            if message.role == "system":
+                continue
+            items.append(
+                {
+                    "message_id": message.id,
+                    "role": message.role,
+                    "content": message.content,
+                    "status": message.status,
+                    "meta_data": self._sanitize_v1_message_meta_data(message.meta_data),
+                    "created_at": message.created_at,
+                    "version": message.version or 1,
+                    "is_current": False if message.is_current is False else True,
+                    "parent_message_id": message.parent_message_id,
+                }
+            )
+
+        return {
+            "conversation_id": conversation.id,
+            "items": items,
+            "limit": limit,
+        }
 
     def get_conversation_with_messages(
             self,


### PR DESCRIPTION
add v1 conversation and message list APIs for external users

## Summary by Sourcery

通过应用服务为外部终端用户暴露 v1 会话和消息列表 API。

新功能：
- 添加服务层 API，为外部用户列出 v1 会话和会话消息，包括基于映射的内部终端用户 ID 的校验和授权。
- 暴露 REST 端点，在应用 API 密钥的作用下，为指定外部用户和会话获取分页的会话列表和最近消息。
- 定义 v1 会话列表条目和消息列表响应的响应模式，包括为外部消费者进行时间戳和元数据的序列化。

改进：
- 扩展会话仓库，加入按应用、工作区和内部用户过滤的活动（非草稿）会话查询，并记录查询结果日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose v1 conversation and message listing APIs for external end users via the app service.

New Features:
- Add service-layer APIs to list v1 conversations and conversation messages for an external user, including validation and authorization based on mapped internal end-user IDs.
- Expose REST endpoints to retrieve paginated conversation lists and recent messages for a given external user and conversation under an app API key.
- Define response schemas for v1 conversation list items and message list responses, including timestamp and metadata serialization for external consumers.

Enhancements:
- Extend the conversation repository with a query for active, non-draft conversations filtered by app, workspace, and internal user, with logging of query results.

</details>