### PR TITLE
Fix/write task retry

### DIFF
--- a/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
+++ b/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
@@ -573,6 +573,10 @@ class NewExtractionOrchestrator:
         # Organise into nested dict;同时记录每个 chunk 的输入上下文，供 snapshot 落盘核查。
         stmt_map: Dict[str, Dict[str, List[StatementStepOutput]]] = {}
         stmt_inputs_map: Dict[str, Dict[str, StatementStepInput]] = {}
+        # statement_temporal_step 是 critical step：任一 chunk 抽取失败都必须中断整个写入
+        # 流程并向上抛出。否则异常会在此被静默吞掉（设为 []），导致 WriteResult.status
+        # 仍为 "success"，最终 Celery 任务被错误标记为 SUCCESS（Flower 显示成功）。
+        first_error: BaseException | None = None
         for i, result in enumerate(results):
             dialog_id, chunk_id, speaker, _, inp = task_meta[i]
             if dialog_id not in stmt_map:
@@ -582,6 +586,8 @@ class NewExtractionOrchestrator:
             if isinstance(result, BaseException):
                 logger.error("Statement extraction failed for chunk %s: %s", chunk_id, result)
                 stmt_map[dialog_id][chunk_id] = []
+                if first_error is None:
+                    first_error = result
             else:
                 # Override speaker from chunk metadata
                 stmts: List[StatementStepOutput] = result if isinstance(result, list) else []
@@ -601,6 +607,12 @@ class NewExtractionOrchestrator:
         # Stash the inputs map so the orchestrator can attach it to
         # ``_last_stage_outputs`` for snapshot/debugging.
         self._last_statement_inputs = stmt_inputs_map
+
+        # critical step 失败 → 中断 pipeline，让上层（WritePipeline → MemoryService.write
+        # → write_message_task）感知失败并将 Celery 任务标记为 FAILURE / 触发重试。
+        if first_error is not None:
+            raise first_error
+
         return stmt_map
 
     async def _extract_all_triplets(

--- a/api/app/core/memory/utils/log/bear_logger.py
+++ b/api/app/core/memory/utils/log/bear_logger.py
@@ -119,7 +119,7 @@ class BearLogger:
         token = _trace_id.set(trace_id)
         start = time.time()
 
-        ctx_parts = [f"{k}={str(v)}" for k, v in context_kv.items()]
+        ctx_parts = [f"{k}={v}" for k, v in context_kv.items()]
         ctx_str = ", ".join(ctx_parts)
 
         self._logger.info(

--- a/api/app/core/memory/utils/log/bear_logger.py
+++ b/api/app/core/memory/utils/log/bear_logger.py
@@ -119,7 +119,7 @@ class BearLogger:
         token = _trace_id.set(trace_id)
         start = time.time()
 
-        ctx_parts = [f"{k}={v}" for k, v in context_kv.items()]
+        ctx_parts = [f"{k}={str(v)}" for k, v in context_kv.items()]
         ctx_str = ", ".join(ctx_parts)
 
         self._logger.info(

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1907,6 +1907,12 @@ def write_message_task(
             "task_id": self.request.id,
         }
     except BaseException as e:
+        from app.schemas.memory_config_schema import (
+            ModelNotFoundError,
+            ModelInactiveError,
+            InvalidConfigError,
+        )
+
         elapsed_time = time.time() - start_time
         if hasattr(e, 'exceptions'):
             error_messages = [f"{type(sub_e).__name__}: {str(sub_e)}" for sub_e in e.exceptions]
@@ -1916,14 +1922,16 @@ def write_message_task(
 
         logger.error(f"[CELERY WRITE] Task failed - elapsed_time={elapsed_time:.2f}s, error={detailed_error}", exc_info=True)
 
-        return {
-            "status": "FAILURE",
-            "error": detailed_error,
-            "end_user_id": end_user_id,
-            "config_id": str(config_id) if config_id else None,
-            "elapsed_time": elapsed_time,
-            "task_id": self.request.id,
-        }
+        # 配置类确定性错误：直接 raise，让 Celery 将任务标记为 FAILURE，不触发重试
+        if isinstance(e, (ModelNotFoundError, ModelInactiveError, InvalidConfigError)):
+            logger.error(
+                f"[CELERY WRITE] Configuration error detected, task will not be retried - "
+                f"error_type={type(e).__name__}, error={detailed_error}"
+            )
+            raise
+
+        # 瞬时错误（网络超时、Neo4j 死锁等）：交由 Celery 按 max_retries 自动重试
+        raise self.retry(exc=e)
     finally:
         if loop:
             _shutdown_loop_gracefully(loop)


### PR DESCRIPTION
## Summary by Sourcery

改进写入任务的错误处理和传播方式，使抽取失败和配置问题能够正确导致 Celery 任务失败，并在合适的情况下触发重试。

Bug 修复：
- 确保写入任务中的配置相关错误会作为 Celery 任务失败暴露出来，而不是被报告为已处理的结果。
- 将关键 temporal 步骤中的语句抽取错误向上传播，从而中止写入流水线，使父 Celery 任务被标记为失败并能够进行重试。

改进：
- 在写入任务中区分确定性的配置错误和瞬时运行时错误，以避免不必要的重试，同时仍然利用 Celery 的自动重试机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve write task error handling and propagation so extraction failures and configuration issues correctly fail Celery tasks and trigger retries when appropriate.

Bug Fixes:
- Ensure configuration-related errors in write tasks are surfaced as Celery task failures instead of being reported as handled results.
- Propagate statement extraction errors from the critical temporal step to abort the write pipeline so the parent Celery task is marked as failed and can retry.

Enhancements:
- Differentiate between deterministic configuration errors and transient runtime errors in the write task to avoid unnecessary retries while still leveraging Celery's automatic retry mechanism.

</details>