### PR TITLE
feat(memory): add entity creation timestamp resolution and extraction

### DIFF
--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -8,7 +8,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel
 
 from datetime import datetime
-from app.core.utils.datetime_utils import utcnow_naive, as_utc_aware, parse_iso_to_utc_naive
+from app.core.utils.datetime_utils import (
+    utcnow_naive,
+    as_utc_aware,
+    convert_neo4j_datetime_to_python,
+)
 from app.core.memory.storage_services.reflection_engine.deterministic.description_checker import (
     scan_merge_candidates,
 )
@@ -47,25 +51,13 @@ from app.repositories.neo4j.cypher_queries import (
 logger = logging.getLogger(__name__)
 
 
-def _resolve_last_seen(raw) -> datetime:
+def _resolve_last_seen(raw) -> datetime | None:
     """把 statement 的 dialog_at 归一为 naive UTC datetime，作为实体 created_at（最近被看到时间）。
 
-    raw 可能是 neo4j 时序对象（execute_query 默认返回 record.data()，dialog_at 为
-    neo4j.time.DateTime）、Python datetime，或字符串。无法解析时回退当前 UTC，不抛异常。
+    无法解析时返回 None（不兜底当前时间），此时 created_at 留空由 Cypher 处理。
     """
-    if raw is None or raw == "":
-        return utcnow_naive()
-    if isinstance(raw, datetime):
-        return as_utc_aware(raw).replace(tzinfo=None)
-    if hasattr(raw, "to_native"):
-        return as_utc_aware(raw.to_native()).replace(tzinfo=None)
-    try:
-        parsed = parse_iso_to_utc_naive(str(raw))
-        if parsed is not None:
-            return parsed
-    except Exception:
-        pass
-    return utcnow_naive()
+    dt = convert_neo4j_datetime_to_python(raw)
+    return as_utc_aware(dt).replace(tzinfo=None) if dt is not None else None
 
 
 # 快照体积控制（仅调试用、不影响写库）：低频 1_input 逐实体存 description，超长会让快照过大、

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel
 
-from app.core.utils.datetime_utils import utcnow_naive
+from datetime import datetime
+from app.core.utils.datetime_utils import utcnow_naive, as_utc_aware, parse_iso_to_utc_naive
 from app.core.memory.storage_services.reflection_engine.deterministic.description_checker import (
     scan_merge_candidates,
 )
@@ -44,6 +45,28 @@ from app.repositories.neo4j.cypher_queries import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_last_seen(raw) -> datetime:
+    """把 statement 的 dialog_at 归一为 naive UTC datetime，作为实体 created_at（最近被看到时间）。
+
+    raw 可能是 neo4j 时序对象（execute_query 默认返回 record.data()，dialog_at 为
+    neo4j.time.DateTime）、Python datetime，或字符串。无法解析时回退当前 UTC，不抛异常。
+    """
+    if raw is None or raw == "":
+        return utcnow_naive()
+    if isinstance(raw, datetime):
+        return as_utc_aware(raw).replace(tzinfo=None)
+    if hasattr(raw, "to_native"):
+        return as_utc_aware(raw.to_native()).replace(tzinfo=None)
+    try:
+        parsed = parse_iso_to_utc_naive(str(raw))
+        if parsed is not None:
+            return parsed
+    except Exception:
+        pass
+    return utcnow_naive()
+
 
 # 快照体积控制（仅调试用、不影响写库）：低频 1_input 逐实体存 description，超长会让快照过大、
 # 上传慢，故截断；aliases 是短词不限长。
@@ -1566,6 +1589,8 @@ class Layer2Inspector:
         # 同 statement 内所有派生实体/边共用一个 run_id：优先复用来源 statement 的 run_id，
         # 老数据为空时一次性兜底，避免实体和关系边拿到不同的随机 run_id。
         fallback_run_id = stmt.get("run_id") or uuid.uuid4().hex
+        # 本条 statement 的最近被看到时间，作为其派生实体的 created_at
+        entity_last_seen = _resolve_last_seen(stmt.get("dialog_at"))
 
         # 4.1 创建实体
         for entity in validated.entities:
@@ -1597,7 +1622,7 @@ class Layer2Inspector:
                 entity_idx=entity.entity_idx,
                 is_explicit_memory=entity.is_explicit_memory,
                 statement_id=stmt["statement_id"],
-                created_at=utcnow_naive(),
+                created_at=entity_last_seen,
             )
             if entity_result:
                 entity_id = entity_result[0].get("entity_id", "")

--- a/api/app/core/utils/datetime_utils.py
+++ b/api/app/core/utils/datetime_utils.py
@@ -166,3 +166,22 @@ def parse_metadata_time_to_utc_naive(value: str | int | float | datetime | None)
         return parse_timestamp_to_utc_naive(timestamp)
 
     return parse_iso_to_utc_naive(stripped)
+
+
+def convert_neo4j_datetime_to_python(value) -> datetime | None:
+    """Neo4j 时序对象 / 字符串 / datetime → Python datetime；无法解析或 None 返回 None。
+
+    不做时区归一，aware/naive 取决于来源；需要 naive UTC 的写库场景由调用方自行归一。
+    """
+    if value is None:
+        return None
+    try:
+        if hasattr(value, "to_native"):
+            return value.to_native()
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except Exception:
+        return None

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2148,10 +2148,11 @@ SET keeper.name = $merged_name,
       WHEN coalesce(loser.importance_score, 0) > coalesce(keeper.importance_score, 0)
       THEN loser.importance_score ELSE keeper.importance_score END,
     keeper.access_count = coalesce(keeper.access_count, 0) + coalesce(loser.access_count, 0),
+    keeper.extraction_count = coalesce(keeper.extraction_count, 1) + coalesce(loser.extraction_count, 1),
     keeper.created_at = CASE
       WHEN keeper.created_at IS NULL THEN loser.created_at
       WHEN loser.created_at IS NULL THEN keeper.created_at
-      WHEN loser.created_at < keeper.created_at THEN loser.created_at
+      WHEN loser.created_at > keeper.created_at THEN loser.created_at
       ELSE keeper.created_at END,
     keeper.core_facts = apoc.coll.toSet(coalesce(keeper.core_facts,[]) + coalesce(loser.core_facts,[])),
     keeper.traits = apoc.coll.toSet(coalesce(keeper.traits,[]) + coalesce(loser.traits,[])),
@@ -2275,12 +2276,19 @@ ON CREATE SET
   e.access_count = 0,
   e.last_access_time = null,
   e.is_explicit_memory = $is_explicit_memory,
-  e.created_at = $created_at
+  e.created_at = $created_at,
+  e.extraction_count = 1
 ON MATCH SET
   e.description = CASE
     WHEN e.description IS NULL OR e.description = "" THEN $description
     ELSE e.description + '；' + $description
-  END
+  END,
+  e.extraction_count = coalesce(e.extraction_count, 1) + 1,
+  e.created_at = CASE
+    WHEN e.created_at IS NULL THEN $created_at
+    WHEN $created_at IS NULL THEN e.created_at
+    WHEN $created_at > e.created_at THEN $created_at
+    ELSE e.created_at END
 RETURN e.id AS entity_id, e.name AS name
 """
 

--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -16,7 +16,11 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
+from app.core.utils.datetime_utils import (
+    to_timestamp_ms,
+    utcnow_naive,
+    convert_neo4j_datetime_to_python as _convert_neo4j_datetime_to_python,
+)
 from app.core.logging_config import get_api_logger
 from app.core.memory.storage_services.forgetting_engine.actr_calculator import ACTRCalculator
 from app.core.memory.storage_services.forgetting_engine.forgetting_strategy import ForgettingStrategy
@@ -34,37 +38,11 @@ api_logger = get_api_logger()
 
 
 def convert_neo4j_datetime_to_python(value: Any) -> Optional[datetime]:
+    """将 Neo4j 时序对象 / 字符串 / datetime 转为 Python datetime，无法解析返回 None。
+
+    实现下沉到 datetime_utils，此处保留同名封装以兼容既有引用。
     """
-    将 Neo4j DateTime 对象转换为 Python datetime 对象
-    
-    Args:
-        value: Neo4j DateTime 对象、Python datetime 对象或字符串
-    
-    Returns:
-        Python datetime 对象或 None
-    """
-    if value is None:
-        return None
-    
-    try:
-        # Neo4j DateTime 对象
-        if hasattr(value, 'to_native'):
-            return value.to_native()
-        # Python datetime 对象
-        elif isinstance(value, datetime):
-            return value
-        # 字符串格式
-        elif isinstance(value, str):
-            if value.endswith('Z'):
-                return datetime.fromisoformat(value.replace('Z', '+00:00'))
-            else:
-                return datetime.fromisoformat(value)
-        # 其他类型，尝试转换为字符串
-        else:
-            return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
-    except Exception as e:
-        api_logger.warning(f"转换时间失败: {value} (类型: {type(value).__name__}), 错误: {e}")
-        return None
+    return _convert_neo4j_datetime_to_python(value)
 
 
 class MemoryForgetService:


### PR DESCRIPTION
## Summary by Sourcery

使用语句时间戳来驱动实体的创建时间，并在 Neo4j 内存实体中跟踪抽取次数。

新功能：
- 将语句中的 `dialog_at` 规范化为一个“UTC 无偏移”的时间戳，并将其用作派生实体的 `created_at`。
- 在实体上引入 `extraction_count` 字段，用于记录实体从语句中被抽取的次数。

改进：
- 调整实体合并逻辑，使 `created_at` 反映最新的源时间戳而不是最早的，并在实体合并时传递 `extraction_count`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use statement timestamps to drive entity creation time and track extraction occurrences in Neo4j memory entities.

New Features:
- Normalize statement dialog_at into a UTC-naive timestamp and use it as the created_at for derived entities.
- Introduce an extraction_count field on entities to record how many times an entity has been extracted from statements.

Enhancements:
- Adjust entity merge logic so created_at reflects the most recent source timestamp instead of the earliest, and propagate extraction_count when entities are merged.

</details>