### PR TITLE
Fix/v0.3.8 zy

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2628,6 +2628,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
           gte: '≥',
           before: 'Before',
           after: 'After',
+          metadataTip: 'Only metadata fields common to all selected knowledge bases can be configured',
         },
         'parameter-extractor': {
           model_id: 'Model',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2638,6 +2638,7 @@ export const zh = {
           gte: '≥',
           before: '早于',
           after: '晚于',
+          metadataTip: '仅支持配置所有已选知识库中共有的元数据字段',
         },
         'parameter-extractor': {
           model_id: '模型',

--- a/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
+++ b/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
@@ -138,7 +138,7 @@ const DocumentMetadata: React.FC<DocumentMetadataProps> = ({ documentId, knowled
             <Form.Item name={field.name} className="rb:mb-0!">
               <DatePicker
                 showTime
-                format="YYYY-MM-DD HH:mm:ss"
+                format="YYYY-MM-DD HH:mm:ssZZ"
               />
             </Form.Item>
           );

--- a/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { useTranslation } from 'react-i18next';
-import { Form, Button, Select, Input, Space, Row, Col, type SelectProps, Flex, Divider, InputNumber } from 'antd';
+import { Form, Button, Select, Input, Space, Row, Col, type SelectProps, Flex, Divider, InputNumber, DatePicker } from 'antd';
 import clsx from 'clsx';
 
 import RbModal from '@/components/RbModal';
@@ -9,6 +9,8 @@ import VariableSelect from '../VariableSelect'
 import { getPublicMetadataFields } from '@/api/knowledgeBase';
 import type { MetadataField } from '@/views/KnowledgeBase/types'
 import Tag from '@/components/Tag'
+import type { Dayjs } from "dayjs";
+import dayjs from "dayjs";
 
 export interface MetadataFilterModalRef {
   open: (metadata_filters: { conditions: FilterCondition[], logic: 'or' | 'and' }) => void;
@@ -25,7 +27,7 @@ export interface FilterCondition {
   field: string;
   operator: string;
   value_type: 'constant' | 'variable';
-  value: string;
+  value: string | Dayjs;
 }
 
 const operatorsObj: { [key: string]: SelectProps['options'] } = {
@@ -87,9 +89,7 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
     form.resetFields();
   }
   const handleOpen = (metadata_filters: { conditions: FilterCondition[], logic: 'or' | 'and' }) => {
-    form.setFieldsValue({
-      metadata_filters
-    });
+    console.log('metadata_filters', metadata_filters)
     setLogicalOperator(metadata_filters.logic || 'and');
     setOpen(true);
 
@@ -97,16 +97,38 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
       getPublicMetadataFields({ kb_ids })
         .then(res => {
           const { custom, builtin_fields } = res as { custom: MetadataField[], builtin_fields: MetadataField[] };
-          setMetadataFields([...custom, ...builtin_fields]);
+          const allMetadataFields = [...custom, ...builtin_fields]
+          setMetadataFields(allMetadataFields);
+
+          // 将 time 类型字段的值转换为 dayjs 格式
+          const processedConditions = metadata_filters.conditions.map(item => {
+            const fieldType = allMetadataFields.find(f => f.name === item.field)?.type;
+            if (fieldType === 'time' && item.value && typeof item.value === 'string') {
+              return { ...item, value: dayjs(item.value) };
+            }
+            return item;
+          });
+          form.setFieldsValue({
+            metadata_filters: {
+              ...metadata_filters,
+              conditions: processedConditions
+            }
+          });
         })
     }
   }
+  
 
   const handleSave = () => {
     form.validateFields().then((values) => {
       const { metadata_filters } = values;
       const validFilters = metadata_filters?.conditions?.filter((v: FilterCondition) => v.field && v.value);
-      onSave({ conditions: validFilters, logic: logicalOperator });
+      onSave({ conditions: validFilters.map((vo: FilterCondition) => ({
+        ...vo,
+        value: typeof vo.value === 'object' && vo.value !== null
+          ? vo.value.format('YYYY-MM-DD HH:mm:ssZZ')
+          : vo.value
+      })), logic: logicalOperator });
       handleCancel();
     });
   };
@@ -119,21 +141,21 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
           ...conditions[index],
           operator: 'eq',
           field: newValue,
-          value: lastFilter.value_type === 'variable' ? undefined : lastFilter.value
+          value: lastFilter.value_type === 'variable'
+            ? undefined
+            : lastFilter.value
         }
       }
     });
   };
 
   const handleInputTypeChange = (index: number) => {
-    form.setFieldValue(['metadata_filters', index, 'value'], undefined);
+    form.setFieldValue(['metadata_filters', 'conditions', index, 'value'], undefined);
   };
 
   const handleChangeLogicalOperator = () => {
     setLogicalOperator(prev => prev === 'and' ? 'or' : 'and');
   };
-
-  console.log('logicalOperator', logicalOperator)
 
   return (
     <RbModal
@@ -176,10 +198,10 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
                     const currentCondition = conditions?.[index] || {};
                     const currentOperator = currentCondition.operator;
                     const leftFieldValue = currentCondition.field;
-                    const leftFieldOption = options.find(option => `{{${option.value}}}` === leftFieldValue)
+                    const leftFieldOption = metadataFields.find(option => option.name === leftFieldValue)
                       ?? options.flatMap(o => o.children ?? []).find(child => `{{${child.value}}}` === leftFieldValue)
                       ?? options.flatMap(o => o.children ?? []).flatMap((c: any) => c.children ?? []).find((gc: any) => `{{${gc.value}}}` === leftFieldValue);
-                    const leftFieldType = leftFieldOption?.dataType;
+                    const leftFieldType = leftFieldOption?.type;
                     const hideRightField = currentOperator === 'is_empty' || currentOperator === 'not_empty';
                     const operatorList = leftFieldType && ['array[object]', 'object'].includes(leftFieldType)
                       ? operatorsObj.object
@@ -190,7 +212,7 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
                       : leftFieldType?.includes('array')
                       ? operatorsObj.array
                       : operatorsObj.default
-                    const valueType = leftFieldType === 'number' ? currentCondition.value_type : undefined;
+                    const valueType = currentCondition.value_type;
                     return (
                       <Flex
                         key={field.key} 
@@ -257,12 +279,22 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
                                         variant="borderless"
                                       />
                                     )
-                                    : leftFieldType === 'number' ? (
+                                    : leftFieldType === 'number'
+                                    ? (
                                       <InputNumber
                                         placeholder={t('common.pleaseEnter')}
                                         variant="borderless"
                                         className="rb:w-full!"
                                         onChange={(value) => form.setFieldValue(['metadata_filters', index, 'value'], value)}
+                                      />
+                                    )
+                                    : leftFieldType === 'time'
+                                    ? (
+                                      <DatePicker
+                                        showTime
+                                        format="YYYY-MM-DD HH:mm:ssZZ"
+                                        className="rb:w-full!"
+                                        variant="borderless"
                                       />
                                     )
                                     : (

--- a/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
@@ -1,6 +1,6 @@
 import { type FC, useRef } from "react";
 import { useTranslation } from 'react-i18next';
-import { Form, Select, Button, Space, Flex } from 'antd';
+import { Form, Select, Button, Space, Flex, Tooltip } from 'antd';
 
 import ModelConfig from '../ModelConfig'
 import MetadataFilterModal, { type MetadataFilterModalRef, type FilterCondition } from './MetadataFilterModal';
@@ -39,7 +39,14 @@ const MetadataFilter: FC<MetadataFilterProps> = ({
   return (
     <>
       <Flex align="center" justify="space-between" className="rb:w-full!">
-        <div className="rb:font-medium rb:text-[12px] rb:leading-4.5">{t('workflow.config.knowledge-retrieval.metadata')}</div>
+        <Flex align="center" gap={4} className="rb:font-medium rb:text-[12px] rb:leading-4.5">
+          {t('workflow.config.knowledge-retrieval.metadata')}
+          {currentMode === 'manual' &&
+            <Tooltip title={t('workflow.config.knowledge-retrieval.metadataTip')}>
+              <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/question.svg')]"></div>
+            </Tooltip>
+          }
+        </Flex>
         <Space size={8}>
           <Form.Item
             name="metadata_filter_mode"


### PR DESCRIPTION
## Summary by Sourcery

改进用于工作流知识检索的元数据过滤用户体验和时间处理。

新功能：
- 允许在工作流元数据过滤弹窗中，对时间类型字段使用 `DatePicker` 来配置元数据过滤器。
- 显示上下文工具提示，解释只有所有已选知识库中共同存在的元数据字段才能被配置。

错误修复：
- 确保在更改输入类型时，元数据过滤表单的值能够被正确初始化和清空。
- 通过使用元数据 schema 而不是变量选项来纠正元数据字段类型检测，从而为每个字段启用正确的操作符和输入类型选择。
- 通过在字符串与 Dayjs 实例之间转换，并在序列化时带上时区信息，实现时间元数据过滤值的持久化和恢复。

增强改进：
- 统一文档元数据及过滤器中时间元数据的显示格式，以包含时区信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve metadata filtering UX and time handling for workflow knowledge retrieval.

New Features:
- Allow configuring metadata filters on time-type fields using a DatePicker in the workflow metadata filter modal.
- Show a contextual tooltip explaining that only metadata fields common to all selected knowledge bases can be configured.

Bug Fixes:
- Ensure metadata filter form values are correctly initialized and cleared when changing input types.
- Correct metadata field type detection by using the metadata schema instead of variable options, enabling proper operator and input selection for each field.
- Persist and restore time metadata filter values by converting between string and Dayjs instances and serializing back with timezone information.

Enhancements:
- Unify time metadata display format to include timezone information in document metadata and filters.

</details>