### PR TITLE
fix(workflow)

### DIFF
--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -572,10 +572,11 @@ class VariablePoolInitializer:
                 # Convert FileInput-format dicts to full FileObject dicts
                 if var_type == VariableType.FILE:
                     if not var_value:
-                        continue
-                    var_value = await self._resolve_file_default(var_value)
-                    if not var_value:
-                        continue
+                        var_value = None
+                    else:
+                        var_value = await self._resolve_file_default(var_value)
+                        if not var_value:
+                            var_value = None
                 elif var_type == VariableType.ARRAY_FILE:
                     if not var_value:
                         var_value = []

--- a/api/app/core/workflow/variable/base_variable.py
+++ b/api/app/core/workflow/variable/base_variable.py
@@ -106,7 +106,7 @@ def DEFAULT_VALUE(var_type: VariableType) -> Any:
         case VariableType.OBJECT:
             return {}
         case VariableType.FILE:
-            return {}
+            return None
         case VariableType.ARRAY_STRING:
             return []
         case VariableType.ARRAY_NUMBER:

--- a/api/app/core/workflow/variable/variable_objects.py
+++ b/api/app/core/workflow/variable/variable_objects.py
@@ -62,10 +62,12 @@ class DictVariable(BaseVariable):
 
 
 class FileVariable(BaseVariable):
-    value: FileObject
+    value: FileObject | None
     type = 'file'
 
-    def valid_value(self, value) -> FileObject:
+    def valid_value(self, value) -> FileObject | None:
+        if value is None:
+            return None
         if isinstance(value, dict):
             if not value.get("is_file"):
                 raise TypeError(f"Value must be a FileObject  - {type(value)}:{value}")
@@ -75,9 +77,13 @@ class FileVariable(BaseVariable):
         raise TypeError(f"Value must be a FileObject - {type(value)}:{value}")
 
     def to_literal(self) -> str:
+        if self.value is None:
+            return ""
         return f'{"!"if self.value.type == FileType.IMAGE else ""}[file]({self.value.url})'
 
     def get_value(self) -> Any:
+        if self.value is None:
+            return None
         return self.value.model_dump(exclude={"content_cache"})
 
     async def get_content(self):

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1413,16 +1413,15 @@ class WorkflowService:
             name = item.get("name")
             if not name:
                 continue
-            if item.get("default") is not None:
-                result[name] = self._build_typed_variable(
-                    item.get("default"),
-                    item.get("type"),
-                )
+            var_type = item.get("type")
+            default = item.get("default")
+            if var_type == VariableType.FILE.value:
+                value = default if isinstance(default, dict) and default.get("is_file") else None
+            elif var_type == VariableType.ARRAY_FILE.value:
+                value = [v for v in (default or []) if isinstance(v, dict) and v.get("is_file")] if default else []
             else:
-                result[name] = self._build_typed_variable(
-                    None,
-                    item.get("type"),
-                )
+                value = default
+            result[name] = self._build_typed_variable(value, var_type)
         return result
 
     def _build_default_debug_state_snapshot(
@@ -1882,9 +1881,15 @@ class WorkflowService:
                 self._unwrap_typed_variable(typed_value),
             )
             resolved_value = self._unwrap_typed_variable(typed_value)
-            if resolved_value is None:
-                if resolved_type == VariableType.FILE:
-                    continue
+            if resolved_type == VariableType.FILE:
+                if not isinstance(resolved_value, dict) or not resolved_value.get("is_file"):
+                    resolved_value = None
+            elif resolved_type == VariableType.ARRAY_FILE:
+                if not isinstance(resolved_value, list):
+                    resolved_value = []
+                else:
+                    resolved_value = [v for v in resolved_value if isinstance(v, dict) and v.get("is_file")]
+            elif resolved_value is None:
                 if resolved_type != VariableType.ANY:
                     resolved_value = DEFAULT_VALUE(resolved_type)
             await variable_pool.new(


### PR DESCRIPTION
handle None value for FILE and ARRAY_FILE variables consistently

The changes ensure FILE and ARRAY_FILE variable types properly handle None or invalid default values by returning None instead of empty dicts or lists, and update type hints and validation logic accordingly. This prevents incorrect variable initialization and improves robustness during workflow execution.

BREAKING CHANGE: FileVariable.value is now Optional[FileObject], and valid_value() and get_value() methods now accept/return None for FILE variables.

## Summary by Sourcery

处理 FILE 和 ARRAY_FILE 工作流变量时加入对 None 的默认值支持和校验，避免初始化为无效的文件值。

Bug Fixes（错误修复）:
- 规范 FILE 和 ARRAY_FILE 默认值的处理方式，使无效或缺失的文件值变为 None 或空数组，而不是空字典或列表。
- 确保在恢复工作流快照时过滤掉无效的文件结构，并将它们视为 None 或空数组。
- 允许 `FileVariable` 接受并安全表示 None，当未设置文件时，从 `get_value` 返回空字面量和 None。

Enhancements（增强）:
- 更新默认值辅助函数，使其对 FILE 变量返回 None，并在变量初始化逻辑中传播这一行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle FILE and ARRAY_FILE workflow variables with None-aware defaults and validation to avoid initializing invalid file values.

Bug Fixes:
- Normalize handling of FILE and ARRAY_FILE defaults so invalid or missing file values become None or empty arrays instead of empty dicts or lists.
- Ensure workflow snapshot restoration filters out invalid file structures and treats them as None or empty arrays.
- Allow FileVariable to accept and safely represent None, returning empty literals and None from get_value when no file is set.

Enhancements:
- Update default value helper to return None for FILE variables and propagate this through variable initialization logic.

</details>