### PR TITLE
fix(base_node): fix input extraction overwriting original error in error branch

### DIFF
--- a/api/app/core/workflow/nodes/base_node.py
+++ b/api/app/core/workflow/nodes/base_node.py
@@ -635,8 +635,19 @@ class BaseNode(ABC):
         # # Check if the node has an error edge defined
         # error_edge = self._find_error_edge()
 
-        # Extract input data (for logging or audit purposes)
-        input_data = self._extract_input(state, variable_pool)
+        # Extract input data (for logging or audit purposes).
+        # This runs in the error-handling path, so it must never mask the
+        # original error: if input extraction itself fails (e.g. a template
+        # references an undefined variable), fall back to a placeholder so
+        # the original error_message is preserved and NodeExecutionError is
+        # raised as designed.
+        try:
+            input_data = self._extract_input(state, variable_pool)
+        except Exception as extract_err:
+            logger.warning(
+                f"Node {self.node_id} failed to extract input during error wrapping: {extract_err}"
+            )
+            input_data = {"_extract_error": str(extract_err)}
 
         # Construct the standardized node output for the error
         node_output = {


### PR DESCRIPTION
Add exception handling in the error processing path. When input extraction fails, use placeholder data and log a warning to ensure the original error is not masked, while preserving the existing `NodeExecutionError` throwing logic.

## Summary by Sourcery

错误修复：
- 通过回退到占位符输入数据并记录警告，防止在错误处理路径中发生的输入提取失败掩盖原始节点执行错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent input extraction failures in the error-handling path from masking the original node execution error by falling back to placeholder input data and logging a warning.

</details>