### PR TITLE
fix(memory): avoid holding db session across pilot run streaming life cycle

### DIFF
--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -310,7 +310,6 @@ async def pilot_run(
         payload: ConfigPilotRun,
         language_type: str = Header(default=None, alias="X-Language-Type"),
         current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
 ) -> StreamingResponse:
     # 使用集中化的语言校验
     language = get_language_from_header(language_type)
@@ -320,8 +319,10 @@ async def pilot_run(
         f"dialogue_text_length={len(payload.dialogue_text)}, "
         f"custom_text_length={len(payload.custom_text) if payload.custom_text else 0}"
     )
-    payload.config_id = resolve_config_id(payload.config_id, db)
-    svc = DataConfigService(db)
+    # resolve_config_id 在 pilot_run_stream 内部的短 session 里执行
+    # controller 层不再注入 db，避免 session 跨越整个流式响应生命周期
+    payload.config_id = resolve_config_id(payload.config_id)
+    svc = DataConfigService()
     return StreamingResponse(
         svc.pilot_run_stream(payload, language=language),
         media_type="text/event-stream",

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -75,11 +75,13 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
     使用 SQLAlchemy ORM 进行数据库操作。
     """
 
-    def __init__(self, db: Session) -> None:
+    def __init__(self, db: Optional[Session] = None) -> None:
         """初始化服务
 
         Args:
-            db: SQLAlchemy 数据库会话
+            db: SQLAlchemy 数据库会话。
+                CRUD 操作（create/update/delete/get_*）必须传入。
+                pilot_run_stream 不需要传入（内部自行开短 session）。
         """
         self.db = db
 
@@ -284,23 +286,31 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
     async def pilot_run_stream(self, payload: ConfigPilotRun, language: str = "zh") -> AsyncGenerator[str, None]:
         """
         流式执行试运行，产生 SSE 格式的进度事件
-        
+
+        db session 生命周期策略：
+        - 阶段1（短 session）：用 get_db_read() 查配置、初始化 llm_client，with 块结束立即归还连接
+        - 阶段2（无 session）：LLM 调用可能耗时数十秒，完全不持有 db 连接
+        - 本方法不依赖 FastAPI Depends(get_db)，自行管理 session 生命周期
+
         Args:
-            payload: 试运行配置和对话文本
+            payload: 试运行配置和对话文本（config_id 已由 controller 解析为 UUID）
             language: 语言类型 ("zh" 中文, "en" 英文)，默认中文
-            
+
         Yields:
             SSE 格式的字符串，包含以下事件类型：
             - 各种阶段名称: 进度更新 (如 starting, knowledge_extraction_complete 等)
             - result: 最终结果
             - error: 错误信息
             - done: 完成标记
-            
+
         Raises:
             ValueError: 当配置无效或参数缺失时
             RuntimeError: 当管线执行失败时
         """
         from pathlib import Path
+        from app.db import get_db_read
+        from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
+
         project_root = str(Path(__file__).resolve().parents[2])
 
         try:
@@ -310,57 +320,64 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 "time": int(time.time() * 1000)
             })
 
-            # 步骤 1: 配置加载和验证（数据库优先）
+            # ── 阶段1：短 session，只读查询，with 块结束立即归还连接 ──────────
             payload_cid = str(getattr(payload, "config_id", "") or "").strip()
             cid: Optional[str] = payload_cid if payload_cid else None
 
             if not cid:
                 raise ValueError("未提供 payload.config_id，禁止启动试运行")
 
-            # Load configuration from database only using centralized manager
-            try:
-                config_service = MemoryConfigService(self.db)
-                memory_config = config_service.load_memory_config(
-                    config_id=str(cid),
-                    service_name="MemoryStorageService.pilot_run_stream"
-                )
-                logger.info(f"Configuration loaded successfully: {memory_config.config_name}")
-            except ConfigurationError as e:
-                raise RuntimeError(f"Configuration loading failed: {e}")
+            with get_db_read() as db:
+                # 1a. 加载记忆配置
+                try:
+                    config_service = MemoryConfigService(db)
+                    memory_config = config_service.load_memory_config(
+                        config_id=str(cid),
+                        service_name="DataConfigService.pilot_run_stream"
+                    )
+                    logger.info(f"Configuration loaded successfully: {memory_config.config_name}")
+                except ConfigurationError as e:
+                    raise RuntimeError(f"Configuration loading failed: {e}")
 
-            # 根据是否关联本体场景选择使用的文本
-            # 如果配置关联了本体场景（scene_id 不为空），使用 custom_text（如果提供）
-            # 否则使用 dialogue_text
-            if memory_config.scene_id:
-                # 关联了本体场景，优先使用 custom_text
-                if hasattr(payload, 'custom_text') and payload.custom_text:
-                    dialogue_text = payload.custom_text.strip()
-                    logger.info(
-                        f"[PILOT_RUN_STREAM] Using custom_text for scene_id={memory_config.scene_id}, length: {len(dialogue_text)}")
+                # 1b. 确定使用的文本
+                if memory_config.scene_id:
+                    if hasattr(payload, 'custom_text') and payload.custom_text:
+                        dialogue_text = payload.custom_text.strip()
+                        logger.info(
+                            f"[PILOT_RUN_STREAM] Using custom_text for scene_id={memory_config.scene_id}, "
+                            f"length: {len(dialogue_text)}")
+                    else:
+                        dialogue_text = payload.dialogue_text.strip() if payload.dialogue_text else ""
+                        logger.info(
+                            f"[PILOT_RUN_STREAM] No custom_text provided, using dialogue_text "
+                            f"for scene_id={memory_config.scene_id}")
                 else:
-                    # 如果没有提供 custom_text，回退到 dialogue_text
                     dialogue_text = payload.dialogue_text.strip() if payload.dialogue_text else ""
-                    logger.info(
-                        f"[PILOT_RUN_STREAM] No custom_text provided, using dialogue_text for scene_id={memory_config.scene_id}")
-            else:
-                # 没有关联本体场景，使用 dialogue_text
-                dialogue_text = payload.dialogue_text.strip() if payload.dialogue_text else ""
-                logger.info(f"[PILOT_RUN_STREAM] No scene_id, using dialogue_text, length: {len(dialogue_text)}")
+                    logger.info(f"[PILOT_RUN_STREAM] No scene_id, using dialogue_text, length: {len(dialogue_text)}")
 
-            # 验证最终使用的文本不为空
-            if not dialogue_text:
-                raise ValueError("试运行模式必须提供有效的文本内容（dialogue_text 或 custom_text）")
+                if not dialogue_text:
+                    raise ValueError("试运行模式必须提供有效的文本内容（dialogue_text 或 custom_text）")
 
-            logger.info(f"[PILOT_RUN_STREAM] Final text preview: {dialogue_text[:100]}")
+                logger.info(f"[PILOT_RUN_STREAM] Final text preview: {dialogue_text[:100]}")
 
-            # 步骤 2: 创建进度回调函数捕获管线进度
+                # 1c. 初始化 LLM 客户端（只需查一次模型配置，之后 llm_client 是独立对象）
+                try:
+                    factory = MemoryClientFactory(db)
+                    llm_client = factory.get_llm_client(str(memory_config.llm_model_id))
+                    logger.info("[PILOT_RUN_STREAM] LLM client initialized")
+                except Exception as e:
+                    raise RuntimeError(f"LLM client initialization failed: {e}")
+            # ── with 块结束，db 连接立即归还连接池 ───────────────────────────
+            logger.info("[PILOT_RUN_STREAM] db session closed, starting LLM pipeline")
+
+            # ── 阶段2：无 session，LLM 管线执行 ──────────────────────────────
             # 使用队列在回调和生成器之间传递进度事件
             progress_queue: asyncio.Queue = asyncio.Queue()
 
             async def progress_callback(stage: str, message: str, data: Optional[Dict[str, Any]] = None) -> None:
                 """
                 进度回调函数，将进度事件放入队列
-                
+
                 Args:
                     stage: 阶段标识
                     message: 进度消息
@@ -368,7 +385,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 """
                 await progress_queue.put((stage, message, data))
 
-            # 步骤 3: 在后台任务中执行管线
+            # 步骤 3: 在后台任务中执行管线（无 db 依赖）
             async def run_pipeline():
                 """在后台执行管线并捕获异常"""
                 try:
@@ -379,7 +396,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     await run_pilot_extraction(
                         memory_config=memory_config,
                         dialogue_text=dialogue_text,
-                        db=self.db,
+                        llm_client=llm_client,
                         progress_callback=progress_callback,
                         language=language,
                     )

--- a/api/app/services/pilot_run_service.py
+++ b/api/app/services/pilot_run_service.py
@@ -12,7 +12,6 @@ Pilot Run Service - 试运行服务
 import os
 import re
 import time
-from datetime import datetime
 from typing import Awaitable, Callable, Optional
 
 from app.core.utils.datetime_utils import utcnow_naive
@@ -28,7 +27,7 @@ from app.core.memory.storage_services.extraction_engine.pipeline_help import (
     export_test_input_doc,
 )
 from app.schemas.memory_config_schema import MemoryConfig
-from sqlalchemy.orm import Session
+from app.core.memory.llm_tools.openai_client import OpenAIClient
 
 logger = get_memory_logger(__name__)
 
@@ -72,7 +71,7 @@ def _save_triplets_from_dialogs(dialog_data_list: list[DialogData], output_path:
 async def run_pilot_extraction(
     memory_config: MemoryConfig,
     dialogue_text: str,
-    db: Session,
+    llm_client: OpenAIClient,
     progress_callback: Optional[Callable[[str, str, Optional[dict]], Awaitable[None]]] = None,
     language: str = "zh",
 ) -> None:
@@ -86,7 +85,7 @@ async def run_pilot_extraction(
     Args:
         memory_config: 从数据库加载的内存配置对象
         dialogue_text: 输入的对话文本
-        db: 数据库会话（用于初始化预处理所需的 LLM 客户端）
+        llm_client: 预先初始化的 LLM 客户端（调用方负责在 db session 关闭前完成初始化）
         progress_callback: 可选的进度回调 (stage, message, data)
         language: 语言类型 ("zh" | "en")
     """
@@ -99,12 +98,8 @@ async def run_pilot_extraction(
     pipeline_start = time.time()
 
     try:
-        # ── 步骤 1: 初始化预处理所需的 LLM 客户端 ──────────────────────────
-        # 只用于语义剪枝和分块，PilotWritePipeline 内部会自行初始化萃取客户端
+        # ── 步骤 1: llm_client 已由调用方在 db session 关闭前初始化传入 ──────
         step_start = time.time()
-        from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
-        factory = MemoryClientFactory(db)
-        llm_client = factory.get_llm_client(str(memory_config.llm_model_id))
         log_time("Client Initialization", time.time() - step_start, log_file)
 
         # ── 步骤 2: 文本解析 ────────────────────────────────────────────────

--- a/api/app/utils/config_utils.py
+++ b/api/app/utils/config_utils.py
@@ -3,18 +3,22 @@ Configuration utility functions
 
 Shared utilities for configuration handling to avoid circular imports.
 """
+from typing import Optional
 from uuid import UUID
 from sqlalchemy.orm import Session
 import uuid as uuid_module
 
 
-def resolve_config_id(config_id: UUID | int | str, db: Session) -> UUID:
+def resolve_config_id(config_id: UUID | int | str, db: Optional[Session] = None) -> UUID:
     """
-    解析 config_id，支持 UUID、UUID字符串、整数等多种格式
+    解析 config_id，支持 UUID、UUID字符串、整数等多种格式。
+
+    当 config_id 已经是 UUID 或 UUID 字符串时，无需 db 即可解析。
+    当 config_id 是整数（需要查 config_id_old）时，若未传 db，则自动开一个短 session。
 
     Args:
         config_id: 配置ID（UUID、UUID字符串 或 整数）
-        db: 数据库会话
+        db: 可选的数据库会话。不传时内部自行开短 session（推荐用于流式端点）
 
     Returns:
         UUID: 解析后的配置ID
@@ -23,52 +27,57 @@ def resolve_config_id(config_id: UUID | int | str, db: Session) -> UUID:
         ValueError: 当找不到对应的配置时或格式无效时
     """
     from app.models.memory_config_model import MemoryConfig
-    
-    # 1. 如果已经是 UUID 类型，直接返回
+
+    # 1. 如果已经是 UUID 类型，直接返回（无需 db）
     if isinstance(config_id, UUID):
         return config_id
-    
-    # 2. 如果是整数类型，通过 config_id_old 查找
-    if isinstance(config_id, int):
-        if config_id <= 0:
-            raise ValueError(f"config_id 必须是正整数: {config_id}")
-        
-        memory_config = db.query(MemoryConfig).filter(
-            MemoryConfig.config_id_old == config_id
-        ).first()
 
-        if not memory_config:
-            raise ValueError(f"未找到 config_id_old={config_id} 对应的配置")
-
-        return memory_config.config_id
-    
-    # 3. 如果是字符串类型
+    # 2. 如果是字符串，先尝试解析为 UUID（无需 db）
     if isinstance(config_id, str):
         config_id_stripped = config_id.strip()
-        
-        # 3.1 先尝试解析为整数（用于查询 config_id_old）
-        # 这样可以处理 "17" 这样的字符串
+
+        # 2.1 先尝试解析为整数（用于查询 config_id_old）
         try:
             old_id = int(config_id_stripped)
             if old_id > 0:
-                memory_config = db.query(MemoryConfig).filter(
-                    MemoryConfig.config_id_old == old_id
-                ).first()
-                if not memory_config:
-                    raise ValueError(f"未找到 config_id_old={old_id} 对应的配置")
-                return memory_config.config_id
+                return _lookup_by_old_id(old_id, db)
         except ValueError:
-            # 不是整数，继续尝试 UUID
             pass
-        
-        # 3.2 尝试解析为 UUID
+
+        # 2.2 尝试解析为 UUID（无需 db）
         try:
             return uuid_module.UUID(config_id_stripped)
         except ValueError:
             pass
-        
-        # 3.3 无法解析的字符串格式
+
         raise ValueError(f"无效的 config_id 格式: '{config_id}'（必须是 UUID 或正整数）")
+
+    # 3. 如果是整数类型，通过 config_id_old 查找
+    if isinstance(config_id, int):
+        if config_id <= 0:
+            raise ValueError(f"config_id 必须是正整数: {config_id}")
+        return _lookup_by_old_id(config_id, db)
 
     # 4. 不支持的类型
     raise ValueError(f"不支持的 config_id 类型: {type(config_id).__name__}")
+
+
+def _lookup_by_old_id(old_id: int, db: Optional[Session]) -> UUID:
+    """通过 config_id_old 查找 UUID，支持传入已有 session 或自动开短 session。"""
+    from app.models.memory_config_model import MemoryConfig
+
+    def _query(session: Session) -> UUID:
+        memory_config = session.query(MemoryConfig).filter(
+            MemoryConfig.config_id_old == old_id
+        ).first()
+        if not memory_config:
+            raise ValueError(f"未找到 config_id_old={old_id} 对应的配置")
+        return memory_config.config_id
+
+    if db is not None:
+        return _query(db)
+
+    # 未传 db，自己开一个只读短 session
+    from app.db import get_db_read
+    with get_db_read() as short_db:
+        return _query(short_db)


### PR DESCRIPTION
## Summary by Sourcery

将试运行（pilot run）流式处理与长生命周期的数据库会话解耦，避免在整个流式处理生命周期中持续占用数据库连接。

Bug Fixes（错误修复）:
- 确保 `pilot_run_stream` 在加载配置和初始化 LLM 客户端时使用短生命周期的只读数据库会话，而不是使用控制器注入的长生命周期会话。
- 允许 `resolve_config_id` 在没有外部数据库会话的情况下运行，在需要时自行打开短生命周期的只读会话，从而防止在流式处理流程中出现会话泄漏。

Enhancements（增强改进）:
- 优化 `DataConfigService` 和 `pilot_run_stream`，使其能够各自管理可选的数据库会话，并将预先初始化好的 LLM 客户端传入试运行的抽取流水线。
- 更新试运行控制器，使其不再依赖数据库会话，将配置 ID 解析和数据库访问委托给服务层，以提升流式处理的安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple pilot run streaming from long-lived database sessions to avoid holding DB connections across the streaming lifecycle.

Bug Fixes:
- Ensure pilot_run_stream uses short-lived read-only DB sessions for configuration loading and LLM client initialization instead of a controller-injected long-lived session.
- Allow resolve_config_id to operate without an external DB session by opening short read-only sessions when needed, preventing session leakage in streaming flows.

Enhancements:
- Refine DataConfigService and pilot_run_stream to manage their own optional DB sessions and to pass a pre-initialized LLM client into the pilot extraction pipeline.
- Update the pilot run controller to stop depending on a DB session, delegating config ID resolution and DB usage to the service layer for better streaming safety.]}**/commentary to=functions.PullRequestSummary _DIPSETTINGassistant:-------------</assistant бүгүнassistantябрь쓴assistant尼斯人assistant$IFnassistantọdọassistant раньassistantgreatassistantользовательassistantassistantBTTagCompoundassistantassistantохойнassistantassistantочнойassistantassistantaciasassistantassistantастаassistantassistant杀码assistantassistantентassistantassistantобходимоassistantassistant្មីassistantassistantuserassistantassistantassistant통령assistantassistantassistant to=functions.PullRequestSummaryীয়াassistant to=functions.PullRequestSummaryгониassistant to=functions.PullRequestSummarygwụassistant to=functions.PullRequestSummary истеҳсолassistant to=functions.PullRequestSummary 빈assistant to=functions.PullRequestSummary  атәылаassistant to=functions.PullRequestSummary  环宇assistant to=functions.PullRequestSummary  আপানিassistant to=functions.PullRequestSummary  😅assistant((&___assistant to=functions.PullRequestSummary  фаъassistant to=functions.PullRequestSummary  !***assistant to=functions.PullRequestSummary  nullassistant to=functions.PullRequestSummary  ☠assistant to=functions.PullRequestSummary  |assistant to=functions.PullRequestSummary  甸assistant to=functions.PullRequestSummary  予assistant to=functions.PullRequestSummary  🚫assistant to=functions.PullRequestSummary  😬assistant to=functions.PullRequestSummary  党assistant to=functions.PullRequestSummary  {

</details>