### PR TITLE
refactor(memory): fix sliding window edge cases and ensure idempotent graph writes

### DIFF
--- a/api/app/controllers/memory_agent_controller.py
+++ b/api/app/controllers/memory_agent_controller.py
@@ -205,7 +205,7 @@ async def write_server(
         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
 
 
-@router.post("/writer_service_async", response_model=ApiResponse)
+@router.post("/write", response_model=ApiResponse)
 @cur_workspace_access_guard()
 async def write_server_async(
         user_input: Write_UserInput,

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -356,12 +356,16 @@ async def dispatch_api_service_async(
     if not written_mms:
         return []
 
-    # 标记 pending
-    mark_conversation_pending(conversation_id)
-
     # 3. 预计算上下文窗口并逐条派发
     task_ids = []
     user_indices = [i for i, m in enumerate(written_mms) if m["role"] == "user"]
+
+    # 先推进 cursor 到 max_seq，防止 flush 路径在 push_write_task 期间扫到这批消息重复派发
+    max_seq = max(mm["message_seq"] for mm in written_mms)
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        repo.advance_write_cursor(conversation_id, max_seq)
+        db.commit()
 
     for p, idx in enumerate(user_indices):
         msg = written_mms[idx]
@@ -393,13 +397,6 @@ async def dispatch_api_service_async(
             language=language,
         )
         task_ids.append(msg_id)
-
-    # 统一推进所有消息的 cursor（user + 非 user 一次性完成）
-    max_seq = max(mm["message_seq"] for mm in written_mms)
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        repo.advance_write_cursor(conversation_id, max_seq)
-        db.commit()
 
     return task_ids
 
@@ -771,6 +768,19 @@ def dispatch_single_message(
         context_before = [message_to_dict(m) for m in repo.build_context_before(conversation_id, target_seq)]
         context_after = [message_to_dict(m) for m in repo.build_context_after(conversation_id, target_seq)]
 
+    # 先推进 cursor，防止并发 flush 重复派发同一条消息
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        acquired = repo.advance_write_cursor(conversation_id, target_seq)
+        db.commit()
+
+    if not acquired:
+        logger.info(
+            f"[WriteDispatcher] cursor 已被推进，跳过重复派发: "
+            f"conv={conversation_id}, seq={target_seq}"
+        )
+        return False
+
     push_write_task(
         end_user_id=end_user_id,
         target_message=msg_dict,
@@ -781,10 +791,5 @@ def dispatch_single_message(
         conversation_id=conversation_id,
         message_seq=target_seq,
     )
-
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        repo.advance_write_cursor(conversation_id, target_seq)
-        db.commit()
 
     return True

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -373,8 +373,12 @@ async def dispatch_api_service_async(
 
         # 下文：向后找最多 WINDOW_SIZE 个 user
         after_user_p = min(len(user_indices) - 1, p + WINDOW_SIZE)
-        after_end = user_indices[after_user_p] + 1
-        context_after = written_mms[idx + 1:after_end]
+        if after_user_p == p:
+            # 当前是最后一条 user 消息，context_after 取到列表末尾（包含尾部 assistant 消息）
+            context_after = written_mms[idx + 1:]
+        else:
+            after_end = user_indices[after_user_p] + 1
+            context_after = written_mms[idx + 1:after_end]
 
         # 派发任务
         msg_id = push_write_task(
@@ -616,6 +620,7 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
 
         # Step 3: 逐条处理
         dispatched = 0
+        skipped_non_user = 0 # 统计在 Flush 流程中因角色不是 user 或 should_memorize=False 而被跳过（只推进游标、不派发写入任务）的消息数量
         for msg in pending_messages:
             target_seq = msg["message_seq"]
 
@@ -623,6 +628,7 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
                 with get_db_context() as db:
                     MemoryMessageRepository(db).advance_write_cursor(conversation_id, target_seq)
                     db.commit()
+                skipped_non_user += 1
                 continue
 
             if dispatch_single_message(
@@ -640,7 +646,8 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
 
         logger.info(
             f"[Dispatcher] Flush 已派发 {dispatched} 个 user 消息任务: "
-            f"conv={conversation_id}, total_pending={len(pending_messages)}"
+            f"conv={conversation_id}, total_pending={len(pending_messages)}, "
+            f"skipped_non_user={skipped_non_user}"
         )
         return dispatched
 
@@ -700,6 +707,21 @@ async def check_sliding_window_and_dispatch(
             logger.info(
                 f"[WriteDispatcher] 下文不足，等待更多消息: conv={conversation_id}, "
                 f"seq={target_seq}, downstream={downstream_count} < {WINDOW_SIZE}"
+            )
+            return
+
+        # 先推进 cursor，确保同一条消息不会被后续调用（flush 或下次 ingest）重复派发。
+        # advance_write_cursor 使用 WHERE write_cursor < seq，具有原子性保护。
+        with get_db_context() as db:
+            repo = MemoryMessageRepository(db)
+            acquired = repo.advance_write_cursor(conversation_id, target_seq)
+            db.commit()
+
+        if not acquired:
+            # cursor 已被推进（该消息已被其他路径处理），跳过
+            logger.info(
+                f"[WriteDispatcher] cursor 已被推进，跳过重复派发: "
+                f"conv={conversation_id}, seq={target_seq}"
             )
             return
 

--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -137,15 +137,8 @@ class PruningPipeline:
             user_content=user_content,
         )
 
-        # Step 3: 写入 Neo4j（Assistant Pruned 节点）
-        try:
-            await self._write_to_neo4j(conversation_id, message_seq, content, pruned_content)
-        except Exception as e:
-            logger.warning(
-                f"[PruningPipeline] Neo4j 写入失败（不影响主流程）: "
-                f"conv={conversation_id}, seq={message_seq}, err={e}",
-                exc_info=True,
-            )
+        # Step 3: Neo4j 写入已统一移至 graph_build_step（通过 assistant_pruning_records metadata），
+        # 此处不再直接写入，避免产生重复边。
 
         # Step 4: 写入 Redis 缓存（TTL=86400s）
         try:

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -421,13 +421,6 @@ class WritePipeline:
                 async with bear.step(6, 6, "摘要", "生成情景记忆"):
                     await self._summarize(chunked_dialogs)
 
-                # 推进 write_cursor（如果需要）
-                if not skip_cursor_advance and conversation_id and message_seq > 0:
-                    await self._advance_write_cursor(
-                        conversation_id=conversation_id,
-                        message_seq=message_seq,
-                    )
-
                 # Step 5: 聚类 - 增量更新社区（Celery 异步任务，无需持锁）
                 async with bear.step(5, 6, "聚类", "增量更新社区") as s:
                     await self._cluster(extraction_result)
@@ -1139,28 +1132,6 @@ class WritePipeline:
                         result[user_idx] = {**result[user_idx], "content": processed_user_msg}
 
         return [m for m in result if m is not None]
-
-    async def _advance_write_cursor(
-        self,
-        conversation_id: str,
-        message_seq: int,
-    ) -> None:
-        """原子性推进对话的 write_cursor。
-
-        通过 MemoryMessageRepository.advance_write_cursor 实现，确保 cursor 单调递增。
-
-        Args:
-            conversation_id: 对话 ID
-            message_seq: 目标 user 消息的 message_seq，作为新的 write_cursor 值
-
-        Requirements: 3.2
-        """
-        from app.db import get_db_context
-        from app.repositories.memory_message_repository import MemoryMessageRepository
-
-        with get_db_context() as db:
-            MemoryMessageRepository(db).advance_write_cursor(conversation_id, message_seq)
-            db.commit()
 
     async def _cleanup(self) -> None:
         """

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -80,11 +80,12 @@ def _convert_pruning_records(raw_records: list) -> List[dict]:
 
     result: List[dict] = []
     _now = datetime.now(_tz.utc).isoformat()
-    _base = uuid.uuid4().hex[:8]  # 每批次唯一前缀，避免跨 task pair_id 碰撞
     for idx, r in enumerate(raw_records):
         conv_id = r.get("conversation_id", "")
         seq = r.get("message_seq", 0)
-        pair_id = f"{conv_id}_{seq}_{_base}_{idx}" if conv_id else f"{_base}_{idx}"
+        # pair_id 基于 conversation_id + message_seq 确定性生成，
+        # graph_build_step 用它构造 Neo4j 节点 ID（orig_{pair_id} / pruned_{pair_id}），确保 MERGE 幂等。
+        pair_id = f"{conv_id}_{seq}" if (conv_id and seq) else f"orphan_{uuid.uuid4().hex[:8]}_{idx}"
 
         # Assistant 消息是 input.msgs 中最后一条
         msgs = r.get("input", {}).get("msgs", [])

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -406,8 +406,10 @@ async def build_graph_nodes_and_edges(
 
         for record in pruning_records:
             pair_id = record["pair_id"]
-            original_id = f"ao_{pair_id}"
-            pruned_id = f"ap_{pair_id}"
+            # 节点 ID 基于 pair_id，确保 MERGE 幂等
+            # （pair_id 在 pruning_records 中固定，同一条消息重复处理时 ID 不变）
+            original_id = f"orig_{pair_id}"
+            pruned_id = f"pruned_{pair_id}"
 
             # AssistantOriginal 始终创建（记录原始对话）
             original_node = AssistantOriginalNode(

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -324,6 +324,9 @@ class MemoryMessageRepository:
         向后查找最多 window_size 个 user 消息，取最大 message_seq 作为下边界，
         查询 (target_seq, lower_bound] 范围内所有消息。
 
+        若下游无 user 消息，则返回 target_seq 之后的所有消息（包含尾部 assistant 消息），
+        确保最后一条 assistant 消息也能作为上下文被处理。
+
         Returns:
             消息列表，按 message_seq 升序排列
         """
@@ -339,7 +342,17 @@ class MemoryMessageRepository:
         ).scalars().all()
 
         if not downstream_q_seqs:
-            return []
+            # 下游无 user 消息，返回 target_seq 之后的所有消息（尾部 assistant 消息）
+            return list(
+                self.db.execute(
+                    select(MemoryMessage)
+                    .where(
+                        MemoryMessage.conversation_id == conversation_id,
+                        MemoryMessage.message_seq > target_seq,
+                    )
+                    .order_by(MemoryMessage.message_seq.asc())
+                ).scalars().all()
+            )
 
         lower_bound = max(downstream_q_seqs)
 


### PR DESCRIPTION
## Summary by Sourcery

优化内存分发和裁剪（pruning）流水线，使游标推进为原子操作，避免重复分发，并确保助手裁剪记录的图写入具有确定性。

Bug 修复：
- 通过在构建滑动窗口或分发单条消息之前原子性地推进写入游标，防止 flush 和 ingest 路径分发重复的写入任务。
- 修复滑动窗口上下文构建逻辑：当会话中最后一条消息是用户消息时，确保包含其后的助手消息。
- 确保 flush 分发在仍然推进游标并记录这些跳过条目的同时，跳过非用户或未被记忆（non-memorized）的消息。

增强：
- 在图构建步骤中统一 Neo4j 助手裁剪写入，使用基于成对记录的确定性节点 ID，使图合并具备幂等性。
- 使裁剪对（pruning pair）ID 在每个会话及消息序列中保持确定性，仅在孤立记录（orphan records）场景下回退到作用域受限的随机 ID。
- 简化写入流水线，移除冗余的游标推进逻辑，并将各路由与集中式分发器对齐。
- 将异步写入器 HTTP 端点重命名为更短且更清晰的路径。

文档：
- 通过内联注释澄清上下文窗口构建以及裁剪/图构建步骤的行为，以记录各种边界情况的处理方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine memory dispatch and pruning pipelines to make cursor advancement atomic, avoid duplicate dispatches, and ensure deterministic graph writes for assistant pruning records.

Bug Fixes:
- Prevent flush and ingest paths from dispatching duplicate write tasks by advancing the write cursor atomically before building sliding windows or dispatching single messages.
- Fix sliding window context construction to include trailing assistant messages when a user message is the last in the conversation.
- Ensure flush dispatch skips non-user or non-memorized messages while still advancing the cursor and logs these skipped entries.

Enhancements:
- Unify Neo4j assistant pruning writes in the graph build step with deterministic pair-based node IDs to make graph merges idempotent.
- Make pruning pair IDs deterministic per conversation and message sequence, falling back to a scoped random ID only for orphan records.
- Simplify write pipelines by removing redundant cursor advancement logic and aligning routes with the centralized dispatcher.
- Rename the async writer HTTP endpoint to a shorter, clearer path.

Documentation:
- Clarify behavior of context window construction and pruning/graph build steps via inline comments to document edge-case handling.

</details>