### PR TITLE
feat(app)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -13,7 +13,7 @@ from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.response_utils import success, fail
-from app.db import get_db
+from app.db import get_db, get_db_context
 from app.dependencies import get_current_user, cur_workspace_access_guard
 from app.models import User
 from app.models.annotation_model import HitLogSource
@@ -668,21 +668,23 @@ async def draft_run(
         if payload.stream:
             source = HitLogSource.EXTERNAL if is_shared else HitLogSource.CONSOLE
             async def event_generator():
-
-                async for event in draft_service.run_stream(
-                        agent_config=agent_cfg,
-                        model_config=model_config,
-                        message=payload.message,
-                        workspace_id=workspace_id,
-                        conversation_id=payload.conversation_id,
-                        user_id=payload.user_id or str(current_user.id),
-                        variables=payload.variables,
-                        storage_type=storage_type,
-                        user_rag_memory_id=user_rag_memory_id,
-                        files=payload.files,  # 传递多模态文件
-                        source=source
-                ):
-                    yield event
+                with get_db_context() as stream_db:
+                    from app.services.draft_run_service import AgentRunService as _AgentRunService
+                    _draft_service = _AgentRunService(stream_db)
+                    async for event in _draft_service.run_stream(
+                            agent_config=agent_cfg,
+                            model_config=model_config,
+                            message=payload.message,
+                            workspace_id=workspace_id,
+                            conversation_id=payload.conversation_id,
+                            user_id=payload.user_id or str(current_user.id),
+                            variables=payload.variables,
+                            storage_type=storage_type,
+                            user_rag_memory_id=user_rag_memory_id,
+                            files=payload.files,
+                            source=source
+                    ):
+                        yield event
 
             return StreamingResponse(
                 event_generator(),
@@ -774,17 +776,19 @@ async def draft_run(
 
             async def event_generator():
                 """多智能体流式事件生成器"""
-                multiservice = MultiAgentService(db)
+                with get_db_context() as stream_db:
+                    from app.services.multi_agent_service import MultiAgentService as _MultiAgentService
+                    multiservice = _MultiAgentService(stream_db)
 
-                # 调用多智能体服务的流式方法
-                async for event in multiservice.run_stream(
-                        app_id=app_id,
-                        request=multi_agent_request,
-                        storage_type=storage_type,
-                        user_rag_memory_id=user_rag_memory_id
+                    # 调用多智能体服务的流式方法
+                    async for event in multiservice.run_stream(
+                            app_id=app_id,
+                            request=multi_agent_request,
+                            storage_type=storage_type,
+                            user_rag_memory_id=user_rag_memory_id
 
-                ):
-                    yield event
+                    ):
+                        yield event
 
             return StreamingResponse(
                 event_generator(),
@@ -853,23 +857,22 @@ async def draft_run(
                 data: <json_data>
                 """
                 import json
-
-                # 调用工作流服务的流式方法
-                async for event in workflow_service.run_stream(
-                        app_id=app_id,
-                        payload=payload,
-                        config=config,
-                        workspace_id=current_user.current_workspace_id,
-                        source=source,
-                        trigger_payload=payload.trigger_payload
-                ):
-                    # 提取事件类型和数据
-                    event_type = event.get("event", "message")
-                    event_data = event.get("data", {})
-
-                    # 转换为标准 SSE 格式（字符串）
-                    sse_message = f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
-                    yield sse_message
+                with get_db_context() as stream_db:
+                    from app.services.workflow_service import WorkflowService as _WorkflowService
+                    _wf_service = _WorkflowService(stream_db)
+                    # 调用工作流服务的流式方法
+                    async for event in _wf_service.run_stream(
+                            app_id=app_id,
+                            payload=payload,
+                            config=config,
+                            workspace_id=current_user.current_workspace_id,
+                            source=source,
+                            trigger_payload=payload.trigger_payload
+                    ):
+                        event_type = event.get("event", "message")
+                        event_data = event.get("data", {})
+                        sse_message = f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
+                        yield sse_message
 
             return StreamingResponse(
                 event_generator(),

--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -12,7 +12,7 @@ from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.response_utils import success
-from app.db import get_db
+from app.db import get_db, get_db_context
 from app.models.app_model import AppType
 from app.models.app_release_model import AppRelease
 from app.models.workflow_model import WorkflowExecution
@@ -184,20 +184,23 @@ async def chat(
         # 流式返回
         if payload.stream:
             async def event_generator():
-                async for event in app_chat_service.agent_chat_stream(
-                        message=payload.message,
-                        conversation_id=conversation.id if conversation else None,
-                        user_id=end_user_id,  # 转换为字符串
-                        variables=payload.variables,
-                        web_search=web_search,
-                        config=agent_config,
-                        memory=memory,
-                        storage_type=storage_type,
-                        user_rag_memory_id=user_rag_memory_id,
-                        workspace_id=workspace_id,
-                        files=payload.files  # 传递多模态文件
-                ):
-                    yield event
+                with get_db_context() as stream_db:
+                    from app.services.app_chat_service import AppChatService as _AppChatService
+                    _chat_service = _AppChatService(stream_db)
+                    async for event in _chat_service.agent_chat_stream(
+                            message=payload.message,
+                            conversation_id=conversation.id if conversation else None,
+                            user_id=end_user_id,
+                            variables=payload.variables,
+                            web_search=web_search,
+                            config=agent_config,
+                            memory=memory,
+                            storage_type=storage_type,
+                            user_rag_memory_id=user_rag_memory_id,
+                            workspace_id=workspace_id,
+                            files=payload.files
+                    ):
+                        yield event
 
             return StreamingResponse(
                 event_generator(),
@@ -229,19 +232,21 @@ async def chat(
         config = multi_agent_config_4_app_release(active_release)
         if payload.stream:
             async def event_generator():
-                async for event in app_chat_service.multi_agent_chat_stream(
-
-                        message=payload.message,
-                        conversation_id=conversation.id,  # 使用已创建的会话 ID
-                        user_id=end_user_id,  # 转换为字符串
-                        variables=payload.variables,
-                        config=config,
-                        web_search=web_search,
-                        memory=memory,
-                        storage_type=storage_type,
-                        user_rag_memory_id=user_rag_memory_id
-                ):
-                    yield event
+                with get_db_context() as stream_db:
+                    from app.services.app_chat_service import AppChatService as _AppChatService
+                    _chat_service = _AppChatService(stream_db)
+                    async for event in _chat_service.multi_agent_chat_stream(
+                            message=payload.message,
+                            conversation_id=conversation.id,
+                            user_id=end_user_id,
+                            variables=payload.variables,
+                            config=config,
+                            web_search=web_search,
+                            memory=memory,
+                            storage_type=storage_type,
+                            user_rag_memory_id=user_rag_memory_id
+                    ):
+                        yield event
 
             return StreamingResponse(
                 event_generator(),
@@ -272,28 +277,29 @@ async def chat(
         config = workflow_config_4_app_release(active_release)
         if payload.stream:
             async def event_generator():
-                async for event in app_chat_service.workflow_chat_stream(
-                        message=payload.message,
-                        conversation_id=conversation.id,  # 使用已创建的会话 ID
-                        user_id=end_user_id,  # 转换为字符串
-                        variables=payload.variables,
-                        files=payload.files,
-                        config=config,
-                        web_search=web_search,
-                        memory=memory,
-                        storage_type=storage_type,
-                        user_rag_memory_id=user_rag_memory_id,
-                        app_id=app.id,
-                        workspace_id=workspace_id,
-                        release_id=active_release.id,
-                        public=True
-                ):
-                    event_type = event.get("event", "message")
-                    event_data = event.get("data", {})
-
-                    # 转换为标准 SSE 格式（字符串）
-                    sse_message = f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
-                    yield sse_message
+                with get_db_context() as stream_db:
+                    from app.services.app_chat_service import AppChatService as _AppChatService
+                    _chat_service = _AppChatService(stream_db)
+                    async for event in _chat_service.workflow_chat_stream(
+                            message=payload.message,
+                            conversation_id=conversation.id,
+                            user_id=end_user_id,
+                            variables=payload.variables,
+                            files=payload.files,
+                            config=config,
+                            web_search=web_search,
+                            memory=memory,
+                            storage_type=storage_type,
+                            user_rag_memory_id=user_rag_memory_id,
+                            app_id=app.id,
+                            workspace_id=workspace_id,
+                            release_id=active_release.id,
+                            public=True
+                    ):
+                        event_type = event.get("event", "message")
+                        event_data = event.get("data", {})
+                        sse_message = f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
+                        yield sse_message
 
             return StreamingResponse(
                 event_generator(),

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -59,13 +59,14 @@ def get_db_context() -> Generator[Session, None, None]:
 
 @contextmanager
 def get_db_read() -> Generator[Session, None, None]:
-    """只读场景专用，出上下文自动 rollback，绝不留下 idle in transaction"""
-    with get_db_context() as db:
-        try:
-            yield db
-        finally:
-            db.rollback()  # 只读任务无需 commit
-            db.close()
+    """只读场景专用，出上下文强制 rollback，绝不留下 idle in transaction"""
+    db: Session = SessionLocal()
+    try:
+        yield db
+    finally:
+        if db.in_transaction():
+            db.rollback()
+        db.close()
 
 
 def get_pool_status():

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -781,11 +781,16 @@ class AppChatService:
                     yield f"event: tool_end\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'output': chunk.get('output'), 'meta': chunk.get('meta')}, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_error":
                     yield f"event: tool_error\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'error': chunk.get('error')}, ensure_ascii=False)}\n\n"
-                else:
+                elif isinstance(chunk, dict) and chunk.get("type") == "agent_log":
+                    yield f"event: agent_log\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
+                elif isinstance(chunk, str):
                     full_content += chunk
                     yield f"event: message\ndata: {json.dumps({'content': chunk}, ensure_ascii=False)}\n\n"
                     if tts_task is not None:
                         await text_queue.put(chunk)
+                elif isinstance(chunk, dict):
+                    event_type = str(chunk.get("type") or "unknown")
+                    yield f"event: {event_type}\ndata: {json.dumps(chunk, ensure_ascii=False)}\n\n"
 
             if tts_task is not None:
                 await text_queue.put(None)


### PR DESCRIPTION
unify streaming DB context handling, refactor get_db_read to use SessionLocal and conditionally rollback

## Summary by Sourcery

统一流式 API 的数据库会话处理方式，并提高流式事件格式化以及只读数据库上下文管理的健壮性。

新功能：
- 在聊天流式响应中，为代理日志分片和其他非消息字典类型的负载发出专用的 SSE 事件。

错误修复：
- 确保通过 `get_db_read` 创建的只读数据库上下文仅在存在活动事务时才执行回滚，避免不必要的回滚和潜在的空闲事务问题。

增强：
- 规范流式控制器，通过 `get_db_context` 为每个流创建独立的数据库会话，并在流生成器内部构造各自的服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify database session handling for streaming APIs and improve robustness of streaming event formatting and read-only DB context management.

New Features:
- Emit dedicated SSE events for agent log chunks and other non-message dictionary payloads in chat streaming responses.

Bug Fixes:
- Ensure read-only database contexts created via get_db_read only rollback when a transaction is active, preventing unnecessary rollbacks and potential idle transaction issues.

Enhancements:
- Standardize streaming controllers to create per-stream database sessions via get_db_context and construct their respective services within the stream generator.

</details>