### PR TITLE
fix(web): human intervention

### DIFF
--- a/web/src/components/Chat/RenderedForm.tsx
+++ b/web/src/components/Chat/RenderedForm.tsx
@@ -106,14 +106,14 @@ const RenderedForm: React.FC<RenderedFormProps> = ({
     }
   }
 
-  if (!renderedContent) {
+  if (!renderedContent && actions.length < 1) {
     return null
   }
   
   // 不可编辑状态使用纯文本展示，可编辑状态使用 Markdown 渲染
   if (!editable) {
     return <div className="rb:text-gray-600 rb:text-sm">
-      <Markdown content={renderedContent} />
+      {renderedContent && <Markdown content={renderedContent} />}
       {resolved_action_id && <>
         <Divider />
         {t('memoryConversation.triggeredAction')}: {resolved_action_id || ''}
@@ -123,7 +123,7 @@ const RenderedForm: React.FC<RenderedFormProps> = ({
   
   return <>
     <form ref={formRef}>
-      <Markdown content={renderedContent} />
+      {renderedContent && <Markdown content={renderedContent} />}
       {editable && actions.length > 0 && (
         <Flex wrap gap={12} className="rb:mt-2!">
           {actions.map((action, index: number) => (


### PR DESCRIPTION
## Summary by Sourcery

处理在没有渲染文本内容的情况下仍存在聊天操作的场景，以避免空白或损坏的表单渲染。

Bug 修复：
- 通过在渲染前增加内容检查，防止将 `null` 内容渲染到 Markdown 组件中。
- 即使在没有可用的文本渲染内容时，也允许聊天表单和操作正常渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle cases where chat actions exist without rendered text content to avoid empty or broken form rendering.

Bug Fixes:
- Prevent rendering null content into the Markdown component by guarding it behind a content check.
- Allow the chat form and actions to render even when no textual rendered content is available.

</details>