### PR TITLE
fix(ci): fallback export_openapi.py from current ref when missing in …

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -116,6 +116,11 @@ jobs:
       - name: Export base OpenAPI schema
         working-directory: api
         run: |
+          # 如果 base 版本没有 export 脚本，从 current 版本拷贝
+          if [ ! -f scripts/export_openapi.py ]; then
+            echo "::notice::Base ref 缺少 export_openapi.py，从 current ref 复制"
+            git show ${{ steps.refs.outputs.current_sha }}:api/scripts/export_openapi.py > scripts/export_openapi.py
+          fi
           uv run python scripts/export_openapi.py --v1-only -o ../artifacts/openapi-base.json
 
       # ─── 恢复当前版本 ───


### PR DESCRIPTION
…base

## Summary by Sourcery

CI:
- 更新 API 文档发布工作流：如果基础引用（base ref）中缺少 OpenAPI 导出脚本，则从当前引用（current ref）复制该脚本，以确保其可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the API docs release workflow to ensure the OpenAPI export script is available by copying it from the current ref if absent in the base ref.

</details>