### PR TITLE
docs(prompts): refine language handling guidance across memory extrac…

### DIFF
--- a/api/app/core/memory/utils/prompt/prompts/alias_belongs_judge.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/alias_belongs_judge.jinja2
@@ -180,7 +180,7 @@ If there are no candidate aliases, return:
 6. `confidence` must be a number between 0.0 and 1.0
 
 {% if language == "zh" %}
-输出语言应始终与输入语言相同。
+`reason` 的语言应跟随规范实体与候选别名描述/摘要的主要语言；`alias_index` 和 `confidence` 保持固定 JSON 格式。
 {% else %}
-The output language should always be the same as the input language.
+The language of `reason` should follow the primary language of the canonical entity and candidate alias descriptions/summaries; `alias_index` and `confidence` keep the fixed JSON format.
 {% endif %}

--- a/api/app/core/memory/utils/prompt/prompts/description_merge.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/description_merge.jinja2
@@ -59,6 +59,7 @@ Description Content:
 5. 不限制长度，有多少独特事实就保留多少
 6. 不编造，只能用输入中的信息
 7. 使用逗号和句号作为分隔符，禁止使用中文分号（；），因为系统用分号作为碎片分隔符
+8. `merged_description` 使用新增碎片 `fragments` 的主要语言；如果新增碎片为空，则跟随上次合并摘要 `summary` 的语言；不要为了规范化翻译专有名词、别名或用户原文给出的名字
 {% else %}
 1. Synthesize all information into a complete new summary
 2. If the same attribute has multiple values, use the most recent one
@@ -67,6 +68,7 @@ Description Content:
 5. No length limit, preserve as many unique facts as available
 6. Do not fabricate; only use information from the input
 7. Use commas and periods as separators, NEVER use Chinese semicolons (；) as the system uses them as fragment delimiters
+8. `merged_description` should use the primary language of the new `fragments`; if there are no new fragments, follow the language of the previous `summary`. Do not translate proper nouns, aliases, or user-provided names just for normalization
 {% endif %}
 
 ===Output Format===
@@ -108,7 +110,7 @@ Output:
 4. Output ONLY the JSON object, no other text
 
 {% if language == "zh" %}
-输出语言应始终与输入语言相同。
+`merged_description` 的语言应跟随新增碎片 `fragments` 的主要语言；固定 JSON 字段名保持不变。
 {% else %}
-The output language should always be the same as the input language.
+The language of `merged_description` should follow the primary language of the new `fragments`; fixed JSON field names stay unchanged.
 {% endif %}

--- a/api/app/core/memory/utils/prompt/prompts/entity_dedup.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/entity_dedup.jinja2
@@ -232,8 +232,8 @@ Context:
 4. Test your JSON output mentally to ensure it can be parsed correctly
 
 {% if language == "zh" %}
-输出语言应始终与输入语言相同。
+`reason` 的语言应跟随两个实体名称、描述和关系陈述的主要语言。`suggested_type` 若输出字符串，必须沿用输入实体类型体系中的标签，不要为了语言一致而翻译。
 {% else %}
-The output language should always be the same as the input language.
+The language of `reason` should follow the primary language of the two entity names, descriptions, and relationship statements. If `suggested_type` is a string, keep the label from the input entity type system; do not translate it for language consistency.
 {% endif %}
 {{ json_schema }}

--- a/api/app/core/memory/utils/prompt/prompts/entity_dedup_reflection.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/entity_dedup_reflection.jinja2
@@ -211,8 +211,8 @@ Return JSON format with the following required fields:
 4. Return only valid JSON, with no Markdown code fence.
 
 {% if language == "zh" %}
-输出语言应始终与输入语言相同。
+flexible 的自然语言输出字段（`new_name`、`new_aliases`、`reason`）应跟随两个实体名称、描述和描述摘要的主要语言。固定 JSON 字段、布尔值、数字和 `null` 保持不变；不合并时 `new_name` 必须为 `null`。
 {% else %}
-The output language should always be the same as the input language.
+Flexible natural-language output fields (`new_name`, `new_aliases`, and `reason`) should follow the primary language of the two entity names, descriptions, and description summaries. Fixed JSON fields, booleans, numbers, and `null` stay unchanged; when not merging, `new_name` must be `null`.
 {% endif %}
 {{ json_schema }}

--- a/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
@@ -148,6 +148,7 @@
 - 自然语言输出字段的语言必须跟随各自输入内容的主要语言。
 - `assistant_memory_hint` 必须跟随 `Assistant.msg` 的主要语言。
 - `processed_user_msg` 必须跟随 `User.msg` 去除文件摘要标签后的主要语言。
+- `assistant_memory_type` 是固定枚举，必须保持英文枚举值，不要翻译。
 
 示例 1
 输入：
@@ -409,6 +410,7 @@ Output requirements:
 - The language of each natural-language output field must follow the primary language of the corresponding input content.
 - `assistant_memory_hint` must follow the primary language of `Assistant.msg`.
 - `processed_user_msg` must follow the primary language of `User.msg` after removing file-summary tags.
+- `assistant_memory_type` is a fixed enum and must keep the English enum value; do not translate it.
 
 Few-shot Example 1
 Input:

--- a/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_statement_temporal.jinja2
@@ -101,9 +101,9 @@ Each output item should be a structured candidate memory statement.
 
 用户主语归一化：
 
-- 如果陈述句的主语是用户本人，无论上下文中给出的用户名称、昵称、别名或真实姓名是什么，都必须使用与输出语言一致的用户锚点，不要使用用户的具体名字或别名。
-- 中文输出使用“用户”作为主语。
-- 英文输出使用 `the user` 作为主语。
+- 如果陈述句的主语是用户本人，无论上下文中给出的用户名称、昵称、别名或真实姓名是什么，都必须使用与 `target_content` 主要语言一致的用户锚点，不要使用用户的具体名字或别名。
+- `target_content` 主要是中文时使用“用户”作为主语。
+- `target_content` 主要是英文时使用 `the user` 作为主语。
 - 这是硬规则；如果用户主语没有按输出语言统一成对应锚点，则该 statement 视为不合格。
 
 共指消解：
@@ -970,14 +970,14 @@ Example Output: {
 **LANGUAGE REQUIREMENT:**
 {% if language == "zh" %}
 
-- 输出语言应以 `language` 参数为准。
-- 如果 `language == "zh"`，用中文提取陈述句。
-- 如果 `language` 参数缺失或无法判断，才跟随输入文本的主要语言。
+- `statement_text` 的语言必须跟随 `target_content` 的主要语言，不要跟随前端传入的 `language` 参数。
+- 如果 `target_content` 主要是中文，用中文提取陈述句。
+- 如果 `target_content` 主要是英文，用英文提取陈述句。
 - 保留原始专有名词和代码片段，不要无必要翻译。
   {% else %}
-- The output language should follow the `language` parameter.
-- If `language != "zh"`, extract statements in English.
-- Only follow the dominant language of the input text when the `language` parameter is missing or unclear.
+- `statement_text` must follow the primary language of `target_content`; do not use the frontend `language` parameter as the source of truth.
+- If `target_content` is primarily Chinese, extract statements in Chinese.
+- If `target_content` is primarily English, extract statements in English.
 - Preserve original proper nouns and code snippets; do not translate them unnecessarily.
   {% endif %}
 

--- a/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_triplet.jinja2
@@ -12,14 +12,14 @@ Extract entities and knowledge triplets from the given statement.
 - 非用户自指代词或指示表达，如“他”“她”“它”“这个”“那个”“这家”“那家”“这里”“那里”，如果能从 `supporting_context` 中稳定解析出具体指代，则必须替换为具体指代实体名。
 - 如果上述代词或指示表达不能稳定解析，则整条跳过。
 - 命名关系中新出现的称呼、别名、昵称、产品名保持原样，不做替换。
-- `description` 必须使用中文。
+- `description` 必须跟随输入 `statement_text` 的主要语言。
 - 每个实体的 `description` 必须以输入中的 `dialog_at` 时间戳开头，格式为 `[dialog_at] 描述文本`；如果输入中 `dialog_at` 为空或不存在，则使用 `[NULL]`。
 - 如果 `statement_text` 表达已发生或正在发生的事件，且上游已经把相对时间解析进 `statement_text` 或 `valid_at`/`invalid_at`，实体 `description` 的正文必须保留这个事件时间；不要只写 `[dialog_at]` 后接无时间描述。
 - `type`、`predicate` 必须使用上方预定义的中文标签。
 - 每个实体必须输出 `type_id`，并且必须与 `type` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_id`，并且必须与 `predicate` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_surface`：尽量使用当前陈述中表达该关系的原文关系短语；如果没有更贴近原文的短语，则使用 canonical `predicate`。
-- 除 `type`、`predicate` 外，其余输出文本字段都必须与输入语言一致；因此在中文输入下，`type_description`、`predicate_description` 也必须使用中文。
+- 除 `type`、`predicate` 外，其余 flexible 输出文本字段都必须与输入 `statement_text` 的主要语言一致；`type_description`、`predicate_description` 使用与 `description` 相同的语言说明。
 - 每个 `triplet` 都必须携带 `valid_at` 和 `invalid_at`，并直接复制输入中的同名字段，不要自行改写或推断新的时间边界。
   {% else %}
   Important:
@@ -31,7 +31,7 @@ Extract entities and knowledge triplets from the given statement.
 - For non-user pronouns or demonstratives such as "he", "she", "it", "this", "that", "this company", "that place", if a stable referent can be resolved from `supporting_context`, replace them with the resolved entity name.
 - If such references cannot be resolved stably, skip the entire statement.
 - Newly introduced names in naming or alias expressions must stay in their original form.
-- Generate `description` in English.
+- Generate `description` in the primary language of the input `statement_text`.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
 - If `statement_text` describes an event that has happened or is happening, and upstream has resolved the relative time into `statement_text` or `valid_at`/`invalid_at`, the entity `description` body MUST preserve that event time; do not write only a `[dialog_at]` prefix followed by a timeless description.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
@@ -462,8 +462,8 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `角色职业` 是例外：角色/职业类别本身可以作为实体，例如 `导师`、`程序员`；但具体人物的稳定关系应通过 triplet 或 description 表达。
 - 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定，例如 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`，不要简化成 `小狗`、`账号`，也不要使用 `用户's小狗` 等中英混合形式。
 - 泛化或未稳定指向的表达不要抽取，例如 `一只狗`、`狗这种动物`、`某个朋友`、`一个账号`、`某个办公室`。
-- `description` 必须使用中文。
-- `type` 必须使用上方预定义的中文标签；`type_description` 必须直接复用对应 `type` 的预定义中文定义。
+- `description` 必须跟随输入 `statement_text` 的主要语言。
+- `type` 必须使用上方预定义的中文标签；`type_description` 使用与 `description` 相同的语言说明对应 `type`。
   {% else %}
 - Do not split generic propositions, causal slogans, or value judgments into low-value abstract entities. For example, "effort brings reward" should not create standalone entities for "effort" or "reward" by default.
 - Do not extract ordinary time expressions as entities, including dates, timestamps, "tomorrow", "next week", or "8 PM tonight".
@@ -479,8 +479,8 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
 - The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
 - Do not extract generic or weakly resolved mentions, such as `a dog`, `dogs as a species`, `some friend`, `an account`, or `some office`.
-- `description` must be in English.
-- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
+- `description` must follow the primary language of the input `statement_text`.
+- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in the same language as `description`.
   {% endif %}
 
 **Semantic Memory (`is_explicit_memory`):**
@@ -887,9 +887,9 @@ JSON 要求：
 - 不要使用中文引号
 - 字符串值中不要换行
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，但用户自指必须规范成 `用户`，可稳定解析的其他代词必须替换为具体指代实体名
-- `description` 必须使用中文，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
+- `description` 必须跟随输入 `statement_text` 的主要语言，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
 - 如果 statement 是有长期记忆价值的事件、经历、变化或里程碑，`description` 正文必须保留已解析事件时间，不能只依赖 `[dialog_at]` 前缀表达时间
-- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用中文说明
+- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用与 `description` 相同的语言说明
 - 每个 entity 都必须包含 `type_id`，且必须与 `type` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_id`，且必须与 `predicate` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_surface`；中文输入下使用中文或原文中的关系表达
@@ -904,9 +904,9 @@ JSON 要求：
 - No Chinese quotation marks
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
-- `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
+- `description` must follow the primary language of the input `statement_text`, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
 - If the statement is a long-term-memory-worthy event, experience, change, or milestone, the `description` body must preserve the resolved event time and must not rely only on the `[dialog_at]` prefix for time
-- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
+- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in the same language as `description`
 - Every entity must include `type_id`, exactly matching the ontology ID for `type`
 - Every triplet must include `predicate_id`, exactly matching the ontology ID for `predicate`
 - Every triplet must include `predicate_surface`; for English input, use English or the source-text relation expression

--- a/api/app/core/memory/utils/prompt/prompts/extract_user_metadata.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_user_metadata.jinja2
@@ -841,18 +841,20 @@ Output:
 ===Output Format===
 ===Output Language Rule===
 {% if language == "zh" %}
-metadata 字符串值的语言必须与输入 `description` 的主要语言一致。
+metadata 字符串值和 `reason` 的语言必须与输入 `description` 的主要语言一致。
 
-- 如果输入 `description` 主要是中文，则 metadata 字符串值用中文输出。
-- 如果输入 `description` 主要是英文，则 metadata 字符串值用英文输出。
+- 如果输入 `description` 主要是中文，则 `value`、`new_value`、`reason` 用中文输出。
+- 如果输入 `description` 主要是英文，则 `value`、`new_value`、`reason` 用英文输出。
+- `old_value` 必须从 `existing_metadata[field]` 原样复制，不得为了语言一致而翻译。
 - 不要为了规范化而将提取的条目翻译成另一种语言。
-- JSON 键名、数组结构、分隔符（如 `|`）保持不变；只有 metadata 字符串值需要跟随输入语言。
+- JSON 键名、数组结构、分隔符（如 `|`）保持不变；只有 flexible 的自然语言字符串值需要跟随输入语言。
   {% else %}
-  The language of metadata string values MUST follow the primary language of the input `description`.
-- If the input `description` is primarily Chinese, output metadata string values in Chinese.
-- If the input `description` is primarily English, output metadata string values in English.
+  The language of metadata string values and `reason` MUST follow the primary language of the input `description`.
+- If the input `description` is primarily Chinese, output `value`, `new_value`, and `reason` in Chinese.
+- If the input `description` is primarily English, output `value`, `new_value`, and `reason` in English.
+- `old_value` must be copied exactly from `existing_metadata[field]`; do not translate it for language consistency.
 - Do not translate extracted items into a different language just for normalization.
-- JSON keys, array structure, and separators such as `|` stay unchanged; only metadata string values need to follow the input language.
+- JSON keys, array structure, and separators such as `|` stay unchanged; only flexible natural-language string values need to follow the input language.
   {% endif %}
 
 {% if language == "zh" %}
@@ -896,7 +898,7 @@ JSON 要求：
 - 字符串内如果包含双引号，必须转义为 `\"`
 - 顶层只允许输出 `operations`
 - 不要输出尾逗号
-- metadata 字符串语言必须与输入 `description` 的主要语言一致
+- metadata 字符串和 `reason` 语言必须与输入 `description` 的主要语言一致；`old_value` 原样复制
   {% else %}
   JSON requirements:
 - Use standard ASCII double quotes `"`
@@ -905,5 +907,5 @@ JSON 要求：
 - Escape internal quotes as `\"`
 - Output only the top-level `operations` key
 - Do not emit trailing commas
-- Metadata string language must match the primary language of the input `description`
+- Metadata string and `reason` language must match the primary language of the input `description`; copy `old_value` verbatim
   {% endif %}

--- a/api/app/core/memory/utils/prompt/prompts/memory_summary.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/memory_summary.jinja2
@@ -6,9 +6,9 @@
 Summarize the provided conversation chunks into a concise Memory summary.
 
 {% if language == "zh" %}
-**重要：请使用中文生成摘要内容。**
+**重要：摘要内容应跟随输入 conversation chunks 的主要语言。**
 {% else %}
-**Important: Please generate the summary content in English.**
+**Important: Generate the summary content in the primary language of the input conversation chunks.**
 {% endif %}
 
 === Requirements ===
@@ -16,9 +16,9 @@ Summarize the provided conversation chunks into a concise Memory summary.
 - Avoid repetition and filler; be specific.
 - Keep it under {{ max_words or 200 }} words.
 {% if language == "zh" %}
-- 摘要内容必须使用中文
+- 摘要内容必须跟随输入 conversation chunks 的主要语言
 {% else %}
-- Summary content must be in English
+- Summary content must follow the primary language of the input conversation chunks
 {% endif %}
 - Output must be valid JSON conforming to the schema below.
 
@@ -36,9 +36,9 @@ Summarize the provided conversation chunks into a concise Memory summary.
 5. Example of proper escaping: "statement": "张曼婷说：\"我很喜欢这本书。\""
 
 {% if language == "zh" %}
-**语言要求：输出内容必须使用中文。**
+**语言要求：flexible 的摘要文本跟随输入 conversation chunks 的主要语言；JSON schema 和字段名保持不变。**
 {% else %}
-**Language Requirement: The output content must be in English.**
+**Language Requirement: Flexible summary text follows the primary language of the input conversation chunks; JSON schema and field names stay unchanged.**
 {% endif %}
 
 Return only a list of extracted labelled statements in the JSON ARRAY of objects that match the schema below:

--- a/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/reflection_summary_timeline.prompt.jinja2
@@ -379,7 +379,9 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - If `should_rename_entity` is true, `suggested_entity_name` must be a non-empty string and must not be `"NULL"`.
 - Use standard ASCII double quotes.
 - Do not emit trailing commas.
-- Natural-language string values should follow the main language of the input descriptions.
+- Flexible natural-language string values (`description_summary`, new/updated `title`, new/updated `fact`, and `suggested_entity_name`) should follow the main language of the input `description`.
+- Fixed schema values stay unchanged: JSON keys, `op`, `category_id`, `category`, dates, and `"NULL"` must keep the required format. `category` must remain the exact Chinese display name mapped to `category_id`.
+- `old_value` must be copied exactly from `event_timeline`; do not translate it for language consistency.
 {% else %}
 - 只输出严格 JSON。
 - 不要输出 markdown 代码块。
@@ -403,7 +405,9 @@ Prefer the highest available stable name. For non-user entities, when a concrete
 - 如果 `should_rename_entity` 是 true，`suggested_entity_name` 必须是非空字符串，且不能是 `"NULL"`。
 - 使用标准 ASCII 双引号。
 - 不要输出尾逗号。
-- 自然语言字符串值应跟随输入 description 的主要语言。
+- flexible 的自然语言字符串值（`description_summary`、新增/更新的 `title`、新增/更新的 `fact`、`suggested_entity_name`）应跟随输入 `description` 的主要语言。
+- 固定 schema 值保持不变：JSON key、`op`、`category_id`、`category`、日期和 `"NULL"` 必须保持指定格式。`category` 必须保留为与 `category_id` 对应的中文展示名。
+- `old_value` 必须从 `event_timeline` 原样复制，不得为了语言一致而翻译。
 {% endif %}
 
 {% if language == "en" %}

--- a/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
@@ -20,13 +20,13 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - 非用户自指代词或指示表达，如“他”“她”“它”“这个”“那个”“这家”“那家”“这里”“那里”，如果能从 `supporting_context` 中稳定解析出具体指代，则必须替换为具体指代实体名。
 - 如果上述代词或指示表达不能稳定解析，则使用描述性名称强制提取。
 - 命名关系中新出现的称呼、别名、昵称、产品名保持原样，不做替换。
-- `description` 必须使用中文。
+- `description` 必须跟随输入 `statement_text` 的主要语言。
 - 每个实体的 `description` 必须以输入中的 `dialog_at` 时间戳开头，格式为 `[dialog_at] 描述文本`；如果输入中 `dialog_at` 为空或不存在，则使用 `[NULL]`。
 - `type`、`predicate` 必须使用上方预定义的中文标签。
 - 每个实体必须输出 `type_id`，并且必须与 `type` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_id`，并且必须与 `predicate` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_surface`：尽量使用当前陈述中表达该关系的原文关系短语；如果没有更贴近原文的短语，则使用 canonical `predicate`。
-- 除 `type`、`predicate` 外，其余输出文本字段都必须与输入语言一致；因此在中文输入下，`type_description`、`predicate_description` 也必须使用中文。
+- 除 `type`、`predicate` 外，其余 flexible 输出文本字段都必须与输入 `statement_text` 的主要语言一致；`type_description`、`predicate_description` 使用与 `description` 相同的语言说明。
 - 每个 `triplet` 都必须携带 `valid_at` 和 `invalid_at`，并直接复制输入中的同名字段，不要自行改写或推断新的时间边界。
   {% else %}
   Important:
@@ -43,7 +43,7 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - If a reference still cannot be resolved stably, create a descriptive weak entity using time, scene, action, or relationship qualifiers from the statement when useful.
 - Output triplets only when the statement itself expresses a valid relation. Do not force `关联于` as a fallback just because resolution failed.
 - Newly introduced names in naming or alias expressions must stay in their original form.
-- Generate `description` in English.
+- Generate `description` in the primary language of the input `statement_text`.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
 - Every entity MUST include `type_id`, and it MUST exactly match the ontology ID for `type`.
@@ -488,8 +488,8 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `角色职业` 是例外：角色/职业类别本身可以作为实体，例如 `导师`、`程序员`；但具体人物的稳定关系应通过 triplet 或 description 表达。
 - 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定，例如 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`，不要简化成 `小狗`、`账号`，也不要使用 `用户's小狗` 等中英混合形式。
 - 泛化表达不要抽取，例如 `一只狗`、`狗这种动物`。但本二次处理阶段允许抽取有 statement 限定的弱实体，例如 `2026年3月加入这家公司的未具名人员`；不要输出裸泛称 `某个朋友`、`一个账号`、`某个办公室`。
-- `description` 必须使用中文。
-- `type` 必须使用上方预定义的中文标签；`type_description` 必须直接复用对应 `type` 的预定义中文定义。
+- `description` 必须跟随输入 `statement_text` 的主要语言。
+- `type` 必须使用上方预定义的中文标签；`type_description` 使用与 `description` 相同的语言说明对应 `type`。
   {% else %}
 - Do not split generic propositions, causal slogans, or value judgments into low-value abstract entities. For example, "effort brings reward" should not create standalone entities for "effort" or "reward" by default.
 - Do not extract ordinary time expressions as entities, including dates, timestamps, "tomorrow", "next week", or "8 PM tonight".
@@ -507,8 +507,8 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
 - The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
 - Do not extract generic mentions such as `a dog` or `dogs as a species`. In this second-pass repair stage, weak entities are allowed only when they include statement-specific qualifiers; do not output bare generic names such as `some friend`, `an account`, or `some office`.
-- `description` must be in English.
-- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
+- `description` must follow the primary language of the input `statement_text`.
+- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in the same language as `description`.
   {% endif %}
 
 **Same-Name Entity Deduplication:**
@@ -952,8 +952,8 @@ JSON 要求：
 - 不要使用中文引号
 - 字符串值中不要换行
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，但用户自指必须规范成 `用户`，可稳定解析的其他代词必须替换为具体指代实体名
-- `description` 必须使用中文，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
-- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用中文说明
+- `description` 必须跟随输入 `statement_text` 的主要语言，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
+- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用与 `description` 相同的语言说明
 - 每个 entity 都必须包含 `type_id`，且必须与 `type` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_id`，且必须与 `predicate` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_surface`；中文输入下使用中文或原文中的关系表达
@@ -973,8 +973,8 @@ JSON 要求：
 - No Chinese quotation marks
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
-- `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
-- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
+- `description` must follow the primary language of the input `statement_text`, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
+- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in the same language as `description`
 - Every entity must include `type_id`, exactly matching the ontology ID for `type`
 - Every triplet must include `predicate_id`, exactly matching the ontology ID for `predicate`
 - Every triplet must include `predicate_surface`; for English input, use English or the source-text relation expression

--- a/api/app/core/memory/utils/prompt/prompts/user_summary.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/user_summary.jinja2
@@ -8,9 +8,9 @@
 Your task is to generate a comprehensive user profile based on the provided entities and statements. The profile should include four distinct sections that capture different aspects of the user's identity and characteristics.
 
 {% if language == "zh" %}
-**重要：请使用中文生成用户画像内容。**
+**重要：用户画像正文应跟随输入 entities/statements 的主要语言。**
 {% else %}
-**Important: Please generate the user profile content in English.**
+**Important: Generate the user profile content in the primary language of the input entities/statements.**
 {% endif %}
 
 ===Inputs===
@@ -173,12 +173,10 @@ Before generating your final output, internally verify:
 
 **LANGUAGE REQUIREMENT:**
 {% if language == "zh" %}
-- 输出语言必须为简体中文
-- 所有部分内容必须使用中文
+- 各部分正文必须跟随输入 entities/statements 的主要语言
 - 部分标题必须使用指定的中文格式：【基本介绍】【性格特点】【核心价值观】【一句话总结】
 {% else %}
-- The output language must be English
-- All section content must be in English
+- Section body content must follow the primary language of the input entities/statements
 - Section headers must use the specified format: 【Basic Introduction】【Personality Traits】【Core Values】【One-Sentence Summary】
 {% endif %}
 


### PR DESCRIPTION
…tion templates

- Update alias_belongs_judge to clarify reason language follows entity/alias descriptions rather than input language
- Modify description_merge to specify merged_description uses fragments language and preserve user-provided names without normalization
- Refactor entity_dedup to require reason language align with entity names/descriptions and preserve entity type labels from input system
- Update entity_dedup_reflection to clarify flexible fields follow entity language while preserving JSON structure
- Add explicit guidance to extract_pruning that assistant_memory_type is fixed enum and must not be translated
- Revise extract_statement_temporal to require statement_text language follow target_content rather than language parameter
- Clarify user subject anchor selection based on target_content primary language instead of output language parameter
- Remove outdated "output language should match input language" directives in favor of content-specific language rules
- Fix formatting: add missing newlines at end of files for consistency

## Summary by Sourcery

将与记忆相关的提示模板与基于内容的语言规则以及枚举约束对齐，用于抽取实体、生成摘要和剪枝操作。

增强内容：
- 统一描述、摘要和原因字段的语言，使其遵循源内容字段的主语言（例如：`statement_text`、`description`、对话片段、实体/陈述）。
- 明确说明：灵活的自然语言字段（例如：`type_description`、`predicate_description`、元数据值、反思摘要）应遵循内容语言，而固定的 schema 字段、枚举和本体（ontology）标签保持不翻译。
- 更新用户主体锚定和 `statement_text` 语言选择逻辑，使其基于 `target_content` 而不是前端语言参数。
- 优化实体去重和别名判断的提示，使推理过程与实体名称/描述保持一致，并保留输入中的类型标签和 `old_value` 字符串。
- 强化 `description_merge` 指南，使 `merged_description` 使用片段的语言，并在不进行规范化的前提下保留用户提供的名称。
- 收紧 `extract_pruning` 规则，确保 `assistant_memory_type` 作为固定的英文枚举，永远不被翻译。
- 改进反思和时间线相关提示，明确要求保留输入时间线中的 `old_value` 条目和类别标签。
- 调整记忆与用户摘要提示，使档案和摘要文本遵循底层对话或实体的语言，而不是全局语言标志。
- 移除过时指令，这些指令曾强制输出语言匹配通用输入语言参数，改为采用基于内容的语言规则。
- 为提示模板文件补齐缺失的结尾换行符，以保持格式一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align memory-related prompt templates with content-driven language rules and enum constraints for extracted entities, summaries, and pruning.

Enhancements:
- Standardize description, summary, and reason language to follow the primary language of source content fields (e.g., statement_text, description, conversation chunks, entities/statements).
- Clarify that flexible natural-language fields (e.g., type_description, predicate_description, metadata values, reflection summaries) follow content language while fixed schema fields, enums, and ontology labels remain untranslated.
- Update user subject anchoring and statement_text language selection to be based on target_content rather than frontend language parameters.
- Refine entity deduplication and alias judgment prompts so reasoning aligns with entity names/descriptions and preserves input type labels and old_value strings.
- Strengthen description_merge guidance so merged_description uses fragment language and preserves user-provided names without normalization.
- Tighten extract_pruning rules so assistant_memory_type remains a fixed English enum and is never translated.
- Improve reflection and timeline prompts to explicitly preserve old_value entries and category labels from the input timeline.
- Adjust memory and user summary prompts so profile and summary text follow the language of the underlying conversation or entities rather than a global language flag.
- Remove outdated directives that forced output language to match a generic input language parameter in favor of content-specific language rules.
- Add missing trailing newlines to prompt template files for formatting consistency.

</details>