### PR TITLE
refactor(community): filter blank entity descriptions in analytics graph data

### DIFF
--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -8,7 +8,7 @@ import os
 import uuid
 from collections import Counter
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -2203,6 +2203,42 @@ async def analytics_community_graph_data(
         raise
 
 
+def _is_blank_content(value: Any) -> bool:
+    """判定一个属性值是否视作「空内容」。
+
+    业务规则（仅用于 ``ExtractedEntity`` 的 ``description`` /
+    ``description_summary``）：``None`` / 空字符串 / 仅空白的字符串 / 空列表
+    / 元素全为空白字符串的列表 —— 均视为「无内容」，不应在响应中暴露。
+
+    Args:
+        value: 属性原始值（``_clean_neo4j_value`` 之前的形态即可，本判定仅看
+            字符串与列表的「空」语义）。
+
+    Returns:
+        ``True`` 表示该字段无展示意义，调用方应跳过写入。
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    if isinstance(value, list):
+        if not value:
+            return True
+        return all(
+            isinstance(item, str) and item.strip() == ""
+            for item in value
+        )
+    return False
+
+
+# ``ExtractedEntity`` 节点中需要做「内容存在性」过滤的字段集合。
+# 命中本集合的字段，若值为空（参见 :func:`_is_blank_content`）将不会写入响应。
+_ENTITY_CONTENT_GATED_FIELDS: FrozenSet[str] = frozenset({
+    "description",
+    "description_summary",
+})
+
+
 def _extract_node_properties(
     label: str,
     properties: Dict[str, Any],
@@ -2218,6 +2254,11 @@ def _extract_node_properties(
 
     保留 ``entity_type`` / ``emotion_type`` / ``emotion_subject`` 三个字段
     的枚举映射逻辑，以维持响应字段的中文化展示。
+
+    业务过滤：当 ``label == "ExtractedEntity"`` 时，``description`` 与
+    ``description_summary`` 仅在「有内容」时才写入响应——空字符串、纯空白、
+    空列表、全空白元素列表均视为无内容（参见 :func:`_is_blank_content`）。
+    其余字段不受影响，节点本身始终返回。
 
     Args:
         label: 节点类型标签（``labels(n)[0]``）。
@@ -2235,6 +2276,15 @@ def _extract_node_properties(
         if field not in properties:
             continue
         value = properties[field]
+        # ExtractedEntity 的 description / description_summary 字段：
+        # 仅在原始值有内容时才纳入响应。判定基于「清洗前」的原始值，避免
+        # _clean_neo4j_value 把空字符串包装成其它形态后再判空。
+        if (
+            label == "ExtractedEntity"
+            and field in _ENTITY_CONTENT_GATED_FIELDS
+            and _is_blank_content(value)
+        ):
+            continue
         mapper = _NODE_FIELD_VALUE_MAPPERS.get(field)
         if mapper is not None:
             value = mapper(value)
@@ -2249,6 +2299,11 @@ _NODE_FIELD_VALUE_MAPPERS: Dict[str, Callable[[Any], Any]] = {
     "entity_type": lambda v: type_mapping.get(v, ""),
     "emotion_type": lambda v: EmotionType.EMOTION_MAPPING.get(v),
     "emotion_subject": lambda v: EmotionSubject.SUBJECT_MAPPING.get(v),
+    # description 存储为分号分隔的字符串，API 返回时拆分为数组
+    "description": lambda v: (
+        [d.strip() for d in v.replace("；", ";").split(";") if d.strip()]
+        if isinstance(v, str) else (v if isinstance(v, list) else [])
+    ),
 }
 
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在分析社区图数据响应中，过滤掉 ExtractedEntity 节点为空的描述。

新功能：
- 在分析图响应中，将 ExtractedEntity 的 description 值从以分号分隔的字符串规范化为去除首尾空格的字符串数组。

错误修复：
- 在分析图响应中，排除 ExtractedEntity 节点中为空或仅包含空白字符的 description 和 description_summary 值，以避免暴露无意义的内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Filter out blank descriptions for ExtractedEntity nodes in analytics community graph data responses.

New Features:
- Normalize ExtractedEntity description values from semicolon-delimited strings to trimmed string arrays in analytics graph responses.

Bug Fixes:
- Exclude empty or whitespace-only description and description_summary values for ExtractedEntity nodes from analytics graph responses to avoid exposing meaningless content.

</details>