### PR TITLE
Feature/model memory zy

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -481,6 +481,9 @@ export const en = {
       updated_at: 'Updated At',
       callbackUrlInvalid: 'Please enter a valid URL',
       switchSpace: 'Switch Space',
+      number: 'number',
+      or: 'or',
+      variable: 'variable',
     },
     model: {
       searchPlaceholder: 'search model…',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1286,6 +1286,9 @@ export const zh = {
       updated_at: '更新时间',
       callbackUrlInvalid: '请输入有效的 URL',
       switchSpace: '切换空间',
+      number: '数字',
+      or: '或',
+      variable: '变量',
     },
     model: {
       searchPlaceholder: '搜索模型…',

--- a/web/src/store/workflow.ts
+++ b/web/src/store/workflow.ts
@@ -5,7 +5,7 @@
  * @Last Modified time: 2026-04-10 18:11:19 
  */
 import { create } from 'zustand'
-import type { NodeCheckResult } from '@/views/Workflow/components/CheckList'
+import type { NodeCheckResult } from '@/views/Workflow/hooks/useWorkflowCheck'
 import type { ChatItem } from '@/components/Chat/types'
 
 interface WorkflowState {

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-04 12:30:24
+ * @Last Modified time: 2026-07-06 11:11:16
  */
 import { type FC, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -103,16 +103,24 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
         applicationModalRef.current?.handleOpen(application)
         break;
       case 'copy':
-        appRef?.current?.handleSave(false)
-          .then(() => {
-            copyModalRef.current?.handleOpen()
-          })
+        if (appRef?.current?.handleSave) {
+          appRef?.current?.handleSave(false)
+            .then(() => {
+              copyModalRef.current?.handleOpen()
+            })
+        } else {
+          copyModalRef.current?.handleOpen()
+        }
         break;
       case 'export':
-        appRef?.current?.handleSave(false)
-          .then(() => {
-            appExport(application.id, application.name)
-          })
+        if (appRef?.current?.handleSave) {
+          appRef?.current?.handleSave(false)
+            .then(() => {
+              appExport(application.id, application.name)
+            })
+        } else {
+          appExport(application.id, application.name)
+        }
         break;
       case 'delete':
         handleDelete()

--- a/web/src/views/Workflow/components/CheckList/CheckListDrawer.tsx
+++ b/web/src/views/Workflow/components/CheckList/CheckListDrawer.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { Node } from '@antv/x6';
 
 import type { WorkflowRef } from '@/views/ApplicationConfig/types'
-import type { NodeCheckResult } from '.'
+import type { NodeCheckResult } from '../../hooks/useWorkflowCheck'
 import RbDrawer from '@/components/RbDrawer'
 
 export interface CheckListDrawerRef {

--- a/web/src/views/Workflow/components/Editor/Jinja2Editor.tsx
+++ b/web/src/views/Workflow/components/Editor/Jinja2Editor.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-04-02 15:15:36 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 11:34:41
+ * @Last Modified time: 2026-07-06 11:08:23
  */
 import { type FC, useEffect, useMemo } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -18,6 +18,7 @@ import Jinja2AutocompletePlugin from './plugin/Jinja2AutocompletePlugin';
 import Jinja2HighlightPlugin from './plugin/Jinja2HighlightPlugin';
 import Jinja2BlurPlugin from './plugin/Jinja2BlurPlugin';
 import LineNumberPlugin from './plugin/LineNumberPlugin';
+import OnBlurPlugin from './plugin/OnBlurPlugin';
 
 const jinja2Theme = {
   paragraph: 'editor-paragraph',
@@ -85,6 +86,7 @@ export interface Jinja2EditorProps {
   height?: number;
   size?: 'default' | 'small';
   className?: string;
+  onBlur?: () => void;
 }
 
 const Jinja2Editor: FC<Jinja2EditorProps> = ({
@@ -96,6 +98,7 @@ const Jinja2Editor: FC<Jinja2EditorProps> = ({
   size = 'default',
   height,
   className,
+  onBlur,
 }) => {
   useEffect(() => {
     if (!document.getElementById(STYLE_ID)) {
@@ -177,6 +180,7 @@ const Jinja2Editor: FC<Jinja2EditorProps> = ({
         <Jinjia2CharacterCountPlugin setCount={() => {}} />
         <Jinja2InitialValuePlugin value={value} onChange={onChange} />
         <Jinja2BlurPlugin />
+        <OnBlurPlugin onBlur={onBlur} />
       </div>
     </LexicalComposer>
   );

--- a/web/src/views/Workflow/components/Editor/index.tsx
+++ b/web/src/views/Workflow/components/Editor/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 18:16:32
+ * @Last Modified time: 2026-07-06 11:04:44
  */
 import { type FC, useState, useMemo } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -17,6 +17,7 @@ import InitialValuePlugin from './plugin/InitialValuePlugin';
 import CommandPlugin from './plugin/CommandPlugin';
 import BlurPlugin from './plugin/BlurPlugin';
 import InsertFormFieldPlugin from './plugin/InsertFormFieldPlugin';
+import OnBlurPlugin from './plugin/OnBlurPlugin';
 import { VariableNode } from './nodes/VariableNode'
 import { FormFieldNode } from './nodes/FormFieldNode';
 import { FormFieldProvider } from './nodes/FormFieldContext';
@@ -45,6 +46,7 @@ export interface LexicalEditorProps {
   waitForInit?: boolean;
   updateFormFields?: (form_fields: FormField[]) => void;
   formFields?: FormField[];
+  onBlur?: () => void;
 }
 
 // Default theme for editor
@@ -70,6 +72,7 @@ const Editor: FC<LexicalEditorProps> =({
   className,
   updateFormFields,
   formFields = [],
+  onBlur,
 }) => {
   // console.log('Editor value', value)
   const [_count, setCount] = useState(0);
@@ -86,6 +89,7 @@ const Editor: FC<LexicalEditorProps> =({
         size={size}
         height={height}
         className={className}
+        onBlur={onBlur}
       />
     );
   }
@@ -176,6 +180,7 @@ const Editor: FC<LexicalEditorProps> =({
           <CharacterCountPlugin setCount={setCount} />
           <InitialValuePlugin value={value} options={options} formFields={formFields} onChange={onChange} />
           <BlurPlugin />
+          <OnBlurPlugin onBlur={onBlur} />
           {updateFormFields &&
             <InsertFormFieldPlugin
               formFields={formFields}

--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 18:16:40
+ * @Last Modified time: 2026-07-06 11:31:31
  */
 import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -61,9 +61,29 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
   useEffect(() => {
     if (value !== prevValueRef.current) {
       if (isUserInputRef.current) {
-        prevValueRef.current = value;
-        isUserInputRef.current = false;
-        return;
+        let currentEditorText = '';
+        editor.getEditorState().read(() => {
+          const root = $getRoot();
+          const paragraphs: string[] = [];
+          root.getChildren().forEach(child => {
+            if ($isParagraphNode(child)) {
+              const paragraphText = child.getChildren().map(n => {
+                if ($isFormFieldNode(n)) {
+                  return n.getTextContent();
+                }
+                return n.getTextContent();
+              }).join('');
+              paragraphs.push(paragraphText);
+            }
+          });
+          currentEditorText = paragraphs.join('\n');
+        });
+
+        if (value === currentEditorText) {
+          prevValueRef.current = value;
+          isUserInputRef.current = false;
+          return;
+        }
       }
       prevValueRef.current = value;
       isUserInputRef.current = false;
@@ -73,7 +93,8 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
           const root = $getRoot();
           root.clear();
 
-          const parts = (value ?? '').split(/(\{\{[^}]+\}\}|\n)/);
+          const strValue = value === null || value === undefined ? '' : String(value);
+          const parts = strValue.split(/(\{\{[^}]+\}\}|\n)/);
           let paragraph = $createParagraphNode();
 
             parts.forEach(part => {

--- a/web/src/views/Workflow/components/Editor/plugin/OnBlurPlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/OnBlurPlugin.tsx
@@ -1,0 +1,28 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useEffect } from 'react';
+import { BLUR_COMMAND } from 'lexical';
+
+interface OnBlurPluginProps {
+  onBlur?: () => void;
+}
+
+export default function OnBlurPlugin({ onBlur }: OnBlurPluginProps) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (!onBlur) return;
+
+    const unregister = editor.registerCommand(
+      BLUR_COMMAND,
+      () => {
+        onBlur();
+        return false;
+      },
+      1
+    );
+
+    return unregister;
+  }, [editor, onBlur]);
+
+  return null;
+}

--- a/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
@@ -167,7 +167,9 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
       initialValue.tool_parameters[vo.name] = vo.default
     })
 
-    form.setFieldsValue(initialValue)
+    setTimeout(() => {
+      form.setFieldsValue(initialValue)
+    }, 0)
   }
 
   // string -> string
@@ -228,6 +230,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
       <Form.Item name="tool_id" hidden />
       <Form.Item name={['tool_parameters', 'operation']} hidden />
       {parameters.map((parameter) => {
+        const isIntegerType = parameter.type === 'integer'
         return (
           <div key={parameter.name}>
             <Form.Item
@@ -239,7 +242,14 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
                 </Tooltip>
               </>}
               rules={[
-                { required: parameter.required, message: t('common.pleaseEnter') }
+                { required: parameter.required, message: t('common.pleaseEnter') },
+                ...(isIntegerType ? [{
+                  validator(_: any, value: any) {
+                    if (value === undefined || value === null || value === '') return Promise.resolve()
+                    if (/^-?\d+(\.\d+)?$/.test(String(value)) || /^\{\{(([^.]+\.[^}]+))\}\}$/.test(String(value))) return Promise.resolve()
+                    return Promise.reject(new Error(t('common.pleaseEnter') + ' ' + t('common.number') + ' ' + t('common.or') + ' ' + t('common.variable')))
+                  }
+                }] : [])
               ]}
               layout={parameter.type === 'boolean' ? 'horizontal' : 'vertical'}
               className={parameter.type === 'boolean' ? 'rb:mb-0!' : ''}
@@ -247,16 +257,34 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
               {parameter.type === 'string' && parameter.enum && parameter.enum.length > 0
                 ? <Select key={values.tool_id} size="small" options={parameter.enum.map(vo => ({ value: vo, label: vo }))} placeholder={t('common.pleaseSelect')} />
                 : parameter.type === 'boolean'
-                  ? <Switch key={values.tool_id} size="small" />
-                  : <Editor
-                    key={values.tool_id}
-                    variant="outlined"
-                    type="input"
-                    size="small"
-                    height={28}
-                    options={getFilterOptions(parameter.type)}
-                    placeholder={t('common.pleaseEnter')}
-                  />
+                ? <Switch key={values.tool_id} size="small" />
+                : <Editor
+                  key={values.tool_id}
+                  variant="outlined"
+                  type="input"
+                  size="small"
+                  height={28}
+                  options={getFilterOptions(parameter.type)}
+                  placeholder={t('common.pleaseEnter')}
+                  onBlur={isIntegerType ? () => {
+                    const fieldKey = ['tool_parameters', parameter.name]
+                    form.validateFields([fieldKey])
+                      .then((values) => {
+                        const value = values.tool_parameters?.[parameter.name]
+                        let normalizedValue = value
+                        if (value === undefined || value === null || value === '') {
+                          normalizedValue = null
+                        } else if (typeof value === 'string' && /^-?\d+(\.\d+)?$/.test(String(value))) {
+                          normalizedValue = Number(value)
+                        }
+                        form.setFieldValue(fieldKey, normalizedValue)
+                      })
+                      .catch((err) => {
+                        console.log('isIntegerType', isIntegerType, fieldKey, err)
+                        form.setFieldValue(fieldKey, null)
+                      })
+                  } : undefined}
+                />
               }
             </Form.Item>
             {parameter.type === 'boolean' && <div className="rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4 rb:mb-6">{parameter.description}</div>}


### PR DESCRIPTION
## Summary by Sourcery

改进工作流工具参数处理、编辑器失焦行为以及应用配置操作，以提升校验能力和用户体验。

New Features:
- 通过共享的 `OnBlurPlugin` 为工作流编辑器和 Jinja2 编辑器添加失焦（blur）回调支持。
- 为工具参数输入引入整数类型规范化逻辑，将数字字符串转换为数值，并将空输入视为 `null`。

Bug Fixes:
- 当外部初始值与当前用户输入一致时，防止编辑器内容被意外覆盖。
- 在编辑器中安全处理 `null` 和 `undefined` 初始值，在解析前将其规范化为空字符串。
- 即使工作流引用缺少 `handleSave` 方法，也允许在应用配置中执行复制和导出操作。
- 确保工作流 store 和检查清单抽屉使用更新后的 `NodeCheckResult` 类型来源，与工作流检查保持同步。

Enhancements:
- 为整数类型工具参数添加校验，只接受数字或变量占位符，并提供本地化错误消息。
- 将工具配置中的表单字段初始化延迟到下一个 tick，以避免表单设置中的时序问题。
- 扩展 i18n 字典，加入数值/变量校验消息中常用术语。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve workflow tool parameter handling, editor blur behavior, and application config actions for better validation and UX.

New Features:
- Add blur callback support to both workflow and Jinja2 editors via a shared OnBlurPlugin.
- Introduce integer-type normalization for tool parameter inputs, converting numeric strings to numbers and treating empty input as null.

Bug Fixes:
- Prevent unintended overwrites of editor content when external initial values match the current user input.
- Handle null and undefined initial values safely in the editor by normalizing them to empty strings before parsing.
- Allow copy and export actions in application config to work even when the workflow reference lacks a handleSave method.
- Ensure workflow store and checklist drawer use the updated NodeCheckResult type source to stay in sync with workflow checks.

Enhancements:
- Add validation for integer-type tool parameters to only accept numbers or variable placeholders, with localized error messages.
- Defer form field initialization in tool configuration to the next tick to avoid timing issues with form setup.
- Extend i18n dictionaries with common terms used in numeric/variable validation messages.

</details>