### PR TITLE
refactor(memory): optimize neo4j connection pool, shared driver, and null-safe queries

### DIFF
--- a/api/app/celery_worker.py
+++ b/api/app/celery_worker.py
@@ -35,6 +35,7 @@ def _reinit_db_pool(**kwargs):
     fork() 后子进程继承了父进程的：
     1. SQLAlchemy 连接池 — 多进程共享 TCP socket 导致 DB 连接损坏
     2. ThreadPoolExecutor — fork 后线程状态不确定，第二个任务会死锁
+    3. Neo4j shared driver — fork 后 socket 和 event loop 失效
     """
     # 重建 DB 连接池
     from app.db import engine
@@ -59,6 +60,18 @@ def _reinit_db_pool(**kwargs):
         logger.info("libre_office.executor recreated")
     except Exception as e:
         logger.warning(f"Failed to recreate libre_office.executor: {e}")
+
+    # 重置进程级共享 Neo4j driver（fork 后子进程继承了失效的 socket 和 event loop）
+    # 子进程首次执行 Neo4j 查询时，_create_or_get_driver() 会检测到 _shared_driver is None
+    # 并自动重建全新 driver（新 socket + 新 event loop）。
+    # 依赖 P0-a：模块级单例必须使用 shared_driver=True，才会走此 PID 自愈路径。
+    try:
+        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+        Neo4jConnector._shared_driver = None
+        Neo4jConnector._shared_driver_pid = None
+        logger.info("Neo4j shared driver reset for forked worker process")
+    except Exception as e:
+        logger.warning(f"Failed to reset Neo4j shared driver: {e}")
 
 
 __all__ = ['celery_app']

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -37,6 +37,12 @@ class Settings:
     NEO4J_URI: str = os.getenv("NEO4J_URI", "bolt://1.94.111.67:7687")
     NEO4J_USERNAME: str = os.getenv("NEO4J_USERNAME", "neo4j")
     NEO4J_PASSWORD: str = os.getenv("NEO4J_PASSWORD", "")
+    # Neo4j 连接池参数（通过环境变量可配）
+    # 默认值参考文档建议值，兼顾资源占用与并发需求
+    NEO4J_MAX_POOL_SIZE: int = int(os.getenv("NEO4J_MAX_POOL_SIZE", "30"))
+    NEO4J_ACQ_TIMEOUT: float = float(os.getenv("NEO4J_ACQ_TIMEOUT", "30.0"))
+    NEO4J_MAX_CONN_LIFETIME: int = int(os.getenv("NEO4J_MAX_CONN_LIFETIME", "3600"))
+    NEO4J_CONN_TIMEOUT: float = float(os.getenv("NEO4J_CONN_TIMEOUT", "30.0"))
 
     # Database configuration (Postgres)
     DB_HOST: str = os.getenv("DB_HOST", "127.0.0.1")

--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -4,8 +4,11 @@ PruningPipeline — 单条 assistant 消息语义剪枝流水线
 职责：
 - 对单条 assistant 消息执行语义剪枝，输出剪枝后内容（A'）
 - 先查询 Redis 缓存，命中则直接返回，避免重复 LLM 调用
-- 未命中则调用 SemanticPruner 执行剪枝，结果写入 Neo4j 和 Redis 缓存
+- 未命中则调用 SemanticPruner 执行剪枝，结果写入 Redis 缓存
 - 作为 WritePipeline 的预处理步骤被调用，其结果可跨任务缓存复用
+
+流程：Redis 缓存 → LLM 剪枝 → Redis 写入
+（Neo4j 写入已迁移至 graph_build_step，通过 assistant_pruning_records metadata 统一处理），现在移除neo4j连接相关内容
 
 Redis key 格式：pruning:{conversation_id}:{message_seq}
 TTL：86400 秒（24 小时）
@@ -17,11 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
-from uuid import uuid4
-
-from app.core.utils.datetime_utils import to_iso_z
 
 if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
@@ -35,12 +34,12 @@ _MEMORY_TYPE_NULL = "NULL"
 class PruningPipeline:
     """单条 assistant 消息语义剪枝流水线。
 
-    对单条 assistant 消息执行语义剪枝，输出 A'，写入 Neo4j 并缓存到 Redis。
+    对单条 assistant 消息执行语义剪枝，输出 A'，缓存到 Redis。
 
     流程：
     1. 查 Redis 缓存 pruning:{conversation_id}:{message_seq}
     2. 命中 → 直接返回 A'
-    3. 未命中 → 调用 LLM 剪枝 → 写 Neo4j → 写 Redis → 返回 A'
+    3. 未命中 → 调用 LLM 剪枝 → 写 Redis → 返回 A'
     """
 
     CACHE_TTL = 86400  # 24 小时兜底
@@ -61,9 +60,8 @@ class PruningPipeline:
         self.end_user_id = end_user_id
         self.language = language
 
-        # 延迟初始化的客户端
+        # 延迟初始化的 LLM 客户端
         self._llm_client = None
-        self._neo4j_connector = None
 
     # ──────────────────────────────────────────────
     # 公开接口
@@ -81,7 +79,7 @@ class PruningPipeline:
 
         1. 查 Redis 缓存 pruning:{conversation_id}:{message_seq}
         2. 命中 → 直接返回 A'（source="cache"）
-        3. 未命中 → 调用 LLM 剪枝 → 写 Neo4j → 写 Redis → 返回 A'（source="llm"）
+        3. 未命中 → 调用 LLM 剪枝 → 写 Redis → 返回 A'（source="llm"）
 
         Args:
             conversation_id: 对话 ID
@@ -137,10 +135,7 @@ class PruningPipeline:
             user_content=user_content,
         )
 
-        # Step 3: Neo4j 写入已统一移至 graph_build_step（通过 assistant_pruning_records metadata），
-        # 此处不再直接写入，避免产生重复边。
-
-        # Step 4: 写入 Redis 缓存（TTL=86400s）
+        # Step 3: 写入 Redis 缓存（TTL=86400s）
         try:
             await self._set_to_cache(cache_key, pruned_content, memory_type)
         except Exception as e:
@@ -250,166 +245,6 @@ class PruningPipeline:
         return result.assistant_memory_hint, result.assistant_memory_type, result.should_process_user_msg, result.processed_user_msg
 
     # ──────────────────────────────────────────────
-    # 内部方法：Neo4j 写入
-    # ──────────────────────────────────────────────
-
-    async def _write_to_neo4j(
-        self,
-        conversation_id: str,
-        message_seq: int,
-        original_content: str,
-        pruned_content: str,
-    ) -> None:
-        """将剪枝结果写入 Neo4j（AssistantOriginal + AssistantPruned + Conversation 中心节点）。
-
-        创建：
-        - Conversation 中心节点：id == conversation_id，MERGE 幂等，跨写入复用
-        - AssistantOriginal 节点：存储原始 assistant 消息
-        - AssistantPruned 节点：存储剪枝后内容（A'）
-        - PRUNED_TO 边：连接 Original → Pruned
-        - BELONGS_TO_CONVERSATION 边：连接 Original → Conversation 中心节点，
-          使同一会话的 assistant 剪枝节点聚成一个连通子图
-
-        Args:
-            conversation_id: 对话 ID（用作 dialog_id 和 Conversation 中心节点 id）
-            message_seq: 消息序号（用于节点命名）
-            original_content: assistant 消息原始内容
-            pruned_content: 剪枝后内容（A'）
-        """
-        from app.core.memory.models.graph_models import (
-            AssistantOriginalNode,
-            AssistantPrunedNode,
-            AssistantPrunedEdge,
-            ConversationNode,
-            AssistantConversationEdge,
-        )
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-        from app.repositories.neo4j.cypher_queries import (
-            ASSISTANT_ORIGINAL_NODE_SAVE,
-            ASSISTANT_PRUNED_NODE_SAVE,
-            ASSISTANT_PRUNED_EDGE_SAVE,
-            CONVERSATION_NODE_SAVE,
-            ASSISTANT_CONVERSATION_EDGE_SAVE,
-        )
-
-        now = datetime.now(timezone.utc)
-        run_id = uuid4().hex
-        pair_id = uuid4().hex
-
-        # 构建节点 ID（基于 conversation_id + message_seq 保证幂等性）
-        original_id = f"orig_{conversation_id}_{message_seq}"
-        pruned_id = f"pruned_{conversation_id}_{message_seq}"
-
-        original_node = AssistantOriginalNode(
-            id=original_id,
-            name=f"AssistantOriginal_{message_seq}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-            dialog_id=conversation_id,
-            text=original_content,
-        )
-
-        pruned_node = AssistantPrunedNode(
-            id=pruned_id,
-            name=f"AssistantPruned_{message_seq}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-            dialog_id=conversation_id,
-            text=pruned_content if pruned_content else "NULL",
-            memory_type="NULL",  # 单条剪枝时 memory_type 由 LLM 返回，此处简化为 NULL
-        )
-
-        pruned_edge = AssistantPrunedEdge(
-            source=original_id,
-            target=pruned_id,
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-        )
-
-        # Conversation 中心节点：id == conversation_id，跨写入任务用 MERGE 复用。
-        # 所有 AssistantOriginal 通过 BELONGS_TO_CONVERSATION 挂到该节点，
-        # 使同一会话的 assistant 剪枝节点在图谱中聚成一个连通子图。
-        conversation_node = ConversationNode(
-            id=conversation_id,
-            name=f"Conversation_{conversation_id}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            conversation_id=conversation_id,
-        )
-
-        conversation_edge = AssistantConversationEdge(
-            source=original_id,
-            target=conversation_id,
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-        )
-
-        # 确保 Neo4j 连接器已初始化
-        self._ensure_neo4j_connector()
-
-        async def _write_in_transaction(tx):
-            # 写入 Conversation 中心节点（MERGE 幂等）
-            conversation_data = [{
-                "id": conversation_node.id,
-                "name": conversation_node.name,
-                "end_user_id": conversation_node.end_user_id,
-                "conversation_id": conversation_node.conversation_id,
-                "run_id": conversation_node.run_id,
-                "created_at": conversation_node.created_at.isoformat(),
-            }]
-            result = await tx.run(CONVERSATION_NODE_SAVE, conversations=conversation_data)
-            await result.consume()
-
-            # 写入 AssistantOriginal 节点
-            original_data = [original_node.model_dump()]
-            result = await tx.run(ASSISTANT_ORIGINAL_NODE_SAVE, originals=original_data)
-            await result.consume()
-
-            # 写入 AssistantPruned 节点
-            pruned_data = [pruned_node.model_dump()]
-            result = await tx.run(ASSISTANT_PRUNED_NODE_SAVE, pruneds=pruned_data)
-            await result.consume()
-
-            # 写入 PRUNED_TO 边
-            edge_data = [{
-                "source": pruned_edge.source,
-                "target": pruned_edge.target,
-                "pair_id": pruned_edge.pair_id,
-                "end_user_id": pruned_edge.end_user_id,
-                "run_id": pruned_edge.run_id,
-                "created_at": to_iso_z(pruned_edge.created_at),
-            }]
-            result = await tx.run(ASSISTANT_PRUNED_EDGE_SAVE, edges=edge_data)
-            await result.consume()
-
-            # 写入 BELONGS_TO_CONVERSATION 边（Original → Conversation 中心节点）
-            conv_edge_data = [{
-                "id": conversation_edge.id,
-                "source": conversation_edge.source,
-                "target": conversation_edge.target,
-                "end_user_id": conversation_edge.end_user_id,
-                "run_id": conversation_edge.run_id,
-                "created_at": conversation_edge.created_at.isoformat(),
-            }]
-            result = await tx.run(ASSISTANT_CONVERSATION_EDGE_SAVE, edges=conv_edge_data)
-            await result.consume()
-
-        await self._neo4j_connector.execute_write_transaction(_write_in_transaction)
-        logger.info(
-            f"[PruningPipeline] Neo4j 写入完成: "
-            f"conv={conversation_id}, seq={message_seq}, "
-            f"original_id={original_id}, pruned_id={pruned_id}"
-        )
-
-    # ──────────────────────────────────────────────
     # 内部方法：Redis 缓存读写
     # ──────────────────────────────────────────────
 
@@ -499,22 +334,6 @@ class PruningPipeline:
 
         logger.info("[PruningPipeline] LLM 客户端初始化完成")
 
-    def _ensure_neo4j_connector(self) -> None:
-        """确保 Neo4j 连接器已初始化（懒加载）。"""
-        if self._neo4j_connector is not None:
-            return
-
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-
-        self._neo4j_connector = Neo4jConnector()
-        logger.info("[PruningPipeline] Neo4j 连接器初始化完成")
-
     async def close(self) -> None:
-        """释放资源：关闭 Neo4j 连接器。"""
-        if self._neo4j_connector is not None:
-            try:
-                await self._neo4j_connector.close()
-            except Exception as e:
-                logger.warning(f"[PruningPipeline] Neo4j 连接器关闭失败: {e}")
-            finally:
-                self._neo4j_connector = None
+        """资源释放（当前无持久资源，预留给将来扩展）。"""
+        pass

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -698,7 +698,7 @@ class WritePipeline:
         摘要：生成情景记忆摘要 → 写入 Neo4j。
 
         摘要生成失败不影响主流程（try/except 吞掉异常）。
-        使用独立的 Neo4j 连接器，避免与主连接器的事务冲突。
+        直接复用 self._neo4j_connector，避免每次写入额外创建一个 driver。
         """
         from app.core.memory.storage_services.extraction_engine.knowledge_extraction.memory_summary import (
             memory_summary_generation,
@@ -707,7 +707,6 @@ class WritePipeline:
             add_memory_summary_statement_edges,
         )
         from app.repositories.neo4j.add_nodes import add_memory_summary_nodes
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
         try:
             summaries = await memory_summary_generation(
@@ -716,15 +715,8 @@ class WritePipeline:
                 embedder_client=self._embedder_client,
                 language=self.language,
             )
-            ms_connector = Neo4jConnector()
-            try:
-                await add_memory_summary_nodes(summaries, ms_connector)
-                await add_memory_summary_statement_edges(summaries, ms_connector)
-            finally:
-                try:
-                    await ms_connector.close()
-                except Exception:
-                    pass
+            await add_memory_summary_nodes(summaries, self._neo4j_connector)
+            await add_memory_summary_statement_edges(summaries, self._neo4j_connector)
         except Exception as e:
             logger.error(f"Memory summary step failed: {e}", exc_info=True)
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1308,7 +1308,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1318,7 +1318,7 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       e.activation_value AS activation_value,
+       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1335,7 +1335,7 @@ RETURN e.id AS id
 GET_COMMUNITY_MEMBERS = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
 RETURN e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, e.activation_value AS activation_value,
+       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description,
        e.example AS example
@@ -1355,7 +1355,7 @@ GET_ALL_COMMUNITY_MEMBERS_BATCH = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN c.community_id AS community_id,
        e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, e.activation_value AS activation_value,
+       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description
 ORDER BY c.community_id, coalesce(e.activation_value, 0) DESC
@@ -1402,7 +1402,7 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       e.activation_value AS activation_value,
+       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 ORDER BY e.id
 SKIP $skip LIMIT $limit
@@ -1425,7 +1425,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1450,7 +1450,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 

--- a/api/app/repositories/neo4j/neo4j_connector.py
+++ b/api/app/repositories/neo4j/neo4j_connector.py
@@ -63,6 +63,11 @@ class Neo4jConnector:
         
         从配置文件和环境变量中读取连接信息。
         
+        Args:
+            shared_driver: 是否使用进程级共享 driver。
+                True  → 所有实例共用一个 driver，通过 PID 检测 fork 后自动重建。
+                False → 每次实例化创建独立 driver（调用方需自行管理生命周期）。
+        
         Raises:
             RuntimeError: 如果NEO4J_PASSWORD环境变量未设置
         """
@@ -82,11 +87,21 @@ class Neo4jConnector:
             )
         return AsyncGraphDatabase.driver(
             uri,
-            auth=basic_auth(username, password)
+            auth=basic_auth(username, password),
+            max_connection_pool_size=settings.NEO4J_MAX_POOL_SIZE,
+            connection_acquisition_timeout=settings.NEO4J_ACQ_TIMEOUT,
+            max_connection_lifetime=settings.NEO4J_MAX_CONN_LIFETIME,
+            connection_timeout=settings.NEO4J_CONN_TIMEOUT,
         )
 
     def _create_or_get_driver(self) -> AsyncDriver:
-        """按配置返回独占或进程级共享的 driver。"""
+        """按配置返回独占或进程级共享的 driver。
+        
+        shared_driver=True 时：
+        - 检测当前 PID 是否与 _shared_driver_pid 一致
+        - PID 变化（fork 后）或首次调用时自动重建
+        - 线程安全（threading.Lock 保护）
+        """
         if not self._shared_driver_enabled:
             return self._build_driver()
 
@@ -113,6 +128,7 @@ class Neo4jConnector:
         """关闭数据库连接
 
         释放数据库连接资源。应在应用程序关闭时调用。
+        共享 driver 不在此处关闭，由 shutdown() 统一管理。
         """
         if self._shared_driver_enabled:
             return
@@ -138,7 +154,7 @@ class Neo4jConnector:
         Returns:
             List[Dict[str, Any]]: 查询结果列表，每个元素是一个字典
             
-        Example:
+
 
         """
         result = await self.driver.execute_query(
@@ -165,7 +181,7 @@ class Neo4jConnector:
         Returns:
             Any: 事务函数的返回值
             
-        Example:
+
 
         """
         async with self.driver.session(database="neo4j") as session:
@@ -183,7 +199,7 @@ class Neo4jConnector:
         Returns:
             Any: 事务函数的返回值
             
-        Example:
+
 
         """
         async with self.driver.session(database="neo4j") as session:
@@ -197,9 +213,6 @@ class Neo4jConnector:
         
         Args:
             end_user_id: 要删除的组ID
-            
-        Example:
-            Group group_123 deleted.
         """
         batch_size = 1000
         total_deleted = 0

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -46,7 +46,7 @@ logger = get_logger(__name__)
 config_logger = get_config_logger()
 
 # Initialize Neo4j connector for analytics functions
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 # 标记当前 task/coroutine 已持有 per-end_user 写入锁（避免重入死锁）
 # 由 flush_conversation_task 在 worker 上下文中设置，防止下游重复加锁

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -40,7 +40,7 @@ config_logger = get_config_logger()
 
 # Load environment variables for Neo4j connector
 load_dotenv()
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 
 class MemoryStorageService:

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -46,7 +46,7 @@ from app.services.memory_short_service import LongService, ShortService
 logger = get_logger(__name__)
 
 # Neo4j connector instance for analytics functions
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 # Default LLM ID for fallback
 DEFAULT_LLM_ID = os.getenv("SELECTED_LLM_ID", "openai/qwen-plus")


### PR DESCRIPTION
## Summary by Sourcery

简化裁剪管线：仅在 Redis 中缓存 LLM 裁剪结果，将 Neo4j 写入操作移到图构建步骤中完成，并通过可配置的共享驱动及更安全的默认值来优化 Neo4j 的使用。

Enhancements:
- 将 `PruningPipeline` 中直接写入 Neo4j 的职责移除，只将其视为一个基于 Redis 的裁剪结果缓存。
- 在写入管线的汇总步骤中重用现有的 Neo4j 连接器，而不是在每次运行中创建并销毁单独的连接器。
- 引入可配置的 Neo4j 连接池参数（池大小、获取连接超时、最大连接生命周期、连接超时），从环境变量中加载。
- 更新 Neo4j 的 Cypher 查询，在值为 null 时使用默认的 `activation_value`，以保证下游使用时对 null 更安全。

Build:
- 调整 Neo4j 驱动的构造方式，使用来自配置的显式连接池和超时设置。

Chores:
- 在与内存相关的服务中启用进程范围共享的 Neo4j 驱动，并在 Celery worker 中添加针对派生进程的安全重新初始化逻辑，以便在 worker 派生（fork）后重置共享驱动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the pruning pipeline to only cache LLM pruning results in Redis while moving Neo4j writes to the graph build step, and optimize Neo4j usage via a configurable shared driver and safer defaults.

Enhancements:
- Remove direct Neo4j write responsibilities from PruningPipeline and treat it purely as a Redis-backed pruning cache.
- Reuse the existing Neo4j connector in the write pipeline summary step instead of creating and tearing down a separate connector for each run.
- Introduce configurable Neo4j connection pool parameters (pool size, acquisition timeout, max connection lifetime, connection timeout) loaded from environment variables.
- Update Neo4j cypher queries to use a default activation_value when null to make downstream consumers null-safe.

Build:
- Tune Neo4j driver construction with explicit connection pool and timeout settings sourced from configuration.

Chores:
- Enable process-wide shared Neo4j drivers in memory-related services and add fork-safe reinitialization logic in the Celery worker to reset shared drivers after worker forks.

</details>