### PR TITLE
feat(memory): add clustering reconciliation to clean up empty communities and sync member counts

### DIFF
--- a/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
+++ b/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
@@ -113,12 +113,17 @@ class LabelPropagationEngine:
         if not has_communities:
             logger.info(f"[Clustering] 用户 {end_user_id} 首次聚类，执行全量初始化")
             await self.full_clustering(end_user_id)
+            # 全量聚类后做全量对账（None = 重算全部社区 member_count）
+            await self.repo.reconcile_after_clustering(end_user_id, refresh_community_ids=None)
         else:
-            if new_entity_ids:
-                logger.info(
-                    f"[Clustering] 增量更新，新实体数: {len(new_entity_ids)}"
-                )
-                await self.incremental_update(new_entity_ids, end_user_id)
+            if not new_entity_ids:
+                return
+            logger.info(
+                f"[Clustering] 增量更新，新实体数: {len(new_entity_ids)}"
+            )
+            affected = await self.incremental_update(new_entity_ids, end_user_id)
+            # 增量后只对本轮触达的社区重算 member_count（删空社区仍全量，覆盖合并解散/并发去重清空）
+            await self.repo.reconcile_after_clustering(end_user_id, refresh_community_ids=affected)
 
     async def full_clustering(self, end_user_id: str) -> None:
         """
@@ -223,7 +228,7 @@ class LabelPropagationEngine:
 
     async def incremental_update(
         self, new_entity_ids: List[str], end_user_id: str
-    ) -> None:
+    ) -> List[str]:
         """
         增量更新：只处理新实体及其邻居，不重跑全图。
 
@@ -234,6 +239,10 @@ class LabelPropagationEngine:
 
         P2 修复：改为按批（每批 CONCURRENT_BATCH 个）并发处理，
         避免大批量新实体时串行积压导致连接池长时间占用。
+
+        Returns:
+            本轮触达（新建 / 加入）的社区 ID 列表，供收尾对账限定 member_count
+            重算范围，避免对全用户社区写放大。
         """
         communities_to_update = set()
 
@@ -253,6 +262,8 @@ class LabelPropagationEngine:
         # 批量生成所有社区的元数据
         if communities_to_update:
             await self._generate_community_metadata(list(communities_to_update), end_user_id, force=True)
+
+        return list(communities_to_update)
 
     # ──────────────────────────────────────────────────────────────────────────
     # 内部方法

--- a/api/app/repositories/neo4j/community_repository.py
+++ b/api/app/repositories/neo4j/community_repository.py
@@ -29,6 +29,9 @@ from app.repositories.neo4j.cypher_queries import (
     CHECK_COMMUNITY_IS_COMPLETE,
     CHECK_COMMUNITY_IS_COMPLETE_WITH_EMBEDDING,
     BATCH_UPDATE_COMMUNITY_METADATA,
+    RECONCILE_DELETE_EMPTY_COMMUNITIES,
+    RECONCILE_REFRESH_ALL_MEMBER_COUNTS,
+    RECONCILE_REFRESH_MEMBER_COUNTS_SCOPED,
 )
 
 logger = logging.getLogger(__name__)
@@ -338,3 +341,56 @@ class CommunityRepository:
         except Exception as e:
             logger.error(f"batch_update_community_metadata failed: {e}")
             return False
+
+    async def reconcile_after_clustering(
+        self, end_user_id: str, refresh_community_ids: Optional[List[str]] = None
+    ) -> Dict[str, int]:
+        """聚类收尾对账：删空社区 + 重算成员数。幂等、低成本。
+
+        兜底去重/反思在聚类期间并发 DETACH DELETE 实体留下的脏数据。
+
+        两步策略（针对性能：增量聚类高频触发，避免对全用户社区写放大）：
+        - 删空社区：**始终全量**。读多写少（仅真正空社区才 DETACH DELETE），
+          覆盖合并解散的社区 + 并发去重清空的任意社区（这些都不在本轮 touched 集合里）。
+        - 重算 member_count：按 ``refresh_community_ids`` 限定范围——
+            * None  → 全量重算（全量聚类后使用）
+            * [...] → 仅重算这些社区（增量聚类后，消除每轮对全用户社区的写放大）
+            * []    → 跳过重算（本轮未触达任何社区）
+
+        Args:
+            end_user_id: 用户 ID
+            refresh_community_ids: member_count 重算范围；None 表示全量。
+
+        Returns:
+            {"deleted": 删除的空社区数, "refreshed": 重算 member_count 的社区数}
+        """
+        try:
+            # Step 1: 删除该用户下所有无成员边的空社区（始终全量）
+            # 覆盖：合并解散的社区、去重/反思并发删实体后清空的社区
+            d = await self.connector.execute_query(
+                RECONCILE_DELETE_EMPTY_COMMUNITIES, end_user_id=end_user_id
+            )
+            deleted = d[0]["deleted"] if d else 0
+
+            refreshed = 0
+            if refresh_community_ids is None:
+                # Step 2a: 全量重算该用户所有存活社区的 member_count（全量聚类后使用）
+                r = await self.connector.execute_query(
+                    RECONCILE_REFRESH_ALL_MEMBER_COUNTS, end_user_id=end_user_id
+                )
+                refreshed = r[0]["refreshed"] if r else 0
+            elif len(refresh_community_ids) > 0:
+                # Step 2b: 仅重算本轮触达的社区的 member_count（增量聚类后使用，避免全用户写放大）
+                r = await self.connector.execute_query(
+                    RECONCILE_REFRESH_MEMBER_COUNTS_SCOPED,
+                    end_user_id=end_user_id,
+                    community_ids=refresh_community_ids,
+                )
+                refreshed = r[0]["refreshed"] if r else 0
+            # else: refresh_community_ids == [] → 本轮未触达任何社区，跳过重算
+
+            logger.info(f"[Reconcile] 删除空社区={deleted}，刷新成员数社区={refreshed}")
+            return {"deleted": deleted, "refreshed": refreshed}
+        except Exception as e:
+            logger.error(f"reconcile_after_clustering failed: {e}")
+            return {"deleted": 0, "refreshed": 0}

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -69,7 +69,7 @@ CONSTRAINT_DEFS: List[Tuple[str, str, str]] = [
     ("entity_id_unique", "ExtractedEntity", "id"),
     ("memory_summary_id_unique", "MemorySummary", "id"),
     ("perceptual_id_unique", "Perceptual", "id"),
-    # Community 存在重复数据，暂不建唯一约束
+    ("community_id_unique", "Community", "community_id"),
 ]
 
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1395,6 +1395,34 @@ SET c.member_count = cnt
 RETURN c.community_id AS community_id, cnt AS member_count
 """
 
+# ─── 聚类收尾对账（兜底去重/反思并发删实体留下的脏数据）───────────────────────
+# 删除该用户下所有"没有任何成员"的社区（含空社区 + member_count=1 但无成员边的孤儿社区）
+RECONCILE_DELETE_EMPTY_COMMUNITIES = """
+MATCH (c:Community {end_user_id: $end_user_id})
+WHERE NOT (:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+DETACH DELETE c
+RETURN count(c) AS deleted
+"""
+
+# 重算该用户下所有存活社区的 member_count（一次性，按真实成员边计数）
+RECONCILE_REFRESH_ALL_MEMBER_COUNTS = """
+MATCH (c:Community {end_user_id: $end_user_id})
+OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+WITH c, count(e) AS cnt
+SET c.member_count = cnt
+RETURN count(c) AS refreshed
+"""
+
+# 仅重算指定社区的 member_count（增量聚类后使用，避免对全用户社区写放大）
+RECONCILE_REFRESH_MEMBER_COUNTS_SCOPED = """
+MATCH (c:Community {end_user_id: $end_user_id})
+WHERE c.community_id IN $community_ids
+OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+WITH c, count(e) AS cnt
+SET c.member_count = cnt
+RETURN count(c) AS refreshed
+"""
+
 UPDATE_COMMUNITY_METADATA = """
 MATCH (c:Community {community_id: $community_id, end_user_id: $end_user_id})
 SET c.id               = coalesce(c.id, $community_id),


### PR DESCRIPTION
## Summary by Sourcery

在聚类后新增“对账”步骤，用于清理空社区并确保成员计数准确，同时为社区 ID 启用唯一约束。

New Features:
- 在社区仓库中引入 `reconcile_after_clustering` API，以便在聚类完成后删除空社区并刷新成员计数。
- 添加针对性和全量范围的 Cypher 查询，根据实际成员关系边重新计算社区的 `member_count` 值。

Enhancements:
- 更新标签传播聚类引擎，在完整和增量运行结束后调用对账步骤；对于增量聚类，将成员计数的重新计算限制在受影响的社区范围内。
- 修改 `incremental_update`，使其返回受影响的社区 ID，以支持后续的对账逻辑。
- 为 `Community.community_id` 启用唯一索引，以强制标识符唯一性并防止重复社区。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a post-clustering reconciliation step to clean up empty communities and ensure accurate member counts, and enable a unique constraint on community IDs.

New Features:
- Introduce reconcile_after_clustering API in the community repository to delete empty communities and refresh member counts after clustering.
- Add targeted and full-scope Cypher queries to recalculate community member_count values based on actual membership edges.

Enhancements:
- Update the label propagation clustering engine to invoke reconciliation after full and incremental runs, limiting member_count recalculation to affected communities for incremental clustering.
- Modify incremental_update to return affected community IDs for downstream reconciliation logic.
- Enable a unique index on Community.community_id to enforce identifier uniqueness and prevent duplicate communities.

</details>