### PR TITLE
feat(controllers): reorganize config endpoints and add end_user manag…

### DIFF
--- a/api/app/controllers/__init__.py
+++ b/api/app/controllers/__init__.py
@@ -15,6 +15,7 @@ from . import (
     document_controller,
     emotion_config_controller,
     emotion_controller,
+    end_user_controller,
     file_controller,
     file_storage_controller,
     home_page_controller,
@@ -28,6 +29,7 @@ from . import (
     mcp_market_config_controller,
     memory_agent_controller,
     memory_analytics_controller,
+    memory_config_controller,
     memory_controller,
     memory_dashboard_controller,
     memory_episodic_controller,
@@ -85,6 +87,8 @@ manager_router.include_router(upload_controller.router)
 manager_router.include_router(memory_agent_controller.router)
 manager_router.include_router(memory_controller.router)
 manager_router.include_router(memory_analytics_controller.router)
+manager_router.include_router(memory_config_controller.router)
+manager_router.include_router(end_user_controller.router)
 manager_router.include_router(memory_dashboard_controller.router)
 manager_router.include_router(memory_storage_controller.router)
 manager_router.include_router(user_memory_controllers.router)

--- a/api/app/controllers/emotion_config_controller.py
+++ b/api/app/controllers/emotion_config_controller.py
@@ -8,24 +8,13 @@ Routes:
     POST /memory/config/emotion - 更新情绪引擎配置
 """
 import uuid
-
-from fastapi import APIRouter, Depends, Query, HTTPException, status
-from pydantic import BaseModel, Field
 from typing import Optional, Union
-from sqlalchemy.orm import Session
 from uuid import UUID
 
-from app.core.response_utils import success
-from app.dependencies import get_current_user
-from app.models.user_model import User
-from app.schemas.response_schema import ApiResponse
-from app.services.emotion_config_service import EmotionConfigService
-from app.core.logging_config import get_api_logger
-from app.db import get_db
-from app.utils.config_utils import resolve_config_id
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
 
-# 获取API专用日志器
-api_logger = get_api_logger()
+from app.dependencies import get_current_user
 
 router = APIRouter(
     prefix="/memory/emotion",
@@ -46,166 +35,8 @@ class EmotionConfigUpdate(BaseModel):
     emotion_min_intensity: float = Field(..., ge=0.0, le=1.0, description="最小情绪强度阈值（0.0-1.0）")
     emotion_enable_subject: bool = Field(..., description="是否启用主体分类")
 
-@router.get("/read_config", response_model=ApiResponse)
-def get_emotion_config(
-    config_id: UUID|int = Query(..., description="配置ID"),
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """获取情绪引擎配置
-    
-    查询指定配置ID的情绪相关配置字段。
-    
-    Args:
-        config_id: 配置ID
-        
-    Returns:
-        ApiResponse: 包含情绪配置数据
-        
-    Example Response:
-        {
-            "code": 2000,
-            "msg": "情绪配置获取成功",
-            "data": {
-                "config_id": 17,
-                "emotion_enabled": true,
-                "emotion_model_id": "gpt-4",
-                "emotion_extract_keywords": true,
-                "emotion_min_intensity": 0.1,
-                "emotion_enable_subject": true
-            }
-        }
-    """
-    try:
-        api_logger.info(
-            f"用户 {current_user.username} 请求获取情绪配置",
-            extra={"config_id": config_id}
-        )
-        config_id=resolve_config_id(config_id, db)
-        # 初始化服务
-        config_service = EmotionConfigService(db)
-        
-        # 调用服务层
-        data = config_service.get_emotion_config(config_id)
-        
-        api_logger.info(
-            "情绪配置获取成功",
-            extra={
-                "config_id": config_id,
-                "emotion_enabled": data.get("emotion_enabled", False)
-            }
-        )
-        
-        return success(data=data, msg="情绪配置获取成功")
-        
-    except ValueError as e:
-        api_logger.warning(
-            f"获取情绪配置失败: {str(e)}",
-            extra={"config_id": config_id}
-        )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e)
-        )
-    except Exception as e:
-        api_logger.error(
-            f"获取情绪配置失败: {str(e)}",
-            extra={"config_id": config_id},
-            exc_info=True
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"获取情绪配置失败: {str(e)}"
-        )
+# ==================== 记忆配置接口已迁移 ====================
+# get_emotion_config / update_emotion_config 已迁移至 memory_config_controller
+# （/memory_config/read_config_emotion、/memory_config/update_config_emotion）。
+# 本文件保留 EmotionConfigUpdate / EmotionConfigQuery 模型供其复用。
 
-
-
-@router.post("/updated_config", response_model=ApiResponse)
-def update_emotion_config(
-    config: EmotionConfigUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """更新情绪引擎配置
-    
-    更新指定配置ID的情绪相关配置字段。
-    
-    Args:
-        config: 配置更新数据（包含config_id）
-        
-    Returns:
-        ApiResponse: 包含更新后的情绪配置数据
-        
-    Example Request:
-        {
-            "config_id": 2,
-            "emotion_enabled": true,
-            "emotion_model_id": "gpt-4",
-            "emotion_extract_keywords": true,
-            "emotion_min_intensity": 0.1,
-            "emotion_enable_subject": true
-        }
-        
-    Example Response:
-        {
-            "code": 2000,
-            "msg": "情绪配置更新成功",
-            "data": {
-                "config_id": 17,
-                "emotion_enabled": true,
-                "emotion_model_id": "gpt-4",
-                "emotion_extract_keywords": true,
-                "emotion_min_intensity": 0.2,
-                "emotion_enable_subject": true
-            }
-        }
-    """
-    config.config_id=resolve_config_id(config.config_id, db)
-    try:
-        api_logger.info(
-            f"用户 {current_user.username} 请求更新情绪配置",
-            extra={
-                "config_id": config.config_id,
-                "emotion_enabled": config.emotion_enabled,
-                "emotion_min_intensity": config.emotion_min_intensity
-            }
-        )
-        
-        # 初始化服务
-        config_service = EmotionConfigService(db)
-        
-        # 转换为字典（排除config_id，因为它作为参数传递）
-        config_data = config.model_dump(exclude={'config_id'})
-        
-        # 调用服务层
-        data = config_service.update_emotion_config(config.config_id, config_data)
-        
-        api_logger.info(
-            "情绪配置更新成功",
-            extra={
-                "config_id": config.config_id,
-                "emotion_enabled": data.get("emotion_enabled", False)
-            }
-        )
-        
-        return success(data=data, msg="情绪配置更新成功")
-        
-    except ValueError as e:
-        api_logger.warning(
-            f"更新情绪配置失败: {str(e)}",
-            extra={"config_id": config.config_id}
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
-        )
-    except Exception as e:
-        api_logger.error(
-            f"更新情绪配置失败: {str(e)}",
-            extra={"config_id": config.config_id},
-            exc_info=True
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"更新情绪配置失败: {str(e)}"
-        )

--- a/api/app/controllers/end_user_controller.py
+++ b/api/app/controllers/end_user_controller.py
@@ -1,0 +1,135 @@
+"""终端用户信息（End User）服务接口 - 基于 JWT 认证
+
+收口终端用户信息的查询与更新（原分散在 memory_analytics_controller 与
+user_memory_controllers），使对内 /api/end_user/* 与对外 /v1/end_user/* 路径一致。
+函数体整体迁入，逻辑不变，仅装饰器路径调整为 /end_user/*。
+
+路由前缀: /end_user
+认证方式: JWT Token
+"""
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import BizCode
+from app.core.logging_config import get_api_logger
+from app.core.response_utils import fail, success
+from app.db import get_db
+from app.dependencies import get_current_user
+from app.models.user_model import User
+from app.repositories.end_user_repository import EndUserRepository
+from app.schemas.end_user_info_schema import EndUserInfoUpdate
+from app.schemas.response_schema import ApiResponse
+from app.services.user_memory_service import UserMemoryService
+
+api_logger = get_api_logger()
+
+user_memory_service = UserMemoryService()
+
+router = APIRouter(
+    prefix="/end_user",
+    tags=["End User"],
+)
+
+
+@router.get("/info", response_model=ApiResponse)
+async def get_end_user_info(
+    end_user_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    查询终端用户信息记录
+
+    根据 end_user_id 查询单条终端用户信息记录。
+    """
+    workspace_id = current_user.current_workspace_id
+
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试查询终端用户信息但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(
+        f"查询终端用户信息请求: end_user_id={end_user_id}, user={current_user.username}, "
+        f"workspace={workspace_id}"
+    )
+
+    # 校验 end_user 是否属于当前工作空间
+    end_user_repo = EndUserRepository(db)
+    end_user = end_user_repo.get_end_user_by_id(end_user_id)
+    if end_user is None:
+        return fail(BizCode.USER_NOT_FOUND, "终端用户不存在", "end_user not found")
+    if str(end_user.workspace_id) != str(workspace_id):
+        api_logger.warning(
+            f"用户 {current_user.username} 尝试查询不属于工作空间 {workspace_id} 的终端用户 {end_user_id}"
+        )
+        return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
+
+    result = user_memory_service.get_end_user_info(db, end_user_id)
+
+    if result["success"]:
+        api_logger.info(f"成功查询终端用户信息: end_user_id={end_user_id}")
+        return success(data=result["data"], msg="查询成功")
+    else:
+        error_msg = result["error"]
+        api_logger.error(f"查询终端用户信息失败: end_user_id={end_user_id}, error={error_msg}")
+
+        if error_msg == "终端用户信息记录不存在":
+            return fail(BizCode.USER_NOT_FOUND, "终端用户信息记录不存在", error_msg)
+        elif error_msg == "无效的终端用户ID格式":
+            return fail(BizCode.INVALID_USER_ID, "无效的终端用户ID格式", error_msg)
+        else:
+            return fail(BizCode.INTERNAL_ERROR, "查询终端用户信息失败", error_msg)
+
+
+@router.post("/info/update", response_model=ApiResponse)
+async def update_end_user_info(
+    info_update: EndUserInfoUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """
+    更新终端用户信息记录
+
+    根据 end_user_id 更新终端用户信息记录，支持批量更新多个别名。
+    """
+    workspace_id = current_user.current_workspace_id
+    end_user_id = info_update.end_user_id
+
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试更新终端用户信息但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(
+        f"更新终端用户信息请求: end_user_id={end_user_id}, user={current_user.username}, "
+        f"workspace={workspace_id}"
+    )
+
+    # 校验 end_user 是否属于当前工作空间
+    end_user_repo = EndUserRepository(db)
+    end_user = end_user_repo.get_end_user_by_id(end_user_id)
+    if end_user is None:
+        return fail(BizCode.USER_NOT_FOUND, "终端用户不存在", "end_user not found")
+    if str(end_user.workspace_id) != str(workspace_id):
+        api_logger.warning(
+            f"用户 {current_user.username} 尝试更新不属于工作空间 {workspace_id} 的终端用户 {end_user_id}"
+        )
+        return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
+
+    # 获取更新数据（排除 end_user_id）
+    update_data = info_update.model_dump(exclude_unset=True, exclude={'end_user_id'})
+
+    result = user_memory_service.update_end_user_info(db, end_user_id, update_data)
+
+    if result["success"]:
+        api_logger.info(f"成功更新终端用户信息: end_user_id={end_user_id}")
+        return success(data=result["data"], msg="更新成功")
+    else:
+        error_msg = result["error"]
+        api_logger.error(f"终端用户信息更新失败: end_user_id={end_user_id}, error={error_msg}")
+
+        if error_msg == "终端用户信息记录不存在":
+            return fail(BizCode.USER_NOT_FOUND, "终端用户信息记录不存在", error_msg)
+        elif error_msg == "无效的终端用户ID格式":
+            return fail(BizCode.INVALID_USER_ID, "无效的终端用户ID格式", error_msg)
+        else:
+            return fail(BizCode.INTERNAL_ERROR, "终端用户信息更新失败", error_msg)

--- a/api/app/controllers/memory_analytics_controller.py
+++ b/api/app/controllers/memory_analytics_controller.py
@@ -24,7 +24,6 @@ from app.core.response_utils import fail, success
 from app.db import get_db
 from app.dependencies import get_current_user
 from app.models.user_model import User
-from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.workspace_repository import WorkspaceRepository
 from app.schemas.memory_storage_schema import GenerateCacheRequest
 from app.schemas.response_schema import ApiResponse
@@ -337,53 +336,7 @@ async def get_community_graph_data_api(
         return fail(BizCode.INTERNAL_ERROR, "社区图谱查询失败", str(e))
 
 
-@router.get("/end_user_info", response_model=ApiResponse)
-async def get_end_user_info(
-    end_user_id: str,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-) -> dict:
-    """
-    查询终端用户信息记录
-
-    根据 end_user_id 查询单条终端用户信息记录。
-    """
-    workspace_id = current_user.current_workspace_id
-
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试查询终端用户信息但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(
-        f"查询终端用户信息请求: end_user_id={end_user_id}, user={current_user.username}, "
-        f"workspace={workspace_id}"
-    )
-
-    end_user_repo = EndUserRepository(db)
-    end_user = end_user_repo.get_end_user_by_id(end_user_id)
-    if end_user is None:
-        return fail(BizCode.USER_NOT_FOUND, "终端用户不存在", "end_user not found")
-    if str(end_user.workspace_id) != str(workspace_id):
-        api_logger.warning(
-            f"用户 {current_user.username} 尝试查询不属于工作空间 {workspace_id} 的终端用户 {end_user_id}"
-        )
-        return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
-
-    result = user_memory_service.get_end_user_info(db, end_user_id)
-
-    if result["success"]:
-        api_logger.info(f"成功查询终端用户信息: end_user_id={end_user_id}")
-        return success(data=result["data"], msg="查询成功")
-    else:
-        error_msg = result["error"]
-        api_logger.error(f"查询终端用户信息失败: end_user_id={end_user_id}, error={error_msg}")
-
-        if error_msg == "终端用户信息记录不存在":
-            return fail(BizCode.USER_NOT_FOUND, "终端用户信息记录不存在", error_msg)
-        elif error_msg == "无效的终端用户ID格式":
-            return fail(BizCode.INVALID_USER_ID, "无效的终端用户ID格式", error_msg)
-        else:
-            return fail(BizCode.INTERNAL_ERROR, "查询终端用户信息失败", error_msg)
+# get_end_user_info 已迁移至 end_user_controller（/end_user/info）
 
 
 @router.get("/interest_distribution", response_model=ApiResponse)

--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -1,0 +1,510 @@
+"""记忆配置（Memory Config）服务接口 - 基于 JWT 认证
+
+将原先分散在 memory_storage / memory_forget / emotion_config / memory_reflection
+控制器中的「记忆配置」读写接口，统一收口到 /memory_config 前缀下，使对内 /api 路由与对外
+/v1（memory_config_api_controller）路径一致。
+
+各 handler 由原域控制器整体迁入（函数体逻辑不变，仅装饰器路径调整为 /memory_config/*）。
+方法沿用对内现状（读 GET、创建/更新 POST、删除 DELETE）。
+
+路由前缀: /memory_config
+认证方式: JWT Token
+"""
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from app.controllers.emotion_config_controller import EmotionConfigUpdate
+from app.core.error_codes import BizCode
+from app.core.language_utils import get_language_from_header
+from app.core.logging_config import get_api_logger
+from app.core.quota_stub import check_memory_engine_quota
+from app.core.response_utils import fail, success
+from app.db import get_db
+from app.dependencies import get_current_user
+from app.models.user_model import User
+from app.repositories.memory_config_repository import MemoryConfigRepository
+from app.schemas.memory_reflection_schemas import Memory_Reflection
+from app.schemas.memory_storage_schema import (
+    ConfigKey,
+    ConfigParamsCreate,
+    ConfigUpdate,
+    ConfigUpdateExtracted,
+    ForgettingConfigResponse,
+    ForgettingConfigUpdateRequest,
+)
+from app.schemas.response_schema import ApiResponse
+from app.services.emotion_config_service import EmotionConfigService
+from app.services.memory_forget_service import MemoryForgetService
+from app.services.memory_storage_service import DataConfigService
+from app.utils.config_utils import resolve_config_id
+
+api_logger = get_api_logger()
+
+# 遗忘引擎服务（迁自 memory_forget_controller）
+forget_service = MemoryForgetService()
+
+router = APIRouter(
+    prefix="/memory_config",
+    tags=["Memory Config"],
+)
+
+
+# ==================== 读取类 ====================
+
+@router.get("/read_all_config", response_model=ApiResponse)  # 读取所有配置文件列表
+def read_all_config(
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    workspace_id = current_user.current_workspace_id
+
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试查询配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取所有配置")
+    try:
+        svc = DataConfigService(db)
+        # 传递 workspace_id 进行过滤（保持为 UUID 类型）
+        result = svc.get_all(workspace_id=workspace_id)
+        return success(data=result, msg="查询成功")
+    except Exception as e:
+        api_logger.error(f"Read all config failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "查询所有配置失败", str(e))
+
+
+@router.get("/read_config_extracted", response_model=ApiResponse)  # 读取某条抽取配置
+def read_config_extracted(
+        config_id: UUID | int,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    workspace_id = current_user.current_workspace_id
+    config_id = resolve_config_id(config_id, db)
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试读取提取配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取提取配置: {config_id}")
+    try:
+        svc = DataConfigService(db)
+        result = svc.get_extracted(ConfigKey(config_id=config_id))
+        return success(data=result, msg="查询成功")
+    except Exception as e:
+        api_logger.error(f"Read config extracted failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "查询配置失败", str(e))
+
+
+@router.get("/read_config_forgetting", response_model=ApiResponse)
+async def read_forgetting_config(
+    config_id: UUID | int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """获取遗忘引擎配置"""
+    workspace_id = current_user.current_workspace_id
+
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试读取遗忘引擎配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(
+        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取遗忘引擎配置: {config_id}"
+    )
+
+    try:
+        config_id = resolve_config_id(config_id, db)
+        config = forget_service.read_forgetting_config(db=db, config_id=config_id)
+        response_data = ForgettingConfigResponse(**config)
+        return success(data=response_data.model_dump(), msg="查询成功")
+    except ValueError as e:
+        api_logger.warning(f"配置不存在: config_id={config_id}, 错误: {str(e)}")
+        return fail(BizCode.INVALID_PARAMETER, f"配置不存在: {config_id}", str(e))
+    except Exception as e:
+        api_logger.error(f"读取遗忘引擎配置失败: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "查询遗忘引擎配置失败", str(e))
+
+
+@router.get("/read_config_emotion", response_model=ApiResponse)
+def get_emotion_config(
+    config_id: UUID | int = Query(..., description="配置ID"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """获取情绪引擎配置"""
+    try:
+        api_logger.info(
+            f"用户 {current_user.username} 请求获取情绪配置",
+            extra={"config_id": config_id}
+        )
+        config_id = resolve_config_id(config_id, db)
+        config_service = EmotionConfigService(db)
+        data = config_service.get_emotion_config(config_id)
+        api_logger.info(
+            "情绪配置获取成功",
+            extra={"config_id": config_id, "emotion_enabled": data.get("emotion_enabled", False)}
+        )
+        return success(data=data, msg="情绪配置获取成功")
+    except ValueError as e:
+        api_logger.warning(f"获取情绪配置失败: {str(e)}", extra={"config_id": config_id})
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except Exception as e:
+        api_logger.error(f"获取情绪配置失败: {str(e)}", extra={"config_id": config_id}, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"获取情绪配置失败: {str(e)}"
+        )
+
+
+@router.get("/read_config_reflection", response_model=ApiResponse)
+async def start_reflection_configs(
+        config_id: UUID | int,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    """查询反思引擎配置"""
+    config_id = resolve_config_id(config_id, db)
+    try:
+        config_id = resolve_config_id(config_id, db)
+        api_logger.info(f"用户 {current_user.username} 查询反思配置，config_id: {config_id}")
+        result = MemoryConfigRepository.query_reflection_config_by_id(db, config_id)
+        memory_config_id = resolve_config_id(result.config_id, db)
+
+        reflection_config = {
+            "config_id": memory_config_id,
+            "reflection_enabled": result.enable_self_reflexion,
+            "reflection_period_in_hours": result.iteration_period,
+            "reflexion_range": result.reflexion_range,
+            "baseline": result.baseline,
+            "reflection_model_id": result.reflection_model_id,
+            "memory_verify": result.memory_verify,
+            "quality_assessment": result.quality_assessment
+        }
+        api_logger.info(f"成功查询反思配置，config_id: {config_id}")
+        return success(data=reflection_config, msg="反思配置查询成功")
+    except HTTPException:
+        raise
+    except Exception as e:
+        api_logger.error(f"查询反思配置失败: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"查询反思配置失败: {str(e)}"
+        )
+
+
+# ==================== 创建 / 更新 / 删除 ====================
+
+@router.post("/create_config", response_model=ApiResponse)  # 创建配置文件，其他参数默认
+@check_memory_engine_quota
+def create_config(
+        payload: ConfigParamsCreate,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+        x_language_type: Optional[str] = Header(None, alias="X-Language-Type"),
+) -> dict:
+    workspace_id = current_user.current_workspace_id
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试创建配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求创建配置: {payload.config_name}")
+    try:
+        # 将 workspace_id 注入到 payload 中（保持为 UUID 类型）
+        payload.workspace_id = workspace_id
+        svc = DataConfigService(db)
+        result = svc.create(payload)
+        return success(data=result, msg="创建成功")
+    except ValueError as e:
+        err_str = str(e)
+        if err_str.startswith("DUPLICATE_CONFIG_NAME:"):
+            config_name = err_str.split(":", 1)[1]
+            api_logger.warning(f"重复的配置名称 '{config_name}' 在工作空间 {workspace_id}")
+            lang = get_language_from_header(x_language_type)
+            if lang == "en":
+                msg = fail(BizCode.BAD_REQUEST, "Config name already exists",
+                           f"A config named \"{config_name}\" already exists in the current workspace. Please use a different name.")
+            else:
+                msg = fail(BizCode.BAD_REQUEST, "配置名称已存在",
+                           f"当前工作空间下已存在名为「{config_name}」的记忆配置，请使用其他名称")
+            return JSONResponse(status_code=400, content=msg)
+        api_logger.error(f"Create config failed: {err_str}")
+        return fail(BizCode.INTERNAL_ERROR, "创建配置失败", err_str)
+    except Exception as e:
+        from sqlalchemy.exc import IntegrityError
+        if isinstance(e, IntegrityError) and "uq_workspace_config_name" in str(getattr(e, 'orig', '')):
+            api_logger.warning(f"重复的配置名称 '{payload.config_name}' 在工作空间 {workspace_id}")
+            lang = get_language_from_header(x_language_type)
+            if lang == "en":
+                msg = fail(BizCode.BAD_REQUEST, "Config name already exists",
+                           f"A config named \"{payload.config_name}\" already exists in the current workspace. Please use a different name.")
+            else:
+                msg = fail(BizCode.BAD_REQUEST, "配置名称已存在",
+                           f"当前工作空间下已存在名为「{payload.config_name}」的记忆配置，请使用其他名称")
+            return JSONResponse(status_code=400, content=msg)
+        api_logger.error(f"Create config failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "创建配置失败", str(e))
+
+
+@router.post("/update_config", response_model=ApiResponse)  # 更新配置文件中name和desc
+def update_config(
+        payload: ConfigUpdate,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    workspace_id = current_user.current_workspace_id
+    payload.config_id = resolve_config_id(payload.config_id, db)
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试更新配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    # 校验至少有一个字段需要更新
+    if payload.config_name is None and payload.config_desc is None and payload.scene_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试更新配置但未提供任何更新字段")
+        return fail(BizCode.INVALID_PARAMETER, "请至少提供一个需要更新的字段",
+                    "config_name, config_desc, scene_id 均为空")
+
+    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新配置: {payload.config_id}")
+    try:
+        svc = DataConfigService(db)
+        result = svc.update(payload)
+        return success(data=result, msg="更新成功")
+    except Exception as e:
+        api_logger.error(f"Update config failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "更新配置失败", str(e))
+
+
+@router.post("/update_config_extracted", response_model=ApiResponse)  # 更新抽取配置 所有业务字段均可选
+def update_config_extracted(
+        payload: ConfigUpdateExtracted,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    workspace_id = current_user.current_workspace_id
+    payload.config_id = resolve_config_id(payload.config_id, db)
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试更新提取配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新提取配置: {payload.config_id}")
+    try:
+        svc = DataConfigService(db)
+        result = svc.update_extracted(payload)
+        return success(data=result, msg="更新成功")
+    except Exception as e:
+        api_logger.error(f"Update config extracted failed: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "更新配置失败", str(e))
+
+
+@router.post("/update_config_forgetting", response_model=ApiResponse)
+async def update_forgetting_config(
+    payload: ForgettingConfigUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """更新遗忘引擎配置"""
+    workspace_id = current_user.current_workspace_id
+    payload.config_id = resolve_config_id((payload.config_id), db)
+
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试更新遗忘引擎配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(
+        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新遗忘引擎配置: {payload.config_id}"
+    )
+
+    try:
+        # 构建更新字段字典（排除 None 值和 config_id）
+        update_data = {
+            key: value
+            for key, value in payload.model_dump(exclude_none=True).items()
+            if key != 'config_id'
+        }
+        config = forget_service.update_forgetting_config(
+            db=db,
+            config_id=payload.config_id,
+            update_fields=update_data
+        )
+        response_data = ForgettingConfigResponse(**config)
+        return success(data=response_data.model_dump(), msg="更新成功")
+    except ValueError as e:
+        api_logger.warning(f"配置不存在: config_id={payload.config_id}, 错误: {str(e)}")
+        return fail(BizCode.INVALID_PARAMETER, str(e), "ValueError")
+    except Exception as e:
+        db.rollback()
+        api_logger.error(f"更新遗忘引擎配置失败: {str(e)}")
+        return fail(BizCode.INTERNAL_ERROR, "更新遗忘引擎配置失败", str(e))
+
+
+@router.post("/update_config_emotion", response_model=ApiResponse)
+def update_emotion_config(
+    config: EmotionConfigUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """更新情绪引擎配置"""
+    config.config_id = resolve_config_id(config.config_id, db)
+    try:
+        api_logger.info(
+            f"用户 {current_user.username} 请求更新情绪配置",
+            extra={
+                "config_id": config.config_id,
+                "emotion_enabled": config.emotion_enabled,
+                "emotion_min_intensity": config.emotion_min_intensity
+            }
+        )
+        config_service = EmotionConfigService(db)
+        config_data = config.model_dump(exclude={'config_id'})
+        data = config_service.update_emotion_config(config.config_id, config_data)
+        api_logger.info(
+            "情绪配置更新成功",
+            extra={"config_id": config.config_id, "emotion_enabled": data.get("emotion_enabled", False)}
+        )
+        return success(data=data, msg="情绪配置更新成功")
+    except ValueError as e:
+        api_logger.warning(f"更新情绪配置失败: {str(e)}", extra={"config_id": config.config_id})
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        api_logger.error(f"更新情绪配置失败: {str(e)}", extra={"config_id": config.config_id}, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"更新情绪配置失败: {str(e)}"
+        )
+
+
+@router.post("/update_config_reflection", response_model=ApiResponse)
+async def save_reflection_config(
+    request: Memory_Reflection,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """保存反思引擎配置"""
+    try:
+        config_id = request.config_id
+        config_id = resolve_config_id(config_id, db)
+        if not config_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="缺少必需参数: config_id"
+            )
+        api_logger.info(f"用户 {current_user.username} 保存反思配置，config_id: {config_id}")
+
+        memory_config = MemoryConfigRepository.update_reflection_config(
+            db,
+            config_id=config_id,
+            enable_self_reflexion=request.reflection_enabled,
+            iteration_period=request.reflection_period_in_hours,
+            reflexion_range=request.reflexion_range,
+            baseline=request.baseline,
+            reflection_model_id=request.reflection_model_id,
+            memory_verify=request.memory_verify,
+            quality_assessment=request.quality_assessment
+        )
+
+        db.commit()
+        db.refresh(memory_config)
+
+        reflection_result = {
+            "config_id": memory_config.config_id,
+            "enable_self_reflexion": memory_config.enable_self_reflexion,
+            "iteration_period": memory_config.iteration_period,
+            "reflexion_range": memory_config.reflexion_range,
+            "baseline": memory_config.baseline,
+            "reflection_model_id": memory_config.reflection_model_id,
+            "memory_verify": memory_config.memory_verify,
+            "quality_assessment": memory_config.quality_assessment}
+
+        return success(data=reflection_result, msg="反思配置成功")
+    except ValueError as ve:
+        api_logger.error(f"参数错误: {str(ve)}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"参数错误: {str(ve)}"
+        )
+    except Exception as e:
+        api_logger.error(f"反思配置保存失败: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"反思配置保存失败: {str(e)}"
+        )
+
+
+@router.delete("/delete_config", response_model=ApiResponse)  # 删除记忆配置（按配置ID）
+def delete_config(
+        config_id: UUID | int,
+        force: bool = Query(False, description="是否强制删除（即使有终端用户正在使用）"),
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db),
+) -> dict:
+    """删除记忆配置（带终端用户保护）
+
+    - 检查是否为默认配置，默认配置不允许删除
+    - 检查是否有终端用户连接到该配置
+    - 如果有连接且 force=False，返回警告
+    - 如果 force=True，清除终端用户引用后删除配置
+    """
+    workspace_id = current_user.current_workspace_id
+    config_id = resolve_config_id(config_id, db)
+    # 检查用户是否已选择工作空间
+    if workspace_id is None:
+        api_logger.warning(f"用户 {current_user.username} 尝试删除配置但未选择工作空间")
+        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
+
+    api_logger.info(
+        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求删除配置: "
+        f"config_id={config_id}, force={force}"
+    )
+
+    try:
+        from app.services.memory_config_service import MemoryConfigService
+
+        config_service = MemoryConfigService(db)
+        result = config_service.delete_config(config_id=config_id, force=force)
+
+        if result["status"] == "error":
+            api_logger.warning(
+                f"记忆配置删除被拒绝: config_id={config_id}, reason={result['message']}"
+            )
+            return fail(
+                code=BizCode.FORBIDDEN,
+                msg=result["message"],
+                data={"config_id": str(config_id), "is_default": result.get("is_default", False)}
+            )
+
+        if result["status"] == "warning":
+            api_logger.warning(
+                f"记忆配置正在使用，无法删除: config_id={config_id}, "
+                f"connected_count={result['connected_count']}"
+            )
+            return fail(
+                code=BizCode.RESOURCE_IN_USE,
+                msg=result["message"],
+                data={
+                    "connected_count": result["connected_count"],
+                    "force_required": result["force_required"]
+                }
+            )
+
+        api_logger.info(
+            f"记忆配置删除成功: config_id={config_id}, "
+            f"affected_users={result['affected_users']}"
+        )
+        return success(
+            msg=result["message"],
+            data={"affected_users": result["affected_users"]}
+        )
+
+    except Exception as e:
+        api_logger.error(f"Delete config failed: {str(e)}", exc_info=True)
+        return fail(BizCode.INTERNAL_ERROR, "删除配置失败", str(e))

--- a/api/app/controllers/memory_forget_controller.py
+++ b/api/app/controllers/memory_forget_controller.py
@@ -11,7 +11,6 @@
 """
 
 from typing import Optional
-from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
@@ -24,8 +23,6 @@ from app.dependencies import get_current_user
 from app.models.user_model import User
 from app.schemas.memory_storage_schema import (
     ForgettingTriggerRequest,
-    ForgettingConfigResponse,
-    ForgettingConfigUpdateRequest,
     ForgettingStatsResponse,
     ForgettingReportResponse,
     ForgettingCurveRequest,
@@ -127,114 +124,9 @@ async def trigger_forgetting_cycle(
         return fail(BizCode.INTERNAL_ERROR, "触发遗忘周期失败", str(e))
 
 
-@router.get("/read_config", response_model=ApiResponse)
-async def read_forgetting_config(
-        config_id: UUID | int,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db)
-):
-    """
-    获取遗忘引擎配置
-    
-    读取指定配置ID的遗忘引擎参数。
-    
-    Args:
-        config_id: 配置ID
-        current_user: 当前用户
-        db: 数据库会话
-    
-    Returns:
-        ApiResponse: 包含配置信息的响应
-    """
-    workspace_id = current_user.current_workspace_id
-
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试读取遗忘引擎配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(
-        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取遗忘引擎配置: {config_id}"
-    )
-
-    try:
-        config_id = resolve_config_id(config_id, db)
-        # 调用服务层读取配置
-        config = forget_service.read_forgetting_config(db=db, config_id=config_id)
-
-        # 构建响应
-        response_data = ForgettingConfigResponse(**config)
-
-        return success(data=response_data.model_dump(), msg="查询成功")
-
-    except ValueError as e:
-        api_logger.warning(f"配置不存在: config_id={config_id}, 错误: {str(e)}")
-        return fail(BizCode.INVALID_PARAMETER, f"配置不存在: {config_id}", str(e))
-
-    except Exception as e:
-        api_logger.error(f"读取遗忘引擎配置失败: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "查询遗忘引擎配置失败", str(e))
-
-
-@router.post("/update_config", response_model=ApiResponse)
-async def update_forgetting_config(
-        payload: ForgettingConfigUpdateRequest,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db)
-):
-    """
-    更新遗忘引擎配置
-    
-    更新指定配置ID的遗忘引擎参数。
-    
-    Args:
-        payload: 配置更新请求
-        current_user: 当前用户
-        db: 数据库会话
-    
-    Returns:
-        ApiResponse: 包含更新结果的响应
-    """
-    workspace_id = current_user.current_workspace_id
-    payload.config_id = resolve_config_id(payload.config_id, db)
-
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试更新遗忘引擎配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(
-        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新遗忘引擎配置: {payload.config_id}"
-    )
-
-    try:
-        # 构建更新字段字典（排除 None 值和 config_id）
-        update_data = {
-            key: value
-            for key, value in payload.model_dump(exclude_none=True).items()
-            if key != 'config_id'
-        }
-
-        # 调用服务层更新配置
-        config = forget_service.update_forgetting_config(
-            db=db,
-            config_id=payload.config_id,
-            update_fields=update_data
-        )
-
-        # 构建响应
-        response_data = ForgettingConfigResponse(**config)
-
-        return success(data=response_data.model_dump(), msg="更新成功")
-
-    except ValueError as e:
-        api_logger.warning(f"配置不存在: config_id={payload.config_id}, 错误: {str(e)}")
-        return fail(BizCode.INVALID_PARAMETER, str(e), "ValueError")
-
-    except Exception as e:
-        db.rollback()
-        api_logger.error(f"更新遗忘引擎配置失败: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "更新遗忘引擎配置失败", str(e))
+# ==================== 记忆配置接口已迁移 ====================
+# read_forgetting_config / update_forgetting_config 已迁移至 memory_config_controller
+# （/memory_config/read_config_forgetting、/memory_config/update_config_forgetting）。
 
 
 @router.get("/stats", response_model=ApiResponse)

--- a/api/app/controllers/memory_reflection_controller.py
+++ b/api/app/controllers/memory_reflection_controller.py
@@ -31,7 +31,6 @@ from app.dependencies import get_current_user
 from app.models.user_model import User
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-from app.schemas.memory_reflection_schemas import Memory_Reflection
 from app.services.memory_reflection_service import (
     MemoryReflectionService,
     WorkspaceAppService,
@@ -194,97 +193,7 @@ def get_reflection_logs(
         api_logger.error(f"查询反思日志列表失败: end_user_id={end_user_id}, error={e}")
         return fail(BizCode.INTERNAL_ERROR, "查询日志列表失败", str(e))
 
-@router.post("/reflection/save")
-async def save_reflection_config(
-    request: Memory_Reflection,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-) -> dict:
-    """
-    Save reflection configuration to memory config table
-    
-    Persists reflection engine configuration settings to the data_config table,
-    including reflection parameters, model settings, and evaluation criteria.
-    Validates configuration parameters and ensures data consistency.
-    
-    Args:
-        request: Memory reflection configuration data including:
-            - config_id: Configuration identifier to update
-            - reflection_enabled: Whether reflection is enabled
-            - reflection_period_in_hours: Reflection execution interval
-            - reflexion_range: Scope of reflection (partial/all)
-            - baseline: Reflection strategy (time/fact/hybrid)
-            - reflection_model_id: LLM model for reflection operations
-            - memory_verify: Enable memory verification checks
-            - quality_assessment: Enable quality assessment evaluation
-        current_user: Authenticated user saving the configuration
-        db: Database session for data operations
-    
-    Returns:
-        dict: Success response with saved reflection configuration data
-        
-    Raises:
-        HTTPException 400: If config_id is missing or parameters are invalid
-        HTTPException 500: If configuration save operation fails
-        
-    Database Operations:
-        - Updates memory_config table with reflection settings
-        - Commits transaction and refreshes entity
-        - Maintains configuration consistency
-    """
-    try:
-        config_id = request.config_id
-        config_id = resolve_config_id(config_id, db)
-        if not config_id:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="缺少必需参数: config_id"
-            )
-        api_logger.info(f"用户 {current_user.username} 保存反思配置，config_id: {config_id}")
-
-        # Update reflection configuration in database
-        memory_config = MemoryConfigRepository.update_reflection_config(
-            db,
-            config_id=config_id,
-            enable_self_reflexion=request.reflection_enabled,
-            iteration_period=request.reflection_period_in_hours,
-            reflexion_range=request.reflexion_range,
-            baseline=request.baseline,
-            reflection_model_id=request.reflection_model_id,
-            memory_verify=request.memory_verify,
-            quality_assessment=request.quality_assessment
-        )
-
-        # Commit transaction and refresh entity
-        db.commit()
-        db.refresh(memory_config)
-
-        reflection_result={
-                "config_id": memory_config.config_id,
-                "enable_self_reflexion": memory_config.enable_self_reflexion,
-                "iteration_period": memory_config.iteration_period,
-                "reflexion_range": memory_config.reflexion_range,
-                "baseline": memory_config.baseline,
-                "reflection_model_id": memory_config.reflection_model_id,
-                "memory_verify": memory_config.memory_verify,
-                "quality_assessment": memory_config.quality_assessment}
-
-        return success(data=reflection_result, msg="反思配置成功")
-        
-
-        
-    except ValueError as ve:
-        api_logger.error(f"参数错误: {str(ve)}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"参数错误: {str(ve)}"
-        )
-    except Exception as e:
-        api_logger.error(f"反思配置保存失败: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"反思配置保存失败: {str(e)}"
-        )
+# save_reflection_config 已迁移至 memory_config_controller（/memory_config/update_config_reflection）
 
 
 @router.get("/reflection")
@@ -411,82 +320,8 @@ async def start_workspace_reflection(
         )
 
 
-@router.get("/reflection/configs")
-async def start_reflection_configs(
-        config_id: uuid.UUID|int,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    """
-    Query reflection configuration information by config_id
-    
-    Retrieves detailed reflection configuration settings from the memory_config
-    table for a specific configuration ID. Provides comprehensive reflection
-    parameters including model settings, evaluation criteria, and operational flags.
-    
-    Args:
-        config_id: Configuration identifier (UUID or integer) to query
-        current_user: Authenticated user making the request
-        db: Database session for data operations
-    
-    Returns:
-        dict: Success response with detailed reflection configuration:
-            - config_id: Resolved configuration identifier
-            - reflection_enabled: Whether reflection is enabled for this config
-            - reflection_period_in_hours: Reflection execution interval
-            - reflexion_range: Scope of reflection operations (partial/all)
-            - baseline: Reflection strategy (time/fact/hybrid)
-            - reflection_model_id: LLM model identifier for reflection
-            - memory_verify: Memory verification flag
-            - quality_assessment: Quality assessment flag
-    
-    Database Operations:
-        - Queries memory_config table by resolved config_id
-        - Retrieves all reflection-related configuration fields
-        - Resolves configuration ID for consistent formatting
-    
-    Raises:
-        HTTPException 404: If configuration with specified ID is not found
-        HTTPException 500: If configuration query operation fails
-        
-    ID Resolution:
-        - Supports both UUID and integer config_id formats
-        - Automatically resolves to appropriate internal format
-        - Maintains consistency across different ID representations
-    """
-    config_id = resolve_config_id(config_id, db)
-    try:
-        config_id=resolve_config_id(config_id,db)
-        api_logger.info(f"用户 {current_user.username} 查询反思配置，config_id: {config_id}")
-        result = MemoryConfigRepository.query_reflection_config_by_id(db, config_id)
-        memory_config_id = resolve_config_id(result.config_id, db)
-        
-        # Build response data with comprehensive configuration details
-        reflection_config = {
-            "config_id": memory_config_id,
-            "reflection_enabled": result.enable_self_reflexion,
-            "reflection_period_in_hours": result.iteration_period,
-            "reflexion_range": result.reflexion_range,
-            "baseline": result.baseline,
-            "reflection_model_id": result.reflection_model_id,
-            "memory_verify": result.memory_verify,
-            "quality_assessment": result.quality_assessment
-        }
-        api_logger.info(f"成功查询反思配置，config_id: {config_id}")
-        return success(data=reflection_config, msg="反思配置查询成功")
+# start_reflection_configs 已迁移至 memory_config_controller（/memory_config/read_config_reflection）
 
-        api_logger.info(f"Successfully queried reflection config, config_id: {config_id}")
-        return success(data=reflection_config, msg="Reflection configuration query successful")
-        
-    except HTTPException:
-        # Re-raise HTTP exceptions without modification
-        raise
-    except Exception as e:
-        api_logger.error(f"查询反思配置失败: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"查询反思配置失败: {str(e)}"
-        )
 
 @router.get("/reflection/run")
 async def reflection_run(

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -1,26 +1,19 @@
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header
-from fastapi import Query
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from app.core.error_codes import BizCode
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
-from app.core.quota_stub import check_memory_engine_quota
 from app.core.response_utils import fail, success
 from app.db import get_db, get_db_context
 from app.dependencies import get_current_user
 from app.models.user_model import User
 from app.schemas.memory_storage_schema import (
-    ConfigKey,
-    ConfigParamsCreate,
     ConfigPilotRun,
-    ConfigUpdate,
-    ConfigUpdateExtracted,
 )
 from app.schemas.response_schema import ApiResponse
 from app.services.memory_storage_service import (
@@ -38,6 +31,8 @@ from app.services.memory_storage_service import (
     search_entity,
     search_statement,
 )
+from fastapi import Header
+
 from app.utils.config_utils import resolve_config_id
 
 # Get API logger
@@ -75,232 +70,10 @@ async def get_storage_info(
         return fail(BizCode.INTERNAL_ERROR, "存储信息获取失败", str(e))
 
 
-@router.post("/create_config", response_model=ApiResponse)  # 创建配置文件，其他参数默认
-@check_memory_engine_quota
-def create_config(
-        payload: ConfigParamsCreate,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-        x_language_type: Optional[str] = Header(None, alias="X-Language-Type"),
-) -> dict:
-    workspace_id = current_user.current_workspace_id
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试创建配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求创建配置: {payload.config_name}")
-    try:
-        # 将 workspace_id 注入到 payload 中（保持为 UUID 类型）
-        payload.workspace_id = workspace_id
-        svc = DataConfigService(db)
-        result = svc.create(payload)
-        return success(data=result, msg="创建成功")
-    except ValueError as e:
-        err_str = str(e)
-        if err_str.startswith("DUPLICATE_CONFIG_NAME:"):
-            config_name = err_str.split(":", 1)[1]
-            api_logger.warning(f"重复的配置名称 '{config_name}' 在工作空间 {workspace_id}")
-            lang = get_language_from_header(x_language_type)
-            if lang == "en":
-                msg = fail(BizCode.BAD_REQUEST, "Config name already exists",
-                           f"A config named \"{config_name}\" already exists in the current workspace. Please use a different name.")
-            else:
-                msg = fail(BizCode.BAD_REQUEST, "配置名称已存在",
-                           f"当前工作空间下已存在名为「{config_name}」的记忆配置，请使用其他名称")
-            return JSONResponse(status_code=400, content=msg)
-        api_logger.error(f"Create config failed: {err_str}")
-        return fail(BizCode.INTERNAL_ERROR, "创建配置失败", err_str)
-    except Exception as e:
-        from sqlalchemy.exc import IntegrityError
-        if isinstance(e, IntegrityError) and "uq_workspace_config_name" in str(getattr(e, 'orig', '')):
-            api_logger.warning(f"重复的配置名称 '{payload.config_name}' 在工作空间 {workspace_id}")
-            lang = get_language_from_header(x_language_type)
-            if lang == "en":
-                msg = fail(BizCode.BAD_REQUEST, "Config name already exists",
-                           f"A config named \"{payload.config_name}\" already exists in the current workspace. Please use a different name.")
-            else:
-                msg = fail(BizCode.BAD_REQUEST, "配置名称已存在",
-                           f"当前工作空间下已存在名为「{payload.config_name}」的记忆配置，请使用其他名称")
-            return JSONResponse(status_code=400, content=msg)
-        api_logger.error(f"Create config failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "创建配置失败", str(e))
-
-
-@router.delete("/delete_config", response_model=ApiResponse)  # 删除数据库中的内容（按配置名称）
-def delete_config(
-        config_id: UUID | int,
-        force: bool = Query(False, description="是否强制删除（即使有终端用户正在使用）"),
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    """删除记忆配置（带终端用户保护）
-    
-    - 检查是否为默认配置，默认配置不允许删除
-    - 检查是否有终端用户连接到该配置
-    - 如果有连接且 force=False，返回警告
-    - 如果 force=True，清除终端用户引用后删除配置
-    
-    Query Parameters:
-        force: 设置为 true 可强制删除（即使有终端用户正在使用）
-    """
-    workspace_id = current_user.current_workspace_id
-    config_id = resolve_config_id(config_id, db)
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试删除配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(
-        f"用户 {current_user.username} 在工作空间 {workspace_id} 请求删除配置: "
-        f"config_id={config_id}, force={force}"
-    )
-
-    try:
-        # 使用带保护的删除服务
-        from app.services.memory_config_service import MemoryConfigService
-
-        config_service = MemoryConfigService(db)
-        result = config_service.delete_config(config_id=config_id, force=force)
-
-        if result["status"] == "error":
-            api_logger.warning(
-                f"记忆配置删除被拒绝: config_id={config_id}, reason={result['message']}"
-            )
-            return fail(
-                code=BizCode.FORBIDDEN,
-                msg=result["message"],
-                data={"config_id": str(config_id), "is_default": result.get("is_default", False)}
-            )
-
-        if result["status"] == "warning":
-            api_logger.warning(
-                f"记忆配置正在使用，无法删除: config_id={config_id}, "
-                f"connected_count={result['connected_count']}"
-            )
-            return fail(
-                code=BizCode.RESOURCE_IN_USE,
-                msg=result["message"],
-                data={
-                    "connected_count": result["connected_count"],
-                    "force_required": result["force_required"]
-                }
-            )
-
-        api_logger.info(
-            f"记忆配置删除成功: config_id={config_id}, "
-            f"affected_users={result['affected_users']}"
-        )
-        return success(
-            msg=result["message"],
-            data={"affected_users": result["affected_users"]}
-        )
-
-    except Exception as e:
-        api_logger.error(f"Delete config failed: {str(e)}", exc_info=True)
-        return fail(BizCode.INTERNAL_ERROR, "删除配置失败", str(e))
-
-
-@router.post("/update_config", response_model=ApiResponse)  # 更新配置文件中name和desc
-def update_config(
-        payload: ConfigUpdate,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    workspace_id = current_user.current_workspace_id
-    payload.config_id = resolve_config_id(payload.config_id, db)
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试更新配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    # 校验至少有一个字段需要更新
-    if payload.config_name is None and payload.config_desc is None and payload.scene_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试更新配置但未提供任何更新字段")
-        return fail(BizCode.INVALID_PARAMETER, "请至少提供一个需要更新的字段",
-                    "config_name, config_desc, scene_id 均为空")
-
-    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新配置: {payload.config_id}")
-    try:
-        svc = DataConfigService(db)
-        result = svc.update(payload)
-        return success(data=result, msg="更新成功")
-    except Exception as e:
-        api_logger.error(f"Update config failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "更新配置失败", str(e))
-
-
-@router.post("/update_config_extracted", response_model=ApiResponse)  # 更新数据库中的部分内容 所有业务字段均可选
-def update_config_extracted(
-        payload: ConfigUpdateExtracted,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    workspace_id = current_user.current_workspace_id
-    payload.config_id = resolve_config_id(payload.config_id, db)
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试更新提取配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求更新提取配置: {payload.config_id}")
-    try:
-        svc = DataConfigService(db)
-        result = svc.update_extracted(payload)
-        return success(data=result, msg="更新成功")
-    except Exception as e:
-        api_logger.error(f"Update config extracted failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "更新配置失败", str(e))
-
-
-# --- Forget config params ---
-# 遗忘引擎配置接口已迁移到 memory_forget_controller.py
-# 使用新接口: /api/memory/forget/read_config 和 /api/memory/forget/update_config
-
-@router.get("/read_config_extracted", response_model=ApiResponse)  # 通过查询参数读取某条配置（固定路径） 没有意义的话就删除
-def read_config_extracted(
-        config_id: UUID | int,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    workspace_id = current_user.current_workspace_id
-    config_id = resolve_config_id(config_id, db)
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试读取提取配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取提取配置: {config_id}")
-    try:
-        svc = DataConfigService(db)
-        result = svc.get_extracted(ConfigKey(config_id=config_id))
-        return success(data=result, msg="查询成功")
-    except Exception as e:
-        api_logger.error(f"Read config extracted failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "查询配置失败", str(e))
-
-
-@router.get("/read_all_config", response_model=ApiResponse)  # 读取所有配置文件列表
-def read_all_config(
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    workspace_id = current_user.current_workspace_id
-
-    # 检查用户是否已选择工作空间
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试查询配置但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(f"用户 {current_user.username} 在工作空间 {workspace_id} 请求读取所有配置")
-    try:
-        svc = DataConfigService(db)
-        # 传递 workspace_id 进行过滤（保持为 UUID 类型）
-        result = svc.get_all(workspace_id=workspace_id)
-        return success(data=result, msg="查询成功")
-    except Exception as e:
-        api_logger.error(f"Read all config failed: {str(e)}")
-        return fail(BizCode.INTERNAL_ERROR, "查询所有配置失败", str(e))
+# ==================== 记忆配置接口已迁移 ====================
+# create_config / delete_config / update_config / update_config_extracted /
+# read_config_extracted / read_all_config 已迁移至 memory_config_controller
+# （前缀 /memory_config），此处不再保留。
 
 
 @router.post("/pilot_run", response_model=None)

--- a/api/app/controllers/service/end_user_api_controller.py
+++ b/api/app/controllers/service/end_user_api_controller.py
@@ -5,7 +5,7 @@ import uuid
 from fastapi import APIRouter, Body, Depends, Query, Request
 from sqlalchemy.orm import Session
 
-from app.controllers import user_memory_controllers, memory_analytics_controller
+from app.controllers import end_user_controller
 from app.core.api_key_auth import require_api_key
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
@@ -217,7 +217,7 @@ async def get_end_user_info(
     Delegates to the manager-side controller for shared logic.
     """
     current_user = _get_current_user(api_key_auth, db)
-    return await memory_analytics_controller.get_end_user_info(
+    return await end_user_controller.get_end_user_info(
         end_user_id=end_user_id,
         current_user=current_user,
         db=db,
@@ -242,7 +242,7 @@ async def update_end_user_info(
     payload = EndUserInfoUpdate(**body)
 
     current_user = _get_current_user(api_key_auth, db)
-    return await user_memory_controllers.update_end_user_info(
+    return await end_user_controller.update_end_user_info(
         info_update=payload,
         current_user=current_user,
         db=db,

--- a/api/app/controllers/service/memory_config_api_controller.py
+++ b/api/app/controllers/service/memory_config_api_controller.py
@@ -7,11 +7,8 @@ from fastapi import APIRouter, Body, Depends, Header, Query, Request
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
-from app.controllers import memory_storage_controller
-from app.controllers import memory_forget_controller
+from app.controllers import memory_config_controller
 from app.controllers import ontology_controller
-from app.controllers import emotion_config_controller
-from app.controllers import memory_reflection_controller
 from app.schemas.memory_storage_schema import ForgettingConfigUpdateRequest
 from app.controllers.emotion_config_controller import EmotionConfigUpdate
 from app.schemas.memory_reflection_schemas import Memory_Reflection
@@ -125,7 +122,7 @@ async def read_all_config(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    return memory_storage_controller.read_all_config(
+    return memory_config_controller.read_all_config(
         current_user=current_user,
         db=db,
     )
@@ -171,7 +168,7 @@ async def read_config_extracted(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    return memory_storage_controller.read_config_extracted(
+    return memory_config_controller.read_config_extracted(
         config_id = config_id,
         current_user = current_user,
         db = db,
@@ -196,7 +193,7 @@ async def read_config_forgetting(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    result = await memory_forget_controller.read_forgetting_config(
+    result = await memory_config_controller.read_forgetting_config(
         config_id = config_id,
         current_user = current_user,
         db = db,
@@ -224,7 +221,7 @@ async def read_config_emotion(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    return jsonable_encoder(emotion_config_controller.get_emotion_config(
+    return jsonable_encoder(memory_config_controller.get_emotion_config(
         config_id=config_id,
         db=db,
         current_user=current_user,
@@ -249,7 +246,7 @@ async def read_config_reflection(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    return jsonable_encoder(await memory_reflection_controller.start_reflection_configs(
+    return jsonable_encoder(await memory_config_controller.start_reflection_configs(
         config_id=config_id,
         current_user=current_user,
         db=db,
@@ -289,7 +286,7 @@ async def create_memory_config(
         emotion_model_id=payload.emotion_model_id,
     )
     #将返回数据中UUID序列化处理
-    result =memory_storage_controller.create_config(
+    result =memory_config_controller.create_config(
         payload=mgmt_payload,
         current_user=current_user,
         db=db,
@@ -326,7 +323,7 @@ async def update_memory_config(
         scene_id = payload.scene_id,
     )
 
-    return memory_storage_controller.update_config(
+    return memory_config_controller.update_config(
         payload = mgmt_payload,
         current_user = current_user,
         db = db,
@@ -358,7 +355,7 @@ async def update_memory_config_extracted(
    update_fields = payload.model_dump(exclude_unset=True)
    mgmt_payload = ConfigUpdateExtracted(**update_fields)
 
-   return memory_storage_controller.update_config_extracted(
+   return memory_config_controller.update_config_extracted(
         payload = mgmt_payload,
         current_user = current_user,
         db = db,
@@ -391,7 +388,7 @@ async def update_memory_config_forgetting(
    mgmt_payload = ForgettingConfigUpdateRequest(**update_fields)
 
    #将返回数据中UUID序列化处理
-   result = await memory_forget_controller.update_forgetting_config(
+   result = await memory_config_controller.update_forgetting_config(
         payload = mgmt_payload,
         current_user = current_user,
         db = db,
@@ -422,7 +419,7 @@ async def update_config_emotion(
     current_user = _get_current_user(api_key_auth, db)
     update_fields = payload.model_dump(exclude_unset=True)
     mgmt_payload = EmotionConfigUpdate(**update_fields)
-    return jsonable_encoder(emotion_config_controller.update_emotion_config(
+    return jsonable_encoder(memory_config_controller.update_emotion_config(
         config=mgmt_payload,
         db=db,
         current_user=current_user,
@@ -453,7 +450,7 @@ async def update_config_reflection(
     update_fields = payload.model_dump(exclude_unset=True)
     mgmt_payload = Memory_Reflection(**update_fields)
 
-    return jsonable_encoder(await memory_reflection_controller.save_reflection_config(
+    return jsonable_encoder(await memory_config_controller.save_reflection_config(
         request=mgmt_payload,
         current_user=current_user,
         db=db,
@@ -483,7 +480,7 @@ async def delete_memory_config(
 
     current_user = _get_current_user(api_key_auth, db)
 
-    return memory_storage_controller.delete_config(
+    return memory_config_controller.delete_config(
         config_id=config_id,
         force=force,
         current_user=current_user,

--- a/api/app/controllers/service/user_memory_api_controller.py
+++ b/api/app/controllers/service/user_memory_api_controller.py
@@ -32,6 +32,7 @@ from app.schemas.memory_storage_schema import GenerateCacheRequest
 
 # 包装内部服务 controller
 from app.controllers import memory_analytics_controller
+from app.controllers import end_user_controller
 
 router = APIRouter(prefix="/memory", tags=["V1 - User Memory API"])
 logger = get_business_logger()
@@ -192,7 +193,7 @@ async def get_end_user_info(
     current_user = get_current_user_from_api_key(db, api_key_auth)
     validate_end_user_in_workspace(db, end_user_id, api_key_auth.workspace_id)
 
-    return await memory_analytics_controller.get_end_user_info(
+    return await end_user_controller.get_end_user_info(
         end_user_id=end_user_id,
         current_user=current_user,
         db=db,

--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -1,7 +1,8 @@
 """
 用户记忆相关的控制器
-保留终端用户信息更新与记忆空间（memory_space）相关接口。
-分析类（analytics）接口已迁移至 memory_analytics_controller。
+保留记忆空间（memory_space）相关接口。
+分析类（analytics）接口已迁移至 memory_analytics_controller；
+终端用户信息接口已迁移至 end_user_controller。
 """
 from fastapi import APIRouter, Depends, Header, Query
 from sqlalchemy.orm import Session
@@ -13,11 +14,7 @@ from app.core.response_utils import success, fail
 from app.db import get_db
 from app.dependencies import get_current_user
 from app.models.user_model import User
-from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.workspace_repository import WorkspaceRepository
-from app.schemas.end_user_info_schema import (
-    EndUserInfoUpdate,
-)
 from app.schemas.memory_storage_schema import DeleteNodeRequest
 from app.schemas.response_schema import ApiResponse
 from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
@@ -36,67 +33,7 @@ router = APIRouter(
 
 
 # =======================终端用户信息接口=======================
-
-@router.post("/end_user_info/updated", response_model=ApiResponse)
-async def update_end_user_info(
-        info_update: EndUserInfoUpdate,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db),
-) -> dict:
-    """
-    更新终端用户信息记录
-
-    根据 end_user_id 更新终端用户信息记录，支持批量更新多个别名。
-    
-    示例请求体：
-    {
-      "end_user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "other_name": "张三1",
-      "aliases": ["小张", "张工"],
-      "meta_data": {"position": "工程师", "department": "技术部"}
-    }
-    """
-    workspace_id = current_user.current_workspace_id
-    end_user_id = info_update.end_user_id
-
-    if workspace_id is None:
-        api_logger.warning(f"用户 {current_user.username} 尝试更新终端用户信息但未选择工作空间")
-        return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间", "current_workspace_id is None")
-
-    api_logger.info(
-        f"更新终端用户信息请求: end_user_id={end_user_id}, user={current_user.username}, "
-        f"workspace={workspace_id}"
-    )
-
-    # 校验 end_user 是否属于当前工作空间
-    end_user_repo = EndUserRepository(db)
-    end_user = end_user_repo.get_end_user_by_id(end_user_id)
-    if end_user is None:
-        return fail(BizCode.USER_NOT_FOUND, "终端用户不存在", "end_user not found")
-    if str(end_user.workspace_id) != str(workspace_id):
-        api_logger.warning(
-            f"用户 {current_user.username} 尝试更新不属于工作空间 {workspace_id} 的终端用户 {end_user_id}"
-        )
-        return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
-
-    # 获取更新数据（排除 end_user_id）
-    update_data = info_update.model_dump(exclude_unset=True, exclude={'end_user_id'})
-
-    result = user_memory_service.update_end_user_info(db, end_user_id, update_data)
-
-    if result["success"]:
-        api_logger.info(f"成功更新终端用户信息: end_user_id={end_user_id}")
-        return success(data=result["data"], msg="更新成功")
-    else:
-        error_msg = result["error"]
-        api_logger.error(f"终端用户信息更新失败: end_user_id={end_user_id}, error={error_msg}")
-
-        if error_msg == "终端用户信息记录不存在":
-            return fail(BizCode.USER_NOT_FOUND, "终端用户信息记录不存在", error_msg)
-        elif error_msg == "无效的终端用户ID格式":
-            return fail(BizCode.INVALID_USER_ID, "无效的终端用户ID格式", error_msg)
-        else:
-            return fail(BizCode.INTERNAL_ERROR, "终端用户信息更新失败", error_msg)
+# update_end_user_info 已迁移至 end_user_controller（/end_user/info/update）
 
 
 @router.get("/memory_space/timeline_memories", response_model=ApiResponse)


### PR DESCRIPTION
…ement

- Migrate emotion config endpoints to centralized memory_config_controller
- Create new end_user_controller for end-user management operations
- Create new memory_config_controller consolidating all memory configuration endpoints
- Refactor emotion_config_controller to retain only shared data models
- Update controller imports and router registration in __init__.py
- Standardize config endpoint naming (read_config, update_config patterns)
- Consolidate configuration management into unified memory_config module for improved maintainability

## Summary by Sourcery

将所有内存配置和终端用户信息相关的接口整合到专用的控制器中，并相应更新路由连接。

New Features:
- 引入 `memory_config_controller`，将与内存、遗忘、情绪和反思相关的配置 API 统一集中到 `/memory_config` 前缀下。
- 引入 `end_user_controller`，在 `/end_user` 前缀下提供统一的、基于 JWT 认证的终端用户信息查询与更新接口。

Enhancements:
- 将现有与配置相关的处理逻辑从 storage、forget、emotion 和 reflection 控制器迁移到新的 `memory_config_controller` 中，而不改变其核心行为。
- 重新定位 `emotion_config_controller`，使其仅承载可被集中配置控制器复用的通用情绪配置模型。
- 从 `memory_storage`、`memory_forget`、`memory_reflection`、`memory_analytics` 和 `user_memory` 控制器中移除配置相关的接口，因为这些接口现在由 `memory_config_controller` 和 `end_user_controller` 提供。
- 更新内部服务层的 API 控制器，使其委托给新的 `memory_config_controller` 和 `end_user_controller`，从而保持外部 `/v1` 路由与内部 `/api` 路由的一致性。
- 在 `manager_router` 上注册新的 `memory_config_controller` 和 `end_user_controller`，以暴露整合后的这些接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate all memory configuration and end-user info endpoints into dedicated controllers and update router wiring accordingly.

New Features:
- Introduce memory_config_controller to centralize memory, forgetting, emotion, and reflection configuration APIs under a unified /memory_config prefix.
- Introduce end_user_controller to provide unified JWT-authenticated endpoints for querying and updating end-user information under /end_user.

Enhancements:
- Migrate existing config-related handlers from storage, forget, emotion, and reflection controllers into the new memory_config_controller without changing their core behavior.
- Refocus emotion_config_controller to only host shared emotion configuration models for reuse by the centralized config controller.
- Remove config-related endpoints from memory_storage, memory_forget, memory_reflection, memory_analytics, and user_memory controllers now that they are served via memory_config_controller and end_user_controller.
- Update internal service-layer API controllers to delegate to the new memory_config_controller and end_user_controller, keeping external /v1 routes aligned with internal /api routes.
- Register the new memory_config_controller and end_user_controller on the manager_router to expose the consolidated endpoints.

</details>