### PR TITLE
fix(tasks): handle memory config loading errors gracefully in scan tasks

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2005,8 +2005,13 @@ def scan_layer2_reflection(self) -> Dict[str, Any]:
         with get_db_context() as db:
             service = WorkspaceAppService(db)
             memory_config_service = MemoryConfigService(db)
-            config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
-            config = memory_config_service.load_memory_config(config_id)
+            try:
+                config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
+                config = memory_config_service.load_memory_config(config_id)
+            except Exception as e:
+                # 单个 workspace 配置异常（无启用配置 / 缺 embedding / 模型被删）只跳过该 workspace
+                logger.warning(f"高频反思scan 跳过配置异常的 workspace={ws_id}: {e}")
+                continue
             iteration_period = config.reflexion_iteration_period or 24
             end_users = get_end_users_by_workspace(db, ws_id_uuid)
             for user in end_users:
@@ -2205,8 +2210,13 @@ def scan_layer2_dedup_full_scan(self) -> Dict[str, Any]:
         ws_id_uuid = uuid.UUID(ws_id)
         with get_db_context() as db:
             memory_config_service = MemoryConfigService(db)
-            config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
-            config = memory_config_service.load_memory_config(config_id)
+            try:
+                config_id = memory_config_service.get_workspace_active_config_id(ws_id_uuid)
+                config = memory_config_service.load_memory_config(config_id)
+            except Exception as e:
+                # 单个 workspace 配置异常（无启用配置 / 缺 embedding / 模型被删）只跳过该 workspace
+                logger.warning(f"反思低频去重scan 跳过配置异常的 workspace={ws_id}: {e}")
+                continue
             if not config.reflexion_enabled:
                 continue
             for user in get_end_users_by_workspace(db, ws_id_uuid):


### PR DESCRIPTION
- Wrap memory config retrieval in try-except blocks in scan_layer2_reflection()
- Wrap memory config retrieval in try-except blocks in scan_layer2_dedup_full_scan()
- Skip workspace processing when config loading fails due to missing/invalid config
- Log warnings with workspace ID and error details for debugging
- Prevents task failures from propagating when individual workspaces have configuration issues (missing active config, missing embedding, deleted model)

## Summary by Sourcery

在第 2 层反射和去重全扫描任务中优雅地处理内存配置加载错误，通过跳过配置错误的工作区并记录警告日志，避免让故障向上传播。

Bug Fixes:
- 当工作区的内存配置缺失或无效时，通过跳过受影响的工作区并记录警告，防止第 2 层扫描反射和去重任务失败。

Enhancements:
- 通过显式错误处理和工作区级别的警告，提高第 2 层扫描任务在内存配置处理方面的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle memory configuration loading errors gracefully in layer 2 reflection and dedup full-scan tasks by skipping misconfigured workspaces and logging warnings instead of letting failures propagate.

Bug Fixes:
- Prevent scan layer 2 reflection and dedup tasks from failing when workspace memory configuration is missing or invalid by skipping affected workspaces and logging a warning.

Enhancements:
- Improve robustness of memory configuration handling in layer 2 scan tasks with explicit error handling and workspace-level warnings.

</details>