### PR TITLE
test: rename write route to verify oasdiff CI

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -78,7 +78,7 @@ async def read_memory_sync(
     })
 
 
-@router.post("/write")
+@router.post("/submit")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_async(


### PR DESCRIPTION
Breaking change: renames POST /v1/memory/write → /v1/memory/submit. Should trigger CI failure.

## Summary by Sourcery

增强：
- 更新内存服务路由，将写入端点暴露为 `/submit`，以反映新的 API 路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the memory service router to expose the write endpoint at /submit to reflect the new API path.

</details>