### PR TITLE
refactor(memory): rename PIPELINE_SNAPSHOT_ENABLED to EXTRACT_SNAPSHOT_ENABLED

### DIFF
--- a/api/app/core/memory/utils/debug/pipeline_snapshot.py
+++ b/api/app/core/memory/utils/debug/pipeline_snapshot.py
@@ -18,7 +18,7 @@ Output structure (OSS):
                         2_statement_outputs.json
                         ...
 
-Controlled by env var PIPELINE_SNAPSHOT_ENABLED (default: false).
+Controlled by env var EXTRACT_SNAPSHOT_ENABLED (default: false).
 """
 
 from __future__ import annotations
@@ -42,7 +42,7 @@ _OSS_SNAPSHOT_PREFIX = "extract_snapshot"
 def _is_enabled() -> bool:
     global _ENABLED
     if _ENABLED is None:
-        _ENABLED = os.getenv("PIPELINE_SNAPSHOT_ENABLED", "false").lower() == "true"
+        _ENABLED = os.getenv("EXTRACT_SNAPSHOT_ENABLED", "false").lower() == "true"
     return _ENABLED
 
 

--- a/api/app/core/memory/utils/debug/reflection_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/reflection_snapshot_recorder.py
@@ -5,7 +5,7 @@
 (`pipeline_snapshot.upload_stage_snapshot`)，自管独立前缀 `reflection_snapshot/`。
 
 受 env 变量 REFLECTION_SNAPSHOT_ENABLED 控制（默认 false），关闭时全部方法 no-op。
-与写链路 PIPELINE_SNAPSHOT_ENABLED 相互独立。
+与写链路 EXTRACT_SNAPSHOT_ENABLED 相互独立。
 """
 
 from __future__ import annotations

--- a/api/app/core/memory/utils/debug/write_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/write_snapshot_recorder.py
@@ -27,7 +27,7 @@ class WriteSnapshotRecorder:
     内部持有一个 PipelineSnapshot 实例，对外暴露语义化方法，
     每个方法对应流水线中的一个可观测阶段。
 
-    当 PIPELINE_SNAPSHOT_ENABLED=false 时，所有方法均为空操作（no-op）。
+    当 EXTRACT_SNAPSHOT_ENABLED=false 时，所有方法均为空操作（no-op）。
     """
 
     def __init__(

--- a/api/env.example
+++ b/api/env.example
@@ -151,8 +151,8 @@ ENABLE_GENERAL_ONTOLOGY_TYPES=true # 总开关，控制是否启用通用本体�
 MAX_ONTOLOGY_TYPES_IN_PROMPT=100 # 限制传给 LLM 的类型数量，防止 Prompt 过长
 
 
-# 萃取阶段快照：将每个阶段的输出保存到 logs/memory-output/snapshots/
-PIPELINE_SNAPSHOT_ENABLED=false
+# 萃取阶段快照：将每个阶段的输出保存到 oss://memorybear-files/extract_snapshot/
+EXTRACT_SNAPSHOT_ENABLED=false
 
 # 反思引擎快照开关（调试用，默认 false）
 REFLECTION_SNAPSHOT_ENABLED=false


### PR DESCRIPTION
## Summary by Sourcery

将用于启用内存快照的环境变量名称，从 `PIPELINE_SNAPSHOT_ENABLED` 重命名为 `EXTRACT_SNAPSHOT_ENABLED`，并在调试工具和配置中统一使用新名称。

Enhancements:
- 使调试快照工具与新的 `EXTRACT_SNAPSHOT_ENABLED` 环境变量名称保持一致。

Build:
- 更新示例环境配置，使用 `EXTRACT_SNAPSHOT_ENABLED` 替代 `PIPELINE_SNAPSHOT_ENABLED`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the memory snapshot enabling environment variable from PIPELINE_SNAPSHOT_ENABLED to EXTRACT_SNAPSHOT_ENABLED across debug utilities and configuration.

Enhancements:
- Align debug snapshot utilities with the new EXTRACT_SNAPSHOT_ENABLED environment variable name.

Build:
- Update example environment configuration to use EXTRACT_SNAPSHOT_ENABLED instead of PIPELINE_SNAPSHOT_ENABLED.

</details>