### PR TITLE
feat(web): space config support default configured model

### DIFF
--- a/web/src/api/workspaces.ts
+++ b/web/src/api/workspaces.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:00:26 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-13 15:29:03
+ * @Last Modified time: 2026-07-03 21:16:31
  */
 import { request } from '@/utils/request'
 import type { SpaceModalData } from '@/views/SpaceManagement/types'
@@ -31,5 +31,21 @@ export const getWorkspaceModels = () => {
 }
 // Update workspace model config
 export const updateWorkspaceModels = (data: SpaceConfigData) => {
+  return request.put(`/workspaces/workspace_models`, data)
+}
+// Get current default configured model
+export const getDefaultWorkspaceModel = () => {
+  return request.get(`/workspaces/default_models`)
+}
+// Get custom workspace models options
+export const getCustomWorkspaceModels = () => {
+  return request.get(`/workspaces/model_options`)
+}
+// Validate workspace models config
+export const validateWorkspaceModels = (data: SpaceConfigData) => {
+  return request.post(`/workspaces/workspace_models/validate`, data)
+}
+// Update workspace models config and validate model availability
+export const updateWorkspaceModelsAndValidate = (data: SpaceConfigData) => {
   return request.put(`/workspaces/workspace_models`, data)
 }

--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:48:03 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-03-30 11:36:24 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-07-03 21:17:09
  */
 /**
  * Space Configuration Page
@@ -10,43 +10,83 @@
  */
 
 import { type FC, useEffect, useState } from 'react';
-import { Form, App, Button, Skeleton } from 'antd';
+import { Form, App, Button, Skeleton, Select } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { SpaceConfigData } from './types'
-import { getWorkspaceModels, updateWorkspaceModels } from '@/api/workspaces'
-import ModelSelect from '@/components/ModelSelect';
+import { getWorkspaceModels, updateWorkspaceModels, getDefaultWorkspaceModel, getCustomWorkspaceModels } from '@/api/workspaces'
+import RadioGroupCard from '@/components/RadioGroupCard'
+import type { Capability, ModelListItem } from '@/views/ModelManagement/types'
+
+/** Required base model selectors */
+const baseModelFields: { name: string; label: string; required?: boolean }[] = [
+  { name: 'llm', label: 'llmModel', required: true },
+  { name: 'embedding', label: 'embeddingModel', required: true },
+  { name: 'rerank', label: 'rerankModel', required: true },
+]
+
+/** Optional multimodal model selectors */
+const multimodalModelFields: { name: string; label: string; capability: Capability }[] = [
+  { name: 'vision', label: 'visionModel', capability: 'vision' },
+  { name: 'audio', label: 'audioModel', capability: 'audio' },
+  { name: 'video', label: 'videoModel', capability: 'video' },
+]
 
 const SpaceConfig: FC = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
-  const [pageLoading, setPageLoding] = useState(false)
+  const [pageLoading, setPageLoading] = useState(false)
   const [form] = Form.useForm<SpaceConfigData>();
   const [loading, setLoading] = useState(false)
 
   const values = Form.useWatch([], form);
 
+  const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
+  const handleGetDefaultModels = () => {
+    getDefaultWorkspaceModel().then(res => {
+      setDefaultModels((res || {}) as Record<string, ModelListItem>)
+    })
+  }
+  const [customModels, setCustomModels] = useState<Record<string, ModelListItem[]>>({})
+  const handleGetCustomModels = () => {
+    getCustomWorkspaceModels().then(res => {
+      setCustomModels((res || {}) as Record<string, ModelListItem[]>)
+    })
+  }
+
   useEffect(() => {
-    setPageLoding(true)
+    setPageLoading(true)
     getWorkspaceModels().then((res) => {
-      const { llm, embedding, rerank } = res as SpaceConfigData
+      const { is_default_config, llm, embedding, rerank, vision, audio, video } = res as SpaceConfigData
       form.setFieldsValue({
+        is_default_config: is_default_config ? '1' : '0',
         llm,
         embedding,
-        rerank
+        rerank,
+        vision,
+        audio,
+        video,
       })
     })
     .finally(() => {
-      setPageLoding(false)
+      setPageLoading(false)
     })
+
+    handleGetDefaultModels()
+    handleGetCustomModels()
   }, [])
   /** Save configuration */
   const handleSave = () => {
     form
       .validateFields()
-      .then(() => {
+      .then(({ is_default_config, ...rest }: SpaceConfigData) => {
+        if (is_default_config === '1') {
+          [...baseModelFields, ...multimodalModelFields].map(field => {
+            (rest as Record<string, any>)[field.name] = undefined
+          })
+        }
         setLoading(true)
-        updateWorkspaceModels(values)
+        updateWorkspaceModels({ ...rest, is_default_config: is_default_config === '1' })
           .then(() => {
             setLoading(false)
             message.success(t('common.updateSuccess'))
@@ -69,40 +109,89 @@ const SpaceConfig: FC = () => {
         : <Form
           form={form}
           layout="vertical"
+          initialValues={{ is_default_config: '1' }}
         >
-          <Form.Item 
-            label={t('space.llmModel')}
-            className="rb:font-medium rb:text-[#212332] rb:mb-6!"
-            name="llm"
-            rules={[{ required: true, message: t('common.pleaseSelect') }]}
-          >
-            <ModelSelect
-              params={{ type: 'llm' }}
-              className="rb:w-137.5!"
+          <Form.Item name="is_default_config" className="rb:mb-6! rb:max-w-137.5">
+            <RadioGroupCard
+              allowClear={false}
+              options={[
+                {
+                  value: '1',
+                  label: t('space.defaultConfigPackage'),
+                  labelDesc: t('space.defaultConfigPackageDesc'),
+                  recommend: true,
+                },
+                {
+                  value: '0',
+                  label: t('space.customConfig'),
+                  labelDesc: t('space.customConfigDesc'),
+                },
+              ]}
             />
           </Form.Item>
-          <Form.Item 
-            label={t('space.embeddingModel')}
-            className="rb:font-medium rb:text-[#212332] rb:mb-6!"
-            name="embedding"
-            rules={[{ required: true, message: t('common.pleaseSelect') }]}
-          >
-            <ModelSelect
-              params={{ type: 'embedding' }}
-              className="rb:w-137.5!"
-            />
-          </Form.Item>
-          <Form.Item 
-            label={t('space.rerankModel')}
-            className="rb:font-medium rb:text-[#212332] rb:mb-6!"
-            name="rerank"
-            rules={[{ required: true, message: t('common.pleaseSelect') }]}
-          >
-            <ModelSelect
-              params={{ type: 'rerank' }}
-              className="rb:w-137.5!"
-            />
-          </Form.Item>
+
+          {values?.is_default_config === '0' ? (
+            <>
+              <div className="rb:flex rb:items-baseline rb:gap-2 rb:pb-3 rb:mb-6 rb:border-b rb:border-[#EBEBEB] rb:max-w-137.5">
+                <span className="rb:font-medium rb:text-[#212332]">{t('space.baseModel')}</span>
+                <span className="rb:text-[12px] rb:text-[#5B6167]">{t('space.baseModelDesc')}</span>
+              </div>
+              {baseModelFields.map(field => (
+                <Form.Item
+                  key={field.name}
+                  label={t(`space.${field.label}`)}
+                  className="rb:font-medium rb:text-[#212332] rb:mb-6!"
+                  name={field.name}
+                  rules={[{ required: true, message: t('common.pleaseSelect') }]}
+                >
+                  <Select
+                    allowClear
+                    showSearch
+                    optionFilterProp="label"
+                    fieldNames={{ label: 'name', value: 'id' }}
+                    placeholder={t('common.pleaseSelect')}
+                    options={customModels[field.name]}
+                    className="rb:w-137.5!"
+                  />
+                </Form.Item>
+              ))}
+
+              <div className="rb:flex rb:items-baseline rb:gap-2 rb:pb-3 rb:mb-6 rb:border-b rb:border-[#EBEBEB] rb:max-w-137.5">
+                <span className="rb:font-medium rb:text-[#212332]">{t('space.multimodalModel')}</span>
+                <span className="rb:text-[12px] rb:text-[#5B6167]">{t('space.multimodalModelDesc')}</span>
+              </div>
+              {multimodalModelFields.map(field => (
+                <Form.Item
+                  key={field.name}
+                  label={<>{t(`space.${field.label}`)}<span className="rb:text-[#5B6167] rb:font-regular">{t('space.optional')}</span></>}
+                  className="rb:font-medium rb:text-[#212332] rb:mb-6!"
+                  name={field.name}
+                >
+                  <Select
+                    allowClear
+                    showSearch
+                    optionFilterProp="label"
+                    fieldNames={{ label: 'name', value: 'id' }}
+                    placeholder={t('common.pleaseSelect')}
+                    options={customModels[field.name]}
+                    className="rb:w-137.5!"
+                  />
+                </Form.Item>
+              ))}
+            </>
+          ) : (
+            <div className="rb:rounded-lg rb:bg-[#F6F6F6] rb:px-4 rb:mb-6 rb:max-w-137.5">
+              {[...baseModelFields, ...multimodalModelFields].map(field => (
+                <div
+                  key={field.name}
+                  className="rb:flex rb:items-center rb:justify-between rb:py-3.5 rb:border-b rb:border-[#EBEBEB] rb:last:border-b-0"
+                >
+                  <span className="rb:text-[#5B6167]">{t(`space.${field.label}`)}</span>
+                  <span className="rb:font-medium rb:text-[#212332]">{defaultModels[field.name]?.name || '-'}</span>
+                </div>
+              ))}
+            </div>
+          )}
 
           <Button type="primary" className="rb:mt-1" onClick={handleSave} loading={loading}>
             {t('common.save')}

--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:48:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 21:17:09
+ * @Last Modified time: 2026-07-03 21:32:20
  */
 /**
  * Space Configuration Page
@@ -31,6 +31,7 @@ const multimodalModelFields: { name: string; label: string; capability: Capabili
   { name: 'audio', label: 'audioModel', capability: 'audio' },
   { name: 'video', label: 'videoModel', capability: 'video' },
 ]
+const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 
 const SpaceConfig: FC = () => {
   const { t } = useTranslation();
@@ -43,6 +44,9 @@ const SpaceConfig: FC = () => {
 
   const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
   const handleGetDefaultModels = () => {
+    if (!isSaas) {
+      return
+    }
     getDefaultWorkspaceModel().then(res => {
       setDefaultModels((res || {}) as Record<string, ModelListItem>)
     })
@@ -59,7 +63,7 @@ const SpaceConfig: FC = () => {
     getWorkspaceModels().then((res) => {
       const { is_default_config, llm, embedding, rerank, vision, audio, video } = res as SpaceConfigData
       form.setFieldsValue({
-        is_default_config: is_default_config ? '1' : '0',
+        is_default_config: is_default_config && isSaas ? '1' : '0',
         llm,
         embedding,
         rerank,
@@ -80,13 +84,14 @@ const SpaceConfig: FC = () => {
     form
       .validateFields()
       .then(({ is_default_config, ...rest }: SpaceConfigData) => {
-        if (is_default_config === '1') {
+        const isDefaultConfig = is_default_config === '1' && isSaas && Object.keys(defaultModels).length > 0
+        if (isDefaultConfig) {
           [...baseModelFields, ...multimodalModelFields].map(field => {
             (rest as Record<string, any>)[field.name] = undefined
           })
         }
         setLoading(true)
-        updateWorkspaceModels({ ...rest, is_default_config: is_default_config === '1' })
+        updateWorkspaceModels({ ...rest, is_default_config: isDefaultConfig })
           .then(() => {
             setLoading(false)
             message.success(t('common.updateSuccess'))
@@ -109,28 +114,30 @@ const SpaceConfig: FC = () => {
         : <Form
           form={form}
           layout="vertical"
-          initialValues={{ is_default_config: '1' }}
+          initialValues={{ is_default_config: isSaas ? '1' : '0' }}
         >
-          <Form.Item name="is_default_config" className="rb:mb-6! rb:max-w-137.5">
-            <RadioGroupCard
-              allowClear={false}
-              options={[
-                {
-                  value: '1',
-                  label: t('space.defaultConfigPackage'),
-                  labelDesc: t('space.defaultConfigPackageDesc'),
-                  recommend: true,
-                },
-                {
-                  value: '0',
-                  label: t('space.customConfig'),
-                  labelDesc: t('space.customConfigDesc'),
-                },
-              ]}
-            />
-          </Form.Item>
+          {isSaas && Object.keys(defaultModels).length > 0 &&
+            <Form.Item name="is_default_config" className="rb:mb-6! rb:max-w-137.5">
+              <RadioGroupCard
+                allowClear={false}
+                options={[
+                  {
+                    value: '1',
+                    label: t('space.defaultConfigPackage'),
+                    labelDesc: t('space.defaultConfigPackageDesc'),
+                    recommend: true,
+                  },
+                  {
+                    value: '0',
+                    label: t('space.customConfig'),
+                    labelDesc: t('space.customConfigDesc'),
+                  },
+                ]}
+              />
+            </Form.Item>
+          }
 
-          {values?.is_default_config === '0' ? (
+          {!isSaas || Object.keys(defaultModels).length === 0 || values?.is_default_config === '0' ? (
             <>
               <div className="rb:flex rb:items-baseline rb:gap-2 rb:pb-3 rb:mb-6 rb:border-b rb:border-[#EBEBEB] rb:max-w-137.5">
                 <span className="rb:font-medium rb:text-[#212332]">{t('space.baseModel')}</span>

--- a/web/src/views/SpaceConfig/types.ts
+++ b/web/src/views/SpaceConfig/types.ts
@@ -4,13 +4,19 @@
  * @Last Modified by:   ZhaoYing 
  * @Last Modified time: 2026-02-03 17:48:06 
  */
+
 /**
  * Space configuration data
  */
 export interface SpaceConfigData {
-  llm: string;
-  embedding: string;
-  rerank: string;
+  /** Config package mode: default recommended package or custom per-model selection */
+  is_default_config?: boolean | string;
+  llm?: string;
+  embedding?: string;
+  rerank?: string;
+  vision?: string;
+  audio?: string;
+  video?: string;
 }
 /**
  * Space config component ref interface

--- a/web/src/views/SpaceManagement/components/SpaceModal.tsx
+++ b/web/src/views/SpaceManagement/components/SpaceModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:49:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 21:10:45
+ * @Last Modified time: 2026-07-03 21:32:55
  */
 /**
  * Space Modal Component
@@ -53,6 +53,7 @@ const customModelFields: { name: 'llm' | 'embedding' | 'rerank' | 'vision' | 'au
   { name: 'video', label: 'videoModel' },
 ]
 
+const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   refresh
 }, ref) => {
@@ -80,6 +81,9 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
     setCurrentStep(prev => prev - 1)
   }
   const handleGetDefaultModels = () => {
+    if (!isSaas) {
+      return
+    }
     getDefaultWorkspaceModel().then(res => {
       setDefaultModels((res || {}) as Record<string, ModelListItem>)
     })
@@ -114,11 +118,12 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
           setCurrentStep(1)
         } else {
           const { icon, is_default_config, ...rest } = values
+          const isDefaultConfig = is_default_config === '1' && isSaas && Object.keys(defaultModels).length > 0
           let formData: SpaceModalData = {
             ...rest,
-            is_default_config: is_default_config === '1',
+            is_default_config: isDefaultConfig,
           }
-          if (is_default_config === '1') {
+          if (isDefaultConfig) {
             customModelFields.forEach(field => {
               formData[field.name] = undefined
             })
@@ -196,7 +201,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
         layout="vertical"
         initialValues={{
           storage_type: types[0],
-          is_default_config: '1',
+          is_default_config: isSaas ? '1' : '0',
         }}
       >
         <Form.Item
@@ -241,27 +246,29 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
 
 
         {currentStep === 1 && <>
-          <Form.Item name="is_default_config" className="rb:mb-6!">
-            <RadioGroupCard
-              allowClear={false}
-              options={[
-                {
-                  value: '1',
-                  label: t('space.defaultConfigPackage'),
-                  labelDesc: t('space.defaultConfigPackageDesc'),
-                  recommend: true,
-                },
-                {
-                  value: '0',
-                  label: t('space.customConfig'),
-                  labelDesc: t('space.customConfigDesc'),
-                },
-              ]}
-              onChange={handleChange}
-            />
-          </Form.Item>
+          {isSaas && Object.keys(defaultModels).length > 0 &&
+            <Form.Item name="is_default_config" className="rb:mb-6!">
+              <RadioGroupCard
+                allowClear={false}
+                options={[
+                  {
+                    value: '1',
+                    label: t('space.defaultConfigPackage'),
+                    labelDesc: t('space.defaultConfigPackageDesc'),
+                    recommend: true,
+                  },
+                  {
+                    value: '0',
+                    label: t('space.customConfig'),
+                    labelDesc: t('space.customConfigDesc'),
+                  },
+                ]}
+                onChange={handleChange}
+              />
+            </Form.Item>
+          }
 
-          {values?.is_default_config === '0' ? (
+          {!isSaas || Object.keys(defaultModels).length === 0 || values?.is_default_config === '0' ? (
             customModelFields.map(field => (
               <Form.Item
                 key={field.name}

--- a/web/src/views/SpaceManagement/components/SpaceModal.tsx
+++ b/web/src/views/SpaceManagement/components/SpaceModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:49:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-25 11:45:54
+ * @Last Modified time: 2026-07-03 21:10:45
  */
 /**
  * Space Modal Component
@@ -10,19 +10,19 @@
  */
 
 import { forwardRef, useImperativeHandle, useState } from 'react';
-import { Form, Input, App, Steps, Button } from 'antd';
+import { Form, Input, App, Steps, Button, Select } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { SpaceModalData, SpaceModalRef, Space, StorageType } from '../types'
 import RbModal from '@/components/RbModal'
-import { createWorkspace } from '@/api/workspaces'
+import { createWorkspace, getDefaultWorkspaceModel, getCustomWorkspaceModels } from '@/api/workspaces'
 import RadioGroupCard from '@/components/RadioGroupCard'
 import UploadImages from '@/components/Upload/UploadImages'
 import { getFileLink } from '@/api/fileStorage'
 import ragIcon from '@/assets/images/space/rag.png'
 import neo4jIcon from '@/assets/images/space/neo4j.png'
 import { stringRegExp } from '@/utils/validator';
-import ModelSelect from '@/components/ModelSelect';
+import type { ModelListItem } from '@/views/ModelManagement/types'
 
 const FormItem = Form.Item;
 
@@ -43,6 +43,16 @@ const typeIcons: Record<StorageType, string> = {
   neo4j: neo4jIcon
 }
 
+/** Custom config model selectors */
+const customModelFields: { name: 'llm' | 'embedding' | 'rerank' | 'vision' | 'audio' | 'video'; label: string; required?: boolean }[] = [
+  { name: 'llm', label: 'llmModel', required: true },
+  { name: 'embedding', label: 'embeddingModel', required: true },
+  { name: 'rerank', label: 'rerankModel', required: true },
+  { name: 'vision', label: 'visionModel' },
+  { name: 'audio', label: 'audioModel' },
+  { name: 'video', label: 'videoModel' },
+]
+
 const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   refresh
 }, ref) => {
@@ -53,6 +63,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   const [loading, setLoading] = useState(false)
   const [editVo, setEditVo] = useState<Space | null>(null)
   const [currentStep, setCurrentStep] = useState(0)
+  const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
 
   const values = Form.useWatch([], form);
 
@@ -68,7 +79,17 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   const handlePrevStep = () => {
     setCurrentStep(prev => prev - 1)
   }
-
+  const handleGetDefaultModels = () => {
+    getDefaultWorkspaceModel().then(res => {
+      setDefaultModels((res || {}) as Record<string, ModelListItem>)
+    })
+  }
+  const [customModels, setCustomModels] = useState<Record<string, ModelListItem[]>>({})
+  const handleGetCustomModels = () => {
+    getCustomWorkspaceModels().then(res => {
+      setCustomModels((res || {}) as Record<string, ModelListItem[]>)
+    })
+  }
   /** Open modal with optional data */
   const handleOpen = (space?: Space) => {
     if (space) {
@@ -80,6 +101,8 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
     } else {
       form.resetFields();
     }
+    handleGetDefaultModels()
+    handleGetCustomModels()
     setVisible(true);
   };
   /** Save or proceed to next step */
@@ -90,9 +113,15 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
         if (currentStep === 0) {
           setCurrentStep(1)
         } else {
-          const { icon, ...rest } = values
-          const formData: SpaceModalData = {
-            ...rest
+          const { icon, is_default_config, ...rest } = values
+          let formData: SpaceModalData = {
+            ...rest,
+            is_default_config: is_default_config === '1',
+          }
+          if (is_default_config === '1') {
+            customModelFields.forEach(field => {
+              formData[field.name] = undefined
+            })
           }
           if (icon?.response?.data.file_id) {
             getFileLink(icon?.response?.data.file_id).then(res => {
@@ -126,6 +155,17 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
         setLoading(false)
       });
   }
+  const handleChange = (value: string | null | undefined) => {
+    const resetFields = {}
+    if (value === '0') {
+      customModelFields.forEach(field => {
+        (resetFields as Record<string, any>)[field.name] = defaultModels[field.name]?.id
+      })
+    }
+    form.setFieldsValue({
+      ...resetFields,
+    })
+  }
 
   /** Expose methods to parent component */
   useImperativeHandle(ref, () => ({
@@ -156,6 +196,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
         layout="vertical"
         initialValues={{
           storage_type: types[0],
+          is_default_config: '1',
         }}
       >
         <Form.Item
@@ -200,39 +241,57 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
 
 
         {currentStep === 1 && <>
-          <Form.Item
-            label={t('space.llmModel')}
-            name="llm"
-            rules={[{ required: true, message: t('common.selectPlaceholder', { title: t('space.llmModel') }) }]}
-          >
-            <ModelSelect
-              params={{ type: 'llm,chat' }}
-              placeholder={t('common.selectPlaceholder', { title: t('space.llmModel') })}
-              className="rb:w-full!"
+          <Form.Item name="is_default_config" className="rb:mb-6!">
+            <RadioGroupCard
+              allowClear={false}
+              options={[
+                {
+                  value: '1',
+                  label: t('space.defaultConfigPackage'),
+                  labelDesc: t('space.defaultConfigPackageDesc'),
+                  recommend: true,
+                },
+                {
+                  value: '0',
+                  label: t('space.customConfig'),
+                  labelDesc: t('space.customConfigDesc'),
+                },
+              ]}
+              onChange={handleChange}
             />
           </Form.Item>
-          <Form.Item
-            label={t('space.embeddingModel')}
-            name="embedding"
-            rules={[{ required: true, message: t('common.selectPlaceholder', { title: t('space.embeddingModel') }) }]}
-          >
-            <ModelSelect
-              params={{ type: 'embedding' }}
-              placeholder={t('common.selectPlaceholder', { title: t('space.embeddingModel') })}
-              className="rb:w-full!"
-            />
-          </Form.Item>
-          <Form.Item
-            label={t('space.rerankModel')}
-            name="rerank"
-            rules={[{ required: true, message: t('common.selectPlaceholder', { title: t('space.rerankModel') }) }]}
-          >
-            <ModelSelect
-              params={{ type: 'rerank' }}
-              placeholder={t('common.selectPlaceholder', { title: t('space.rerankModel') })}
-              className="rb:w-full!"
-            />
-          </Form.Item>
+
+          {values?.is_default_config === '0' ? (
+            customModelFields.map(field => (
+              <Form.Item
+                key={field.name}
+                label={t(`space.${field.label}`)}
+                name={field.name}
+                rules={[{ required: field.required, message: t('common.selectPlaceholder', { title: t(`space.${field.label}`) }) }]}
+              >
+                <Select
+                  allowClear
+                  showSearch
+                  optionFilterProp="label"
+                  fieldNames={{ label: 'name', value: 'id' }}
+                  placeholder={t('common.pleaseSelect')}
+                  options={customModels[field.name]}
+                />
+              </Form.Item>
+            ))
+          ) : (
+            <div className="rb:rounded-lg rb:bg-[#F6F6F6] rb:px-4">
+              {customModelFields.map(field => (
+                <div
+                  key={field.name}
+                  className="rb:flex rb:items-center rb:justify-between rb:py-3.5 rb:border-b rb:border-[#EBEBEB] rb:last:border-b-0"
+                >
+                  <span className="rb:text-[#5B6167]">{t(`space.${field.label}`)}</span>
+                  <span className="rb:font-medium rb:text-[#212332]">{defaultModels[field.name]?.name || '-'}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </>}
       </Form>
     </RbModal>

--- a/web/src/views/SpaceManagement/types.ts
+++ b/web/src/views/SpaceManagement/types.ts
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:48:51 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-02-03 17:48:51 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-07-03 21:17:27
  */
 /**
  * Application data type
@@ -33,10 +33,16 @@ export interface SpaceModalData {
   type: string;
   icon?: any;
   iconType?: 'remote';
-  llm: string;
-  embedding: string;
-  rerank: string;
+  /** Config package mode: default recommended package or custom per-model selection */
+  is_default_config?: boolean | string;
+  llm?: string;
+  embedding?: string;
+  rerank?: string;
+  vision?: string;
+  audio?: string;
+  video?: string;
   storage_type: StorageType;
+  [key: string]: any;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

为空间添加支持：可在默认推荐模型包和按模型自定义配置之间进行选择（包括多模态模型），并在空间创建与配置流程中展示默认/自定义模型选项。

新功能：
- 在空间配置页面中，为工作区模型引入“默认配置”和“自定义配置”模式。
- 在空间配置中允许选择并展示额外的多模态模型（视觉、音频、视频）。
- 在空间创建弹窗中暴露默认和自定义的工作区模型选项，并支持按模型进行覆盖配置。

增强：
- 扩展工作区 API 层，增加用于获取默认模型包、自定义模型选项以及验证工作区模型配置的端点。
- 放宽空间配置和弹窗类型约束，以支持可选和多模态模型字段及通用配置映射表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for choosing between default recommended model packages and custom per-model configurations for spaces, including multimodal models, and surface default/custom model options in space creation and configuration flows.

New Features:
- Introduce a default vs custom configuration mode for workspace models in the space configuration page.
- Allow selection and display of additional multimodal models (vision, audio, video) in space configurations.
- Expose default and custom workspace model options in the space creation modal with per-model overrides.

Enhancements:
- Extend workspace API layer with endpoints for fetching default model packages, custom model options, and validating workspace model configurations.
- Relax space configuration and modal types to support optional and multimodal model fields and a generic config map.

</details>