### PR TITLE
feat(speedbear)

### DIFF
--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -92,6 +92,15 @@ def parse_timestamp_to_utc_naive(timestamp: int | float | None) -> datetime | No
     return datetime.fromtimestamp(timestamp, UTC).replace(tzinfo=None)
 
 
+def parse_timestamp_to_utc(timestamp: int | float | None) -> datetime | None:
+    """Convert a second/millisecond timestamp to UTC datetime."""
+    if timestamp is None:
+        return None
+    if timestamp > 1e10:
+        timestamp = timestamp / 1000
+    return datetime.fromtimestamp(timestamp, UTC)
+
+
 def parse_iso_to_utc_naive(value: str | None) -> datetime | None:
     """Parse an ISO datetime and normalize it to naive UTC."""
     if not value:


### PR DESCRIPTION
update datetime handling to use unified UTC parsing utilities

- Replace manual datetime combining with `parse_iso_to_utc_naive` in SpeedBear service
- Switch from `parse_timestamp_to_utc_naive` to new `parse_timestamp_to_utc` in controller
- Add `parse_timestamp_to_utc` utility supporting both second and millisecond timestamps

## Summary by Sourcery

通过引入共享的解析辅助方法，统一对 UTC 时间戳的处理，可支持秒级和毫秒级 Unix 时间戳。

New Features:
- 添加一个 `parse_timestamp_to_utc` 工具方法，用于将以秒或毫秒为单位的 Unix 时间戳转换为带时区信息的 UTC datetime。

Enhancements:
- 通过提供一个非 naive 的 UTC 时间戳解析器（与现有的 ISO 解析辅助方法并列），推动调用方使用集中化的 datetime 解析工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify UTC timestamp handling by introducing a shared parsing helper for second and millisecond Unix timestamps.

New Features:
- Add a `parse_timestamp_to_utc` utility that converts Unix timestamps in seconds or milliseconds to timezone-aware UTC datetimes.

Enhancements:
- Move callers toward centralized datetime parsing utilities by providing a non-naive UTC timestamp parser alongside existing ISO parsing helpers.

</details>