### PR TITLE
test: verify openapi-diff CI workflow

### DIFF
--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -27,23 +27,27 @@ jobs:
           uv run python scripts/export_openapi.py --v1-only -o openapi-current.json
 
       - name: Run openapi-diff
-        uses: docker://openapitools/openapi-diff:latest
-        with:
-          args: >
-            /github/workspace/api/openapi-baseline.json
-            /github/workspace/api/openapi-current.json
-            --fail-on-incompatible
-            --markdown /github/workspace/api/openapi-diff-report.md
+        id: diff
+        run: |
+          # Generate markdown report (always succeeds)
+          docker run --rm \
+            -v ${{ github.workspace }}/api:/work \
+            openapitools/openapi-diff:latest \
+            /work/openapi-baseline.json \
+            /work/openapi-current.json \
+            --markdown /work/openapi-diff-report.md || true
 
-      - name: Upload diff report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: openapi-diff-report
-          path: api/openapi-diff-report.md
+          # Run again with --fail-on-incompatible for exit code
+          docker run --rm \
+            -v ${{ github.workspace }}/api:/work \
+            openapitools/openapi-diff:latest \
+            /work/openapi-baseline.json \
+            /work/openapi-current.json \
+            --fail-on-incompatible
 
       - name: Comment PR with diff
-        if: failure()
+        if: always() && hashFiles('api/openapi-diff-report.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: openapi-diff
           path: api/openapi-diff-report.md

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -78,7 +78,7 @@ async def read_memory_sync(
     })
 
 
-@router.post("/write")
+@router.post("/write", deprecated=True)
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_async(

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -78,7 +78,7 @@ async def read_memory_sync(
     })
 
 
-@router.post("/write", deprecated=True)
+@router.post("/write")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_async(
@@ -86,7 +86,7 @@ async def write_memory_async(
         api_key_auth: ApiKeyAuth = None,
         db: Session = Depends(get_db),
         body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
-        language_type: str = Header(default=None, alias="X-Language-Type"),
+        language_type: str = Header(..., alias="X-Language-Type"),
 ):
     """
     Write memory asynchronously (Celery task).

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -73,7 +73,7 @@ async def read_memory_sync(
     )
     memory = await service.read(payload.message, search_switch=SearchStrategy(payload.search_switch))
     return success(data={
-        "answer": memory.content,
+        "response": memory.content,
         "intermediate_outputs": [_.model_dump() for _ in memory.memories]
     })
 
@@ -86,7 +86,7 @@ async def write_memory_async(
         api_key_auth: ApiKeyAuth = None,
         db: Session = Depends(get_db),
         body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
-        language_type: str = Header(..., alias="X-Language-Type"),
+        language_type: str = Header(default=None, alias="X-Language-Type"),
 ):
     """
     Write memory asynchronously (Celery task).

--- a/api/scripts/export_openapi.py
+++ b/api/scripts/export_openapi.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Export OpenAPI schema from the FastAPI app without running the server.
 
+Mocks all external connections (ES, Neo4j, Redis) so it can run in CI
+without any infrastructure.
+
 Usage:
     uv run python scripts/export_openapi.py
     uv run python scripts/export_openapi.py --output openapi-current.json
@@ -13,11 +16,27 @@ import pathlib
 import sys
 from unittest.mock import patch, MagicMock
 
+# Ensure app is importable
+api_dir = str(pathlib.Path(__file__).resolve().parent.parent)
+if api_dir not in sys.path:
+    sys.path.insert(0, api_dir)
+
 # Disable startup tasks
 os.environ.setdefault("DB_AUTO_UPGRADE", "false")
 os.environ.setdefault("LOAD_MODEL", "false")
 os.environ.setdefault("ELASTICSEARCH_HOST", "127.0.0.1")
 os.environ.setdefault("ELASTICSEARCH_PORT", "19999")
+os.environ.setdefault("NEO4J_URI", "bolt://localhost:7687")
+os.environ.setdefault("NEO4J_USERNAME", "neo4j")
+os.environ.setdefault("NEO4J_PASSWORD", "dummy_for_schema_export")
+os.environ.setdefault("REDIS_HOST", "127.0.0.1")
+os.environ.setdefault("REDIS_PORT", "6379")
+os.environ.setdefault("SECRET_KEY", "dummy_for_schema_export")
+os.environ.setdefault("DB_HOST", "127.0.0.1")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "postgres")
+os.environ.setdefault("DB_PASSWORD", "dummy")
+os.environ.setdefault("DB_NAME", "dummy")
 
 
 def main():
@@ -26,17 +45,20 @@ def main():
     parser.add_argument("--v1-only", action="store_true", help="Only include /v1 paths")
     args = parser.parse_args()
 
-    # Ensure app is importable
-    api_dir = str(pathlib.Path(__file__).resolve().parent.parent)
-    if api_dir not in sys.path:
-        sys.path.insert(0, api_dir)
-
-    # Mock ES to avoid connection timeout
+    # Mock external connections
     es_mock = MagicMock()
     es_mock.return_value.info.return_value = {"status": "green"}
     es_mock.return_value.ping.return_value = True
 
-    with patch("elasticsearch.Elasticsearch", es_mock):
+    neo4j_mock = MagicMock()
+    redis_mock = MagicMock()
+
+    with patch("elasticsearch.Elasticsearch", es_mock), \
+         patch("neo4j.GraphDatabase.driver", return_value=neo4j_mock), \
+         patch("app.repositories.neo4j.neo4j_connector.Neo4jConnector._build_driver", return_value=neo4j_mock), \
+         patch("app.repositories.neo4j.neo4j_connector.Neo4jConnector._create_or_get_driver", return_value=neo4j_mock), \
+         patch("redis.Redis", return_value=redis_mock), \
+         patch("redis.StrictRedis", return_value=redis_mock):
         from app.main import app
         schema = app.openapi()
 


### PR DESCRIPTION
测试 PR：验证 openapi-diff CI workflow 能否正确检测 API 变更。

改动：给 `POST /v1/memory/write` 加了 `deprecated=True`，会触发 OpenAPI schema 变更。

验证后删除此分支。

## Summary by Sourcery

增强功能：
- 在 OpenAPI 架构中将 `POST /v1/memory/write` 端点标记为已弃用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Flag the POST /v1/memory/write endpoint as deprecated in the OpenAPI schema.

</details>