### PR TITLE
refactor(memory): convert time fields to millisecond timestamps

### DIFF
--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -8,13 +8,13 @@ import asyncio
 import json
 import os
 import time
-from datetime import datetime
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from dotenv import load_dotenv
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_config_logger, get_logger
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.core.memory.analytics.hot_memory_tags import (
     filter_tags_with_llm,
     get_raw_tags_batch,
@@ -82,36 +82,6 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             db: SQLAlchemy 数据库会话
         """
         self.db = db
-
-    @staticmethod
-    def _convert_timestamps_to_format(data_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """将 created_at 和 updated_at 字段从 datetime 对象转换为 YYYYMMDDHHmmss 格式"""
-
-        for item in data_list:
-            for field in ['created_at', 'updated_at']:
-                if field in item and item[field] is not None:
-                    value = item[field]
-                    dt = None
-
-                    # 处理不同类型的时间值
-                    if hasattr(value, 'to_native'):
-                        # Neo4j DateTime 对象
-                        dt = value.to_native()
-                    elif isinstance(value, datetime):
-                        # Python datetime 对象
-                        dt = value
-                    elif isinstance(value, str):
-                        # 字符串格式
-                        try:
-                            dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
-                        except Exception:
-                            pass  # 保持原值
-
-                    # 转换为 YYYYMMDDHHmmss 格式
-                    if dt:
-                        item[field] = dt.strftime('%Y%m%d%H%M%S')
-
-        return data_list
 
     # --- Create ---
     def create(self, params: ConfigParamsCreate) -> Dict[str, Any]:  # 创建配置参数（仅名称与描述）
@@ -230,7 +200,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         if needs_commit:
             self.db.commit()
 
-        # 将 ORM 对象转换为字典列表
+        # 将 ORM 对象转换为字典列表，时间字段统一转为 UTC 毫秒时间戳
         data_list = []
         for config, scene_name in results:
             # 安全地转换 user_id 为 int
@@ -276,13 +246,12 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 "lambda_time": config.lambda_time,
                 "lambda_mem": config.lambda_mem,
                 "offset": config.offset,
-                "created_at": config.created_at,
-                "updated_at": config.updated_at,
+                "created_at": to_timestamp_ms(config.created_at),
+                "updated_at": to_timestamp_ms(config.updated_at),
             }
             data_list.append(config_dict)
 
-        # 将 created_at 和 updated_at 转换为 YYYYMMDDHHmmss 格式
-        return self._convert_timestamps_to_format(data_list)
+        return data_list
 
     async def pilot_run_stream(self, payload: ConfigPilotRun, language: str = "zh") -> AsyncGenerator[str, None]:
         """


### PR DESCRIPTION
## Summary by Sourcery

通过在 `get_all` API 响应中为 `created_at` 和 `updated_at` 字段返回 UTC 毫秒级时间戳，统一内存配置时间戳的处理方式。

Bug Fixes:
- 确保 `created_at` 和 `updated_at` 的值能够从各种不同的 datetime 类型一致地序列化为毫秒级时间戳。

Enhancements:
- 移除旧的时间戳字符串格式化辅助方法，改用统一的 `to_timestamp_ms` 转换工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify memory configuration timestamp handling by returning UTC millisecond timestamps for created_at and updated_at fields in the get_all API response.

Bug Fixes:
- Ensure created_at and updated_at values are consistently serialized from various datetime types into millisecond timestamps.

Enhancements:
- Remove legacy timestamp string formatting helper in favor of a centralized to_timestamp_ms conversion utility.

</details>