### PR TITLE
feat(storage): add MinIO object storage support

### DIFF
--- a/api/app/controllers/file_storage_controller.py
+++ b/api/app/controllers/file_storage_controller.py
@@ -62,6 +62,31 @@ def _match_scheme(request: Request, url: str) -> str:
         return "http://" + url[8:]
     return url
 
+def _is_internal_host(url: str) -> bool:
+    """
+    判断 URL 的主机是否为内网/本机地址。
+
+    用于 /public-url：如果存储后端返回的是 localhost/私有 IP 等浏览器无法直接
+    访问的地址，则降级为应用自身的永久下载入口。
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        return True
+    if host.lower() in ("localhost",):
+        return True
+    parts = host.split(".")
+    if len(parts) == 4 and all(p.isdigit() for p in parts):
+        ip = [int(p) for p in parts]
+        if ip[0] == 10:
+            return True
+        if ip[0] == 172 and 16 <= ip[1] <= 31:
+            return True
+        if ip[0] == 192 and ip[1] == 168:
+            return True
+        if ip[0] == 127:
+            return True
+    return False
 
 @router.post("/files", response_model=ApiResponse)
 async def upload_file(
@@ -632,6 +657,10 @@ async def get_permanent_file_url(
             if not url:
                 raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED,
                                     detail="Permanent URL not supported for current storage backend")
+            # 如果 permanent URL 指向内网/本机地址（如 Docker 里的 MinIO），
+            # 浏览器或其他设备可能无法直接访问，降级为应用自身的永久公开下载入口。
+            if _is_internal_host(url):
+                url = f"{settings.FILE_LOCAL_SERVER_URL}/storage/permanent/{file_id}"
 
         api_logger.info(f"Generated permanent URL: file_id={file_id}")
         return success(

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -118,6 +118,14 @@ class Settings:
     S3_BUCKET_NAME: str = os.getenv("S3_BUCKET_NAME", "")
     S3_ENDPOINT_URL: str = os.getenv("S3_ENDPOINT_URL", "")
 
+    # MinIO Configuration (required when STORAGE_TYPE=minio)
+    # MinIO is a self-hosted S3-compatible object storage, ideal for development
+    MINIO_ENDPOINT_URL: str = os.getenv("MINIO_ENDPOINT_URL", "")
+    MINIO_ACCESS_KEY_ID: str = os.getenv("MINIO_ACCESS_KEY_ID", "")
+    MINIO_SECRET_ACCESS_KEY: str = os.getenv("MINIO_SECRET_ACCESS_KEY", "")
+    MINIO_BUCKET_NAME: str = os.getenv("MINIO_BUCKET_NAME", "")
+    MINIO_REGION: str = os.getenv("MINIO_REGION", "")
+
     # VOLC ASR settings
     VOLC_APP_KEY: str = os.getenv("VOLC_APP_KEY", "")
     VOLC_ACCESS_KEY: str = os.getenv("VOLC_ACCESS_KEY", "")

--- a/api/app/core/storage/factory.py
+++ b/api/app/core/storage/factory.py
@@ -88,6 +88,18 @@ class StorageFactory:
                 endpoint_url=settings.S3_ENDPOINT_URL,
             )
 
+        elif storage_type == "minio":
+            from app.core.storage.s3 import S3Storage
+
+            # MinIO is S3-compatible; reuse S3Storage with MinIO endpoint
+            return S3Storage(
+                region=settings.MINIO_REGION,
+                access_key_id=settings.MINIO_ACCESS_KEY_ID,
+                secret_access_key=settings.MINIO_SECRET_ACCESS_KEY,
+                bucket_name=settings.MINIO_BUCKET_NAME,
+                endpoint_url=settings.MINIO_ENDPOINT_URL,
+            )
+
         else:
             logger.error(f"Unsupported storage type: {storage_type}")
             raise ValueError(f"Unsupported storage type: {storage_type}")

--- a/api/app/core/storage/factory.py
+++ b/api/app/core/storage/factory.py
@@ -91,9 +91,12 @@ class StorageFactory:
         elif storage_type == "minio":
             from app.core.storage.s3 import S3Storage
 
-            # MinIO is S3-compatible; reuse S3Storage with MinIO endpoint
+            # MinIO is S3-compatible; reuse S3Storage with MinIO endpoint.
+            # MinIO ignores the region for most setups; use a safe default
+            # to avoid AWS-specific LocationConstraint issues when
+            # MINIO_REGION is empty or a custom value.
             return S3Storage(
-                region=settings.MINIO_REGION,
+                region=settings.MINIO_REGION or "us-east-1",
                 access_key_id=settings.MINIO_ACCESS_KEY_ID,
                 secret_access_key=settings.MINIO_SECRET_ACCESS_KEY,
                 bucket_name=settings.MINIO_BUCKET_NAME,

--- a/api/app/core/storage/s3.py
+++ b/api/app/core/storage/s3.py
@@ -27,15 +27,17 @@ logger = logging.getLogger(__name__)
 
 class S3Storage(StorageBackend):
     """
-    AWS S3 storage implementation.
+    AWS S3-compatible storage implementation.
 
     This class implements the StorageBackend interface for storing files
-    on AWS Simple Storage Service (S3).
+    on AWS Simple Storage Service (S3) or S3-compatible services (e.g., MinIO)
+    using the boto3 SDK.
 
     Attributes:
         client: The boto3 S3 client instance.
         bucket_name: The name of the S3 bucket.
         region: The AWS region.
+        endpoint_url: The endpoint URL (AWS or custom S3-compatible endpoint).
     """
     AMAZON_S3_ENDPOINT_MAP = {
         "us-east-1": "https://s3.us-east-1.amazonaws.com",  # 特殊：无地域后缀
@@ -94,6 +96,8 @@ class S3Storage(StorageBackend):
             else:
                 endpoint_url = f"https://s3.{region}.amazonaws.com"
 
+        self.endpoint_url = endpoint_url
+
         try:
             self.client = boto3.client(
                 "s3",
@@ -103,7 +107,8 @@ class S3Storage(StorageBackend):
                 aws_secret_access_key=secret_access_key,
             )
             logger.info(
-                f"S3Storage initialized with region: {region}, bucket: {bucket_name}"
+                f"S3Storage initialized with region: {region}, bucket: {bucket_name}, "
+                f"endpoint: {endpoint_url}"
             )
         except NoCredentialsError as e:
             logger.error(f"Invalid AWS credentials: {e}")
@@ -117,6 +122,34 @@ class S3Storage(StorageBackend):
                 message=f"Failed to initialize S3 client: {e}",
                 cause=e,
             )
+
+        # Auto-create bucket if it doesn't exist (useful for MinIO / self-hosted S3)
+        try:
+            self.client.head_bucket(Bucket=bucket_name)
+            logger.info(f"Bucket '{bucket_name}' already exists")
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("404", "NoSuchBucket"):
+                try:
+                    if region == "us-east-1":
+                        # us-east-1 has special create_bucket behavior (no LocationConstraint)
+                        self.client.create_bucket(Bucket=bucket_name)
+                    else:
+                        self.client.create_bucket(
+                            Bucket=bucket_name,
+                            CreateBucketConfiguration={"LocationConstraint": region},
+                        )
+                    logger.info(f"Bucket '{bucket_name}' created automatically")
+                except ClientError as create_err:
+                    logger.warning(
+                        f"Failed to create bucket '{bucket_name}': {create_err}. "
+                        f"Upload will fail if bucket does not exist."
+                    )
+            else:
+                logger.warning(
+                    f"Failed to check bucket '{bucket_name}' existence: {e}. "
+                    f"Proceeding anyway."
+                )
 
     async def upload(
         self,
@@ -384,13 +417,26 @@ class S3Storage(StorageBackend):
             return url
         except Exception as e:
             logger.error(f"Failed to generate presigned URL for {file_key}: {e}")
+            # Fallback: construct URL manually based on endpoint type
+            if self.endpoint_url and "amazonaws.com" not in self.endpoint_url:
+                return f"{self.endpoint_url}/{self.bucket_name}/{file_key}"
             return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{file_key}"
 
     async def get_permanent_url(self, file_key: str) -> str:
         """
         Get a permanent public URL for the file (requires bucket public read).
 
+        For custom S3-compatible endpoints (MinIO etc.), returns:
+            {endpoint_url}/{bucket_name}/{file_key}
+
+        For AWS S3, returns:
+            https://{bucket_name}.s3.{region}.amazonaws.com/{file_key}
+
         Returns:
-            A permanent URL in the format: https://{bucket}.s3.{region}.amazonaws.com/{file_key}
+            A permanent URL for the file.
         """
+        # Custom S3-compatible endpoint (MinIO, Ceph, etc.)
+        if self.endpoint_url and "amazonaws.com" not in self.endpoint_url:
+            return f"{self.endpoint_url}/{self.bucket_name}/{file_key}"
+        # AWS S3 standard format
         return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{file_key}"

--- a/api/app/core/storage/s3.py
+++ b/api/app/core/storage/s3.py
@@ -123,33 +123,38 @@ class S3Storage(StorageBackend):
                 cause=e,
             )
 
-        # Auto-create bucket if it doesn't exist (useful for MinIO / self-hosted S3)
-        try:
-            self.client.head_bucket(Bucket=bucket_name)
-            logger.info(f"Bucket '{bucket_name}' already exists")
-        except ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code", "")
-            if error_code in ("404", "NoSuchBucket"):
-                try:
-                    if region == "us-east-1":
-                        # us-east-1 has special create_bucket behavior (no LocationConstraint)
-                        self.client.create_bucket(Bucket=bucket_name)
-                    else:
-                        self.client.create_bucket(
-                            Bucket=bucket_name,
-                            CreateBucketConfiguration={"LocationConstraint": region},
+        # Auto-create bucket only for self-hosted / S3-compatible endpoints (e.g. MinIO, Ceph).
+        # Skip this for AWS S3 to avoid accidental bucket creation and IAM permission issues.
+        is_custom_endpoint = self.endpoint_url and "amazonaws.com" not in self.endpoint_url
+        if is_custom_endpoint:
+            try:
+                self.client.head_bucket(Bucket=bucket_name)
+                logger.info(f"Bucket '{bucket_name}' already exists")
+            except ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code", "")
+                if error_code in ("404", "NoSuchBucket"):
+                    try:
+                        if region == "us-east-1":
+                            # us-east-1 has special create_bucket behavior (no LocationConstraint)
+                            self.client.create_bucket(Bucket=bucket_name)
+                        else:
+                            self.client.create_bucket(
+                                Bucket=bucket_name,
+                                CreateBucketConfiguration={"LocationConstraint": region},
+                            )
+                        logger.info(f"Bucket '{bucket_name}' created automatically")
+                    except ClientError as create_err:
+                        logger.warning(
+                            f"Failed to create bucket '{bucket_name}': {create_err}. "
+                            f"Upload will fail if bucket does not exist."
                         )
-                    logger.info(f"Bucket '{bucket_name}' created automatically")
-                except ClientError as create_err:
+                else:
                     logger.warning(
-                        f"Failed to create bucket '{bucket_name}': {create_err}. "
-                        f"Upload will fail if bucket does not exist."
+                        f"Failed to check bucket '{bucket_name}' existence: {e}. "
+                        f"Proceeding anyway."
                     )
-            else:
-                logger.warning(
-                    f"Failed to check bucket '{bucket_name}' existence: {e}. "
-                    f"Proceeding anyway."
-                )
+        else:
+            logger.info(f"Skipping auto-create bucket for AWS S3 endpoint: bucket='{bucket_name}'")
 
     async def upload(
         self,


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为 MinIO 和其他兼容 S3 的对象存储后端添加支持，并改进内部端点的 URL 处理。

新功能：
- 在存储工厂中引入 MinIO 存储类型，复用现有的兼容 S3 后端。
- 添加 MinIO 连接凭据、桶（bucket）、区域（region）和端点 URL 的配置选项。

增强改进：
- 将 S3 存储后端泛化，以支持自定义的兼容 S3 端点，包括在桶不存在时自动创建桶。
- 改进永久和预签名文件 URL 的生成，使其同时适用于 AWS S3 和自定义兼容 S3 的端点，并记录端点详细信息。
- 当存储返回内部或不可路由的主机时，回退到由应用托管的永久下载 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for MinIO and other S3-compatible object storage backends and improve URL handling for internal endpoints.

New Features:
- Introduce a MinIO storage type in the storage factory using the existing S3-compatible backend.
- Add configuration options for MinIO connection credentials, bucket, region, and endpoint URL.

Enhancements:
- Generalize the S3 storage backend to support custom S3-compatible endpoints, including automatic bucket creation when missing.
- Improve generation of permanent and presigned file URLs to work with both AWS S3 and custom S3-compatible endpoints and log endpoint details.
- Fallback to application-hosted permanent download URLs when storage returns internal or non-routable hosts.

</details>