### PR TITLE
Feature/kb zy

### DIFF
--- a/web/src/api/knowledgeBase.ts
+++ b/web/src/api/knowledgeBase.ts
@@ -345,6 +345,10 @@ export const batchDownloadFilesByKb = async (kb_id: string, fileName: string, ca
   const response = await request.downloadFile(`/knowledges/${kb_id}/batch-download`, fileName, undefined, callback);
   return response;
 };
+// 知识库 QA 对导出接口
+export const exportQaByKb = (kb_id: string, file_name: string, callback: () => void) => {
+  return request.getDownloadFile(`/knowledges/${kb_id}/qa/export`, file_name, undefined, callback);
+}
 // 知识库分块模式
 export const knowledgesChunkPolicy = async (kb_id: string) => {
   return request.get(`/knowledges/${kb_id}/chunk-policy`);

--- a/web/src/components/IconButton/IconButtonGroup.tsx
+++ b/web/src/components/IconButton/IconButtonGroup.tsx
@@ -7,17 +7,18 @@
  * @LastEditTime: 2026-06-12 16:25:23
  */
 import type { FC, ReactNode } from 'react';
-import { Flex } from 'antd';
+import { Flex, Dropdown, type MenuProps } from 'antd';
 import clsx from 'clsx';
 
 import IconButton from './index';
 
 export interface IconButtonItem {
-  title: ReactNode;
+  title?: ReactNode;
   icon: string;
-  onClick: () => void;
+  onClick?: () => void;
   className?: string;
   badge?: number;
+  items?: MenuProps['items'];
 }
 
 interface IconButtonGroupProps {
@@ -35,16 +36,40 @@ const IconButtonGroup: FC<IconButtonGroupProps> = ({ items, className, iconClass
       align="center"
       className={clsx('rb-border rb:rounded-lg rb:h-8', className)}
     >
-      {items.map((item, index) => (
-        <IconButton
-          key={index}
-          title={item.title}
-          icon={item.icon}
-          onClick={item.onClick}
-          className={item.className || iconClassName}
-          badge={item.badge}
-        />
-      ))}
+      {items.map((item, index) => {
+        if (item.items && Array.isArray(item.items)) {
+          return (
+            <Dropdown
+              key={`dropdown-${index}`}
+              menu={{
+                items: item.items
+              }}
+              trigger={['click', 'hover']}
+            >
+              <span>
+                <IconButton
+                  title={item.title}
+                  icon={item.icon}
+                  className={item.className || iconClassName}
+                  badge={item.badge}
+                  hideTooltip={true}
+                />
+              </span>
+            </Dropdown>
+          )
+        }
+        return (
+          <IconButton
+            key={`icon-${index}`}
+            title={item.title}
+            icon={item.icon}
+            onClick={item.onClick}
+            className={item.className || iconClassName}
+            badge={item.badge}
+            hideTooltip={!item.title}
+          />
+        )
+      })}
     </Flex>
   );
 };

--- a/web/src/components/IconButton/index.tsx
+++ b/web/src/components/IconButton/index.tsx
@@ -11,34 +11,46 @@ import { Tooltip, Flex, Badge } from 'antd';
 import clsx from 'clsx';
 
 interface IconButtonProps {
-  title: ReactNode;
+  title?: ReactNode;
   icon: string;
-  onClick: () => void;
+  onClick?: () => void;
   className?: string;
   badge?: number;
+  hideTooltip?: boolean;
 }
 
-const IconButton: FC<IconButtonProps> = ({ title, icon, onClick, className, badge }) => {
-  return (
-    <Tooltip title={title}>
-      <Flex
-        align="center"
-        justify="center"
-        className={clsx("rb:relative rb:size-7.5 rb:cursor-pointer rb:rounded-lg rb:hover:bg-[#F6F6F6] rb:overflow-visible", className)}
-        onClick={onClick}
+const IconBtn: FC<IconButtonProps> = ({ icon, onClick, className, badge }) => (
+  <Flex
+    align="center"
+    justify="center"
+    className={clsx("rb:relative rb:size-7.5 rb:cursor-pointer rb:rounded-lg rb:hover:bg-[#F6F6F6] rb:overflow-visible", className)}
+    onClick={onClick}
+  >
+    {badge !== undefined && badge !== null ? (
+      <Badge
+        count={badge}
+        size="small"
+        overflowCount={99}
       >
-        {badge !== undefined && badge !== null ? (
-          <Badge
-            count={badge}
-            size="small"
-            overflowCount={99}
-          >
-            <div className={`rb:size-4 rb:bg-cover ${icon}`} />
-          </Badge>
-        ) : (
-          <div className={`rb:size-4 rb:bg-cover ${icon}`} />
-        )}
-      </Flex>
+        <div className={`rb:size-4 rb:bg-cover ${icon}`} />
+      </Badge>
+    ) : (
+      <div className={`rb:size-4 rb:bg-cover ${icon}`} />
+    )}
+  </Flex>
+)
+
+const IconButton: FC<IconButtonProps> = ({ title, icon, onClick, className, badge, hideTooltip = false }) => {
+  if (hideTooltip || !title) {
+    return (
+      <IconBtn icon={icon} onClick={onClick} className={className} badge={badge} />
+    )
+  }
+  return (
+    <Tooltip title={title} trigger="hover">
+      <span>
+        <IconBtn icon={icon} onClick={onClick} className={className} badge={badge} />
+      </span>
     </Tooltip>
   );
 };

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -481,6 +481,9 @@ export const en = {
       updated_at: 'Updated At',
       callbackUrlInvalid: 'Please enter a valid URL',
       switchSpace: 'Switch Space',
+      number: 'number',
+      or: 'or',
+      variable: 'variable',
     },
     model: {
       searchPlaceholder: 'search model…',

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -999,6 +999,8 @@ export const en = {
         feishuFolderTokenPlaceholder: 'Enter your Feishu Folder Token',
       },
       csvTemplate: 'Click to download CSV template',
+      exportQa: 'Export QA',
+      exportQaSuccess: 'QA exported successfully',
     },
     api: {
       pageTitle: 'Memory library IAP document',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1286,6 +1286,9 @@ export const zh = {
       updated_at: '更新时间',
       callbackUrlInvalid: '请输入有效的 URL',
       switchSpace: '切换空间',
+      number: '数字',
+      or: '或',
+      variable: '变量',
     },
     model: {
       searchPlaceholder: '搜索模型…',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -481,6 +481,8 @@ export const zh = {
         feishuFolderTokenPlaceholder: '请输入您的飞书文件夹 Token',
       },
       csvTemplate: '点击下载 CSV 模板',
+      exportQa: '导出QA',
+      exportQaSuccess: 'QA 导出成功',
     },
     application: {
       searchPlaceholder: '搜索应用',

--- a/web/src/store/workflow.ts
+++ b/web/src/store/workflow.ts
@@ -5,7 +5,7 @@
  * @Last Modified time: 2026-04-10 18:11:19 
  */
 import { create } from 'zustand'
-import type { NodeCheckResult } from '@/views/Workflow/components/CheckList'
+import type { NodeCheckResult } from '@/views/Workflow/hooks/useWorkflowCheck'
 import type { ChatItem } from '@/components/Chat/types'
 
 interface WorkflowState {

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -95,7 +95,7 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
   const getActiveMemoryConfig = () => {
     getMemoryConfigList()
       .then((res) => {
-        setActiveMemoryConfig((res as Memory[])[0])
+        setActiveMemoryConfig((res as Memory[]).find(item => item.is_active) || null)
       })
       .catch(() => {
         setActiveMemoryConfig(null)

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:27:52 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-04 12:30:24
+ * @Last Modified time: 2026-07-06 11:11:16
  */
 import { type FC, useRef, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -103,16 +103,24 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
         applicationModalRef.current?.handleOpen(application)
         break;
       case 'copy':
-        appRef?.current?.handleSave(false)
-          .then(() => {
-            copyModalRef.current?.handleOpen()
-          })
+        if (appRef?.current?.handleSave) {
+          appRef?.current?.handleSave(false)
+            .then(() => {
+              copyModalRef.current?.handleOpen()
+            })
+        } else {
+          copyModalRef.current?.handleOpen()
+        }
         break;
       case 'export':
-        appRef?.current?.handleSave(false)
-          .then(() => {
-            appExport(application.id, application.name)
-          })
+        if (appRef?.current?.handleSave) {
+          appRef?.current?.handleSave(false)
+            .then(() => {
+              appExport(application.id, application.name)
+            })
+        } else {
+          appExport(application.id, application.name)
+        }
         break;
       case 'delete':
         handleDelete()

--- a/web/src/views/ApplicationManagement/components/ApplicationModal.tsx
+++ b/web/src/views/ApplicationManagement/components/ApplicationModal.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 16:34:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-02 16:30:53
+ * @Last Modified time: 2026-07-06 16:01:16
  */
 /**
  * Application Modal
@@ -121,7 +121,7 @@ const ApplicationModal = forwardRef<ApplicationModalRef, ApplicationModalProps>(
   const getActiveMemoryConfig = () => {
     getMemoryConfigList()
       .then((res) => {
-        setActiveMemoryConfig((res as Memory[])[0])
+        setActiveMemoryConfig((res as Memory[]).find(item => item.is_active) || null)
       })
       .catch(() => {
         setActiveMemoryConfig(null)

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/Private.tsx
@@ -14,7 +14,7 @@ import textIcon from '@/assets/images/knowledgeBase/text.png';
 
 // import blankIcon from '@/assets/images/knowledgeBase/blankDocument.png';
 // import imageIcon from '@/assets/images/knowledgeBase/image.png'
-import { getKnowledgeBaseDetail, deleteDocument, downloadFile, updateKnowledgeBase, createSync, batchDownloadFilesByKb } from '@/api/knowledgeBase';
+import { getKnowledgeBaseDetail, deleteDocument, downloadFile, updateKnowledgeBase, createSync, batchDownloadFilesByKb, exportQaByKb } from '@/api/knowledgeBase';
 import { 
   type CreateModalRef, 
   type KnowledgeBaseListItem, 
@@ -804,6 +804,11 @@ const Private: FC = () => {
       messageApi.success(t('knowledgeBase.batchDownloadSuccess'))
     })
   }
+  const handleExportQa = () => {
+    exportQaByKb(knowledgeBase.id, `${knowledgeBase.name}.csv`, () => {
+      messageApi.success(t('knowledgeBase.exportQaSuccess'))
+    })
+  }
 
   return (
     <>
@@ -889,9 +894,11 @@ const Private: FC = () => {
                   onClick: handleSetting,
                 },
                 {
-                  title: t('knowledgeBase.batchDownload'),
                   icon: "rb:bg-[url('@/assets/images/knowledgeBase/export.svg')]",
-                  onClick: handleBatchDownload,
+                  items: [
+                    { key: 'batchDownload', label: t('knowledgeBase.batchDownload'), onClick: handleBatchDownload },
+                    { key: 'exportQa', label: t('knowledgeBase.exportQa'), onClick: handleExportQa },
+                  ]
                 },
               ]}
             />

--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:48:03 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 21:32:20
+ * @Last Modified time: 2026-07-06 15:52:33
  */
 /**
  * Space Configuration Page
@@ -57,6 +57,22 @@ const SpaceConfig: FC = () => {
       setCustomModels((res || {}) as Record<string, ModelListItem[]>)
     })
   }
+
+  useEffect(() => {
+    const allFields = [...baseModelFields, ...multimodalModelFields]
+    const currentValues = form.getFieldsValue() as Record<string, string | undefined>
+    
+    allFields.forEach(field => {
+      const currentValue = currentValues[field.name]
+      if (currentValue) {
+        const availableModels = customModels[field.name] || []
+        const exists = availableModels.some(model => model.model_id === currentValue || (model as any).id === currentValue)
+        if (!exists) {
+          form.setFieldsValue({ [field.name]: undefined })
+        }
+      }
+    })
+  }, [customModels])
 
   useEffect(() => {
     setPageLoading(true)

--- a/web/src/views/Workflow/components/CheckList/CheckListDrawer.tsx
+++ b/web/src/views/Workflow/components/CheckList/CheckListDrawer.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { Node } from '@antv/x6';
 
 import type { WorkflowRef } from '@/views/ApplicationConfig/types'
-import type { NodeCheckResult } from '.'
+import type { NodeCheckResult } from '../../hooks/useWorkflowCheck'
 import RbDrawer from '@/components/RbDrawer'
 
 export interface CheckListDrawerRef {

--- a/web/src/views/Workflow/components/Editor/Jinja2Editor.tsx
+++ b/web/src/views/Workflow/components/Editor/Jinja2Editor.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-04-02 15:15:36 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-16 11:34:41
+ * @Last Modified time: 2026-07-06 11:08:23
  */
 import { type FC, useEffect, useMemo } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -18,6 +18,7 @@ import Jinja2AutocompletePlugin from './plugin/Jinja2AutocompletePlugin';
 import Jinja2HighlightPlugin from './plugin/Jinja2HighlightPlugin';
 import Jinja2BlurPlugin from './plugin/Jinja2BlurPlugin';
 import LineNumberPlugin from './plugin/LineNumberPlugin';
+import OnBlurPlugin from './plugin/OnBlurPlugin';
 
 const jinja2Theme = {
   paragraph: 'editor-paragraph',
@@ -85,6 +86,7 @@ export interface Jinja2EditorProps {
   height?: number;
   size?: 'default' | 'small';
   className?: string;
+  onBlur?: () => void;
 }
 
 const Jinja2Editor: FC<Jinja2EditorProps> = ({
@@ -96,6 +98,7 @@ const Jinja2Editor: FC<Jinja2EditorProps> = ({
   size = 'default',
   height,
   className,
+  onBlur,
 }) => {
   useEffect(() => {
     if (!document.getElementById(STYLE_ID)) {
@@ -177,6 +180,7 @@ const Jinja2Editor: FC<Jinja2EditorProps> = ({
         <Jinjia2CharacterCountPlugin setCount={() => {}} />
         <Jinja2InitialValuePlugin value={value} onChange={onChange} />
         <Jinja2BlurPlugin />
+        <OnBlurPlugin onBlur={onBlur} />
       </div>
     </LexicalComposer>
   );

--- a/web/src/views/Workflow/components/Editor/index.tsx
+++ b/web/src/views/Workflow/components/Editor/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 18:16:32
+ * @Last Modified time: 2026-07-06 11:04:44
  */
 import { type FC, useState, useMemo } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -17,6 +17,7 @@ import InitialValuePlugin from './plugin/InitialValuePlugin';
 import CommandPlugin from './plugin/CommandPlugin';
 import BlurPlugin from './plugin/BlurPlugin';
 import InsertFormFieldPlugin from './plugin/InsertFormFieldPlugin';
+import OnBlurPlugin from './plugin/OnBlurPlugin';
 import { VariableNode } from './nodes/VariableNode'
 import { FormFieldNode } from './nodes/FormFieldNode';
 import { FormFieldProvider } from './nodes/FormFieldContext';
@@ -45,6 +46,7 @@ export interface LexicalEditorProps {
   waitForInit?: boolean;
   updateFormFields?: (form_fields: FormField[]) => void;
   formFields?: FormField[];
+  onBlur?: () => void;
 }
 
 // Default theme for editor
@@ -70,6 +72,7 @@ const Editor: FC<LexicalEditorProps> =({
   className,
   updateFormFields,
   formFields = [],
+  onBlur,
 }) => {
   // console.log('Editor value', value)
   const [_count, setCount] = useState(0);
@@ -86,6 +89,7 @@ const Editor: FC<LexicalEditorProps> =({
         size={size}
         height={height}
         className={className}
+        onBlur={onBlur}
       />
     );
   }
@@ -176,6 +180,7 @@ const Editor: FC<LexicalEditorProps> =({
           <CharacterCountPlugin setCount={setCount} />
           <InitialValuePlugin value={value} options={options} formFields={formFields} onChange={onChange} />
           <BlurPlugin />
+          <OnBlurPlugin onBlur={onBlur} />
           {updateFormFields &&
             <InsertFormFieldPlugin
               formFields={formFields}

--- a/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/InitialValuePlugin.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-23 16:22:51 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 18:16:40
+ * @Last Modified time: 2026-07-06 11:31:31
  */
 import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
@@ -61,9 +61,29 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
   useEffect(() => {
     if (value !== prevValueRef.current) {
       if (isUserInputRef.current) {
-        prevValueRef.current = value;
-        isUserInputRef.current = false;
-        return;
+        let currentEditorText = '';
+        editor.getEditorState().read(() => {
+          const root = $getRoot();
+          const paragraphs: string[] = [];
+          root.getChildren().forEach(child => {
+            if ($isParagraphNode(child)) {
+              const paragraphText = child.getChildren().map(n => {
+                if ($isFormFieldNode(n)) {
+                  return n.getTextContent();
+                }
+                return n.getTextContent();
+              }).join('');
+              paragraphs.push(paragraphText);
+            }
+          });
+          currentEditorText = paragraphs.join('\n');
+        });
+
+        if (value === currentEditorText) {
+          prevValueRef.current = value;
+          isUserInputRef.current = false;
+          return;
+        }
       }
       prevValueRef.current = value;
       isUserInputRef.current = false;
@@ -73,7 +93,8 @@ const InitialValuePlugin: React.FC<InitialValuePluginProps> = ({ value, options 
           const root = $getRoot();
           root.clear();
 
-          const parts = (value ?? '').split(/(\{\{[^}]+\}\}|\n)/);
+          const strValue = value === null || value === undefined ? '' : String(value);
+          const parts = strValue.split(/(\{\{[^}]+\}\}|\n)/);
           let paragraph = $createParagraphNode();
 
             parts.forEach(part => {

--- a/web/src/views/Workflow/components/Editor/plugin/OnBlurPlugin.tsx
+++ b/web/src/views/Workflow/components/Editor/plugin/OnBlurPlugin.tsx
@@ -1,0 +1,28 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useEffect } from 'react';
+import { BLUR_COMMAND } from 'lexical';
+
+interface OnBlurPluginProps {
+  onBlur?: () => void;
+}
+
+export default function OnBlurPlugin({ onBlur }: OnBlurPluginProps) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (!onBlur) return;
+
+    const unregister = editor.registerCommand(
+      BLUR_COMMAND,
+      () => {
+        onBlur();
+        return false;
+      },
+      1
+    );
+
+    return unregister;
+  }, [editor, onBlur]);
+
+  return null;
+}

--- a/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
@@ -167,7 +167,9 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
       initialValue.tool_parameters[vo.name] = vo.default
     })
 
-    form.setFieldsValue(initialValue)
+    setTimeout(() => {
+      form.setFieldsValue(initialValue)
+    }, 0)
   }
 
   // string -> string
@@ -228,6 +230,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
       <Form.Item name="tool_id" hidden />
       <Form.Item name={['tool_parameters', 'operation']} hidden />
       {parameters.map((parameter) => {
+        const isIntegerType = parameter.type === 'integer'
         return (
           <div key={parameter.name}>
             <Form.Item
@@ -239,7 +242,14 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
                 </Tooltip>
               </>}
               rules={[
-                { required: parameter.required, message: t('common.pleaseEnter') }
+                { required: parameter.required, message: t('common.pleaseEnter') },
+                ...(isIntegerType ? [{
+                  validator(_: any, value: any) {
+                    if (value === undefined || value === null || value === '') return Promise.resolve()
+                    if (/^-?\d+(\.\d+)?$/.test(String(value)) || /^\{\{(([^.]+\.[^}]+))\}\}$/.test(String(value))) return Promise.resolve()
+                    return Promise.reject(new Error(t('common.pleaseEnter') + ' ' + t('common.number') + ' ' + t('common.or') + ' ' + t('common.variable')))
+                  }
+                }] : [])
               ]}
               layout={parameter.type === 'boolean' ? 'horizontal' : 'vertical'}
               className={parameter.type === 'boolean' ? 'rb:mb-0!' : ''}
@@ -247,16 +257,34 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
               {parameter.type === 'string' && parameter.enum && parameter.enum.length > 0
                 ? <Select key={values.tool_id} size="small" options={parameter.enum.map(vo => ({ value: vo, label: vo }))} placeholder={t('common.pleaseSelect')} />
                 : parameter.type === 'boolean'
-                  ? <Switch key={values.tool_id} size="small" />
-                  : <Editor
-                    key={values.tool_id}
-                    variant="outlined"
-                    type="input"
-                    size="small"
-                    height={28}
-                    options={getFilterOptions(parameter.type)}
-                    placeholder={t('common.pleaseEnter')}
-                  />
+                ? <Switch key={values.tool_id} size="small" />
+                : <Editor
+                  key={values.tool_id}
+                  variant="outlined"
+                  type="input"
+                  size="small"
+                  height={28}
+                  options={getFilterOptions(parameter.type)}
+                  placeholder={t('common.pleaseEnter')}
+                  onBlur={isIntegerType ? () => {
+                    const fieldKey = ['tool_parameters', parameter.name]
+                    form.validateFields([fieldKey])
+                      .then((values) => {
+                        const value = values.tool_parameters?.[parameter.name]
+                        let normalizedValue = value
+                        if (value === undefined || value === null || value === '') {
+                          normalizedValue = null
+                        } else if (typeof value === 'string' && /^-?\d+(\.\d+)?$/.test(String(value))) {
+                          normalizedValue = Number(value)
+                        }
+                        form.setFieldValue(fieldKey, normalizedValue)
+                      })
+                      .catch((err) => {
+                        console.log('isIntegerType', isIntegerType, fieldKey, err)
+                        form.setFieldValue(fieldKey, null)
+                      })
+                  } : undefined}
+                />
               }
             </Form.Item>
             {parameter.type === 'boolean' && <div className="rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4 rb:mb-6">{parameter.description}</div>}

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:17:48 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-02 16:50:05
+ * @Last Modified time: 2026-07-06 16:01:59
  */
 import { Clipboard, Graph, Keyboard, MiniMap, Node, Snapline, History, Selection,
   Scroller,
@@ -157,7 +157,7 @@ export const useWorkflowGraph = ({
   const getActiveMemoryConfig = () => {
     getMemoryConfigList()
       .then((res) => {
-        setActiveMemoryConfig((res as Memory[])[0])
+        setActiveMemoryConfig((res as Memory[]).find(item => item.is_active) || null)
       })
       .catch(() => {
         setActiveMemoryConfig(null)


### PR DESCRIPTION
## Summary by Sourcery

添加新的编辑器失焦处理、整数参数校验和知识库问答导出功能，同时改进图标按钮行为和配置健壮性。

新功能：
- 支持在图标按钮组中使用下拉菜单，并可选显示工具提示。
- 通过共享插件在标准编辑器和 Jinja2 编辑器中引入 onBlur 回调。
- 为导出知识库问答数据为 CSV 文件新增 API 和 UI 支持。

缺陷修复：
- 当外部传入的值与当前内容一致时，防止覆盖编辑器中的用户输入。
- 确保整数类型的工具参数被校验并规范化为数值，若无效则清空。
- 当在没有可用的 appRef.handleSave 方法时触发应用配置复制/导出操作，避免报错。
- 当当前值在自定义模型中已不存在时，重置空间配置中的模型选择。
- 确保主动记忆配置选择使用显式激活的条目，而不是列表中的第一个元素。

改进：
- 允许图标按钮在没有标题或点击处理函数的情况下使用，并可选择隐藏工具提示。
- 延迟工具配置表单初始化，以避免在设置初始字段值时可能出现的时序问题。
- 更新工作流检查清单类型的导入，改为使用专用的工作流检查钩子。
- 改进编辑器对 null/undefined 初始值的处理，通过规范化为空字符串。

文档：
- 扩展用于数字/变量校验消息和知识库问答导出成功反馈的 i18n 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new editor blur handling, integer parameter validation, and knowledge base QA export, while improving icon button behavior and configuration robustness.

New Features:
- Support dropdown menus in icon button groups with optional tooltips.
- Introduce onBlur callbacks in both standard and Jinja2 editors via a shared plugin.
- Add API and UI support to export knowledge base QA data as a CSV file.

Bug Fixes:
- Prevent overwriting editor user input when external value matches current content.
- Ensure integer-type tool parameters are validated and normalized to numeric values or cleared when invalid.
- Avoid errors when application config copy/export is triggered without an available appRef handleSave method.
- Reset model selection in space configuration when the current value is no longer present in custom models.
- Ensure active memory config selection uses the explicitly active item instead of the first list element.

Enhancements:
- Allow icon buttons to be used without titles or click handlers and optionally hide tooltips.
- Delay tool configuration form initialization to avoid potential timing issues when setting initial field values.
- Update workflow checklist type imports to use the dedicated workflow check hook.
- Improve editor initial value handling of null/undefined by normalizing to an empty string.

Documentation:
- Extend i18n strings for number/variable validation messages and knowledge base QA export success feedback.

</details>