### PR TITLE
fix(app-chat)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -225,7 +225,7 @@ class AppChatService:
         tools.extend(kb_tools)
         if memory:
             memory_tools, _ = self.agent_service.load_memory_config(
-                config.memory, user_id, uuid.UUID(workspace_id), storage_type, user_rag_memory_id
+                config.memory, user_id, uuid.UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id, storage_type, user_rag_memory_id
             )
             tools.extend(memory_tools)
 
@@ -653,7 +653,7 @@ class AppChatService:
             # 添加长期记忆工具
             if memory:
                 memory_tools, _ = self.agent_service.load_memory_config(
-                    config.memory, user_id, uuid.UUID(workspace_id), storage_type, user_rag_memory_id
+                    config.memory, user_id, uuid.UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id, storage_type, user_rag_memory_id
                 )
                 tools.extend(memory_tools)
 


### PR DESCRIPTION
handle both string and UUID types for workspace_id in memory config loading

## Summary by Sourcery

Bug Fixes:
- 通过在 chat 和 chat_stream 流程中，在加载记忆配置之前有条件地将字符串形式的 `workspace_id` 转换为 UUID，防止在 `workspace_id` 以字符串提供时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent errors when workspace_id is provided as a string by conditionally converting it to a UUID before loading memory configuration in chat and chat_stream flows.

</details>