### PR TITLE
feat(memory): skip pruning LLM calls when pruning is disabled

### DIFF
--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -97,6 +97,14 @@ class PruningPipeline:
             - should_process_user_msg: 是否需要对 user 消息做规整
             - processed_user_msg: 规整后的 user 消息文本，不需要处理时为 None
         """
+        # pruning_enabled=False 时直接透传原内容，不做任何 LLM 调用
+        if not self.memory_config.pruning_enabled:
+            logger.debug(
+                f"[PruningPipeline] 剪枝开关已关闭，跳过: "
+                f"conv={conversation_id}, seq={message_seq}"
+            )
+            return content, False, None
+
         cache_key = self._cache_key(conversation_id, message_seq)
 
         # Step 1: 查询 Redis 缓存
@@ -217,7 +225,7 @@ class PruningPipeline:
         self._ensure_llm_client()
 
         pruning_config = PruningConfig(
-            pruning_switch=True,
+            pruning_switch=self.memory_config.pruning_enabled,
             pruning_scene=self.memory_config.pruning_scene or "education",
             pruning_threshold=self.memory_config.pruning_threshold,
             scene_id=(


### PR DESCRIPTION
## Summary by Sourcery

当裁剪功能被禁用时，跳过基于 LLM 的记忆裁剪，并将裁剪配置开关与运行时设置对齐。

New Features:
- 当在记忆配置中禁用裁剪时，绕过裁剪流水线，直接返回原始内容。

Enhancements:
- 将裁剪配置开关连接到记忆配置标志，使 LLM 裁剪能够遵循全局裁剪设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip LLM-based memory pruning when the pruning feature is disabled and align the pruning configuration switch with the runtime setting.

New Features:
- Bypass the pruning pipeline and return original content directly when pruning is disabled in the memory configuration.

Enhancements:
- Wire the pruning configuration switch to the memory configuration flag so LLM pruning respects the global pruning setting.

</details>