### PR TITLE
test: demo breaking API change without approval

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -78,7 +78,7 @@ async def read_memory_sync(
     })
 
 
-@router.post("/write")
+@router.post("/submit")
 @require_api_key(scopes=["memory"])
 @check_end_user_quota
 async def write_memory_async(


### PR DESCRIPTION
Demo PR for API Breaking Change Check.\n\nCase: breaking change without `api-breaking-approved` label.\n\nChange:\n- Rename external route `POST /v1/memory/write` to `POST /v1/memory/submit`.\n\nExpected result:\n- `API Breaking Change Check` fails.\n- The PR demonstrates the default gate behavior when a breaking API change is not approved.

## Summary by Sourcery

将外部内存写入 API 端点从 `POST /v1/memory/write` 重命名为 `POST /v1/memory/submit`，以在演示中体现一次破坏性（不兼容）的 API 变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the external memory write API endpoint from POST /v1/memory/write to POST /v1/memory/submit to represent a breaking API change for demo purposes.

</details>