### PR TITLE
fix(web): help center ui

### DIFF
--- a/web/src/components/Header/index.tsx
+++ b/web/src/components/Header/index.tsx
@@ -14,7 +14,7 @@
  */
 
 import { type FC, useRef, useState } from 'react';
-import { Layout, Dropdown, Breadcrumb, Flex, Tooltip } from 'antd';
+import { Layout, Dropdown, Breadcrumb, Flex, Tooltip, Button } from 'antd';
 import type { MenuProps, BreadcrumbProps } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -110,16 +110,6 @@ const AppHeader: FC<{ source?: 'space' | 'manage'; }> = ({ source = 'manage' }) 
       },
     },
     {
-      key: '7',
-      icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/question_bold.svg')]"></div>,
-      label: <Flex justify="space-between" align="center">
-        {t('quickActions.helpCenter')}
-        <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/menuNew/arrow_t_r.svg')]"></div>
-      </Flex>,
-      className: 'rb:text-[#212332]!',
-      onClick: gotoHelpCenter,
-    },
-    {
       key: '4',
       icon: <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/menuNew/settings.svg')]"></div>,
       label: <Flex justify="space-between" align="center">
@@ -185,30 +175,41 @@ const AppHeader: FC<{ source?: 'space' | 'manage'; }> = ({ source = 'manage' }) 
   const handleOpenChange = (open: boolean) => {
     setOpen(open);
   }
+
   return (
     <Header className={styles.header}>
       {/* Breadcrumb navigation */}
       <Breadcrumb separator="<" items={formatBreadcrumbNames() as BreadcrumbProps['items']} className="rb:font-medium!" />
-      {/* User info dropdown menu */}
-      {user.username && (
-        <Dropdown
-          menu={{
-            items: userMenuItems
-          }}
-          onOpenChange={handleOpenChange}
-          overlayClassName={styles.userDropdown}
+
+      <Flex gap={12} align="center">
+        <Button
+          icon={<div className="rb:size-3.5 rb:bg-cover rb:bg-[url('@/assets/images/common/question.svg')]"></div>}
+          className="rb:px-2! rb:rounded-[10px]!"
+          onClick={gotoHelpCenter}
         >
-          <Flex align="center" className="rb:cursor-pointer rb:font-medium">
-            {user.username && <Flex align="center" justify="center" className="rb:size-8 rb:rounded-xl rb:bg-[#155EEF] rb:text-white rb:mr-2!">
-              {/[\u4e00-\u9fa5]/.test(user.username) ? user.username.slice(-2) : user.username[0]}
-            </Flex>}
-            <span className="rb:text-[#212332] rb:text-[12px] rb:leading-4 rb:mr-1">{user.username}</span>
-            <div className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/arrow_up.svg')]", {
-              'rb:rotate-180': !open,
-            })}></div>
-          </Flex>
-        </Dropdown>
-      )}
+          {t('quickActions.helpCenter')}
+        </Button>
+        {/* User info dropdown menu */}
+        {user.username && (
+          <Dropdown
+            menu={{
+              items: userMenuItems
+            }}
+            onOpenChange={handleOpenChange}
+            overlayClassName={styles.userDropdown}
+          >
+            <Flex align="center" className="rb:cursor-pointer rb:font-medium">
+              {user.username && <Flex align="center" justify="center" className="rb:size-8 rb:rounded-xl rb:bg-[#155EEF] rb:text-white rb:mr-2!">
+                {/[\u4e00-\u9fa5]/.test(user.username) ? user.username.slice(-2) : user.username[0]}
+              </Flex>}
+              <span className="rb:text-[#212332] rb:text-[12px] rb:leading-4 rb:mr-1">{user.username}</span>
+              <div className={clsx("rb:size-3 rb:bg-cover rb:bg-[url('@/assets/images/common/arrow_up.svg')]", {
+                'rb:rotate-180': !open,
+              })}></div>
+            </Flex>
+          </Dropdown>
+        )}
+      </Flex>
       <SettingModal
         ref={settingModalRef}
       />

--- a/web/src/views/Index/components/GuideCard.tsx
+++ b/web/src/views/Index/components/GuideCard.tsx
@@ -3,8 +3,8 @@
  * @Version: 0.0.1
  * @Author: yujiangping
  * @Date: 2026-01-13 11:44:06
- * @LastEditors: yujiangping
- * @LastEditTime: 2026-01-15 20:59:57
+ * @LastEditors: Please set LastEditors
+ * @LastEditTime: 2026-06-23 10:43:55
  */
 import React, { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,10 +12,8 @@ import { useNavigate } from 'react-router-dom';
 import { Button, Tour, Flex } from 'antd';
 import type { TourProps } from 'antd';
 
-import { openHelpCenter } from '@/utils/help';
-
 const GuideCard: React.FC = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [open, setOpen] = useState<boolean>(false);
   const [currentStep, setCurrentStep] = useState<number>(0);
@@ -65,12 +63,6 @@ const GuideCard: React.FC = () => {
     navigate('/model');
   };
 
-  const gotoHelpCenter = () => {
-    const currentLang = i18n.language;
-    const lang = currentLang === 'zh' ? 'zh' : 'en';
-    openHelpCenter(lang);
-  };
-
   return (
     <>
       <div className='rb:w-full rb:bg-white rb:rounded-xl rb:pb-3'>
@@ -78,13 +70,7 @@ const GuideCard: React.FC = () => {
           className=' rb:leading-5 rb:p-3! rb:bg-cover rb:rounded-tl-xl rb:rounded-tr-xl rb:bg-[url("@/assets/images/index/guide_bg@2x.png")]'
         >
           <div className="rb:font-[MiSans-Bold] rb:font-bold">{ t('index.getStarted')}</div>
-          <Flex align="center" gap={4}
-            className="rb:text-[12px] rb:text-[#5F6266] rb:cursor-pointer"
-            onClick={gotoHelpCenter}
-          >
-            <div className="rb:size-3.5 rb:bg-cover rb:bg-[url('@/assets/images/common/question.svg')]"></div>
-            {t('quickActions.helpCenter')}
-          </Flex>
+          
         </Flex>
         <div className='rb:leading-4.5 rb:text-[12px] rb:-mt-2 rb:pl-3 rb:pr-1.75'>
             { t('index.startedDesc')}


### PR DESCRIPTION
## Summary by Sourcery

更新网页页眉中帮助中心入口的布局，并清理指南卡片中多余的帮助中心访问入口。

New Features:
- 在页眉中用户下拉菜单旁新增一个独立的帮助中心按钮。

Enhancements:
- 从用户下拉菜单中移除帮助中心项，以获得更清晰的菜单结构。
- 从指南卡片的标题中移除帮助中心链接，以避免重复的入口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update layout of the help center entry point in the web header and clean up redundant help center access in the guide card.

New Features:
- Add a dedicated help center button next to the user dropdown in the header.

Enhancements:
- Remove the help center item from the user dropdown menu for a clearer menu structure.
- Remove the help center link from the guide card header to avoid duplicated entry points.

</details>