### PR TITLE
feat(rag): add structured markdown block chunking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ api/res/
 .venv
 docs/
 examples/
+AGENTS.md
 
 # Environment variables
 .env
@@ -29,7 +30,8 @@ search_results.json
 redbear-mem-metrics/
 redbear-mem-benchmark/
 pitch-deck/
-output/
+output
+api/tests/rag/
 api/migrations/versions
 tmp
 files

--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -26,6 +26,29 @@ class LogicalChunkType(str, Enum):
     IMAGE = "image"
 
 
+class ParsedBlockType(str, Enum):
+    HEADING = "heading"
+    TEXT = "text"
+    LIST = "list"
+    BLOCKQUOTE = "blockquote"
+    CODE = "code"
+    TABLE = "table"
+    IMAGE = "image"
+
+
+@dataclass
+class ParsedBlock:
+    type: ParsedBlockType
+    content: Any = ""
+    raw: str = ""
+    seq: int = 0
+    start_line: int | None = None
+    end_line: int | None = None
+    image: Any = None
+    positions: list | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 @dataclass
 class LogicalChunk:
     type: LogicalChunkType
@@ -63,6 +86,7 @@ class ParseResult:
     merge_strategy: str = "naive"
     url_res: list | None = None
     append_embed: bool = True
+    blocks: list[ParsedBlock] | None = None
 
 
 @dataclass

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -1,0 +1,403 @@
+from copy import deepcopy
+from html import escape
+
+from bs4 import BeautifulSoup
+
+from app.core.rag.common.token_utils import encoder, num_tokens_from_string
+from app.core.rag.chunk.context import (
+    ChunkContext,
+    ChunkOutputMode,
+    LogicalChunk,
+    LogicalChunkType,
+    MergeResult,
+    ParsedBlock,
+    ParsedBlockType,
+    ParseResult,
+)
+
+from .base import ChunkMerger
+from .text import TextMerger
+
+
+TEXT_LIKE_TYPES = {
+    ParsedBlockType.HEADING,
+    ParsedBlockType.TEXT,
+    ParsedBlockType.LIST,
+    ParsedBlockType.BLOCKQUOTE,
+}
+
+
+class BlockMerger(ChunkMerger):
+    def __init__(self):
+        self.text_merger = TextMerger()
+
+    def merge(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
+        blocks = parse_result.blocks or []
+        token_num = int(ctx.parser_config.get("chunk_token_num", 128))
+        delimiter = ctx.parser_config.get("delimiter", "\n\n")
+
+        if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
+            parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
+            parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter", "\n\n")
+            parent_chunks = self._blocks_to_logical_chunks(blocks, parent_token_num, parent_chunk_delimiter)
+            child_chunks, parent_id_map = self._build_children_from_parents(parent_chunks, token_num, delimiter)
+            return MergeResult(
+                chunks=self._serialize_chunk_contents(child_chunks),
+                logical_chunks=child_chunks,
+                parent_chunks=parent_chunks,
+                child_chunks=child_chunks,
+                parent_id_map=parent_id_map,
+                pdf_parser=parse_result.pdf_parser,
+            )
+
+        logical_chunks = self._blocks_to_logical_chunks(blocks, token_num, delimiter)
+        return MergeResult(
+            chunks=self._serialize_chunk_contents(logical_chunks),
+            logical_chunks=logical_chunks,
+            pdf_parser=parse_result.pdf_parser,
+        )
+
+    def _blocks_to_logical_chunks(
+        self,
+        blocks: list[ParsedBlock],
+        token_num: int,
+        delimiter: str,
+    ) -> list[LogicalChunk]:
+        logical_chunks: list[LogicalChunk] = []
+        text_group: list[ParsedBlock] = []
+
+        def flush_text_group():
+            if not text_group:
+                return
+            metadata = self._metadata_for_range(text_group, "text")
+            content = "\n\n".join(str(block.content) for block in text_group if str(block.content).strip())
+            for chunk in self.text_merger.merge(content, token_num, delimiter):
+                logical_chunks.append(
+                    LogicalChunk(
+                        type=LogicalChunkType.TEXT,
+                        content=chunk,
+                        metadata=deepcopy(metadata),
+                    )
+                )
+            text_group.clear()
+
+        for block in blocks:
+            if block.type in TEXT_LIKE_TYPES:
+                text_group.append(block)
+                continue
+
+            flush_text_group()
+
+            if block.type is ParsedBlockType.CODE:
+                logical_chunks.extend(self._code_logical_chunks(block, token_num))
+                continue
+
+            if block.type is ParsedBlockType.TABLE:
+                logical_chunks.extend(self._table_logical_chunks(block, token_num))
+                continue
+
+            if block.type is ParsedBlockType.IMAGE:
+                content = block.metadata.get("vision_text") or block.content
+                logical_chunks.append(
+                    LogicalChunk(
+                        type=LogicalChunkType.IMAGE,
+                        content=content,
+                        image=block.image,
+                        positions=deepcopy(block.positions),
+                        metadata=self._metadata_for_block(block),
+                    )
+                )
+
+        flush_text_group()
+        return logical_chunks
+
+    def _build_children_from_parents(
+        self,
+        parent_chunks: list[LogicalChunk],
+        child_token_num: int,
+        delimiter: str,
+    ) -> tuple[list[LogicalChunk], dict[int, int]]:
+        child_chunks: list[LogicalChunk] = []
+        parent_id_map: dict[int, int] = {}
+
+        for parent_index, parent in enumerate(parent_chunks):
+            children = self._split_parent_chunk(parent, child_token_num, delimiter)
+            for child in children:
+                parent_id_map[len(child_chunks)] = parent_index
+                child_chunks.append(child)
+
+        return child_chunks, parent_id_map
+
+    def _split_parent_chunk(self, parent: LogicalChunk, token_num: int, delimiter: str) -> list[LogicalChunk]:
+        if parent.type is LogicalChunkType.TABLE:
+            return self._split_logical_table_chunk(parent, token_num)
+
+        if parent.type is LogicalChunkType.IMAGE:
+            return [deepcopy(parent)]
+
+        block_type = parent.metadata.get("block_type")
+        if block_type == ParsedBlockType.CODE.value:
+            return [
+                LogicalChunk(
+                    type=LogicalChunkType.TEXT,
+                    content=chunk,
+                    image=parent.image,
+                    positions=deepcopy(parent.positions),
+                    metadata=deepcopy(parent.metadata),
+                )
+                for chunk in self._split_code_content(str(parent.content), token_num, parent.metadata.get("language", ""))
+                if chunk.strip()
+            ]
+
+        return [
+            LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=chunk,
+                image=parent.image,
+                positions=deepcopy(parent.positions),
+                metadata=deepcopy(parent.metadata),
+            )
+            for chunk in self.text_merger.merge(str(parent.content), token_num, delimiter)
+            if chunk.strip()
+        ]
+
+    def _code_logical_chunks(self, block: ParsedBlock, token_num: int) -> list[LogicalChunk]:
+        metadata = self._metadata_for_block(block)
+        language = str(block.metadata.get("language", ""))
+        return [
+            LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=chunk,
+                positions=deepcopy(block.positions),
+                metadata=deepcopy(metadata),
+            )
+            for chunk in self._split_code_content(str(block.content), token_num, language)
+            if chunk.strip()
+        ]
+
+    def _table_logical_chunks(self, block: ParsedBlock, token_num: int) -> list[LogicalChunk]:
+        metadata = self._metadata_for_block(block)
+        contents = self._split_table_content(str(block.content), token_num)
+        total = len(contents)
+        result: list[LogicalChunk] = []
+        for index, content in enumerate(contents):
+            chunk_metadata = deepcopy(metadata)
+            if total > 1:
+                chunk_metadata["table_part_index"] = index
+                chunk_metadata["table_part_total"] = total
+            result.append(
+                LogicalChunk(
+                    type=LogicalChunkType.TABLE,
+                    content=content,
+                    image=block.image,
+                    positions=deepcopy(block.positions),
+                    metadata=chunk_metadata,
+                )
+            )
+        return result
+
+    def _split_logical_table_chunk(self, chunk: LogicalChunk, token_num: int) -> list[LogicalChunk]:
+        contents = self._split_table_content(str(chunk.content), token_num)
+        if len(contents) == 1:
+            return [deepcopy(chunk)]
+
+        result: list[LogicalChunk] = []
+        total = len(contents)
+        for index, content in enumerate(contents):
+            metadata = deepcopy(chunk.metadata)
+            metadata["table_part_index"] = index
+            metadata["table_part_total"] = total
+            result.append(
+                LogicalChunk(
+                    type=LogicalChunkType.TABLE,
+                    content=content,
+                    image=chunk.image,
+                    positions=deepcopy(chunk.positions),
+                    metadata=metadata,
+                )
+            )
+        return result
+
+    def _split_table_content(self, content: str, token_num: int) -> list[str]:
+        if num_tokens_from_string(content) <= token_num:
+            return [content]
+
+        table = BeautifulSoup(content, "html.parser").find("table")
+        if table is None:
+            return self._hard_split_wrapped(content, token_num, lambda piece: piece)
+
+        header_html, row_htmls = self._extract_table_parts(table)
+        if not row_htmls:
+            return self._hard_split_wrapped(content, token_num, lambda piece: piece)
+
+        chunks: list[str] = []
+        current_rows: list[str] = []
+
+        for row_html in row_htmls:
+            single_row_table = self._build_table_html(header_html, [row_html])
+            if num_tokens_from_string(single_row_table) > token_num:
+                if current_rows:
+                    chunks.append(self._build_table_html(header_html, current_rows))
+                    current_rows = []
+                chunks.extend(self._split_oversized_table_row(header_html, row_html, token_num))
+                continue
+
+            candidate_rows = [*current_rows, row_html]
+            candidate = self._build_table_html(header_html, candidate_rows)
+            if current_rows and num_tokens_from_string(candidate) > token_num:
+                chunks.append(self._build_table_html(header_html, current_rows))
+                current_rows = [row_html]
+            else:
+                current_rows = candidate_rows
+
+        if current_rows:
+            chunks.append(self._build_table_html(header_html, current_rows))
+
+        return chunks or [content]
+
+    def _extract_table_parts(self, table) -> tuple[str, list[str]]:
+        thead = table.find("thead")
+        if thead is not None:
+            header_html = str(thead)
+            rows = [
+                str(row)
+                for row in table.find_all("tr")
+                if row.find_parent("thead") is None
+            ]
+            return header_html, rows
+
+        rows = table.find_all("tr")
+        if not rows:
+            return "", []
+        header_html = f"<thead>{rows[0]}</thead>"
+        return header_html, [str(row) for row in rows[1:]]
+
+    def _build_table_html(self, header_html: str, row_htmls: list[str]) -> str:
+        body = "".join(row_htmls)
+        if header_html:
+            return f"<table>{header_html}<tbody>{body}</tbody></table>"
+        return f"<table><tbody>{body}</tbody></table>"
+
+    def _split_oversized_table_row(self, header_html: str, row_html: str, token_num: int) -> list[str]:
+        row = BeautifulSoup(row_html, "html.parser").find("tr")
+        row_text = row.get_text(" | ", strip=True) if row is not None else row_html
+
+        def wrap(piece: str) -> str:
+            row_fragment = f"<tr><td>{escape(piece)}</td></tr>"
+            return self._build_table_html(header_html, [row_fragment])
+
+        return self._hard_split_wrapped(row_text, token_num, wrap)
+
+    def _split_code_content(self, content: str, token_num: int, language: str = "") -> list[str]:
+        if num_tokens_from_string(content) <= token_num:
+            return [content]
+
+        body_lines = content.split("\n")
+        fence_start = ""
+        fence_end = ""
+        if body_lines and body_lines[0].strip().startswith("```"):
+            fence_start = body_lines[0]
+            if body_lines[-1].strip().startswith("```"):
+                fence_end = body_lines[-1]
+                body_lines = body_lines[1:-1]
+            else:
+                body_lines = body_lines[1:]
+        elif language:
+            fence_start = f"```{language}"
+            fence_end = "```"
+
+        chunks: list[str] = []
+        current_lines: list[str] = []
+
+        for line in body_lines:
+            if num_tokens_from_string(self._wrap_code_lines([line], fence_start, fence_end)) > token_num:
+                if current_lines:
+                    chunks.append(self._wrap_code_lines(current_lines, fence_start, fence_end))
+                    current_lines = []
+                chunks.extend(self._split_oversized_code_line(line, token_num, fence_start, fence_end))
+                continue
+
+            candidate_lines = current_lines + [line]
+            candidate = self._wrap_code_lines(candidate_lines, fence_start, fence_end)
+            if current_lines and num_tokens_from_string(candidate) > token_num:
+                chunks.append(self._wrap_code_lines(current_lines, fence_start, fence_end))
+                current_lines = [line]
+            else:
+                current_lines = candidate_lines
+
+        if current_lines:
+            chunks.append(self._wrap_code_lines(current_lines, fence_start, fence_end))
+
+        return chunks or [content]
+
+    def _split_oversized_code_line(
+        self,
+        line: str,
+        token_num: int,
+        fence_start: str,
+        fence_end: str,
+    ) -> list[str]:
+        return self._hard_split_wrapped(
+            line,
+            token_num,
+            lambda piece: self._wrap_code_lines([piece], fence_start, fence_end),
+        )
+
+    def _hard_split_wrapped(self, text: str, token_num: int, wrap) -> list[str]:
+        tokens = encoder.encode(text)
+        chunks: list[str] = []
+        index = 0
+        while index < len(tokens):
+            low = 1
+            high = len(tokens) - index
+            best = 0
+            while low <= high:
+                mid = (low + high) // 2
+                piece = encoder.decode(tokens[index:index + mid])
+                wrapped = wrap(piece)
+                if num_tokens_from_string(wrapped) <= token_num:
+                    best = mid
+                    low = mid + 1
+                else:
+                    high = mid - 1
+
+            if best <= 0:
+                best = 1
+            piece = encoder.decode(tokens[index:index + best])
+            chunks.append(wrap(piece))
+            index += best
+        return chunks
+
+    def _wrap_code_lines(self, lines: list[str], fence_start: str, fence_end: str) -> str:
+        if not fence_start:
+            return "\n".join(lines)
+        end = fence_end or "```"
+        return "\n".join([fence_start, *lines, end])
+
+    def _metadata_for_block(self, block: ParsedBlock) -> dict:
+        metadata = deepcopy(block.metadata)
+        metadata.update(
+            {
+                "block_type": block.type.value,
+                "block_seq_start": block.seq,
+                "block_seq_end": block.seq,
+                "start_line": block.start_line,
+                "end_line": block.end_line,
+            }
+        )
+        return metadata
+
+    def _metadata_for_range(self, blocks: list[ParsedBlock], block_type: str) -> dict:
+        first = blocks[0]
+        last = blocks[-1]
+        return {
+            "block_type": block_type,
+            "block_types": [block.type.value for block in blocks],
+            "block_seq_start": first.seq,
+            "block_seq_end": last.seq,
+            "start_line": first.start_line,
+            "end_line": last.end_line,
+        }
+
+    def _serialize_chunk_contents(self, chunks: list[LogicalChunk]) -> list[str]:
+        return [str(chunk.content) for chunk in chunks if str(chunk.content or "").strip()]

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -1,0 +1,76 @@
+from app.core.rag.common.token_utils import encoder, num_tokens_from_string
+
+
+DEFAULT_TEXT_SEPARATORS = ["\n\n", "\n", "。", "；", " ", ""]
+
+
+class TextMerger:
+    def __init__(self, separators: list[str] | None = None):
+        self.separators = separators or DEFAULT_TEXT_SEPARATORS
+
+    def merge(self, value: str | list, chunk_num: int, delimiter: str | None = None) -> list[str]:
+        limit = max(int(chunk_num), 1)
+        separators = self._build_separators(delimiter)
+        chunks: list[str] = []
+        for text in self._extract_strings(value):
+            chunks.extend(self._split_recursive(text, limit, separators, 0))
+        return chunks
+
+    def _build_separators(self, delimiter: str | None) -> list[str]:
+        if delimiter is None:
+            return list(self.separators)
+        return [delimiter] + [separator for separator in self.separators if separator != delimiter]
+
+    def _extract_strings(self, value: str | list) -> list[str]:
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, str)]
+        return []
+
+    def _split_recursive(self, text: str, limit: int, separators: list[str], separator_index: int) -> list[str]:
+        if not text or not text.strip():
+            return []
+
+        separator = separators[separator_index] if separator_index < len(separators) else ""
+        if self._within_limit(text, limit) and (separator_index > 0 or not separator or separator not in text):
+            return [text]
+
+        if separator == "":
+            return self._hard_split(text, limit)
+
+        parts = self._split_with_separator(text, separator)
+        if len(parts) <= 1:
+            return self._split_recursive(text, limit, separators, separator_index + 1)
+
+        result: list[str] = []
+        for part in parts:
+            if not part or not part.strip():
+                continue
+            if self._within_limit(part, limit):
+                result.append(part)
+            else:
+                result.extend(self._split_recursive(part, limit, separators, separator_index + 1))
+        return result
+
+    def _split_with_separator(self, text: str, separator: str) -> list[str]:
+        raw_parts = text.split(separator)
+        if separator in {"。", "；"}:
+            return [
+                part + (separator if index < len(raw_parts) - 1 else "")
+                for index, part in enumerate(raw_parts)
+                if part
+            ]
+        return [part for part in raw_parts if part]
+
+    def _hard_split(self, text: str, limit: int) -> list[str]:
+        tokens = encoder.encode(text)
+        return [
+            encoder.decode(tokens[index:index + limit])
+            for index in range(0, len(tokens), limit)
+            if tokens[index:index + limit]
+        ]
+
+    @staticmethod
+    def _within_limit(text: str, limit: int) -> bool:
+        return num_tokens_from_string(text) <= limit

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -1,0 +1,337 @@
+import logging
+import re
+from io import BytesIO
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from markdown import markdown
+from PIL import Image
+
+from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
+from app.core.rag.chunk.parser.base import DocumentParser
+from app.core.rag.nlp import find_codec
+
+
+IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+HEADING_PATTERN = re.compile(r"^(#{1,6})\s+.*$")
+LIST_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+\.\s+).*$")
+
+
+class StructMarkdownParser(DocumentParser):
+    def parse(self, ctx):
+        text = self._read_text(ctx.filename, ctx.binary)
+        return self.parse_text(text)
+
+    def parse_text(self, text: str) -> list[ParsedBlock]:
+        self._seq = 0
+        self.blocks: list[ParsedBlock] = []
+        self.lines = text.split("\n")
+
+        index = 0
+        while index < len(self.lines):
+            line = self.lines[index]
+            stripped = line.strip()
+            if not stripped:
+                index += 1
+                continue
+
+            if self._is_heading(line):
+                index = self._append_heading(index)
+                continue
+            if stripped.startswith("```"):
+                index = self._append_code(index)
+                continue
+            if self._is_html_table_start(line):
+                index = self._append_html_table(index)
+                continue
+            if self._is_markdown_table_start(index):
+                index = self._append_markdown_table(index)
+                continue
+            if IMAGE_PATTERN.search(line):
+                index = self._append_image_line(index)
+                continue
+            if LIST_PATTERN.match(line):
+                index = self._append_list(index)
+                continue
+            if stripped.startswith(">"):
+                index = self._append_blockquote(index)
+                continue
+
+            index = self._append_text(index)
+
+        return self.blocks
+
+    def md_to_html(self, text: str):
+        if not text:
+            return []
+        return BeautifulSoup(markdown(text), "html.parser")
+
+    def get_hyperlink_urls(self, soup):
+        if soup:
+            return {a.get("href") for a in soup.find_all("a") if a.get("href")}
+        return set()
+
+    def load_image(self, src: str):
+        import requests
+
+        if not src:
+            return None
+        try:
+            if src.startswith(("http://", "https://")):
+                response = requests.get(src, stream=True, timeout=30)
+                content_type = response.headers.get("Content-Type", "")
+                if response.status_code == 200 and content_type.startswith("image/"):
+                    return Image.open(BytesIO(response.content)).convert("RGB")
+                return None
+
+            local_path = Path(src)
+            if not local_path.exists():
+                logging.warning(f"Local image file not found: {src}")
+                return None
+            return Image.open(local_path).convert("RGB")
+        except Exception as exc:
+            logging.error(f"Failed to download/open image from {src}: {exc}")
+            return None
+
+    def _read_text(self, filename: str, binary: bytes | None) -> str:
+        if binary:
+            encoding = find_codec(binary)
+            return binary.decode(encoding, errors="ignore")
+        with open(filename, "r") as file:
+            return file.read()
+
+    def _append_block(
+        self,
+        block_type: ParsedBlockType,
+        content,
+        raw: str = "",
+        start_line: int | None = None,
+        end_line: int | None = None,
+        metadata: dict | None = None,
+        image=None,
+    ) -> None:
+        if isinstance(content, str) and not content.strip() and block_type is not ParsedBlockType.IMAGE:
+            return
+        self.blocks.append(
+            ParsedBlock(
+                type=block_type,
+                content=content,
+                raw=raw or (content if isinstance(content, str) else ""),
+                seq=self._seq,
+                start_line=start_line,
+                end_line=end_line,
+                image=image,
+                metadata=metadata or {},
+            )
+        )
+        self._seq += 1
+
+    def _is_heading(self, line: str) -> bool:
+        return bool(HEADING_PATTERN.match(line))
+
+    def _append_heading(self, index: int) -> int:
+        line = self.lines[index]
+        match = HEADING_PATTERN.match(line)
+        level = len(match.group(1)) if match else 1
+        self._append_block(
+            ParsedBlockType.HEADING,
+            line,
+            start_line=index + 1,
+            end_line=index + 1,
+            metadata={"level": level},
+        )
+        return index + 1
+
+    def _append_code(self, index: int) -> int:
+        start = index
+        first_line = self.lines[index].strip()
+        language = first_line[3:].strip()
+        index += 1
+        while index < len(self.lines):
+            if self.lines[index].strip().startswith("```"):
+                index += 1
+                break
+            index += 1
+        content = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.CODE,
+            content,
+            start_line=start + 1,
+            end_line=index,
+            metadata={"language": language},
+        )
+        return index
+
+    def _is_html_table_start(self, line: str) -> bool:
+        return bool(re.search(r"<table\b", line, re.IGNORECASE))
+
+    def _append_html_table(self, index: int) -> int:
+        start = index
+        while index < len(self.lines):
+            if re.search(r"</table>", self.lines[index], re.IGNORECASE):
+                index += 1
+                break
+            index += 1
+        raw = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.TABLE,
+            self._normalize_html_table(raw),
+            raw=raw,
+            start_line=start + 1,
+            end_line=index,
+            metadata={"table_format": "html"},
+        )
+        return index
+
+    def _is_markdown_table_start(self, index: int) -> bool:
+        if index + 1 >= len(self.lines):
+            return False
+        return "|" in self.lines[index] and self._is_table_separator(self.lines[index + 1])
+
+    def _append_markdown_table(self, index: int) -> int:
+        start = index
+        index += 2
+        while index < len(self.lines):
+            line = self.lines[index]
+            if not line.strip() or "|" not in line:
+                break
+            index += 1
+        raw = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.TABLE,
+            markdown(raw, extensions=["markdown.extensions.tables"]),
+            raw=raw,
+            start_line=start + 1,
+            end_line=index,
+            metadata={"table_format": "markdown"},
+        )
+        return index
+
+    def _append_image_line(self, index: int) -> int:
+        line = self.lines[index]
+        cursor = 0
+        for match in IMAGE_PATTERN.finditer(line):
+            before = line[cursor:match.start()]
+            if before.strip():
+                self._append_block(
+                    ParsedBlockType.TEXT,
+                    before,
+                    start_line=index + 1,
+                    end_line=index + 1,
+                )
+            alt, src = match.group(1), match.group(2)
+            self._append_block(
+                ParsedBlockType.IMAGE,
+                match.group(0),
+                raw=match.group(0),
+                start_line=index + 1,
+                end_line=index + 1,
+                metadata={"alt": alt, "src": src},
+            )
+            cursor = match.end()
+        after = line[cursor:]
+        if after.strip():
+            self._append_block(
+                ParsedBlockType.TEXT,
+                after,
+                start_line=index + 1,
+                end_line=index + 1,
+            )
+        return index + 1
+
+    def _append_list(self, index: int) -> int:
+        start = index
+        index += 1
+        while index < len(self.lines):
+            line = self.lines[index]
+            if LIST_PATTERN.match(line) or line.startswith((" ", "\t")) or not line.strip():
+                index += 1
+                continue
+            break
+        content = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.LIST,
+            content,
+            start_line=start + 1,
+            end_line=index,
+        )
+        return index
+
+    def _append_blockquote(self, index: int) -> int:
+        start = index
+        index += 1
+        while index < len(self.lines):
+            line = self.lines[index]
+            if line.strip().startswith(">") or not line.strip():
+                index += 1
+                continue
+            break
+        content = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.BLOCKQUOTE,
+            content,
+            start_line=start + 1,
+            end_line=index,
+        )
+        return index
+
+    def _append_text(self, index: int) -> int:
+        start = index
+        index += 1
+        while index < len(self.lines):
+            line = self.lines[index]
+            stripped = line.strip()
+            if not stripped:
+                if index + 1 < len(self.lines) and self._is_text_continuation(index + 1):
+                    index += 1
+                    continue
+                break
+            if self._is_block_start(index) or IMAGE_PATTERN.search(line):
+                break
+            index += 1
+        content = "\n".join(self.lines[start:index])
+        self._append_block(
+            ParsedBlockType.TEXT,
+            content,
+            start_line=start + 1,
+            end_line=index,
+        )
+        return index
+
+    def _is_text_continuation(self, index: int) -> bool:
+        return (
+            index < len(self.lines)
+            and self.lines[index].strip()
+            and not self._is_block_start(index)
+            and not IMAGE_PATTERN.search(self.lines[index])
+        )
+
+    def _is_block_start(self, index: int) -> bool:
+        line = self.lines[index]
+        stripped = line.strip()
+        return (
+            self._is_heading(line)
+            or stripped.startswith("```")
+            or self._is_html_table_start(line)
+            or self._is_markdown_table_start(index)
+            or LIST_PATTERN.match(line)
+            or stripped.startswith(">")
+        )
+
+    def _is_table_separator(self, line: str) -> bool:
+        if "|" not in line:
+            return False
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) < 2:
+            return False
+        return all(re.match(r"^:?-{3,}:?$", cell.replace(" ", "")) for cell in cells if cell)
+
+    def _normalize_html_table(self, raw: str) -> str:
+        tags = ["table", "td", "tr", "th", "tbody", "thead", "div"]
+        pattern = re.compile(rf"<(?:{'|'.join(tags)})[^>]*>", re.IGNORECASE)
+
+        def replace_tag(match):
+            tag_name = re.match(r"<(\w+)", match.group()).group(1)
+            return f"<{tag_name}>"
+
+        return re.sub(pattern, replace_tag, raw)

--- a/api/app/core/rag/chunk/pipeline/base.py
+++ b/api/app/core/rag/chunk/pipeline/base.py
@@ -84,7 +84,11 @@ class ChunkPipeline(ABC):
         pass
 
     def merge(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
+        from ..merger.block import BlockMerger
         from ..merger.naive import DocxMerger, ImageMerger, NaiveMerger
+
+        if parse_result.merge_strategy == "blocks" and parse_result.blocks:
+            return BlockMerger().merge(ctx, parse_result)
 
         if parse_result.merge_strategy == "docx":
             return DocxMerger().merge(ctx, parse_result)

--- a/api/app/core/rag/chunk/pipeline/text.py
+++ b/api/app/core/rag/chunk/pipeline/text.py
@@ -1,15 +1,13 @@
 import logging
 import os
 import tempfile
-from functools import reduce
 
 from app.core.rag.deepdoc.parser.figure_parser import VisionFigureParser
-from app.core.rag.chunk.context import ChunkContext, ParseResult
+from app.core.rag.chunk.context import ChunkContext, ParsedBlock, ParsedBlockType, ParseResult
 from app.core.rag.chunk.parser.html import HtmlParser
 from app.core.rag.chunk.parser.json import JsonParser
-from app.core.rag.chunk.parser.markdown import MarkdownParser
+from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
 from app.core.rag.chunk.parser.txt import TxtParser
-from app.core.rag.nlp import concat_img
 
 from .base import ChunkPipeline
 
@@ -19,55 +17,64 @@ class TextChunkPipeline(ChunkPipeline):
         ctx.callback(0.1, "Start to parse.")
         sections = TxtParser().parse(ctx)
         ctx.callback(0.8, "Finish parsing.")
-        return ParseResult(sections=sections)
+        texts = [section[0] if isinstance(section, tuple) else section for section in sections]
+        content = "\n\n".join(text for text in texts if isinstance(text, str) and text.strip())
+        blocks = []
+        if content:
+            blocks.append(
+                ParsedBlock(
+                    type=ParsedBlockType.TEXT,
+                    content=content,
+                    seq=0,
+                    start_line=1,
+                    end_line=content.count("\n") + 1,
+                )
+            )
+        return ParseResult(blocks=blocks, merge_strategy="blocks")
 
 
 class MarkdownChunkPipeline(ChunkPipeline):
     def parse(self, ctx: ChunkContext) -> ParseResult:
         urls = set()
-        section_images = None
         ctx.callback(0.1, "Start to parse.")
-        markdown_parser = MarkdownParser(ctx.parser_config.get("chunk_token_num", 128))
-        sections, tables = markdown_parser.parse(ctx)
+        markdown_parser = StructMarkdownParser()
+        blocks = markdown_parser.parse(ctx)
 
         if ctx.vision_model:
-            section_images = []
-            for index, (section_text, _) in enumerate(sections):
-                images = markdown_parser.get_pictures(section_text) if section_text else None
-
-                if images:
-                    combined_image = reduce(concat_img, images) if len(images) > 1 else images[0]
-                    section_images.append(combined_image)
+            for block in blocks:
+                if block.type is not ParsedBlockType.IMAGE:
+                    continue
+                image = markdown_parser.load_image(str(block.metadata.get("src", "")))
+                if image:
+                    block.image = image
                     markdown_vision_parser = VisionFigureParser(
                         vision_model=ctx.vision_model,
-                        figures_data=[((combined_image, ["markdown image"]), [(0, 0, 0, 0, 0)])],
+                        figures_data=[((image, ["markdown image"]), [(0, 0, 0, 0, 0)])],
                         **ctx.kwargs,
                     )
                     boosted_figures = markdown_vision_parser(callback=ctx.callback)
-                    sections[index] = (
-                        section_text + "\n\n" + "\n\n".join([fig[0][1][0] for fig in boosted_figures]),
-                        sections[index][1],
-                    )
-                else:
-                    section_images.append(None)
+                    vision_text = "\n\n".join([fig[0][1][0] for fig in boosted_figures])
+                    if vision_text:
+                        block.metadata["vision_text"] = vision_text
         else:
             logging.warning("No visual model detected. Skipping figure parsing enhancement.")
 
         if ctx.parser_config.get("hyperlink_urls", False) and ctx.is_root:
-            for section_text, _ in sections:
-                soup = markdown_parser.md_to_html(section_text)
+            for block in blocks:
+                if block.type not in {
+                    ParsedBlockType.HEADING,
+                    ParsedBlockType.TEXT,
+                    ParsedBlockType.LIST,
+                    ParsedBlockType.BLOCKQUOTE,
+                }:
+                    continue
+                soup = markdown_parser.md_to_html(str(block.content))
                 hyperlink_urls = markdown_parser.get_hyperlink_urls(soup)
                 urls.update(hyperlink_urls)
 
         ctx.callback(0.8, "Finish parsing.")
-        merge_strategy = "with_images" if section_images else "naive"
-        return ParseResult(
-            sections=sections,
-            tables=tables,
-            section_images=section_images,
-            urls=urls,
-            merge_strategy=merge_strategy,
-        )
+        logging.debug(f"[Markdown Parsing Blocks]: {blocks}")
+        return ParseResult(blocks=blocks, urls=urls, merge_strategy="blocks")
 
 
 class HtmlChunkPipeline(ChunkPipeline):

--- a/api/app/core/rag/chunk/postprocessor.py
+++ b/api/app/core/rag/chunk/postprocessor.py
@@ -5,6 +5,26 @@ from app.core.rag.nlp import add_positions, tokenize
 from .context import ChunkContext, LogicalChunk, LogicalChunkType, MergeResult, ParseResult
 
 
+ZERO_WIDTH_TRANSLATION = str.maketrans("", "", "\u200b\u200c\u200d\ufeff")
+ZERO_WIDTH_HTML_ENTITIES = (
+    "&ZeroWidthSpace;",
+    "&zwj;",
+    "&zwnj;",
+    "&#8203;",
+    "&#8204;",
+    "&#8205;",
+    "&#65279;",
+    "&#x200b;",
+    "&#x200B;",
+    "&#x200c;",
+    "&#x200C;",
+    "&#x200d;",
+    "&#x200D;",
+    "&#xfeff;",
+    "&#xFEFF;",
+)
+
+
 class ChunkPostProcessor:
     def process(
         self,
@@ -56,7 +76,7 @@ class ChunkPostProcessor:
         merge_result: MergeResult,
         index: int,
     ) -> dict | None:
-        content = str(chunk.content or "")
+        content = self._clean_content(str(chunk.content or ""))
         if not content.strip():
             return None
         doc = copy.deepcopy(ctx.doc)
@@ -65,7 +85,9 @@ class ChunkPostProcessor:
             try:
                 doc["image"], positions = pdf_parser.crop(content, need_position=True)
                 add_positions(doc, positions)
-                content = pdf_parser.remove_tag(content)
+                content = self._clean_content(pdf_parser.remove_tag(content))
+                if not content.strip():
+                    return None
             except NotImplementedError:
                 pass
         elif chunk.positions:
@@ -74,6 +96,8 @@ class ChunkPostProcessor:
             add_positions(doc, [[index] * 5])
         if chunk.image is not None:
             doc["image"] = chunk.image
+        if chunk.metadata:
+            doc["metadata"] = copy.deepcopy(chunk.metadata)
         tokenize(doc, content, ctx.is_english)
         return doc
 
@@ -86,6 +110,7 @@ class ChunkPostProcessor:
             content = delimiter.join(str(row) for row in rows if row)
         else:
             content = str(rows)
+        content = self._clean_content(content)
         if not content.strip():
             return None
         doc = copy.deepcopy(ctx.doc)
@@ -94,6 +119,14 @@ class ChunkPostProcessor:
             doc["doc_type_kwd"] = "image"
         if chunk.positions:
             add_positions(doc, chunk.positions)
+        if chunk.metadata:
+            doc["metadata"] = copy.deepcopy(chunk.metadata)
         tokenize(doc, content, ctx.is_english)
         doc["content_with_weight"] = content
         return doc
+
+    def _clean_content(self, content: str) -> str:
+        content = content.translate(ZERO_WIDTH_TRANSLATION)
+        for entity in ZERO_WIDTH_HTML_ENTITIES:
+            content = content.replace(entity, "")
+        return content

--- a/api/app/models/document_model.py
+++ b/api/app/models/document_model.py
@@ -42,7 +42,7 @@ class Document(Base):
                                "html4excel": False,
                                "parent_child_mode": False,
                                "parent_chunk_token_num": 1024,
-                               "parent_delimiter": "\n",
+                               "parent_chunk_delimiter": "\n\n",
                                "graphrag": {
                                    "use_graphrag": False,
                                    "scene_name": "",

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -84,7 +84,7 @@ class Knowledge(Base):
                                "html4excel": False,
                                "parent_child_mode": False,
                                "parent_chunk_token_num": 1024,
-                               "parent_delimiter": "\n",
+                               "parent_chunk_delimiter": "\n\n",
                                "graphrag": {
                                    "use_graphrag": False,
                                    "scene_name": "",


### PR DESCRIPTION
## Summary
- Add ordered structured markdown blocks for headings, text, lists, blockquotes, code, tables, and images.
- Route Markdown and text files through TextMerger and BlockMerger, including parent-child chunking with user-configured delimiters.
- Split oversized tables by row with repeated headers, and split oversized code blocks while preserving fences.
- Clean zero-width characters during chunk postprocessing and ignore local parser test artifacts.

## Changes
```text
.gitignore                                         |   4 +-
api/app/core/rag/chunk/context.py                  |  24 ++
api/app/core/rag/chunk/merger/block.py             | 403 +++++++++++++++++++++
api/app/core/rag/chunk/merger/text.py              |  76 ++++
api/app/core/rag/chunk/parser/structured_markdown.py   | 337 +++++++++++++++++
api/app/core/rag/chunk/pipeline/base.py            |   4 +
api/app/core/rag/chunk/pipeline/text.py            |  71 ++--
api/app/core/rag/chunk/postprocessor.py            |  37 +-
api/app/models/document_model.py                   |   2 +-
api/app/models/knowledge_model.py                  |   2 +-
10 files changed, 923 insertions(+), 37 deletions(-)
```

## API Impact
- No controller or service route changes.
- External API-key routes under `app/controllers/service` are not changed.

## Test Plan
- [x] `cd api && ./.venv/bin/python -m pytest -q tests/rag/chunk/test_text_merger.py tests/rag/chunk/test_structured_markdown_parser.py tests/rag/chunk/test_block_merger.py tests/rag/chunk/test_chunk_boundary_refactor.py`
- [x] `cd api && ./.venv/bin/python -m compileall -q app/core/rag/chunk`

## Summary by Sourcery

为文本和 Markdown 输入引入结构化的 Markdown 解析和基于块的分块管线，实现更丰富的元数据感知分块，并改进对表格、代码、图片以及父子块的处理。

New Features:
- 添加 `ParsedBlock` 和 `ParsedBlockType` 抽象，用于表示带有位置信息元数据的结构化 Markdown 和文本块。
- 添加结构化 Markdown 解析器，将标题、文本、列表、引用块、代码、表格和图片分割为有序块。
- 引入基于块的合并器，将解析后的块转换为逻辑分块，包括使用可配置分隔符和 token 限制的父子分块。
- 添加可复用的文本合并工具，用于基于 token 感知地按可自定义分隔符拆分文本内容。

Enhancements:
- 将文本和 Markdown 处理管线接入新的基于块的合并策略，将基于视觉的图像解析和超链接提取与块元数据集成。
- 在分块后处理阶段清理零宽字符及相关 HTML 实体，并将块元数据传播到序列化文档中。
- 更新默认解析器配置，使用“双换行”作为父块分隔符，以实现更好的段落级父子分块。

Tests:
- 添加/扩展针对文本合并工具、结构化 Markdown 解析器、块合并器以及分块边界重构的测试，以覆盖新的基于块的分块行为。

Chores:
- 在版本控制中忽略本地解析器测试产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a structured markdown parsing and block-based chunking pipeline for text and markdown inputs, enabling richer metadata-aware chunking and improved handling of tables, code, images, and parent-child chunks.

New Features:
- Add ParsedBlock and ParsedBlockType abstractions to represent structured markdown and text blocks with positional metadata.
- Add a structured markdown parser that segments headings, text, lists, blockquotes, code, tables, and images into ordered blocks.
- Introduce a block-based merger that converts parsed blocks into logical chunks, including parent-child chunking using configurable delimiters and token limits.
- Add a reusable text merger utility for token-aware splitting of text content using customizable separators.

Enhancements:
- Route text and markdown pipelines through the new block-based merge strategy, integrating vision-based figure parsing and hyperlink extraction with block metadata.
- Clean zero-width characters and related HTML entities during chunk postprocessing and propagate block metadata into serialized documents.
- Update default parser configuration to use a double-newline parent chunk delimiter for better paragraph-level parent-child chunking.

Tests:
- Add/extend tests for the text merger, structured markdown parser, block merger, and chunk boundary refactoring to cover the new block-based chunking behavior.

Chores:
- Ignore local parser test artifacts in version control.

</details>