### PR TITLE
fix(rag): apply local hybrid rerank threshold

### DIFF
--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -26,6 +26,7 @@ class KnowledgeBaseConfig(BaseModel):
     kb_id: uuid.UUID = Field(..., description="Knowledge base ID")
     similarity_threshold: float = Field(default=0.2, ge=0, le=1, description="Knowledge base similarity threshold")
     vector_similarity_weight: float = Field(default=0.3, ge=0, le=1, description="Knowledge base vector similarity weight")
+    rerank_score_threshold: float | None = Field(default=None, ge=0, le=1, description="Knowledge base rerank score threshold")
     top_k: int = Field(default=4, ge=1, le=100, description="Knowledge base top k")
     retrieve_type: RetrieveType = Field(default=RetrieveType.PARTICIPLE, description="Retrieve type")
 

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -399,6 +399,26 @@ class KnowledgeRetrievalService:
         )
 
     @staticmethod
+    def _resolve_rerank_score_threshold(
+            request: KnowledgeRetrievalRequest,
+            config: KnowledgeBaseConfig | None = None,
+    ) -> float:
+        explicit_fields = config.model_fields_set if config else set()
+        if (
+                config
+                and "rerank_score_threshold" in explicit_fields
+                and config.rerank_score_threshold is not None
+        ):
+            return config.rerank_score_threshold
+        if config and "vector_similarity_weight" in explicit_fields:
+            return config.vector_similarity_weight
+        if request.rerank_score_threshold is not None:
+            return request.rerank_score_threshold
+        if request.vector_similarity_weight is not None:
+            return request.vector_similarity_weight
+        return 0.1
+
+    @staticmethod
     def _build_retrieval_params(
             request: KnowledgeRetrievalRequest,
             config: KnowledgeBaseConfig | None = None,
@@ -416,13 +436,7 @@ class KnowledgeRetrievalService:
             if config and "vector_similarity_weight" in explicit_fields
             else request.vector_similarity_weight
         )
-        rerank_score_threshold = (
-            config.rerank_score_threshold
-            if config and "rerank_score_threshold" in explicit_fields
-            else config.vector_similarity_weight
-            if config and "vector_similarity_weight" in explicit_fields
-            else request.rerank_score_threshold or request.vector_similarity_weight or 0.1
-        )
+        rerank_score_threshold = KnowledgeRetrievalService._resolve_rerank_score_threshold(request, config)
         top_n = max(top_k, request.top_n or top_k)
         return RetrievalParams(
             similarity_threshold=similarity_threshold,
@@ -879,7 +893,7 @@ class KnowledgeRetrievalService:
             used_rerank: bool,
     ) -> float:
         if used_rerank:
-            return request.rerank_score_threshold or request.vector_similarity_weight or 0.1
+            return KnowledgeRetrievalService._resolve_rerank_score_threshold(request)
 
         retrieve_types = {target.params.retrieve_type for target in targets}
         if retrieve_types == {RetrieveType.PARTICIPLE}:
@@ -999,7 +1013,7 @@ class KnowledgeRetrievalService:
 
         logger.debug(f"[rerank]rerank_id:{request.rerank_id}, returned {len(reranked_chunks)} docs")
 
-        rerank_score_threshold = request.rerank_score_threshold or request.vector_similarity_weight or 0.1
+        rerank_score_threshold = cls._resolve_rerank_score_threshold(request)
 
         filtered_chunks = [
             chunk

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -74,6 +74,7 @@ class RetrievalParams:
     top_k: int
     top_n: int
     retrieve_type: RetrieveType
+    rerank_score_threshold: float = 0.1
 
 
 @dataclass(frozen=True)
@@ -415,6 +416,13 @@ class KnowledgeRetrievalService:
             if config and "vector_similarity_weight" in explicit_fields
             else request.vector_similarity_weight
         )
+        rerank_score_threshold = (
+            config.rerank_score_threshold
+            if config and "rerank_score_threshold" in explicit_fields
+            else config.vector_similarity_weight
+            if config and "vector_similarity_weight" in explicit_fields
+            else request.rerank_score_threshold or request.vector_similarity_weight or 0.1
+        )
         top_n = max(top_k, request.top_n or top_k)
         return RetrievalParams(
             similarity_threshold=similarity_threshold,
@@ -422,6 +430,7 @@ class KnowledgeRetrievalService:
             top_k=top_k,
             top_n=top_n,
             retrieve_type=retrieve_type,
+            rerank_score_threshold=rerank_score_threshold,
         )
 
     @classmethod
@@ -756,6 +765,11 @@ class KnowledgeRetrievalService:
             docs=unique_chunks,
             top_k=target.params.top_k,
         )
+        chunks = [
+            chunk
+            for chunk in chunks
+            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
+        ]
         if log_id:
             logger.info(
                 "[Retrieval] target_done %s",


### PR DESCRIPTION
## Summary
- Add KB-local rerank score threshold support to retrieval configuration.
- Resolve local rerank threshold from child rerank threshold, child vector threshold, root rerank threshold, then root vector threshold.
- Filter single-KB hybrid rerank results with the resolved KB-local rerank threshold.

## Changes
- api/app/schemas/chunk_schema.py
- api/app/services/knowledge_retrieval_service.py

## API Impact
- Backward compatible: existing callers can continue using root-level retrieval parameters.
- External callers that do not pass per-KB rerank thresholds keep the existing fallback behavior through root retrieval thresholds.

## Risk
- Limited to RAG retrieval threshold resolution and local hybrid rerank filtering.
- No frontend, docs, or committed test files are included.

## Test Plan
- [x] cd api && ./.venv/bin/python -m pytest tests/rag/test_knowledge_retrieval_config.py -q
- [x] cd api && ./.venv/bin/python -m compileall app/services/knowledge_retrieval_service.py app/schemas/chunk_schema.py
- [x] git diff --check origin/develop..HEAD

## 由 Sourcery 提供的总结

为每个知识库新增重排序分数阈值，并在混合检索过滤过程中应用这些阈值。

新功能：
- 在知识库检索配置中引入重排序分数阈值字段。
- 将重排序分数阈值传播到用于单目标检索的检索参数中。

增强：
- 基于解析后的重排序分数阈值，对单知识库的混合重排序结果进行过滤；当未显式设置阈值时，保留现有的回退行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-knowledge-base rerank score thresholds and apply them during hybrid retrieval filtering.

New Features:
- Introduce a rerank score threshold field to knowledge base retrieval configuration.
- Propagate rerank score thresholds into retrieval parameters used for single-target retrievals.

Enhancements:
- Filter single-knowledge-base hybrid rerank results based on the resolved rerank score threshold, preserving existing fallback behavior when thresholds are not explicitly set.

</details>