### PR TITLE
Fix/v0.3.8 zy

### DIFF
--- a/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
@@ -134,16 +134,13 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
   };
 
   const handleLeftFieldChange = (index: number, newValue?: string | string[]) => {
-    const lastFilter = conditions[index];
     form.setFieldsValue({
       metadata_filters: {
         [index]: {
           ...conditions[index],
           operator: 'eq',
           field: newValue,
-          value: lastFilter.value_type === 'variable'
-            ? undefined
-            : lastFilter.value
+          value: undefined
         }
       }
     });

--- a/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/MetadataFilterModal.tsx
@@ -134,15 +134,12 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
   };
 
   const handleLeftFieldChange = (index: number, newValue?: string | string[]) => {
-    form.setFieldsValue({
-      metadata_filters: {
-        [index]: {
-          ...conditions[index],
-          operator: 'eq',
-          field: newValue,
-          value: undefined
-        }
-      }
+    form.setFieldValue(['metadata_filters', 'conditions', index], {
+      ...conditions[index],
+      operator: 'eq',
+      field: newValue,
+      value_type: 'constant',
+      value: undefined
     });
   };
 
@@ -255,17 +252,19 @@ const MetadataFilterModal = forwardRef<MetadataFilterModalRef, MetadataFilterMod
                           {!hideRightField && (
                             <div>
                               <Flex align="center">
-                                <Form.Item name={[field.name, 'value_type']} noStyle>
-                                  <Select
-                                    placeholder={t('common.pleaseSelect')}
-                                    options={inputTypeOptions}
-                                    popupMatchSelectWidth={false}
-                                    variant="borderless"
-                                    className="rb:w-30!"
-                                    onChange={() => handleInputTypeChange(index)}
-                                  />
-                                </Form.Item>
-                                <Divider type="vertical" />
+                                {leftFieldType !== 'time' && <>
+                                  <Form.Item name={[field.name, 'value_type']} noStyle>
+                                    <Select
+                                      placeholder={t('common.pleaseSelect')}
+                                      options={inputTypeOptions}
+                                      popupMatchSelectWidth={false}
+                                      variant="borderless"
+                                      className="rb:w-30!"
+                                      onChange={() => handleInputTypeChange(index)}
+                                    />
+                                  </Form.Item>
+                                  <Divider type="vertical" />
+                                </>}
                                 <Form.Item name={[field.name, 'value']} noStyle>
                                   {valueType === 'variable'
                                     ? (


### PR DESCRIPTION
## Summary by Sourcery

在更改字段时调整元数据过滤器模态框的行为，并改进对时间类型元数据值的处理。

Bug 修复：
- 当左侧字段发生变化时，一致地重置元数据过滤器的值类型和值，以防止无效或过期的值。
- 对于基于时间的元数据字段，避免显示值类型选择器，以防止出现不受支持的输入配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust metadata filter modal behavior when changing fields and improve handling of time-type metadata values.

Bug Fixes:
- Reset metadata filter value type and value consistently when the left field changes to prevent invalid or stale values.
- Avoid showing the value type selector for time-based metadata fields to prevent unsupported input configurations.

</details>