### PR TITLE
refactor(memory)

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -564,15 +564,6 @@ async def chat(
             original_user_id=user_id
         )
 
-        # Only extract and set memory_config_id when the end user doesn't have one yet
-        if not new_end_user.memory_config_id:
-            from app.services.memory_config_service import MemoryConfigService
-            memory_config_service = MemoryConfigService(db)
-            memory_config_id, _ = memory_config_service.extract_memory_config_id(release.type, release.config or {})
-            if memory_config_id:
-                new_end_user.memory_config_id = memory_config_id
-                db.commit()
-                db.refresh(new_end_user)
         end_user_id = str(new_end_user.id)
 
         # appid = share.app_id

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -382,6 +382,7 @@ class MemoryService:
 def create_long_term_memory_tool(
         memory_config: Dict[str, Any],
         end_user_id: str,
+        workspace_id: uuid.UUID | None,
         storage_type: Optional[str] = None,
         user_rag_memory_id: Optional[str] = None,
         memory_name: Optional[str] = None,
@@ -394,6 +395,7 @@ def create_long_term_memory_tool(
     Args:
         memory_config: 记忆配置字典（来自 app_releases.config.memory）
         end_user_id: 用户 ID
+        workspace_id: 工作空间 ID
         storage_type: 存储类型（可选）
         user_rag_memory_id: 用户 RAG 记忆 ID（可选）
         memory_name: 记忆配置名称（可选，若提供 db 则自动查询）
@@ -407,7 +409,13 @@ def create_long_term_memory_tool(
 
     from langchain.tools import tool
 
-    config_id = memory_config.get("memory_config_id") or memory_config.get("memory_content", None)
+    config_id = None
+    if workspace_id:
+        try:
+            with get_db_read() as read_db:
+                config_id = MemoryConfigService(read_db).get_workspace_active_config_id(workspace_id)
+        except Exception:
+            logger.warning("按工作空间解析长期记忆配置失败", exc_info=True)
 
     # 若未显式传入 memory_name 但提供了 db，则自动查询
     if not memory_name and config_id and db is not None:
@@ -420,7 +428,10 @@ def create_long_term_memory_tool(
         except Exception:
             pass
 
-    logger.info(f"创建长期记忆工具，配置: end_user_id={end_user_id}, config_id={config_id}, storage_type={storage_type}")
+    logger.info(
+        f"创建长期记忆工具，配置: end_user_id={end_user_id}, "
+        f"workspace_id={workspace_id}, active_config_id={config_id}, storage_type={storage_type}"
+    )
 
     @tool(args_schema=LongTermMemoryInput)
     async def long_term_memory(question: str, search_mode: str) -> str:
@@ -431,7 +442,7 @@ def create_long_term_memory_tool(
         """
         logger.info(f" 长期记忆工具被调用！question={question}, user={end_user_id}")
         try:
-            memory_service = MemoryService(config_id, end_user_id)
+            memory_service = MemoryService(config_id, end_user_id, workspace_id=workspace_id)
             search_result = await memory_service.read(question, SearchStrategy(search_mode))
             return f"检索到以下历史记忆：\n\n{search_result.content}"
         except Exception as e:

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -13,10 +13,7 @@ MemoryWriteDispatcher — 记忆写入派发层
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, List, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from app.models.conversation_model import Message
+from typing import Any, List
 
 from app.db import get_db_context, get_db_read
 from app.repositories.memory_message_repository import MemoryMessageRepository
@@ -512,56 +509,38 @@ async def ingest_workflow_messages(
 #
 # 调用链路：
 #   dispatch_flush_conversation (扫描待处理消息)
-#     ├── _resolve_release_memory_config_id (从 app_releases 解析 config_id)
+#     ├── _resolve_workspace_memory_config_id (按工作空间解析当前生效配置)
 #     └── dispatch_single_message [write_dispatcher] (构建上下文 + push_write_task + 推进 cursor)
 #           └── push_write_task (发 Celery 任务)
 # ──────────────────────────────────────────────
 
 
-def _resolve_release_memory_config_id(conversation_id: str) -> "uuid.UUID | None":
-    """从应用当前发布版本的 config 中解析 memory_config_id。
-
-    查询链路：conversations.app_id → apps.current_release_id → app_releases.config["memory"]["memory_config_id"]
-    """
+def _resolve_workspace_memory_config_id(conversation_id: str) -> "uuid.UUID | None":
+    """根据对话所属工作空间解析当前生效的记忆配置 ID。"""
     try:
         from sqlalchemy import select as sa_select
-        from app.models.app_model import App
-        from app.models.app_release_model import AppRelease
         from app.models.conversation_model import Conversation
         from app.services.memory_config_service import MemoryConfigService
 
         with get_db_context() as db:
             row = db.execute(
                 sa_select(
-                    App.id,
-                    App.type,
-                    App.current_release_id,
-                    AppRelease.config,
+                    Conversation.workspace_id,
                 )
                 .select_from(Conversation)
-                .join(App, App.id == Conversation.app_id)
-                .outerjoin(AppRelease, AppRelease.id == App.current_release_id)
                 .where(Conversation.id == conversation_id)
             ).one_or_none()
 
             if row is None:
                 return None
 
-            app_id, app_type, current_release_id, release_config = row
-
-            if not current_release_id:
+            (workspace_id,) = row
+            if not workspace_id:
                 return None
 
-            if not isinstance(release_config, dict) or not release_config:
-                return None
-
-            config_id, _ = MemoryConfigService(db).extract_memory_config_id(
-                app_type=str(app_type) if app_type else "",
-                config=release_config,
-            )
-            return config_id
+            return MemoryConfigService(db).get_workspace_active_config_id(workspace_id)
     except Exception as e:
-        logger.error(f"[Dispatcher] 解析 release memory_config_id 异常: conv={conversation_id}, err={e}", exc_info=True)
+        logger.error(f"[Dispatcher] 解析工作空间记忆配置异常: conv={conversation_id}, err={e}", exc_info=True)
         return None
 
 
@@ -623,13 +602,12 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
                 logger.info(f"[Dispatcher] Flush 无未写入消息，跳过: conv={conversation_id}")
                 return 0
 
-        # Step 2: 解析 memory_config_id
-        config_id = ""
-        release_config_id = _resolve_release_memory_config_id(conversation_id)
-        if not release_config_id:
-            logger.warning(f"[Dispatcher] Flush 未能解析 memory_config_id，跳过: conv={conversation_id}")
+        # Step 2: 解析工作空间当前生效记忆配置
+        workspace_config_id = _resolve_workspace_memory_config_id(conversation_id)
+        if not workspace_config_id:
+            logger.warning(f"[Dispatcher] Flush 未能解析工作空间记忆配置，跳过: conv={conversation_id}")
             return 0
-        config_id = str(release_config_id)
+        config_id = str(workspace_config_id)
 
         # Step 3: 逐条处理
         dispatched = 0

--- a/api/app/core/workflow/nodes/memory/config.py
+++ b/api/app/core/workflow/nodes/memory/config.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from pydantic import BaseModel, field_validator, Field
 
 from app.core.workflow.nodes.base_config import BaseNodeConfig
@@ -33,10 +31,6 @@ class MemoryReadNodeConfig(BaseNodeConfig):
         ...
     )
 
-    config_id: UUID | int = Field(
-        ...
-    )
-
     search_switch: str = Field(
         "0",
         description="Search mode: 0=verify, 1=direct, 2=context"
@@ -50,8 +44,4 @@ class MemoryWriteNodeConfig(BaseNodeConfig):
 
     messages: list[MessageConfig] = Field(
         default_factory=list
-    )
-
-    config_id: UUID | int = Field(
-        ...
     )

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from typing import Any
 
 from app.core.memory.enums import SearchStrategy
@@ -9,7 +10,9 @@ from app.core.workflow.nodes.base_node import BaseNode
 from app.core.workflow.nodes.memory.config import MemoryReadNodeConfig, MemoryWriteNodeConfig
 from app.core.workflow.variable.base_variable import VariableType
 from app.core.workflow.variable.variable_objects import FileVariable, ArrayVariable
+from app.db import get_db_context
 from app.schemas import FileInput
+from app.services.memory_config_service import MemoryConfigService
 
 
 class MemoryReadNode(BaseNode):
@@ -27,6 +30,16 @@ class MemoryReadNode(BaseNode):
             "intermediate_outputs": VariableType.ARRAY_OBJECT
         }
 
+    @staticmethod
+    def _get_workspace_memory_config_id(state: WorkflowState) -> uuid.UUID:
+        workspace_id = state.get("workspace_id")
+        if not workspace_id:
+            raise RuntimeError("Workspace id is required")
+
+        workspace_uuid = workspace_id if isinstance(workspace_id, uuid.UUID) else uuid.UUID(str(workspace_id))
+        with get_db_context() as db:
+            return MemoryConfigService(db).get_workspace_active_config_id(workspace_uuid)
+
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
         self.typed_config = MemoryReadNodeConfig(**self.config)
         end_user_id = self.get_variable("sys.user_id", variable_pool)
@@ -34,15 +47,17 @@ class MemoryReadNode(BaseNode):
         if not end_user_id:
             raise RuntimeError("End user id is required")
 
+        config_id = self._get_workspace_memory_config_id(state)
+
         memory_service = MemoryService(
             storage_type=state["memory_storage_type"],
-            config_id=self.typed_config.config_id,
+            config_id=config_id,
             end_user_id=end_user_id,
             user_rag_memory_id=state["user_rag_memory_id"],
             conversation_id=variable_pool.get_value("sys.conversation_id"),
         )
         query = self._render_template(self.typed_config.message, variable_pool)
-        self._process = {"query": query, "config_id": str(self.typed_config.config_id)}
+        self._process = {"query": query, "config_id": config_id}
         # TODO: Historical Messages -> Used to refer to coreference resolution
         search_result = await memory_service.read(
             query,
@@ -86,6 +101,7 @@ class MemoryWriteNode(BaseNode):
 
         if not end_user_id:
             raise RuntimeError("End user id is required")
+        config_id = MemoryReadNode._get_workspace_memory_config_id(state)
         messages = []
         if self.typed_config.message:
             messages.append({
@@ -131,7 +147,7 @@ class MemoryWriteNode(BaseNode):
             messages=messages,
             conversation_id=conversation_id,
             end_user_id=end_user_id,
-            config_id=str(self.typed_config.config_id),
+            config_id=str(config_id),
             workspace_id=workspace_id,
             language="zh",
         )

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -268,7 +268,6 @@ class MemoryConfig(BaseModel):
     """记忆配置"""
     enabled: bool = Field(default=True, description="是否启用对话历史记忆")
     memory_config_id: Optional[str] = Field(default=None, description="选择记忆的内容类型")
-    max_history: int = Field(default=10, ge=0, le=100, description="最大保留的历史对话轮数")
 
 
 class ModelParameters(BaseModel):

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -225,7 +225,7 @@ class AppChatService:
         tools.extend(kb_tools)
         if memory:
             memory_tools, _ = self.agent_service.load_memory_config(
-                config.memory, user_id, storage_type, user_rag_memory_id
+                config.memory, user_id, uuid.UUID(workspace_id), storage_type, user_rag_memory_id
             )
             tools.extend(memory_tools)
 
@@ -653,7 +653,7 @@ class AppChatService:
             # 添加长期记忆工具
             if memory:
                 memory_tools, _ = self.agent_service.load_memory_config(
-                    config.memory, user_id, storage_type, user_rag_memory_id
+                    config.memory, user_id, uuid.UUID(workspace_id), storage_type, user_rag_memory_id
                 )
                 tools.extend(memory_tools)
 
@@ -1447,11 +1447,10 @@ class AppChatService:
 
         # 6. 加载上下文（到父消息为止）
         conversation_id = original_msg.conversation_id
-        max_history = config.memory.get("max_history", 10) if config.memory else 10
         filtered_history = await self._load_history_before_message(
             conversation_id=conversation_id,
             before_time=parent_msg.created_at,
-            max_history=max_history
+            max_history=settings.AGENT_MAX_HISTORY
         )
 
         # 7. 调用 agent_chat（传入版本参数，由 agent_chat 保存）
@@ -1603,11 +1602,10 @@ class AppChatService:
 
         # 6. 加载上下文
         conversation_id = original_msg.conversation_id
-        max_history = config.memory.get("max_history", 10) if config.memory else 10
         filtered_history = await self._load_history_before_message(
             conversation_id=conversation_id,
             before_time=parent_msg.created_at,
-            max_history=max_history
+            max_history=settings.AGENT_MAX_HISTORY
         )
 
         # 7. 流式调用（传入版本参数，由 agent_chat_stream 保存）

--- a/api/app/services/app_dsl_service.py
+++ b/api/app/services/app_dsl_service.py
@@ -214,6 +214,8 @@ class AppDslService:
                 if model_id:
                     config["model_ref"] = self._model_ref(model_id)
                     del config["model_id"]
+            elif node_type in (NodeType.MEMORY_READ.value, NodeType.MEMORY_WRITE.value):
+                config.pop("config_id", None)
             
             enriched_nodes.append({**node, "config": config})
         return enriched_nodes
@@ -714,14 +716,7 @@ class AppDslService:
                         if "model_ref" in config:
                             del config["model_ref"]
             elif node_type in (NodeType.MEMORY_READ.value, NodeType.MEMORY_WRITE.value):
-                memory_config_id = config.get("config_id")
-                if memory_config_id:
-                    resolved_memory = self._resolve_workflow_memory(memory_config_id, workspace_id)
-                    if resolved_memory:
-                        config["config_id"] = resolved_memory
-                    else:
-                        warnings.append(f"[{node_label}] 记忆配置 '{memory_config_id}' 未匹配，已置空，请导入后手动配置")
-                        config["config_id"] = None
+                config.pop("config_id", None)
             resolved_nodes.append({**node, "config": config})
         return resolved_nodes
 
@@ -764,30 +759,6 @@ class AppDslService:
             warnings.append(f"记忆配置 '{config_id}' 未匹配，已置空，请导入后手动配置")
             return {**memory, "memory_config_id": None, "enabled": memory.get("enabled", True)}
         return memory
-
-    def _resolve_workflow_memory(self, memory_config_id: str, workspace_id: uuid.UUID) -> Optional[str]:
-        """解析工作流节点中的记忆配置ID"""
-        if not memory_config_id:
-            return None
-        try:
-            config_uuid = uuid.UUID(str(memory_config_id))
-            exists = self.db.query(MemoryConfigModel).filter(
-                MemoryConfigModel.config_id == config_uuid,
-                MemoryConfigModel.workspace_id == workspace_id
-            ).first()
-            if exists:
-                return str(config_uuid)
-        except (ValueError, AttributeError):
-            try:
-                exists = self.db.query(MemoryConfigModel).filter(
-                    MemoryConfigModel.config_id_old == int(memory_config_id),
-                    MemoryConfigModel.workspace_id == workspace_id
-                ).first()
-                if exists:
-                    return str(exists.config_id)
-            except (ValueError, TypeError):
-                pass
-        return None
 
     def _resolve_skills(self, skills: Optional[dict], tenant_id: uuid.UUID, warnings: list) -> dict:
         if not skills:

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -319,8 +319,13 @@ class AppService:
                 multi_agent_config.default_model_config_id = master_agent_release.default_model_config_id
 
             from app.repositories.tool_repository import ToolRepository
+            from app.models import App
 
-            tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(app.workspace_id))
+            db_app = self.db.get(App, app_id)
+            if not db_app:
+                raise BusinessException("应用不存在", BizCode.NOT_FOUND)
+
+            tenant_id = ToolRepository.get_tenant_id_by_workspace_id(self.db, str(db_app.workspace_id))
             model_api_key = ModelApiKeyService.get_available_api_key(
                 self.db,
                 multi_agent_config.default_model_config_id,
@@ -1559,7 +1564,6 @@ class AppService:
             memory={
                 "enabled": True,
                 "memory_config_id": None,
-                "max_history": 10
             },
             variables=[],
             tools=[],
@@ -1921,8 +1925,6 @@ class AppService:
             if agent_cfg.default_model_config_id is None:
                 miss_params.append("模型配置")
 
-            if agent_cfg.memory.get("enabled") and not agent_cfg.memory.get("memory_config_id"):
-                miss_params.append("记忆配置")
             if miss_params:
                 raise BusinessException(
                     f"应用发布失败：检测到以下必要配置尚未完成：{', '.join(miss_params)}。请返回应用编辑页面完成相关配置后再尝试发布。",
@@ -2032,29 +2034,6 @@ class AppService:
         )
         self.db.add(release)
         self.db.flush()  # 先 flush，确保 release 已插入数据库
-
-        # 提取记忆配置ID并更新终端用户
-        memory_config_id, is_legacy_int = self._get_memory_config_id_from_release(app.type, config)
-
-        # 如果检测到旧格式 int 数据，回退到工作空间默认配置
-        if is_legacy_int and not memory_config_id:
-            memory_config_id = self._get_workspace_default_memory_config_id(app.workspace_id)
-            if memory_config_id:
-                logger.info(
-                    f"发布时使用工作空间默认记忆配置（旧数据兼容）: app_id={app_id}, "
-                    f"workspace_id={app.workspace_id}, memory_config_id={memory_config_id}"
-                )
-
-        if memory_config_id:
-            app = self.db.query(App).filter(App.id == app_id).first()
-            if app:
-                updated_count = self._update_endusers_memory_config_by_app(
-                    app_id, memory_config_id
-                )
-                logger.info(
-                    f"发布时更新终端用户记忆配置: app_id={app_id}, workspace_id={app.workspace_id}, "
-                    f"memory_config_id={memory_config_id}, updated_count={updated_count}"
-                )
 
         # 更新当前发布版本指针
         app.current_release_id = release.id
@@ -2170,26 +2149,6 @@ class AppService:
                 extra={"app_id": str(app_id), "version": version}
             )
             raise ResourceNotFoundException("发布版本", f"app_id={app_id}, version={version}")
-
-        # 提取记忆配置ID并更新终端用户
-        memory_config_id, is_legacy_int = self._get_memory_config_id_from_release(release.type, release.config)
-
-        # 如果检测到旧格式 int 数据，回退到工作空间默认配置
-        if is_legacy_int and not memory_config_id:
-            memory_config_id = self._get_workspace_default_memory_config_id(app.workspace_id)
-            if memory_config_id:
-                logger.info(
-                    f"回滚时使用工作空间默认记忆配置（旧数据兼容）: app_id={app_id}, "
-                    f"workspace_id={app.workspace_id}, memory_config_id={memory_config_id}"
-                )
-
-        if memory_config_id:
-
-            updated_count = self._update_endusers_memory_config_by_app(app_id, memory_config_id)
-            logger.info(
-                f"回滚时更新终端用户记忆配置: app_id={app_id}, version={version}, "
-                f"memory_config_id={memory_config_id}, updated_count={updated_count}"
-            )
 
         app.current_release_id = release.id
         app.updated_at = utcnow_naive()

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -587,6 +587,7 @@ class AgentRunService:
             self,
             memory_config: dict | None,
             user_id,
+            workspace_id: uuid.UUID,
             storage_type,
             user_rag_memory_id
     ) -> tuple[list, bool]:
@@ -595,7 +596,7 @@ class AgentRunService:
 
         enabled = bool(memory_config and memory_config.get("enabled"))
         tool = create_long_term_memory_tool(
-            memory_config, user_id, storage_type, user_rag_memory_id,
+            memory_config, user_id, workspace_id, storage_type, user_rag_memory_id,
             db=self.db,
         )
         tools = [tool] if tool else []
@@ -805,7 +806,7 @@ class AgentRunService:
             # 添加长期记忆工具
             if memory:
                 memory_tools, _ = self.load_memory_config(
-                    memory_config, user_id, storage_type, user_rag_memory_id
+                    memory_config, user_id, workspace_id, storage_type, user_rag_memory_id
                 )
                 tools.extend(memory_tools)
 
@@ -1217,7 +1218,7 @@ class AgentRunService:
             # 添加长期记忆工具
             if memory:
                 memory_tools, _ = self.load_memory_config(
-                    memory_config, user_id, storage_type, user_rag_memory_id
+                    memory_config, user_id, workspace_id, storage_type, user_rag_memory_id
                 )
                 tools.extend(memory_tools)
 
@@ -3342,13 +3343,12 @@ class AgentRunService:
 
         # 4. 加载上下文（到父消息为止，不包含当前要重新生成的消息）
         conversation_id = str(original_msg.conversation_id)
-        max_history = agent_config.memory.get("max_history", 10) if agent_config.memory else 10
 
         # 使用封装的方法加载父消息之前的历史
         filtered_history = await self._load_history_before_message(
             conversation_id=original_msg.conversation_id,
             before_time=parent_msg.created_at,
-            max_history=max_history
+            max_history=settings.AGENT_MAX_HISTORY
         )
 
         # 5. 调用 LLM（复用现有 run 方法，传入过滤后的历史和文件）
@@ -3501,12 +3501,11 @@ class AgentRunService:
 
         # 4. 加载上下文
         conversation_id = str(original_msg.conversation_id)
-        max_history = agent_config.memory.get("max_history", 10) if agent_config.memory else 10
 
         filtered_history = await self._load_history_before_message(
             conversation_id=original_msg.conversation_id,
             before_time=parent_msg.created_at,
-            max_history=max_history
+            max_history=settings.AGENT_MAX_HISTORY
         )
 
         # 5. 流式调用 LLM

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -711,10 +711,7 @@ class MemoryAgentService:
 # TODO: move to memory_config_service.py
 def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, Any]:
     """
-    获取终端用户关联的记忆配置
-
-    兼容旧数据：如果 end_user.memory_config_id 为空，则从 AppRelease.config 中获取
-    并回填到 end_user.memory_config_id 字段（懒迁移）。
+    获取终端用户所在工作空间当前生效的记忆配置。
 
     Args:
         end_user_id: 终端用户ID
@@ -726,16 +723,11 @@ def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, An
     Raises:
         ValueError: 当终端用户不存在或应用未发布时
     """
-    import json as json_module
-
-    from sqlalchemy import select
-
     from app.models.app_model import App
-    from app.models.app_release_model import AppRelease
     from app.repositories.end_user_repository import EndUserRepository
     from app.services.memory_config_service import MemoryConfigService
 
-    logger.info(f"Getting connected config for end_user_id: {end_user_id}")
+    logger.info(f"Getting workspace memory config for end_user_id: {end_user_id}")
 
     # TODO: check sources for enduserid, should be one of these three: chat, draft, apikey
     # 1. 获取 end_user 及其 app_id
@@ -763,73 +755,10 @@ def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, An
     #     logger.warning(f"No current release for app: {app_id}")
     #     raise ValueError(f"应用未发布: {app_id}")
 
-    # 3. 兼容旧数据：如果 memory_config_id 为空，从 AppRelease.config 获取并回填
-    memory_config_id_to_use = end_user.memory_config_id
-
-    # 如果已有 memory_config_id，直接使用
-    # 如果新创建enduser，enduser.memory_config_id 必定为none
-    # 那么使用从release中获取memory_config_id为预期行为，并且回填到
-    # end_user.memory_config_id
-    if not memory_config_id_to_use:
-        logger.info(f"end_user.memory_config_id is None, migrating from AppRelease.config")
-
-        # 获取最新发布版本
-        stmt = (
-            select(AppRelease)
-            .where(AppRelease.app_id == app_id, AppRelease.is_active.is_(True))
-            .order_by(AppRelease.version.desc())
-        )
-        # TODO: change to current_release_id
-        latest_release = db.scalars(stmt).first()
-
-        if latest_release:
-            config = latest_release.config or {}
-
-            # 如果 config 是字符串，解析为字典
-            if isinstance(config, str):
-                try:
-                    config = json_module.loads(config)
-                except json_module.JSONDecodeError:
-                    logger.warning(f"Failed to parse config JSON for release {latest_release.id}")
-                    config = {}
-
-            # 使用 MemoryConfigService 的提取方法
-            memory_config_service = MemoryConfigService(db)
-            legacy_config_id, is_legacy_int = memory_config_service.extract_memory_config_id(
-                app_type=app.type,
-                config=config
-            )
-
-            if legacy_config_id:
-                # 验证提取的 config_id 是否存在于数据库中
-                from app.models.memory_config_model import (
-                    MemoryConfig as MemoryConfigModel,
-                )
-                existing_config = db.get(MemoryConfigModel, legacy_config_id)
-
-                if existing_config:
-                    memory_config_id_to_use = legacy_config_id
-
-                    # 回填到 end_user 表（lazy update）
-                    end_user.memory_config_id = memory_config_id_to_use
-                    db.commit()
-                    logger.info(
-                        f"Migrated memory_config_id for end_user {end_user_id}: {memory_config_id_to_use}"
-                    )
-                else:
-                    logger.warning(
-                        f"Extracted memory_config_id does not exist, skipping backfill: "
-                        f"end_user_id={end_user_id}, config_id={legacy_config_id}"
-                    )
-            elif is_legacy_int:
-                logger.info(
-                    f"Legacy int config detected for end_user {end_user_id}, will use workspace default"
-                )
-
-    # 4. 使用 get_config_with_fallback 获取记忆配置
+    # 3. 统一按工作空间生效配置获取记忆配置
     memory_config_service = MemoryConfigService(db)
     memory_config = memory_config_service.get_config_with_fallback(
-        memory_config_id=memory_config_id_to_use,
+        memory_config_id=None,
         workspace_id=end_user.workspace_id
     )
 
@@ -842,7 +771,9 @@ def get_end_user_connected_config(end_user_id: str, db: Session) -> Dict[str, An
     }
 
     logger.info(
-        f"Successfully retrieved connected config: memory_config_id = {memory_config_id}, workspace_id = {end_user.workspace_id}")
+        f"Successfully retrieved workspace memory config: memory_config_id = {memory_config_id}, "
+        f"workspace_id = {end_user.workspace_id}"
+    )
     return result
 
 
@@ -851,15 +782,14 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
     批量获取多个终端用户关联的记忆配置。
 
     逻辑：
-    1. 优先使用 end_user.memory_config_id
-    2. 如果没有，回退到工作空间默认配置
+    1. 统一使用工作空间生效记忆配置
 
     实现说明：
     - 之前是 4 次串行查询（end_users → apps → 直接配置 → 工作空间默认配置），
       冷链路上的 RT 累计成本较高；
     - 现在合并为最多 2 次：
-        a) 一次 JOIN：EndUser LEFT JOIN App，一次性拿到 app_id / memory_config_id / workspace_id
-        b) 一次 MemoryConfig 查询：用 OR 同时取"直接绑定的配置"和"工作空间默认配置"。
+        a) 一次 JOIN：EndUser LEFT JOIN App，一次性拿到 workspace_id
+        b) 一次 MemoryConfig 查询：按 workspace_id 取工作空间默认配置。
 
     Args:
         end_user_ids: 终端用户ID列表
@@ -868,7 +798,7 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
     Returns:
         字典，key 为 end_user_id，value 为包含 memory_config_id 和 memory_config_name 的字典
     """
-    from sqlalchemy import and_, or_
+    from sqlalchemy import and_
 
     from app.models.memory_config_model import MemoryConfig
     from app.repositories.end_user_repository import EndUserRepository
@@ -880,17 +810,15 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
     if not end_user_ids:
         return result
 
-    # 1) 一次 JOIN 拿齐 (end_user_id, app_id, memory_config_id, workspace_id)
+    # 1) 一次 JOIN 拿齐 (end_user_id, workspace_id)
     repo = EndUserRepository(db)
     rows = repo.get_config_batch_by_ids([UUID(uid) if isinstance(uid, str) else uid for uid in end_user_ids])
 
     # found_ids 用于补齐"未找到的用户"
     found_ids = set()
-    direct_config_ids: set = set()
     workspace_ids: set = set()
 
-    # row_index: end_user_id -> (memory_config_id, workspace_id)
-    # workspace_id 取 App.workspace_id，回退到 EndUser.workspace_id（兼容历史数据）
+    # row_index: end_user_id -> workspace_id
     row_index: Dict[str, Dict[str, Any]] = {}
 
     for row in rows:
@@ -898,39 +826,21 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
         found_ids.add(end_user_id)
 
         workspace_id = row.app_workspace_id or row.end_user_workspace_id
-        memory_config_id = row.memory_config_id
-
         row_index[end_user_id] = {
-            "memory_config_id": memory_config_id,
             "workspace_id": workspace_id,
         }
 
-        if memory_config_id:
-            direct_config_ids.add(memory_config_id)
-        elif workspace_id:
+        if workspace_id:
             workspace_ids.add(workspace_id)
 
     # 未找到的用户直接补空结果
     for missing_id in set(end_user_ids) - found_ids:
         result[missing_id] = {"memory_config_id": None, "memory_config_name": None}
 
-    # 2) 一次 MemoryConfig 查询：OR(直接配置, 工作空间默认配置)
-    config_id_to_config: Dict[Any, Any] = {}
+    # 2) 一次 MemoryConfig 查询：工作空间默认配置
     workspace_default_configs: Dict[Any, Any] = {}
 
-    if direct_config_ids or workspace_ids:
-        filters = []
-        if direct_config_ids:
-            filters.append(MemoryConfig.config_id.in_(direct_config_ids))
-        if workspace_ids:
-            filters.append(
-                and_(
-                    MemoryConfig.workspace_id.in_(workspace_ids),
-                    MemoryConfig.is_default.is_(True),
-                    MemoryConfig.state.is_(True),
-                )
-            )
-
+    if workspace_ids:
         configs = (
             db.query(MemoryConfig)
             .options(load_only(
@@ -940,26 +850,23 @@ def get_end_users_connected_configs_batch(end_user_ids: List[str], db: Session) 
                 MemoryConfig.is_default,
                 MemoryConfig.state,
             ))
-            .filter(or_(*filters) if len(filters) > 1 else filters[0])
+            .filter(
+                and_(
+                    MemoryConfig.workspace_id.in_(workspace_ids),
+                    MemoryConfig.is_default.is_(True),
+                    MemoryConfig.state.is_(True),
+                )
+            )
             .all()
         )
 
         for cfg in configs:
-            # 直接配置查询命中
-            if cfg.config_id in direct_config_ids:
-                config_id_to_config[cfg.config_id] = cfg
-            # 工作空间默认配置命中（同一个 workspace 可能有多个 is_default=True，最后一个胜出，
-            # 行为与原实现一致）
             if cfg.is_default and cfg.state and cfg.workspace_id in workspace_ids:
                 workspace_default_configs[cfg.workspace_id] = cfg
 
     # 3) 拼装最终结果
     for end_user_id, data in row_index.items():
-        memory_config = None
-        if data["memory_config_id"]:
-            memory_config = config_id_to_config.get(data["memory_config_id"])
-        if not memory_config and data["workspace_id"]:
-            memory_config = workspace_default_configs.get(data["workspace_id"])
+        memory_config = workspace_default_configs.get(data["workspace_id"])
 
         if memory_config:
             result[end_user_id] = {

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -1082,7 +1082,7 @@ class MemoryConfigService:
         if app_type == AppType.AGENT:
             return self._extract_memory_config_id_from_agent(config)
         elif app_type in (AppType.WORKFLOW, AppType.PURE_WORKFLOW):
-            return self._extract_memory_config_id_from_workflow(config)
+            return None, False
         elif app_type == AppType.MULTI_AGENT:
             # Multi-agent 暂不支持记忆配置提取
             logger.debug(f"多智能体应用暂不支持记忆配置提取: app_type={app_type}")
@@ -1168,63 +1168,3 @@ class MemoryConfigService:
                 f"Agent 配置中 memory_config_id 格式无效: error={str(e)}"
             )
             return None, False
-
-    def _extract_memory_config_id_from_workflow(
-            self,
-            config: dict
-    ) -> tuple[Optional[uuid.UUID], bool]:
-        """从 Workflow 应用配置中提取 memory_config_id
-        
-        扫描工作流节点，查找 MemoryRead 或 MemoryWrite 节点。
-        返回第一个找到的记忆节点的 config_id。
-        
-        Args:
-            config: Workflow 配置字典
-            
-        Returns:
-            Tuple[Optional[uuid.UUID], bool]: (memory_config_id, is_legacy_int)
-                - memory_config_id: 记忆配置ID，如果不存在或为旧格式则返回 None
-                - is_legacy_int: 是否检测到旧格式 int 数据
-        """
-        nodes = config.get("nodes", [])
-
-        for node in nodes:
-            node_type = node.get("type", "")
-
-            # 检查是否为记忆节点 (support both formats: memory-read/memory-write and MemoryRead/MemoryWrite)
-            if node_type.lower() in ["memoryread", "memorywrite", "memory-read", "memory-write"]:
-                config_id = node.get("config", {}).get("config_id")
-
-                if config_id:
-                    try:
-                        # 处理字符串、UUID 和 int（旧数据兼容）三种情况
-                        if isinstance(config_id, uuid.UUID):
-                            return config_id, False
-                        elif isinstance(config_id, str):
-                            return uuid.UUID(config_id), False
-                        elif isinstance(config_id, int):
-                            resolved = self._resolve_config_id_old(config_id)
-                            if resolved:
-                                logger.info(
-                                    f"Resolved workflow legacy config_id_old={config_id} to config_id={resolved}: "
-                                    f"node_id={node.get('id')}, node_type={node_type}"
-                                )
-                                return resolved, False
-                            logger.warning(
-                                f"未找到工作流记忆节点 config_id_old={config_id} 对应的配置，将使用工作空间默认配置: "
-                                f"node_id={node.get('id')}, node_type={node_type}"
-                            )
-                            return None, True
-                        else:
-                            logger.warning(
-                                f"工作流记忆节点 config_id 格式无效: node_id={node.get('id')}, "
-                                f"node_type={node_type}, type={type(config_id)}"
-                            )
-                    except (ValueError, TypeError) as e:
-                        logger.warning(
-                            f"工作流记忆节点 config_id 格式无效: node_id={node.get('id')}, "
-                            f"node_type={node_type}, error={str(e)}"
-                        )
-
-        logger.debug("工作流配置中未找到记忆节点")
-        return None, False

--- a/api/app/services/shared_chat_service.py
+++ b/api/app/services/shared_chat_service.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict, Any, AsyncGenerator
 from deprecated import deprecated
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException, ResourceNotFoundException
 from app.core.logging_config import get_business_logger
@@ -254,7 +255,11 @@ class SharedChatService:
         # 添加长期记忆工具
         if memory:
             memory_config = config.get("memory", {})
-            memory_tool = create_long_term_memory_tool(memory_config, user_id)
+            memory_tool = create_long_term_memory_tool(
+                memory_config,
+                user_id,
+                release.app.workspace_id if release.app else None,
+            )
             if memory_tool:
                 tools.append(memory_tool)
 
@@ -294,17 +299,14 @@ class SharedChatService:
         )
 
         # 加载历史消息
-        history = []
-        memory_config = {"enabled": True, 'max_history': 10}
-        if memory_config.get("enabled"):
-            messages = self.conversation_service.get_messages(
-                conversation_id=conversation.id,
-                limit=memory_config.get("max_history", 10)
-            )
-            history = [
-                {"role": msg.role, "content": msg.content}
-                for msg in messages
-            ]
+        messages = self.conversation_service.get_messages(
+            conversation_id=conversation.id,
+            limit=settings.AGENT_MAX_HISTORY
+        )
+        history = [
+            {"role": msg.role, "content": msg.content}
+            for msg in messages
+        ]
 
         # 调用 Agent
         result = await agent.chat(
@@ -384,8 +386,6 @@ class SharedChatService:
 
         if variables is None:
             variables = {}
-        # 兼容新旧字段名：使用 memory_config_id
-        memory_config = {"enabled": memory, "memory_config_id": "17", "max_history": 10}
 
         try:
             # 获取发布版本和配置
@@ -464,7 +464,11 @@ class SharedChatService:
             # 添加长期记忆工具
             if memory:
                 memory_config = config.get("memory", {})
-                memory_tool = create_long_term_memory_tool(memory_config, user_id)
+                memory_tool = create_long_term_memory_tool(
+                    memory_config,
+                    user_id,
+                    release.app.workspace_id if release.app else None,
+                )
                 if memory_tool:
                     tools.append(memory_tool)
 
@@ -505,17 +509,14 @@ class SharedChatService:
             )
 
             # 加载历史消息
-            history = []
-            memory_config = {"enabled": True, 'max_history': 10}
-            if memory_config.get("enabled"):
-                messages = self.conversation_service.get_messages(
-                    conversation_id=conversation.id,
-                    limit=memory_config.get("max_history", 10)
-                )
-                history = [
-                    {"role": msg.role, "content": msg.content}
-                    for msg in messages
-                ]
+            messages = self.conversation_service.get_messages(
+                conversation_id=conversation.id,
+                limit=settings.AGENT_MAX_HISTORY
+            )
+            history = [
+                {"role": msg.role, "content": msg.content}
+                for msg in messages
+            ]
 
             # 发送开始事件
             yield f"event: start\ndata: {json.dumps({'conversation_id': str(conversation.id)}, ensure_ascii=False)}\n\n"

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -5393,6 +5393,7 @@ class WorkflowService:
             # 工作流引擎执行期间不需要 db，提前归还连接给连接池
             # execution 对象保持内存状态，事件处理时通过 self.db 懒重连写入
             # 写完后再调用 self.db.close() 归还连接
+            self.db.refresh(execution)
             self.db.close()
 
             async for event in execute_workflow_stream(


### PR DESCRIPTION
migrate memory config resolution from app release to workspace scope

The memory configuration resolution logic has been refactored to shift from app release-based lookup to workspace-based active config resolution. This includes:
- Replacing `_resolve_release_memory_config_id` with `_resolve_workspace_memory_config_id` in dispatcher
- Removing deprecated `config_id` field from memory node config schema
- Dropping `_extract_memory_config_id_from_workflow` as workflow apps no longer carry memory config in their release config
- Removing memory config validation and auto-update during app release flow
- Updating app service to use workspace ID from persisted App instance instead of passed app object

BREAKING CHANGE: Memory configuration is now exclusively resolved from workspace-level active config; app release configs no longer influence memory behavior. Existing workflow apps relying on embedded memory node config_id will fall back to workspace default.

## Summary by Sourcery

重构内存配置，使其在工作区级别进行解析，而不是按应用发布版本进行解析，从而简化长期记忆工具和工作流记忆节点的使用，使其始终使用工作区的活动内存配置。

增强点：
- 统一终端用户和批处理的内存配置查找逻辑，始终使用工作区级别的活动内存配置，而不是基于用户或发布版本绑定的 ID。
- 更新内存调度器、工作流内存节点和长期记忆工具，使其从会话或工作流所属的工作区中派生 `memory_config_id`，而不是从应用发布配置或节点的 `config_id` 字段中获取。
- 简化应用发布和回滚流程，移除基于内存配置驱动的终端用户迁移和发布时内存校验，改为依赖工作区默认配置。
- 移除已弃用的内存节点 `config_id` 字段及相关的 DSL 解析逻辑，将工作流内存行为统一标准化为仅依赖工作区级别配置。
- 将智能体与共享聊天历史加载逻辑标准化为使用全局 `AGENT_MAX_HISTORY` 设置，而不是每个应用的 `memory.max_history` 配置。
- 确保多智能体检查和内存工具的接线逻辑一致地使用持久化 `App` 记录和执行上下文中的工作区 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor memory configuration to be resolved at the workspace level instead of per app release, simplifying long-term memory tooling and workflow memory nodes to always use the workspace’s active memory config.

Enhancements:
- Unify end-user and batch memory configuration lookup to always use the active workspace-level memory config instead of per-user or release-bound IDs.
- Update memory dispatcher, workflow memory nodes, and long-term memory tools to derive memory_config_id from the conversation or workflow workspace rather than app release config or node config_id fields.
- Simplify app publishing and rollback flows by removing memory-config-driven end-user migrations and release-time memory validation, relying on workspace defaults instead.
- Remove deprecated memory node config_id fields and related DSL resolution logic, standardizing workflow memory behavior on workspace-level configuration only.
- Standardize agent and shared chat history loading on a global AGENT_MAX_HISTORY setting instead of per-app memory.max_history configuration.
- Ensure multi-agent checks and memory tool wiring consistently use workspace IDs from persisted App records and execution context.

</details>