### PR TITLE
fix(workflow_service)

### DIFF
--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -4511,6 +4511,8 @@ class WorkflowService:
         if not latest:
             return None
         conv_messages = self._trace_context_chain(latest)
+        if latest.role in ("user", "assistant"):
+            conv_messages.append({"role": latest.role, "content": latest.content})
         return conv_vars, conv_messages
 
 


### PR DESCRIPTION
append latest message to conversation trace when role is user or assistant

## Summary by Sourcery

Bug Fixes:
- 将最新的用户或助手消息追加到会话轨迹中，以便历史记录检索能够反映最新的消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Append the latest user or assistant message to the conversation trace so history retrieval reflects the most recent message

</details>