### PR TITLE
feat(memory): add node deletion API and forgetting pipeline

### DIFF
--- a/api/app/config/default_free_plan.py
+++ b/api/app/config/default_free_plan.py
@@ -64,6 +64,7 @@ def _build_default_free_plan():
             "ontology_project_quota": 3,
             "model_quota": 1,
             "api_ops_rate_limit": 50,
+            "end_user_memory_limit": 300
         },
     }
 

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -594,6 +594,11 @@ async def delete_end_user(
             if not end_user:
                 api_logger.warning(f"终端用户不存在或已删除: end_user_id={end_user_id_str}")
                 return fail(BizCode.NOT_FOUND, "终端用户不存在或已删除", f"end_user_id={end_user_id_str}")
+            if str(end_user.workspace_id) != str(workspace_id):
+                api_logger.warning(
+                    f"用户 {current_user.username} 尝试删除不属于工作空间 {workspace_id} 的终端用户 {end_user_id_str}"
+                )
+                return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
 
         from app.core.memory.memory_service import MemoryService
 

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -587,13 +587,19 @@ async def delete_end_user(
     )
 
     try:
+        from app.repositories.end_user_repository import EndUserRepository
+
+        with get_db_context() as db:
+            end_user = EndUserRepository(db).get_end_user_by_id(end_user_id)
+            if not end_user:
+                api_logger.warning(f"终端用户不存在或已删除: end_user_id={end_user_id_str}")
+                return fail(BizCode.NOT_FOUND, "终端用户不存在或已删除", f"end_user_id={end_user_id_str}")
+
         from app.core.memory.memory_service import MemoryService
 
         total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(end_user_id_str)
 
         try:
-            from app.repositories.end_user_repository import EndUserRepository
-
             with get_db_context() as db:
                 repo = EndUserRepository(db)
                 repo.update_memory_count(end_user_id, 0)

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -9,7 +9,7 @@ from app.core.error_codes import BizCode
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import fail, success
-from app.db import get_db
+from app.db import get_db, get_db_context
 from app.dependencies import get_current_user
 from app.models.user_model import User
 from app.schemas.memory_storage_schema import (
@@ -559,3 +559,56 @@ async def get_recent_activity_stats_api(
     except Exception as e:
         api_logger.error(f"Recent activity stats failed: {str(e)}")
         return fail(BizCode.INTERNAL_ERROR, "最近活动统计失败", str(e))
+
+
+@router.delete("/end-users/{end_user_id}", response_model=ApiResponse)
+async def delete_end_user(
+        end_user_id: UUID,
+        current_user: User = Depends(get_current_user),
+) -> dict:
+    """删除终端用户的全部记忆数据（Neo4j 节点 + PostgreSQL 记录）。
+
+    1. DETACH DELETE 清除 Neo4j 中该用户所有节点和边
+    2. memory_count 归零
+    3. 软删除 end_user 记录（is_active=False）
+
+    这是一个危险操作，不可撤销。
+    """
+    workspace_id = current_user.current_workspace_id
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试删除终端用户但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    end_user_id_str = str(end_user_id)
+
+    api_logger.info(
+        f"删除终端用户请求: end_user_id={end_user_id_str}, "
+        f"user={current_user.username}, workspace={workspace_id}"
+    )
+
+    try:
+        from app.core.memory.memory_service import MemoryService
+
+        total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(end_user_id_str)
+
+        try:
+            from app.repositories.end_user_repository import EndUserRepository
+
+            with get_db_context() as db:
+                repo = EndUserRepository(db)
+                repo.update_memory_count(end_user_id, 0)
+                repo.soft_delete_by_end_user_id(end_user_id)
+        except Exception as sync_err:
+            api_logger.warning(f"同步 end_user 失败（不影响 Neo4j 删除结果）: {sync_err}")
+
+        api_logger.info(
+            f"终端用户删除完成: end_user_id={end_user_id_str}, total_deleted={total_deleted}"
+        )
+        return success(
+            data={"deleted": True, "end_user_id": end_user_id_str, "total_deleted": total_deleted},
+            msg=f"删除用户{end_user_id_str}记忆库成功"
+        )
+
+    except Exception as e:
+        api_logger.error(f"删除终端用户失败: end_user_id={end_user_id_str}, error={str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "删除终端用户失败", str(e))

--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -18,7 +18,7 @@ from app.repositories.workspace_repository import WorkspaceRepository
 from app.schemas.end_user_info_schema import (
     EndUserInfoUpdate,
 )
-from app.schemas.memory_storage_schema import DeleteNodeRequest, DeleteAllNodesRequest
+from app.schemas.memory_storage_schema import DeleteNodeRequest
 from app.schemas.response_schema import ApiResponse
 from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
 from app.services.user_memory_service import UserMemoryService
@@ -267,49 +267,3 @@ async def delete_node_api(
         api_logger.error(f"节点删除失败: element_id={element_id}, error={str(e)}")
         return fail(BizCode.INTERNAL_ERROR, "节点删除失败", str(e))
 
-
-@router.post("/nodes/delete-all", response_model=ApiResponse)
-async def delete_all_nodes_api(
-        request: DeleteAllNodesRequest,
-        current_user: User = Depends(get_current_user),
-) -> dict:
-    """删除指定用户的所有 Neo4j 记忆节点和边。
-
-    分批 DETACH DELETE + 清理残留边，完成后同步 memory_count 到 PostgreSQL。
-    这是一个危险操作，会永久删除该用户的所有记忆图数据。
-    """
-    workspace_id = current_user.current_workspace_id
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试删除所有节点但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    end_user_id = request.end_user_id
-
-    api_logger.info(
-        f"批量删除节点请求: end_user_id={end_user_id}, "
-        f"user={current_user.username}, workspace={workspace_id}"
-    )
-
-    try:
-        from app.core.memory.memory_service import MemoryService
-
-        total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(end_user_id)
-
-        try:
-            from app.repositories.end_user_repository import EndUserRepository
-            from app.db import get_db_context
-            from uuid import UUID
-            with get_db_context() as db:
-                EndUserRepository(db).update_memory_count(UUID(end_user_id), 0)
-        except Exception as sync_err:
-            api_logger.warning(f"同步 memory_count 失败（不影响删除结果）: {sync_err}")
-
-        api_logger.info(f"批量删除完成: end_user_id={end_user_id}, total_deleted={total_deleted}")
-        return success(
-            data={"deleted": True, "end_user_id": end_user_id, "total_deleted": total_deleted},
-            msg=f"成功删除 {total_deleted} 个节点"
-        )
-
-    except Exception as e:
-        api_logger.error(f"批量删除节点失败: end_user_id={end_user_id}, error={str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "批量删除节点失败", str(e))

--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -3,28 +3,25 @@
 保留终端用户信息更新与记忆空间（memory_space）相关接口。
 分析类（analytics）接口已迁移至 memory_analytics_controller。
 """
-import datetime
-from sqlalchemy.orm import Session
 from fastapi import APIRouter, Depends, Header, Query
+from sqlalchemy.orm import Session
 
-from app.db import get_db
+from app.core.error_codes import BizCode
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import success, fail
-from app.core.error_codes import BizCode
-from app.core.api_key_utils import timestamp_to_datetime
-from app.services.user_memory_service import UserMemoryService
-from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
-from app.schemas.response_schema import ApiResponse
-from app.repositories.workspace_repository import WorkspaceRepository
-from app.repositories.end_user_repository import EndUserRepository
-from app.schemas.end_user_info_schema import (
-    EndUserInfoResponse,
-    EndUserInfoCreate,
-    EndUserInfoUpdate,
-)
+from app.db import get_db
 from app.dependencies import get_current_user
 from app.models.user_model import User
+from app.repositories.end_user_repository import EndUserRepository
+from app.repositories.workspace_repository import WorkspaceRepository
+from app.schemas.end_user_info_schema import (
+    EndUserInfoUpdate,
+)
+from app.schemas.memory_storage_schema import DeleteNodeRequest, DeleteAllNodesRequest
+from app.schemas.response_schema import ApiResponse
+from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
+from app.services.user_memory_service import UserMemoryService
 
 # Get API logger
 api_logger = get_api_logger()
@@ -38,13 +35,13 @@ router = APIRouter(
 )
 
 
-#=======================终端用户信息接口=======================
+# =======================终端用户信息接口=======================
 
 @router.post("/end_user_info/updated", response_model=ApiResponse)
 async def update_end_user_info(
-    info_update: EndUserInfoUpdate,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+        info_update: EndUserInfoUpdate,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
 ) -> dict:
     """
     更新终端用户信息记录
@@ -84,7 +81,7 @@ async def update_end_user_info(
 
     # 获取更新数据（排除 end_user_id）
     update_data = info_update.model_dump(exclude_unset=True, exclude={'end_user_id'})
-    
+
     result = user_memory_service.update_end_user_info(db, end_user_id, update_data)
 
     if result["success"]:
@@ -93,13 +90,14 @@ async def update_end_user_info(
     else:
         error_msg = result["error"]
         api_logger.error(f"终端用户信息更新失败: end_user_id={end_user_id}, error={error_msg}")
-        
+
         if error_msg == "终端用户信息记录不存在":
             return fail(BizCode.USER_NOT_FOUND, "终端用户信息记录不存在", error_msg)
         elif error_msg == "无效的终端用户ID格式":
             return fail(BizCode.INVALID_USER_ID, "无效的终端用户ID格式", error_msg)
         else:
             return fail(BizCode.INTERNAL_ERROR, "终端用户信息更新失败", error_msg)
+
 
 @router.get("/memory_space/timeline_memories", response_model=ApiResponse)
 async def memory_space_timeline_of_shared_memories(
@@ -216,3 +214,102 @@ async def memory_space_relationship_evolution(id: str, label: str,
     except Exception as e:
         api_logger.error(f"关系演变查询失败: id={id}, table={label}, error={str(e)}", exc_info=True)
         return fail(BizCode.INTERNAL_ERROR, "关系演变查询失败", str(e))
+
+
+@router.post("/node/delete", response_model=ApiResponse)
+async def delete_node_api(
+        request: DeleteNodeRequest,
+        current_user: User = Depends(get_current_user),
+) -> dict:
+    """通过 elementId 删除 Neo4j 图节点（含关联边）。
+
+    会自动校验节点归属的 end_user_id，仅删除属于指定用户的节点。
+    """
+    workspace_id = current_user.current_workspace_id
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试删除节点但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    element_id = request.element_id
+    end_user_id = request.end_user_id
+
+    api_logger.info(
+        f"节点删除请求: element_id={element_id}, end_user_id={end_user_id}, "
+        f"user={current_user.username}, workspace={workspace_id}"
+    )
+
+    try:
+        from app.core.memory.memory_service import MemoryService
+
+        deleted = await MemoryService.delete_node_by_element_id(
+            element_id=element_id,
+            end_user_id=end_user_id,
+        )
+
+        if deleted:
+            api_logger.info(f"节点删除成功: element_id={element_id}, end_user_id={end_user_id}")
+
+            # 同步 memory_count 到 PostgreSQL
+            try:
+                from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
+                from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+                async with Neo4jConnector() as sync_connector:
+                    await sync_end_user_memory_count_from_neo4j(end_user_id, sync_connector)
+            except Exception as sync_err:
+                api_logger.warning(f"同步 memory_count 失败（不影响删除结果）: {sync_err}")
+
+            return success(data={"deleted": True, "element_id": element_id}, msg="节点删除成功")
+        else:
+            api_logger.warning(f"节点未找到或不属于该用户: element_id={element_id}, end_user_id={end_user_id}")
+            return fail(BizCode.NOT_FOUND, "节点未找到或不属于该用户", f"element_id={element_id}")
+
+    except Exception as e:
+        api_logger.error(f"节点删除失败: element_id={element_id}, error={str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "节点删除失败", str(e))
+
+
+@router.post("/nodes/delete-all", response_model=ApiResponse)
+async def delete_all_nodes_api(
+        request: DeleteAllNodesRequest,
+        current_user: User = Depends(get_current_user),
+) -> dict:
+    """删除指定用户的所有 Neo4j 记忆节点和边。
+
+    分批 DETACH DELETE + 清理残留边，完成后同步 memory_count 到 PostgreSQL。
+    这是一个危险操作，会永久删除该用户的所有记忆图数据。
+    """
+    workspace_id = current_user.current_workspace_id
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试删除所有节点但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    end_user_id = request.end_user_id
+
+    api_logger.info(
+        f"批量删除节点请求: end_user_id={end_user_id}, "
+        f"user={current_user.username}, workspace={workspace_id}"
+    )
+
+    try:
+        from app.core.memory.memory_service import MemoryService
+
+        total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(end_user_id)
+
+        try:
+            from app.repositories.end_user_repository import EndUserRepository
+            from app.db import get_db_context
+            from uuid import UUID
+            with get_db_context() as db:
+                EndUserRepository(db).update_memory_count(UUID(end_user_id), 0)
+        except Exception as sync_err:
+            api_logger.warning(f"同步 memory_count 失败（不影响删除结果）: {sync_err}")
+
+        api_logger.info(f"批量删除完成: end_user_id={end_user_id}, total_deleted={total_deleted}")
+        return success(
+            data={"deleted": True, "end_user_id": end_user_id, "total_deleted": total_deleted},
+            msg=f"成功删除 {total_deleted} 个节点"
+        )
+
+    except Exception as e:
+        api_logger.error(f"批量删除节点失败: end_user_id={end_user_id}, error={str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "批量删除节点失败", str(e))

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -205,6 +205,31 @@ class MemoryService:
         from app.core.memory.pipelines.dispatcher import dispatch_flush_conversation
         return dispatch_flush_conversation(conversation_id)
 
+    @staticmethod
+    async def delete_node_by_element_id(element_id: str, end_user_id: str) -> bool:
+        """通过 elementId 删除 Neo4j 图节点（同时 DETACH DELETE 关联边）。"""
+        from app.core.memory.models.service_models import MemoryContext
+        from app.core.memory.pipelines.forgetting_pipeline import ForgettingPipeline
+
+        pipeline = ForgettingPipeline(MemoryContext(end_user_id=end_user_id))
+        return await pipeline.delete_node_by_element_id(
+            element_id=element_id,
+            end_user_id=end_user_id,
+        )
+
+    @staticmethod
+    async def delete_all_nodes_by_end_user_id(end_user_id: str) -> int:
+        """删除指定用户的所有 Neo4j 记忆节点和边。
+
+        Returns:
+            删除的节点总数
+        """
+        from app.core.memory.models.service_models import MemoryContext
+        from app.core.memory.pipelines.forgetting_pipeline import ForgettingPipeline
+
+        pipeline = ForgettingPipeline(MemoryContext(end_user_id=end_user_id))
+        return await pipeline.delete_all_nodes_by_end_user_id(end_user_id)
+
     # ──────────────────────────────────────────────
     # 实例方法：写入执行（由 write_message_task 调用）
     # ──────────────────────────────────────────────

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -1,0 +1,50 @@
+import uuid
+
+from app.core.memory.pipelines.base_pipeline import BasePipeline
+from app.core.memory.storage_services.forgetting_engine.forget_service import ForgetService
+from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
+from app.core.quota_manager import get_end_user_memory_limit
+from app.db import get_db_read, get_db_context
+from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
+from app.repositories.neo4j.cypher_queries import DELETE_NODE_BY_ELEMENT_ID
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+
+class ForgettingPipeline(BasePipeline):
+    async def run(self):
+        with get_db_read() as db:
+            tenant_id = get_tenant_id_by_end_user_id(db, uuid.UUID(self.ctx.end_user_id))
+            if tenant_id is None:
+                raise Exception(f"End user not found. - User ID:{self.ctx.end_user_id}")
+            memory_limit = get_end_user_memory_limit(db, tenant_id)
+            if memory_limit is None:
+                raise Exception(f"Memory limit not found. - Tenant ID:{tenant_id}")
+        if memory_limit <= 0:
+            return
+        await ForgetService(self.ctx, memory_limit).run()
+
+        async with Neo4jConnector() as connector:
+            await sync_end_user_memory_count_from_neo4j(self.ctx.end_user_id, connector)
+
+    @staticmethod
+    async def delete_node_by_element_id(element_id: str, end_user_id: str) -> bool:
+        """通过 elementId 删除 Neo4j 图节点（同时 DETACH DELETE 关联边）。"""
+
+        async with Neo4jConnector() as connector:
+            result = await connector.execute_query(
+                DELETE_NODE_BY_ELEMENT_ID,
+                element_id=element_id,
+                end_user_id=end_user_id,
+            )
+            return result[0]['deleted'] > 0 if result else False
+
+    @staticmethod
+    async def delete_all_nodes_by_end_user_id(end_user_id: str) -> int:
+        """删除指定用户的所有 Neo4j 记忆节点和边。
+
+        Returns:
+            删除的节点总数
+        """
+
+        async with Neo4jConnector() as connector:
+            return await connector.delete_group(end_user_id)

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -1,0 +1,25 @@
+from app.core.memory.models.service_models import MemoryContext
+from app.repositories.neo4j import Neo4jConnector
+
+
+class ForgetService:
+    def __init__(
+            self,
+            ctx: MemoryContext,
+            memory_limit: int,
+    ):
+        self.ctx = ctx
+        self.memory_limit = memory_limit
+
+    async def run(self):
+        async with Neo4jConnector() as connector:
+            pass
+
+    def important_rank(self):
+        pass
+
+    async def chunk_stmt_clean(self):
+        pass
+
+    async def entity_clean(self):
+        pass

--- a/api/app/core/quota_manager.py
+++ b/api/app/core/quota_manager.py
@@ -146,6 +146,13 @@ def get_api_ops_rate_limit(db: Session, tenant_id: UUID) -> Optional[int]:
     return None
 
 
+def get_end_user_memory_limit(db: Session, tenant_id: UUID) -> Optional[int]:
+    quota_config = _get_quota_config(db, tenant_id)
+    if quota_config:
+        return quota_config.get("end_user_memory_limit")
+    return None
+
+
 class QuotaUsageRepository:
     """配额使用量数据访问层"""
 
@@ -268,12 +275,12 @@ class QuotaUsageRepository:
 
 
 def _check_quota(
-    db: Session,
-    tenant_id: UUID,
-    quota_type: str,
-    resource_name: str,
-    usage_func: Optional[Callable] = None,
-    workspace_id: Optional[UUID] = None,
+        db: Session,
+        tenant_id: UUID,
+        quota_type: str,
+        resource_name: str,
+        usage_func: Optional[Callable] = None,
+        workspace_id: Optional[UUID] = None,
 ) -> None:
     """核心配额检查逻辑：对比使用量和配额限制"""
     try:
@@ -441,7 +448,8 @@ def check_memory_engine_quota(func: Callable) -> Callable:
     async def async_wrapper(*args, **kwargs):
         db: Session = kwargs.get("db")
         user = _get_user_from_kwargs(kwargs)
-        logger.debug(f"check_memory_engine_quota async_wrapper: db={db is not None}, user={user}, kwargs_keys={list(kwargs.keys())}")
+        logger.debug(
+            f"check_memory_engine_quota async_wrapper: db={db is not None}, user={user}, kwargs_keys={list(kwargs.keys())}")
         if not db or not user:
             logger.error(f"配额检查失败：{func.__name__} 缺少 db 或 user 参数，拒绝请求")
             raise InternalServerError()
@@ -456,7 +464,8 @@ def check_memory_engine_quota(func: Callable) -> Callable:
     def sync_wrapper(*args, **kwargs):
         db: Session = kwargs.get("db")
         user = _get_user_from_kwargs(kwargs)
-        logger.debug(f"check_memory_engine_quota sync_wrapper: db={db is not None}, user={user}, kwargs_keys={list(kwargs.keys())}")
+        logger.debug(
+            f"check_memory_engine_quota sync_wrapper: db={db is not None}, user={user}, kwargs_keys={list(kwargs.keys())}")
         if not db or not user:
             logger.error(f"配额检查失败：{func.__name__} 缺少 db 或 user 参数，拒绝请求")
             raise InternalServerError()
@@ -566,6 +575,7 @@ def check_model_quota(func: Callable) -> Callable:
 
 def check_model_activation_quota(func: Callable) -> Callable:
     """模型激活时的配额检查装饰器"""
+
     @wraps(func)
     async def async_wrapper(*args, **kwargs):
         db: Session = kwargs.get("db")
@@ -639,6 +649,7 @@ def check_model_activation_quota(func: Callable) -> Callable:
 
 def check_quota(quota_type: str, resource_name: str, usage_func: Optional[Callable] = None):
     """通用配额检查装饰器，支持自定义使用量获取函数"""
+
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
@@ -661,6 +672,7 @@ def check_quota(quota_type: str, resource_name: str, usage_func: Optional[Callab
             return func(*args, **kwargs)
 
         return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
+
     return decorator
 
 
@@ -678,7 +690,7 @@ async def get_quota_usage(db: Session, tenant_id: UUID) -> dict:
     quota_config = _get_quota_config(db, tenant_id)
     if not quota_config:
         return {}
-    
+
     repo = QuotaUsageRepository(db)
 
     def pct(used, limit):
@@ -753,8 +765,10 @@ async def get_quota_usage(db: Session, tenant_id: UUID) -> dict:
         logger.warning(f"获取 api_ops_current 失败，返回 0: {type(e).__name__}: {e}")
 
     return {
-        "workspace": {"used": workspace_count, "limit": quota_config.get("workspace_quota"), "percentage": pct(workspace_count, quota_config.get("workspace_quota"))},
-        "skill": {"used": skill_count, "limit": quota_config.get("skill_quota"), "percentage": pct(skill_count, quota_config.get("skill_quota"))},
+        "workspace": {"used": workspace_count, "limit": quota_config.get("workspace_quota"),
+                      "percentage": pct(workspace_count, quota_config.get("workspace_quota"))},
+        "skill": {"used": skill_count, "limit": quota_config.get("skill_quota"),
+                  "percentage": pct(skill_count, quota_config.get("skill_quota"))},
         "app": {
             "used": app_count,
             "limit": app_effective_limit,
@@ -786,6 +800,8 @@ async def get_quota_usage(db: Session, tenant_id: UUID) -> dict:
             "percentage": pct(ontology_count, ontology_effective_limit),
             "per_workspace": _build_per_workspace_detail(repo.count_ontology_projects, ontology_quota_per_ws),
         },
-        "model": {"used": model_count, "limit": quota_config.get("model_quota"), "percentage": pct(model_count, quota_config.get("model_quota"))},
-        "api_ops_rate_limit": {"current": api_ops_current, "limit": quota_config.get("api_ops_rate_limit"), "percentage": None, "unit": "次/秒"},
+        "model": {"used": model_count, "limit": quota_config.get("model_quota"),
+                  "percentage": pct(model_count, quota_config.get("model_quota"))},
+        "api_ops_rate_limit": {"current": api_ops_current, "limit": quota_config.get("api_ops_rate_limit"),
+                               "percentage": None, "unit": "次/秒"},
     }

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -30,42 +30,30 @@ class MemoryReadNode(BaseNode):
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
         self.typed_config = MemoryReadNodeConfig(**self.config)
-        with get_db_context() as db:
-            end_user_id = self.get_variable("sys.user_id", variable_pool)
+        end_user_id = self.get_variable("sys.user_id", variable_pool)
 
-            if not end_user_id:
-                raise RuntimeError("End user id is required")
+        if not end_user_id:
+            raise RuntimeError("End user id is required")
 
-            memory_service = MemoryService(
-                storage_type=state["memory_storage_type"],
-                config_id=str(self.typed_config.config_id),
-                end_user_id=end_user_id,
-                user_rag_memory_id=state["user_rag_memory_id"],
-                conversation_id=variable_pool.get_value("sys.conversation_id"),
-            )
-            query = self._render_template(self.typed_config.message, variable_pool)
-            self._process = {"query": query, "config_id": str(self.typed_config.config_id)}
-            # TODO: Historical Messages -> Used to refer to coreference resolution
-            search_result = await memory_service.read(
-                query,
-                search_switch=SearchStrategy(self.typed_config.search_switch)
-            )
-            self._process["memories_count"] = len(search_result.memories)
-            return {
-                "answer": search_result.content,
-                "intermediate_outputs": [_.model_dump() for _ in search_result.memories]
-            }
-
-            # return await MemoryAgentService().read_memory(
-            #     end_user_id=end_user_id,
-            #     message=self._render_template(self.typed_config.message, variable_pool),
-            #     config_id=self.typed_config.config_id,
-            #     search_switch=self.typed_config.search_switch,
-            #     history=[],
-            #     db=db,
-            #     storage_type=state["memory_storage_type"],
-            #     user_rag_memory_id=state["user_rag_memory_id"]
-            # )
+        memory_service = MemoryService(
+            storage_type=state["memory_storage_type"],
+            config_id=str(self.typed_config.config_id),
+            end_user_id=end_user_id,
+            user_rag_memory_id=state["user_rag_memory_id"],
+            conversation_id=variable_pool.get_value("sys.conversation_id"),
+        )
+        query = self._render_template(self.typed_config.message, variable_pool)
+        self._process = {"query": query, "config_id": str(self.typed_config.config_id)}
+        # TODO: Historical Messages -> Used to refer to coreference resolution
+        search_result = await memory_service.read(
+            query,
+            search_switch=SearchStrategy(self.typed_config.search_switch)
+        )
+        self._process["memories_count"] = len(search_result.memories)
+        return {
+            "answer": search_result.content,
+            "intermediate_outputs": [_.model_dump() for _ in search_result.memories]
+        }
 
 
 class MemoryWriteNode(BaseNode):

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1144,6 +1144,18 @@ def get_end_user_by_id(db: Session, end_user_id: uuid.UUID) -> Optional[EndUser]
     end_user = repo.get_end_user_by_id(end_user_id)
     return end_user
 
+
+def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
+    """根据 end_user_id 查询对应的 tenant_id，单次 JOIN 查询，不加载 ORM 对象"""
+    from app.models.workspace_model import Workspace
+
+    return (
+        db.query(Workspace.tenant_id)
+        .join(EndUser, EndUser.workspace_id == Workspace.id)
+        .filter(EndUser.id == end_user_id, EndUser.is_active == True)
+        .scalar()
+    )
+
 # 新增的缓存操作函数（保持与类方法一致的接口）
 def get_by_id(db: Session, end_user_id: uuid.UUID) -> Optional[EndUser]:
     """根据ID获取终端用户（用于缓存操作）"""

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -860,6 +860,41 @@ class EndUserRepository:
             )
             raise
 
+    def soft_delete_by_end_user_id(self, end_user_id: uuid.UUID) -> bool:
+        """软删除指定 EndUser（按 end_user_id）。
+
+        设置 is_active=False，数据保留，查询时通过 is_active=True 过滤。
+        同时操作 EndUserInfo（通过 ORM cascade 或显式标记）。
+
+        Args:
+            end_user_id: 终端用户 ID
+
+        Returns:
+            bool: 是否成功删除（更新了至少一行）
+        """
+        try:
+            updated = (
+                self.db.query(EndUser)
+                .filter(
+                    EndUser.id == end_user_id,
+                    EndUser.is_active == True,
+                )
+                .update(
+                    {"is_active": False},
+                    synchronize_session=False,
+                )
+            )
+            self.db.commit()
+            if updated:
+                db_logger.info(f"软删除终端用户: end_user_id={end_user_id}")
+            else:
+                db_logger.warning(f"未找到活跃终端用户，无法软删除: end_user_id={end_user_id}")
+            return updated > 0
+        except Exception as e:
+            self.db.rollback()
+            db_logger.error(f"软删除终端用户失败: end_user_id={end_user_id}, error={str(e)}")
+            raise
+
     def soft_delete_by_user_id(self, user_id: uuid.UUID) -> int:
         """软删除指定 User（通过 other_id 关联）的所有 EndUser。
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2461,3 +2461,10 @@ MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id AND toLower(e.name) IN $names
 RETURN e.id AS id, e.name AS name
 """
+
+DELETE_NODE_BY_ELEMENT_ID = """
+MATCH (n)
+WHERE elementId(n) = $element_id AND n.end_user_id = $end_user_id
+DETACH DELETE n
+RETURN count(n) AS deleted
+"""

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -36,90 +36,90 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 logger = logging.getLogger(__name__)
 
 
-async def _update_activation_values_batch(
-        nodes: List[Dict[str, Any]],
-        node_label: str,
-        end_user_id: Optional[str] = None,
-        max_retries: int = 3
-) -> List[Dict[str, Any]]:
-    """
-    批量更新节点的激活值
-    
-    为提高性能，批量更新多个节点的访问历史和激活值。
-    使用重试机制处理更新失败的情况。
-    
-    Args:
-        connector: Neo4j连接器
-        nodes: 节点列表，每个节点必须包含 'id' 字段
-        node_label: 节点标签（Statement, ExtractedEntity, MemorySummary）
-        end_user_id: 组ID（可选）
-        max_retries: 最大重试次数
-    
-    Returns:
-        List[Dict[str, Any]]: 成功更新的节点列表
-    """
-    async with Neo4jConnector() as connector:
-        if not nodes:
-            return []
-
-        # 延迟导入以避免循环依赖
-        from app.core.memory.storage_services.forgetting_engine.access_history_manager import (
-            AccessHistoryManager,
-        )
-        from app.core.memory.storage_services.forgetting_engine.actr_calculator import (
-            ACTRCalculator,
-        )
-
-        # 创建计算器和管理器实例
-        actr_calculator = ACTRCalculator()
-        access_manager = AccessHistoryManager(
-            connector=connector,
-            actr_calculator=actr_calculator,
-            max_retries=max_retries
-        )
-
-        # 提取节点ID列表并去重（保持原始顺序）
-        seen_ids = set()
-        unique_node_ids = []
-        for node in nodes:
-            node_id = node.get('id')
-            if node_id and node_id not in seen_ids:
-                seen_ids.add(node_id)
-                unique_node_ids.append(node_id)
-
-        if not unique_node_ids:
-            logger.warning("批量更新激活值：没有有效的节点ID")
-            return nodes
-
-        # 记录去重信息（仅针对具有有效 ID 的节点）
-        id_nodes_count = sum(1 for n in nodes if n.get("id"))
-        if len(unique_node_ids) < id_nodes_count:
-            logger.info(
-                f"批量更新激活值：检测到重复节点，具有有效ID的节点数量={id_nodes_count}, "
-                f"去重后唯一ID数量={len(unique_node_ids)}"
-            )
-
-        # 批量记录访问
-        try:
-            updated_nodes = await access_manager.record_batch_access(
-                node_ids=unique_node_ids,
-                node_label=node_label,
-                end_user_id=end_user_id
-            )
-
-            logger.debug(
-                f"批量更新激活值成功: {node_label}, "
-                f"更新数量={len(updated_nodes)}/{len(unique_node_ids)}"
-            )
-
-            return updated_nodes
-
-        except Exception as e:
-            logger.error(
-                f"批量更新激活值失败: {node_label}, 错误: {str(e)}"
-            )
-            # 失败时返回原始节点列表
-            return nodes
+# async def _update_activation_values_batch(
+#         nodes: List[Dict[str, Any]],
+#         node_label: str,
+#         end_user_id: Optional[str] = None,
+#         max_retries: int = 3
+# ) -> List[Dict[str, Any]]:
+#     """
+#     批量更新节点的激活值
+#
+#     为提高性能，批量更新多个节点的访问历史和激活值。
+#     使用重试机制处理更新失败的情况。
+#
+#     Args:
+#         connector: Neo4j连接器
+#         nodes: 节点列表，每个节点必须包含 'id' 字段
+#         node_label: 节点标签（Statement, ExtractedEntity, MemorySummary）
+#         end_user_id: 组ID（可选）
+#         max_retries: 最大重试次数
+#
+#     Returns:
+#         List[Dict[str, Any]]: 成功更新的节点列表
+#     """
+#     async with Neo4jConnector() as connector:
+#         if not nodes:
+#             return []
+#
+#         # 延迟导入以避免循环依赖
+#         from app.core.memory.storage_services.forgetting_engine.access_history_manager import (
+#             AccessHistoryManager,
+#         )
+#         from app.core.memory.storage_services.forgetting_engine.actr_calculator import (
+#             ACTRCalculator,
+#         )
+#
+#         # 创建计算器和管理器实例
+#         actr_calculator = ACTRCalculator()
+#         access_manager = AccessHistoryManager(
+#             connector=connector,
+#             actr_calculator=actr_calculator,
+#             max_retries=max_retries
+#         )
+#
+#         # 提取节点ID列表并去重（保持原始顺序）
+#         seen_ids = set()
+#         unique_node_ids = []
+#         for node in nodes:
+#             node_id = node.get('id')
+#             if node_id and node_id not in seen_ids:
+#                 seen_ids.add(node_id)
+#                 unique_node_ids.append(node_id)
+#
+#         if not unique_node_ids:
+#             logger.warning("批量更新激活值：没有有效的节点ID")
+#             return nodes
+#
+#         # 记录去重信息（仅针对具有有效 ID 的节点）
+#         id_nodes_count = sum(1 for n in nodes if n.get("id"))
+#         if len(unique_node_ids) < id_nodes_count:
+#             logger.info(
+#                 f"批量更新激活值：检测到重复节点，具有有效ID的节点数量={id_nodes_count}, "
+#                 f"去重后唯一ID数量={len(unique_node_ids)}"
+#             )
+#
+#         # 批量记录访问
+#         try:
+#             updated_nodes = await access_manager.record_batch_access(
+#                 node_ids=unique_node_ids,
+#                 node_label=node_label,
+#                 end_user_id=end_user_id
+#             )
+#
+#             logger.debug(
+#                 f"批量更新激活值成功: {node_label}, "
+#                 f"更新数量={len(updated_nodes)}/{len(unique_node_ids)}"
+#             )
+#
+#             return updated_nodes
+#
+#         except Exception as e:
+#             logger.error(
+#                 f"批量更新激活值失败: {node_label}, 错误: {str(e)}"
+#             )
+#             # 失败时返回原始节点列表
+#             return nodes
 
 
 async def _update_search_results_activation(

--- a/api/app/repositories/neo4j/neo4j_connector.py
+++ b/api/app/repositories/neo4j/neo4j_connector.py
@@ -67,7 +67,7 @@ class Neo4jConnector:
             shared_driver: 是否使用进程级共享 driver。
                 True  → 所有实例共用一个 driver，通过 PID 检测 fork 后自动重建。
                 False → 每次实例化创建独立 driver（调用方需自行管理生命周期）。
-        
+
         Raises:
             RuntimeError: 如果NEO4J_PASSWORD环境变量未设置
         """
@@ -96,7 +96,7 @@ class Neo4jConnector:
 
     def _create_or_get_driver(self) -> AsyncDriver:
         """按配置返回独占或进程级共享的 driver。
-        
+
         shared_driver=True 时：
         - 检测当前 PID 是否与 _shared_driver_pid 一致
         - PID 变化（fork 后）或首次调用时自动重建
@@ -153,8 +153,6 @@ class Neo4jConnector:
             
         Returns:
             List[Dict[str, Any]]: 查询结果列表，每个元素是一个字典
-            
-
 
         """
         result = await self.driver.execute_query(
@@ -180,7 +178,6 @@ class Neo4jConnector:
             
         Returns:
             Any: 事务函数的返回值
-            
 
 
         """
@@ -198,21 +195,22 @@ class Neo4jConnector:
             
         Returns:
             Any: 事务函数的返回值
-            
-
 
         """
         async with self.driver.session(database="neo4j") as session:
             return await session.execute_read(transaction_func, **kwargs)
     
-    async def delete_group(self, end_user_id: str):
+    async def delete_group(self, end_user_id: str) -> int:
         """删除指定组的所有数据
-        
+
         删除所有属于指定end_user_id的节点和边。
         这是一个危险操作，会永久删除数据。
-        
+
         Args:
             end_user_id: 要删除的组ID
+
+        Returns:
+            删除的节点总数
         """
         batch_size = 1000
         total_deleted = 0
@@ -235,3 +233,4 @@ class Neo4jConnector:
             end_user_id=end_user_id,
         )
         logger.info(f"Group {end_user_id} deleted ({total_deleted} nodes).")
+        return total_deleted

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -544,3 +544,18 @@ class ForgettingCurveResponse(BaseModel):
 
     curve_data: List[ForgettingCurvePoint] = Field(..., description="遗忘曲线数据点列表")
     config: Dict[str, Any] = Field(..., description="使用的配置参数")
+
+
+class DeleteNodeRequest(BaseModel):
+    """删除单个图节点请求"""
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    element_id: str = Field(..., description="Neo4j elementId")
+    end_user_id: str = Field(..., description="端用户 ID")
+
+
+class DeleteAllNodesRequest(BaseModel):
+    """删除用户所有记忆节点请求"""
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    end_user_id: str = Field(..., description="端用户 ID")


### PR DESCRIPTION
## Summary by Sourcery

引入用于删除内存图节点和执行每个终端用户内存限制的 API 与管线支持，包括完整用户内存删除和软停用流程。

New Features:
- 添加 REST 端点，通过 `elementId` 删除单个 Neo4j 内存节点，并进行终端用户归属校验和 `memory_count` 重新同步。
- 添加 REST 端点，用于删除某终端用户的所有内存数据，包括 Neo4j 节点和 PostgreSQL 记录，并对该终端用户进行软删除。
- 引入 `ForgettingPipeline` 和 `MemoryService` 辅助工具，用于按 `end_user_id` 执行节点删除和批量删除，并接入 Neo4j 删除工具。
- 添加用于删除终端用户单个或全部内存节点的请求 schema。
- 添加支持通过 `elementId` 删除节点并返回删除数量的 Cypher 查询能力。
- 在配额配置和默认免费套餐设置中暴露按租户维度的 `end_user_memory_limit`。

Enhancements:
- 从 `Neo4jConnector.delete_group` 返回已删除节点总数，以支持在更高层级的 API 中进行统计上报。
- 添加仓库辅助函数，用于按 `end_user_id` 对终端用户进行软删除，并根据 `end_user_id` 解析 `tenant_id`，以支持遗忘（forgetting）流程。
- 简化 `MemoryReadNode` 工作流执行，移除未使用的数据库上下文和历史代理调用。
- 将遗忘管线接入 Neo4j，在清理操作后同步终端用户的内存计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce APIs and pipeline support for deleting memory graph nodes and enforcing per-end-user memory limits, including full user memory deletion and soft-deactivation flows.

New Features:
- Add REST endpoint to delete a single Neo4j memory node by elementId with end-user ownership validation and memory_count resync.
- Add REST endpoint to delete all memory data for an end user, including Neo4j nodes and PostgreSQL records, with soft deletion of the end user.
- Introduce a ForgettingPipeline and MemoryService helpers to perform node deletion and bulk deletion by end_user_id, wired to Neo4j deletion utilities.
- Add request schemas for deleting single or all memory nodes for an end user.
- Add Cypher query support for deleting a node by elementId and returning deleted count.
- Expose per-tenant end_user_memory_limit in quota configuration and default free plan settings.

Enhancements:
- Return total deleted node count from Neo4jConnector.delete_group to support reporting in higher-level APIs.
- Add repository helpers to soft-delete end users by end_user_id and to resolve tenant_id from end_user_id for forgetting workflows.
- Simplify MemoryReadNode workflow execution by removing unused DB context and legacy agent call.
- Wire forgetting pipeline to sync end_user memory counts from Neo4j after cleanup operations.

</details>