### PR TITLE
refactor(memory): use short-lived db sessions in celery write tasks to avoid long-running llm calls holding db connections

### DIFF
--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -83,12 +83,12 @@ async def get_chunked_dialogs(
         from app.services.memory_config_service import MemoryConfigService
         from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
         
-        # 加载剪枝配置
+        # 加载剪枝配置（短暂 DB session，查完即关）
         pruning_config = None
+        llm_client = None
         if config_id:
             try:
                 with get_db_context() as db:
-                    # 使用 MemoryConfigService 加载完整的 MemoryConfig 对象
                     config_service = MemoryConfigService(db)
                     memory_config = config_service.load_memory_config(
                         config_id=config_id,
@@ -106,44 +106,46 @@ async def get_chunked_dialogs(
                         )
                         logger.info(f"[剪枝] 加载配置: switch={pruning_config.pruning_switch}, scene={pruning_config.pruning_scene}, threshold={pruning_config.pruning_threshold}")
                         
-                        # 获取LLM客户端用于剪枝
+                        # 获取 LLM 客户端（仅读取 API key/base_url，不做 LLM 调用）
                         if pruning_config.pruning_switch:
                             factory = MemoryClientFactory(db)
                             llm_client = factory.get_llm_client_from_config(memory_config)
-                            
-                            # 执行剪枝 - 使用 prune_dataset 支持消息级剪枝
-                            import re
-                            import langid
-                            user_text = " ".join(
-                                re.sub(r"<input-file-summary>.*?</input-file-summary>", "", m.msg, flags=re.DOTALL).strip()
-                                for m in dialog_data.context.msgs if m.role == "user" and m.msg
-                            )
-                            pruning_language = langid.classify(user_text)[0] if user_text else "zh"
-                            if pruning_language not in ("zh", "en"):
-                                pruning_language = "en"
-                            pruner = SemanticPruner(config=pruning_config, llm_client=llm_client, language=pruning_language, snapshot=snapshot)
-                            original_msg_count = len(dialog_data.context.msgs)
-                            
-                            # 使用 prune_dataset 而不是 prune_dialog
-                            # prune_dataset 会进行消息级剪枝，即使对话整体相关也会删除不重要消息
-                            pruned_dialogs = await pruner.prune_dataset([dialog_data])
-                            
-                            if pruned_dialogs:
-                                dialog_data = pruned_dialogs[0]
-                                remaining_msg_count = len(dialog_data.context.msgs)
-                                deleted_count = original_msg_count - remaining_msg_count
-                                logger.info(f"[剪枝] 完成: 原始{original_msg_count}条 -> 保留{remaining_msg_count}条 (删除{deleted_count}条)")
-                                
-                                # 将剪枝记录挂到 metadata，供 graph_build_step 构建节点
-                                if pruner.pruning_records:
-                                    dialog_data.metadata["assistant_pruning_records"] = [
-                                        r.model_dump() for r in pruner.pruning_records
-                                    ]
-                                    logger.info(f"[剪枝] 收集到 {len(pruner.pruning_records)} 条剪枝记录")
-                            else:
-                                logger.warning("[剪枝] prune_dataset 返回空列表")
                         else:
                             logger.info("[剪枝] 配置中剪枝开关关闭，跳过剪枝")
+                # session 在此关闭，关闭DB连接
+
+                # 执行剪枝（LLM 调用在 session 外，不占用 DB 连接）
+                if pruning_config and pruning_config.pruning_switch and llm_client:
+                    import re
+                    import langid
+                    user_text = " ".join(
+                        re.sub(r"<input-file-summary>.*?</input-file-summary>", "", m.msg, flags=re.DOTALL).strip()
+                        for m in dialog_data.context.msgs if m.role == "user" and m.msg
+                    )
+                    pruning_language = langid.classify(user_text)[0] if user_text else "zh"
+                    if pruning_language not in ("zh", "en"):
+                        pruning_language = "en"
+                    pruner = SemanticPruner(config=pruning_config, llm_client=llm_client, language=pruning_language, snapshot=snapshot)
+                    original_msg_count = len(dialog_data.context.msgs)
+                    
+                    # 使用 prune_dataset 而不是 prune_dialog
+                    # prune_dataset 会进行消息级剪枝，即使对话整体相关也会删除不重要消息
+                    pruned_dialogs = await pruner.prune_dataset([dialog_data])
+                    
+                    if pruned_dialogs:
+                        dialog_data = pruned_dialogs[0]
+                        remaining_msg_count = len(dialog_data.context.msgs)
+                        deleted_count = original_msg_count - remaining_msg_count
+                        logger.info(f"[剪枝] 完成: 原始{original_msg_count}条 -> 保留{remaining_msg_count}条 (删除{deleted_count}条)")
+                        
+                        # 将剪枝记录挂到 metadata，供 graph_build_step 构建节点
+                        if pruner.pruning_records:
+                            dialog_data.metadata["assistant_pruning_records"] = [
+                                r.model_dump() for r in pruner.pruning_records
+                            ]
+                            logger.info(f"[剪枝] 收集到 {len(pruner.pruning_records)} 条剪枝记录")
+                    else:
+                        logger.warning("[剪枝] prune_dataset 返回空列表")
             except Exception as e:
                 logger.warning(f"[剪枝] 加载配置失败，跳过剪枝: {e}", exc_info=True)
     except Exception as e:

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -289,14 +289,14 @@ class MemoryAgentService:
     async def write_memory(
             self,
             request: WriteMemoryRequest,
-            db: Session,
+            db: Optional[Session] = None,
     ) -> str:
         """
         长期记忆写入
 
         Args:
             request: 写入请求参数（end_user_id、messages、config_id、storage_type、language 等）
-            db: SQLAlchemy database session
+            db: SQLAlchemy database session（可选，传 None 时内部自行管理短暂 session）
 
         Returns:
             Write operation result status
@@ -405,7 +405,7 @@ class MemoryAgentService:
             user_rag_memory_id,
             language,
             conversation_id,
-            db: Session,
+            db: Optional[Session],
             start_time: float,
     ) -> str:
         """write_memory 的核心实现（已持有 per-end_user 锁）。"""
@@ -495,13 +495,21 @@ class MemoryAgentService:
             self,
             end_user_id: str,
             config_id: Optional[uuid.UUID] | int,
-            db: Session,
+            db: Optional[Session],
             start_time: float,
     ):
-        """解析 end_user 关联配置并从数据库加载完整 memory_config。"""
+        """解析 end_user 关联配置并从数据库加载完整 memory_config。
+
+        当 db=None 时（Celery 后台任务路径），内部自行开短暂 session 完成查询。
+        """
         workspace_id = None
         try:
-            connected_config = get_end_user_connected_config(end_user_id, db)
+            # 短暂 session：仅用于查询 end_user 关联配置
+            if db is not None:
+                connected_config = get_end_user_connected_config(end_user_id, db)
+            else:
+                with get_db_context() as _db:
+                    connected_config = get_end_user_connected_config(end_user_id, _db)
             # get_end_user_connected_config 返回字符串，需转为 UUID
             workspace_id_raw = connected_config.get("workspace_id")
             if workspace_id_raw and workspace_id_raw != "None":
@@ -556,10 +564,13 @@ class MemoryAgentService:
             messages: list[MessageItem] | list[dict],
             end_user_id: str,
             memory_config,
-            db: Session,
+            db: Optional[Session],
     ) -> list[dict]:
-        """处理消息中附带的文件，生成感知记忆对象并挂载到 message['file_content']。"""
-        perceptual_service = MemoryPerceptualService(db)
+        """处理消息中附带的文件，生成感知记忆对象并挂载到 message['file_content']。
+
+        当 db=None 时（Celery 后台任务路径），每个文件单独开短暂 session，
+        避免长时间持有 DB 连接等待 LLM 推理。
+        """
         for message in messages:
             if isinstance(message, dict):
                 message["file_content"] = []
@@ -568,12 +579,26 @@ class MemoryAgentService:
                 message.file_content = []
                 files = message.files or []
             for file in files:
-                file_object = await perceptual_service.generate_perceptual_memory(
-                    end_user_id=end_user_id,
-                    memory_config=memory_config,
-                    file=FileInput(**file),
-                    content=message.content if isinstance(message, MessageItem) else message["content"],
-                )
+                # 每个文件独立开 session：查询/创建 Perceptual 记录 + LLM 推理 + commit
+                # 注意：generate_perceptual_memory 内部含 LLM 调用（10-60s），
+                # 此处复用外层 db（Controller 路径）或自行开 session（Celery 路径）
+                if db is not None:
+                    perceptual_service = MemoryPerceptualService(db)
+                    file_object = await perceptual_service.generate_perceptual_memory(
+                        end_user_id=end_user_id,
+                        memory_config=memory_config,
+                        file=FileInput(**file),
+                        content=message.content if isinstance(message, MessageItem) else message["content"],
+                    )
+                else:
+                    with get_db_context() as _db:
+                        perceptual_service = MemoryPerceptualService(_db)
+                        file_object = await perceptual_service.generate_perceptual_memory(
+                            end_user_id=end_user_id,
+                            memory_config=memory_config,
+                            file=FileInput(**file),
+                            content=message.content if isinstance(message, MessageItem) else message["content"],
+                        )
                 if file_object is None:
                     continue
                 if isinstance(message, dict):

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -571,6 +571,9 @@ class MemoryAgentService:
         当 db=None 时（Celery 后台任务路径），每个文件单独开短暂 session，
         避免长时间持有 DB 连接等待 LLM 推理。
         """
+        # 当外层提供 db 时，复用同一个 service 实例，避免每个文件重复实例化
+        perceptual_service = MemoryPerceptualService(db) if db is not None else None
+
         for message in messages:
             if isinstance(message, dict):
                 message["file_content"] = []
@@ -579,11 +582,9 @@ class MemoryAgentService:
                 message.file_content = []
                 files = message.files or []
             for file in files:
-                # 每个文件独立开 session：查询/创建 Perceptual 记录 + LLM 推理 + commit
                 # 注意：generate_perceptual_memory 内部含 LLM 调用（10-60s），
                 # 此处复用外层 db（Controller 路径）或自行开 session（Celery 路径）
-                if db is not None:
-                    perceptual_service = MemoryPerceptualService(db)
+                if perceptual_service is not None:
                     file_object = await perceptual_service.generate_perceptual_memory(
                         end_user_id=end_user_id,
                         memory_config=memory_config,
@@ -592,8 +593,8 @@ class MemoryAgentService:
                     )
                 else:
                     with get_db_context() as _db:
-                        perceptual_service = MemoryPerceptualService(_db)
-                        file_object = await perceptual_service.generate_perceptual_memory(
+                        _perceptual_service = MemoryPerceptualService(_db)
+                        file_object = await _perceptual_service.generate_perceptual_memory(
                             end_user_id=end_user_id,
                             memory_config=memory_config,
                             file=FileInput(**file),

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1769,31 +1769,30 @@ def write_message_task(
             return {"status": "success", "processed": processed}
 
         # 完整写入模式（API write 路径，带 messages）
-        with get_db_context() as db:
-            logger.info(
-                f"[CELERY WRITE] Executing MemoryAgentService.write_memory "
-                f"with config_id = {actual_config_id} (type: {type(actual_config_id).__name__}), language={language}")
+        logger.info(
+            f"[CELERY WRITE] Executing MemoryAgentService.write_memory "
+            f"with config_id = {actual_config_id} (type: {type(actual_config_id).__name__}), language={language}")
 
-            _default_dialog_at = to_iso_z(utcnow_naive())
-            for msg in message:
-                if isinstance(msg, dict) and not msg.get("dialog_at"):
-                    msg["dialog_at"] = _default_dialog_at
+        _default_dialog_at = to_iso_z(utcnow_naive())
+        for msg in message:
+            if isinstance(msg, dict) and not msg.get("dialog_at"):
+                msg["dialog_at"] = _default_dialog_at
 
-            service = MemoryAgentService()
-            result = await service.write_memory(
-                WriteMemoryRequest(
-                    end_user_id=end_user_id,
-                    messages=message,
-                    config_id=actual_config_id,
-                    storage_type=storage_type,
-                    user_rag_memory_id=user_rag_memory_id,
-                    language=language,
-                    conversation_id=conversation_id,
-                ),
-                db,
-            )
-            logger.info(f"[CELERY WRITE] Write completed successfully: {result}")
-            return result
+        service = MemoryAgentService()
+        result = await service.write_memory(
+            WriteMemoryRequest(
+                end_user_id=end_user_id,
+                messages=message,
+                config_id=actual_config_id,
+                storage_type=storage_type,
+                user_rag_memory_id=user_rag_memory_id,
+                language=language,
+                conversation_id=conversation_id,
+            ),
+            db=None,
+        )
+        logger.info(f"[CELERY WRITE] Write completed successfully: {result}")
+        return result
 
     redis_client = get_sync_redis_client()
     lock = None


### PR DESCRIPTION
## Summary by Sourcery

重构内存写入和裁剪流程，以避免在可能耗时较长的 LLM 操作（尤其是 Celery 任务）期间持有长生命周期的数据库会话；当未传入会话时，改为使用短生命周期、由内部管理的会话。

Enhancements:
- 使用短生命周期的数据库会话加载裁剪配置和 LLM 客户端，然后在会话之外执行语义裁剪，以更早释放数据库连接。
- 允许 `MemoryAgentService.write_memory` 及其辅助方法接受可选的数据库会话；在 Celery/后台上下文中运行时，如果未传入会话，则在内部创建短生命周期的会话。
- 在处理内存写入请求中附带的文件时，如果未提供外部会话，则为每个文件使用短生命周期的数据库会话，从而在基于 LLM 的感知记忆生成过程中缩短数据库连接的占用时间。
- 调整 Celery 的 write-memory 任务流程，使其在调用 `MemoryAgentService` 时不传入外部数据库上下文，从而依赖新的短生命周期会话行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor memory write and pruning flows to avoid long-lived database sessions during potentially long LLM operations, especially in Celery tasks by using short-lived, internally managed sessions when no session is passed in.

Enhancements:
- Load pruning configuration and LLM client using a short-lived DB session, then perform semantic pruning outside the session to release DB connections sooner.
- Allow MemoryAgentService.write_memory and its helpers to accept an optional DB session and create short-lived sessions internally when running in Celery/background contexts.
- Process attached files in memory write requests using per-file short-lived DB sessions when no external session is provided, reducing DB connection hold times during LLM-based perceptual memory generation.
- Adjust Celery write-memory task flow to call MemoryAgentService without an external DB context so that it relies on the new short-lived session behavior.

</details>