### PR TITLE
refactor(app_chat_service,draft_run_service)

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -347,6 +347,12 @@ class Settings:
     # 实验模式开关（允许通过 API 动态切换本体配置）
     ONTOLOGY_EXPERIMENT_MODE: bool = os.getenv("ONTOLOGY_EXPERIMENT_MODE", "true").lower() == "true"
 
+    # ========================================================================
+    # Context Engine History Configuration
+    # ========================================================================
+    # context engine的agent历史消息条数上限
+    AGENT_MAX_HISTORY: int = int(os.getenv("AGENT_MAX_HISTORY", 20))
+
     def get_memory_output_path(self, filename: str = "") -> str:
         """
         Get the full path for memory module output files.

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -25,6 +25,7 @@ from app.schemas.model_schema import ModelInfo
 from app.schemas.prompt_schema import render_prompt_message, PromptMessageRole
 from app.services.conversation_service import ConversationService
 from app.services.context_engine_manager import ContextEngineManager
+from app.core.config import settings
 from app.services.draft_run_service import AgentRunService
 from app.services.model_service import ModelApiKeyService
 from app.services.multi_agent_orchestrator import MultiAgentOrchestrator
@@ -232,7 +233,7 @@ class AppChatService:
                 current_input=message,
                 current_provider=api_key_obj.provider,
                 current_is_omni=api_key_obj.is_omni,
-                legacy_max_history=6,
+                legacy_max_history=settings.AGENT_MAX_HISTORY,
                 model_config_id=config.default_model_config_id,
             )
             if prepared_input:
@@ -241,7 +242,7 @@ class AppChatService:
             else:
                 history = await self.conversation_service.get_conversation_history(
                     conversation_id=conversation_id,
-                    max_history=20,
+                    max_history=settings.AGENT_MAX_HISTORY,
                     current_provider=api_key_obj.provider,
                     current_is_omni=api_key_obj.is_omni
                 )
@@ -264,7 +265,7 @@ class AppChatService:
                 # 重新加载历史（包含刚写入的开场白）
                 history = await self.conversation_service.get_conversation_history(
                     conversation_id=conversation_id,
-                    max_history=10,
+                    max_history=settings.AGENT_MAX_HISTORY,
                     current_provider=api_key_obj.provider,
                     current_is_omni=api_key_obj.is_omni
                 )
@@ -479,7 +480,7 @@ class AppChatService:
                     conversation_id=conversation_id,
                     current_provider=api_key_obj.provider,
                     current_is_omni=api_key_obj.is_omni,
-                    legacy_max_history=6,
+                    legacy_max_history=settings.AGENT_MAX_HISTORY,
                     model_config_id=config.default_model_config_id,
                 )
         else:
@@ -652,7 +653,7 @@ class AppChatService:
                     current_input=message,
                     current_provider=api_key_obj.provider,
                     current_is_omni=api_key_obj.is_omni,
-                    legacy_max_history=6,
+                    legacy_max_history=settings.AGENT_MAX_HISTORY,
                     model_config_id=config.default_model_config_id,
                 )
                 if prepared_input:
@@ -661,7 +662,7 @@ class AppChatService:
                 else:
                     history = await self.conversation_service.get_conversation_history(
                         conversation_id=conversation_id,
-                        max_history=20,
+                        max_history=settings.AGENT_MAX_HISTORY,
                         current_provider=api_key_obj.provider,
                         current_is_omni=api_key_obj.is_omni
                     )
@@ -684,7 +685,7 @@ class AppChatService:
                     # 重新加载历史（包含刚写入的开场白）
                     history = await self.conversation_service.get_conversation_history(
                         conversation_id=conversation_id,
-                        max_history=10,
+                        max_history=settings.AGENT_MAX_HISTORY,
                         current_provider=api_key_obj.provider,
                         current_is_omni=api_key_obj.is_omni
                     )
@@ -945,7 +946,7 @@ class AppChatService:
                         conversation_id=conversation_id,
                         current_provider=api_key_obj.provider,
                         current_is_omni=api_key_obj.is_omni,
-                        legacy_max_history=6,
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
                         model_config_id=config.default_model_config_id,
                     )
             else:

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -872,7 +872,7 @@ class AgentRunService:
                     current_input=message,
                     current_provider=api_key_config.get("provider"),
                     current_is_omni=api_key_config.get("is_omni", False),
-                    legacy_max_history=6,
+                    legacy_max_history=settings.AGENT_MAX_HISTORY,
                     model_config_id=model_config.id,
                 )
                 if prepared_input:
@@ -881,7 +881,7 @@ class AgentRunService:
                 else:
                     history = await self._load_conversation_history(
                         conversation_id=conversation_id,
-                        max_history=20,
+                        max_history=settings.AGENT_MAX_HISTORY,
                         current_provider=api_key_config.get("provider"),
                         current_is_omni=api_key_config.get("is_omni", False)
                     )
@@ -1050,7 +1050,7 @@ class AgentRunService:
                         conversation_id=uuid.UUID(conversation_id),
                         current_provider=api_key_config.get("provider"),
                         current_is_omni=api_key_config.get("is_omni", False),
-                        legacy_max_history=6,
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
                         model_config_id=model_config.id,
                     )
 
@@ -1292,7 +1292,7 @@ class AgentRunService:
                     current_input=message,
                     current_provider=api_key_config.get("provider"),
                     current_is_omni=api_key_config.get("is_omni", False),
-                    legacy_max_history=6,
+                    legacy_max_history=settings.AGENT_MAX_HISTORY,
                     model_config_id=model_config.id,
                 )
                 if prepared_input:
@@ -1301,7 +1301,7 @@ class AgentRunService:
                 else:
                     history = await self._load_conversation_history(
                         conversation_id=conversation_id,
-                        max_history=20,
+                        max_history=settings.AGENT_MAX_HISTORY,
                         current_provider=api_key_config.get("provider"),
                         current_is_omni=api_key_config.get("is_omni", False)
                     )
@@ -1516,7 +1516,7 @@ class AgentRunService:
                         conversation_id=uuid.UUID(conversation_id),
                         current_provider=api_key_config.get("provider"),
                         current_is_omni=api_key_config.get("is_omni", False),
-                        legacy_max_history=6,
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
                         model_config_id=model_config.id,
                     )
 


### PR DESCRIPTION
replace hardcoded agent history limits with configurable AGENT_MAX_HISTORY

## Summary by Sourcery

使代理对话历史记录的限制可配置，并通过新的 `AGENT_MAX_HISTORY` 设置进行统一。

增强内容：
- 将 `app_chat_service` 和 `draft_run_service` 中硬编码的 `legacy_max_history` 和 `max_history` 值，替换为共享的 `AGENT_MAX_HISTORY` 配置值。
- 在全局 `Settings` 配置中引入 `AGENT_MAX_HISTORY` 设置，默认值为 20，并可通过环境变量进行覆写。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make agent conversation history limits configurable and unify them under a new AGENT_MAX_HISTORY setting.

Enhancements:
- Replace hardcoded legacy_max_history and max_history values in app_chat_service and draft_run_service with a shared AGENT_MAX_HISTORY configuration value.
- Introduce AGENT_MAX_HISTORY setting in the global Settings configuration, defaulting to 20 and overridable via environment variable.

</details>