### PR TITLE
Add  dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+
+version: 2
+updates:
+- package-ecosystem: "" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
## Summary by Sourcery

构建：
- 添加一个每周运行的 Dependabot 配置，目标为仓库根目录，并且不指定具体的包生态系统。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add a weekly Dependabot configuration targeting the repository root without specifying a package ecosystem.

</details>