### PR TITLE
fix(rag): prioritize vectorized chunks for ES writes

### DIFF
--- a/api/app/core/rag/utils/chunk_write_order.py
+++ b/api/app/core/rag/utils/chunk_write_order.py
@@ -1,0 +1,32 @@
+from app.core.rag.models.chunk import DocumentChunk
+
+
+NON_VECTORIZED_CHUNK_TYPES = {"source", "parent"}
+
+
+def chunk_requires_vector(chunk: DocumentChunk) -> bool:
+    chunk_type = (chunk.metadata or {}).get("chunk_type", "chunk")
+    return chunk_type not in NON_VECTORIZED_CHUNK_TYPES
+
+
+def prioritize_vectorized_chunks(chunks: list[DocumentChunk]) -> list[DocumentChunk]:
+    vectorized_chunks: list[DocumentChunk] = []
+    non_vectorized_chunks: list[DocumentChunk] = []
+
+    for chunk in chunks:
+        if chunk_requires_vector(chunk):
+            vectorized_chunks.append(chunk)
+        else:
+            non_vectorized_chunks.append(chunk)
+
+    return vectorized_chunks + non_vectorized_chunks
+
+
+def pop_vectorized_bootstrap_batch(
+    batches: list[list[DocumentChunk]],
+) -> tuple[int | None, list[DocumentChunk] | None]:
+    for idx, batch in enumerate(batches):
+        if any(chunk_requires_vector(chunk) for chunk in batch):
+            return idx, batches.pop(idx)
+
+    return None, None

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -8,7 +8,6 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
-from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -31,6 +30,10 @@ from app.core.logging_config import get_logger
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
 from app.core.rag.graphrag.utils import get_llm_cache, set_llm_cache
+from app.core.rag.utils.chunk_write_order import (
+    pop_vectorized_bootstrap_batch,
+    prioritize_vectorized_chunks,
+)
 from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
 from app.core.rag.integrations.feishu.models import FileInfo
@@ -424,8 +427,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
         if total_chunks == 0:
             progress_lines.append(f"{_progress_ts()} No chunks generated, skipping vectorization.")
         else:
-            total_batches = ceil(total_chunks / EMBEDDING_BATCH_SIZE)
-            progress_per_batch = 0.2 / total_batches
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
             # 2.1 Delete document vector index
             vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
@@ -447,7 +448,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             all_batch_chunks: list[list[DocumentChunk]] = []
 
             if parent_child_mode:
-                # 父子分块模式：parent chunks + child chunks
+                # Parent-child mode writes child chunks first so ES mapping is created from vectorized chunks.
                 parent_chunks_list = []
                 parent_id_to_doc_id = {}
 
@@ -487,7 +488,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     child_chunks_list.append(
                         DocumentChunk(page_content=item["content_with_weight"], metadata=meta))
 
-                all_chunks = parent_chunks_list + child_chunks_list
+                all_chunks = prioritize_vectorized_chunks(parent_chunks_list + child_chunks_list)
                 for batch_start in range(0, len(all_chunks), EMBEDDING_BATCH_SIZE):
                     batch_end = min(batch_start + EMBEDDING_BATCH_SIZE, len(all_chunks))
                     all_batch_chunks.append(all_chunks[batch_start:batch_end])
@@ -497,9 +498,9 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     f"{len(child_chunks_list)} child chunks prepared.")
 
             elif auto_questions_topn:
-                # QA 模式（FastGPT 方案）：
-                # 1. 原 chunk 标记为 source（保留供 GraphRAG 使用，不参与检索）
-                # 2. LLM 生成 QA 对，每个 QA 对独立存储为 qa chunk
+                # QA mode keeps source chunks but writes QA chunks first for vectorized index creation.
+                # 1. Original chunks are marked as source for full-text retrieval, provenance, and GraphRAG.
+                # 2. LLM-generated QA pairs are stored as independent qa chunks.
                 indexed_items = list(enumerate(res))
 
                 def _generate_qa(idx_item: tuple[int, dict]) -> tuple[int, list]:
@@ -560,7 +561,7 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     item = res[global_idx]
                     source_chunk_id = uuid.uuid4().hex
 
-                    # source chunk：保留原文，供 GraphRAG 使用，不参与向量检索
+                    # Source chunks keep the original text and are not vectorized.
                     source_meta = {
                         "doc_id": source_chunk_id,
                         "file_id": str(db_document.file_id),
@@ -597,8 +598,8 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                             DocumentChunk(page_content=pair["question"], metadata=qa_meta))
                         qa_sort_id += 1
 
-                # 按 batch 分组（source + qa 一起）
-                all_chunks = source_chunks + qa_chunks
+                # Batch QA chunks before source chunks so vectorized writes create ES mapping first.
+                all_chunks = prioritize_vectorized_chunks(source_chunks + qa_chunks)
                 for batch_start in range(0, len(all_chunks), EMBEDDING_BATCH_SIZE):
                     batch_end = min(batch_start + EMBEDDING_BATCH_SIZE, len(all_chunks))
                     all_batch_chunks.append(all_chunks[batch_start:batch_end])
@@ -626,6 +627,8 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                         chunks.append(DocumentChunk(page_content=item["content_with_weight"], metadata=metadata))
                     all_batch_chunks.append(chunks)
 
+            total_batches = len(all_batch_chunks)
+
             # 并发提交 embedding + ES 写入，max_workers 控制模型 API 并发压力
             batch_errors: dict[int, Exception] = {}
 
@@ -639,6 +642,22 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                     except Exception as retry_exc:
                         logger.error(f"[ParseDoc] batch {batch_idx} retry failed: {retry_exc}", exc_info=True)
                         batch_errors[batch_idx] = retry_exc
+
+            bootstrap_batch_idx, bootstrap_batch = pop_vectorized_bootstrap_batch(all_batch_chunks)
+            if bootstrap_batch is not None:
+                logger.info(
+                    "[ParseDoc] writing vectorized bootstrap batch before concurrent ES writes: "
+                    f"batch={bootstrap_batch_idx}, chunks={len(bootstrap_batch)}"
+                )
+                _embed_and_store(bootstrap_batch_idx, bootstrap_batch)
+                if bootstrap_batch_idx in batch_errors:
+                    failed_detail = "; ".join(
+                        f"batch {i}: {type(err).__name__}: {err}"
+                        for i, err in sorted(batch_errors.items())
+                    )
+                    raise RuntimeError(
+                        f"Embedding failed for {len(batch_errors)}/{total_batches} batch(es). {failed_detail}"
+                    )
 
             with ThreadPoolExecutor(max_workers=EMBEDDING_MAX_WORKERS) as executor:
                 futures = {


### PR DESCRIPTION
## Summary
- Prioritize vectorized chunks before source/parent chunks when writing parsed document batches to Elasticsearch.
- Bootstrap one vectorized batch synchronously before concurrent batch writes so new ES mappings use the real embedding dimension.
- Keep source and parent chunks written for full-text retrieval, provenance, and GraphRAG use.

## Changes
- api/app/core/rag/utils/chunk_write_order.py | new helper for vectorized chunk ordering and bootstrap batch selection
- api/app/tasks.py | apply QA/parent-child write ordering and bootstrap the first vectorized batch before concurrent writes

## Impact
- No controller or route changes.
- Internal document parsing and API-key document parsing both benefit because they share the parse task path.
- QA-empty source-only fallback remains out of scope for this PR.

## Risks
- Existing incorrectly-created Elasticsearch indices still need reindex/delete; this change only affects future writes.
- If QA mode generates no QA pairs, the source-only mapping fallback risk is unchanged.

## Test Plan
- [x] cd api && PYTHONPATH=. .venv/bin/pytest tests/rag/test_chunk_write_order.py -q
- [x] cd api && PYTHONPATH=. .venv/bin/python -m py_compile app/tasks.py app/core/rag/utils/chunk_write_order.py

## Summary by Sourcery

在并发写入 Elasticsearch 之前，优先处理向量化的分块，并预先引导一个初始嵌入批次，以确保 RAG 文档摄入时的索引映射正确。

Bug 修复：
- 确保 Elasticsearch 向量索引映射是基于已向量化的分块创建，而不是基于未向量化的原始分块或父分块，从而防止在新写入时出现错误的嵌入维度。

增强：
- 引入工具以对分块进行排序，使向量化分块在未向量化分块之前写入，并选择一个向量化的引导批次，在并行嵌入之前进行同步处理。
- 在保留原始分块和父分块以用于全文搜索和溯源（provenance）的同时，将新的分块写入顺序和引导逻辑应用于父子模式和 QA 解析模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize vectorized chunks and bootstrap an initial embedding batch before concurrent Elasticsearch writes to ensure correct index mappings for RAG document ingestion.

Bug Fixes:
- Ensure Elasticsearch vector index mappings are created from vectorized chunks instead of non-vectorized source or parent chunks, preventing incorrect embedding dimensions on new writes.

Enhancements:
- Introduce utilities to order chunks so vectorized chunks are written before non-vectorized ones and to select a vectorized bootstrap batch for synchronous processing before parallel embedding.
- Apply the new chunk write ordering and bootstrap logic to parent-child and QA parsing modes while preserving source and parent chunks for full-text and provenance use.

</details>