### PR TITLE
fix(web): file variable cache

### DIFF
--- a/web/src/views/Workflow/components/VariableInspector.tsx
+++ b/web/src/views/Workflow/components/VariableInspector.tsx
@@ -90,7 +90,13 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
         {
           name: selectedVariable.name,
           type: selectedVariable.type,
-          value: currentValue,
+          value: selectedVariable.type === 'file' && (!currentValue || currentValue.length < 1)
+            ? null
+            : selectedVariable.type === 'file'
+            ? currentValue[0]
+            : selectedVariable.type === 'array[file]' && (!currentValue || currentValue.length < 1)
+            ? []
+            : currentValue
         }
       ]
     });
@@ -132,7 +138,7 @@ const VariableInspector = forwardRef<VariableInspectorRef, VariableInspectorProp
               ...groupVariables[varName],
               nodeKey,
 
-              value: groupVariables[varName].type === 'object' || (groupVariables[varName].type?.includes('file') && typeof groupVariables[varName].value === 'object')
+              value: groupVariables[varName].type === 'object' || (!groupVariables[varName].type?.includes('file') && typeof groupVariables[varName].value === 'object')
                 ? JSON.stringify(groupVariables[varName].value, null, 2)
                 : groupVariables[varName].value,
             };


### PR DESCRIPTION
## Summary by Sourcery

调整文件类型变量的变量检查器处理方式，避免对文件值进行错误的缓存和字符串化。

Bug Fixes:
- 确保单文件变量在为空时存储为 `null`，在有文件时存储为第一个文件；多文件数组在没有文件时使用空数组，而不是重复使用过期的旧值。
- 防止文件类型变量被 JSON 字符串化，将对象到 JSON 的转换限制为非文件类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust variable inspector handling for file-based variables to avoid incorrect caching and stringification of file values.

Bug Fixes:
- Ensure single file variables store null when empty, the first file when populated, and arrays of files use an empty array when no files are present instead of reusing stale values.
- Prevent file-typed variables from being JSON-stringified by restricting object-to-JSON conversion to non-file types.

</details>