### PR TITLE
fix(web): add default model config check

### DIFF
--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:48:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 21:17:09
+ * @Last Modified time: 2026-07-03 21:32:20
  */
 /**
  * Space Configuration Page
@@ -31,6 +31,7 @@ const multimodalModelFields: { name: string; label: string; capability: Capabili
   { name: 'audio', label: 'audioModel', capability: 'audio' },
   { name: 'video', label: 'videoModel', capability: 'video' },
 ]
+const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 
 const SpaceConfig: FC = () => {
   const { t } = useTranslation();
@@ -43,6 +44,9 @@ const SpaceConfig: FC = () => {
 
   const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
   const handleGetDefaultModels = () => {
+    if (!isSaas) {
+      return
+    }
     getDefaultWorkspaceModel().then(res => {
       setDefaultModels((res || {}) as Record<string, ModelListItem>)
     })
@@ -59,7 +63,7 @@ const SpaceConfig: FC = () => {
     getWorkspaceModels().then((res) => {
       const { is_default_config, llm, embedding, rerank, vision, audio, video } = res as SpaceConfigData
       form.setFieldsValue({
-        is_default_config: is_default_config ? '1' : '0',
+        is_default_config: is_default_config && isSaas ? '1' : '0',
         llm,
         embedding,
         rerank,
@@ -80,13 +84,14 @@ const SpaceConfig: FC = () => {
     form
       .validateFields()
       .then(({ is_default_config, ...rest }: SpaceConfigData) => {
-        if (is_default_config === '1') {
+        const isDefaultConfig = is_default_config === '1' && isSaas && Object.keys(defaultModels).length > 0
+        if (isDefaultConfig) {
           [...baseModelFields, ...multimodalModelFields].map(field => {
             (rest as Record<string, any>)[field.name] = undefined
           })
         }
         setLoading(true)
-        updateWorkspaceModels({ ...rest, is_default_config: is_default_config === '1' })
+        updateWorkspaceModels({ ...rest, is_default_config: isDefaultConfig })
           .then(() => {
             setLoading(false)
             message.success(t('common.updateSuccess'))
@@ -109,28 +114,30 @@ const SpaceConfig: FC = () => {
         : <Form
           form={form}
           layout="vertical"
-          initialValues={{ is_default_config: '1' }}
+          initialValues={{ is_default_config: isSaas ? '1' : '0' }}
         >
-          <Form.Item name="is_default_config" className="rb:mb-6! rb:max-w-137.5">
-            <RadioGroupCard
-              allowClear={false}
-              options={[
-                {
-                  value: '1',
-                  label: t('space.defaultConfigPackage'),
-                  labelDesc: t('space.defaultConfigPackageDesc'),
-                  recommend: true,
-                },
-                {
-                  value: '0',
-                  label: t('space.customConfig'),
-                  labelDesc: t('space.customConfigDesc'),
-                },
-              ]}
-            />
-          </Form.Item>
+          {isSaas && Object.keys(defaultModels).length > 0 &&
+            <Form.Item name="is_default_config" className="rb:mb-6! rb:max-w-137.5">
+              <RadioGroupCard
+                allowClear={false}
+                options={[
+                  {
+                    value: '1',
+                    label: t('space.defaultConfigPackage'),
+                    labelDesc: t('space.defaultConfigPackageDesc'),
+                    recommend: true,
+                  },
+                  {
+                    value: '0',
+                    label: t('space.customConfig'),
+                    labelDesc: t('space.customConfigDesc'),
+                  },
+                ]}
+              />
+            </Form.Item>
+          }
 
-          {values?.is_default_config === '0' ? (
+          {!isSaas || Object.keys(defaultModels).length === 0 || values?.is_default_config === '0' ? (
             <>
               <div className="rb:flex rb:items-baseline rb:gap-2 rb:pb-3 rb:mb-6 rb:border-b rb:border-[#EBEBEB] rb:max-w-137.5">
                 <span className="rb:font-medium rb:text-[#212332]">{t('space.baseModel')}</span>

--- a/web/src/views/SpaceManagement/components/SpaceModal.tsx
+++ b/web/src/views/SpaceManagement/components/SpaceModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:49:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 21:10:45
+ * @Last Modified time: 2026-07-03 21:32:55
  */
 /**
  * Space Modal Component
@@ -53,6 +53,7 @@ const customModelFields: { name: 'llm' | 'embedding' | 'rerank' | 'vision' | 'au
   { name: 'video', label: 'videoModel' },
 ]
 
+const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   refresh
 }, ref) => {
@@ -80,6 +81,9 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
     setCurrentStep(prev => prev - 1)
   }
   const handleGetDefaultModels = () => {
+    if (!isSaas) {
+      return
+    }
     getDefaultWorkspaceModel().then(res => {
       setDefaultModels((res || {}) as Record<string, ModelListItem>)
     })
@@ -114,11 +118,12 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
           setCurrentStep(1)
         } else {
           const { icon, is_default_config, ...rest } = values
+          const isDefaultConfig = is_default_config === '1' && isSaas && Object.keys(defaultModels).length > 0
           let formData: SpaceModalData = {
             ...rest,
-            is_default_config: is_default_config === '1',
+            is_default_config: isDefaultConfig,
           }
-          if (is_default_config === '1') {
+          if (isDefaultConfig) {
             customModelFields.forEach(field => {
               formData[field.name] = undefined
             })
@@ -196,7 +201,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
         layout="vertical"
         initialValues={{
           storage_type: types[0],
-          is_default_config: '1',
+          is_default_config: isSaas ? '1' : '0',
         }}
       >
         <Form.Item
@@ -241,27 +246,29 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
 
 
         {currentStep === 1 && <>
-          <Form.Item name="is_default_config" className="rb:mb-6!">
-            <RadioGroupCard
-              allowClear={false}
-              options={[
-                {
-                  value: '1',
-                  label: t('space.defaultConfigPackage'),
-                  labelDesc: t('space.defaultConfigPackageDesc'),
-                  recommend: true,
-                },
-                {
-                  value: '0',
-                  label: t('space.customConfig'),
-                  labelDesc: t('space.customConfigDesc'),
-                },
-              ]}
-              onChange={handleChange}
-            />
-          </Form.Item>
+          {isSaas && Object.keys(defaultModels).length > 0 &&
+            <Form.Item name="is_default_config" className="rb:mb-6!">
+              <RadioGroupCard
+                allowClear={false}
+                options={[
+                  {
+                    value: '1',
+                    label: t('space.defaultConfigPackage'),
+                    labelDesc: t('space.defaultConfigPackageDesc'),
+                    recommend: true,
+                  },
+                  {
+                    value: '0',
+                    label: t('space.customConfig'),
+                    labelDesc: t('space.customConfigDesc'),
+                  },
+                ]}
+                onChange={handleChange}
+              />
+            </Form.Item>
+          }
 
-          {values?.is_default_config === '0' ? (
+          {!isSaas || Object.keys(defaultModels).length === 0 || values?.is_default_config === '0' ? (
             customModelFields.map(field => (
               <Form.Item
                 key={field.name}


### PR DESCRIPTION
## Summary by Sourcery

根据环境和可用性保护默认模型配置行为

增强功能：
- 通过 SaaS 环境标志控制默认工作区模型获取和默认配置选项
- 当默认模型不可用时，隐藏默认配置单选控件，并使用自定义配置
- 将表单初始值和 `is_default_config` 提交逻辑与仅 SaaS 的默认模型包对齐

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard default model configuration behavior by environment and availability

Enhancements:
- Gate default workspace model fetching and default config options behind a SaaS environment flag
- Hide default configuration radio controls and use custom configurations when default models are unavailable
- Align form initial values and is_default_config submission logic with SaaS-only default model packages

</details>