### PR TITLE
fix(web): kb metadata init

### DIFF
--- a/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
+++ b/web/src/views/Workflow/components/Properties/MetadataFilter/index.tsx
@@ -27,6 +27,8 @@ const MetadataFilter: FC<MetadataFilterProps> = ({
   const knowledge_bases = Form.useWatch(['knowledge_retrieval', 'knowledge_bases'], form) || [];
   const currentMode = Form.useWatch(['metadata_filter_mode'], form) || 'disabled';
   const metadata_filters = Form.useWatch(['metadata_filters'], form) || { conditions: [], logic: 'and' };
+  const isInitialized = useRef(false);
+  const prevKnowledgeBases = useRef<any[]>([]);
 
   const handleOpenModal = () => {
     metadataFilterModalRef.current?.open(metadata_filters);
@@ -48,20 +50,32 @@ const MetadataFilter: FC<MetadataFilterProps> = ({
           const conditions = metadata_filters.conditions || []
           const filterConditions = conditions.filter((item: FilterCondition) => allMetadataFields.find(f => f.name === item.field))
 
-          form.setFieldsValue({
-            metadata_filters: {
-              conditions: filterConditions,
-              logic: metadata_filters.logic
-            }
-          })
+          if (!isInitialized.current) {
+            isInitialized.current = true;
+            prevKnowledgeBases.current = knowledge_bases;
+            return;
+          }
+
+          const isKnowledgeBasesChanged = JSON.stringify(prevKnowledgeBases.current) !== JSON.stringify(knowledge_bases);
+          if (isKnowledgeBasesChanged) {
+            prevKnowledgeBases.current = knowledge_bases;
+            form.setFieldsValue({
+              metadata_filters: {
+                conditions: filterConditions,
+                logic: metadata_filters.logic
+              }
+            })
+          }
         })
     } else {
-      form.setFieldsValue({
-        metadata_filters: {
-          conditions: [],
-          logic: 'and'
-        }
-      })
+      if (isInitialized.current) {
+        form.setFieldsValue({
+          metadata_filters: {
+            conditions: [],
+            logic: 'and'
+          }
+        })
+      }
     }
   }, [knowledge_bases, metadata_filters])
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过在应用更新之前跟踪初始化状态和之前的知识库选择，防止在首次渲染时无意重置或覆盖元数据筛选器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unintended resetting or overriding of metadata filters on first render by tracking initialization state and previous knowledge base selections before applying updates.

</details>