### PR TITLE
fix(public share): filter node events in regenerate stream and include execution metadata

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -46,7 +46,6 @@ router = APIRouter(prefix="/public/share", tags=["Public Share"])
 logger = get_business_logger()
 
 # 体验分享 regenerate 接口只透传给 end-user 一组精简的 SSE 事件。
-# 这里把工作流/agent/multi-agent 的所有"节点"类事件统一过滤掉——
 # 前端只关心 `message` 文本流、`start` / `error` / `regenerate_end` / `end` 这几个
 # 端点事件、以及内容审核时的 `message_replace`。
 SHARE_FORWARD_EVENTS = frozenset({
@@ -59,7 +58,6 @@ SHARE_FORWARD_EVENTS = frozenset({
 })
 
 # SSE 字符串中 `event: <type>` 行的正则——AGENT 路径吐出来的是已序列化的 SSE 字符串，
-# 控制器需要先把事件名解析出来再做白名单判断。MULTILINE 模式确保只匹配行首。
 SSE_EVENT_LINE = re.compile(r"^event:\s*(\S+)\s*$", re.MULTILINE)
 
 
@@ -1414,7 +1412,6 @@ async def regenerate_message(
             ):
                 # AGENT 路径吐出来的是已序列化的 SSE 字符串（f"event: ...\ndata: ...\n\n"）。
                 # 解析 `event:` 行做白名单过滤，丢弃 reasoning/tool_*/agent_log/
-                # multi-agent 编排事件等节点类事件。
                 m = SSE_EVENT_LINE.search(event)
                 if m and m.group(1) not in SHARE_FORWARD_EVENTS:
                     continue

--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import re
 import uuid
 from typing import Annotated
 
@@ -43,6 +44,23 @@ from app.models import Message, MessageFeedback
 
 router = APIRouter(prefix="/public/share", tags=["Public Share"])
 logger = get_business_logger()
+
+# 体验分享 regenerate 接口只透传给 end-user 一组精简的 SSE 事件。
+# 这里把工作流/agent/multi-agent 的所有"节点"类事件统一过滤掉——
+# 前端只关心 `message` 文本流、`start` / `error` / `regenerate_end` / `end` 这几个
+# 端点事件、以及内容审核时的 `message_replace`。
+SHARE_FORWARD_EVENTS = frozenset({
+    "start",
+    "message",
+    "message_replace",
+    "end",
+    "error",
+    "regenerate_end",
+})
+
+# SSE 字符串中 `event: <type>` 行的正则——AGENT 路径吐出来的是已序列化的 SSE 字符串，
+# 控制器需要先把事件名解析出来再做白名单判断。MULTILINE 模式确保只匹配行首。
+SSE_EVENT_LINE = re.compile(r"^event:\s*(\S+)\s*$", re.MULTILINE)
 
 
 def _to_ms(iso_str: str | None) -> int | None:
@@ -1325,8 +1343,13 @@ async def regenerate_message(
                             workspace_id=workspace_id,
                             user_id=str(end_user.id),
                             override_variables=payload.variables,
+                            pre_create_execution=True,  # 让 start 事件携带真实 execution_id
                     ):
                         event_type = event.get("event", "message")
+                        # 体验分享端：只透出内容类事件与端点事件，过滤掉
+                        # node_*/workflow_*/cycle_item/intervention_* 等节点类事件
+                        if event_type not in SHARE_FORWARD_EVENTS:
+                            continue
                         event_data = event.get("data", {})
                         yield f"event: {event_type}\ndata: {json.dumps(event_data, default=str, ensure_ascii=False)}\n\n"
 
@@ -1389,6 +1412,12 @@ async def regenerate_message(
                     storage_type=storage_type,
                     user_rag_memory_id=user_rag_memory_id,
             ):
+                # AGENT 路径吐出来的是已序列化的 SSE 字符串（f"event: ...\ndata: ...\n\n"）。
+                # 解析 `event:` 行做白名单过滤，丢弃 reasoning/tool_*/agent_log/
+                # multi-agent 编排事件等节点类事件。
+                m = SSE_EVENT_LINE.search(event)
+                if m and m.group(1) not in SHARE_FORWARD_EVENTS:
+                    continue
                 yield event
 
         return StreamingResponse(

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -4074,10 +4074,17 @@ class WorkflowService:
             workspace_id: uuid.UUID,
             user_id: str,
             override_variables: Optional[dict[str, Any]] = None,
+            pre_create_execution: bool = False,
     ):
         """工作流重新生成（流式，多版本支持）。
 
         Yields SSE 事件：在 run_stream 事件外包裹 start（含新版本号）与最终落库。
+
+        Args:
+            pre_create_execution: 若为 True，在 yield `start` 事件之前预创建
+                `WorkflowExecution` 行，并把 execution 对象传入 `run_stream` 复用，
+                避免在 run_stream 内部二次创建。预创建后 start 事件携带真实
+                `execution_id`，供体验分享场景在流开头就把 ID 返回给前端。
         """
         from app.models import Message, Conversation
 
@@ -4125,11 +4132,35 @@ class WorkflowService:
             trigger_payload=input_snapshot.get("trigger_payload"),
         )
 
+        # 体验分享场景：yield start 之前预创建 execution，让 start 事件携带真实
+        # execution_id；同时把 execution 对象透传给 run_stream 复用，避免其内部
+        # create_execution 二次落库。
+        preserved_execution = None
+        if pre_create_execution:
+            # WorkflowConfig 运行时对象没有 release_id/workflow_config_id 属性
+            # （只有 `id`，对应 workflow_config_id）；release_id 复用原始
+            # execution 的记录，与非预创建路径下 run_stream 内部创建 execution
+            # 时的取值来源一致。
+            preserved_execution = self.create_execution(
+                workflow_config_id=config.id,
+                app_id=app_id,
+                release_id=original_execution.release_id if original_execution else None,
+                trigger_type=input_snapshot.get("trigger_type", "manual"),
+                # triggered_by 外键指向内部 users 表；user_id 这里可能是终端访客
+                # （end_user）的 ID，不是 users.id，传入会触发外键违反，与
+                # run_stream 内部其它 create_execution 调用（均传 None）保持一致。
+                triggered_by=None,
+                conversation_id=conversation_id,
+                input_data=input_snapshot,
+            )
+
         full_content = ""
         token_usage: dict[str, Any] = {}
         citations: list[Any] = []
         elapsed_time: Optional[float] = None
-        execution_id: Optional[str] = None
+        execution_id: Optional[str] = (
+            preserved_execution.execution_id if preserved_execution is not None else None
+        )
         stream_status = "completed"
         stream_error: Optional[str] = None
         paused_for_intervention = False
@@ -4138,6 +4169,9 @@ class WorkflowService:
             "event": "start",
             "data": {
                 "conversation_id": str(conversation_id),
+                "message_id": str(new_message_id),
+                "execution_id": execution_id,
+                "user_message_id": str(parent_msg_id),
                 "version": new_version,
             },
         }
@@ -4160,6 +4194,7 @@ class WorkflowService:
                     regenerate_mode=True,
                     regenerate_history=history,
                     regenerate_message_id=new_message_id,
+                    preserved_execution=preserved_execution,
             ):
                 event_type = event.get("event", "message")
                 event_data = event.get("data", {}) or {}
@@ -4232,6 +4267,21 @@ class WorkflowService:
         if conv:
             conv.message_count += 1
         self.db.commit()
+
+        # run_stream 内部吐出的收尾事件类型是 workflow_end（不是 end），不在体验
+        # 分享控制器的 SHARE_FORWARD_EVENTS 白名单里会被过滤掉，导致流里直接从
+        # 内容事件跳到 regenerate_end、中间缺一个 end。这里显式补一个标准 end
+        # 事件，语义与非重新生成首轮对话的 end 事件保持一致。
+        yield {
+            "event": "end",
+            "data": {
+                "status": stream_status,
+                "elapsed_time": elapsed_time,
+                "message_length": len(full_content),
+                "error": stream_error,
+                "output": full_content,
+            },
+        }
 
         yield {
             "event": "regenerate_end",
@@ -4870,15 +4920,18 @@ class WorkflowService:
                         content=preset_response,
                         meta_data={"usage": {}, "moderation_flagged": True},
                     )
-                execution = self.create_execution(
-                    workflow_config_id=config.id,
-                    app_id=app_id,
-                    trigger_type="manual",
-                    triggered_by=None,
-                    conversation_id=conversation_id_uuid,
-                    input_data={"message": payload.message, "moderation_flagged": True},
-                    release_id=release_id,
-                )
+                if preserved_execution is not None:
+                    execution = preserved_execution
+                else:
+                    execution = self.create_execution(
+                        workflow_config_id=config.id,
+                        app_id=app_id,
+                        trigger_type="manual",
+                        triggered_by=None,
+                        conversation_id=conversation_id_uuid,
+                        input_data={"message": payload.message, "moderation_flagged": True},
+                        release_id=release_id,
+                    )
                 execution.status = "completed"
                 execution.output_data = {"answer": preset_response, "moderation_flagged": True}
                 execution.elapsed_time = 0
@@ -5183,7 +5236,12 @@ class WorkflowService:
             regenerate_mode: bool = False,
             regenerate_history: Optional[tuple] = None,
             regenerate_message_id: Optional[uuid.UUID] = None,
+            preserved_execution: "WorkflowExecution | None" = None,
     ):
+        """当 `preserved_execution` 不为 None 时，跳过本方法内部三处
+        `create_execution` 调用，复用调用方已创建的 WorkflowExecution 行。
+        主要用于体验分享 regenerate 场景在 yield `start` 事件前先拿到
+        execution_id。"""
         """运行工作流（流式）
 
         Args:
@@ -5283,15 +5341,18 @@ class WorkflowService:
                 )
 
             # 创建 WorkflowExecution 记录，用于日志显示
-            execution = self.create_execution(
-                workflow_config_id=config.id,
-                app_id=app_id,
-                trigger_type=trigger_type,
-                triggered_by=None,
-                conversation_id=conversation_id_uuid,
-                input_data=input_data,
-                release_id=release_id,
-            )
+            if preserved_execution is not None:
+                execution = preserved_execution
+            else:
+                execution = self.create_execution(
+                    workflow_config_id=config.id,
+                    app_id=app_id,
+                    trigger_type=trigger_type,
+                    triggered_by=None,
+                    conversation_id=conversation_id_uuid,
+                    input_data=input_data,
+                    release_id=release_id,
+                )
             self._store_trigger_meta(execution, trigger_id, trigger_meta)
             execution.status = "completed"
             output_messages = prev_messages + [
@@ -5387,15 +5448,18 @@ class WorkflowService:
                         content=preset_response,
                         meta_data={"usage": {}, "moderation_flagged": True},
                     )
-                execution = self.create_execution(
-                    workflow_config_id=config.id,
-                    app_id=app_id,
-                    trigger_type="manual",
-                    triggered_by=None,
-                    conversation_id=conversation_id_uuid,
-                    input_data={"message": payload.message, "moderation_flagged": True},
-                    release_id=release_id,
-                )
+                if preserved_execution is not None:
+                    execution = preserved_execution
+                else:
+                    execution = self.create_execution(
+                        workflow_config_id=config.id,
+                        app_id=app_id,
+                        trigger_type="manual",
+                        triggered_by=None,
+                        conversation_id=conversation_id_uuid,
+                        input_data={"message": payload.message, "moderation_flagged": True},
+                        release_id=release_id,
+                    )
                 execution.status = "completed"
                 execution.output_data = {"answer": preset_response, "moderation_flagged": True}
                 execution.elapsed_time = 0
@@ -5441,15 +5505,18 @@ class WorkflowService:
                 return
 
         # 2. 创建执行记录
-        execution = self.create_execution(
-            workflow_config_id=config.id,
-            app_id=app_id,
-            trigger_type=trigger_type,
-            triggered_by=None,
-            conversation_id=conversation_id_uuid,
-            input_data=input_data,
-            release_id=release_id,
-        )
+        if preserved_execution is not None:
+            execution = preserved_execution
+        else:
+            execution = self.create_execution(
+                workflow_config_id=config.id,
+                app_id=app_id,
+                trigger_type=trigger_type,
+                triggered_by=None,
+                conversation_id=conversation_id_uuid,
+                input_data=input_data,
+                release_id=release_id,
+            )
         self._store_trigger_meta(execution, trigger_id, trigger_meta)
         self.db.commit()
 


### PR DESCRIPTION
## Summary by Sourcery

改进公共分享的重新生成流式处理，以暴露稳定的执行元数据，并为终端用户简化 SSE 事件界面。

新功能：
- 在 `regenerate_stream` 和 `run_stream` 中支持可选的 WorkflowExecution 记录预创建与复用，使启动事件携带真实的 `execution_id`。
- 在公共分享流程的重新生成启动 SSE 事件中暴露附加标识符（`message_id`、`execution_id`、`user_message_id`）。
- 在公共分享的重新生成端点中过滤工作流、代理和多代理的节点级 SSE 事件，仅转发一组经过筛选的高层事件。

改进：
- 统一 `run` 和 `run_stream` 的执行复用逻辑，避免在审核（moderation）路径和正常路径中重复创建执行记录。
- 在 `regenerate_stream` 之后添加一个合成的标准结束 SSE 事件，使公共分享流程与正常会话结束行为保持一致。

文档：
- 扩展 `regenerate_stream` 和 `run_stream` 的 docstring，描述 `preserved_execution` 行为和预创建执行的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve public share regenerate streaming to expose stable execution metadata and simplify SSE event surface for end users.

New Features:
- Support optional pre-creation and reuse of WorkflowExecution records in regenerate_stream and run_stream so start events carry a real execution_id.
- Expose additional identifiers (message_id, execution_id, user_message_id) in regenerate start SSE events for public share flows.
- Filter workflow, agent, and multi-agent node-level SSE events in public share regenerate endpoints, forwarding only a curated set of high-level events.

Enhancements:
- Unify execution reuse logic across run and run_stream to avoid duplicate execution creation in moderation and normal paths.
- Add a synthesized standard end SSE event after regenerate_stream to align public share flows with normal conversation endings.

Documentation:
- Extend docstrings for regenerate_stream and run_stream to describe preserved_execution behavior and pre-create execution semantics.

</details>