### PR TITLE
Refactor/restructure celery task routing

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -186,9 +186,15 @@ except ImportError:
 
 # Celery Beat schedule for periodic tasks
 memory_increment_schedule = crontab(hour=settings.MEMORY_INCREMENT_HOUR, minute=settings.MEMORY_INCREMENT_MINUTE)
-memory_cache_regeneration_schedule = timedelta(hours=settings.MEMORY_CACHE_REGENERATION_HOURS)
+memory_cache_regeneration_schedule = crontab(
+    hour=settings.MEMORY_CACHE_REGENERATION_HOUR,
+    minute=settings.MEMORY_CACHE_REGENERATION_MINUTE,
+)
 workspace_reflection_schedule = timedelta(seconds=settings.WORKSPACE_REFLECTION_INTERVAL_SECONDS)
-forgetting_cycle_schedule = timedelta(hours=settings.FORGETTING_CYCLE_INTERVAL_HOURS)
+forgetting_cycle_schedule = crontab(
+    hour=settings.FORGETTING_CYCLE_HOUR,
+    minute=settings.FORGETTING_CYCLE_MINUTE,
+)
 implicit_emotions_update_schedule = crontab(
     hour=settings.IMPLICIT_EMOTIONS_UPDATE_HOUR,
     minute=settings.IMPLICIT_EMOTIONS_UPDATE_MINUTE,

--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -99,20 +99,19 @@ celery_app.conf.update(
     # task routing
     task_routes={
         # Memory tasks → memory_tasks queue (threads worker)
-        'app.core.memory.agent.read_message_priority': {'queue': 'memory_tasks'},
+        # 'app.core.memory.agent.read_message_priority': {'queue': 'memory_tasks'}, # NOTE：只有路由可以删除
         'app.core.memory.agent.read_message': {'queue': 'memory_tasks'},
         'app.core.memory.agent.write_message': {'queue': 'memory_tasks'},
 
-        # Long-term storage tasks → memory_tasks queue (batched write strategies)
-        'app.core.memory.agent.long_term_storage.window': {'queue': 'memory_tasks'},
-        'app.core.memory.agent.long_term_storage.time': {'queue': 'memory_tasks'},
-        'app.core.memory.agent.long_term_storage.aggregate': {'queue': 'memory_tasks'},
+        # # Long-term storage tasks → memory_tasks queue (batched write strategies)  # NOTE：只有路由可以删除
+        # 'app.core.memory.agent.long_term_storage.window': {'queue': 'memory_tasks'},
+        # 'app.core.memory.agent.long_term_storage.time': {'queue': 'memory_tasks'},
+        # 'app.core.memory.agent.long_term_storage.aggregate': {'queue': 'memory_tasks'},
 
-        # Clustering tasks → memory_tasks queue (使用相同的 worker，避免 macOS fork 问题)
-        'app.tasks.run_incremental_clustering': {'queue': 'memory_tasks'},
+
 
         # Metadata extraction → memory_tasks queue
-        'app.tasks.extract_user_metadata': {'queue': 'memory_tasks'},
+        # 'app.tasks.extract_user_metadata': {'queue': 'memory_tasks'}, # NOTE：没有使用地方，可以删除
 
         # Async emotion extraction → memory_tasks queue (IO-bound LLM calls)
         'app.tasks.extract_emotion_batch': {'queue': 'memory_tasks'},
@@ -145,14 +144,23 @@ celery_app.conf.update(
 
         # Sliding window write tasks → memory_tasks queue (IO-bound async tasks)
         'app.tasks.sliding_window_write': {'queue': 'memory_tasks'},
-        'app.tasks.flush_conversation': {'queue': 'memory_tasks'},
+        'app.tasks.flush_conversation': {'queue': 'periodic_tasks'},
 
-        # Sliding window idle scan → periodic_tasks queue (Beat scheduler)
-        'app.tasks.scan_idle_conversations': {'queue': 'periodic_tasks'},
         'app.tasks.scan_workflow_schedule_triggers': {'queue': 'periodic_tasks'},
         'app.tasks.run_workflow_schedule_trigger': {'queue': 'workflow_trigger_tasks'},
+        
+        # Memory-heavy tasks → memory_heavy_tasks queue (prefork worker, CPU-bound + beat long tasks)
+        'app.tasks.refresh_memory_insight_and_summary_cache': {'queue': 'memory_heavy_tasks'}, # NOTE：生成记忆洞察、用户摘要缓存
+        'app.tasks.run_forgetting_cycle_task': {'queue': 'memory_heavy_tasks'},# NOTE：定时任务，跑遗忘 可以暂时关闭
+        'app.tasks.write_all_workspaces_memory_task': {'queue': 'memory_heavy_tasks'}, #NOTE：定时任务，记忆增量统计
+        'app.tasks.update_implicit_emotions_storage': {'queue': 'memory_heavy_tasks'},
+        'app.tasks.init_implicit_emotions_for_users': {'queue': 'memory_heavy_tasks'},
+        'app.tasks.init_interest_distribution_for_users': {'queue': 'memory_heavy_tasks'},
+        'app.tasks.init_community_clustering_for_users': {'queue': 'memory_heavy_tasks'},
+        'app.tasks.run_incremental_clustering': {'queue': 'memory_heavy_tasks'},
     },
 )
+
 
 # 自动发现任务模块
 celery_app.autodiscover_tasks(['app'])
@@ -196,7 +204,7 @@ beat_schedule_config = {
     #     "args": (),
     # },
     "regenerate-memory-cache": {
-        "task": "app.tasks.regenerate_memory_cache",
+        "task": "app.tasks.refresh_memory_insight_and_summary_cache",
         "schedule": memory_cache_regeneration_schedule,
         "args": (),
     },

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -249,9 +249,6 @@ class Settings:
     HEALTH_CHECK_SECONDS: float = float(os.getenv("HEALTH_CHECK_SECONDS", "600"))
     REFLECTION_INTERVAL_TIME: Optional[str] = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
 
-    # Memory Cache Regeneration Configuration
-    MEMORY_CACHE_REGENERATION_HOURS: int = int(os.getenv("MEMORY_CACHE_REGENERATION_HOURS", "24"))
-
     # Celery Beat Schedule Configuration (定时任务执行频率)
     MEMORY_INCREMENT_HOUR: int = TypeAdapter(
         Annotated[int, Field(ge=0, le=23, description="cron hour [0, 23]")]
@@ -262,10 +259,23 @@ class Settings:
     WORKSPACE_REFLECTION_INTERVAL_SECONDS: int = TypeAdapter(
         Annotated[int, Field(ge=1, description="reflection interval in seconds, must be >= 1")]
     ).validate_python(int(os.getenv("WORKSPACE_REFLECTION_INTERVAL_SECONDS", "30")))
-    FORGETTING_CYCLE_INTERVAL_HOURS: int = TypeAdapter(
-        Annotated[int, Field(ge=1, description="forgetting cycle interval in hours, must be >= 1")]
-    ).validate_python(int(os.getenv("FORGETTING_CYCLE_INTERVAL_HOURS", "24")))
-    
+
+    # memory cache regeneration 执行时间点（UTC 小时 0-23，默认 18 = 北京时间 2:00）
+    MEMORY_CACHE_REGENERATION_HOUR: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=23, description="memory cache regeneration cron hour [0, 23]")]
+    ).validate_python(int(os.getenv("MEMORY_CACHE_REGENERATION_HOUR", "18")))
+    MEMORY_CACHE_REGENERATION_MINUTE: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=59, description="memory cache regeneration cron minute [0, 59]")]
+    ).validate_python(int(os.getenv("MEMORY_CACHE_REGENERATION_MINUTE", "0")))
+
+    # forgetting cycle 执行时间点（UTC 小时 0-23，默认 18 = 北京时间 2:00）
+    FORGETTING_CYCLE_HOUR: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=23, description="forgetting cycle cron hour [0, 23]")]
+    ).validate_python(int(os.getenv("FORGETTING_CYCLE_HOUR", "18")))
+    FORGETTING_CYCLE_MINUTE: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=59, description="forgetting cycle cron minute [0, 59]")]
+    ).validate_python(int(os.getenv("FORGETTING_CYCLE_MINUTE", "0")))
+
     IMPLICIT_EMOTIONS_UPDATE_HOUR: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_HOUR", "2"))
     # implicit_emotions_update: 每天几分执行（分钟，0-59）
     IMPLICIT_EMOTIONS_UPDATE_MINUTE: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_MINUTE", "0"))  

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3164,7 +3164,7 @@ def write_all_workspaces_memory_task(self) -> Dict[str, Any]:
 
 
 @celery_app.task(
-    name="app.tasks.regenerate_memory_cache",
+    name="app.tasks.refresh_memory_insight_and_summary_cache",
     bind=True,
     ignore_result=True,
     max_retries=0,
@@ -3172,7 +3172,7 @@ def write_all_workspaces_memory_task(self) -> Dict[str, Any]:
     time_limit=3600,
     soft_time_limit=3300,
 )
-def regenerate_memory_cache(self) -> Dict[str, Any]:
+def refresh_memory_insight_and_summary_cache(self) -> Dict[str, Any]:
     """定时任务：为所有用户重新生成记忆洞察和用户摘要缓存
 
     遍历所有活动工作空间的所有终端用户，为每个用户重新生成记忆洞察和用户摘要。

--- a/api/env.example
+++ b/api/env.example
@@ -35,9 +35,14 @@ REDIS_DB_CELERY_BROKER=
 REDIS_DB_CELERY_BACKEND=
 
 # Memory Cache Regeneration Configuration
-# Interval in hours for regenerating memory insight and user summary cache
-# Default: 24 hours
-MEMORY_CACHE_REGENERATION_HOURS=24
+# 执行时间点（UTC 小时 0-23，默认 18 = 北京时间 2:00）
+MEMORY_CACHE_REGENERATION_HOUR=18
+MEMORY_CACHE_REGENERATION_MINUTE=0
+
+# Forgetting Cycle Configuration
+# 执行时间点（UTC 小时 0-23，默认 18 = 北京时间 2:00）
+FORGETTING_CYCLE_HOUR=18
+FORGETTING_CYCLE_MINUTE=0
 
 # ElasticSearch configuration
 # Vector Search Mode（knn/script_score, default:script_score）


### PR DESCRIPTION
## Summary by Sourcery

优化与内存相关的 Celery 任务路由和调度，以及周期性任务的执行方式。

Enhancements:
- 移除未使用的 Celery 任务路由，并将 `flush_conversation` 从 memory_tasks 队列调整为在 periodic_tasks 队列中运行。
- 新增专用的 memory_heavy_tasks 队列，并将内存洞察、遗忘周期、聚类以及隐式情绪相关任务路由到该队列，以更好地隔离重负载任务。
- 将内存缓存重建和遗忘周期从基于间隔的调度切换为可配置的基于 cron 的调度，并支持分别设置小时和分钟。
- 将内存缓存重建任务重命名为 `refresh_memory_insight_and_summary_cache`，并使其 Celery 任务名称和 beat 配置与新名称保持一致。
- 扩展配置以支持对内存缓存重建和遗忘周期任务进行更精细的 cron 定时设置，替代之前仅支持按小时设置的间隔配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Celery task routing and scheduling for memory-related workloads and periodic jobs.

Enhancements:
- Retire unused Celery task routes and adjust `flush_conversation` to run on the periodic_tasks queue instead of memory_tasks.
- Introduce a dedicated memory_heavy_tasks queue and route memory insight, forgetting cycle, clustering, and implicit emotion tasks to it to better isolate heavy workloads.
- Switch memory cache regeneration and forgetting cycle from interval-based scheduling to configurable cron-based schedules with separate hour/minute settings.
- Rename the memory cache regeneration task to `refresh_memory_insight_and_summary_cache` and align its Celery task name and beat configuration with the new name.
- Extend configuration to support fine-grained cron timing for memory cache regeneration and forgetting cycle tasks, replacing the previous hour-only interval settings.

</details>