### PR TITLE
fix(rag): format metadata time responses with timezone

### DIFF
--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -56,6 +56,14 @@ def to_iso_z(dt: datetime | None) -> str | None:
     return aware_dt.isoformat().replace("+00:00", "Z")
 
 
+def to_utc_offset_string(dt: datetime | None) -> str | None:
+    """Serialize a datetime as an explicit UTC offset string."""
+    aware_dt = as_utc_aware(dt)
+    if aware_dt is None:
+        return None
+    return aware_dt.strftime("%Y-%m-%d %H:%M:%S%z")
+
+
 def normalize_progress_message_timestamps(message: str | None, reference_dt: datetime | None) -> str | None:
     """Convert legacy leading HH:MM:SS progress lines to explicit UTC ISO strings."""
     if not message:

--- a/api/app/services/knowledge_metadata_service.py
+++ b/api/app/services/knowledge_metadata_service.py
@@ -2,7 +2,11 @@ import uuid
 from typing import Any
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
-from app.core.utils.datetime_utils import parse_metadata_time_to_utc_naive, utcnow_naive
+from app.core.utils.datetime_utils import (
+    parse_metadata_time_to_utc_naive,
+    to_utc_offset_string,
+    utcnow_naive,
+)
 from app.core.exceptions import (
     BusinessException,
     ResourceNotFoundException,
@@ -472,10 +476,15 @@ class KnowledgeMetadataService:
         # 获取字段定义
         custom_fields = KnowledgeMetadataRepository.get_by_knowledge_id(db, doc.kb_id)
         field_map = {f.id: f for f in custom_fields}
+        field_defs_by_name = {f.name: f for f in custom_fields}
+        metadata = KnowledgeMetadataService._serialize_metadata_for_response(
+            doc.meta_data or {},
+            field_defs_by_name,
+        )
 
         result = {
             "document_id": str(document_id),
-            "metadata": doc.meta_data or {},
+            "metadata": metadata,
             "fields": [],
         }
 
@@ -486,7 +495,7 @@ class KnowledgeMetadataService:
                     "field_id": str(field_def.id),
                     "name": field_def.name,
                     "type": field_def.type,
-                    "value": doc.meta_data.get(field_def.name) if doc.meta_data else None,
+                    "value": metadata.get(field_def.name),
                 })
 
         return result
@@ -608,6 +617,41 @@ class KnowledgeMetadataService:
                     f"stored_value={normalized[field_name]!r}"
                 )
         return normalized
+
+    @staticmethod
+    def _serialize_metadata_value_for_response(field_type: str, value: Any) -> Any:
+        """Format metadata values for API responses without changing storage."""
+        if value is None or field_type != "time":
+            return value
+        try:
+            dt = parse_metadata_time_to_utc_naive(value)
+        except (TypeError, ValueError):
+            api_logger.warning(
+                "Skipped invalid document time metadata response formatting: "
+                f"raw_value={value!r}, raw_type={type(value).__name__}"
+            )
+            return value
+        if dt is None:
+            return value
+        return to_utc_offset_string(dt)
+
+    @staticmethod
+    def _serialize_metadata_for_response(
+        metadata: dict[str, Any],
+        field_defs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Format typed metadata values for API responses."""
+        serialized = {}
+        for field_name, value in metadata.items():
+            field_def = field_defs.get(field_name)
+            if not field_def:
+                serialized[field_name] = value
+                continue
+            serialized[field_name] = KnowledgeMetadataService._serialize_metadata_value_for_response(
+                field_def.type,
+                value,
+            )
+        return serialized
 
     @staticmethod
     def get_metadata_defs_for_filtering(


### PR DESCRIPTION
## Summary

- Format document metadata values whose database field definition is `time` with an explicit UTC offset, such as `2026-06-17 16:00:00+0000`.
- Keep non-time metadata values unchanged, even if their string value looks like a timestamp.
- Reuse the existing project convention that naive database datetimes are interpreted as UTC.

## Root Cause

Document metadata responses returned stored `time` values directly from `Document.meta_data`, so frontend clients received naive datetime strings without explicit timezone information.

## Impact

Internal document metadata responses now provide timezone-explicit values for custom metadata fields defined as `time`. API Key document routes that reuse the internal controller/service path receive the same behavior. Storage format and metadata filtering behavior are unchanged.

## Validation

- `.venv/bin/python -m pytest tests/rag/test_metadata_time_response_format.py -q`
- `.venv/bin/python -m py_compile app/core/utils/datetime_utils.py app/services/knowledge_metadata_service.py`
- `git diff --check`

## Summary by Sourcery

确保在文档元数据 API 响应中，文档元数据中的时间字段以带有显式 UTC 偏移量的形式序列化，同时保持存储和过滤行为不变。

Bug Fixes:
- 将在文档元数据中被定义为 `time` 的字段，在 API 响应中格式化为带有显式 UTC 偏移量的字符串，而不是返回不带时区信息的 naive datetime 值。
- 保留非时间类型的元数据值原样返回，即使它们看起来像时间戳，也要避免被意外重新格式化。

Enhancements:
- 引入可复用的 datetime 工具，用于将 datetime 序列化为带 UTC 偏移量的字符串，并在元数据序列化中使用该工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure document metadata time fields in document metadata API responses are serialized with explicit UTC offsets while leaving storage and filtering behavior unchanged.

Bug Fixes:
- Format document metadata fields defined as `time` using explicit UTC offset strings in API responses instead of returning naive datetime values.
- Preserve non-time metadata values as-is even when they resemble timestamps, avoiding unintended reformatting.

Enhancements:
- Introduce reusable datetime utility to serialize datetimes as UTC offset strings and apply it in metadata serialization.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保在文档元数据 API 响应中，文档元数据中的时间字段以带有显式 UTC 偏移量的形式序列化，同时保持存储和过滤行为不变。

Bug Fixes:
- 将在文档元数据中被定义为 `time` 的字段，在 API 响应中格式化为带有显式 UTC 偏移量的字符串，而不是返回不带时区信息的 naive datetime 值。
- 保留非时间类型的元数据值原样返回，即使它们看起来像时间戳，也要避免被意外重新格式化。

Enhancements:
- 引入可复用的 datetime 工具，用于将 datetime 序列化为带 UTC 偏移量的字符串，并在元数据序列化中使用该工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure document metadata time fields in document metadata API responses are serialized with explicit UTC offsets while leaving storage and filtering behavior unchanged.

Bug Fixes:
- Format document metadata fields defined as `time` using explicit UTC offset strings in API responses instead of returning naive datetime values.
- Preserve non-time metadata values as-is even when they resemble timestamps, avoiding unintended reformatting.

Enhancements:
- Introduce reusable datetime utility to serialize datetimes as UTC offset strings and apply it in metadata serialization.

</details>

</details>