### PR TITLE
fix(web): parent child mode

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -504,6 +504,7 @@ const DocumentDetails: FC = () => {
             parserMode={parserMode}
             handleCopy={handleCopy}
             handleInsert={handleInsert}
+            isParentChildMode={isParentChildMode}
           />
         </div>
       </div>

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -33,6 +33,7 @@ interface RecallTestResultProps {
   parserMode?: number; // Parser mode, 1 means QA format
   handleCopy?: (text?: string) => void;
   handleInsert?: (parentChunkId?: string) => void;
+  isParentChildMode?: boolean | string;
 }
 
 const RecallTestResult = ({ 
@@ -48,7 +49,8 @@ const RecallTestResult = ({
   onItemClick,
   parserMode = 0,
   handleCopy,
-  handleInsert
+  handleInsert,
+  isParentChildMode
 }: RecallTestResultProps) => {
   const { t } = useTranslation();
   const { modal, message } = App.useApp()
@@ -228,7 +230,7 @@ const RecallTestResult = ({
   }
 
   const renderChild = (children: RecallTestData[], item: RecallTestData, index: number) => {
-    if (children.length === 0 && !editable) {
+    if (children.length === 0 && !editable || !isParentChildMode) {
       return null;
     }
     const isExpanded = expandedChunks[`chunk_${item.metadata?.doc_id || index}`];


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当父子模式被禁用时，防止子回忆测试项被渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent child recall test items from rendering when parent-child mode is disabled.

</details>