### PR TITLE
fix(neo4j): add DISTINCT clause to entity merge query

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2163,21 +2163,21 @@ WHERE NOT (s)-[:REFERENCES_ENTITY]->(keeper)
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
   CREATE (s)-[:REFERENCES_ENTITY]->(keeper)
 )
-WITH keeper, loser
+WITH DISTINCT keeper, loser
 OPTIONAL MATCH (loser)-[r:EXTRACTED_RELATIONSHIP]->(target)
 WHERE target <> keeper
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
   MERGE (keeper)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(target)
   SET nr += properties(r)
 )
-WITH keeper, loser
+WITH DISTINCT keeper, loser
 OPTIONAL MATCH (source)-[r:EXTRACTED_RELATIONSHIP]->(loser)
 WHERE source <> keeper
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
   MERGE (source)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(keeper)
   SET nr += properties(r)
 )
-WITH keeper, loser
+WITH DISTINCT keeper, loser
 DETACH DELETE loser
 RETURN keeper.id AS merged_id
 """


### PR DESCRIPTION
- Add DISTINCT keyword to WITH clauses in entity merge Cypher query
- Prevent duplicate rows in multi-step entity consolidation pipeline
- Ensure deterministic merge behavior when consolidating duplicate entities

## Summary by Sourcery

Bug Fixes:
- 在实体合并的 Cypher 查询中，为中间的 WITH 子句添加 DISTINCT，以防止在整合步骤中出现重复行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add DISTINCT to intermediate WITH clauses in the entity merge Cypher query to prevent duplicate rows across consolidation steps.

</details>