### PR TITLE
feat(rag): support threaded cross-kb retrieval

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -2,7 +2,6 @@ import json
 import os
 import csv
 import io
-import time
 from typing import Any, Optional
 import uuid
 
@@ -32,6 +31,7 @@ from app.core.utils.datetime_utils import to_timestamp_ms
 
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
+
 
 router = APIRouter(
     prefix="/chunks",
@@ -950,26 +950,34 @@ def get_retrieve_types():
     return success(msg="Successfully obtained the retrieval type", data=list(chunk_schema.RetrieveType))
 
 
-@router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
-async def retrieve_chunks(
+async def retrieve_chunks_with_caller(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: Session,
+        current_user: User,
+        caller: chunk_schema.KnowledgeRetrievalCaller,
 ):
     """
     retrieve chunk
     """
-    api_logger.info(f"retrieve chunk: query={retrieve_data.query}, username: {current_user.username}")
+    api_logger.info(
+        "retrieve chunk request received: username=%s, caller=%s, query_len=%s, kb_count=%s, "
+        "ex_id_count=%s, retrieve_type=%s, top_k=%s, "
+        "metadata_mode=%s, metadata_filter_groups=%s",
+        current_user.username,
+        caller,
+        len(retrieve_data.query or ""),
+        len(retrieve_data.kb_ids or []),
+        len(retrieve_data.ex_ids or []),
+        retrieve_data.retrieve_type,
+        retrieve_data.top_k,
+        retrieve_data.metadata_filter_mode,
+        len(retrieve_data.metadata_filters or []),
+    )
 
     try:
         retrieval_payload = retrieve_data.model_dump(exclude_none=True)
-        if retrieve_data.knowledge_bases:
-            retrieval_payload["knowledge_bases"] = [
-                kb_config.model_dump(exclude_none=True, exclude_unset=True)
-                for kb_config in retrieve_data.knowledge_bases
-            ]
+        retrieval_payload["caller"] = caller
         request = KnowledgeRetrievalRequest(**retrieval_payload)
-        api_logger.info(f"retrieve chunk: request={request}")
         result = KnowledgeRetrievalService.retrieve(
             db=db,
             request=request,
@@ -982,3 +990,17 @@ async def retrieve_chunks(
         ) from exc
 
     return success(data=jsonable_encoder(result.chunks), msg="retrieval successful")
+
+
+@router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
+async def retrieve_chunks(
+        retrieve_data: chunk_schema.ChunkRetrieve,
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
+):
+    return await retrieve_chunks_with_caller(
+        retrieve_data=retrieve_data,
+        db=db,
+        current_user=current_user,
+        caller=chunk_schema.KnowledgeRetrievalCaller.IN_API,
+    )

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -962,7 +962,13 @@ async def retrieve_chunks(
     api_logger.info(f"retrieve chunk: query={retrieve_data.query}, username: {current_user.username}")
 
     try:
-        request = KnowledgeRetrievalRequest(**retrieve_data.model_dump(exclude_none=True))
+        retrieval_payload = retrieve_data.model_dump(exclude_none=True)
+        if retrieve_data.knowledge_bases:
+            retrieval_payload["knowledge_bases"] = [
+                kb_config.model_dump(exclude_none=True, exclude_unset=True)
+                for kb_config in retrieve_data.knowledge_bases
+            ]
+        request = KnowledgeRetrievalRequest(**retrieval_payload)
         api_logger.info(f"retrieve chunk: request={request}")
         result = KnowledgeRetrievalService.retrieve(
             db=db,

--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -245,9 +245,12 @@ async def retrieve_chunks(
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
-    return await chunk_controller.retrieve_chunks(retrieve_data=retrieve_data,
-                                                  db=db,
-                                                  current_user=current_user)
+    return await chunk_controller.retrieve_chunks_with_caller(
+        retrieve_data=retrieve_data,
+        db=db,
+        current_user=current_user,
+        caller=chunk_schema.KnowledgeRetrievalCaller.EX_API,
+    )
 
 
 @router.post("/{kb_id}/import_qa", response_model=ApiResponse)
@@ -276,4 +279,3 @@ async def import_qa_new_doc(
         current_user=current_user,
         storage_service=storage_service,
     )
-

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -82,6 +82,7 @@ class Settings:
     ELASTICSEARCH_REQUEST_TIMEOUT: int = int(os.getenv("ELASTICSEARCH_REQUEST_TIMEOUT", "100000"))
     ELASTICSEARCH_RETRY_ON_TIMEOUT: bool = os.getenv("ELASTICSEARCH_RETRY_ON_TIMEOUT", "True").lower() == "true"
     ELASTICSEARCH_MAX_RETRIES: int = int(os.getenv("ELASTICSEARCH_MAX_RETRIES", "10"))
+    KNOWLEDGE_RETRIEVAL_MAX_WORKERS: int = int(os.getenv("KNOWLEDGE_RETRIEVAL_MAX_WORKERS", "3"))
 
     # Xinference configuration
     XINFERENCE_URL: str = os.getenv("XINFERENCE_URL", "http://127.0.0.1")

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -582,11 +582,13 @@ class ElasticSearchVector(BaseVector):
     def _vector_search_result_to_chunks(
         self,
         result,
-        score_threshold: float,
+        score_threshold: float | None,
         *,
         normalize_script_score: bool,
         resolve_parents: bool,
+        indices: str | None = None,
     ) -> list[DocumentChunk]:
+        self._raise_on_shard_failures(result, "vector search")
         if "errors" in result:
             raise ValueError(f"Error during query: {result['errors']}")
 
@@ -607,11 +609,30 @@ class ElasticSearchVector(BaseVector):
                 metadata["question"] = question
                 metadata["answer"] = answer
 
-            if score > score_threshold:
+            if score_threshold is None or score > score_threshold:
                 metadata["score"] = score
                 docs.append(DocumentChunk(page_content=page_content, metadata=metadata))
 
-        return self.resolve_parent_chunks(docs) if resolve_parents else docs
+        return self.resolve_parent_chunks(docs, indices=indices) if resolve_parents else docs
+
+    @staticmethod
+    def _raise_on_shard_failures(result: dict[str, Any], context: str) -> None:
+        shards = result.get("_shards") or {}
+        failed = int(shards.get("failed") or 0)
+        if failed <= 0:
+            return
+        failures = shards.get("failures") or []
+        failure_summary = []
+        for failure in failures[:3]:
+            index = failure.get("index")
+            reason = failure.get("reason") or {}
+            reason_type = reason.get("type")
+            reason_text = reason.get("reason")
+            failure_summary.append(f"index={index}, type={reason_type}, reason={reason_text}")
+        raise ValueError(
+            f"Elasticsearch shard failures during {context}: failed={failed}, "
+            f"failures={failure_summary}"
+        )
 
     def search_by_vector(self, query: str, resolve_parents: bool = True, **kwargs: Any) -> list[DocumentChunk]:
         """Search the nearest neighbors to a vector."""
@@ -623,7 +644,8 @@ class ElasticSearchVector(BaseVector):
         query_vector = self._normalize_vector(query_vector)
 
         top_k = int(kwargs.get("top_k") or 1024)
-        score_threshold = float(kwargs.get("score_threshold") or 0.3)
+        raw_score_threshold = kwargs.get("score_threshold", 0.3)
+        score_threshold = None if raw_score_threshold is None else float(raw_score_threshold or 0.3)
         indices = kwargs.get("indices", self._collection_name)  # Default single index, multi-index available，etc "index1,index2,index3"
         file_names_filter = kwargs.get("file_names_filter") # ["doc1", "doc2", "doc3"]
         document_ids_include = kwargs.get("document_ids_include")
@@ -650,6 +672,7 @@ class ElasticSearchVector(BaseVector):
                     score_threshold,
                     normalize_script_score=False,
                     resolve_parents=resolve_parents,
+                    indices=indices,
                 )
                 logger.debug(
                     f"[ES search_by_vector] mode=knn hits={len(result.get('hits', {}).get('hits', []))} "
@@ -657,6 +680,8 @@ class ElasticSearchVector(BaseVector):
                 )
                 return docs
             except Exception as exc:
+                if "Elasticsearch shard failures" in str(exc):
+                    raise
                 logger.warning(f"[ES search_by_vector] KNN search failed, falling back to script_score: {exc}")
 
         result = self._search_by_vector_script(
@@ -670,6 +695,7 @@ class ElasticSearchVector(BaseVector):
             score_threshold,
             normalize_script_score=True,
             resolve_parents=resolve_parents,
+            indices=indices,
         )
         logger.debug(
             f"[ES search_by_vector] mode=script_score hits={len(result.get('hits', {}).get('hits', []))} "
@@ -688,7 +714,8 @@ class ElasticSearchVector(BaseVector):
             List of Documents most similar to the query.
         """
         top_k = kwargs.get("top_k", 1024)
-        score_threshold = float(kwargs.get("score_threshold") or 0.2)
+        raw_score_threshold = kwargs.get("score_threshold", 0.2)
+        score_threshold = None if raw_score_threshold is None else float(raw_score_threshold or 0.2)
         indices = kwargs.get("indices", self._collection_name)  # Default single index, multiple indexes are also supported, such as "index1, index2, index3"
         file_names_filter = kwargs.get("file_names_filter") # ["doc1", "doc2", "doc3"]
 
@@ -749,6 +776,7 @@ class ElasticSearchVector(BaseVector):
         )
         # logger.info(result)
 
+        self._raise_on_shard_failures(result, "full text search")
         if "errors" in result:
             raise ValueError(f"Error during query: {result['errors']}")
 
@@ -777,14 +805,14 @@ class ElasticSearchVector(BaseVector):
         docs = []
         for doc, score in docs_and_scores:
             # check score threshold
-            if score > score_threshold:
+            if score_threshold is None or score > score_threshold:
                 if doc.metadata is not None:
                     doc.metadata["score"] = score
                     docs.append(doc)
 
-        return self.resolve_parent_chunks(docs) if resolve_parents else docs
+        return self.resolve_parent_chunks(docs, indices=indices) if resolve_parents else docs
 
-    def resolve_parent_chunks(self, chunks: list[DocumentChunk]) -> list[DocumentChunk]:
+    def resolve_parent_chunks(self, chunks: list[DocumentChunk], indices: str | None = None) -> list[DocumentChunk]:
         """
         For child chunks (chunk_type == "child"), replace page_content with the
         parent chunk's page_content. Deduplicate when multiple children share
@@ -812,7 +840,7 @@ class ElasticSearchVector(BaseVector):
         parent_map = {}
         try:
             result = self._client.search(
-                index=self._collection_name,
+                index=indices or self._collection_name,
                 body={
                     "query": {
                         "bool": {
@@ -1188,6 +1216,22 @@ class ElasticSearchVectorFactory:
 
         return ElasticSearchVector(
             index_name=collection_name,
+            client=client,
+            embedding_config=embedding_config,
+            reranker_config=reranker_config,
+        )
+
+    @classmethod
+    def init_vector_from_configs(
+        cls,
+        index_name: str,
+        embedding_config: ModelApiKey,
+        reranker_config: ModelApiKey,
+    ) -> ElasticSearchVector:
+        """Create a vector service from resolved model config snapshots."""
+        client = ElasticSearchVectorClientProvider.get_shared_client()
+        return ElasticSearchVector(
+            index_name=index_name,
             client=client,
             embedding_config=embedding_config,
             reranker_config=reranker_config,

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -654,8 +654,13 @@ class ElasticSearchVector(BaseVector):
         filters = self._build_vector_filter_clauses(file_names_filter, document_ids_include)
 
         logger.info(
-            f"[ES search_by_vector] filter_summary file_name_count={len(file_names_filter or [])} "
-            f"included_document_id_count={len(document_ids_include or [])}"
+            "[ES vector_search] indices=%s top_k=%s score_threshold=%s "
+            "file_filter_count=%s document_filter_count=%s",
+            indices,
+            top_k,
+            score_threshold,
+            len(file_names_filter or []),
+            len(document_ids_include or []),
         )
 
         if self._resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:
@@ -762,9 +767,24 @@ class ElasticSearchVector(BaseVector):
             query_str["bool"]["filter"].append({
                 "terms": {Field.DOCUMENT_ID.value: document_ids_include}
             })
-            logger.info(f"[ES search_by_full_text] including document_ids: {document_ids_include}")
+            logger.info(
+                "[ES full_text_search] indices=%s top_k=%s score_threshold=%s "
+                "file_filter_count=%s document_filter_count=%s",
+                indices,
+                top_k,
+                score_threshold,
+                len(file_names_filter or []),
+                len(document_ids_include),
+            )
         else:
-            logger.info("[ES search_by_full_text] no document_ids_include")
+            logger.info(
+                "[ES full_text_search] indices=%s top_k=%s score_threshold=%s "
+                "file_filter_count=%s document_filter_count=0",
+                indices,
+                top_k,
+                score_threshold,
+                len(file_names_filter or []),
+            )
 
         logger.debug(f"[ES search_by_full_text] query DSL: {query_str}")
 
@@ -810,6 +830,12 @@ class ElasticSearchVector(BaseVector):
                     doc.metadata["score"] = score
                     docs.append(doc)
 
+        logger.debug(
+            "[ES full_text_search] hits=%s returned_docs=%s score_threshold=%s",
+            len(result.get("hits", {}).get("hits", [])),
+            len(docs),
+            score_threshold,
+        )
         return self.resolve_parent_chunks(docs, indices=indices) if resolve_parents else docs
 
     def resolve_parent_chunks(self, chunks: list[DocumentChunk], indices: str | None = None) -> list[DocumentChunk]:

--- a/api/app/core/workflow/nodes/knowledge/config.py
+++ b/api/app/core/workflow/nodes/knowledge/config.py
@@ -17,7 +17,7 @@ from app.core.workflow.nodes.llm.config import (
     LLMTopPConfig,
 )
 
-from app.schemas.chunk_schema import RetrieveType
+from app.schemas.chunk_schema import KnowledgeBaseConfig
 from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
 
 
@@ -97,33 +97,6 @@ class KnowledgeModelConfig(BaseModel):
         normalized = {k: v for k, v in value.items() if k not in flat_param_keys}
         normalized["completion_params"] = collected
         return normalized
-
-
-class KnowledgeBaseConfig(BaseModel):
-    kb_id: UUID = Field(
-        ...,
-        description="Knowledge base IDs"
-    )
-
-    similarity_threshold: float = Field(
-        default=0.2,
-        description="Knowledge base similarity threshold"
-    )
-
-    vector_similarity_weight: float = Field(
-        default=0.3,
-        description="Knowledge base vector similarity weight"
-    )
-
-    top_k: int = Field(
-        default=4,
-        description="Knowledge base top k"
-    )
-
-    retrieve_type: RetrieveType = Field(
-        default=RetrieveType.PARTICIPLE,
-        description="Retrieve type"
-    )
 
 
 class KnowledgeRetrievalNodeConfig(BaseNodeConfig):

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -354,16 +354,16 @@ class KnowledgeRetrievalNode(BaseNode):
             )
 
         # 3. Construct KnowledgeRetrievalRequest
-        #    Use first KB's config as global defaults (user confirmed: accept global params)
         first_kb = self.typed_config.knowledge_bases[0]
         kb_ids = [kb.kb_id for kb in self.typed_config.knowledge_bases]
 
         request = KnowledgeRetrievalRequest(
             query=query,
             kb_ids=kb_ids,
+            knowledge_bases=self.typed_config.knowledge_bases,
             similarity_threshold=first_kb.similarity_threshold,
             vector_similarity_weight=first_kb.vector_similarity_weight,
-            top_k=first_kb.top_k,
+            top_k=self.typed_config.reranker_top_k or first_kb.top_k,
             retrieve_type=first_kb.retrieve_type,
             rerank_id=self.typed_config.reranker_id,
             metadata_filter_mode=self.typed_config.metadata_filter_mode,

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -12,6 +12,7 @@ from app.core.workflow.nodes.base_node import BaseNode
 from app.core.workflow.nodes.knowledge import KnowledgeRetrievalNodeConfig
 from app.core.workflow.variable.base_variable import VariableType
 from app.db import get_db_read
+from app.schemas.chunk_schema import KnowledgeRetrievalCaller
 from app.schemas.knowledge_metadata_schema import FilterCondition, FilterGroup, MetadataFilterMode
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_metadata_service import KnowledgeMetadataService
@@ -359,6 +360,7 @@ class KnowledgeRetrievalNode(BaseNode):
 
         request = KnowledgeRetrievalRequest(
             query=query,
+            caller=KnowledgeRetrievalCaller.WORKFLOW,
             kb_ids=kb_ids,
             knowledge_bases=self.typed_config.knowledge_bases,
             similarity_threshold=first_kb.similarity_threshold,

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -20,6 +20,14 @@ class KnowledgeRetrievalCaller(StrEnum):
     WORKFLOW = "workflow"
 
 
+class KnowledgeBaseConfig(BaseModel):
+    kb_id: uuid.UUID = Field(..., description="Knowledge base ID")
+    similarity_threshold: float = Field(default=0.2, ge=0, le=1, description="Knowledge base similarity threshold")
+    vector_similarity_weight: float = Field(default=0.3, ge=0, le=1, description="Knowledge base vector similarity weight")
+    top_k: int = Field(default=4, ge=1, le=100, description="Knowledge base top k")
+    retrieve_type: RetrieveType = Field(default=RetrieveType.PARTICIPLE, description="Retrieve type")
+
+
 class ChunkType(StrEnum):
     """Chunk type enumeration"""
     CHUNK = "chunk"
@@ -96,8 +104,9 @@ class ChunkUpdate(BaseModel):
 
 class ChunkRetrieve(BaseModel):
     query: str
-    kb_ids: list[uuid.UUID]
+    kb_ids: list[uuid.UUID] = Field(default_factory=list)
     ex_ids: list[str] | None = Field(None)
+    knowledge_bases: list[KnowledgeBaseConfig] = Field(default_factory=list)
     file_names_filter: list[str] | None = Field(None)
     similarity_threshold: float | None = Field(None)
     vector_similarity_weight: float | None = Field(None)
@@ -111,6 +120,8 @@ class ChunkRetrieve(BaseModel):
 
     @model_validator(mode="after")
     def resolve_top_n(self):
+        if not self.kb_ids and not self.ex_ids and not self.knowledge_bases:
+            raise ValueError("kb_ids, ex_ids and knowledge_bases cannot all be empty")
         top_k = self.top_k or 20
         if self.top_n is None or "top_n" not in self.model_fields_set:
             self.top_n = max(top_k, 20)

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 import uuid
 from enum import StrEnum
 from app.core.rag.models.chunk import QAChunk
@@ -16,6 +16,8 @@ class RetrieveType(StrEnum):
 
 class KnowledgeRetrievalCaller(StrEnum):
     GENERAL = "general"
+    EX_API = "ex_api"
+    IN_API = "in_api"
     AGENT = "agent"
     WORKFLOW = "workflow"
 
@@ -103,16 +105,17 @@ class ChunkUpdate(BaseModel):
 
 
 class ChunkRetrieve(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    caller: KnowledgeRetrievalCaller = Field(KnowledgeRetrievalCaller.GENERAL)
     query: str
     kb_ids: list[uuid.UUID] = Field(default_factory=list)
     ex_ids: list[str] | None = Field(None)
-    knowledge_bases: list[KnowledgeBaseConfig] = Field(default_factory=list)
     file_names_filter: list[str] | None = Field(None)
     similarity_threshold: float | None = Field(None)
     vector_similarity_weight: float | None = Field(None)
     top_k: int | None = Field(20, ge=1, le=100)
     top_n: int | None = Field(20, ge=1, le=100)
-    caller: KnowledgeRetrievalCaller = Field(KnowledgeRetrievalCaller.GENERAL)
     retrieve_type: RetrieveType | None = Field(None)
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
     metadata_filters: list[FilterGroup] | None = Field(None, description="filter condition groups")
@@ -120,8 +123,8 @@ class ChunkRetrieve(BaseModel):
 
     @model_validator(mode="after")
     def resolve_top_n(self):
-        if not self.kb_ids and not self.ex_ids and not self.knowledge_bases:
-            raise ValueError("kb_ids, ex_ids and knowledge_bases cannot all be empty")
+        if not self.kb_ids and not self.ex_ids:
+            raise ValueError("kb_ids and ex_ids cannot both be empty")
         top_k = self.top_k or 20
         if self.top_n is None or "top_n" not in self.model_fields_set:
             self.top_n = max(top_k, 20)

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
+from app.schemas.chunk_schema import KnowledgeBaseConfig, KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
 
 
@@ -11,6 +11,7 @@ class KnowledgeRetrievalRequest(BaseModel):
     query: str
     kb_ids: list[UUID] = Field(default_factory=list)
     ex_ids: list[str] = Field(default_factory=list)
+    knowledge_bases: list[KnowledgeBaseConfig] = Field(default_factory=list)
     file_names_filter: list[str] = Field(default_factory=list)
     similarity_threshold: float = Field(default=0.3, ge=0, le=1)
     vector_similarity_weight: float = Field(default=0.3, ge=0, le=1)
@@ -33,8 +34,8 @@ class KnowledgeRetrievalRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_knowledge_ids(self) -> "KnowledgeRetrievalRequest":
-        if not self.kb_ids and not self.ex_ids:
-            raise ValueError("kb_ids and ex_ids cannot both be empty")
+        if not self.kb_ids and not self.ex_ids and not self.knowledge_bases:
+            raise ValueError("kb_ids, ex_ids and knowledge_bases cannot all be empty")
         if self.top_n is None or "top_n" not in self.model_fields_set:
             self.top_n = max(self.top_k, 20)
         elif self.top_n < self.top_k:

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -22,7 +22,7 @@ from app.core.config import settings
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
-from app.schemas.chunk_schema import RetrieveType
+from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
 from app.db import get_db_context
@@ -143,6 +143,7 @@ def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list
 
     request = KnowledgeRetrievalRequest(
         query=query,
+        caller=KnowledgeRetrievalCaller.AGENT,
         kb_ids=[uuid.UUID(kid) for kid in kb_ids],
         top_k=_as_int(first_kb.get("top_k"), 3),
         similarity_threshold=_as_float(first_kb.get("similarity_threshold"), 0.7),

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1,7 +1,9 @@
 import logging
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Optional
 
 from langchain_core.documents import Document
@@ -92,6 +94,139 @@ class RetrievalTarget:
 
 class KnowledgeRetrievalService:
     @staticmethod
+    def _new_retrieval_log_id() -> str:
+        return uuid.uuid4().hex[:8]
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return max(0, int((time.perf_counter() - started_at) * 1000))
+
+    @staticmethod
+    def _compact_id(value: Any) -> str:
+        text = str(value)
+        return text[:8] if len(text) > 8 else text
+
+    @classmethod
+    def _compact_ids(cls, values: list[Any], limit: int = 10) -> list[str]:
+        compacted = [cls._compact_id(value) for value in values[:limit]]
+        if len(values) > limit:
+            compacted.append(f"+{len(values) - limit}")
+        return compacted
+
+    @classmethod
+    def _format_log_fields(cls, fields: dict[str, Any]) -> str:
+        return " ".join(
+            f"{key}={cls._format_log_value(value)}"
+            for key, value in fields.items()
+        )
+
+    @classmethod
+    def _format_log_value(cls, value: Any) -> str:
+        if value is None:
+            return "none"
+        if isinstance(value, bool):
+            return str(value).lower()
+        if isinstance(value, Enum):
+            return str(value.value)
+        if isinstance(value, (list, tuple, set)):
+            return "[" + ",".join(cls._format_log_value(item) for item in value) + "]"
+        return str(value)
+
+    @classmethod
+    def _build_retrieval_start_log_fields(
+            cls,
+            log_id: str,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> dict[str, Any]:
+        return {
+            "id": log_id,
+            "user": getattr(current_user, "username", None) or getattr(current_user, "id", None) or "anonymous",
+            "kb_count": len(request.kb_ids or []),
+            "ex_id_count": len(request.ex_ids or []),
+            "knowledge_base_count": len(request.knowledge_bases or []),
+            "query_len": len(request.query or ""),
+            "type": request.retrieve_type.value,
+            "top_k": request.top_k,
+            "top_n": request.top_n,
+            "similarity_threshold": request.similarity_threshold,
+            "vector_weight": request.vector_similarity_weight,
+            "rerank_threshold": request.rerank_score_threshold,
+            "metadata_mode": request.metadata_filter_mode.value,
+            "metadata_filter_groups": len(request.metadata_filters or []),
+            "file_filter_count": len(request.file_names_filter or []),
+        }
+
+    @classmethod
+    def _build_targets_log_fields(
+            cls,
+            log_id: str,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            max_workers: int,
+    ) -> dict[str, Any]:
+        return {
+            "id": log_id,
+            "requested_kb_count": len(request.kb_ids or []) + len(request.knowledge_bases or []),
+            "target_count": len(targets),
+            "max_workers": max_workers,
+            "target_kbs": cls._compact_ids([target.knowledge_id for target in targets]),
+        }
+
+    @staticmethod
+    def _build_metadata_filter_log_fields(
+            log_id: str,
+            request: KnowledgeRetrievalRequest,
+            effective: bool,
+            reason: str,
+            document_count: int | None,
+            common_fields: int | None = None,
+            effective_groups: int | None = None,
+    ) -> dict[str, Any]:
+        fields = {
+            "id": log_id,
+            "mode": request.metadata_filter_mode.value,
+            "provided_groups": len(request.metadata_filters or []),
+            "effective": effective,
+            "reason": reason,
+            "matched_documents": document_count if document_count is not None else "none",
+        }
+        if common_fields is not None:
+            fields["common_fields"] = common_fields
+        if effective_groups is not None:
+            fields["effective_groups"] = effective_groups
+        return fields
+
+    @classmethod
+    def _build_target_done_log_fields(
+            cls,
+            log_id: str,
+            target: RetrievalTarget,
+            target_position: int,
+            vector_count: int,
+            full_text_count: int,
+            merged_count: int,
+            result_count: int,
+            elapsed_ms: int,
+            local_rerank: bool,
+    ) -> dict[str, Any]:
+        return {
+            "id": log_id,
+            "target": target_position,
+            "kb_id": cls._compact_id(target.knowledge_id),
+            "index": target.index_name,
+            "type": target.params.retrieve_type.value,
+            "top_k": target.params.top_k,
+            "top_n": target.params.top_n,
+            "vector_kept": vector_count,
+            "fulltext_kept": full_text_count,
+            "merged": merged_count,
+            "local_rerank": local_rerank,
+            "result_count": result_count,
+            "elapsed_ms": elapsed_ms,
+        }
+
+    @staticmethod
     def _resolve_tenant_id(
             db: Session,
             current_user: Any = None,
@@ -114,13 +249,28 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             current_user: Any = None,
     ) -> KnowledgeRetrievalResult:
-        logger.info("Knowledge retrieval request params: %s", request.model_dump() if hasattr(request, "model_dump") else request.dict())
+        log_id = cls._new_retrieval_log_id()
+        started_at = time.perf_counter()
+        logger.info(
+            "[Retrieval] start %s",
+            cls._format_log_fields(cls._build_retrieval_start_log_fields(log_id, request, current_user)),
+        )
         targets, tenant_id = cls._resolve_retrieval_targets(
             db=db,
             request=request,
             current_user=current_user,
         )
         if not targets:
+            logger.info(
+                "[Retrieval] finish %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "reason": "no_targets",
+                    "target_count": 0,
+                    "final_count": 0,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                }),
+            )
             return KnowledgeRetrievalResult(chunks=[])
 
         knowledge_ids = [target.knowledge_id for target in targets]
@@ -138,8 +288,19 @@ class KnowledgeRetrievalService:
             request=request,
             knowledge_ids=knowledge_ids,
             tenant_id=tenant_id,
+            log_id=log_id,
         )
         if document_ids_include == []:
+            logger.info(
+                "[Retrieval] finish %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "reason": "metadata_filter_empty",
+                    "target_count": len(targets),
+                    "final_count": 0,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                }),
+            )
             return KnowledgeRetrievalResult(chunks=[])
 
         chunks = cls._retrieve_targets(
@@ -148,6 +309,7 @@ class KnowledgeRetrievalService:
             targets=targets,
             document_ids_include=document_ids_include,
             tenant_id=tenant_id,
+            log_id=log_id,
         )
         if any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
             graph_doc = cls._retrieve_graph(
@@ -161,6 +323,17 @@ class KnowledgeRetrievalService:
             if graph_doc:
                 chunks.insert(0, graph_doc)
         chunks = cls._include_document_ids(chunks, document_ids_include)
+        logger.info(
+            "[Retrieval] finish %s",
+            cls._format_log_fields({
+                "id": log_id,
+                "reason": "ok",
+                "target_count": len(targets),
+                "document_filter_count": len(document_ids_include or []),
+                "final_count": len(chunks),
+                "elapsed_ms": cls._elapsed_ms(started_at),
+            }),
+        )
         return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
@@ -440,11 +613,17 @@ class KnowledgeRetrievalService:
             targets: list[RetrievalTarget],
             document_ids_include: list[str] | None,
             tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
     ) -> list[Any]:
         if not targets:
             return []
 
         max_workers = max(1, min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3))
+        if log_id:
+            logger.info(
+                "[Retrieval] targets %s",
+                cls._format_log_fields(cls._build_targets_log_fields(log_id, request, targets, max_workers)),
+            )
         results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
         with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="knowledge-retrieval") as executor:
             futures = {
@@ -453,6 +632,8 @@ class KnowledgeRetrievalService:
                     request,
                     target,
                     document_ids_include,
+                    log_id,
+                    index + 1,
                 ): index
                 for index, target in enumerate(targets)
             }
@@ -477,6 +658,7 @@ class KnowledgeRetrievalService:
             targets=targets,
             chunks=candidates,
             tenant_id=tenant_id,
+            log_id=log_id,
         )
 
     @classmethod
@@ -485,7 +667,10 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             target: RetrievalTarget,
             document_ids_include: list[str] | None,
+            log_id: str | None = None,
+            target_position: int = 0,
     ) -> list[DocumentChunk]:
+        started_at = time.perf_counter()
         vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
             index_name=target.index_name,
             embedding_config=target.embedding_config,
@@ -500,7 +685,7 @@ class KnowledgeRetrievalService:
         })
 
         if target.params.retrieve_type == RetrieveType.PARTICIPLE:
-            return cls._search_full_text(
+            chunks = cls._search_full_text(
                 vector_service,
                 local_request,
                 target.index_name,
@@ -508,14 +693,46 @@ class KnowledgeRetrievalService:
                 topk=target.params.top_k,
                 apply_score_threshold=False,
             )
+            if log_id:
+                logger.info(
+                    "[Retrieval] target_done %s",
+                    cls._format_log_fields(cls._build_target_done_log_fields(
+                        log_id=log_id,
+                        target=target,
+                        target_position=target_position,
+                        vector_count=0,
+                        full_text_count=len(chunks),
+                        merged_count=len(chunks),
+                        result_count=len(chunks),
+                        elapsed_ms=cls._elapsed_ms(started_at),
+                        local_rerank=False,
+                    )),
+                )
+            return chunks
         if target.params.retrieve_type == RetrieveType.SEMANTIC:
-            return cls._search_vector(
+            chunks = cls._search_vector(
                 vector_service,
                 local_request,
                 target.index_name,
                 document_ids_include,
                 topk=target.params.top_k,
             )
+            if log_id:
+                logger.info(
+                    "[Retrieval] target_done %s",
+                    cls._format_log_fields(cls._build_target_done_log_fields(
+                        log_id=log_id,
+                        target=target,
+                        target_position=target_position,
+                        vector_count=len(chunks),
+                        full_text_count=0,
+                        merged_count=len(chunks),
+                        result_count=len(chunks),
+                        elapsed_ms=cls._elapsed_ms(started_at),
+                        local_rerank=False,
+                    )),
+                )
+            return chunks
 
         vector_chunks = cls._search_vector(
             vector_service,
@@ -534,11 +751,27 @@ class KnowledgeRetrievalService:
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         # if len(unique_chunks) <= target.params.top_k:
         #     return unique_chunks
-        return vector_service.rerank(
+        chunks = vector_service.rerank(
             query=request.query,
             docs=unique_chunks,
             top_k=target.params.top_k,
         )
+        if log_id:
+            logger.info(
+                "[Retrieval] target_done %s",
+                cls._format_log_fields(cls._build_target_done_log_fields(
+                    log_id=log_id,
+                    target=target,
+                    target_position=target_position,
+                    vector_count=len(vector_chunks),
+                    full_text_count=len(full_text_chunks),
+                    merged_count=len(unique_chunks),
+                    result_count=len(chunks),
+                    elapsed_ms=cls._elapsed_ms(started_at),
+                    local_rerank=True,
+                )),
+            )
+        return chunks
 
     @classmethod
     def _finalize_retrieval_chunks(
@@ -548,9 +781,24 @@ class KnowledgeRetrievalService:
             targets: list[RetrievalTarget],
             chunks: list[DocumentChunk],
             tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
     ) -> list[DocumentChunk]:
+        candidate_count = len(chunks)
         unique_chunks = cls._deduplicate_chunks(chunks)
         if not unique_chunks:
+            if log_id:
+                logger.info(
+                    "[Retrieval] finalize %s",
+                    cls._format_log_fields({
+                        "id": log_id,
+                        "candidates": candidate_count,
+                        "deduped": 0,
+                        "global_rerank": False,
+                        "threshold": "none",
+                        "filtered": 0,
+                        "result_count": 0,
+                    }),
+                )
             return []
 
         has_rerankable_target = any(
@@ -601,7 +849,22 @@ class KnowledgeRetrievalService:
             for chunk in ranked_chunks
             if (chunk.metadata or {}).get("score", 0) > threshold
         ]
-        return filtered_chunks[:request.top_k]
+        result_chunks = filtered_chunks[:request.top_k]
+        if log_id:
+            logger.info(
+                "[Retrieval] finalize %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "candidates": candidate_count,
+                    "deduped": len(unique_chunks),
+                    "global_rerank": needs_global_rerank,
+                    "ranked": len(ranked_chunks),
+                    "threshold": threshold,
+                    "filtered": len(filtered_chunks),
+                    "result_count": len(result_chunks),
+                }),
+            )
+        return result_chunks
 
     @staticmethod
     def _resolve_global_score_threshold(
@@ -962,11 +1225,34 @@ class KnowledgeRetrievalService:
             request: KnowledgeRetrievalRequest,
             knowledge_ids: list[uuid.UUID],
             tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
     ) -> list[str] | None:
         if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="mode_disabled",
+                        document_count=None,
+                    )),
+                )
             return None
 
         if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="no_filters",
+                        document_count=None,
+                    )),
+                )
             return None
 
         metadata_defs_by_kb = {
@@ -983,6 +1269,19 @@ class KnowledgeRetrievalService:
         )
         if not filter_groups:
             logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="no_effective_groups",
+                        document_count=None,
+                        common_fields=len(common_metadata_defs),
+                        effective_groups=0,
+                    )),
+                )
             return None
 
         document_ids = set()
@@ -994,6 +1293,19 @@ class KnowledgeRetrievalService:
                 metadata_defs=metadata_defs_by_kb[knowledge_id],
             )
             document_ids.update(matched_ids)
+        if log_id:
+            logger.info(
+                "[Retrieval] metadata_filter %s",
+                cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                    log_id=log_id,
+                    request=request,
+                    effective=True,
+                    reason="matched",
+                    document_count=len(document_ids),
+                    common_fields=len(common_metadata_defs),
+                    effective_groups=len(filter_groups),
+                )),
+            )
         return [str(document_id) for document_id in document_ids]
 
     @classmethod

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1,10 +1,13 @@
 import logging
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from langchain_core.documents import Document
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.models import RedBearRerank
@@ -20,12 +23,13 @@ from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVector,
     ElasticSearchVectorFactory,
+    ElasticSearchVectorIndexOps,
 )
 from app.models import knowledge_model, knowledgeshare_model
 from app.models.models_model import ModelApiKey
 from app.repositories import knowledge_repository
 from app.repositories.tool_repository import ToolRepository
-from app.schemas.chunk_schema import RetrieveType
+from app.schemas.chunk_schema import KnowledgeBaseConfig, RetrieveType
 from app.schemas.knowledge_metadata_schema import MetadataFilterMode
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest, KnowledgeRetrievalResult
 from app.services import knowledge_service, knowledgeshare_service
@@ -42,6 +46,48 @@ class KnowledgeRetrievalAccessDenied(Exception):
 
 class KnowledgeRetrievalConfigError(Exception):
     pass
+
+
+@dataclass(frozen=True)
+class ModelApiKeySnapshot:
+    model_name: str
+    provider: str
+    api_key: str
+    api_base: str | None
+
+    @classmethod
+    def from_api_key(cls, api_key: ModelApiKey) -> "ModelApiKeySnapshot":
+        return cls(
+            model_name=api_key.model_name,
+            provider=api_key.provider,
+            api_key=api_key.api_key,
+            api_base=api_key.api_base,
+        )
+
+
+@dataclass(frozen=True)
+class RetrievalParams:
+    similarity_threshold: float
+    vector_similarity_weight: float
+    top_k: int
+    top_n: int
+    retrieve_type: RetrieveType
+
+
+@dataclass(frozen=True)
+class KnowledgeRetrievalRef:
+    knowledge: Any
+    config: KnowledgeBaseConfig | None
+
+
+@dataclass(frozen=True)
+class RetrievalTarget:
+    knowledge_id: uuid.UUID
+    workspace_id: uuid.UUID
+    index_name: str
+    params: RetrievalParams
+    embedding_config: ModelApiKeySnapshot
+    reranker_config: ModelApiKeySnapshot
 
 
 class KnowledgeRetrievalService:
@@ -69,27 +115,23 @@ class KnowledgeRetrievalService:
             current_user: Any = None,
     ) -> KnowledgeRetrievalResult:
         logger.info("Knowledge retrieval request params: %s", request.model_dump() if hasattr(request, "model_dump") else request.dict())
-        knowledge_ids, workspace_ids = cls._resolve_retrievable_knowledge_ids(
+        targets, tenant_id = cls._resolve_retrieval_targets(
             db=db,
             request=request,
             current_user=current_user,
         )
-        if not knowledge_ids:
+        if not targets:
             return KnowledgeRetrievalResult(chunks=[])
 
+        knowledge_ids = [target.knowledge_id for target in targets]
+        workspace_ids = [target.workspace_id for target in targets]
         db_knowledge = cls._get_first_knowledge(
             db=db,
-            knowledge_id=knowledge_ids[0],
+            knowledge_id=targets[0].knowledge_id,
             current_user=current_user,
         )
         if not db_knowledge:
             raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
-
-        tenant_id = cls._resolve_tenant_id(
-            db=db,
-            current_user=current_user,
-            workspace_id=getattr(db_knowledge, "workspace_id", None),
-        )
 
         document_ids_include = cls._build_metadata_document_filter(
             db=db,
@@ -100,17 +142,482 @@ class KnowledgeRetrievalService:
         if document_ids_include == []:
             return KnowledgeRetrievalResult(chunks=[])
 
-        chunks = cls._retrieve_by_type(
+        chunks = cls._retrieve_targets(
             db=db,
             request=request,
-            knowledge_ids=knowledge_ids,
-            workspace_ids=workspace_ids,
-            db_knowledge=db_knowledge,
+            targets=targets,
             document_ids_include=document_ids_include,
             tenant_id=tenant_id,
         )
+        if any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
+            graph_doc = cls._retrieve_graph(
+                db=db,
+                request=request,
+                knowledge_ids=knowledge_ids,
+                workspace_ids=workspace_ids,
+                db_knowledge=db_knowledge,
+                tenant_id=tenant_id,
+            )
+            if graph_doc:
+                chunks.insert(0, graph_doc)
         chunks = cls._include_document_ids(chunks, document_ids_include)
         return KnowledgeRetrievalResult(chunks=chunks)
+
+    @classmethod
+    def _resolve_retrieval_targets(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> tuple[list[RetrievalTarget], uuid.UUID | None]:
+        refs = cls._resolve_retrievable_knowledge_refs(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not refs:
+            return [], None
+
+        tenant_id = cls._resolve_tenant_id(
+            db=db,
+            current_user=current_user,
+            workspace_id=getattr(refs[0].knowledge, "workspace_id", None),
+        )
+        targets = [
+            cls._build_retrieval_target(
+                db=db,
+                request=request,
+                ref=ref,
+                tenant_id=tenant_id,
+            )
+            for ref in refs
+        ]
+        return targets, tenant_id
+
+    @classmethod
+    def _build_retrieval_target(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            ref: KnowledgeRetrievalRef,
+            tenant_id: uuid.UUID | None,
+    ) -> RetrievalTarget:
+        knowledge = ref.knowledge
+        if not knowledge.embedding_id:
+            raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
+        if not knowledge.reranker_id:
+            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+
+        embedding_config = ModelApiKeyService.get_available_api_key(db, knowledge.embedding_id, tenant_id=tenant_id)
+        reranker_config = ModelApiKeyService.get_available_api_key(db, knowledge.reranker_id, tenant_id=tenant_id)
+        if not embedding_config:
+            raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
+        if not reranker_config:
+            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+
+        return RetrievalTarget(
+            knowledge_id=knowledge.id,
+            workspace_id=knowledge.workspace_id,
+            index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
+            params=cls._build_retrieval_params(request, ref.config),
+            embedding_config=ModelApiKeySnapshot.from_api_key(embedding_config),
+            reranker_config=ModelApiKeySnapshot.from_api_key(reranker_config),
+        )
+
+    @staticmethod
+    def _build_retrieval_params(
+            request: KnowledgeRetrievalRequest,
+            config: KnowledgeBaseConfig | None = None,
+    ) -> RetrievalParams:
+        explicit_fields = config.model_fields_set if config else set()
+        top_k = config.top_k if config and "top_k" in explicit_fields else request.top_k
+        retrieve_type = config.retrieve_type if config and "retrieve_type" in explicit_fields else request.retrieve_type
+        similarity_threshold = (
+            config.similarity_threshold
+            if config and "similarity_threshold" in explicit_fields
+            else request.similarity_threshold
+        )
+        vector_similarity_weight = (
+            config.vector_similarity_weight
+            if config and "vector_similarity_weight" in explicit_fields
+            else request.vector_similarity_weight
+        )
+        top_n = max(top_k, request.top_n or top_k)
+        return RetrievalParams(
+            similarity_threshold=similarity_threshold,
+            vector_similarity_weight=vector_similarity_weight,
+            top_k=top_k,
+            top_n=top_n,
+            retrieve_type=retrieve_type,
+        )
+
+    @classmethod
+    def _resolve_retrievable_knowledge_refs(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> list[KnowledgeRetrievalRef]:
+        requested_kb_ids, explicit_configs = cls._resolve_requested_kb_ids_and_configs(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not requested_kb_ids:
+            return []
+
+        refs: list[KnowledgeRetrievalRef] = []
+        ref_positions: dict[uuid.UUID, int] = {}
+
+        def append_refs(items: list[KnowledgeRetrievalRef]) -> None:
+            for item in items:
+                knowledge_id = item.knowledge.id
+                if knowledge_id in ref_positions:
+                    if item.config is not None:
+                        refs[ref_positions[knowledge_id]] = item
+                    continue
+                ref_positions[knowledge_id] = len(refs)
+                refs.append(item)
+
+        if current_user is None:
+            knowledges = (
+                db.query(knowledge_model.Knowledge)
+                .filter(
+                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
+                    knowledge_model.Knowledge.status == 1,
+                )
+                .all()
+            )
+            knowledge_by_id = {knowledge.id: knowledge for knowledge in knowledges}
+            for kb_id in requested_kb_ids:
+                knowledge = knowledge_by_id.get(kb_id)
+                if not knowledge:
+                    continue
+                append_refs(cls._expand_knowledge_to_leaf_refs(
+                    db=db,
+                    knowledge=knowledge,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+            return refs
+
+        for kb_id in requested_kb_ids:
+            private_target = (
+                db.query(knowledge_model.Knowledge)
+                .filter(
+                    knowledge_model.Knowledge.id == kb_id,
+                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
+                    knowledge_model.Knowledge.status == 1,
+                )
+                .first()
+            )
+            if private_target:
+                append_refs(cls._expand_knowledge_to_leaf_refs(
+                    db=db,
+                    knowledge=private_target,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+                continue
+
+            share_target = (
+                db.query(knowledge_model.Knowledge)
+                .filter(
+                    knowledge_model.Knowledge.id == kb_id,
+                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
+                    knowledge_model.Knowledge.status == 1,
+                )
+                .first()
+            )
+            if not share_target:
+                continue
+
+            filters = [
+                knowledgeshare_model.KnowledgeShare.target_kb_id == share_target.id,
+                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
+            ]
+            share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
+                db=db,
+                filters=filters,
+                current_user=current_user,
+            )
+            for source_kb_id, _source_workspace_id in share_items:
+                source_knowledge = knowledge_repository.get_knowledge_by_id(
+                    db=db,
+                    knowledge_id=source_kb_id,
+                )
+                append_refs(cls._expand_knowledge_to_leaf_refs(
+                    db=db,
+                    knowledge=source_knowledge,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+
+        return refs
+
+    @classmethod
+    def _resolve_requested_kb_ids_and_configs(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> tuple[list[uuid.UUID], dict[uuid.UUID, KnowledgeBaseConfig]]:
+        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig] = {}
+        requested_kb_ids = list(request.kb_ids)
+
+        if request.ex_ids:
+            if current_user is None:
+                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
+            resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
+                db=db,
+                external_ids=request.ex_ids,
+                workspace_id=current_user.current_workspace_id,
+                current_user=current_user,
+            )
+            requested_kb_ids.extend(resolved_ids)
+
+        for config in request.knowledge_bases:
+            if config.kb_id in explicit_configs:
+                logger.warning("Duplicate KnowledgeBaseConfig found, using the last one: kb_id=%s", config.kb_id)
+            explicit_configs[config.kb_id] = config
+            requested_kb_ids.append(config.kb_id)
+
+        return cls._unique_ids(requested_kb_ids), explicit_configs
+
+    @classmethod
+    def _expand_knowledge_to_leaf_refs(
+            cls,
+            db: Session,
+            knowledge: Any,
+            inherited_config: KnowledgeBaseConfig | None,
+            explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig],
+            visited: set[uuid.UUID] | None = None,
+    ) -> list[KnowledgeRetrievalRef]:
+        if not knowledge or not knowledge.is_active:
+            return []
+        current_config = explicit_configs.get(knowledge.id) or inherited_config
+        if knowledge.is_retrievable_leaf:
+            return [KnowledgeRetrievalRef(knowledge=knowledge, config=current_config)]
+        if not knowledge.is_folder:
+            return []
+
+        if visited is None:
+            visited = set()
+        if knowledge.id in visited:
+            logger.warning(
+                "Detected cyclic knowledge folder while expanding retrieval targets: knowledge_id=%s",
+                knowledge.id,
+            )
+            return []
+        visited.add(knowledge.id)
+
+        refs = []
+        children = knowledge_repository.get_knowledges_by_parent_id(db=db, parent_id=knowledge.id)
+        for child in children:
+            if child.workspace_id != knowledge.workspace_id:
+                logger.warning(
+                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
+                    knowledge.id,
+                    child.id,
+                )
+                continue
+            refs.extend(cls._expand_knowledge_to_leaf_refs(
+                db=db,
+                knowledge=child,
+                inherited_config=current_config,
+                explicit_configs=explicit_configs,
+                visited=visited,
+            ))
+        return refs
+
+    @classmethod
+    def _retrieve_targets(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            document_ids_include: list[str] | None,
+            tenant_id: uuid.UUID | None,
+    ) -> list[Any]:
+        if not targets:
+            return []
+
+        max_workers = max(1, min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3))
+        results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="knowledge-retrieval") as executor:
+            futures = {
+                executor.submit(
+                    cls._retrieve_single_target,
+                    request,
+                    target,
+                    document_ids_include,
+                ): index
+                for index, target in enumerate(targets)
+            }
+            for future in as_completed(futures):
+                index = futures[future]
+                target = targets[index]
+                try:
+                    results_by_index[index] = future.result()
+                except Exception:
+                    logger.exception(
+                        "Knowledge retrieval target failed: knowledge_id=%s index=%s retrieve_type=%s",
+                        target.knowledge_id,
+                        target.index_name,
+                        target.params.retrieve_type,
+                    )
+                    raise
+
+        candidates = [chunk for target_chunks in results_by_index for chunk in target_chunks]
+        return cls._finalize_retrieval_chunks(
+            db=db,
+            request=request,
+            targets=targets,
+            chunks=candidates,
+            tenant_id=tenant_id,
+        )
+
+    @classmethod
+    def _retrieve_single_target(
+            cls,
+            request: KnowledgeRetrievalRequest,
+            target: RetrievalTarget,
+            document_ids_include: list[str] | None,
+    ) -> list[DocumentChunk]:
+        vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
+            index_name=target.index_name,
+            embedding_config=target.embedding_config,
+            reranker_config=target.reranker_config,
+        )
+        local_request = request.model_copy(update={
+            "similarity_threshold": target.params.similarity_threshold,
+            "vector_similarity_weight": target.params.vector_similarity_weight,
+            "top_k": target.params.top_k,
+            "top_n": target.params.top_n,
+            "retrieve_type": target.params.retrieve_type,
+        })
+
+        if target.params.retrieve_type == RetrieveType.PARTICIPLE:
+            return cls._search_full_text(
+                vector_service,
+                local_request,
+                target.index_name,
+                document_ids_include,
+                topk=target.params.top_k,
+                apply_score_threshold=False,
+            )
+        if target.params.retrieve_type == RetrieveType.SEMANTIC:
+            return cls._search_vector(
+                vector_service,
+                local_request,
+                target.index_name,
+                document_ids_include,
+                topk=target.params.top_k,
+            )
+
+        vector_chunks = cls._search_vector(
+            vector_service,
+            local_request,
+            target.index_name,
+            document_ids_include,
+            topk=target.params.top_n,
+        )
+        full_text_chunks = cls._search_full_text(
+            vector_service,
+            local_request,
+            target.index_name,
+            document_ids_include,
+            topk=target.params.top_n,
+        )
+        unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+        # if len(unique_chunks) <= target.params.top_k:
+        #     return unique_chunks
+        return vector_service.rerank(
+            query=request.query,
+            docs=unique_chunks,
+            top_k=target.params.top_k,
+        )
+
+    @classmethod
+    def _finalize_retrieval_chunks(
+            cls,
+            db: Session,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            chunks: list[DocumentChunk],
+            tenant_id: uuid.UUID | None,
+    ) -> list[DocumentChunk]:
+        unique_chunks = cls._deduplicate_chunks(chunks)
+        if not unique_chunks:
+            return []
+
+        has_rerankable_target = any(
+            target.params.retrieve_type in (RetrieveType.HYBRID, RetrieveType.Graph)
+            for target in targets
+        )
+        # is required rerank ？
+        needs_global_rerank = request.rerank_id is not None or len(targets) > 1
+        # must rerank
+        if request.rerank_id:
+            ranked_chunks = cls.rerank_documents(
+                db=db,
+                rerank_id=request.rerank_id,
+                query=request.query,
+                docs=unique_chunks,
+                top_k=request.top_k,
+                tenant_id=tenant_id,
+            )
+        # should rerank
+        elif needs_global_rerank:
+            first_target = targets[0]
+            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
+                index_name=first_target.index_name,
+                embedding_config=first_target.embedding_config,
+                reranker_config=first_target.reranker_config,
+            )
+            ranked_chunks = vector_service.rerank(
+                query=request.query,
+                docs=unique_chunks,
+                top_k=request.top_k,
+            )
+        # not rerank
+        else:
+            ranked_chunks = sorted(
+                unique_chunks,
+                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
+                reverse=True,
+            )
+
+        # global threshold filter
+        threshold = cls._resolve_global_score_threshold(
+            request=request,
+            targets=targets,
+            used_rerank=needs_global_rerank,
+        )
+        filtered_chunks = [
+            chunk
+            for chunk in ranked_chunks
+            if (chunk.metadata or {}).get("score", 0) > threshold
+        ]
+        return filtered_chunks[:request.top_k]
+
+    @staticmethod
+    def _resolve_global_score_threshold(
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            used_rerank: bool,
+    ) -> float:
+        if used_rerank:
+            return request.rerank_score_threshold or request.vector_similarity_weight or 0.1
+
+        retrieve_types = {target.params.retrieve_type for target in targets}
+        if retrieve_types == {RetrieveType.PARTICIPLE}:
+            return request.similarity_threshold
+        if retrieve_types == {RetrieveType.SEMANTIC}:
+            return request.vector_similarity_weight
+        return min(request.similarity_threshold, request.vector_similarity_weight)
 
     @classmethod
     def _retrieve_by_type(
@@ -165,12 +672,13 @@ class KnowledgeRetrievalService:
             indices: str,
             document_ids_include: list[str] | None,
             topk: Optional[int] = -1,
+            apply_score_threshold: bool = True,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_vector(
             query=request.query,
             top_k=topk,
             indices=indices,
-            score_threshold=request.vector_similarity_weight,
+            score_threshold=request.vector_similarity_weight if apply_score_threshold else None,
             document_ids_include=document_ids_include,
             file_names_filter=request.file_names_filter,
             resolve_parents=True,
@@ -183,12 +691,13 @@ class KnowledgeRetrievalService:
             indices: str,
             document_ids_include: list[str] | None,
             topk: Optional[int] = -1,
+            apply_score_threshold: bool = True,
     ) -> list[DocumentChunk]:
         return vector_service.search_by_full_text(
             query=request.query,
             top_k=topk,
             indices=indices,
-            score_threshold=request.similarity_threshold,
+            score_threshold=request.similarity_threshold if apply_score_threshold else None,
             document_ids_include=document_ids_include,
             file_names_filter=request.file_names_filter,
             resolve_parents=True,
@@ -597,13 +1106,22 @@ class KnowledgeRetrievalService:
 
     @staticmethod
     def _deduplicate_chunks(chunks: list[DocumentChunk]) -> list[DocumentChunk]:
-        seen_doc_ids = set()
+        seen_keys = set()
         result = []
         for chunk in chunks:
-            doc_id = chunk.metadata["doc_id"]
-            if doc_id in seen_doc_ids:
+            metadata = chunk.metadata or {}
+            doc_id = metadata.get("doc_id")
+            document_id = metadata.get("document_id")
+            sort_id = metadata.get("sort_id")
+            if doc_id:
+                dedupe_key = ("doc_id", doc_id)
+            elif document_id is not None and sort_id is not None:
+                dedupe_key = ("document_sort", document_id, sort_id)
+            else:
+                dedupe_key = ("content", hash(chunk.page_content))
+            if dedupe_key in seen_keys:
                 continue
-            seen_doc_ids.add(doc_id)
+            seen_keys.add(dedupe_key)
             result.append(chunk)
         return result
 

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -801,13 +801,7 @@ class KnowledgeRetrievalService:
                 )
             return []
 
-        has_rerankable_target = any(
-            target.params.retrieve_type in (RetrieveType.HYBRID, RetrieveType.Graph)
-            for target in targets
-        )
-        # is required rerank ？
         needs_global_rerank = request.rerank_id is not None or len(targets) > 1
-        # must rerank
         if request.rerank_id:
             ranked_chunks = cls.rerank_documents(
                 db=db,
@@ -817,7 +811,6 @@ class KnowledgeRetrievalService:
                 top_k=request.top_k,
                 tenant_id=tenant_id,
             )
-        # should rerank
         elif needs_global_rerank:
             first_target = targets[0]
             vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
@@ -830,7 +823,6 @@ class KnowledgeRetrievalService:
                 docs=unique_chunks,
                 top_k=request.top_k,
             )
-        # not rerank
         else:
             ranked_chunks = sorted(
                 unique_chunks,
@@ -838,7 +830,7 @@ class KnowledgeRetrievalService:
                 reverse=True,
             )
 
-        # global threshold filter
+        # Apply the final global score threshold after optional cross-KB rerank.
         threshold = cls._resolve_global_score_threshold(
             request=request,
             targets=targets,


### PR DESCRIPTION
## Summary
- Support threaded cross-KB retrieval with per-knowledge-base model and index configuration.
- Preserve existing kb_ids/ex_ids compatibility while allowing custom KnowledgeBaseConfig retrieval targets.
- Keep participle retrieval top-k oriented, semantic threshold filtering, and cross-KB global rerank behavior.
- Clarify retrieval logging and caller/source context for internal and API-key routes.

## Changes
api/app/controllers/chunk_controller.py            |  44 +-
api/app/controllers/service/rag_api_chunk_controller.py |  10 +-
api/app/core/config.py                             |   1 +
api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py  |  96 ++-
api/app/core/workflow/nodes/knowledge/config.py    |  29 +-
api/app/core/workflow/nodes/knowledge/node.py      |   6 +-
api/app/schemas/chunk_schema.py                    |  20 +-
api/app/schemas/knowledge_retrieval_schema.py      |   7 +-
api/app/services/knowledge_retrieval_service.py    | 872 ++++++++++++++++++++-

## Test Plan
- [x] cd api && ./.venv/bin/python -m pytest tests/rag/test_knowledge_retrieval_config.py -q
- [x] cd api && ./.venv/bin/python -m compileall app/services/knowledge_retrieval_service.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py app/controllers/chunk_controller.py app/controllers/service/rag_api_chunk_controller.py
- [x] git diff --check origin/develop..HEAD

## Summary by Sourcery

支持可配置的多知识库检索，提供每个知识库独立配置与多线程执行，同时增强日志记录与 Elasticsearch 的健壮性。

New Features:
- 允许在知识检索请求中为每个知识库单独指定检索配置，包括阈值、top-k 和检索类型（retrieve type）。
- 支持跨知识库检索，将文件夹展开到叶子知识库，并使用共享的 Elasticsearch 客户端并行执行检索。
- 为知识检索引入显式的调用方上下文（caller context），覆盖 UI、外部 API、agents 和 workflows，以区分请求来源。

Bug Fixes:
- 显式处理 Elasticsearch 分片故障，在某些向量与全文检索中不再静默降级，而是暴露详细错误信息。
- 通过将当前活跃索引集合传入父级查找逻辑，确保在多索引检索中父 chunk 的解析能正确工作。

Enhancements:
- 统一并集中管理知识检索参数处理，使用结构化的快照和目标定义，并改进跨知识库的去重及全局重排序（reranking）。
- 改进检索与元数据过滤日志记录，采用紧凑的结构化字段及耗时信息，以提升可观测性。
- 放宽单次检索的分数阈值，以支持可选的检索后全局阈值控制与重排序逻辑。
- 为检索输入增加校验与默认值，包括强制要求非空的知识库/外部 ID，并限制每个知识库的参数范围。

Build:
- 通过 `KNOWLEDGE_RETRIEVAL_MAX_WORKERS` 引入可配置的并发知识检索 worker 数量上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable, multi-knowledge-base retrieval with per-KB settings and threaded execution, while enhancing logging and Elasticsearch resilience.

New Features:
- Allow specifying per-knowledge-base retrieval configuration, including thresholds, top-k, and retrieve type, in knowledge retrieval requests.
- Support cross-knowledge-base retrieval that expands folders to leaf knowledge bases and executes retrieval in parallel using a shared Elasticsearch client.
- Introduce explicit caller context for knowledge retrieval across UI, external API, agents, and workflows to distinguish request origins.

Bug Fixes:
- Handle Elasticsearch shard failures explicitly by surfacing detailed errors instead of silently degrading in certain vector and full-text searches.
- Ensure parent chunk resolution works correctly across multi-index searches by passing the active index set into parent lookup.

Enhancements:
- Unify and centralize knowledge retrieval parameter handling with structured snapshots and target definitions, including improved deduplication and global reranking across knowledge bases.
- Improve retrieval and metadata filter logging with compact, structured fields and timing information for better observability.
- Relax per-search score thresholds to allow optional post-retrieval global thresholding and reranking logic.
- Add validation and defaults for retrieval inputs, including enforcing non-empty KB/external IDs and limiting per-KB parameters.

Build:
- Introduce a configurable limit for concurrent knowledge retrieval workers via KNOWLEDGE_RETRIEVAL_MAX_WORKERS.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

支持可配置的多知识库检索，提供每个知识库独立配置与多线程执行，同时增强日志记录与 Elasticsearch 的健壮性。

New Features:
- 允许在知识检索请求中为每个知识库单独指定检索配置，包括阈值、top-k 和检索类型（retrieve type）。
- 支持跨知识库检索，将文件夹展开到叶子知识库，并使用共享的 Elasticsearch 客户端并行执行检索。
- 为知识检索引入显式的调用方上下文（caller context），覆盖 UI、外部 API、agents 和 workflows，以区分请求来源。

Bug Fixes:
- 显式处理 Elasticsearch 分片故障，在某些向量与全文检索中不再静默降级，而是暴露详细错误信息。
- 通过将当前活跃索引集合传入父级查找逻辑，确保在多索引检索中父 chunk 的解析能正确工作。

Enhancements:
- 统一并集中管理知识检索参数处理，使用结构化的快照和目标定义，并改进跨知识库的去重及全局重排序（reranking）。
- 改进检索与元数据过滤日志记录，采用紧凑的结构化字段及耗时信息，以提升可观测性。
- 放宽单次检索的分数阈值，以支持可选的检索后全局阈值控制与重排序逻辑。
- 为检索输入增加校验与默认值，包括强制要求非空的知识库/外部 ID，并限制每个知识库的参数范围。

Build:
- 通过 `KNOWLEDGE_RETRIEVAL_MAX_WORKERS` 引入可配置的并发知识检索 worker 数量上限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable, multi-knowledge-base retrieval with per-KB settings and threaded execution, while enhancing logging and Elasticsearch resilience.

New Features:
- Allow specifying per-knowledge-base retrieval configuration, including thresholds, top-k, and retrieve type, in knowledge retrieval requests.
- Support cross-knowledge-base retrieval that expands folders to leaf knowledge bases and executes retrieval in parallel using a shared Elasticsearch client.
- Introduce explicit caller context for knowledge retrieval across UI, external API, agents, and workflows to distinguish request origins.

Bug Fixes:
- Handle Elasticsearch shard failures explicitly by surfacing detailed errors instead of silently degrading in certain vector and full-text searches.
- Ensure parent chunk resolution works correctly across multi-index searches by passing the active index set into parent lookup.

Enhancements:
- Unify and centralize knowledge retrieval parameter handling with structured snapshots and target definitions, including improved deduplication and global reranking across knowledge bases.
- Improve retrieval and metadata filter logging with compact, structured fields and timing information for better observability.
- Relax per-search score thresholds to allow optional post-retrieval global thresholding and reranking logic.
- Add validation and defaults for retrieval inputs, including enforcing non-empty KB/external IDs and limiting per-KB parameters.

Build:
- Introduce a configurable limit for concurrent knowledge retrieval workers via KNOWLEDGE_RETRIEVAL_MAX_WORKERS.

</details>

</details>