### PR TITLE
fix(memory-config): Fix is_default type coercion and delete config workspace validation

### DIFF
--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -497,7 +497,6 @@ async def save_reflection_config(
 @router.delete("/delete_config", response_model=ApiResponse)  # 删除记忆配置（按配置ID）
 def delete_config(
         config_id: UUID | int,
-        force: bool = Query(False, description="是否强制删除（即使有终端用户正在使用）"),
         current_user: User = Depends(get_current_user),
         db: Session = Depends(get_db),
 ) -> dict:
@@ -517,14 +516,14 @@ def delete_config(
 
     api_logger.info(
         f"用户 {current_user.username} 在工作空间 {workspace_id} 请求删除配置: "
-        f"config_id={config_id}, force={force}"
+        f"config_id={config_id}"
     )
 
     try:
         from app.services.memory_config_service import MemoryConfigService
 
         config_service = MemoryConfigService(db)
-        result = config_service.delete_config(config_id=config_id, force=force, workspace_id=workspace_id)
+        result = config_service.delete_config(config_id=config_id, workspace_id=workspace_id)
 
         if result["status"] == "error":
             api_logger.warning(

--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -239,7 +239,7 @@ async def start_reflection_configs(
             "reflection_model_id": result.reflection_model_id,
             "memory_verify": result.memory_verify,
             "quality_assessment": result.quality_assessment,
-            "is_default": result.is_default
+            "is_default": bool(result.is_default)
         }
         api_logger.info(f"成功查询反思配置，config_id: {config_id}")
         return success(data=reflection_config, msg="反思配置查询成功")
@@ -524,7 +524,7 @@ def delete_config(
         from app.services.memory_config_service import MemoryConfigService
 
         config_service = MemoryConfigService(db)
-        result = config_service.delete_config(config_id=config_id, force=force)
+        result = config_service.delete_config(config_id=config_id, force=force, workspace_id=workspace_id)
 
         if result["status"] == "error":
             api_logger.warning(

--- a/api/app/core/memory/storage_services/forgetting_engine/config_utils.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/config_utils.py
@@ -135,7 +135,7 @@ def load_actr_config_from_db(
             'enable_llm_summary': enable_llm_summary,
             'max_merge_batch_size': max_merge_batch_size,
             'forgetting_interval_hours': forgetting_interval_hours,
-            'is_default': is_default
+            'is_default': bool(is_default)
             # 注意：llm_id 不包含在配置响应中，仅在内部使用
         }
         

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -71,6 +71,21 @@ class EndUserRepository:
             db_logger.error(f"查询工作空间 {workspace_id} 下终端用户时出错: {str(e)}")
             raise
 
+    def get_end_users_count_by_workspace(self, workspace_id: uuid.UUID) -> int:
+        """获取指定 workspace 下的所有 end_user"""
+        try:
+            end_users_count = (
+                self.db.query(EndUser)
+                .filter(EndUser.workspace_id == workspace_id, EndUser.is_active == True)
+                .count()
+            )
+            db_logger.info(f"成功查询工作空间 {workspace_id} 下的 {end_users_count} 个终端用户")
+            return end_users_count
+        except Exception as e:
+            self.db.rollback()
+            db_logger.error(f"查询工作空间 {workspace_id} 下终端用户时出错: {str(e)}")
+            raise
+
     def get_end_user_by_id(self, end_user_id: uuid.UUID) -> Optional[EndUser]:
         """根据 end_user_id 查询宿主"""
         try:
@@ -1206,6 +1221,11 @@ def get_end_users_by_workspace(db: Session, workspace_id: uuid.UUID) -> List[End
     repo = EndUserRepository(db)
     end_users = repo.get_end_users_by_workspace(workspace_id)
     return end_users
+
+def get_end_users_count_by_workspace(db: Session, workspace_id: uuid.UUID) -> int:
+    repo = EndUserRepository(db)
+    end_users_count = repo.get_end_users_count_by_workspace(workspace_id)
+    return end_users_count
 
 def get_end_user_by_id(db: Session, end_user_id: uuid.UUID) -> Optional[EndUser]:
     """根据 end_user_id 查询对应宿主"""

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -72,7 +72,7 @@ class EndUserRepository:
             raise
 
     def get_end_users_count_by_workspace(self, workspace_id: uuid.UUID) -> int:
-        """获取指定 workspace 下的所有 end_user"""
+        """获取指定 workspace 下的所有 end_user数量"""
         try:
             end_users_count = (
                 self.db.query(EndUser)

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -437,7 +437,7 @@ class MemoryConfigRepository:
                 "iteration_period": db_config.iteration_period,
                 "reflexion_range": db_config.reflexion_range,
                 "baseline": db_config.baseline,
-                "is_default": db_config.is_default,
+                "is_default": bool(db_config.is_default),
             }
 
             db_logger.debug(f"萃取配置查询成功: config_id={config_id}")

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -441,6 +441,7 @@ class ForgettingConfigResponse(BaseModel):
     enable_llm_summary: bool = Field(..., description="是否使用 LLM 生成摘要")
     max_merge_batch_size: int = Field(..., description="单次最大融合节点对数")
     forgetting_interval_hours: int = Field(..., description="遗忘周期间隔（小时）")
+    is_default: bool = Field(..., description="是否为默认配置")
 
 
 class ForgettingConfigUpdateRequest(BaseModel):

--- a/api/app/services/emotion_config_service.py
+++ b/api/app/services/emotion_config_service.py
@@ -79,7 +79,7 @@ class EmotionConfigService:
                 "emotion_extract_keywords": config.emotion_extract_keywords,
                 "emotion_min_intensity": config.emotion_min_intensity,
                 "emotion_enable_subject": config.emotion_enable_subject,
-                "is_default": config.is_default
+                "is_default": bool(config.is_default)
             }
             
             logger.info(f"情绪配置获取成功: config_id={config_id}")

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -938,7 +938,6 @@ class MemoryConfigService:
             self,
             config_id: UUID | int,
             workspace_id: uuid.UUID,
-            force: bool = False
     ) -> dict:
         """Delete memory config with protection against in-use configs.
         
@@ -948,7 +947,6 @@ class MemoryConfigService:
         Args:
             workspace_id:
             config_id: Memory config ID to delete (UUID or legacy int)
-            force: If True, clear end user references before deleting
             
         Returns:
             Dict with status, message, and affected_users count
@@ -960,7 +958,6 @@ class MemoryConfigService:
 
         from app.core.exceptions import ResourceNotFoundException
         from app.models.memory_config_model import MemoryConfig as MemoryConfigModel
-        from app.repositories.end_user_repository import EndUserRepository
 
         # 处理旧格式 int 类型的 config_id
         if isinstance(config_id, int):
@@ -991,7 +988,7 @@ class MemoryConfigService:
             }
         active_config_id = MemoryConfigService(self.db).get_workspace_active_config_id(workspace_id)
 
-        if str(config.config_id) == str(active_config_id) and not force:
+        if str(config.config_id) == str(active_config_id):
             logger.warning(
                 "Attempted to delete memory config with connected end users",
                 extra={
@@ -1005,16 +1002,6 @@ class MemoryConfigService:
                 "force_required": True
             }
 
-        # Force delete: use repository to clear end user references first
-        if str(config.config_id) == str(active_config_id) and force:
-            logger.warning(
-                "Force deleting memory config, clearing end user references",
-                extra={
-                    "config_id": str(config_id),
-                    "end_user_count": get_end_users_by_workspace
-                }
-            )
-        end_users_count = get_end_users_count_by_workspace(self.db, workspace_id)
         try:
             self.db.delete(config)
             self.db.commit()
@@ -1023,14 +1010,12 @@ class MemoryConfigService:
                 "Memory config deleted",
                 extra={
                     "config_id": str(config_id),
-                    "force": force
                 }
             )
 
             return {
                 "status": "success",
                 "message": "记忆配置删除成功",
-                "affected_users": end_users_count
             }
 
         except IntegrityError as e:

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -23,7 +23,8 @@ from app.core.validators.memory_config_validators import (
 )
 from app.models import Workspace
 from app.models.app_model import AppType
-from app.repositories.end_user_repository import get_end_user_by_id
+from app.repositories.end_user_repository import get_end_user_by_id, get_end_users_by_workspace, \
+    get_end_users_count_by_workspace
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.workspace_repository import get_workspace_memory_config_id
 from app.schemas.memory_config_schema import (
@@ -170,13 +171,13 @@ class MemoryConfigService:
         self.db = db
 
     async def _validate_model_connectivity(
-        self,
-        model_id: str,
-        model_type_label: str,
-        tenant_id: UUID | None,
-        config_id: UUID,
-        workspace_id: UUID | None,
-        locale: str = "zh",
+            self,
+            model_id: str,
+            model_type_label: str,
+            tenant_id: UUID | None,
+            config_id: UUID,
+            workspace_id: UUID | None,
+            locale: str = "zh",
     ) -> None:
         """解析模型凭证并调用 validate_model_config 验证 API 连通性。
 
@@ -283,7 +284,7 @@ class MemoryConfigService:
 
         all_models = [
             ("llm", config.llm_id, "extracted"),
-            ("embedding", config.embedding_id,"extracted"),
+            ("embedding", config.embedding_id, "extracted"),
             ("rerank", config.rerank_id, "extracted"),
             ("vision", config.vision_id, "extracted"),
             ("video", config.video_id, "extracted"),
@@ -308,7 +309,14 @@ class MemoryConfigService:
         async def _validate_one(model_type: str, model_id: str) -> dict | None:
             validate_type = "llm" if model_type in _VALIDATE_AS_LLM else model_type
             try:
-                await self._validate_model_connectivity(model_id, validate_type, tenant_id, config_id, workspace_id, locale=locale)
+                await self._validate_model_connectivity(
+                    model_id,
+                    validate_type,
+                    tenant_id,
+                    config_id,
+                    workspace_id,
+                    locale=locale
+                )
                 return None
             except ConfigurationError as e:
                 logger.warning(
@@ -929,6 +937,7 @@ class MemoryConfigService:
     def delete_config(
             self,
             config_id: UUID | int,
+            workspace_id: uuid.UUID,
             force: bool = False
     ) -> dict:
         """Delete memory config with protection against in-use configs.
@@ -937,6 +946,7 @@ class MemoryConfigService:
         that are actively being used by end users or marked as default.
         
         Args:
+            workspace_id:
             config_id: Memory config ID to delete (UUID or legacy int)
             force: If True, clear end user references before deleting
             
@@ -979,39 +989,32 @@ class MemoryConfigService:
                 "message": "默认配置不允许删除",
                 "is_default": True
             }
+        active_config_id = MemoryConfigService(self.db).get_workspace_active_config_id(workspace_id)
 
-        # Use repository to count connected end users
-        end_user_repo = EndUserRepository(self.db)
-        connected_count = end_user_repo.count_by_memory_config_id(config_id)
-
-        if connected_count > 0 and not force:
+        if str(config.config_id) == str(active_config_id) and not force:
             logger.warning(
                 "Attempted to delete memory config with connected end users",
                 extra={
                     "config_id": str(config_id),
-                    "connected_count": connected_count
                 }
             )
 
             return {
                 "status": "warning",
-                "message": f"无法删除记忆配置：{connected_count} 个终端用户正在使用此配置",
-                "connected_count": connected_count,
+                "message": f"无法删除记忆配置：当前空间正在使用此配置",
                 "force_required": True
             }
 
         # Force delete: use repository to clear end user references first
-        if connected_count > 0 and force:
-            cleared_count = end_user_repo.clear_memory_config_id(config_id)
-
+        if str(config.config_id) == str(active_config_id) and force:
             logger.warning(
                 "Force deleting memory config, clearing end user references",
                 extra={
                     "config_id": str(config_id),
-                    "cleared_end_users": cleared_count
+                    "end_user_count": get_end_users_by_workspace
                 }
             )
-
+        end_users_count = get_end_users_count_by_workspace(self.db, workspace_id)
         try:
             self.db.delete(config)
             self.db.commit()
@@ -1020,15 +1023,14 @@ class MemoryConfigService:
                 "Memory config deleted",
                 extra={
                     "config_id": str(config_id),
-                    "force": force,
-                    "affected_users": connected_count
+                    "force": force
                 }
             )
 
             return {
                 "status": "success",
                 "message": "记忆配置删除成功",
-                "affected_users": connected_count
+                "affected_users": end_users_count
             }
 
         except IntegrityError as e:

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -16,15 +16,14 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_config_logger, get_logger
-from app.i18n.service import t
 from app.core.utils.datetime_utils import utcnow_naive
 from app.core.validators.memory_config_validators import (
     validate_and_resolve_model_id,
 )
+from app.i18n.service import t
 from app.models import Workspace
 from app.models.app_model import AppType
-from app.repositories.end_user_repository import get_end_user_by_id, get_end_users_by_workspace, \
-    get_end_users_count_by_workspace
+from app.repositories.end_user_repository import get_end_user_by_id
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.workspace_repository import get_workspace_memory_config_id
 from app.schemas.memory_config_schema import (
@@ -986,7 +985,7 @@ class MemoryConfigService:
                 "message": "默认配置不允许删除",
                 "is_default": True
             }
-        active_config_id = MemoryConfigService(self.db).get_workspace_active_config_id(workspace_id)
+        active_config_id = self.get_workspace_active_config_id(workspace_id)
 
         if str(config.config_id) == str(active_config_id):
             logger.warning(

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -97,7 +97,6 @@ class WorkspaceAppService:
                 "config": memory_content
             }
 
-
             if memory_content:
                 processed_configs.add(memory_content)
                 memory_config_info = self._get_memory_config(memory_content)

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -99,16 +99,12 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         if not workspace:
             raise BusinessException(t("workspace.not_found", locale=locale))
         validation_result = await MemoryConfigService(self.db).valid_config(config_id, locale=locale)
-        warnings = validation_result.get("warnings", [])
-        success = False
-        if not warnings:
-            workspace.memory_config = config_id
-            success = True
+        workspace.memory_config = config_id
         self.db.commit()
         return {
             "config_id": config_id,
             "warnings": validation_result.get("warnings", []),
-            "success": success,
+            "success": True,
         }
 
     # --- Create ---


### PR DESCRIPTION
- Ensure is_default field is returned as boolean in all config serialization paths
- Add is_default field to memory storage schema
- Pass workspace_id to delete_config and validate against active config instead of connected end users
- Add get_end_users_count_by_workspace repository method
- Fix formatting and indentation in memory_config_service

## Summary by Sourcery

确保内存配置的默认标志始终以布尔值的形式处理，并基于工作区级别的使用情况收紧删除保护措施。

New Features:
- 在遗忘引擎的内存存储 API 响应中暴露 `is_default` 布尔字段。

Bug Fixes:
- 在内存、反思和情绪配置的序列化路径中，将 `is_default` 统一规范为布尔值，避免类型不一致的问题。
- 使用工作区上下文替代按终端用户绑定的方式，防止删除当前正被某个工作区使用的内存配置，除非强制删除。

Enhancements:
- 增加工作区范围的终端用户数量获取能力，以便在强制删除配置时报告受影响用户数量。
- 简化内存存储激活流程，使其始终将请求的配置设置为当前激活配置，同时仍然对外暴露验证警告。
- 对内存配置服务和仓储中的格式和日志进行小幅调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure memory configuration default flags are consistently handled as booleans and tighten deletion safeguards based on workspace-level usage.

New Features:
- Expose an is_default boolean field in forgetting engine memory storage API responses.

Bug Fixes:
- Normalize is_default to a boolean across memory, reflection, and emotion configuration serialization paths to avoid type inconsistencies.
- Prevent deletion of a memory configuration currently active for a workspace unless forced, using workspace context instead of per-end-user bindings.

Enhancements:
- Add workspace-scoped end user count retrieval to support reporting how many users are affected when force-deleting a configuration.
- Simplify memory storage activation to always set the requested configuration as active while still surfacing validation warnings.
- Minor formatting and logging adjustments in memory configuration services and repositories.

</details>