### PR TITLE
fix(knowledge node): optimize variable rendering logic to preserve native types

### DIFF
--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 from typing import Any
 
 from app.core.workflow.engine.state_manager import WorkflowState
@@ -13,6 +14,10 @@ from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
 
 logger = logging.getLogger(__name__)
+
+# 匹配"纯变量引用"，如 {{node.x.output}} / {{ sys.message }}（无其它文本）。
+# 用于把数组/数字等变量解析为原生值，而不是被 Jinja2 str 化成 Python repr（如 ['22222']）。
+_PURE_VARIABLE_PATTERN = re.compile(r"^\{\{\s*(.*?)\s*\}\}$", re.DOTALL)
 
 
 class KnowledgeRetrievalNode(BaseNode):
@@ -82,8 +87,11 @@ class KnowledgeRetrievalNode(BaseNode):
     ) -> FilterGroup | None:
         """渲染 metadata_filters 中 value_type=variable 的条件值。
 
-        遍历 FilterGroup，对 value_type 为 'variable' 且值含 {{...}} 的条件，
-        使用 BaseNode._render_template 渲染工作流变量模板后返回新的 FilterGroup。
+        遍历 FilterGroup，对 value_type 为 'variable' 且值含 {{...}} 的条件：
+          - 纯变量引用（如 {{node.x.output}}）：直接取变量池中的原生值，
+            保留 list/number/dict 等结构，避免 Jinja2 把数组 str 化成 Python repr（如 ['22222']）。
+            这样数组既能在 input 里显示为 JSON 数组，也能让 in/not_in 等操作符正确工作。
+          - 混合模板（如 "前缀 {{x}}"）：退回到 _render_template 字符串渲染。
         """
         if not filter_group:
             return None
@@ -91,9 +99,14 @@ class KnowledgeRetrievalNode(BaseNode):
         rendered_conditions = []
         for condition in filter_group.conditions:
             value = condition.value
-            # Render variable templates (e.g. {{sys.message}})
             if condition.value_type == "variable" and isinstance(value, str) and "{{" in value:
-                value = self._render_template(value, variable_pool, strict=False)
+                pure_ref = _PURE_VARIABLE_PATTERN.match(value.strip())
+                if pure_ref and variable_pool.has(value.strip()):
+                    # 纯变量引用：保留原生结构（list/number/...）
+                    value = variable_pool.get_value(value.strip(), default=value, strict=False)
+                else:
+                    # 混合模板或变量不存在：字符串渲染
+                    value = self._render_template(value, variable_pool, strict=False)
             rendered_conditions.append(FilterCondition(
                 field=condition.field,
                 operator=condition.operator,

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -51,6 +51,7 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             current_user: Any = None,
     ) -> KnowledgeRetrievalResult:
+        logger.info("Knowledge retrieval request params: %s", request.model_dump() if hasattr(request, "model_dump") else request.dict())
         knowledge_ids, workspace_ids = cls._resolve_retrievable_knowledge_ids(
             db=db,
             request=request,


### PR DESCRIPTION
For pure variable reference scenarios, directly fetch the native value from the variable pool to prevent Jinja2 from converting arrays and other types into repr strings. Meanwhile, retain the rendering logic for mixed templates.

## 由 Sourcery 提供的总结

优化知识节点过滤器变量的渲染机制：在保持混合表达式仍使用模板渲染的同时，对纯变量引用保留其原生类型。

Bug 修复：
- 确保在元数据过滤条件中使用纯变量引用时，能够获取原生的列表 / 数字 / 字典值，而不是 Jinja2 字符串化后的结果，从而使 `in` / `not_in` 等运算符能够正常工作。

增强功能：
- 新增对“纯变量引用模板”的检测，并对其跳过 Jinja2 渲染，仅在混合模板中回退为字符串渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize knowledge node filter variable rendering to preserve native types for pure variable references while retaining template rendering for mixed expressions.

Bug Fixes:
- Ensure metadata filter conditions using pure variable references retrieve native list/number/dict values instead of Jinja2 stringified representations, so operators like in/not_in work correctly.

Enhancements:
- Introduce detection of pure variable reference templates and bypass Jinja2 rendering for them, falling back to string rendering only for mixed templates.

</details>