### PR TITLE
Fix/v0.3.8 zy

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -324,7 +324,11 @@ const DocumentDetails: FC = () => {
         return true;
       } else {
         // Insert mode: Create new chunk
-        await createDocumentChunk(knowledgeBaseId || '', documentId, { content, chunk_type: parentChunkId ? 'child' : undefined, parent_id: parentChunkId });
+        await createDocumentChunk(knowledgeBaseId || '', documentId, {
+          content,
+          chunk_type: parentChunkId ? 'child' : isParentChildMode ? 'parent' : undefined,
+          parent_id: parentChunkId
+        });
         return true;
       }
     } catch (error) {

--- a/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
+++ b/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-06-05 13:33:10 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-08 09:58:25
+ * @Last Modified time: 2026-06-17 15:08:31
  */
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -55,7 +55,7 @@ const DocumentMetadata: React.FC<DocumentMetadataProps> = ({ documentId, knowled
     const values: Record<string, any> = {}
     documentMetadataFields.map((item: MetadataField) => {
       if (item.type === 'time') {
-        values[item.name] = dayjs.tz(item.value);
+        values[item.name] = item.value ? dayjs.tz(item.value) : undefined;
       } else {
         values[item.name] = item.value;
       }

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -228,7 +228,7 @@ const RecallTestResult = ({
   }
 
   const renderChild = (children: RecallTestData[], item: RecallTestData, index: number) => {
-    if (children.length === 0) {
+    if (children.length === 0 && !editable) {
       return null;
     }
     const isExpanded = expandedChunks[`chunk_${item.metadata?.doc_id || index}`];
@@ -270,11 +270,12 @@ const RecallTestResult = ({
             >+ {t('common.add')}</span>
           }
         </Flex>
-        {isExpanded && (
+        {isExpanded && children.length > 0 && (
           <Flex vertical gap={8} className="rb:pl-3! rb:border-l-2 rb:border-l-[#155EEF]">
             {children?.map((child, childIndex) => (
               <Flex
                 key={child.metadata?.doc_id || childIndex}
+                gap={8}
                 className="rb:group rb:bg-[#c8ceda33] rb:hover:bg-[rgba(21,94,239,0.25)]"
               >
                 <Flex


### PR DESCRIPTION
## Summary by Sourcery

调整知识库文档的编辑与显示行为，以适配分块层级结构、回忆测试子项渲染，以及可选时间元数据的处理。

Bug Fixes:
- 确保在当前父子模式和选中状态下，新建文档分块会根据实际情况使用正确的父/子分块类型。
- 在非可编辑模式下，当不存在子项时，防止在回忆测试结果中渲染空的子章节，并且仅在确实存在子项时才展示展开的子列表。
- 当底层元数据值缺失时，避免用无效日期值来初始化时间类型的文档元数据字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust knowledge base document editing and display behavior for chunk hierarchy, recall test children rendering, and optional time metadata handling.

Bug Fixes:
- Ensure new document chunks are created with correct parent/child chunk type based on the current parent-child mode and selection.
- Prevent empty child sections from rendering in recall test results when there are no children in non-editable mode, and only show expanded child lists when children exist.
- Avoid initializing time-type document metadata fields with an invalid date value when the underlying metadata value is missing.

</details>