### PR TITLE
fix(rag): update folder counts and metadata time filters

### DIFF
--- a/api/app/core/rag/metadata/filter_engine.py
+++ b/api/app/core/rag/metadata/filter_engine.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import and_, or_
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
-from app.core.utils.datetime_utils import parse_iso_to_utc_naive
+from app.core.utils.datetime_utils import parse_metadata_time_to_utc_naive
 from app.models.document_model import Document
 from .filter_strategies import StringFilterStrategy, NumberFilterStrategy, TimeFilterStrategy, _escape_like
 from .builtin_resolver import BuiltinFieldResolver
@@ -175,14 +175,23 @@ class MetadataFilterEngine:
         dt = None
         if operator in ("eq", "before", "after"):
             try:
-                dt = parse_iso_to_utc_naive(str(value))
+                dt = parse_metadata_time_to_utc_naive(value)
                 if dt is None:
                     raise ValueError
-            except ValueError as exc:
+            except (TypeError, ValueError) as exc:
                 raise BusinessException(
-                    "时间字段过滤参数必须为 ISO 时间格式，例如: 2024-12-31T23:59:59",
+                    "时间字段过滤参数必须为 ISO 时间格式或 Unix 时间戳，例如: 2024-12-31T23:59:59+08:00",
                     code=BizCode.METADATA_INVALID_VALUE_TYPE,
                 ) from exc
+            logger.debug(
+                "[MetadataFilterEngine] normalized builtin time filter: "
+                "column=%s operator=%s raw_value=%r raw_type=%s utc_naive=%s",
+                column_name,
+                operator,
+                value,
+                type(value).__name__,
+                dt.isoformat(sep=" "),
+            )
         dt_lit = literal(dt, DateTime) if dt else None
         match operator:
             case "eq":

--- a/api/app/core/rag/metadata/filter_strategies.py
+++ b/api/app/core/rag/metadata/filter_strategies.py
@@ -1,10 +1,13 @@
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
 from sqlalchemy import or_, and_, cast, func, DateTime, Numeric, String
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
-from app.core.utils.datetime_utils import parse_iso_to_utc_naive
+from app.core.utils.datetime_utils import parse_metadata_time_to_utc_naive
 from app.models.document_model import Document
+
+logger = logging.getLogger(__name__)
 
 
 def _escape_like(value: str) -> str:
@@ -114,18 +117,28 @@ class TimeFilterStrategy(FilterStrategy):
 
     def apply(self, field_name: str, operator: str, value: Any):
         from sqlalchemy import literal
-        col = cast(Document.meta_data[field_name].astext, DateTime)
+        col_text = Document.meta_data[field_name].astext
+        col = func.timezone("UTC", cast(col_text, DateTime(timezone=True)))
         dt = None
         if operator in ("eq", "before", "after"):
             try:
-                dt = parse_iso_to_utc_naive(str(value))
+                dt = parse_metadata_time_to_utc_naive(value)
                 if dt is None:
                     raise ValueError
-            except ValueError as exc:
+            except (TypeError, ValueError) as exc:
                 raise BusinessException(
-                    "时间字段过滤参数必须为 ISO 时间格式，例如: 2024-12-31T23:59:59",
+                    "时间字段过滤参数必须为 ISO 时间格式或 Unix 时间戳，例如: 2024-12-31T23:59:59+08:00",
                     code=BizCode.METADATA_INVALID_VALUE_TYPE,
                 ) from exc
+            logger.debug(
+                "[MetadataFilterStrategy] normalized custom time filter: "
+                "field=%s operator=%s raw_value=%r raw_type=%s utc_naive=%s",
+                field_name,
+                operator,
+                value,
+                type(value).__name__,
+                dt.isoformat(sep=" "),
+            )
         dt_lit = literal(dt, DateTime) if dt else None
 
         match operator:

--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -15,6 +15,7 @@ UTC = timezone.utc
 _BARE_CLOCK_LINE_RE = re.compile(
     r"(?m)^(?P<hour>[01]\d|2[0-3]):(?P<minute>[0-5]\d):(?P<second>[0-5]\d)(?P<rest>\s+)"
 )
+_NUMERIC_TIMESTAMP_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?$")
 
 
 def utcnow() -> datetime:
@@ -91,3 +92,33 @@ def parse_iso_to_utc_naive(value: str | None) -> datetime | None:
     if dt.tzinfo is None:
         return dt
     return dt.astimezone(UTC).replace(tzinfo=None)
+
+
+def parse_metadata_time_to_utc_naive(value: str | int | float | datetime | None) -> datetime | None:
+    """Parse metadata time values and normalize them to naive UTC.
+
+    Metadata filters accept ISO datetime strings with an optional timezone
+    offset, or Unix timestamps in seconds/milliseconds. Naive datetime strings
+    keep the project convention and are interpreted as UTC.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return as_utc_aware(value).replace(tzinfo=None)
+    if isinstance(value, bool):
+        raise ValueError("boolean is not a valid metadata time value")
+    if isinstance(value, (int, float)):
+        return parse_timestamp_to_utc_naive(value)
+    if not isinstance(value, str):
+        raise ValueError("metadata time value must be a string, timestamp, or datetime")
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    numeric_part = stripped.lstrip("+-").split(".", 1)[0]
+    if _NUMERIC_TIMESTAMP_RE.fullmatch(stripped) and len(numeric_part) >= 10:
+        timestamp = float(stripped) if "." in stripped else int(stripped)
+        return parse_timestamp_to_utc_naive(timestamp)
+
+    return parse_iso_to_utc_naive(stripped)

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -1,6 +1,8 @@
 import uuid
+from sqlalchemy import func
 from sqlalchemy.orm import Session
-from app.models.knowledge_model import Knowledge
+from app.models.document_model import Document
+from app.models.knowledge_model import Knowledge, KnowledgeType, PermissionType
 from app.schemas import knowledge_schema
 from app.core.logging_config import get_db_logger
 
@@ -162,6 +164,91 @@ def get_knowledges_by_parent_id(db: Session, parent_id: uuid.UUID) -> list[Knowl
         raise
 
 
+def get_folder_doc_counts(
+        db: Session,
+        folder_ids: list[uuid.UUID],
+        workspace_id: uuid.UUID,
+) -> dict[uuid.UUID, int]:
+    db_logger.debug(
+        f"Query real folder document counts: folder_count={len(folder_ids)}, workspace_id={workspace_id}"
+    )
+    if not folder_ids:
+        return {}
+
+    unique_folder_ids = list(dict.fromkeys(folder_ids))
+    knowledge_ids_by_folder = {folder_id: {folder_id} for folder_id in unique_folder_ids}
+    parent_roots = {folder_id: {folder_id} for folder_id in unique_folder_ids}
+    processed_roots_by_parent: dict[uuid.UUID, set[uuid.UUID]] = {}
+
+    try:
+        while parent_roots:
+            current_parent_roots = {}
+            for parent_id, root_ids in parent_roots.items():
+                processed_root_ids = processed_roots_by_parent.get(parent_id, set())
+                unprocessed_root_ids = root_ids - processed_root_ids
+                if unprocessed_root_ids:
+                    current_parent_roots[parent_id] = unprocessed_root_ids
+
+            if not current_parent_roots:
+                break
+
+            for parent_id, root_ids in current_parent_roots.items():
+                processed_roots_by_parent.setdefault(parent_id, set()).update(root_ids)
+
+            children = (
+                db.query(Knowledge.id, Knowledge.parent_id, Knowledge.type)
+                .filter(
+                    Knowledge.parent_id.in_(list(current_parent_roots.keys())),
+                    Knowledge.workspace_id == workspace_id,
+                    Knowledge.status != 2,
+                    Knowledge.permission_id != PermissionType.Memory,
+                )
+                .all()
+            )
+
+            next_parent_roots: dict[uuid.UUID, set[uuid.UUID]] = {}
+            for child_id, parent_id, knowledge_type in children:
+                root_ids = current_parent_roots.get(parent_id, set())
+                for root_id in root_ids:
+                    knowledge_ids_by_folder[root_id].add(child_id)
+                if knowledge_type == KnowledgeType.FOLDER:
+                    next_parent_roots.setdefault(child_id, set()).update(root_ids)
+
+            parent_roots = next_parent_roots
+
+        all_knowledge_ids = list({
+            knowledge_id
+            for knowledge_ids in knowledge_ids_by_folder.values()
+            for knowledge_id in knowledge_ids
+        })
+        if not all_knowledge_ids:
+            return {folder_id: 0 for folder_id in unique_folder_ids}
+
+        document_count_rows = (
+            db.query(Document.kb_id, func.count(Document.id))
+            .filter(
+                Document.kb_id.in_(all_knowledge_ids),
+                Document.status == 1,
+            )
+            .group_by(Document.kb_id)
+            .all()
+        )
+        document_counts = {
+            kb_id: int(count)
+            for kb_id, count in document_count_rows
+        }
+
+        return {
+            folder_id: sum(document_counts.get(knowledge_id, 0) for knowledge_id in knowledge_ids)
+            for folder_id, knowledge_ids in knowledge_ids_by_folder.items()
+        }
+    except Exception as e:
+        db_logger.error(
+            f"Failed to query real folder document counts: workspace_id={workspace_id} - {str(e)}"
+        )
+        raise
+
+
 def get_knowledge_by_name(db: Session, name: str, workspace_id: uuid.UUID) -> Knowledge | None:
     db_logger.debug(f"Query knowledge base based on name and workspace_id: name={name}, workspace_id={workspace_id}")
 
@@ -304,4 +391,3 @@ def get_non_user_kb_count_by_workspace(db: Session, workspace_id: uuid.UUID) -> 
     except Exception as e:
         db_logger.error(f"Failed to query non-user KB count: workspace_id={workspace_id} - {str(e)}")
         raise
-

--- a/api/app/services/knowledge_metadata_service.py
+++ b/api/app/services/knowledge_metadata_service.py
@@ -2,7 +2,7 @@ import uuid
 from typing import Any
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
-from app.core.utils.datetime_utils import parse_iso_to_utc_naive, utcnow_naive
+from app.core.utils.datetime_utils import parse_metadata_time_to_utc_naive, utcnow_naive
 from app.core.exceptions import (
     BusinessException,
     ResourceNotFoundException,
@@ -349,8 +349,12 @@ class KnowledgeMetadataService:
                 doc_id = item["document_id"]
                 metadata = item["metadata"]
                 doc = doc_map[doc_id]
+                normalized_metadata = KnowledgeMetadataService._normalize_metadata_for_storage(
+                    metadata,
+                    field_defs,
+                )
                 doc.meta_data = doc.meta_data or {}
-                doc.meta_data.update(metadata)
+                doc.meta_data.update(normalized_metadata)
                 flag_modified(doc, "meta_data")
                 doc.updated_at = utcnow_naive()
 
@@ -420,8 +424,12 @@ class KnowledgeMetadataService:
                 )
 
         # 4. 更新 metadata JSON
+        normalized_metadata = KnowledgeMetadataService._normalize_metadata_for_storage(
+            metadata,
+            field_defs,
+        )
         doc.meta_data = doc.meta_data or {}
-        doc.meta_data.update(metadata)
+        doc.meta_data.update(normalized_metadata)
         flag_modified(doc, "meta_data")
         doc.updated_at = utcnow_naive()
 
@@ -563,14 +571,43 @@ class KnowledgeMetadataService:
             case "number":
                 return isinstance(value, (int, float)) and not isinstance(value, bool)
             case "time":
-                if not isinstance(value, str):
-                    return False
                 try:
-                    return parse_iso_to_utc_naive(value) is not None
-                except ValueError:
+                    return parse_metadata_time_to_utc_naive(value) is not None
+                except (TypeError, ValueError):
                     return False
             case _:
                 return False
+
+    @staticmethod
+    def _normalize_metadata_value_for_storage(field_type: str, value: Any) -> Any:
+        """Normalize metadata values before storing them in Document.meta_data."""
+        if value is None or field_type != "time":
+            return value
+        dt = parse_metadata_time_to_utc_naive(value)
+        if dt is None:
+            return None
+        return dt.isoformat(sep=" ")
+
+    @staticmethod
+    def _normalize_metadata_for_storage(
+        metadata: dict[str, Any],
+        field_defs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Normalize time metadata to naive UTC strings before JSONB storage."""
+        normalized = {}
+        for field_name, value in metadata.items():
+            field_def = field_defs[field_name]
+            normalized[field_name] = KnowledgeMetadataService._normalize_metadata_value_for_storage(
+                field_def.type,
+                value,
+            )
+            if field_def.type == "time":
+                api_logger.debug(
+                    "Normalized document time metadata: "
+                    f"field={field_name}, raw_value={value!r}, raw_type={type(value).__name__}, "
+                    f"stored_value={normalized[field_name]!r}"
+                )
+        return normalized
 
     @staticmethod
     def get_metadata_defs_for_filtering(

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -1,7 +1,7 @@
 import uuid
 from sqlalchemy.orm import Session
 from app.models.user_model import User
-from app.models.knowledge_model import Knowledge
+from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.models.workspace_model import Workspace
 from app.models.models_model import ModelConfig
 from app.schemas.knowledge_schema import KnowledgeCreate, KnowledgeUpdate
@@ -12,6 +12,29 @@ from app.core.error_codes import BizCode
 from app.models.models_model import ModelType
 
 business_logger = get_business_logger()
+
+
+def _replace_folder_doc_nums(
+        db: Session,
+        items: list,
+        workspace_id: uuid.UUID,
+) -> list:
+    folder_ids = [
+        item.id for item in items
+        if item.type == KnowledgeType.FOLDER
+    ]
+    if not folder_ids:
+        return items
+
+    doc_counts = knowledge_repository.get_folder_doc_counts(
+        db=db,
+        folder_ids=folder_ids,
+        workspace_id=workspace_id,
+    )
+    for item in items:
+        if item.id in doc_counts:
+            item.doc_num = doc_counts[item.id]
+    return items
 
 
 def get_knowledges_paginated(
@@ -34,6 +57,11 @@ def get_knowledges_paginated(
                 orderby=orderby,
                 desc=desc
             )
+        items = _replace_folder_doc_nums(
+            db=db,
+            items=items,
+            workspace_id=current_user.current_workspace_id,
+        )
         business_logger.info(f"The knowledge base paging query has been successful: username={current_user.username}, total={total}, Number of current page={len(items)}")
         return total, items
     except Exception as e:


### PR DESCRIPTION
## Background

This PR contains RAG backend fixes prepared for the release branch.

## Changes

- Return real folder document counts for knowledge folder queries.
- Normalize metadata time filter inputs to UTC-naive datetimes before SQL comparison.
- Support ISO values with timezone offsets and Unix timestamps for metadata time filters.
- Normalize custom `time` metadata values before storing them in `Document.meta_data`.
- Add debug logs for metadata time normalization and generated filter SQL.

## Impact

Users can filter built-in and custom metadata time fields with values such as `2026-06-11 18:59:00+0800`, `2026-06-11T18:59:00+08:00`, or millisecond timestamps. Naive datetime strings keep the existing backend convention and are interpreted as UTC.

## Risks

- Existing naive datetime filter values continue to be treated as UTC for compatibility.
- Existing custom metadata values with timezone offsets are normalized during comparison; new writes are stored as UTC-naive strings.

## Validation

- `PYTHONPATH=. uv run pytest tests/rag/test_metadata_filter_fields_requirement.py tests/rag/test_knowledge_retrieval_entry.py -q`
- Result: `40 passed, 49 warnings`

## Summary by Sourcery

修复知识文件夹文档计数，并在存储和过滤逻辑中统一元数据时间处理方式。

新功能：
- 允许元数据时间过滤器接受 Unix 时间戳以及带时区偏移的 ISO 日期时间字符串，适用于内置字段和自定义字段。

错误修复：
- 通过聚合所有子级知识项中的文档，返回知识文件夹的准确文档数量。
- 确保元数据时间过滤器在比较值时始终使用统一规范化的、UTC-naive 的日期时间。

改进：
- 在将自定义时间元数据持久化到文档元数据之前，将其规范化为 UTC-naive 字符串，以便实现一致的查询行为。
- 在时间元数据规范化过程以及生成的时间过滤器值周围添加调试日志，以便更容易进行故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix knowledge folder document counts and normalize metadata time handling across storage and filtering.

New Features:
- Allow metadata time filters to accept Unix timestamps and ISO datetime strings with timezone offsets for both built-in and custom fields.

Bug Fixes:
- Return accurate document counts for knowledge folders by aggregating documents from all descendant knowledge items.
- Ensure metadata time filters compare values using consistently normalized UTC-naive datetimes.

Enhancements:
- Normalize custom time metadata values to UTC-naive strings before persisting them in document metadata for consistent querying.
- Add debug logging around time metadata normalization and generated time filter values for easier troubleshooting.

</details>

新功能：
- 为内置和自定义字段的元数据时间过滤器提供 Unix 时间戳和支持时区的 ISO 格式支持。

错误修复：
- 返回知识文件夹的准确文档数量，而不是依赖过期或推导得出的数值。
- 确保元数据时间过滤器在比较值时使用统一规范化的、UTC-无时区偏移的 datetime。

改进：
- 在将自定义时间元数据持久化到文档元数据存储之前进行规范化，以保证查询一致性。
- 增加围绕时间元数据规范化和生成的时间过滤器值的调试日志，以便排查问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复知识文件夹文档计数，并在存储和过滤逻辑中统一元数据时间处理方式。

新功能：
- 允许元数据时间过滤器接受 Unix 时间戳以及带时区偏移的 ISO 日期时间字符串，适用于内置字段和自定义字段。

错误修复：
- 通过聚合所有子级知识项中的文档，返回知识文件夹的准确文档数量。
- 确保元数据时间过滤器在比较值时始终使用统一规范化的、UTC-naive 的日期时间。

改进：
- 在将自定义时间元数据持久化到文档元数据之前，将其规范化为 UTC-naive 字符串，以便实现一致的查询行为。
- 在时间元数据规范化过程以及生成的时间过滤器值周围添加调试日志，以便更容易进行故障排查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix knowledge folder document counts and normalize metadata time handling across storage and filtering.

New Features:
- Allow metadata time filters to accept Unix timestamps and ISO datetime strings with timezone offsets for both built-in and custom fields.

Bug Fixes:
- Return accurate document counts for knowledge folders by aggregating documents from all descendant knowledge items.
- Ensure metadata time filters compare values using consistently normalized UTC-naive datetimes.

Enhancements:
- Normalize custom time metadata values to UTC-naive strings before persisting them in document metadata for consistent querying.
- Add debug logging around time metadata normalization and generated time filter values for easier troubleshooting.

</details>

</details>