### PR TITLE
fix(web): QUOTA_EXCEEDED error not support chat

### DIFF
--- a/web/src/views/Conversation/components/DesktopLayout.tsx
+++ b/web/src/views/Conversation/components/DesktopLayout.tsx
@@ -25,7 +25,7 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
   const {
     t, conversation_id, historyList, groupHistoryList, hasMore, scrollRef, toolbarCallbackRef, config,
     isShare, chatTitle,
-    getHistory, handleChangeHistory, handleShare,
+    getHistory, handleChangeHistory, handleShare, disabled,
   } = ctx
 
   return (
@@ -45,7 +45,10 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
           </Flex>
 
           <Flex align="center" gap={12}
-            className="rb:cursor-pointer rb:border rb:border-[#155EEF] rb:rounded-xl rb:p-3! rb:mx-4! rb:text-[16px] rb:font-medium rb:text-[#155EEF] rb:h-12! rb:mb-5!"
+            className={clsx("rb:border rb:border-[#155EEF] rb:rounded-xl rb:p-3! rb:mx-4! rb:text-[16px] rb:font-medium rb:text-[#155EEF] rb:h-12! rb:mb-5!", {
+              'rb:cursor-not-allowed rb:opacity-65': disabled,
+              'rb:cursor-pointer': !disabled,
+            })}
             onClick={() => handleChangeHistory(null)}
           >
             <div
@@ -114,6 +117,7 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
             {...buildSharedChatProps(ctx)}
             empty={<Empty url={ChatEmpty} className="rb:h-full" size={[320, 180]} title={t('memoryConversation.chatEmpty')} subTitle={t('memoryConversation.emptyDesc')} />}
             labelFormat={(item) => formatDateTime(item.created_at, 'MMMM D, YYYY [at] h:mm A', 'en')}
+            readOnly={disabled}
           >
             <ChatToolbar
               ref={toolbarCallbackRef}

--- a/web/src/views/Conversation/components/MobileLayout.tsx
+++ b/web/src/views/Conversation/components/MobileLayout.tsx
@@ -25,7 +25,7 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
   const {
     t, conversation_id, historyList, hasMore, scrollRef, toolbarCallbackRef, config,
     isShare, isIframe, isFloatBtn, isSmallScreen, chatTitle, showHistory, setShowHistory,
-    getHistory, handleChangeHistory, handleShare,
+    getHistory, handleChangeHistory, handleShare, disabled,
   } = ctx
 
   return (
@@ -67,8 +67,10 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
               }
               <Tooltip placement="left" title={t('memoryConversation.startANewConversation')}>
                 <div
-                  className={clsx("rb:size-3.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/refresh_dark.svg')]", {
+                  className={clsx("rb:size-3.5 rb:bg-cover rb:bg-[url('@/assets/images/refresh_dark.svg')]", {
                     "rb:bg-[url('@/assets/images/refresh_white.svg')]": isFloatBtn,
+                    'rb:cursor-not-allowed rb:opacity-65': disabled,
+                    'rb:cursor-pointer': !disabled,
                   })}
                   onClick={() => handleChangeHistory(null)}
                 ></div>
@@ -94,6 +96,7 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
             {...buildSharedChatProps(ctx)}
             empty={isShare ? null : <Empty url={ChatEmpty} className="rb:h-full" size={[320, 180]} title={t('memoryConversation.chatEmpty')} subTitle={t('memoryConversation.emptyDesc')} />}
             labelFormat={(item) => isFloatBtn ? formatDateTime(item.created_at, 'HH:mm') : formatDateTime(item.created_at, 'MMMM D, YYYY [at] h:mm A', 'en')}
+            readOnly={disabled}
           >
             <ChatToolbar
               ref={toolbarCallbackRef}

--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -189,6 +189,7 @@ export function useConversation() {
   }
 
   /** 分页拉取会话历史 */
+  const [disabled, setDisabled] = useState(false)
   const getHistory = (flag: boolean = false) => {
     if (!shareToken || shareToken === '' || (pageLoading || !hasMore) && !flag) return
     setPageLoading(true)
@@ -213,11 +214,15 @@ export function useConversation() {
         setHasMore(response.page.hasnext)
         setLoading(false)
       })
+      .catch(err => {
+        setDisabled(err?.response?.data?.error_code === 'QUOTA_EXCEEDED')
+      })
       .finally(() => setPageLoading(false))
   }
 
   /** 切换会话或开启新会话 */
   const handleChangeHistory = (id: string | null) => {
+    if (disabled && id === null) return
     if (id !== conversation_id) setConversationId(id)
     if (!id) setMessage('')
     abortRef.current?.()
@@ -570,6 +575,7 @@ export function useConversation() {
     handleShare,
     handleFeedback,
     handleFavorite,
+    disabled,
   }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

在会话视图中处理配额超限状态，并在配额耗尽时阻止开启新聊天。

错误修复：
- 当后端在加载历史记录时返回 `QUOTA_EXCEEDED` 错误时，阻止开启新会话。

增强功能：
- 从会话 hook 向桌面和移动端布局传播禁用状态，使聊天历史以只读方式呈现，并相应更新 UI 交互元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle quota-exceeded state in conversation views and prevent starting new chats when quota is exhausted.

Bug Fixes:
- Prevent starting a new conversation when the backend returns a QUOTA_EXCEEDED error for history loading.

Enhancements:
- Propagate a disabled state from the conversation hook to desktop and mobile layouts to render chat history read-only and update UI affordances accordingly.

</details>