### PR TITLE
fix: MCP创建enduser时同步写入end_user_info表

### DIFF
--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -208,6 +208,17 @@ class EndUserRepository:
                     other_id=user_id
                 )
                 self.db.add(end_user)
+                self.db.flush()  # flush to get end_user.id before creating EndUserInfo
+
+                # Create corresponding EndUserInfo record
+                end_user_info = EndUserInfo(
+                    end_user_id=end_user.id,
+                    other_name="",
+                    aliases=[],
+                    meta_data={}
+                )
+                self.db.add(end_user_info)
+
                 self.db.commit()
                 self.db.refresh(end_user)
                 return end_user.id, end_user.other_id


### PR DESCRIPTION
## 问题

`get_or_create_end_user_mcp` 方法在创建 EndUser 时未同步写入 `end_user_info` 表，而另外两个方法 `get_or_create_end_user` 和 `get_or_create_end_user_with_config` 均已正确创建 EndUserInfo 记录。

## 修复

在 `get_or_create_end_user_mcp` 中新增 EndUserInfo 创建逻辑，与现有方法保持一致，在同一事务中原子提交。

## Summary by Sourcery

Bug Fixes:
- 在创建 MCP 终端用户时，同时创建对应的 `EndUserInfo` 记录，从而避免相关信息缺失。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Create corresponding EndUserInfo records when MCP end users are created so related info is no longer missing.

</details>