### PR TITLE
refactor(workflow,app_chat_service)

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -667,6 +667,8 @@ async def draft_run(
         # 流式返回
         if payload.stream:
             source = HitLogSource.EXTERNAL if is_shared else HitLogSource.CONSOLE
+            # 提前提取 current_user 的值，避免闭包持有 ORM 对象引用导致 db 连接不释放
+            _current_user_id = str(current_user.id)
             async def event_generator():
                 with get_db_context() as stream_db:
                     from app.services.draft_run_service import AgentRunService as _AgentRunService
@@ -677,7 +679,7 @@ async def draft_run(
                             message=payload.message,
                             workspace_id=workspace_id,
                             conversation_id=payload.conversation_id,
-                            user_id=payload.user_id or str(current_user.id),
+                            user_id=payload.user_id or _current_user_id,
                             variables=payload.variables,
                             storage_type=storage_type,
                             user_rag_memory_id=user_rag_memory_id,
@@ -837,6 +839,13 @@ async def draft_run(
             config = service._workflow_config_from_release(release)
         else:
             config = workflow_service.check_config(app_id)
+            # check_config 完成后立即将 config 从 session 脱离，并关闭连接归还连接池
+            # 避免 workflow_service.db 在整个流式期间处于 idle in transaction 状态
+            _config_id = config.id
+            from sqlalchemy.orm import make_transient
+            make_transient(config)
+            config.id = _config_id
+            workflow_service.db.close()
         # 3. 流式返回
         if payload.stream:
             logger.debug(
@@ -865,7 +874,7 @@ async def draft_run(
                             app_id=app_id,
                             payload=payload,
                             config=config,
-                            workspace_id=current_user.current_workspace_id,
+                            workspace_id=workspace_id,
                             source=source,
                             trigger_payload=payload.trigger_payload
                     ):

--- a/api/app/controllers/service/app_api_controller.py
+++ b/api/app/controllers/service/app_api_controller.py
@@ -170,6 +170,11 @@ async def chat(
             conversation_id=payload.conversation_id
         )
 
+    # 提前提取 ORM 对象属性为纯值，避免 event_generator 闭包持有 ORM 引用导致 db 连接无法释放
+    _app_id = app.id
+    _release_id = active_release.id if active_release else None
+    _conversation_id = conversation.id if conversation else None
+
     if app_type == AppType.AGENT:
 
         # print("="*50)
@@ -189,7 +194,7 @@ async def chat(
                     _chat_service = _AppChatService(stream_db)
                     async for event in _chat_service.agent_chat_stream(
                             message=payload.message,
-                            conversation_id=conversation.id if conversation else None,
+                             conversation_id=_conversation_id,
                             user_id=end_user_id,
                             variables=payload.variables,
                             web_search=web_search,
@@ -237,7 +242,7 @@ async def chat(
                     _chat_service = _AppChatService(stream_db)
                     async for event in _chat_service.multi_agent_chat_stream(
                             message=payload.message,
-                            conversation_id=conversation.id,
+                             conversation_id=_conversation_id,
                             user_id=end_user_id,
                             variables=payload.variables,
                             config=config,
@@ -282,7 +287,7 @@ async def chat(
                     _chat_service = _AppChatService(stream_db)
                     async for event in _chat_service.workflow_chat_stream(
                             message=payload.message,
-                            conversation_id=conversation.id,
+                             conversation_id=_conversation_id,
                             user_id=end_user_id,
                             variables=payload.variables,
                             files=payload.files,
@@ -291,9 +296,9 @@ async def chat(
                             memory=memory,
                             storage_type=storage_type,
                             user_rag_memory_id=user_rag_memory_id,
-                            app_id=app.id,
+                             app_id=_app_id,
                             workspace_id=workspace_id,
-                            release_id=active_release.id,
+                             release_id=_release_id,
                             public=True
                     ):
                         event_type = event.get("event", "message")

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -797,6 +797,16 @@ class AppChatService:
             agent_exec_repo.create(agent_execution)
             self.db.commit()
 
+
+            # close() 前预读 ORM 属性，防止 close 后触发 DetachedInstanceError
+            _api_key_id = api_key_obj.id
+            _api_key_model_name = api_key_obj.model_name
+            _agent_execution_id = agent_execution.id
+            # LLM 推理期间不需要 db，提前归还连接给连接池
+            # 所有工具（knowledge/memory/web_search）均使用独立连接，不依赖 self.db
+            # SQLAlchemy Session.close() 只归还底层连接，session 对象仍可复用（懒重连）
+            self.db.close()
+
             # 流式调用 Agent（支持多模态），同时并行启动 TTS
             full_content = ""
             full_reasoning = ""
@@ -850,7 +860,7 @@ class AppChatService:
                 await text_queue.put(None)
 
             elapsed_time = time.time() - start_time
-            ModelApiKeyService.record_api_key_usage(self.db, api_key_obj.id)
+            ModelApiKeyService.record_api_key_usage(self.db, _api_key_id)
 
             # 发送结束事件（包含 suggested_questions、tts、audio_status、citations）
             end_data: dict = {"elapsed_time": elapsed_time, "message_length": len(full_content), "error": None}
@@ -884,7 +894,7 @@ class AppChatService:
                 "history_files": {}
             }
             assistant_meta = {
-                "model": api_key_obj.model_name,
+                "model": _api_key_model_name,
                 "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
                 "audio_url": None,
                 "citations": filtered_citations,
@@ -980,7 +990,7 @@ class AppChatService:
             # 更新 Agent 执行记录为 completed
             all_node_executions = orchestrator_node_executions + node_executions
             agent_exec_repo.update_completed(
-                execution_id=agent_execution.id,
+                    execution_id=_agent_execution_id,
                 steps=all_node_executions,
                 status="completed",
                 elapsed_time=elapsed_time,
@@ -1027,7 +1037,7 @@ class AppChatService:
             try:
                 elapsed_time = time.time() - start_time
                 agent_exec_repo.update_completed(
-                    execution_id=agent_execution.id,
+                    execution_id=_agent_execution_id,
                     steps=node_executions if 'node_executions' in dir() else [],
                     status="failed",
                     elapsed_time=elapsed_time,

--- a/api/app/services/context_engine_manager.py
+++ b/api/app/services/context_engine_manager.py
@@ -423,6 +423,12 @@ class ContextEngineManager:
                 self._serialize_history_message(msg, current_provider, current_is_omni)
                 for msg in recent_records
             ]
+            # close() 前预读 boundary_message 属性，防止 close 后 DetachedInstanceError
+            boundary_message = recent_records[-window_size - 1]
+            _boundary_id = boundary_message.id
+            _boundary_at = boundary_message.created_at
+            # LLM 调用期间不需要 db，提前归还连接给连接池
+            self.db.close()
             summary_text = await provider.warm_up_summary(
                 session_id=self._build_session_id(conversation_id, scope_key),
                 full_history=recent_messages,
@@ -432,14 +438,13 @@ class ContextEngineManager:
             if not summary_text:
                 return False
 
-            boundary_message = recent_records[-window_size - 1]
             await self._upsert_state(
                 conversation_id=conversation_id,
                 scope_key=scope_key,
                 source_type="conversation",
                 summary_text=summary_text,
-                summarized_until_message_id=boundary_message.id,
-                summarized_until_at=boundary_message.created_at,
+                summarized_until_message_id=_boundary_id,
+                summarized_until_at=_boundary_at,
             )
             await provider.prime_summary(
                 session_id=self._build_session_id(conversation_id, scope_key),
@@ -454,7 +459,7 @@ class ContextEngineManager:
                     "provider": provider_name,
                     "window_size": window_size,
                     "recent_count": len(recent_messages),
-                    "boundary_message_id": str(boundary_message.id),
+                    "boundary_message_id": str(_boundary_id),
                 }
             )
             return True

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -1432,6 +1432,17 @@ class AgentRunService:
                 agent_exec_repo.create(agent_execution)
                 self.db.commit()
 
+            # close() 前把后续还会用到的 ORM 属性读成普通值，防止 close 后触发 DetachedInstanceError
+            _app_id = agent_config.app_id
+            _model_config_id = model_config.id
+            _model_config_name = model_config.name
+            _agent_execution_id = agent_execution.id if (not sub_agent and not skip_save) else None
+
+            # LLM 推理期间不需要 db，提前归还连接给连接池
+            # 所有工具（knowledge/memory/web_search）均使用独立连接，不依赖 self.db
+            # SQLAlchemy Session.close() 只归还底层连接，session 对象仍可复用（懒重连）
+            self.db.close()
+
             # 9. 流式调用 Agent（支持多模态），同时并行启动 TTS
             full_content = ""
             full_reasoning = ""
@@ -1500,7 +1511,7 @@ class AgentRunService:
                     conversation_id=conversation_id,
                     user_message=message,
                     assistant_message=full_content,
-                    app_id=agent_config.app_id,
+                    app_id=_app_id,
                     user_id=user_id,
                     meta_data={
                         "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
@@ -1521,7 +1532,7 @@ class AgentRunService:
                         current_provider=api_key_config.get("provider"),
                         current_is_omni=api_key_config.get("is_omni", False),
                         legacy_max_history=settings.AGENT_MAX_HISTORY,
-                        model_config_id=model_config.id,
+                        model_config_id=_model_config_id,
                     )
                     async def _run_after_turn(kwargs=_ctx_kwargs):
                         with get_db_context() as db2:
@@ -1531,7 +1542,7 @@ class AgentRunService:
             # 11.5 更新 Agent 执行记录为 completed
             if not sub_agent:
                 agent_exec_repo.update_completed(
-                    execution_id=agent_execution.id,
+                    execution_id=_agent_execution_id,
                     steps=orchestrator_node_executions + node_executions,
                     status="completed",
                     elapsed_time=elapsed_time,
@@ -1565,7 +1576,7 @@ class AgentRunService:
             logger.info(
                 "流式试运行完成",
                 extra={
-                    "model": model_config.name,
+                    "model": _model_config_name,
                     "elapsed_time": elapsed_time,
                     "message_length": len(full_content)
                 }
@@ -1610,7 +1621,7 @@ class AgentRunService:
                 try:
                     elapsed_time = time.time() - start_time
                     agent_exec_repo.update_completed(
-                        execution_id=agent_execution.id,
+                        execution_id=_agent_execution_id,
                         steps=node_executions if 'node_executions' in dir() else [],
                         status="failed",
                         elapsed_time=elapsed_time,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1354,8 +1354,9 @@ class WorkflowService:
             execution: WorkflowExecution,
             node_executions: list[WorkflowNodeExecution],
             output_data: dict[str, Any],
+            workflow_config: "WorkflowConfig | None" = None,
     ) -> dict[str, Any]:
-        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        workflow_config = workflow_config or execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
         type_maps = self._build_snapshot_type_maps(workflow_config)
         raw_groups = self._extract_execution_snapshot_raw_groups(
             output_data=output_data,
@@ -1686,9 +1687,16 @@ class WorkflowService:
             source=source,
         )
 
-    def _refresh_workflow_debug_state_from_execution(self, execution: WorkflowExecution) -> None:
-        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
-        snapshot = self._build_public_execution_snapshot_from_record(execution)
+    def _refresh_workflow_debug_state_from_execution(self, execution: WorkflowExecution, workflow_config: WorkflowConfig | None = None) -> None:
+        workflow_config = workflow_config or execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        node_executions = self.node_execution_repo.get_by_execution_id(execution.id)
+        output_data = self._serialize_execution_value(execution.output_data or {})
+        snapshot = self._build_public_execution_snapshot_record(
+            execution=execution,
+            node_executions=node_executions,
+            output_data=output_data if isinstance(output_data, dict) else {},
+            workflow_config=workflow_config,
+        )
         self._write_workflow_debug_state(
             app_id=execution.app_id,
             workflow_config=workflow_config,
@@ -4438,6 +4446,11 @@ class WorkflowService:
             moderation_flagged = False
             active_llm_nodes: set[str] = set()  # 已 node_start 但尚未 node_end 的 LLM 节点
 
+            # 工作流引擎执行期间不需要 db，提前归还连接给连接池
+            # execution 对象保持内存状态，事件处理时通过 self.db 懒重连写入
+            # 写完后再调用 self.db.close() 归还连接
+            self.db.close()
+
             async for event in execute_workflow_stream(
                     workflow_config=workflow_config_dict,
                     input_data=input_data,
@@ -4540,7 +4553,7 @@ class WorkflowService:
                             execution = self.get_execution(execution.execution_id)
                             if execution and execution.output_data:
                                 self._persist_workflow_node_executions(execution, config, execution.output_data)
-                                self._refresh_workflow_debug_state_from_execution(execution)
+                                self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                         except Exception as persist_err:
                             logger.warning(f"Failed to persist node executions on moderation: {persist_err}")
                         break
@@ -4645,7 +4658,7 @@ class WorkflowService:
                             execution = self.get_execution(execution.execution_id)
                             if execution and execution.output_data:
                                 self._persist_workflow_node_executions(execution, config, execution.output_data)
-                                self._refresh_workflow_debug_state_from_execution(execution)
+                                self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                         except Exception as persist_err:
                             logger.warning(f"Failed to persist node executions on stream failed: {persist_err}")
                     elif status == "waiting_human":
@@ -4744,7 +4757,7 @@ class WorkflowService:
                             },
                         }
                         self.db.commit()
-                        self.db.refresh(execution)
+                        self.db.close()
 
                         # Save the user message so that the conversation title
                         # gets updated from the first user message, rather than
@@ -4836,9 +4849,10 @@ class WorkflowService:
                                 node_outputs[cycle_node_id] = {"cycle_items": items}
                         execution.output_data = new_output_data
                         self.db.commit()
+                        self.db.close()
                     if status in {"completed", "failed"} and execution.output_data:
                         self._persist_workflow_node_executions(execution, config, execution.output_data)
-                        self._refresh_workflow_debug_state_from_execution(execution)
+                        self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                 elif event.get("event") == "workflow_start":
                     event["data"]["message_id"] = str(message_id)
                 # 记录活跃 LLM 节点：node_start 加入，node_end 移除，合成时只为活跃节点补发
@@ -4902,6 +4916,7 @@ class WorkflowService:
                             },
                         }
                         self.db.commit()
+                        self.db.close()
 
                     # Handle timeout signal from the background scheduler
                     # Resume the workflow via the timeout branch (TIMEOUT) instead of terminating
@@ -4994,6 +5009,7 @@ class WorkflowService:
                                     backlog_interventions=clean_remaining,
                                 )
                                 self.db.commit()
+                                self.db.close()
 
                                 register_intervention(execution.execution_id, new_map)
                                 if new_pending:
@@ -5072,10 +5088,11 @@ class WorkflowService:
                                 # is durable across requests. update_message()
                                 # only flushes; it relies on the caller to commit.
                                 self.db.commit()
+                                self.db.close()
 
                                 try:
                                     self._persist_workflow_node_executions(execution, config, execution.output_data)
-                                    self._refresh_workflow_debug_state_from_execution(execution)
+                                    self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                                 except Exception as persist_err:
                                     logger.warning(f"Failed to persist node executions on intervention resolved: {persist_err}")
 
@@ -5160,10 +5177,11 @@ class WorkflowService:
                                 # is durable across requests. update_message()
                                 # only flushes; it relies on the caller to commit.
                                 self.db.commit()
+                                self.db.close()
 
                                 try:
                                     self._persist_workflow_node_executions(execution, config, execution.output_data)
-                                    self._refresh_workflow_debug_state_from_execution(execution)
+                                    self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                                 except Exception as persist_err:
                                     logger.warning(f"Failed to persist node executions on intervention complete: {persist_err}")
 
@@ -5198,10 +5216,11 @@ class WorkflowService:
                                     meta_data=_resolved_meta,
                                 )
                                 self.db.commit()
+                                self.db.close()
 
                                 try:
                                     self._persist_workflow_node_executions(execution, config, execution.output_data)
-                                    self._refresh_workflow_debug_state_from_execution(execution)
+                                    self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
                                 except Exception as persist_err:
                                     logger.warning(f"Failed to persist node executions on intervention failed: {persist_err}")
                             emitted = self._emit(public, resume_event)
@@ -5259,6 +5278,7 @@ class WorkflowService:
                                 commit_context = True
                             if commit_context:
                                 self.db.commit()
+                                self.db.close()
                             yield next_evt
                             break
 
@@ -5272,7 +5292,7 @@ class WorkflowService:
                 execution = self.get_execution(execution.execution_id)
                 if execution and execution.output_data:
                     self._persist_workflow_node_executions(execution, config, execution.output_data)
-                    self._refresh_workflow_debug_state_from_execution(execution)
+                    self._refresh_workflow_debug_state_from_execution(execution, workflow_config=config)
             except Exception as persist_err:
                 logger.warning(f"Failed to persist node executions on stream error: {persist_err}")
             # Clean up registry on failure to avoid leaks.


### PR DESCRIPTION
optimize database connection management and workflow debug state refresh

- Close database sessions earlier to return connections to pool during long-running operations (LLM inference, workflow execution)
- Pass pre-fetched workflow config to `_refresh_workflow_debug_state_from_execution` to avoid redundant DB queries
- Pre-read ORM attributes before `db.close()` to prevent `DetachedInstanceError`
- Update all callers of `_refresh_workflow_debug_state_from_execution` to pass workflow config explicitly

## Summary by Sourcery

优化工作流和聊天流式服务，在长时间运行的 LLM 和工作流执行过程中更早释放数据库连接，同时避免冗余的工作流调试状态查询。

改进内容：
- 将预先获取的工作流配置传入工作流调试状态刷新流程，以避免重复的数据库查找，并复用现有的快照构建逻辑。
- 在长时间运行的工作流和智能体流式操作周围关闭 SQLAlchemy 会话，预先读取所需的 ORM 属性以防止 `DetachedInstanceError`，并保持会话可按需重新连接。
- 确保应用和草稿控制器在创建异步生成器之前，从 ORM 对象中提取标量 ID，以便流式生命周期不会占用空闲的数据库事务。
- 调整上下文引擎摘要逻辑，在关闭会话之前缓存边界消息元数据，并在更新会话状态时使用这些缓存数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine workflow and chat streaming services to release database connections earlier during long-running LLM and workflow executions while avoiding redundant workflow debug state queries.

Enhancements:
- Pass pre-fetched workflow configuration into workflow debug state refresh to avoid duplicate database lookups and reuse existing snapshot-building logic.
- Close SQLAlchemy sessions around long-running workflow and agent streaming operations, pre-reading required ORM attributes to prevent DetachedInstanceError and keeping sessions lazily reconnectable.
- Ensure app and draft controllers extract scalar IDs from ORM objects before creating async generators so that streaming lifecycles do not hold idle database transactions.
- Adjust context engine summarization to cache boundary message metadata before closing the session and use it when updating conversation state.

</details>