### PR TITLE
Refactor/clustering cleanup

### DIFF
--- a/api/app/celery_worker.py
+++ b/api/app/celery_worker.py
@@ -35,6 +35,7 @@ def _reinit_db_pool(**kwargs):
     fork() 后子进程继承了父进程的：
     1. SQLAlchemy 连接池 — 多进程共享 TCP socket 导致 DB 连接损坏
     2. ThreadPoolExecutor — fork 后线程状态不确定，第二个任务会死锁
+    3. Neo4j shared driver — fork 后 socket 和 event loop 失效
     """
     # 重建 DB 连接池
     from app.db import engine
@@ -59,6 +60,18 @@ def _reinit_db_pool(**kwargs):
         logger.info("libre_office.executor recreated")
     except Exception as e:
         logger.warning(f"Failed to recreate libre_office.executor: {e}")
+
+    # 重置进程级共享 Neo4j driver（fork 后子进程继承了失效的 socket 和 event loop）
+    # 子进程首次执行 Neo4j 查询时，_create_or_get_driver() 会检测到 _shared_driver is None
+    # 并自动重建全新 driver（新 socket + 新 event loop）。
+    # 依赖 P0-a：模块级单例必须使用 shared_driver=True，才会走此 PID 自愈路径。
+    try:
+        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+        Neo4jConnector._shared_driver = None
+        Neo4jConnector._shared_driver_pid = None
+        logger.info("Neo4j shared driver reset for forked worker process")
+    except Exception as e:
+        logger.warning(f"Failed to reset Neo4j shared driver: {e}")
 
 
 __all__ = ['celery_app']

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -37,6 +37,12 @@ class Settings:
     NEO4J_URI: str = os.getenv("NEO4J_URI", "bolt://1.94.111.67:7687")
     NEO4J_USERNAME: str = os.getenv("NEO4J_USERNAME", "neo4j")
     NEO4J_PASSWORD: str = os.getenv("NEO4J_PASSWORD", "")
+    # Neo4j 连接池参数（通过环境变量可配）
+    # 默认值参考文档建议值，兼顾资源占用与并发需求
+    NEO4J_MAX_POOL_SIZE: int = int(os.getenv("NEO4J_MAX_POOL_SIZE", "30"))
+    NEO4J_ACQ_TIMEOUT: float = float(os.getenv("NEO4J_ACQ_TIMEOUT", "30.0"))
+    NEO4J_MAX_CONN_LIFETIME: int = int(os.getenv("NEO4J_MAX_CONN_LIFETIME", "3600"))
+    NEO4J_CONN_TIMEOUT: float = float(os.getenv("NEO4J_CONN_TIMEOUT", "30.0"))
 
     # Database configuration (Postgres)
     DB_HOST: str = os.getenv("DB_HOST", "127.0.0.1")

--- a/api/app/core/memory/pipelines/pruning_pipeline.py
+++ b/api/app/core/memory/pipelines/pruning_pipeline.py
@@ -4,8 +4,11 @@ PruningPipeline — 单条 assistant 消息语义剪枝流水线
 职责：
 - 对单条 assistant 消息执行语义剪枝，输出剪枝后内容（A'）
 - 先查询 Redis 缓存，命中则直接返回，避免重复 LLM 调用
-- 未命中则调用 SemanticPruner 执行剪枝，结果写入 Neo4j 和 Redis 缓存
+- 未命中则调用 SemanticPruner 执行剪枝，结果写入 Redis 缓存
 - 作为 WritePipeline 的预处理步骤被调用，其结果可跨任务缓存复用
+
+流程：Redis 缓存 → LLM 剪枝 → Redis 写入
+（Neo4j 写入已迁移至 graph_build_step，通过 assistant_pruning_records metadata 统一处理），现在移除neo4j连接相关内容
 
 Redis key 格式：pruning:{conversation_id}:{message_seq}
 TTL：86400 秒（24 小时）
@@ -17,11 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
-from uuid import uuid4
-
-from app.core.utils.datetime_utils import to_iso_z
 
 if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
@@ -35,12 +34,12 @@ _MEMORY_TYPE_NULL = "NULL"
 class PruningPipeline:
     """单条 assistant 消息语义剪枝流水线。
 
-    对单条 assistant 消息执行语义剪枝，输出 A'，写入 Neo4j 并缓存到 Redis。
+    对单条 assistant 消息执行语义剪枝，输出 A'，缓存到 Redis。
 
     流程：
     1. 查 Redis 缓存 pruning:{conversation_id}:{message_seq}
     2. 命中 → 直接返回 A'
-    3. 未命中 → 调用 LLM 剪枝 → 写 Neo4j → 写 Redis → 返回 A'
+    3. 未命中 → 调用 LLM 剪枝 → 写 Redis → 返回 A'
     """
 
     CACHE_TTL = 86400  # 24 小时兜底
@@ -61,9 +60,8 @@ class PruningPipeline:
         self.end_user_id = end_user_id
         self.language = language
 
-        # 延迟初始化的客户端
+        # 延迟初始化的 LLM 客户端
         self._llm_client = None
-        self._neo4j_connector = None
 
     # ──────────────────────────────────────────────
     # 公开接口
@@ -81,7 +79,7 @@ class PruningPipeline:
 
         1. 查 Redis 缓存 pruning:{conversation_id}:{message_seq}
         2. 命中 → 直接返回 A'（source="cache"）
-        3. 未命中 → 调用 LLM 剪枝 → 写 Neo4j → 写 Redis → 返回 A'（source="llm"）
+        3. 未命中 → 调用 LLM 剪枝 → 写 Redis → 返回 A'（source="llm"）
 
         Args:
             conversation_id: 对话 ID
@@ -137,10 +135,7 @@ class PruningPipeline:
             user_content=user_content,
         )
 
-        # Step 3: Neo4j 写入已统一移至 graph_build_step（通过 assistant_pruning_records metadata），
-        # 此处不再直接写入，避免产生重复边。
-
-        # Step 4: 写入 Redis 缓存（TTL=86400s）
+        # Step 3: 写入 Redis 缓存（TTL=86400s）
         try:
             await self._set_to_cache(cache_key, pruned_content, memory_type)
         except Exception as e:
@@ -250,166 +245,6 @@ class PruningPipeline:
         return result.assistant_memory_hint, result.assistant_memory_type, result.should_process_user_msg, result.processed_user_msg
 
     # ──────────────────────────────────────────────
-    # 内部方法：Neo4j 写入
-    # ──────────────────────────────────────────────
-
-    async def _write_to_neo4j(
-        self,
-        conversation_id: str,
-        message_seq: int,
-        original_content: str,
-        pruned_content: str,
-    ) -> None:
-        """将剪枝结果写入 Neo4j（AssistantOriginal + AssistantPruned + Conversation 中心节点）。
-
-        创建：
-        - Conversation 中心节点：id == conversation_id，MERGE 幂等，跨写入复用
-        - AssistantOriginal 节点：存储原始 assistant 消息
-        - AssistantPruned 节点：存储剪枝后内容（A'）
-        - PRUNED_TO 边：连接 Original → Pruned
-        - BELONGS_TO_CONVERSATION 边：连接 Original → Conversation 中心节点，
-          使同一会话的 assistant 剪枝节点聚成一个连通子图
-
-        Args:
-            conversation_id: 对话 ID（用作 dialog_id 和 Conversation 中心节点 id）
-            message_seq: 消息序号（用于节点命名）
-            original_content: assistant 消息原始内容
-            pruned_content: 剪枝后内容（A'）
-        """
-        from app.core.memory.models.graph_models import (
-            AssistantOriginalNode,
-            AssistantPrunedNode,
-            AssistantPrunedEdge,
-            ConversationNode,
-            AssistantConversationEdge,
-        )
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-        from app.repositories.neo4j.cypher_queries import (
-            ASSISTANT_ORIGINAL_NODE_SAVE,
-            ASSISTANT_PRUNED_NODE_SAVE,
-            ASSISTANT_PRUNED_EDGE_SAVE,
-            CONVERSATION_NODE_SAVE,
-            ASSISTANT_CONVERSATION_EDGE_SAVE,
-        )
-
-        now = datetime.now(timezone.utc)
-        run_id = uuid4().hex
-        pair_id = uuid4().hex
-
-        # 构建节点 ID（基于 conversation_id + message_seq 保证幂等性）
-        original_id = f"orig_{conversation_id}_{message_seq}"
-        pruned_id = f"pruned_{conversation_id}_{message_seq}"
-
-        original_node = AssistantOriginalNode(
-            id=original_id,
-            name=f"AssistantOriginal_{message_seq}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-            dialog_id=conversation_id,
-            text=original_content,
-        )
-
-        pruned_node = AssistantPrunedNode(
-            id=pruned_id,
-            name=f"AssistantPruned_{message_seq}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-            dialog_id=conversation_id,
-            text=pruned_content if pruned_content else "NULL",
-            memory_type="NULL",  # 单条剪枝时 memory_type 由 LLM 返回，此处简化为 NULL
-        )
-
-        pruned_edge = AssistantPrunedEdge(
-            source=original_id,
-            target=pruned_id,
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            pair_id=pair_id,
-        )
-
-        # Conversation 中心节点：id == conversation_id，跨写入任务用 MERGE 复用。
-        # 所有 AssistantOriginal 通过 BELONGS_TO_CONVERSATION 挂到该节点，
-        # 使同一会话的 assistant 剪枝节点在图谱中聚成一个连通子图。
-        conversation_node = ConversationNode(
-            id=conversation_id,
-            name=f"Conversation_{conversation_id}",
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-            conversation_id=conversation_id,
-        )
-
-        conversation_edge = AssistantConversationEdge(
-            source=original_id,
-            target=conversation_id,
-            end_user_id=self.end_user_id,
-            run_id=run_id,
-            created_at=now,
-        )
-
-        # 确保 Neo4j 连接器已初始化
-        self._ensure_neo4j_connector()
-
-        async def _write_in_transaction(tx):
-            # 写入 Conversation 中心节点（MERGE 幂等）
-            conversation_data = [{
-                "id": conversation_node.id,
-                "name": conversation_node.name,
-                "end_user_id": conversation_node.end_user_id,
-                "conversation_id": conversation_node.conversation_id,
-                "run_id": conversation_node.run_id,
-                "created_at": conversation_node.created_at.isoformat(),
-            }]
-            result = await tx.run(CONVERSATION_NODE_SAVE, conversations=conversation_data)
-            await result.consume()
-
-            # 写入 AssistantOriginal 节点
-            original_data = [original_node.model_dump()]
-            result = await tx.run(ASSISTANT_ORIGINAL_NODE_SAVE, originals=original_data)
-            await result.consume()
-
-            # 写入 AssistantPruned 节点
-            pruned_data = [pruned_node.model_dump()]
-            result = await tx.run(ASSISTANT_PRUNED_NODE_SAVE, pruneds=pruned_data)
-            await result.consume()
-
-            # 写入 PRUNED_TO 边
-            edge_data = [{
-                "source": pruned_edge.source,
-                "target": pruned_edge.target,
-                "pair_id": pruned_edge.pair_id,
-                "end_user_id": pruned_edge.end_user_id,
-                "run_id": pruned_edge.run_id,
-                "created_at": to_iso_z(pruned_edge.created_at),
-            }]
-            result = await tx.run(ASSISTANT_PRUNED_EDGE_SAVE, edges=edge_data)
-            await result.consume()
-
-            # 写入 BELONGS_TO_CONVERSATION 边（Original → Conversation 中心节点）
-            conv_edge_data = [{
-                "id": conversation_edge.id,
-                "source": conversation_edge.source,
-                "target": conversation_edge.target,
-                "end_user_id": conversation_edge.end_user_id,
-                "run_id": conversation_edge.run_id,
-                "created_at": conversation_edge.created_at.isoformat(),
-            }]
-            result = await tx.run(ASSISTANT_CONVERSATION_EDGE_SAVE, edges=conv_edge_data)
-            await result.consume()
-
-        await self._neo4j_connector.execute_write_transaction(_write_in_transaction)
-        logger.info(
-            f"[PruningPipeline] Neo4j 写入完成: "
-            f"conv={conversation_id}, seq={message_seq}, "
-            f"original_id={original_id}, pruned_id={pruned_id}"
-        )
-
-    # ──────────────────────────────────────────────
     # 内部方法：Redis 缓存读写
     # ──────────────────────────────────────────────
 
@@ -499,22 +334,6 @@ class PruningPipeline:
 
         logger.info("[PruningPipeline] LLM 客户端初始化完成")
 
-    def _ensure_neo4j_connector(self) -> None:
-        """确保 Neo4j 连接器已初始化（懒加载）。"""
-        if self._neo4j_connector is not None:
-            return
-
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-
-        self._neo4j_connector = Neo4jConnector()
-        logger.info("[PruningPipeline] Neo4j 连接器初始化完成")
-
     async def close(self) -> None:
-        """释放资源：关闭 Neo4j 连接器。"""
-        if self._neo4j_connector is not None:
-            try:
-                await self._neo4j_connector.close()
-            except Exception as e:
-                logger.warning(f"[PruningPipeline] Neo4j 连接器关闭失败: {e}")
-            finally:
-                self._neo4j_connector = None
+        """资源释放（当前无持久资源，预留给将来扩展）。"""
+        pass

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -698,7 +698,7 @@ class WritePipeline:
         摘要：生成情景记忆摘要 → 写入 Neo4j。
 
         摘要生成失败不影响主流程（try/except 吞掉异常）。
-        使用独立的 Neo4j 连接器，避免与主连接器的事务冲突。
+        直接复用 self._neo4j_connector，避免每次写入额外创建一个 driver。
         """
         from app.core.memory.storage_services.extraction_engine.knowledge_extraction.memory_summary import (
             memory_summary_generation,
@@ -707,7 +707,6 @@ class WritePipeline:
             add_memory_summary_statement_edges,
         )
         from app.repositories.neo4j.add_nodes import add_memory_summary_nodes
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
         try:
             summaries = await memory_summary_generation(
@@ -716,15 +715,8 @@ class WritePipeline:
                 embedder_client=self._embedder_client,
                 language=self.language,
             )
-            ms_connector = Neo4jConnector()
-            try:
-                await add_memory_summary_nodes(summaries, ms_connector)
-                await add_memory_summary_statement_edges(summaries, ms_connector)
-            finally:
-                try:
-                    await ms_connector.close()
-                except Exception:
-                    pass
+            await add_memory_summary_nodes(summaries, self._neo4j_connector)
+            await add_memory_summary_statement_edges(summaries, self._neo4j_connector)
         except Exception as e:
             logger.error(f"Memory summary step failed: {e}", exc_info=True)
 

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -651,40 +651,39 @@ class WritePipeline:
         两阶段去重消歧（_run_dedup_and_write_summary）后的结果，
         聚类直接基于去重后的实体 ID 执行。
 
-        P6 修复：改用 scheduler.push_task 替代 apply_async 直接投递，
-        利用 scheduler 内置 lock_key = f"{task_name}:{user_id}" 保证同用户
-        聚类任务串行排队执行，消除同用户多任务并行导致的 Neo4j 死锁问题。
+        派发方式：直接使用 run_incremental_clustering.apply_async 投递到
+        memory_heavy_tasks 队列（不再经 scheduler.push_task）。
+        同用户聚类并发导致的 Neo4j 锁竞争，由 P0 批量 UNWIND（事务毫秒级）
+        + Neo4j 死锁自动重试两层防御兜底。
         """
         if not result.entity_nodes:
             return
 
         try:
-            from app.celery_task_scheduler import scheduler
+            from app.tasks import run_incremental_clustering
 
             new_entity_ids = [e.id for e in result.entity_nodes]
-            params = {
-                "end_user_id": self.end_user_id,
-                "new_entity_ids": new_entity_ids,
-                "llm_model_id": (
-                    str(self.memory_config.llm_model_id)
-                    if self.memory_config.llm_model_id
-                    else None
-                ),
-                "embedding_model_id": (
-                    str(self.memory_config.embedding_model_id)
-                    if self.memory_config.embedding_model_id
-                    else None
-                ),
-                "language": self.language,
-            }
-            msg_id = scheduler.push_task(
-                task_name="app.tasks.run_incremental_clustering",
-                user_id=self.end_user_id,
-                params=params,
+            task = run_incremental_clustering.apply_async(
+                kwargs={
+                    "end_user_id": self.end_user_id,
+                    "new_entity_ids": new_entity_ids,
+                    "llm_model_id": (
+                        str(self.memory_config.llm_model_id)
+                        if self.memory_config.llm_model_id
+                        else None
+                    ),
+                    "embedding_model_id": (
+                        str(self.memory_config.embedding_model_id)
+                        if self.memory_config.embedding_model_id
+                        else None
+                    ),
+                    "language": self.language,
+                },
+                priority=3,
             )
             logger.info(
-                f"[Clustering] 增量聚类任务已入队（scheduler） - "
-                f"msg_id={msg_id}, "
+                f"[Clustering] 增量聚类任务已提交 - "
+                f"task_id={task.id}, "
                 f"entity_count={len(new_entity_ids)}, "
                 f"source=dedup"
             )

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -650,36 +650,42 @@ class WritePipeline:
         注意：ExtractionResult.entity_nodes 已经是经过 _extract() 中
         两阶段去重消歧（_run_dedup_and_write_summary）后的结果，
         聚类直接基于去重后的实体 ID 执行。
+
+        P6 修复：改用 scheduler.push_task 替代 apply_async 直接投递，
+        利用 scheduler 内置 lock_key = f"{task_name}:{user_id}" 保证同用户
+        聚类任务串行排队执行，消除同用户多任务并行导致的 Neo4j 死锁问题。
         """
         if not result.entity_nodes:
             return
 
         try:
-            from app.tasks import run_incremental_clustering
+            from app.celery_task_scheduler import scheduler
 
             new_entity_ids = [e.id for e in result.entity_nodes]
-            task = run_incremental_clustering.apply_async(
-                kwargs={
-                    "end_user_id": self.end_user_id,
-                    "new_entity_ids": new_entity_ids,
-                    "llm_model_id": (
-                        str(self.memory_config.llm_model_id)
-                        if self.memory_config.llm_model_id
-                        else None
-                    ),
-                    "embedding_model_id": (
-                        str(self.memory_config.embedding_model_id)
-                        if self.memory_config.embedding_model_id
-                        else None
-                    ),
-                    "language": self.language,
-                },
-                priority=3,
+            params = {
+                "end_user_id": self.end_user_id,
+                "new_entity_ids": new_entity_ids,
+                "llm_model_id": (
+                    str(self.memory_config.llm_model_id)
+                    if self.memory_config.llm_model_id
+                    else None
+                ),
+                "embedding_model_id": (
+                    str(self.memory_config.embedding_model_id)
+                    if self.memory_config.embedding_model_id
+                    else None
+                ),
+                "language": self.language,
+            }
+            msg_id = scheduler.push_task(
+                task_name="app.tasks.run_incremental_clustering",
+                user_id=self.end_user_id,
+                params=params,
             )
             logger.info(
-                f"[Clustering] 增量聚类任务已提交 - "
-                f"task_id = {task.id}, "
-                f"entity_count = {len(new_entity_ids)}, "
+                f"[Clustering] 增量聚类任务已入队（scheduler） - "
+                f"msg_id={msg_id}, "
+                f"entity_count={len(new_entity_ids)}, "
                 f"source=dedup"
             )
         except Exception as e:

--- a/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
+++ b/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
@@ -24,6 +24,18 @@ MAX_ITERATIONS = 10
 # 社区核心实体取 top-N 数量
 CORE_ENTITY_LIMIT = 10
 
+# P4：prompt 中最多引用的成员数，防止超大社区超出 LLM 输入上限
+MAX_MEMBERS_FOR_PROMPT = 50
+
+# P4：社区合并后允许的最大规模，防止超级社区
+MAX_COMMUNITY_SIZE = 200
+
+# P2：incremental_update 每批并发处理的实体数
+CONCURRENT_BATCH = 10
+
+# P1：_generate_community_metadata 最大并发 Neo4j 查询数（不超过连接池上限）
+METADATA_PREPARE_CONCURRENCY = 10
+
 
 def _cosine_similarity(v1: Optional[List[float]], v2: Optional[List[float]]) -> float:
     """计算两个向量的余弦相似度，任一为空则返回 0。"""
@@ -219,15 +231,25 @@ class LabelPropagationEngine:
         2. 加权多数投票决定社区归属
         3. 若邻居无社区 → 创建新社区
         4. 若邻居分属多个社区 → 评估是否合并
+
+        P2 修复：改为按批（每批 CONCURRENT_BATCH 个）并发处理，
+        避免大批量新实体时串行积压导致连接池长时间占用。
         """
-        # 收集所有需要生成元数据的社区ID
         communities_to_update = set()
-        
-        for entity_id in new_entity_ids:
-            cid = await self._process_single_entity(entity_id, end_user_id)
-            if cid:
-                communities_to_update.add(cid)
-        
+
+        # 分批并发，每批最多 CONCURRENT_BATCH 个实体
+        for i in range(0, len(new_entity_ids), CONCURRENT_BATCH):
+            batch = new_entity_ids[i:i + CONCURRENT_BATCH]
+            results = await asyncio.gather(
+                *[self._process_single_entity(eid, end_user_id) for eid in batch],
+                return_exceptions=True,
+            )
+            for res in results:
+                if isinstance(res, Exception):
+                    logger.warning(f"[Clustering] _process_single_entity 失败（已忽略）: {res}")
+                elif res:
+                    communities_to_update.add(res)
+
         # 批量生成所有社区的元数据
         if communities_to_update:
             await self._generate_community_metadata(list(communities_to_update), end_user_id, force=True)
@@ -307,52 +329,31 @@ class LabelPropagationEngine:
         """
         评估多个社区是否应合并。
 
-        策略：计算各社区成员 embedding 的平均向量，若两两余弦相似度 > 0.75 则合并。
+        策略：计算各社区成员 embedding 的平均向量，若两两余弦相似度 > MERGE_THRESHOLD 则合并。
         合并时保留成员数最多的社区，其余成员迁移过来。
 
-        全量场景（社区数 > 20）使用批量查询，避免 N 次数据库往返。
+        P7 修复：改为 Neo4j 侧计算平均向量（APOC 聚合），不再拉取全量成员到 Python，
+                 将 ~62 MB 内存峰值降至几百 KB。
+        P3 修复：合并成员迁移改为 batch_assign_entities_to_communities，消除逐成员循环写。
+        P4 修复：合并前检查合并后规模，超过 MAX_COMMUNITY_SIZE 时跳过，防止超级社区。
         """
         MERGE_THRESHOLD = 0.85
-        BATCH_THRESHOLD = 20  # 超过此数量走批量查询
 
         community_embeddings: Dict[str, Optional[List[float]]] = {}
         community_sizes: Dict[str, int] = {}
 
-        if len(community_ids) > BATCH_THRESHOLD:
-            # 批量查询：一次拉取所有社区成员
-            all_members = await self.repo.get_all_community_members_batch(
-                community_ids, end_user_id
-            )
-            for cid in community_ids:
-                members = all_members.get(cid, [])
-                community_sizes[cid] = len(members)
-                valid_embeddings = [
-                    m["name_embedding"] for m in members if m.get("name_embedding")
-                ]
-                if valid_embeddings:
-                    dim = len(valid_embeddings[0])
-                    community_embeddings[cid] = [
-                        sum(e[i] for e in valid_embeddings) / len(valid_embeddings)
-                        for i in range(dim)
-                    ]
-                else:
-                    community_embeddings[cid] = None
-        else:
-            # 增量场景：逐个查询
-            for cid in community_ids:
+        # P7：Neo4j 侧批量计算平均 embedding，无需拉取全量成员到 Python
+        avg_data = await self.repo.get_community_avg_embeddings_batch(community_ids, end_user_id)
+        for cid in community_ids:
+            entry = avg_data.get(cid)
+            if entry:
+                community_sizes[cid] = entry["member_count"]
+                community_embeddings[cid] = entry["avg_embedding"]
+            else:
+                # 无带 embedding 成员的社区：回退到查询成员数
                 members = await self.repo.get_community_members(cid, end_user_id)
                 community_sizes[cid] = len(members)
-                valid_embeddings = [
-                    m["name_embedding"] for m in members if m.get("name_embedding")
-                ]
-                if valid_embeddings:
-                    dim = len(valid_embeddings[0])
-                    community_embeddings[cid] = [
-                        sum(e[i] for e in valid_embeddings) / len(valid_embeddings)
-                        for i in range(dim)
-                    ]
-                else:
-                    community_embeddings[cid] = None
+                community_embeddings[cid] = None
 
         # 找出应合并的社区对
         to_merge: List[tuple] = []
@@ -385,6 +386,15 @@ class LabelPropagationEngine:
             if root1 == root2:
                 continue
 
+            # P4：合并规模保护，防止超级社区
+            merged_size = community_sizes.get(root1, 0) + community_sizes.get(root2, 0)
+            if merged_size > MAX_COMMUNITY_SIZE:
+                logger.info(
+                    f"[Clustering] 跳过合并 {root1} ↔ {root2}，"
+                    f"合并后规模 {merged_size} > {MAX_COMMUNITY_SIZE}"
+                )
+                continue
+
             # 用合并后的最新平均向量重新验证相似度
             # 防止链式传递：A≈B 合并后 B 的向量已更新，C 必须和新 B 相似才能合并
             current_sim = _cosine_similarity(
@@ -392,7 +402,6 @@ class LabelPropagationEngine:
                 community_embeddings.get(root2),
             )
             if current_sim <= MERGE_THRESHOLD:
-                # 合并后向量已漂移，不再满足阈值，跳过
                 logger.debug(
                     f"[Clustering] 跳过合并 {root1} ↔ {root2}，"
                     f"当前相似度 {current_sim:.3f} ≤ {MERGE_THRESHOLD}"
@@ -403,11 +412,13 @@ class LabelPropagationEngine:
             dissolve = root2 if keep == root1 else root1
             merged_into[dissolve] = keep
 
+            # P3：批量迁移成员，一次 UNWIND 替代逐成员循环写
             members = await self.repo.get_community_members(dissolve, end_user_id)
-            for m in members:
-                await self.repo.assign_entity_to_community(m["id"], keep, end_user_id)
+            if members:
+                assignments = [{"entity_id": m["id"], "community_id": keep} for m in members]
+                await self.repo.batch_assign_entities_to_communities(assignments, end_user_id)
 
-            # 合并后重新计算 keep 的平均向量（加权平均）
+            # 合并后更新内存中的平均向量（加权平均），供后续对比使用
             keep_emb = community_embeddings.get(keep)
             dissolve_emb = community_embeddings.get(dissolve)
             keep_size = community_sizes.get(keep, 0)
@@ -432,21 +443,30 @@ class LabelPropagationEngine:
     async def _flush_labels(
         self, labels: Dict[str, str], end_user_id: str
     ) -> None:
-        """将内存中的标签批量写入 Neo4j。"""
-        # 先创建所有唯一社区节点
+        """将内存中的标签批量写入 Neo4j。
+
+        P0 修复：用单条 UNWIND Cypher 替代 N×2 次串行查询，
+        将 10000 实体原先 ~600s 的写入阶段压缩到秒级。
+        """
         unique_communities = set(labels.values())
+
+        # 先创建所有唯一社区节点（数量远少于实体，串行可接受）
         for cid in unique_communities:
             await self.repo.upsert_community(cid, end_user_id)
 
-        # 再批量分配实体
-        for entity_id, community_id in labels.items():
-            await self.repo.assign_entity_to_community(
-                entity_id, community_id, end_user_id
-            )
+        # 批量分配实体：一次 UNWIND 替代 N×2 次串行 Cypher
+        assignments = [
+            {"entity_id": eid, "community_id": cid}
+            for eid, cid in labels.items()
+        ]
+        await self.repo.batch_assign_entities_to_communities(assignments, end_user_id)
+        logger.info(f"[Clustering] _flush_labels 批量写入完成，实体数={len(assignments)}，社区数={len(unique_communities)}")
 
-        # 刷新成员数
-        for cid in unique_communities:
-            await self.repo.refresh_member_count(cid, end_user_id)
+        # 刷新成员数（并发执行）
+        await asyncio.gather(
+            *[self.repo.refresh_member_count(cid, end_user_id) for cid in unique_communities],
+            return_exceptions=True,
+        )
 
     async def _get_entity_embedding(
         self, entity_id: str, end_user_id: str
@@ -521,7 +541,9 @@ class LabelPropagationEngine:
                 # 准备 LLM prompt（如果配置了 LLM）
                 prompt = None
                 if self.llm_model_id:
-                    entity_list_str = "\n".join(self._build_entity_lines(members))
+                    # P4：只取 Top-MAX_MEMBERS_FOR_PROMPT 成员参与 prompt，防止超大社区超出 LLM 输入上限
+                    prompt_members = sorted_members[:MAX_MEMBERS_FOR_PROMPT]
+                    entity_list_str = "\n".join(self._build_entity_lines(prompt_members))
                     relationships = await self.repo.get_community_relationships(cid, end_user_id)
                     rel_lines = [
                         f"- {r['subject']} → {r['predicate']} → {r['object']}"
@@ -568,9 +590,18 @@ class LabelPropagationEngine:
                 logger.error(f"[Clustering] 社区 {cid} 元数据准备失败: {e}", exc_info=True)
                 return None
 
-        # --- 阶段1：并发准备所有社区数据 ---
+        # --- 阶段1：并发准备所有社区数据（P1：Semaphore 限制并发 Neo4j 查询数） ---
+        # 每个 _prepare_one 内部有 2 次 Neo4j 查询（get_community_members + get_community_relationships）
+        # Semaphore(METADATA_PREPARE_CONCURRENCY) 确保最多同时 METADATA_PREPARE_CONCURRENCY 个社区并发查询，
+        # 不超过连接池上限，避免大量社区时连接超时断连
+        sem = asyncio.Semaphore(METADATA_PREPARE_CONCURRENCY)
+
+        async def _prepare_one_limited(cid: str) -> Optional[Dict]:
+            async with sem:
+                return await _prepare_one(cid)
+
         results = await asyncio.gather(
-            *[_prepare_one(cid) for cid in community_ids],
+            *[_prepare_one_limited(cid) for cid in community_ids],
             return_exceptions=True,
         )
         metadata_list = []
@@ -598,17 +629,21 @@ class LabelPropagationEngine:
                 if prompts_to_process:
                     logger.info(f"[Clustering] 批量调用 LLM 生成 {len(prompts_to_process)} 个社区元数据")
                     
+                    # LLM 并发限流：避免大量社区同时调用触发 LLM 侧限流
+                    llm_sem = asyncio.Semaphore(5)
+
                     async def _call_llm(idx: int, meta: Dict) -> tuple:
-                        """单个 LLM 调用"""
-                        try:
-                            response = await llm_client.chat([{"role": "user", "content": meta["prompt"]}])
-                            text = response.content if hasattr(response, "content") else str(response)
-                            return (idx, text, None)
-                        except Exception as e:
-                            logger.warning(f"[Clustering] 社区 {meta['community_id']} LLM 生成失败: {e}")
-                            return (idx, None, e)
+                        """单个 LLM 调用（受 Semaphore 保护）"""
+                        async with llm_sem:
+                            try:
+                                response = await llm_client.chat([{"role": "user", "content": meta["prompt"]}])
+                                text = response.content if hasattr(response, "content") else str(response)
+                                return (idx, text, None)
+                            except Exception as e:
+                                logger.warning(f"[Clustering] 社区 {meta['community_id']} LLM 生成失败: {e}")
+                                return (idx, None, e)
                     
-                    # 并发调用所有 LLM 请求
+                    # 并发调用所有 LLM 请求（最多 5 个同时进行）
                     llm_results = await asyncio.gather(
                         *[_call_llm(idx, meta) for idx, meta in prompts_to_process],
                         return_exceptions=True

--- a/api/app/repositories/neo4j/community_repository.py
+++ b/api/app/repositories/neo4j/community_repository.py
@@ -19,6 +19,8 @@ from app.repositories.neo4j.cypher_queries import (
     GET_COMMUNITY_MEMBERS,
     GET_COMMUNITY_RELATIONSHIPS,
     GET_ALL_COMMUNITY_MEMBERS_BATCH,
+    BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES,
+    GET_COMMUNITY_AVG_EMBEDDINGS_BATCH,
     GET_ALL_ENTITY_NEIGHBORS_BATCH,
     GET_ENTITY_NEIGHBORS_BATCH_FOR_IDS,
     CHECK_USER_HAS_COMMUNITIES,
@@ -224,6 +226,59 @@ class CommunityRepository:
             return result
         except Exception as e:
             logger.error(f"get_all_community_members_batch failed: {e}")
+            return {}
+
+    async def batch_assign_entities_to_communities(
+        self, assignments: List[Dict], end_user_id: str
+    ) -> bool:
+        """批量将实体分配到社区（UNWIND，一次 Cypher 替代 N×2 次串行查询）。
+
+        Args:
+            assignments: [{"entity_id": str, "community_id": str}, ...]
+            end_user_id: 用户 ID
+
+        Returns:
+            True 表示执行成功（即使部分实体未匹配到也不抛出异常）。
+        """
+        if not assignments:
+            return True
+        try:
+            await self.connector.execute_query(
+                BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES,
+                assignments=assignments,
+                end_user_id=end_user_id,
+            )
+            return True
+        except Exception as e:
+            logger.error(f"batch_assign_entities_to_communities failed: {e}")
+            return False
+
+    async def get_community_avg_embeddings_batch(
+        self, community_ids: List[str], end_user_id: str
+    ) -> Dict[str, Dict]:
+        """批量计算各社区的平均 name_embedding（Neo4j 侧聚合，无需拉取全量成员）。
+
+        Returns:
+            {community_id: {"member_count": int, "avg_embedding": list[float]}}
+            若某社区无带 embedding 的成员，则该 community_id 不在返回字典中。
+        """
+        if not community_ids:
+            return {}
+        try:
+            rows = await self.connector.execute_query(
+                GET_COMMUNITY_AVG_EMBEDDINGS_BATCH,
+                community_ids=community_ids,
+                end_user_id=end_user_id,
+            )
+            result: Dict[str, Dict] = {}
+            for row in rows:
+                result[row["cid"]] = {
+                    "member_count": row["member_count"],
+                    "avg_embedding": row["avg_embedding"],
+                }
+            return result
+        except Exception as e:
+            logger.error(f"get_community_avg_embeddings_batch failed: {e}")
             return {}
 
     async def has_communities(self, end_user_id: str) -> bool:

--- a/api/app/repositories/neo4j/community_repository.py
+++ b/api/app/repositories/neo4j/community_repository.py
@@ -18,10 +18,8 @@ from app.repositories.neo4j.cypher_queries import (
     GET_ENTITIES_PAGE,
     GET_COMMUNITY_MEMBERS,
     GET_COMMUNITY_RELATIONSHIPS,
-    GET_ALL_COMMUNITY_MEMBERS_BATCH,
     BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES,
     GET_COMMUNITY_AVG_EMBEDDINGS_BATCH,
-    GET_ALL_ENTITY_NEIGHBORS_BATCH,
     GET_ENTITY_NEIGHBORS_BATCH_FOR_IDS,
     CHECK_USER_HAS_COMMUNITIES,
     UPDATE_COMMUNITY_MEMBER_COUNT,
@@ -90,26 +88,6 @@ class CommunityRepository:
         except Exception as e:
             logger.error(f"get_entity_neighbors failed: {e}")
             return []
-
-    async def get_all_entity_neighbors_batch(
-        self, end_user_id: str
-    ) -> Dict[str, List[Dict]]:
-        """一次性批量拉取该用户下所有实体的邻居，返回 {entity_id: [neighbors]} 字典。
-        用于全量聚类预加载，避免每个实体单独查询。"""
-        try:
-            rows = await self.connector.execute_query(
-                GET_ALL_ENTITY_NEIGHBORS_BATCH,
-                end_user_id=end_user_id,
-            )
-            result: Dict[str, List[Dict]] = {}
-            for row in rows:
-                eid = row["entity_id"]
-                neighbor = {k: v for k, v in row.items() if k != "entity_id"}
-                result.setdefault(eid, []).append(neighbor)
-            return result
-        except Exception as e:
-            logger.error(f"get_all_entity_neighbors_batch failed: {e}")
-            return {}
 
     async def get_all_entities(self, end_user_id: str) -> List[Dict]:
         """拉取某用户下所有实体及其当前社区归属。"""
@@ -208,25 +186,6 @@ class CommunityRepository:
         except Exception as e:
             logger.error(f"get_community_relationships failed: {e}")
             return []
-
-    async def get_all_community_members_batch(
-        self, community_ids: List[str], end_user_id: str
-    ) -> Dict[str, List[Dict]]:
-        """批量查询多个社区的成员，返回 {community_id: [members]} 字典。"""
-        try:
-            rows = await self.connector.execute_query(
-                GET_ALL_COMMUNITY_MEMBERS_BATCH,
-                community_ids=community_ids,
-                end_user_id=end_user_id,
-            )
-            result: Dict[str, List[Dict]] = {}
-            for row in rows:
-                cid = row["community_id"]
-                result.setdefault(cid, []).append(row)
-            return result
-        except Exception as e:
-            logger.error(f"get_all_community_members_batch failed: {e}")
-            return {}
 
     async def batch_assign_entities_to_communities(
         self, assignments: List[Dict], end_user_id: str

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1349,16 +1349,6 @@ ORDER BY e1.name, r.predicate, e2.name
 LIMIT 20
 """
 
-GET_ALL_COMMUNITY_MEMBERS_BATCH = """
-MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community)
-RETURN c.community_id AS community_id,
-       e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score,
-       e.name_embedding AS name_embedding,
-       e.aliases AS aliases, e.description AS description
-ORDER BY c.community_id, coalesce(e.importance_score, 0) DESC
-"""
-
 # P0 修复：批量将实体分配到社区（UNWIND），替换逐实体循环的 assign_entity_to_community
 BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES = """
 UNWIND $assignments AS row
@@ -1459,30 +1449,6 @@ RETURN DISTINCT
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
-GET_ALL_ENTITY_NEIGHBORS_BATCH = """
-// 批量拉取某用户下所有实体的邻居（用于全量聚类预加载）
-MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
-
-// 来源一：直接关系邻居
-OPTIONAL MATCH (e)-[:EXTRACTED_RELATIONSHIP]-(nb1:ExtractedEntity {end_user_id: $end_user_id})
-
-// 来源二：同 Statement 共现邻居
-OPTIONAL MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e)
-OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(nb2:ExtractedEntity {end_user_id: $end_user_id})
-WHERE nb2.id <> e.id
-
-WITH e, collect(DISTINCT nb1) + collect(DISTINCT nb2) AS all_neighbors
-UNWIND all_neighbors AS nb
-WITH e, nb WHERE nb IS NOT NULL
-OPTIONAL MATCH (nb)-[:BELONGS_TO_COMMUNITY]->(c:Community)
-RETURN DISTINCT
-    e.id                AS entity_id,
-    nb.id               AS id,
-    nb.name             AS name,
-    nb.name_embedding   AS name_embedding,
-    CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
-"""
-
 GET_COMMUNITY_GRAPH_DATA = """
 MATCH (c:Community {end_user_id: $end_user_id})
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[b:BELONGS_TO_COMMUNITY]->(c)
@@ -1534,25 +1500,6 @@ WHERE c.name IS NULL OR c.name = ''
    OR c.core_entities IS NULL
    OR (c.summary_embedding IS NULL AND c.summary IS NOT NULL AND c.summary <> '(empty)')
 RETURN c.community_id AS community_id
-"""
-
-# Community 向量检索 ──────────────────────────────────────────────────
-# Community embedding-based search: cosine similarity on Community.summary_embedding
-COMMUNITY_EMBEDDING_SEARCH = """
-CALL db.index.vector.queryNodes('community_summary_embedding_index', $limit * 100, $embedding)
-YIELD node AS c, score
-WHERE c.summary_embedding IS NOT NULL
-  AND ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
-RETURN c.community_id AS id,
-       c.name AS name,
-       c.summary AS content,
-       c.core_entities AS core_entities,
-       c.member_count AS member_count,
-       c.end_user_id AS end_user_id,
-       c.updated_at AS updated_at,
-       score
-ORDER BY score DESC
-LIMIT $limit
 """
 
 # Community 展开检索 ──────────────────────────────────────────────────

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1308,7 +1308,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1318,7 +1318,7 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       e.activation_value AS activation_value,
+       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1335,7 +1335,7 @@ RETURN e.id AS id
 GET_COMMUNITY_MEMBERS = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
 RETURN e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, e.activation_value AS activation_value,
+       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description,
        e.example AS example
@@ -1355,7 +1355,7 @@ GET_ALL_COMMUNITY_MEMBERS_BATCH = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN c.community_id AS community_id,
        e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, e.activation_value AS activation_value,
+       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description
 ORDER BY c.community_id, coalesce(e.activation_value, 0) DESC
@@ -1402,7 +1402,7 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       e.activation_value AS activation_value,
+       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 ORDER BY e.id
 SKIP $skip LIMIT $limit
@@ -1425,7 +1425,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1450,7 +1450,7 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    nb.activation_value AS activation_value,
+    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1339,7 +1339,7 @@ RETURN e.id AS id, e.name AS name, e.entity_type AS entity_type,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description,
        e.example AS example
-ORDER BY coalesce(e.activation_value, 0) DESC
+ORDER BY coalesce(e.importance_score, 0) DESC
 """
 
 GET_COMMUNITY_RELATIONSHIPS = """
@@ -1358,7 +1358,41 @@ RETURN c.community_id AS community_id,
        e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description
-ORDER BY c.community_id, coalesce(e.activation_value, 0) DESC
+ORDER BY c.community_id, coalesce(e.importance_score, 0) DESC
+"""
+
+# P0 修复：批量将实体分配到社区（UNWIND），替换逐实体循环的 assign_entity_to_community
+BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES = """
+UNWIND $assignments AS row
+MATCH (e:ExtractedEntity {id: row.entity_id, end_user_id: $end_user_id})
+OPTIONAL MATCH (e)-[old_r:BELONGS_TO_COMMUNITY]->(:Community)
+DELETE old_r
+WITH e, row
+MATCH (c:Community {community_id: row.community_id, end_user_id: $end_user_id})
+MERGE (e)-[:BELONGS_TO_COMMUNITY]->(c)
+SET c.updated_at = datetime()
+RETURN count(e) AS assigned_count
+"""
+
+# P7 修复：批量计算各社区的平均 embedding，利用 APOC apoc.coll.zip 做逐元素加法
+# 返回每个社区的成员数和平均向量，避免将全量成员数据拉取到 Python 侧
+GET_COMMUNITY_AVG_EMBEDDINGS_BATCH = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+      -[:BELONGS_TO_COMMUNITY]->(c:Community)
+WHERE c.community_id IN $community_ids
+  AND e.name_embedding IS NOT NULL
+WITH c.community_id AS cid,
+     count(e) AS member_count,
+     collect(e.name_embedding) AS all_embeddings
+WITH cid, member_count,
+     reduce(
+       acc = head(all_embeddings),
+       emb IN tail(all_embeddings) |
+       [pair IN apoc.coll.zip(acc, emb) | pair[0] + pair[1]]
+     ) AS sum_vec
+RETURN cid,
+       member_count,
+       [v IN sum_vec | v / member_count] AS avg_embedding
 """
 
 CHECK_USER_HAS_COMMUNITIES = """

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1308,7 +1308,6 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1318,7 +1317,6 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1335,7 +1333,7 @@ RETURN e.id AS id
 GET_COMMUNITY_MEMBERS = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
 RETURN e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
+       e.importance_score AS importance_score,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description,
        e.example AS example
@@ -1355,7 +1353,7 @@ GET_ALL_COMMUNITY_MEMBERS_BATCH = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN c.community_id AS community_id,
        e.id AS id, e.name AS name, e.entity_type AS entity_type,
-       e.importance_score AS importance_score, COALESCE(e.activation_value, 0.5) AS activation_value,
+       e.importance_score AS importance_score,
        e.name_embedding AS name_embedding,
        e.aliases AS aliases, e.description AS description
 ORDER BY c.community_id, coalesce(e.importance_score, 0) DESC
@@ -1374,7 +1372,7 @@ SET c.updated_at = datetime()
 RETURN count(e) AS assigned_count
 """
 
-# P7 修复：批量计算各社区的平均 embedding，利用 APOC apoc.coll.zip 做逐元素加法
+# P7 修复：批量计算各社区的平均 embedding，纯 Cypher 逐元素向量加法（不依赖 APOC）
 # 返回每个社区的成员数和平均向量，避免将全量成员数据拉取到 Python 侧
 GET_COMMUNITY_AVG_EMBEDDINGS_BATCH = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
@@ -1388,7 +1386,7 @@ WITH cid, member_count,
      reduce(
        acc = head(all_embeddings),
        emb IN tail(all_embeddings) |
-       [pair IN apoc.coll.zip(acc, emb) | pair[0] + pair[1]]
+       [i IN range(0, size(acc) - 1) | acc[i] + emb[i]]
      ) AS sum_vec
 RETURN cid,
        member_count,
@@ -1436,7 +1434,6 @@ OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
        e.name_embedding AS name_embedding,
-       COALESCE(e.activation_value, 0.5) AS activation_value,
        CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 ORDER BY e.id
 SKIP $skip LIMIT $limit
@@ -1459,7 +1456,6 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 
@@ -1484,7 +1480,6 @@ RETURN DISTINCT
     nb.id               AS id,
     nb.name             AS name,
     nb.name_embedding   AS name_embedding,
-    COALESCE(nb.activation_value, 0.5) AS activation_value,
     CASE WHEN c IS NOT NULL THEN c.community_id ELSE null END AS community_id
 """
 

--- a/api/app/repositories/neo4j/neo4j_connector.py
+++ b/api/app/repositories/neo4j/neo4j_connector.py
@@ -63,6 +63,11 @@ class Neo4jConnector:
         
         从配置文件和环境变量中读取连接信息。
         
+        Args:
+            shared_driver: 是否使用进程级共享 driver。
+                True  → 所有实例共用一个 driver，通过 PID 检测 fork 后自动重建。
+                False → 每次实例化创建独立 driver（调用方需自行管理生命周期）。
+        
         Raises:
             RuntimeError: 如果NEO4J_PASSWORD环境变量未设置
         """
@@ -82,11 +87,21 @@ class Neo4jConnector:
             )
         return AsyncGraphDatabase.driver(
             uri,
-            auth=basic_auth(username, password)
+            auth=basic_auth(username, password),
+            max_connection_pool_size=settings.NEO4J_MAX_POOL_SIZE,
+            connection_acquisition_timeout=settings.NEO4J_ACQ_TIMEOUT,
+            max_connection_lifetime=settings.NEO4J_MAX_CONN_LIFETIME,
+            connection_timeout=settings.NEO4J_CONN_TIMEOUT,
         )
 
     def _create_or_get_driver(self) -> AsyncDriver:
-        """按配置返回独占或进程级共享的 driver。"""
+        """按配置返回独占或进程级共享的 driver。
+        
+        shared_driver=True 时：
+        - 检测当前 PID 是否与 _shared_driver_pid 一致
+        - PID 变化（fork 后）或首次调用时自动重建
+        - 线程安全（threading.Lock 保护）
+        """
         if not self._shared_driver_enabled:
             return self._build_driver()
 
@@ -113,6 +128,7 @@ class Neo4jConnector:
         """关闭数据库连接
 
         释放数据库连接资源。应在应用程序关闭时调用。
+        共享 driver 不在此处关闭，由 shutdown() 统一管理。
         """
         if self._shared_driver_enabled:
             return
@@ -138,7 +154,7 @@ class Neo4jConnector:
         Returns:
             List[Dict[str, Any]]: 查询结果列表，每个元素是一个字典
             
-        Example:
+
 
         """
         result = await self.driver.execute_query(
@@ -165,7 +181,7 @@ class Neo4jConnector:
         Returns:
             Any: 事务函数的返回值
             
-        Example:
+
 
         """
         async with self.driver.session(database="neo4j") as session:
@@ -183,7 +199,7 @@ class Neo4jConnector:
         Returns:
             Any: 事务函数的返回值
             
-        Example:
+
 
         """
         async with self.driver.session(database="neo4j") as session:
@@ -197,9 +213,6 @@ class Neo4jConnector:
         
         Args:
             end_user_id: 要删除的组ID
-            
-        Example:
-            Group group_123 deleted.
         """
         batch_size = 1000
         total_deleted = 0

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -46,7 +46,7 @@ logger = get_logger(__name__)
 config_logger = get_config_logger()
 
 # Initialize Neo4j connector for analytics functions
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 # 标记当前 task/coroutine 已持有 per-end_user 写入锁（避免重入死锁）
 # 由 flush_conversation_task 在 worker 上下文中设置，防止下游重复加锁

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -40,7 +40,7 @@ config_logger = get_config_logger()
 
 # Load environment variables for Neo4j connector
 load_dotenv()
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 
 class MemoryStorageService:

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -46,7 +46,7 @@ from app.services.memory_short_service import LongService, ShortService
 logger = get_logger(__name__)
 
 # Neo4j connector instance for analytics functions
-_neo4j_connector = Neo4jConnector()
+_neo4j_connector = Neo4jConnector(shared_driver=True)
 
 # Default LLM ID for fallback
 DEFAULT_LLM_ID = os.getenv("SELECTED_LLM_ID", "openai/qwen-plus")


### PR DESCRIPTION
## Summary by Sourcery

将剪枝流水线与 Neo4j 写入解耦，并强化聚类与 Neo4j 的使用以提升可扩展性与稳定性。

Enhancements:
- 将 Neo4j 写入职责从助手剪枝流水线中移除，使其仅执行基于 Redis 缓存的 LLM 剪枝。
- 优化聚类标签传播，通过对实体处理、元数据生成和 LLM 调用使用批处理和并发限制的操作，以减少锁争用并降低资源使用。
- 更改社区成员排序和平均计算方式，改为依赖重要性评分和 Neo4j 端的聚合，避免大规模内存加载和社区规模过大。
- 引入批量 Cypher 查询，用于将实体分配到社区以及计算社区平均向量，以提升图更新效率。
- 配置 Neo4j 驱动的可调连接池和超时设置，并为 Celery worker 和分析服务增加带进程分叉感知重初始化的共享驱动模式。
- 重用用于内存摘要的现有 Neo4j 连接器，而不是创建短生命周期驱动，以简化资源管理。

Build:
- 在应用设置中新增可配置的 Neo4j 连接池和超时参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple pruning pipeline from Neo4j writes and harden clustering and Neo4j usage for scalability and stability.

Enhancements:
- Remove Neo4j write responsibilities from the assistant pruning pipeline, keeping it purely Redis-cached LLM pruning.
- Optimize clustering label propagation with batched and concurrency-limited operations for entity processing, metadata generation, and LLM calls to reduce lock contention and resource usage.
- Change community member ordering and averaging to rely on importance scores and Neo4j-side aggregation, preventing large in-memory loads and oversized communities.
- Introduce batch Cypher queries for assigning entities to communities and computing community-average embeddings to make graph updates more efficient.
- Configure Neo4j driver with tunable pool and timeout settings and add a shared driver mode with fork-aware reinitialization for Celery workers and analytics services.
- Reuse existing Neo4j connectors for memory summaries instead of creating short-lived drivers to simplify resource management.

Build:
- Add configurable Neo4j connection pool and timeout parameters to application settings.

</details>