### PR TITLE
feat(context-engine)

### DIFF
--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -541,7 +541,7 @@ class MessageRepository:
 
         stmt = stmt.order_by(Message.created_at)
         messages = list(self.db.scalars(stmt).all())
-        logger.info(
+        logger.debug(
             "Fetched messages since boundary",
             extra={
                 "conversation_id": str(conversation_id),

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -551,3 +551,46 @@ class MessageRepository:
             }
         )
         return messages
+
+    def get_recent_messages_from_other_conversations(
+            self,
+            *,
+            app_id: uuid.UUID,
+            user_id: str,
+            exclude_conversation_id: uuid.UUID,
+            limit: int,
+            current_only: bool = True,
+    ) -> list[Message]:
+        """读取同应用同用户其他会话的最近消息，结果按时间正序返回。"""
+        if not user_id or limit <= 0:
+            return []
+
+        stmt = (
+            select(Message)
+            .join(Conversation, Conversation.id == Message.conversation_id)
+            .where(
+                Conversation.app_id == app_id,
+                Conversation.user_id == user_id,
+                Conversation.id != exclude_conversation_id,
+                Message.is_deleted.is_not(True),
+            )
+            .order_by(Message.created_at.desc())
+            .limit(limit)
+        )
+
+        if current_only:
+            stmt = stmt.where(Message.is_current.is_not(False))
+
+        messages = list(self.db.scalars(stmt).all())
+        messages.reverse()
+        logger.info(
+            "Fetched recent messages from other conversations",
+            extra={
+                "app_id": str(app_id),
+                "user_id": user_id,
+                "exclude_conversation_id": str(exclude_conversation_id),
+                "returned": len(messages),
+                "current_only": current_only,
+            }
+        )
+        return messages

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -235,6 +235,16 @@ class WebSearchConfig(BaseModel):
 class ContextEngineFeatureConfig(BaseModel):
     """上下文引擎功能配置。"""
     enabled: bool = Field(default=False, description="是否启用上下文引擎")
+    cross_session_recent_enabled: bool = Field(
+        default=False,
+        description="是否注入同应用同用户其他会话的最近消息",
+    )
+    cross_session_recent_limit: int = Field(
+        default=6,
+        ge=1,
+        le=50,
+        description="跨会话注入的最近消息条数",
+    )
 
 
 class AppFeatures(BaseModel):

--- a/api/app/services/context_engine_manager.py
+++ b/api/app/services/context_engine_manager.py
@@ -264,6 +264,38 @@ class ContextEngineManager:
         return {"role": msg.role, "content": content}
 
     @staticmethod
+    def _get_cross_session_recent_limit(context_config: dict[str, Any]) -> int:
+        if not context_config.get("cross_session_recent_enabled"):
+            return 0
+        try:
+            return max(int(context_config.get("cross_session_recent_limit") or 0), 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _get_cross_session_recent_records(
+            self,
+            *,
+            conversation_id: uuid.UUID,
+            context_config: dict[str, Any],
+    ) -> list[Any]:
+        limit = self._get_cross_session_recent_limit(context_config)
+        if limit <= 0:
+            return []
+
+        conversation = self.conversation_service.conversation_repo.get_conversation_by_conversation_id(
+            conversation_id
+        )
+        if not conversation or not getattr(conversation, "user_id", None):
+            return []
+
+        return self.conversation_service.message_repo.get_recent_messages_from_other_conversations(
+            app_id=conversation.app_id,
+            user_id=conversation.user_id,
+            exclude_conversation_id=conversation_id,
+            limit=limit,
+        )
+
+    @staticmethod
     def _trim_messages_after_boundary(messages: list[Any], state: Optional[dict[str, Any]]) -> list[Any]:
         if not state:
             return list(messages)
@@ -342,11 +374,19 @@ class ContextEngineManager:
                 conversation_id=conversation_id,
                 since_at=state.get("summarized_until_at") if state else None,
             )
+            cross_session_records = self._get_cross_session_recent_records(
+                conversation_id=conversation_id,
+                context_config=context_config,
+            )
             recent_records = self._trim_messages_after_boundary(messages, state)
             recent_messages = [
                 self._serialize_history_message(msg, current_provider, current_is_omni)
-                for msg in recent_records
+                for msg in cross_session_records
             ]
+            recent_messages.extend([
+                self._serialize_history_message(msg, current_provider, current_is_omni)
+                for msg in recent_records
+            ])
             options = self._build_options(
                 context_config,
                 window_size=legacy_max_history,
@@ -367,6 +407,7 @@ class ContextEngineManager:
                     "conversation_id": str(conversation_id),
                     "scope_key": scope_key,
                     "provider": provider_name,
+                    "cross_session_count": len(cross_session_records),
                     "recent_count": len(recent_messages),
                     "prepared_count": len(normalized),
                 }
@@ -495,15 +536,24 @@ class ContextEngineManager:
         try:
             state = await self._get_state(conversation_uuid, scope_key)
             normalized_messages = self._normalize_workflow_messages(workflow_messages)
+            cross_session_records = self._get_cross_session_recent_records(
+                conversation_id=conversation_uuid,
+                context_config=context_config,
+            )
             recent_messages = self._trim_workflow_messages_after_seq(
                 normalized_messages,
                 state.get("summarized_until_seq") if state else None,
             )
+            provider_recent_messages = [
+                self._serialize_history_message(msg, None, None)
+                for msg in cross_session_records
+            ]
+            provider_recent_messages.extend(self._strip_workflow_seq(recent_messages))
             prepared = await provider.prepare_messages(
                 session_id=self._build_session_id(conversation_uuid, scope_key),
                 system_prompt=None,
                 current_input=current_input,
-                recent_messages=self._strip_workflow_seq(recent_messages),
+                recent_messages=provider_recent_messages,
                 summary_text=state.get("summary_text") if state else None,
                 options=self._build_options(
                     context_config,
@@ -521,7 +571,8 @@ class ContextEngineManager:
                     "conversation_id": str(conversation_uuid),
                     "scope_key": scope_key,
                     "provider": provider_name,
-                    "recent_count": len(recent_messages),
+                    "cross_session_count": len(cross_session_records),
+                    "recent_count": len(provider_recent_messages),
                     "prepared_count": len(normalized),
                 }
             )


### PR DESCRIPTION
add cross-session recent messages support

## Summary by Sourcery

为上下文引擎添加支持，可将用户其他会话中的最近消息注入上下文中，适用于应用代理（app agents）和工作流（workflows）。

新功能：
- 在上下文引擎中引入可配置的跨会话最近消息注入机制，包含启用开关以及按应用配置的限制。
- 在准备应用代理和工作流提供方输入时，除当前会话历史外，还包括来自同一用户其他会话的最近消息。

增强：
- 新增仓库方法，用于获取同一用户和应用下其他会话中最近的、未删除且当前有效的消息，并带有日志记录与按时间倒序排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for injecting recent messages from a user’s other conversations into the context engine for both app agents and workflows.

New Features:
- Introduce configurable cross-session recent message injection in the context engine with enable flag and per-app limits.
- Include recent messages from other conversations when preparing app agent and workflow provider inputs, alongside current conversation history.

Enhancements:
- Add repository method to fetch recent non-deleted, current messages from other conversations of the same user and app, with logging and ordering by recency.

</details>