### PR TITLE
fix(ci): patch OpenAPI 3.1 exclusiveMinimum/Maximum for oasdiff 3.0 c…

### DIFF
--- a/.github/workflows/api-docs-release-report.yml
+++ b/.github/workflows/api-docs-release-report.yml
@@ -169,6 +169,44 @@ jobs:
           chmod +x /usr/local/bin/oasdiff
           oasdiff --version
 
+      - name: Patch OpenAPI schemas for oasdiff compatibility
+        run: |
+          # oasdiff 的底层解析器不支持 OpenAPI 3.1 的 exclusiveMinimum/Maximum (数字格式)
+          # 需要转换为 3.0 兼容格式 (布尔 + minimum/maximum)
+          python3 << 'PYEOF'
+          import json, pathlib
+
+          def patch_schema_for_oasdiff(filepath):
+              """将 OpenAPI 3.1 的 exclusiveMinimum/Maximum 数字格式转为 3.0 兼容格式"""
+              path = pathlib.Path(filepath)
+              schema = json.loads(path.read_text(encoding="utf-8"))
+
+              def fix(obj):
+                  if isinstance(obj, dict):
+                      # exclusiveMinimum: number → minimum: number + exclusiveMinimum: true
+                      if "exclusiveMinimum" in obj and isinstance(obj["exclusiveMinimum"], (int, float)):
+                          val = obj.pop("exclusiveMinimum")
+                          obj["minimum"] = val
+                          obj["exclusiveMinimum"] = True
+                      # exclusiveMaximum: number → maximum: number + exclusiveMaximum: true
+                      if "exclusiveMaximum" in obj and isinstance(obj["exclusiveMaximum"], (int, float)):
+                          val = obj.pop("exclusiveMaximum")
+                          obj["maximum"] = val
+                          obj["exclusiveMaximum"] = True
+                      for v in obj.values():
+                          fix(v)
+                  elif isinstance(obj, list):
+                      for item in obj:
+                          fix(item)
+
+              fix(schema)
+              path.write_text(json.dumps(schema, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+              print(f"Patched: {filepath}")
+
+          patch_schema_for_oasdiff("artifacts/openapi-base.json")
+          patch_schema_for_oasdiff("artifacts/openapi-current.json")
+          PYEOF
+
       - name: Generate API change report
         id: report
         env:


### PR DESCRIPTION
…ompat

oasdiff's parser doesn't support OpenAPI 3.1 numeric exclusiveMinimum/Maximum. Add a pre-processing step that converts them to 3.0 format (boolean + minimum/maximum) before running oasdiff.

## Summary by Sourcery

CI:
- 在运行 oasdiff 之前，更新 api-docs-release-report 工作流，将 OpenAPI 3.1 构件中的数值型 `exclusiveMinimum`/`exclusiveMaximum` 字段转换为与 OpenAPI 3.0 兼容的布尔值 + `minimum`/`maximum` 格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the api-docs-release-report workflow to convert numeric exclusiveMinimum/exclusiveMaximum fields in OpenAPI 3.1 artifacts to the OpenAPI 3.0-compatible boolean + minimum/maximum format before running oasdiff.

</details>