### PR TITLE
feat(web): kb chunk block size

### DIFF
--- a/web/src/components/Markdown/Code.tsx
+++ b/web/src/components/Markdown/Code.tsx
@@ -30,14 +30,14 @@ import MermaidChart from './MermaidChart'
 type ICodeProps = {
   children: string;
   className: string;
+  isNeedCopy?: boolean;
 }
 
 /** Code block component that renders syntax-highlighted code or special visualizations */
 const Code: FC<ICodeProps> = (props) => {
-  const { children, className } = props;
+  const { children, className, isNeedCopy = true } = props;
   /** Extract language from className (e.g., 'language-javascript' -> 'javascript') */
   const language = className?.split('-')[1]
-  console.log('Code', props)
 
   // Parse ECharts configuration from code content
   const charData = useMemo(() => {
@@ -97,14 +97,16 @@ const Code: FC<ICodeProps> = (props) => {
         >
           {children}
         </SyntaxHighlighter>
-        <CopyBtn
-          value={children}
-          style={{
-          position: 'absolute',
-          top: 20,
-          right: 20,
-        }}
-      />
+        {isNeedCopy &&
+          <CopyBtn
+            value={children}
+            style={{
+              position: 'absolute',
+              top: 20,
+              right: 20,
+            }}
+          />
+        }
     </div>
     )
   }

--- a/web/src/components/Markdown/index.tsx
+++ b/web/src/components/Markdown/index.tsx
@@ -63,10 +63,12 @@ interface RbMarkdownProps {
   className?: string;
   /** Callback when a form button is clicked, receives form field values */
   onFormSubmit?: (values: Record<string, any>) => void;
+  /** Whether to show copy button (default: true) */
+  isNeedCopy?: boolean;
 }
 
 /** Build stable components map — form submission handled via FormContext */
-const buildComponents = () => ({
+const buildComponents = (isNeedCopy = true) => ({
   h1: ({ children, ...props }: any) => <h1 className="rb:text-2xl rb:font-bold rb:mb-2" {...props}>{children}</h1>,
   h2: ({ children, ...props }: any) => <h2 className="rb:text-xl rb:font-bold rb:mb-2" {...props}>{children}</h2>,
   h3: ({ children, ...props }: any) => <h3 className="rb:text-lg rb:font-bold rb:mb-2" {...props}>{children}</h3>,
@@ -89,7 +91,7 @@ const buildComponents = () => ({
     return <span style={style} {...restProps}>{children}</span>
   },
 
-  code: ({ children, className, ...props }: any) => <Code children={String(children)} className={className || ''} {...props} />,
+  code: ({ children, className, ...props }: any) => <Code children={String(children)} isNeedCopy={isNeedCopy ?? true} className={className || ''} {...props} />,
   img: ({ src, alt, ...props }: any) => <Image src={src} alt={alt} {...props} />,
   video: ({ src, ...props }: any) => <VideoBlock node={{ children: [{ properties: { src: src || '' } }] }} {...props} />,
   audio: ({ src, ...props }: any) => <AudioBlock node={{ children: [{ properties: { src: src || '' } }] }} {...props} />,
@@ -167,11 +169,12 @@ const RbMarkdown: FC<RbMarkdownProps> = ({
   onContentChange,
   className,
   onFormSubmit,
+  isNeedCopy = true,
 }) => {
   const [formValues, setFormValues] = useState<Record<string, any>>({})
   const setValue = useCallback((name: string, value: any) => setFormValues(prev => ({ ...prev, [name]: value })), [])
   const formCtx = useMemo(() => ({ values: formValues, setValue, onSubmit: onFormSubmit }), [formValues, setValue, onFormSubmit])
-  const components = useMemo(() => buildComponents(), [])
+  const components = useMemo(() => buildComponents(isNeedCopy), [isNeedCopy])
   const [editContent, setEditContent] = useState(content)
   const textareaRef = useRef<any>(null)
 

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -611,6 +611,13 @@ const CreateDataset = () => {
     };
   }, [location.pathname]);
 
+  const handleChangeProcessingMethod = (method: ProcessingMethod) => {
+    if (method === 'directBlock') {
+      setBlockSize(512)
+    }
+    setProcessingMethod(method)
+  }
+
   return (<>
     <div className='rb:p-3 rb:pt-2 rb:h-full rb:flex rb:flex-col'>
       {/* <Typography.Title level={4} className='rb:!m-0 rb:!mb-4'>
@@ -795,7 +802,7 @@ const CreateDataset = () => {
               </div>
               <Radio.Group
                 value={processingMethod}
-                onChange={(e) => setProcessingMethod(e.target.value)}
+                onChange={(e) => handleChangeProcessingMethod(e.target.value as ProcessingMethod)}
                 style={style}
               >
                 <Radio value='directBlock' disabled={isParentChildMode === true} style={getActiveRadioStyle(processingMethod === 'directBlock')}>

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -104,7 +104,7 @@ const RecallTestResult = ({
       }
       
       // Fallback to Markdown rendering
-      return <RbMarkdown content={content} showHtmlComments={true} />;
+      return <RbMarkdown content={content} showHtmlComments={true} isNeedCopy={false} />;
     };
   }, []);
 


### PR DESCRIPTION
## 由 Sourcery 提供的总结

允许控制代码块复制按钮的可见性，并在使用直接块处理（direct block processing）时调整数据集块大小。

新特性：
- 为 Markdown 代码块和 RbMarkdown 新增可选的 `isNeedCopy` 属性，用于切换是否渲染复制按钮。

增强改进：
- 在知识库召回测试结果中，默认隐藏代码块复制按钮。
- 在知识库数据集创建中，当切换到 `directBlock` 处理方式时，自动将数据集块大小重置为 512。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow controlling visibility of code block copy buttons and adjust dataset block size when using direct block processing.

New Features:
- Add optional isNeedCopy prop to Markdown code blocks and RbMarkdown to toggle rendering of the copy button.

Enhancements:
- Default code block copy button is now hidden in knowledge base recall test results.
- Automatically reset dataset block size to 512 when switching to directBlock processing method in knowledge base dataset creation.

</details>