### PR TITLE
feat(web): doc link update

### DIFF
--- a/web/src/utils/help.ts
+++ b/web/src/utils/help.ts
@@ -1,17 +1,11 @@
 const urlConfig = {
-  help: (lang: 'zh' | 'en') => `https://docs.redbearai.com/s/${lang}-memorybear`,
-  'memory-read': (lang: 'zh' | 'en') => `https://docs.redbearai.com/s/${lang}-memorybear/doc/6k6w5bg5oq5yw-qhmjyEHYOK`,
-  'memory-write': (lang: 'zh' | 'en') => `https://docs.redbearai.com/s/${lang}-memorybear/doc/6k6w5bg5yko5a2y-BxNYN479dv`,
+  help: (lang: 'zh' | 'en') => `/docs/?lang=${lang}`,
+  'memory-read': (lang: 'zh' | 'en') => `/docs/?lang=${lang}&page=u63`,
+  'memory-write': (lang: 'zh' | 'en') => `/docs/?lang=${lang}&page=u64`,
+  'api-key': (lang: 'zh' | 'en') => `/docs/?lang=${lang}&page=api-overview`,
 }
 export const openHelpCenter = (currentLang: 'zh' | 'en', type: string | undefined = 'help') => {
   const lang = currentLang === 'zh' ? 'zh' : 'en';
 
-  // 创建隐藏的 a 标签来避免弹窗拦截
-  const link = document.createElement('a');
-  link.href = urlConfig[type as keyof typeof urlConfig](lang);
-  link.target = '_blank';
-  link.rel = 'noopener noreferrer';
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  window.open(urlConfig[type as keyof typeof urlConfig](lang), '_blank')
 };

--- a/web/src/views/ApiKeyManagement/index.tsx
+++ b/web/src/views/ApiKeyManagement/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 15:52:50 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-30 16:00:54
+ * @Last Modified time: 2026-07-06 18:02:10
  */
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +23,7 @@ import { formatDateTime } from '@/utils/format';
 import Tag from '@/components/Tag'
 import { maskApiKeys } from '@/utils/apiKeyReplacer';
 import RbDescriptions from '@/components/RbDescriptions';
+import { openHelpCenter } from '@/utils/help';
 
 /**
  * API Key Management page component
@@ -81,7 +82,7 @@ const ApiKeyManagement: React.FC = () => {
     message.success(t('common.copySuccess'))
   }
   const handleGotoEndpointConfig = () => {
-    window.open(`/docs/?lang=${i18n.language}`, '_blank')
+    openHelpCenter(i18n.language as 'zh' | 'en', 'api-key')
   }
   return (
     <>


### PR DESCRIPTION
## Summary by Sourcery

将帮助文档链接更新为使用内部 `/docs` 路由，并复用来自 API 密钥管理页面的帮助中心工具。

新功能：
- 通过共享的帮助工具，为 API 密钥文档添加专用的帮助中心链接。

改进：
- 简化打开帮助中心的逻辑，改为使用 `window.open`，而不是构造临时的锚点元素。
- 将帮助、内存读写和 API 密钥页面的文档 URL 统一标准化为基于查询参数的内部 `/docs` 路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update help documentation links to use internal /docs routes and reuse the help center utility from the API Key Management page.

New Features:
- Add a dedicated help center link for API key documentation via the shared help utility.

Enhancements:
- Simplify help center opening logic to use window.open instead of constructing a temporary anchor element.
- Standardize documentation URLs for help, memory read/write, and API key pages to internal /docs query-based routes.

</details>