### PR TITLE
Refactor/mcp write path

### DIFF
--- a/api/app/controllers/service/mcp_memory.py
+++ b/api/app/controllers/service/mcp_memory.py
@@ -15,7 +15,6 @@ import warnings
 
 from fastmcp import FastMCP
 
-from app.celery_task_scheduler import scheduler
 from app.controllers.service.mcp_auth_middleware import (
     mcp_config_id,
     mcp_end_user_id,
@@ -71,19 +70,27 @@ async def write_memory(
         from datetime import datetime, timezone
         dialog_at = datetime.now(timezone.utc).isoformat()
 
-        msg_id = scheduler.push_task(
-            "app.core.memory.agent.write_message",
-            end_user_id,
-            {
-                "end_user_id": end_user_id,
-                "messages": [{"role": "user", "content": message, "dialog_at": dialog_at}],
-                "config_id": config_id,
-                "storage_type": storage_type,
-                "user_rag_memory_id": "",
-                "workspace_id": str(workspace_id),
-            },
+        # RAG 存储类型走独立路径
+        if storage_type and storage_type.lower() == "rag":
+            from app.core.memory.pipelines.dispatcher import write_messages_to_rag
+            await write_messages_to_rag(
+                messages=[{"role": "user", "content": message, "dialog_at": dialog_at}],
+                end_user_id=end_user_id,
+                user_rag_memory_id="",
+            )
+            return {"success": True}
+
+        # Neo4j 路径：走 MCP 专用 dispatcher 入口，消息落 memory_messages 表
+        from app.core.memory.pipelines.dispatcher import dispatch_mcp_write
+        msg_id = await dispatch_mcp_write(
+            message=message,
+            end_user_id=end_user_id,
+            config_id=config_id,
+            workspace_id=str(workspace_id),
+            dialog_at=dialog_at,
         )
-        logger.info(f"MCP write_memory queued: msg_id={msg_id}, end_user={end_user_id}")
+
+        logger.info(f"MCP write_memory dispatched: msg_id={msg_id}, end_user={end_user_id}")
         return {"success": True, "msg_id": msg_id}
     except Exception as e:
         logger.error(f"MCP write_memory failed for end_user={end_user_id}: {e}")

--- a/api/app/controllers/service/mcp_memory.py
+++ b/api/app/controllers/service/mcp_memory.py
@@ -24,7 +24,6 @@ from app.controllers.service.mcp_auth_middleware import (
 from app.core.logging_config import get_logger
 from app.core.memory.enums import SearchStrategy
 from app.core.memory.memory_service import MemoryService
-from app.db import get_db_context
 
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="scipy")
 
@@ -70,23 +69,12 @@ async def write_memory(
         from datetime import datetime, timezone
         dialog_at = datetime.now(timezone.utc).isoformat()
 
-        # RAG 存储类型走独立路径
-        if storage_type and storage_type.lower() == "rag":
-            from app.core.memory.pipelines.dispatcher import write_messages_to_rag
-            await write_messages_to_rag(
-                messages=[{"role": "user", "content": message, "dialog_at": dialog_at}],
-                end_user_id=end_user_id,
-                user_rag_memory_id="",
-            )
-            return {"success": True}
-
-        # Neo4j 路径：走 MCP 专用 dispatcher 入口，消息落 memory_messages 表
-        from app.core.memory.pipelines.dispatcher import dispatch_mcp_write
-        msg_id = await dispatch_mcp_write(
+        msg_id = await MemoryService.dispatch_mcp_write(
             message=message,
             end_user_id=end_user_id,
             config_id=config_id,
             workspace_id=str(workspace_id),
+            storage_type=storage_type,
             dialog_at=dialog_at,
         )
 

--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -159,6 +159,8 @@ async def get_chunked_dialogs(
     logger.info(f"DialogData created with {len(extracted_chunks)} chunks")
 
 # step4: 注入结构化上下文（滑动窗口写入场景）
+    # 当 context_before/after 均为空时也显式注入空结构，避免萃取阶段走 fallback
+    # 将 dialog.content 错误地当成上文重复放入 before_msgs。
     if context_before or context_after:
         from app.core.memory.storage_services.extraction_engine.steps.schema.extraction_step_schema import MessageItem
         before_msgs = [
@@ -179,5 +181,13 @@ async def get_chunked_dialogs(
             f"[SupportingContext] 注入上下文消息: "
             f"before={len(before_msgs)}, after={len(after_msgs)}"
         )
+    else:
+        # 无上下文（MCP 单条写入路径）：注入空结构，防止萃取阶段走 fallback
+        from app.core.memory.storage_services.extraction_engine.steps.schema.extraction_step_schema import MessageItem
+        dialog_data.metadata["supporting_context"] = {
+            "before_msgs": [],
+            "after_msgs": [],
+        }
+        logger.info("[SupportingContext] 无上下文，注入空结构")
 
     return [dialog_data]

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -20,7 +20,7 @@ from app.core.memory.models.service_models import LongTermMemoryInput, MemoryCon
 from app.core.memory.pipelines.memory_read import ReadPipeLine
 from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
 from app.core.memory.pipelines.write_pipeline import WriteResult
-from app.db import get_db_context, get_db_read
+from app.db import get_db_read
 from app.services.memory_config_service import MemoryConfigService
 
 logger = logging.getLogger(__name__)
@@ -138,6 +138,51 @@ class MemoryService:
             config_id=config_id,
             workspace_id=workspace_id,
             language=language,
+        )
+
+    @staticmethod
+    async def dispatch_mcp_write(
+        message: str,
+        end_user_id: str,
+        config_id: str,
+        workspace_id: str,
+        storage_type: str = "neo4j",
+        dialog_at: str = "",
+    ) -> str:
+        """MCP 单条消息写入入口。
+
+        根据 storage_type 选择走 RAG 或 Neo4j 路径。
+
+        Args:
+            message: 用户消息内容
+            end_user_id: 终端用户 ID
+            config_id: 记忆配置 ID
+            workspace_id: 工作空间 ID
+            storage_type: 存储类型 ("neo4j" | "rag")
+            dialog_at: 对话发生时间（ISO 8601）
+
+        Returns:
+            派发的任务 msg_id（RAG 路径返回空字符串）
+        """
+        from app.core.memory.pipelines.dispatcher import (
+            dispatch_mcp_write,
+            write_messages_to_rag,
+        )
+
+        if storage_type and storage_type.lower() == "rag":
+            await write_messages_to_rag(
+                messages=[{"role": "user", "content": message, "dialog_at": dialog_at}],
+                end_user_id=end_user_id,
+                user_rag_memory_id="",
+            )
+            return ""
+
+        return await dispatch_mcp_write(
+            message=message,
+            end_user_id=end_user_id,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            dialog_at=dialog_at,
         )
 
     @staticmethod

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -793,3 +793,78 @@ def dispatch_single_message(
     )
 
     return True
+
+
+# ──────────────────────────────────────────────
+# 入口5: MCP 写入
+# ──────────────────────────────────────────────
+
+
+async def dispatch_mcp_write(
+    message: str,
+    end_user_id: str,
+    config_id: str,
+    workspace_id: str,
+    dialog_at: str = "",
+) -> str:
+    """MCP 写入入口。
+
+    MCP 每次仅写入单条 user message，不需要上下文窗口。
+    流程：
+    1. 获取/创建虚拟 conversation（复用哨兵 App）
+    2. 写入 memory_messages 表
+    3. 立即推进 write_cursor
+    4. 直接派发写入任务（context_before=[], context_after=[]）
+
+    Args:
+        message: 用户消息内容
+        end_user_id: 终端用户 ID
+        config_id: 记忆配置 ID
+        workspace_id: 工作空间 ID
+        dialog_at: 对话发生时间（ISO 8601）
+
+    Returns:
+        派发的任务 msg_id
+    """
+    # 1. 获取/创建虚拟 conversation
+    conversation_id = get_or_create_service_api_conversation(
+        workspace_id=workspace_id,
+        end_user_id=end_user_id,
+    )
+
+    # 2. 写入 memory_messages 表
+    messages = [{"role": "user", "content": message, "dialog_at": dialog_at}]
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        written_mms = repo.write_batch(conversation_id, messages)
+        db.commit()
+
+    if not written_mms:
+        raise ValueError("MCP write: 消息内容为空，写入失败")
+
+    target_msg = written_mms[0]
+    target_seq = target_msg["message_seq"]
+
+    # 3. 推进 write_cursor
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        repo.advance_write_cursor(conversation_id, target_seq)
+        db.commit()
+
+    # 4. 直接派发写入任务（无上下文）
+    msg_id = push_write_task(
+        end_user_id=end_user_id,
+        target_message=target_msg,
+        context_before=[],
+        context_after=[],
+        config_id=config_id,
+        workspace_id=workspace_id,
+        conversation_id=conversation_id,
+        message_seq=target_seq,
+    )
+
+    logger.info(
+        f"[Dispatcher] MCP 写入任务已推送: end_user={end_user_id}, "
+        f"conv={conversation_id}, seq={target_seq}, msg_id={msg_id}"
+    )
+    return msg_id

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -839,9 +839,6 @@ async def dispatch_mcp_write(
         written_mms = repo.write_batch(conversation_id, messages)
         db.commit()
 
-    if not written_mms:
-        raise ValueError("MCP write: 消息内容为空，写入失败")
-
     target_msg = written_mms[0]
     target_seq = target_msg["message_seq"]
 

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -875,8 +875,8 @@ class WritePipeline:
         if not assistant_content:
             # 没有配对的 assistant 消息，跳过 User 侧 pruning
             logger.debug(
-                f"[WritePipeline] target_message User 侧 pruning 跳过: "
-                f"context_after 中无 assistant 消息"
+                "[WritePipeline] target_message User 侧 pruning 跳过: "
+                "context_after 中无 assistant 消息"
             )
             return
 

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -499,7 +499,7 @@ class SemanticPruner:
             self._log(f"[剪枝] 保存统计日志失败：{e}")
 
     def _save_snapshot(self) -> None:
-        """将剪枝结果保存到 PipelineSnapshot（1_assistant_pruning.json）。
+        """将剪枝结果保存到 PipelineSnapshot（1_user_assistant_pruning.json）。
 
         输出格式：每个 User-Assistant 消息对一条记录，包含：
         - input.msgs: 原始消息对 [{role, msg}, {role, msg}]
@@ -510,10 +510,10 @@ class SemanticPruner:
             return
 
         try:
-            self._snapshot.save_stage("1_assistant_pruning", self._snapshot_records)
+            self._snapshot.save_stage("1_user_assistant_pruning", self._snapshot_records)
             self._log(
                 f"[剪枝-快照] 已保存 {len(self._snapshot_records)} 条记录 "
-                f"到 1_assistant_pruning.json"
+                f"到 1_user_assistant_pruning.json"
             )
         except Exception as e:
             self._log(f"[剪枝-快照] 保存失败: {e}")

--- a/api/app/core/memory/utils/debug/pipeline_snapshot.py
+++ b/api/app/core/memory/utils/debug/pipeline_snapshot.py
@@ -9,19 +9,14 @@ Usage:
 Output structure (OSS):
 
     Sliding-window 写入（推荐路径，含完整定位上下文）:
-        redbear-files/snapshot/
+        redbear-files/extract_snapshot/
             {end_user_id}/
                 {conversation_id}/
                     seq_{message_seq:06d}_{YYYYmmdd_HHMMSS}/
                         0_summary.json
-                        1_assistant_pruning.json
+                        1_user_assistant_pruning.json
                         2_statement_outputs.json
                         ...
-
-    旧的整轮写入（无 conversation/seq 时的兼容路径）:
-        redbear-files/snapshot/
-            {end_user_id}_{YYYYmmdd_HHMMSS}/
-                ...
 
 Controlled by env var PIPELINE_SNAPSHOT_ENABLED (default: false).
 """
@@ -41,7 +36,7 @@ _ENABLED: Optional[bool] = None
 _OSS_BUCKET: Optional[Any] = None
 
 # OSS 上快照文件的根前缀（对应 bucket 内的 "目录"）
-_OSS_SNAPSHOT_PREFIX = "snapshot"
+_OSS_SNAPSHOT_PREFIX = "extract_snapshot"
 
 
 def _is_enabled() -> bool:

--- a/api/app/core/memory/utils/debug/write_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/write_snapshot_recorder.py
@@ -77,7 +77,7 @@ class WriteSnapshotRecorder:
         """
         if not pruning_records:
             return
-        self._snapshot.save_stage("1_assistant_pruning", pruning_records)
+        self._snapshot.save_stage("1_user_assistant_pruning", pruning_records)
 
     # ── Stage 2-5: 萃取阶段各步骤输出 ──
 

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -87,6 +87,7 @@ class MemoryMessageRepository:
                 "role": role,
                 "message_seq": next_seq,
                 "content": content,
+                "dialog_at": mm.dialog_at,
             })
             logger.debug(
                 f"[MemoryMessageRepository] 写入 memory_messages: "


### PR DESCRIPTION
## Summary by Sourcery

引入专门的 MCP 单消息写入入口，并使下游的内存管线和调试工具与该路径保持一致。

New Features:
- 添加一个异步 MCP 写入分发器，用于写入单条用户消息、推进写入游标，并在无周围上下文的情况下触发写入任务。
- 暴露 `MemoryService.dispatch_mcp_write` API，根据 `storage_type` 将 MCP 写入路由到基于 Neo4j 的管线或 RAG 存储。

Bug Fixes:
- 确保在提取管线中，当不存在 before/after 上下文时注入显式的空 `supporting_context`，以避免错误的回退行为。
- 在将内存消息批量写入数据库时持久化 `dialog_at` 时间戳。

Enhancements:
- 重命名并重组管线快照路径和阶段名称，使用 `extract_snapshot` 和 `1_user_assistant_pruning` 以提供更清晰的语义。
- 简化 MCP 内存控制器，使其直接调用 `MemoryService` 而不是排队通用调度任务。
- 改进写入管线修剪以及辅助上下文注入中的日志消息，以提升可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated MCP single-message write entrypoint and align downstream memory pipelines and debugging utilities with this path.

New Features:
- Add an async MCP write dispatcher that writes a single user message, advances the write cursor, and triggers a write task without surrounding context.
- Expose a MemoryService.dispatch_mcp_write API that routes MCP writes to either Neo4j-backed pipelines or RAG storage based on storage_type.

Bug Fixes:
- Ensure extraction pipelines inject an explicit empty supporting_context when no before/after context exists to avoid incorrect fallback behavior.
- Persist dialog_at timestamps when writing memory messages in batch to the database.

Enhancements:
- Rename and reorganize pipeline snapshot paths and stage names to use extract_snapshot and 1_user_assistant_pruning for clearer semantics.
- Simplify the MCP memory controller to call MemoryService directly instead of queuing a generic scheduler task.
- Improve logging messages in write pipeline pruning and supporting context injection for better observability.

</details>