### PR TITLE
feat(web): http node support cURL parse

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2826,6 +2826,11 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
           max_attempts: 'Max Retry Attempts',
           retry_interval: 'Retry Interval',
           errorBranch: 'Error Branch',
+          importCurl: 'Import cURL',
+          curlPlaceholder: 'Paste cURL string',
+          curlParseError: 'Failed to parse cURL, please check the format',
+          curlEmpty: 'Please paste a cURL string',
+          curlImportSuccess: 'Imported successfully',
         },
         'jinja-render': {
           template: 'Code',

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2837,6 +2837,11 @@ export const zh = {
           max_attempts: '最大重试次数',
           retry_interval: '重试间隔',
           errorBranch: '异常分支',
+          importCurl: '导入 cURL',
+          curlPlaceholder: '粘贴 cURL 字符串',
+          curlParseError: 'cURL 解析失败，请检查格式',
+          curlEmpty: '请粘贴 cURL 字符串',
+          curlImportSuccess: '导入成功',
         },
         'jinja-render': {
           template: '代码',

--- a/web/src/views/Workflow/components/Properties/HttpRequest/ImportCurlModal.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/ImportCurlModal.tsx
@@ -1,0 +1,73 @@
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Input, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import RbModal from '@/components/RbModal'
+import { parseCurl, type ParsedCurl } from './parseCurl'
+
+export interface ImportCurlModalRef {
+  handleOpen: () => void;
+  handleClose: () => void;
+}
+
+interface ImportCurlModalProps {
+  /** 解析成功后的回调，返回可回填表单的结构。 */
+  onImport: (parsed: ParsedCurl) => void;
+}
+
+const ImportCurlModal = forwardRef<ImportCurlModalRef, ImportCurlModalProps>(({
+  onImport,
+}, ref) => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [curl, setCurl] = useState('');
+
+  const handleClose = () => {
+    setVisible(false);
+    setCurl('');
+  };
+
+  const handleOpen = () => {
+    setCurl('');
+    setVisible(true);
+  };
+
+  const handleSave = () => {
+    if (!curl.trim()) {
+      message.warning(t('workflow.config.http-request.curlEmpty'));
+      return;
+    }
+    const parsed = parseCurl(curl);
+    if (!parsed) {
+      message.error(t('workflow.config.http-request.curlParseError'));
+      return;
+    }
+    onImport(parsed);
+    message.success(t('workflow.config.http-request.curlImportSuccess'));
+    handleClose();
+  };
+
+  useImperativeHandle(ref, () => ({
+    handleOpen,
+    handleClose,
+  }));
+
+  return (
+    <RbModal
+      title={t('workflow.config.http-request.importCurl')}
+      open={visible}
+      onCancel={handleClose}
+      okText={t('common.save')}
+      onOk={handleSave}
+    >
+      <Input.TextArea
+        value={curl}
+        onChange={(e) => setCurl(e.target.value)}
+        placeholder={t('workflow.config.http-request.curlPlaceholder')}
+        autoSize={{ minRows: 8, maxRows: 16 }}
+      />
+    </RbModal>
+  );
+});
+
+export default ImportCurlModal;

--- a/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-09 18:35:43 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-03 19:07:11
+ * @Last Modified time: 2026-07-06 15:58:16
  */
 import { type FC, useMemo, useRef, useState } from "react";
 import { useTranslation } from 'react-i18next'
@@ -12,6 +12,9 @@ import { CaretDownOutlined, CaretRightOutlined, SettingOutlined } from '@ant-des
 import Editor from '../../Editor'
 import type { Suggestion } from '../../Editor/plugin/AutocompletePlugin'
 import AuthConfigModal from './AuthConfigModal'
+import ImportCurlModal from './ImportCurlModal'
+import type { ImportCurlModalRef } from './ImportCurlModal'
+import type { ParsedCurl } from './parseCurl'
 import type { AuthConfigModalRef, HttpRequestConfigForm } from './types'
 import MessageEditor from '../MessageEditor'
 import EditableTable from './EditableTable'
@@ -27,6 +30,7 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
   const form = Form.useFormInstance();
   const values = Form.useWatch([], form) || {}
   const authConfigModalRef = useRef<AuthConfigModalRef>(null)
+  const importCurlModalRef = useRef<ImportCurlModalRef>(null)
 
   const handleChangeAuth = () => {
     authConfigModalRef.current?.handleOpen(values?.auth)
@@ -34,6 +38,22 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
   const handleRefresh = (auth: HttpRequestConfigForm['auth']) => {
     console.log('handleRefresh', auth)
     form.setFieldsValue({ auth })
+  }
+
+  const handleOpenImportCurl = () => {
+    importCurlModalRef.current?.handleOpen()
+  }
+
+  /** 将解析后的 cURL 信息回填到对应表单字段，未涉及的字段保持不变。 */
+  const handleImportCurl = (parsed: ParsedCurl) => {
+    const patch: Record<string, any> = {}
+    if (parsed.method) patch.method = parsed.method
+    if (parsed.url !== undefined) patch.url = parsed.url
+    if (parsed.headers) patch.headers = parsed.headers
+    if (parsed.params) patch.params = parsed.params
+    if (parsed.body) patch.body = parsed.body
+    if (parsed.auth) patch.auth = parsed.auth
+    form.setFieldsValue(patch)
   }
 
   const handleChangeBodyContentType = () => {
@@ -162,12 +182,19 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
         <div className="rb:font-medium rb:text-[12px] rb:leading-4.5">
           <span className="rb:text-[#ff5d34] rb:text-[14px] rb:font-[SimSun,sans-serif] rb:mr-1">*</span>API
         </div>
-        <Button onClick={handleChangeAuth}
-          size="small"
-          type="text"
-          icon={<SettingOutlined />}
-          className="rb:mt-1 rb:text-[12px]!"
-        >{t('workflow.config.http-request.auth')}: {!values?.auth?.auth_type || values?.auth?.auth_type === 'none' ? t('workflow.config.http-request.none') : t('workflow.config.http-request.apiKey')}</Button>
+        <Flex align="center" gap={4}>
+          <Button onClick={handleChangeAuth}
+            size="small"
+            type="text"
+            icon={<SettingOutlined />}
+            className="rb:mt-1 rb:text-[12px]!"
+          >{t('workflow.config.http-request.auth')}: {!values?.auth?.auth_type || values?.auth?.auth_type === 'none' ? t('workflow.config.http-request.none') : t('workflow.config.http-request.apiKey')}</Button>
+          <Button onClick={handleOpenImportCurl}
+            size="small"
+            type="text"
+            className="rb:mt-1 rb:text-[12px]!"
+          >{t('workflow.config.http-request.importCurl')}</Button>
+        </Flex>
       </Flex>
       <Row gutter={4}>
         <Col span={8}>
@@ -434,9 +461,14 @@ const HttpRequest: FC<{ options: Suggestion[]; selectedNode?: any; graphRef?: an
       }
       <Divider />
 
-      <AuthConfigModal 
+      <AuthConfigModal
         ref={authConfigModalRef}
         refresh={handleRefresh}
+      />
+
+      <ImportCurlModal
+        ref={importCurlModalRef}
+        onImport={handleImportCurl}
       />
     </>
   );

--- a/web/src/views/Workflow/components/Properties/HttpRequest/parseCurl.ts
+++ b/web/src/views/Workflow/components/Properties/HttpRequest/parseCurl.ts
@@ -1,0 +1,242 @@
+/*
+ * cURL 字符串解析工具
+ * 将粘贴的 cURL 命令解析为 HttpRequest 节点表单可直接回填的结构。
+ */
+import type { HttpRequestConfigForm } from './types'
+
+/** 表单中 headers / params / form-data 行的数据结构。 */
+export interface KeyValueRow {
+  key: string;
+  value: string;
+  type?: string;
+}
+
+/** cURL 解析结果，字段与 HttpRequest 表单一一对应。 */
+export interface ParsedCurl {
+  method?: string;
+  url?: string;
+  headers?: KeyValueRow[];
+  params?: KeyValueRow[];
+  body?: {
+    content_type: string;
+    data: string | KeyValueRow[];
+  };
+  auth?: HttpRequestConfigForm['auth'];
+}
+
+/**
+ * 将 cURL 命令按 shell 词法切分为参数数组。
+ * 支持单引号 / 双引号包裹、反斜杠续行、以及 `$'...'` 形式。
+ */
+const tokenize = (input: string): string[] => {
+  // 去掉行尾用于续行的反斜杠，使多行 cURL 合并为一行
+  const normalized = input.replace(/\\\r?\n/g, ' ')
+  const tokens: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let hasToken = false
+
+  for (let i = 0; i < normalized.length; i++) {
+    const char = normalized[i]
+
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      } else if (char === '\\' && quote === '"') {
+        // 双引号内支持转义
+        const next = normalized[i + 1]
+        if (next !== undefined) {
+          current += next
+          i++
+        }
+      } else {
+        current += char
+      }
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      hasToken = true
+      continue
+    }
+
+    if (char === '\\') {
+      const next = normalized[i + 1]
+      if (next !== undefined) {
+        current += next
+        i++
+        hasToken = true
+      }
+      continue
+    }
+
+    if (/\s/.test(char)) {
+      if (hasToken) {
+        tokens.push(current)
+        current = ''
+        hasToken = false
+      }
+      continue
+    }
+
+    current += char
+    hasToken = true
+  }
+
+  if (hasToken) tokens.push(current)
+  return tokens
+}
+
+/** 将 `key: value` 或 `key=value` 形式的头部字符串拆分为键值对。 */
+const splitHeader = (raw: string): KeyValueRow | null => {
+  const index = raw.indexOf(':')
+  if (index === -1) return null
+  const key = raw.slice(0, index).trim()
+  const value = raw.slice(index + 1).trim()
+  if (!key) return null
+  return { key, value }
+}
+
+/** 解析时忽略的请求头（仅 Cookie，其余请求头一律保留）。 */
+const IGNORED_HEADERS = ['cookie']
+
+/** 判断某个请求头是否需要被忽略。 */
+const isIgnoredHeader = (key: string) => IGNORED_HEADERS.includes(key.trim().toLowerCase())
+
+/**
+ * 解析 cURL 字符串。解析失败（无有效 url）时返回 null。
+ */
+export const parseCurl = (curl: string): ParsedCurl | null => {
+  if (!curl || !curl.trim()) return null
+
+  const tokens = tokenize(curl.trim())
+  if (tokens.length === 0) return null
+
+  // 跳过起始的 curl 关键字
+  let start = 0
+  if (tokens[0] === 'curl') start = 1
+
+  const result: ParsedCurl = {}
+  const headers: KeyValueRow[] = []
+  const dataParts: string[] = []
+  const formParts: KeyValueRow[] = []
+  let explicitMethod: string | undefined
+  let hasBody = false
+
+  for (let i = start; i < tokens.length; i++) {
+    const token = tokens[i]
+
+    switch (token) {
+      case '-X':
+      case '--request':
+        explicitMethod = tokens[++i]?.toUpperCase()
+        break
+      case '-H':
+      case '--header': {
+        const header = splitHeader(tokens[++i] ?? '')
+        // 仅忽略 Cookie，其余请求头一律保留
+        if (header && !isIgnoredHeader(header.key)) headers.push(header)
+        break
+      }
+      case '-A':
+      case '--user-agent':
+        headers.push({ key: 'User-Agent', value: tokens[++i] ?? '' })
+        break
+      case '-e':
+      case '--referer':
+        headers.push({ key: 'Referer', value: tokens[++i] ?? '' })
+        break
+      case '-b':
+      case '--cookie':
+        // 忽略 Cookie
+        i++
+        break
+      case '-d':
+      case '--data':
+      case '--data-raw':
+      case '--data-ascii':
+      case '--data-binary':
+        dataParts.push(tokens[++i] ?? '')
+        hasBody = true
+        break
+      case '--data-urlencode': {
+        dataParts.push(tokens[++i] ?? '')
+        hasBody = true
+        break
+      }
+      case '-F':
+      case '--form': {
+        const raw = tokens[++i] ?? ''
+        const eqIndex = raw.indexOf('=')
+        if (eqIndex !== -1) {
+          formParts.push({ key: raw.slice(0, eqIndex).trim(), value: raw.slice(eqIndex + 1).trim() })
+        }
+        hasBody = true
+        break
+      }
+      case '-u':
+      case '--user': {
+        // 基础鉴权 user:password
+        const cred = tokens[++i] ?? ''
+        result.auth = {
+          auth_type: 'basic',
+          api_key: cred,
+        }
+        break
+      }
+      case '-G':
+      case '--get':
+        explicitMethod = 'GET'
+        break
+      default: {
+        // 未知参数：带值的长/短选项跳过其值；否则视为 url
+        if (token.startsWith('-')) {
+          // 形如 --key=value 的忽略；--key value 无法确定是否带值，保守跳过单独 token
+          break
+        }
+        if (!result.url) {
+          result.url = token
+        }
+        break
+      }
+    }
+  }
+
+  if (!result.url) return null
+
+  // 拆分 url 中的 query 作为 params
+  const params: KeyValueRow[] = []
+  const questionIndex = result.url.indexOf('?')
+  if (questionIndex !== -1) {
+    const query = result.url.slice(questionIndex + 1)
+    result.url = result.url.slice(0, questionIndex)
+    query.split('&').forEach(pair => {
+      if (!pair) return
+      const eqIndex = pair.indexOf('=')
+      const key = eqIndex === -1 ? pair : pair.slice(0, eqIndex)
+      const value = eqIndex === -1 ? '' : pair.slice(eqIndex + 1)
+      try {
+        params.push({ key: decodeURIComponent(key), value: decodeURIComponent(value) })
+      } catch {
+        params.push({ key, value })
+      }
+    })
+  }
+  if (params.length > 0) result.params = params
+
+  // Authorization 保留在 headers 中，不再抽取为独立鉴权配置
+  if (headers.length > 0) result.headers = headers
+
+  // 归类请求方法：显式优先，否则有 body 时默认 POST，其余 GET
+  result.method = explicitMethod || (hasBody ? 'POST' : 'GET')
+
+  // 归类 body：form-data 单独处理，其余（-d/--data 等）一律作为 raw
+  if (formParts.length > 0) {
+    result.body = { content_type: 'form-data', data: formParts }
+  } else if (dataParts.length > 0) {
+    result.body = { content_type: 'raw', data: dataParts.join('&') }
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary by Sourcery

为 HTTP Request 工作流节点添加 cURL 导入支持，允许用户粘贴 cURL 命令并自动填充请求配置表单。

New Features:
- 引入 cURL 解析工具，将 cURL 命令转换为与 HttpRequest 表单兼容的结构。
- 添加 `ImportCurlModal` 组件，用于捕获 cURL 字符串、解析它，并将结果回填到 HTTP Request 节点配置中。
- 在 HTTP Request 节点的 UI 中暴露一个 “Import cURL” 操作，用于触发基于 cURL 的配置导入。

Enhancements:
- 调整 HTTP Request 认证区域的布局，在现有认证配置控件旁加入新的导入操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add cURL import support to the HTTP Request workflow node, allowing users to paste a cURL command and automatically populate the request configuration form.

New Features:
- Introduce a cURL parsing utility that converts cURL commands into HttpRequest form-compatible structures.
- Add an ImportCurlModal component to capture a cURL string, parse it, and feed the result back into the HTTP Request node configuration.
- Expose an "Import cURL" action in the HTTP Request node UI to trigger cURL-based configuration import.

Enhancements:
- Adjust the HTTP Request auth section layout to include the new import action alongside existing auth configuration controls.

</details>