### PR TITLE
fix(app)

### DIFF
--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -16,7 +16,7 @@ from langchain_core.documents import Document
 from app.core.models.base import RedBearModelConfig
 from app.core.models import RedBearRerank
 from app.core.models.embedding import RedBearEmbeddings
-from app.models.models_model import ModelApiKey
+from app.models.models_model import ModelApiKey, ModelProvider
 
 from app.models.knowledge_model import Knowledge
 from app.core.rag.vdb.field import Field
@@ -1179,12 +1179,11 @@ class ElasticSearchVectorFactory:
             raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
         if knowledge.reranker is None:
             raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
-        if not knowledge.embedding.api_keys:
-            raise ValueError(f"No embedding api key found for knowledge {knowledge.id}")
-        if not knowledge.reranker.api_keys:
-            raise ValueError(f"No reranker api key found for knowledge {knowledge.id}")
-        embedding_config = knowledge.embedding.api_keys[0]
-        reranker_config = knowledge.reranker.api_keys[0]
+
+        tenant_id = cls._resolve_tenant_id(knowledge)
+
+        embedding_config = cls._resolve_api_key(knowledge.embedding, knowledge.id, "embedding", tenant_id)
+        reranker_config = cls._resolve_api_key(knowledge.reranker, knowledge.id, "reranker", tenant_id)
 
         return ElasticSearchVector(
             index_name=collection_name,
@@ -1192,3 +1191,35 @@ class ElasticSearchVectorFactory:
             embedding_config=embedding_config,
             reranker_config=reranker_config,
         )
+
+    @staticmethod
+    def _resolve_tenant_id(knowledge: Knowledge):
+        """Look up tenant_id via the knowledge's workspace."""
+        from app.db import get_db_context
+        from app.models.workspace_model import Workspace
+        with get_db_context() as db:
+            ws = db.query(Workspace).filter(Workspace.id == knowledge.workspace_id).first()
+            return ws.tenant_id if ws else None
+
+    @staticmethod
+    def _resolve_api_key(model_config, knowledge_id, role: str, tenant_id) -> ModelApiKey:
+        """Resolve ModelApiKey, handling public SpeedBear models that have no stored api_keys."""
+        is_public_speedbear = (
+            model_config.provider == ModelProvider.SPEEDBEAR
+            and bool(model_config.is_public)
+        )
+        if is_public_speedbear:
+            from app.db import get_db_context
+            from app.services.model_service import ModelApiKeyService
+            with get_db_context() as db:
+                api_key = ModelApiKeyService.get_available_api_key(db, model_config.id, tenant_id)
+            if not api_key:
+                raise ValueError(
+                    f"No {role} api key found for knowledge {knowledge_id} "
+                    f"(SpeedBear tenant binding missing)"
+                )
+            return api_key
+
+        if not model_config.api_keys:
+            raise ValueError(f"No {role} api key found for knowledge {knowledge_id}")
+        return model_config.api_keys[0]

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -319,8 +319,13 @@ class AppService:
                 multi_agent_config.default_model_config_id = master_agent_release.default_model_config_id
 
             from app.repositories.tool_repository import ToolRepository
+            from app.models import App
 
-            tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(app.workspace_id))
+            db_app = self.db.get(App, app_id)
+            if not db_app:
+                raise BusinessException("应用不存在", BizCode.NOT_FOUND)
+
+            tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(db_app.workspace_id))
             model_api_key = ModelApiKeyService.get_available_api_key(
                 self.db,
                 multi_agent_config.default_model_config_id,

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -556,6 +556,12 @@ class ModelApiKeyService:
 
         from premium.platform_admin.models import TenantSpeedBearBinding
 
+        if not model_config.is_active:
+            raise BusinessException(
+                "当前模型已禁用，无法调用",
+                BizCode.AGENT_CONFIG_MISSING,
+            )
+
         binding = (
             db.query(TenantSpeedBearBinding)
             .filter(TenantSpeedBearBinding.tenant_id == tenant_id)
@@ -814,6 +820,9 @@ class ModelApiKeyService:
         """获取可用的API Key（根据负载均衡策略）"""
         model_config = ModelConfigRepository.get_by_id(db, model_config_id)
         if not model_config:
+            return None
+
+        if not model_config.is_active:
             return None
 
         if ModelApiKeyService._is_public_speedbear_model(model_config):


### PR DESCRIPTION
validate app existence and model activation status, improve API key resolution in RAG

- Add app existence check in app_service.py to prevent operations on non-existent apps
- Enforce model activation check in model_service.py for both invocation and retrieval
- Refactor Elasticsearch vector API key resolution to support SpeedBear public models and tenant-aware key lookup

## Summary by Sourcery

在使用前确保应用和模型有效且处于激活状态，并改进针对多租户的 RAG Elasticsearch 向量 API Key 解析机制。

Bug 修复：
- 在解析 workspace 和 tenant ID 之前验证应用是否存在，防止多代理（multi-agent）配置在不存在的应用上运行。
- 在 SpeedBear 模型服务 API 中强制检查模型是否已激活，避免对已停用的模型进行调用或解析其 API Key。
- 在无法为指定知识库或租户找到合适的模型 API Key 时，确保抛出合适的错误。

增强功能：
- 通过支持租户感知（tenant-aware）的查找来解析 Elasticsearch 向量嵌入和重排序（reranker）API Key，包括对未存储 API Key 的公共 SpeedBear 模型的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure apps and models are valid and active before use, and improve tenant-aware API key resolution for RAG Elasticsearch vectors.

Bug Fixes:
- Prevent multi-agent configuration from running against non-existent apps by validating app existence before resolving workspace and tenant IDs.
- Avoid invoking or resolving API keys for deactivated models by enforcing model activation checks in SpeedBear model service APIs.
- Ensure appropriate errors are raised when no suitable model API key can be found for a given knowledge base or tenant.

Enhancements:
- Resolve Elasticsearch vector embedding and reranker API keys via tenant-aware lookup, including support for public SpeedBear models without stored API keys.

</details>