### PR TITLE
fix(knowledge retrieval): add disabled metadata filter check

### DIFF
--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -422,6 +422,9 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             knowledge_ids: list[uuid.UUID],
     ) -> list[str] | None:
+        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            return None
+
         if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
             return None
 
@@ -459,6 +462,9 @@ class KnowledgeRetrievalService:
             knowledge_ids: list[uuid.UUID],
             common_metadata_defs: dict[str, dict],
     ) -> list[EngineFilterGroup]:
+        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            return []
+
         if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
             if not request.metadata_filters:
                 return []


### PR DESCRIPTION
Handle the case where the metadata filter mode is set to DISABLED in advance during the retrieval and filter generation logic, returning empty results directly to avoid unnecessary computations.

## Summary by Sourcery

错误修复：
- 处理 `DISABLED` 的 `metadata_filter_mode` 情况，通过不返回任何元数据过滤器或过滤器组，来避免不必要的检索处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle DISABLED metadata_filter_mode by returning no metadata filters or filter groups to avoid unnecessary retrieval processing.

</details>