### PR TITLE
fix(memory-config): remove detailed data from delete response for warning and success cases

### DIFF
--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -537,25 +537,18 @@ def delete_config(
 
         if result["status"] == "warning":
             api_logger.warning(
-                f"记忆配置正在使用，无法删除: config_id={config_id}, "
-                f"connected_count={result['connected_count']}"
+                f"记忆配置正在使用，无法删除: config_id={config_id}"
             )
             return fail(
                 code=BizCode.RESOURCE_IN_USE,
-                msg=result["message"],
-                data={
-                    "connected_count": result["connected_count"],
-                    "force_required": result["force_required"]
-                }
+                msg=result["message"]
             )
 
         api_logger.info(
-            f"记忆配置删除成功: config_id={config_id}, "
-            f"affected_users={result['affected_users']}"
+            f"记忆配置删除成功: config_id={config_id}"
         )
         return success(
-            msg=result["message"],
-            data={"affected_users": result["affected_users"]}
+            msg=result["message"]
         )
 
     except Exception as e:


### PR DESCRIPTION
- Remove `connected_count` and `force_required` from the warning response body
- Remove `affected_users` from the success response body
- Keep only the message in both response branches

## 由 Sourcery 提供的总结

通过在警告和成功的情况下仅返回一条消息来简化内存配置删除接口的响应，从负载中移除详细数据。

错误修复：
- 在删除内存配置时，停止在警告响应中暴露已连接数量和强制要求指示器。
- 在删除内存配置时，停止在成功响应中暴露受影响用户数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify memory configuration delete responses by returning only a message in warning and success cases, removing detailed data from the payload.

Bug Fixes:
- Stop exposing connected count and force-required indicators in warning responses when deleting memory configurations.
- Stop exposing affected user counts in success responses when deleting memory configurations.

</details>