### PR TITLE
fix(web): relationship network

### DIFF
--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -238,11 +238,12 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
         : <div className="rb:absolute rb:inset-0">
           {categories.length > 0 &&
             <Flex gap={24} align="center" justify="space-between" wrap={false}
-              className={clsx('rb:absolute! rb:z-9999 rb:top-4 rb:bg-[#FFFFFF] rb:rounded-xl rb:py-2! rb:px-3!', {
+              className={clsx('rb:absolute! rb:z-999 rb:top-4 rb:bg-[#FFFFFF] rb:rounded-xl rb:py-2! rb:px-3!', {
                 'rb:w-full': !selectedNode && !selectedKey,
                 'rb:w-[calc(100%-412px)]': selectedNode,
                 'rb:left-103 rb:w-[calc(100%-412px)]': selectedKey,
-                'rb:left-0': !selectedKey
+                'rb:left-0': !selectedKey,
+                'rb:left-103 rb:w-[calc(100%-824px)]': selectedKey && selectedNode,
               })}
             >
               <Flex wrap gap={8}>

--- a/web/src/views/UserMemoryDetail/pages/ExtractedEntityGraphDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/ExtractedEntityGraphDetail.tsx
@@ -70,6 +70,7 @@ const ExtractedEntityGraphDetail: FC = () => {
     pagesize: PAGE_SIZE,
   });
   const [total, setTotal] = useState(0);
+  const [totalCount, setTotalCount] = useState(0)
   const nodeId = searchParams.get('nodeId')
   const nodeLabel = searchParams.get('nodeLabel')
   const nodeName = searchParams.get('nodeName')
@@ -126,7 +127,8 @@ const ExtractedEntityGraphDetail: FC = () => {
           page: { hasnext: boolean; pagesize: number; total: number; }
         }
         setTypeStats(response.type_stats || [])
-        setTotal(response.total_count)
+        setTotal(response.page.total)
+        setTotalCount(response.total_count)
         setTimelineMemories(response.items)
       })
       .finally(() => setTimelineLoading(false))
@@ -161,7 +163,7 @@ const ExtractedEntityGraphDetail: FC = () => {
                     {t('userMemory.totalCategoryStats')}
                   </div>
                   <div className="rb:mt-1 rb:font-[MiSans-Bold] rb:font-bold rb:text-[18px] rb:text-[#171719] rb:leading-6.5">
-                    {total || 0}
+                    {totalCount || 0}
                   </div>
                 </div>
                 <div className="rb:grid rb:grid-cols-2 rb:gap-3">


### PR DESCRIPTION
## Summary by Sourcery

修复关系网络和实体图总数显示问题。

错误修复：
- 通过区分页码总数与全局总数，纠正提取实体图中的统计总数。
- 调整关系网络标题的位置和层级，当同时选中节点和键时，使其能够正确对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix relationship network and entity graph totals display issues.

Bug Fixes:
- Correct total statistics in extracted entity graph by distinguishing between paginated total and global total count.
- Adjust relationship network header positioning and stacking to align correctly when both a node and a key are selected.

</details>