### PR TITLE
Feature/reflection dedup prompt lm

### DIFF
--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -95,7 +95,7 @@ class ReflectionPipeline:
         # 构建 embedding_client（用于更名后重新生成 name_embedding）
         if not hasattr(self, '_embedding_client'):
             self._embedding_client = None
-            embedding_id = getattr(self.memory_config, 'embedding_id', None)
+            embedding_id = getattr(self.memory_config, 'embedding_model_id', None)
             if embedding_id:
                 try:
                     from app.core.memory.pipelines.base_pipeline import ModelClientMixin

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/cypher_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/cypher_merger.py
@@ -1,6 +1,6 @@
 """子问题 3 · 合并执行：Neo4j 事务（方案A和B共用）"""
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -10,28 +10,76 @@ logger = logging.getLogger(__name__)
 def choose_keeper(
     entity_a, entity_b,
     llm_winner: Optional[str] = None,
+    degree_a: int = 0,
+    degree_b: int = 0,
 ) -> tuple:
     """选择 keeper（保留方）
 
-    优先级：LLM指定 > activation_value高 > 默认A
-    支持 dict 和对象两种入参。
+    优先级：LLM指定 > 默认A
+
+    NOTE: 当前版本暂时关闭"度数优先"。下版本打开时把"度数绝对优先"块取消注释,
+    并恢复 fetch_degrees / fetch_degrees_batch 的调用即可。degree_a/degree_b 参数
+    仍保留以保持调用方签名兼容。
     """
+    # === 度数优先（暂时关闭，下版打开）===
+    # 度数优先是为了让度数小的当 loser，最小化边迁移量、规避超级节点 OOM。
+    # if degree_a != degree_b:
+    #     return (entity_a, entity_b) if degree_a > degree_b else (entity_b, entity_a)
+    # ====================================
+
+    # LLM 指定
     if llm_winner == "a":
         return entity_a, entity_b
     if llm_winner == "b":
         return entity_b, entity_a
 
-    def _get_activation(e):
-        if isinstance(e, dict):
-            return e.get("activation_value", 0) or 0
-        return getattr(e, "activation_value", 0) or 0
-
-    act_a = _get_activation(entity_a)
-    act_b = _get_activation(entity_b)
-    if act_a != act_b:
-        return (entity_a, entity_b) if act_a > act_b else (entity_b, entity_a)
-
+    # 默认 A
     return (entity_a, entity_b)
+
+
+# === 度数查询（暂时关闭，下版打开 choose_keeper 度数优先时一并恢复）===
+# async def fetch_degrees(
+#     connector: Neo4jConnector,
+#     end_user_id: str,
+#     id_a: str,
+#     id_b: str,
+# ) -> Tuple[int, int]:
+#     """查两实体度数，返回 (degree_a, degree_b)；查不到按 0 处理"""
+#     from app.repositories.neo4j.cypher_queries import ENTITY_DEGREE_COUNT
+#     try:
+#         rows = await connector.execute_query(
+#             ENTITY_DEGREE_COUNT,
+#             end_user_id=end_user_id, id_a=id_a, id_b=id_b,
+#         )
+#         deg = {r["id"]: r["degree"] for r in rows}
+#         return deg.get(id_a, 0), deg.get(id_b, 0)
+#     except Exception as e:
+#         logger.warning(f"度数查询失败 {id_a}/{id_b}: {e}")
+#         return 0, 0
+#
+#
+# async def fetch_degrees_batch(
+#     connector: Neo4jConnector,
+#     end_user_id: str,
+#     ids: List[str],
+# ) -> Dict[str, int]:
+#     """批量查多个实体度数，返回 {id: degree}；查不到的按 0 处理（调用方用 .get(id, 0)）。
+#
+#     用于方案B 同名同类型直合的桶内度数批量获取，避免 N-1 次成对查询。
+#     """
+#     from app.repositories.neo4j.cypher_queries import ENTITY_DEGREES_BY_IDS
+#     if not ids:
+#         return {}
+#     try:
+#         rows = await connector.execute_query(
+#             ENTITY_DEGREES_BY_IDS,
+#             end_user_id=end_user_id, ids=ids,
+#         )
+#         return {r["id"]: r["degree"] for r in rows}
+#     except Exception as e:
+#         logger.warning(f"批量度数查询失败 ids_count={len(ids)}: {e}")
+#         return {}
+# ========================================================================
 
 
 async def execute_merge(
@@ -41,13 +89,28 @@ async def execute_merge(
     loser_id: str,
     merged_name: str,
     merged_aliases: List[str],
-) -> bool:
+    loser_degree: int = 0,
+    merge_max_degree: int = 1000,
+) -> str:
     """执行合并事务（属性合并 + 边迁移 + 删除 loser）
 
-    单条 Cypher 事务，耗时约 20~50ms。
-    如果 loser 已被其他进程删除，MATCH 返回空，自动跳过。
+    返回状态："success" | "skipped_super_node" | "failed"
+    - loser_degree > merge_max_degree：跳过（避免单事务 OOM / 锁阻塞），仅 logger 记录。
+    - 否则执行单条 Cypher 事务（原子）。
+
+    NOTE: 当前版本暂时关闭超级节点保护（loser_degree / merge_max_degree 参数仍保留，
+    用于度数优先的 keeper 选择 / 调用方签名兼容）。下个版本恢复时把下方 if 块取消注释即可。
     """
     from app.repositories.neo4j.cypher_queries import DEDUP_MERGE_ENTITIES
+
+    # === 超级节点保护（暂时关闭，下版打开）===
+    # if loser_degree > merge_max_degree:
+    #     logger.warning(
+    #         f"跳过超级节点合并 keeper={keeper_id} loser={loser_id} "
+    #         f"loser_degree={loser_degree} > merge_max_degree={merge_max_degree}"
+    #     )
+    #     return "skipped_super_node"
+    # ========================================
 
     try:
         result = await connector.execute_query(
@@ -58,24 +121,26 @@ async def execute_merge(
             merged_name=merged_name,
             merged_aliases=merged_aliases,
         )
-        return bool(result)
+        return "success" if result else "failed"
     except Exception as e:
         logger.error(f"合并事务失败 keeper={keeper_id} loser={loser_id}: {e}")
-        return False
+        return "failed"
 
 
-def build_merged_aliases(keeper: Dict, loser: Dict, merged_name: str) -> List[str]:
+def build_merged_aliases(
+    keeper: Dict, loser: Dict, merged_name: str,
+    new_aliases: Optional[List[str]] = None,
+) -> List[str]:
     """构建合并后的 aliases 列表
 
-    规则：两侧 aliases 并集 + loser.name 降为 alias，去掉 merged_name 本身
+    规则：两侧已有 aliases 并集 ∪ LLM new_aliases，去掉 merged_name 与空串。
+    不再做旧名降级（旧名是否保留为别名由 LLM 在 new_aliases 决定）。
     """
     all_names = set()
     all_names.update(keeper.get("aliases") or [])
     all_names.update(loser.get("aliases") or [])
-    if loser.get("name") and loser["name"] != merged_name:
-        all_names.add(loser["name"])
-    if keeper.get("name") and keeper["name"] != merged_name:
-        all_names.add(keeper["name"])
+    if new_aliases:
+        all_names.update(new_aliases)
     all_names.discard(merged_name)
     all_names.discard("")
     return sorted(all_names)

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/entity_similarity.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/entity_similarity.py
@@ -30,7 +30,7 @@ def _prefixed_row(row: dict, prefix: str, end_user_id: str) -> dict:
         "entity_type": row["entity_type"],
         "description": row.get(f"{prefix}_desc", ""),
         "aliases": row.get(f"{prefix}_aliases") or [],
-        "name_embedding": row.get(f"{prefix}_embed") or [],
+        "name_embedding": [],
         "end_user_id": end_user_id,
         **_ENTITY_DEFAULTS,
     }
@@ -83,7 +83,9 @@ async def fetch_name_candidates(
         if _would_merge_cross_role(entity_a, entity_b):
             continue
 
-        sim_result = name_similarity_with_aliases(entity_a, entity_b)
+        # emb_sim 由 Neo4j 侧 vector.similarity.cosine 算好直接传入，避免拉回向量在 Python 重算
+        emb_sim = row.get("emb_sim") or 0.0
+        sim_result = name_similarity_with_aliases(entity_a, entity_b, emb_sim=emb_sim)
         sim = sim_result[0]
 
         has_exact = has_exact_alias_match(entity_a, entity_b)

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/entity_similarity.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/entity_similarity.py
@@ -45,6 +45,8 @@ class DedupCandidatePair(BaseModel):
     entity_type: str = ""
     a_desc: str = ""
     b_desc: str = ""
+    a_desc_summary: str = ""
+    b_desc_summary: str = ""
     a_aliases: List[str] = Field(default_factory=list)
     b_aliases: List[str] = Field(default_factory=list)
     sim_name: float = 0.0       # 路径A：名称相似度（0~1）
@@ -100,6 +102,8 @@ async def fetch_name_candidates(
                 entity_type=row["entity_type"],
                 a_desc=row.get("a_desc", ""),
                 b_desc=row.get("b_desc", ""),
+                a_desc_summary=row.get("a_desc_summary") or "",
+                b_desc_summary=row.get("b_desc_summary") or "",
                 a_aliases=row.get("a_aliases") or [],
                 b_aliases=row.get("b_aliases") or [],
                 sim_name=sim,
@@ -142,6 +146,8 @@ async def fetch_embed_candidates(
             entity_type=row["entity_type"],
             a_desc=row.get("a_desc", ""),
             b_desc=row.get("b_desc", ""),
+            a_desc_summary=row.get("a_desc_summary") or "",
+            b_desc_summary=row.get("b_desc_summary") or "",
             a_aliases=row.get("a_aliases") or [],
             b_aliases=row.get("b_aliases") or [],
             sim_embed=row["sim_embed"],

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -2,10 +2,12 @@
 import asyncio
 import logging
 import time
+import uuid
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.core.memory.storage_services.reflection_engine.deterministic.description_checker import (
     scan_merge_candidates,
 )
@@ -31,6 +33,7 @@ from app.repositories.neo4j.cypher_queries import (
     REFLECTION_UPDATE_NAME_EMBEDDING,
     UNRESOLVED_CREATE_ENTITY,
     UNRESOLVED_UPDATE_NAME_EMBEDDING,
+    UNRESOLVED_APPEND_USER_INFO,
     UNRESOLVED_CREATE_RELATIONSHIP,
     UNRESOLVED_CREATE_STATEMENT_ENTITY_EDGE,
     UNRESOLVED_UPDATE_STATEMENT_FLAG,
@@ -59,6 +62,7 @@ class EntityDedupConfig(BaseModel):
     llm_merge_threshold: float = 0.85   # LLM确认后合并阈值
     max_merges_per_run: int = 20        # 单次最多合并数
     merge_concurrency: int = 5          # LLM并发数
+    merge_max_degree: int = 1000        # loser 度数 ≤ 此值原子合并；> 则跳过（超级节点保护，需压测校准）
 
     # === 方案B：低频分组 LLM ===
     min_entities_for_scan: int = 3      # 少于此数不扫描
@@ -219,6 +223,56 @@ class Layer2Inspector:
 
         # 3. 过滤丢弃缓存
         candidates = await filter_discarded(end_user_id, candidates)
+        # 记录候选总数（用于返回值；直合池剥离前的总和）
+        total_candidates = len(candidates)
+
+        # 3.5 同名同类型直合池：name 完全相同（归一化后）→ 不进 LLM，确定性合并
+        # entity_type 在候选对里两侧本就相同（召回 Cypher 已约束），故只需判 name。
+        merged_count = 0
+        direct_merged_count = 0
+        removed_ids: set = set()  # 直合中被删除的 loser id，用于过滤后续 LLM 池
+        # id -> {description, aliases}：直合过程中 keeper 的累积态。
+        # 同一 keeper 出现在多对里时，前次合并已经把 loser 的描述/别名累加进 DB，
+        # 但本对 pair 里仍是召回快照值。用这里的覆盖确保下一对日志 old 用累积态、
+        # 同时 build_merged_aliases 也能按累积态去重并入。
+        keeper_state_overrides: Dict[str, Dict[str, Any]] = {}
+
+        def _norm(s: str) -> str:
+            return (s or "").strip().lower()
+
+        direct_pairs, rest = [], []
+        for c in candidates:
+            if c.a_name and _norm(c.a_name) == _norm(c.b_name):
+                direct_pairs.append(c)
+            else:
+                rest.append(c)
+
+        for c in direct_pairs:
+            if merged_count >= config.max_merges_per_run:
+                break
+            ok, removed_id, keeper_id, keeper_desc, keeper_aliases = (
+                await self._apply_direct_merge(c, end_user_id, baseline,
+                                               keeper_state_overrides)
+            )
+            if ok:
+                merged_count += 1
+                direct_merged_count += 1
+                if removed_id:
+                    removed_ids.add(removed_id)
+                # 把 keeper 的累积态(合并后真实状态)写回 overrides,
+                # 让下一对涉及同一 keeper 的合并能看到真实累积,日志 old/new 才能正确反映本次增量
+                if keeper_id is not None:
+                    keeper_state_overrides[keeper_id] = {
+                        "description": keeper_desc or "",
+                        "aliases": list(keeper_aliases or []),
+                    }
+
+        # 过滤掉涉及已被直合删除的实体的候选对（避免后续 LLM 调用浪费 + 合并失败）
+        candidates = [
+            c for c in rest
+            if c.a_id not in removed_ids and c.b_id not in removed_ids
+        ]
+
         # 4. 两档分流（去掉自动合并，全部走 LLM）
         llm_pool, discard_pool = partition_by_probability(
             candidates, config.theta_low)
@@ -241,7 +295,7 @@ class Layer2Inspector:
         }
 
         # 6. 合并执行（全部经 LLM 确认后才合并）
-        merged_count = 0
+        # merged_count 已在 3.5 直合池处初始化，与直合共享上限
         recorded_count = 0
         rejected_pairs = []
         for pair, decision in llm_results:
@@ -290,10 +344,11 @@ class Layer2Inspector:
 
         return {
             "status": "success",
-            "candidate_count": len(candidates),
+            "candidate_count": total_candidates,
             "llm_pool": len(llm_pool),
             "discard_pool": len(discard_pool),
             "merged_count": merged_count,
+            "direct_merged_count": direct_merged_count,
             "recorded_count": recorded_count,
         }
 
@@ -309,10 +364,14 @@ class Layer2Inspector:
             fetch_entities_by_type, update_scan_time,
         )
         from .llm.entity_dedup_batch_judge import judge_batch_dedup
-        from .deterministic.cypher_merger import execute_merge, build_merged_aliases
+        from .deterministic.cypher_merger import (
+            choose_keeper, execute_merge, build_merged_aliases,
+            # fetch_degrees,  # 暂时关闭度数优先,下版打开
+        )
 
         config = self.dedup_config
         total_merged = 0
+        total_direct_merged = 0
         scanned_types = 0
 
         entity_types = await get_entity_types(self.connector, end_user_id)
@@ -334,6 +393,16 @@ class Layer2Inspector:
             scanned_types += 1
             entities = await fetch_entities_by_type(self.connector, end_user_id, entity_type)
 
+            # 同名同类型直合（确定性快路）：分组内 name 完全相同 → 直接合并不进 LLM
+            # 受 max_pairs_per_run 限制；被合并的实体从 entities 剔除，避免送 LLM 浪费
+            direct_merged_count, removed_ids = await self._direct_merge_in_group(
+                entities, entity_type, end_user_id, baseline,
+                max_merges=config.max_pairs_per_run,
+            )
+            total_merged += direct_merged_count
+            total_direct_merged += direct_merged_count
+            if removed_ids:
+                entities = [e for e in entities if e["entity_id"] not in removed_ids]
             # LLM 分组判定 — 计时
             t0 = time.perf_counter()
             pairs = await judge_batch_dedup(self.llm_client, entities, entity_type)
@@ -341,8 +410,9 @@ class Layer2Inspector:
             llm_ms_per_pair = llm_ms // max(len(pairs), 1)
 
             merged_count = 0
-            for idx_a, idx_b, conf, reason in pairs:
-                if merged_count >= config.max_pairs_per_run:
+            for idx_a, idx_b, conf, reason, new_name, new_aliases in pairs:
+                # 单类型 LLM 合并数 + 直合数共享 max_pairs_per_run 上限
+                if (merged_count + direct_merged_count) >= config.max_pairs_per_run:
                     break
                 if idx_a == idx_b:
                     continue  # 跳过无效对（同一实体）
@@ -354,20 +424,30 @@ class Layer2Inspector:
                 # confidence 阈值检查（和方案A一致）
                 if conf < config.llm_merge_threshold:
                     continue
-                keeper, loser = ea, eb
-                merged_name = keeper["name"]
-                merged_aliases = build_merged_aliases(keeper, loser, merged_name)
+
+                degree_a, degree_b = 0, 0
+                # === 度数优先（暂时关闭，下版打开）===
+                # degree_a, degree_b = await fetch_degrees(
+                #     self.connector, end_user_id, ea["entity_id"], eb["entity_id"])
+                # =====================================
+                keeper, loser = choose_keeper(ea, eb, None, degree_a, degree_b)
+                loser_degree = degree_b if loser is eb else degree_a
+                merged_name = new_name or keeper["name"]
+                merged_aliases = build_merged_aliases(keeper, loser, merged_name, new_aliases)
 
                 t1 = time.perf_counter()
-                success = await execute_merge(
+                merge_status = await execute_merge(
                     self.connector, end_user_id,
                     keeper["entity_id"], loser["entity_id"],
                     merged_name, merged_aliases,
+                    loser_degree=loser_degree,
+                    merge_max_degree=config.merge_max_degree,
                 )
                 write_ms = int((time.perf_counter() - t1) * 1000)
 
-                if success:
+                if merge_status == "success":
                     merged_count += 1
+                    await self._reembed_if_name_changed(keeper, merged_name)
                     # 写 ReflectionLog
                     self._write_dedup_log(
                         end_user_id=end_user_id,
@@ -394,16 +474,38 @@ class Layer2Inspector:
             total_merged += merged_count
             await update_scan_time(end_user_id, entity_type)
 
-        return {"scanned_types": scanned_types, "merged_count": total_merged}
-
+        return {
+            "scanned_types": scanned_types,
+            "merged_count": total_merged,
+            "direct_merged_count": total_direct_merged,
+        }
+    @staticmethod
+    def _merged_description(keeper_desc: str, loser_desc: str) -> str:
+        """与 Cypher DEDUP_MERGE_ENTITIES 一致的 description 拼接策略：
+        任一为空取另一边，两边都有用 '；' 拼。日志和本地回填共用。
+        """
+        kd = keeper_desc or ""
+        ld = loser_desc or ""
+        if not kd:
+            return ld
+        if not ld:
+            return kd
+        return f"{kd}；{ld}"
 
     def _write_dedup_log(self, end_user_id: str, keeper: Dict, loser: Dict,
                          entity_type: str, merged_name: str, merged_aliases: List,
                          confidence: float, execution_detail: Dict, reason: str = "",
                          status: str = "resolved", strategy: str = "MERGE",
-                         baseline: str = "HYBRID"):
-        """写去重 ReflectionLog（方案A和B共用，支持 resolved/recorded）"""
+                         baseline: str = "HYBRID", source: str = "llm"):
+        """写去重 ReflectionLog（方案A和B共用，支持 resolved/recorded）
+
+        Args:
+            source: 合并来源；"llm"=LLM 确认合并，"deterministic"=同名同类型确定性合并。
+                title 显示按此区分，不依赖 reason 字符串硬编码。
+        """
         if status == "resolved":
+            merged_desc = self._merged_description(
+                keeper.get("description", ""), loser.get("description", ""))
             changes = [c for c in [
                 {"field": "name", "old": keeper["name"], "new": merged_name},
                 {"field": "aliases",
@@ -411,10 +513,13 @@ class Layer2Inspector:
                  "new": ", ".join(sorted(merged_aliases))},
                 {"field": "description",
                  "old": keeper.get("description", ""),
-                 "new": f"{keeper.get('description', '')}；{loser.get('description', '')}"},
+                 "new": merged_desc},
             ] if c["old"] != c["new"]]
             summary = f'"{keeper["name"]}" ≈ "{loser["name"]}" → 合并'
-            title = f"MERGE — LLM确认（confidence={confidence:.2f}）" if confidence else "MERGE"
+            if source == "deterministic":
+                title = "MERGE — 同名同类型确定性合并"
+            else:
+                title = f"MERGE — LLM确认（confidence={confidence:.2f}）" if confidence else "MERGE"
         else:
             changes = []
             summary = f'"{keeper["name"]}" ≈ "{loser["name"]}" → 未合并'
@@ -453,7 +558,10 @@ class Layer2Inspector:
     async def _apply_dedup_merge(self, pair, end_user_id: str, baseline: str,
                                 llm_decision=None, step_timing=None) -> bool:
         """执行单对合并 + 写 ReflectionLog"""
-        from .deterministic.cypher_merger import choose_keeper, execute_merge, build_merged_aliases
+        from .deterministic.cypher_merger import (
+            choose_keeper, execute_merge, build_merged_aliases,
+            # fetch_degrees,  # 暂时关闭度数优先,下版打开
+        )
 
         tracker = ExecutionTracker(model=getattr(self.llm_client, "model_name", ""))
         timing = step_timing or {}
@@ -484,22 +592,41 @@ class Layer2Inspector:
         entity_b = {"entity_id": pair.b_id, "name": pair.b_name, "entity_type": pair.entity_type,
                     "description": pair.b_desc, "aliases": pair.b_aliases}
         winner = llm_decision.winner_id if llm_decision else None
-        keeper, loser = choose_keeper(entity_a, entity_b, winner)
+
+        # 度数查询：用于 keeper 选择 + 超级节点保护
+        degree_a, degree_b = 0, 0
+        # === 度数优先（暂时关闭，下版打开）===
+        # degree_a, degree_b = await fetch_degrees(
+        #     self.connector, end_user_id, pair.a_id, pair.b_id)
+        # =====================================
+        keeper, loser = choose_keeper(entity_a, entity_b, winner, degree_a, degree_b)
+        loser_degree = degree_b if loser is entity_b else degree_a
+
         merged_name = llm_decision.merged_name if llm_decision and llm_decision.merged_name else keeper["name"]
-        merged_aliases = build_merged_aliases(keeper, loser, merged_name)
+        new_aliases = llm_decision.new_aliases if llm_decision else None
+        merged_aliases = build_merged_aliases(keeper, loser, merged_name, new_aliases)
         tracker.end_step(f"keeper={keeper['name']}")
 
         # Step 5: 写入
         tracker.start_step("写入", "write")
-        success = await execute_merge(
+        merge_status = await execute_merge(
             self.connector, end_user_id,
             keeper["entity_id"], loser["entity_id"],
             merged_name, merged_aliases,
+            loser_degree=loser_degree,
+            merge_max_degree=self.dedup_config.merge_max_degree,
         )
-        if not success:
+        if merge_status == "skipped_super_node":
+            # 当前版本超级节点保护已关闭，理论上不会进此分支；保留兜底。
+            tracker.end_step("跳过超级节点", success=False)
+            return False
+        if merge_status != "success":
             tracker.end_step("合并失败", success=False)
             return False
         tracker.end_step("合并完成")
+
+        # Step 5.5: name 变更则重算 name_embedding
+        await self._reembed_if_name_changed(keeper, merged_name)
 
         # Step 6: 写 ReflectionLog
         self._write_dedup_log(
@@ -514,6 +641,237 @@ class Layer2Inspector:
             baseline=baseline,
         )
         return True
+
+    async def _reembed_if_name_changed(self, keeper: Dict, merged_name: str) -> None:
+        """合并后若 name 变化，重算 name_embedding（与更名流程一致；失败只告警不回滚）"""
+        old_name = keeper.get("name") or ""
+        if not merged_name or merged_name == old_name:
+            return
+        if not self.embedding_client:
+            return
+        try:
+            emb = self.embedding_client.embed_query(merged_name)
+            if emb:
+                await self.connector.execute_query(
+                    REFLECTION_UPDATE_NAME_EMBEDDING,
+                    entity_id=keeper.get("entity_id") or keeper.get("id"),
+                    name_embedding=emb,
+                )
+        except Exception as e:
+            logger.warning(f"合并后重算 name_embedding 失败 name={merged_name}: {e}")
+
+    async def _apply_direct_merge(
+        self, pair, end_user_id: str, baseline: str,
+        keeper_state_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
+    ) -> Tuple[bool, Optional[str], Optional[str], Optional[str], Optional[List[str]]]:
+        """同名同类型确定性合并（不经 LLM），写 ReflectionLog
+
+        Args:
+            keeper_state_overrides: 可选 {entity_id: {description, aliases}}，
+                同一直合循环内若 keeper 已经被前次合并累积过，从这里取覆盖值，
+                而非 pair 上的召回快照值。这样日志 old/new 与 build_merged_aliases
+                都能基于真实累积态。
+
+        Returns:
+            (是否合并成功, 被删除的 loser_id,
+             keeper_id, keeper 合并后的 description, keeper 合并后的 aliases)。
+            失败时返回 (False, None, None, None, None)。
+            调用方据 loser_id 过滤后续 LLM 池中涉及该实体的候选对，避免无效调用。
+            keeper_id/desc/aliases 用于回填 overrides，让下一对涉及同 keeper 的合并
+            能拿到累积态。
+        """
+        from .deterministic.cypher_merger import (
+            choose_keeper, execute_merge, build_merged_aliases,
+            # fetch_degrees,  # 暂时关闭度数优先,下版打开
+        )
+
+        entity_a = {"entity_id": pair.a_id, "name": pair.a_name, "entity_type": pair.entity_type,
+                    "description": pair.a_desc, "aliases": pair.a_aliases}
+        entity_b = {"entity_id": pair.b_id, "name": pair.b_name, "entity_type": pair.entity_type,
+                    "description": pair.b_desc, "aliases": pair.b_aliases}
+
+        # 若该 entity 在本次直合循环里已是某次合并的 keeper，用累积态覆盖召回快照值，
+        # 让日志 old 和 build_merged_aliases 都基于真实累积。
+        if keeper_state_overrides:
+            for ent in (entity_a, entity_b):
+                ov = keeper_state_overrides.get(ent["entity_id"])
+                if ov:
+                    ent["description"] = ov.get("description", ent.get("description", ""))
+                    ent["aliases"] = list(ov.get("aliases", ent.get("aliases", []) or []))
+
+        degree_a, degree_b = 0, 0
+        # === 度数优先（暂时关闭，下版打开）===
+        # degree_a, degree_b = await fetch_degrees(
+        #     self.connector, end_user_id, pair.a_id, pair.b_id)
+        # =====================================
+        keeper, loser = choose_keeper(entity_a, entity_b, None, degree_a, degree_b)
+        loser_degree = degree_b if loser is entity_b else degree_a
+        merged_name = keeper["name"]
+        merged_aliases = build_merged_aliases(keeper, loser, merged_name)  # 不传 new_aliases
+
+        merge_status = await execute_merge(
+            self.connector, end_user_id,
+            keeper["entity_id"], loser["entity_id"],
+            merged_name, merged_aliases,
+            loser_degree=loser_degree,
+            merge_max_degree=self.dedup_config.merge_max_degree,
+        )
+        if merge_status != "success":
+            return False, None, None, None, None
+
+        # name 同名不变，无需重算 embedding
+        self._write_dedup_log(
+            end_user_id=end_user_id,
+            keeper=keeper, loser=loser,
+            entity_type=pair.entity_type,
+            merged_name=merged_name,
+            merged_aliases=merged_aliases,
+            confidence=1.0,
+            execution_detail={
+                "steps": [
+                    {"name": "同名同类型匹配", "type": "decide", "duration_ms": 0,
+                     "output": f'name="{merged_name}" type={pair.entity_type}', "success": True},
+                    {"name": "写入", "type": "write", "duration_ms": 0,
+                     "output": "合并完成", "success": True},
+                ],
+                "total_ms": 0,
+                "model": "",
+            },
+            reason="同名同类型确定性合并",
+            baseline=baseline,
+            strategy="MERGE",
+            status="resolved",
+            source="deterministic",
+        )
+        # 返回 keeper 合并后的累积态(与 Cypher DEDUP_MERGE_ENTITIES 一致)，
+        # 供调用方写入 overrides，让下一对涉及同 keeper 的合并能用上。
+        merged_desc = self._merged_description(
+            keeper.get("description", ""), loser.get("description", ""))
+        return (True, loser["entity_id"], keeper["entity_id"],
+                merged_desc, merged_aliases)
+
+    async def _direct_merge_in_group(
+        self,
+        entities: List[Dict],
+        entity_type: str,
+        end_user_id: str,
+        baseline: str,
+        max_merges: int,
+    ) -> Tuple[int, set]:
+        """方案B 桶内同名同类型确定性合并：分组内 name 完全相同（归一化后）的实体直接合并。
+
+        策略：
+          - 按 (归一化 name) 分桶；
+          - 桶内 ≥2 个 → 度数最大的当 keeper，其余依次合到 keeper；
+          - 受 max_merges 限制（与 LLM 合并共享单类型上限）；
+          - 失败的子合并不影响其他子合并继续。
+
+        Returns:
+            (合并次数, 被删除的 loser entity_id 集合)
+        """
+        from .deterministic.cypher_merger import (
+            execute_merge, build_merged_aliases,
+            # fetch_degrees_batch,  # 暂时关闭度数优先,下版打开
+        )
+
+        if not entities or max_merges <= 0:
+            return 0, set()
+
+        # 1) 按 (归一化 name, entity_type) 分桶
+        # entity_type 实际由调用方保证一致（按类型分组扫描），加进 key 让代码自说明。
+        buckets: Dict[Tuple[str, str], List[Dict]] = {}
+        for e in entities:
+            name_key = (e.get("name") or "").strip().lower()
+            if not name_key:
+                continue
+            type_key = e.get("entity_type") or ""
+            buckets.setdefault((name_key, type_key), []).append(e)
+
+        # 度数关闭后所有实体按 0 处理,keeper 退化为桶内首个
+        degrees: Dict[str, int] = {}
+        # === 桶内度数批量查询（暂时关闭，下版打开）===
+        # ids_for_degree: List[str] = []
+        # for bucket in buckets.values():
+        #     if len(bucket) >= 2:
+        #         ids_for_degree.extend(e["entity_id"] for e in bucket)
+        # degrees = await fetch_degrees_batch(
+        #     self.connector, end_user_id, ids_for_degree)
+        # ===========================================
+
+        merged = 0
+        removed_ids: set = set()
+        for bucket in buckets.values():
+            if len(bucket) < 2:
+                continue
+
+            # 2) 桶内挑度数最大者为 keeper（与方案A 度数绝对优先一致）
+            # 度数优先关闭时所有度数都是 0，max 会取桶内首个（Python max 稳定退化），
+            # 同名同类型反正都会合到一起，keeper 选谁不影响结果。
+            keeper = max(bucket, key=lambda e: degrees.get(e["entity_id"], 0))
+            keeper_id = keeper["entity_id"]
+            merged_name = keeper["name"]
+
+            # 3) 桶内非 keeper 实体逐个合到 keeper
+            for loser in bucket:
+                if loser["entity_id"] == keeper_id:
+                    continue
+                if merged >= max_merges:
+                    break
+
+                merged_aliases = build_merged_aliases(keeper, loser, merged_name)
+                loser_degree = degrees.get(loser["entity_id"], 0)
+
+                merge_status = await execute_merge(
+                    self.connector, end_user_id,
+                    keeper_id, loser["entity_id"],
+                    merged_name, merged_aliases,
+                    loser_degree=loser_degree,
+                    merge_max_degree=self.dedup_config.merge_max_degree,
+                )
+                if merge_status != "success":
+                    continue
+
+                merged += 1
+                removed_ids.add(loser["entity_id"])
+
+                # 写 ReflectionLog（与方案A 直合一致：source="deterministic"）
+                #   注意：必须先写日志再回填本地 keeper（aliases / description），
+                #   这样日志里 old=合并前快照 / new=合并后累积，能正确反映本次增量。
+                self._write_dedup_log(
+                    end_user_id=end_user_id,
+                    keeper=keeper, loser=loser,
+                    entity_type=entity_type,
+                    merged_name=merged_name,
+                    merged_aliases=merged_aliases,
+                    confidence=1.0,
+                    execution_detail={
+                        "steps": [
+                            {"name": "同名同类型匹配", "type": "decide", "duration_ms": 0,
+                             "output": f'name="{merged_name}" type={entity_type}', "success": True},
+                            {"name": "写入", "type": "write", "duration_ms": 0,
+                             "output": "合并完成", "success": True},
+                        ],
+                        "total_ms": 0,
+                        "model": "",
+                    },
+                    reason="同名同类型确定性合并",
+                    baseline=baseline,
+                    strategy="MERGE",
+                    status="resolved",
+                    source="deterministic",
+                )
+
+                # 同步本地 keeper 为最新累积态（与 Cypher DEDUP_MERGE_ENTITIES 一致）：
+                #   - aliases：避免桶内 ≥3 个实体多次合并时丢失中间并入
+                #   - description：让下一次循环的日志快照正确反映 DB 真实累积
+                keeper["aliases"] = merged_aliases
+                keeper["description"] = self._merged_description(
+                    keeper.get("description", ""), loser.get("description", ""))
+
+            if merged >= max_merges:
+                break
+
+        return merged, removed_ids
 
     #子问题6：实体描述合并
     async def _run_unresolved_resolver(self, end_user_id: str, baseline: str,
@@ -610,11 +968,27 @@ class Layer2Inspector:
         # Step 4: 写入 Neo4j
         tracker.start_step("写入Neo4j", "write")
         created_entity_ids = []
+        # 同 statement 内所有派生实体/边共用一个 run_id：优先复用来源 statement 的 run_id，
+        # 老数据为空时一次性兜底，避免实体和关系边拿到不同的随机 run_id。
+        fallback_run_id = stmt.get("run_id") or uuid.uuid4().hex
 
         # 4.1 创建实体
         for entity in validated.entities:
-            # 跳过"用户"实体（用户节点已存在，不需要重复创建）
+            # "用户"实体不重新创建（全局用户节点已存在），改为把本次 LLM 输出的
+            # description 累加到全局用户节点，避免反思补救出来的语义被丢弃。
+            # description 用 '；' 拼接，与 DEDUP_MERGE_ENTITIES 的语义保持一致。
             if entity.name.strip() == "用户":
+                if entity.description:
+                    try:
+                        await self.connector.execute_query(
+                            UNRESOLVED_APPEND_USER_INFO,
+                            end_user_id=end_user_id,
+                            description=entity.description,
+                        )
+                    except Exception as user_err:
+                        logger.warning(
+                            f"追加用户实体描述失败 end_user={end_user_id}: {user_err}"
+                        )
                 continue
             entity_result = await self.connector.execute_query(
                 UNRESOLVED_CREATE_ENTITY,
@@ -622,6 +996,12 @@ class Layer2Inspector:
                 name=entity.name,
                 entity_type=entity.type,
                 description=entity.description,
+                run_id=fallback_run_id,
+                type_id=entity.type_id,
+                type_description=entity.type_description,
+                entity_idx=entity.entity_idx,
+                is_explicit_memory=entity.is_explicit_memory,
+                created_at=utcnow_naive(),
             )
             if entity_result:
                 entity_id = entity_result[0].get("entity_id", "")
@@ -650,9 +1030,12 @@ class Layer2Inspector:
                     predicate=triplet.predicate,
                     predicate_id=triplet.predicate_id,
                     predicate_surface=triplet.predicate_surface,
+                    predicate_description=triplet.predicate_description,
                     statement_id=stmt["statement_id"],
                     valid_at=triplet.valid_at,
                     invalid_at=triplet.invalid_at,
+                    run_id=fallback_run_id,
+                    created_at=utcnow_naive(),
                 )
             except Exception as rel_err:
                 logger.warning(f"创建关系边失败: {rel_err}")
@@ -664,6 +1047,8 @@ class Layer2Inspector:
                 statement_id=stmt["statement_id"],
                 end_user_id=end_user_id,
                 entity_name=entity.name,
+                run_id=fallback_run_id,
+                created_at=utcnow_naive(),
             )
 
         # 4.4 更新 Statement 标记

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
@@ -3,7 +3,7 @@
 """
 import logging
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 from jinja2 import Environment, FileSystemLoader
@@ -21,6 +21,8 @@ _prompt_env = Environment(loader=FileSystemLoader(_prompt_dir))
 class DedupResultItem(BaseModel):
     """单个重复对结果"""
     pair: List[int]             # [1, 3] 索引从1开始
+    new_name: Optional[str] = None   # 合并后主名
+    new_aliases: List[str] = []      # 合并后新增/保留别名
     confidence: float = 0.9
     reason: str = ""
 
@@ -35,7 +37,7 @@ async def judge_batch_dedup(
     entities: List[Dict],
     entity_type: str,
     language: str = "zh",
-) -> List[Tuple[int, int, float, str]]:
+) -> List[Tuple[int, int, float, str, Optional[str], List[str]]]:
     """分组 LLM 判定：一次性找出所有重复对
 
     Args:
@@ -76,7 +78,8 @@ async def judge_batch_dedup(
                 continue
             seen_entities.add(idx_a)
             seen_entities.add(idx_b)
-            results.append((idx_a, idx_b, item.confidence, item.reason))
+            results.append((idx_a, idx_b, item.confidence, item.reason,
+                            item.new_name, item.new_aliases or []))
 
         return results
     except Exception as e:

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
@@ -1,5 +1,5 @@
 """子问题 3 · 方案A LLM层：单对去重判定
-复用已有模板 entity_dedup.jinja2，直接渲染 + call_structured。
+渲染 entity_dedup_reflection.jinja2 + call_structured。
 """
 import asyncio
 import json
@@ -23,15 +23,18 @@ class DedupLLMDecision(BaseModel):
     """LLM 去重判定结果"""
     same_entity: bool           # 是否同一实体
     confidence: float           # 置信度 0~1
-    winner_id: str = "a"        # 保留哪个: "a" | "b"
-    merged_name: str = ""       # 合并后名称
+    winner_id: str = "a"        # 保留哪个: "a" | "b"（canonical_idx 映射）
+    merged_name: str = ""       # 合并后主名（取自 LLM new_name）
+    new_aliases: List[str] = []  # LLM 给出的新别名
     reason: str = ""            # 判定理由
 
 
 class DedupJudgeOutput(BaseModel):
-    """LLM 结构化输出（对应 entity_dedup.jinja2 的 Output format）"""
+    """LLM 结构化输出（对应 entity_dedup_reflection.jinja2 的 Output format）"""
     same_entity: bool
     canonical_idx: int          # 0=A, 1=B
+    new_name: Optional[str] = None      # 合并后主名；same_entity=false 时为 None
+    new_aliases: List[str] = []         # 合并后新增/保留别名；same_entity=false 时为 []
     confidence: float
     reason: str
 
@@ -45,37 +48,28 @@ async def judge_pair_for_dedup(
 ) -> Optional[DedupLLMDecision]:
     """对单对候选调用 LLM 判定
 
-    直接渲染 entity_dedup.jinja2，把两路召回已计算好的分数传入。
-    entity_a/entity_b 只需有 name, entity_type, description, aliases, connect_strength 属性。
+    直接渲染 entity_dedup_reflection.jinja2，把两路召回已计算好的分数传入。
+    entity_a/entity_b 需有 name, entity_type, description, description_summary, aliases 属性。
     """
     try:
         from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
 
-        template = _prompt_env.get_template("entity_dedup.jinja2")
+        template = _prompt_env.get_template("entity_dedup_reflection.jinja2")
         rendered_prompt = template.render(
             entity_a={
                 "name": entity_a.name,
                 "entity_type": entity_a.entity_type,
+                "description_summary": getattr(entity_a, "description_summary", ""),
                 "description": getattr(entity_a, "description", ""),
                 "aliases": getattr(entity_a, "aliases", []),
-                "connect_strength": getattr(entity_a, "connect_strength", ""),
             },
             entity_b={
                 "name": entity_b.name,
                 "entity_type": entity_b.entity_type,
+                "description_summary": getattr(entity_b, "description_summary", ""),
                 "description": getattr(entity_b, "description", ""),
                 "aliases": getattr(entity_b, "aliases", []),
-                "connect_strength": getattr(entity_b, "connect_strength", ""),
             },
-            disambiguation_mode=False,
-            same_group=True,
-            type_ok=True,
-            type_similarity=1.0,
-            name_text_sim=scores.get("sim_name", 0.0),
-            name_embed_sim=scores.get("sim_embed", 0.0),
-            name_contains=False,
-            co_occurrence=False,
-            relation_statements=[],
             language=language,
             json_schema=json.dumps(DedupJudgeOutput.model_json_schema(), indent=2),
         )
@@ -84,11 +78,14 @@ async def judge_pair_for_dedup(
         response = await call_structured(llm_client, messages, DedupJudgeOutput)
 
         if isinstance(response, DedupJudgeOutput):
+            # new_name 为空时回退到 canonical_idx 对应实体名
+            fallback_name = entity_a.name if response.canonical_idx == 0 else entity_b.name
             return DedupLLMDecision(
                 same_entity=response.same_entity,
                 confidence=response.confidence,
                 winner_id="a" if response.canonical_idx == 0 else "b",
-                merged_name=entity_a.name if response.canonical_idx == 0 else entity_b.name,
+                merged_name=(response.new_name or fallback_name),
+                new_aliases=response.new_aliases or [],
                 reason=response.reason,
             )
         return None
@@ -116,13 +113,13 @@ async def judge_batch(
             # 直接从 pair 构造简单对象供模板渲染
             entity_a = type("E", (), {
                 "name": pair.a_name, "entity_type": pair.entity_type,
+                "description_summary": pair.a_desc_summary,
                 "description": pair.a_desc, "aliases": pair.a_aliases or [],
-                "connect_strength": "",
             })()
             entity_b = type("E", (), {
                 "name": pair.b_name, "entity_type": pair.entity_type,
+                "description_summary": pair.b_desc_summary,
                 "description": pair.b_desc, "aliases": pair.b_aliases or [],
-                "connect_strength": "",
             })()
             scores = {"sim_name": pair.sim_name, "sim_embed": pair.sim_embed}
             decision = await judge_pair_for_dedup(llm_client, entity_a, entity_b, scores, language)

--- a/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
@@ -27,6 +27,7 @@ class EntityOutput(BaseModel):
     description: str = ""
     type_description: str = ""
     is_explicit_memory: bool = False
+    entity_idx: int = 0
 
 
 class TripletOutput(BaseModel):
@@ -34,6 +35,7 @@ class TripletOutput(BaseModel):
     predicate: str
     predicate_id: int
     predicate_surface: str = ""
+    predicate_description: str = ""
     object_name: str
     valid_at: str = "NULL"
     invalid_at: str = "NULL"

--- a/api/app/core/memory/utils/name_similarity_utils.py
+++ b/api/app/core/memory/utils/name_similarity_utils.py
@@ -4,7 +4,7 @@
 供 extraction_engine 和 reflection_engine 共用。
 """
 import re
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from app.core.memory.models.graph_models import ExtractedEntityNode
 
@@ -86,7 +86,8 @@ def has_exact_alias_match(e1: ExtractedEntityNode, e2: ExtractedEntityNode) -> b
 
 
 def name_similarity_with_aliases(
-    e1: ExtractedEntityNode, e2: ExtractedEntityNode
+    e1: ExtractedEntityNode, e2: ExtractedEntityNode,
+    emb_sim: Optional[float] = None,
 ) -> Tuple[float, float, float, float, float, bool]:
     """名称相似度综合评分
 
@@ -102,15 +103,23 @@ def name_similarity_with_aliases(
     - 有完全匹配：embedding(40%) + primary_jaccard(20%) + max_alias_sim(40%)
     - 无完全匹配：embedding(60%) + primary_jaccard(20%) + max_alias_sim(20%)
 
+    Args:
+        e1, e2: 实体节点
+        emb_sim: 主名称向量相似度。若调用方已在 Neo4j 侧用
+            vector.similarity.cosine 算好则直接传入，避免在 Python 侧用
+            name_embedding 重新计算（省向量传输与内存）；为 None 时回退到
+            Python 内部用 _cosine 计算。
+
     Returns:
         (综合相似度, 向量相似度, 主名称Jaccard, 别名Jaccard,
          最佳别名匹配度, 是否完全匹配)
     """
-    # 1. 主名称向量相似度
-    emb_sim = _cosine(
-        getattr(e1, "name_embedding", []) or [],
-        getattr(e2, "name_embedding", []) or [],
-    )
+    # 1. 主名称向量相似度：优先用外部传入（Neo4j 已算），否则 Python 兜底计算
+    if emb_sim is None:
+        emb_sim = _cosine(
+            getattr(e1, "name_embedding", []) or [],
+            getattr(e2, "name_embedding", []) or [],
+        )
 
     # 2. 主名称 token 相似度
     tokens1 = set(_tokenize(getattr(e1, "name", "") or ""))

--- a/api/app/core/memory/utils/prompt/prompts/entity_dedup_batch.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/entity_dedup_batch.jinja2
@@ -1,13 +1,13 @@
 ===Task===
 {% if language == "zh" %}
 你是一个实体去重专家。你将被提供同一用户下同一类型的多个实体信息。
-请严格根据指引，找出其中可能指向同一真实世界实体的重复对。
+请严格根据指引，找出其中指向同一真实世界实体的重复对。
 
 类型: {{ entity_type }}
 实体数量: {{ entities | length }}
 {% else %}
-You are an entity deduplication expert. You will be provided with multiple entities of the same type belonging to the same user.
-Please strictly follow the guidelines to identify pairs that likely refer to the same real-world entity.
+You are an entity deduplication expert. You will be given multiple entities of the same type belonging to the same user.
+Strictly follow the guidelines and identify pairs that refer to the same real-world entity.
 
 Type: {{ entity_type }}
 Entity Count: {{ entities | length }}
@@ -19,6 +19,7 @@ Entity Count: {{ entities | length }}
 
 {% for e in entities %}
 {{ loop.index }}. 名称: "{{ e.name | default('') }}"
+   - 描述摘要: "{{ e.description_summary | default('') }}"
    - 描述: "{{ e.description | default('') }}"
    - 别名: {{ e.aliases | default([]) }}
 {% endfor %}
@@ -27,6 +28,7 @@ Entity Count: {{ entities | length }}
 
 {% for e in entities %}
 {{ loop.index }}. Name: "{{ e.name | default('') }}"
+   - Description Summary: "{{ e.description_summary | default('') }}"
    - Description: "{{ e.description | default('') }}"
    - Aliases: {{ e.aliases | default([]) }}
 {% endfor %}
@@ -36,65 +38,138 @@ Entity Count: {{ entities | length }}
 {% if language == "zh" %}
 ## 判断规则
 
-1. **别名匹配（最高优先级）**:
-   - 如果一个实体的名称出现在另一个实体的别名列表中，应视为高置信度匹配
-   - 如果两个实体的别名列表有交集，这是强烈的同一性信号
-   - 别名匹配的权重应高于单纯的名称文本相似度
+1. **描述摘要优先**
+   - 判断两个实体是否重复时，主要依据 `description_summary`。
+   - 如果某个实体的 `description_summary` 为空，再回退使用它的 `description`。
+   - 名称和别名是重要信号，但不要让名称/别名覆盖摘要中的核心身份信息。
 
-2. **名称相似**:
-   - 名称字面相似（如"张三"和"张三丰"包含关系）
-   - 名称语义相似（如"张三"和"张总"可能是同一人的不同称呼）
-   - 中英文对应（如"北京"和"Beijing"）
+2. **只配对同一真实世界实体**
+   - 只输出真正指向同一个人、组织、地点、物品、事件、概念或其他具体对象的重复对。
+   - 相关、从属、包含、参与、拥有、发生于、命名来源相同，都不等于同一实体，不要配对。
 
-3. **描述一致**:
-   - 描述内容高度重叠，指向同一个对象
-   - 描述互补但不矛盾（如一个说"后端工程师"，另一个说"负责微服务架构"）
+3. **上下位 / 部分整体 / 实例泛称关系不配对**
+   - 小概念合到大概念、局部合到整体、子类合到父类、具体实例合到泛称，都不是同一实体。
+   - 如果一方语义上是另一方的“一部分”“一个下级”“一个实例”“一个成员”“一个子品牌/子系统/子部门”，不要配对。
+   - 公司与部门不配对：例如“星河数据” vs “设计部”、“星河数据” vs “星河数据设计部”、“某科技公司” vs “某科技公司研发部”。
+   - 即使部门名称包含完整公司名，也不要因为名称包含关系而配对；“公司名 + 部门/团队/小组/事业部/中心/实验室”等通常是下属组织，不是公司本体。
+   - 群体与成员不配对：例如“2026年6月12日来的客户王总和李总” vs “王总”。
+   - 反例：研发部 vs 某科技公司；设计部 vs 某科技公司；腾讯云 vs 腾讯；阿里云 vs 阿里巴巴；2024北京马拉松 vs 马拉松；上海 vs 上海马拉松；支付子系统 vs 电商系统；Model 3 vs 特斯拉。
 
-4. **保守决策**:
-   - 不确定时不要配对
-   - 同名但描述明显矛盾的不配对（如"张三-后端工程师" vs "张三-前端设计师"可能是不同人）
-   - 名称有包含关系但语义不同的不配对（如"上海" vs "上海马拉松"）
+4. **核心身份冲突不配对，细节互补可配对**
+   - 如果摘要/描述中的核心身份属性冲突，不配对。例如职业、所属组织、地点、角色、对象类别、时间范围等互斥。
+   - 如果一方提供经历、关系、偏好或补充细节，另一方没有矛盾，且名称/别名/摘要共同指向同一对象，可以配对。
 
-5. **唯一性约束（必须遵守）**:
-   - 每个序号只能出现在一个配对中，不允许重复
-   - 错误示例：[[1,2],[1,3]] ← 序号1出现了两次，违规
-   - 正确示例：[[1,2],[6,7]] ← 每个序号只出现一次
-   - 如果实体A同时与B和C相似，只输出最确定的一对，另一对留给下次处理
+5. **别名是强信号，但不可滥用**
+   - 名称与对方别名完全匹配、别名互相匹配、常见中英文名对应，都是强同一性信号。
+   - 但当摘要/描述显示核心身份冲突时，即使别名相同也不要配对。
+   - 对“老板”“老师”“朋友”“公司”“系统”“项目”等泛称别名要特别保守。
 
-6. **其他注意事项**:
-   - 只找同一真实世界实体的重复，不要把相关但不同的实体配对
-   - 不确定时不要配对
+6. **保守决策**
+   - 信息不足、证据含糊、只能判断相关但不能判断同一时，不要配对。
+   - 去重时少合并比错合并更安全。
+
+7. **唯一性约束（必须遵守）**
+   - 每个序号最多只能出现在一个配对中，不允许重复。
+   - 错误示例：[[1,2],[1,3]]，因为序号1出现了两次。
+   - 正确示例：[[1,2],[6,7]]，每个序号只出现一次。
+   - 如果一个实体同时与多个实体相似，只输出证据最强、最确定的一对，其余不输出。
+
+8. **输出顺序**
+   - 优先输出置信度高、证据明确的重复对。
+   - 不要输出低置信度候选对。
+   - `results` 只能包含你判断为“同一真实世界实体”的正例重复对。
+   - 不要把不应合并的 pair 放进 `results` 里解释原因；上下位、部分整体、相关但不同的 pair 应直接省略。
+   - 输出前必须核对 pair 序号和 reason：reason 支持的是哪两个实体名称，`pair` 就必须填写这两个实体的序号。
+   - 如果 reason 中出现“正确重复对是 1 与 3”，则 `pair` 必须是 `[1, 3]`，不能写成其他序号。
+   - 如果 reason 中说明某两个实体是产品/公司、子品牌/母公司、从属关系或不构成重复，则这两个序号绝不能出现在同一个 `pair` 中。
+
+9. **合并后命名**
+   - 每个输出的重复对都必须包含 `new_name` 和 `new_aliases`。
+   - `new_name` 是该 pair 合并后的主实体名，可以重新生成，不限于从两个旧名称中二选一。
+   - 主实体名优先保留对用户有用的关系限定、时间限定和具体名称。
+   - 抽象/临时指代与具体名称合并时，优先合成“限定信息 + 具体名称”。
+   - 当一个名称或摘要提供用户关系/身份角色，另一个名称提供具体称呼时，应优先合成主名，而不是只保留具体称呼。例如“用户的吉他搭档”与“阿凯”应输出“用户的吉他搭档阿凯”，“用户的后端同事”与“张伟”应输出“用户的后端同事张伟”，“用户的同事”与“小林”应输出“用户的同事小林”。
+   - 如果摘要/描述中有明确日期或可解析的相对时间，且该时间是该指代的重要限定，应写进 `new_name`，并尽量使用具体日期而不是“后天/明天/下周”等相对表达。
+   - 如果抽象指代实际指向多个人，应把多个人都写入 `new_name`，例如“后天来的客户”指王总和李总时，输出“2026年6月12日来的客户王总和李总”。但如果另一实体只是其中一个成员（例如只有“王总”），则这是群体 vs 成员，不能配对。
+   - 注意区分“群体 vs 单个成员”和“群体 vs 完整成员集合名称”：前者不配对，后者可以配对。例如“2026年6月12日来的客户（包括王总和李总）”与“王总”不配对；但与“王总和李总”可以配对，并输出“2026年6月12日来的客户王总和李总”。
+   - 更名前后同一组织/项目合并时，主名优先使用当前名称或更正式名称，旧名称进入 `new_aliases`。
+   - `new_aliases` 是强合并信号，必须保守。只保留能长期稳定、低歧义地指向同一实体的替代名称。
+   - 输入中的 `aliases` 只用于判断同一性，不能自动复制到输出的 `new_aliases`。输出前必须重新按本节规则过滤。
+   - 应进入 `new_aliases` 的典型名称：原名、笔名、英文名、改名前旧名、正式简称、明确的产品代号/仓库名。
+   - 不应进入 `new_aliases` 的典型名称：相对时间指代（如“后天来的客户”）、泛称（如“客户/老师/老板/同事/朋友/公司/项目”）、单次场景描述（如“这次来的客户”）、群体中的单个成员名、容易重复的短称或职务称呼（如单独的“王总”）。
+   - 如果 `new_name` 已经综合了关系、日期和具体称呼，通常不需要再把其中的普通短称放进 `new_aliases`。
+   - 如果只有人物短称、职务称呼、临时关系称呼可作为别名候选，宁可输出空数组 `[]`。
+   - 对人物短称要特别保守；除非摘要明确说明这是稳定唯一的别名、笔名或长期称呼，否则不要加入 `new_aliases`。
+   - 对人物实体，`new_aliases` 默认应为空数组。只有原名、笔名、法定姓名、英文名等稳定身份名可以进入；普通昵称或称呼后缀（如“哥/总/工/老师/同学”）、单独姓名、职务称呼不要进入。
+   - 例如 `new_name="用户的后端同事张伟"` 时，不要输出“张伟”或“张工”为 alias。
+   - 输出前自检：如果某个 pair 的 reason 会说明“这两者不应合并”“从属关系”“部分/整体”“产品/公司”“群体/成员”，这个 pair 绝不能出现在 `results`。
 {% else %}
 ## Judgment Rules
 
-1. **Alias Matching (Highest Priority)**:
-   - If one entity's name appears in another entity's alias list, it should be considered a high-confidence match
-   - If two entities' alias lists have intersections, this is a strong signal of identity
-   - Alias matching weight should be higher than pure name text similarity
+1. **Description summary first**
+   - Use `description_summary` as the primary evidence when judging duplicate entities.
+   - If an entity's `description_summary` is empty, fall back to its `description`.
+   - Names and aliases are important signals, but they must not override core identity evidence in the summaries.
 
-2. **Name Similarity**:
-   - Literal name similarity (e.g., "Zhang San" contains "Zhang")
-   - Semantic name similarity (e.g., "Zhang San" and "Boss Zhang" may be the same person)
-   - Cross-language correspondence (e.g., "北京" and "Beijing")
+2. **Pair only the same real-world entity**
+   - Output pairs only when both entities truly refer to the same person, organization, place, object, event, concept, or other concrete target.
+   - Being related, subordinate, contained, participating, owning, occurring at, or sharing a naming source does not mean the entities are identical.
 
-3. **Description Consistency**:
-   - Highly overlapping descriptions pointing to the same object
-   - Complementary but non-contradictory descriptions (e.g., "backend engineer" and "responsible for microservice architecture")
+3. **Do not pair hypernym/subtype, part/whole, or instance/generic relations**
+   - A smaller concept merged into a larger concept, a part merged into a whole, a subtype merged into a parent type, or a concrete instance merged into a generic term is not identity.
+   - If one entity is semantically a part, subordinate unit, instance, member, sub-brand, subsystem, or sub-department of the other, do not pair them.
+   - Do not pair a company with one of its departments, such as "Xinghe Data" vs "Design Department", "Xinghe Data" vs "Xinghe Data Design Department", or a technology company vs its R&D Department.
+   - Even when the department name contains the full company name, do not pair based on name containment; patterns like "company name + department/team/group/business unit/center/lab" usually indicate a subordinate organization, not the company itself.
+   - Do not pair a group with one member, such as "the clients coming on June 12, 2026, Mr. Wang and Mr. Li" vs "Mr. Wang".
+   - Negative examples: R&D Department vs a technology company; Design Department vs a technology company; Tencent Cloud vs Tencent; Alibaba Cloud vs Alibaba; 2024 Beijing Marathon vs marathon; Shanghai vs Shanghai Marathon; payment subsystem vs e-commerce system; Model 3 vs Tesla.
 
-4. **Conservative Decision**:
-   - Do not pair when uncertain
-   - Do not pair entities with same name but clearly contradictory descriptions
-   - Do not pair entities with name containment but different semantics (e.g., "Shanghai" vs "Shanghai Marathon")
+4. **Core identity conflict blocks pairing; complementary details may pair**
+   - Do not pair if summaries/descriptions conflict on core identity attributes such as occupation, organization, location, role, object category, or time range.
+   - If one side adds experience, relationships, preferences, or other details without contradiction, and names/aliases/summaries jointly point to the same target, pairing is allowed.
 
-5. **Uniqueness Constraint (MUST follow)**:
-   - Each index can only appear in ONE pair, no duplicates allowed
-   - WRONG: [[1,2],[1,3]] ← index 1 appears twice, violation
-   - CORRECT: [[1,2],[6,7]] ← each index appears only once
-   - If entity A is similar to both B and C, only output the most confident pair, leave the other for next round
+5. **Aliases are strong but not absolute**
+   - Exact name-to-alias matches, shared aliases, and common cross-language name correspondences are strong identity signals.
+   - However, if summaries/descriptions show a core identity conflict, do not pair even when aliases match.
+   - Be especially conservative with generic aliases such as boss, teacher, friend, company, system, or project.
 
-6. **Other Notes**:
-   - Only find duplicates of the same real-world entity, do not pair related but different entities
-   - Do not pair when uncertain
+6. **Conservative decision**
+   - If evidence is insufficient, ambiguous, or only proves relatedness rather than identity, do not pair.
+   - In deduplication, under-merging is safer than wrong merging.
+
+7. **Uniqueness constraint (MUST follow)**
+   - Each index may appear in at most one pair. No duplicates are allowed.
+   - Wrong example: [[1,2],[1,3]], because index 1 appears twice.
+   - Correct example: [[1,2],[6,7]], each index appears only once.
+   - If one entity is similar to multiple entities, output only the strongest and most certain pair; omit the others.
+
+8. **Output ordering**
+   - Output high-confidence, clearly supported duplicate pairs first.
+   - Do not output low-confidence candidate pairs.
+   - `results` must contain only positive duplicate pairs that you judge to be the same real-world entity.
+   - Do not include non-merge pairs in `results` just to explain why they should not merge; omit hypernym/subtype, part/whole, and related-but-different pairs entirely.
+
+9. **Post-merge naming**
+   - Every duplicate pair you output must include `new_name` and `new_aliases`.
+   - `new_name` is the primary entity name after merging that pair. You may generate a new combined name; it is not limited to choosing one of the two old names.
+   - Prefer a primary name that preserves user-useful relationship qualifiers, time qualifiers, and the concrete name.
+   - When an abstract or temporary reference merges with a concrete name, prefer "qualifier + concrete name".
+   - When one name or summary provides the user relationship/role and the other provides the concrete name, prefer a combined primary name instead of only the concrete name. For example, merge "the user's backend coworker" with "Zhang Wei" as "the user's backend coworker Zhang Wei".
+   - If summaries/descriptions contain an explicit date or a resolvable relative time and that time is an important qualifier for the reference, include the concrete date in `new_name` instead of relative wording such as tomorrow/the day after tomorrow/next week.
+   - If an abstract reference actually refers to multiple people, include all concrete people in `new_name`. But if the other entity is only one member, this is group vs member and must not pair.
+   - Distinguish "group vs single member" from "group vs complete member-set name": the former must not pair, while the latter may pair. For example, "the clients coming on June 12, 2026, including Mr. Wang and Mr. Li" must not pair with only "Mr. Wang", but may pair with "Mr. Wang and Mr. Li".
+   - When an organization or project was renamed, prefer the current or more official name as `new_name`, and put old names in `new_aliases`.
+   - `new_aliases` is a strong merge signal, so it must be conservative. Keep only alternative names that are stable, long-lived, and low-ambiguity.
+   - Input `aliases` are evidence for identity judgment only. Do not automatically copy them into output `new_aliases`; re-filter them using this section before output.
+   - Typical names that should enter `new_aliases`: original names, pen names, English names, former names after renaming, official short names, clear product codenames, and repository names.
+   - Typical names that should not enter `new_aliases`: relative-time references, generic roles, one-off situational descriptions, individual member names of a group, and ambiguous short titles such as a bare "Mr. Wang", "customer", "teacher", "boss", "coworker", "friend", "company", or "project".
+   - If `new_name` already combines the relationship, date, and concrete appellation, usually do not add the ordinary short appellation to `new_aliases`.
+   - If the only alias candidates are personal short names, title-based appellations, or temporary relationship references, prefer an empty array `[]`.
+   - Be especially conservative with personal short names; include them only when the summaries clearly establish them as stable unique aliases, pen names, or long-term names.
+   - For person entities, `new_aliases` should default to an empty array. Only stable identity names such as original names, pen names, legal names, or English names may enter; ordinary nicknames, suffix/title forms, bare personal names, and role titles should not.
+   - For example, when `new_name` is "the user's backend coworker Zhang Wei", do not output "Zhang Wei" or "Engineer Zhang" as aliases.
+   - Final self-check before output: if a pair's reason would say "should not merge", "subordinate", "part/whole", "product/company", or "group/member", that pair must not appear in `results`.
+   - Before output, verify that each `pair` index matches the exact two entity names supported by its reason. If the reason says the correct duplicate pair is 1 and 3, the `pair` must be `[1, 3]`, not any other indices.
+   - If the reason says two entities are product/company, sub-brand/parent-company, subordinate, or non-duplicate, those two indices must never appear together in a `pair`.
 {% endif %}
 
 ===Output===
@@ -102,16 +177,18 @@ Entity Count: {{ entities | length }}
 返回JSON格式，必须包含以下字段：
 {
   "results": [
-    {"pair": [1, 3], "confidence": 0.95, "reason": "阿里巴巴的别名包含阿里"},
-    {"pair": [2, 5], "confidence": 0.88, "reason": "描述高度一致"}
+    {"pair": [1, 3], "new_name": "阿里巴巴", "new_aliases": ["阿里", "Alibaba"], "confidence": 0.95, "reason": "阿里巴巴与阿里别名互指，摘要均指向同一电商集团"},
+    {"pair": [2, 5], "new_name": "鲁迅", "new_aliases": ["周树人"], "confidence": 0.88, "reason": "鲁迅与周树人是同一作家的笔名和原名"}
   ]
 }
 
 **字段说明**:
-- results: 重复对列表，每项包含：
-  - pair: 两个实体的序号（从1开始）
-  - confidence: 置信度（0.0~1.0）
-  - reason: 简短判定理由（不超过50字，使用实体名称而非序号（如实体x））
+- results: 重复对列表；没有重复对时返回空数组。
+- pair: 两个实体的序号，从1开始；每个序号最多出现一次。
+- new_name: 该 pair 合并后的实体名称。
+- new_aliases: 该 pair 合并后建议保留或新增的别名数组。
+- confidence: 置信度，范围0.0-1.0。
+- reason: 简短判定理由，使用实体名称而非“实体1/实体2”；不超过100字。
 
 如果没有发现重复对，返回：
 {"results": []}
@@ -119,26 +196,30 @@ Entity Count: {{ entities | length }}
 Return JSON format with the following required fields:
 {
   "results": [
-    {"pair": [1, 3], "confidence": 0.95, "reason": "Alibaba's alias contains Ali"},
-    {"pair": [2, 5], "confidence": 0.88, "reason": "descriptions highly consistent"}
+    {"pair": [1, 3], "new_name": "Alibaba", "new_aliases": ["Ali", "阿里巴巴"], "confidence": 0.95, "reason": "Alibaba and Ali have mutually matching aliases and summaries point to the same e-commerce group"},
+    {"pair": [2, 5], "new_name": "Lu Xun", "new_aliases": ["Zhou Shuren"], "confidence": 0.88, "reason": "Lu Xun and Zhou Shuren are the pen name and original name of the same writer"}
   ]
 }
 
 **Field Descriptions**:
-- results: List of duplicate pairs, each containing:
-  - pair: two entity indices (starting from 1)
-  - confidence: confidence score (0.0~1.0)
-  - reason: brief judgment reason (max 50 chars, use entity names not indices like "entity 3")
+- results: List of duplicate pairs; return an empty array if no duplicates are found.
+- pair: Two entity indices, starting from 1; each index may appear at most once.
+- new_name: Entity name after merging this pair.
+- new_aliases: Aliases to keep or add after merging this pair.
+- confidence: Confidence score, range 0.0-1.0.
+- reason: Brief reason using entity names rather than "entity 1/entity 2"; keep it within 100 words.
 
-If no duplicates found, return:
+If no duplicates are found, return:
 {"results": []}
 {% endif %}
 
 **CRITICAL JSON FORMATTING REQUIREMENTS:**
-1. Use only standard ASCII double quotes (") for JSON structure - never use Chinese quotation marks ("") or other Unicode quotes
-2. Ensure all JSON strings are properly closed and comma-separated
-3. Do not include line breaks within JSON string values
-4. The indices in pairs must be valid (between 1 and {{ entities | length }})
+1. Use only standard ASCII double quotes (") for JSON structure.
+2. Ensure all JSON strings are properly closed and comma-separated.
+3. Do not include line breaks within JSON string values.
+4. The indices in pairs must be valid integers between 1 and {{ entities | length }}.
+5. Each index may appear in at most one pair.
+6. Return only valid JSON, with no Markdown code fence.
 
 {% if language == "zh" %}
 输出语言应始终与输入语言相同。

--- a/api/app/core/memory/utils/prompt/prompts/entity_dedup_reflection.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/entity_dedup_reflection.jinja2
@@ -1,0 +1,218 @@
+===Task===
+{% if language == "zh" %}
+你是一个实体去重判断助手。你将被提供两个实体的信息，请判断它们是否指向同一个真实世界实体。
+{% else %}
+You are an entity deduplication assistant. You will be given information about two entities. Determine whether they refer to the same real-world entity.
+{% endif %}
+
+===Input===
+{% if language == "zh" %}
+实体A:
+- 名称: "{{ entity_a.name | default('') }}"
+- 类型: "{{ entity_a.entity_type | default('') }}"
+- 描述摘要: "{{ entity_a.description_summary | default('') }}"
+- 描述: "{{ entity_a.description | default('') }}"
+- 别名: {{ entity_a.aliases | default([]) }}
+
+实体B:
+- 名称: "{{ entity_b.name | default('') }}"
+- 类型: "{{ entity_b.entity_type | default('') }}"
+- 描述摘要: "{{ entity_b.description_summary | default('') }}"
+- 描述: "{{ entity_b.description | default('') }}"
+- 别名: {{ entity_b.aliases | default([]) }}
+{% else %}
+Entity A:
+- Name: "{{ entity_a.name | default('') }}"
+- Type: "{{ entity_a.entity_type | default('') }}"
+- Description Summary: "{{ entity_a.description_summary | default('') }}"
+- Description: "{{ entity_a.description | default('') }}"
+- Aliases: {{ entity_a.aliases | default([]) }}
+
+Entity B:
+- Name: "{{ entity_b.name | default('') }}"
+- Type: "{{ entity_b.entity_type | default('') }}"
+- Description Summary: "{{ entity_b.description_summary | default('') }}"
+- Description: "{{ entity_b.description | default('') }}"
+- Aliases: {{ entity_b.aliases | default([]) }}
+{% endif %}
+
+===Guidelines===
+{% if language == "zh" %}
+## 判断规则
+
+1. **描述摘要优先**
+   - 判断两者是否同一实体时，主要依据 `description_summary`。
+   - 如果某个实体的 `description_summary` 为空，再回退使用它的 `description`。
+   - 名称和别名是重要信号，但不要让名称/别名覆盖摘要中的核心身份信息。
+
+2. **只合并同一真实世界实体**
+   - 只有当两个实体指向同一个人、组织、地点、物品、事件、概念或其他具体对象时，才输出 `same_entity=true`。
+   - 相关、从属、包含、参与、拥有、发生于、命名来源相同，都不等于同一实体。
+
+3. **上下位 / 部分整体 / 实例泛称关系不合并**
+   - 小概念合到大概念、局部合到整体、子类合到父类、具体实例合到泛称，都不是同一实体。
+   - 如果一方语义上是另一方的“一部分”“一个下级”“一个实例”“一个成员”“一个子品牌/子系统/子部门”，判定为 `same_entity=false`。
+   - 公司与部门不合并：例如“星河数据” vs “设计部”、“星河数据” vs “星河数据设计部”、“某科技公司” vs “某科技公司研发部”。
+   - 即使部门名称包含完整公司名，也不要因为名称包含关系而合并；“公司名 + 部门/团队/小组/事业部/中心/实验室”等通常是下属组织，不是公司本体。
+   - 群体与成员不合并：例如“2026年6月12日来的客户王总和李总” vs “王总”。
+   - 反例：研发部 vs 某科技公司；设计部 vs 某科技公司；腾讯云 vs 腾讯；阿里云 vs 阿里巴巴；2024北京马拉松 vs 马拉松；上海 vs 上海马拉松；支付子系统 vs 电商系统；Model 3 vs 特斯拉。
+
+4. **核心身份冲突不合并，细节互补可合并**
+   - 如果摘要/描述中的核心身份属性冲突，不合并。例如职业、所属组织、地点、角色、对象类别、时间范围等互斥。
+   - 如果一方提供经历、关系、偏好或补充细节，另一方没有矛盾，且名称/别名/摘要共同指向同一对象，可以合并。
+
+5. **别名是强信号，但不可滥用**
+   - 名称与对方别名完全匹配、别名互相匹配、常见中英文名对应，都是强同一性信号。
+   - 但当摘要/描述显示核心身份冲突时，即使别名相同也不合并。
+   - 对“老板”“老师”“朋友”“公司”“系统”“项目”等泛称别名要特别保守。
+
+6. **类型判断**
+   - 类型相同或任一为空时，可以继续判断。
+   - 类型明显冲突时，默认不合并，除非摘要/描述明确说明它们是同一对象的不同命名或类型标注错误。
+
+7. **保守决策**
+   - 信息不足、证据含糊、只能判断相关但不能判断同一时，输出 `same_entity=false`。
+   - 去重时少合并比错合并更安全。
+
+8. **规范实体选择**
+   - 如果 `same_entity=true`，选择信息更完整、更适合作为规范节点的一方。
+   - 优先选择 `description_summary` 更丰富的一方；如果一方的 `description_summary` 为空而另一方非空，必须选择非空摘要的一方。
+   - 只有当双方 `description_summary` 都为空或信息量相当时，才比较 `description`；仍相当则选择实体A，即 `canonical_idx=0`。
+   - 如果 `same_entity=false`，仍返回 `canonical_idx=0`。
+
+9. **合并后命名**
+   - 如果 `same_entity=true`，必须输出 `new_name` 和 `new_aliases`。
+   - `new_name` 是合并后的主实体名，可以重新生成，不限于从实体A/B旧名称中二选一。
+   - 主实体名优先保留对用户有用的关系限定、时间限定和具体名称。
+   - 抽象/临时指代与具体名称合并时，优先合成“限定信息 + 具体名称”。例如“我的室友”与“小李”可输出“我的室友小李”。
+   - 当一个名称或摘要提供用户关系/身份角色，另一个名称提供具体称呼时，应优先合成主名，而不是只保留具体称呼。例如“用户的吉他搭档”与“阿凯”应输出“用户的吉他搭档阿凯”，“用户的后端同事”与“张伟”应输出“用户的后端同事张伟”，“用户的同事”与“小林”应输出“用户的同事小林”。
+   - 如果摘要/描述中有明确日期或可解析的相对时间，且该时间是该指代的重要限定，应写进 `new_name`，并尽量使用具体日期而不是“后天/明天/下周”等相对表达。例如“后天来的客户”在摘要中可解析为“2026年6月12日”时，与“王总”合并应输出“2026年6月12日来的客户王总”。
+   - 如果抽象指代实际指向多个人，应把多个人都写入 `new_name`，例如“后天来的客户”指王总和李总时，输出“2026年6月12日来的客户王总和李总”。但如果另一实体只是其中一个成员（例如只有“王总”），则这是群体 vs 成员，不能合并。
+   - 注意区分“群体 vs 单个成员”和“群体 vs 完整成员集合名称”：前者不合并，后者可以合并。例如“2026年6月12日来的客户（包括王总和李总）”与“王总”不合并；但与“王总和李总”可以合并，并输出“2026年6月12日来的客户王总和李总”。
+   - 更名前后同一组织/项目合并时，主名优先使用当前名称或更正式名称，旧名称进入 `new_aliases`。
+   - `new_aliases` 是强合并信号，必须保守。只保留能长期稳定、低歧义地指向同一实体的替代名称。
+   - 输入中的 `aliases` 只用于判断同一性，不能自动复制到输出的 `new_aliases`。输出前必须重新按本节规则过滤。
+   - 应进入 `new_aliases` 的典型名称：原名、笔名、英文名、改名前旧名、正式简称、明确的产品代号/仓库名。
+   - 不应进入 `new_aliases` 的典型名称：相对时间指代（如“后天来的客户”）、泛称（如“客户/老师/老板/同事/朋友/公司/项目”）、单次场景描述（如“这次来的客户”）、群体中的单个成员名、容易重复的短称或职务称呼（如单独的“王总”）。
+   - 如果 `new_name` 已经综合了关系、日期和具体称呼，通常不需要再把其中的普通短称放进 `new_aliases`。例如 `new_name="2026年6月12日来的客户王总"` 时，`new_aliases` 应为空数组或只包含其他稳定正式别名，不要加入“后天来的客户”“客户”“王总”。
+   - 如果只有人物短称、职务称呼、临时关系称呼可作为别名候选，宁可输出空数组 `[]`。
+   - 对人物短称要特别保守；除非摘要明确说明这是稳定唯一的别名、笔名或长期称呼，否则不要加入 `new_aliases`。
+   - 对人物实体，`new_aliases` 默认应为空数组。只有原名、笔名、法定姓名、英文名等稳定身份名可以进入；普通昵称或称呼后缀（如“哥/总/工/老师/同学”）、单独姓名、职务称呼不要进入。
+   - 例如 `new_name="用户的吉他搭档阿凯"` 时，不要输出“阿凯”或“凯哥”为 alias；`new_name="用户的后端同事张伟"` 时，不要输出“张伟”或“张工”为 alias；`new_name="用户的同事小林"` 时，不要输出“小林”或“林同学”为 alias。
+   - 如果 `same_entity=false`，`new_name` 必须为 `null`，`new_aliases` 必须为空数组 `[]`。
+{% else %}
+## Judgment Rules
+
+1. **Description summary first**
+   - Use `description_summary` as the primary evidence when judging identity.
+   - If an entity's `description_summary` is empty, fall back to its `description`.
+   - Names and aliases are important signals, but they must not override core identity evidence in the summaries.
+
+2. **Merge only the same real-world entity**
+   - Return `same_entity=true` only when both entities refer to the same person, organization, place, object, event, concept, or other concrete target.
+   - Being related, subordinate, contained, participating, owning, occurring at, or sharing a naming source does not mean the entities are identical.
+
+3. **Do not merge hypernym/subtype, part/whole, or instance/generic relations**
+   - A smaller concept merged into a larger concept, a part merged into a whole, a subtype merged into a parent type, or a concrete instance merged into a generic term is not identity.
+   - If one entity is semantically a part, subordinate unit, instance, member, sub-brand, subsystem, or sub-department of the other, return `same_entity=false`.
+   - Do not merge a company with one of its departments, such as "Xinghe Data" vs "Design Department", "Xinghe Data" vs "Xinghe Data Design Department", or a technology company vs its R&D Department.
+   - Even when the department name contains the full company name, do not merge based on name containment; patterns like "company name + department/team/group/business unit/center/lab" usually indicate a subordinate organization, not the company itself.
+   - Do not merge a group with one member, such as "the clients coming on June 12, 2026, Mr. Wang and Mr. Li" vs "Mr. Wang".
+   - Negative examples: R&D Department vs a technology company; Design Department vs a technology company; Tencent Cloud vs Tencent; Alibaba Cloud vs Alibaba; 2024 Beijing Marathon vs marathon; Shanghai vs Shanghai Marathon; payment subsystem vs e-commerce system; Model 3 vs Tesla.
+
+4. **Core identity conflict blocks merging; complementary details may merge**
+   - Do not merge if summaries/descriptions conflict on core identity attributes such as occupation, organization, location, role, object category, or time range.
+   - If one side adds experience, relationships, preferences, or other details without contradiction, and names/aliases/summaries jointly point to the same target, merging is allowed.
+
+5. **Aliases are strong but not absolute**
+   - Exact name-to-alias matches, shared aliases, and common cross-language name correspondences are strong identity signals.
+   - However, if summaries/descriptions show a core identity conflict, do not merge even when aliases match.
+   - Be especially conservative with generic aliases such as boss, teacher, friend, company, system, or project.
+
+6. **Type handling**
+   - If types are the same or either type is empty, continue judging.
+   - If types clearly conflict, default to not merging unless the summary/description clearly proves they are the same target with different names or a type-labeling error.
+
+7. **Conservative decision**
+   - If evidence is insufficient, ambiguous, or only proves relatedness rather than identity, return `same_entity=false`.
+   - In deduplication, under-merging is safer than wrong merging.
+
+8. **Canonical entity selection**
+   - If `same_entity=true`, choose the entity that is more complete and more suitable as the canonical node.
+   - Prefer the entity with richer `description_summary`; if one entity has an empty `description_summary` and the other has a non-empty one, you must choose the entity with the non-empty summary.
+   - Compare `description` only when both `description_summary` values are empty or similarly informative; if still similar, choose Entity A with `canonical_idx=0`.
+   - If `same_entity=false`, still return `canonical_idx=0`.
+
+9. **Post-merge naming**
+   - If `same_entity=true`, you must output `new_name` and `new_aliases`.
+   - `new_name` is the primary entity name after merging. You may generate a new combined name; it is not limited to choosing Entity A or Entity B's old name.
+   - Prefer a primary name that preserves user-useful relationship qualifiers, time qualifiers, and the concrete name.
+   - When an abstract or temporary reference merges with a concrete name, prefer "qualifier + concrete name". For example, merge "my roommate" with "Xiao Li" as "my roommate Xiao Li".
+   - When one name or summary provides the user relationship/role and the other provides the concrete name, prefer a combined primary name instead of only the concrete name. For example, merge "the user's guitar partner" with "Akai" as "the user's guitar partner Akai", "the user's backend coworker" with "Zhang Wei" as "the user's backend coworker Zhang Wei", and "the user's coworker" with "Xiao Lin" as "the user's coworker Xiao Lin".
+   - If summaries/descriptions contain an explicit date or a resolvable relative time and that time is an important qualifier for the reference, include the concrete date in `new_name` instead of relative wording such as tomorrow/the day after tomorrow/next week.
+   - If an abstract reference actually refers to multiple people, include all concrete people in `new_name`; for example, if "the clients coming the day after tomorrow" refers to Mr. Wang and Mr. Li on June 12, 2026, output "the clients coming on June 12, 2026, Mr. Wang and Mr. Li". But if the other entity is only one member, such as "Mr. Wang", this is group vs member and must not merge.
+   - Distinguish "group vs single member" from "group vs complete member-set name": the former must not merge, while the latter may merge. For example, "the clients coming on June 12, 2026, including Mr. Wang and Mr. Li" must not merge with only "Mr. Wang", but may merge with "Mr. Wang and Mr. Li".
+   - When an organization or project was renamed, prefer the current or more official name as `new_name`, and put old names in `new_aliases`.
+   - `new_aliases` is a strong merge signal, so it must be conservative. Keep only alternative names that are stable, long-lived, and low-ambiguity.
+   - Input `aliases` are evidence for identity judgment only. Do not automatically copy them into output `new_aliases`; re-filter them using this section before output.
+   - Typical names that should enter `new_aliases`: original names, pen names, English names, former names after renaming, official short names, clear product codenames, and repository names.
+   - Typical names that should not enter `new_aliases`: relative-time references, generic roles, one-off situational descriptions, individual member names of a group, and ambiguous short titles such as a bare "Mr. Wang", "customer", "teacher", "boss", "coworker", "friend", "company", or "project".
+   - If `new_name` already combines the relationship, date, and concrete appellation, usually do not add the ordinary short appellation to `new_aliases`. For example, when `new_name` is "the client coming on June 12, 2026, Mr. Wang", `new_aliases` should be empty unless there is another stable official alias.
+   - If the only alias candidates are personal short names, title-based appellations, or temporary relationship references, prefer an empty array `[]`.
+   - Be especially conservative with personal short names; include them only when the summaries clearly establish them as stable unique aliases, pen names, or long-term names.
+   - For person entities, `new_aliases` should default to an empty array. Only stable identity names such as original names, pen names, legal names, or English names may enter; ordinary nicknames, suffix/title forms, bare personal names, and role titles should not.
+   - For example, when `new_name` is "the user's guitar partner Akai", do not output "Akai" or "Brother Kai" as aliases; when `new_name` is "the user's backend coworker Zhang Wei", do not output "Zhang Wei" or "Engineer Zhang" as aliases.
+   - If `same_entity=false`, `new_name` must be `null` and `new_aliases` must be an empty array `[]`.
+{% endif %}
+
+===Output===
+{% if language == "zh" %}
+返回JSON格式，必须包含以下字段：
+{
+  "same_entity": boolean,
+  "canonical_idx": 0 or 1,
+  "new_name": "string or null",
+  "new_aliases": ["string"],
+  "confidence": float (0.0-1.0),
+  "reason": "string"
+}
+
+**字段说明**:
+- same_entity: 两个实体是否指向同一真实世界实体。
+- canonical_idx: 规范实体索引，0表示实体A，1表示实体B；不同实体时固定返回0。
+- new_name: 合并后的实体名称；不合并时必须为null。
+- new_aliases: 合并后建议保留或新增的别名数组；不合并时必须为空数组。
+- confidence: 当前判断的置信度，范围0.0-1.0。
+- reason: 简短理由，说明主要依据；不超过100字。
+{% else %}
+Return JSON format with the following required fields:
+{
+  "same_entity": boolean,
+  "canonical_idx": 0 or 1,
+  "new_name": "string or null",
+  "new_aliases": ["string"],
+  "confidence": float (0.0-1.0),
+  "reason": "string"
+}
+
+**Field Descriptions**:
+- same_entity: Whether the two entities refer to the same real-world entity.
+- canonical_idx: Canonical entity index, 0 for Entity A and 1 for Entity B; return 0 when they are different entities.
+- new_name: Entity name after merging; must be null when not merging.
+- new_aliases: Aliases to keep or add after merging; must be an empty array when not merging.
+- confidence: Confidence of the judgment, range 0.0-1.0.
+- reason: Brief reason naming the main evidence; keep it within 100 words.
+{% endif %}
+
+**CRITICAL JSON FORMATTING REQUIREMENTS:**
+1. Use only standard ASCII double quotes (") for JSON structure.
+2. Ensure all JSON strings are properly closed and comma-separated.
+3. Do not include line breaks within JSON string values.
+4. Return only valid JSON, with no Markdown code fence.
+
+{% if language == "zh" %}
+输出语言应始终与输入语言相同。
+{% else %}
+The output language should always be the same as the input language.
+{% endif %}
+{{ json_schema }}

--- a/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
@@ -1,13 +1,16 @@
-===Task===
+﻿===Task===
 Resolve unresolved references and extract entities and knowledge triplets from the given statement.
 
 {% if language == "zh" %}
 重要：
 - 这是对已标记为 has_unsolved_reference=true 的 statement 进行二次处理。
+- 本 prompt 只用于 retry/reflection 队列；输入一定来自写入阶段已跳过的 unresolved statement。
+- `has_unsolved_reference` 在本阶段只是来源标记，不是判断是否抽取的开关。
 - 必须从上下文中尝试消解未识别指代（如"他""那个""该活动"等）。
-- 无论是否成功消解，都必须提取至少一个实体和三元组（不允许返回空结果）。
-- 如果无法消解，使用描述性名称强制提取，谓词用 `关联于`（predicate_id=13）兜底。
-- 如果上下文为空，只用 statement 本身的信息强制提取。
+- 不要检查 `has_unsolved_reference` 后返回空结果；写入阶段已经做过 hard gate，本阶段负责补救。
+- 如果无法稳定消解，允许生成带时间、场景、动作或关系限定的描述性弱实体。
+- 只在 statement 本身表达了有效关系时输出 triplet；不要为了补救 unresolved 而强行使用 `关联于` 兜底。
+- 如果上下文为空，只能使用 statement 本身的信息生成弱实体或有效关系。
 
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，不要翻译。
 - 但在抽取前，必须先做指代解析。
@@ -34,6 +37,11 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - Normalize user possessive expressions by input language: for Chinese source text, use `用户的X`; for English source text, use `the user's X`; never output mixed possessives such as `用户'sX`, `用户's X`, or `user的X`.
 - For non-user pronouns or demonstratives such as "he", "she", "it", "this", "that", "this company", "that place", if a stable referent can be resolved from `supporting_context`, replace them with the resolved entity name.
 - If such references cannot be resolved stably, use descriptive names for forced extraction.
+- This prompt is a second-pass repair stage for statements already skipped by the write-time hard gate; do not return the empty result merely because `has_unsolved_reference=true`.
+- This prompt is used only for the retry/reflection queue. The input is always an unresolved statement skipped by the write-time extraction stage.
+- `has_unsolved_reference` is only a source marker in this stage, not a switch for whether extraction should run.
+- If a reference still cannot be resolved stably, create a descriptive weak entity using time, scene, action, or relationship qualifiers from the statement when useful.
+- Output triplets only when the statement itself expresses a valid relation. Do not force `关联于` as a fallback just because resolution failed.
 - Newly introduced names in naming or alias expressions must stay in their original form.
 - Generate `description` in English.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
@@ -53,24 +61,24 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - `statement_text`: 陈述句文本
 - `statement_type`: 上游提供的陈述类别，例如 `FACT` / `OPINION` / `OTHER`
 - `temporal_type`: 上游提供的时间类别，例如 `STATIC` / `DYNAMIC` / `ATEMPORAL`
-- `supporting_context`: 时间最近的对话原文列表（纯字符串数组，按时间正序）
+- `supporting_context`: 可为时间最近的对话原文列表（纯字符串数组，按时间正序），也可为包含 `before_msgs` / `after_msgs` 的上下文对象
 - `speaker`: `user` / `assistant`
 - `dialog_at`: 会话时间，ISO 8601 时间点；每个实体 `description` 必须复制该值作为开头时间戳
 - `valid_at`: ISO 8601 时间点，或 `NULL`
 - `invalid_at`: ISO 8601 时间点，或 `NULL`
-- `has_unsolved_reference`: 布尔值
+- `has_unsolved_reference`: 固定为 `true`；表示该 statement 来自 unresolved retry/reflection 队列
   {% else %}
   The input JSON contains these fields:
 - `statement_id`: unique statement ID
 - `statement_text`: statement text
 - `statement_type`: upstream statement category such as `FACT` / `OPINION` / `OTHER`
 - `temporal_type`: upstream temporal category such as `STATIC` / `DYNAMIC` / `ATEMPORAL`
-- `supporting_context`: nearby dialogue texts (string array, chronological order)
+- `supporting_context`: nearby dialogue texts as a string array, or a context object containing `before_msgs` / `after_msgs`
 - `speaker`: `user` / `assistant`
 - `dialog_at`: session time as an ISO 8601 timestamp; every entity `description` must copy this value as its leading timestamp
 - `valid_at`: ISO 8601 timestamp or `NULL`
 - `invalid_at`: ISO 8601 timestamp or `NULL`
-- `has_unsolved_reference`: boolean
+- `has_unsolved_reference`: always `true`; indicates this statement comes from the unresolved retry/reflection queue
   {% endif %}
 
 Input JSON:
@@ -95,10 +103,17 @@ Primary statement to analyze:
 
 - 先尝试从 `supporting_context` 中消解未识别指代。
 - 用户自指（"我""我的"）统一规范为"用户"，"用户"本身不是未识别指代。
-- 如果能从上下文确定具体指代对象，替换为具体实体名，设 `resolved=true`。
-- 如果无法确定，使用描述性名称强制提取，设 `resolved=false`。
-- 绝不允许返回空的 `entities` 或 `triplets`。
-- 无法消解时，谓词用"关联于"(predicate_id=13)兜底。
+- 如果能从上下文确定所有关键指代对象，替换为具体实体名，并在输出中设 `resolved=true`。
+- 如果任一关键指代无法确定，使用描述性弱实体名称提取仍有记忆价值的内容，并在输出中设 `resolved=false`。
+- “稳定解析”不要求一定有身份证式专名；只要上下文能唯一确定被指对象，也可以解析为稳定限定名，例如 `用户的小狗`、`用户今天联系的几个客户`、`星河数据设计部`。
+- 所有格实体如果边界清楚，应视为稳定解析。例如上下文出现 `我家小狗`，则 `它` 可以稳定解析为 `用户的小狗`，即使不知道小狗专名。
+- 如果上下文中只有一个类型匹配且语义相容的候选先行词，应优先解析到该候选，而不是生成新的弱实体。例如前文唯一部门是 `星河数据设计部`，则 `那个部门` 应解析为 `星河数据设计部`。
+- 如果上下文只能提供宽泛背景，不能唯一确定指代对象，则不要过度消解。例如只知道“王磊最近在找工作”，不能把 `那家公司` 解析为某个稳定公司；应生成弱实体。
+- 输出一致性：只要任何关键实体名称包含 `未具名`，或 `resolution_note` 明确说明某个关键指代无法稳定解析，则 `resolved` 必须为 `false`。
+- 弱实体名称必须带限定信息，不能直接输出 `他`、`她`、`它`、`这个`、`那个`、`这家公司`、`那个地方` 等原始弱指代表达。
+- 弱实体名称只能使用 `statement_text` 已有信息、`dialog_at`/`valid_at`/`invalid_at` 中的时间信息，以及上下文能支持但不足以确定专名的关系信息；不要引入外部推断。
+- 允许 `triplets` 为空；只有当 statement 本身表达了有效关系时才输出 triplet。
+- 不要使用"关联于"(predicate_id=13)作为 unresolved 的默认兜底关系。
 - 上下文为空时，只用 `statement_text` 本身信息强制提取。
 - 强制提取命名规则：泛指动物/物品保持原文；跨对话指代人物用关系限定；未具名角色用描述限定。
 {% else %}
@@ -106,10 +121,17 @@ Resolution rules:
 
 - First attempt to resolve references from `supporting_context`.
 - Normalize user self-reference to "用户"; "用户" itself is NOT unresolved.
-- If context supports resolution, use resolved name, set `resolved=true`.
-- If unresolvable, use descriptive name for forced extraction, set `resolved=false`.
-- NEVER return empty `entities` or `triplets`.
-- Fallback predicate: "关联于" (predicate_id=13).
+- If context resolves all key references, use resolved names and set output `resolved=true`.
+- If any key reference is still unresolvable, extract useful content with descriptive weak entity names and set output `resolved=false`.
+- Stable resolution does not require a legal or proper name. If context uniquely identifies the referent, a stable qualified name is allowed, such as `the user's dog`, `the customers the user contacted today`, or `Xinghe Data Design Department`.
+- Possessive entities with clear boundaries count as stable resolution. For example, if context mentions `my dog`, then `it` can be resolved to `the user's dog` even if the dog's proper name is unknown.
+- If context contains exactly one type-compatible and semantically compatible antecedent, prefer resolving to that antecedent instead of creating a new weak entity. For example, if the only prior department is `Xinghe Data Design Department`, resolve `that department` to it.
+- If context only gives broad background and does not uniquely identify the referent, do not over-resolve. For example, knowing only that "Wang Lei is job hunting" is not enough to resolve `that company` to a stable company; create a weak entity instead.
+- Output consistency: if any key entity name contains an unnamed/unknown marker, or if `resolution_note` says a key reference cannot be stably resolved, `resolved` must be `false`.
+- A weak entity name must include qualifiers and must not preserve raw weak references such as "he", "she", "it", "this", "that", "this company", or "that place".
+- Weak entity names may use only information from `statement_text`, time fields, and context-supported relationship information that is still insufficient for a proper name. Do not add external inference.
+- `triplets` may be empty. Output triplets only when the statement itself expresses a valid relation.
+- Do not use "关联于" (predicate_id=13) as the default fallback for unresolved references.
 - If context is empty, extract from `statement_text` alone.
 {% endif %}
  
@@ -225,11 +247,11 @@ Resolution rules:
 
 实体类型总规则：
 
-- unresolved 或边界不稳的表达，不因“看起来像名词”就创建实体。
+- unresolved 或边界不稳的表达，不因“看起来像名词”就创建实体；但本二次处理阶段允许为仍有记忆价值的 unresolved 指代生成带限定信息的弱实体。
 - 情绪、心理状态、金额、数量、普通时间、一次性动作短语，默认不作为独立实体抽取。
 - 抽象命题片段、泛化结果、价值判断，默认不创建实体；如有保留价值，应写入相关高价值实体的 `description`。
 - 只有当某个名字、概念、对象、群体或地点在当前陈述中承担明确语义角色，或是理解有效关系所必需时，才创建实体。
-- 如果陈述里有值得保留的实体信息，但没有有效关系，可以只返回 `entities`，并把 `triplets` 设为 `[]`。
+- 如果陈述里有值得保留的实体信息或弱实体信息，但没有有效关系，可以只返回 `entities`，并把 `triplets` 设为 `[]`。
 
 ===关系本体大类===
 以下大类是当前 `predicate` 本体树的第一层，用于帮助理解和约束后面的具体关系白名单。输出具体 `predicate` 时仍然必须使用后文列出的细关系，而不是直接输出这些大类名称。
@@ -399,20 +421,24 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 {% if language == "zh" %}
 按以下顺序执行：
 
-0. 先检查 `has_unsolved_reference`；如果为 `true`，直接返回空结果。
+0. 把输入视为 unresolved retry/reflection 任务，不执行写入阶段的 hard gate。
 1. 先做指代解析：用户自指统一替换为 `用户`；其他可稳定解析的代词或指示表达替换为具体指代实体名。
-2. 如果仍存在无法稳定解析的代词、指示词或省略主体，直接返回空结果。
-3. 识别 `statement_text` 中值得抽取的稳定实体。
-4. 判断这些实体之间是否存在可由预定义关系类型表达的有效关系。
-5. 最后补充实体字段和关系字段。
+2. 标记消解结果：所有关键指代都稳定解析时 `resolved=true`；否则 `resolved=false`。
+3. 如果仍存在无法稳定解析的代词、指示词或省略主体，用描述性弱实体名称替代，而不是保留原代词或返回空。
+4. 识别 `statement_text` 中值得抽取的实体，包括已解析实体和有记忆价值的弱实体。
+5. 判断这些实体之间是否存在可由预定义关系类型表达的有效关系；没有有效关系时允许 `triplets: []`。
+6. 对同名实体去重，并确保同一个 `name` 只对应一个 `type/type_id`。
+7. 最后补充实体字段和关系字段。
    {% else %}
    Follow this order:
-6. First check `has_unsolved_reference`; if it is `true`, immediately return the empty result.
-7. Resolve references first: normalize user self-reference to `用户`; replace other stably resolvable pronouns or demonstratives with their resolved entity names.
-8. If unresolved pronouns, demonstratives, or omitted subjects still remain, immediately return the empty result.
-9. Identify stable entities worth extracting from `statement_text`.
-10. Determine whether any valid relations between those entities can be expressed using the predefined Chinese predicates.
-11. Finally fill auxiliary entity and predicate fields.
+0. Treat the input as an unresolved retry/reflection task; do not run the write-time hard gate.
+1. Resolve references first: normalize user self-reference to `用户`; replace other stably resolvable pronouns or demonstratives with their resolved entity names.
+2. Set the resolution status: `resolved=true` only if all key references are stably resolved; otherwise `resolved=false`.
+3. If unresolved pronouns, demonstratives, or omitted subjects still remain, replace them with descriptive weak entity names instead of preserving raw pronouns or returning empty.
+4. Identify entities worth extracting from `statement_text`, including resolved entities and memory-worthy weak entities.
+5. Determine whether any valid relations between those entities can be expressed using the predefined Chinese predicates; if no valid relation exists, `triplets: []` is allowed.
+6. Deduplicate entities by exact `name`, and make sure one `name` maps to only one `type/type_id`.
+7. Finally fill auxiliary entity and predicate fields.
     {% endif %}
 
 ===Guidelines===
@@ -422,14 +448,24 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 
 - 指代解析优先于实体抽取和关系抽取。
 - 所有用户自指表达都必须规范成 `用户`，包括“我”“我的”“我自己”等。
+- `他说`、`她说`、`他们说` 中的 `他/她/他们` 是非用户指代，不是 speaker，也不能规范为 `用户`；如果上下文不能解析，应生成未具名说话者弱实体。
 - 对“他”“她”“它”“这个”“那个”“这家”“那家”“这里”“那里”等非用户自指表达，若上下文可稳定解析，则必须用解析后的具体实体名替换。
-- 若非用户自指表达无法稳定解析，则整条跳过，不输出部分结果。
+- 若非用户自指表达无法稳定解析，则生成描述性弱实体名称，不要整条跳过。
+- 弱实体名称要说明“哪个上下文中的哪个对象”，例如 `2026年3月加入这家公司的未具名人员`、`statement中提到的这家公司`、`用户昨天提到的那个项目`。
+- 弱实体名称不能是裸代词或裸指示词，例如 `他`、`她`、`它`、`这个`、`那个`、`这家公司`。
+- 复数指代或集合指代要保持为 `群体`，不要拆成单个 `生命体`。例如 `他们` 指向几个客户时，应生成 `用户今天联系的几个客户` 或类似群体名，type 为 `群体`。
+- 当角色名后面紧跟代词，且语义上代词回指该角色承担者时，应把二者合并为同一个具体人或弱人物实体。例如 `导师说他下周会帮我看论文` 中，`他` 回指 `导师`，应输出 `用户的未具名导师` 这个 `生命体`，不要同时输出 `导师` 作为 `角色职业` 和另一个未具名人员。
 - 新出现的称呼、别名、昵称、产品名不是待消解代词，应保持原样。
   {% else %}
 - Reference resolution happens before entity or relation extraction.
 - All user self-reference must be normalized to `用户`, including forms such as "I", "me", "my", and "myself".
+- In phrases like `he said`, `she said`, or `they said`, the third-person pronoun is a non-user reference, not the speaker, and must not be normalized to `用户`; if context cannot resolve it, create an unnamed speaker weak entity.
 - For non-user references such as "he", "she", "it", "this", "that", "this company", "that place", "here", or "there", if the context supports a stable resolution, replace them with the resolved entity name.
-- If a non-user reference cannot be resolved stably, skip the entire statement and do not output partial results.
+- If a non-user reference cannot be resolved stably, create a descriptive weak entity name instead of skipping the whole statement.
+- The weak entity name should identify which object in which context is being referenced, such as `the unnamed person who joined this company in March 2026`, `the company mentioned in the statement`, or `the project the user mentioned yesterday`.
+- The weak entity name must not be a bare pronoun or demonstrative such as `he`, `she`, `it`, `this`, `that`, or `this company`.
+- Preserve plural or set references as `群体`; do not collapse them into one `生命体`. For example, if `they` refers to several customers, create a group entity such as `the customers the user contacted today`.
+- When a role name is followed by a pronoun and the pronoun refers back to the role holder, merge them into one concrete or weak person entity. For example, in `the advisor said he will review my paper next week`, `he` refers to the advisor, so output a `生命体` such as `the user's unnamed advisor`; do not output both `导师` as `角色职业` and another unnamed person.
 - Newly introduced names, aliases, nicknames, and product names are not pronouns to be resolved; keep them in their original form.
   {% endif %}
 
@@ -443,13 +479,15 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 当句子只是在讨论一般道理、抽象规律、空泛结果或非个体化概念，而这些概念本身不构成可复用记忆时，不要创建实体。
 - 如果句子表达的是用户的观点、信念、判断、愿望或目标倾向，但其中抽象对象不值得作为独立实体保留，则只保留相关高价值实体，不要再创建这些低价值对象实体；只有当未抽取内容适合作为该实体的稳定描述时，才写入相关实体的 `description`。
 - 当前阶段不要把情绪或心理状态抽成实体；像“紧张”“开心”“难过”“焦虑”“放松”等不应映射到 `知识能力`、`偏好习惯`、`具体目标` 或其他近似类型。
-- triplet 阶段不重新判断 unresolved reference；应从当前 statement 抽取可表达的实体，无法消解的使用描述性名称。
+- triplet 阶段不重新执行 hard gate；应从当前 statement 抽取可表达的实体，无法消解的使用描述性弱实体名称。
 - 实体 `name` 必须尽量具体，避免同名同类型误合并。命名优先级：1）有专名或上游已解析到具体实体时，使用该具体实体名，例如 `海底捞`；2）没有专名但表达稳定关系时，使用稳定语义限定，例如 `用户就职的公司`、`用户常去的图书馆`、`用户的手机`；3）只有泛称时，使用 `statement_text` 中已有或已由上游解析出的具体时间、动作、用途、内容、地点或场景限定补全 name，例如 `2026-05-15早上去吃饭的饭店`，不要只写 `饭店`。
 - 补全 name 时只能使用 `statement_text` 中已有或上游已解析出的信息，不要引入外部推断，也不要使用未解析的相对时间。
+- 弱实体仍然要选择真实语义 type，而不是统一归入 `称呼别名` 或 `角色职业`。例如 `2026年3月加入这家公司的未具名人员` 是 `生命体`，`statement中提到的这家公司` 是 `组织`。
+- 复数人物、客户、同事、来访者等集合性弱实体应使用 `群体`，不是 `生命体`。
 - 对 `文档媒体`、`物品设备`、`地点设施`、`组织`、`群体`、`识别联系信息`，尤其避免直接使用泛称 name；如果已有专名、稳定归属、平台、主题、内容、用途、地点、时间或场景限定，应写进 name。
 - `角色职业` 是例外：角色/职业类别本身可以作为实体，例如 `导师`、`程序员`；但具体人物的稳定关系应通过 triplet 或 description 表达。
 - 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定，例如 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`，不要简化成 `小狗`、`账号`，也不要使用 `用户's小狗` 等中英混合形式。
-- 泛化或未稳定指向的表达不要抽取，例如 `一只狗`、`狗这种动物`、`某个朋友`、`一个账号`、`某个办公室`。
+- 泛化表达不要抽取，例如 `一只狗`、`狗这种动物`。但本二次处理阶段允许抽取有 statement 限定的弱实体，例如 `2026年3月加入这家公司的未具名人员`；不要输出裸泛称 `某个朋友`、`一个账号`、`某个办公室`。
 - `description` 必须使用中文。
 - `type` 必须使用上方预定义的中文标签；`type_description` 必须直接复用对应 `type` 的预定义中文定义。
   {% else %}
@@ -460,15 +498,45 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - If the sentence is only about a generic principle, abstract outcome, or non-personalized concept that is not worth remembering on its own, do not create an entity for it.
 - If a statement expresses the user's belief, judgment, opinion, wish, or goal tendency but the referenced abstract concepts are not worth keeping as standalone entities, keep only the relevant high-value entities and do not create those low-value concept entities; write the unextracted content into an entity `description` only when it is suitable as a stable description of that entity.
 - In the current stage, do not extract emotional or psychological states as entities. States such as nervousness, happiness, sadness, anxiety, or relief should not be mapped to `知识能力`, `偏好习惯`, `具体目标`, or any other approximate type.
-- The triplet stage must not re-decide unresolved references. Extract expressible entities from the current statement; use descriptive names for unresolved references.
+- The triplet stage must not re-run the hard gate. Extract expressible entities from the current statement; use descriptive weak entity names for unresolved references.
 - Entity `name` must be as specific as possible to avoid same-name same-type false merges. Naming priority: 1) if there is a proper name or upstream has resolved the mention to a concrete entity, use that concrete name, such as `Haidilao`; 2) if there is no proper name but the statement expresses a stable relation, use a stable semantic qualifier, such as `the company where the user works`, `the library the user often visits`, or `the user's phone`; 3) if there is only a generic name, complete `name` using concrete time, action, purpose, content, location, or scene qualifiers already present in `statement_text` or resolved from context, such as `the restaurant where the user will eat on the morning of 2026-05-15`, rather than only `restaurant`.
 - When completing `name`, use only information already present in `statement_text` or resolved upstream. Do not introduce external inference, and do not use unresolved relative time.
+- Weak entities must still use their true semantic type, not default to `称呼别名` or `角色职业`. For example, `the unnamed person who joined this company in March 2026` is `生命体`, and `the company mentioned in the statement` is `组织`.
+- Weak entities that refer to multiple people, customers, coworkers, or visitors should use `群体`, not `生命体`.
 - For `文档媒体`, `物品设备`, `地点设施`, `组织`, `群体`, and `识别联系信息`, especially avoid generic names. If a proper name, stable owner, platform, topic, content, purpose, location, time, or scene qualifier is available, include it in `name`.
 - `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
 - The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
-- Do not extract generic or weakly resolved mentions, such as `a dog`, `dogs as a species`, `some friend`, `an account`, or `some office`.
+- Do not extract generic mentions such as `a dog` or `dogs as a species`. In this second-pass repair stage, weak entities are allowed only when they include statement-specific qualifiers; do not output bare generic names such as `some friend`, `an account`, or `some office`.
 - `description` must be in English.
 - `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
+  {% endif %}
+
+**Same-Name Entity Deduplication:**
+{% if language == "zh" %}
+
+- 同一次输出中，`entities` 必须按 `name` 去重；同一个 `name` 只能出现一次。
+- 如果多个候选实体的 `name` 完全相同，只保留一个 `entity_idx`，并让所有 triplet 引用这个唯一实体。
+- 同一个 `name` 不能同时输出为不同 `type/type_id`。
+- type 决策优先级：
+  1. 如果该 `name` 指向具体对象，优先使用真实实体类型，如 `生命体`、`组织`、`地点设施`、`软件平台`。
+  2. 只有当该 `name` 明确只是名字、昵称、代号本身，而不是被称呼的对象时，才使用 `称呼别名`。
+  3. 只有当该 `name` 表达身份、职业或类别本身，而不是某个具体人时，才使用 `角色职业`。
+  4. 如果同名候选在 `称呼别名` 与真实实体类型之间冲突，优先保留真实实体类型；只有不同名字之间才用 `别名属于`。
+- 不允许输出同名 alias entity 和 canonical entity。`别名属于` 的两端 `name` 必须不同。
+- 例如，不要同时输出 `{"name": "王总", "type": "生命体"}` 和 `{"name": "王总", "type": "称呼别名"}`。
+- 例如，如果 `导师` 指某个具体人但没有名字，应输出带限定的 `生命体`，如 `用户的未具名导师`；如果只是在说导师这个身份，才输出 `角色职业: 导师`。
+  {% else %}
+- Within one output, deduplicate `entities` by exact `name`; the same `name` may appear only once.
+- If several candidate entities have the exact same `name`, keep one `entity_idx` and make all triplets point to that single entity.
+- One `name` must not be emitted with multiple `type/type_id` values.
+- Type priority:
+  1. If the `name` refers to a concrete object, prefer the true entity type such as `生命体`, `组织`, `地点设施`, or `软件平台`.
+  2. Use `称呼别名` only when the `name` is explicitly the name, nickname, or code itself, not the object being named.
+  3. Use `角色职业` only when the `name` denotes the role, occupation, or category itself, not a specific person.
+  4. If the same-name candidate conflicts between `称呼别名` and a real entity type, keep the real entity type. Use `别名属于` only between different names.
+- Do not emit a same-name alias entity and canonical entity. The two ends of `别名属于` must have different `name` values.
+- For example, do not output both `{"name": "Mr. Wang", "type": "生命体"}` and `{"name": "Mr. Wang", "type": "称呼别名"}`.
+- If `advisor` refers to a specific unnamed person, output a qualified `生命体` such as `the user's unnamed advisor`; use `角色职业: advisor` only when the statement is about the role itself.
   {% endif %}
 
 **Semantic Memory (`is_explicit_memory`):**
@@ -519,7 +587,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `predicate` 只能使用上方预定义的中文关系类型。
 - `predicate_id` 必须只由 `predicate` 决定，并严格使用“本体 ID 映射”中的整数。
 - `predicate_surface` 用于记录当前陈述中更贴近原文的关系表达；它可以比 `predicate` 更自然或更细，但不得改变 `predicate_id` 和 `predicate` 的 canonical 判断。
-
+- 如果没有任何预定义关系适用，返回 `triplets: []`。
 - 不要为了保留一句抽象判断或泛因果命题，而强行构造“用户-拥有-努力”“努力-导致-回报”这类低价值 triplet。
 - `关联于` 不用于补救无法成立的关系，也不用于连接“努力”“回报”“成功”“意义”这类抽象概念。
 - `偏好` 只用于具体、明确、用户特异且值得保留的对象或目标；如果相关内容过于抽象或空泛，不要抽取 `偏好`，应改写进相关实体的 `description`。
@@ -531,7 +599,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `predicate` must use one of the predefined Chinese relation labels above.
 - `predicate_id` must be determined only by `predicate` and must strictly use the integer from the ontology ID mapping.
 - `predicate_surface` records the relation expression closer to the source statement; it may be more natural or specific than `predicate`, but it must not change the canonical `predicate_id` or `predicate`.
-
+- If no predefined relation fits, return `triplets: []`.
 - Do not force low-value triplets such as "user-has-effort" or "effort-causes-reward" just to preserve a generic causal belief or slogan-like proposition.
 - Do not use `关联于` as a rescue relation when no real relation exists, and do not connect abstract concepts such as "effort", "reward", "success", or "meaning" with it.
 - Use `偏好` only for concrete, specific, user-grounded objects or goals worth retaining; if the relevant content is too abstract or generic, do not extract `偏好` and instead rewrite it into the relevant entity `description`.
@@ -581,6 +649,11 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
   {% endif %}
 
 ===Examples===
+{% if language == "zh" %}
+说明：本 prompt 的真实输入一定是 unresolved statement。部分通用抽取示例只展示 entity/triplet 结构；遇到冲突时，以 unresolved repair 规则和示例 9 为准。最终输出必须以 `Output Format` 为准，始终包含 `resolved` 和 `resolution_note`。
+{% else %}
+Note: Real inputs to this prompt are always unresolved statements. Some general extraction examples only demonstrate entity/triplet structure; if there is any conflict, follow the unresolved repair rules and Example 9. The final output must still follow `Output Format` and always include `resolved` and `resolution_note`.
+{% endif %}
 {% if language == "zh" %}
 **示例 1**
 Statement: "我住在巴黎。"
@@ -714,8 +787,15 @@ Input JSON includes: `"dialog_at": "2026-03-01T09:00:00Z"`
 
 Output:
 {
-  "triplets": [],
-  "entities": []
+  "resolved": false,
+  "resolution_note": "has_unsolved_reference 为 true，且上下文未提供足够信息确定“他”和“这家公司”的专名；使用带时间和关系限定的弱实体名称。",
+  "triplets": [
+    {"subject_name": "2026年3月加入这家公司的未具名人员", "subject_id": 0, "predicate_id": 2, "predicate": "属于类型", "predicate_surface": "加入了", "predicate_description": "表达主体所属的类别、身份、职业、角色，或其与组织、群体、集合之间的归属关系。", "object_name": "2026年3月被加入的未具名公司", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
+  ],
+  "entities": [
+    {"entity_idx": 0, "name": "2026年3月加入这家公司的未具名人员", "type_id": 1, "type": "生命体", "type_description": "可稳定指向、可被当作具体个体区分和归并的生命体个体。", "description": "[2026-03-01T09:00:00Z] 2026年3月加入这家公司的未具名人员；上下文不足以确定其专名", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "2026年3月被加入的未具名公司", "type_id": 2, "type": "组织", "type_description": "公司、机构、学校、实验室、团队、社群等组织性主体。", "description": "[2026-03-01T09:00:00Z] 有未具名人员在2026年3月加入的公司；上下文不足以确定公司专名", "is_explicit_memory": false}
+  ]
 }
 {% else %}
 **Example 1**
@@ -850,8 +930,15 @@ Input JSON includes: `"dialog_at": "2026-03-01T09:00:00Z"`
 
 Output:
 {
-  "triplets": [],
-  "entities": []
+  "resolved": false,
+  "resolution_note": "`has_unsolved_reference` is true, and context is insufficient to identify the proper names of `he` and `this company`; descriptive weak entity names are used.",
+  "triplets": [
+    {"subject_name": "the unnamed person who joined this company in March 2026", "subject_id": 0, "predicate_id": 2, "predicate": "属于类型", "predicate_surface": "joined", "predicate_description": "A relation expressing the type, identity, profession, role, or organizational/group affiliation of a subject.", "object_name": "the unnamed company joined in March 2026", "object_id": 1, "valid_at": "NULL", "invalid_at": "NULL"}
+  ],
+  "entities": [
+    {"entity_idx": 0, "name": "the unnamed person who joined this company in March 2026", "type_id": 1, "type": "生命体", "type_description": "A living individual that can be stably referred to, distinguished, and deduplicated as a specific entity.", "description": "[2026-03-01T09:00:00Z] The unnamed person who joined this company in March 2026; context is insufficient to identify the proper name.", "is_explicit_memory": false},
+    {"entity_idx": 1, "name": "the unnamed company joined in March 2026", "type_id": 2, "type": "组织", "type_description": "An organizational actor such as a company, institution, school, lab, team, or community.", "description": "[2026-03-01T09:00:00Z] The unnamed company joined by an unnamed person in March 2026; context is insufficient to identify the proper name.", "is_explicit_memory": false}
+  ]
 }
 {% endif %}
 ===End of Examples===
@@ -872,10 +959,13 @@ JSON 要求：
 - 每个 triplet 都必须包含 `predicate_surface`；中文输入下使用中文或原文中的关系表达
 - 每个 triplet 都必须包含 `valid_at` 和 `invalid_at`，并与输入中的同名字段完全一致
 - 输出必须包含 `resolved`（bool）和 `resolution_note`（string）字段
-- `resolved` 为 true 表示成功从上下文消解了指代，false 表示使用描述性名称强制提取
+- `resolved` 为 true 表示所有关键指代都成功从上下文消解为稳定实体名，false 表示至少一个关键指代使用了描述性弱实体名称
+- 在输出最终 JSON 前必须做一致性检查：如果任一关键实体 `name` 或 `description` 包含 `未具名`、`未知`、`不明`，或 `resolution_note` 中写了“无法稳定解析”“上下文未提供”“未提供其名称”，则 `resolved` 必须是 `false`。
+- 只有当所有关键指代都被替换为不含 `未具名`/`未知`/`不明` 的稳定实体名时，`resolved` 才能是 `true`。
 - `resolution_note` 简要说明消解结果或无法消解的原因
-- 绝不允许返回空的 `entities` 或 `triplets`
-- 如果没有有效 triplet，使用 `关联于`(predicate_id=13) 兜底创建至少一个
+- 允许 `triplets` 为空；不要为了补救 unresolved 而使用 `关联于`(predicate_id=13) 兜底创建关系
+- 如果 `entities` 中包含弱实体，弱实体名称必须带具体限定，不能是裸代词、裸角色或裸泛称
+- 同一次输出中，`entities` 必须按 `name` 去重；同一个 `name` 不能对应多个 `type/type_id`
   {% else %}
   JSON Requirements:
 - Use standard ASCII double quotes (`"`)
@@ -890,10 +980,13 @@ JSON 要求：
 - Every triplet must include `predicate_surface`; for English input, use English or the source-text relation expression
 - Every triplet must include `valid_at` and `invalid_at`, exactly matching the input fields with the same names
 - Output must include `resolved` (bool) and `resolution_note` (string) fields
-- `resolved` is true if references were successfully resolved from context, false if descriptive names were used for forced extraction
+- `resolved` is true only if all key references were resolved to stable entity names from context; false if at least one key reference uses a descriptive weak entity name
+- Before emitting the final JSON, run a consistency check: if any key entity `name` or `description` contains markers such as `未具名`, `未知`, `不明`, `unnamed`, `unknown`, or if `resolution_note` says context is insufficient or the name is not provided, `resolved` MUST be `false`.
+- `resolved` may be `true` only when all key references are replaced by stable entity names without unnamed/unknown markers.
 - `resolution_note` briefly explains the resolution result or why resolution failed
-- NEVER return empty `entities` or `triplets`
-- If no valid triplet exists, use `关联于` (predicate_id=13) as fallback to create at least one
+- `triplets` may be empty. Do not use `关联于` (predicate_id=13) as a fallback just to repair unresolved references
+- If `entities` contains weak entities, their names must include concrete qualifiers and must not be bare pronouns, bare roles, or bare generic nouns
+- Within one output, deduplicate `entities` by `name`; one `name` must not map to multiple `type/type_id` values
   {% endif %}
 
 {% if language == "zh" %}
@@ -904,7 +997,7 @@ Output JSON structure:
 
 ```json
 {
-  "resolved": "<boolean: true if resolved, false if forced>",
+  "resolved": false,
   "resolution_note": "<string: 消解说明或无法消解的原因>",
   "entities": [
     {

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2008,7 +2008,10 @@ RETURN e1.id AS a_id, e2.id AS b_id,
        e1.entity_type AS entity_type,
        e1.description AS a_desc, e2.description AS b_desc,
        e1.aliases AS a_aliases, e2.aliases AS b_aliases,
-       e1.name_embedding AS a_embed, e2.name_embedding AS b_embed
+       CASE
+         WHEN e1.name_embedding IS NULL OR e2.name_embedding IS NULL THEN 0.0
+         ELSE vector.similarity.cosine(e1.name_embedding, e2.name_embedding)
+       END AS emb_sim
 LIMIT $candidate_cap
 """
 
@@ -2135,7 +2138,8 @@ RETURN s.id AS statement_id,
        s.temporal_info AS temporal_info,
        s.speaker AS speaker,
        s.valid_at AS valid_at,
-       s.invalid_at AS invalid_at
+       s.invalid_at AS invalid_at,
+       s.run_id AS run_id
 ORDER BY s.created_at ASC
 LIMIT $batch_size
 """
@@ -2167,7 +2171,16 @@ ON CREATE SET
   e.aliases = [],
   e.connect_strength = "weak",
   e.source = "reflection_unresolved",
-  e.created_at = localdatetime()
+  e.run_id = $run_id,
+  e.type_id = $type_id,
+  e.type_description = $type_description,
+  e.importance_score = 0.5,
+  e.activation_value = null,
+  e.access_history = [],
+  e.access_count = 0,
+  e.last_access_time = null,
+  e.is_explicit_memory = $is_explicit_memory,
+  e.created_at = $created_at
 ON MATCH SET
   e.description = CASE
     WHEN e.description IS NULL OR e.description = "" THEN $description
@@ -2193,9 +2206,10 @@ CREATE (subj)-[r:EXTRACTED_RELATIONSHIP {
   valid_at: $valid_at,
   invalid_at: $invalid_at,
   end_user_id: $end_user_id,
+  run_id: $run_id,
   connect_strength: "weak",
   source: "reflection_unresolved",
-  created_at: datetime()
+  created_at: $created_at
 }]->(obj)
 RETURN r.predicate AS predicate
 """
@@ -2203,7 +2217,11 @@ RETURN r.predicate AS predicate
 UNRESOLVED_CREATE_STATEMENT_ENTITY_EDGE = """
 MATCH (s:Statement {id: $statement_id})
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id, name: $entity_name})
-MERGE (s)-[:REFERENCES_ENTITY]->(e)
+MERGE (s)-[r:REFERENCES_ENTITY]->(e)
+SET r.end_user_id = $end_user_id,
+    r.run_id = $run_id,
+    r.created_at = $created_at,
+    r.connect_strength = "weak"
 RETURN s.id AS statement_id
 """
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2008,6 +2008,7 @@ RETURN e1.id AS a_id, e2.id AS b_id,
        e1.entity_type AS entity_type,
        e1.description AS a_desc, e2.description AS b_desc,
        e1.aliases AS a_aliases, e2.aliases AS b_aliases,
+       e1.description_summary AS a_desc_summary, e2.description_summary AS b_desc_summary,
        CASE
          WHEN e1.name_embedding IS NULL OR e2.name_embedding IS NULL THEN 0.0
          ELSE vector.similarity.cosine(e1.name_embedding, e2.name_embedding)
@@ -2033,8 +2034,23 @@ RETURN e1.id AS a_id, e2.id AS b_id,
        e1.entity_type AS entity_type,
        e1.description AS a_desc, e2.description AS b_desc,
        e1.aliases AS a_aliases, e2.aliases AS b_aliases,
+       e1.description_summary AS a_desc_summary, e2.description_summary AS b_desc_summary,
        score AS sim_embed
 LIMIT $candidate_cap
+"""
+
+# 查两个实体各自度数（用于超级节点保护）
+ENTITY_DEGREE_COUNT = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.id IN [$id_a, $id_b]
+RETURN e.id AS id, COUNT{ (e)--() } AS degree
+"""
+
+# 批量查多个实体度数（方案B 桶内同名直合用）
+ENTITY_DEGREES_BY_IDS = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.id IN $ids
+RETURN e.id AS id, COUNT{ (e)--() } AS degree
 """
 
 # 去重两个实体合并
@@ -2102,7 +2118,8 @@ WHERE e.end_user_id = $end_user_id
   AND e.entity_type = $entity_type
   AND NOT toLower(e.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
 RETURN e.id AS entity_id, e.name AS name, e.entity_type AS entity_type,
-       e.description AS description, e.aliases AS aliases, e.created_at AS created_at
+       e.description AS description, e.description_summary AS description_summary,
+       e.aliases AS aliases, e.created_at AS created_at
 ORDER BY e.created_at
 """
 
@@ -2174,6 +2191,7 @@ ON CREATE SET
   e.run_id = $run_id,
   e.type_id = $type_id,
   e.type_description = $type_description,
+  e.entity_idx = $entity_idx,
   e.importance_score = 0.5,
   e.activation_value = null,
   e.access_history = [],
@@ -2195,6 +2213,19 @@ SET e.name_embedding = $name_embedding
 RETURN e.id
 """
 
+# 反思未解析消解中：把 LLM 输出的"用户"实体的 description 追加到全局用户节点。
+# 用 entity_type='用户' 定位（而非 name='用户'）：兼容用户节点 name 是 "我"/"User" 等
+# 历史变体的情况；end_user_id 唯一约束保证只命中一个全局用户节点。
+UNRESOLVED_APPEND_USER_INFO = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id, entity_type: '用户'})
+SET e.description = CASE
+    WHEN $description IS NULL OR $description = '' THEN e.description
+    WHEN e.description IS NULL OR e.description = '' THEN $description
+    ELSE e.description + '；' + $description
+END
+RETURN e.id AS entity_id
+"""
+
 UNRESOLVED_CREATE_RELATIONSHIP = """
 MATCH (subj:ExtractedEntity {end_user_id: $end_user_id, name: $subject_name})
 MATCH (obj:ExtractedEntity {end_user_id: $end_user_id, name: $object_name})
@@ -2202,6 +2233,7 @@ CREATE (subj)-[r:EXTRACTED_RELATIONSHIP {
   predicate: $predicate,
   predicate_id: $predicate_id,
   predicate_surface: $predicate_surface,
+  predicate_description: $predicate_description,
   statement_id: $statement_id,
   valid_at: $valid_at,
   invalid_at: $invalid_at,


### PR DESCRIPTION
## Summary by Sourcery

引入确定性的同名实体合并、更丰富的 LLM 引导去重决策，以及增强的未解析反射（reflection）处理，同时在 Neo4j 存储和提示词（prompts）中收紧日志和元数据一致性。

New Features:
- 在增量和全量扫描去重流程中，新增对同名同类型实体的确定性合并路径，包括直接合并池（direct-merge pools）以及在安全情况下可绕过 LLM 的组级合并。
- 扩展基于 LLM 的实体去重提示词和输出，以便提出合并后的规范名称（canonical names）及别名，并在非合并场景中依赖描述摘要并使用更严格的规则。
- 增强未解析语句（unresolved-statement）反射能力，以支持弱实体（weak-entity）抽取、更丰富的模式信息（类型、索引、谓词描述），以及在实体、关系和语句边中一致地传递 run_id/created_at。

Bug Fixes:
- 确保去重指标能够反映候选实体对的总数，并区分确定性合并与由 LLM 确认的合并。
- 通过使用正确的嵌入模型配置键修复嵌入客户端初始化问题，并在合并实体名称变化时重新计算名称嵌入。
- 通过强制同名下类型一致，以及在单次反射输出内对实体去重，防止重复或冲突的同名实体。

Enhancements:
- 优化保留实体（keeper）选择和合并执行流程，以支持未来基于度数的超级节点保护，并将合并状态处理和别名组合逻辑集中化。
- 改进反射日志，增加确定性与 LLM 来源标记、合并描述处理，以及在链式合并中更准确的合并前/合并后快照。
- 在可能的情况下，将名称嵌入相似度计算下放到 Neo4j，并在候选生成和 LLM 提示词中贯穿描述摘要，以提升去重质量。

Documentation:
- 收紧并扩展中英文提示词指南，用于批量实体去重和未解析三元组（unresolved-triplet）解析，强调保守合并、弱实体处理以及明确的输出格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce deterministic same-name entity merging, richer LLM-guided dedup decisions, and enhanced unresolved reflection handling, while tightening logging and metadata consistency across Neo4j storage and prompts.

New Features:
- Add deterministic same-name, same-type entity merge paths in both incremental and full-scan dedup flows, including direct-merge pools and group-level merges that bypass LLM when safe.
- Extend LLM-based entity dedup prompts and outputs to propose merged canonical names and aliases, and to rely on description summaries with stricter rules for non-merge cases.
- Enhance unresolved-statement reflection to support weak-entity extraction, richer schema (types, indices, predicate descriptions), and consistent run_id/created_at propagation for entities, relations, and statement edges.

Bug Fixes:
- Ensure dedup metrics reflect total candidate pairs and distinguish deterministic from LLM-confirmed merges.
- Fix embedding client initialization by using the correct embedding model config key and recomputing name embeddings when merged entity names change.
- Prevent duplicate or conflicting same-name entities by enforcing per-name type consistency and de-duplicating entities within a single reflection output.

Enhancements:
- Refine keeper selection and merge execution to support future degree-based super-node protection, centralizing merge status handling and alias combination logic.
- Improve reflection logs with deterministic vs LLM source tagging, merged-description handling, and more accurate before/after snapshots across chained merges.
- Offload name-embedding similarity computation to Neo4j where possible and thread description summaries through candidate generation and LLM prompts for better dedup quality.

Documentation:
- Tighten and expand Chinese and English prompt guidelines for batch entity deduplication and unresolved-triplet resolution, emphasizing conservative merging, weak entity handling, and explicit output formats.

</details>