### PR TITLE
Feat/edge groups and content filter

### DIFF
--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -73,6 +73,32 @@ class GraphStatistics(BaseModel):
     )
 
 
+class GraphEdgeGroup(BaseModel):
+    """同一对节点之间的多边聚合（含双向）。
+
+    仅当两个节点间存在 ``>= 2`` 条边（无论方向）时，才会出现在响应的
+    ``edge_groups`` 数组中。``node_a`` / ``node_b`` 取两端 elementId 的字典序
+    升序，保证同一对节点对应唯一的分组——不论 Cypher 返回顺序如何，前端
+    都能用 ``(node_a, node_b)`` 作为稳定 key。
+
+    自环（``source == target``）不会构成分组。
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    node_a: str = Field(..., description="按 elementId 字典序较小的端点")
+    node_b: str = Field(..., description="按 elementId 字典序较大的端点")
+    total: int = Field(..., ge=2, description="本组涵盖的边总数（双向合计），最少 2")
+    a_to_b: List[str] = Field(
+        default_factory=list,
+        description="source=node_a, target=node_b 的边 id 列表；按 edges 中出现顺序",
+    )
+    b_to_a: List[str] = Field(
+        default_factory=list,
+        description="source=node_b, target=node_a 的边 id 列表；按 edges 中出现顺序",
+    )
+
+
 class GraphDataResponse(BaseModel):
     """``analytics_graph_data`` 的返回结构。controller 仍包一层 ApiResponse。"""
 
@@ -80,6 +106,13 @@ class GraphDataResponse(BaseModel):
 
     nodes: List[GraphNode] = Field(default_factory=list)
     edges: List[GraphEdge] = Field(default_factory=list)
+    edge_groups: List[GraphEdgeGroup] = Field(
+        default_factory=list,
+        description=(
+            "同一对节点之间存在多条边（双向合计 >= 2）的聚合视图。"
+            "便于前端在重边场景渲染聚合标签或多边弧线。"
+        ),
+    )
     statistics: GraphStatistics = Field(
         default_factory=GraphStatistics,
         description="节点/边统计信息，包含旧字段与新增 per_type",

--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -3,9 +3,16 @@
 所有模型均为 Pydantic v2，统一使用 ``ConfigDict(extra="ignore")`` 静默丢弃多余字段，
 以保证后端在装配响应或前端在反序列化时都能向后兼容（Requirement 3.1 / 7.4）。
 """
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# 边类型枚举
+# ---------------------------------------------------------------------------
+
+EdgeType = Literal["SINGLE", "UNIDIRECTIONAL_MULTI", "BIDIRECTIONAL", "MULTI_BIDIRECTIONAL"]
 
 
 class GraphNode(BaseModel):
@@ -20,23 +27,6 @@ class GraphNode(BaseModel):
         description="按 NODE_PROPERTY_WHITELIST 过滤后的属性 + associative_memory 计数",
     )
     caption: str = Field(..., description="前端展示文案；优先取 properties.caption，否则取 label")
-
-
-class GraphEdge(BaseModel):
-    """单条边的展示形态。两端节点必定都在响应 nodes 数组中。"""
-
-    model_config = ConfigDict(extra="ignore")
-
-    id: str = Field(..., description="Neo4j 关系 elementId")
-    source: str = Field(..., description="起点节点 elementId")
-    target: str = Field(..., description="终点节点 elementId")
-    type: str = Field(..., description="关系类型（type(r)）")
-    properties: Dict[str, Any] = Field(default_factory=dict, description="关系属性")
-    caption: str = Field(..., description="前端展示文案，缺省时由 service 层填充关系类型")
-    predicate_description: Optional[str] = Field(
-        default=None,
-        description="关系描述，仅在 EXTRACTED_RELATIONSHIP 等关系类型上存在",
-    )
 
 
 class PerTypeStat(BaseModel):
@@ -78,12 +68,18 @@ class GraphStatistics(BaseModel):
 
 
 class EdgeGroupItem(BaseModel):
-    """edge_groups 中 a_to_b / b_to_a 的边条目，携带边类型和关系描述。"""
+    """a_to_b / b_to_a 中的单条边条目，携带边类型和关系描述。"""
 
     model_config = ConfigDict(extra="ignore")
 
     id: str = Field(..., description="边 elementId")
     type: str = Field(..., description="关系类型")
+    created_at: Optional[str] = Field(
+        default=None, description="关系创建时间 (ISO 8601)"
+    )
+    valid_at: Optional[str] = Field(
+        default=None, description="关系有效期 (ISO 8601)"
+    )
     predicate: Optional[str] = Field(
         default=None, description="关系谓词"
     )
@@ -95,37 +91,40 @@ class EdgeGroupItem(BaseModel):
     )
 
 
-class GraphEdgeGroup(BaseModel):
-    """同一对节点之间的多边聚合（含双向）。
+class UnifiedEdge(BaseModel):
+    """统一的边条目——合并了原 edges 和 edge_groups。
 
-    仅当两个节点间存在 ``>= 2`` 条边（无论方向）时，才会出现在响应的
-    ``edge_groups`` 数组中。``node_a`` / ``node_b`` 取两端 elementId 的字典序
-    升序，保证同一对节点对应唯一的分组——不论 Cypher 返回顺序如何，前端
-    都能用 ``(node_a, node_b)`` 作为稳定 key。
+    所有边（无论单边还是重边聚合组）都使用此结构：
 
-    自环（``source == target``）不会构成分组。
+    - ``node_a`` / ``node_b`` 始终按 elementId 字典序排序，保证同一对节点对
+      应的条目唯一。
+    - 方向信息由 ``a_to_b``（node_a → node_b）和 ``b_to_a``（node_b → node_a）
+      两个桶承载。
+    - ``edge_type`` 枚举区分四种类型：
+        * SINGLE：该对节点间仅 1 条边；
+        * UNIDIRECTIONAL_MULTI：>=2 条边，所有边指向同一方向；
+        * BIDIRECTIONAL：恰好 2 条边，双向各 1 条；
+        * MULTI_BIDIRECTIONAL：>=3 条边，两个方向均有。
+
+    自环（source == target）不会创建条目。
     """
 
     model_config = ConfigDict(extra="ignore")
 
     node_a: str = Field(..., description="按 elementId 字典序较小的端点")
     node_b: str = Field(..., description="按 elementId 字典序较大的端点")
-    total: int = Field(..., ge=2, description="本组涵盖的边总数（双向合计），最少 2")
-    edge_type: Optional[str] = Field(
-        default=None,
-        description=(
-            "边的种类：'单向多维边'（复数边指向同一方向）、"
-            "'双向边'（恰好 2 条边双向各一）、"
-            "'双向多维边'（>=3 条边且双向均有）"
-        ),
+    total: int = Field(..., ge=1, description="本组涵盖的边总数，最少 1")
+    edge_type: EdgeType = Field(
+        ...,
+        description="边类型：SINGLE | UNIDIRECTIONAL_MULTI | BIDIRECTIONAL | MULTI_BIDIRECTIONAL",
     )
     a_to_b: List[EdgeGroupItem] = Field(
         default_factory=list,
-        description="source=node_a, target=node_b 的边列表；按 edges 中出现顺序",
+        description="source=node_a, target=node_b 的边列表",
     )
     b_to_a: List[EdgeGroupItem] = Field(
         default_factory=list,
-        description="source=node_b, target=node_a 的边列表；按 edges 中出现顺序",
+        description="source=node_b, target=node_a 的边列表",
     )
 
 
@@ -135,13 +134,9 @@ class GraphDataResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     nodes: List[GraphNode] = Field(default_factory=list)
-    edges: List[GraphEdge] = Field(default_factory=list)
-    edge_groups: List[GraphEdgeGroup] = Field(
+    edges: List[UnifiedEdge] = Field(
         default_factory=list,
-        description=(
-            "同一对节点之间存在多条边（双向合计 >= 2）的聚合视图。"
-            "便于前端在重边场景渲染聚合标签或多边弧线。"
-        ),
+        description="统一的边列表。所有边（单边和重边聚合组）均以此结构表示，通过 edge_type 区分类型。",
     )
     statistics: GraphStatistics = Field(
         default_factory=GraphStatistics,

--- a/api/app/schemas/graph_data_schema.py
+++ b/api/app/schemas/graph_data_schema.py
@@ -33,6 +33,10 @@ class GraphEdge(BaseModel):
     type: str = Field(..., description="关系类型（type(r)）")
     properties: Dict[str, Any] = Field(default_factory=dict, description="关系属性")
     caption: str = Field(..., description="前端展示文案，缺省时由 service 层填充关系类型")
+    predicate_description: Optional[str] = Field(
+        default=None,
+        description="关系描述，仅在 EXTRACTED_RELATIONSHIP 等关系类型上存在",
+    )
 
 
 class PerTypeStat(BaseModel):
@@ -73,6 +77,24 @@ class GraphStatistics(BaseModel):
     )
 
 
+class EdgeGroupItem(BaseModel):
+    """edge_groups 中 a_to_b / b_to_a 的边条目，携带边类型和关系描述。"""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., description="边 elementId")
+    type: str = Field(..., description="关系类型")
+    predicate: Optional[str] = Field(
+        default=None, description="关系谓词"
+    )
+    predicate_surface: Optional[str] = Field(
+        default=None, description="关系原文表述"
+    )
+    predicate_description: Optional[str] = Field(
+        default=None, description="关系描述"
+    )
+
+
 class GraphEdgeGroup(BaseModel):
     """同一对节点之间的多边聚合（含双向）。
 
@@ -89,13 +111,21 @@ class GraphEdgeGroup(BaseModel):
     node_a: str = Field(..., description="按 elementId 字典序较小的端点")
     node_b: str = Field(..., description="按 elementId 字典序较大的端点")
     total: int = Field(..., ge=2, description="本组涵盖的边总数（双向合计），最少 2")
-    a_to_b: List[str] = Field(
-        default_factory=list,
-        description="source=node_a, target=node_b 的边 id 列表；按 edges 中出现顺序",
+    edge_type: Optional[str] = Field(
+        default=None,
+        description=(
+            "边的种类：'单向多维边'（复数边指向同一方向）、"
+            "'双向边'（恰好 2 条边双向各一）、"
+            "'双向多维边'（>=3 条边且双向均有）"
+        ),
     )
-    b_to_a: List[str] = Field(
+    a_to_b: List[EdgeGroupItem] = Field(
         default_factory=list,
-        description="source=node_b, target=node_a 的边 id 列表；按 edges 中出现顺序",
+        description="source=node_a, target=node_b 的边列表；按 edges 中出现顺序",
+    )
+    b_to_a: List[EdgeGroupItem] = Field(
+        default_factory=list,
+        description="source=node_b, target=node_a 的边列表；按 edges 中出现顺序",
     )
 
 

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -42,6 +42,7 @@ __all__ = [
     "compute_stat_types",
     "assemble_per_type_stat",
     "assemble_center_per_type_stat",
+    "build_edge_groups",
     # Neo4j 查询封装
     "query_nodes_by_type_limits",
     "query_rel_count_batch",
@@ -438,6 +439,79 @@ def assemble_center_per_type_stat(
             "truncated": truncated,
         }
     return per_type_stat
+
+
+def build_edge_groups(
+    edges: Iterable[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """聚合「同一对节点之间的多条边」并按方向分桶（纯逻辑）。
+
+    业务背景：``EXTRACTED_RELATIONSHIP`` 等关系常常出现在同一对实体之间多次，
+    例如 (A)-[:关联于 {predicate_surface: 女朋友}]->(B) 与
+    (A)-[:关联于 {predicate_surface: 给…过生日}]->(B)。这些边在顶层 ``edges``
+    数组中是平铺的；前端如果想呈现「重边」效果，需要自己做一次 O(N) 聚合。
+    本函数把这部分逻辑下沉到后端，输出与方向无关的稳定分组。
+    
+    Args:
+        edges: 已经装配好的响应边列表。每项至少含 ``id`` / ``source`` /
+            ``target`` 三个字符串键；其它字段（type / properties / caption）
+            本函数不读取，由调用方维护。
+
+    Returns:
+        ``edge_groups`` 字段对应的列表。每个元素形如::
+
+            {
+                "node_a": "A",
+                "node_b": "B",
+                "total": 3,
+                "a_to_b": ["e1", "e3"],
+                "b_to_a": ["e2"],
+            }
+
+        当不存在任何重边对时返回 ``[]``。
+    """
+    # 用 dict 收口，键 = (node_a, node_b) 元组（已字典序排序）。
+    # 值同时记录两个方向的边 id 列表，避免二次遍历。
+    groups: Dict[Tuple[str, str], Dict[str, List[str]]] = {}
+
+    for edge in edges:
+        edge_id = edge.get("id")
+        source = edge.get("source")
+        target = edge.get("target")
+        if not edge_id or not source or not target:
+            continue
+        if source == target:
+            # 自环不属于「双向重边」语义，跳过。
+            continue
+
+        if source < target:
+            node_a, node_b = source, target
+            direction = "a_to_b"
+        else:
+            node_a, node_b = target, source
+            # source > target 时，原边实际是 b_to_a 方向。
+            direction = "b_to_a"
+
+        bucket = groups.get((node_a, node_b))
+        if bucket is None:
+            bucket = {"a_to_b": [], "b_to_a": []}
+            groups[(node_a, node_b)] = bucket
+        bucket[direction].append(edge_id)
+
+    result: List[Dict[str, Any]] = []
+    for (node_a, node_b), bucket in sorted(groups.items()):
+        total = len(bucket["a_to_b"]) + len(bucket["b_to_a"])
+        if total < 2:
+            # 单边对不进 edge_groups；它已经在顶层 edges 中，前端无需再聚合。
+            continue
+        result.append({
+            "node_a": node_a,
+            "node_b": node_b,
+            "total": total,
+            "a_to_b": bucket["a_to_b"],
+            "b_to_a": bucket["b_to_a"],
+        })
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -10,7 +10,7 @@ Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 6.1, 6.3, 6.4,
 import logging
 import math
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from app.core.memory.constants.graph_data_constants import (
     DEFAULT_PER_TYPE_LIMIT_MAP,
@@ -443,7 +443,7 @@ def assemble_center_per_type_stat(
 
 def build_edge_groups(
     edges: Iterable[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
+) -> Tuple[List[Dict[str, Any]], Set[str]]:
     """聚合「同一对节点之间的多条边」并按方向分桶（纯逻辑）。
 
     业务背景：``EXTRACTED_RELATIONSHIP`` 等关系常常出现在同一对实体之间多次，
@@ -454,25 +454,36 @@ def build_edge_groups(
     
     Args:
         edges: 已经装配好的响应边列表。每项至少含 ``id`` / ``source`` /
-            ``target`` 三个字符串键；其它字段（type / properties / caption）
-            本函数不读取，由调用方维护。
+            ``target`` 三个字符串键；还会读取 ``type`` / ``properties``
+            以填充 edge_groups 中的边对象。
+
+    说明：仅聚合 ``type == "EXTRACTED_RELATIONSHIP"`` 的边（实体间语义关系），
+    其他边类型（如 REFERENCES_ENTITY）不参与聚合。
 
     Returns:
-        ``edge_groups`` 字段对应的列表。每个元素形如::
+        ``(edge_groups, grouped_edge_ids)`` 二元组：
+        - ``edge_groups``: 聚合后的分组列表，每个元素形如::
 
             {
                 "node_a": "A",
                 "node_b": "B",
                 "total": 3,
-                "a_to_b": ["e1", "e3"],
-                "b_to_a": ["e2"],
+                "edge_type": "双向多维边",
+                "a_to_b": [
+                    {"id": "e1", "type": "EXTRACTED_RELATIONSHIP", "predicate": "相关于", "predicate_surface": "和...有关", "predicate_description": "表达实体间的相关关系"},
+                    ...
+                ],
+                "b_to_a": [...],
             }
 
-        当不存在任何重边对时返回 ``[]``。
+        - ``grouped_edge_ids``: 已被聚合的边 id 集合，调用方应从 ``edges``
+          中剔除这些边，避免与 ``edge_groups`` 重复。
+
+        当不存在任何重边对时返回 ``([], set())``。
     """
     # 用 dict 收口，键 = (node_a, node_b) 元组（已字典序排序）。
-    # 值同时记录两个方向的边 id 列表，避免二次遍历。
-    groups: Dict[Tuple[str, str], Dict[str, List[str]]] = {}
+    # 值同时记录两个方向的边对象列表（含 id/type/predicate_description）。
+    groups: Dict[Tuple[str, str], Dict[str, List[Dict[str, Any]]]] = {}
 
     for edge in edges:
         edge_id = edge.get("id")
@@ -483,6 +494,20 @@ def build_edge_groups(
         if source == target:
             # 自环不属于「双向重边」语义，跳过。
             continue
+
+        # 仅聚合 EXTRACTED_RELATIONSHIP 类型的边
+        rel_type = edge.get("type", "")
+        if rel_type != "EXTRACTED_RELATIONSHIP":
+            continue
+
+        edge_props = edge.get("properties") or {}
+        edge_item = {
+            "id": edge_id,
+            "type": rel_type,
+            "predicate": edge_props.get("predicate"),
+            "predicate_surface": edge_props.get("predicate_surface"),
+            "predicate_description": edge.get("predicate_description"),
+        }
 
         if source < target:
             node_a, node_b = source, target
@@ -496,22 +521,41 @@ def build_edge_groups(
         if bucket is None:
             bucket = {"a_to_b": [], "b_to_a": []}
             groups[(node_a, node_b)] = bucket
-        bucket[direction].append(edge_id)
+        bucket[direction].append(edge_item)
 
     result: List[Dict[str, Any]] = []
+    grouped_edge_ids: Set[str] = set()
     for (node_a, node_b), bucket in sorted(groups.items()):
-        total = len(bucket["a_to_b"]) + len(bucket["b_to_a"])
+        a_to_b_count = len(bucket["a_to_b"])
+        b_to_a_count = len(bucket["b_to_a"])
+        total = a_to_b_count + b_to_a_count
         if total < 2:
             # 单边对不进 edge_groups；它已经在顶层 edges 中，前端无需再聚合。
             continue
+
+        # 收集被聚合的边 id
+        for item in bucket["a_to_b"]:
+            grouped_edge_ids.add(item["id"])
+        for item in bucket["b_to_a"]:
+            grouped_edge_ids.add(item["id"])
+
+        # 计算 edge_type
+        if total == 2 and a_to_b_count == 1 and b_to_a_count == 1:
+            edge_type = "双向边"
+        elif a_to_b_count > 0 and b_to_a_count > 0:
+            edge_type = "双向多维边"
+        else:
+            edge_type = "单向多维边"
+
         result.append({
             "node_a": node_a,
             "node_b": node_b,
             "total": total,
+            "edge_type": edge_type,
             "a_to_b": bucket["a_to_b"],
             "b_to_a": bucket["b_to_a"],
         })
-    return result
+    return result, grouped_edge_ids
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/_graph_data_helpers.py
+++ b/api/app/services/_graph_data_helpers.py
@@ -10,7 +10,7 @@ Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 6.1, 6.3, 6.4,
 import logging
 import math
 from logging import Logger
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from app.core.memory.constants.graph_data_constants import (
     DEFAULT_PER_TYPE_LIMIT_MAP,
@@ -42,7 +42,7 @@ __all__ = [
     "compute_stat_types",
     "assemble_per_type_stat",
     "assemble_center_per_type_stat",
-    "build_edge_groups",
+    "build_unified_edges",
     # Neo4j 查询封装
     "query_nodes_by_type_limits",
     "query_rel_count_batch",
@@ -441,49 +441,72 @@ def assemble_center_per_type_stat(
     return per_type_stat
 
 
-def build_edge_groups(
-    edges: Iterable[Dict[str, Any]],
-) -> Tuple[List[Dict[str, Any]], Set[str]]:
-    """聚合「同一对节点之间的多条边」并按方向分桶（纯逻辑）。
+def _make_edge_item(edge: Dict[str, Any]) -> Dict[str, Any]:
+    """从原始边 dict 构造 EdgeGroupItem 风格的边条目。"""
+    edge_props = edge.get("properties") or {}
+    rel_type = edge.get("type", "")
+    item: Dict[str, Any] = {
+        "id": edge.get("id"),
+        "type": rel_type,
+    }
+    created_at = edge_props.get("created_at")
+    valid_at = edge_props.get("valid_at")
+    if created_at is not None:
+        item["created_at"] = created_at
+    if valid_at is not None:
+        item["valid_at"] = valid_at
+    if rel_type == "EXTRACTED_RELATIONSHIP":
+        item["predicate"] = edge_props.get("predicate")
+        item["predicate_surface"] = edge_props.get("predicate_surface")
+        item["predicate_description"] = edge.get("predicate_description")
+    return item
 
-    业务背景：``EXTRACTED_RELATIONSHIP`` 等关系常常出现在同一对实体之间多次，
-    例如 (A)-[:关联于 {predicate_surface: 女朋友}]->(B) 与
-    (A)-[:关联于 {predicate_surface: 给…过生日}]->(B)。这些边在顶层 ``edges``
-    数组中是平铺的；前端如果想呈现「重边」效果，需要自己做一次 O(N) 聚合。
-    本函数把这部分逻辑下沉到后端，输出与方向无关的稳定分组。
+
+def _classify_edge_type(a_to_b_count: int, b_to_a_count: int) -> str:
+    """根据双向桶中的边数判定边类型。"""
+    total = a_to_b_count + b_to_a_count
+    if total == 1:
+        return "SINGLE"
+    if total == 2 and a_to_b_count == 1 and b_to_a_count == 1:
+        return "BIDIRECTIONAL"
+    if a_to_b_count > 0 and b_to_a_count > 0:
+        return "MULTI_BIDIRECTIONAL"
+    return "UNIDIRECTIONAL_MULTI"
+
+
+def build_unified_edges(
+    edges: Iterable[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """将所有边统一为 UnifiedEdge 列表（纯逻辑）。
+
+    合并了原 ``edges`` 与 ``edge_groups`` 的二分结构：
     
+    - ``EXTRACTED_RELATIONSHIP`` 类型的边按 ``(node_a, node_b)`` 聚合分组，
+      根据双向桶中的边数产出 ``SINGLE`` / ``UNIDIRECTIONAL_MULTI`` /
+      ``BIDIRECTIONAL`` / ``MULTI_BIDIRECTIONAL`` 条目。
+    - 其他边类型（如 ``REFERENCES_ENTITY``、``PRUNED_TO`` 等）各自生成
+      独立的 ``SINGLE`` 条目。
+    - 自环（``source == target``）直接跳过。
+
     Args:
         edges: 已经装配好的响应边列表。每项至少含 ``id`` / ``source`` /
-            ``target`` 三个字符串键；还会读取 ``type`` / ``properties``
-            以填充 edge_groups 中的边对象。
-
-    说明：仅聚合 ``type == "EXTRACTED_RELATIONSHIP"`` 的边（实体间语义关系），
-    其他边类型（如 REFERENCES_ENTITY）不参与聚合。
+            ``target`` / ``type`` 字符串键。
 
     Returns:
-        ``(edge_groups, grouped_edge_ids)`` 二元组：
-        - ``edge_groups``: 聚合后的分组列表，每个元素形如::
+        统一边列表，每项形如::
 
             {
                 "node_a": "A",
                 "node_b": "B",
-                "total": 3,
-                "edge_type": "双向多维边",
-                "a_to_b": [
-                    {"id": "e1", "type": "EXTRACTED_RELATIONSHIP", "predicate": "相关于", "predicate_surface": "和...有关", "predicate_description": "表达实体间的相关关系"},
-                    ...
-                ],
-                "b_to_a": [...],
+                "total": 1,
+                "edge_type": "SINGLE",
+                "a_to_b": [{"id": "e1", "type": "REFERENCES_ENTITY"}],
+                "b_to_a": [],
             }
-
-        - ``grouped_edge_ids``: 已被聚合的边 id 集合，调用方应从 ``edges``
-          中剔除这些边，避免与 ``edge_groups`` 重复。
-
-        当不存在任何重边对时返回 ``([], set())``。
     """
-    # 用 dict 收口，键 = (node_a, node_b) 元组（已字典序排序）。
-    # 值同时记录两个方向的边对象列表（含 id/type/predicate_description）。
-    groups: Dict[Tuple[str, str], Dict[str, List[Dict[str, Any]]]] = {}
+    # 分两路处理：EXTRACTED_RELATIONSHIP 边聚合分组，其他边各成独立条目。
+    relationship_groups: Dict[Tuple[str, str], Dict[str, List[Dict[str, Any]]]] = {}
+    standalone_items: List[Dict[str, Any]] = []
 
     for edge in edges:
         edge_id = edge.get("id")
@@ -492,70 +515,63 @@ def build_edge_groups(
         if not edge_id or not source or not target:
             continue
         if source == target:
-            # 自环不属于「双向重边」语义，跳过。
             continue
 
-        # 仅聚合 EXTRACTED_RELATIONSHIP 类型的边
         rel_type = edge.get("type", "")
-        if rel_type != "EXTRACTED_RELATIONSHIP":
-            continue
-
-        edge_props = edge.get("properties") or {}
-        edge_item = {
-            "id": edge_id,
-            "type": rel_type,
-            "predicate": edge_props.get("predicate"),
-            "predicate_surface": edge_props.get("predicate_surface"),
-            "predicate_description": edge.get("predicate_description"),
-        }
+        edge_item = _make_edge_item(edge)
 
         if source < target:
             node_a, node_b = source, target
             direction = "a_to_b"
         else:
             node_a, node_b = target, source
-            # source > target 时，原边实际是 b_to_a 方向。
             direction = "b_to_a"
 
-        bucket = groups.get((node_a, node_b))
-        if bucket is None:
-            bucket = {"a_to_b": [], "b_to_a": []}
-            groups[(node_a, node_b)] = bucket
-        bucket[direction].append(edge_item)
+        if rel_type == "EXTRACTED_RELATIONSHIP":
+            bucket = relationship_groups.get((node_a, node_b))
+            if bucket is None:
+                bucket = {"a_to_b": [], "b_to_a": []}
+                relationship_groups[(node_a, node_b)] = bucket
+            bucket[direction].append(edge_item)
+        else:
+            standalone_items.append({
+                "node_a": node_a,
+                "node_b": node_b,
+                "edge_item": edge_item,
+                "direction": direction,
+            })
 
     result: List[Dict[str, Any]] = []
-    grouped_edge_ids: Set[str] = set()
-    for (node_a, node_b), bucket in sorted(groups.items()):
+
+    # 处理 EXTRACTED_RELATIONSHIP 分组
+    for (node_a, node_b), bucket in sorted(relationship_groups.items()):
         a_to_b_count = len(bucket["a_to_b"])
         b_to_a_count = len(bucket["b_to_a"])
-        total = a_to_b_count + b_to_a_count
-        if total < 2:
-            # 单边对不进 edge_groups；它已经在顶层 edges 中，前端无需再聚合。
-            continue
-
-        # 收集被聚合的边 id
-        for item in bucket["a_to_b"]:
-            grouped_edge_ids.add(item["id"])
-        for item in bucket["b_to_a"]:
-            grouped_edge_ids.add(item["id"])
-
-        # 计算 edge_type
-        if total == 2 and a_to_b_count == 1 and b_to_a_count == 1:
-            edge_type = "双向边"
-        elif a_to_b_count > 0 and b_to_a_count > 0:
-            edge_type = "双向多维边"
-        else:
-            edge_type = "单向多维边"
-
+        edge_type = _classify_edge_type(a_to_b_count, b_to_a_count)
         result.append({
             "node_a": node_a,
             "node_b": node_b,
-            "total": total,
+            "total": a_to_b_count + b_to_a_count,
             "edge_type": edge_type,
             "a_to_b": bucket["a_to_b"],
             "b_to_a": bucket["b_to_a"],
         })
-    return result, grouped_edge_ids
+
+    # 处理非 EXTRACTED_RELATIONSHIP 的独立边
+    for item in standalone_items:
+        direction = item["direction"]
+        a_to_b = [item["edge_item"]] if direction == "a_to_b" else []
+        b_to_a = [item["edge_item"]] if direction == "b_to_a" else []
+        result.append({
+            "node_a": item["node_a"],
+            "node_b": item["node_b"],
+            "total": 1,
+            "edge_type": "SINGLE",
+            "a_to_b": a_to_b,
+            "b_to_a": b_to_a,
+        })
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -1764,7 +1764,10 @@ async def analytics_graph_data(
         edges, edge_type_counts = await _format_edges(node_ids)
 
         # 6.1 同对节点重边聚合（双向分桶）。仅依赖 edges 列表，纯逻辑无 IO。
-        edge_groups = build_edge_groups(edges)
+        edge_groups, grouped_edge_ids = build_edge_groups(edges)
+
+        # 6.2 从 edges 中剔除已聚合到 edge_groups 的边，避免重复
+        edges = [e for e in edges if e["id"] not in grouped_edge_ids]
 
         # 7. Q4 全量计数 + statistics.per_type 装配
         per_type_stat = await _build_per_type_stat(
@@ -1929,10 +1932,13 @@ async def _format_edges(
         if source not in node_id_set or target not in node_id_set:
             continue
         rel_type = record.get("rel_type")
+        raw_props = record.get("properties") or {}
         cleaned_edge_props = {
-            key: _clean_neo4j_value(value)
-            for key, value in (record.get("properties") or {}).items()
+            key: _clean_neo4j_value(value) for key, value in raw_props.items()
         }
+        predicate_description = _clean_neo4j_value(
+            raw_props.get("predicate_description")
+        )
         edges.append({
             "id": record.get("id"),
             "source": source,
@@ -1940,6 +1946,7 @@ async def _format_edges(
             "type": rel_type,
             "properties": cleaned_edge_props,
             "caption": _resolve_edge_caption(rel_type, cleaned_edge_props),
+            "predicate_description": predicate_description if predicate_description else None,
         })
         edge_type_counts[rel_type] = edge_type_counts.get(rel_type, 0) + 1
 
@@ -2003,6 +2010,7 @@ def _empty_graph_response(message: str) -> Dict[str, Any]:
     return {
         "nodes": [],
         "edges": [],
+        "edge_groups": [],
         "statistics": {
             "total_nodes": 0,
             "total_edges": 0,
@@ -2163,11 +2171,14 @@ async def analytics_community_graph_data(
                 r_props = {k: _clean_neo4j_value(v) for k, v in (row["r_props"] or {}).items()}
                 source = e_id if row.get("r_from_e") else e2_id
                 target = e2_id if row.get("r_from_e") else e_id
-                edges_map[r_id] = {
+                edge_entry: Dict[str, Any] = {
                     "id": r_id,
                     "source": source,
                     "target": target,
+                    "properties": r_props,
+                    "predicate_description": r_props.get("predicate_description"),
                 }
+                edges_map[r_id] = edge_entry
 
         nodes = list(nodes_map.values())
         edges = list(edges_map.values())

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -29,7 +29,7 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services._graph_data_helpers import (
     assemble_per_type_stat,
     assemble_center_per_type_stat,
-    build_edge_groups,
+    build_unified_edges,
     compute_stat_types,
     resolve_mode_and_type_limits,
     _query_nodes_by_type_limits,
@@ -1730,9 +1730,9 @@ async def analytics_graph_data(
 
     Returns:
         ``GraphDataResponse.model_dump()`` 后的字典，顶层键为
-        ``nodes / edges / edge_groups / statistics``，必要时附带 ``message``。
-        ``edge_groups`` 把同一对节点之间的多条边按方向分桶（仅当某对节点的
-        总边数 ≥ 2 时才出现），便于前端做重边聚合渲染。
+        ``nodes / edges / statistics``，必要时附带 ``message``。
+        ``edges`` 为统一边列表，所有边均以 UnifiedEdge 结构表示，
+        通过 ``edge_type`` 区分 SINGLE / UNIDIRECTIONAL_MULTI / BIDIRECTIONAL / MULTI_BIDIRECTIONAL。
     """
     try:
         # 1. 用户校验
@@ -1763,11 +1763,9 @@ async def analytics_graph_data(
         # 6. Q3 边查询（try/except 降级，Requirement 8.4）
         edges, edge_type_counts = await _format_edges(node_ids)
 
-        # 6.1 同对节点重边聚合（双向分桶）。仅依赖 edges 列表，纯逻辑无 IO。
-        edge_groups, grouped_edge_ids = build_edge_groups(edges)
-
-        # 6.2 从 edges 中剔除已聚合到 edge_groups 的边，避免重复
-        edges = [e for e in edges if e["id"] not in grouped_edge_ids]
+        # 6.1 统一边聚合：EXTRACTED_RELATIONSHIP 按同对节点聚合，
+        # 其他边类型各成独立 SINGLE 边条目。纯逻辑无 IO。
+        unified_edges = build_unified_edges(edges)
 
         # 7. Q4 全量计数 + statistics.per_type 装配
         per_type_stat = await _build_per_type_stat(
@@ -1781,7 +1779,7 @@ async def analytics_graph_data(
 
         statistics = {
             "total_nodes": len(nodes),
-            "total_edges": len(edges),
+            "total_edges": len(unified_edges),
             "node_types": node_type_counts,
             "edge_types": edge_type_counts,
             "per_type": per_type_stat,
@@ -1794,16 +1792,15 @@ async def analytics_graph_data(
         )
         logger.info(
             f"图数据查询: end_user_id={end_user_id} mode={mode} "
-            f"nodes={len(nodes)} edges={len(edges)} "
-            f"edge_groups={len(edge_groups)} per_type=[{per_type_log}]"
+            f"nodes={len(nodes)} edges={len(unified_edges)} "
+            f"per_type=[{per_type_log}]"
         )
 
         # 通过 GraphDataResponse 装配响应：拿到 ge=0 / 必填字段校验与向后兼容契约，
         # 再 model_dump() 回 dict 以维持 controller 接口形态。无 message 时不输出该键。
         response = GraphDataResponse(
             nodes=nodes,
-            edges=edges,
-            edge_groups=edge_groups,
+            edges=unified_edges,
             statistics=statistics,
         )
         return response.model_dump(exclude_none=True)
@@ -2010,7 +2007,6 @@ def _empty_graph_response(message: str) -> Dict[str, Any]:
     return {
         "nodes": [],
         "edges": [],
-        "edge_groups": [],
         "statistics": {
             "total_nodes": 0,
             "total_edges": 0,

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -29,6 +29,7 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.services._graph_data_helpers import (
     assemble_per_type_stat,
     assemble_center_per_type_stat,
+    build_edge_groups,
     compute_stat_types,
     resolve_mode_and_type_limits,
     _query_nodes_by_type_limits,
@@ -1729,7 +1730,9 @@ async def analytics_graph_data(
 
     Returns:
         ``GraphDataResponse.model_dump()`` 后的字典，顶层键为
-        ``nodes / edges / statistics``，必要时附带 ``message``。
+        ``nodes / edges / edge_groups / statistics``，必要时附带 ``message``。
+        ``edge_groups`` 把同一对节点之间的多条边按方向分桶（仅当某对节点的
+        总边数 ≥ 2 时才出现），便于前端做重边聚合渲染。
     """
     try:
         # 1. 用户校验
@@ -1760,6 +1763,9 @@ async def analytics_graph_data(
         # 6. Q3 边查询（try/except 降级，Requirement 8.4）
         edges, edge_type_counts = await _format_edges(node_ids)
 
+        # 6.1 同对节点重边聚合（双向分桶）。仅依赖 edges 列表，纯逻辑无 IO。
+        edge_groups = build_edge_groups(edges)
+
         # 7. Q4 全量计数 + statistics.per_type 装配
         per_type_stat = await _build_per_type_stat(
             mode=mode,
@@ -1785,7 +1791,8 @@ async def analytics_graph_data(
         )
         logger.info(
             f"图数据查询: end_user_id={end_user_id} mode={mode} "
-            f"nodes={len(nodes)} edges={len(edges)} per_type=[{per_type_log}]"
+            f"nodes={len(nodes)} edges={len(edges)} "
+            f"edge_groups={len(edge_groups)} per_type=[{per_type_log}]"
         )
 
         # 通过 GraphDataResponse 装配响应：拿到 ge=0 / 必填字段校验与向后兼容契约，
@@ -1793,6 +1800,7 @@ async def analytics_graph_data(
         response = GraphDataResponse(
             nodes=nodes,
             edges=edges,
+            edge_groups=edge_groups,
             statistics=statistics,
         )
         return response.model_dump(exclude_none=True)


### PR DESCRIPTION
## Summary by Sourcery

在分析响应中统一图边表示方式，并将提取出的关系边聚合为分组、带类型的边条目。

新功能：
- 引入统一的边聚合函数，对 `EXTRACTED_RELATIONSHIP` 边进行双向分组，并将其分类为 `SINGLE`、`UNIDIRECTIONAL_MULTI`、`BIDIRECTIONAL` 和 `MULTI_BIDIRECTIONAL` 类型。
- 暴露新的 `UnifiedEdge` 模式（schema），包含方向桶（directional buckets）和边元数据，用于图分析响应，取代之前按边的 `GraphEdge` 模型。

增强：
- 扩展分析图数据和社区图数据服务，以构建并返回统一的边结构，包括更新后的边总数统计和日志。
- 在边条目上保留并呈现 `predicate_description` 和相关谓词字段，以在分析输出中提供更丰富的关系描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify graph edge representation in analytics responses and aggregate extracted relationship edges into grouped, typed edge entries.

New Features:
- Introduce a unified edge aggregation function that groups EXTRACTED_RELATIONSHIP edges bidirectionally and classifies them into SINGLE, UNIDIRECTIONAL_MULTI, BIDIRECTIONAL, and MULTI_BIDIRECTIONAL types.
- Expose a new UnifiedEdge schema with directional buckets and edge metadata for use in graph analytics responses, replacing the previous per-edge GraphEdge model.

Enhancements:
- Extend analytics graph data and community graph data services to build and return unified edge structures, including updated total edge statistics and logs.
- Preserve and surface predicate_description and related predicate fields on edge items for richer relationship descriptions in analytics outputs.

</details>