### PR TITLE
fix(memory-config): add config_id and is_default to delete and validation responses

### DIFF
--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -125,7 +125,8 @@ async def validate_active_config_models(
         config_id = MemoryConfigService(db).get_workspace_active_config_id(workspace_id)
     except BusinessException:
         from app.i18n.service import t
-        return success(data={"valid": False, "warnings": [{"message": t("memory_config.workspace.no_active_config", locale=locale)}]})
+        return success(data={"valid": False,
+                             "warnings": [{"message": t("memory_config.workspace.no_active_config", locale=locale)}]})
 
     result = await MemoryConfigService(db).valid_config(config_id, locale=locale)
     return success(data=result)
@@ -541,14 +542,16 @@ def delete_config(
             )
             return fail(
                 code=BizCode.RESOURCE_IN_USE,
-                msg=result["message"]
+                msg=result["message"],
+                data={"config_id": str(config_id), "is_default": result.get("is_default", False)}
             )
 
         api_logger.info(
             f"记忆配置删除成功: config_id={config_id}"
         )
         return success(
-            msg=result["message"]
+            msg=result["message"],
+            data={"config_id": str(config_id), "is_default": result.get("is_default", False)}
         )
 
     except Exception as e:


### PR DESCRIPTION
- Return config_id and is_default in delete success and in-use failure responses
- Format validation warning response for consistency

## Summary by Sourcery

在删除响应中返回内存配置标识符和默认状态，并统一验证警告响应的格式。

新功能：
- 在内存配置删除成功以及“正在使用”导致删除失败的响应中，包含 `config_id` 和 `is_default` 字段。

改进：
- 标准化内存配置验证警告响应的结构，以提升一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Return memory config identifiers and default status in delete responses and align validation warning response formatting.

New Features:
- Include config_id and is_default fields in memory config delete success and in-use failure responses.

Enhancements:
- Standardize the structure of memory config validation warning responses for consistency.

</details>