### PR TITLE
Fix/v0.3.8 zy

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -125,7 +125,12 @@ const DocumentDetails: FC = () => {
       {
         key: 'file_name',
         label: t('knowledgeBase.fileName') || '文件名',
-        value: doc.file_name ?? '-',
+        value: <span onClick={() => handleCopy(doc.file_name ?? '-')}>
+          {doc.file_name ?? '-'}
+          <span
+            className="rb:cursor-pointer rb:-mb-0.5 rb:ml-1 rb:inline-block rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/copy_dark.svg')]"
+          ></span>
+        </span>,
       },
       {
         key: 'status',

--- a/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
+++ b/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
@@ -55,7 +55,7 @@ const DocumentMetadata: React.FC<DocumentMetadataProps> = ({ documentId, knowled
     const values: Record<string, any> = {}
     documentMetadataFields.map((item: MetadataField) => {
       if (item.type === 'time') {
-        values[item.name] = dayjs(item.value);
+        values[item.name] = dayjs.tz(item.value);
       } else {
         values[item.name] = item.value;
       }
@@ -96,7 +96,7 @@ const DocumentMetadata: React.FC<DocumentMetadataProps> = ({ documentId, knowled
 
       Object.keys(values).forEach(key => {
         if (typeof values[key] === 'object') {
-          values[key] = values[key].format('YYYY-MM-DD HH:mm:ss');
+          values[key] = values[key].format('YYYY-MM-DD HH:mm:ssZZ');
         }
       });
 


### PR DESCRIPTION
## Summary by Sourcery

为文档文件名添加复制到剪贴板的交互功能，并调整文档元数据时间的处理方式，以使用支持时区感知的解析和格式化。

增强内容：
- 允许在详情视图中通过可点击的 UI 元素复制文档文件名。
- 使用支持时区感知的 Dayjs API 解析时间类型的文档元数据值，并在其格式化输出中包含时区信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add copy-to-clipboard interaction for document file names and adjust document metadata time handling to use timezone-aware parsing and formatting.

Enhancements:
- Allow copying the document file name from the details view via a clickable UI element.
- Parse time-type document metadata values using timezone-aware Dayjs APIs and include timezone information in their formatted output.

</details>