### PR TITLE
feat(minio): add backend streaming download support to resolve unreachable presigned URL in intranet

### DIFF
--- a/api/app/controllers/file_storage_controller.py
+++ b/api/app/controllers/file_storage_controller.py
@@ -19,13 +19,13 @@ import mimetypes
 from urllib.parse import urlparse, unquote, quote
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import success
-from app.core.storage import LocalStorage
+from app.core.storage import LocalStorage, MinIOStorage
 from app.core.storage.url_signer import generate_signed_url, verify_signed_url
 from app.core.storage_exceptions import (
     StorageDeleteError,
@@ -61,6 +61,48 @@ def _match_scheme(request: Request, url: str) -> str:
     if url.startswith("https://") and incoming_scheme == "http":
         return "http://" + url[8:]
     return url
+
+
+async def _stream_remote_file(
+    storage: MinIOStorage,
+    file_metadata: FileMetadata,
+    file_key: str,
+) -> StreamingResponse:
+    """
+    通过 API 流式回传 MinIO 上的文件内容。
+
+    仅用于 MinIO：其 presigned URL 指向内网端点（如 http://10.x.x.x:9000），
+    浏览器不可达且不支持 TLS，走 302 重定向会触发 ERR_SSL_PROTOCOL_ERROR。
+    故改为后端代理流式回传，浏览器只与本服务通信。S3/OSS 的 presigned URL
+    为公网 HTTPS，仍走重定向，不走此方法。
+
+    先预取首个 chunk：MinIO 上文件缺失时能在响应发出前抛出 404，而不是
+    发出 200 后再中断流。
+    """
+    content_type = (
+        file_metadata.content_type
+        or mimetypes.guess_type(file_metadata.file_name)[0]
+        or "application/octet-stream"
+    )
+    encoded_filename = quote(file_metadata.file_name)
+
+    stream = storage.download_stream(file_key)
+    try:
+        first_chunk = await stream.__anext__()
+    except StopAsyncIteration:
+        first_chunk = None  # 空对象
+
+    async def _body():
+        if first_chunk is not None:
+            yield first_chunk
+        async for chunk in stream:
+            yield chunk
+
+    return StreamingResponse(
+        _body(),
+        media_type=content_type,
+        headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"},
+    )
 
 
 @router.post("/files", response_model=ApiResponse)
@@ -436,7 +478,25 @@ async def download_file(
             media_type=file_metadata.content_type or "application/octet-stream",
             headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
         )
+    elif isinstance(storage, MinIOStorage):
+        # MinIO 部署在内网，presigned URL 指向内网端点，浏览器不可达且不支持 TLS；
+        # 改为后端代理流式回传，浏览器只与本服务通信。
+        try:
+            return await _stream_remote_file(storage, file_metadata, file_key)
+        except FileNotFoundError:
+            api_logger.warning(f"File not found in MinIO: file_key={file_key}")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="File not found in storage"
+            )
+        except Exception as e:
+            api_logger.error(f"Failed to stream file from MinIO: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to retrieve file: {str(e)}"
+            )
     else:
+        # S3/OSS：presigned URL 为公网 HTTPS，保留 302 重定向（浏览器直连对象存储）
         try:
             presigned_url = await storage_service.get_file_url(file_key, expires=3600)
             presigned_url = _match_scheme(request, presigned_url)
@@ -717,8 +777,25 @@ async def public_download_file(
             media_type=file_metadata.content_type or "application/octet-stream",
             headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
         )
+    elif isinstance(storage, MinIOStorage):
+        # MinIO 部署在内网，presigned URL 指向内网端点，浏览器不可达且不支持 TLS；
+        # 改为后端代理流式回传，浏览器只与本服务通信。
+        try:
+            return await _stream_remote_file(storage, file_metadata, file_key)
+        except FileNotFoundError:
+            api_logger.warning(f"File not found in MinIO: file_key={file_key}")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="File not found in storage"
+            )
+        except Exception as e:
+            api_logger.error(f"Failed to stream file from MinIO: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to retrieve file: {str(e)}"
+            )
     else:
-        # For remote storage, redirect to presigned URL
+        # S3/OSS：presigned URL 为公网 HTTPS，保留 302 重定向（浏览器直连对象存储）
         try:
             presigned_url = await storage_service.get_file_url(file_key, expires=3600)
             presigned_url = _match_scheme(request, presigned_url)
@@ -789,8 +866,25 @@ async def permanent_download_file(
             media_type=file_metadata.content_type or "application/octet-stream",
             headers={"Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}"}
         )
+    elif isinstance(storage, MinIOStorage):
+        # MinIO 部署在内网，presigned URL 指向内网端点，浏览器不可达且不支持 TLS；
+        # 改为后端代理流式回传，浏览器只与本服务通信。
+        try:
+            return await _stream_remote_file(storage, file_metadata, file_key)
+        except FileNotFoundError:
+            api_logger.warning(f"File not found in MinIO: file_key={file_key}")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="File not found in storage"
+            )
+        except Exception as e:
+            api_logger.error(f"Failed to stream file from MinIO: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to retrieve file: {str(e)}"
+            )
     else:
-        # For remote storage, redirect to presigned URL with long expiration
+        # S3/OSS：presigned URL 为公网 HTTPS，保留 302 重定向（浏览器直连对象存储）
         try:
             # Use a very long expiration (7 days max for most cloud providers)
             presigned_url = await storage_service.get_file_url(file_key, expires=604800, file_name=file_metadata.file_name)

--- a/api/app/core/storage/minio.py
+++ b/api/app/core/storage/minio.py
@@ -11,12 +11,14 @@ exists/presigned-URL behavior from S3Storage) and only customizes:
     {endpoint_url}/{bucket_name}/{file_key}
 """
 
+import asyncio
 import logging
+from typing import AsyncIterator
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from app.core.storage.s3 import S3Storage
-from app.core.storage_exceptions import StorageConfigError
+from app.core.storage_exceptions import StorageConfigError, StorageDownloadError
 
 logger = logging.getLogger(__name__)
 
@@ -118,3 +120,63 @@ class MinIOStorage(S3Storage):
             A permanent URL for the file.
         """
         return f"{self.endpoint_url}/{self.bucket_name}/{file_key}"
+
+    async def download_stream(self, file_key: str) -> AsyncIterator[bytes]:
+        """
+        Stream a file from MinIO in chunks (suitable for StreamingResponse)。
+
+        仅 MinIO 需要此方法：MinIO 通常部署在内网，其 presigned URL 指向内网端点
+        （如 http://10.x.x.x:9000），浏览器不可达且不支持 TLS，若走 302 重定向会
+        触发 ERR_SSL_PROTOCOL_ERROR。故 MinIO 的文件下载改为后端代理流式回传，
+        浏览器只与本服务通信。S3/OSS 的 presigned URL 为公网 HTTPS、重定向可用，
+        不需要此方法。
+
+        同步 boto3 调用通过 asyncio.to_thread 卸载，避免阻塞事件循环。
+
+        Args:
+            file_key: Unique identifier for the file in the storage system.
+
+        Yields:
+            Bytes chunks of the file content.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            StorageDownloadError: If the download operation fails.
+        """
+        try:
+            response = await asyncio.to_thread(
+                self.client.get_object,
+                Bucket=self.bucket_name,
+                Key=file_key,
+            )
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            if error_code in ("NoSuchKey", "404"):
+                logger.warning(f"File not found in MinIO: {file_key}")
+                raise FileNotFoundError(f"File not found: {file_key}")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+            logger.error(f"MinIO ClientError opening stream for {file_key}: {error_message}")
+            raise StorageDownloadError(
+                message=f"Failed to download file from MinIO ({error_code}): {error_message}",
+                file_key=file_key,
+                cause=e,
+            )
+        except BotoCoreError as e:
+            logger.error(f"MinIO BotoCoreError opening stream for {file_key}: {e}")
+            raise StorageDownloadError(
+                message=f"Failed to download file from MinIO: {e}",
+                file_key=file_key,
+                cause=e,
+            )
+
+        body = response["Body"]
+        chunk_iter = body.iter_chunks(chunk_size=64 * 1024)
+        try:
+            while True:
+                chunk = await asyncio.to_thread(next, chunk_iter, None)
+                if not chunk:
+                    break
+                yield chunk
+        finally:
+            # 释放底层连接（客户端提前断开时尤为重要）
+            await asyncio.to_thread(body.close)


### PR DESCRIPTION
For MinIO deployed in intranet environments, presigned URLs point to internal endpoints that are inaccessible from browsers and do not support TLS, triggering SSL protocol errors. This commit implements a backend proxy streaming download:

1. Add an async streaming download method in `MinIOStorage`, using `asyncio.to_thread` to avoid blocking the event loop.
2. Add MinIO-specific streaming response logic in the file download controller, unifying the handling across all three download interfaces.
3. Prefetch the first chunk to capture file-not-found errors early, preventing empty 200 responses.

## Summary by Sourcery

为使用 MinIO 作为存储后端的环境添加后端流式文件下载支持，以避免在内网部署中预签名 URL 带来的问题，并统一所有下载端点对 MinIO 的处理方式。

New Features:
- 在 `MinIOStorage` 中引入异步流式下载 API，以异步字节迭代器的形式暴露文件内容，便于用于 HTTP 流式响应。
- 为私有、公共和永久下载端点添加 MinIO 专用的后端流式下载响应机制，替代之前通过预签名 URL 重定向的方式。

Bug Fixes:
- 确保在 MinIO 中缺失的文件会在发送任何响应体内容之前，以 HTTP 404 响应返回，避免在下载失败时出现空的 200 响应。

Enhancements:
- 通过结构化的 `StorageDownloadError` 异常以及对客户端错误和 BotoCore 错误的详细日志记录，改进 MinIO 下载错误处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add backend-streamed file download support for MinIO-backed storage to avoid presigned URL issues in intranet deployments and align MinIO handling across all download endpoints.

New Features:
- Introduce an async streaming download API in MinIOStorage that exposes file content as an async byte iterator suitable for HTTP streaming responses.
- Add MinIO-specific backend streaming responses for file downloads across private, public, and permanent download endpoints instead of redirecting via presigned URLs.

Bug Fixes:
- Ensure missing files in MinIO surface as HTTP 404 responses before sending any body content, preventing empty 200 responses on download failures.

Enhancements:
- Improve MinIO download error handling with structured StorageDownloadError exceptions and detailed logging for client and BotoCore errors.

</details>