### PR TITLE
refactor(memory): deprecate async memory read endpoint

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -7,7 +7,7 @@
 认证方式: API Key (@require_api_key)
 """
 
-from fastapi import APIRouter, Body, Depends, Header, Query, Request
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 from starlette.responses import Response
@@ -156,7 +156,7 @@ async def read_memory_async(
     Requires API Key with 'memory' scope.
     Returns task_id for polling via GET /read/status.
     """
-    raise Exception("该接口已弃用，请使用同步读取接口/v1/memory/read/sync")
+    raise HTTPException(status_code=410, detail="该接口已弃用，请使用同步读取接口 /v1/memory/read/sync")
 
 
 @router.get("/write/status")

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -156,20 +156,7 @@ async def read_memory_async(
     Requires API Key with 'memory' scope.
     Returns task_id for polling via GET /read/status.
     """
-    body = await request.json()
-    payload = UserInput(**body)
-
-    current_user = get_current_user_from_api_key(db, api_key_auth)
-    validate_end_user_in_workspace(db, payload.end_user_id, api_key_auth.workspace_id)
-
-    logger.info(f"V1 memory read (async) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
-
-    result = await memory_agent_controller.read_server_async(
-        user_input=payload,
-        db=db,
-        current_user=current_user,
-    )
-    return _encode_result(result)
+    raise Exception("该接口已弃用，请使用同步读取接口/v1/memory/read/sync")
 
 
 @router.get("/write/status")


### PR DESCRIPTION
- Remove implementation of POST /v1/memory/read/async
- Raise exception directing users to use synchronous endpoint /v1/memory/read/sync

## Summary by Sourcery

弃用异步内存读取 API 端点，并在调用该异步端点时抛出异常，从而将用户重定向到同步的 `/v1/memory/read/sync` 端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deprecate the asynchronous memory read API endpoint and redirect users to the synchronous /v1/memory/read/sync endpoint by raising an exception when the async endpoint is called.

</details>