### PR TITLE
fix(web): kb time type zone

### DIFF
--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 16:34:43 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-02 16:34:43 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-06-17 17:17:56
  */
 /**
  * Format Utility
@@ -39,8 +39,6 @@ export const formatDateTime = (
 
   /** Get current timezone setting from localStorage */
   const currentTimeZone = localStorage.getItem('timeZone') || 'Asia/Shanghai';
-  dayjs.tz.setDefault(currentTimeZone);
   
-  /** Format date with current timezone */
-  return dayjs.tz(value).format(format);
+  return dayjs(value).tz(currentTimeZone).format(format);
 };

--- a/web/src/views/ApplicationConfig/Logs.tsx
+++ b/web/src/views/ApplicationConfig/Logs.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-24 15:41:20 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-26 14:30:53
+ * @Last Modified time: 2026-06-17 17:04:45
  */
 import { type FC, useRef, useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -315,7 +315,7 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
         />
         <LogDetailModal ref={logDetailRef} source={application?.type} />
       </>}
-      {isHideAnnotations && activeTab === 'annotations' && <>
+      {!isHideAnnotations && activeTab === 'annotations' && <>
         <Table<AnnotationItem>
           ref={annotationsTableRef}
           apiUrl={getAnnotationsListUrl(id || '')}

--- a/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
+++ b/web/src/views/KnowledgeBase/components/DocumentMetadata.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-06-05 13:33:10 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-17 15:08:31
+ * @Last Modified time: 2026-06-17 17:20:34
  */
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,6 +13,7 @@ import type { MetadataField } from '../types';
 import { getDocumentMetadata, updateDocumentMetadata, deleteDocumentMetadata } from '@/api/knowledgeBase';
 import MetadataFieldSelectorModal, { type MetadataFieldSelectorModalRef } from './MetadataFieldSelectorModal';
 import dayjs from 'dayjs';
+import { formatDateTime } from '@/utils/format'
 
 interface DocumentMetadataProps {
   documentId: string;
@@ -34,12 +35,21 @@ const DocumentMetadata: React.FC<DocumentMetadataProps> = ({ documentId, knowled
     setLoading(true);
     getDocumentMetadata(documentId)
       .then((res) => {
-        const response = res as {
+        const { metadata, fields } = res as {
           metadata: Record<string, any>;
           fields: MetadataField[];
         }
-        setDocumentMetadataFields(response.fields || []);
-        setDocumentMetadata(response.metadata || {});
+        const newMetadata: Record<string, any> = {}
+        Object.keys(metadata || {}).forEach(key => {
+          const filterField = fields.find(item => item.name === key);
+          if (filterField && filterField.type === 'time') {
+            newMetadata[key] = metadata[key] ? formatDateTime(metadata[key], 'YYYY-MM-DD HH:mm:ssZZ') : null;
+          } else {
+            newMetadata[key] = metadata[key];
+          }
+        })
+        setDocumentMetadataFields(fields || []);
+        setDocumentMetadata(newMetadata || {});
       })
       .finally(() => {
         setLoading(false);


### PR DESCRIPTION
## Summary by Sourcery

调整知识库元数据时间格式以尊重所选时区，并修复应用日志中批注标签页的可见性问题。

Bug 修复：
- 确保时间类型的文档元数据值使用用户选择的时区进行格式化，而不是使用全局默认时区。
- 修正控制应用日志视图中批注标签页内容可见性的条件。

增强：
- 通过共享的日期时间格式化器映射时间类型字段，以规范化文档元数据的加载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust knowledge base metadata time formatting to respect the selected timezone and fix annotations tab visibility in application logs.

Bug Fixes:
- Ensure time-type document metadata values are formatted using the user-selected timezone instead of a global default.
- Correct the condition controlling visibility of the annotations tab content in the application logs view.

Enhancements:
- Normalize document metadata loading by mapping time-type fields through a shared date-time formatter.

</details>