### PR TITLE
fix(ci): preserve artifacts/ dir during git clean between checkouts

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -113,8 +113,8 @@ jobs:
       # ─── 导出基线版本 OpenAPI schema ───
       - name: Checkout base ref
         run: |
-          # 清理 current 阶段可能产生的未跟踪文件，避免 checkout 冲突
-          git clean -fd
+          # 清理 current 阶段可能产生的未跟踪文件，但保留 artifacts/
+          git clean -fd --exclude=artifacts
           git checkout ${{ steps.refs.outputs.base_sha }}
 
       - name: Install dependencies (base)
@@ -127,6 +127,8 @@ jobs:
         id: export_base
         working-directory: api
         run: |
+          # 确保 artifacts 目录存在（git clean 可能已删除）
+          mkdir -p ../artifacts/raw
           # 如果 base 版本没有 export 脚本，从 current 版本拷贝
           if [ ! -f scripts/export_openapi.py ]; then
             echo "::notice::Base ref 缺少 export_openapi.py，从 current ref 复制"
@@ -138,7 +140,7 @@ jobs:
       # ─── 恢复当前版本 ───
       - name: Restore current ref
         run: |
-          git clean -fd
+          git clean -fd --exclude=artifacts
           git checkout -f ${{ steps.refs.outputs.current_sha }}
 
       # ─── 生成 Markdown API 文档 ───


### PR DESCRIPTION
## 由 Sourcery 提供的总结

在 API 文档发布报告工作流中，在基础分支（base）和当前分支（current）之间切换时保留 artifacts 目录。

CI：
- 更新 API 文档发布报告工作流中的 `git clean` 命令，在检出之间排除 artifacts 目录。
- 确保在导出基础分支的 OpenAPI schema 之前重新创建 `artifacts/raw` 目录，以便在不同引用（ref）检出之间保持 artifacts 可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve the artifacts directory when switching between base and current refs in the API docs release report workflow.

CI:
- Update git clean commands in the API docs release report workflow to exclude the artifacts directory between checkouts.
- Ensure the artifacts/raw directory is recreated before exporting the base OpenAPI schema so artifacts are available across ref checkouts.

</details>