### PR TITLE
test: verify openapi-diff detects response field changes

### DIFF
--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -28,8 +28,7 @@ jobs:
 
       - name: Install oasdiff
         run: |
-          curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sh
-          sudo mv ./oasdiff /usr/local/bin/
+          curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
 
       - name: Check breaking changes
         run: |

--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -31,6 +31,32 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
 
       - name: Check breaking changes
+        id: oasdiff
         run: |
           cd api
+          # Generate report
+          echo "## 🔍 API Breaking Change Report" > oasdiff-report.md
+          echo "" >> oasdiff-report.md
+
+          OUTPUT=$(oasdiff breaking openapi-baseline.json openapi-current.json 2>&1) || true
+          EXIT_CODE=$(oasdiff breaking openapi-baseline.json openapi-current.json > /dev/null 2>&1; echo $?)
+
+          if [ "$EXIT_CODE" = "0" ]; then
+            echo "✅ No breaking changes detected." >> oasdiff-report.md
+          else
+            echo "❌ **Breaking changes detected:**" >> oasdiff-report.md
+            echo "" >> oasdiff-report.md
+            echo '```' >> oasdiff-report.md
+            echo "$OUTPUT" >> oasdiff-report.md
+            echo '```' >> oasdiff-report.md
+          fi
+
+          # Fail the step if breaking
           oasdiff breaking openapi-baseline.json openapi-current.json --fail-on ERR
+
+      - name: Comment PR
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: oasdiff
+          path: api/oasdiff-report.md

--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -26,28 +26,12 @@ jobs:
           cd api
           uv run python scripts/export_openapi.py --v1-only -o openapi-current.json
 
-      - name: Run openapi-diff
-        id: diff
+      - name: Install oasdiff
         run: |
-          # Generate markdown report (always succeeds)
-          docker run --rm \
-            -v ${{ github.workspace }}/api:/work \
-            openapitools/openapi-diff:latest \
-            /work/openapi-baseline.json \
-            /work/openapi-current.json \
-            --markdown /work/openapi-diff-report.md || true
+          curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sh
+          sudo mv ./oasdiff /usr/local/bin/
 
-          # Run again with --fail-on-incompatible for exit code
-          docker run --rm \
-            -v ${{ github.workspace }}/api:/work \
-            openapitools/openapi-diff:latest \
-            /work/openapi-baseline.json \
-            /work/openapi-current.json \
-            --fail-on-incompatible
-
-      - name: Comment PR with diff
-        if: always() && hashFiles('api/openapi-diff-report.md') != ''
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: openapi-diff
-          path: api/openapi-diff-report.md
+      - name: Check breaking changes
+        run: |
+          cd api
+          oasdiff breaking openapi-baseline.json openapi-current.json --fail-on ERR

--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -1,44 +1,69 @@
 name: API Breaking Change Check
 on:
   pull_request:
-    paths:
-      - 'api/app/**'
-      - 'api/openapi-baseline.json'
 
 jobs:
   openapi-diff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if API files changed
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'api/app/' 'api/openapi-baseline.json' | head -1)
+          if [ -z "$CHANGED" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if no API changes
+        if: steps.filter.outputs.skip == 'true'
+        run: echo "No API files changed, skipping check."
 
       - name: Setup Python
+        if: steps.filter.outputs.skip == 'false'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Install dependencies
+        if: steps.filter.outputs.skip == 'false'
         run: |
-          pip install uv
+          pip install uv==0.7.12
           cd api && uv sync
 
       - name: Export current OpenAPI schema
+        if: steps.filter.outputs.skip == 'false'
         run: |
           cd api
           uv run python scripts/export_openapi.py --v1-only -o openapi-current.json
 
+      - name: Get baseline from target branch
+        if: steps.filter.outputs.skip == 'false'
+        run: |
+          cd api
+          git show origin/${{ github.base_ref }}:api/openapi-baseline.json > openapi-target-baseline.json
+
       - name: Install oasdiff
+        if: steps.filter.outputs.skip == 'false'
         run: |
           curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
 
       - name: Run oasdiff
-        id: oasdiff
+        if: steps.filter.outputs.skip == 'false'
         run: |
           cd api
           echo "## 🔍 API Breaking Change Report" > oasdiff-report.md
           echo "" >> oasdiff-report.md
+          echo "Comparing against \`${{ github.base_ref }}\` baseline." >> oasdiff-report.md
+          echo "" >> oasdiff-report.md
 
           echo "### oasdiff" >> oasdiff-report.md
-          OUTPUT=$(oasdiff breaking openapi-baseline.json openapi-current.json 2>&1) || true
+          OUTPUT=$(oasdiff breaking openapi-target-baseline.json openapi-current.json 2>&1) || true
           if [ -z "$OUTPUT" ]; then
             echo "✅ No breaking changes detected." >> oasdiff-report.md
           else
@@ -50,21 +75,20 @@ jobs:
 
           echo "" >> oasdiff-report.md
           echo "### openapi-diff" >> oasdiff-report.md
-
           ODIFF=$(docker run --rm \
             -v ${{ github.workspace }}/api:/work \
-            openapitools/openapi-diff:latest \
-            /work/openapi-baseline.json \
+            openapitools/openapi-diff:2.1.0-beta.11 \
+            /work/openapi-target-baseline.json \
             /work/openapi-current.json 2>&1) || true
           echo '```' >> oasdiff-report.md
           echo "$ODIFF" >> oasdiff-report.md
           echo '```' >> oasdiff-report.md
 
           # Fail if oasdiff detects breaking changes
-          oasdiff breaking openapi-baseline.json openapi-current.json --fail-on ERR
+          oasdiff breaking openapi-target-baseline.json openapi-current.json --fail-on ERR
 
       - name: Comment PR
-        if: always()
+        if: always() && steps.filter.outputs.skip == 'false'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: oasdiff

--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -30,28 +30,37 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
 
-      - name: Check breaking changes
+      - name: Run oasdiff
         id: oasdiff
         run: |
           cd api
-          # Generate report
           echo "## 🔍 API Breaking Change Report" > oasdiff-report.md
           echo "" >> oasdiff-report.md
 
+          echo "### oasdiff" >> oasdiff-report.md
           OUTPUT=$(oasdiff breaking openapi-baseline.json openapi-current.json 2>&1) || true
-          EXIT_CODE=$(oasdiff breaking openapi-baseline.json openapi-current.json > /dev/null 2>&1; echo $?)
-
-          if [ "$EXIT_CODE" = "0" ]; then
+          if [ -z "$OUTPUT" ]; then
             echo "✅ No breaking changes detected." >> oasdiff-report.md
           else
             echo "❌ **Breaking changes detected:**" >> oasdiff-report.md
-            echo "" >> oasdiff-report.md
             echo '```' >> oasdiff-report.md
             echo "$OUTPUT" >> oasdiff-report.md
             echo '```' >> oasdiff-report.md
           fi
 
-          # Fail the step if breaking
+          echo "" >> oasdiff-report.md
+          echo "### openapi-diff" >> oasdiff-report.md
+
+          ODIFF=$(docker run --rm \
+            -v ${{ github.workspace }}/api:/work \
+            openapitools/openapi-diff:latest \
+            /work/openapi-baseline.json \
+            /work/openapi-current.json 2>&1) || true
+          echo '```' >> oasdiff-report.md
+          echo "$ODIFF" >> oasdiff-report.md
+          echo '```' >> oasdiff-report.md
+
+          # Fail if oasdiff detects breaking changes
           oasdiff breaking openapi-baseline.json openapi-current.json --fail-on ERR
 
       - name: Comment PR

--- a/.github/workflows/api-breaking-change.yml
+++ b/.github/workflows/api-breaking-change.yml
@@ -53,39 +53,89 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
 
-      - name: Run oasdiff
+      - name: Run OpenAPI breaking change checks
         if: steps.filter.outputs.skip == 'false'
+        id: api_diff
         run: |
           cd api
-          echo "## 🔍 API Breaking Change Report" > oasdiff-report.md
-          echo "" >> oasdiff-report.md
-          echo "Comparing against \`${{ github.base_ref }}\` baseline." >> oasdiff-report.md
-          echo "" >> oasdiff-report.md
+          set +e
 
-          echo "### oasdiff" >> oasdiff-report.md
-          OUTPUT=$(oasdiff breaking openapi-target-baseline.json openapi-current.json 2>&1) || true
-          if [ -z "$OUTPUT" ]; then
-            echo "✅ No breaking changes detected." >> oasdiff-report.md
+          REPORT="oasdiff-report.md"
+          BASELINE="openapi-target-baseline.json"
+          CURRENT="openapi-current.json"
+
+          {
+            echo "# API Breaking Change Report"
+            echo ""
+            echo "Comparing against \`${{ github.base_ref }}\` baseline."
+            echo ""
+            echo "| Tool | Result |"
+            echo "| --- | --- |"
+          } > "$REPORT"
+
+          OASDIFF_OUTPUT=$(oasdiff breaking "$BASELINE" "$CURRENT" --fail-on ERR 2>&1)
+          OASDIFF_EXIT=$?
+
+          if [ "$OASDIFF_EXIT" -eq 0 ]; then
+            echo "| oasdiff | ✅ PASS |" >> "$REPORT"
           else
-            echo "❌ **Breaking changes detected:**" >> oasdiff-report.md
-            echo '```' >> oasdiff-report.md
-            echo "$OUTPUT" >> oasdiff-report.md
-            echo '```' >> oasdiff-report.md
+            echo "| oasdiff | ❌ FAIL |" >> "$REPORT"
           fi
 
-          echo "" >> oasdiff-report.md
-          echo "### openapi-diff" >> oasdiff-report.md
-          ODIFF=$(docker run --rm \
-            -v ${{ github.workspace }}/api:/work \
+          OPENAPI_DIFF_OUTPUT=$(docker run --rm \
+            -v "${{ github.workspace }}/api:/work" \
             openapitools/openapi-diff:2.1.0-beta.11 \
-            /work/openapi-target-baseline.json \
-            /work/openapi-current.json 2>&1) || true
-          echo '```' >> oasdiff-report.md
-          echo "$ODIFF" >> oasdiff-report.md
-          echo '```' >> oasdiff-report.md
+            --fail-on-incompatible \
+            /work/"$BASELINE" \
+            /work/"$CURRENT" 2>&1)
+          OPENAPI_DIFF_EXIT=$?
 
-          # Fail if oasdiff detects breaking changes
-          oasdiff breaking openapi-target-baseline.json openapi-current.json --fail-on ERR
+          if [ "$OPENAPI_DIFF_EXIT" -eq 0 ]; then
+            echo "| openapi-diff | ✅ PASS |" >> "$REPORT"
+          else
+            echo "| openapi-diff | ❌ FAIL |" >> "$REPORT"
+          fi
+
+          {
+            echo ""
+            echo "## oasdiff"
+            echo ""
+            echo "<details open>"
+            echo "<summary>Output</summary>"
+            echo ""
+            echo '```text'
+            if [ -n "$OASDIFF_OUTPUT" ]; then
+              echo "$OASDIFF_OUTPUT"
+            else
+              echo "No breaking changes detected."
+            fi
+            echo '```'
+            echo ""
+            echo "</details>"
+
+            echo ""
+            echo "## openapi-diff"
+            echo ""
+            echo "<details open>"
+            echo "<summary>Output</summary>"
+            echo ""
+            echo '```text'
+            if [ -n "$OPENAPI_DIFF_OUTPUT" ]; then
+              echo "$OPENAPI_DIFF_OUTPUT"
+            else
+              echo "No incompatible changes detected."
+            fi
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$REPORT"
+
+          echo "oasdiff_exit=$OASDIFF_EXIT" >> "$GITHUB_OUTPUT"
+          echo "openapi_diff_exit=$OPENAPI_DIFF_EXIT" >> "$GITHUB_OUTPUT"
+
+          if [ "$OASDIFF_EXIT" -ne 0 ] || [ "$OPENAPI_DIFF_EXIT" -ne 0 ]; then
+            exit 1
+          fi
 
       - name: Comment PR
         if: always() && steps.filter.outputs.skip == 'false'

--- a/api/app/schemas/v1_response.py
+++ b/api/app/schemas/v1_response.py
@@ -18,7 +18,7 @@ class ApiResponse(BaseModel, Generic[T]):
 class NodeStatItem(BaseModel):
     """单个记忆类型统计项。"""
     type: str = Field(..., description="记忆节点类型")
-    count: int = Field(..., description="数量")
+    counts: List[int] = Field(..., description="数量列表")
     percentage: float = Field(..., description="占比")
 
 


### PR DESCRIPTION
测试：验证有 response_model 时，改字段名/类型能被 openapi-diff 检测到。

改动：NodeStatItem.count (int) → NodeStatItem.counts (list[int])

预期：CI fail（incompatible change：字段删除 + 类型变更）

## Summary by Sourcery

为节点统计信息端点定义一个明确的 OpenAPI 响应模式，以便在 CI 中通过 openapi-diff 检测响应字段的变化。

New Features:
- 为 V1 用户内存 API 的节点统计信息端点添加类型化的 `NodeStatisticsResponse` 模式以及通用的 `ApiResponse` 包装结构。

Enhancements:
- 将节点统计信息端点接入使用新的 `NodeStatisticsResponse` 作为其 FastAPI 的 `response_model`，以便在 OpenAPI 中暴露响应结构的变化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Define an explicit OpenAPI response schema for the node statistics endpoint so that response field changes can be detected by openapi-diff in CI.

New Features:
- Add a typed NodeStatisticsResponse schema and generic ApiResponse envelope for the V1 user memory API node statistics endpoint.

Enhancements:
- Wire the node statistics endpoint to use the new NodeStatisticsResponse as its FastAPI response_model to surface response structure changes in OpenAPI.

</details>