### PR TITLE
refactor(memory): stop sliding window processing on non-user messages

### DIFF
--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -689,12 +689,10 @@ async def check_sliding_window_and_dispatch(
 
     for msg in pending_dicts:
         # 滑动窗口路径只负责派发 user 消息的写入任务，cursor 只推进到 user 消息的 seq。
-        # non-user 消息（assistant）的 cursor 推进不在这里做，
-        # 完全交给 flush 兜底路径处理——flush 扫完所有 pending 后 cursor 才会推进到偶数。
-        # 这样保证：滑动窗口路径 cursor 始终停在奇数（user seq），
-        # 偶数（assistant seq）只在 flush 完成后出现。
+        # non-user 消息（assistant）不推进 cursor，跳过继续往后找第一条待派发的 user 消息。
+        # assistant 的 cursor 推进完全交给 flush 兜底路径处理。
         if msg.get("role") != "user" or not msg.get("should_memorize", True):
-            return
+            continue
 
         target_seq = msg["message_seq"]
 

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -688,13 +688,13 @@ async def check_sliding_window_and_dispatch(
         all_user_seqs: List[int] = repo.get_user_seqs(conversation_id)
 
     for msg in pending_dicts:
-        # 跳过非 user 或不需记忆的消息，直接推进 cursor
+        # 滑动窗口路径只负责派发 user 消息的写入任务，cursor 只推进到 user 消息的 seq。
+        # non-user 消息（assistant）的 cursor 推进不在这里做，
+        # 完全交给 flush 兜底路径处理——flush 扫完所有 pending 后 cursor 才会推进到偶数。
+        # 这样保证：滑动窗口路径 cursor 始终停在奇数（user seq），
+        # 偶数（assistant seq）只在 flush 完成后出现。
         if msg.get("role") != "user" or not msg.get("should_memorize", True):
-            with get_db_context() as db:
-                repo = MemoryMessageRepository(db)
-                repo.advance_write_cursor(conversation_id, msg["message_seq"])
-                db.commit()
-            continue
+            return
 
         target_seq = msg["message_seq"]
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 确保滑动窗口内存游标只在用户消息时前进，避免错误地越过助手消息或未被记忆的消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the sliding-window memory cursor only advances on user messages to avoid incorrectly moving past assistant or non-memorized messages.

</details>