### PR TITLE
fix(web): kb change add metadata_filters reset

### DIFF
--- a/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
@@ -1,10 +1,12 @@
-import { type FC, useRef } from "react";
+import { type FC, useEffect, useRef } from "react";
 import { useTranslation } from 'react-i18next';
 import { Form, Select, Button, Space, Flex, Tooltip } from 'antd';
 
 import ModelConfig from '../ModelConfig'
 import MetadataFilterModal, { type MetadataFilterModalRef, type FilterCondition } from './MetadataFilterModal';
 import type { Suggestion } from '../../Editor/plugin/AutocompletePlugin'
+import { getPublicMetadataFields } from '@/api/knowledgeBase';
+import type { MetadataField } from '@/views/KnowledgeBase/types'
 
 interface MetadataFilterProps {
   options: Suggestion[];
@@ -35,6 +37,33 @@ const MetadataFilter: FC<MetadataFilterProps> = ({
       metadata_filters: newFilters
     })
   };
+
+  useEffect(() => {
+    const kb_ids = knowledge_bases?.map((kb: any) => kb.kb_id || kb.id).filter(Boolean) || [];
+    if (kb_ids.length) {
+      getPublicMetadataFields({ kb_ids })
+        .then(res => {
+          const { custom, builtin_fields } = res as { custom: MetadataField[], builtin_fields: MetadataField[] };
+          const allMetadataFields = [...custom, ...builtin_fields]
+          const conditions = metadata_filters.conditions || []
+          const filterConditions = conditions.filter((item: FilterCondition) => allMetadataFields.find(f => f.name === item.field))
+
+          form.setFieldsValue({
+            metadata_filters: {
+              conditions: filterConditions,
+              logic: metadata_filters.logic
+            }
+          })
+        })
+    } else {
+      form.setFieldsValue({
+        metadata_filters: {
+          conditions: [],
+          logic: 'and'
+        }
+      })
+    }
+  }, [knowledge_bases, metadata_filters])
 
   return (
     <>


### PR DESCRIPTION
## Summary by Sourcery

确保工作流元数据过滤器与所选知识库保持同步，并在未选择知识库时重置。

Bug 修复：
- 过滤掉引用在当前所选知识库中已不再可用字段的元数据过滤条件。
- 在未选择任何知识库时，重置元数据过滤条件及其逻辑。

增强功能：
- 在渲染工作流元数据过滤属性时，为所选知识库加载公共元数据字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure workflow metadata filters stay in sync with selected knowledge bases and reset when no knowledge base is chosen.

Bug Fixes:
- Filter out metadata filter conditions that reference fields no longer available for the selected knowledge bases.
- Reset metadata filter conditions and logic when no knowledge base is selected.

Enhancements:
- Load public metadata fields for the selected knowledge bases when rendering the workflow metadata filter properties.

</details>