### PR TITLE
feat(reflection-engine): add dynamic budget-based reflection and retr…

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -115,6 +115,7 @@ celery_app.conf.update(
         'app.tasks.do_layer2_reflection': {'queue': 'reflection_tasks'},
         'app.tasks.scan_layer2_dedup_full_scan': {'queue': 'periodic_tasks'},
         'app.tasks.do_layer2_dedup_full_scan': {'queue': 'reflection_tasks'},
+        'app.tasks.scan_reflection_retry': {'queue': 'periodic_tasks'},
         'app.tasks.regenerate_memory_cache': {'queue': 'periodic_tasks'},
         'app.tasks.refresh_hot_memory_tags_cache': {'queue': 'periodic_tasks'},
 
@@ -179,6 +180,7 @@ implicit_emotions_update_schedule = crontab(
 )
 layer2_reflection_schedule = timedelta(minutes=settings.LAYER2_REFLECTION_INTERVAL_MINUTES)
 layer2_dedup_full_scan_schedule = crontab(hour=settings.LAYER2_DEDUP_FULL_SCAN_HOUR, minute=0)
+reflection_retry_schedule = timedelta(minutes=settings.REFLECTION_RETRY_SCAN_INTERVAL_MINUTES)
 hot_memory_tags_refresh_schedule = crontab(hour=settings.HOT_MEMORY_TAGS_REFRESH_HOUR, minute=0)
 draft_data_clean_schedule = crontab(hour=settings.DRAFT_DATA_CLEAN_HOUR, minute=0)
 # 构建定时任务配置
@@ -218,6 +220,11 @@ beat_schedule_config = {
     "run-layer2-dedup-full-scan": {
         "task": "app.tasks.scan_layer2_dedup_full_scan",
         "schedule": layer2_dedup_full_scan_schedule,
+        "args": (),
+    },
+    "scan-reflection-retry": {
+        "task": "app.tasks.scan_reflection_retry",
+        "schedule": reflection_retry_schedule,
         "args": (),
     },
     "refresh-hot-memory-tags-cache": {

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -315,6 +315,15 @@ class Settings:
     REFLECT_LAYER2_INACTIVE_HOURS: int = TypeAdapter(
         Annotated[int, Field(ge=1, description="Layer 2 inactivity filter in hours, must be >= 1")]
     ).validate_python(int(os.getenv("REFLECT_LAYER2_INACTIVE_HOURS", "36")))
+    # Layer2 反思整轮总时间预算（秒）：高频 run() 与低频 _run_dedup_full_scan 共用。
+    # 应用层动态预算熔断的上限；500 = Celery soft_time_limit 540 留 40s 框架余量。
+    LAYER2_REFLECTION_BUDGET_SECONDS: int = TypeAdapter(
+        Annotated[int, Field(ge=1, description="Layer 2 reflection total time budget in seconds")]
+    ).validate_python(int(os.getenv("LAYER2_REFLECTION_BUDGET_SECONDS", "500")))
+
+    # 反思失败用户重试：派发任务扫描间隔（分钟）。默认 10。
+    # beat 注册需从 settings 读取，故放这里；其余重试策略常量在 retry_registry.py。
+    REFLECTION_RETRY_SCAN_INTERVAL_MINUTES: int = int(os.getenv("REFLECTION_RETRY_SCAN_INTERVAL_MINUTES", "10"))
     # 热门记忆标签缓存预热时间（UTC 小时，0-23）。19 = 北京时间 03:00
     HOT_MEMORY_TAGS_REFRESH_HOUR: int = TypeAdapter(
         Annotated[int, Field(ge=0, le=23, description="Hot memory tags cache refresh hour (UTC), 0-23. 19=Beijing 03:00")]

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/discard_cache.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/discard_cache.py
@@ -1,6 +1,6 @@
 """子问题 3 · 丢弃缓存：Redis 7天TTL，避免重复计算低分对"""
 import logging
-from app.aioRedis import get_redis_connection
+from app.aioRedis import get_thread_safe_redis
 
 logger = logging.getLogger(__name__)
 TTL_SECONDS = 7 * 24 * 3600  # 7 天
@@ -15,7 +15,9 @@ async def filter_discarded(end_user_id: str, candidates: list) -> list:
     """过滤掉近 7 天已评估过的低分对（批量 mget）"""
     if not candidates:
         return candidates
-    redis = await get_redis_connection()
+    # get_thread_safe_redis：按 pid+线程+loop 绑定连接池，避免 --pool=threads 下
+    # 复用全局 client 触发 "Future attached to a different loop"。
+    redis = get_thread_safe_redis()
     keys = [_cache_key(end_user_id, p.a_id, p.b_id) for p in candidates]
     results = await redis.mget(keys)
     return [p for p, cached in zip(candidates, results) if cached is None]
@@ -30,7 +32,7 @@ async def cache_discarded(end_user_id: str, discard_pool: list) -> None:
     """
     if not discard_pool:
         return
-    redis = await get_redis_connection()
+    redis = get_thread_safe_redis()
     pipe = redis.pipeline()
     for pair in discard_pool:
         key = _cache_key(end_user_id, pair.a_id, pair.b_id)

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel
 
 from app.core.utils.datetime_utils import utcnow_naive
+from app.core.config import settings
 from app.core.memory.storage_services.reflection_engine.deterministic.description_checker import (
     scan_merge_candidates,
 )
@@ -201,15 +202,41 @@ class Layer2Inspector:
         except Exception as e:
             logger.warning(f"[ReflectionSnapshot] 0_summary 落盘失败: {e}")
 
+    async def _run_step(self, name: str, end_user_id: str, coro,
+                        remaining: float) -> Dict[str, Any]:
+        """在剩余预算内执行一个子步骤。
+
+        remaining <= 0（预算耗尽）→ 关闭未 await 的协程并返回
+            {"status": "skipped", "reason": "budget_exhausted"}；
+        执行超出 remaining → 返回 {"status": "timeout"}；
+        否则返回子步骤原始结果。
+        """
+        if remaining <= 0:
+            logger.warning(f"[Layer2 高频] 预算耗尽跳过 {name} end_user_id={end_user_id}")
+            coro.close()                       # 关闭未 await 的协程，避免 "coroutine never awaited" 警告
+            return {"status": "skipped", "reason": "budget_exhausted"}
+        try:
+            return await asyncio.wait_for(coro, timeout=remaining)
+        except asyncio.TimeoutError:
+            logger.warning(f"[Layer2 高频] {name}超时跳过 end_user_id={end_user_id}")
+            return {"status": "timeout"}
+
     async def run(self, end_user_id: str, baseline: str = "HYBRID",
                   language: str = "zh") -> Dict[str, Any]:
-        """执行 Layer 2 巡检
+        """执行 Layer 2 巡检（动态预算熔断：应用层总耗时不超过 LAYER2_REFLECTION_BUDGET_SECONDS）。
 
-        执行顺序按架构设计：1→2→5→3→6→4
-        当前已实现子问题 3（去重）和 6（描述合并），其他预留。
+        执行顺序：未识别实体 → 别名归并 → 实体去重 → 元数据提取 → 描述合并。
+        预算不足以再起一步 → {"status":"skipped","reason":"budget_exhausted"}；
+        步骤自身超时 → {"status":"timeout"}；二者都跳过该步、不影响后续。
+        元数据提取未完成（skipped/timeout）时描述合并一并 skipped（强依赖：描述合并会清空 description 碎片）。
         """
-        results = {}
+        results: Dict[str, Any] = {}
         run_t0 = time.perf_counter()
+        deadline = run_t0 + settings.LAYER2_REFLECTION_BUDGET_SECONDS
+
+        def remaining() -> float:
+            return deadline - time.perf_counter()      # 不加下限，可为负，由 _run_step 判断
+
         logger.info(f"[Layer2] 巡检开始 end_user_id={end_user_id}, baseline={baseline}")
 
         # 反思快照（高频）：开关关闭时 recorder 内部 no-op，零开销
@@ -223,58 +250,76 @@ class Layer2Inspector:
             # TODO: 子问题 2 — 事实矛盾检测（fact_contradiction）
 
             # 未识别实体处理：把"未识别实体"语句解析成正式实体/关系并入图
-            unresolved = await self._run_unresolved_resolver(
-                end_user_id, baseline, language
+            unresolved = await self._run_step(
+                "未识别实体处理", end_user_id,
+                self._run_unresolved_resolver(end_user_id, baseline, language), remaining(),
             )
             results["unresolved_entity"] = unresolved
-            logger.info(
-                f"[Layer2 高频] 未识别实体处理完成 end_user_id={end_user_id}, "
-                f"候选={unresolved.get('total', 0)}, 解析={unresolved.get('resolved', 0)}, "
-                f"强制入库={unresolved.get('forced', 0)}, 失败={unresolved.get('failed', 0)}"
-            )
+            if unresolved.get("status") not in ("timeout", "skipped"):
+                logger.info(
+                    f"[Layer2 高频] 未识别实体处理完成 end_user_id={end_user_id}, "
+                    f"候选={unresolved.get('total', 0)}, 解析={unresolved.get('resolved', 0)}, "
+                    f"强制入库={unresolved.get('forced', 0)}, 失败={unresolved.get('failed', 0)}"
+                )
 
             # 别名归并：LLM 校验后按 merge/drop 处理 "别名属于" 关系
             # 放在 unresolved 之后、entity_dedup 之前：先清理别名节点
-            alias = await self._run_alias_merge(end_user_id, baseline, language)
-            results["alias_merge"] = alias
-            logger.info(
-                f"[Layer2 高频] 别名归并完成 end_user_id={end_user_id}, "
-                f"合并={alias.get('merge_count', 0)}, 丢弃={alias.get('drop_count', 0)}, "
-                f"边重定向={alias.get('edges_redirected', 0)}, 节点删除={alias.get('alias_nodes_deleted', 0)}, "
-                f"PG同步={alias.get('pg_synced', False)}"
+            alias = await self._run_step(
+                "别名归并", end_user_id,
+                self._run_alias_merge(end_user_id, baseline, language), remaining(),
             )
+            results["alias_merge"] = alias
+            if alias.get("status") not in ("timeout", "skipped"):
+                logger.info(
+                    f"[Layer2 高频] 别名归并完成 end_user_id={end_user_id}, "
+                    f"合并={alias.get('merge_count', 0)}, 丢弃={alias.get('drop_count', 0)}, "
+                    f"边重定向={alias.get('edges_redirected', 0)}, 节点删除={alias.get('alias_nodes_deleted', 0)}, "
+                    f"PG同步={alias.get('pg_synced', False)}"
+                )
 
             # 复杂去重消歧：两路召回候选 + LLM 判定后合并重复实体
-            dedup = await self._run_entity_dedup(end_user_id, baseline)
-            results["entity_dedup"] = dedup
-            logger.info(
-                f"[Layer2 高频] 实体去重完成 end_user_id={end_user_id}, "
-                f"候选={dedup.get('candidate_count', 0)}, LLM判定={dedup.get('llm_pool', 0)}, "
-                f"合并={dedup.get('merged_count', 0)}, 记录未合并={dedup.get('recorded_count', 0)}"
+            dedup = await self._run_step(
+                "实体去重", end_user_id,
+                self._run_entity_dedup(end_user_id, baseline), remaining(),
             )
+            results["entity_dedup"] = dedup
+            if dedup.get("status") not in ("timeout", "skipped"):
+                logger.info(
+                    f"[Layer2 高频] 实体去重完成 end_user_id={end_user_id}, "
+                    f"候选={dedup.get('candidate_count', 0)}, LLM判定={dedup.get('llm_pool', 0)}, "
+                    f"合并={dedup.get('merged_count', 0)}, 记录未合并={dedup.get('recorded_count', 0)}"
+                )
 
-            # 子问题 7 — 用户实体元数据提取
-            # 放在 description_merge 之前：metadata 提取的输入是 description 原始碎片，
-            # description_merge 会清空 description 并写入 description_summary
-            meta = await self._run_metadata_extraction(
-                end_user_id, language
+            # 元数据提取：输入是 description 原始碎片，必须在 description_merge（会清空碎片）之前
+            meta = await self._run_step(
+                "元数据提取", end_user_id,
+                self._run_metadata_extraction(end_user_id, language), remaining(),
             )
             results["metadata_extraction"] = meta
-            logger.info(
-                f"[Layer2 高频] 元数据提取完成 end_user_id={end_user_id}, "
-                f"提取={meta.get('extracted', 0)}, 失败={meta.get('failed', 0)}"
-            )
+            meta_ok = meta.get("status") not in ("timeout", "skipped")
+            if meta_ok:
+                logger.info(
+                    f"[Layer2 高频] 元数据提取完成 end_user_id={end_user_id}, "
+                    f"提取={meta.get('extracted', 0)}, 失败={meta.get('failed', 0)}"
+                )
 
-            # 描述合并：把同一实体的多条描述合并、必要时更名
-            desc = await self._run_description_merge(
-                end_user_id, baseline, language
-            )
-            results["description_merge"] = desc
-            logger.info(
-                f"[Layer2 高频] 描述合并完成 end_user_id={end_user_id}, "
-                f"候选={desc.get('candidate_count', 0)}, 合并={desc.get('merged_count', 0)}, "
-                f"失败={desc.get('failed_count', 0)}"
-            )
+            # 描述合并：强依赖元数据提取完成；元数据未完成则整体跳过，保留 description 碎片
+            if not meta_ok:
+                logger.warning(f"[Layer2 高频] 元数据未完成，描述合并跳过 end_user_id={end_user_id}")
+                results["description_merge"] = {"status": "skipped",
+                                                "reason": "metadata_extraction_incomplete"}
+            else:
+                desc = await self._run_step(
+                    "描述合并", end_user_id,
+                    self._run_description_merge(end_user_id, baseline, language), remaining(),
+                )
+                results["description_merge"] = desc
+                if desc.get("status") not in ("timeout", "skipped"):
+                    logger.info(
+                        f"[Layer2 高频] 描述合并完成 end_user_id={end_user_id}, "
+                        f"候选={desc.get('candidate_count', 0)}, 合并={desc.get('merged_count', 0)}, "
+                        f"失败={desc.get('failed_count', 0)}"
+                    )
 
             # TODO: 子问题 4 — 本体 Metadata 校验（metadata_validation）
 
@@ -618,102 +663,110 @@ class Layer2Inspector:
                 extra={"loser_id": p.b_id, "probability": p.probability},
             ))
 
-        # 5. LLM 判定（所有候选均需 LLM 确认）— 计时
-        t0 = time.perf_counter()
-        llm_results = await judge_batch(
-            self.llm_client, llm_pool,
-            config.merge_concurrency,
-        )
-        llm_ms = int((time.perf_counter() - t0) * 1000)
-
-        # 快照：LLM 池 + 逐对裁决（pair 用名字便于阅读，另带 id 定位）
-        if snap_on:
-            self._snap("entity_dedup", "2_llm_raw", {
-                "llm_pool": [f"{p.a_name} ↔ {p.b_name}" for p in llm_pool],
-                "decisions": [
-                    {"pair": f"{pair.a_name} ↔ {pair.b_name}",
-                     "a_id": pair.a_id, "b_id": pair.b_id,
-                     "same_entity": bool(d and d.same_entity),
-                     "confidence": (d.confidence if d else 0.0),
-                     "winner_id": (d.winner_id if d else "a"),
-                     "merged_name": (d.merged_name if d else ""),
-                     "new_aliases": (d.new_aliases if d else []),
-                     "reason": (d.reason if d else "")}
-                    for pair, d in llm_results
-                ],
-            })
-
-        # 均摊耗时（每对候选分摊批量耗时）
-        n = max(len(llm_pool), 1)
-        step_timing = {
-            "recall_ms": recall_ms // n,
-            "score_ms": score_ms // n,
-            "llm_ms": llm_ms // n,
-        }
-
-        # 6. 合并执行（全部经 LLM 确认后才合并）
-        # merged_count 已在 3.5 直合池处初始化，与直合共享上限
+        # 5+6. 分块 judge → merge → commit（替换原「整池 judge 后统一合并」）
+        # 每块判完立即逐对合并并提交，中断（软超时/熔断 wait_for 取消）时已提交的块保住，多轮可收敛。
+        # merged_count 已在 3.5 直合池处初始化，与直合共享上限。
         recorded_count = 0
-        rejected_pairs = []
-        for pair, decision in llm_results:
-            if merged_count >= config.max_merges_per_run:
-                break
-            if decision and decision.same_entity and decision.confidence >= config.llm_merge_threshold:
-                success = await self._apply_dedup_merge(pair, end_user_id, baseline, llm_decision=decision, step_timing=step_timing)
-                if success:
-                    merged_count += 1
-                    # 快照：LLM 确认合并
-                    snap_changes.append(change(
-                        "entity", "merge", target_id=pair.a_id, target_name=pair.a_name,
-                        extra={"loser_id": pair.b_id, "confidence": decision.confidence,
-                               "source": "llm"},
-                    ))
-            else:
-                # LLM 拒绝或 confidence 不够 → 收集待写缓存 + 写 recorded 日志
-                rejected_pairs.append(pair)
-                reason = decision.reason if decision else "LLM 判定失败"
-                conf = decision.confidence if decision else 0.0
-                entity_a = {"entity_id": pair.a_id, "name": pair.a_name, "entity_type": pair.entity_type,
-                            "description": pair.a_desc, "aliases": pair.a_aliases}
-                entity_b = {"entity_id": pair.b_id, "name": pair.b_name, "entity_type": pair.entity_type,
-                            "description": pair.b_desc, "aliases": pair.b_aliases}
-                self._write_dedup_log(
-                    end_user_id=end_user_id,
-                    keeper=entity_a, loser=entity_b,
-                    entity_type=pair.entity_type,
-                    merged_name="", merged_aliases=[],
-                    confidence=conf,
-                    execution_detail={
-                        "steps": [
-                            {"name": "候选召回", "type": "prompt", "duration_ms": step_timing.get("recall_ms"),
-                             "output": f"sim_name={pair.sim_name:.2f}, sim_embed={pair.sim_embed:.2f}", "success": True},
-                            {"name": "综合打分", "type": "decide", "duration_ms": step_timing.get("score_ms"),
-                             "output": f"P={pair.probability:.2f}", "success": True},
-                            {"name": "LLM 判定", "type": "llm", "duration_ms": step_timing.get("llm_ms"),
-                             "output": f"same_entity=False, confidence={conf:.2f}", "success": True},
-                        ],
-                        "total_ms": sum(v for v in step_timing.values() if v),
-                        "model": getattr(self.llm_client, "model_name", ""),
-                    },
-                    reason=reason,
-                    status="recorded", strategy="NO_OP",
-                    baseline=baseline,
+        chunk_size = max(config.merge_concurrency, 1)   # 块大小=并发数，每块一个并发波
+        n = max(len(llm_pool), 1)                       # 均摊 recall/score 计时用，近似即可
+        snap_decisions: list = []                       # 2_llm_raw 裁决按块累积，出循环统一落
+        try:
+            for start in range(0, len(llm_pool), chunk_size):
+                if merged_count >= config.max_merges_per_run:
+                    break
+                chunk = llm_pool[start:start + chunk_size]
+
+                # 块内并发判定（复用 judge_batch，只判这一块）— 计时
+                t0 = time.perf_counter()
+                chunk_results = await judge_batch(
+                    self.llm_client, chunk, config.merge_concurrency,
                 )
-                recorded_count += 1
-                # 快照：LLM 拒绝（NO_OP）
-                snap_changes.append(change(
-                    "entity", "merge", target_id=pair.a_id, target_name=pair.a_name,
-                    status="rejected", reason="llm_no_op",
-                    extra={"loser_id": pair.b_id, "confidence": conf},
-                ))
+                llm_ms = int((time.perf_counter() - t0) * 1000)
+                step_timing = {
+                    "recall_ms": recall_ms // n,
+                    "score_ms": score_ms // n,
+                    "llm_ms": llm_ms // max(len(chunk), 1),
+                }
 
-        # 批量写入丢弃缓存（一次 Redis 往返）
-        if rejected_pairs:
-            await cache_discarded(end_user_id, rejected_pairs)
+                # 判完立刻合并 + 提交这一块（每对 _apply_dedup_merge 内部自带 commit + 写 ReflectionLog）
+                rejected_pairs = []
+                for pair, decision in chunk_results:
+                    if snap_on:
+                        snap_decisions.append({
+                            "pair": f"{pair.a_name} ↔ {pair.b_name}",
+                            "a_id": pair.a_id, "b_id": pair.b_id,
+                            "same_entity": bool(decision and decision.same_entity),
+                            "confidence": (decision.confidence if decision else 0.0),
+                            "winner_id": (decision.winner_id if decision else "a"),
+                            "merged_name": (decision.merged_name if decision else ""),
+                            "new_aliases": (decision.new_aliases if decision else []),
+                            "reason": (decision.reason if decision else ""),
+                        })
+                    if merged_count >= config.max_merges_per_run:
+                        break
+                    if decision and decision.same_entity and decision.confidence >= config.llm_merge_threshold:
+                        success = await self._apply_dedup_merge(
+                            pair, end_user_id, baseline,
+                            llm_decision=decision, step_timing=step_timing)
+                        if success:
+                            merged_count += 1
+                            # 快照：LLM 确认合并
+                            snap_changes.append(change(
+                                "entity", "merge", target_id=pair.a_id, target_name=pair.a_name,
+                                extra={"loser_id": pair.b_id, "confidence": decision.confidence,
+                                       "source": "llm"},
+                            ))
+                    else:
+                        # LLM 拒绝或 confidence 不够 → 收集待写缓存 + 写 recorded 日志
+                        rejected_pairs.append(pair)
+                        reason = decision.reason if decision else "LLM 判定失败"
+                        conf = decision.confidence if decision else 0.0
+                        entity_a = {"entity_id": pair.a_id, "name": pair.a_name, "entity_type": pair.entity_type,
+                                    "description": pair.a_desc, "aliases": pair.a_aliases}
+                        entity_b = {"entity_id": pair.b_id, "name": pair.b_name, "entity_type": pair.entity_type,
+                                    "description": pair.b_desc, "aliases": pair.b_aliases}
+                        self._write_dedup_log(
+                            end_user_id=end_user_id,
+                            keeper=entity_a, loser=entity_b,
+                            entity_type=pair.entity_type,
+                            merged_name="", merged_aliases=[],
+                            confidence=conf,
+                            execution_detail={
+                                "steps": [
+                                    {"name": "候选召回", "type": "prompt", "duration_ms": step_timing.get("recall_ms"),
+                                     "output": f"sim_name={pair.sim_name:.2f}, sim_embed={pair.sim_embed:.2f}", "success": True},
+                                    {"name": "综合打分", "type": "decide", "duration_ms": step_timing.get("score_ms"),
+                                     "output": f"P={pair.probability:.2f}", "success": True},
+                                    {"name": "LLM 判定", "type": "llm", "duration_ms": step_timing.get("llm_ms"),
+                                     "output": f"same_entity=False, confidence={conf:.2f}", "success": True},
+                                ],
+                                "total_ms": sum(v for v in step_timing.values() if v),
+                                "model": getattr(self.llm_client, "model_name", ""),
+                            },
+                            reason=reason,
+                            status="recorded", strategy="NO_OP",
+                            baseline=baseline,
+                        )
+                        recorded_count += 1
+                        # 快照：LLM 拒绝（NO_OP）
+                        snap_changes.append(change(
+                            "entity", "merge", target_id=pair.a_id, target_name=pair.a_name,
+                            status="rejected", reason="llm_no_op",
+                            extra={"loser_id": pair.b_id, "confidence": conf},
+                        ))
 
-        # 快照：落 3_changes（空轮 snap_on=False 时不写）
-        if snap_on:
-            self._snap_changes("entity_dedup", snap_changes)
+                # 丢弃缓存按块写（中断不丢本块缓存；缓存是优化项，丢失不影响正确性）
+                if rejected_pairs:
+                    await cache_discarded(end_user_id, rejected_pairs)
+        finally:
+            # 快照 finally 落盘：正常仅一次上传（零额外开销），软超时/熔断取消时也落已累积的 change。
+            # _snap / _snap_changes 均为同步、自带 try/except，可在 finally 安全调用。
+            if snap_on:
+                self._snap("entity_dedup", "2_llm_raw", {
+                    "llm_pool": [f"{p.a_name} ↔ {p.b_name}" for p in llm_pool],
+                    "decisions": snap_decisions,
+                })
+                self._snap_changes("entity_dedup", snap_changes)
 
         return {
             "status": "success",
@@ -749,11 +802,18 @@ class Layer2Inspector:
         finally:
             self._snap_summary({"entity_dedup": result})
 
-    async def _run_dedup_full_scan(self, end_user_id: str, baseline: str = "HYBRID") -> Dict[str, Any]:
-        """子问题 3 复杂去重 方案B：低频全量扫描去重"""
+    async def _process_one_type(self, type_row: Dict[str, Any], end_user_id: str, baseline: str,
+                                snap_input: list, snap_llm: list, snap_changes: list,
+                                ) -> Dict[str, Any]:
+        """处理单个实体类型的去重，返回 {scanned, merged, direct_merged}。
+
+        被 _run_dedup_full_scan 的 wait_for 包裹，可在预算耗尽时被取消；
+        已 commit 的 merge 保留，未 update_scan_time 的类型下轮由 check_new_entities 续扫。
+        快照按类型累积进入参数容器，由主循环在出循环后统一落盘。
+        类型内分块 judge → merge → commit：单类型判不完时已提交的块也保住。
+        """
         from .deterministic.full_scan_dedup import (
-            get_entity_types, get_last_scan_time, check_new_entities,
-            fetch_entities_by_type, update_scan_time,
+            get_last_scan_time, check_new_entities, fetch_entities_by_type, update_scan_time,
         )
         from .llm.entity_dedup_batch_judge import judge_batch_dedup
         from .deterministic.cypher_merger import (
@@ -762,89 +822,81 @@ class Layer2Inspector:
         )
 
         config = self.dedup_config
-        total_merged = 0
-        total_direct_merged = 0
-        scanned_types = 0
-        # 快照累积（跨类型聚合到 entity_dedup 一个子目录）
-        snap_input: list = []
-        snap_llm: list = []
-        snap_changes: list = []
+        entity_type = type_row["entity_type"]
+        count = type_row["count"]
 
-        entity_types = await get_entity_types(self.connector, end_user_id)
+        if count < config.min_entities_for_scan:
+            return {"scanned": False, "merged": 0, "direct_merged": 0}
 
-        for type_row in entity_types:
-            entity_type = type_row["entity_type"]
-            count = type_row["count"]
+        last_time = await get_last_scan_time(end_user_id, entity_type)
+        if last_time:
+            new_count = await check_new_entities(
+                self.connector, end_user_id, entity_type, last_time)
+            if new_count == 0:
+                return {"scanned": False, "merged": 0, "direct_merged": 0}
 
-            if count < config.min_entities_for_scan:
+        entities = await fetch_entities_by_type(self.connector, end_user_id, entity_type)
+
+        # 快照：1_input（按类型分组的实体）；description 截断、aliases 限长以控体积
+        snap_input.append({
+            "scanned_type": entity_type,
+            "entity_count": len(entities),
+            "entities": [
+                {"entity_id": e.get("entity_id"), "name": e.get("name"),
+                 "entity_type": e.get("entity_type"),
+                 "description": _snap_trunc_text(e.get("description")),
+                 "aliases": e.get("aliases") or []}
+                for e in entities
+            ],
+        })
+
+        # 同名同类型直合（确定性快路）：分组内 name 完全相同 → 直接合并不进 LLM
+        # 受 max_pairs_per_run 限制；被合并的实体从 entities 剔除，避免送 LLM 浪费
+        direct_merged_count, removed_ids = await self._direct_merge_in_group(
+            entities, entity_type, end_user_id, baseline,
+            max_merges=config.max_pairs_per_run,
+            snap_sink=snap_changes,
+        )
+        if removed_ids:
+            entities = [e for e in entities if e["entity_id"] not in removed_ids]
+
+        # 类型内分块 judge → merge → commit（替换原「整类型 judge_batch_dedup 后统一合并」）
+        merged_count = 0
+        chunk = max(config.merge_concurrency, 1)
+        snap_pairs: list = []
+        for start in range(0, len(entities), chunk):
+            if (merged_count + direct_merged_count) >= config.max_pairs_per_run:
+                break
+            group = entities[start:start + chunk]
+            if len(group) < 2:
                 continue
 
-            last_time = await get_last_scan_time(end_user_id, entity_type)
-            if last_time:
-                new_count = await check_new_entities(
-                    self.connector, end_user_id, entity_type, last_time)
-                if new_count == 0:
-                    continue
-
-            scanned_types += 1
-            entities = await fetch_entities_by_type(self.connector, end_user_id, entity_type)
-
-            # 快照：1_input（按类型分组的实体）；description 截断、aliases 限长以控体积
-            snap_input.append({
-                "scanned_type": entity_type,
-                "entity_count": len(entities),
-                "entities": [
-                    {"entity_id": e.get("entity_id"), "name": e.get("name"),
-                     "entity_type": e.get("entity_type"),
-                     "description": _snap_trunc_text(e.get("description")),
-                     "aliases": e.get("aliases") or []}
-                    for e in entities
-                ],
-            })
-
-            # 同名同类型直合（确定性快路）：分组内 name 完全相同 → 直接合并不进 LLM
-            # 受 max_pairs_per_run 限制；被合并的实体从 entities 剔除，避免送 LLM 浪费
-            direct_merged_count, removed_ids = await self._direct_merge_in_group(
-                entities, entity_type, end_user_id, baseline,
-                max_merges=config.max_pairs_per_run,
-                snap_sink=snap_changes,
-            )
-            total_merged += direct_merged_count
-            total_direct_merged += direct_merged_count
-            if removed_ids:
-                entities = [e for e in entities if e["entity_id"] not in removed_ids]
-            # LLM 分组判定 — 计时
+            # LLM 分组判定（只判这一块）— 计时
             t0 = time.perf_counter()
-            pairs = await judge_batch_dedup(self.llm_client, entities, entity_type)
+            pairs = await judge_batch_dedup(self.llm_client, group, entity_type)
             llm_ms = int((time.perf_counter() - t0) * 1000)
             llm_ms_per_pair = llm_ms // max(len(pairs), 1)
 
-            # 快照：2_llm_raw（judge_batch_dedup 元组裁决，idx 映射成名字便于阅读）
             def _ename(idx):
-                return entities[idx]["name"] if 0 <= idx < len(entities) else None
+                return group[idx]["name"] if 0 <= idx < len(group) else None
 
             def _eid(idx):
-                return entities[idx]["entity_id"] if 0 <= idx < len(entities) else None
+                return group[idx]["entity_id"] if 0 <= idx < len(group) else None
 
-            snap_llm.append({
-                "scanned_type": entity_type,
-                "pairs": [
-                    {"pair": f"{_ename(ia)} ↔ {_ename(ib)}",
-                     "a_id": _eid(ia), "b_id": _eid(ib), "idx_a": ia, "idx_b": ib,
-                     "confidence": cf, "new_name": nn, "new_aliases": na, "reason": rs}
-                    for (ia, ib, cf, rs, nn, na) in pairs
-                ],
-            })
-
-            merged_count = 0
             for idx_a, idx_b, conf, reason, new_name, new_aliases in pairs:
+                # 快照：2_llm_raw（judge_batch_dedup 元组裁决，idx 映射成名字便于阅读）
+                snap_pairs.append({
+                    "pair": f"{_ename(idx_a)} ↔ {_ename(idx_b)}",
+                    "a_id": _eid(idx_a), "b_id": _eid(idx_b), "idx_a": idx_a, "idx_b": idx_b,
+                    "confidence": conf, "new_name": new_name, "new_aliases": new_aliases, "reason": reason,
+                })
                 # 单类型 LLM 合并数 + 直合数共享 max_pairs_per_run 上限
                 if (merged_count + direct_merged_count) >= config.max_pairs_per_run:
                     break
                 if idx_a == idx_b:
                     continue  # 跳过无效对（同一实体）
 
-                ea, eb = entities[idx_a], entities[idx_b]
+                ea, eb = group[idx_a], group[idx_b]
                 if ea["entity_id"] == eb["entity_id"]:
                     continue  # 跳过同 ID 实体
 
@@ -906,19 +958,81 @@ class Layer2Inspector:
                         },
                     )
 
-            total_merged += merged_count
-            await update_scan_time(end_user_id, entity_type)
+        snap_llm.append({"scanned_type": entity_type, "pairs": snap_pairs})
+        await update_scan_time(end_user_id, entity_type)
+        return {"scanned": True,
+                "merged": direct_merged_count + merged_count,
+                "direct_merged": direct_merged_count}
 
-        # 快照：扫描到类型才落盘（空轮不产生文件）
-        if scanned_types > 0:
-            self._snap("entity_dedup", "1_input", {"types": snap_input})
-            self._snap("entity_dedup", "2_llm_raw", {"types": snap_llm})
-            self._snap_changes("entity_dedup", snap_changes)
+    async def _run_dedup_full_scan(self, end_user_id: str, baseline: str = "HYBRID") -> Dict[str, Any]:
+        """子问题 3 复杂去重 方案B：低频全量扫描去重。
+
+        按实体类型循环，每个类型套 wait_for(剩余预算)：整轮总耗时不超过
+        LAYER2_REFLECTION_BUDGET_SECONDS。预算耗尽/类型超时 → truncated 停本轮（剩余类型留下轮）；
+        单类型真异常 → had_type_error 跳过继续。快照跨类型累积、出循环统一落盘。
+        """
+        from .deterministic.full_scan_dedup import get_entity_types
+        from celery.exceptions import SoftTimeLimitExceeded
+
+        entity_types = await get_entity_types(self.connector, end_user_id)
+        deadline = time.perf_counter() + settings.LAYER2_REFLECTION_BUDGET_SECONDS
+
+        def remaining() -> float:
+            return deadline - time.perf_counter()      # 不加下限，可为负
+
+        scanned_types = 0
+        total_merged = 0
+        total_direct_merged = 0
+        truncated = False
+        had_type_error = False
+        # 快照累积（跨类型聚合到 entity_dedup 一个子目录）
+        snap_input: list = []
+        snap_llm: list = []
+        snap_changes: list = []
+
+        try:
+            for type_row in entity_types:
+                if remaining() <= 0:                    # 预算耗尽，不再开新类型
+                    truncated = True
+                    break
+                entity_type = type_row["entity_type"]
+                try:
+                    r = await asyncio.wait_for(
+                        self._process_one_type(type_row, end_user_id, baseline,
+                                               snap_input, snap_llm, snap_changes),
+                        timeout=remaining(),
+                    )
+                except asyncio.TimeoutError:            # 该类型没在预算内做完
+                    truncated = True
+                    logger.warning(f"[Layer2 低频] 类型超时未完成 type={entity_type}")
+                    break                               # 预算没了，剩余类型留给下次调度
+                except SoftTimeLimitExceeded:           # 防御：万一仍触发软超时
+                    truncated = True
+                    logger.warning(f"[Layer2 低频] 触发软超时 type={entity_type}")
+                    break
+                except Exception as e:                  # 单类型真异常：跳过、继续下一个
+                    had_type_error = True
+                    logger.warning(f"[Layer2 低频] 类型处理失败 type={entity_type}: {e}")
+                    continue
+
+                if r["scanned"]:
+                    scanned_types += 1
+                total_merged += r["merged"]
+                total_direct_merged += r["direct_merged"]
+        finally:
+            # 快照：扫描到类型才落盘（空轮不产生文件），中断也保留已累积内容
+            if scanned_types > 0:
+                self._snap("entity_dedup", "1_input", {"types": snap_input})
+                self._snap("entity_dedup", "2_llm_raw", {"types": snap_llm})
+                self._snap_changes("entity_dedup", snap_changes)
 
         return {
             "scanned_types": scanned_types,
             "merged_count": total_merged,
             "direct_merged_count": total_direct_merged,
+            "total_types": len(entity_types),     # 新增
+            "truncated": truncated,               # 新增：预算耗尽/类型超时未扫完
+            "had_type_error": had_type_error,     # 新增：有类型抛异常被兜底跳过
         }
     @staticmethod
     def _merged_description(keeper_desc: str, loser_desc: str) -> str:

--- a/api/app/core/memory/storage_services/reflection_engine/retry_registry.py
+++ b/api/app/core/memory/storage_services/reflection_engine/retry_registry.py
@@ -1,0 +1,223 @@
+"""反思失败用户重试登记（纯 Redis 运维态）。
+
+两个 key 成对（pipeline 原子）：
+- ZSet  reflection:retry:{task_type}            member=end_user_id, score=下次可见时间戳(epoch 秒)
+- String reflection:retry:meta:{task_type}:{uid} JSON：重跑参数 + 状态
+
+task_type ∈ {"high_freq", "dedup"}。completion ∈ {in_progress, partial, failed, exhausted}。
+rc 为 None（Redis 不可用）时所有写接口安全 no-op（仅 warning），不影响反思主流程。
+"""
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from app.core.utils.datetime_utils import utcnow, to_timestamp_ms
+
+logger = logging.getLogger(__name__)
+
+# 重试登记内部策略常量（运维态调参，改这一处即可；非部署必填项，故不进 Settings）。
+# 派发扫描间隔在 settings.REFLECTION_RETRY_SCAN_INTERVAL_MINUTES（beat 注册需从 settings 读）。
+RETRY_LEASE_SECONDS = 900       # 开工租约时长（秒），必须 > 硬超时 600，确保任务必然已结束才判进程死亡
+RETRY_MAX = 5                   # 「跑完但无推进」最大重试次数，超过置 exhausted 出队
+RETRY_DEAD_MAX = 3              # 「进程死亡（租约到期）」最大兜底次数，超过置 exhausted
+RETRY_BACKOFF_BASE = 1800       # 指数退避基数（秒），30 分钟
+RETRY_BACKOFF_CAP = 21600       # 退避封顶（秒），6 小时
+RETRY_TTL_SECONDS = 604800      # meta key TTL（秒），7 天，到期自动放弃永久不活跃用户
+RETRY_BATCH = 200               # 派发任务每轮每队列最多取多少到点用户，防集体失败灌爆队列
+
+
+def _zkey(task_type: str) -> str:
+    return f"reflection:retry:{task_type}"
+
+
+def _mkey(task_type: str, uid: str) -> str:
+    return f"reflection:retry:meta:{task_type}:{uid}"
+
+
+def load_meta(rc, task_type: str, uid: str) -> Optional[Dict[str, Any]]:
+    """读 meta JSON；不存在 / Redis 不可用 / 解析失败 → None。"""
+    if rc is None:
+        return None
+    try:
+        raw = rc.get(_mkey(task_type, uid))
+        if not raw:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return json.loads(raw)
+    except Exception as e:
+        logger.warning(f"[ReflectionRetry] load_meta 失败 task_type={task_type} uid={uid}: {e}")
+        return None
+
+
+def lease(rc, task_type: str, uid: str, params: Dict[str, Any],
+          from_retry: bool) -> None:
+    """开工登记：标 in_progress，score=now+租约。
+
+    from_retry=True（重试派发续约）→ 保留 retry_count/dead_count；
+    from_retry=False（正常 scan 新一轮）→ 重置计数、清 exhausted（给新调度周期新预算）。
+    """
+    if rc is None:
+        logger.warning(f"[ReflectionRetry] Redis 不可用，跳过 lease uid={uid}")
+        return
+    try:
+        old = load_meta(rc, task_type, uid) or {}
+        if from_retry:
+            retry_count = old.get("retry_count", 0)
+            dead_count = old.get("dead_count", 0)
+        else:
+            retry_count = 0
+            dead_count = 0
+        meta = {
+            **params,                      # config_id / workspace_id /（高频）iteration_period
+            "completion": "in_progress",
+            "retry_count": retry_count,
+            "dead_count": dead_count,
+            "leased_at": to_timestamp_ms(utcnow()),
+        }
+        score = time.time() + RETRY_LEASE_SECONDS
+        pipe = rc.pipeline()
+        pipe.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
+                 ex=RETRY_TTL_SECONDS)
+        pipe.zadd(_zkey(task_type), {uid: score})
+        pipe.execute()
+    except Exception as e:
+        logger.warning(f"[ReflectionRetry] lease 失败 task_type={task_type} uid={uid}: {e}")
+
+
+def resolve(rc, task_type: str, uid: str) -> None:
+    """completion==full：成对删除 member + meta。"""
+    if rc is None:
+        return
+    try:
+        pipe = rc.pipeline()
+        pipe.zrem(_zkey(task_type), uid)
+        pipe.delete(_mkey(task_type, uid))
+        pipe.execute()
+    except Exception as e:
+        logger.warning(f"[ReflectionRetry] resolve 失败 task_type={task_type} uid={uid}: {e}")
+
+
+def record(rc, task_type: str, uid: str, completion: str, progressed: bool,
+           skipped_steps: Optional[List[str]] = None, last_error: str = "") -> None:
+    """completion==partial/failed：累计 retry_count（有推进则重置 0），指数退避更新 score；
+    达 REFLECTION_RETRY_MAX → exhausted 出队（meta 留待 TTL）。"""
+    if rc is None:
+        logger.warning(f"[ReflectionRetry] Redis 不可用，跳过 record uid={uid}")
+        return
+    try:
+        old = load_meta(rc, task_type, uid) or {}
+        retry_count = 0 if progressed else old.get("retry_count", 0) + 1
+        if retry_count >= RETRY_MAX:
+            _set_exhausted(rc, task_type, uid, old, last_error or "retry_max")
+            return
+        # 有推进：score=now，下次扫描立即可见；无推进：指数退避
+        if progressed:
+            score = time.time()
+        else:
+            backoff = min(RETRY_BACKOFF_BASE * (2 ** retry_count), RETRY_BACKOFF_CAP)
+            score = time.time() + backoff
+        meta = {
+            **old,
+            "completion": completion,
+            "retry_count": retry_count,
+            "skipped_steps": skipped_steps or [],
+            "last_error": last_error,
+            "last_failed_at": to_timestamp_ms(utcnow()),
+        }
+        pipe = rc.pipeline()
+        pipe.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
+                 ex=RETRY_TTL_SECONDS)
+        pipe.zadd(_zkey(task_type), {uid: score})
+        pipe.execute()
+    except Exception as e:
+        logger.warning(f"[ReflectionRetry] record 失败 task_type={task_type} uid={uid}: {e}")
+
+
+def mark_dead(rc, task_type: str, uid: str) -> bool:
+    """租约到期且仍 in_progress：判定上次开工后进程死亡，dead_count+1。
+
+    未超 REFLECTION_RETRY_DEAD_MAX → 留在队列等重派，返回 True（可重派）；
+    达上限 → exhausted 出队，返回 False（不再重派）。
+    """
+    if rc is None:
+        return False
+    try:
+        old = load_meta(rc, task_type, uid) or {}
+        dead_count = old.get("dead_count", 0) + 1
+        if dead_count >= RETRY_DEAD_MAX:
+            _set_exhausted(rc, task_type, uid, old, "process_dead_max")
+            return False
+        meta = {**old, "dead_count": dead_count, "last_failed_at": to_timestamp_ms(utcnow())}
+        rc.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
+               ex=RETRY_TTL_SECONDS)
+        return True
+    except Exception as e:
+        logger.warning(f"[ReflectionRetry] mark_dead 失败 task_type={task_type} uid={uid}: {e}")
+        return False
+
+
+def _set_exhausted(rc, task_type: str, uid: str, old: Dict[str, Any], last_error: str) -> None:
+    """置 exhausted、移出 ZSet；meta 保留（completion=exhausted）等 TTL 过期，便于查询。"""
+    meta = {**old, "completion": "exhausted", "last_error": last_error,
+            "last_failed_at": to_timestamp_ms(utcnow())}
+    pipe = rc.pipeline()
+    pipe.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
+             ex=RETRY_TTL_SECONDS)
+    pipe.zrem(_zkey(task_type), uid)
+    pipe.execute()
+    logger.warning(f"[ReflectionRetry] 置 exhausted 出队 task_type={task_type} uid={uid} reason={last_error}")
+
+
+# ---- completion / progressed 解析（从 run() 返回的 results 读，不额外探测）----
+
+_LAYER2_STEPS = ["unresolved_entity", "alias_merge", "entity_dedup",
+                 "metadata_extraction", "description_merge"]
+
+
+def completion_of_layer2(results: Dict[str, Any]) -> str:
+    """高频：任一步骤 status ∈ {timeout, skipped, error} → partial；否则 full。
+    条目级 failed_count 不算未完成（步骤 status 仍为 success）。"""
+    for k in _LAYER2_STEPS:
+        st = (results.get(k) or {}).get("status")
+        if st in ("timeout", "skipped", "error"):
+            return "partial"
+    return "full"
+
+
+def completion_of_dedup(r: Dict[str, Any]) -> str:
+    """低频：truncated 或 had_type_error → partial；否则 full。"""
+    if r.get("truncated") or r.get("had_type_error"):
+        return "partial"
+    return "full"
+
+
+def progressed_layer2(results: Dict[str, Any]) -> bool:
+    """高频是否有推进（覆盖 5 个子步骤中任一产生真实写入）：
+    未识别实体解析/强制入库、别名归并合并/丢弃边、实体去重合并、
+    元数据提取写入、描述合并。任一 > 0 视为本轮收缩了后续工作量，用于重置 retry_count。
+
+    字段名以各 _run_* 返回为准：alias_merge 用 merge_count/drop_count（非 merged_count），
+    metadata_extraction 用 extracted（仅统计真正写入 patch 的实体，静态数据不会虚报）。"""
+    unresolved = results.get("unresolved_entity") or {}
+    alias = results.get("alias_merge") or {}
+    dedup = results.get("entity_dedup") or {}
+    meta = results.get("metadata_extraction") or {}
+    desc = results.get("description_merge") or {}
+    return bool(unresolved.get("resolved", 0) or unresolved.get("forced", 0)
+                or alias.get("merge_count", 0) or alias.get("drop_count", 0)
+                or dedup.get("merged_count", 0)
+                or meta.get("extracted", 0)
+                or desc.get("merged_count", 0))
+
+
+def progressed_dedup(r: Dict[str, Any]) -> bool:
+    """低频是否有推进：有合并或扫描到类型。"""
+    return bool(r.get("merged_count", 0) or r.get("scanned_types", 0))
+
+
+def skipped_steps_of_layer2(results: Dict[str, Any]) -> List[str]:
+    """高频命中的未完成步骤名，供 record 记录便于排查。"""
+    return [k for k in _LAYER2_STEPS
+            if (results.get(k) or {}).get("status") in ("timeout", "skipped", "error")]

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -20,6 +20,7 @@ from sqlalchemy import select, cast, String
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
+from app.core.memory.storage_services.reflection_engine import retry_registry as rr
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
@@ -1871,88 +1872,50 @@ def write_message_task(
             _shutdown_loop_gracefully(loop)
 
 
-def _should_skip_reflection_by_inactivity(db, end_user_id: str, inactive_hours: int | None = None) -> bool:
-    """反思任务前置过滤：用户最近一次会话更新距今 >= inactive_hours 小时则跳过。
+def _is_active_recently(db, end_user_id: str, inactive_hours: int | None = None) -> bool:
+    """用户是否活跃：end_user.write_time 距今 < inactive_hours 小时（NULL 或读取失败视为不活跃）。
 
-    通过 conversations.user_id（存的是 end_user_id 的 UUID 字符串）取该用户所有会话
-    的最新 updated_at（最后写入时间），与当前 UTC 时间比较。
-
-    Args:
-        inactive_hours: 不活跃阈值（小时）。为 None 时取 settings.REFLECT_LAYER2_INACTIVE_HOURS。
-
-    Returns:
-        True  -> 跳过反思（无会话记录，或最近更新已超过 inactive_hours 小时）
-        False -> 正常执行反思
+    write_time 由 write_message_task 写入成功后刷新，覆盖 API / MCP 等全部写入路径。
+    inactive_hours 为 None 时取 settings.REFLECT_LAYER2_INACTIVE_HOURS。
     """
-    from sqlalchemy import func
-    from app.models.conversation_model import Conversation
+    from app.services.memory_reflection_service import WorkspaceAppService
 
     if inactive_hours is None:
         inactive_hours = settings.REFLECT_LAYER2_INACTIVE_HOURS
 
-    try:
-        last_updated = (
-            db.query(func.max(Conversation.updated_at))
-            .filter(Conversation.user_id == str(end_user_id))
-            .scalar()
-        )
-    except Exception as e:
-        # 查询异常时不跳过，保证反思仍能执行（保守策略）。
-        # 必须先 rollback：否则本次失败让事务进入 aborted，
-        # 同一 session 后续用户的查询会连环报 current transaction is aborted。
-        logger.warning(f"反思活跃度前置查询失败 user={end_user_id}: {e}")
-        try:
-            db.rollback()
-        except Exception:
-            pass
+    last_write = WorkspaceAppService(db).get_end_user_write_time(end_user_id)
+    if last_write is None:
         return False
+    last_write = as_utc_aware(last_write).replace(tzinfo=None)
+    return (utcnow_naive() - last_write).total_seconds() / 3600 < inactive_hours
 
-    if last_updated is None:
-        # 无任何会话记录 -> 没有可反思的新数据，跳过
-        return True
 
-    # 统一走 datetime 规范：当前时间 utcnow_naive，DB 读出的值 as_utc_aware 后去 tz
-    now_utc = utcnow_naive()
-    last_updated = as_utc_aware(last_updated).replace(tzinfo=None)
-    return (now_utc - last_updated) >= timedelta(hours=inactive_hours)
+def _should_skip_reflection_by_inactivity(db, end_user_id: str, inactive_hours: int | None = None) -> bool:
+    """低频反思前置过滤：不活跃则跳过（True=跳过，False=执行）。
+
+    仅按 write_time 做活跃过滤，不含周期判断——低频全量去重的增量节奏由
+    run_dedup_full_scan 内部按实体类型的扫描时间自行控制。
+    """
+    return not _is_active_recently(db, end_user_id, inactive_hours)
 
 
 def _should_reflect_now(db, end_user_id: str, reflection_time, iteration_period: int) -> bool:
-    """判断该用户现在是否需要反思。scan 派发前和 do 执行前都用它（保证一致 + 幂等）。
+    """高频反思：判断该用户现在是否需要反思。scan 派发前和 do 执行前都用它（保证一致 + 幂等）。
 
-    需同时满足两个条件才反思：
-      1. 活跃：最后一次写入距今 < REFLECT_LAYER2_INACTIVE_HOURS 小时
-      2. 到周期：距上次反思 >= iteration_period 小时
-
-    活跃口径取 end_user.write_time（write_message_task 写入成功后刷新，覆盖含 API / MCP
-    的全部写入路径）。write_time 为 NULL 表示从未写入、无可反思数据，直接跳过。
-    reflection_time 为 None 表示从未反思，此时只看活跃条件即可放行（首次反思）。
-
-    Args:
-        reflection_time: 上次反思时间 end_user.reflection_time（naive UTC 或 None=从未反思）
-        iteration_period: 反思周期（小时），由用户记忆配置 iteration_period 决定
-    Returns:
-        True 需要反思；False 跳过
+    放行需同时满足：活跃（_is_active_recently，口径 write_time）+ 
+    到周期（距上次反思 reflection_time >= iteration_period 小时）。
+    reflection_time 为 None 表示从未反思，活跃即放行（首次反思）。
     """
-    from app.services.memory_reflection_service import WorkspaceAppService
-
-    last_write = WorkspaceAppService(db).get_end_user_write_time(end_user_id)
-    if last_write is None:
-        return False  # 从未写入记忆且无历史会话 → 无可反思活动
-    last_active = as_utc_aware(last_write).replace(tzinfo=None)  # 统一 naive UTC
+    if not _is_active_recently(db, end_user_id):
+        return False  # 不活跃（无 write_time 或距今超阈值）→ 无需反思
 
     now = utcnow_naive()
-    inactive_hours = settings.REFLECT_LAYER2_INACTIVE_HOURS
-    is_active = (now - last_active).total_seconds() / 3600 < inactive_hours  # 条件1：最近活跃
-
     if reflection_time is None:
-        # 从未反思过：只要写过且最近活跃，就反思（首次）
-        return is_active
+        return True  # 从未反思：活跃即放行（首次反思）
 
     reflection_time = as_utc_aware(reflection_time).replace(tzinfo=None)  # 统一 naive UTC
-    period_reached = (now - reflection_time).total_seconds() / 3600 >= iteration_period  # 条件2：够周期
-    # 同时满足「活跃 + 到周期」放行（不再看「上次反思后是否有新写入」）
-    return is_active and period_reached
+    period_reached = (now - reflection_time).total_seconds() / 3600 >= iteration_period  # 距上次反思够周期
+    return period_reached
 
 
 @celery_app.task(
@@ -1986,8 +1949,14 @@ def scan_layer2_reflection(self) -> Dict[str, Any]:
         with get_db_context() as db:
             service = WorkspaceAppService(db)
             memory_config_service = MemoryConfigService(db)
-            config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
-            config = memory_config_service.load_memory_config(config_id)
+            # 单个 workspace 配置缺失/无效（如未配 embedding、无启用配置）只跳过该空间，
+            # 不让一个坏配置拖垮整轮 scan、影响其它正常用户。
+            try:
+                config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
+                config = memory_config_service.load_memory_config(config_id)
+            except Exception as e:
+                logger.warning(f"高频反思scan 跳过配置异常的 workspace={ws_id}: {e}")
+                continue
             iteration_period = config.reflexion_iteration_period or 24
             end_users = get_end_users_by_workspace(db, ws_id_uuid)
             for user in end_users:
@@ -2049,7 +2018,7 @@ def scan_layer2_reflection(self) -> Dict[str, Any]:
     soft_time_limit=540,
 )
 def do_layer2_reflection(self, user_id: str, config_id: str, workspace_id: str,
-                         iteration_period: int = 24) -> Dict[str, Any]:
+                         iteration_period: int = 24, from_retry: bool = False) -> Dict[str, Any]:
     """对【单个用户】执行一次 Layer2 反思（实体去重 / 描述合并 / 未识别实体处理等）。
 
     由 scan_layer2_reflection 派发，每个用户一个独立任务、独立 db session，跑完即释放内存。
@@ -2069,11 +2038,13 @@ def do_layer2_reflection(self, user_id: str, config_id: str, workspace_id: str,
         # 步骤1 执行前再判一次是否真的要反思：
         #   任务从 scan 派发到这里可能排队了一段时间，期间该用户可能已被别的
         #   反思任务处理过（reflection_time 已更新），这里复判避免重复反思。
-        with get_db_read() as db:
-            ws_svc = WorkspaceAppService(db)
-            rt = ws_svc.get_end_user_reflection_time(user_id)
-            if not _should_reflect_now(db, user_id, rt, iteration_period):
-                return {"status": "skipped_idempotent"}
+        #   from_retry=True（重试派发）跳过活跃/周期幂等门，否则刚被闸门挡掉的用户重派进来又被自己挡掉。
+        if not from_retry:
+            with get_db_read() as db:
+                ws_svc = WorkspaceAppService(db)
+                rt = ws_svc.get_end_user_reflection_time(user_id)
+                if not _should_reflect_now(db, user_id, rt, iteration_period):
+                    return {"status": "skipped_idempotent"}
 
         # 步骤2 抢该用户的写锁：与该用户的记忆写入 pipeline、去重任务互斥，
         #   保证同一用户的图谱不被并发修改。抢不到（超时30s）就本次放弃。
@@ -2092,13 +2063,21 @@ def do_layer2_reflection(self, user_id: str, config_id: str, workspace_id: str,
             # 步骤2.5 double-check：拿到写锁后再复查一次是否仍需反思。
             #   并发下（concurrency>1 或多 worker 副本）另一个 do 可能在我们抢锁
             #   期间已完成同一用户的反思并刷新了 reflection_time，
-            #   不满足则放弃，避免同一批数据被反思两次。
-            with get_db_read() as db:
-                ws_svc = WorkspaceAppService(db)
-                rt_recheck = ws_svc.get_end_user_reflection_time(user_id)
-                if not _should_reflect_now(db, user_id, rt_recheck, iteration_period):
-                    logger.info(f"反思高频do 拿锁后复查已无需反思，跳过 user={user_id}")
-                    return {"status": "skipped_idempotent"}
+            #   不满足则放弃，避免同一批数据被反思两次。from_retry 同样跳过该门。
+            if not from_retry:
+                with get_db_read() as db:
+                    ws_svc = WorkspaceAppService(db)
+                    rt_recheck = ws_svc.get_end_user_reflection_time(user_id)
+                    if not _should_reflect_now(db, user_id, rt_recheck, iteration_period):
+                        logger.info(f"反思高频do 拿锁后复查已无需反思，跳过 user={user_id}")
+                        return {"status": "skipped_idempotent"}
+
+            # 步骤2.8 开工租约：通过幂等门 + 抢到写锁后、run() 前登记，进程被硬杀也能被租约兜底重派。
+            _rc = get_sync_redis_client()
+            rr.lease(_rc, "high_freq", user_id,
+                     {"config_id": config_id, "workspace_id": workspace_id,
+                      "iteration_period": iteration_period},
+                     from_retry=from_retry)
 
             # 步骤3 执行反思（读图谱 → LLM → 写回，全程持锁）
             memory_service = MemoryService(
@@ -2107,32 +2086,59 @@ def do_layer2_reflection(self, user_id: str, config_id: str, workspace_id: str,
             )
             r = await memory_service.run_reflection_layer2()
 
-            # 步骤4 成功后把"上次反思时间"刷新为当前，供下次周期/增量判断
-            with get_db_context() as db:
-                WorkspaceAppService(db).update_end_user_reflection_time(user_id)
+            completion = rr.completion_of_layer2(r)
+            progressed = rr.progressed_layer2(r)
 
             unresolved_info = r.get("unresolved_entity", {})
             alias_info = r.get("alias_merge", {})
             dedup_info = r.get("entity_dedup", {})
             meta_info = r.get("metadata_extraction", {})
             merge_info = r.get("description_merge", {})
-            logger.info(
-                f"反思高频do 完成 user={user_id} status=success "
-                f"未识别解析={unresolved_info.get('resolved', 0)}/{unresolved_info.get('total', 0)} "
-                f"别名归并={alias_info.get('alias_merged', 0)} "
-                f"实体去重={dedup_info.get('merged_count', 0)}(候选{dedup_info.get('candidate_count', 0)}) "
-                f"元数据提取={meta_info.get('extracted', 0)} "
-                f"描述合并={merge_info.get('merged_count', 0)}(候选{merge_info.get('candidate_count', 0)}) "
+
+            if completion == "full":
+                # 步骤4 完整跑完：刷新"上次反思时间"，注销重试登记
+                with get_db_context() as db:
+                    WorkspaceAppService(db).update_end_user_reflection_time(user_id)
+                rr.resolve(_rc, "high_freq", user_id)
+                logger.info(
+                    f"反思高频do 完成 user={user_id} status=success "
+                    f"未识别解析={unresolved_info.get('resolved', 0)}/{unresolved_info.get('total', 0)} "
+                    f"别名归并={alias_info.get('alias_merged', 0)} "
+                    f"实体去重={dedup_info.get('merged_count', 0)}(候选{dedup_info.get('candidate_count', 0)}) "
+                    f"元数据提取={meta_info.get('extracted', 0)} "
+                    f"描述合并={merge_info.get('merged_count', 0)}(候选{merge_info.get('candidate_count', 0)}) "
+                    f"耗时={time.time() - start_time:.1f}s"
+                )
+                # 返回各步骤关键计数（扁平标量，便于 Flower / 调用方一眼查看）
+                return {
+                    "status": "success",
+                    "unresolved_resolved": unresolved_info.get("resolved", 0),
+                    "alias_merged": alias_info.get("alias_merged", 0),
+                    "dedup_merged": dedup_info.get("merged_count", 0),
+                    "metadata_extracted": meta_info.get("extracted", 0),
+                    "desc_merged": merge_info.get("merged_count", 0),
+                }
+
+            # partial：有步骤被熔断跳过/超时。已有推进，刷新 reflection_time（重派交给重试队列独占）。
+            # failed 不会到这里（真异常冒到外层 except 处理）。
+            if completion == "partial":
+                with get_db_context() as db:
+                    WorkspaceAppService(db).update_end_user_reflection_time(user_id)
+            skipped_steps = rr.skipped_steps_of_layer2(r)
+            rr.record(_rc, "high_freq", user_id, completion, progressed,
+                      skipped_steps=skipped_steps)
+            logger.warning(
+                f"反思高频do 未完整完成 user={user_id} completion={completion} "
+                f"progressed={progressed} skipped={skipped_steps} "
                 f"耗时={time.time() - start_time:.1f}s"
             )
-            # 返回各步骤关键计数（扁平标量，便于 Flower / 调用方一眼查看）
+            # 收尾已 record/refresh。partial 不当报错：正常 return（Celery SUCCESS），
+            # Result 带 status=partial + 提示，便于在 flower 一眼区分「熔断未完成」与真报错(FAILURE)。
             return {
-                "status": "success",
-                "unresolved_resolved": unresolved_info.get("resolved", 0),
-                "alias_merged": alias_info.get("alias_merged", 0),
-                "dedup_merged": dedup_info.get("merged_count", 0),
-                "metadata_extracted": meta_info.get("extracted", 0),
-                "desc_merged": merge_info.get("merged_count", 0),
+                "status": "partial",
+                "progressed": progressed,
+                "skipped": skipped_steps,
+                "note": "步骤级熔断/未完成（预期，非报错）；已登记重试队列，后续多轮收敛",
             }
         finally:
             # 步骤5 释放写锁（无论成功失败）
@@ -2143,8 +2149,14 @@ def do_layer2_reflection(self, user_id: str, config_id: str, workspace_id: str,
     try:
         result = loop.run_until_complete(_run())
     except Exception as e:
+        # 真异常：run() 抛出未达 completion 逻辑，补登记 failed（无推进），再 re-raise（FAILURE + traceback，需排查）
         logger.error(f"反思高频do 失败 user={user_id}: {e}", exc_info=True)
-        result = {"status": "failed", "error": str(e)}
+        try:
+            _rc = get_sync_redis_client()
+            rr.record(_rc, "high_freq", user_id, "failed", progressed=False, last_error=str(e))
+        except Exception:
+            pass
+        raise
     finally:
         _shutdown_loop_gracefully(loop)
         # 步骤6 删除在途标记：放行下一轮 scan 对该用户的派发（成功/失败/跳过都要删）
@@ -2186,8 +2198,13 @@ def scan_layer2_dedup_full_scan(self) -> Dict[str, Any]:
         ws_id_uuid = uuid.UUID(ws_id)
         with get_db_context() as db:
             memory_config_service = MemoryConfigService(db)
-            config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
-            config = memory_config_service.load_memory_config(config_id)
+            # 配置缺失/无效只跳过该空间，不拖垮整轮 scan。
+            try:
+                config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
+                config = memory_config_service.load_memory_config(config_id)
+            except Exception as e:
+                logger.warning(f"反思低频去重scan 跳过配置异常的 workspace={ws_id}: {e}")
+                continue
             if not config.reflexion_enabled:
                 continue
             for user in get_end_users_by_workspace(db, ws_id_uuid):
@@ -2242,7 +2259,7 @@ def scan_layer2_dedup_full_scan(self) -> Dict[str, Any]:
     soft_time_limit=540,
 )
 def do_layer2_dedup_full_scan(self, user_id: str, config_id: str,
-                              workspace_id: str) -> Dict[str, Any]:
+                              workspace_id: str, from_retry: bool = False) -> Dict[str, Any]:
     """对【单个用户】执行一次低频全量去重扫描。
 
     由 scan_layer2_dedup_full_scan 派发。精确的增量判断在 run_dedup_full_scan 内部
@@ -2269,18 +2286,46 @@ def do_layer2_dedup_full_scan(self, user_id: str, config_id: str,
                 logger.warning(f"反思低频去重do 获取写锁超时，跳过 user={user_id}")
                 return {"status": "lock_timeout"}
         try:
+            _rc = get_sync_redis_client()
+            rr.lease(_rc, "dedup", user_id,
+                     {"config_id": config_id, "workspace_id": workspace_id},
+                     from_retry=from_retry)
+
             memory_service = MemoryService(
                 config_id=uuid.UUID(config_id),
                 end_user_id=user_id, workspace_id=workspace_id,
             )
             r = await memory_service.run_dedup_full_scan()
+            completion = rr.completion_of_dedup(r)
+            progressed = rr.progressed_dedup(r)
             merged = r.get("merged_count", 0)
-            logger.info(
-                f"反思低频去重do 完成 user={user_id} status=success "
-                f"扫描类型={r.get('scanned_types', 0)} 合并={merged} "
+
+            if completion == "full":
+                rr.resolve(_rc, "dedup", user_id)
+                logger.info(
+                    f"反思低频去重do 完成 user={user_id} status=success "
+                    f"扫描类型={r.get('scanned_types', 0)} 合并={merged} "
+                    f"耗时={time.time() - start_time:.1f}s"
+                )
+                return {"status": "success", "merged_count": merged}
+
+            # partial：truncated / had_type_error。低频不刷 reflection_time（靠 update_scan_time 续扫）。
+            rr.record(_rc, "dedup", user_id, completion, progressed)
+            logger.warning(
+                f"反思低频去重do 未完整完成 user={user_id} completion={completion} "
+                f"progressed={progressed} truncated={r.get('truncated')} "
+                f"had_type_error={r.get('had_type_error')} 合并={merged} "
                 f"耗时={time.time() - start_time:.1f}s"
             )
-            return {"status": "success", "merged_count": merged}
+            # partial 不当报错：正常 return（Celery SUCCESS），Result 带 status=partial + 提示。
+            return {
+                "status": "partial",
+                "progressed": progressed,
+                "merged_count": merged,
+                "truncated": bool(r.get("truncated")),
+                "had_type_error": bool(r.get("had_type_error")),
+                "note": "低频去重未扫完（预期，非报错）；已登记重试队列，后续多轮收敛",
+            }
         finally:
             if write_lock is not None:
                 await asyncio.to_thread(write_lock.release)
@@ -2290,7 +2335,12 @@ def do_layer2_dedup_full_scan(self, user_id: str, config_id: str,
         result = loop.run_until_complete(_run())
     except Exception as e:
         logger.error(f"反思低频去重do 失败 user={user_id}: {e}", exc_info=True)
-        result = {"status": "failed", "error": str(e)}
+        try:
+            _rc = get_sync_redis_client()
+            rr.record(_rc, "dedup", user_id, "failed", progressed=False, last_error=str(e))
+        except Exception:
+            pass
+        raise
     finally:
         _shutdown_loop_gracefully(loop)
         # 删除在途标记：放行下一轮 scan 对该用户的派发（成功/失败都删）
@@ -2303,6 +2353,71 @@ def do_layer2_dedup_full_scan(self, user_id: str, config_id: str,
     result["elapsed_time"] = time.time() - start_time
     result["task_id"] = self.request.id
     return result
+
+
+@celery_app.task(
+    name="app.tasks.scan_reflection_retry",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+)
+def scan_reflection_retry(self) -> Dict[str, Any]:
+    """重试派发：扫两个重试 ZSet，对「已到点」用户绕活跃闸门重派对应 do。
+
+    租约到期且仍 in_progress → 判进程死亡 mark_dead；meta 缺失的孤儿 member → zrem 清理；
+    仍走 inflight 锁与正常 scan 互斥去重；派发的 do 进 reflection_tasks 队列（与正常 scan 同队列）。
+    Redis 不可用时整轮 no-op，不影响反思主流程。
+    """
+    start_time = time.time()
+    rc = get_sync_redis_client()
+    if rc is None:
+        logger.warning("scan_reflection_retry: Redis 不可用，跳过本轮")
+        return {"status": "SKIPPED", "reason": "redis_unavailable"}
+
+    now = time.time()
+    batch = rr.RETRY_BATCH
+    dispatched = 0
+    cleaned = 0
+    for task_type, do_task, inflight_prefix in (
+        ("high_freq", do_layer2_reflection, "reflection:inflight"),
+        ("dedup", do_layer2_dedup_full_scan, "dedup:inflight"),
+    ):
+        zkey = f"reflection:retry:{task_type}"
+        try:
+            uids = rc.zrangebyscore(zkey, "-inf", now, start=0, num=batch)
+        except Exception as e:
+            logger.warning(f"scan_reflection_retry: zrangebyscore 失败 {zkey}: {e}")
+            continue
+        for uid in uids:
+            if isinstance(uid, bytes):
+                uid = uid.decode("utf-8")
+            try:
+                meta = rr.load_meta(rc, task_type, uid)
+                if not meta:
+                    rc.zrem(zkey, uid)            # 孤儿（meta 已 TTL 过期）→ 清理
+                    cleaned += 1
+                    continue
+                if meta.get("completion") == "exhausted":
+                    continue
+                if meta.get("completion") == "in_progress":   # 租约到期 = 上次开工后进程死亡
+                    if not rr.mark_dead(rc, task_type, uid):   # 达 dead 上限置 exhausted 返回 False
+                        continue
+                # 仍走 inflight 锁，避免与正常 scan 派的同一用户撞车
+                if not rc.set(f"{inflight_prefix}:{uid}", "1", nx=True, ex=1500):
+                    continue
+                kwargs = {"user_id": uid, "config_id": meta["config_id"],
+                          "workspace_id": meta["workspace_id"], "from_retry": True}
+                if task_type == "high_freq":
+                    kwargs["iteration_period"] = meta.get("iteration_period", 24)
+                do_task.apply_async(kwargs=kwargs, queue="reflection_tasks")
+                dispatched += 1
+            except Exception as e:
+                logger.error(f"scan_reflection_retry 处理用户失败 task_type={task_type} uid={uid}: {e}")
+
+    logger.info(f"scan_reflection_retry 完成: 派发 {dispatched}, 清理孤儿 {cleaned}, "
+                f"耗时 {time.time() - start_time:.1f}s")
+    return {"status": "SUCCESS", "dispatched": dispatched, "cleaned": cleaned}
 
 
 # unused task


### PR DESCRIPTION
registry

- Add LAYER2_REFLECTION_BUDGET_SECONDS config for time-budget-based circuit breaker in Layer2 reflection
- Add REFLECTION_RETRY_SCAN_INTERVAL_MINUTES config for failed user retry scan interval
- Implement _run_step() method in Layer2Inspector to enforce remaining time budget across substeps
- Update run() method to dynamically skip substeps when budget exhausted or timeout occurs
- Create retry_registry.py module for reflection failure retry strategy constants
- Add scan_reflection_retry periodic task to Celery beat schedule for retrying failed reflections
- Replace get_redis_connection() with get_thread_safe_redis() in discard_cache to prevent event loop conflicts under thread pool
- Fixes potential "Future attached to a different loop" errors during concurrent reflection processing
- Improves reflection reliability by gracefully handling timeout and budget exhaustion scenarios

## Summary by Sourcery

引入基于时间预算的熔断与重试基础设施，用于 Layer2 reflection，以提升鲁棒性并防止长时间运行的任务耗尽资源。

新功能：
- 为 Layer2 reflection 添加可配置的总时间预算和非活跃（inactivity）设置，并通过应用设置对其进行暴露。
- 引入基于 Redis 的 reflection 重试注册表，并结合 Celery 任务支持，用于重新调度未完成或失败的高频 reflection 和低频去重（dedup）运行。
- 添加周期性 Celery 任务，根据重试注册表扫描并调度 reflection 重试作业。

错误修复：
- 将 reflection 丢弃缓存中使用的非线程安全 Redis 客户端替换为线程安全变体，以避免事件循环和 Future 附着错误。

改进：
- 在 Layer2Inspector 各步骤中应用动态时间预算熔断器，当预算耗尽时跳过或超时子步骤。
- 优化实体去重逻辑，将 LLM 决策拆分为分块（chunks）处理，支持增量提交，并在取消情况下提供更健壮的快照处理。
- 重构低频去重的全量扫描，使其遵守每个用户共享的 reflection 时间预算，并在达到预算或特定类型超时后优雅地截断工作。
- 收紧 reflection 调度逻辑，更好地区分用户非活跃与 reflection 频率节奏，并在不影响其他用户的情况下跳过内存配置无效的工作区。
- 为高频 reflection 和全量扫描去重任务补充结构化完成状态、进度检测和日志记录，以区分完整、部分以及失败的运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce time-budget-based circuit breaking and retry infrastructure for Layer2 reflection to improve robustness and prevent long-running tasks from exhausting resources.

New Features:
- Add configurable total time budget and inactivity settings for Layer2 reflection and expose them via application settings.
- Introduce a Redis-backed reflection retry registry with Celery task support to reschedule incomplete or failed high-frequency reflection and low-frequency dedup runs.
- Add a periodic Celery task to scan and dispatch reflection retry jobs based on the retry registry.

Bug Fixes:
- Replace non-thread-safe Redis client usage in reflection discard cache with a thread-safe variant to avoid event loop and Future attachment errors.

Enhancements:
- Apply a dynamic time-budget circuit breaker across Layer2Inspector steps, skipping or timing out substeps when the budget is exhausted.
- Refine entity deduplication to process LLM decisions in chunks with incremental commits and more resilient snapshot handling under cancellations.
- Rework low-frequency dedup full-scan to respect the shared reflection time budget per user and to gracefully truncate work when budget or type-specific timeouts are hit.
- Tighten reflection scheduling logic to better distinguish user inactivity from reflection cadence and to skip workspaces with invalid memory configurations without impacting others.
- Augment high-frequency reflection and full-scan dedup tasks with structured completion states, progress detection, and logging to differentiate full, partial, and failed runs.

</details>