### PR TITLE
feat(web): end user support delete

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:00:06 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-11 10:20:26
+ * @Last Modified time: 2026-06-29 15:02:13
  */
 import { request } from '@/utils/request'
 import type { AxiosRequestConfig } from 'axios'
@@ -65,6 +65,10 @@ export const getDashboardData = () => {
 export const userMemoryListUrl = '/dashboard/end_users'
 export const getUserMemoryList = (query?: { keyword?: string }) => {
   return request.get(userMemoryListUrl, query)
+}
+// User Memory - Delete end user
+export const deleteEndUser = (end_user_id: string) => {
+  return request.delete(`/memory-storage/end-users/${end_user_id}`)
 }
 // User Memory - Total end users
 export const getTotalEndUsers = () => {

--- a/web/src/components/MoreDropdown/index.tsx
+++ b/web/src/components/MoreDropdown/index.tsx
@@ -16,7 +16,17 @@ interface MoreDropdownProps {
  */
 const MoreDropdown: FC<MoreDropdownProps> = ({ items, placement = 'bottomRight', onClick, iconClassName = '', variant = 'borderless' }) => {
   return (
-    <Dropdown menu={{ items }} placement={placement}>
+    <Dropdown 
+      menu={{ 
+        items,
+        onClick: (e) => {
+          if (e.domEvent) {
+            e.domEvent.stopPropagation();
+          }
+        }
+      }} 
+      placement={placement}
+    >
       {variant === 'outline'
         ? <Flex align="center" justify="center" className="rb:cursor-pointer rb:border rb:border-[#EBEBEB] rb:rounded-lg rb:size-6! rb:hover:border-[#171719]">
           <div

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1634,6 +1634,13 @@ export const en = {
       total_num: 'Total Number of Users',
       online_num: 'Number of Online Users',
 
+      deleteMemoryStore: 'Delete Memory Store',
+      deleteWarning: 'All {{count}} memories of "{{name}}" will be permanently deleted and unrecoverable, including perception, episodic, emotional, and long-term memories.',
+      enterNameConfirm: 'Enter the memory store name "{{name}}" to confirm deletion',
+      enterNamePlaceholder: 'Enter name to confirm',
+      permanentDelete: 'Permanently Delete',
+      deleteConfirmNameError: 'Please enter the correct name',
+
       user: 'User',
       knowledgeEntryCount: 'Knowledge Entry Count',
       interactionCount: 'Interaction Count',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1629,6 +1629,13 @@ export const zh = {
       total_num: '用户总数',
       online_num: '在线用户数',
 
+      deleteMemoryStore: '删除记忆库',
+      deleteWarning: '「{{name}}」的全部 {{count}} 条记忆将被永久删除且不可恢复，包括其感知、情景、情绪与长期记忆。',
+      enterNameConfirm: '请输入记忆库名称 「{{name}}」 以确认删除',
+      enterNamePlaceholder: '请输入名称确认',
+      permanentDelete: '永久删除',
+      deleteConfirmNameError: '请输入正确的名称',
+
       user: '用户',
       knowledgeEntryCount: '知识条目数',
       interactionCount: '交互次数',

--- a/web/src/views/UserMemory/components/DeleteConfirmModal.tsx
+++ b/web/src/views/UserMemory/components/DeleteConfirmModal.tsx
@@ -1,0 +1,134 @@
+/*
+ * @Author: ZhaoYing 
+ * @Date: 2026-06-29 15:01:28 
+ * @Last Modified by:   ZhaoYing 
+ * @Last Modified time: 2026-06-29 15:01:28 
+ */
+/**
+ * Delete Confirm Modal
+ * Confirmation modal for deleting user memory with name verification
+ */
+
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Form, Input, App } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import type { Data } from '../types'
+import RbModal from '@/components/RbModal'
+import { deleteEndUser } from '@/api/memory';
+
+interface DeleteConfirmModalProps {
+  refreshTable: () => void;
+}
+
+export interface DeleteConfirmModalRef {
+  handleOpen: (item: Data) => void;
+  handleClose: () => void;
+}
+
+const DeleteConfirmModal = forwardRef<DeleteConfirmModalRef, DeleteConfirmModalProps>(({
+  refreshTable
+}, ref) => {
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const [visible, setVisible] = useState(false);
+  const [form] = Form.useForm();
+  const [currentItem, setCurrentItem] = useState<Data | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  /** Get user display name */
+  const getUserName = (item: Data | null) => {
+    if (!item) return '';
+    return item?.end_user?.other_name && item?.end_user?.other_name !== '' 
+      ? item?.end_user?.other_name 
+      : item?.end_user?.id || ''
+  }
+
+  /** Custom validator for name confirmation */
+  const confirmNameValidator = () => {
+    const expectedName = getUserName(currentItem);
+    return {
+      validator: async (_: unknown, value: string) => {
+        if (value !== expectedName) {
+          throw new Error(t('userMemory.deleteConfirmNameError'));
+        }
+      },
+    };
+  };
+
+  /** Close modal and reset form */
+  const handleClose = () => {
+    setVisible(false);
+    setCurrentItem(null);
+    form.resetFields();
+  };
+
+  /** Open modal */
+  const handleOpen = (item: Data) => {
+    setCurrentItem(item);
+    form.resetFields();
+    setVisible(true);
+  };
+
+  /** Confirm delete action */
+  const handleConfirmDelete = async () => {
+    const id = currentItem?.end_user?.id;
+    if (!id) return
+    form.validateFields()
+      .then(() => {
+        setLoading(true)
+        deleteEndUser(id)
+          .then(() => {
+            message.success(t('common.deleteSuccess'));
+            refreshTable();
+            handleClose();
+          })
+          .finally(() => {
+            setLoading(false)
+          })
+      })
+  };
+
+  /** Expose methods to parent component */
+  useImperativeHandle(ref, () => ({
+    handleOpen,
+    handleClose
+  }));
+
+  return (
+    <RbModal
+      title={t('userMemory.deleteMemoryStore')}
+      open={visible}
+      onCancel={handleClose}
+      confirmLoading={loading}
+      okText={t('userMemory.permanentDelete')}
+      okButtonProps={{ danger: true }}
+      onOk={handleConfirmDelete}
+    >
+      <div className="rb:space-y-4">
+        <p className="rb:text-[#5B6167]">
+          {t('userMemory.deleteWarning', {
+            name: getUserName(currentItem),
+            count: currentItem?.memory_num?.total || 0
+          })}
+        </p>
+        <Form form={form} layout="vertical">
+          <Form.Item
+            name="confirmName"
+            label={t('userMemory.enterNameConfirm', { name: getUserName(currentItem) })}
+            rules={[
+              confirmNameValidator(),
+            ]}
+          >
+            <Input 
+              placeholder={t('userMemory.enterNamePlaceholder')}
+              className="rb:w-full"
+            />
+          </Form.Item>
+        </Form>
+      </div>
+    </RbModal>
+  );
+});
+
+export default DeleteConfirmModal;

--- a/web/src/views/UserMemory/index.tsx
+++ b/web/src/views/UserMemory/index.tsx
@@ -21,7 +21,9 @@ import { useUser } from '@/store/user'
 import RbCard from '@/components/RbCard/Card'
 import SearchInput from '@/components/SearchInput';
 import RbStatistic from '@/components/RbStatistic';
+import MoreDropdown from '@/components/MoreDropdown'
 import PageScrollList, { type PageScrollListRef } from '@/components/PageScrollList'
+import DeleteConfirmModal, { type DeleteConfirmModalRef } from './components/DeleteConfirmModal';
 
 export default function UserMemory() {
   const { t } = useTranslation();
@@ -33,6 +35,7 @@ export default function UserMemory() {
   const keyword = Form.useWatch(['keyword'], form)
 
   const scrollListRef = useRef<PageScrollListRef>(null)
+  const deleteConfirmModalRef = useRef<DeleteConfirmModalRef>(null)
 
   /** Navigate to user memory detail */
   const handleViewDetail = (id: string | number) => {
@@ -59,6 +62,18 @@ export default function UserMemory() {
     message.success(t('common.copySuccess'))
   }
 
+  /** Open delete confirmation modal */
+  const handleDelete = (item: Data) => {
+    deleteConfirmModalRef.current?.handleOpen(item);
+  }
+
+  // 获取用户显示名称
+  const getUserName = (item: Data) => {
+    return item?.end_user?.other_name && item?.end_user?.other_name !== '' 
+      ? item?.end_user?.other_name 
+      : item?.end_user?.id || ''
+  }
+
   return (
     <div>
       <Form form={form}>
@@ -74,7 +89,7 @@ export default function UserMemory() {
         </Row>
       </Form>
 
-      
+    
       <PageScrollList<Data, { keyword: string; }>
         ref={scrollListRef}
         url={userMemoryListUrl}
@@ -82,20 +97,34 @@ export default function UserMemory() {
         column={3}
         renderItem={(item) => {
           const { end_user, memory_num, memory_config } = item as Data;
-          const name = end_user?.other_name && end_user?.other_name !== '' ? end_user?.other_name : end_user?.id
+          const name = getUserName(item)
           return (
             <RbCard
-              key={item.end_user.id}
+              key={item.end_user?.id}
               title={() => <Flex gap={4}>
                 <div className="rb:size-6 rb:text-center rb:font-semibold rb:leading-6 rb:rounded-md rb:text-white rb:bg-[#155EEF] rb:shrink-0">{name[0]}</div>
 
                 <Tooltip title={name || '-'}><div className={`rb:flex-1 rb:text-ellipsis rb:overflow-hidden rb:whitespace-nowrap`}>{name || '-'}</div></Tooltip>
               </Flex>}
+              extra={<MoreDropdown
+                items={[
+                  {
+                    key: 'delete',
+                    danger: true,
+                    icon: <div className="rb:size-4 rb:bg-cover rb:cursor-pointer rb:bg-[url('@/assets/images/common/delete_red_big.svg')]" />,
+                    label: t('common.delete'),
+                    onClick: (info) => {
+                      info.domEvent?.stopPropagation();
+                      handleDelete(item);
+                    },
+                  },
+                ]}
+              />}
               headerType="border"
               headerClassName="rb:h-[48px]! rb:mx-4!"
               bodyClassName="rb:py-3! rb:px-4!"
               className="rb:cursor-pointer"
-              onClick={() => handleViewDetail(end_user.id)}
+              onClick={() => handleViewDetail(end_user?.id)}
             >
               <Flex align="center" gap={8} className="rb:mb-3! rb:w-full rb:cursor-pointer" onClick={(e) => handleCopy(e, end_user?.id || '')}>
                 <div className="rb:text-[#5B6167]">ID:</div>
@@ -125,6 +154,12 @@ export default function UserMemory() {
             </RbCard>
           )
         }}
+      />
+
+      {/* 删除确认弹窗 */}
+      <DeleteConfirmModal
+        ref={deleteConfirmModalRef}
+        refreshTable={() => scrollListRef.current?.refresh()}
       />
     </div>
   );


### PR DESCRIPTION
## Summary by Sourcery

在“用户记忆”页面中添加支持删除终端用户的记忆存储，并通过需要名称验证的确认弹窗进行确认。

新功能：
- 在“用户记忆”卡片的上下文下拉菜单中，引入用于终端用户记忆存储的删除操作。
- 添加 `DeleteConfirmModal` 组件，在继续删除前通过验证输入的记忆存储名称来确认删除操作。

改进：
- 防止下拉菜单点击事件向上传递到父级卡片的点击处理程序，以避免出现意外的页面跳转。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for deleting an end user’s memory store from the User Memory page with a confirmation modal requiring name verification.

New Features:
- Introduce a delete action for end user memory stores via a contextual dropdown on User Memory cards.
- Add a DeleteConfirmModal component that confirms deletion by validating the entered memory store name before proceeding.

Enhancements:
- Prevent dropdown menu clicks from propagating to parent card click handlers to avoid unintended navigation.

</details>