### PR TITLE
refactor(workflow): fix intervention status judgment logic and optimize log output

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -440,9 +440,20 @@ def get_conversation(
                 return "interrupt"
             return kind
 
+        # Determine intervention status based on whether ALL intervention nodes
+        # have been resolved, NOT based on the workflow's overall execution status.
+        # When a HITL node enters the timeout branch, it has completed (resolved)
+        # its intervention — the node chose the timeout path. Even if the overall
+        # workflow later fails on a downstream node, the intervention itself is done.
+        all_resolved = all(
+            i.get("resolved_action_id") or i.get("resolved_kind")
+            for i in ordered
+        )
+        intervention_status = "completed" if all_resolved else "waiting_human"
+
         intervention_map[message_id] = {
             "execution_id": wf_exec.execution_id,
-            "status": wf_exec.status,
+            "status": intervention_status,
             "interventions": [{
                 "node_id": i["node_id"],
                 "node_name": i.get("node_name", ""),

--- a/api/app/services/app_log_service.py
+++ b/api/app/services/app_log_service.py
@@ -212,9 +212,20 @@ class AppLogService:
 
             ordered = sorted(merged_by_node.values(), key=_sort_key)
 
+            # Determine intervention status based on whether ALL intervention nodes
+            # have been resolved, NOT based on the workflow's overall execution status.
+            # When a HITL node enters the timeout branch, it has completed (resolved)
+            # its intervention — the node chose the timeout path. Even if the overall
+            # workflow later fails on a downstream node, the intervention itself is done.
+            all_resolved = all(
+                i.get("resolved_action_id") or i.get("resolved_kind")
+                for i in ordered
+            )
+            intervention_status = "completed" if all_resolved else "waiting_human"
+
             intervention_map[message_id] = {
                 "execution_id": wf_exec.execution_id,
-                "status": wf_exec.status,
+                "status": intervention_status,
                 "interventions": [{
                     "node_id": i["node_id"],
                     "node_name": i.get("node_name", ""),
@@ -387,7 +398,9 @@ class AppLogService:
                     output_content = _extract_text(execution.output_data)
                 meta = {"usage": execution.token_usage or {}, "elapsed_time": execution.elapsed_time}
             elif execution.status == "waiting_human":
-                output_content = _extract_text(execution.output_data) or ""
+                # waiting_human 状态下工作流暂停等待人工介入，没有 AI 输出文本。
+                # 不应将 output_data 原始 JSON dump 为 content（包含 node_outputs 等内部数据）。
+                output_content = ""
                 intervention_ctx = (execution.context or {}).get("human_intervention", {})
                 meta = {
                     "waiting_human": True,
@@ -395,10 +408,11 @@ class AppLogService:
                     "elapsed_time": execution.elapsed_time,
                 }
             elif execution.status == "timeout":
-                output_content = _extract_text(execution.output_data) or execution.error_message or ""
+                output_content = execution.error_message or ""
                 meta = {"timeout": True, "error_node_id": execution.error_node_id, "elapsed_time": execution.elapsed_time}
             else:
-                output_content = _extract_text(execution.output_data) or ""
+                # failed 状态：优先用 error_message，不要 dump output_data
+                output_content = execution.error_message or ""
                 meta = {"error": execution.error_message, "error_node_id": execution.error_node_id}
 
             assistant_msg = AppLogMessage(
@@ -588,15 +602,22 @@ class AppLogService:
 def _extract_text(data: Optional[dict]) -> str:
     """从 workflow execution 的 input_data / output_data 中提取可读文本。
 
-    优先取 'text'、'content'、'output' 字段；若都没有则 JSON 序列化整个 dict。
+    优先取 'text'、'content'、'output' 字段（字符串或可转为字符串的值）；
+    若都没有则返回空字符串（不再将整个 dict dump 为 JSON，避免暴露 node_outputs
+    等内部数据作为 assistant 消息的 content）。
     """
     if not data:
         return ""
     for key in ("message", "text", "content", "output", "result", "answer"):
-        if key in data and isinstance(data[key], str):
-            return data[key]
-    import json
-    return json.dumps(data, ensure_ascii=False)
+        val = data.get(key)
+        if val is None:
+            continue
+        if isinstance(val, str):
+            return val
+        # output_data["output"] 可能是 End 节点的输出字符串，直接转 str
+        if key == "output" and val is not None:
+            return str(val)
+    return ""
 
 
 def _build_nodes_from_output_data(output_data: Optional[dict]) -> list[AppLogNodeExecution]:

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -5171,6 +5171,38 @@ class WorkflowService:
                                     f"accumulated_output_length={len(accumulated_content)}, "
                                     f"execution_id={execution.execution_id}"
                                 )
+
+                            # 如果在 resume 时，遇到了 status 为 failed 的 workflow_end
+                            if resume_event.get("event") == "workflow_end" and resume_event.get("data", {}).get("status") == "failed":
+                                resume_data = resume_event.get("data", {})
+                                # 如果 resume_data 包含 node_outputs（图正常返回 failed 状态，
+                                # 如 _wrap_error 有错误边），用它更新 execution.output_data。
+                                # 否则（异常场景：resume_workflow_stream 只 yield {status, error,
+                                # execution_id}），保留 execution.output_data（异常处理已
+                                # 正确构建了含 node_outputs 的数据），不覆盖。
+                                if isinstance(resume_data.get("node_outputs"), dict) and resume_data["node_outputs"]:
+                                    execution.output_data = resume_data
+                                elif not execution.output_data:
+                                    execution.output_data = resume_data
+                                execution.status = "failed"
+                                execution.completed_at = utcnow_naive()
+                                execution.elapsed_time = (execution.completed_at - execution.started_at).total_seconds()
+                                execution.error_node_id = resume_data.get("error_node")
+                                execution.error_message = resume_data.get("error")
+
+                                # 失败时清除 waiting_human 标记，更新消息
+                                _resolved_meta = {"waiting_human": False, "execution_id": execution.execution_id}
+                                self.conversation_service.update_message(
+                                    message_id=message_id,
+                                    meta_data=_resolved_meta,
+                                )
+                                self.db.commit()
+
+                                try:
+                                    self._persist_workflow_node_executions(execution, config, execution.output_data)
+                                    self._refresh_workflow_debug_state_from_execution(execution)
+                                except Exception as persist_err:
+                                    logger.warning(f"Failed to persist node executions on intervention failed: {persist_err}")
                             emitted = self._emit(public, resume_event)
                             if emitted:
                                 if resume_event.get("event") == "workflow_end" and resume_event.get("data", {}).get("status") == "completed":
@@ -5700,6 +5732,43 @@ class WorkflowService:
                             self._refresh_workflow_debug_state_from_execution(execution)
                         except Exception as persist_err:
                             logger.warning(f"Failed to persist node executions on resume complete: {persist_err}")
+
+                    # 如果在 resume 时，遇到了 status 为 failed 的 workflow_end
+                    if resume_event.get("event") == "workflow_end" and \
+                            resume_event.get("data", {}).get("status") == "failed":
+                        resume_data = resume_event.get("data", {})
+                        # 如果 resume_data 包含 node_outputs（图正常返回 failed 状态，
+                        # 如 _wrap_error 有错误边），用它更新 execution.output_data。
+                        # 否则（异常场景：resume_workflow_stream 只 yield {status, error,
+                        # execution_id}），保留 execution.output_data（异常处理已
+                        # 正确构建了含 node_outputs 的数据），不覆盖。
+                        if isinstance(resume_data.get("node_outputs"), dict) and resume_data["node_outputs"]:
+                            execution.output_data = resume_data
+                        elif not execution.output_data:
+                            execution.output_data = resume_data
+                        execution.status = "failed"
+                        execution.completed_at = utcnow_naive()
+                        execution.elapsed_time = (execution.completed_at - execution.started_at).total_seconds()
+                        execution.error_node_id = resume_data.get("error_node")
+                        execution.error_message = resume_data.get("error")
+
+                        # 失败时清除 waiting_human 标记，更新消息
+                        if conversation_id_uuid:
+                            resolved_meta = {"waiting_human": False, "execution_id": execution_id}
+                            if hitl_message_id:
+                                self.conversation_service.update_message(
+                                    hitl_message_id,
+                                    meta_data=resolved_meta,
+                                )
+
+                        self._touch_conversation(conversation_id_uuid)
+                        self.db.commit()
+
+                        try:
+                            self._persist_workflow_node_executions(execution, config, execution.output_data)
+                            self._refresh_workflow_debug_state_from_execution(execution)
+                        except Exception as persist_err:
+                            logger.warning(f"Failed to persist node executions on resume failed: {persist_err}")
                     emitted = self._emit(public, resume_event)
                     if emitted:
                         if resume_event.get("event") == "workflow_end" and \
@@ -6861,6 +6930,16 @@ class WorkflowService:
                     execution.output_data = new_output_data
             except Exception as recover_err:
                 logger.warning(f"Failed to recover state on resume error: {recover_err}")
+
+            # If the error is a NodeExecutionError, inject the failed node's output
+            # into node_outputs so it appears in the log (same pattern as executor.py).
+            from app.core.workflow.nodes.base_node import NodeExecutionError
+            if isinstance(e, NodeExecutionError):
+                if not execution.output_data:
+                    execution.output_data = {}
+                node_outputs = execution.output_data.setdefault("node_outputs", {})
+                node_outputs.setdefault(e.node_id, e.node_output)
+                execution.error_node_id = e.node_id
 
             execution.status = "failed"
             execution.error_message = str(e)


### PR DESCRIPTION
1. Adjust the criteria for determining intervention status to be based on whether all intervention nodes are resolved, rather than the overall workflow execution status.
2. Optimize the text extraction logic in `_app_log_service` to prevent internal data from being exposed in conversation content.
3. Add handling logic for workflow failures in resume scenarios, improving node execution data persistence and message updates during exceptions.

## Summary by Sourcery

调整恢复（resumed）工作流的介入状态评估与失败处理逻辑，并收紧日志中文本提取规则，以避免暴露内部数据。

Bug 修复：
- 修正介入状态报告逻辑，使其依赖于「所有介入节点是否已解决」，而不是整个工作流的执行状态。
- 防止在 `waiting_human`、`timeout` 和 `failed` 状态下，将原始工作流 `output_data`（包括内部 `node_outputs`）作为 assistant 消息内容输出。
- 确保工作流在恢复过程中发生失败时，能够正确持久化节点执行输出、传递 `NodeExecutionError` 上下文，并清除 `waiting_human` 标记的同时更新会话消息。

增强：
- 在应用日志和公开分享响应中统一介入状态的计算方式，使用基于「已解决介入」的状态字段。
- 改进从工作流输入/输出中提取可读文本的方式，只返回特定字段，并避免对整个结构进行 JSON dump。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust intervention status evaluation and failure handling for resumed workflows, while tightening log text extraction to avoid exposing internal data.

Bug Fixes:
- Correct intervention status reporting to depend on whether all intervention nodes are resolved instead of the overall workflow execution status.
- Prevent raw workflow output_data (including internal node_outputs) from being emitted as assistant message content in waiting_human, timeout, and failed states.
- Ensure workflow failures during resume correctly persist node execution outputs, propagate NodeExecutionError context, and clear waiting_human flags while updating conversation messages.

Enhancements:
- Unify intervention status calculation in app logs and public share responses using a resolved-interventions-based status field.
- Improve extraction of human-readable text from workflow input/output by only returning specific fields and avoiding JSON dumping of entire structures.

</details>