### PR TITLE
feat(rag): support custom auto metadata filter model

### DIFF
--- a/api/app/core/rag/metadata/auto_filter_llm.py
+++ b/api/app/core/rag/metadata/auto_filter_llm.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Any
+
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
+from app.core.models import RedBearLLM, RedBearModelConfig
+from app.models.models_model import ModelApiKey, ModelConfig, ModelType
+from app.schemas.knowledge_metadata_schema import MetadataAutoFilterModelParameters
+
+logger = logging.getLogger(__name__)
+
+
+class MetadataAutoFilterLLM:
+    """RedBear LLM adapter for metadata auto filter extraction."""
+
+    def __init__(self, llm: RedBearLLM):
+        self._llm = llm
+
+    @classmethod
+    def from_model_config(
+            cls,
+            *,
+            model_config: ModelConfig,
+            api_key: ModelApiKey,
+            model_parameters: MetadataAutoFilterModelParameters | None = None,
+    ) -> "MetadataAutoFilterLLM":
+        model_type = cls._coerce_model_type(getattr(model_config, "type", None))
+        if model_type not in {ModelType.LLM, ModelType.CHAT}:
+            raise BusinessException(
+                "auto 元数据过滤模型仅支持 llm/chat 类型",
+                code=BizCode.INVALID_PARAMETER,
+            )
+
+        redbear_config = RedBearModelConfig(
+            model_name=api_key.model_name,
+            provider=cls._enum_value(getattr(model_config, "provider", None) or api_key.provider),
+            api_key=api_key.api_key,
+            base_url=api_key.api_base,
+            capability=list(getattr(model_config, "capability", None) or api_key.capability or []),
+            is_omni=cls._resolve_is_omni(model_config, api_key),
+            **cls._build_config_kwargs(model_parameters),
+        )
+        return cls(RedBearLLM(redbear_config, type=model_type))
+
+    def generate(self, *, system_prompt: str, user_prompt: str) -> str:
+        prompt = f"{system_prompt}\n\n{user_prompt}"
+        try:
+            response = self._llm.invoke(prompt)
+        except Exception:
+            logger.exception("[MetadataAutoFilter] RedBearLLM invocation failed")
+            return ""
+
+        content = getattr(response, "content", response)
+        return str(content or "").strip()
+
+    @staticmethod
+    def _build_config_kwargs(
+            model_parameters: MetadataAutoFilterModelParameters | None,
+    ) -> dict[str, Any]:
+        params = model_parameters.model_dump(exclude_none=True) if model_parameters else {}
+        raw_extra_params = params.pop("extra_params", {}) or {}
+        extra_params = dict(raw_extra_params)
+        extra_params.setdefault("temperature", 0)
+
+        config_kwargs: dict[str, Any] = {"extra_params": extra_params}
+        for key in ("deep_thinking", "json_output", "timeout", "max_retries", "concurrency"):
+            if key in params:
+                config_kwargs[key] = params[key]
+        return config_kwargs
+
+    @staticmethod
+    def _coerce_model_type(value: Any) -> ModelType:
+        if isinstance(value, ModelType):
+            return value
+        try:
+            return ModelType(str(value))
+        except ValueError as exc:
+            raise BusinessException(
+                "auto 元数据过滤模型仅支持 llm/chat 类型",
+                code=BizCode.INVALID_PARAMETER,
+            ) from exc
+
+    @staticmethod
+    def _enum_value(value: Any) -> Any:
+        return value.value if hasattr(value, "value") else value
+
+    @staticmethod
+    def _resolve_is_omni(model_config: ModelConfig, api_key: ModelApiKey) -> bool:
+        model_value = getattr(model_config, "is_omni", None)
+        if model_value is not None:
+            return bool(model_value)
+        return bool(getattr(api_key, "is_omni", False))

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -2,7 +2,12 @@ from pydantic import BaseModel, Field, model_validator
 import uuid
 from enum import StrEnum
 from app.core.rag.models.chunk import QAChunk
-from app.schemas.knowledge_metadata_schema import FilterCondition, FilterGroup, MetadataFilterMode
+from app.schemas.knowledge_metadata_schema import (
+    FilterCondition,
+    FilterGroup,
+    MetadataAutoFilterModelConfig,
+    MetadataFilterMode,
+)
 from typing import Union
 
 
@@ -108,6 +113,10 @@ class ChunkRetrieve(BaseModel):
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
     metadata_filters: list[FilterGroup] | None = Field(None, description="filter condition groups")
     metadata_filter_mode: MetadataFilterMode = Field(MetadataFilterMode.MANUAL, description="filter mode")
+    metadata_auto_filter_model: MetadataAutoFilterModelConfig | None = Field(
+        None,
+        description="auto metadata filter model configuration",
+    )
 
     @model_validator(mode="after")
     def resolve_top_n(self):

--- a/api/app/schemas/knowledge_metadata_schema.py
+++ b/api/app/schemas/knowledge_metadata_schema.py
@@ -44,6 +44,39 @@ class MetadataFilterMode(StrEnum):
     AUTO = "auto"
 
 
+class MetadataAutoFilterExtraParams(BaseModel):
+    temperature: float | None = Field(None, ge=0.0, le=2.0, description="温度参数")
+    max_tokens: int | None = Field(None, ge=1, le=32000, description="最大生成 token 数")
+    top_p: float | None = Field(None, ge=0.0, le=1.0, description="Top-p 采样参数")
+    stop: list[str] | None = Field(None, max_length=4, description="停止序列，最多 4 个")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MetadataAutoFilterModelParameters(BaseModel):
+    deep_thinking: bool | None = Field(None, description="是否启用深度思考模式")
+    json_output: bool | None = Field(None, description="是否强制 JSON 输出")
+    timeout: float | None = Field(None, gt=0, description="请求超时时间（秒）")
+    max_retries: int | None = Field(None, ge=0, description="最大重试次数")
+    concurrency: int | None = Field(None, ge=1, description="并发限制")
+    extra_params: MetadataAutoFilterExtraParams = Field(
+        default_factory=MetadataAutoFilterExtraParams,
+        description="RedBearModelConfig.extra_params 支持的 auto metadata filter 参数",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MetadataAutoFilterModelConfig(BaseModel):
+    model_config_id: uuid.UUID = Field(..., description="用于 auto 元数据过滤的模型配置 ID")
+    model_parameters: MetadataAutoFilterModelParameters = Field(
+        default_factory=MetadataAutoFilterModelParameters,
+        description="auto 元数据过滤模型参数",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 # === KnowledgeMetadata CRUD Schemas ===
 
 class KnowledgeMetadataCreate(BaseModel):

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -4,7 +4,11 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
-from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
+from app.schemas.knowledge_metadata_schema import (
+    FilterGroup,
+    MetadataAutoFilterModelConfig,
+    MetadataFilterMode,
+)
 
 
 class KnowledgeRetrievalRequest(BaseModel):
@@ -22,6 +26,7 @@ class KnowledgeRetrievalRequest(BaseModel):
     rerank_score_threshold: float | None = Field(default=None, ge=0, le=1)
     metadata_filters: list[FilterGroup] = Field(default_factory=list)
     metadata_filter_mode: MetadataFilterMode = MetadataFilterMode.MANUAL
+    metadata_auto_filter_model: MetadataAutoFilterModelConfig | None = None
 
     @field_validator("query")
     @classmethod

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -11,6 +11,7 @@ from app.core.models import RedBearRerank
 from app.core.models.base import RedBearModelConfig
 from app.core.rag.llm.chat_model import Base
 from app.core.rag.llm.embedding_model import OpenAIEmbed
+from app.core.rag.metadata.auto_filter_llm import MetadataAutoFilterLLM
 from app.core.rag.metadata.filter_engine import (
     FilterCondition as EngineFilterCondition,
     FilterGroup as EngineFilterGroup,
@@ -67,11 +68,14 @@ class KnowledgeRetrievalService:
         if not db_knowledge:
             raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
 
-        document_ids_include = cls._build_metadata_document_filter(
-            db=db,
-            request=request,
-            knowledge_ids=knowledge_ids,
-        )
+        metadata_filter_kwargs = {
+            "db": db,
+            "request": request,
+            "knowledge_ids": knowledge_ids,
+        }
+        if current_user is not None:
+            metadata_filter_kwargs["current_user"] = current_user
+        document_ids_include = cls._build_metadata_document_filter(**metadata_filter_kwargs)
         if document_ids_include == []:
             return KnowledgeRetrievalResult(chunks=[])
 
@@ -421,6 +425,7 @@ class KnowledgeRetrievalService:
             db: Session,
             request: KnowledgeRetrievalRequest,
             knowledge_ids: list[uuid.UUID],
+            current_user: Any = None,
     ) -> list[str] | None:
         if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
             return None
@@ -435,6 +440,7 @@ class KnowledgeRetrievalService:
             request=request,
             knowledge_ids=knowledge_ids,
             common_metadata_defs=common_metadata_defs,
+            current_user=current_user,
         )
         if not filter_groups:
             logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
@@ -458,6 +464,7 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             knowledge_ids: list[uuid.UUID],
             common_metadata_defs: dict[str, dict],
+            current_user: Any = None,
     ) -> list[EngineFilterGroup]:
         if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
             if not request.metadata_filters:
@@ -472,7 +479,9 @@ class KnowledgeRetrievalService:
                 return []
             llm = cls._build_metadata_auto_filter_llm(
                 db=db,
+                request=request,
                 knowledge_id=knowledge_ids[0],
+                current_user=current_user,
             )
             if not llm:
                 logger.warning("[MetadataAutoFilter] LLM is unavailable; skipping metadata filter")
@@ -492,16 +501,63 @@ class KnowledgeRetrievalService:
     def _build_metadata_auto_filter_llm(
             cls,
             db: Session,
+            request: KnowledgeRetrievalRequest,
             knowledge_id: uuid.UUID,
-    ) -> Base | None:
-        knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
-        if not knowledge or not knowledge.llm_id:
+            current_user: Any = None,
+    ) -> MetadataAutoFilterLLM | None:
+        tenant_id = getattr(current_user, "tenant_id", None) if current_user is not None else None
+        auto_filter_model = request.metadata_auto_filter_model
+
+        if auto_filter_model:
+            model_config = ModelConfigService.get_model_by_id(
+                db=db,
+                model_id=auto_filter_model.model_config_id,
+                tenant_id=tenant_id,
+            )
+            model_parameters = auto_filter_model.model_parameters
+            model_source = "custom"
+        else:
+            knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
+            if not knowledge or not knowledge.llm_id:
+                return None
+            model_config = ModelConfigService.get_model_by_id(
+                db=db,
+                model_id=knowledge.llm_id,
+                tenant_id=tenant_id,
+            )
+            model_parameters = None
+            model_source = "first_kb_fallback"
+
+        api_key = ModelApiKeyService.get_available_api_key(db, model_config.id)
+        if not api_key:
+            if auto_filter_model:
+                raise BusinessException(
+                    "auto 元数据过滤模型没有可用的 API Key",
+                    code=BizCode.AGENT_CONFIG_MISSING,
+                )
             return None
 
-        api_key = ModelApiKeyService.get_available_api_key(db, knowledge.llm_id)
-        if not api_key:
-            return None
-        return cls._build_chat_model(api_key)
+        parameter_keys, extra_parameter_keys = cls._metadata_auto_filter_parameter_keys(model_parameters)
+        logger.info(
+            "[MetadataAutoFilter] using %s model: model_config_id=%s, parameter_keys=%s, extra_parameter_keys=%s",
+            model_source,
+            model_config.id,
+            parameter_keys,
+            extra_parameter_keys,
+        )
+        return MetadataAutoFilterLLM.from_model_config(
+            model_config=model_config,
+            api_key=api_key,
+            model_parameters=model_parameters,
+        )
+
+    @staticmethod
+    def _metadata_auto_filter_parameter_keys(model_parameters: Any) -> tuple[list[str], list[str]]:
+        if not model_parameters:
+            return [], []
+        params = model_parameters.model_dump(exclude_none=True)
+        extra_params = params.pop("extra_params", {}) or {}
+        return sorted(params.keys()), sorted(extra_params.keys())
 
     @staticmethod
     def _get_common_metadata_defs(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> dict[str, dict]:

--- a/api/app/services/metadata_auto_filter_service.py
+++ b/api/app/services/metadata_auto_filter_service.py
@@ -104,10 +104,18 @@ class MetadataAutoFilterService:
             "You are a text metadata extract engine. Extract only metadata filters that are clearly "
             "present in the user's input and only use fields from the provided metadata list."
         )
+        user_prompt = cls._build_prompt(query=query, metadata_defs=metadata_defs)
+        if hasattr(llm, "generate"):
+            content = llm.generate(system_prompt=system_prompt, user_prompt=user_prompt)
+            if not content:
+                logger.warning("[MetadataAutoFilter] LLM returned no usable content")
+                return []
+            return cls._parse_llm_response(str(content))
+
         history = [
             {
                 "role": "user",
-                "content": cls._build_prompt(query=query, metadata_defs=metadata_defs),
+                "content": user_prompt,
             }
         ]
         response = llm.chat(

--- a/api/app/services/metadata_auto_filter_service.py
+++ b/api/app/services/metadata_auto_filter_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from typing import Any
@@ -78,12 +79,23 @@ class MetadataAutoFilterService:
             metadata_defs=metadata_defs,
             llm=llm,
         )
+        logger.info(
+            "[MetadataAutoFilter] generated candidate conditions: candidate_count=%s, conditions=%s",
+            len(raw_conditions),
+            cls._summarize_raw_conditions(raw_conditions),
+        )
         conditions = []
         for raw_condition in raw_conditions:
             condition = cls._normalize_condition(raw_condition, metadata_defs)
             if condition:
                 conditions.append(condition)
 
+        logger.info(
+            "[MetadataAutoFilter] generated normalized conditions: valid_count=%s, candidate_count=%s, conditions=%s",
+            len(conditions),
+            len(raw_conditions),
+            cls._summarize_normalized_conditions(conditions),
+        )
         logger.info(
             "[MetadataAutoFilter] extracted %s valid conditions from %s candidates",
             len(conditions),
@@ -268,6 +280,54 @@ class MetadataAutoFilterService:
         except ValueError:
             return _InvalidValue
         return value.strip()
+
+    @classmethod
+    def _summarize_raw_conditions(cls, raw_conditions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "field": cls._get_first_present(raw_condition, ("metadata_field_name", "field", "name")),
+                "operator": cls._get_first_present(raw_condition, ("comparison_operator", "operator")),
+                "value": cls._summarize_value_for_log(
+                    cls._get_first_present(raw_condition, ("metadata_field_value", "value"))
+                ),
+            }
+            for raw_condition in raw_conditions
+        ]
+
+    @classmethod
+    def _summarize_normalized_conditions(
+        cls,
+        conditions: list[EngineFilterCondition],
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "field": condition.field,
+                "operator": condition.operator,
+                "value": cls._summarize_value_for_log(condition.value),
+            }
+            for condition in conditions
+        ]
+
+    @staticmethod
+    def _summarize_value_for_log(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(value, str):
+            return {
+                "type": "string",
+                "length": len(value),
+                "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest()[:12],
+            }
+        if isinstance(value, (list, tuple, set)):
+            return {
+                "type": type(value).__name__,
+                "length": len(value),
+            }
+        return {"type": type(value).__name__}
 
 
 _InvalidValue = object()


### PR DESCRIPTION
## Summary
- Support selecting a custom workspace model for auto metadata filtering while keeping the first-knowledge-base model fallback.
- Add a RedBearLLM-backed metadata auto-filter adapter and pass supported model parameters from RedBearModelConfig-shaped request data.
- Add info logs for generated candidate conditions and normalized valid conditions, with safe value summaries for easier testing.

## Changes
```
 api/app/core/rag/metadata/auto_filter_llm.py     | 92 ++++++++++++++++++++++++
 api/app/schemas/chunk_schema.py                  | 11 ++-
 api/app/schemas/knowledge_metadata_schema.py     | 33 +++++++++
 api/app/schemas/knowledge_retrieval_schema.py    |  7 +-
 api/app/services/knowledge_retrieval_service.py  | 78 +++++++++++++++++---
 api/app/services/metadata_auto_filter_service.py | 70 +++++++++++++++++-
 6 files changed, 277 insertions(+), 14 deletions(-)
```

## API Impact
- Adds an optional `metadata_auto_filter_model` request field for retrieval auto metadata filtering; existing requests remain compatible.
- No new external API route is exposed.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/python /tmp/test_metadata_auto_filter_logging.py`
- [x] `PYTHONPATH=. .venv/bin/python -m py_compile app/schemas/knowledge_metadata_schema.py app/schemas/knowledge_retrieval_schema.py app/schemas/chunk_schema.py app/services/metadata_auto_filter_service.py app/services/knowledge_retrieval_service.py app/core/rag/metadata/auto_filter_llm.py`
- [x] `git diff --check origin/develop..HEAD`
- [ ] `PYTHONPATH=. .venv/bin/pytest tests/rag -q` currently fails in local untracked `tests/rag/test_metadata_time_response_format.py`: expected `2026-06-17 16:00:00+0000`, got `2026-06-17 16:00:00`; this is outside this PR changed-file set.

## Summary by Sourcery

为知识检索中的自动元数据过滤添加可配置的 LLM 支持，包括一个 RedBearLLM 适配器，以及更丰富的生成过滤条件日志。

New Features:
- 允许检索请求为自动元数据过滤指定自定义模型配置，并在工作区范围内进行校验。
- 引入基于 RedBearLLM 的适配器，专门用于在结构化模型参数下运行元数据自动过滤提取。

Enhancements:
- 扩展知识检索，将当前用户上下文传入元数据自动过滤模型的解析与键查找过程。
- 为自动元数据过滤模型配置和参数添加结构化请求模式（schema），并在检索和分片（chunk）API 中复用。
- 增强元数据自动过滤服务，支持简单的 generate 风格 LLM 接口，并为候选与规范化过滤条件添加安全、摘要化的日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable LLM support for automatic metadata filtering in knowledge retrieval, including a RedBearLLM adapter and richer logging of generated filter conditions.

New Features:
- Allow retrieval requests to specify a custom model configuration for automatic metadata filtering with workspace-scoped validation.
- Introduce a RedBearLLM-based adapter dedicated to running metadata auto-filter extraction with structured model parameters.

Enhancements:
- Extend knowledge retrieval to pass current user context into metadata auto-filter model resolution and key lookup.
- Add structured request schemas for auto metadata filter model configuration and parameters, reusing them in both retrieval and chunk APIs.
- Enhance metadata auto-filter service with support for a simple generate-style LLM interface and add safe, summarized logging of candidate and normalized filter conditions.

</details>