### PR TITLE
fix: DingTalk webhook format

### DIFF
--- a/.github/workflows/release-notify-wechat.yml
+++ b/.github/workflows/release-notify-wechat.yml
@@ -152,7 +152,7 @@ jobs:
             "---\n"
             "🔗 [查看PR详情](" + os.environ["PR_URL"] + ")"
           )
-          payload = {"msgtype": "markdown", "markdown": {"content": content}}
+          payload = {"msgtype": "markdown", "markdown": {"title": "🚀 Release 发布通知", "text": content}}
           data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
           req = urllib.request.Request(
             os.environ["WECHAT_WEBHOOK"],


### PR DESCRIPTION
Fix markdown payload to use DingTalk format (add title field, content→text)

## Summary by Sourcery

错误修复：
- 在发布通知中，通过添加 `title` 字段并将 `content` 字段重命名为 `text`，修正钉钉 Markdown Webhook 的负载结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct DingTalk markdown webhook payload structure by adding a title field and renaming the content field to text in release notifications.

</details>