### PR TITLE
fix(rag): return folder tree with real doc counts

### DIFF
--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -164,6 +164,39 @@ def get_knowledges_by_parent_id(db: Session, parent_id: uuid.UUID) -> list[Knowl
         raise
 
 
+def get_knowledges_by_parent_ids(
+        db: Session,
+        parent_ids: list[uuid.UUID],
+        workspace_id: uuid.UUID,
+) -> list[knowledge_schema.Knowledge]:
+    db_logger.debug(
+        f"Batch query knowledge bases by parent IDs: parent_count={len(parent_ids)}, workspace_id={workspace_id}"
+    )
+    if not parent_ids:
+        return []
+
+    try:
+        knowledges = (
+            db.query(Knowledge)
+            .filter(
+                Knowledge.parent_id.in_(parent_ids),
+                Knowledge.workspace_id == workspace_id,
+                Knowledge.status != 2,
+                Knowledge.permission_id != PermissionType.Memory,
+            )
+            .all()
+        )
+        db_logger.debug(
+            f"Batch knowledge bases query successful: parent_count={len(parent_ids)}, count={len(knowledges)}"
+        )
+        return [knowledge_schema.Knowledge.model_validate(item) for item in knowledges]
+    except Exception as e:
+        db_logger.error(
+            f"Failed to batch query knowledge bases by parent IDs: workspace_id={workspace_id} - {str(e)}"
+        )
+        raise
+
+
 def get_folder_doc_counts(
         db: Session,
         folder_ids: list[uuid.UUID],

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -2,7 +2,7 @@ import uuid
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 from app.models.document_model import Document
-from app.models.knowledge_model import Knowledge, KnowledgeType, PermissionType
+from app.models.knowledge_model import Knowledge, PermissionType
 from app.schemas import knowledge_schema
 from app.core.logging_config import get_db_logger
 
@@ -197,87 +197,35 @@ def get_knowledges_by_parent_ids(
         raise
 
 
-def get_folder_doc_counts(
+def get_document_counts_by_knowledge_ids(
         db: Session,
-        folder_ids: list[uuid.UUID],
-        workspace_id: uuid.UUID,
+        knowledge_ids: list[uuid.UUID],
 ) -> dict[uuid.UUID, int]:
     db_logger.debug(
-        f"Query real folder document counts: folder_count={len(folder_ids)}, workspace_id={workspace_id}"
+        f"Query document counts by knowledge IDs: knowledge_count={len(knowledge_ids)}"
     )
-    if not folder_ids:
+    if not knowledge_ids:
         return {}
 
-    unique_folder_ids = list(dict.fromkeys(folder_ids))
-    knowledge_ids_by_folder = {folder_id: {folder_id} for folder_id in unique_folder_ids}
-    parent_roots = {folder_id: {folder_id} for folder_id in unique_folder_ids}
-    processed_roots_by_parent: dict[uuid.UUID, set[uuid.UUID]] = {}
+    unique_knowledge_ids = list(dict.fromkeys(knowledge_ids))
 
     try:
-        while parent_roots:
-            current_parent_roots = {}
-            for parent_id, root_ids in parent_roots.items():
-                processed_root_ids = processed_roots_by_parent.get(parent_id, set())
-                unprocessed_root_ids = root_ids - processed_root_ids
-                if unprocessed_root_ids:
-                    current_parent_roots[parent_id] = unprocessed_root_ids
-
-            if not current_parent_roots:
-                break
-
-            for parent_id, root_ids in current_parent_roots.items():
-                processed_roots_by_parent.setdefault(parent_id, set()).update(root_ids)
-
-            children = (
-                db.query(Knowledge.id, Knowledge.parent_id, Knowledge.type)
-                .filter(
-                    Knowledge.parent_id.in_(list(current_parent_roots.keys())),
-                    Knowledge.workspace_id == workspace_id,
-                    Knowledge.status != 2,
-                    Knowledge.permission_id != PermissionType.Memory,
-                )
-                .all()
-            )
-
-            next_parent_roots: dict[uuid.UUID, set[uuid.UUID]] = {}
-            for child_id, parent_id, knowledge_type in children:
-                root_ids = current_parent_roots.get(parent_id, set())
-                for root_id in root_ids:
-                    knowledge_ids_by_folder[root_id].add(child_id)
-                if knowledge_type == KnowledgeType.FOLDER:
-                    next_parent_roots.setdefault(child_id, set()).update(root_ids)
-
-            parent_roots = next_parent_roots
-
-        all_knowledge_ids = list({
-            knowledge_id
-            for knowledge_ids in knowledge_ids_by_folder.values()
-            for knowledge_id in knowledge_ids
-        })
-        if not all_knowledge_ids:
-            return {folder_id: 0 for folder_id in unique_folder_ids}
-
         document_count_rows = (
             db.query(Document.kb_id, func.count(Document.id))
             .filter(
-                Document.kb_id.in_(all_knowledge_ids),
+                Document.kb_id.in_(unique_knowledge_ids),
                 Document.status == 1,
             )
             .group_by(Document.kb_id)
             .all()
         )
-        document_counts = {
+        return {
             kb_id: int(count)
             for kb_id, count in document_count_rows
         }
-
-        return {
-            folder_id: sum(document_counts.get(knowledge_id, 0) for knowledge_id in knowledge_ids)
-            for folder_id, knowledge_ids in knowledge_ids_by_folder.items()
-        }
     except Exception as e:
         db_logger.error(
-            f"Failed to query real folder document counts: workspace_id={workspace_id} - {str(e)}"
+            f"Failed to query document counts by knowledge IDs: {str(e)}"
         )
         raise
 

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -61,11 +61,42 @@ def _build_knowledge_items_with_folder_trees(
                 pending_parent_ids.append(child.id)
 
     all_folder_ids = list(dict.fromkeys(all_folder_ids))
-    doc_counts = knowledge_repository.get_folder_doc_counts(
+    knowledge_ids_by_folder: dict[uuid.UUID, set[uuid.UUID]] = {}
+
+    def collect_knowledge_ids(folder_id: uuid.UUID, ancestors: set[uuid.UUID]) -> set[uuid.UUID]:
+        if folder_id in knowledge_ids_by_folder:
+            return knowledge_ids_by_folder[folder_id]
+        if folder_id in ancestors:
+            return set()
+
+        knowledge_ids = {folder_id}
+        next_ancestors = ancestors | {folder_id}
+        for child in children_by_parent.get(folder_id, []):
+            if child.id in next_ancestors:
+                continue
+            knowledge_ids.add(child.id)
+            if child.type == KnowledgeType.FOLDER:
+                knowledge_ids.update(collect_knowledge_ids(child.id, next_ancestors))
+
+        knowledge_ids_by_folder[folder_id] = knowledge_ids
+        return knowledge_ids
+
+    for folder_id in all_folder_ids:
+        collect_knowledge_ids(folder_id, set())
+
+    counted_knowledge_ids = list({
+        knowledge_id
+        for knowledge_ids in knowledge_ids_by_folder.values()
+        for knowledge_id in knowledge_ids
+    })
+    document_counts = knowledge_repository.get_document_counts_by_knowledge_ids(
         db=db,
-        folder_ids=all_folder_ids,
-        workspace_id=workspace_id,
+        knowledge_ids=counted_knowledge_ids,
     )
+    doc_counts = {
+        folder_id: sum(document_counts.get(knowledge_id, 0) for knowledge_id in knowledge_ids)
+        for folder_id, knowledge_ids in knowledge_ids_by_folder.items()
+    }
 
     def build_item(item: knowledge_schema.Knowledge, ancestors: set[uuid.UUID]) -> dict[str, Any]:
         data = item.model_dump(mode="json")

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -1,9 +1,12 @@
 import uuid
+from typing import Any
+
 from sqlalchemy.orm import Session
 from app.models.user_model import User
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.models.workspace_model import Workspace
 from app.models.models_model import ModelConfig
+from app.schemas import knowledge_schema
 from app.schemas.knowledge_schema import KnowledgeCreate, KnowledgeUpdate
 from app.repositories import knowledge_repository
 from app.core.logging_config import get_business_logger
@@ -14,27 +17,73 @@ from app.models.models_model import ModelType
 business_logger = get_business_logger()
 
 
-def _replace_folder_doc_nums(
+def _build_knowledge_items_with_folder_trees(
         db: Session,
         items: list,
         workspace_id: uuid.UUID,
-) -> list:
+) -> list[dict[str, Any]]:
+    knowledge_items = [
+        knowledge_schema.Knowledge.model_validate(item)
+        for item in items
+    ]
     folder_ids = [
-        item.id for item in items
+        item.id for item in knowledge_items
         if item.type == KnowledgeType.FOLDER
     ]
     if not folder_ids:
-        return items
+        return [item.model_dump(mode="json") for item in knowledge_items]
 
+    children_by_parent: dict[uuid.UUID, list[knowledge_schema.Knowledge]] = {}
+    pending_parent_ids = list(folder_ids)
+    visited_parent_ids: set[uuid.UUID] = set()
+    all_folder_ids = list(folder_ids)
+
+    while pending_parent_ids:
+        current_parent_ids = [
+            parent_id for parent_id in pending_parent_ids
+            if parent_id not in visited_parent_ids
+        ]
+        if not current_parent_ids:
+            break
+
+        visited_parent_ids.update(current_parent_ids)
+        children = knowledge_repository.get_knowledges_by_parent_ids(
+            db=db,
+            parent_ids=current_parent_ids,
+            workspace_id=workspace_id,
+        )
+        pending_parent_ids = []
+
+        for child in children:
+            children_by_parent.setdefault(child.parent_id, []).append(child)
+            if child.type == KnowledgeType.FOLDER:
+                all_folder_ids.append(child.id)
+                pending_parent_ids.append(child.id)
+
+    all_folder_ids = list(dict.fromkeys(all_folder_ids))
     doc_counts = knowledge_repository.get_folder_doc_counts(
         db=db,
-        folder_ids=folder_ids,
+        folder_ids=all_folder_ids,
         workspace_id=workspace_id,
     )
-    for item in items:
+
+    def build_item(item: knowledge_schema.Knowledge, ancestors: set[uuid.UUID]) -> dict[str, Any]:
+        data = item.model_dump(mode="json")
         if item.id in doc_counts:
-            item.doc_num = doc_counts[item.id]
-    return items
+            data["doc_num"] = doc_counts[item.id]
+        if item.type == KnowledgeType.FOLDER:
+            next_ancestors = ancestors | {item.id}
+            data["children"] = [
+                build_item(child, next_ancestors)
+                for child in children_by_parent.get(item.id, [])
+                if child.id not in next_ancestors
+            ]
+        return data
+
+    return [
+        build_item(item, set())
+        for item in knowledge_items
+    ]
 
 
 def get_knowledges_paginated(
@@ -57,7 +106,7 @@ def get_knowledges_paginated(
                 orderby=orderby,
                 desc=desc
             )
-        items = _replace_folder_doc_nums(
+        items = _build_knowledge_items_with_folder_trees(
             db=db,
             items=items,
             workspace_id=current_user.current_workspace_id,


### PR DESCRIPTION
## Background
`GET /api/knowledges/knowledges` needs to return folder knowledge bases with complete nested folder data, and folder `doc_num` must reflect the real number of active documents under the folder and its descendants.

## Changes
- Return recursive `children` for folder knowledge bases in the paginated knowledge list response.
- Compute real folder `doc_num` from active documents under each folder and its descendants.
- Reuse the already loaded folder tree to derive descendant knowledge IDs, then run one grouped document count query instead of traversing the knowledge tree again for counts.
- Preserve existing pagination semantics: page totals still describe the original paginated query result, not nested children.
- Keep non-folder knowledge items unchanged except for normal serialization.

## Impact
- Web-facing and API Key-facing knowledge list routes both pick up the behavior because the external route delegates to the internal controller/service.
- Response payloads for folder items now include `children`; consumers should handle the additional field.
- Folder count calculation is more reliable for deep folder trees because it avoids duplicate descendant traversal for `doc_num`.

## Risks
- Large folder trees still require one batched knowledge query per folder depth to load nested `children`.
- Folder responses can be larger because nested children are now included.
- Existing clients that assume folder items never include `children` should ignore the extra field or adapt.

## Test Results
- `PYTHONPATH=. .venv/bin/python -m pytest tests/controllers/test_knowledge_folder_doc_num.py tests/controllers/test_knowledge_update_missing_model_key.py tests/controllers/test_kb_batch_download_session_scope.py -v` (5 passed, warnings only)
- `PYTHONPATH=. .venv/bin/python -m py_compile app/services/knowledge_service.py app/repositories/knowledge_repository.py`
- `git diff --check -- api/app/services/knowledge_service.py api/app/repositories/knowledge_repository.py`
