### PR TITLE
refactor(app_chat_service,draft_run_service)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -475,13 +475,15 @@ class AppChatService:
                 should_memorize=memory,
             )
             if used_context_engine:
-                await context_engine_manager.after_app_turn(
-                    features=features_config,
-                    conversation_id=conversation_id,
-                    current_provider=api_key_obj.provider,
-                    current_is_omni=api_key_obj.is_omni,
-                    legacy_max_history=settings.AGENT_MAX_HISTORY,
-                    model_config_id=config.default_model_config_id,
+                asyncio.create_task(
+                    context_engine_manager.after_app_turn(
+                        features=features_config,
+                        conversation_id=conversation_id,
+                        current_provider=api_key_obj.provider,
+                        current_is_omni=api_key_obj.is_omni,
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
+                        model_config_id=config.default_model_config_id,
+                    )
                 )
         else:
             new_msg = Message(
@@ -941,13 +943,15 @@ class AppChatService:
                     should_memorize=memory,
                 )
                 if used_context_engine:
-                    await context_engine_manager.after_app_turn(
-                        features=features_config,
-                        conversation_id=conversation_id,
-                        current_provider=api_key_obj.provider,
-                        current_is_omni=api_key_obj.is_omni,
-                        legacy_max_history=settings.AGENT_MAX_HISTORY,
-                        model_config_id=config.default_model_config_id,
+                    asyncio.create_task(
+                        context_engine_manager.after_app_turn(
+                            features=features_config,
+                            conversation_id=conversation_id,
+                            current_provider=api_key_obj.provider,
+                            current_is_omni=api_key_obj.is_omni,
+                            legacy_max_history=settings.AGENT_MAX_HISTORY,
+                            model_config_id=config.default_model_config_id,
+                        )
                     )
             else:
                 new_msg = Message(

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -1045,13 +1045,15 @@ class AgentRunService:
                     is_omni=api_key_config.get("is_omni", False)
                 )
                 if used_context_engine and not skip_save:
-                    await context_engine_manager.after_app_turn(
-                        features=features_config,
-                        conversation_id=uuid.UUID(conversation_id),
-                        current_provider=api_key_config.get("provider"),
-                        current_is_omni=api_key_config.get("is_omni", False),
-                        legacy_max_history=settings.AGENT_MAX_HISTORY,
-                        model_config_id=model_config.id,
+                    asyncio.create_task(
+                        context_engine_manager.after_app_turn(
+                            features=features_config,
+                            conversation_id=uuid.UUID(conversation_id),
+                            current_provider=api_key_config.get("provider"),
+                            current_is_omni=api_key_config.get("is_omni", False),
+                            legacy_max_history=settings.AGENT_MAX_HISTORY,
+                            model_config_id=model_config.id,
+                        )
                     )
 
             # 11. 更新 Agent 执行记录为 completed
@@ -1511,13 +1513,15 @@ class AgentRunService:
                     is_omni=api_key_config.get("is_omni", False)
                 )
                 if used_context_engine and not skip_save:
-                    await context_engine_manager.after_app_turn(
-                        features=features_config,
-                        conversation_id=uuid.UUID(conversation_id),
-                        current_provider=api_key_config.get("provider"),
-                        current_is_omni=api_key_config.get("is_omni", False),
-                        legacy_max_history=settings.AGENT_MAX_HISTORY,
-                        model_config_id=model_config.id,
+                    asyncio.create_task(
+                        context_engine_manager.after_app_turn(
+                            features=features_config,
+                            conversation_id=uuid.UUID(conversation_id),
+                            current_provider=api_key_config.get("provider"),
+                            current_is_omni=api_key_config.get("is_omni", False),
+                            legacy_max_history=settings.AGENT_MAX_HISTORY,
+                            model_config_id=model_config.id,
+                        )
                     )
 
             # 11.5 更新 Agent 执行记录为 completed


### PR DESCRIPTION
convert await calls to asyncio.create_task for non-blocking context engine execution

## Summary by Sourcery

Enhancements:
- 将在聊天和草稿运行服务中等待的 `context_engine_manager.after_app_turn` 调用替换为后台任务，以提升响应速度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace awaited context_engine_manager.after_app_turn calls with background tasks in chat and draft run services to improve responsiveness.

</details>