### PR TITLE
Fix/timebomb 039

### DIFF
--- a/api/app/core/workflow/nodes/agent/node.py
+++ b/api/app/core/workflow/nodes/agent/node.py
@@ -8,6 +8,7 @@ Agent 节点实现
 （error_handle / memory / thinking）。
 """
 
+import asyncio
 import logging
 import json
 from copy import deepcopy
@@ -402,16 +403,18 @@ class AgentNode(BaseNode):
             if self.typed_config.memory.enable:
                 conversation_id = self.get_variable("sys.conversation_id", variable_pool, default="", strict=False)
                 if conversation_id:
-                    with get_db_context() as db:
-                        context_engine_manager = ContextEngineManager(db)
-                        await context_engine_manager.after_workflow_turn(
-                            features=self.workflow_config.get("features", {}),
-                            conversation_id=conversation_id,
-                            scope_key=f"node:{self.node_id}",
-                            workflow_messages=state.get("messages", []),
-                            window_size=self.typed_config.memory.window_size,
-                            model_config_id=self.typed_config.model.model_id,
-                        )
+                    _kwargs = dict(
+                        features=self.workflow_config.get("features", {}),
+                        conversation_id=conversation_id,
+                        scope_key=f"node:{self.node_id}",
+                        workflow_messages=state.get("messages", []),
+                        window_size=self.typed_config.memory.window_size,
+                        model_config_id=self.typed_config.model.model_id,
+                    )
+                    async def _run_after_workflow_turn(kwargs=_kwargs):
+                        with get_db_context() as db:
+                            await ContextEngineManager(db).after_workflow_turn(**kwargs)
+                    asyncio.create_task(_run_after_workflow_turn())
 
             return {
                 "llm_result": AIMessage(
@@ -494,16 +497,18 @@ class AgentNode(BaseNode):
             if self.typed_config.memory.enable:
                 conversation_id = self.get_variable("sys.conversation_id", variable_pool, default="", strict=False)
                 if conversation_id:
-                    with get_db_context() as db:
-                        context_engine_manager = ContextEngineManager(db)
-                        await context_engine_manager.after_workflow_turn(
-                            features=self.workflow_config.get("features", {}),
-                            conversation_id=conversation_id,
-                            scope_key=f"node:{self.node_id}",
-                            workflow_messages=state.get("messages", []),
-                            window_size=self.typed_config.memory.window_size,
-                            model_config_id=self.typed_config.model.model_id,
-                        )
+                    _kwargs = dict(
+                        features=self.workflow_config.get("features", {}),
+                        conversation_id=conversation_id,
+                        scope_key=f"node:{self.node_id}",
+                        workflow_messages=state.get("messages", []),
+                        window_size=self.typed_config.memory.window_size,
+                        model_config_id=self.typed_config.model.model_id,
+                    )
+                    async def _run_after_workflow_turn(kwargs=_kwargs):
+                        with get_db_context() as db:
+                            await ContextEngineManager(db).after_workflow_turn(**kwargs)
+                    asyncio.create_task(_run_after_workflow_turn())
 
             final_message = AIMessage(
                 content=full_response,

--- a/api/app/core/workflow/nodes/llm/node.py
+++ b/api/app/core/workflow/nodes/llm/node.py
@@ -4,6 +4,7 @@ LLM 节点实现
 调用 LLM 模型进行文本生成。
 """
 
+import asyncio
 import logging
 import json
 from copy import deepcopy
@@ -804,8 +805,6 @@ class LLMNode(BaseNode):
             dict: {"llm_result": AIMessage, "branch_signal": "SUCCESS"} on success,
                   {"llm_result": None, "branch_signal": "ERROR"} on branch error
         """
-        import asyncio
-        
         llm = await self._prepare_llm(state, variable_pool, False)
         max_attempts = self.typed_config.retry.max_attempts + 1 if self.typed_config.retry.enable else 1
         last_error = None
@@ -853,16 +852,18 @@ class LLMNode(BaseNode):
                 if self.typed_config.memory.enable:
                     conversation_id = self.get_variable("sys.conversation_id", variable_pool, default="", strict=False)
                     if conversation_id:
-                        with get_db_context() as db:
-                            context_engine_manager = ContextEngineManager(db)
-                            await context_engine_manager.after_workflow_turn(
-                                features=self.workflow_config.get("features", {}),
-                                conversation_id=conversation_id,
-                                scope_key=f"node:{self.node_id}",
-                                workflow_messages=state.get("messages", []),
-                                window_size=self.typed_config.memory.window_size,
-                                model_config_id=self.typed_config.model_id,
-                            )
+                        _kwargs = dict(
+                            features=self.workflow_config.get("features", {}),
+                            conversation_id=conversation_id,
+                            scope_key=f"node:{self.node_id}",
+                            workflow_messages=state.get("messages", []),
+                            window_size=self.typed_config.memory.window_size,
+                            model_config_id=self.typed_config.model_id,
+                        )
+                        async def _run_after_workflow_turn(kwargs=_kwargs):
+                            with get_db_context() as db:
+                                await ContextEngineManager(db).after_workflow_turn(**kwargs)
+                        asyncio.create_task(_run_after_workflow_turn())
                 
                 return result
                 
@@ -1005,8 +1006,6 @@ class LLMNode(BaseNode):
         Yields:
             文本片段（chunk）或完成标记
         """
-        import asyncio as _asyncio
-
         self.typed_config = LLMNodeConfig(**self.config)
         max_attempts = self.typed_config.retry.max_attempts + 1 if self.typed_config.retry.enable else 1
         last_error = None
@@ -1133,16 +1132,18 @@ class LLMNode(BaseNode):
                 if self.typed_config.memory.enable:
                     conversation_id = self.get_variable("sys.conversation_id", variable_pool, default="", strict=False)
                     if conversation_id:
-                        with get_db_context() as db:
-                            context_engine_manager = ContextEngineManager(db)
-                            await context_engine_manager.after_workflow_turn(
-                                features=self.workflow_config.get("features", {}),
-                                conversation_id=conversation_id,
-                                scope_key=f"node:{self.node_id}",
-                                workflow_messages=state.get("messages", []),
-                                window_size=self.typed_config.memory.window_size,
-                                model_config_id=self.typed_config.model_id,
-                            )
+                        _kwargs = dict(
+                            features=self.workflow_config.get("features", {}),
+                            conversation_id=conversation_id,
+                            scope_key=f"node:{self.node_id}",
+                            workflow_messages=state.get("messages", []),
+                            window_size=self.typed_config.memory.window_size,
+                            model_config_id=self.typed_config.model_id,
+                        )
+                        async def _run_after_workflow_turn(kwargs=_kwargs):
+                            with get_db_context() as db:
+                                await ContextEngineManager(db).after_workflow_turn(**kwargs)
+                        asyncio.create_task(_run_after_workflow_turn())
 
                 yield {"__final__": True, "result": result}
                 return
@@ -1152,7 +1153,7 @@ class LLMNode(BaseNode):
                 logger.error(f"节点 {self.node_id} LLM 流式调用失败（尝试 {attempt + 1}/{max_attempts}）: {e}")
 
                 if attempt < max_attempts - 1 and self.typed_config.retry.enable:
-                    await _asyncio.sleep(self.typed_config.retry.retry_interval / 1000)
+                    await asyncio.sleep(self.typed_config.retry.retry_interval / 1000)
                 else:
                     break
 

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -475,16 +475,19 @@ class AppChatService:
                 should_memorize=memory,
             )
             if used_context_engine:
-                asyncio.create_task(
-                    context_engine_manager.after_app_turn(
-                        features=features_config,
-                        conversation_id=conversation_id,
-                        current_provider=api_key_obj.provider,
-                        current_is_omni=api_key_obj.is_omni,
-                        legacy_max_history=settings.AGENT_MAX_HISTORY,
-                        model_config_id=config.default_model_config_id,
-                    )
+                _ctx_kwargs = dict(
+                    features=features_config,
+                    conversation_id=conversation_id,
+                    current_provider=api_key_obj.provider,
+                    current_is_omni=api_key_obj.is_omni,
+                    legacy_max_history=settings.AGENT_MAX_HISTORY,
+                    model_config_id=config.default_model_config_id,
                 )
+                async def _run_after_turn(kwargs=_ctx_kwargs):
+                    from app.db import get_db_context
+                    with get_db_context() as db2:
+                        await ContextEngineManager(db2).after_app_turn(**kwargs)
+                asyncio.create_task(_run_after_turn())
         else:
             new_msg = Message(
                 id=message_id,
@@ -943,16 +946,19 @@ class AppChatService:
                     should_memorize=memory,
                 )
                 if used_context_engine:
-                    asyncio.create_task(
-                        context_engine_manager.after_app_turn(
-                            features=features_config,
-                            conversation_id=conversation_id,
-                            current_provider=api_key_obj.provider,
-                            current_is_omni=api_key_obj.is_omni,
-                            legacy_max_history=settings.AGENT_MAX_HISTORY,
-                            model_config_id=config.default_model_config_id,
-                        )
+                    _ctx_kwargs = dict(
+                        features=features_config,
+                        conversation_id=conversation_id,
+                        current_provider=api_key_obj.provider,
+                        current_is_omni=api_key_obj.is_omni,
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
+                        model_config_id=config.default_model_config_id,
                     )
+                    async def _run_after_turn(kwargs=_ctx_kwargs):
+                        from app.db import get_db_context
+                        with get_db_context() as db2:
+                            await ContextEngineManager(db2).after_app_turn(**kwargs)
+                    asyncio.create_task(_run_after_turn())
             else:
                 new_msg = Message(
                     id=message_id,

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -1045,16 +1045,18 @@ class AgentRunService:
                     is_omni=api_key_config.get("is_omni", False)
                 )
                 if used_context_engine and not skip_save:
-                    asyncio.create_task(
-                        context_engine_manager.after_app_turn(
-                            features=features_config,
-                            conversation_id=uuid.UUID(conversation_id),
-                            current_provider=api_key_config.get("provider"),
-                            current_is_omni=api_key_config.get("is_omni", False),
-                            legacy_max_history=settings.AGENT_MAX_HISTORY,
-                            model_config_id=model_config.id,
-                        )
+                    _ctx_kwargs = dict(
+                        features=features_config,
+                        conversation_id=uuid.UUID(conversation_id),
+                        current_provider=api_key_config.get("provider"),
+                        current_is_omni=api_key_config.get("is_omni", False),
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
+                        model_config_id=model_config.id,
                     )
+                    async def _run_after_turn(kwargs=_ctx_kwargs):
+                        with get_db_context() as db2:
+                            await ContextEngineManager(db2).after_app_turn(**kwargs)
+                    asyncio.create_task(_run_after_turn())
 
             # 11. 更新 Agent 执行记录为 completed
             node_executions = result.get("node_executions", [])
@@ -1513,16 +1515,18 @@ class AgentRunService:
                     is_omni=api_key_config.get("is_omni", False)
                 )
                 if used_context_engine and not skip_save:
-                    asyncio.create_task(
-                        context_engine_manager.after_app_turn(
-                            features=features_config,
-                            conversation_id=uuid.UUID(conversation_id),
-                            current_provider=api_key_config.get("provider"),
-                            current_is_omni=api_key_config.get("is_omni", False),
-                            legacy_max_history=settings.AGENT_MAX_HISTORY,
-                            model_config_id=model_config.id,
-                        )
+                    _ctx_kwargs = dict(
+                        features=features_config,
+                        conversation_id=uuid.UUID(conversation_id),
+                        current_provider=api_key_config.get("provider"),
+                        current_is_omni=api_key_config.get("is_omni", False),
+                        legacy_max_history=settings.AGENT_MAX_HISTORY,
+                        model_config_id=model_config.id,
                     )
+                    async def _run_after_turn(kwargs=_ctx_kwargs):
+                        with get_db_context() as db2:
+                            await ContextEngineManager(db2).after_app_turn(**kwargs)
+                    asyncio.create_task(_run_after_turn())
 
             # 11.5 更新 Agent 执行记录为 completed
             if not sub_agent:


### PR DESCRIPTION
isolate database context in async context engine calls

## Summary by Sourcery

在处理应用对话和草稿运行时，将上下文引擎的后台处理与主数据库会话隔离开来。

Bug 修复：
- 确保上下文引擎的 after-turn 钩子在其独立的数据库上下文中运行，而不是在后台任务中重用调用请求的数据库会话。

增强：
- 将上下文引擎的 after-turn 调用包裹在专用的异步任务中，并使用显式的参数快照，以避免与外部作用域产生耦合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate context engine background processing from the main database session when handling app chats and draft runs.

Bug Fixes:
- Ensure context engine after-turn hooks run with their own database context instead of reusing the calling request's DB session in background tasks.

Enhancements:
- Wrap context engine after-turn calls in dedicated async tasks with explicit argument snapshots to avoid coupling to outer scopes.

</details>