### PR TITLE
feat(rag): add QA CSV export

### DIFF
--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -43,6 +43,7 @@ from app.services import file_service
 from app.services.file_service import _is_qa_doc
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.model_service import ModelConfigService
+from app.services.qa_export_service import iter_qa_csv_chunks, make_qa_export_filename
 from app.core.quota_stub import check_knowledge_capacity_quota
 
 # Obtain a dedicated API logger
@@ -466,6 +467,36 @@ async def update_knowledge(
     api_logger.info(f"Update knowledge base request: knowledge_id={knowledge_id}, username: {current_user.username}")
     db_knowledge = await _update_knowledge(knowledge_id=knowledge_id, update_data=update_data, db=db, current_user=current_user)
     return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="The knowledge base information has been successfully updated")
+
+
+@router.get("/{kb_id}/qa/export")
+async def export_knowledge_qa_csv(
+        kb_id: uuid.UUID,
+        current_user: User = Depends(get_current_user),
+):
+    """Export all active QA pairs in a knowledge base as a two-column CSV."""
+    api_logger.info(f"KB QA CSV export: kb_id={kb_id}, username={current_user.username}")
+
+    with get_db_context() as db:
+        db_knowledge = knowledge_service.get_knowledge_by_id(
+            db, knowledge_id=kb_id, current_user=current_user
+        )
+        if not db_knowledge:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The knowledge base does not exist or you do not have permission to access it",
+            )
+        filename = make_qa_export_filename(db_knowledge.name)
+
+    from urllib.parse import quote
+
+    return StreamingResponse(
+        iter_qa_csv_chunks(kb_id),
+        media_type="text/csv; charset=utf-8",
+        headers={
+            "Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}",
+        },
+    )
 
 
 @router.post("/{kb_id}/batch-download")

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -1,0 +1,122 @@
+import csv
+import io
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
+    ElasticSearchVectorClientProvider,
+    ElasticSearchVectorIndexOps,
+)
+from app.core.rag.vdb.field import Field
+
+
+QA_EXPORT_COLUMNS = ("question", "answer")
+QA_EXPORT_BATCH_SIZE = 1000
+
+
+def make_qa_export_filename(knowledge_name: str | None) -> str:
+    safe_name = (knowledge_name or "").strip().replace("/", "_").replace("\\", "_")
+    if not safe_name:
+        return "qa_export.csv"
+    return f"{safe_name}_qa_export.csv"
+
+
+def iter_qa_pairs_by_knowledge(
+    kb_id: uuid.UUID | str,
+    batch_size: int = QA_EXPORT_BATCH_SIZE,
+) -> Iterator[dict[str, str]]:
+    kb_id_str = str(kb_id)
+    batch_size = max(1, batch_size)
+    index_name = ElasticSearchVectorIndexOps.collection_name_for_knowledge(kb_id_str)
+    client = ElasticSearchVectorClientProvider.get_shared_client()
+
+    if not client.indices.exists(index=index_name):
+        return
+
+    search_after: list[Any] | None = None
+    while True:
+        body = _build_qa_export_search_body(kb_id_str, batch_size, search_after)
+        result = client.search(index=index_name, body=body)
+        hits = result.get("hits", {}).get("hits", [])
+        if not hits:
+            return
+
+        for hit in hits:
+            source = hit.get("_source") or {}
+            yield {
+                "question": _normalize_csv_value(source.get(Field.QUESTION.value)),
+                "answer": _normalize_csv_value(source.get(Field.ANSWER.value)),
+            }
+
+        search_after = hits[-1].get("sort")
+        if not search_after:
+            return
+
+
+def iter_qa_csv_chunks(
+    kb_id: uuid.UUID | str,
+    batch_size: int = QA_EXPORT_BATCH_SIZE,
+) -> Iterator[bytes]:
+    yield _write_csv_rows([QA_EXPORT_COLUMNS]).encode("utf-8-sig")
+    for pair in iter_qa_pairs_by_knowledge(kb_id=kb_id, batch_size=batch_size):
+        yield _write_csv_rows([(pair["question"], pair["answer"])]).encode("utf-8")
+
+
+def _build_qa_export_search_body(
+    kb_id: str,
+    batch_size: int,
+    search_after: list[Any] | None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {Field.CHUNK_TYPE.value: "qa"}},
+                    {"term": {Field.KNOWLEDGE_ID.value: kb_id}},
+                    {"term": {"metadata.status": 1}},
+                ]
+            }
+        },
+        "_source": [Field.QUESTION.value, Field.ANSWER.value],
+        "size": batch_size,
+        "sort": [
+            {
+                Field.DOCUMENT_ID.value: {
+                    "order": "asc",
+                    "unmapped_type": "keyword",
+                    "missing": "_last",
+                }
+            },
+            {
+                Field.SORT_ID.value: {
+                    "order": "asc",
+                    "unmapped_type": "long",
+                    "missing": "_last",
+                }
+            },
+            {
+                Field.DOC_ID.value: {
+                    "order": "asc",
+                    "unmapped_type": "keyword",
+                    "missing": "_last",
+                }
+            },
+        ],
+    }
+    if search_after:
+        body["search_after"] = search_after
+    return body
+
+
+def _write_csv_rows(rows: list[tuple[str, ...]]) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _normalize_csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)


### PR DESCRIPTION
## Summary
- Add an internal knowledge-base QA CSV export endpoint.
- Export only `question` and `answer` columns from active QA chunks.
- Use paginated Elasticsearch reads so large exports are not limited to the first 10000 rows.

## Changes
```
api/app/controllers/knowledge_controller.py |  31 +++++++
api/app/services/qa_export_service.py       | 122 ++++++++++++++++++++++++++++
2 files changed, 153 insertions(+)
```

## Test Plan
- [x] `cd api && ./.venv/bin/python -m pytest -q tests/rag/test_qa_csv_export.py`
- [x] `cd api && ./.venv/bin/python -m py_compile app/controllers/knowledge_controller.py app/services/qa_export_service.py`
- [x] `git diff --check origin/develop..HEAD`

## External API Impact
- Internal Web route only: `GET /api/knowledges/{kb_id}/qa/export`.
- No `/v1` API Key route is added in this change.

## Summary by Sourcery

添加一个内部端点，用于通过分页读取 Elasticsearch，将知识库问答对导出为 CSV 文件。

新功能：
- 暴露一个已认证的内部路由，用于将某个知识库中所有“活动”状态的问答对以 CSV 附件形式下载。
- 引入一个问答导出服务，从基于 Elasticsearch 的知识库中以分页批次流式导出问答对。

增强项：
- 生成安全的、基于知识库名称的文件名，并输出适用于大规模导出的 UTF-8 编码 CSV。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an internal endpoint to export knowledge-base QA pairs as a CSV file using paginated Elasticsearch reads.

New Features:
- Expose an authenticated internal route to download all active QA pairs for a knowledge base as a CSV attachment.
- Introduce a QA export service that streams question and answer pairs from Elasticsearch-backed knowledge bases in paginated batches.

Enhancements:
- Generate safe, knowledge-based filenames and UTF-8 encoded CSV output optimized for large exports.

</details>