### PR TITLE
Feature/reflection alias llm judge lm

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
@@ -17,14 +17,45 @@ from app.repositories.neo4j.cypher_queries import (
     REDIRECT_ALIAS_EDGES,
     DELETE_ALIAS_NODES,
     GET_USER_ENTITY_ALIASES,
+    GET_ALIAS_BELONGS_CANDIDATES,
+    DROP_ALIAS_BELONGS_EDGES,
 )
 
 logger = logging.getLogger(__name__)
 
 
+async def collect_alias_candidates(
+    connector: Neo4jConnector,
+    end_user_id: str,
+) -> List[Dict[str, Any]]:
+    """收集该 user 全部 "别名属于" 候选（含两端节点上下文）。"""
+    records = await connector.execute_query(
+        GET_ALIAS_BELONGS_CANDIDATES,
+        end_user_id=end_user_id,
+    )
+    return list(records or [])
+
+
+async def drop_alias_edges(
+    connector: Neo4jConnector,
+    end_user_id: str,
+    drop_alias_ids: List[str],
+) -> int:
+    """删除被判 drop 的 "别名属于" 边（只删边，不删节点）。返回删除条数。"""
+    if not drop_alias_ids:
+        return 0
+    records = await connector.execute_query(
+        DROP_ALIAS_BELONGS_EDGES,
+        end_user_id=end_user_id,
+        drop_alias_ids=drop_alias_ids,
+    )
+    return records[0].get("dropped_count", 0) if records else 0
+
+
 async def merge_alias_belongs_to(
     connector: Neo4jConnector,
     end_user_id: str,
+    alias_ids: List[str],
 ) -> Dict[str, Any]:
     """按 end_user_id 全量处理 "别名属于" 关系。
 
@@ -51,58 +82,65 @@ async def merge_alias_belongs_to(
         "errors": {},
     }
 
-    # ── 1. 别名归并（name 进 aliases，description 拼接） ──
-    try:
-        records = await connector.execute_query(
-            MERGE_ALIAS_BELONGS_TO,
-            end_user_id=end_user_id,
-        )
-        result["alias_merged"] = len(records) if records else 0
-        logger.info(
-            f"[AliasMerge] 别名归并完成 end_user_id={end_user_id}, "
-            f"影响 target={result['alias_merged']}"
-        )
-    except Exception as e:
-        logger.warning(f"[AliasMerge] 别名归并失败 end_user_id={end_user_id}: {e}")
-        result["errors"]["merge"] = str(e)
-
-    # ── 2. 边重定向（别名节点其它边 → 规范实体） ──
-    try:
-        redirect_records = await connector.execute_query(
-            REDIRECT_ALIAS_EDGES,
-            end_user_id=end_user_id,
-        )
-        if redirect_records:
-            row = redirect_records[0]
-            result["edges_redirected"] = (
-                (row.get("redirected_incoming") or 0)
-                + (row.get("redirected_outgoing") or 0)
-                + (row.get("redirected_stmt") or 0)
+    # ── 1~3 步仅在有 merge 候选时执行（按 alias_ids 筛选）──
+    if not alias_ids:
+        logger.debug(f"[AliasMerge] merge 集合为空，跳过归并三步 end_user_id={end_user_id}")
+    else:
+        # ── 1. 别名归并（name 进 aliases，description 拼接） ──
+        try:
+            records = await connector.execute_query(
+                MERGE_ALIAS_BELONGS_TO,
+                end_user_id=end_user_id,
+                alias_ids=alias_ids,
             )
-        logger.info(
-            f"[AliasMerge] 边重定向完成 end_user_id={end_user_id}, "
-            f"汇总={result['edges_redirected']}"
-        )
-    except Exception as e:
-        logger.warning(f"[AliasMerge] 边重定向失败 end_user_id={end_user_id}: {e}")
-        result["errors"]["redirect"] = str(e)
+            result["alias_merged"] = len(records) if records else 0
+            logger.info(
+                f"[AliasMerge] 别名归并完成 end_user_id={end_user_id}, "
+                f"影响 target={result['alias_merged']}"
+            )
+        except Exception as e:
+            logger.warning(f"[AliasMerge] 别名归并失败 end_user_id={end_user_id}: {e}")
+            result["errors"]["merge"] = str(e)
 
-    # ── 3. 删除别名节点（DETACH DELETE） ──
-    try:
-        delete_records = await connector.execute_query(
-            DELETE_ALIAS_NODES,
-            end_user_id=end_user_id,
-        )
-        result["alias_nodes_deleted"] = (
-            delete_records[0].get("deleted_count", 0) if delete_records else 0
-        )
-        logger.info(
-            f"[AliasMerge] 别名节点删除完成 end_user_id={end_user_id}, "
-            f"删除={result['alias_nodes_deleted']}"
-        )
-    except Exception as e:
-        logger.warning(f"[AliasMerge] 别名节点删除失败 end_user_id={end_user_id}: {e}")
-        result["errors"]["delete"] = str(e)
+        # ── 2. 边重定向（别名节点其它边 → 规范实体） ──
+        try:
+            redirect_records = await connector.execute_query(
+                REDIRECT_ALIAS_EDGES,
+                end_user_id=end_user_id,
+                alias_ids=alias_ids,
+            )
+            if redirect_records:
+                row = redirect_records[0]
+                result["edges_redirected"] = (
+                    (row.get("redirected_incoming") or 0)
+                    + (row.get("redirected_outgoing") or 0)
+                    + (row.get("redirected_stmt") or 0)
+                )
+            logger.info(
+                f"[AliasMerge] 边重定向完成 end_user_id={end_user_id}, "
+                f"汇总={result['edges_redirected']}"
+            )
+        except Exception as e:
+            logger.warning(f"[AliasMerge] 边重定向失败 end_user_id={end_user_id}: {e}")
+            result["errors"]["redirect"] = str(e)
+
+        # ── 3. 删除别名节点（DETACH DELETE） ──
+        try:
+            delete_records = await connector.execute_query(
+                DELETE_ALIAS_NODES,
+                end_user_id=end_user_id,
+                alias_ids=alias_ids,
+            )
+            result["alias_nodes_deleted"] = (
+                delete_records[0].get("deleted_count", 0) if delete_records else 0
+            )
+            logger.info(
+                f"[AliasMerge] 别名节点删除完成 end_user_id={end_user_id}, "
+                f"删除={result['alias_nodes_deleted']}"
+            )
+        except Exception as e:
+            logger.warning(f"[AliasMerge] 别名节点删除失败 end_user_id={end_user_id}: {e}")
+            result["errors"]["delete"] = str(e)
 
     # ── 4. 同步用户实体最新 aliases 到 PostgreSQL end_user_info ──
     try:

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -70,6 +70,12 @@ class EntityDedupConfig(BaseModel):
     max_pairs_per_run: int = 10         # 单次最多合并对数
 
 
+class AliasMergeConfig(BaseModel):
+    """别名归并 LLM 校验配置"""
+    confidence_threshold: float = 0.9   # merge 阈值，confidence >= 此值才合并
+    max_per_run: int = 20               # 单次反思最多判定/处理的候选别名数
+
+
 class ReflectionConfig(BaseModel):
     """反思引擎统一配置"""
     # === 基础 ===
@@ -82,6 +88,8 @@ class ReflectionConfig(BaseModel):
     entity_dedup: EntityDedupConfig = EntityDedupConfig()
     # 子问题 6 — 描述合并
     description_merge: DescriptionMergeConfig = DescriptionMergeConfig()
+    # 别名归并 LLM 校验
+    alias_merge: AliasMergeConfig = AliasMergeConfig()
     # stale_detection: StaleDetectionConfig = StaleDetectionConfig()        # 待实现
     # fact_contradiction: FactContradictionConfig = ...                     # 待实现
     # metadata_validation: MetadataValidationConfig = ...                   # 待实现
@@ -174,9 +182,16 @@ class Layer2Inspector:
             f"强制入库={unresolved.get('forced', 0)}, 失败={unresolved.get('failed', 0)}"
         )
 
-        # 别名归并：处理 "别名属于" 关系（确定性 Cypher，无 LLM）
+        # 别名归并：LLM 校验后按 merge/drop 处理 "别名属于" 关系
         # 放在 unresolved 之后、entity_dedup 之前：先清理别名节点
-        results["alias_merge"] = await self._run_alias_merge(end_user_id)
+        alias = await self._run_alias_merge(end_user_id, baseline, language)
+        results["alias_merge"] = alias
+        logger.info(
+            f"[Layer2 高频] 别名归并完成 end_user_id={end_user_id}, "
+            f"合并={alias.get('merge_count', 0)}, 丢弃={alias.get('drop_count', 0)}, "
+            f"边重定向={alias.get('edges_redirected', 0)}, 节点删除={alias.get('alias_nodes_deleted', 0)}, "
+            f"PG同步={alias.get('pg_synced', False)}"
+        )
 
         # 复杂去重消歧：两路召回候选 + LLM 判定后合并重复实体
         dedup = await self._run_entity_dedup(end_user_id, baseline)
@@ -221,16 +236,98 @@ class Layer2Inspector:
         )
         return results
 
-    async def _run_alias_merge(self, end_user_id: str) -> Dict[str, Any]:
-        """别名归并：处理 "别名属于" 关系（确定性 Cypher，无 LLM）
+    async def _run_alias_merge(self, end_user_id: str, baseline: str = "HYBRID",
+                               language: str = "zh") -> Dict[str, Any]:
+        """别名归并：LLM 校验后按 merge/drop 处理 "别名属于" 关系。
 
-        将别名节点的 name/description 归并进规范实体，重定向其它边，
-        最后删除别名节点。逻辑迁移自原写入后处理任务。
+        S0 收集候选 → S1 LLM 分组判定（merge/drop/skip）→ S2 删 drop 边 →
+        S3-5 按 merge 集合归并 → S6 PG 同步（在 merge_alias_belongs_to 内）→ 写日志。
+        判定失败的候选 skip（保留边，下次重判）；删边只在明确低置信时发生。
         """
-        from .deterministic.alias_merger import merge_alias_belongs_to
+        from collections import defaultdict
+        from .deterministic.alias_merger import (
+            merge_alias_belongs_to, collect_alias_candidates, drop_alias_edges,
+        )
+        from .llm.alias_belongs_judge import judge_alias_belongs
 
+        cfg = self.config.alias_merge
         try:
-            return await merge_alias_belongs_to(self.connector, end_user_id)
+            t0 = time.perf_counter()
+            candidates = await collect_alias_candidates(self.connector, end_user_id)
+            recall_ms = int((time.perf_counter() - t0) * 1000)
+            if not candidates:
+                # 无候选，仅做 PG 同步（幂等）
+                return await merge_alias_belongs_to(self.connector, end_user_id, alias_ids=[])
+
+            # 每轮限流（处理后候选会减少，超出部分留待下次）
+            candidates = candidates[:cfg.max_per_run]
+
+            # 按 target 分组（一个 canonical 一组判定）
+            groups: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+            for c in candidates:
+                groups[c["target_id"]].append(c)
+
+            merge_ids: List[str] = []
+            drop_ids: List[str] = []
+            decided_log: List[tuple] = []   # (canonical, cand, decided) 仅 LLM 判定过的，用于写日志
+
+            llm_t0 = time.perf_counter()
+            for target_id, group in groups.items():
+                head = group[0]
+                canonical = {
+                    "name": head["target_name"],
+                    "entity_type": head["target_entity_type"],
+                    "description": head["target_description"],
+                    "description_summary": head["target_description_summary"],
+                    "aliases": head["target_aliases"] or [],
+                }
+                existing_lower = {a.lower() for a in canonical["aliases"] if a}
+
+                to_judge: List[Dict[str, Any]] = []
+                for c in group:
+                    # 重复短路：候选名已在 target.aliases（忽略大小写）→ 直接 merge，
+                    # 不送 LLM，但写反思日志表
+                    if (c["alias_name"] or "").strip().lower() in existing_lower:
+                        merge_ids.append(c["alias_id"])
+                        decided_log.append((canonical, c, {
+                            "alias_id": c["alias_id"],
+                            "decision": "merge",
+                            "confidence": 1.0,
+                            "reason": "已是现有别名，直接归并",
+                            "shortcut": True,
+                        }))
+                    else:
+                        to_judge.append(c)
+
+                if not to_judge:
+                    continue
+
+                decided = await judge_alias_belongs(
+                    self.llm_client, canonical, to_judge,
+                    threshold=cfg.confidence_threshold, language=language,
+                )
+                decided_by_id = {d["alias_id"]: d for d in decided}
+                for c in to_judge:
+                    d = decided_by_id.get(c["alias_id"])
+                    if d is None:
+                        continue  # skip：保留边，下次重判
+                    (merge_ids if d["decision"] == "merge" else drop_ids).append(c["alias_id"])
+                    decided_log.append((canonical, c, d))
+            llm_ms = int((time.perf_counter() - llm_t0) * 1000)
+
+            # S2 drop（只删边）
+            await drop_alias_edges(self.connector, end_user_id, drop_ids)
+            # S3-5 merge（按 merge 集合）+ S6 PG 同步
+            result = await merge_alias_belongs_to(self.connector, end_user_id, alias_ids=merge_ids)
+
+            # 写日志（含 LLM 判定与重复短路命中的候选；仅 skip 不写）
+            timing = {"recall_ms": recall_ms, "llm_ms": llm_ms}
+            for canonical, cand, d in decided_log:
+                self._write_alias_log(end_user_id, canonical, cand, d, timing, baseline)
+
+            result["merge_count"] = len(merge_ids)
+            result["drop_count"] = len(drop_ids)
+            return result
         except Exception as e:
             logger.warning(f"[AliasMerge] 执行失败 end_user_id={end_user_id}: {e}")
             return {"status": "error", "error": str(e)}
@@ -636,6 +733,87 @@ class Layer2Inspector:
             execution_detail=execution_detail,
         )
         
+    def _write_alias_log(self, end_user_id: str, canonical: Dict[str, Any],
+                         cand: Dict[str, Any], decided: Dict[str, Any],
+                         timing: Dict[str, Any], baseline: str = "HYBRID"):
+        """写别名归并 ReflectionLog（merge / drop 各一条）。"""
+        is_merge = decided["decision"] == "merge"
+        confidence = decided["confidence"]
+        reason = decided["reason"]
+        shortcut = decided.get("shortcut", False)
+
+        tracker = ExecutionTracker(model=getattr(self.llm_client, "model_name", ""))
+        tracker.steps.append(ExecutionStep(
+            name="候选收集", type="prompt", duration_ms=timing.get("recall_ms") or 0,
+            output=f"alias={cand['alias_name']}", success=True,
+        ))
+        if shortcut:
+            tracker.steps.append(ExecutionStep(
+                name="规则判定", type="decide", duration_ms=0,
+                output="候选名已是现有别名，直接归并", success=True,
+            ))
+        else:
+            tracker.steps.append(ExecutionStep(
+                name="LLM 判定", type="llm", duration_ms=timing.get("llm_ms") or 0,
+                output=f"decision={decided['decision']}, confidence={confidence:.2f}", success=True,
+            ))
+        tracker.steps.append(ExecutionStep(
+            name="归并" if is_merge else "删边", type="write",
+            duration_ms=0,
+            output=(f'已并入 "{canonical["name"]}" 的 aliases' if is_merge else "已删除「别名属于」边"),
+            success=True,
+        ))
+
+        # 有效描述：description_summary 优先，回退 description
+        canon_desc = (canonical.get("description_summary") or "").strip() or (canonical.get("description") or "")
+        alias_desc = (cand.get("alias_description_summary") or "").strip() or (cand.get("alias_description") or "")
+        canon_aliases = canonical.get("aliases") or []
+
+        entity_a = {"entity_id": cand["target_id"], "name": canonical["name"],
+                    "entity_type": canonical.get("entity_type"),
+                    "description": canon_desc, "aliases": canon_aliases}
+        entity_b = {"entity_id": cand["alias_id"], "name": cand["alias_name"],
+                    "entity_type": cand.get("alias_entity_type"),
+                    "description": alias_desc, "aliases": cand.get("alias_aliases") or []}
+        trigger = {"entity_a": entity_a, "entity_b": entity_b, "reason": reason[:200]}
+
+        if is_merge:
+            already = cand["alias_name"].strip().lower() in {a.strip().lower() for a in canon_aliases if a}
+            summary = f'"{cand["alias_name"]}" → "{canonical["name"]}" 合并别名'
+            title = "MERGE — 已是现有别名，直接归并" if shortcut else "MERGE — LLM确认别名归并"
+            # 别名已存在（无实际新增）时不产出 diff，避免前端展示 old==new 的无意义对比
+            changes = [] if already else [{
+                "field": "aliases",
+                "old": ", ".join(canon_aliases),
+                "new": ", ".join(canon_aliases + [cand["alias_name"]]),
+            }]
+            strategy = "MERGE"
+        else:
+            summary = f'"{cand["alias_name"]}" ✗ 判定非别名 → 丢弃别名属于边'
+            title = "DROP — LLM判定非别名"
+            changes = [{
+                "field": "别名属于关系",
+                "old": f'{cand["alias_name"]} →(别名属于) {canonical["name"]}',
+                "new": "关系已删除（非本人别名）",
+            }]
+            strategy = "DROP"
+
+        log_repo = self.log_repo_factory()
+        log_repo.create(
+            end_user_id=end_user_id,
+            sub_problem="alias_merge",
+            trigger_type="scheduled",
+            baseline=baseline,
+            strategy=strategy,
+            confidence=confidence,
+            status="resolved",
+            summary_text=summary[:256],
+            entity_ids=[cand["target_id"], cand["alias_id"]],
+            trigger_detail=trigger,
+            solution_detail={"title": title, "changes": changes},
+            execution_detail=tracker.to_dict(),
+        )
+
     async def _apply_dedup_merge(self, pair, end_user_id: str, baseline: str,
                                 llm_decision=None, step_timing=None) -> bool:
         """执行单对合并 + 写 ReflectionLog"""

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -281,11 +281,11 @@ class Layer2Inspector:
                     "description_summary": head["target_description_summary"],
                     "aliases": head["target_aliases"] or [],
                 }
-                existing_lower = {a.lower() for a in canonical["aliases"] if a}
+                existing_lower = {a.strip().lower() for a in canonical["aliases"] if a and a.strip()}
 
                 to_judge: List[Dict[str, Any]] = []
                 for c in group:
-                    # 重复短路：候选名已在 target.aliases（忽略大小写）→ 直接 merge，
+                    # 重复短路：候选名已在 target.aliases（忽略大小写与前后空白）→ 直接 merge，
                     # 不送 LLM，但写反思日志表
                     if (c["alias_name"] or "").strip().lower() in existing_lower:
                         merge_ids.append(c["alias_id"])
@@ -741,11 +741,12 @@ class Layer2Inspector:
         confidence = decided["confidence"]
         reason = decided["reason"]
         shortcut = decided.get("shortcut", False)
+        alias_name = (cand.get("alias_name") or "").strip()
 
         tracker = ExecutionTracker(model=getattr(self.llm_client, "model_name", ""))
         tracker.steps.append(ExecutionStep(
             name="候选收集", type="prompt", duration_ms=timing.get("recall_ms") or 0,
-            output=f"alias={cand['alias_name']}", success=True,
+            output=f"alias={alias_name}", success=True,
         ))
         if shortcut:
             tracker.steps.append(ExecutionStep(
@@ -772,28 +773,28 @@ class Layer2Inspector:
         entity_a = {"entity_id": cand["target_id"], "name": canonical["name"],
                     "entity_type": canonical.get("entity_type"),
                     "description": canon_desc, "aliases": canon_aliases}
-        entity_b = {"entity_id": cand["alias_id"], "name": cand["alias_name"],
+        entity_b = {"entity_id": cand["alias_id"], "name": alias_name,
                     "entity_type": cand.get("alias_entity_type"),
                     "description": alias_desc, "aliases": cand.get("alias_aliases") or []}
         trigger = {"entity_a": entity_a, "entity_b": entity_b, "reason": reason[:200]}
 
         if is_merge:
-            already = cand["alias_name"].strip().lower() in {a.strip().lower() for a in canon_aliases if a}
-            summary = f'"{cand["alias_name"]}" → "{canonical["name"]}" 合并别名'
+            already = alias_name.lower() in {a.strip().lower() for a in canon_aliases if a and a.strip()}
+            summary = f'"{alias_name}" → "{canonical["name"]}" 合并别名'
             title = "MERGE — 已是现有别名，直接归并" if shortcut else "MERGE — LLM确认别名归并"
             # 别名已存在（无实际新增）时不产出 diff，避免前端展示 old==new 的无意义对比
             changes = [] if already else [{
                 "field": "aliases",
                 "old": ", ".join(canon_aliases),
-                "new": ", ".join(canon_aliases + [cand["alias_name"]]),
+                "new": ", ".join(canon_aliases + [alias_name]),
             }]
             strategy = "MERGE"
         else:
-            summary = f'"{cand["alias_name"]}" ✗ 判定非别名 → 丢弃别名属于边'
+            summary = f'"{alias_name}" ✗ 判定非别名 → 丢弃别名属于边'
             title = "DROP — LLM判定非别名"
             changes = [{
                 "field": "别名属于关系",
-                "old": f'{cand["alias_name"]} →(别名属于) {canonical["name"]}',
+                "old": f'{alias_name} →(别名属于) {canonical["name"]}',
                 "new": "关系已删除（非本人别名）",
             }]
             strategy = "DROP"

--- a/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
@@ -1,0 +1,100 @@
+"""反思阶段 · 别名归并 LLM 校验
+使用 alias_belongs_judge.jinja2 模板，对一个规范实体下的全部候选别名一次性判定，
+为每个候选输出 0.0-1.0 置信度，按阈值二分为 merge / drop。
+"""
+import logging
+import os
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+from jinja2 import Environment, FileSystemLoader
+
+logger = logging.getLogger(__name__)
+
+# 加载模板（与 entity_dedup_batch_judge 同路径）
+_prompt_dir = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "..", "..", "utils", "prompt", "prompts"
+))
+_prompt_env = Environment(loader=FileSystemLoader(_prompt_dir))
+
+
+class AliasJudgeItem(BaseModel):
+    """单个候选别名判定结果"""
+    alias_index: int                 # 候选序号，从 1 开始
+    confidence: float = 0.0          # 0.0-1.0
+    reason: str = ""
+
+
+class AliasBatchJudgeOutput(BaseModel):
+    """LLM 分组判定输出"""
+    results: List[AliasJudgeItem] = Field(default_factory=list)
+
+
+async def judge_alias_belongs(
+    llm_client: Any,
+    canonical: Dict[str, Any],
+    candidates: List[Dict[str, Any]],
+    threshold: float = 0.9,
+    language: str = "zh",
+) -> List[Dict[str, Any]]:
+    """对一个规范实体的全部候选别名做分组判定。
+
+    Args:
+        llm_client: LLM 客户端（同 entity_dedup 用法）
+        canonical: 规范实体 dict，含 name/entity_type/description/description_summary/aliases
+        candidates: 候选别名列表，每项含 alias_id/alias_name/alias_entity_type/
+                    alias_description/alias_description_summary/aliases
+        threshold: merge 阈值，confidence >= threshold 判 merge
+        language: zh / en
+
+    Returns:
+        已判定的候选列表，每项：{alias_id, decision("merge"|"drop"), confidence, reason}。
+        未拿到有效判定（LLM 异常/缺失/越界/非法分数）的候选不在返回中 —— 调用方据此 skip（保留边）。
+    """
+    from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
+
+    if not candidates:
+        return []
+
+    try:
+        template = _prompt_env.get_template("alias_belongs_judge.jinja2")
+        rendered_prompt = template.render(
+            canonical_entity=canonical,
+            candidates=candidates,
+            language=language,
+        )
+        messages = [{"role": "user", "content": rendered_prompt}]
+        response = await call_structured(llm_client, messages, AliasBatchJudgeOutput)
+
+        if not isinstance(response, AliasBatchJudgeOutput):
+            logger.warning("[AliasJudge] LLM 返回类型异常，整组按 skip 处理")
+            return []
+
+        # alias_index(1-based) → AliasJudgeItem
+        by_index: Dict[int, AliasJudgeItem] = {}
+        for item in response.results:
+            if 1 <= item.alias_index <= len(candidates):
+                by_index[item.alias_index] = item
+
+        decided: List[Dict[str, Any]] = []
+        for i, cand in enumerate(candidates, start=1):
+            item = by_index.get(i)
+            if item is None:
+                continue  # 未返回 → skip
+            try:
+                conf = float(item.confidence)
+            except (TypeError, ValueError):
+                continue  # 非法分数 → skip
+            if not (0.0 <= conf <= 1.0):
+                continue  # 越界 → skip
+            decided.append({
+                "alias_id": cand["alias_id"],
+                "decision": "merge" if conf >= threshold else "drop",
+                "confidence": conf,
+                "reason": (item.reason or "")[:200],
+            })
+        return decided
+    except Exception as e:
+        logger.error(f"[AliasJudge] 别名校验 LLM 判定失败，整组 skip: {e}")
+        return []

--- a/api/app/core/memory/utils/prompt/prompts/alias_belongs_judge.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/alias_belongs_judge.jinja2
@@ -1,0 +1,186 @@
+===Task===
+{% set canonical = canonical_entity | default(entity_b | default(user_entity | default({}))) %}
+{% set alias_candidates = candidates | default([]) %}
+{% if language == "zh" %}
+你是一个实体别名归并校验助手。你将被提供一个规范实体和若干候选「别名属于」关系。
+请逐个判断每个候选别名实体是否确实是该规范实体的别名、昵称、简称、全名、代号、产品名、账号名或其他稳定命名表达，并给出 0.0-1.0 的置信度。
+
+这是反思阶段归并前的安全闸门，不是三元组抽取任务。你只负责评估候选关系是否可信。
+{% else %}
+You are an entity alias-merge validation assistant. You will be provided with one canonical entity and several candidate "alias belongs to" relations.
+For each candidate alias entity, judge whether it is truly an alias, nickname, short name, full name, code name, product name, account name, or other stable naming expression of the canonical entity, and output a confidence score from 0.0 to 1.0.
+
+This is a pre-merge safety gate in the reflection stage, not a triplet extraction task. Your only responsibility is to evaluate whether each candidate relation is trustworthy.
+{% endif %}
+
+===Input===
+{% if language == "zh" %}
+## 规范实体
+
+- 名称: "{{ canonical.name | default(canonical_name | default(user_name | default(''))) }}"
+- 类型: "{{ canonical.entity_type | default(canonical.type | default(canonical_type | default(''))) }}"
+- 描述: "{{ canonical.description | default(canonical_description | default(user_description | default(''))) }}"
+- 描述摘要: "{{ canonical.description_summary | default(canonical_description_summary | default(user_description_summary | default(''))) }}"
+- 已确认别名: {{ canonical.aliases | default(canonical_aliases | default(user_aliases | default([]))) }}
+
+## 候选别名关系
+
+方向固定为：候选别名实体 -> 别名属于 -> 规范实体
+
+{% for c in alias_candidates %}
+{{ loop.index }}. 名称: "{{ c.alias_name | default(c.name | default('')) }}"
+   - 类型: "{{ c.alias_entity_type | default(c.entity_type | default(c.type | default(''))) }}"
+   - 描述: "{{ c.alias_description | default(c.description | default('')) }}"
+   - 描述摘要: "{{ c.alias_description_summary | default(c.description_summary | default('')) }}"
+   - 已有别名: {{ c.aliases | default([]) }}
+   - 关系表面词: "{{ c.predicate_surface | default('别名属于') }}"
+{% endfor %}
+{% else %}
+## Canonical Entity
+
+- Name: "{{ canonical.name | default(canonical_name | default(user_name | default(''))) }}"
+- Type: "{{ canonical.entity_type | default(canonical.type | default(canonical_type | default(''))) }}"
+- Description: "{{ canonical.description | default(canonical_description | default(user_description | default(''))) }}"
+- Description Summary: "{{ canonical.description_summary | default(canonical_description_summary | default(user_description_summary | default(''))) }}"
+- Confirmed Aliases: {{ canonical.aliases | default(canonical_aliases | default(user_aliases | default([]))) }}
+
+## Candidate Alias Relations
+
+Fixed direction: candidate alias entity -> 别名属于 -> canonical entity
+
+{% for c in alias_candidates %}
+{{ loop.index }}. Name: "{{ c.alias_name | default(c.name | default('')) }}"
+   - Type: "{{ c.alias_entity_type | default(c.entity_type | default(c.type | default(''))) }}"
+   - Description: "{{ c.alias_description | default(c.description | default('')) }}"
+   - Description Summary: "{{ c.alias_description_summary | default(c.description_summary | default('')) }}"
+   - Existing Aliases: {{ c.aliases | default([]) }}
+   - Predicate Surface: "{{ c.predicate_surface | default('别名属于') }}"
+{% endfor %}
+{% endif %}
+
+===Guidelines===
+{% if language == "zh" %}
+## 判断规则
+
+1. **判断对象**
+   - 判断的是候选别名实体是否可以作为规范实体的名字性表达并入，而不是判断两者是否只是相关。
+   - `别名属于` 的方向必须成立：候选别名实体是名字，规范实体是被命名的对象。
+   - 规范实体可以是人、宠物、组织、地点、软件、账号、文档、项目、产品等任意实体。
+   - 对“X 的 Y 叫 Z / X 的 Y 名字是 Z / X 的 Y 用户名是 Z / X 的 Y 账号名是 Z”这类所有格或从属命名表达，Z 只能作为 `X 的 Y` 的别名或名称，不能作为 X 的别名。
+
+2. **高置信别名**
+   - 候选名称是规范实体的昵称、别名、简称、全称、英文名、代号、产品名、账号名、文件名或稳定称呼。
+   - 规范实体的描述、描述摘要或已确认别名明确支持该候选名称。
+   - 候选描述与规范实体描述互补且不冲突，明显指向同一真实世界实体。
+   - `predicate_surface` 是明确命名表达，如"叫"、"名叫"、"名字是"、"昵称"、"简称"、"别名"、"代号"。
+
+3. **低置信或应拒绝的候选**
+   - 候选是与规范实体相关但不同的实体，例如所有者、使用者、作者、同事、朋友、客户、上级对象、所属组织或组成部分。
+   - 如果候选描述表明它是规范实体所拥有或关联的另一个对象的名称、用户名、编号、文件名、宠物名或亲属名，而不是规范实体自身的名称，应给低置信度。
+   - 候选是角色词、职业词、身份词、类别词、泛称、评价词或状态词，例如"导师"、"程序员"、"好人"、"项目"、"公司"。
+   - 候选描述与规范实体描述存在核心身份冲突、类型冲突或方向冲突。
+   - 候选只是对话中的称呼对象、被提到的相关对象、关系另一端，或指代解析不稳的对象。
+   - 候选名称只是规范实体名称中的普通词片段，但输入没有支持它是独立别名。
+
+4. **证据边界**
+   - 只使用输入中的规范实体信息、候选别名信息、已确认别名和关系表面词判断。
+   - 不要引入外部知识，不要凭常识或名字相似强行推断。
+   - 已确认别名是强信号，但如果描述或摘要显示候选与规范实体不是同一对象，必须降低置信度。
+   - 信息不足、上下文含糊或只能说"可能是"时，给中低置信度，不要给高分。
+
+5. **Rubric / 置信度标尺**
+   - 0.95-1.00: 有明确命名证据，且候选描述和规范实体描述一致无冲突。
+   - 0.90-0.94: 已确认别名、描述摘要或关系表面词强支持同一命名关系，仅缺少少量细节。
+   - 0.70-0.89: 大概率是别名，但证据不完整、描述较短，或只靠名称/摘要弱支持。
+   - 0.40-0.69: 可能相关，但缺少命名证据、方向不清，或无法排除是另一个相关实体。
+   - 0.10-0.39: 更像相关但不同的实体、角色/类别/泛称，或存在明显疑点。
+   - 0.00-0.09: 明确不是别名，存在核心身份冲突、类型冲突或方向错误。
+{% else %}
+## Judgment Rules
+
+1. **Judgment Target**
+   - Judge whether the candidate alias entity can be merged as a name-like expression of the canonical entity, not whether the two are merely related.
+   - The `别名属于` direction must hold: the candidate alias entity is the name; the canonical entity is the object being named.
+   - The canonical entity can be any entity type, such as a person, pet, organization, place, software, account, document, project, or product.
+   - For possessive or subordinate naming expressions such as "X's Y is called Z", "X's Y's name is Z", "X's Y's username is Z", or "X's Y's account name is Z", Z can only be an alias/name of `X's Y`, not an alias of X.
+
+2. **High-confidence aliases**
+   - The candidate name is the canonical entity's nickname, alias, short name, full name, English name, code name, product name, account name, file name, or stable appellation.
+   - The canonical entity description, description summary, or confirmed aliases explicitly support the candidate name.
+   - The candidate description is complementary to the canonical entity description and does not conflict, clearly pointing to the same real-world entity.
+   - `predicate_surface` is an explicit naming expression, such as "called", "named", "name is", "nickname", "short name", "alias", or "code name".
+
+3. **Low-confidence or rejected candidates**
+   - The candidate is related to but different from the canonical entity, such as an owner, user, author, colleague, friend, customer, parent object, affiliated organization, or component.
+   - If the candidate description shows it is the name, username, identifier, file name, pet name, or relative's name of another object owned by or related to the canonical entity, rather than the canonical entity's own name, assign low confidence.
+   - The candidate is a role, occupation, identity label, category word, generic term, evaluation word, or state word, such as "mentor", "programmer", "good person", "project", or "company".
+   - The candidate description has a core identity conflict, type conflict, or direction conflict with the canonical entity description.
+   - The candidate is merely an addressee, mentioned related object, opposite endpoint of another relation, or unstably resolved reference.
+   - The candidate name is only an ordinary token inside the canonical entity name, without evidence that it is an independent alias.
+
+4. **Evidence Boundary**
+   - Use only the provided canonical entity information, candidate alias information, confirmed aliases, and predicate surface.
+   - Do not introduce world knowledge, and do not force a conclusion based only on common sense or name similarity.
+   - Confirmed aliases are strong signals, but if descriptions or summaries show the candidate is not the same object as the canonical entity, lower the confidence.
+   - When evidence is insufficient, ambiguous, or only suggests "possibly", assign medium-low confidence instead of a high score.
+
+5. **Rubric / Confidence Scale**
+   - 0.95-1.00: Explicit naming evidence, and candidate/canonical descriptions are consistent with no conflict.
+   - 0.90-0.94: Confirmed alias, description summary, or predicate surface strongly supports the naming relation, with only minor missing details.
+   - 0.70-0.89: Likely an alias, but evidence is incomplete, descriptions are short, or support comes only from weak name/summary evidence.
+   - 0.40-0.69: Possibly related, but naming evidence is missing, direction is unclear, or another related entity cannot be ruled out.
+   - 0.10-0.39: More likely a related-but-different entity, role/category/generic term, or there are clear doubts.
+   - 0.00-0.09: Clearly not an alias due to core identity conflict, type conflict, or wrong direction.
+{% endif %}
+
+===Output===
+{% if language == "zh" %}
+返回 JSON 格式，必须包含以下字段：
+{
+  "results": [
+    {"alias_index": 1, "confidence": 0.96, "reason": "多多是用户的小狗的名字"},
+    {"alias_index": 2, "confidence": 0.18, "reason": "导师是角色词，不是张三的别名"}
+  ]
+}
+
+**字段说明**:
+- results: 候选别名判定列表，每项包含：
+  - alias_index: 候选别名序号，从 1 开始，必须与上方列表一致。
+  - confidence: 该候选确为规范实体别名的置信度，范围 0.0-1.0。
+  - reason: 简短判定理由，不超过 50 字；使用具体名称，不要只写"候选1"。
+
+如果没有候选别名，返回：
+{"results": []}
+{% else %}
+Return JSON format with the following required fields:
+{
+  "results": [
+    {"alias_index": 1, "confidence": 0.96, "reason": "Duoduo is the name of the user's dog"},
+    {"alias_index": 2, "confidence": 0.18, "reason": "mentor is a role word, not an alias of Zhang San"}
+  ]
+}
+
+**Field Descriptions**:
+- results: list of candidate alias judgments, each containing:
+  - alias_index: candidate alias index, starting from 1, must match the list above.
+  - confidence: confidence that this candidate is truly an alias of the canonical entity, range 0.0-1.0.
+  - reason: brief judgment reason; use concrete names instead of only "candidate 1".
+
+If there are no candidate aliases, return:
+{"results": []}
+{% endif %}
+
+**CRITICAL JSON FORMATTING REQUIREMENTS:**
+
+1. Use only standard ASCII double quotes (") for JSON structure - never use Chinese quotation marks or other Unicode quotes
+2. Ensure all JSON strings are properly closed and comma-separated
+3. Do not include line breaks within JSON string values
+4. Return only valid JSON, with no Markdown code fence or extra explanation
+5. `alias_index` must be a valid integer between 1 and {{ alias_candidates | length }}
+6. `confidence` must be a number between 0.0 and 1.0
+
+{% if language == "zh" %}
+输出语言应始终与输入语言相同。
+{% else %}
+The output language should always be the same as the input language.
+{% endif %}

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2342,22 +2342,45 @@ RETURN s.id AS statement_id
 #   3. DELETE_ALIAS_NODES：DETACH DELETE 别名节点（连同 "别名属于" 边）
 # ============================================================================
 
+# 别名校验候选收集：拉取所有 "别名属于" 边及两端节点上下文，喂给 LLM 判定。
+# target 可为任意实体类型（canonical），不限用户实体。
+GET_ALIAS_BELONGS_CANDIDATES = """
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})
+      -[r:EXTRACTED_RELATIONSHIP {predicate: '别名属于'}]->
+      (target:ExtractedEntity {end_user_id: $end_user_id})
+WHERE alias.id <> target.id
+RETURN alias.id   AS alias_id,
+       alias.name AS alias_name,
+       alias.entity_type AS alias_entity_type,
+       alias.description AS alias_description,
+       alias.description_summary AS alias_description_summary,
+       coalesce(alias.aliases, []) AS alias_aliases,
+       target.id   AS target_id,
+       target.name AS target_name,
+       target.entity_type AS target_entity_type,
+       target.description AS target_description,
+       target.description_summary AS target_description_summary,
+       coalesce(target.aliases, []) AS target_aliases
+ORDER BY target.id, alias.id
+"""
+
 # 别名归并：将 predicate="别名属于" 的 EXTRACTED_RELATIONSHIP 边的 source.name
 # 合并进 target.aliases（去重），并将 source.description 追加到 target.description（分号分隔）
+# 仅处理 source.id 在 $alias_ids（LLM 判 merge 的别名）内的边。
 MERGE_ALIAS_BELONGS_TO = """
 // 先按 target 分组，将所有 source.name 和 source.description 聚合，
 // 再一次性 SET，避免多条 别名属于 边对同一 target 反复覆盖。
 MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
-WHERE r.predicate = '别名属于'
+WHERE r.predicate = '别名属于' AND source.id IN $alias_ids
 WITH target,
      coalesce(target.aliases, []) AS existing_aliases,
      coalesce(target.description, '') AS tgt_desc,
      collect(DISTINCT source.name) AS source_names,
      collect(DISTINCT coalesce(source.description, '')) AS source_descs
 
-// 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值）
+// 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值与大小写）
 WITH target, tgt_desc, source_names, source_descs, existing_aliases,
-     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT n IN existing_aliases] AS new_aliases
+     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT toLower(n) IN [x IN existing_aliases | toLower(x)]] AS new_aliases
 
 // 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
 WITH target, new_aliases, existing_aliases, source_descs,
@@ -2375,66 +2398,70 @@ SET target.aliases = new_aliases,
 RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_aliases) - size(existing_aliases) AS added_count
 """
 
-# 边重定向：将指向别名节点（"别名属于"关系的 source）的所有其他边，重定向到用户节点（target）。
+# 边重定向：将别名节点（"别名属于"关系的 source，且在 $alias_ids 内）上的其他边重定向到 target。
 # 处理两类边：
 #   1. EXTRACTED_RELATIONSHIP：其他实体 → 别名节点 或 别名节点 → 其他实体
 #   2. STATEMENT_ENTITY：陈述句 → 别名节点
-# 对于每条需要重定向的边，创建一条指向用户节点的新边（复制所有属性），然后删除旧边。
+# 三段用独立 CALL {} 子查询隔离，避免空输入时分组聚合丢行导致后续段被跳过。
 REDIRECT_ALIAS_EDGES = """
-// 找到所有 别名→用户 的映射
-MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar.predicate = '别名属于'
-WITH collect({alias_id: elementId(alias), user_id: elementId(user), alias_eid: alias.id, user_eid: user.id}) AS mappings
-
-// 1. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 target 的情况
-UNWIND mappings AS m
-MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias:ExtractedEntity {end_user_id: $end_user_id})
-WHERE alias.id = m.alias_eid
-  AND r.predicate <> '别名属于'
-  AND other.id <> m.user_eid
-WITH m, other, r, alias
-MATCH (user:ExtractedEntity {id: m.user_eid, end_user_id: $end_user_id})
-CREATE (other)-[nr:EXTRACTED_RELATIONSHIP]->(user)
-SET nr = properties(r)
-DELETE r
-WITH count(*) AS redirected_incoming
-
-// 2. 重定向 EXTRACTED_RELATIONSHIP 边：别名节点作为 source 的情况
-MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar2.predicate = '别名属于'
-WITH alias, user2, redirected_incoming
-MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
-WHERE r.predicate <> '别名属于'
-  AND other.id <> user2.id
-WITH user2, other, r, redirected_incoming
-CREATE (user2)-[nr:EXTRACTED_RELATIONSHIP]->(other)
-SET nr = properties(r)
-DELETE r
-WITH redirected_incoming, count(*) AS redirected_outgoing
-
-// 3. 重定向 STATEMENT_ENTITY 边：陈述句 → 别名节点
-MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
-WHERE ar3.predicate = '别名属于'
-WITH alias, user3, redirected_incoming, redirected_outgoing
-MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
-WITH user3, stmt, r, redirected_incoming, redirected_outgoing
-CREATE (stmt)-[nr:STATEMENT_ENTITY]->(user3)
-SET nr = properties(r)
-DELETE r
-
-RETURN redirected_incoming, redirected_outgoing, count(*) AS redirected_stmt
+// 1. 入边：其他实体 → 别名节点，重定向到 target
+CALL {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar.predicate = '别名属于' AND alias.id IN $alias_ids
+  WITH DISTINCT alias, user
+  MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias)
+  WHERE r.predicate <> '别名属于' AND other.id <> user.id
+  CREATE (other)-[nr:EXTRACTED_RELATIONSHIP]->(user)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_incoming
+}
+// 2. 出边：别名节点 → 其他实体，重定向到 target
+CALL {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar2.predicate = '别名属于' AND alias.id IN $alias_ids
+  WITH DISTINCT alias, user2
+  MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
+  WHERE r.predicate <> '别名属于' AND other.id <> user2.id
+  CREATE (user2)-[nr:EXTRACTED_RELATIONSHIP]->(other)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_outgoing
+}
+// 3. 陈述句 → 别名节点，重定向到 target
+CALL {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar3.predicate = '别名属于' AND alias.id IN $alias_ids
+  WITH DISTINCT alias, user3
+  MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
+  CREATE (stmt)-[nr:STATEMENT_ENTITY]->(user3)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_stmt
+}
+RETURN redirected_incoming, redirected_outgoing, redirected_stmt
 """
 
-# 删除别名节点：在别名归并和边重定向完成后，删除所有 predicate="别名属于" 关系的 source 节点。
+# 删除别名节点：在别名归并和边重定向完成后，删除 $alias_ids 内 predicate="别名属于" 的 source 节点。
 # 此时这些节点的其他边已被 REDIRECT_ALIAS_EDGES 重定向完毕，
 # 唯一剩余的边就是 (alias)-[:EXTRACTED_RELATIONSHIP {predicate:'别名属于'}]->(user)，
 # 使用 DETACH DELETE 一并删除节点和该关系。
 DELETE_ALIAS_NODES = """
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-WHERE r.predicate = '别名属于'
+WHERE r.predicate = '别名属于' AND alias.id IN $alias_ids
 WITH alias, count(r) AS rel_count
 DETACH DELETE alias
 RETURN count(alias) AS deleted_count
+"""
+
+# drop：删除 LLM 判定为非别名的 "别名属于" 边，仅删边、保留别名节点。
+DROP_ALIAS_BELONGS_EDGES = """
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})
+      -[r:EXTRACTED_RELATIONSHIP {predicate: '别名属于'}]->
+      (target:ExtractedEntity {end_user_id: $end_user_id})
+WHERE alias.id IN $drop_alias_ids
+DELETE r
+RETURN count(r) AS dropped_count
 """
 
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2380,7 +2380,7 @@ WITH target,
 
 // 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值与大小写）
 WITH target, tgt_desc, source_names, source_descs, existing_aliases,
-     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT toLower(n) IN [x IN existing_aliases | toLower(x)]] AS new_aliases
+     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT toLower(n) IN [x IN existing_aliases WHERE x IS NOT NULL | toLower(x)]] AS new_aliases
 
 // 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
 WITH target, new_aliases, existing_aliases, source_descs,

--- a/api/app/schemas/memory_reflection_schemas.py
+++ b/api/app/schemas/memory_reflection_schemas.py
@@ -22,6 +22,7 @@ class SubProblemEnum(str, Enum):
     FACT_CONTRADICTION = "fact_contradiction"
     METADATA_VALIDATION = "metadata_validation"
     UNRESOLVED_ENTITY = "unresolved_entity"
+    ALIAS_MERGE = "alias_merge"
 
 class TriggerTypeEnum(str, Enum):
     """触发方式枚举"""


### PR DESCRIPTION
- Add AliasBelongsJudge LLM service to validate alias-entity relationships with confidence scoring
- Create alias_belongs_judge.jinja2 prompt template for relationship validation
- Add collect_alias_candidates() and drop_alias_edges() functions to support selective merging
- Introduce AliasMergeConfig with confidence threshold and max candidates per run
- Update merge_alias_belongs_to() to accept alias_ids list and skip merge steps when empty
- Add GET_ALIAS_BELONGS_CANDIDATES and DROP_ALIAS_BELONGS_EDGES Cypher queries
- Update Layer2Inspector to include alias_merge configuration and orchestrate LLM validation
- Modify reflection schemas to support alias validation and selective merge workflows
- Enable conditional merge execution based on LLM judgment rather than full batch processing

## Summary by Sourcery

在反射引擎中引入基于 LLM 的别名-实体关系校验机制，并将别名合并操作限定在高置信度判断之上。

New Features:
- 新增可配置的 `AliasMergeConfig`，用于控制别名合并的置信度阈值以及每次运行的合并上限。
- 引入基于 LLM 的 `alias_belongs_judge` 服务和提示词流程，用于在合并前批量验证别名与实体之间的关系。

Enhancements:
- 重构 `Layer2Inspector` 中的别名合并工作流，用于收集候选项、有选择地合并或丢弃边，并为每个决策记录详细的反射步骤日志。
- 将别名合并的 Cypher 操作限制为仅针对经 LLM 批准的别名 ID，包括有选择地重定向边和删除别名节点，同时始终将别名同步到 PostgreSQL。
- 扩展反射日志的 schema 和枚举，以支持 `alias_merge` 子问题跟踪以及结构化变更描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce LLM-based validation for alias-entity relationships in the reflection engine and gate alias merge operations on high-confidence judgments.

New Features:
- Add configurable AliasMergeConfig to control alias merge confidence threshold and per-run limits.
- Introduce an LLM-driven alias_belongs_judge service and prompt for batch validation of alias-to-entity relationships before merging.

Enhancements:
- Refactor alias merge workflow in Layer2Inspector to collect candidates, selectively merge or drop edges, and log detailed reflection steps per decision.
- Limit alias merge Cypher operations to LLM-approved alias IDs, including selective edge redirection and alias node deletion, while always syncing aliases to PostgreSQL.
- Extend reflection logging schemas and enums to support alias_merge subproblem tracking and structured change descriptions.

</details>