### PR TITLE
Refactor/extract dashboard queries to repository

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -189,8 +189,8 @@ def get_workspace_end_users(
     # 构建响应数据（先返回给用户，Redis/Celery 操作放后台）
     items = []
     for index, end_user in enumerate(end_users):
-        user_id = str(end_user.id)
-        config_info = memory_configs_map.get(user_id, {})
+        end_user_id = str(end_user.id)
+        config_info = memory_configs_map.get(end_user_id, {})
 
         if current_workspace_type == "rag":
             memory_total = int(raw_items[index].get("memory_count", 0) or 0)
@@ -198,9 +198,8 @@ def get_workspace_end_users(
             memory_total = int(getattr(end_user, "memory_count", 0) or 0)
 
         items.append({
-            "end_user_id": user_id,
             "end_user": {
-                "id": user_id,
+                "end_user_id": end_user_id,
                 "other_name": end_user.other_name,
             },
             "memory_num": {"total": memory_total},

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -198,6 +198,7 @@ def get_workspace_end_users(
             memory_total = int(getattr(end_user, "memory_count", 0) or 0)
 
         items.append({
+            "end_user_id": user_id,
             "end_user": {
                 "id": user_id,
                 "other_name": end_user.other_name,

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -935,6 +935,171 @@ class EndUserRepository:
             db_logger.error(f"批量查询配置信息时出错: {str(e)}")
             raise
 
+    def get_paginated_with_memory(
+        self,
+        workspace_id: uuid.UUID,
+        page: int,
+        pagesize: int,
+        keyword: Optional[str] = None,
+    ) -> tuple[List[EndUser], int]:
+        """Dashboard 专用：分页查询有记忆的宿主（memory_count > 0）
+
+        返回结果按 created_at 从新到旧排序（NULL 值排在最后），
+        只加载接口所需列以避免加载大 Text 字段。
+
+        Args:
+            workspace_id: 工作空间ID
+            page: 页码（从1开始）
+            pagesize: 每页数量
+            keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
+
+        Returns:
+            tuple[List[EndUser], int]: (当前页宿主列表, 符合条件的总数)
+        """
+        from sqlalchemy import desc, String, cast
+        from sqlalchemy.orm import load_only
+        from sqlalchemy.sql.expression import nullslast
+
+        columns = load_only(
+            EndUser.id,
+            EndUser.other_name,
+            EndUser.memory_count,
+            EndUser.app_id,
+            EndUser.memory_config_id,
+            EndUser.created_at,
+            EndUser.workspace_id,
+        )
+        query = self.db.query(EndUser).options(columns).filter(
+            EndUser.workspace_id == workspace_id,
+            EndUser.memory_count > 0,
+            EndUser.is_active == True,
+        )
+
+        if keyword:
+            keyword = keyword.strip()
+        if keyword:
+            pattern = f"%{keyword}%"
+            query = query.filter(
+                or_(
+                    EndUser.other_name.ilike(pattern),
+                    cast(EndUser.id, String).ilike(pattern),
+                )
+            )
+
+        total = query.count()
+        if total == 0:
+            return [], 0
+
+        items = (
+            query.order_by(nullslast(desc(EndUser.created_at)), desc(EndUser.id))
+            .offset((page - 1) * pagesize)
+            .limit(pagesize)
+            .all()
+        )
+        return items, total
+
+    def get_paginated_with_memory_rag(
+        self,
+        workspace_id: uuid.UUID,
+        page: int,
+        pagesize: int,
+        keyword: Optional[str] = None,
+    ) -> tuple[list, int]:
+        """Dashboard RAG 模式：分页查询有记忆的宿主
+
+        RAG 记忆数量以 documents.chunk_num 为准：
+        - file_name = end_user_id + ".txt"
+        - 只统计当前 workspace 下 permission_id="Memory" 的用户记忆知识库
+        - 在 SQL 层过滤 chunk 总数为 0 的宿主
+
+        Args:
+            workspace_id: 工作空间ID
+            page: 页码（从1开始）
+            pagesize: 每页数量
+            keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
+
+        Returns:
+            tuple[list, int]: (items列表[{"end_user": ORM, "memory_count": int}], 总数)
+        """
+        from sqlalchemy import desc, String, cast, func
+        from sqlalchemy.orm import load_only
+        from sqlalchemy.sql.expression import nullslast
+        from app.models.document_model import Document
+        from app.models.knowledge_model import Knowledge
+
+        chunk_subquery = (
+            self.db.query(
+                Document.file_name.label("file_name"),
+                func.coalesce(func.sum(Document.chunk_num), 0).label("memory_count"),
+            )
+            .join(Knowledge, Document.kb_id == Knowledge.id)
+            .filter(
+                Knowledge.workspace_id == workspace_id,
+                Knowledge.status == 1,
+                Knowledge.permission_id == "Memory",
+                Document.status == 1,
+            )
+            .group_by(Document.file_name)
+            .subquery()
+        )
+
+        columns = load_only(
+            EndUser.id,
+            EndUser.other_name,
+            EndUser.memory_count,
+            EndUser.app_id,
+            EndUser.memory_config_id,
+            EndUser.created_at,
+            EndUser.workspace_id,
+        )
+
+        base_query = (
+            self.db.query(
+                EndUser,
+                chunk_subquery.c.memory_count.label("memory_count"),
+            )
+            .options(columns)
+            .join(
+                chunk_subquery,
+                chunk_subquery.c.file_name == func.concat(cast(EndUser.id, String), ".txt"),
+            )
+            .filter(
+                EndUser.workspace_id == workspace_id,
+                chunk_subquery.c.memory_count > 0,
+                EndUser.is_active == True,
+            )
+        )
+
+        if keyword:
+            keyword = keyword.strip()
+        if keyword:
+            pattern = f"%{keyword}%"
+            base_query = base_query.filter(
+                or_(
+                    EndUser.other_name.ilike(pattern),
+                    cast(EndUser.id, String).ilike(pattern),
+                )
+            )
+
+        total = base_query.count()
+        if total == 0:
+            return [], 0
+
+        rows = (
+            base_query.order_by(nullslast(desc(EndUser.created_at)), desc(EndUser.id))
+            .offset((page - 1) * pagesize)
+            .limit(pagesize)
+            .all()
+        )
+
+        items = []
+        for end_user_orm, memory_count in rows:
+            items.append({
+                "end_user": end_user_orm,
+                "memory_count": int(memory_count or 0),
+            })
+        return items, total
+
     def update_memory_count(self, end_user_id: uuid.UUID, node_count: int) -> bool:
         """更新终端用户的记忆节点计数（仅活跃用户）"""
         try:

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -121,50 +121,16 @@ def get_workspace_end_users_paginated(
     business_logger.info(f"获取工作空间宿主列表（分页）: workspace_id={workspace_id}, keyword={keyword}, page={page}, pagesize={pagesize}, 操作者: {current_user.username}")
 
     try:
-        # 构建基础查询 — 只加载接口需要的列，避免加载大 Text 字段
-        _dashboard_columns = load_only(
-            EndUserModel.id,
-            EndUserModel.other_name,
-            EndUserModel.memory_count,
-            EndUserModel.app_id,
-            EndUserModel.memory_config_id,
-            EndUserModel.created_at,
-            EndUserModel.workspace_id,
-        )
-        base_query = db.query(EndUserModel).options(_dashboard_columns).filter(
-            EndUserModel.workspace_id == workspace_id,
-            EndUserModel.memory_count > 0,  # 只查询有记忆的宿主
-            EndUserModel.is_active == True,
+        from app.repositories.end_user_repository import EndUserRepository
+
+        repo = EndUserRepository(db)
+        end_users_orm, total = repo.get_paginated_with_memory(
+            workspace_id=workspace_id,
+            page=page,
+            pagesize=pagesize,
+            keyword=keyword,
         )
 
-        # 构建搜索条件（过滤空字符串和None）
-        keyword = keyword.strip() if keyword else None
-
-        if keyword:
-            keyword_pattern = f"%{keyword}%"
-            base_query = base_query.filter(
-                or_(
-                    EndUserModel.other_name.ilike(keyword_pattern),
-                    cast(EndUserModel.id, String).ilike(keyword_pattern),
-                )
-            )
-            business_logger.info(f"应用模糊搜索: keyword={keyword}（匹配 other_name 或 id）")
-
-        # 获取总记录数
-        total = base_query.count()
-
-        if total == 0:
-            business_logger.info("工作空间下没有宿主")
-            return {"items": [], "total": 0}
-
-        # 分页查询
-        # 按 created_at 降序排序，NULL 值排在最后；id 作为次级排序键保证确定性
-        end_users_orm = base_query.order_by(
-            nullslast(desc(EndUserModel.created_at)),
-            desc(EndUserModel.id)
-        ).offset((page - 1) * pagesize).limit(pagesize).all()
-
-        # 直接返回 ORM 对象，controller 只需要 id/other_name/memory_count
         business_logger.info(f"成功获取 {len(end_users_orm)} 个宿主记录，总计 {total} 条")
         return {"items": end_users_orm, "total": total}
 
@@ -195,76 +161,15 @@ def get_workspace_end_users_paginated_rag(
     )
 
     try:
-        from app.models.document_model import Document
-        from app.models.knowledge_model import Knowledge
+        from app.repositories.end_user_repository import EndUserRepository
 
-        chunk_subquery = (
-            db.query(
-                Document.file_name.label("file_name"),
-                func.coalesce(func.sum(Document.chunk_num), 0).label("memory_count"),
-            )
-            .join(Knowledge, Document.kb_id == Knowledge.id)
-            .filter(
-                Knowledge.workspace_id == workspace_id,
-                Knowledge.status == 1,
-                Knowledge.permission_id == "Memory",
-                Document.status == 1,
-            )
-            .group_by(Document.file_name)
-            .subquery()
+        repo = EndUserRepository(db)
+        items, total = repo.get_paginated_with_memory_rag(
+            workspace_id=workspace_id,
+            page=page,
+            pagesize=pagesize,
+            keyword=keyword,
         )
-
-        base_query = (
-            db.query(
-                EndUserModel,
-                chunk_subquery.c.memory_count.label("memory_count"),
-            )
-            .options(load_only(
-                EndUserModel.id,
-                EndUserModel.other_name,
-                EndUserModel.memory_count,
-                EndUserModel.app_id,
-                EndUserModel.memory_config_id,
-                EndUserModel.created_at,
-                EndUserModel.workspace_id,
-            ))
-            .join(
-                chunk_subquery,
-                chunk_subquery.c.file_name == func.concat(cast(EndUserModel.id, String), ".txt"),
-            )
-            .filter(
-                EndUserModel.workspace_id == workspace_id,
-                chunk_subquery.c.memory_count > 0,
-                EndUserModel.is_active == True,
-            )
-        )
-
-        keyword = keyword.strip() if keyword else None
-        if keyword:
-            keyword_pattern = f"%{keyword}%"
-            base_query = base_query.filter(
-                or_(
-                    EndUserModel.other_name.ilike(keyword_pattern),
-                    cast(EndUserModel.id, String).ilike(keyword_pattern),
-                )
-            )
-
-        total = base_query.count()
-        if total == 0:
-            business_logger.info("RAG 模式下没有符合条件的宿主")
-            return {"items": [], "total": 0}
-
-        rows = base_query.order_by(
-            nullslast(desc(EndUserModel.created_at)),
-            desc(EndUserModel.id),
-        ).offset((page - 1) * pagesize).limit(pagesize).all()
-
-        items = []
-        for end_user_orm, memory_count in rows:
-            items.append({
-                "end_user": end_user_orm,
-                "memory_count": int(memory_count or 0),
-            })
 
         business_logger.info(f"成功获取 RAG 宿主记录 {len(items)} 条，总计 {total} 条")
         return {"items": items, "total": total}


### PR DESCRIPTION
## Summary by Sourcery

将仪表板终端用户的分页查询提取到 `end_user_repository` 中，并将服务接入以使用新的仓库方法，从而同时支持标准和 RAG 记忆仪表板。

Enhancements:
- 添加仓库方法，用于分页查询带有记忆的活跃终端用户，以及基于文档分片数量分页查询处于 RAG 模式的终端用户。
- 更新记忆仪表板服务，使其将终端用户的分页与过滤委托给仓库层，从而让控制器与服务专注于编排逻辑。
- 调整记忆仪表板控制器的响应，在构建响应条目时使用显式的 `end_user_id` 字段命名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract dashboard end-user pagination queries into the end_user_repository and wire services to use the new repository methods for both standard and RAG memory dashboards.

Enhancements:
- Add repository methods to paginate active end users with memory and to paginate RAG-mode end users based on document chunk counts.
- Update memory dashboard services to delegate end-user pagination and filtering to the repository layer, keeping controllers and services focused on orchestration.
- Adjust memory dashboard controller response to use explicit end_user_id field naming when building response items.

</details>