### PR TITLE
feat(end-user): add incremental update for aliases and metadata

### DIFF
--- a/api/app/repositories/end_user_info_repository.py
+++ b/api/app/repositories/end_user_info_repository.py
@@ -70,6 +70,79 @@ class EndUserInfoRepository:
         logger.info(f"删除用户所有信息记录: end_user_id={end_user_id}, count={count}")
         return count
 
+    def update_aliases_and_metadata(
+        self,
+        end_user_id: uuid.UUID,
+        new_aliases: Optional[List[str]] = None,
+        new_metadata: Optional[dict] = None,
+    ) -> Optional["EndUserInfo"]:
+        """增量更新用户别名列表和元数据。
+
+        - aliases：将 ``new_aliases`` 合并到现有列表（去重，忽略大小写），不覆盖
+        - meta_data：将 ``new_metadata`` 的各字段列表合并到现有 ``meta_data``
+          （去重），不覆盖
+        - other_name：若当前为空且 aliases 非空，则取 ``aliases[0]`` 作为
+          ``other_name``
+
+        Args:
+            end_user_id: 终端用户 ID
+            new_aliases: 本次新增的别名列表
+            new_metadata: 本次提取的 extracted_metadata 字典
+
+        Returns:
+            更新后的 EndUserInfo；若记录不存在则返回 None
+        """
+        end_user_info = self.get_by_end_user_id(end_user_id)
+        if not end_user_info:
+            logger.warning(
+                f"[EndUserInfo] 记录不存在，跳过更新: end_user_id={end_user_id}"
+            )
+            return None
+
+        changed = False
+
+        # 合并 aliases（去重，忽略大小写）
+        if new_aliases:
+            existing = list(end_user_info.aliases or [])
+            existing_lower = {a.lower() for a in existing}
+            for alias in new_aliases:
+                alias = alias.strip()
+                if alias and alias.lower() not in existing_lower:
+                    existing.append(alias)
+                    existing_lower.add(alias.lower())
+            end_user_info.aliases = existing
+            changed = True
+
+        # 同步 other_name：取 aliases[0]（仅当当前为空）
+        if end_user_info.aliases and not (end_user_info.other_name or "").strip():
+            end_user_info.other_name = end_user_info.aliases[0]
+            changed = True
+
+        # 合并 meta_data（各字段列表去重追加）
+        if new_metadata:
+            existing_meta = dict(end_user_info.meta_data or {})
+            for field, values in new_metadata.items():
+                if not isinstance(values, list):
+                    continue
+                existing_list = list(existing_meta.get(field) or [])
+                existing_set = {str(v).lower() for v in existing_list}
+                for v in values:
+                    if str(v).lower() not in existing_set:
+                        existing_list.append(v)
+                        existing_set.add(str(v).lower())
+                existing_meta[field] = existing_list
+            end_user_info.meta_data = existing_meta
+            changed = True
+
+        if changed:
+            self.db.commit()
+            self.db.refresh(end_user_info)
+            logger.info(
+                f"[EndUserInfo] 更新完成: end_user_id={end_user_id}, "
+                f"aliases_count={len(end_user_info.aliases or [])}"
+            )
+        return end_user_info
+
     def replace_metadata_fields(
         self,
         end_user_id: uuid.UUID,


### PR DESCRIPTION
- Add `update_aliases_and_metadata()` method to EndUserInfoRepository for incremental updates
- Merge new aliases into existing list with case-insensitive deduplication
- Populate `other_name` from first alias when currently empty
- Merge metadata field values with deduplication, preserving existing data
- Skip update and return None if EndUserInfo record does not exist
- Log operation details including alias count after successful update
- Enables non-destructive accumulation of user identifiers and extracted metadata

## Summary by Sourcery

新功能：
- 在 `EndUserInfoRepository` 上引入 `update_aliases_and_metadata` API，用于将新的别名和元数据合并到现有终端用户记录中，并以不区分大小写的方式去重。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce update_aliases_and_metadata API on EndUserInfoRepository to merge new aliases and metadata into existing end-user records with case-insensitive deduplication.

</details>