### PR TITLE
Fix/v0.3.8 zy

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat.tsx
@@ -211,7 +211,7 @@ const Chat: FC<ChatProps> = ({
   }
   /** Update assistant message when error occurs */
   const updateErrorAssistantMessage = (message_length: number, model_config_id?: string, error?: { message?: string; }) => {
-    if (!model_config_id || !error) return
+    if (!model_config_id && !error) return
 
     if (message_length > 0) {
       updateChatList(prev => {
@@ -227,6 +227,8 @@ const Chat: FC<ChatProps> = ({
           const subContent = lastAssistantMsg.subContent || []
           const hasFailed = subContent.some(vo => vo.status === 'failed')
           let messageStatus = hasFailed ? 'failed' : 'completed'
+
+          console.log('messageStatus', messageStatus)
 
           modelChatList[targetIndex] = {
             ...modelChatList[targetIndex],

--- a/web/src/views/KnowledgeBase/components/MetadataDrawer.tsx
+++ b/web/src/views/KnowledgeBase/components/MetadataDrawer.tsx
@@ -142,9 +142,9 @@ const MetadataDrawer = forwardRef<MetadataDrawerRef>((_props, ref) => {
                       <span className="rb:font-medium">{item.name}</span>
                       <Tag color="blue">{item.type}</Tag>
                     </div>
-                    {/* <span className="rb:text-[12px] rb:text-[#5B6167]">
+                    <span className="rb:text-[12px] rb:text-[#5B6167]">
                       {item.count || 0} {t('knowledgeBase.metadata.valueCount')}
-                    </span> */}
+                    </span>
                     <Space size={8} className="rb:absolute rb:right-0 rb:hidden! rb:group-hover:inline-flex! rb:bg-white rb:p-2! rb:rounded-tr-lg rb:rounded-br-lg">
                       <div
                         className="rb:size-4.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/common/edit.svg')]"


### PR DESCRIPTION
## Summary by Sourcery

调整聊天错误处理逻辑，并在知识库界面中恢复元数据值数量的展示。

Bug Fixes:
- 修正更新助手消息时的保护条件，确保当模型配置或错误信息二者其一存在时，都能正确处理错误。

Enhancements:
- 在知识库的元数据抽屉列表项中重新启用元数据值数量的显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust chat error handling and restore metadata value count display in the knowledge base UI.

Bug Fixes:
- Correct the guard condition when updating assistant messages on error to ensure errors are handled when either model config or error info is present.

Enhancements:
- Re-enable display of metadata value counts in the knowledge base metadata drawer list items.

</details>