### PR TITLE
feat(web): parent_child_mode

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/DocumentDetails.tsx
@@ -171,9 +171,8 @@ const DocumentDetails: FC = () => {
       const url = `${window.location.origin}/api/files/${response.file_id}`;
       setFileUrl(url);
       const auto_questions = response?.parser_config?.auto_questions || 0
-      const parent_chunk_mode = response?.parser_config?.parent_chunk_mode || false
       setParserMode(auto_questions)
-      setIsParentChildMode(auto_questions === 0 && parent_chunk_mode)
+      setIsParentChildMode(response.parent_child_mode || false)
       // ChunkList will be called automatically in useEffect based on document.progress
     } catch (error) {
       console.error('Failed to fetch document details:', error);

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -145,6 +145,7 @@ export interface KnowledgeBaseDocumentData { // 知识库文档数据
   updated_at?: string; // 更新时间
   qa_prompt?: string; // 提示词
   metadata?: Record<string, any>; // 文档元数据
+  parent_child_mode?: boolean; // 是否开启父子模式
 }
 export interface DocumentModalRef {
   handleOpen: (file?: KnowledgeBaseDocumentData | null) => void;


### PR DESCRIPTION
## Summary by Sourcery

更新文档详情视图，从文档响应中直接获取父子模式标志，并扩展文档数据类型以包含该字段。

新功能：
- 在知识库文档的元数据中新增 `parent_child_mode` 布尔字段。

增强：
- 调整文档详情视图中父子模式的判定方式，使其依赖后端返回的新的 `parent_child_mode` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update document details view to source the parent-child mode flag directly from the document response and extend the document data type to include this field.

New Features:
- Add a parent_child_mode boolean field to knowledge base document metadata.

Enhancements:
- Adjust parent-child mode determination in the document details view to rely on the new parent_child_mode field returned from the backend.

</details>