### PR TITLE
fix(rag): use file local server URL for MinerU images

### DIFF
--- a/api/app/core/rag/chunk/parser/image_storage.py
+++ b/api/app/core/rag/chunk/parser/image_storage.py
@@ -96,13 +96,11 @@ def store_mineru_v3_image(
 
 
 def _build_image_download_url(file_id: uuid.UUID) -> str:
-    path = f"/api/storage/permanent/{file_id}"
-    base_url = (settings.BASE_URL or "").rstrip("/")
-    if not base_url:
+    server_url = (settings.FILE_LOCAL_SERVER_URL or "").rstrip("/")
+    path = f"/storage/permanent/{file_id}"
+    if not server_url:
         return path
-    if base_url.endswith("/api") and path.startswith("/api/"):
-        path = path[len("/api"):]
-    return f"{base_url}{path}"
+    return f"{server_url}{path}"
 
 
 def _parse_uuid(value: Any) -> uuid.UUID | None:

--- a/api/env.example
+++ b/api/env.example
@@ -85,7 +85,6 @@ ENABLE_SINGLE_SESSION=
 MAX_FILE_SIZE=52428800  # 50MB:50 * 1024 * 1024
 FILE_PATH=/files
 
-# Public backend base URL used for permanent image links in chunk metadata
 BASE_URL=http://localhost:8000
 FILE_LOCAL_SERVER_URL="http://localhost:8000/api"
 # Storage Backend Configuration


### PR DESCRIPTION
## Summary
- Use FILE_LOCAL_SERVER_URL when building MinerU V3 permanent image URLs.
- Keep generated image URLs consistent with existing file storage permanent URLs.
- Remove misleading BASE_URL comment from env.example.

## Changes
- api/app/core/rag/chunk/parser/image_storage.py | 10 ++++------
- api/env.example | 1 -

## Test Plan
- [x] .venv/bin/python -m py_compile app/core/rag/chunk/parser/image_storage.py
- [x] git diff --check -- api/app/core/rag/chunk/parser/image_storage.py api/env.example

## Summary by Sourcery

更新 MinerU V3 图像 URL 生成逻辑，改为使用文件本地服务器 URL，并与现有的永久存储 URL 模式保持一致。

Bug Fixes:
- 通过从 `BASE_URL` 切换为 `FILE_LOCAL_SERVER_URL` 并修正永久存储路径，修复 MinerU V3 图像下载 URL。

Enhancements:
- 简化 MinerU V3 图像下载 URL 的构建逻辑。

Documentation:
- 通过移除与存储 URL 相关的过时 `BASE_URL` 注释，澄清环境配置示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MinerU V3 image URL generation to use the file local server URL and align with existing permanent storage URL patterns.

Bug Fixes:
- Fix MinerU V3 image download URLs by switching from BASE_URL to FILE_LOCAL_SERVER_URL and correcting the permanent storage path.

Enhancements:
- Simplify image download URL construction logic for MinerU V3 images.

Documentation:
- Clarify environment example by removing an outdated BASE_URL comment related to storage URLs.

</details>