### PR TITLE
feat(api-key): add MCP user association and concurrency lock to end user creation

### DIFF
--- a/api/app/controllers/api_key_controller.py
+++ b/api/app/controllers/api_key_controller.py
@@ -11,6 +11,7 @@ from app.dependencies import get_current_user, cur_workspace_access_guard
 from app.models import ApiKeyType
 from app.models.user_model import User
 from app.core.response_utils import success
+from app.repositories.end_user_repository import EndUserRepository
 from app.schemas import api_key_schema
 from app.schemas.response_schema import ApiResponse
 from app.services.api_key_service import ApiKeyService
@@ -50,8 +51,13 @@ def create_api_key(
             user_id=current_user.id,
             data=data
         )
+        end_user_id, other_id = None, None
+        if "memory" in data.scopes and data.user_id:
+            end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
 
         response_data = api_key_schema.ApiKeyResponse.model_validate(api_key_obj)
+        response_data.end_user_id = end_user_id
+        response_data.other_id = other_id
 
         return success(data=response_data, msg="API Key 创建成功")
     except BusinessException:

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -95,7 +95,7 @@ class ReadPipeLine(ModelClientMixin, DBRequiredPipeline):
             self.get_llm_client(self.db, self.ctx.memory_config.llm_model_id)
         )
         if memory_evidence:
-            memory_l0.content_str = memory_evidence
+            memory_l0.content_str = str(memory_evidence)
             return memory_l0
         all_tasks = []
         for question in questions:

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1,23 +1,45 @@
-import datetime
 import uuid
+from contextlib import contextmanager
 from typing import List, Optional
 
+import sqlalchemy as sa
+from sqlalchemy import select, or_
 from sqlalchemy.orm import Session
 
-from app.core.utils.datetime_utils import utcnow_naive
 from app.core.logging_config import get_db_logger
-from app.models.app_model import App
-from app.models.end_user_model import EndUser
+from app.core.utils.datetime_utils import utcnow_naive
+from app.models import User
 from app.models.end_user_info_model import EndUserInfo
+from app.models.end_user_model import EndUser
 from app.models.workspace_model import Workspace
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
 
 
+def is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, TypeError):
+        return False
+
 class EndUserRepository:
     def __init__(self, db: Session):
         self.db = db
+
+    @contextmanager
+    def _acquire_eu_lock(self, workspace_id, other_id):
+        """获取 EndUser 创建/查找的排他锁，防止并发重复创建。
+
+        使用 pg_advisory_xact_lock，锁在事务提交/回滚时自动释放，
+        无需显式 unlock。
+        """
+        self.db.execute(
+            sa.text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+            {"key": f"{workspace_id}|{other_id}"},
+        )
+        yield
 
     def get_end_users_by_app_id(self, app_id: uuid.UUID) -> List[EndUser]:
         """根据应用ID查询宿主"""
@@ -75,7 +97,7 @@ class EndUserRepository:
                 EndUser.workspace_id == workspace_id,
                 EndUser.other_id == other_id,
                 EndUser.is_active == True,
-            )
+            ).order_by(EndUser.created_at.asc())
             .first()
         )
 
@@ -97,45 +119,46 @@ class EndUserRepository:
             other_name: 用户名称（用于创建 EndUserInfo）
         """
         try:
-            # 尝试查找现有用户
-            end_user = (
-                self.db.query(EndUser)
-                .filter(
-                    EndUser.workspace_id == workspace_id,
-                    EndUser.other_id == other_id,
-                    EndUser.is_active == True,
+            with self._acquire_eu_lock(workspace_id, other_id):
+                # 尝试查找现有用户
+                end_user = (
+                    self.db.query(EndUser)
+                    .filter(
+                        EndUser.workspace_id == workspace_id,
+                        EndUser.other_id == other_id,
+                        EndUser.is_active == True,
+                    )
+                    .order_by(EndUser.created_at.asc())
+                    .first()
                 )
-                .order_by(EndUser.created_at.asc())
-                .first()
-            )
 
-            if end_user:
-                db_logger.debug(f"找到现有终端用户: 应用ID {workspace_id}、第三方ID {other_id}")
-                end_user.app_id=app_id
+                if end_user:
+                    db_logger.debug(f"找到现有终端用户: 应用ID {workspace_id}、第三方ID {other_id}")
+                    end_user.app_id = app_id
+                    self.db.commit()
+                    self.db.refresh(end_user)
+                    return end_user
+
+                # 创建新用户
+                end_user = EndUser(
+                    app_id=app_id,
+                    workspace_id=workspace_id,
+                    other_id=other_id
+                )
+                self.db.add(end_user)
+                self.db.flush()  # 刷新以获取 end_user.id，但不提交事务
+
+                # 创建对应的 EndUserInfo 记录
+                end_user_info = EndUserInfo(
+                    end_user_id=end_user.id,
+                    other_name=other_name or "",  # 如果没有提供 other_name，使用空字符串
+                    aliases=[],
+                    meta_data={}
+                )
+                self.db.add(end_user_info)
+
+                # 一起提交
                 self.db.commit()
-                self.db.refresh(end_user)
-                return end_user
-
-            # 创建新用户
-            end_user = EndUser(
-                app_id=app_id,
-                workspace_id=workspace_id,
-                other_id=other_id
-            )
-            self.db.add(end_user)
-            self.db.flush()  # 刷新以获取 end_user.id，但不提交事务
-            
-            # 创建对应的 EndUserInfo 记录
-            end_user_info = EndUserInfo(
-                end_user_id=end_user.id,
-                other_name=other_name or "",  # 如果没有提供 other_name，使用空字符串
-                aliases=[],
-                meta_data={}  
-            )
-            self.db.add(end_user_info)
-            
-            # 一起提交
-            self.db.commit()
             self.db.refresh(end_user)
             
             db_logger.info(f"创建新终端用户及其信息: (other_id: {other_id}) for workspace {workspace_id}")
@@ -144,6 +167,54 @@ class EndUserRepository:
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"获取或创建终端用户时出错: {str(e)}")
+            raise
+
+    def get_or_create_end_user_mcp(
+            self,
+            workspace_id: uuid.UUID,
+            user_id: str
+    ):
+        try:
+            with self._acquire_eu_lock(workspace_id, user_id):
+                if is_uuid(user_id):
+                    user_stmt = select(User.id).where(
+                        User.is_active == True,
+                        User.id == user_id
+                    )
+                    if self.db.scalar(user_stmt):
+                        raise Exception("不可对草稿运行用户创建mcp user")
+
+                    end_user_stmt = select(EndUser).where(
+                        EndUser.is_active == True,
+                        EndUser.workspace_id == workspace_id,
+                        or_(
+                            EndUser.id == user_id,
+                            EndUser.other_id == user_id,
+                        )
+                    ).order_by(EndUser.created_at.asc()).limit(1)
+                else:
+                    end_user_stmt = select(EndUser).where(
+                        EndUser.is_active == True,
+                        EndUser.workspace_id == workspace_id,
+                        EndUser.other_id == user_id,
+                    ).order_by(EndUser.created_at.asc()).limit(1)
+
+                existing: EndUser | None = self.db.scalar(end_user_stmt)
+                if existing:
+                    return existing.id, existing.other_id
+
+                end_user = EndUser(
+                    workspace_id=workspace_id,
+                    other_id=user_id
+                )
+                self.db.add(end_user)
+                self.db.commit()
+                self.db.refresh(end_user)
+                return end_user.id, end_user.other_id
+
+        except Exception as e:
+            self.db.rollback()
+            db_logger.error(f"获取或创建终端用户出错: {str(e)}")
             raise
 
     def get_or_create_end_user_with_config(

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -15,6 +15,7 @@ class ApiKeyCreate(BaseModel):
     description: Optional[str] = Field(None, description="描述")
     type: ApiKeyType = Field(..., description="API Key 类型")
     scopes: List[str] = Field(default_factory=list, description="权限范围列表")
+    user_id: str | None = Field(default=None, description="user/other_id")
     resource_id: Optional[uuid.UUID] = Field(None, description="关联资源ID")
     rate_limit: Optional[int] = Field(50, ge=1, le=1000, description="QPS限制（请求/秒）")
     daily_request_limit: Optional[int] = Field(100000, description="日请求限制", ge=1)
@@ -119,6 +120,8 @@ class ApiKeyResponse(BaseModel):
     is_active: bool
     expires_at: Optional[datetime.datetime]
     created_at: datetime.datetime
+    end_user_id: Optional[uuid.UUID] = Field(default=None)
+    other_id: Optional[str] = Field(default=None)
 
     @computed_field
     @property

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -1,26 +1,26 @@
 """API Key Service"""
+import math
 import time
 import uuid
-import math
-from typing import Optional, Tuple
 from datetime import timedelta
+from typing import Optional, Tuple
 
-from sqlalchemy.orm import Session
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
-from app.core.utils.datetime_utils import as_utc_aware, utcnow_naive
 from app.aioRedis import aio_redis
-from app.models.api_key_model import ApiKey, ApiKeyType
-from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
-from app.schemas import api_key_schema
-from app.schemas.response_schema import PageData, PageMeta
 from app.core.api_key_utils import generate_api_key
+from app.core.error_codes import BizCode
 from app.core.exceptions import (
     BusinessException,
 )
-from app.core.error_codes import BizCode
 from app.core.logging_config import get_business_logger
+from app.core.utils.datetime_utils import as_utc_aware, utcnow_naive
+from app.models.api_key_model import ApiKey, ApiKeyType
 from app.models.app_model import App
+from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
+from app.schemas import api_key_schema
+from app.schemas.response_schema import PageData, PageMeta
 
 logger = get_business_logger()
 


### PR DESCRIPTION
- Add `user_id` field to API key creation schema for MCP user binding
- Introduce `get_or_create_end_user_mcp` method with advisory lock to prevent duplicate end user creation
- Return `end_user_id` and `other_id` in API key response when memory scope is used
- Fix import ordering in api_key_service.py
- Add `is_uuid` helper and `_acquire_eu_lock` context manager to EndUserRepository
- Ensure memory read pipeline converts evidence to string explicitly

## Summary by Sourcery

将 API 密钥与 MCP 终端用户关联，并在并发情况下防止重复创建终端用户。

新功能：
- 允许在创建 API 密钥的请求中包含用户标识符，以绑定到 MCP 终端用户。
- 当请求 memory scope 时，在 API 密钥响应中暴露终端用户标识符。
- 在仓储层中添加对「在并发安全的建议锁下 get-or-create MCP 终端用户」的支持。

错误修复：
- 确保内存读取流水线在使用前将获取到的 evidence 转换为字符串。

改进：
- 在终端用户仓储中新增可复用的 UUID 检测辅助工具和终端用户建议锁上下文管理器。
- 通过在解析已有记录时按创建时间排序，使终端用户查找具有确定性。
- 清理 API key 服务模块中的导入顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Associate API keys with MCP end users and prevent duplicate end user creation under concurrency.

New Features:
- Allow API key creation requests to include a user identifier for binding to an MCP end user.
- Expose end user identifiers on API key responses when memory scope is requested.
- Add repository support for get-or-create MCP end users with a concurrency-safe advisory lock.

Bug Fixes:
- Ensure memory read pipeline converts retrieved evidence to a string before use.

Enhancements:
- Add a reusable UUID detection helper and end user advisory lock context manager in the end user repository.
- Make end user lookup deterministic by ordering by creation time when resolving existing records.
- Clean up import ordering in the API key service module.

</details>