### PR TITLE
fix(rag): normalize metadata filter logic

### DIFF
--- a/api/app/core/rag/metadata/filter_engine.py
+++ b/api/app/core/rag/metadata/filter_engine.py
@@ -25,7 +25,7 @@ class FilterGroup:
     """条件组"""
     def __init__(self, conditions: list[FilterCondition], logic: str = "AND"):
         self.conditions = conditions
-        logic_upper = logic.upper()
+        logic_upper = str(logic).strip().upper()
         if logic_upper not in ("AND", "OR"):
             raise BusinessException(
                 f"无效的组内逻辑: {logic}（仅支持 AND/OR）",

--- a/api/app/schemas/knowledge_metadata_schema.py
+++ b/api/app/schemas/knowledge_metadata_schema.py
@@ -1,7 +1,7 @@
 import datetime
 import uuid
 from typing import Any
-from pydantic import BaseModel, Field, field_serializer, ConfigDict
+from pydantic import BaseModel, Field, field_serializer, field_validator, ConfigDict
 from enum import StrEnum
 from app.core.utils.datetime_utils import to_timestamp_ms
 
@@ -21,13 +21,20 @@ class FilterCondition(BaseModel):
 
 
 class GroupLogic(StrEnum):
-    AND = "AND"
-    OR = "OR"
+    AND = "and"
+    OR = "or"
 
 
 class FilterGroup(BaseModel):
     conditions: list[FilterCondition] = Field(..., description="条件列表")
-    logic: GroupLogic = Field(GroupLogic.AND, description="组内逻辑: AND | OR")
+    logic: GroupLogic = Field(GroupLogic.AND, description="组内逻辑: and | or")
+
+    @field_validator("logic", mode="before")
+    @classmethod
+    def normalize_logic(cls, value):
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
 
 class MetadataFilterMode(StrEnum):


### PR DESCRIPTION
## Summary
- Normalize metadata filter group logic so `and` / `or` accept uppercase and lowercase input and serialize as lowercase.

## Changes
- Make `GroupLogic` canonical values lowercase and normalize incoming string logic.
- Make metadata filter execution compare group logic case-insensitively.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/pytest tests/rag/test_metadata_filter_fields_requirement.py tests/rag/test_metadata_auto_filter_requirement.py -q`
- [x] `PYTHONPATH=. .venv/bin/python -m py_compile app/schemas/knowledge_metadata_schema.py app/core/rag/metadata/filter_engine.py app/services/knowledge_retrieval_service.py`
- [x] `git diff --check origin/develop..HEAD`

## External API Impact
- API Key `/chunks/retrieval` reuses the same metadata filter request schema, so group logic now accepts uppercase/lowercase there as well and serializes normalized lowercase values.
- No new external route was added.

## Summary by Sourcery

将元数据过滤器组逻辑的处理规范为不区分大小写，同时将序列化后的值统一标准化为小写。

Bug Fixes:
- 允许以任意大小写形式提供元数据过滤器组逻辑值，并对其进行正确的校验和规范化。

Enhancements:
- 将 `GroupLogic` 枚举值规范为小写，并相应更新模式校验以及过滤引擎的逻辑解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize metadata filter group logic handling to be case-insensitive while standardizing serialized values to lowercase.

Bug Fixes:
- Allow metadata filter group logic values to be provided in any casing while validating and normalizing them correctly.

Enhancements:
- Canonicalize GroupLogic enum values to lowercase and update schema validation and filter engine logic parsing accordingly.

</details>