### PR TITLE
fix(web): api key create other id

### DIFF
--- a/web/src/views/ApiKeyManagement/components/ApiKeyModal.tsx
+++ b/web/src/views/ApiKeyManagement/components/ApiKeyModal.tsx
@@ -189,19 +189,21 @@ const ApiKeyModal = forwardRef<ApiKeyModalRef, CreateModalProps>(({
             className="rb:pt-0! rb:pb-4!"
           />
 
-          <div className="rb:mb-4">
-            <div className="rb:text-sm rb:text-gray-500 rb:mb-2">{t('apiKey.id')}</div>
-            <Flex align="center" justify="space-between" className="rb:bg-[#F6F6F6] rb:text-[#5B6167] rb:rounded-lg rb:px-3! rb:py-2!">
-              <span className="rb:text-sm">{createdApiKey?.other_id}</span>
- 
-              <Button className="rb:px-2! rb:h-7! rb:group" onClick={() => handleCopy(createdApiKey?.other_id || '')}>
-                <div
-                  className="rb:w-4 rb:h-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/copy.svg')] rb:group-hover:bg-[url('@/assets/images/copy_active.svg')]"
-                ></div>
-                {t('common.copy')}
-              </Button>
-            </Flex>
-          </div>
+          {createdApiKey?.other_id &&
+            <div className="rb:mb-4">
+              <div className="rb:text-sm rb:text-gray-500 rb:mb-2">{t('apiKey.id')}</div>
+              <Flex align="center" justify="space-between" className="rb:bg-[#F6F6F6] rb:text-[#5B6167] rb:rounded-lg rb:px-3! rb:py-2!">
+                <span className="rb:text-sm">{createdApiKey?.other_id}</span>
+  
+                <Button className="rb:px-2! rb:h-7! rb:group" onClick={() => handleCopy(createdApiKey?.other_id || '')}>
+                  <div
+                    className="rb:w-4 rb:h-4 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/copy.svg')] rb:group-hover:bg-[url('@/assets/images/copy_active.svg')]"
+                  ></div>
+                  {t('common.copy')}
+                </Button>
+              </Flex>
+            </div>
+          }
 
           <div className="rb:mb-4">
             <div className="rb:flex rb:items-center rb:justify-between rb:mb-2">


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当为新创建的密钥未返回备用 ID 时，防止显示空的 API 密钥 ID 和复制控件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent displaying an empty API key ID and copy control when no alternate ID is returned for the created key.

</details>