### PR TITLE
fix(web): structured output

### DIFF
--- a/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
@@ -34,6 +34,8 @@ interface ModelConfigModalProps {
   /** Callback to update model configuration */
   refresh: (values?: ModelConfigForm) => void;
   variableOptions: Suggestion[];
+  /** Whether to show structured_output and json_output_fields configuration */
+  hideStructuredOutputConfig?: boolean;
 }
 
 export const fieldConfigs: Record<string, any> = {
@@ -65,6 +67,7 @@ export const fieldConfigs: Record<string, any> = {
   },
   json_output_fields: {
     type: 'editor',
+    dependence: 'capability',
   },
   top_p: {
     enable: {
@@ -205,7 +208,8 @@ export const fieldConfigs: Record<string, any> = {
 const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(({
   refresh,
   variableOptions,
-  name = 'model_id'
+  name = 'model_id',
+  hideStructuredOutputConfig = false
 }, ref) => {
   const { t } = useTranslation();
   const { message } = App.useApp();
@@ -339,7 +343,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
               const dependence = firstFieldConfigs.dependence as keyof ModelConfigForm
               const dependenceValue = (values as any)?.[dependence] as string[] | undefined
               const isHidden = field === 'structured_output'
-                ? !dependenceValue?.includes('json_output')
+                ? !dependenceValue?.includes('json_output') || hideStructuredOutputConfig
                 : dependence && !dependenceValue?.includes(field)
               const isThinkingOnly = values?.capability?.includes('thinking_only')
 

--- a/web/src/views/Workflow/components/Properties/ModelConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/index.tsx
@@ -19,12 +19,14 @@ interface ModelConfigProps {
   variableOptions: Suggestion[];
   needLabel?: boolean;
   name?: string;
+  hideStructuredOutputConfig?: boolean;
 }
 const ModelConfig: FC<ModelConfigProps> = ({
   parentName,
   variableOptions,
   needLabel = true,
-  name = 'model_id'
+  name = 'model_id',
+  hideStructuredOutputConfig
 }) => {
   const { t } = useTranslation()
   const form = Form.useFormInstance()
@@ -90,6 +92,7 @@ const ModelConfig: FC<ModelConfigProps> = ({
         name={name}
         refresh={handleRefresh}
         variableOptions={variableOptions}
+        hideStructuredOutputConfig={hideStructuredOutputConfig}
       />
     </>
   );

--- a/web/src/views/Workflow/components/Properties/index.tsx
+++ b/web/src/views/Workflow/components/Properties/index.tsx
@@ -796,6 +796,7 @@ const Properties: FC<PropertiesProps> = ({
                                     key={key}
                                     parentName={selectedNode?.data?.type === 'agent' ? key : undefined}
                                     variableOptions={getFilteredVariableList(selectedNode?.data?.type)}
+                                    hideStructuredOutputConfig={!(key === 'model_id' && selectedNode?.data?.type === 'llm')}
                                   />
                                 )
                               }


### PR DESCRIPTION
## Summary by Sourcery

为非 LLM 模型隐藏结构化输出配置，同时为 JSON 输出字段接入基于能力的依赖。

New Features:
- 新增可选标志位，用于控制在模型配置弹窗中 `structured_output` 和 `json_output_fields` 配置项的可见性。

Enhancements:
- 将 `hideStructuredOutputConfig` 从工作流属性传递到模型配置中，从而只在 LLM 模型配置中暴露结构化输出设置。
- 将 `json_output_fields` 编辑器的可见性与模型能力配置关联起来。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Hide structured output configuration for non-LLM models while wiring capability-based dependencies for JSON output fields.

New Features:
- Add optional flag to control visibility of structured_output and json_output_fields configuration in model config modals.

Enhancements:
- Pass through hideStructuredOutputConfig from workflow properties to model config so only LLM model configs expose structured output settings.
- Tie json_output_fields editor visibility to the model capability configuration.

</details>