### PR TITLE
feat(memory): add video, audio, and vision fields to memory config creation

### DIFF
--- a/api/app/core/memory/pipelines/base_pipeline.py
+++ b/api/app/core/memory/pipelines/base_pipeline.py
@@ -17,6 +17,7 @@ class ModelClientMixin(ABC):
             RedBearModelConfig(
                 model_name=api_config.model_name,
                 provider=api_config.provider,
+                capability=api_config.capability,
                 api_key=api_config.api_key,
                 base_url=api_config.api_base,
                 is_omni=api_config.is_omni

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -249,6 +249,9 @@ class MemoryConfigRepository:
                 rerank_id=params.rerank_id,
                 reflection_model_id=params.reflection_model_id,
                 emotion_model_id=params.emotion_model_id,
+                video_id=params.video_id,
+                audio_id=params.audio_id,
+                vision_id=params.vision_id,
             )
             db.add(db_config)
             db.flush()  # 获取自增ID但不提交事务


### PR DESCRIPTION
- Include video_id, audio_id, and vision_id when creating a new memory config record

## Summary by Sourcery

新功能：
- 在新的内存配置记录中存储 `video_id`、`audio_id` 和 `vision_id`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Store video_id, audio_id, and vision_id on new memory config records.

</details>