### PR TITLE
fix(memory): ensure config_id is converted to string in memory service and workflow node

### DIFF
--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -454,6 +454,6 @@ def create_long_term_memory_tool(
 
     long_term_memory._tool_meta = {
         "tool_type": "long_term_memory",
-        "sources": [{"id": config_id, "name": memory_name or config_id}],
+        "sources": [{"id": str(config_id), "name": memory_name or str(config_id)}],
     }
     return long_term_memory

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -57,7 +57,7 @@ class MemoryReadNode(BaseNode):
             conversation_id=variable_pool.get_value("sys.conversation_id"),
         )
         query = self._render_template(self.typed_config.message, variable_pool)
-        self._process = {"query": query, "config_id": config_id}
+        self._process = {"query": query, "config_id": str(config_id)}
         # TODO: Historical Messages -> Used to refer to coreference resolution
         search_result = await memory_service.read(
             query,


### PR DESCRIPTION
- Convert config_id to string in memory_service.py to avoid type mismatch in tool_meta sources
- Convert config_id to string in workflow node to ensure consistent serialization

## Summary by Sourcery

确保在内存工具和工作流中，将内存配置标识符始终视为字符串，以避免类型不匹配。

Bug 修复：
- 将长期内存工具元数据的 source ID 和名称转换为字符串，以防止类型不匹配。
- 将工作流内存节点的 `config_id` 序列化为字符串，以保持一致的进程状态表示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure memory config identifiers are consistently treated as strings to avoid type mismatches in memory tooling and workflows.

Bug Fixes:
- Convert long-term memory tool metadata source IDs and names to strings to prevent type mismatches.
- Serialize workflow memory node config_id as a string to maintain consistent process state representation.

</details>