### PR TITLE
Fix/v0.3.10 zy

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2240,6 +2240,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       pleaseSave: 'Displayed only once, please save it properly',
       basicInfo: 'Basic Information',
       regenerate: 'Regenerate',
+      endpointConfig: 'Endpoint Configuration',
     },
     tool: {
       mcp: 'MCP Services',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2234,6 +2234,7 @@ export const zh = {
       pleaseSave: '仅展示一次，请妥善保存',
       basicInfo: '基础信息',
       regenerate: '重新生成',
+      endpointConfig: '端点配置',
     },
     tool: {
       mcp: 'MCP 服务',

--- a/web/src/views/ApiKeyManagement/index.tsx
+++ b/web/src/views/ApiKeyManagement/index.tsx
@@ -2,11 +2,12 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:52:50 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-22 12:07:40
+ * @Last Modified time: 2026-06-30 16:00:54
  */
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, App, Flex } from 'antd';
+import { Button, App, Flex, Space } from 'antd';
+import { ExportOutlined } from '@ant-design/icons';
 import clsx from 'clsx';
 import copy from 'copy-to-clipboard'
 
@@ -29,7 +30,7 @@ import RbDescriptions from '@/components/RbDescriptions';
  */
 const ApiKeyManagement: React.FC = () => {
   // Hooks
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { message } = App.useApp();
   const deleteConfirm = useDeleteConfirm();
   
@@ -79,12 +80,21 @@ const ApiKeyManagement: React.FC = () => {
     copy(content)
     message.success(t('common.copySuccess'))
   }
+  const handleGotoEndpointConfig = () => {
+    window.open(`/docs/?lang=${i18n.language}`, '_blank')
+  }
   return (
     <>
       <Flex justify="flex-end" className="rb:mb-3!">
-        <Button type="primary" onClick={() => handleEdit()}>
-          {t('apiKey.createApiKey')}
-        </Button>
+        <Space>
+          <Button onClick={() => handleGotoEndpointConfig()}>
+            {t('apiKey.endpointConfig')}
+            <ExportOutlined />
+          </Button>
+          <Button type="primary" onClick={() => handleEdit()}>
+            {t('apiKey.createApiKey')}
+          </Button>
+        </Space>
       </Flex>
 
       <PageScrollList<ApiKey, { is_active: boolean; type: string }>

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -94,7 +94,7 @@ const CreateDataset = () => {
   const [pollingLoading, setPollingLoading] = useState<boolean>(false);
   const pollingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [delimiter, setDelimiter] = useState<string | undefined>(undefined);
-  const [blockSize, setBlockSize] = useState<number>(130);
+  const [blockSize, setBlockSize] = useState<number>(512);
   const [qaPrompt, setQaPrompt] = useState<string | undefined>()
   console.log('qaPrompt', qaPrompt)
   const [processingMethod, setProcessingMethod] = useState<ProcessingMethod>('directBlock');
@@ -614,6 +614,8 @@ const CreateDataset = () => {
   const handleChangeProcessingMethod = (method: ProcessingMethod) => {
     if (method === 'directBlock') {
       setBlockSize(512)
+    } else {
+      setBlockSize(130)
     }
     setProcessingMethod(method)
   }


### PR DESCRIPTION
## Summary by Sourcery

添加 API 密钥端点配置快捷方式，并根据处理方式调整数据集块大小默认值。

新功能：
- 在 API 密钥管理视图中添加“端点配置”按钮，用于打开与语言相关的文档。

增强：
- 对于直接块处理，将数据集块大小默认值设置为 512；切换到其他处理方式时，将默认值重置为 130。
- 在英文和中文 i18n 资源中增加与新端点配置操作相关的标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add API key endpoint configuration shortcut and adjust dataset block size defaults based on processing method.

New Features:
- Add an Endpoint Configuration button in the API key management view that opens language-specific documentation.

Enhancements:
- Default dataset block size to 512 for direct block processing and reset to 130 when switching to other processing methods.
- Extend English and Chinese i18n resources with labels for the new endpoint configuration action.

</details>