### PR TITLE
fix: enforce user_id required when scopes includes memory

### DIFF
--- a/api/app/controllers/api_key_controller.py
+++ b/api/app/controllers/api_key_controller.py
@@ -52,10 +52,8 @@ def create_api_key(
             data=data
         )
         end_user_id, other_id = None, None
-        if "memory" in data.scopes:
-            if data.user_id:
-                end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
-            # user_id 为空时允许不绑定 end_user，后续通过 X-End-User-Other-Id 头指定
+        if "memory" in data.scopes and data.user_id:
+            end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
 
         response_data = api_key_schema.ApiKeyResponse.model_validate(api_key_obj)
         response_data.end_user_id = end_user_id

--- a/api/app/controllers/api_key_controller.py
+++ b/api/app/controllers/api_key_controller.py
@@ -52,8 +52,10 @@ def create_api_key(
             data=data
         )
         end_user_id, other_id = None, None
-        if "memory" in data.scopes and data.user_id:
-            end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
+        if "memory" in data.scopes:
+            if data.user_id:
+                end_user_id, other_id = EndUserRepository(db).get_or_create_end_user_mcp(workspace_id, data.user_id)
+            # user_id 为空时允许不绑定 end_user，后续通过 X-End-User-Other-Id 头指定
 
         response_data = api_key_schema.ApiKeyResponse.model_validate(api_key_obj)
         response_data.end_user_id = end_user_id

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -61,10 +61,10 @@ class ApiKeyCreate(BaseModel):
             if not self.resource_id:
                 raise ValueError(f"{self.type.value} 类型 API Key 必须指定 resource_id（指向应用）")
 
-        # memory scope 时 user_id 可选，不强制要求
+        # memory scope requires user_id to be non-empty
         if "memory" in self.scopes:
-            if self.user_id is not None and not isinstance(self.user_id, str):
-                raise ValueError("user_id 必须是字符串类型")
+            if not self.user_id or not self.user_id.strip():
+                raise ValueError("memory 权限范围必须提供 user_id")
         return self
 
 

--- a/api/app/schemas/api_key_schema.py
+++ b/api/app/schemas/api_key_schema.py
@@ -60,6 +60,11 @@ class ApiKeyCreate(BaseModel):
                 raise ValueError(f"{self.type.value} 类型 API Key 的权限范围必须包含 app")
             if not self.resource_id:
                 raise ValueError(f"{self.type.value} 类型 API Key 必须指定 resource_id（指向应用）")
+
+        # memory scope 时 user_id 可选，不强制要求
+        if "memory" in self.scopes:
+            if self.user_id is not None and not isinstance(self.user_id, str):
+                raise ValueError("user_id 必须是字符串类型")
         return self
 
 


### PR DESCRIPTION
## Problem
When creating an API key with memory scope, user_id was not validated at the schema level. An empty or missing user_id would pass validation but cause downstream failures in MCP request handling.

## Fix
Add explicit validation in ApiKeyCreate.validate_type_constraints: when scopes includes memory, user_id must be a non-empty string. Returns a clear validation error at the API boundary.

## Summary by Sourcery

Bug Fixes:
- 通过添加架构级验证，在 `user_id` 缺失或为空时，防止创建具有 memory 作用域的 API 密钥。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent creation of API keys with memory scope when user_id is missing or empty by adding schema-level validation.

</details>