### PR TITLE
feat(memory): skip user-side message pruning when pruning is disabled

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -852,6 +852,13 @@ class WritePipeline:
         if not messages:
             return
 
+        # 剪枝开关关闭时跳过 User 侧规整
+        if not self.memory_config.pruning_enabled:
+            logger.debug(
+                "[WritePipeline] target_message User 侧 pruning 跳过: 剪枝开关已关闭"
+            )
+            return
+
         target_msg = messages[0]
         target_content = target_msg.get("content", "")
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 当全局清理功能关闭时，防止在用户端出现非预期的目标消息清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unintended user-side target message pruning when the global pruning feature is turned off.

</details>