### PR TITLE
refactor(memory): deprecate async memory read endpoint

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -16,15 +16,17 @@ from starlette.responses import Response
 from app.controllers import memory_agent_controller
 from app.core.api_key_auth import require_api_key
 from app.core.api_key_utils import get_current_user_from_api_key, validate_end_user_in_workspace
+from app.core.error_codes import BizCode, HTTP_MAPPING
 from app.core.logging_config import get_business_logger
 from app.core.memory.enums import SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.quota_stub import check_end_user_quota
-from app.core.response_utils import success
+from app.core.response_utils import success, fail
 from app.db import get_db
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.memory_agent_schema import Write_UserInput, UserInput
 from app.services.memory_agent_service import get_end_user_connected_config as get_config
+
 
 router = APIRouter(prefix="/memory", tags=["V1 - Memory API"])
 logger = get_business_logger()
@@ -156,7 +158,7 @@ async def read_memory_async(
     Requires API Key with 'memory' scope.
     Returns task_id for polling via GET /read/status.
     """
-    raise HTTPException(status_code=410, detail="该接口已弃用，请使用同步读取接口 /v1/memory/read/sync")
+    return fail(code=BizCode.INTERNAL_ERROR, msg="该接口已弃用，请使用同步读取接口 /v1/memory/read/sync")
 
 
 @router.get("/write/status")


### PR DESCRIPTION
- Remove implementation of POST /v1/memory/read/async
- Raise exception directing users to use synchronous endpoint /v1/memory/read/sync

## Summary by Sourcery

Bug Fixes:
- 将已弃用的异步内存读取端点与集中式业务错误处理对齐，使用 BizCode 和 `fail()`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Align the deprecated async memory read endpoint with centralized business error handling using BizCode and fail().

</details>