### PR TITLE
refactor(memory): remove force parameter from delete memory config endpoint

### DIFF
--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -505,8 +505,7 @@ def delete_config(
 
     - 检查是否为默认配置，默认配置不允许删除
     - 检查是否有终端用户连接到该配置
-    - 如果有连接且 force=False，返回警告
-    - 如果 force=True，清除终端用户引用后删除配置
+    - 如果有连接，返回警告
     """
     workspace_id = current_user.current_workspace_id
     config_id = resolve_config_id(config_id, db)

--- a/api/app/controllers/service/memory_config_api_controller.py
+++ b/api/app/controllers/service/memory_config_api_controller.py
@@ -475,12 +475,11 @@ async def delete_memory_config(
     Delete a memory config.
 
     - Default configs cannot be deleted.
-    - If end users are connected and force=False, returns a warning.
-    - If force=True, clears end user references and deletes the config.
+    - If end users are connected, returns a warning.
 
     Only configs belonging to the authorized workspace can be deleted.
     """
-    logger.info(f"V1 delete config - config_id: {config_id}, force: {force}, workspace: {api_key_auth.workspace_id}")
+    logger.info(f"V1 delete config - config_id: {config_id}, workspace: {api_key_auth.workspace_id}")
 
     _verify_config_ownership(config_id, api_key_auth.workspace_id, db)
 

--- a/api/openapi-baseline.json
+++ b/api/openapi-baseline.json
@@ -3708,7 +3708,7 @@
           "V1 - Memory Config API"
         ],
         "summary": "Delete Memory Config",
-        "description": "Delete a memory config.\n\n- Default configs cannot be deleted.\n- If end users are connected and force=False, returns a warning.\n- If force=True, clears end user references and deletes the config.\n\nOnly configs belonging to the authorized workspace can be deleted.",
+        "description": "Delete a memory config.\n\n- Default configs cannot be deleted.\n- If end users are connected, returns a warning.\n\nOnly configs belonging to the authorized workspace can be deleted.",
         "operationId": "delete_memory_config_v1_memory_config_delete_config_delete",
         "parameters": [
           {
@@ -3719,18 +3719,6 @@
               "type": "string",
               "title": "Config Id"
             }
-          },
-          {
-            "name": "force",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "description": "是否强制删除（即使有终端用户正在使用）",
-              "default": false,
-              "title": "Force"
-            },
-            "description": "是否强制删除（即使有终端用户正在使用）"
           }
         ],
         "requestBody": {


### PR DESCRIPTION
- Remove the `force` query parameter from the delete memory config API
- Update docstrings to reflect that connected end users always prevent deletion
- Update OpenAPI baseline to remove the `force` parameter definition

## Summary by Sourcery

从删除 memory 配置的 API 中移除 `force` 查询参数，并相应更新文档和日志。

Enhancements:
- 明确删除 memory 配置行为：当仍有终端用户连接时，始终返回警告。
- 简化删除 memory 配置控制器的日志记录，从日志输出中移除 `force` 标志。

Build:
- 更新 OpenAPI 基线，从删除 memory 配置端点定义中移除 `force` 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the force query parameter from the delete memory config API and align documentation and logging accordingly.

Enhancements:
- Clarify delete memory config behavior to always return a warning when end users are connected.
- Simplify delete memory config controller logging by removing the force flag from log output.

Build:
- Update the OpenAPI baseline to remove the force parameter from the delete memory config endpoint definition.

</details>