### PR TITLE
feat(ci): API Report Workflow

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -1,0 +1,340 @@
+name: API Docs & Release Change Report
+
+on:
+  # 自动触发：release 分支有新 push 时（合并 PR 等）
+  push:
+    branches:
+      - 'release/**'
+
+  # 手动触发：可指定 base/current 版本
+  workflow_dispatch:
+    inputs:
+      current_ref:
+        description: "当前版本分支（如 release/v0.3.11）"
+        required: true
+        default: "release/v0.3.11"
+      base_ref:
+        description: "基线版本分支（如 release/v0.3.10）"
+        required: true
+        default: "release/v0.3.10"
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ─── Checkout（完整历史） ───
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ─── 解析 current 和 base 版本 ───
+      - name: Resolve version refs
+        id: refs
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CURRENT_REF="${{ inputs.current_ref }}"
+            BASE_REF="${{ inputs.base_ref }}"
+          else
+            # push 事件：current = 当前推送的分支, base = 上一个 patch 版本
+            CURRENT_REF="${{ github.ref_name }}"
+            VERSION=$(echo "$CURRENT_REF" | sed 's|release/||')
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            PATCH=$(echo "$VERSION" | sed 's/^v//' | cut -d. -f3)
+            PREV_PATCH=$((PATCH - 1))
+            if [ "$PREV_PATCH" -lt 0 ]; then
+              echo "::error::无法计算上一个 release 版本：$CURRENT_REF (patch=0)"
+              exit 1
+            fi
+            BASE_REF="release/${MAJOR}.${MINOR}.${PREV_PATCH}"
+          fi
+
+          echo "current_ref=$CURRENT_REF" >> $GITHUB_OUTPUT
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+
+          # 解析 SHA
+          CURRENT_SHA=$(git rev-parse "origin/$CURRENT_REF" 2>/dev/null || git rev-parse "$CURRENT_REF" 2>/dev/null || true)
+          if [ -z "$CURRENT_SHA" ]; then
+            echo "::error::无法解析 current ref: $CURRENT_REF"
+            exit 1
+          fi
+          CURRENT_SHORT=$(git rev-parse --short "$CURRENT_SHA")
+
+          BASE_SHA=$(git rev-parse "origin/$BASE_REF" 2>/dev/null || git rev-parse "$BASE_REF" 2>/dev/null || true)
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::无法解析 base ref: $BASE_REF — 该分支是否存在？"
+            exit 1
+          fi
+          BASE_SHORT=$(git rev-parse --short "$BASE_SHA")
+
+          echo "current_sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
+          echo "current_short=$CURRENT_SHORT" >> $GITHUB_OUTPUT
+          echo "base_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "base_short=$BASE_SHORT" >> $GITHUB_OUTPUT
+
+          CURRENT_VERSION=$(echo "$CURRENT_REF" | sed 's|release/||')
+          BASE_VERSION=$(echo "$BASE_REF" | sed 's|release/||')
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+
+          echo "当前版本: $CURRENT_REF ($CURRENT_SHORT)"
+          echo "基线版本: $BASE_REF ($BASE_SHORT)"
+
+      # ─── 安装 Python + uv ───
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv==0.7.12
+
+      # ─── 导出当前版本 OpenAPI schema ───
+      - name: Checkout current ref
+        run: git checkout ${{ steps.refs.outputs.current_sha }}
+
+      - name: Install dependencies (current)
+        working-directory: api
+        run: uv sync
+
+      - name: Export current OpenAPI schema
+        working-directory: api
+        run: |
+          mkdir -p ../artifacts/raw
+          uv run python scripts/export_openapi.py --v1-only -o ../artifacts/openapi-current.json
+
+      # ─── 导出基线版本 OpenAPI schema ───
+      - name: Checkout base ref
+        run: git checkout ${{ steps.refs.outputs.base_sha }}
+
+      - name: Install dependencies (base)
+        working-directory: api
+        run: uv sync
+
+      - name: Export base OpenAPI schema
+        working-directory: api
+        run: |
+          uv run python scripts/export_openapi.py --v1-only -o ../artifacts/openapi-base.json
+
+      # ─── 恢复当前版本 ───
+      - name: Restore current ref
+        run: git checkout ${{ steps.refs.outputs.current_sha }}
+
+      # ─── 生成 Markdown API 文档 ───
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Generate Markdown API documentation
+        run: |
+          npx --yes widdershins@4.0.1 \
+            artifacts/openapi-current.json \
+            -o artifacts/openapi-doc.md \
+            --language_tabs 'python:Python' 'shell:cURL' \
+            --summary \
+            --omitHeader
+
+      # ─── 生成变更报告（oasdiff） ───
+      - name: Install oasdiff
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/Tufin/oasdiff/main/install.sh | sudo sh
+
+      - name: Generate API change report
+        env:
+          BASE_REF: ${{ steps.refs.outputs.base_ref }}
+          BASE_VERSION: ${{ steps.refs.outputs.base_version }}
+          BASE_SHA: ${{ steps.refs.outputs.base_sha }}
+          BASE_SHORT: ${{ steps.refs.outputs.base_short }}
+          CURRENT_REF: ${{ steps.refs.outputs.current_ref }}
+          CURRENT_VERSION: ${{ steps.refs.outputs.current_version }}
+          CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
+          CURRENT_SHORT: ${{ steps.refs.outputs.current_short }}
+        run: |
+          # oasdiff 完整变更日志
+          oasdiff changelog \
+            artifacts/openapi-base.json \
+            artifacts/openapi-current.json \
+            --format text > artifacts/raw/oasdiff-changelog.txt 2>&1 || true
+
+          # oasdiff 仅 breaking changes
+          oasdiff breaking \
+            artifacts/openapi-base.json \
+            artifacts/openapi-current.json \
+            --format text > artifacts/raw/oasdiff-breaking.txt 2>&1 || true
+
+          # openapi-diff（与 breaking-change workflow 保持一致）
+          docker run --rm \
+            -v "${{ github.workspace }}/artifacts:/work" \
+            openapitools/openapi-diff:2.1.0-beta.11 \
+            /work/openapi-base.json \
+            /work/openapi-current.json \
+            --markdown /work/raw/openapi-diff-output.md 2>&1 || true
+
+          # 生成中文 Markdown 报告
+          python3 << 'PYEOF'
+          import os
+
+          base_version = os.environ["BASE_VERSION"]
+          base_ref = os.environ["BASE_REF"]
+          base_sha = os.environ["BASE_SHA"]
+          base_short = os.environ["BASE_SHORT"]
+          current_version = os.environ["CURRENT_VERSION"]
+          current_ref = os.environ["CURRENT_REF"]
+          current_sha = os.environ["CURRENT_SHA"]
+          current_short = os.environ["CURRENT_SHORT"]
+
+          def read_file(path):
+              try:
+                  with open(path, "r") as f:
+                      return f.read().strip()
+              except FileNotFoundError:
+                  return ""
+
+          changelog = read_file("artifacts/raw/oasdiff-changelog.txt")
+          breaking = read_file("artifacts/raw/oasdiff-breaking.txt")
+          openapi_diff = read_file("artifacts/raw/openapi-diff-output.md")
+
+          has_breaking = bool(breaking and "No changes detected" not in breaking and "No breaking changes" not in breaking and len(breaking) > 5)
+          has_changelog = bool(changelog and "No changes detected" not in changelog and len(changelog) > 5)
+
+          lines = []
+          lines.append(f"# API 变更报告：{base_version} → {current_version}\n")
+          lines.append("## 对比范围\n")
+          lines.append("| 字段 | 值 |")
+          lines.append("|------|---|")
+          lines.append(f"| 基线版本 | `{base_ref}` (`{base_short}`) |")
+          lines.append(f"| 当前版本 | `{current_ref}` (`{current_short}`) |")
+          lines.append(f"| 基线 SHA | `{base_sha}` |")
+          lines.append(f"| 当前 SHA | `{current_sha}` |")
+          lines.append("")
+
+          lines.append("## 摘要\n")
+          lines.append("| 指标 | 状态 |")
+          lines.append("|------|------|")
+          lines.append(f"| 破坏性变更 | {'⚠️ 有' if has_breaking else '✅ 无'} |")
+          lines.append(f"| 非破坏性变更 | {'📝 有' if has_changelog else '✅ 无'} |")
+          lines.append("")
+
+          if has_breaking:
+              lines.append("## ⚠️ 破坏性变更（Breaking Changes）\n")
+              lines.append("```")
+              lines.append(breaking)
+              lines.append("```\n")
+
+          if has_changelog:
+              lines.append("## 变更端点详情\n")
+              lines.append("<details>")
+              lines.append("<summary>点击展开 oasdiff 完整变更日志</summary>\n")
+              lines.append("```")
+              lines.append(changelog)
+              lines.append("```\n")
+              lines.append("</details>\n")
+
+          if openapi_diff:
+              lines.append("## openapi-diff 报告\n")
+              lines.append("<details>")
+              lines.append("<summary>点击展开 openapi-diff 输出</summary>\n")
+              lines.append(openapi_diff)
+              lines.append("\n</details>\n")
+
+          if not has_breaking and not has_changelog:
+              lines.append("> 两个版本之间未检测到 API 变更。\n")
+
+          with open("artifacts/openapi-change-report.md", "w") as f:
+              f.write("\n".join(lines))
+
+          print(f"报告已生成：{base_version} → {current_version}")
+          PYEOF
+
+      # ─── 上传产物 ───
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-${{ steps.refs.outputs.base_version }}-to-${{ steps.refs.outputs.current_version }}
+          path: artifacts/
+          retention-days: 90
+
+      # ─── 发送企业微信通知 ───
+      - name: Notify WeChat
+        if: always()
+        env:
+          WECHAT_WEBHOOK: ${{ secrets.WECHAT_WEBHOOK }}
+          BASE_VERSION: ${{ steps.refs.outputs.base_version }}
+          CURRENT_VERSION: ${{ steps.refs.outputs.current_version }}
+          BASE_SHORT: ${{ steps.refs.outputs.base_short }}
+          CURRENT_SHORT: ${{ steps.refs.outputs.current_short }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, urllib.request
+
+          base_ver = os.environ["BASE_VERSION"]
+          current_ver = os.environ["CURRENT_VERSION"]
+          base_short = os.environ["BASE_SHORT"]
+          current_short = os.environ["CURRENT_SHORT"]
+          run_url = os.environ["RUN_URL"]
+          webhook = os.environ.get("WECHAT_WEBHOOK", "")
+
+          if not webhook:
+              print("WECHAT_WEBHOOK 未配置，跳过通知")
+              exit(0)
+
+          # 读取摘要
+          def read_file(path):
+              try:
+                  with open(path, "r") as f:
+                      return f.read().strip()
+              except FileNotFoundError:
+                  return ""
+
+          breaking = read_file("artifacts/raw/oasdiff-breaking.txt")
+          changelog = read_file("artifacts/raw/oasdiff-changelog.txt")
+
+          has_breaking = bool(breaking and "No changes detected" not in breaking and "No breaking changes" not in breaking and len(breaking) > 5)
+          has_changelog = bool(changelog and "No changes detected" not in changelog and len(changelog) > 5)
+
+          # 统计变更数
+          change_count = 0
+          for line in changelog.split("\n"):
+              if line.strip().startswith(("info", "warning", "error")):
+                  change_count += 1
+
+          # 构建企业微信 Markdown 消息
+          status_icon = "⚠️" if has_breaking else "✅"
+          content = (
+              f"## 📋 API 变更报告\n"
+              f"> **版本对比**: {base_ver} → {current_ver}\n"
+              f"> **Commit**: `{base_short}` → `{current_short}`\n\n"
+              f"### 摘要\n"
+              f"- 破坏性变更: {status_icon} {'有' if has_breaking else '无'}\n"
+              f"- 变更端点数: {change_count}\n"
+          )
+
+          if has_breaking:
+              # 截取前 500 字符避免消息过长
+              breaking_preview = breaking[:500]
+              if len(breaking) > 500:
+                  breaking_preview += "\n... (完整报告见 Artifacts)"
+              content += f"\n### ⚠️ 破坏性变更\n```\n{breaking_preview}\n```\n"
+
+          content += f"\n---\n🔗 [查看完整报告与下载 Artifacts]({run_url})"
+
+          payload = {
+              "msgtype": "markdown",
+              "markdown": {
+                  "title": f"📋 API 变更报告 {base_ver} → {current_ver}",
+                  "text": content,
+              }
+          }
+          data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+          req = urllib.request.Request(
+              webhook,
+              data=data,
+              headers={"Content-Type": "application/json"}
+          )
+          resp = urllib.request.urlopen(req)
+          print(resp.read().decode())
+          PYEOF


### PR DESCRIPTION
## 变更内容

新增 GitHub Actions workflow：`.github/workflows/api-docs-release-report.yml`

### 功能

- **自动触发**：release 分支有新 push 时自动运行，对比当前版本与上一个 patch 版本
- **手动触发**：支持 workflow_dispatch 指定任意 current_ref 和 base_ref
- **OpenAPI 导出**：复用现有 `scripts/export_openapi.py`，分别导出 base 和 current 的 schema
- **Markdown API 文档**：使用 widdershins@4.0.1 生成完整 API 文档
- **变更报告**：使用 oasdiff + openapi-diff 生成中文变更报告
- **产物上传**：所有文件上传为 GitHub Actions Artifacts（保留 90 天）
- **企业微信通知**：将变更摘要推送至企业微信群（复用 WECHAT_WEBHOOK secret）

### 输出产物

| 文件 | 说明 |
|------|------|
| openapi-current.json | 当前版本 OpenAPI schema |
| openapi-base.json | 基线版本 OpenAPI schema |
| openapi-doc.md | Markdown API 文档 |
| openapi-change-report.md | 中文变更报告 |
| raw/oasdiff-*.txt | 原始工具输出 |

### 不影响

- 不影响现有 `api-breaking-change.yml` PR 门禁逻辑
- 不修改任何现有文件

## Summary by Sourcery

添加一个 CI 工作流，用于在发布分支更新时自动生成并分发 API 文档和变更报告。

新功能：
- 引入一个用于 API 文档和发布变更报告的 GitHub Actions 工作流，在发布分支推送以及手动触发时运行。
- 为基础版本和当前版本生成 OpenAPI schema，并产出 Markdown 格式的 API 文档工件。
- 创建 Markdown 格式的 API 变更报告，总结发布版本之间的破坏性与非破坏性变更。
- 将生成的 API 文档和变更报告工件上传至 GitHub 以长期保存。
- 使用现有的 webhook 密钥，将摘要化的 API 变更通知发送到企业微信群。

CI：
- 新增一个专用于基于发布分支的 API 文档生成与变更报告的 GitHub Actions 工作流，不修改现有的 CI 工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a CI workflow to automatically generate and distribute API documentation and change reports for release branch updates.

New Features:
- Introduce an API docs & release change report GitHub Actions workflow triggered on release branch pushes and manual dispatch.
- Generate OpenAPI schemas for base and current versions and produce a Markdown API documentation artifact.
- Create a Markdown API change report summarizing breaking and non-breaking changes between release versions.
- Upload generated API documentation and change report artifacts to GitHub for long-term retention.
- Send summarized API change notifications to an enterprise WeChat group using an existing webhook secret.

CI:
- Add a dedicated GitHub Actions workflow for release-based API documentation and change reporting, without modifying existing CI workflows.

</details>