### PR TITLE
feat(memory-config): Add i18n support and new model types to memory config validation

### DIFF
--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -83,6 +83,7 @@ async def active_config(
         config_id: UUID = Body(..., embed=True),
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
+        language_type: Optional[str] = Header(None, alias="X-Language-Type"),
 ) -> dict:
     workspace_id = current_user.current_workspace_id
 
@@ -92,9 +93,10 @@ async def active_config(
     from app.core.exceptions import BusinessException
     from app.schemas.memory_config_schema import ConfigurationError
 
+    locale = get_language_from_header(language_type)
     svc = DataConfigService(db)
     try:
-        result = await svc.active(workspace_id, config_id)
+        result = await svc.active(workspace_id, config_id, locale=locale)
         return success(data=result)
     except ConfigurationError as e:
         return fail(BizCode.INVALID_PARAMETER, str(e))
@@ -106,6 +108,7 @@ async def active_config(
 async def validate_active_config_models(
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
+        language_type: Optional[str] = Header(None, alias="X-Language-Type"),
 ) -> dict:
     """校验当前工作空间激活记忆配置中的模型 API 可用性"""
     from app.core.exceptions import BusinessException
@@ -116,13 +119,14 @@ async def validate_active_config_models(
         return fail(BizCode.INVALID_PARAMETER, "请先切换到一个工作空间")
 
     api_logger.info(f"用户 {current_user.username} 请求校验激活配置模型: workspace_id={workspace_id}")
+    locale = get_language_from_header(language_type)
 
     try:
         config_id = MemoryConfigService(db).get_workspace_active_config_id(workspace_id)
     except BusinessException:
         return success(data={"valid": False, "warnings": [{"message": "当前工作空间无启用的记忆配置"}]})
 
-    result = await MemoryConfigService(db).valid_config(config_id)
+    result = await MemoryConfigService(db).valid_config(config_id, locale=locale)
     return success(data=result)
 
 

--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -124,7 +124,8 @@ async def validate_active_config_models(
     try:
         config_id = MemoryConfigService(db).get_workspace_active_config_id(workspace_id)
     except BusinessException:
-        return success(data={"valid": False, "warnings": [{"message": "当前工作空间无启用的记忆配置"}]})
+        from app.i18n.service import t
+        return success(data={"valid": False, "warnings": [{"message": t("memory_config.workspace.no_active_config", locale=locale)}]})
 
     result = await MemoryConfigService(db).valid_config(config_id, locale=locale)
     return success(data=result)

--- a/api/app/controllers/workspace_controller.py
+++ b/api/app/controllers/workspace_controller.py
@@ -441,17 +441,22 @@ async def update_workspace_models_configs(
         models_update: WorkspaceModelsUpdate,
         db: Session = Depends(get_db),
         current_user: User = Depends(get_current_user),
+        language: str = Depends(get_current_language),
         t: callable = Depends(get_translator)
 ):
     """更新当前工作空间的模型配置，并校验模型可用性"""
+    from app.core.language_utils import get_language_from_header
+
     workspace_id = current_user.current_workspace_id
+    locale = get_language_from_header(language)
     api_logger.info(f"用户 {current_user.username} 请求更新工作空间 {workspace_id} 的模型配置")
 
     updated_workspace, warnings = await workspace_service.update_workspace_models_configs(
         db=db,
         workspace_id=workspace_id,
         models_update=models_update,
-        user=current_user
+        user=current_user,
+        locale=locale,
     )
 
     api_logger.info(

--- a/api/app/locales/en/memory_config.json
+++ b/api/app/locales/en/memory_config.json
@@ -8,5 +8,8 @@
   },
   "config": {
     "not_found": "Configuration not found: {config_id}"
+  },
+  "workspace": {
+    "no_active_config": "No active memory configuration in the current workspace"
   }
 }

--- a/api/app/locales/en/memory_config.json
+++ b/api/app/locales/en/memory_config.json
@@ -1,0 +1,12 @@
+{
+  "model": {
+    "not_configured": "{model_type} model is not configured",
+    "not_found": "{model_type} model {model_id} not found",
+    "not_found_with_error": "{model_type} model {model_id} not found: {error}",
+    "no_api_key": "{model_type} model {model_name} has no available API key",
+    "api_verify_failed": "{model_type} model {model_name} API verification failed: {error}"
+  },
+  "config": {
+    "not_found": "Configuration not found: {config_id}"
+  }
+}

--- a/api/app/locales/zh/memory_config.json
+++ b/api/app/locales/zh/memory_config.json
@@ -1,0 +1,12 @@
+{
+  "model": {
+    "not_configured": "{model_type} 模型未配置",
+    "not_found": "{model_type} 模型 {model_id} 不存在",
+    "not_found_with_error": "{model_type} 模型 {model_id} 不存在: {error}",
+    "no_api_key": "{model_type} 模型 {model_name} 没有可用的 API 密钥",
+    "api_verify_failed": "{model_type} 模型 {model_name} API 验证失败: {error}"
+  },
+  "config": {
+    "not_found": "配置不存在: {config_id}"
+  }
+}

--- a/api/app/locales/zh/memory_config.json
+++ b/api/app/locales/zh/memory_config.json
@@ -8,5 +8,8 @@
   },
   "config": {
     "not_found": "配置不存在: {config_id}"
+  },
+  "workspace": {
+    "no_active_config": "当前工作空间无启用的记忆配置"
   }
 }

--- a/api/app/schemas/memory_config_schema.py
+++ b/api/app/schemas/memory_config_schema.py
@@ -50,7 +50,8 @@ class ConfigurationError(Exception):
         self.config_id = config_id
         self.workspace_id = workspace_id
         self.context = context or {}
-        
+        self.err_message = message
+
         # Build detailed error message with context
         detailed_message = message
         if config_id is not None:

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_config_logger, get_logger
+from app.i18n.service import t
 from app.core.utils.datetime_utils import utcnow_naive
 from app.core.validators.memory_config_validators import (
     validate_and_resolve_model_id,
@@ -175,6 +176,7 @@ class MemoryConfigService:
         tenant_id: UUID | None,
         config_id: UUID,
         workspace_id: UUID | None,
+        locale: str = "zh",
     ) -> None:
         """解析模型凭证并调用 validate_model_config 验证 API 连通性。
 
@@ -184,6 +186,7 @@ class MemoryConfigService:
             tenant_id: 租户 ID
             config_id: 记忆配置 ID（用于错误上下文）
             workspace_id: 工作空间 ID（用于错误上下文）
+            locale: 语言代码（zh / en），用于 i18n 错误消息
 
         Raises:
             ModelNotFoundError: 模型不存在或没有可用 API 密钥
@@ -201,7 +204,8 @@ class MemoryConfigService:
                 model_type=model_type_label,
                 config_id=config_id,
                 workspace_id=workspace_id,
-                message=f"{model_type_label} 模型 {model_id} 不存在: {e}",
+                message=t("memory_config.model.not_found_with_error", locale=locale,
+                          model_type=model_type_label, model_id=model_id, error=str(e)),
             )
 
         # 2. 获取可用 API Key
@@ -215,7 +219,8 @@ class MemoryConfigService:
                 model_type=model_type_label,
                 config_id=config_id,
                 workspace_id=workspace_id,
-                message=f"{model_type_label} 模型 {model_config.name} 没有可用的 API 密钥",
+                message=t("memory_config.model.no_api_key", locale=locale,
+                          model_type=model_type_label, model_name=model_config.name),
             )
 
         # 3. 实际 API 连通性验证
@@ -237,16 +242,19 @@ class MemoryConfigService:
                 model_type=model_type_label,
                 config_id=config_id,
                 workspace_id=workspace_id,
-                message=f"{model_type_label} 模型 {api_key_config.model_name} API 验证失败: {result.get('error', '未知错误')}",
+                message=t("memory_config.model.api_verify_failed", locale=locale,
+                          model_type=model_type_label, model_name=api_key_config.model_name,
+                          error=result.get('error', 'Unknown error')),
             )
 
-    async def valid_config(self, config_id: uuid.UUID) -> dict:
+    async def valid_config(self, config_id: uuid.UUID, locale: str = "zh") -> dict:
         """验证配置是否存在且关联模型 API 可用。
 
         所有模型验证失败均不阻断，统一收集到 warnings 返回前端告警。
 
         Args:
             config_id: 配置 UUID
+            locale: 语言代码（zh / en），用于 i18n 告警消息
 
         Returns:
             dict: {
@@ -264,7 +272,7 @@ class MemoryConfigService:
         config = self.db.get(MemoryConfigModel, config_id)
         if not config:
             raise InvalidConfigError(
-                f"配置不存在: config_id={config_id}",
+                t("memory_config.config.not_found", locale=locale, config_id=str(config_id)),
                 field_name="config_id",
                 invalid_value=config_id,
             )
@@ -274,41 +282,44 @@ class MemoryConfigService:
         workspace_id = workspace.id if workspace else None
 
         all_models = [
-            ("llm", config.llm_id),
-            ("embedding", config.embedding_id),
-            ("rerank", config.rerank_id),
-            ("vision", config.vision_id),
-            ("video", config.video_id),
-            ("audio", config.audio_id),
+            ("llm", config.llm_id, "extracted"),
+            ("embedding", config.embedding_id,"extracted"),
+            ("rerank", config.rerank_id, "extracted"),
+            ("vision", config.vision_id, "extracted"),
+            ("video", config.video_id, "extracted"),
+            ("audio", config.audio_id, "extracted"),
+            ("reflection", config.reflection_model_id, "reflection"),
+            ("emotion", config.emotion_model_id, "emotion"),
         ]
 
         warnings: list[dict] = []
 
-        for model_type, model_id in all_models:
+        for model_type, model_id, source in all_models:
             if not model_id:
                 warnings.append({
                     "model_type": model_type,
                     "model_id": None,
-                    "message": f"{model_type} 模型未配置",
+                    "source": source,
+                    "message": t("memory_config.model.not_configured", locale=locale, model_type=model_type),
                 })
 
-        _VALIDATE_AS_LLM = {"vision", "video", "audio"}
+        _VALIDATE_AS_LLM = {"vision", "video", "audio", "reflection", "emotion"}
 
         async def _validate_one(model_type: str, model_id: str) -> dict | None:
             validate_type = "llm" if model_type in _VALIDATE_AS_LLM else model_type
             try:
-                await self._validate_model_connectivity(model_id, validate_type, tenant_id, config_id, workspace_id)
+                await self._validate_model_connectivity(model_id, validate_type, tenant_id, config_id, workspace_id, locale=locale)
                 return None
             except ConfigurationError as e:
                 logger.warning(
                     f"模型 {model_type} API 验证失败: {e}",
                     extra={"config_id": str(config_id), "model_type": model_type, "model_id": str(model_id)},
                 )
-                return {"model_type": model_type, "model_id": str(model_id), "message": str(e)}
+                return {"model_type": model_type, "model_id": str(model_id), "message": e.err_message}
 
         tasks = [
             _validate_one(model_type, model_id)
-            for model_type, model_id in all_models
+            for model_type, model_id, _ in all_models
             if model_id
         ]
         if tasks:

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_config_logger, get_logger
+from app.i18n.service import t
 from app.core.memory.analytics.hot_memory_tags import (
     filter_tags_with_llm,
     get_raw_tags_batch,
@@ -96,7 +97,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         )
         workspace = self.db.scalar(stmt)
         if not workspace:
-            raise BusinessException("空间不存在")
+            raise BusinessException(t("workspace.not_found", locale=locale))
         validation_result = await MemoryConfigService(self.db).valid_config(config_id, locale=locale)
         warnings = validation_result.get("warnings", [])
         success = False

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -89,7 +89,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         """
         self.db = db
 
-    async def active(self, workspace_id: uuid.UUID, config_id: uuid.UUID) -> Dict[str, Any]:
+    async def active(self, workspace_id: uuid.UUID, config_id: uuid.UUID, locale: str = "zh") -> Dict[str, Any]:
         stmt = select(Workspace).where(
             Workspace.id == workspace_id,
             Workspace.is_active.is_(True)
@@ -97,7 +97,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         workspace = self.db.scalar(stmt)
         if not workspace:
             raise BusinessException("空间不存在")
-        validation_result = await MemoryConfigService(self.db).valid_config(config_id)
+        validation_result = await MemoryConfigService(self.db).valid_config(config_id, locale=locale)
         warnings = validation_result.get("warnings", [])
         success = False
         if not warnings:

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -929,6 +929,7 @@ async def update_workspace_models_configs(
         workspace_id: uuid.UUID,
         models_update: WorkspaceModelsUpdate,
         user: User,
+        locale: str = "zh",
 ) -> tuple[Workspace, list[dict]]:
     """更新工作空间的模型配置，并校验关联默认配置的模型可用性。
 
@@ -937,6 +938,7 @@ async def update_workspace_models_configs(
         workspace_id: 工作空间ID
         models_update: 模型配置更新对象
         user: 当前用户
+        locale: 语言代码（zh / en），用于 i18n 告警消息
 
     Returns:
         tuple[Workspace, list[dict]]: (更新后的工作空间对象, 模型校验告警列表)
@@ -957,6 +959,8 @@ async def update_workspace_models_configs(
 
         if default_memory_config:
             default_memory_config.llm = str(models_update.llm) if models_update.llm else None
+            default_memory_config.reflection_model_id = str(models_update.llm) if models_update.llm else None
+            default_memory_config.emotion_model_id = str(models_update.llm) if models_update.llm else None
             default_memory_config.embedding = str(models_update.embedding) if models_update.embedding else None
             default_memory_config.rerank = str(models_update.rerank) if models_update.rerank else None
             default_memory_config.vision = str(models_update.vision) if models_update.vision else None
@@ -979,8 +983,12 @@ async def update_workspace_models_configs(
         # 校验默认配置的模型可用性
         warnings: list[dict] = []
         if default_memory_config:
-            result = await MemoryConfigService(db).valid_config(default_memory_config.config_id)
-            warnings = result.get("warnings", [])
+            result = await MemoryConfigService(db).valid_config(default_memory_config.config_id, locale=locale)
+            warnings = [
+                warning
+                for warning in result.get("warnings", [])
+                if warning.get("source") == "extracted"
+            ]
 
         return db_workspace, warnings
 


### PR DESCRIPTION
- Add locale parameter to memory config validation functions for i18n error messages
- Add reflection and emotion model types to validation list
- Sync reflection and emotion model IDs from workspace LLM update
- Filter warnings to only include extracted source in workspace service
- Add err_message field to ConfigurationError schema
- Add English and Chinese locale files for memory config messages

## Summary by Sourcery

为内存配置添加国际化的校验和警告信息，并将模型校验范围扩展到新的反思（reflection）和情绪（emotion）模型类型。

新功能：
- 在内存配置校验及相关控制器/服务中支持本地化（中文/英文）的错误和警告信息。
- 在内存配置连通性校验和默认工作区内存模型设置中纳入反思模型和情绪模型。
- 为内存配置相关消息提供独立的英文和中文本地化文件。

增强点：
- 通过工作区和内存配置 API 传递语言环境信息，使校验时使用正确的语言。
- 在更新工作区模型配置时，仅对提取出的源模型进行过滤后的工作区模型校验警告输出。
- 通过 `ConfigurationError` 模式向下游使用方暴露来自配置校验的原始错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add internationalized validation and warning messages for memory configuration and extend model validation coverage to new reflection and emotion model types.

New Features:
- Support locale-aware (Chinese/English) error and warning messages in memory configuration validation and related controllers/services.
- Include reflection and emotion models in memory configuration connectivity validation and default workspace memory model settings.
- Provide dedicated locale files for memory configuration messages in English and Chinese.

Enhancements:
- Propagate locale information through workspace and memory configuration APIs so validation uses the correct language.
- Filter workspace model validation warnings to only include extracted source models when updating workspace model configs.
- Expose the raw error message from configuration validation via the ConfigurationError schema for downstream consumers.

</details>