### PR TITLE
fix(rag): require metadata binding for custom filters

### DIFF
--- a/api/app/core/rag/metadata/filter_engine.py
+++ b/api/app/core/rag/metadata/filter_engine.py
@@ -2,11 +2,12 @@ import uuid
 import logging
 from typing import Any
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, exists, or_
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
 from app.core.utils.datetime_utils import parse_metadata_time_to_utc_naive
 from app.models.document_model import Document
+from app.models.knowledge_metadata_model import KnowledgeMetadataBinding
 from .filter_strategies import StringFilterStrategy, NumberFilterStrategy, TimeFilterStrategy, _escape_like
 from .builtin_resolver import BuiltinFieldResolver
 
@@ -79,13 +80,13 @@ class MetadataFilterEngine:
                     filter_expr = self._build_builtin_filter(cond, field_def)
                 else:
                     strategy = self._strategies[field_def["type"]]
-                    if not strategy.supports(cond.operator):
+                    if cond.operator not in ("is_missing", "not_missing") and not strategy.supports(cond.operator):
                         raise BusinessException(
                             f"字段 '{cond.field}' (类型 {field_def['type']}) "
                             f"不支持操作符 '{cond.operator}'",
                             code=BizCode.METADATA_INVALID_OPERATOR,
                         )
-                    filter_expr = strategy.apply(cond.field, cond.operator, cond.value)
+                    filter_expr = self._build_custom_filter(cond, field_def, strategy)
 
                 conditions.append(filter_expr)
 
@@ -111,6 +112,33 @@ class MetadataFilterEngine:
         """执行过滤，返回符合条件的 document_id 列表"""
         query = self.build_query(*args, **kwargs)
         return [row[0] for row in query.all()]
+
+    def _build_custom_filter(self, cond: FilterCondition, field_def: dict, strategy):
+        metadata_id = field_def.get("id")
+        if metadata_id is None:
+            raise BusinessException(
+                f"元数据字段缺少绑定标识: {cond.field}",
+                code=BizCode.METADATA_FIELD_NOT_FOUND,
+            )
+
+        exists_binding = self._build_custom_binding_exists_filter(metadata_id)
+        match cond.operator:
+            case "is_missing":
+                return ~exists_binding
+            case "not_missing":
+                return exists_binding
+            case _:
+                return and_(exists_binding, strategy.apply(cond.field, cond.operator, cond.value))
+
+    @staticmethod
+    def _build_custom_binding_exists_filter(metadata_id: uuid.UUID):
+        return exists().where(
+            and_(
+                KnowledgeMetadataBinding.knowledge_id == Document.kb_id,
+                KnowledgeMetadataBinding.document_id == Document.id,
+                KnowledgeMetadataBinding.metadata_id == metadata_id,
+            )
+        )
 
     def _build_builtin_filter(self, cond: FilterCondition, field_def: dict):
         """构建内置字段的过滤表达式（查真实列）"""

--- a/api/app/services/knowledge_metadata_service.py
+++ b/api/app/services/knowledge_metadata_service.py
@@ -616,7 +616,7 @@ class KnowledgeMetadataService:
     ) -> dict[str, dict]:
         """
         获取用于过滤的字段定义映射
-        Returns: {field_name: {"type": "string", "is_builtin": False}}
+        Returns: {field_name: {"id": uuid, "type": "string", "is_builtin": False}}
         """
         from app.models.knowledge_model import Knowledge
 
@@ -625,7 +625,7 @@ class KnowledgeMetadataService:
         # 自定义字段
         custom_fields = KnowledgeMetadataRepository.get_by_knowledge_id(db, knowledge_id)
         for f in custom_fields:
-            result[f.name] = {"type": f.type, "is_builtin": False}
+            result[f.name] = {"id": f.id, "type": f.type, "is_builtin": False}
 
         # 内置字段（如果开启）
         knowledge = db.query(Knowledge).filter(Knowledge.id == knowledge_id).first()

--- a/api/app/services/metadata_auto_filter_service.py
+++ b/api/app/services/metadata_auto_filter_service.py
@@ -53,14 +53,30 @@ class MetadataAutoFilterService:
         "not empty": "not_empty",
         "is not empty": "not_empty",
         "not_empty": "not_empty",
+        "missing": "is_missing",
+        "is missing": "is_missing",
+        "not exists": "is_missing",
+        "not_exist": "is_missing",
+        "not_exists": "is_missing",
+        "is_missing": "is_missing",
+        "exists": "not_missing",
+        "exist": "not_missing",
+        "is exists": "not_missing",
+        "is exist": "not_missing",
+        "not missing": "not_missing",
+        "not_missing": "not_missing",
     }
     _SUPPORTED_OPERATORS = {
         "string": {
             "eq", "ne", "contains", "not_contains",
             "starts_with", "ends_with", "is_empty", "not_empty",
+            "is_missing", "not_missing",
         },
-        "number": {"eq", "ne", "gt", "lt", "gte", "lte", "is_empty", "not_empty"},
-        "time": {"eq", "before", "after", "is_empty", "not_empty"},
+        "number": {
+            "eq", "ne", "gt", "lt", "gte", "lte", "is_empty", "not_empty",
+            "is_missing", "not_missing",
+        },
+        "time": {"eq", "before", "after", "is_empty", "not_empty", "is_missing", "not_missing"},
     }
 
     @classmethod
@@ -136,8 +152,8 @@ class MetadataAutoFilterService:
             "### Task\n"
             "Only extract metadata that exists in the input text from the provided metadata list. "
             "Use one of these operators: [\"contains\", \"not contains\", \"start with\", "
-            "\"end with\", \"is\", \"is not\", \"empty\", \"not empty\", \"=\", \"≠\", "
-            "\">\", \"<\", \"≥\", \"≤\", \"before\", \"after\"].\n"
+            "\"end with\", \"is\", \"is not\", \"empty\", \"not empty\", \"missing\", "
+            "\"exists\", \"=\", \"≠\", \">\", \"<\", \"≥\", \"≤\", \"before\", \"after\"].\n"
             "### Format\n"
             "Return a JSON object with key \"metadata_fields\". The value must be an array of objects. "
             "Each object must contain \"metadata_field_name\", \"metadata_field_value\", "
@@ -227,7 +243,7 @@ class MetadataAutoFilterService:
 
     @classmethod
     def _normalize_value(cls, value: Any, field_type: str, operator: str) -> Any:
-        if operator in ("is_empty", "not_empty"):
+        if operator in ("is_empty", "not_empty", "is_missing", "not_missing"):
             return None
         match field_type:
             case "string":


### PR DESCRIPTION
## Background
Custom metadata filters previously evaluated document JSON metadata directly. That made missing custom metadata fields indistinguishable from empty values for some operators, especially `is_empty`, and left negative value operators semantically ambiguous.

## Changes
- Include custom metadata definition IDs in retrieval filter metadata definitions.
- Require a `knowledge_metadata_bindings` match before evaluating any custom metadata value predicate.
- Add `is_missing` / `not_missing` handling for custom metadata filters.
- Extend auto metadata filter operator normalization for missing/existing field intent.

## Impact
- Custom metadata value filters now only match documents that are bound to the target metadata field.
- `is_empty` now means the field is bound and its stored value is empty, not that the field is absent.
- Built-in metadata filters continue to use real document columns and do not depend on bindings.

## Risks
- Existing users who expected `is_empty` to include documents without the metadata field will see stricter results.
- If historical documents have `meta_data` values but missing binding rows, those fields will now be treated as missing until bindings are repaired.

## Test Results
- PASS: `PYTHONPATH=. uv run pytest tests/rag/test_metadata_filter_binding_existence.py -q`
- PASS: `PYTHONPATH=. uv run pytest tests/rag/test_metadata_filter_fields_requirement.py -q`
- NOTE: `PYTHONPATH=. uv run pytest tests/rag/test_metadata_auto_filter_requirement.py -q` has 3 pre-existing local test failures because untracked tests reference `MetadataAutoFilterLLM` and `metadata_auto_filter_model`, which do not exist on this branch.

## Summary by Sourcery

在评估自定义元数据筛选器时强制执行知识元数据绑定，并在检索和自动元数据筛选器中扩展对缺失/存在字段的运算符支持。

新功能：
- 在手动和自动生成的筛选器中，支持用于检查字段缺失和存在情况的新自定义元数据筛选运算符（`is_missing` 和 `not_missing`）。

错误修复：
- 通过在评估前要求进行绑定检查，防止自定义元数据值筛选器匹配到未绑定到相应元数据定义的文档。

增强项：
- 在可筛选的自定义元数据定义中包含元数据定义 ID，并通过专用的辅助工具集中构建自定义筛选器。

文档：
- 明确用于筛选的元数据定义返回结构，使其包含元数据 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce knowledge metadata bindings when evaluating custom metadata filters and extend operator support for missing/existing fields in retrieval and auto metadata filters.

New Features:
- Support new custom metadata filter operators for checking missing and existing fields (`is_missing` and `not_missing`) in both manual and auto-generated filters.

Bug Fixes:
- Prevent custom metadata value filters from matching documents that are not bound to the corresponding metadata definition by requiring a binding check before evaluation.

Enhancements:
- Include metadata definition IDs in filterable custom metadata definitions and centralize custom filter construction through a dedicated helper.

Documentation:
- Clarify the structure of metadata definitions returned for filtering to include metadata IDs.

</details>