### PR TITLE
feat(rag): add retrieval caller and top_n controls

### DIFF
--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -480,44 +480,17 @@ class ElasticSearchVector(BaseVector):
     @staticmethod
     def _build_vector_filter_clauses(
         file_names_filter: list[str] | None,
-        document_ids_filter: list[str] | None,
+        document_ids_include: list[str] | None,
     ) -> list[dict[str, Any]]:
         filters: list[dict[str, Any]] = [
             {"term": {"metadata.status": 1}},
             {"exists": {"field": Field.VECTOR.value}},
         ]
         if file_names_filter:
-            query_str = {
-                "bool": {
-                    "must": {
-                        "script_score": {
-                            "query": {
-                                "match_all": {}
-                            },
-                            "script": {
-                                "source": f"cosineSimilarity(params.query_vector, '{Field.VECTOR.value}') + 1.0",
-                                "params": {"query_vector": query_vector}
-                            }
-                        }
-                    },
-                    "filter": [
-                        {"term": {"metadata.status": 1}},
-                        {"terms": {"metadata.file_name": file_names_filter}},
-                        {"exists": {"field": Field.VECTOR.value}},
-                    ],
-                }
-            }
-
-        document_ids_include = kwargs.get("document_ids_include")
-        if document_ids_include is None:
-            document_ids_include = kwargs.get("document_ids_filter")
+            filters.append({"terms": {"metadata.file_name": file_names_filter}})
         if document_ids_include:
-            query_str["bool"]["filter"].append({
-                "terms": {Field.DOCUMENT_ID.value: document_ids_include}
-            })
-            logger.info(f"[ES search_by_vector] including document_ids: {document_ids_include}")
-        else:
-            logger.info("[ES search_by_vector] no document_ids_include")
+            filters.append({"terms": {Field.DOCUMENT_ID.value: document_ids_include}})
+        return filters
 
     @staticmethod
     def _resolve_knn_num_candidates(top_k: int, configured: Any = None) -> int:
@@ -653,12 +626,14 @@ class ElasticSearchVector(BaseVector):
         score_threshold = float(kwargs.get("score_threshold") or 0.3)
         indices = kwargs.get("indices", self._collection_name)  # Default single index, multi-index available，etc "index1,index2,index3"
         file_names_filter = kwargs.get("file_names_filter") # ["doc1", "doc2", "doc3"]
-        document_ids_filter = kwargs.get("document_ids_filter")
-        filters = self._build_vector_filter_clauses(file_names_filter, document_ids_filter)
+        document_ids_include = kwargs.get("document_ids_include")
+        if document_ids_include is None:
+            document_ids_include = kwargs.get("document_ids_filter")
+        filters = self._build_vector_filter_clauses(file_names_filter, document_ids_include)
 
         logger.info(
             f"[ES search_by_vector] filter_summary file_name_count={len(file_names_filter or [])} "
-            f"excluded_document_id_count={len(document_ids_filter or [])}"
+            f"included_document_id_count={len(document_ids_include or [])}"
         )
 
         if self._resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -14,6 +14,12 @@ class RetrieveType(StrEnum):
     Graph = "graph"
 
 
+class KnowledgeRetrievalCaller(StrEnum):
+    GENERAL = "general"
+    AGENT = "agent"
+    WORKFLOW = "workflow"
+
+
 class ChunkType(StrEnum):
     """Chunk type enumeration"""
     CHUNK = "chunk"
@@ -97,6 +103,7 @@ class ChunkRetrieve(BaseModel):
     vector_similarity_weight: float | None = Field(None)
     top_k: int | None = Field(20, ge=1, le=100)
     top_n: int | None = Field(20, ge=1, le=100)
+    caller: KnowledgeRetrievalCaller = Field(KnowledgeRetrievalCaller.GENERAL)
     retrieve_type: RetrieveType | None = Field(None)
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
     metadata_filters: list[FilterGroup] | None = Field(None, description="filter condition groups")

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.schemas.chunk_schema import RetrieveType
+from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
 
 
@@ -15,6 +15,8 @@ class KnowledgeRetrievalRequest(BaseModel):
     similarity_threshold: float = Field(default=0.3, ge=0, le=1)
     vector_similarity_weight: float = Field(default=0.3, ge=0, le=1)
     top_k: int = Field(default=100, ge=1, le=100)
+    top_n: int | None = Field(default=None, ge=1, le=100)
+    caller: KnowledgeRetrievalCaller = KnowledgeRetrievalCaller.GENERAL
     retrieve_type: RetrieveType = RetrieveType.HYBRID
     rerank_id: UUID | None = None
     rerank_score_threshold: float | None = Field(default=None, ge=0, le=1)
@@ -33,6 +35,10 @@ class KnowledgeRetrievalRequest(BaseModel):
     def validate_knowledge_ids(self) -> "KnowledgeRetrievalRequest":
         if not self.kb_ids and not self.ex_ids:
             raise ValueError("kb_ids and ex_ids cannot both be empty")
+        if self.top_n is None or "top_n" not in self.model_fields_set:
+            self.top_n = max(self.top_k, 20)
+        elif self.top_n < self.top_k:
+            raise ValueError("top_n must be greater than or equal to top_k")
         if self.rerank_score_threshold is None:
             self.rerank_score_threshold = self.vector_similarity_weight
         return self

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from typing import Any
+from typing import Any, Optional
 
 from langchain_core.documents import Document
 from sqlalchemy.orm import Session
@@ -99,13 +99,17 @@ class KnowledgeRetrievalService:
         vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
         indices = ",".join(f"Vector_index_{knowledge_id}_Node".lower() for knowledge_id in knowledge_ids)
 
-        if request.retrieve_type == RetrieveType.PARTICIPLE:
-            return cls._search_full_text(vector_service, request, indices, document_ids_include)
-        if request.retrieve_type == RetrieveType.SEMANTIC:
-            return cls._search_vector(vector_service, request, indices, document_ids_include)
+        top_n = request.top_k
 
-        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_include)
-        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_include)
+        if request.retrieve_type == RetrieveType.PARTICIPLE:
+            return cls._search_full_text(vector_service, request, indices, document_ids_include, topk=top_n)
+        if request.retrieve_type == RetrieveType.SEMANTIC:
+            return cls._search_vector(vector_service, request, indices, document_ids_include, topk=top_n)
+
+        top_n = request.top_n
+
+        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_include, topk=top_n)
+        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_include, topk=top_n)
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         logger.debug(f"Retrieved {len(unique_chunks)} chunks")
         if not unique_chunks:
@@ -132,10 +136,11 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             indices: str,
             document_ids_include: list[str] | None,
+            topk: Optional[int] = -1,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_vector(
             query=request.query,
-            top_k=request.top_k,
+            top_k=topk,
             indices=indices,
             score_threshold=request.vector_similarity_weight,
             document_ids_include=document_ids_include,
@@ -149,10 +154,11 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             indices: str,
             document_ids_include: list[str] | None,
+            topk: Optional[int] = -1,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_full_text(
             query=request.query,
-            top_k=request.top_k,
+            top_k=topk,
             indices=indices,
             score_threshold=request.similarity_threshold,
             document_ids_include=document_ids_include,
@@ -187,11 +193,12 @@ class KnowledgeRetrievalService:
 
         rerank_score_threshold = request.rerank_score_threshold or request.vector_similarity_weight or 0.1
 
-        return [
+        filtered_chunks = [
             chunk
             for chunk in reranked_chunks
             if (chunk.metadata or {}).get("score", 0) > rerank_score_threshold
         ]
+        return filtered_chunks[:request.top_k]
 
     @staticmethod
     def _retrieve_graph(

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -619,7 +619,7 @@ class KnowledgeRetrievalService:
                 )
                 for doc in docs
             ]
-            reranked_docs = list(reranker.compress_documents(documents, query, topn=top_k))
+            reranked_docs = list(reranker.compress_documents(documents, query, top_n=top_k))
             reranked_docs.sort(
                 key=lambda item: item.metadata.get("relevance_score", 0),
                 reverse=True,


### PR DESCRIPTION
## Summary
- Repair Elasticsearch vector filter construction after a bad merge resolution.
- Add retrieval caller support with general, agent, and workflow sources.
- Add top_n request handling so hybrid retrieval can fetch rerank candidates separately from final top_k output.

## Changes
- app/core/rag/vdb/elasticsearch/elasticsearch_vector.py: restore shared vector filter construction and include document-id filtering.
- app/schemas/chunk_schema.py: add KnowledgeRetrievalCaller and expose caller on ChunkRetrieve.
- app/schemas/knowledge_retrieval_schema.py: add caller and top_n validation/defaulting to KnowledgeRetrievalRequest.
- app/services/knowledge_retrieval_service.py: use top_n for hybrid vector/full-text candidate retrieval and keep final output capped by top_k.

## API Impact
- Internal and API-key retrieval endpoints both accept caller/top_n because the external controller reuses ChunkRetrieve and the internal retrieval controller.
- New fields are backward compatible: caller defaults to general; top_n is derived from top_k when omitted.

## Test Plan
- [x] PYTHONPATH=. uv run --frozen pytest tests/rag -q
- [x] PYTHONPATH=. uv run --frozen python -m compileall -q app/schemas/chunk_schema.py app/schemas/knowledge_retrieval_schema.py app/services/knowledge_retrieval_service.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
- [x] git diff --check -- api/app/schemas/chunk_schema.py api/app/schemas/knowledge_retrieval_schema.py api/app/services/knowledge_retrieval_service.py

## Summary by Sourcery

引入调用方感知的知识检索机制，支持单独控制候选结果的 top_n，并修复 Elasticsearch 向量过滤器的构造问题。

New Features:
- 新增 `KnowledgeRetrievalCaller` 枚举，并在分片（chunk）和检索请求的 schema 中暴露调用方信息。
- 支持为候选检索单独配置 `top_n`，同时保留 `top_k` 作为最终结果上限。

Bug Fixes:
- 恢复 Elasticsearch 向量搜索过滤器的正确行为，以便正确应用文件名和文档 ID 的约束。

Enhancements:
- 使用 `top_n` 控制混合向量与全文检索的候选结果数，并通过 `top_k` 对重排后的输出进行封顶。
- 对齐重排器（reranker）的 API 使用方式和日志记录，以确保在 Elasticsearch 向量搜索中包含文档 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce caller-aware knowledge retrieval with separate top_n candidate control and fix Elasticsearch vector filter construction.

New Features:
- Add KnowledgeRetrievalCaller enum and expose caller on chunk and retrieval request schemas.
- Support separate top_n configuration for candidate retrieval while keeping top_k as the final result cap.

Bug Fixes:
- Restore Elasticsearch vector search filters to correctly apply file name and document ID constraints.

Enhancements:
- Use top_n to control hybrid vector and full-text candidate retrieval and cap reranked output by top_k.
- Align reranker API usage and logging for document ID inclusion in Elasticsearch vector search.

</details>