### PR TITLE
feat(memory): refactor event timeline operations to support add/delet…

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -19,7 +19,8 @@ from app.core.memory.storage_services.reflection_engine.llm.description_synthesi
     merge_description,
     summarize_extract_and_rename,
     validate_summary_output,
-    filter_events,
+    apply_event_operations,
+    validate_event_operations,
 )
 from app.core.memory.storage_services.reflection_engine.llm.unresolved_resolver import (
     resolve_unresolved_statement,
@@ -1263,7 +1264,7 @@ class Layer2Inspector:
 
         tracker.end_step(
             f"summary={len(result.description_summary)}字, "
-            f"events={len(result.events)}, "
+            f"operations={len(result.operations)}, "
             f"rename={result.should_rename_entity}"
         )
 
@@ -1278,27 +1279,14 @@ class Layer2Inspector:
             return False
         tracker.end_step("校验通过")
 
-        # Step 4: 过滤 events
+        # Step 4: 应用事件操作（add/delete/update）
         tracker.start_step("事件过滤", "decide")
-        valid_events = filter_events(result.events)
-
-        # 构建 event_timeline
-        # 单条格式：[valid_at|invalid_at] fact|title|category|category_id
-        # title / category / category_id 已在 filter_events 内兜底为合法值或 "NULL"
-        if valid_events:
-            events_str = '；'.join(
-                f'[{e.valid_at}|{e.invalid_at}] {e.fact}|{e.title}|{e.category}|{e.category_id}'
-                for e in valid_events
-            )
-            if existing_event_timeline:
-                event_timeline = existing_event_timeline + "；" + events_str
-            else:
-                event_timeline = events_str
-        else:
-            event_timeline = existing_event_timeline
-
+        valid_ops = validate_event_operations(result.operations)
+        event_timeline, ev_stats = apply_event_operations(
+            existing_event_timeline, valid_ops
+        )
         tracker.end_step(
-            f"有效事件 {len(valid_events)}/{len(result.events)}"
+            f"事件操作 新增{ev_stats['added']} 更新{ev_stats['updated']} 删除{ev_stats['deleted']}"
         )
 
         # Step 5: 写入 Neo4j（summary + timeline + event_timeline + 清空 description）

--- a/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 from typing import List, Optional
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
@@ -87,13 +88,26 @@ async def merge_description(
 # ===== 新增：描述合并 + 事件提取 + 更名判断（一次调用） =====
 
 class EventItem(BaseModel):
-    """单个事件"""
-    valid_at: str
-    invalid_at: str
-    fact: str
+    """单条事件对象（add.value / delete.old_value / update.old_value / update.new_value 通用）"""
     title: str = "NULL"
+    category_id: str = "NULL"   # 稳定分类ID，直接存、不做枚举校验
     category: str = "NULL"
-    category_id: str = "NULL"   # 稳定分类ID，按需求直接存、不做枚举校验
+    valid_at: str = "NULL"
+    invalid_at: str = "NULL"
+    fact: str = "NULL"
+
+
+class EventOperation(BaseModel):
+    """单条事件操作：add / delete / update
+
+    - add:    仅 value
+    - delete: 仅 old_value（定位旧事件）
+    - update: old_value（定位）+ new_value（覆盖值）
+    """
+    op: str
+    value: Optional[EventItem] = None
+    old_value: Optional[EventItem] = None
+    new_value: Optional[EventItem] = None
 
 
 def _sanitize_field(value: str) -> str:
@@ -109,9 +123,9 @@ def _sanitize_field(value: str) -> str:
 
 
 class SummarizeExtractRenameOutput(BaseModel):
-    """LLM 输出：合并摘要 + 事件列表 + 更名判断"""
+    """LLM 输出：合并摘要 + 事件操作列表 + 更名判断"""
     description_summary: str
-    events: List[EventItem] = []
+    operations: List[EventOperation] = []
     should_rename_entity: bool = False
     suggested_entity_name: Optional[str] = None
 
@@ -136,45 +150,201 @@ def validate_summary_output(
     return True, "ok"
 
 
-def filter_events(
-    events: List[EventItem],
-) -> List[EventItem]:
-    """过滤无效事件
+# ===== 事件时间线 patch：解析 / 匹配 / 应用 =====
 
-    Args:
-        events: LLM 输出的新事件列表
+# 单条事件格式：[valid_at|invalid_at] fact|title|category|category_id
+_TIMELINE_HEAD_RE = re.compile(r'^\[([^|]*)\|([^\]]*)\]\s*(.*)$')
 
-    Returns:
-        过滤后的有效事件列表
+
+def _norm_match_key(value: str) -> str:
+    """归一化匹配键：NULL/空 → ''，去空白、转小写。"""
+    if value is None:
+        return ""
+    v = value.strip()
+    if v == "NULL":
+        return ""
+    return re.sub(r'\s+', '', v).lower()
+
+
+def _parse_timeline_full(event_timeline: str) -> List[dict]:
+    """解析 event_timeline 为全字段 dict 列表，不过滤、不转换，保证写回无损。
+
+    旧格式（仅 fact）按 fact=正文、其余 NULL 保留。
     """
-    valid_events = []
-    seen_facts = set()
+    if not event_timeline or not event_timeline.strip():
+        return []
 
-    for event in events:
-        # 过滤 fact 为空
-        if not event.fact or not event.fact.strip():
+    events: List[dict] = []
+    for item in event_timeline.split('；'):
+        item = item.strip()
+        if not item:
             continue
 
-        # 过滤"说话者"后缀
-        if "的说话者" in event.fact:
-            continue
+        m = _TIMELINE_HEAD_RE.match(item)
+        if m:
+            valid_at = m.group(1).strip() or "NULL"
+            invalid_at = m.group(2).strip() or "NULL"
+            body = m.group(3)
+        else:
+            valid_at = "NULL"
+            invalid_at = "NULL"
+            body = item
 
-        # 本轮内去重
-        fact_lower = event.fact.strip().lower()
-        if fact_lower in seen_facts:
-            continue
-        seen_facts.add(fact_lower)
+        parts = body.split('|')
+        fact = parts[0].strip() if len(parts) > 0 else ""
+        title = parts[1].strip() if len(parts) > 1 else "NULL"
+        category = parts[2].strip() if len(parts) > 2 else "NULL"
+        category_id = parts[3].strip() if len(parts) > 3 else "NULL"
 
-        # 写入前兜底：清洗分隔符 + category 枚举校验，保证拼接结构稳定
-        event.fact = _sanitize_field(event.fact)
-        event.title = _sanitize_field(event.title) if (event.title and event.title != "NULL") else "NULL"
-        event.category = event.category if event.category in EVENT_CATEGORY_NAME_SET else "NULL"
-        # category_id 不做枚举校验，仅清洗分隔符后原样透传（后续检索/聚合使用）
-        event.category_id = _sanitize_field(event.category_id) if (event.category_id and event.category_id != "NULL") else "NULL"
+        events.append({
+            "valid_at": valid_at or "NULL",
+            "invalid_at": invalid_at or "NULL",
+            "fact": fact,
+            "title": title or "NULL",
+            "category": category or "NULL",
+            "category_id": category_id or "NULL",
+        })
+    return events
 
-        valid_events.append(event)
 
-    return valid_events
+def _serialize_timeline(events: List[dict]) -> str:
+    """dict 列表序列化为 event_timeline 字符串。
+
+    旧格式兼容：title/category/category_id 全为 NULL 时不补后缀，前端继续跳过。
+    """
+    parts = []
+    for e in events:
+        valid_at = e.get("valid_at") or "NULL"
+        invalid_at = e.get("invalid_at") or "NULL"
+        fact = e.get("fact") or ""
+        title = e.get("title") or "NULL"
+        category = e.get("category") or "NULL"
+        category_id = e.get("category_id") or "NULL"
+
+        # 旧格式兼容：三段全 NULL 时保持原样（不补 |NULL|NULL|NULL）
+        if title == "NULL" and category == "NULL" and category_id == "NULL":
+            body = fact
+        else:
+            body = f'{fact}|{title}|{category}|{category_id}'
+
+        parts.append(f'[{valid_at}|{invalid_at}] {body}')
+    return '；'.join(parts)
+
+
+def _clean_event_item(item: EventItem) -> dict:
+    """清洗事件对象为可写入 dict：分隔符转义、category 枚举校验。"""
+    fact = _sanitize_field(item.fact) if item.fact and item.fact != "NULL" else ""
+    title = _sanitize_field(item.title) if (item.title and item.title != "NULL") else "NULL"
+    category = item.category if item.category in EVENT_CATEGORY_NAME_SET else "NULL"
+    category_id = _sanitize_field(item.category_id) if (item.category_id and item.category_id != "NULL") else "NULL"
+    return {
+        "valid_at": item.valid_at or "NULL",
+        "invalid_at": item.invalid_at or "NULL",
+        "fact": fact,
+        "title": title,
+        "category": category,
+        "category_id": category_id,
+    }
+
+
+def _find_matches(events: List[dict], old_value: EventItem) -> List[int]:
+    """fact + title 双键定位旧事件，返回命中下标列表。
+
+    一级精确 → 二级归一化回退；空串与 'NULL' 等价。
+    """
+    # 一级：精确
+    f_exact = _sanitize_field(old_value.fact) if old_value.fact else ""
+    t_exact = _sanitize_field(old_value.title) if (old_value.title and old_value.title != "NULL") else ""
+    exact = [
+        i for i, e in enumerate(events)
+        if (_sanitize_field(e["fact"]) if e["fact"] else "") == f_exact
+        and (_sanitize_field(e["title"]) if (e["title"] and e["title"] != "NULL") else "") == t_exact
+    ]
+    if exact:
+        return exact
+
+    # 二级：归一化
+    f_norm = _norm_match_key(old_value.fact)
+    t_norm = _norm_match_key(old_value.title)
+    return [
+        i for i, e in enumerate(events)
+        if _norm_match_key(e["fact"]) == f_norm and _norm_match_key(e["title"]) == t_norm
+    ]
+
+
+def validate_event_operations(operations: List[EventOperation]) -> List[EventOperation]:
+    """过滤非法操作，返回合法子集。非法的直接丢弃。"""
+    valid = []
+    for op in operations or []:
+        kind = (op.op or "").strip().lower()
+        if kind == "add":
+            if op.value and op.value.fact and op.value.fact.strip() and op.value.fact != "NULL":
+                valid.append(op)
+        elif kind == "delete":
+            if op.old_value and _norm_match_key(op.old_value.fact):
+                valid.append(op)
+        elif kind == "update":
+            if (op.old_value and op.new_value
+                    and _norm_match_key(op.old_value.fact)
+                    and op.new_value.fact and op.new_value.fact.strip() and op.new_value.fact != "NULL"):
+                valid.append(op)
+        # 其余 op 一律丢弃
+    return valid
+
+
+def apply_event_operations(
+    existing_event_timeline: str,
+    operations: List[EventOperation],
+) -> tuple:
+    """对已有 event_timeline 应用 add/delete/update patch 操作。
+
+    返回 (new_event_timeline, stats)，stats = {added, updated, deleted}。
+    匹配不上或多命中的操作静默跳过。
+    """
+    events = _parse_timeline_full(existing_event_timeline)
+    stats = {"added": 0, "updated": 0, "deleted": 0}
+
+    # 无有效操作时直接返回原串，避免纯解析→序列化造成格式微变
+    if not operations:
+        return existing_event_timeline or "", stats
+
+    # add 去重用：已有 + 本轮 fact 的归一化集合
+    seen_facts = {_norm_match_key(e["fact"]) for e in events if e["fact"]}
+
+    for op in operations:
+        kind = (op.op or "").strip().lower()
+
+        if kind == "add":
+            cleaned = _clean_event_item(op.value)
+            if not cleaned["fact"]:
+                continue
+            if "的说话者" in cleaned["fact"]:
+                continue
+            key = _norm_match_key(cleaned["fact"])
+            if key in seen_facts:
+                continue
+            seen_facts.add(key)
+            events.append(cleaned)
+            stats["added"] += 1
+
+        elif kind == "delete":
+            idxs = _find_matches(events, op.old_value)
+            if len(idxs) != 1:
+                continue
+            events.pop(idxs[0])
+            stats["deleted"] += 1
+
+        elif kind == "update":
+            idxs = _find_matches(events, op.old_value)
+            if len(idxs) != 1:
+                continue
+            cleaned = _clean_event_item(op.new_value)
+            if not cleaned["fact"]:
+                continue
+            events[idxs[0]] = cleaned
+            stats["updated"] += 1
+
+    return _serialize_timeline(events), stats
 
 
 async def summarize_extract_and_rename(
@@ -194,7 +364,7 @@ async def summarize_extract_and_rename(
         entity_type: 实体类型
         description: 当前 description 碎片（；分隔字符串）
         summary: 上次的摘要（首次为 None）
-        event_timeline: 已有的 event_timeline（全量，用于去重）
+        event_timeline: 已有的 event_timeline（全量，作为 patch 基准与去重依据）
         language: 语言类型
 
     Returns:
@@ -210,7 +380,7 @@ async def summarize_extract_and_rename(
             "entity_type": entity_type,
             "description": description,
             "description_summary": summary or "",
-            "event_timeline": event_timeline or "",
+            "event_timeline": _parse_timeline_full(event_timeline) if event_timeline else [],
         }
 
         rendered_prompt = template.render(
@@ -226,7 +396,7 @@ async def summarize_extract_and_rename(
         elif isinstance(response, dict):
             result = SummarizeExtractRenameOutput(
                 description_summary=response.get("description_summary", ""),
-                events=[EventItem(**e) for e in response.get("events", [])],
+                operations=[EventOperation(**o) for o in response.get("operations", [])],
                 should_rename_entity=response.get("should_rename_entity", False),
                 suggested_entity_name=response.get("suggested_entity_name"),
             )
@@ -234,7 +404,7 @@ async def summarize_extract_and_rename(
             data = response.model_dump()
             result = SummarizeExtractRenameOutput(
                 description_summary=data.get("description_summary", ""),
-                events=[EventItem(**e) for e in data.get("events", [])],
+                operations=[EventOperation(**o) for o in data.get("operations", [])],
                 should_rename_entity=data.get("should_rename_entity", False),
                 suggested_entity_name=data.get("suggested_entity_name"),
             )

--- a/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
@@ -1,18 +1,18 @@
 {% if language == "en" %}
-You are an entity-level description reflection, event extraction, and rename-suggestion assistant.
+You are an entity-level description reflection, timeline patch, and rename-suggestion assistant.
 
 Your task has three parts:
 1. Merge new `description` fragments into the existing `description_summary`, and output a complete updated summary.
-2. Extract only new event candidates from the current `description`, and output them as `events`.
+2. Generate patch operations for the existing structured `event_timeline`: add new events, delete invalid events, or update existing events with durable new facts and details.
 3. Decide whether the entity should be renamed to a clearer, more specific, and more stable name.
 
 This is an entity-node reflection step. It is not raw-dialogue extraction.
 {% else %}
-你是一个实体级描述反思、事件提取与实体重命名建议助手。
+你是一个实体级描述反思、时间线 patch 与实体重命名建议助手。
 
 你的任务有三部分：
 1. 将新的 `description` 碎片合并进已有 `description_summary`，输出完整的新摘要。
-2. 只从本轮 `description` 中提取新增事件候选，输出为 `events`。
+2. 为已有结构化 `event_timeline` 生成增删改 patch operations：新增事件、删除无效事件，或用本轮长期有价值的新事实和细节更新已有事件。
 3. 判断当前实体是否应该重命名为更清晰、更具体、更稳定的名字。
 
 这是实体节点级反思步骤，不是从原始对话重新抽取事实。
@@ -23,7 +23,7 @@ This is an entity-node reflection step. It is not raw-dialogue extraction.
 The input JSON contains these entity fields:
 - `description`: current new description fragments; it may be a string, semicolon-separated text, or an array of strings; this is the main evidence for this run
 - `description_summary`: the entity's existing summary; use it as the current summary state
-- `event_timeline`: the entity's existing structured event timeline; use it only for event deduplication
+- `event_timeline`: the entity's existing structured event timeline; each event uses the current event schema with `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`
 - `entity_type`: the entity type
 - `entity_name`: the current entity name
 
@@ -32,7 +32,7 @@ Input JSON:
 输入 JSON 包含以下实体字段：
 - `description`: 实体当前新增的 description 碎片；可能是字符串、分号分隔文本或字符串数组；这是本轮主要证据
 - `description_summary`: 实体当前已有的 description_summary；这是当前摘要状态
-- `event_timeline`: 实体当前已有的结构化事件时间线；只用于事件去重
+- `event_timeline`: 实体当前已有的结构化事件时间线；每个事件使用当前事件 schema，包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`
 - `entity_type`: 实体的 entity_type
 - `entity_name`: 实体当前 name
 
@@ -46,13 +46,13 @@ Input JSON:
 {% if language == "en" %}
 Return exactly four fields:
 - `description_summary`: the complete updated summary after merging existing summary and new fragments
-- `events`: only newly extracted event candidates from current `description`; each event must include `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`; do not output a full timeline
+- `operations`: timeline patch operations derived from the current `description` and existing `event_timeline`; do not output a full timeline
 - `should_rename_entity`: whether the current entity should be renamed
 - `suggested_entity_name`: the suggested new name if renaming is needed; otherwise the string `"NULL"`
 {% else %}
 严格返回四个字段：
 - `description_summary`: 合并已有摘要和新增碎片后的完整新摘要
-- `events`: 只输出本轮从 `description` 中提取的新增事件候选；每个事件必须包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`；不要输出完整时间线
+- `operations`: 基于本轮 `description` 和已有 `event_timeline` 生成的时间线 patch operations；不要输出完整时间线
 - `should_rename_entity`: 是否建议重命名当前实体
 - `suggested_entity_name`: 如果需要重命名，输出建议的新实体名；如果不需要，输出字符串 `"NULL"`
 {% endif %}
@@ -78,7 +78,7 @@ Return exactly four fields:
 - Remove duplicates and low-value wording.
 - Remove source-like suffixes such as "the speaker", "mentioned by the user", or equivalent boilerplate.
 - Prefer concise natural prose over a timeline-like list.
-- Do not over-focus on one-off event details in the summary; event details should usually live in `events`.
+- Do not over-focus on one-off event details in the summary; event details should usually live in timeline `operations`.
 - Preserve useful stable facts even when they are not events.
 - For non-user entities, preserve the stable relationship between the entity and the user when supported by the input.
 - For non-user entities, if the input states a user relationship such as ownership, care, use, membership, study, attention, or dependence, the summary MUST keep that relationship explicitly.
@@ -88,34 +88,46 @@ Return exactly four fields:
 - 删除重复、空泛、低价值表述。
 - 删除“的说话者”“用户提到的对象”等来源性或模板化后缀。
 - 摘要应是简洁自然的描述，不要写成时间线列表。
-- 不要在摘要中过度堆叠一次性事件细节；事件细节通常进入 `events`。
+- 不要在摘要中过度堆叠一次性事件细节；事件细节通常进入时间线 `operations`。
 - 对重要稳定事实，即使不是事件，也应保留在摘要里。
 - 对非用户实体，如果输入支持，应在摘要中保留该实体与用户的稳定关系。
 - 对非用户实体，如果输入中出现用户拥有、照顾、使用、加入、学习、关注或依赖该实体等关系，摘要必须明确保留这种用户关系。
 - 摘要中避免使用“它”“其”“这只”“那个”等弱指代；优先写实体名或清晰关系名。
 {% endif %}
 
-===New Event Extraction Rules===
+===Timeline Operation Rules===
 {% if language == "en" %}
-- Output only `events` extracted from the current `description`.
-- Do not output the full existing event timeline.
-- Use `event_timeline` only for deduplication.
-- If a candidate event is semantically the same as an existing event, do not output it.
-- If a candidate event has the same core action and participants as an existing event, treat it as duplicate even if the new wording is more specific, has a fuller object name, or contains more detail.
-- If a new fragment only enriches an existing event, do not output it in this first version; it can be logged for later review.
-- A duplicate event must not appear in `events`.
-- If a candidate event is genuinely different from existing events, output it.
+- Output only `operations`, not the full updated timeline.
+- Use `event_timeline` as the current timeline state that operations will patch.
+- Use `description` as the new evidence for deciding whether to add, delete, or update timeline events.
+- If the current `description` contains a genuinely new event that is not already represented in `event_timeline`, output an `add` operation.
+- If the current `description` and an existing event refer to the same real-world event or event context, but the new evidence adds durable facts, corrects wrong facts, or clarifies important details such as exact date, location, object, participant, completion status, outcome, title, category, or validity range, output an `update` operation.
+- Use `update` for fact/detail enrichment or factual correction of the same event context. Do not ignore it as a duplicate.
+- If an existing event's core statement is wrong but the new evidence provides the corrected version of the same event context, use `update` rather than `delete`.
+- Do not use `update` to rewrite one event into a different event. If the new evidence describes a separate event, use `add`.
+- Use `delete` only when the current `description` clearly proves an existing event is wrong, invalid, duplicated, or should not be kept as a timeline event.
+- Use `delete` for an existing event only when it should be removed without a corrected replacement, or when it is a duplicate of another existing timeline event.
+- If the current `description` does not provide enough evidence to change an existing event, output no operation for that event.
+- Prefer `update` over `delete` + `add` when the old event and new evidence refer to the same real-world event.
+- `old_value` in `delete` and `update` must be copied exactly from one item in the input `event_timeline`; do not paraphrase, normalize, reorder, add, or remove fields inside `old_value`.
+- `value` in `add` and `new_value` in `update` must be complete event objects with exactly `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
 - `title`, `category_id`, and `category` must be supported by the same evidence as `fact`; do not add unsupported details through them.
 {% else %}
-- 只输出从当前 `description` 中提取的 `events`。
-- 不要输出完整已有时间线。
-- `event_timeline` 只用于去重。
-- 如果候选事件与已有事件语义相同，不要输出。
-- 如果候选事件和已有事件的核心动作、参与者相同，即使新说法更具体、对象名称更完整、细节更多，也视为重复事件，不要输出。
-- 如果新碎片只是补充了已有事件的细节，第一版不要输出该事件；可以交给后端记录 review。
-- 重复事件绝不能进入 `events`。
-- 只有确实是不同事件时，才输出到 `events`。
-- `title`、`category_id` 和 `category` 必须由 `fact` 的同一组证据支持；不要通过这两个字段加入无依据的新信息。
+- 只输出 `operations`，不要输出完整更新后的时间线。
+- `event_timeline` 是当前时间线状态，`operations` 将对它进行 patch。
+- `description` 是本轮判断新增、删除、更新事件的新增证据。
+- 如果本轮 `description` 中出现一个确实未被 `event_timeline` 表达的新事件，输出 `add` operation。
+- 如果本轮 `description` 和已有事件指向同一个现实事件或同一个事件背景，但新证据补充了长期有价值的事实、纠正了错误事实，或澄清了具体时间、地点、对象、参与者、完成状态、结果、标题、分类、有效期等重要细节，输出 `update` operation。
+- 同一事件背景下的事实和细节补充、事实纠错应使用 `update`，不要当作重复事件忽略。
+- 如果已有事件的核心表述是错的，但新证据给出了同一事件背景下的修正版本，使用 `update`，不要使用 `delete`。
+- 不要用 `update` 把一个事件改写成另一个不同事件；如果新证据描述的是独立事件，使用 `add`。
+- 只有当本轮 `description` 明确证明已有事件错误、失效、重复，或不应作为时间线事件保留时，才输出 `delete`。
+- 只有当已有事件应被移除且没有修正后的替代版本，或它是另一个已有 timeline 事件的重复记录时，才使用 `delete`。
+- 如果本轮 `description` 没有足够证据改变已有事件，不要对该事件输出 operation。
+- 当旧事件和新证据指向同一个现实事件时，优先使用 `update`，不要拆成 `delete` + `add`。
+- `delete` 和 `update` 里的 `old_value` 必须逐字段原样复制输入 `event_timeline` 中的某一个 event；不要改写、归一化、重排、添加或删除 `old_value` 内部字段。
+- `add` 里的 `value` 和 `update` 里的 `new_value` 必须是完整事件对象，且只能包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- `title`、`category_id` 和 `category` 必须由 `fact` 的同一组证据支持；不要通过这些字段加入无依据的新信息。
 {% endif %}
 
 ===What Counts As An Event===
@@ -125,25 +137,25 @@ An event is a concrete action, experience, change, or milestone that happened at
 Examples of event-like content:
 - entering school, graduating, joining a company, leaving a job, moving, marrying, breaking up, adopting, buying, finishing, attending, meeting, traveling, taking an exam, joining a competition, surgery, project milestone
 
-Do not add these to `events`:
+Do not add these to timeline operations:
 - attributes, identity labels, occupation, personality, preference, habit, long-term state, goal, wish, evaluation, abstract belief
 
 Important non-event information may still be merged into `description_summary`.
 {% else %}
 事件是发生在某个时间点或时间段的具体动作、经历、变化或里程碑。
 
-可以进入 `events` 的内容包括：
+可以进入时间线 operations 的内容包括：
 - 入学、毕业、入职、离职、搬家、结婚、分手、收养、购买、完成、参加、见面、旅行、考试、比赛、手术、项目节点等。
 
-不要进入 `events` 的内容包括：
+不要进入时间线 operations 的内容包括：
 - 属性、身份、职业、性格、偏好、习惯、长期状态、目标、愿望、评价、抽象观点。
 
 这些非事件信息如果重要，可以合并进 `description_summary`。
 {% endif %}
 
-===Event Title And Category Rules===
+===Event Object Title And Category Rules===
 {% if language == "en" %}
-Each `events` item must include:
+Each event object in `add.value` and `update.new_value` must include:
 - `title`: a short event title for timeline display and retrieval snippets
 - `category_id`: exactly one stable event category id selected from the fixed category pool below
 - `category`: the Chinese display name that exactly matches the selected `category_id`
@@ -182,7 +194,7 @@ Category selection rules:
 - If the event is about a pet that the user owns, cares for, or depends on, prefer `category_id: "pet_care"` and `category: "宠物照护"`.
 - Use `other_life_event` / `其他生活事件` only when the event is concrete and useful but no listed category fits.
 {% else %}
-每个 `events` item 必须包含：
+`add.value` 和 `update.new_value` 中的每个事件对象必须包含：
 - `title`: 用于时间线展示和检索结果摘要的短事件标题
 - `category_id`: 从下面固定类型池中选择的稳定事件类型 ID
 - `category`: 与 `category_id` 精确对应的中文展示名
@@ -267,7 +279,8 @@ If `entity_name` is not the user node:
 {% if language == "en" %}
 - A bracketed timestamp at the beginning of a description fragment, such as `[2026-05-15T14:00:00+08:00]`, is the dialogue time, not necessarily the event time.
 - Use the bracketed timestamp as the reference time for relative phrases in that fragment when needed.
-- Every `events` item must include `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
+- Every event object in `add.value` and `update.new_value` must include `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
+- Every event object copied into `delete.old_value` or `update.old_value` must preserve the original dates from the input `event_timeline`.
 - `title`, `category_id`, `category`, and `fact` must be strings.
 - `valid_at` and `invalid_at` must be either `YYYY-MM-DD` or the string `"NULL"`.
 - Point event: set `valid_at` and `invalid_at` to the same date.
@@ -286,7 +299,8 @@ If `entity_name` is not the user node:
 {% else %}
 - description 碎片开头的方括号时间戳，例如 `[2026-05-15T14:00:00+08:00]`，是对话时间，不一定是事件发生时间。
 - 对“昨天”“上个月”“三年前”等相对时间，必要时用该碎片开头的方括号时间戳作为参考时间。
-- 每个 `events` item 必须包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- `add.value` 和 `update.new_value` 中的每个事件对象必须包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- 复制到 `delete.old_value` 或 `update.old_value` 的每个事件对象必须保留输入 `event_timeline` 中的原始日期。
 - `title`、`category_id`、`category` 和 `fact` 必须是字符串。
 - `valid_at` 和 `invalid_at` 只能是 `YYYY-MM-DD` 或字符串 `"NULL"`。
 - 点事件：`valid_at` 和 `invalid_at` 填同一个日期。
@@ -349,8 +363,14 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - Do not output extra keys.
 - Do not output JSON null.
 - If there is no summary, output an empty string for `description_summary`.
-- If there are no new events, output an empty array for `events`.
-- Every `events` item must include exactly `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
+- If there are no timeline changes, output an empty array for `operations`.
+- Every operation must include `op`.
+- `op` must be exactly one of `"add"`, `"delete"`, or `"update"`.
+- An `add` operation must include exactly `op` and `value`.
+- A `delete` operation must include exactly `op` and `old_value`.
+- An `update` operation must include exactly `op`, `old_value`, and `new_value`.
+- `old_value` must be copied exactly from one input `event_timeline` event.
+- `value` and `new_value` must each include exactly `title`, `category_id`, `category`, `valid_at`, `invalid_at`, and `fact`.
 - `category_id` must be one of the fixed category ids listed in the prompt.
 - `category` must be the exact Chinese display name mapped to `category_id`.
 - `valid_at` and `invalid_at` must be strings, not JSON null.
@@ -367,8 +387,14 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - 不要输出额外字段。
 - 不要输出 JSON null。
 - 如果没有摘要，`description_summary` 输出空字符串。
-- 如果没有新增事件，`events` 输出空数组。
-- 每个 `events` item 必须且只能包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
+- 如果没有时间线变化，`operations` 输出空数组。
+- 每个 operation 必须包含 `op`。
+- `op` 必须且只能是 `"add"`、`"delete"` 或 `"update"`。
+- `add` operation 必须且只能包含 `op` 和 `value`。
+- `delete` operation 必须且只能包含 `op` 和 `old_value`。
+- `update` operation 必须且只能包含 `op`、`old_value` 和 `new_value`。
+- `old_value` 必须从输入 `event_timeline` 中的某一个 event 原样复制。
+- `value` 和 `new_value` 必须且只能包含 `title`、`category_id`、`category`、`valid_at`、`invalid_at` 和 `fact`。
 - `category_id` 必须是 prompt 中固定类型池里的一个 ID。
 - `category` 必须是与 `category_id` 精确对应的中文展示名。
 - `valid_at` 和 `invalid_at` 必须是字符串，不能是 JSON null。
@@ -381,22 +407,80 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 {% endif %}
 
 {% if language == "en" %}
-Return exactly this JSON shape:
+Return exactly this top-level JSON shape. The `operations` array may be empty, or may contain any number of operation objects using the allowed shapes below:
 {% else %}
-严格返回以下 JSON 结构：
+严格返回以下顶层 JSON 结构。`operations` 数组可以为空，也可以包含任意数量的 operation object；operation object 只能使用下面允许的形状：
 {% endif %}
 {
   "description_summary": "string",
-  "events": [
+  "operations": [
     {
-      "title": "string",
-      "category_id": "education_learning | career_work | project_milestone | residence_relocation | relationship_family | pet_care | health_medical | travel_visit | purchase_asset | creation_publication | achievement_award | finance_legal_admin | other_life_event",
-      "category": "教育学习 | 职业工作 | 项目里程碑 | 居住迁移 | 关系家庭 | 宠物照护 | 健康医疗 | 旅行到访 | 购买资产 | 创作发布 | 成就荣誉 | 财务法务行政 | 其他生活事件",
-      "valid_at": "YYYY-MM-DD | NULL",
-      "invalid_at": "YYYY-MM-DD | NULL",
-      "fact": "string"
+      "op": "add",
+      "value": {
+        "title": "string",
+        "category_id": "education_learning | career_work | project_milestone | residence_relocation | relationship_family | pet_care | health_medical | travel_visit | purchase_asset | creation_publication | achievement_award | finance_legal_admin | other_life_event",
+        "category": "教育学习 | 职业工作 | 项目里程碑 | 居住迁移 | 关系家庭 | 宠物照护 | 健康医疗 | 旅行到访 | 购买资产 | 创作发布 | 成就荣誉 | 财务法务行政 | 其他生活事件",
+        "valid_at": "YYYY-MM-DD | NULL",
+        "invalid_at": "YYYY-MM-DD | NULL",
+        "fact": "string"
+      }
+    },
+    {
+      "op": "delete",
+      "old_value": {
+        "title": "string copied exactly from event_timeline",
+        "category_id": "category_id copied exactly from event_timeline",
+        "category": "category copied exactly from event_timeline",
+        "valid_at": "valid_at copied exactly from event_timeline",
+        "invalid_at": "invalid_at copied exactly from event_timeline",
+        "fact": "fact copied exactly from event_timeline"
+      }
+    },
+    {
+      "op": "update",
+      "old_value": {
+        "title": "string copied exactly from event_timeline",
+        "category_id": "category_id copied exactly from event_timeline",
+        "category": "category copied exactly from event_timeline",
+        "valid_at": "valid_at copied exactly from event_timeline",
+        "invalid_at": "invalid_at copied exactly from event_timeline",
+        "fact": "fact copied exactly from event_timeline"
+      },
+      "new_value": {
+        "title": "string",
+        "category_id": "education_learning | career_work | project_milestone | residence_relocation | relationship_family | pet_care | health_medical | travel_visit | purchase_asset | creation_publication | achievement_award | finance_legal_admin | other_life_event",
+        "category": "教育学习 | 职业工作 | 项目里程碑 | 居住迁移 | 关系家庭 | 宠物照护 | 健康医疗 | 旅行到访 | 购买资产 | 创作发布 | 成就荣誉 | 财务法务行政 | 其他生活事件",
+        "valid_at": "YYYY-MM-DD | NULL",
+        "invalid_at": "YYYY-MM-DD | NULL",
+        "fact": "string"
+      }
     }
   ],
   "should_rename_entity": false,
   "suggested_entity_name": "NULL"
+}
+
+{% if language == "en" %}
+Example `update` for enriching the same real-world event:
+{% else %}
+同一现实事件补充事实和细节时的 `update` 示例：
+{% endif %}
+{
+  "op": "update",
+  "old_value": {
+    "title": "搬到深圳",
+    "category_id": "residence_relocation",
+    "category": "居住迁移",
+    "valid_at": "2026-05-19",
+    "invalid_at": "2026-05-19",
+    "fact": "用户从上海搬到深圳"
+  },
+  "new_value": {
+    "title": "搬到深圳南山区",
+    "category_id": "residence_relocation",
+    "category": "居住迁移",
+    "valid_at": "2026-05-19",
+    "invalid_at": "2026-05-19",
+    "fact": "用户在2026年5月19日从上海搬到深圳南山区，开始在深圳长期居住"
+  }
 }

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -185,13 +185,14 @@ class MemoryEntityService:
             if not fact:
                 continue
 
-            # 时间为空的事件不返回给前端
-            if not valid_at:
+            # valid_at 为空时用 invalid_at 兜底（事件有结束日期但开始不确定）
+            display_at = valid_at or invalid_at
+            if not display_at:
                 continue
 
-            # valid_at 转为 Unix 毫秒时间戳（UTC）；无法解析则跳过
-            valid_at_ms = MemoryEntityService._to_epoch_ms(valid_at)
-            if valid_at_ms is None:
+            # 转为 Unix 毫秒时间戳（UTC）；无法解析则跳过
+            display_at_ms = MemoryEntityService._to_epoch_ms(display_at)
+            if display_at_ms is None:
                 continue
 
             # 不返回 invalid_at / category_id（前端不需要）
@@ -199,7 +200,7 @@ class MemoryEntityService:
                 "title": title,
                 "fact": fact,
                 "category": category,
-                "valid_at": valid_at_ms,
+                "valid_at": display_at_ms,
             })
 
         # 排序：valid_at 降序（最新在前）


### PR DESCRIPTION
…e/update semantics

- Replace filter_events with validate_event_operations and apply_event_operations for explicit operation handling
- Introduce EventOperation model supporting add/delete/update with optional value fields (value, old_value, new_value)
- Add timeline parsing and serialization functions (_parse_timeline_full, _serialize_timeline) for lossless round-trip handling
- Implement event matching logic (_norm_match_key) for robust old_value matching across operation types
- Update Layer2Inspector to track operation statistics (added/updated/deleted) instead of simple event count
- Maintain backward compatibility with old timeline format (fact-only events without metadata)
- Replace "events" field with "operations" in SummarizeExtractRenameOutput
- Update reflection_summary_timeline.prompt.jinja2 to generate proper EventOperation structures
- Update memory_entity_relationship_service.py to work with new operation-based API

## Summary by Sourcery

重构反思摘要时间线流程，使其在现有时间线上使用结构化的事件补丁操作（添加/删除/更新），而不是简单追加原始事件。

新功能：
- 引入 `EventOperation` 模型和基于操作的时间线补丁 API，支持添加（add）、删除（delete）和更新（update）语义，并使用 `value` / `old_value` / `new_value` 作为载荷。
- 添加稳健的事件时间线解析与序列化工具，实现字符串与结构化表示之间的无损往返转换。

错误修复：
- 确保仅具有结束日期（`invalid_at`）的事件在缺少 `valid_at` 时，仍可通过将 `invalid_at` 作为展示时间暴露给前端。

增强：
- 将 LLM 提示词与输出模式从扁平事件列表更新为操作列表，并加入详细规则，用于生成时间线补丁而非完整时间线。
- 修改反思层检查器，使其在日志中跟踪新增/更新/删除计数的同时，对存储的时间线进行事件操作的校验与应用。
- 调整事件展示逻辑，在缺少 `valid_at` 时回退使用 `invalid_at`，并计算用于排序的单一展示时间戳。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the reflection summary timeline flow to use structured event patch operations (add/delete/update) over an existing timeline instead of appending raw events.

New Features:
- Introduce an EventOperation model and operation-based API for timeline patching, supporting add, delete, and update semantics with value/old_value/new_value payloads.
- Add robust parsing and serialization utilities for event timelines to enable lossless round-tripping between string and structured representations.

Bug Fixes:
- Ensure events with only an end date (invalid_at) can still be surfaced to the frontend by using it as the display time when valid_at is absent.

Enhancements:
- Update LLM prompt and output schema from flat event lists to operation lists, with detailed rules for generating timeline patches rather than full timelines.
- Change the reflection layer inspector to validate and apply event operations to the stored timeline while tracking added/updated/deleted counts in logs.
- Adjust event display logic to fall back to invalid_at when valid_at is missing and to compute a single display timestamp for sorting.

</details>