### PR TITLE
fix(web): model type i18n update

### DIFF
--- a/web/src/views/ModelManagement/Group.tsx
+++ b/web/src/views/ModelManagement/Group.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:00 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-20 18:50:41
+ * @Last Modified time: 2026-07-01 10:18:39
  */
 /**
  * Group Model View
@@ -21,6 +21,7 @@ import { getModelNewList } from '@/api/models'
 import PageEmpty from '@/components/Empty/PageEmpty';
 import { formatDateTime } from '@/utils/format';
 import Tag from '@/components/Tag'
+import { formatModelType } from './utils'
 
 /**
  * Group model list component
@@ -49,7 +50,7 @@ const Group = forwardRef <BaseRef,{ query: any; handleEdit: (data: ModelListItem
       {
         key: 'type',
         label: t(`modelNew.type`),
-        children: data.type ? t(`modelNew.${data.type}`) : '-',
+        children: data.type ? formatModelType(data.type) : '-',
       },
       {
         key: 'created_at',

--- a/web/src/views/ModelManagement/Square.tsx
+++ b/web/src/views/ModelManagement/Square.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:14 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-25 12:19:24
+ * @Last Modified time: 2026-07-01 10:13:27
  */
 /**
  * Model Square View
@@ -21,7 +21,7 @@ import RbCard from '@/components/RbCard'
 import { getModelPlaza, addModelPlaza } from '@/api/models'
 import PageEmpty from '@/components/Empty/PageEmpty';
 import Tag from '@/components/Tag';
-import { getLogoUrl } from './utils'
+import { getLogoUrl, formatModelType } from './utils'
 
 /**
  * Model square component
@@ -71,7 +71,7 @@ const ModelSquare = forwardRef <BaseRef, { query: any; }>(({ query }, ref) => {
                 key={vo.provider}
                 className={clsx('rb:border rb:border-[#171719] rb:rounded-full rb:px-2 rb:py-1 rb:cursor-pointer', {
                   'rb:text-white rb:bg-[#171719]': activeProvider === vo.provider,
-                  'rb:text-[#171719]': activeProvider === vo.provider,
+                  'rb:text-[#171719]': activeProvider !== vo.provider,
                 })}
                 onClick={() => setActiveProvider(vo.provider)}
               >{String(vo.provider).charAt(0).toUpperCase() + String(vo.provider).slice(1)}</div>
@@ -92,7 +92,7 @@ const ModelSquare = forwardRef <BaseRef, { query: any; }>(({ query }, ref) => {
                             <div className="rb:wrap-break-word rb:line-clamp-1">{item.name}</div>
                           </Tooltip>
                           <Space size={8} className="rb:mt-1!">
-                            <Tag>{t(`modelNew.${item.type}`)}</Tag>
+                            <Tag>{formatModelType(item.type)}</Tag>
                             {item.is_official && <Tag color="success">{t(`modelNew.official`)}</Tag>}
                           </Space>
                         </Flex>

--- a/web/src/views/ModelManagement/components/CustomModelModal.tsx
+++ b/web/src/views/ModelManagement/components/CustomModelModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:28 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-14 16:32:45
+ * @Last Modified time: 2026-07-01 10:13:47
  */
 /**
  * Custom Model Modal
@@ -21,6 +21,7 @@ import UploadImages from '@/components/Upload/UploadImages'
 import { updateCustomModel, addCustomModel, modelTypeUrl, modelProviderUrl } from '@/api/models'
 import { getFileLink } from '@/api/fileStorage'
 import { validateSquareImage, stringRegExp } from '@/utils/validator'
+import { formatModelType } from '../utils'
 
 /**
  * Custom model modal component
@@ -215,7 +216,7 @@ const CustomModelModal = forwardRef<CustomModelModalRef, CustomModelModalProps>(
             url={modelTypeUrl}
             hasAll={false}
             disabled={isEdit}
-            format={(items) => items.map((item) => ({ label: t(`modelNew.${item}`), value: String(item) }))}
+            format={(items) => items.map((item) => ({ label: formatModelType(item), value: String(item) }))}
           />
         </Form.Item>
 

--- a/web/src/views/ModelManagement/components/GroupModelModal.tsx
+++ b/web/src/views/ModelManagement/components/GroupModelModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:33 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-02 12:23:13
+ * @Last Modified time: 2026-07-01 10:12:44
  */
 /**
  * Group Model Modal
@@ -22,6 +22,7 @@ import UploadImages from '@/components/Upload/UploadImages'
 import ModelImplement from './ModelImplement'
 import { getFileLink } from '@/api/fileStorage'
 import { validateSquareImage, stringRegExp } from '@/utils/validator'
+import { formatModelType } from '../utils'
 
 /**
  * Group model modal component
@@ -166,10 +167,7 @@ const GroupModelModal = forwardRef<GroupModelModalRef, GroupModelModalProps>(({
           <CustomSelect
             url={modelTypeUrl}
             hasAll={false}
-            format={(items) => items.map((item) => ({ 
-              label: t(`modelNew.${typeof item === 'object' ? item.value : item}`), 
-              value: typeof item === 'object' ? item.value : item 
-            }))}
+            format={(items) => items.map((item) => ({ label: formatModelType(item), value: String(item) }))}
             disabled={isEdit}
           />
         </Form.Item>

--- a/web/src/views/ModelManagement/components/ModelImplement/SubModelModal.tsx
+++ b/web/src/views/ModelManagement/components/ModelImplement/SubModelModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:20 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-25 14:07:08
+ * @Last Modified time: 2026-07-01 10:20:56
  */
 /**
  * Sub-Model Modal
@@ -20,6 +20,7 @@ import CustomSelect from '@/components/CustomSelect'
 import { modelProviderUrl, getModelNewList } from '@/api/models'
 import type { ProviderModelItem } from '../../types'
 import Tag from '@/components/Tag';
+import { formatModelType } from '../../utils'
 
 const { SHOW_CHILD } = Cascader;
 
@@ -119,7 +120,7 @@ const SubModelModal = forwardRef<SubModelModalRef, SubModelModalProps>(({
               ...vo,
               label: <Space>
                 {vo.name}
-                <Tag>{t(`modelNew.${vo.type}`)}</Tag>
+                <Tag>{formatModelType(vo.type)}</Tag>
                 {vo.capability?.filter(item => item !== 'video').map(vo => <Tag key={vo}>{t(`modelNew.${vo}`)}</Tag>)}
               </Space>,
               value: vo.id,

--- a/web/src/views/ModelManagement/components/ModelListDetail.tsx
+++ b/web/src/views/ModelManagement/components/ModelListDetail.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:49:45 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-30 15:23:02
+ * @Last Modified time: 2026-07-01 10:20:14
  */
 /**
  * Model List Detail Drawer
@@ -25,6 +25,7 @@ import MultiKeyConfigModal from './MultiKeyConfigModal'
 import { getModelNewList, updateModelStatus, modelTypeUrl } from '@/api/models'
 import { getLogoUrl } from '../utils'
 import CustomSelect from '@/components/CustomSelect'
+import { formatModelType } from '../utils'
 
 /**
  * Component props
@@ -125,7 +126,7 @@ const ModelListDetail = forwardRef<ModelListDetailRef, ModelListDetailProps>(({ 
             value={type}
             url={modelTypeUrl}
             hasAll={false}
-            format={(items) => items.map((item) => ({ label: t(`modelNew.${item}`), value: String(item) }))}
+            format={(items) => items.map((item) => ({ label: formatModelType(item), value: String(item) }))}
             onChange={handleTypeChange}
             className="rb:w-full"
             allowClear={true}
@@ -143,7 +144,7 @@ const ModelListDetail = forwardRef<ModelListDetailRef, ModelListDetailProps>(({ 
               subTitle={
                 <OverflowTags
                   items={[
-                    <Tag>{t(`modelNew.${item.type}`)}</Tag>,
+                    <Tag>{formatModelType(item.type)}</Tag>,
                     item.provider !== 'speedbear' ? <Tag color="warning">{item.api_keys.length}{t('modelNew.apiKeyNum')}</Tag> : null,
                     ...(item.capability ?? []).map(vo => <Tag>{t(`modelNew.${vo}`)}</Tag>)
                   ].filter(Boolean)}

--- a/web/src/views/ModelManagement/index.tsx
+++ b/web/src/views/ModelManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:05 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-05-22 15:17:07
+ * @Last Modified time: 2026-07-01 10:15:57
  */
 /**
  * Model Management Main Page
@@ -24,6 +24,7 @@ import ModelSquare from './Square'
 import CustomModelModal from './components/CustomModelModal'
 import CustomSelect from '@/components/CustomSelect'
 import { modelTypeUrl, modelProviderUrl } from '@/api/models'
+import { formatModelType } from './utils'
 
 /**
  * Available tab keys
@@ -99,7 +100,7 @@ const tabKeys = ['square', 'list', 'group']
                 <CustomSelect
                   url={modelTypeUrl}
                   hasAll={false}
-                  format={(items) => items.map((item) => ({ label: t(`modelNew.${item}`), value: String(item) }))}
+                  format={(items) => items.map((item) => ({ label: formatModelType(item), value: String(item) }))}
                   className="rb:w-40"
                   allowClear={true}
                   placeholder={t('modelNew.type')}

--- a/web/src/views/ModelManagement/utils.ts
+++ b/web/src/views/ModelManagement/utils.ts
@@ -2,11 +2,12 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:50:22 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-30 15:10:52
+ * @Last Modified time: 2026-07-01 10:15:54
  */
 /**
  * Utility functions for Model Management
  */
+import type { OptionType } from '@/components/CustomSelect'
 
 import bedrockIcon from '@/assets/images/model/bedrock.png'
 import dashscopeIcon from '@/assets/images/model/dashscope.png'
@@ -66,4 +67,11 @@ export const getListLogoUrl = (provider?: string, logo?: string) => {
   }
 
   return ICONS[logo as keyof typeof ICONS] || undefined
+}
+
+export const formatModelType = (type: OptionType['value']) => {
+  if (type === 'llm') {
+    return 'LLM'
+  }
+  return type.charAt(0).toUpperCase() + type.slice(1)
 }


### PR DESCRIPTION
## Summary by Sourcery

在所有模型管理视图中统一模型类型展示格式，并修复一个提供商标签的样式问题。

Bug 修复：
- 修正模型方块视图中激活提供商标签文本颜色的逻辑，使非激活提供商使用较浅的文本颜色。

增强功能：
- 新增共享的 `formatModelType` 工具，并在各模型管理页面和选择器中统一使用，以一致地格式化并去国际化模型类型标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify model type display formatting across model management views and fix a provider tab styling issue.

Bug Fixes:
- Correct the active provider tab text color logic in the model square view so inactive providers use the muted text color.

Enhancements:
- Introduce a shared formatModelType utility and apply it across model management pages and selectors to consistently format and de-i18n model type labels.

</details>