### PR TITLE
feat(memory): add extraction_count tracking for entities

### DIFF
--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -479,6 +479,7 @@ class ExtractedEntityNode(Node):
     beliefs_or_stances: List[str] = Field(default_factory=list, description="Stable beliefs, values, or stances")
     anchors: List[str] = Field(default_factory=list, description="Personally meaningful objects or symbols")
     events: List[str] = Field(default_factory=list, description="Durable personal experiences or milestones")
+    extraction_count: int = Field(default=1, description="Number of times this entity was extracted")
 
     @field_validator('aliases', mode='before')
     @classmethod

--- a/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
+++ b/api/app/core/memory/storage_services/extraction_engine/deduplication/deduped_and_disamb.py
@@ -196,10 +196,16 @@ def _merge_attribute(canonical: ExtractedEntityNode, ent: ExtractedEntityNode):
     except Exception:
         pass
 
-    # 时间范围合并
+    # 时间范围合并（取更接近现在的时间）
     try:
-        if getattr(ent, "created_at", None) and getattr(canonical, "created_at", None) and ent.created_at < canonical.created_at:
+        if getattr(ent, "created_at", None) and getattr(canonical, "created_at", None) and ent.created_at > canonical.created_at:
             canonical.created_at = ent.created_at
+    except Exception:
+        pass
+
+    # 提取次数累加
+    try:
+        canonical.extraction_count = getattr(canonical, "extraction_count", 1) + getattr(ent, "extraction_count", 1)
     except Exception:
         pass
 

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/triplet_extraction.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/triplet_extraction.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict, Optional
+from typing import Dict, Optional
 
 from app.core.logging_config import get_memory_logger
 from app.core.memory.llm_tools.openai_client import OpenAIClient
@@ -191,49 +191,3 @@ class TripletExtractor:
 
         return statement_triplet_map
 
-    def save_triplets(self, triplet_responses: List[TripletExtractionResponse], output_path: str = None) -> str:
-        """Save extracted triplets and entities to a file
-
-        Args:
-            triplet_responses: List of TripletExtractionResponse objects
-            output_path: Optional path to save the results
-
-        Returns:
-            Path where the triplets were saved
-        """
-        if output_path is None:
-            from app.core.config import settings
-            settings.ensure_memory_output_dir()
-            output_path = settings.get_memory_output_path("extracted_triplets.txt")
-
-        # Flatten all triplets and entities
-        all_triplets = []
-        all_entities = []
-
-        for response in triplet_responses:
-            all_triplets.extend(response.triplets)
-            all_entities.extend(response.entities)
-
-        # Save to file
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(f"=== EXTRACTED TRIPLETS ({len(all_triplets)} total) ===\n\n")
-            for i, triplet in enumerate(all_triplets, 1):
-                f.write(f"Triplet {i}:\n")
-                f.write(f"  Subject: {triplet.subject_name} (ID: {triplet.subject_id})\n")
-                f.write(f"  Predicate: {triplet.predicate}\n")
-                f.write(f"  Object: {triplet.object_name} (ID: {triplet.object_id})\n")
-                if triplet.value:
-                    f.write(f"  Value: {triplet.value}\n")
-                f.write("\n")
-
-            f.write(f"\n=== EXTRACTED ENTITIES ({len(all_entities)} total) ===\n\n")
-            for i, entity in enumerate(all_entities, 1):
-                f.write(f"Entity {i}:\n")
-                f.write(f"  ID: {entity.entity_idx}\n")
-                f.write(f"  Name: {entity.name}\n")
-                f.write(f"  Type: {entity.type}\n")
-                f.write(f"  Description: {entity.description}\n")
-                f.write("\n")
-
-        logger.info(f"Saved {len(all_triplets)} triplets and {len(all_entities)} entities to: {output_path}")
-        return output_path

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -291,6 +291,7 @@ async def build_graph_nodes_and_edges(
                             aliases=getattr(entity, "aliases", []) or [],
                             name_embedding=getattr(entity, "name_embedding", None),
                             is_explicit_memory=getattr(entity, "is_explicit_memory", False),
+                            extraction_count=1,
                             end_user_id=dialog_data.end_user_id,
                             run_id=dialog_data.run_id,
                             created_at=dialog_data.created_at,

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -133,7 +133,8 @@ SET e.name = CASE WHEN entity.name IS NOT NULL AND entity.name <> '' THEN entity
     e.access_history = CASE WHEN entity.access_history IS NOT NULL THEN entity.access_history ELSE coalesce(e.access_history, []) END,
     e.last_access_time = CASE WHEN entity.last_access_time IS NOT NULL THEN entity.last_access_time ELSE e.last_access_time END,
     e.access_count = CASE WHEN entity.access_count IS NOT NULL THEN entity.access_count ELSE coalesce(e.access_count, 0) END,
-    e.is_explicit_memory = CASE WHEN entity.is_explicit_memory IS NOT NULL THEN entity.is_explicit_memory ELSE coalesce(e.is_explicit_memory, false) END
+    e.is_explicit_memory = CASE WHEN entity.is_explicit_memory IS NOT NULL THEN entity.is_explicit_memory ELSE coalesce(e.is_explicit_memory, false) END,
+    e.extraction_count = CASE WHEN entity.extraction_count IS NOT NULL THEN entity.extraction_count + coalesce(e.extraction_count, 0) ELSE coalesce(e.extraction_count, 1) END
 RETURN e.id AS uuid
 """
 


### PR DESCRIPTION
## Summary by Sourcery

在整个图构建、去重以及 Neo4j 存储的过程中，跟踪实体被提取的次数，并持久化保存该计数。

新功能：
- 在已提取的实体图模型中添加 `extraction_count` 字段，并在创建图节点时进行初始化。
- 在 Neo4j 实体 upsert 查询中持久化并聚合 `extraction_count`，使重复提取会增加已存储的计数。

改进：
- 调整实体去重逻辑，优先保留 `created_at` 时间戳较新的实体，并在合并实体时累积 `extraction_count`。
- 从三元组提取模块中移除未使用的三元组保存辅助函数以及相关的类型导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track how many times entities are extracted and persist this count through graph building, deduplication, and Neo4j storage.

New Features:
- Add extraction_count field to extracted entity graph model and initialize it when creating graph nodes.
- Persist and aggregate extraction_count in Neo4j entity upsert queries so repeated extractions increment the stored count.

Enhancements:
- Adjust entity deduplication to prefer more recent created_at timestamps and to accumulate extraction_count across merged entities.
- Remove unused triplet saving helper and related typing import from the triplet extraction module.

</details>