### PR TITLE
fix: /api/apikeys scopes含memory时user_id允许为空

### DIFF
--- a/api/app/controllers/api_key_controller.py
+++ b/api/app/controllers/api_key_controller.py
@@ -52,10 +52,8 @@ def create_api_key(
             data=data
         )
         end_user_id, other_id = None, None
-        if "memory" in data.scopes:
-            if data.user_id:
-                end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
-            # user_id 为空时允许不绑定 end_user，后续通过 X-End-User-Other-Id 头指定
+        if "memory" in data.scopes and data.user_id:
+            end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
 
         response_data = api_key_schema.ApiKeyResponse.model_validate(api_key_obj)
         response_data.end_user_id = end_user_id

--- a/api/app/controllers/api_key_controller.py
+++ b/api/app/controllers/api_key_controller.py
@@ -52,8 +52,10 @@ def create_api_key(
             data=data
         )
         end_user_id, other_id = None, None
-        if "memory" in data.scopes and data.user_id:
-            end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
+        if "memory" in data.scopes:
+            if data.user_id:
+                end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
+            # user_id 为空时允许不绑定 end_user，后续通过 X-End-User-Other-Id 头指定
 
         response_data = api_key_schema.ApiKeyResponse.model_validate(api_key_obj)
         response_data.end_user_id = end_user_id

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -61,10 +61,10 @@ class ApiKeyCreate(BaseModel):
             if not self.resource_id:
                 raise ValueError(f"{self.type.value} 类型 API Key 必须指定 resource_id（指向应用）")
 
-        # memory scope 时 user_id 可选，不强制要求
+        # memory scope requires user_id to be non-empty
         if "memory" in self.scopes:
-            if self.user_id is not None and not isinstance(self.user_id, str):
-                raise ValueError("user_id 必须是字符串类型")
+            if not self.user_id or not self.user_id.strip():
+                raise ValueError("memory scope requires user_id to be non-empty")
         return self
 
 

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -60,6 +60,11 @@ class ApiKeyCreate(BaseModel):
                 raise ValueError(f"{self.type.value} 类型 API Key 的权限范围必须包含 app")
             if not self.resource_id:
                 raise ValueError(f"{self.type.value} 类型 API Key 必须指定 resource_id（指向应用）")
+
+        # memory scope 时 user_id 可选，不强制要求
+        if "memory" in self.scopes:
+            if self.user_id is not None and not isinstance(self.user_id, str):
+                raise ValueError("user_id 必须是字符串类型")
         return self
 
 


### PR DESCRIPTION
## 问题

创建 scopes 包含 memory 的 API Key 时，若不传 user_id 会报错。

## 修复

- schema 层显式允许 memory scope 时 user_id 可选
- controller 层分离 scopes 检查和 user_id 检查，空值时正常创建 key 但不绑定 end_user
- 后续 MCP 请求通过 X-End-User-Other-Id 头指定用户

## 由 Sourcery 提供的摘要

允许在不需要 `user_id` 的情况下创建具有 memory 作用域的 API 密钥，并在 `user_id` 缺失时避免绑定终端用户。

错误修复：
- 放宽 API 密钥模式验证规则，当包含 memory 作用域时，将 `user_id` 设置为可选字段，仅在提供时强制其为字符串。
- 调整 API 密钥创建逻辑，仅当提供了 `user_id` 时，才为具有 memory 作用域的密钥创建或绑定终端用户，从而允许创建没有关联终端用户的密钥。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow creating API keys with the memory scope without requiring a user_id and avoid binding an end user when user_id is absent.

Bug Fixes:
- Relax API key schema validation so that user_id is optional when the memory scope is included, only enforcing it to be a string when provided.
- Adjust API key creation logic to only create or bind an end user for memory-scoped keys when user_id is present, allowing keys without an associated end user.

</details>