### PR TITLE
fix(web): structured output schema

### DIFF
--- a/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/ModelConfigModal.tsx
@@ -217,7 +217,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
   const [form] = Form.useForm<ModelConfigForm>();
   const [options, setOptions] = useState<Model[]>([]);
   const structuredOutputSchemaModalRef = useRef<StructuredOutputSchemaModalRef>(null);
-
+  const json_output = Form.useWatch('json_output', form)
 
   const values = Form.useWatch([], form);
 
@@ -304,6 +304,11 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
   const handleSaveSchema = (schema: JsonSchema) => {
     form.setFieldValue('json_output_fields', schema)
   }
+  const handleSwitch = (checked: boolean, field: string) => {
+    if (field === 'json_output' && !checked) {
+      form.setFieldValue('structured_output', false)
+    }
+  }
 
   return (
     <>
@@ -343,7 +348,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
               const dependence = firstFieldConfigs.dependence as keyof ModelConfigForm
               const dependenceValue = (values as any)?.[dependence] as string[] | undefined
               const isHidden = field === 'structured_output'
-                ? !dependenceValue?.includes('json_output') || hideStructuredOutputConfig
+                ? !dependenceValue?.includes('json_output') || !json_output || hideStructuredOutputConfig
                 : dependence && !dependenceValue?.includes(field)
               const isThinkingOnly = values?.capability?.includes('thinking_only')
 
@@ -421,7 +426,7 @@ const ModelConfigModal = forwardRef<ModelConfigModalRef, ModelConfigModalProps>(
                           name={field}
                           noStyle
                         >
-                          <Switch />
+                          <Switch onChange={(checked) => handleSwitch(checked, field)} />
                         </FormItem>
                         <Flex align="center" gap={4}>
                           {t(`workflow.config.llm.${field}`)}

--- a/web/src/views/Workflow/components/Properties/ModelConfig/StructuredOutputSchemaModal.tsx
+++ b/web/src/views/Workflow/components/Properties/ModelConfig/StructuredOutputSchemaModal.tsx
@@ -47,6 +47,21 @@ interface StructuredOutputSchemaModalProps {
   refresh: (schema: JsonSchema) => void;
 }
 
+// 默认展开所有 object 类型节点的 key
+const getAllObjectKeys = (list: Field[], path: number[] = []): string[] => {
+  const keys: string[] = [];
+  list.forEach((field, index) => {
+    const currentPath = [...path, index];
+    if (field.type.includes('object')) {
+      keys.push(currentPath.join(','));
+      if (field.children) {
+        keys.push(...getAllObjectKeys(field.children, currentPath));
+      }
+    }
+  });
+  return keys;
+};
+
 export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModalRef, StructuredOutputSchemaModalProps>(({
   refresh,
 }, ref) => {
@@ -56,18 +71,22 @@ export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModa
   const [activeTab, setActiveTab] = useState<'visual' | 'json'>('visual');
   const [fields, setFields] = useState<Field[]>(defaultJsonSchema);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
   const [editForm] = Form.useForm();
   const importModalRef = useRef<JsonImportModalRef>(null);
 
   const handleOpen = (schema: JsonSchema) => {
     setFields(schema || defaultJsonSchema);
     setVisible(true);
+
+    setExpandedKeys(getAllObjectKeys(schema || defaultJsonSchema))
   };
 
   const handleClose = () => {
     setVisible(false);
     setFields([...defaultJsonSchema]);
     setEditingId(null);
+    setExpandedKeys([]);
   };
 
   const handleSave = () => {
@@ -129,6 +148,12 @@ export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModa
       }));
       
       newFieldIndexPath = [...parentIndexPath, parentChildrenCount];
+
+      // 展开父节点
+      const parentKey = parentIndexPath.join(',');
+      if (!expandedKeys.includes(parentKey)) {
+        setExpandedKeys([...expandedKeys, parentKey]);
+      }
     }
 
     setFields(newFields);
@@ -142,27 +167,19 @@ export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModa
     
     const deleteFromList = (list: Field[], indices: number[]): Field[] => {
       if (indices.length === 1) {
-        // Check if it's the last field and whether it's a new field (name is undefined)
-        const isNewField = !list[indices[0]]?.name;
-        if (isNewField || list.length > 1) {
-          return list.filter((_, i) => i !== indices[0]);
-        }
-        return list;
+        // Always allow deletion
+        return list.filter((_, i) => i !== indices[0]);
       }
       
       const [first, ...rest] = indices;
       return list.map((field, i) => {
         if (i !== first) return field;
         const children = field.children || [];
-        // Check if it's the last child and whether it's a new field
-        const isNewField = rest.length === 1 && !children[rest[0]]?.name;
-        if (isNewField || children.length > 1) {
-          return {
-            ...field,
-            children: deleteFromList(children, rest)
-          };
-        }
-        return field;
+        // Always allow deletion
+        return {
+          ...field,
+          children: deleteFromList(children, rest)
+        };
       });
     };
     
@@ -484,14 +501,6 @@ export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModa
           <Button
             size="small"
             type="text"
-            onClick={syncToJson}
-          >
-            AI 生成
-          </Button>
-          <Divider type="vertical" />
-          <Button
-            size="small"
-            type="text"
             onClick={openImportModal}
           >
             {t('workflow.config.llm.importFromJson')}
@@ -511,7 +520,8 @@ export const StructuredOutputSchemaModal = forwardRef<StructuredOutputSchemaModa
             switcherIcon={<DownOutlined />}
             showLine
             blockNode
-            defaultExpandAll
+            expandedKeys={expandedKeys}
+            onExpand={(keys) => setExpandedKeys(keys)}
             selectable={false}
             titleRender={(node) => {
               if (node.key === '__add_field_root__') {


### PR DESCRIPTION
## Summary by Sourcery

更新结构化输出配置的用户体验，以及其在工作流模型配置弹窗中与 JSON 输出的交互方式。

新功能：
- 在打开模式编辑器以及添加嵌套字段时，自动展开结构化输出树中所有对象类型的节点。

错误修复：
- 允许删除结构化输出模式中的任意字段或子字段，而不受其是否为最后一个字段或新建字段的限制。
- 确保在禁用 JSON 输出时关闭结构化输出选项，并在未启用 JSON 输出时隐藏结构化输出配置。

优化改进：
- 用受控的展开状态替代默认“全部展开”的行为，在结构化输出树中持久化用户的展开/收起操作。
- 从结构化输出模式表单的头部移除 AI 生成快捷按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update structured output configuration UX and its interaction with JSON output in the workflow model config modal.

New Features:
- Automatically expand all object-type nodes in the structured output tree when opening the schema editor and when adding nested fields.

Bug Fixes:
- Allow deleting any field or child field in the structured output schema regardless of whether it is the last or a new field.
- Ensure the structured output option is turned off when JSON output is disabled and hide structured output config when JSON output is not enabled.

Enhancements:
- Replace default-expand-all behavior with controlled expansion state in the structured output tree, persisting user expand/collapse actions.
- Remove the AI generation shortcut button from the structured output schema form header.

</details>