### PR TITLE
fix(ci): mkdir -p scripts before copying export_openapi.py fallback

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -119,6 +119,7 @@ jobs:
           # 如果 base 版本没有 export 脚本，从 current 版本拷贝
           if [ ! -f scripts/export_openapi.py ]; then
             echo "::notice::Base ref 缺少 export_openapi.py，从 current ref 复制"
+            mkdir -p scripts
             git show ${{ steps.refs.outputs.current_sha }}:api/scripts/export_openapi.py > scripts/export_openapi.py
           fi
           uv run python scripts/export_openapi.py --v1-only -o ../artifacts/openapi-base.json


### PR DESCRIPTION
## 由 Sourcery 提供的总结

CI：
- 更新 `api-docs-release-report` 工作流，在作为后备方案从当前引用复制 `export_openapi.py` 之前，先创建 `scripts` 目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the api-docs-release-report workflow to create the scripts directory before copying export_openapi.py from the current ref as a fallback.

</details>