### PR TITLE
Feat/memory api mcp working memory

### DIFF
--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -1,13 +1,16 @@
 import uuid
+from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import success
+from app.core.utils.datetime_utils import to_timestamp_ms
 from app.db import get_db
 from app.dependencies import get_current_user
 from app.models import User
+from app.repositories.memory_message_repository import MemoryMessageRepository
 from app.schemas import conversation_schema
 from app.schemas.response_schema import ApiResponse
 from app.services.conversation_service import ConversationService
@@ -141,3 +144,81 @@ async def get_conversation_detail(
         workspace_id=current_user.current_workspace_id
     )
     return success(data=detail.model_dump(), msg="get conversation detail success")
+
+
+# ──────────────────────────────────────────────
+# API/MCP 工作记忆展示接口
+# ──────────────────────────────────────────────
+
+
+def _parse_dialog_at_to_ms(dialog_at: str | None) -> int | None:
+    """将 dialog_at（ISO 8601 字符串）解析为毫秒时间戳；无法解析时返回 None。"""
+    if not dialog_at:
+        return None
+    try:
+        dt = datetime.fromisoformat(dialog_at)
+        return to_timestamp_ms(dt)
+    except (ValueError, TypeError):
+        return None
+
+
+@router.get("/{end_user_id}/sources", response_model=ApiResponse)
+def get_sources(
+        end_user_id: uuid.UUID,
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db)
+):
+    """查询该用户通过 API/MCP 写入的记忆来源摘要。
+
+    每个来源（service_api / mcp）最多返回一条，包含消息总数和最后写入时间。
+    用户从未用过 API/MCP 时 items 为空数组。
+    """
+    memory_message_repo = MemoryMessageRepository(db)
+    sources = memory_message_repo.get_working_memory_sources(str(end_user_id))
+    items = [
+        {
+            "source": row["source"],
+            "message_count": row["message_count"],
+            "latest_at": to_timestamp_ms(row["latest_at"]),
+        }
+        for row in sources
+    ]
+    return success(data={"items": items}, msg="查询成功")
+
+
+@router.get("/{end_user_id}/source_messages", response_model=ApiResponse)
+def get_source_messages(
+        end_user_id: uuid.UUID,
+        source: str = Query(..., description="来源：service_api 或 mcp"),
+        limit: int = Query(default=20, ge=1, le=100, description="返回条数上限"),
+        current_user: User = Depends(get_current_user),
+        db: Session = Depends(get_db)
+):
+    """按来源获取最近 N 条消息，从旧到新排列，形成连贯对话流。
+
+    Args:
+        end_user_id: 终端用户 UUID
+        source: service_api 或 mcp
+        limit: 返回条数上限（默认 20，最大 100）
+    """
+    allowed_sources = {"service_api", "mcp"}
+    if source not in allowed_sources:
+        return success(data={"items": [], "total": 0, "source": source}, msg="unsupported source")
+
+    memory_message_repo = MemoryMessageRepository(db)
+    rows, total = memory_message_repo.list_recent_messages_by_source(
+        end_user_id=str(end_user_id),
+        source=source,
+        limit=limit,
+    )
+    items = [
+        {
+            "role": m.role,
+            "content": m.content,
+            "message_seq": m.message_seq,
+            "created_at": to_timestamp_ms(m.created_at),
+            "dialog_at": _parse_dialog_at_to_ms(m.dialog_at),
+        }
+        for m in rows
+    ]
+    return success(data={"items": items, "total": total, "source": source}, msg="查询成功")

--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_api_logger
+from app.core.memory.enums import MemoryMessageSource
 from app.core.response_utils import success
 from app.core.utils.datetime_utils import to_timestamp_ms
 from app.db import get_db
@@ -175,7 +176,7 @@ def get_sources(
     """
     memory_message_repo = MemoryMessageRepository(db)
     sources = memory_message_repo.get_working_memory_sources(str(end_user_id))
-    items = [
+    data = [
         {
             "source": row["source"],
             "message_count": row["message_count"],
@@ -183,7 +184,7 @@ def get_sources(
         }
         for row in sources
     ]
-    return success(data={"items": items}, msg="查询成功")
+    return success(data=data, msg="查询成功")
 
 
 @router.get("/{end_user_id}/source_messages", response_model=ApiResponse)
@@ -201,7 +202,7 @@ def get_source_messages(
         source: service_api 或 mcp
         limit: 返回条数上限（默认 20，最大 100）
     """
-    allowed_sources = {"service_api", "mcp"}
+    allowed_sources = {MemoryMessageSource.SERVICE_API.value, MemoryMessageSource.MCP.value}
     if source not in allowed_sources:
         return success(data={"items": [], "total": 0, "source": source}, msg="unsupported source")
 

--- a/api/app/core/memory/enums.py
+++ b/api/app/core/memory/enums.py
@@ -184,3 +184,18 @@ class TripletPredicate(Enum):
             f"- {item.predicate_id} ({item.value}): {item.description}"
             for item in cls
         )
+
+
+class MemoryMessageSource(StrEnum):
+    """memory_messages.source 枚举 — 标识记忆消息的写入来源。
+
+    - AGENT: agent 对话（走 conversation_id）
+    - SERVICE_API: /writer_service_async 写入（conversation_id 为 NULL）
+    - MCP: MCP 客户端写入（conversation_id 为 NULL）
+    - WORKFLOW: 对话流 workflow 的 MemoryWriteNode 写入（走 conversation_id）
+    """
+
+    AGENT = "agent"
+    SERVICE_API = "service_api"
+    MCP = "mcp"
+    WORKFLOW = "workflow"

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -245,6 +245,7 @@ class MemoryService:
             is_pilot_run: bool = False,
             skip_cursor_advance: bool = False,
             dispatch_at: str = "",
+            source: str = "",
             progress_callback: Optional[
                 Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
             ] = None,
@@ -262,6 +263,7 @@ class MemoryService:
             is_pilot_run: 试运行模式（只萃取不写入）
             skip_cursor_advance: 跳过 write_cursor 推进（直接写入路径）
             dispatch_at: 任务派发时刻的 UTC ISO 8601 时间戳
+            source: 写入来源（agent/service_api/mcp/workflow），用于快照路径和节点 ID 生成
             progress_callback: 可选的进度回调
 
         Returns:
@@ -287,6 +289,7 @@ class MemoryService:
             is_pilot_run=is_pilot_run,
             skip_cursor_advance=skip_cursor_advance,
             dispatch_at=dispatch_at,
+            source=source,
         )
 
     async def pilot_write(

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -733,13 +733,6 @@ async def dispatch_mcp_write(
     target_msg = written[0]
     target_seq = target_msg["message_seq"]
 
-    # 3. 推进 write_cursor
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        repo.advance_write_cursor(conversation_id, target_seq)
-        db.commit()
-
-    # 4. 直接派发写入任务（空 assistant 通过标记传递给 pipeline）
     # 在 target_message 上添加标记，告知 WritePipeline 需要追加空 assistant 配对
     target_msg_with_marker = {**target_msg, "_mcp_pair_assistant": True}
     msg_id = push_write_task(

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -2,10 +2,16 @@
 MemoryWriteDispatcher — 记忆写入派发层
 
 职责：
-- 统一各入口点（API Service、Agent、Workflow、Flush）向 write_message_task 的派发逻辑
+- 统一各入口点（API Service、Agent、Workflow、MCP、Flush）向 write_message_task 的派发逻辑
 - 管理 memory_messages 表的消息写入
-- 处理 Redis pending 集合和活跃 key
-- 判断滑动窗口条件是否满足
+- 处理 Redis pending 集合和活跃 key（仅 agent/workflow 路径）
+- 判断滑动窗口条件是否满足（仅 agent/workflow 路径）
+
+写入路径分成两组：
+1. **agent / workflow**：走 conversation_id 通道，产生 conversation 行，
+   有 write_cursor、滑动窗口、Redis pending 集合、Flush 兜底。
+2. **service_api / mcp**：无 conversation，写 memory_messages 时 conversation_id=NULL，
+   用 (end_user_id, source) 作为分组键，写入后立即逐条派发任务。
 
 各入口点保持原位置，通过本模块的函数进行统一派发。
 """
@@ -13,8 +19,9 @@ MemoryWriteDispatcher — 记忆写入派发层
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, List
+from typing import Any, List, Optional
 
+from app.core.memory.enums import MemoryMessageSource
 from app.db import get_db_context, get_db_read
 from app.repositories.memory_message_repository import MemoryMessageRepository
 
@@ -25,7 +32,7 @@ WINDOW_SIZE = 3
 
 
 # ──────────────────────────────────────────────
-# Redis 活跃 key 管理
+# Redis 活跃 key 管理（仅 agent/workflow 路径使用）
 # ──────────────────────────────────────────────
 
 CONV_ACTIVE_KEY_PREFIX = "conv_active:"
@@ -104,115 +111,6 @@ def verify_unmark_safe(conversation_id: str) -> bool:
 
 
 # ──────────────────────────────────────────────
-# Conversation 管理
-# ──────────────────────────────────────────────
-
-# 全局哨兵 App ID（Service API 虚拟会话专用）
-SENTINEL_APP_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
-_sentinel_app_verified: bool = False
-
-
-def _ensure_sentinel_app_exists() -> None:
-    """确保哨兵 App 在 apps 表中存在。"""
-    global _sentinel_app_verified
-    if _sentinel_app_verified:
-        return
-
-    from app.models.app_model import App
-
-    try:
-        with get_db_context() as db:
-            existing = db.get(App, SENTINEL_APP_ID)
-            if existing is not None:
-                _sentinel_app_verified = True
-                return
-
-            sentinel = App(
-                id=SENTINEL_APP_ID,
-                workspace_id=uuid.UUID("00000000-0000-0000-0000-000000000000"),
-                created_by=uuid.UUID("00000000-0000-0000-0000-000000000000"),
-                name="__system_memory_service__",
-                type="agent",
-                visibility="private",
-                status="active",
-                is_active=True,
-            )
-            db.add(sentinel)
-            db.commit()
-            _sentinel_app_verified = True
-    except Exception:
-        _sentinel_app_verified = True
-
-
-def get_or_create_service_api_conversation(
-    workspace_id: str,
-    end_user_id: str,
-) -> str:
-    """按 (workspace_id, end_user_id, app_id=SENTINEL) 查找或创建虚拟会话。"""
-    from app.models.conversation_model import Conversation
-
-    _ensure_sentinel_app_exists()
-
-    try:
-        _ws_id = uuid.UUID(workspace_id)
-    except (ValueError, AttributeError) as e:
-        raise ValueError(f"workspace_id 格式非法: {workspace_id!r}") from e
-
-    with get_db_context() as db:
-        conv = (
-            db.query(Conversation)
-            .filter(
-                Conversation.workspace_id == _ws_id,
-                Conversation.app_id == SENTINEL_APP_ID,
-                Conversation.user_id == end_user_id,
-            )
-            .first()
-        )
-
-        if conv:
-            return str(conv.id)
-
-        conv = Conversation(
-            id=uuid.uuid4(),
-            app_id=SENTINEL_APP_ID,
-            workspace_id=_ws_id,
-            user_id=end_user_id,
-            is_draft=True,
-            write_cursor=0,
-        )
-        db.add(conv)
-        db.commit()
-        return str(conv.id)
-
-
-async def ensure_conversation_exists(
-    conversation_id: str,
-    workspace_id: str = "",
-) -> None:
-    """确保 conversations 表中存在该记录。"""
-    from app.models.conversation_model import Conversation
-
-    try:
-        with get_db_context() as db:
-            existing = db.get(Conversation, uuid.UUID(conversation_id))
-            if existing is not None:
-                return
-
-            _ws_id = uuid.UUID(workspace_id) if workspace_id else uuid.UUID("00000000-0000-0000-0000-000000000000")
-
-            conv = Conversation(
-                id=uuid.UUID(conversation_id),
-                app_id=SENTINEL_APP_ID,
-                workspace_id=_ws_id,
-                is_draft=True,
-            )
-            db.add(conv)
-            db.commit()
-    except Exception as e:
-        logger.warning(f"[Dispatcher] ensure_conversation_exists 失败: conv={conversation_id}, err={e}")
-
-
-# ──────────────────────────────────────────────
 # 派发函数：各入口点使用
 # ──────────────────────────────────────────────
 
@@ -226,10 +124,13 @@ def push_write_task(
     conversation_id: str,
     message_seq: int,
     language: str = "zh",
+    skip_cursor_advance: bool = False,
+    source: str = "",
 ) -> str:
     """推送单条消息写入任务到 Celery。
 
-    所有入口最终都通过这个函数派发任务。
+    所有入口最终都通过这个函数派发任务。conversation_id 允许为空字符串
+    （API/MCP 场景），下游 WritePipeline 已容忍空 conversation_id。
 
     Args:
         end_user_id: 终端用户 ID（分片键）
@@ -238,9 +139,11 @@ def push_write_task(
         context_after: 下文消息列表
         config_id: 记忆配置 ID
         workspace_id: 工作空间 ID
-        conversation_id: 对话 ID
+        conversation_id: 对话 ID；API/MCP 场景传空字符串
         message_seq: 消息序号
         language: 语言
+        skip_cursor_advance: 是否跳过 cursor 推进（API/MCP 场景为 True）
+        source: 写入来源（agent/service_api/mcp/workflow）
 
     Returns:
         任务 msg_id
@@ -260,15 +163,17 @@ def push_write_task(
             "context_after": context_after,
             "config_id": config_id,
             "workspace_id": workspace_id,
-            "conversation_id": conversation_id,
+            "conversation_id": conversation_id or "",
             "message_seq": message_seq,
             "language": language,
             "dispatch_at": dispatch_at,
+            "skip_cursor_advance": skip_cursor_advance,
+            "source": source,
         },
     )
     logger.info(
         f"[Dispatcher] 写入任务已推送: end_user={end_user_id}, "
-        f"conv={conversation_id}, seq={message_seq}, msg_id={msg_id}"
+        f"conv={conversation_id or '-'}, seq={message_seq}, msg_id={msg_id}"
     )
     return msg_id
 
@@ -334,59 +239,53 @@ async def dispatch_api_service_async(
     workspace_id: str,
     language: str = "zh",
 ) -> List[str]:
-    """API Service 异步写入入口。
+    """API Service 异步写入入口（仅写 memory_messages，无 conversation）。
 
-    1. 获取/创建虚拟 conversation
-    2. 批量写入 memory_messages 表
-    3. 逐条派发 user 消息的写入任务
+    流程（对应设计文档 §3.5）：
+    1. 批量写入 memory_messages 表（conversation_id=NULL, source=service_api）
+    2. 逐条对 user 消息派发 WritePipeline 任务，邻近 assistant 消息作为上下文
+
+    API 写入的 role 不确定——可能 user 连续、assistant 连续、也可能交替。
+    此处为每条 user 消息构建滑动窗口上下文（向前/后各找 WINDOW_SIZE 个 user 消息
+    范围内的所有消息，包含中间穿插的 assistant），确保 WritePipeline 能获取充分信息。
 
     Returns:
         派发的任务 ID 列表
     """
-    # 1. 获取/创建虚拟 conversation
-    conversation_id = get_or_create_service_api_conversation(
-        workspace_id=workspace_id,
-        end_user_id=end_user_id,
-    )
-
-    # 2. 批量写入 memory_messages 表
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        written_mms = repo.write_batch(conversation_id, messages)
+        written_mms = repo.write_batch(
+            conversation_id=None,
+            messages=messages,
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.SERVICE_API,
+        )
         db.commit()
 
     if not written_mms:
         return []
 
-    # 3. 预计算上下文窗口并逐条派发
-    task_ids = []
+    # 预计算上下文窗口：找出所有 user 消息索引，为每条 user 构建 context_before/after
+    task_ids: List[str] = []
     user_indices = [i for i, m in enumerate(written_mms) if m["role"] == "user"]
-
-    # 先推进 cursor 到 max_seq，防止 flush 路径在 push_write_task 期间扫到这批消息重复派发
-    max_seq = max(mm["message_seq"] for mm in written_mms)
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        repo.advance_write_cursor(conversation_id, max_seq)
-        db.commit()
 
     for p, idx in enumerate(user_indices):
         msg = written_mms[idx]
 
-        # 上文：向前找最多 WINDOW_SIZE 个 user
+        # 上文：向前找最多 WINDOW_SIZE 个 user 消息，取最早那个的位置作为起点
         before_user_p = max(0, p - WINDOW_SIZE)
         before_start = user_indices[before_user_p]
         context_before = written_mms[before_start:idx]
 
-        # 下文：向后找最多 WINDOW_SIZE 个 user
+        # 下文：向后找最多 WINDOW_SIZE 个 user 消息，取最晚那个的下一位作为终点
         after_user_p = min(len(user_indices) - 1, p + WINDOW_SIZE)
         if after_user_p == p:
-            # 当前是最后一条 user 消息，context_after 取到列表末尾（包含尾部 assistant 消息）
+            # 当前是最后一条 user（或窗口内没有更后面的 user），取到列表末尾
             context_after = written_mms[idx + 1:]
         else:
             after_end = user_indices[after_user_p] + 1
             context_after = written_mms[idx + 1:after_end]
 
-        # 派发任务
         msg_id = push_write_task(
             end_user_id=end_user_id,
             target_message=msg,
@@ -394,9 +293,11 @@ async def dispatch_api_service_async(
             context_after=context_after,
             config_id=config_id,
             workspace_id=workspace_id,
-            conversation_id=conversation_id,
+            conversation_id="",  # API 场景无 conversation
             message_seq=msg["message_seq"],
             language=language,
+            skip_cursor_advance=True,
+            source=MemoryMessageSource.SERVICE_API.value,
         )
         task_ids.append(msg_id)
 
@@ -404,7 +305,7 @@ async def dispatch_api_service_async(
 
 
 # ──────────────────────────────────────────────
-# 入口2: Agent 消息摄入
+# 入口2: Agent 消息摄入（走 conversation_id 通道）
 # ──────────────────────────────────────────────
 
 
@@ -432,7 +333,7 @@ async def ingest_agent_message(
         files = message.meta_data.get("files")
 
     # Agent 路径：用 message.created_at 作为 dialog_at，语义上是对话真实发生的时间
-    dialog_at: str | None = None
+    dialog_at: Optional[str] = None
     if hasattr(message, "created_at") and message.created_at:
         _created = message.created_at
         if isinstance(_created, datetime):
@@ -443,17 +344,21 @@ async def ingest_agent_message(
 
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        memory_msg = repo.write_single(
+        written = repo.write_batch(
             conversation_id=str(conversation_id),
-            original_message_id=message.id,
-            role=message.role,
-            content=message.content,
-            created_at=message.created_at,
-            should_memorize=should_memorize,
-            files=files,
-            dialog_at=dialog_at,
+            messages=[{
+                "role": message.role,
+                "content": message.content,
+                "original_message_id": message.id,
+                "created_at": message.created_at,
+                "should_memorize": should_memorize,
+                "files": files,
+                "dialog_at": dialog_at,
+            }],
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.AGENT,
         )
-        if memory_msg is None:
+        if not written:
             return False
         db.commit()
 
@@ -483,13 +388,21 @@ async def ingest_workflow_messages(
     workspace_id: str,
     language: str = "zh",
 ) -> None:
-    """Workflow 消息摄入：批量写入 memory_messages 表 + 触发滑动窗口派发。"""
+    """Workflow 消息摄入：批量写入 memory_messages 表 + 触发滑动窗口派发。
 
-    await ensure_conversation_exists(conversation_id, workspace_id)
-
+    MemoryWriteNode 仅存在于对话流 workflow 中，执行前已由 create_or_get_conversation
+    在 conversations 表创建真实会话，sys.conversation_id 始终有效（与 MemoryReadNode
+    的假设一致）。pure_workflow（策略工作流）没有记忆存储节点、无会话，不会走到这里。
+    因此直接走 conversation 通道，无需空值守卫或哨兵兜底。
+    """
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        repo.write_batch(conversation_id, messages)
+        repo.write_batch(
+            conversation_id=conversation_id,
+            messages=messages,
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.WORKFLOW,
+        )
         db.commit()
 
     await refresh_active_key(conversation_id)
@@ -505,55 +418,45 @@ async def ingest_workflow_messages(
 
 
 # ──────────────────────────────────────────────
-# 入口4: Flush 兜底任务
+# 入口4: Flush 兜底任务（仅服务 agent/workflow 路径）
 #
-# 调用链路：
-#   dispatch_flush_conversation (扫描待处理消息)
-#     ├── _resolve_workspace_memory_config_id (按工作空间解析当前生效配置)
-#     └── dispatch_single_message [write_dispatcher] (构建上下文 + push_write_task + 推进 cursor)
-#           └── push_write_task (发 Celery 任务)
+# API/MCP 消息 conversation_id=NULL，JOIN conversations 天然扫不到，
+# 无需 flush 兜底；本函数只处理 agent/workflow 的未派发消息。
 # ──────────────────────────────────────────────
 
 
-def _resolve_workspace_memory_config_id(conversation_id: str) -> "uuid.UUID | None":
-    """根据对话所属工作空间解析当前生效的记忆配置 ID。"""
+def _resolve_memory_config_id(conversation_id: str) -> "uuid.UUID | None":
+    """从 conversation 所属 workspace 获取默认记忆配置 ID。
+
+    查询链路：conversations.workspace_id → get_workspace_memory_config_id(workspace_id)
+    与滑动窗口路径（conversation_service → MemoryConfigService.get_workspace_active_config_id）
+    使用同一个底层函数，确保同一会话的所有消息使用相同的记忆配置。
+    """
     try:
         from sqlalchemy import select as sa_select
         from app.models.conversation_model import Conversation
-        from app.services.memory_config_service import MemoryConfigService
+        from app.repositories.workspace_repository import get_workspace_memory_config_id
 
         with get_db_context() as db:
-            row = db.execute(
-                sa_select(
-                    Conversation.workspace_id,
-                )
-                .select_from(Conversation)
+            workspace_id = db.execute(
+                sa_select(Conversation.workspace_id)
                 .where(Conversation.id == conversation_id)
-            ).one_or_none()
+            ).scalar_one_or_none()
 
-            if row is None:
+            if workspace_id is None:
                 return None
 
-            (workspace_id,) = row
-            if not workspace_id:
-                return None
-
-            return MemoryConfigService(db).get_workspace_active_config_id(workspace_id)
+            return get_workspace_memory_config_id(db, workspace_id)
     except Exception as e:
-        logger.error(f"[Dispatcher] 解析工作空间记忆配置异常: conv={conversation_id}, err={e}", exc_info=True)
+        logger.error(f"[Dispatcher] 解析 workspace memory_config 异常: conv={conversation_id}, err={e}", exc_info=True)
         return None
 
 
 def dispatch_flush_conversation(conversation_id: str) -> int:
     """Flush 兜底任务派发：处理单个对话的所有未写入消息。
 
+    仅服务 agent/workflow 路径。API/MCP 消息 conversation_id=NULL 不会被扫到。
     只派发 role=user + should_memorize=TRUE 的消息，其余直接推进 cursor。
-
-    Args:
-        conversation_id: 对话 ID
-
-    Returns:
-        派发的任务数
     """
     from sqlalchemy import select as sa_select
     from app.models.conversation_model import Conversation
@@ -602,16 +505,16 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
                 logger.info(f"[Dispatcher] Flush 无未写入消息，跳过: conv={conversation_id}")
                 return 0
 
-        # Step 2: 解析工作空间当前生效记忆配置
-        workspace_config_id = _resolve_workspace_memory_config_id(conversation_id)
-        if not workspace_config_id:
-            logger.warning(f"[Dispatcher] Flush 未能解析工作空间记忆配置，跳过: conv={conversation_id}")
+        # Step 2: 解析 memory_config_id（走 workspace 默认配置，与滑动窗口路径一致）
+        config_id_resolved = _resolve_memory_config_id(conversation_id)
+        if not config_id_resolved:
+            logger.warning(f"[Dispatcher] Flush 未能解析 memory_config_id，跳过: conv={conversation_id}")
             return 0
-        config_id = str(workspace_config_id)
+        config_id = str(config_id_resolved)
 
         # Step 3: 逐条处理
         dispatched = 0
-        skipped_non_user = 0 # 统计在 Flush 流程中因角色不是 user 或 should_memorize=False 而被跳过（只推进游标、不派发写入任务）的消息数量
+        skipped_non_user = 0  # 因角色不是 user 或 should_memorize=False 被跳过（只推进游标）
         for msg in pending_messages:
             target_seq = msg["message_seq"]
 
@@ -658,7 +561,7 @@ async def check_sliding_window_and_dispatch(
     workspace_id: str,
     language: str = "zh",
 ) -> None:
-    """滑动窗口条件检查 + 派发。
+    """滑动窗口条件检查 + 派发（agent/workflow 路径）。
 
     检查 pending user 消息下文是否 ≥ WINDOW_SIZE，满足则构建上下文并 push_write_task。
     一次只派发一条。
@@ -731,6 +634,7 @@ async def check_sliding_window_and_dispatch(
             conversation_id=conversation_id,
             message_seq=target_seq,
             language=language,
+            source=MemoryMessageSource.AGENT.value,
         )
 
         # 一次只派发一条
@@ -744,11 +648,7 @@ def dispatch_single_message(
     config_id: str,
     workspace_id: str,
 ) -> bool:
-    """为单条 user 消息构建上下文并派发写入任务（Flush 路径使用）。
-
-    Returns:
-        True 表示成功派发，False 表示消息不存在
-    """
+    """为单条 user 消息构建上下文并派发写入任务（Flush 路径使用）。"""
     from app.repositories.memory_message_repository import message_to_dict
 
     with get_db_context() as db:
@@ -782,13 +682,14 @@ def dispatch_single_message(
         workspace_id=workspace_id,
         conversation_id=conversation_id,
         message_seq=target_seq,
+        source=MemoryMessageSource.AGENT.value,
     )
 
     return True
 
 
 # ──────────────────────────────────────────────
-# 入口5: MCP 写入
+# 入口5: MCP 写入（无 conversation，直接派发）
 # ──────────────────────────────────────────────
 
 
@@ -802,11 +703,9 @@ async def dispatch_mcp_write(
     """MCP 写入入口。
 
     MCP 每次仅写入单条 user message，不需要上下文窗口。
-    流程：
-    1. 获取/创建虚拟 conversation（复用哨兵 App）
-    2. 写入 memory_messages 表
-    3. 立即推进 write_cursor
-    4. 直接派发写入任务（context_before=[], context_after=[]）
+    流程（对应设计文档 §3.5）：
+    1. 写入 memory_messages 表（conversation_id=NULL, source=mcp, end_user_id=X）
+    2. 直接派发写入任务（context_before=[], context_after=[]）
 
     Args:
         message: 用户消息内容
@@ -818,20 +717,20 @@ async def dispatch_mcp_write(
     Returns:
         派发的任务 msg_id
     """
-    # 1. 获取/创建虚拟 conversation
-    conversation_id = get_or_create_service_api_conversation(
-        workspace_id=workspace_id,
-        end_user_id=end_user_id,
-    )
-
-    # 2. 写入 memory_messages 表
-    messages = [{"role": "user", "content": message, "dialog_at": dialog_at}]
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        written_mms = repo.write_batch(conversation_id, messages)
+        written = repo.write_batch(
+            conversation_id=None,
+            messages=[{"role": "user", "content": message, "dialog_at": dialog_at}],
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.MCP,
+        )
         db.commit()
 
-    target_msg = written_mms[0]
+    if not written:
+        return ""
+
+    target_msg = written[0]
     target_seq = target_msg["message_seq"]
 
     # 3. 推进 write_cursor
@@ -848,14 +747,16 @@ async def dispatch_mcp_write(
         target_message=target_msg_with_marker,
         context_before=[],
         context_after=[],
-        config_id=config_id,
+        config_id=str(config_id),
         workspace_id=workspace_id,
-        conversation_id=conversation_id,
+        conversation_id="",  # MCP 无 conversation
         message_seq=target_seq,
+        skip_cursor_advance=True,
+        source=MemoryMessageSource.MCP.value,
     )
 
     logger.info(
         f"[Dispatcher] MCP 写入任务已推送: end_user={end_user_id}, "
-        f"conv={conversation_id}, seq={target_seq}, msg_id={msg_id}"
+        f"source=mcp, seq={target_seq}, msg_id={msg_id}"
     )
     return msg_id

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -51,7 +51,7 @@ bear = BearLogger("memory.pipeline")
 # ──────────────────────────────────────────────
 
 
-def _convert_pruning_records(raw_records: list) -> List[dict]:
+def _convert_pruning_records(raw_records: list, end_user_id: str = "", source: str = "") -> List[dict]:
     """将 PruningPipeline 收集的剪枝记录转换为 graph_build_step 期望的格式。
 
     PruningPipeline.prune() 产生的记录格式（用于快照/日志）：
@@ -75,6 +75,11 @@ def _convert_pruning_records(raw_records: list) -> List[dict]:
         "memory_type": str,
         "created_at": str,
       }
+
+    Args:
+        raw_records: 原始剪枝记录列表
+        end_user_id: 终端用户 ID，用于 API/MCP 路径生成确定性 pair_id
+        source: 写入来源（service_api/mcp），用于 API/MCP 路径生成确定性 pair_id
     """
     from datetime import timezone as _tz
 
@@ -85,7 +90,13 @@ def _convert_pruning_records(raw_records: list) -> List[dict]:
         seq = r.get("message_seq", 0)
         # pair_id 基于 conversation_id + message_seq 确定性生成，
         # graph_build_step 用它构造 Neo4j 节点 ID（orig_{pair_id} / pruned_{pair_id}），确保 MERGE 幂等。
-        pair_id = f"{conv_id}_{seq}" if (conv_id and seq) else f"orphan_{uuid.uuid4().hex[:8]}_{idx}"
+        # API/MCP 路径 conversation_id 为空，使用 (end_user_id, source, seq) 保证确定性。
+        if conv_id and seq:
+            pair_id = f"{conv_id}_{seq}"
+        elif end_user_id and source and seq:
+            pair_id = f"{end_user_id}_{source}_{seq}"
+        else:
+            pair_id = f"orphan_{uuid.uuid4().hex[:8]}_{idx}"
 
         # Assistant 消息是 input.msgs 中最后一条
         msgs = r.get("input", {}).get("msgs", [])
@@ -227,6 +238,7 @@ class WritePipeline:
         is_pilot_run: bool = False,
         skip_cursor_advance: bool = False,
         dispatch_at: str = "",
+        source: str = "",
     ) -> WriteResult:
         """
         执行写入流水线（滑动窗口模式）。
@@ -243,6 +255,7 @@ class WritePipeline:
             is_pilot_run: 试运行模式（只萃取不写入）
             skip_cursor_advance: 直接写入路径设为 True，跳过 write_cursor 推进
             dispatch_at: 任务派发时刻的 UTC ISO 8601 时间戳
+            source: 写入来源（agent/service_api/mcp/workflow），用于快照路径和节点 ID 生成
 
         Returns:
             WriteResult 包含状态和统计信息
@@ -306,9 +319,11 @@ class WritePipeline:
                     end_user_id=self.end_user_id,
                     conversation_id=conversation_id,
                     message_seq=message_seq,
+                    source=source or None,
                     extra_metadata={
                         "mode": "sliding_window",
                         "ref_id": ref_id,
+                        "source": source,
                         "dispatch_at": dispatch_at,
                         "dialog_at": _dialog_at,
                         "language": self.language,
@@ -393,13 +408,24 @@ class WritePipeline:
                     )
                     # 注入剪枝记录到 dialog_data.metadata
                     if pruning_records:
-                        converted = _convert_pruning_records(pruning_records)
+                        converted = _convert_pruning_records(
+                            pruning_records,
+                            end_user_id=self.end_user_id,
+                            source=source,
+                        )
                         for dd in chunked_dialogs:
                             existing = dd.metadata.get("assistant_pruning_records", [])
                             dd.metadata["assistant_pruning_records"] = existing + converted
 
                     # 注入 conversation_id 到 metadata
-                    _conv_id = conversation_id or f"batch_{self.end_user_id}_{ref_id}"
+                    # API/MCP 路径无 conversation_id，用 (end_user_id, source) 作为确定性 hub ID，
+                    # 确保同一用户同一来源的所有 assistant 节点聚合到同一个 Conversation hub。
+                    if conversation_id:
+                        _conv_id = conversation_id
+                    elif source:
+                        _conv_id = f"{self.end_user_id}_{source}"
+                    else:
+                        _conv_id = f"batch_{self.end_user_id}_{ref_id}"
                     for dd in chunked_dialogs:
                         dd.metadata["conversation_id"] = _conv_id
 

--- a/api/app/core/memory/utils/debug/pipeline_snapshot.py
+++ b/api/app/core/memory/utils/debug/pipeline_snapshot.py
@@ -121,6 +121,7 @@ class PipelineSnapshot:
         end_user_id: str,
         conversation_id: Optional[str] = None,
         message_seq: Optional[int] = None,
+        source: Optional[str] = None,
         extra_metadata: Optional[Dict[str, Any]] = None,
     ):
         """
@@ -131,6 +132,8 @@ class PipelineSnapshot:
             message_seq: 目标 user 消息的 message_seq（滑动窗口写入时传入）。
                 提供后会写入叶子目录名（``seq_{message_seq:06d}_{时间戳}``），
                 字典序与数值序一致，方便在 OSS Browser 里顺序定位。
+            source: 写入来源（'service_api' / 'mcp'）。当 conversation_id 为空时
+                用作第二级目录名，按来源分类快照输出。
             extra_metadata: 任意可序列化的额外字段，会写入 ``0_summary.json``，
                 典型字段：ref_id / dispatch_at / dialog_at / language /
                 target_content_preview。
@@ -139,24 +142,31 @@ class PipelineSnapshot:
         self.end_user_id = end_user_id
         self.conversation_id = conversation_id
         self.message_seq = message_seq
+        self.source = source
         self.extra_metadata: Dict[str, Any] = dict(extra_metadata or {})
         self._oss_prefix: Optional[str] = None
 
         if self.enabled:
             ts = utcnow_naive().strftime("%Y%m%d_%H%M%S")
+            seq_part = (
+                f"seq_{int(message_seq):06d}_{ts}"
+                if message_seq is not None
+                else f"seq_unknown_{ts}"
+            )
             if conversation_id:
-                # 滑动窗口路径：按 user / conversation / seq_xxx_时间戳 三级组织
-                seq_part = (
-                    f"seq_{int(message_seq):06d}_{ts}"
-                    if message_seq is not None
-                    else f"seq_unknown_{ts}"
-                )
+                # Agent/Workflow 路径：按 user / conversation / seq_xxx_时间戳 三级组织
                 self._oss_prefix = (
                     f"{_OSS_SNAPSHOT_PREFIX}/{end_user_id}/"
                     f"{conversation_id}/{seq_part}"
                 )
+            elif source:
+                # API/MCP 路径：按 user / source / seq_xxx_时间戳 三级组织
+                self._oss_prefix = (
+                    f"{_OSS_SNAPSHOT_PREFIX}/{end_user_id}/"
+                    f"{source}/{seq_part}"
+                )
             else:
-                # 兼容旧路径（整轮 messages 写入）
+                # 兼容旧路径（未传 conversation_id 也未传 source）
                 self._oss_prefix = f"{_OSS_SNAPSHOT_PREFIX}/{end_user_id}_{ts}"
             logger.debug(f"[Snapshot] 已启用，OSS 前缀: {self._oss_prefix}")
 

--- a/api/app/core/memory/utils/debug/write_snapshot_recorder.py
+++ b/api/app/core/memory/utils/debug/write_snapshot_recorder.py
@@ -35,12 +35,14 @@ class WriteSnapshotRecorder:
         end_user_id: str,
         conversation_id: Optional[str] = None,
         message_seq: Optional[int] = None,
+        source: Optional[str] = None,
         extra_metadata: Optional[Dict[str, Any]] = None,
     ):
         self._snapshot = PipelineSnapshot(
             end_user_id=end_user_id,
             conversation_id=conversation_id,
             message_seq=message_seq,
+            source=source,
             extra_metadata=extra_metadata,
         )
 

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -140,7 +140,7 @@ class MemoryWriteNode(BaseNode):
                 "files": file_info
             })
 
-        conversation_id = variable_pool.get_value("sys.conversation_id") or ""
+        conversation_id = variable_pool.get_value("sys.conversation_id")
         workspace_id = str(state.get("workspace_id", "") or "")
 
         await MemoryService.ingest_workflow_messages(

--- a/api/app/models/memory_message_model.py
+++ b/api/app/models/memory_message_model.py
@@ -4,9 +4,10 @@
 平替 messages 表在滑动窗口写入流程中的功能。
 仅存储来自 memory.enabled = true 应用的消息，或工作流 MemoryWriteNode 写入的消息。
 
-Agent 对话消息和工作流 MemoryWriteNode 消息均使用 conversation_id 关联会话。
+Agent 对话和工作流 MemoryWriteNode 通常使用 conversation_id 关联会话；
+API Service / MCP 直接写入时 conversation_id 为 NULL，用 (end_user_id, source)
+标识归属，详见 api/docs/v0.3.11/2-设计文档-评审.md。
 """
-import datetime
 import uuid
 
 from sqlalchemy import Column, String, Boolean, DateTime, Integer, Text, ForeignKey, Index
@@ -20,12 +21,19 @@ from app.core.utils.datetime_utils import utcnow_naive
 class MemoryMessage(Base):
     """记忆消息表 — 平替 messages 表在滑动窗口写入中的功能
 
-    Agent 对话消息和工作流 MemoryWriteNode 消息均使用 conversation_id 关联会话。
-    工作流本身是一个 Agent，对应一个 conversation_id；多次执行同一工作流往同一个会话存入消息。
+    写入来源分两类：
+    - agent / workflow：走 conversation_id 通道，seq 按 conversation_id 分组编号；
+      end_user_id 取自 conversation.user_id。
+    - service_api / mcp：conversation_id=NULL，用 (end_user_id, source) 标识归属，
+      seq 按 (end_user_id, source) 分组编号，两条 seq 序列彼此独立。
+
+    end_user_id 为字符串且 NOT NULL——记忆必须归属到某个终端用户，
+    类型与 conversation.user_id / 各 schema 的 end_user_id 保持一致。
     """
     __tablename__ = "memory_messages"
     __table_args__ = (
         Index("idx_memory_messages_conv_seq", "conversation_id", "message_seq"),
+        Index("idx_memory_messages_user_source", "end_user_id", "source"),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
@@ -34,28 +42,41 @@ class MemoryMessage(Base):
     conversation_id = Column(
         UUID(as_uuid=True),
         ForeignKey("conversations.id"),
-        nullable=False,
-        comment="会话ID（Agent对话和工作流消息均使用此字段）",
+        nullable=True,
+        comment="会话 ID（agent/workflow 写入时非空；API/MCP 写入时为 NULL）",
     )
     original_message_id = Column(
         UUID(as_uuid=True),
         ForeignKey("messages.id"),
         nullable=True,
-        comment="原始消息ID（对 messages 表的引用，工作流消息时为 NULL）",
+        comment="原始消息 ID（对 messages 表的引用；工作流/API/MCP 消息为 NULL）",
+    )
+
+    # 归属与来源标识（用于替代哨兵 App 机制）
+    end_user_id = Column(
+        String,
+        nullable=False,
+        comment="终端用户 ID（字符串，与 conversation.user_id / 各 schema 的 end_user_id 对齐）；所有写入路径必填",
+    )
+    source = Column(
+        String(32),
+        nullable=False,
+        default="agent",
+        comment="写入来源：agent | service_api | mcp | workflow",
     )
 
     # 消息内容
     role = Column(String(20), nullable=False, comment="角色: user/assistant/system")
     content = Column(Text, nullable=False, comment="消息内容")
 
-    # 消息序列编号：按 conversation_id 维度递增，从 1 开始
+    # 消息序列编号：分组规则见类 docstring
     message_seq = Column(
         Integer,
         nullable=False,
-        comment="消息序列编号，从 1 开始，按 conversation_id 维度递增",
+        comment="消息序列编号，从 1 开始，分组键取决于 source：agent/workflow 按 conversation_id；service_api/mcp 按 (end_user_id, source)",
     )
 
-    # 消息级记忆标记：TRUE → 触发 Write_Pipeline；FALSE → 跳过写入但 Write_Cursor 继续推进
+    # 消息级记忆标记：TRUE → 触发 Write_Pipeline；FALSE → 跳过写入但 write_cursor 继续推进
     # 工作流 MemoryWriteNode 消息强制为 TRUE
     should_memorize = Column(
         Boolean,

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -44,17 +44,25 @@ class MemoryMessageRepository:
     @contextmanager
     def _acquire_mm_seq_lock(
         self,
+        conversation_id: Optional[str],
         end_user_id: str,
         source: MemoryMessageSource,
     ):
-        """在同一 (end_user_id, source) 内串行化 seq 分配。
+        """在 seq 分组维度串行化 seq 分配，防止并发请求抢到重复 seq。
 
-        使用 pg_advisory_xact_lock，事务提交/回滚时自动释放；锁 key 按 source 区分，
-        API 并发不阻塞 MCP，反之亦然。详见设计文档 §3.3。
+        使用 pg_advisory_xact_lock，事务提交/回滚时自动释放：
+        - 有 conversation_id（agent/workflow）→ 锁 key 按 conversation_id
+        - 无 conversation_id（service_api/mcp）→ 锁 key 按 (end_user_id, source)
+
+        不同分组之间互不阻塞。详见设计文档 §3.3。
         """
+        if conversation_id is not None:
+            lock_key = f"mm_seq:conv:{conversation_id}"
+        else:
+            lock_key = f"mm_seq:{end_user_id}:{source.value}"
         self.db.execute(
             sa.text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
-            {"key": f"mm_seq:{end_user_id}:{source.value}"},
+            {"key": lock_key},
         )
         yield
 
@@ -108,15 +116,11 @@ class MemoryMessageRepository:
             成功写入的消息摘要列表 [{"role": "user", "message_seq": 1, "content": "..."}, ...]
             （跳过 content 为空的消息）
         """
-        if conversation_id is None:
-            # API/MCP 路径：先拿分布式锁再分配 seq
-            with self._acquire_mm_seq_lock(end_user_id, source):
-                return self._write_batch_inner(
-                    None, messages, end_user_id, source,
-                )
-        return self._write_batch_inner(
-            conversation_id, messages, end_user_id, source,
-        )
+        # 所有路径统一持锁分配 seq，防止同一分组的并发请求抢到重复 seq
+        with self._acquire_mm_seq_lock(conversation_id, end_user_id, source):
+            return self._write_batch_inner(
+                conversation_id, messages, end_user_id, source,
+            )
 
     def _write_batch_inner(
         self,
@@ -287,9 +291,7 @@ class MemoryMessageRepository:
         ]
 
         total = int(self.db.execute(
-            select(func.count()).select_from(
-                select(MemoryMessage.id).where(*base_filter).subquery()
-            )
+            select(func.count(MemoryMessage.id)).where(*base_filter)
         ).scalar_one())
 
         if total == 0:

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -228,6 +228,94 @@ class MemoryMessageRepository:
         ).scalar()
 
     # ──────────────────────────────────────────────
+    # 工作记忆查询（API/MCP 展示接口）
+    # ──────────────────────────────────────────────
+
+    _API_MCP_SOURCES = ("service_api", "mcp")
+
+    def get_working_memory_sources(self, end_user_id: str) -> List[dict]:
+        """返回该用户 API/MCP 各来源的记忆摘要（每 source 一行）。
+
+        Returns:
+            [{"source": "service_api", "message_count": 30, "latest_at": datetime}, ...]
+        """
+        rows = self.db.execute(
+            select(
+                MemoryMessage.source,
+                func.count().label("message_count"),
+                func.max(MemoryMessage.created_at).label("latest_at"),
+            )
+            .where(
+                MemoryMessage.end_user_id == end_user_id,
+                MemoryMessage.conversation_id.is_(None),
+                MemoryMessage.source.in_(self._API_MCP_SOURCES),
+            )
+            .group_by(MemoryMessage.source)
+        ).all()
+        return [
+            {"source": r.source, "message_count": int(r.message_count), "latest_at": r.latest_at}
+            for r in rows
+        ]
+
+    def has_api_mcp_messages(self, end_user_id: str) -> bool:
+        """判断该用户是否有任何 API/MCP 来源的记忆消息（用于 work_count +1 判断）。"""
+        exists = self.db.execute(
+            select(MemoryMessage.id)
+            .where(
+                MemoryMessage.end_user_id == end_user_id,
+                MemoryMessage.conversation_id.is_(None),
+                MemoryMessage.source.in_(self._API_MCP_SOURCES),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        return exists is not None
+
+    def list_recent_messages_by_source(
+        self,
+        end_user_id: str,
+        source: str,
+        limit: int = 20,
+    ) -> tuple[list[MemoryMessage], int]:
+        """按来源取最近 N 条消息（从旧到新排列）+ 该来源总条数。
+
+        先按 created_at DESC 取最新 limit 条 ID，再按 created_at ASC 查询完整行返回。
+        """
+        base_filter = [
+            MemoryMessage.end_user_id == end_user_id,
+            MemoryMessage.conversation_id.is_(None),
+            MemoryMessage.source == source,
+        ]
+
+        total = int(self.db.execute(
+            select(func.count()).select_from(
+                select(MemoryMessage.id).where(*base_filter).subquery()
+            )
+        ).scalar_one())
+
+        if total == 0:
+            return [], 0
+
+        # 取最新 limit 条的 ID
+        recent_ids = list(self.db.execute(
+            select(MemoryMessage.id)
+            .where(*base_filter)
+            .order_by(MemoryMessage.created_at.desc())
+            .limit(limit)
+        ).scalars().all())
+
+        if not recent_ids:
+            return [], total
+
+        # 按 created_at ASC 排序返回完整行（从旧到新）
+        rows = list(self.db.execute(
+            select(MemoryMessage)
+            .where(MemoryMessage.id.in_(recent_ids))
+            .order_by(MemoryMessage.created_at.asc())
+        ).scalars().all())
+
+        return rows, total
+
+    # ──────────────────────────────────────────────
     # write_cursor 操作（仅服务 agent/workflow 路径）
     # ──────────────────────────────────────────────
 

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -3,19 +3,23 @@ MemoryMessageRepository — memory_messages 表的数据访问层
 
 职责：
 - 封装 memory_messages 表的 CRUD 操作
-- 提供 write_cursor 原子推进
-- 提供批量写入能力
+- 提供 write_cursor 原子推进（仅 agent/workflow 路径）
+- 提供批量写入能力，支持两条独立的 seq 序列：
+    * agent / workflow：按 conversation_id 分组
+    * service_api / mcp：按 (end_user_id, source) 分组，用 pg_advisory_xact_lock 串行化
 - 供 MemoryWriteDispatcher 共用
 """
 
 import logging
 import uuid
-from datetime import datetime
+from contextlib import contextmanager
 from typing import List, Optional
 
+import sqlalchemy as sa
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
+from app.core.memory.enums import MemoryMessageSource
 from app.core.utils.datetime_utils import ensure_dialog_at, to_iso_z, utcnow_naive
 from app.models.conversation_model import Conversation
 from app.models.memory_message_model import MemoryMessage
@@ -34,13 +38,60 @@ class MemoryMessageRepository:
         self.db = db
 
     # ──────────────────────────────────────────────
+    # 内部工具：seq 分配与并发锁
+    # ──────────────────────────────────────────────
+
+    @contextmanager
+    def _acquire_mm_seq_lock(
+        self,
+        end_user_id: str,
+        source: MemoryMessageSource,
+    ):
+        """在同一 (end_user_id, source) 内串行化 seq 分配。
+
+        使用 pg_advisory_xact_lock，事务提交/回滚时自动释放；锁 key 按 source 区分，
+        API 并发不阻塞 MCP，反之亦然。详见设计文档 §3.3。
+        """
+        self.db.execute(
+            sa.text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+            {"key": f"mm_seq:{end_user_id}:{source.value}"},
+        )
+        yield
+
+    def _next_seq(
+        self,
+        *,
+        conversation_id: Optional[str],
+        end_user_id: str,
+        source: MemoryMessageSource,
+    ) -> int:
+        """按写入路径分流查询 max(message_seq)。
+
+        - 有 conversation_id：按 conversation_id 查（agent/workflow 原逻辑）
+        - conversation_id 为 NULL：按 (end_user_id, source) 查（API/MCP 新逻辑）
+        """
+        stmt = select(func.coalesce(func.max(MemoryMessage.message_seq), 0))
+        if conversation_id is not None:
+            stmt = stmt.where(MemoryMessage.conversation_id == uuid.UUID(conversation_id))
+        else:
+            stmt = stmt.where(
+                MemoryMessage.conversation_id.is_(None),
+                MemoryMessage.end_user_id == end_user_id,
+                MemoryMessage.source == source.value,
+            )
+        return int(self.db.execute(stmt).scalar() or 0)
+
+    # ──────────────────────────────────────────────
     # 消息写入
     # ──────────────────────────────────────────────
 
     def write_batch(
         self,
-        conversation_id: str,
+        conversation_id: Optional[str],
         messages: List[dict],
+        *,
+        end_user_id: str,
+        source: MemoryMessageSource = MemoryMessageSource.AGENT,
     ) -> List[dict]:
         """批量写入 memory_messages 表，自动分配递增 message_seq。
 
@@ -48,20 +99,40 @@ class MemoryMessageRepository:
         调用方需自行 commit。
 
         Args:
-            conversation_id: 对话 ID
+            conversation_id: 对话 ID。agent/workflow 传字符串；service_api/mcp 传 None
             messages: 消息列表，每条格式 {"role": "user"|"assistant", "content": "...", "files": [...]}
+            end_user_id: 终端用户 ID（必填）
+            source: 写入来源枚举，决定 seq 分组键与 memory_messages.source 字段值
 
         Returns:
             成功写入的消息摘要列表 [{"role": "user", "message_seq": 1, "content": "..."}, ...]
             （跳过 content 为空的消息）
         """
-        written: List[dict] = []
+        if conversation_id is None:
+            # API/MCP 路径：先拿分布式锁再分配 seq
+            with self._acquire_mm_seq_lock(end_user_id, source):
+                return self._write_batch_inner(
+                    None, messages, end_user_id, source,
+                )
+        return self._write_batch_inner(
+            conversation_id, messages, end_user_id, source,
+        )
 
-        max_seq_result = self.db.execute(
-            select(func.coalesce(func.max(MemoryMessage.message_seq), 0))
-            .where(MemoryMessage.conversation_id == uuid.UUID(conversation_id))
-        ).scalar()
-        next_seq = max_seq_result or 0
+    def _write_batch_inner(
+        self,
+        conversation_id: Optional[str],
+        messages: List[dict],
+        end_user_id: str,
+        source: MemoryMessageSource,
+    ) -> List[dict]:
+        written: List[dict] = []
+        next_seq = self._next_seq(
+            conversation_id=conversation_id,
+            end_user_id=end_user_id,
+            source=source,
+        )
+
+        conv_uuid = uuid.UUID(conversation_id) if conversation_id else None
 
         for msg in messages:
             role = str(msg.get("role", "user"))
@@ -70,92 +141,34 @@ class MemoryMessageRepository:
                 continue
 
             next_seq += 1
-            mm = MemoryMessage(
+            memory_message = MemoryMessage(
                 id=uuid.uuid4(),
-                conversation_id=uuid.UUID(conversation_id),
-                original_message_id=None,
+                conversation_id=conv_uuid,
+                original_message_id=msg.get("original_message_id"),
+                end_user_id=end_user_id,
+                source=source.value,
                 role=role,
                 content=content,
                 message_seq=next_seq,
                 should_memorize=msg.get("should_memorize", True),
-                created_at=utcnow_naive(),
+                created_at=msg.get("created_at") or utcnow_naive(),
                 dialog_at=ensure_dialog_at(msg.get("dialog_at")),
                 files=msg.get("files"),
             )
-            self.db.add(mm)
+            self.db.add(memory_message)
             written.append({
                 "role": role,
                 "message_seq": next_seq,
                 "content": content,
-                "dialog_at": mm.dialog_at,
+                "dialog_at": memory_message.dialog_at,
             })
             logger.debug(
-                f"[MemoryMessageRepository] 写入 memory_messages: "
-                f"conv={conversation_id}, seq={next_seq}, role={role}"
+                "[MemoryMessageRepository] 写入 memory_messages: "
+                f"conv={conversation_id or 'NULL'}, source={source.value}, "
+                f"end_user={end_user_id}, seq={next_seq}, role={role}"
             )
 
         return written
-
-    def write_single(
-        self,
-        conversation_id: str,
-        original_message_id: Optional[uuid.UUID],
-        role: str,
-        content: str,
-        created_at: datetime,
-        should_memorize: bool = True,
-        files: Optional[list] = None,
-        dialog_at: Optional[str] = None,
-    ) -> Optional[MemoryMessage]:
-        """写入单条消息到 memory_messages 表。
-
-        自动分配递增 message_seq。调用方需自行 commit。
-
-        Args:
-            conversation_id: 会话 ID（字符串）
-            original_message_id: 原始 messages 表行的 id（用于反查源消息）
-            role: user/assistant/system
-            content: 消息内容
-            created_at: 时间戳
-            should_memorize: 是否触发 Write_Pipeline
-            files: 多模态文件信息列表
-            dialog_at: 对话发生时间 ISO 8601 格式
-
-        Returns:
-            写入成功的 MemoryMessage 实例；失败时返回 None
-        """
-        try:
-            max_seq = self.db.execute(
-                select(func.coalesce(func.max(MemoryMessage.message_seq), 0))
-                .where(MemoryMessage.conversation_id == uuid.UUID(conversation_id))
-            ).scalar()
-            next_seq = (max_seq or 0) + 1
-
-            memory_msg = MemoryMessage(
-                id=uuid.uuid4(),
-                conversation_id=uuid.UUID(conversation_id),
-                original_message_id=original_message_id,
-                role=role,
-                content=content,
-                message_seq=next_seq,
-                should_memorize=should_memorize,
-                created_at=created_at,
-                dialog_at=ensure_dialog_at(dialog_at),
-                files=files,
-            )
-            self.db.add(memory_msg)
-            logger.debug(
-                f"[MemoryMessageRepository] 单条写入: "
-                f"conv={conversation_id}, seq={next_seq}, role={role}"
-            )
-            return memory_msg
-        except Exception as e:
-            logger.error(
-                f"[MemoryMessageRepository] 写入失败: "
-                f"conv={conversation_id}, err={e}",
-                exc_info=True,
-            )
-            return None
 
     # ──────────────────────────────────────────────
     # 消息查询
@@ -181,16 +194,7 @@ class MemoryMessageRepository:
         write_cursor: int,
         role: Optional[str] = None,
     ) -> List[MemoryMessage]:
-        """查询 message_seq > write_cursor 的待处理消息。
-
-        Args:
-            conversation_id: 对话 ID
-            write_cursor: 当前游标位置
-            role: 可选角色过滤（"user" / "assistant"）
-
-        Returns:
-            待处理消息列表，按 message_seq 升序排列
-        """
+        """查询 message_seq > write_cursor 的待处理消息（agent/workflow 路径）。"""
         stmt = (
             select(MemoryMessage)
             .where(
@@ -224,7 +228,7 @@ class MemoryMessageRepository:
         ).scalar()
 
     # ──────────────────────────────────────────────
-    # write_cursor 操作
+    # write_cursor 操作（仅服务 agent/workflow 路径）
     # ──────────────────────────────────────────────
 
     def get_write_cursor(self, conversation_id: str) -> Optional[int]:
@@ -244,12 +248,8 @@ class MemoryMessageRepository:
         UPDATE conversations SET write_cursor = :seq
         WHERE id = :conv_id AND write_cursor < :seq
 
-        Args:
-            conversation_id: 对话 ID
-            message_seq: 目标 message_seq
-
         Returns:
-            是否成功推进（True 表示推进了，False 表示 cursor 已 >= seq）
+            是否成功推进（True 表示推进了，False 表示 cursor 已 >= seq 或 conversation 不存在）
         """
         result = self.db.execute(
             update(Conversation)
@@ -268,7 +268,7 @@ class MemoryMessageRepository:
         return max_seq is None or max_seq <= cursor
 
     # ──────────────────────────────────────────────
-    # 上下文窗口查询
+    # 上下文窗口查询（agent/workflow 滑动窗口路径使用）
     # ──────────────────────────────────────────────
 
     def build_context_before(
@@ -281,9 +281,6 @@ class MemoryMessageRepository:
 
         向前查找最多 window_size 个 user 消息，取最小 message_seq 作为上边界，
         查询 [upper_bound, target_seq) 范围内所有消息。
-
-        Returns:
-            消息列表，按 message_seq 升序排列
         """
         # 向前查找 user 消息 seq
         upstream_q_seqs = self.db.execute(
@@ -323,13 +320,9 @@ class MemoryMessageRepository:
         """构建下文消息列表。
 
         向后查找最多 window_size 个 user 消息，取最大 message_seq 作为下边界，
-        查询 (target_seq, lower_bound] 范围内所有消息。
-
-        若下游无 user 消息，则返回 target_seq 之后的所有消息（包含尾部 assistant 消息），
+        查询 (target_seq, lower_bound] 范围内所有消息。若下游无 user 消息，
+        则返回 target_seq 之后的所有消息（包含尾部 assistant 消息），
         确保最后一条 assistant 消息也能作为上下文被处理。
-
-        Returns:
-            消息列表，按 message_seq 升序排列
         """
         downstream_q_seqs = self.db.execute(
             select(MemoryMessage.message_seq)

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -1576,19 +1576,30 @@ async def analytics_memory_types(
     else:
         perceptual_count = 0
     
-    # 获取工作记忆数量（基于会话数量）
+    # 获取工作记忆数量（agent/workflow 会话数 + API/MCP 有记录则 +1）
     work_count = 0
     if end_user_id:
         try:
+            from app.repositories.memory_message_repository import MemoryMessageRepository
+
             conversation_repo = ConversationRepository(db)
             conversations, total = conversation_repo.get_conversation_by_user_id(
                 user_id=uuid.UUID(end_user_id),
                 is_activate=True
             )
-            work_count = total
-            logger.debug(f"工作记忆数量（会话数）: {work_count} (end_user_id={end_user_id})")
+            agent_workflow_count = total
+
+            memory_message_repo = MemoryMessageRepository(db)
+            api_mcp_count = 1 if memory_message_repo.has_api_mcp_messages(end_user_id) else 0
+
+            work_count = agent_workflow_count + api_mcp_count
+            logger.debug(
+                f"工作记忆数量: total={work_count} "
+                f"(agent_workflow={agent_workflow_count}, api_mcp={api_mcp_count}) "
+                f"(end_user_id={end_user_id})"
+            )
         except Exception as e:
-            logger.warning(f"获取会话数量失败，工作记忆数量设为0: {str(e)}")
+            logger.warning(f"获取工作记忆数量失败，设为0: {str(e)}")
             work_count = 0
     
     # 获取隐性记忆数量（基于有关联关系的 MemorySummary 节点数量，需 >= MIN_MEMORY_SUMMARY_COUNT 才计入）

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1693,6 +1693,7 @@ def write_message_task(
         language: str = "zh",
         skip_cursor_advance: bool = False,
         dispatch_at: str = "",  # 任务执行时间
+        source: str = "",  # 写入来源（agent/service_api/mcp/workflow）
         # MCP 入口兼容字段（不经过 memory_messages 表，直接写入）
         messages: Optional[List[dict]] = None,
         storage_type: str = "neo4j",
@@ -1778,6 +1779,7 @@ def write_message_task(
             language=language,
             skip_cursor_advance=skip_cursor_advance,
             dispatch_at=dispatch_at,
+            source=source,
         )
         return {"status": result.status, "extraction": result.extraction}
 


### PR DESCRIPTION
feat/memory-api-mcp-working-memory

## Summary by Sourcery

为 API 和 MCP 的记忆消息新增 working-memory 支持，并在智能体、工作流及外部来源之间统一分发和写入路径。

New Features:
- 引入 API 和 MCP 的 working-memory 浏览端点，用于为终端用户列出来源及最近消息。
- 支持在没有会话（conversation）的情况下写入记忆消息，通过 `(end_user_id, source)` 分组，并为消息打上其来源类型标签。
- 使 MCP 能够直接写入记忆，并支持逐消息任务以及确定性的图（graph）快照标识符。

Enhancements:
- 重构记忆分发器和写入流水线，以携带 `source` 属性，将智能体/工作流与 API/MCP 路径拆分，并移除哨兵式的会话/应用机制。
- 扩展记忆分析，将 API/MCP working memory 计入智能体/工作流会话统计中。
- 改进快照记录和裁剪（pruning）元数据，以在非会话记忆写入场景中保持确定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add working-memory support for API and MCP memory messages while unifying dispatch and write paths across agents, workflows, and external sources.

New Features:
- Introduce API and MCP working-memory browsing endpoints to list sources and recent messages for an end user.
- Support memory message writes without conversations by grouping on (end_user_id, source) and tagging messages with their origin source type.
- Enable MCP to write memory directly with per-message tasks and deterministic graph snapshot identifiers.

Enhancements:
- Refactor memory dispatcher and write pipeline to carry a source attribute, split agent/workflow vs API/MCP paths, and remove the sentinel conversation/app mechanism.
- Extend memory analytics to count API/MCP working memory alongside agent/workflow conversations.
- Improve snapshot recording and pruning metadata to remain deterministic for non-conversation memory writes.

</details>