### PR TITLE
fix(memory): ensure dialog_at always has a value via multi-tier fallback

### DIFF
--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -12,6 +12,7 @@ MemoryWriteDispatcher — 记忆写入派发层
 
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, List, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -249,6 +250,9 @@ def push_write_task(
     """
     from app.celery_task_scheduler import scheduler as celery_scheduler
 
+    # 记录任务派发时刻，作为 pipeline 内 dialog_at 的第二级兜底
+    dispatch_at = datetime.now(timezone.utc).isoformat()
+
     msg_id = celery_scheduler.push_task(
         "app.core.memory.agent.write_message",
         end_user_id,
@@ -262,6 +266,7 @@ def push_write_task(
             "conversation_id": conversation_id,
             "message_seq": message_seq,
             "language": language,
+            "dispatch_at": dispatch_at,
         },
     )
     logger.info(
@@ -429,6 +434,16 @@ async def ingest_agent_message(
     if hasattr(message, "meta_data") and message.meta_data:
         files = message.meta_data.get("files")
 
+    # Agent 路径：用 message.created_at 作为 dialog_at，语义上是对话真实发生的时间
+    dialog_at: str | None = None
+    if hasattr(message, "created_at") and message.created_at:
+        _created = message.created_at
+        if isinstance(_created, datetime):
+            _created = _created.replace(tzinfo=timezone.utc) if _created.tzinfo is None else _created
+            dialog_at = _created.isoformat()
+        elif isinstance(_created, str):
+            dialog_at = _created
+
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
         memory_msg = repo.write_single(
@@ -439,6 +454,7 @@ async def ingest_agent_message(
             created_at=message.created_at,
             should_memorize=should_memorize,
             files=files,
+            dialog_at=dialog_at,
         )
         if memory_msg is None:
             return False

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -270,12 +270,12 @@ class WritePipeline:
             self.language = detected if detected in ("zh", "en") else "en"
             logger.info(f"[LanguageDetect] detected={detected}, language={self.language}, text_len={len(user_content)}")
 
-        # 处理 dialog_at
-        _dialog_at = (
+        # 处理 dialog_at：三级降级，最终由 ensure_dialog_at 用服务端当前时间兜底
+        from app.core.utils.datetime_utils import ensure_dialog_at
+        _dialog_at = ensure_dialog_at(
             target_message.get("dialog_at")
             or dispatch_at
-            or target_message.get("created_at", "")
-            or ""
+            or target_message.get("created_at")
         )
         target_message = {**target_message, "dialog_at": _dialog_at}
 
@@ -875,8 +875,8 @@ class WritePipeline:
         if not assistant_content:
             # 没有配对的 assistant 消息，跳过 User 侧 pruning
             logger.debug(
-                f"[WritePipeline] target_message User 侧 pruning 跳过: "
-                f"context_after 中无 assistant 消息"
+                "[WritePipeline] target_message User 侧 pruning 跳过: "
+                "context_after 中无 assistant 消息"
             )
             return
 

--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -103,19 +103,29 @@ def parse_iso_to_utc_naive(value: str | None) -> datetime | None:
 
 
 def ensure_dialog_at(dialog_at: str | None) -> str:
-    """确保 dialog_at 有值，没有则用服务端当前 UTC 时间兜底。
+    """确保 dialog_at 是合法的 UTC ISO 8601 字符串。
+
+    处理逻辑：
+    1. 若传入值非空，尝试解析为 UTC datetime，成功则规范化输出。
+    2. 解析失败（格式非法）或传入为空，用服务端当前 UTC 时间兜底。
 
     各写入入口（write_batch / write_single / write_pipeline）统一调用此函数，
-    保证记忆写入链路上的每条消息都携带有效的对话时间戳。
+    保证 memory_messages.dialog_at 字段和 pipeline 内始终携带合法的时间戳。
 
     Args:
-        dialog_at: 调用方提供的 ISO 8601 字符串，可为 None 或空字符串。
+        dialog_at: 调用方提供的时间字符串，可为 None、空字符串或任意格式。
 
     Returns:
-        有效的 ISO 8601 UTC 字符串。
+        规范化的 ISO 8601 UTC 字符串（含 +00:00 或 Z 后缀）。
     """
     if dialog_at and dialog_at.strip():
-        return dialog_at
+        try:
+            parsed = parse_iso_to_utc_naive(dialog_at.strip())
+            if parsed is not None:
+                # 转回 aware UTC 再序列化，统一输出格式
+                return parsed.replace(tzinfo=UTC).isoformat()
+        except Exception:
+            pass
     return datetime.now(UTC).isoformat()
 
 

--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -102,6 +102,23 @@ def parse_iso_to_utc_naive(value: str | None) -> datetime | None:
     return dt.astimezone(UTC).replace(tzinfo=None)
 
 
+def ensure_dialog_at(dialog_at: str | None) -> str:
+    """确保 dialog_at 有值，没有则用服务端当前 UTC 时间兜底。
+
+    各写入入口（write_batch / write_single / write_pipeline）统一调用此函数，
+    保证记忆写入链路上的每条消息都携带有效的对话时间戳。
+
+    Args:
+        dialog_at: 调用方提供的 ISO 8601 字符串，可为 None 或空字符串。
+
+    Returns:
+        有效的 ISO 8601 UTC 字符串。
+    """
+    if dialog_at and dialog_at.strip():
+        return dialog_at
+    return datetime.now(UTC).isoformat()
+
+
 def parse_metadata_time_to_utc_naive(value: str | int | float | datetime | None) -> datetime | None:
     """Parse metadata time values and normalize them to naive UTC.
 

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
-from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+from app.core.utils.datetime_utils import ensure_dialog_at, to_iso_z, utcnow_naive
 from app.models.conversation_model import Conversation
 from app.models.memory_message_model import MemoryMessage
 
@@ -79,7 +79,7 @@ class MemoryMessageRepository:
                 message_seq=next_seq,
                 should_memorize=msg.get("should_memorize", True),
                 created_at=utcnow_naive(),
-                dialog_at=msg.get("dialog_at") or None,
+                dialog_at=ensure_dialog_at(msg.get("dialog_at")),
                 files=msg.get("files"),
             )
             self.db.add(mm)
@@ -139,7 +139,7 @@ class MemoryMessageRepository:
                 message_seq=next_seq,
                 should_memorize=should_memorize,
                 created_at=created_at,
-                dialog_at=dialog_at,
+                dialog_at=ensure_dialog_at(dialog_at),
                 files=files,
             )
             self.db.add(memory_msg)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1767,6 +1767,7 @@ def write_message_task(
         message_seq: int = 0,
         language: str = "zh",
         skip_cursor_advance: bool = False,
+        dispatch_at: str = "", # 任务执行时间
         # MCP 入口兼容字段（不经过 memory_messages 表，直接写入）
         messages: Optional[List[dict]] = None,
         storage_type: str = "neo4j",
@@ -1785,6 +1786,7 @@ def write_message_task(
         message_seq: 消息序号
         language: 语言
         skip_cursor_advance: 是否跳过 cursor 推进（MCP 等直接写入路径）
+        dispatch_at: 任务派发时刻的 UTC ISO 8601 时间戳，由 push_write_task 自动注入
         messages: MCP 入口兼容字段，单条消息列表 [{"role", "content", "dialog_at"}]
         storage_type: MCP 入口兼容字段，存储类型（neo4j / rag）
         user_rag_memory_id: MCP 入口兼容字段，RAG 记忆 ID
@@ -1853,6 +1855,7 @@ def write_message_task(
             message_seq=message_seq,
             language=language,
             skip_cursor_advance=skip_cursor_advance,
+            dispatch_at=dispatch_at,
         )
         return {"status": result.status, "extraction": result.extraction}
 


### PR DESCRIPTION
## Summary by Sourcery

确保所有内存写入路径都附带有效的 `dialog_at` 时间戳，并采用多层回退机制。

New Features:
- 新增 `ensure_dialog_at` 实用工具，用于规范化并回填 `dialog_at`，在缺失时使用当前服务器 UTC 时间。
- 在任务分发时捕获 `dispatch_at`，并在写入流水线中向下传递，作为 `dialog_at` 的二级回退值。
- 在代理（agent）数据摄入路径中，将代理消息的 `created_at` 用作 `dialog_at`，以反映实际的对话时间。

Bug Fixes:
- 通过在批量写入和单条写入操作中强制执行回退逻辑，防止在没有有效 `dialog_at` 的情况下写入内存消息。

Enhancements:
- 优化写入流水线中的 `dialog_at` 处理逻辑，采用三级回退链（显式 `dialog_at`、`dispatch_at`、`created_at`），并将回退逻辑集中化。
- 对写入流水线中的日志字符串进行小幅清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure all memory write paths attach a valid dialog_at timestamp with multi-tier fallbacks.

New Features:
- Add ensure_dialog_at utility to normalize and backfill dialog_at using current server UTC time when missing.
- Capture dispatch_at at task dispatch time and propagate it through the write pipeline as a secondary dialog_at fallback.
- Use agent message created_at as dialog_at for agent ingestion paths to reflect the actual conversation time.

Bug Fixes:
- Prevent memory messages from being written without a valid dialog_at by enforcing fallback logic in batch and single write operations.

Enhancements:
- Refine write pipeline dialog_at handling to use a three-level fallback chain (explicit dialog_at, dispatch_at, created_at) and centralize fallback logic.
- Make minor logging string cleanup in the write pipeline.

</details>