### PR TITLE
fix(ci): add 'Release 发布通知' keyword to match WeChat bot filter

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -336,7 +336,7 @@ jobs:
           # 构建企业微信 Markdown 消息
           status_icon = "⚠️" if has_breaking else "✅"
           content = (
-              f"## 📋 API 变更报告\n"
+              f"## 📋 Release 发布通知 — API 变更报告\n"
               f"> **版本对比**: {base_ver} → {current_ver}\n"
               f"> **Commit**: `{base_short}` → `{current_short}`\n\n"
               f"### 摘要\n"


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 调整 API 文档发布报告工作流中的微信 Markdown 通知标题，以包含关键字“Release 发布通知”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust WeChat Markdown notification heading in the API docs release report workflow to include the "Release 发布通知" keyword.

</details>