### PR TITLE
fix(web): update blockSize init value

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -614,8 +614,6 @@ const CreateDataset = () => {
   const handleChangeProcessingMethod = (method: ProcessingMethod) => {
     if (method === 'directBlock') {
       setBlockSize(512)
-    } else {
-      setBlockSize(130)
     }
     setProcessingMethod(method)
   }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保块大小仅在使用直接块处理时默认为 512，避免对其他处理方式造成意外重置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure block size defaults to 512 only when using direct block processing, avoiding unintended resets for other processing methods.

</details>