### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/core/workflow/nodes/cycle_graph/iteration.py
+++ b/api/app/core/workflow/nodes/cycle_graph/iteration.py
@@ -201,7 +201,7 @@ class IterationRuntime:
                 result = await graph.ainvoke(init_state, config=checkpoint)
 
             output = child_pool.get_value(self.output_value)
-            stopped = result["looping"] == 2
+            stopped = result.get("looping") == 2 if isinstance(result, dict) else False
             return idx, output, result, child_pool, stopped, True
         except Exception as e:
             logger.warning(f"Iteration node {self.node_id}: iteration idx={idx} failed: {e}")


### PR DESCRIPTION
safely access 'looping' key in iteration node result

## Summary by Sourcery

Bug Fixes:
- 通过安全读取迭代节点结果中的循环标志，避免潜在崩溃；这些结果可能不包含该键，或可能并非字典。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid potential crashes by safely reading the looping flag from iteration node results that may not include the key or may not be dictionaries.

</details>