### PR TITLE
docs(memory): clarify language handling in entity extraction prompt

### DIFF
--- a/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
@@ -35,7 +35,7 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - But you MUST resolve references before extraction.
 - Normalize user self-reference such as "I", "me", and "myself" to `用户`.
 - The entity `name` for the user themself MUST always be `用户`; do not output `user`, `the user`, or any translated variant as the user entity name.
-- Normalize user possessive expressions by input language: for Chinese source text, use `用户的X`; for English source text, use `the user's X`; never output mixed possessives such as `用户'sX`, `用户's X`, or `user的X`.
+- Normalize user possessive expressions by the primary language of `statement_text`: for Chinese source text, use `用户的X`; for English source text, use `the user's X`; never output mixed possessives such as `用户'sX`, `用户's X`, or `user的X`.
 - For non-user pronouns or demonstratives such as "he", "she", "it", "this", "that", "this company", "that place", if a stable referent can be resolved from `supporting_context`, replace them with the resolved entity name.
 - If such references cannot be resolved stably, use descriptive names for forced extraction.
 - This prompt is a second-pass repair stage for statements already skipped by the write-time hard gate; do not return the empty result merely because `has_unsolved_reference=true`.
@@ -44,13 +44,14 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - If a reference still cannot be resolved stably, create a descriptive weak entity using time, scene, action, or relationship qualifiers from the statement when useful.
 - Output triplets only when the statement itself expresses a valid relation. Do not force `关联于` as a fallback just because resolution failed.
 - Newly introduced names in naming or alias expressions must stay in their original form.
-- Generate `description` in English.
+- Natural-language output is determined by the primary language of `statement_text`, not by the external `language` parameter. `supporting_context` is only used to resolve references and must not change the output language.
+- Generate `description` in the primary language of `statement_text`.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
 - Every entity MUST include `type_id`, and it MUST exactly match the ontology ID for `type`.
 - Every triplet MUST include `predicate_id`, and it MUST exactly match the ontology ID for `predicate`.
 - Every triplet MUST include `predicate_surface`: use the source-text relation phrase that expresses this relation when available; otherwise use the canonical `predicate`.
-- Except for `type` and `predicate`, all other output text fields must match the input language; therefore under English input, `type_description` and `predicate_description` must be written in English.
+- Except for `type`, `predicate`, and the fixed user entity name `用户`, all other output text fields must match the primary language of `statement_text`; therefore under Chinese statements they must be Chinese, and under English statements they must be English or source surface forms.
 - Every `triplet` MUST include `valid_at` and `invalid_at`, copied directly from the input fields with the same names; do not rewrite or infer new temporal bounds.
   {% endif %}
 
@@ -500,16 +501,16 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - If a statement expresses the user's belief, judgment, opinion, wish, or goal tendency but the referenced abstract concepts are not worth keeping as standalone entities, keep only the relevant high-value entities and do not create those low-value concept entities; write the unextracted content into an entity `description` only when it is suitable as a stable description of that entity.
 - In the current stage, do not extract emotional or psychological states as entities. States such as nervousness, happiness, sadness, anxiety, or relief should not be mapped to `知识能力`, `偏好习惯`, `具体目标`, or any other approximate type.
 - The triplet stage must not re-run the hard gate. Extract expressible entities from the current statement; use descriptive weak entity names for unresolved references.
-- Entity `name` must be as specific as possible to avoid same-name same-type false merges. Naming priority: 1) if there is a proper name or upstream has resolved the mention to a concrete entity, use that concrete name, such as `Haidilao`; 2) if there is no proper name but the statement expresses a stable relation, use a stable semantic qualifier, such as `the company where the user works`, `the library the user often visits`, or `the user's phone`; 3) if there is only a generic name, complete `name` using concrete time, action, purpose, content, location, or scene qualifiers already present in `statement_text` or resolved from context, such as `the restaurant where the user will eat on the morning of 2026-05-15`, rather than only `restaurant`.
+- Entity `name` must be as specific as possible to avoid same-name same-type false merges. Naming priority: 1) if there is a proper name or upstream has resolved the mention to a concrete entity, use that concrete name, such as `Haidilao` / `海底捞`; 2) if there is no proper name but the statement expresses a stable relation, use a stable semantic qualifier in the primary language of `statement_text`, such as English `the company where the user works`, `the library the user often visits`, `the user's phone`, or Chinese `用户就职的公司`, `用户常去的图书馆`, `用户的手机`; 3) if there is only a generic name, complete `name` using concrete time, action, purpose, content, location, or scene qualifiers already present in `statement_text` or resolved from context, such as English `the restaurant where the user will eat on the morning of 2026-05-15` or Chinese `2026-05-15早上去吃饭的饭店`, rather than only `restaurant` / `饭店`.
 - When completing `name`, use only information already present in `statement_text` or resolved upstream. Do not introduce external inference, and do not use unresolved relative time.
-- Weak entities must still use their true semantic type, not default to `称呼别名` or `角色职业`. For example, `the unnamed person who joined this company in March 2026` is `生命体`, and `the company mentioned in the statement` is `组织`.
+- Weak entities must still use their true semantic type, not default to `称呼别名` or `角色职业`. For English statements, write weak names such as `the unnamed person who joined this company in March 2026`; for Chinese statements, write `2026年3月加入这家公司的未具名人员`. Both are `生命体`; `the company mentioned in the statement` / `statement中提到的这家公司` is `组织`.
 - Weak entities that refer to multiple people, customers, coworkers, or visitors should use `群体`, not `生命体`.
 - For `文档媒体`, `物品设备`, `地点设施`, `组织`, `群体`, and `识别联系信息`, especially avoid generic names. If a proper name, stable owner, platform, topic, content, purpose, location, time, or scene qualifier is available, include it in `name`.
 - `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
-- The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
-- Do not extract generic mentions such as `a dog` or `dogs as a species`. In this second-pass repair stage, weak entities are allowed only when they include statement-specific qualifiers; do not output bare generic names such as `some friend`, `an account`, or `some office`.
-- `description` must be in English.
-- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
+- The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier in the primary language of `statement_text`, such as English `the user's dog`, `the user's GitHub account`, `the user's company office`, `the company where the user works`, or Chinese `用户的小狗`, `用户的 GitHub 账号`, `用户的公司办公室`, `用户就职的公司`. Do not collapse these names to `dog` / `account` / `小狗` / `账号`, and never use mixed forms such as `用户's dog`.
+- Do not extract generic mentions such as `a dog`, `dogs as a species`, `一只狗`, or `狗这种动物`. In this second-pass repair stage, weak entities are allowed only when they include statement-specific qualifiers; do not output bare generic names such as `some friend`, `an account`, `some office`, `某个朋友`, `一个账号`, or `某个办公室`.
+- `description` must use the primary language of `statement_text`.
+- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in the primary language of `statement_text`.
   {% endif %}
 
 **Same-Name Entity Deduplication:**
@@ -565,9 +566,10 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 如果实体应保留，但当前 statement 中没有适合长期附着在该实体上的稳定描述，则 `description` 仍必须保留时间戳前缀，可写为 `[dialog_at]` 或 `[NULL]`，不要输出空字符串。
   {% else %}
 - `description` MUST start with `[dialog_at]`, where `dialog_at` is copied directly from the input `dialog_at` field (ISO 8601 timestamp); if `dialog_at` is empty or absent, write `[NULL]`. Format example: `[2025-03-15T10:00:00Z] The speaker who lives in Paris`.
+- The body of `description` must follow the primary language of `statement_text`; if the statement is Chinese, write Chinese after the timestamp, such as `[2025-03-15T10:00:00Z] 居住在巴黎的说话者`.
 - `description` should be concise, context-grounded, and discriminative.
 - Prefer describing the entity's role, identity, relation, ownership, and qualifiers in the current statement and necessary supporting context; include directly related contextual qualifiers as much as possible without adding unsupported inference.
-- For identification/contact information such as accounts, usernames, IDs, emails, or phone numbers, `description` should specify which entity, account/platform, or contact method it belongs to, such as `the username of the user's GitHub account`, rather than a generic `username`.
+- For identification/contact information such as accounts, usernames, IDs, emails, or phone numbers, `description` should specify which entity, account/platform, or contact method it belongs to; for English statements use `the username of the user's GitHub account`, and for Chinese statements use `用户的 GitHub 账号的用户名`, rather than a generic `username` / `用户名`.
 - `description` should keep only information suitable to remain attached to the entity over time, such as stable identity, stable relations, long-term preferences/interests/habits, relatively stable beliefs, or persistent distinguishing traits.
 - Do not put short-lived states, one-off events, temporary plans, current emotions, concrete time anchors, or information that only briefly holds in the current sentence into `description`.
 - If an entity should be retained but the current statement does not provide any suitable stable description for it, `description` must still keep the timestamp prefix and may be `[dialog_at]` or `[NULL]`; do not output an empty string.
@@ -975,11 +977,11 @@ JSON 要求：
 - No Chinese quotation marks
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
-- `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
-- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
+- `description` must use the primary language of `statement_text`, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
+- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must use the primary language of `statement_text`
 - Every entity must include `type_id`, exactly matching the ontology ID for `type`
 - Every triplet must include `predicate_id`, exactly matching the ontology ID for `predicate`
-- Every triplet must include `predicate_surface`; for English input, use English or the source-text relation expression
+- Every triplet must include `predicate_surface`; prefer the source-text relation expression from `statement_text`, and do not translate it into another language
 - Every triplet must include `valid_at` and `invalid_at`, exactly matching the input fields with the same names
 - Output must include `resolved` (bool) and `resolution_note` (string) fields
 - `resolved` is true only if all key references were resolved to stable entity names from context; false if at least one key reference uses a descriptive weak entity name

--- a/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/resolve_unresolved_triplet.jinja2
@@ -16,17 +16,18 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - 但在抽取前，必须先做指代解析。
 - 用户自指表达，如“我”“我的”“我自己”，一律规范为 `用户`。
 - 用户本人这个实体的 `name` 必须始终是 `用户`，不要输出 `user`、`the user` 或其他翻译形式。
-- 用户所有格表达必须按输入语言规范化：中文输入使用 `用户的X`，禁止输出 `用户'sX`、`用户's X`、`user的X` 等中英混合所有格。
+- 用户所有格表达必须按 `statement_text` 的主语言规范化：中文输入使用 `用户的X`，英文输入使用 `the user's X`，禁止输出 `用户'sX`、`用户's X`、`user的X` 等中英混合所有格。
 - 非用户自指代词或指示表达，如“他”“她”“它”“这个”“那个”“这家”“那家”“这里”“那里”，如果能从 `supporting_context` 中稳定解析出具体指代，则必须替换为具体指代实体名。
 - 如果上述代词或指示表达不能稳定解析，则使用描述性名称强制提取。
 - 命名关系中新出现的称呼、别名、昵称、产品名保持原样，不做替换。
-- `description` 必须跟随输入 `statement_text` 的主要语言。
+- 自然语言输出不以 `language` 参数决定，而以 `statement_text` 的主语言决定；`supporting_context` 只用于消解指代，不改变输出语言。
+- `description` 必须使用 `statement_text` 的主语言。
 - 每个实体的 `description` 必须以输入中的 `dialog_at` 时间戳开头，格式为 `[dialog_at] 描述文本`；如果输入中 `dialog_at` 为空或不存在，则使用 `[NULL]`。
 - `type`、`predicate` 必须使用上方预定义的中文标签。
 - 每个实体必须输出 `type_id`，并且必须与 `type` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_id`，并且必须与 `predicate` 对应的本体 ID 完全一致。
 - 每个 triplet 必须输出 `predicate_surface`：尽量使用当前陈述中表达该关系的原文关系短语；如果没有更贴近原文的短语，则使用 canonical `predicate`。
-- 除 `type`、`predicate` 外，其余 flexible 输出文本字段都必须与输入 `statement_text` 的主要语言一致；`type_description`、`predicate_description` 使用与 `description` 相同的语言说明。
+- 除 `type`、`predicate` 和用户本人固定名称 `用户` 外，其余输出文本字段都必须与 `statement_text` 的主语言一致；因此英文 statement 下，`name`、`subject_name`、`object_name`、`description`、`type_description`、`predicate_description`、`predicate_surface` 必须使用英文或原文表面形式。
 - 每个 `triplet` 都必须携带 `valid_at` 和 `invalid_at`，并直接复制输入中的同名字段，不要自行改写或推断新的时间边界。
   {% else %}
   Important:
@@ -43,7 +44,7 @@ Resolve unresolved references and extract entities and knowledge triplets from t
 - If a reference still cannot be resolved stably, create a descriptive weak entity using time, scene, action, or relationship qualifiers from the statement when useful.
 - Output triplets only when the statement itself expresses a valid relation. Do not force `关联于` as a fallback just because resolution failed.
 - Newly introduced names in naming or alias expressions must stay in their original form.
-- Generate `description` in the primary language of the input `statement_text`.
+- Generate `description` in English.
 - Every entity `description` MUST start with the input `dialog_at` timestamp, formatted as `[dialog_at] description text`; if `dialog_at` is empty or absent, use `[NULL]`.
 - Always generate `type` and `predicate` using the predefined Chinese labels above.
 - Every entity MUST include `type_id`, and it MUST exactly match the ontology ID for `type`.
@@ -480,16 +481,16 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - 如果句子表达的是用户的观点、信念、判断、愿望或目标倾向，但其中抽象对象不值得作为独立实体保留，则只保留相关高价值实体，不要再创建这些低价值对象实体；只有当未抽取内容适合作为该实体的稳定描述时，才写入相关实体的 `description`。
 - 当前阶段不要把情绪或心理状态抽成实体；像“紧张”“开心”“难过”“焦虑”“放松”等不应映射到 `知识能力`、`偏好习惯`、`具体目标` 或其他近似类型。
 - triplet 阶段不重新执行 hard gate；应从当前 statement 抽取可表达的实体，无法消解的使用描述性弱实体名称。
-- 实体 `name` 必须尽量具体，避免同名同类型误合并。命名优先级：1）有专名或上游已解析到具体实体时，使用该具体实体名，例如 `海底捞`；2）没有专名但表达稳定关系时，使用稳定语义限定，例如 `用户就职的公司`、`用户常去的图书馆`、`用户的手机`；3）只有泛称时，使用 `statement_text` 中已有或已由上游解析出的具体时间、动作、用途、内容、地点或场景限定补全 name，例如 `2026-05-15早上去吃饭的饭店`，不要只写 `饭店`。
+- 实体 `name` 必须尽量具体，避免同名同类型误合并。命名优先级：1）有专名或上游已解析到具体实体时，使用该具体实体名，例如 `海底捞` / `Haidilao`；2）没有专名但表达稳定关系时，使用稳定语义限定，中文 statement 可用 `用户就职的公司`、`用户常去的图书馆`、`用户的手机`，英文 statement 必须用 `the company where the user works`、`the library the user often visits`、`the user's phone`；3）只有泛称时，使用 `statement_text` 中已有或已由上游解析出的具体时间、动作、用途、内容、地点或场景限定补全 name，例如中文 `2026-05-15早上去吃饭的饭店`，英文 `the restaurant where the user will eat on the morning of 2026-05-15`，不要只写 `饭店` / `restaurant`。
 - 补全 name 时只能使用 `statement_text` 中已有或上游已解析出的信息，不要引入外部推断，也不要使用未解析的相对时间。
-- 弱实体仍然要选择真实语义 type，而不是统一归入 `称呼别名` 或 `角色职业`。例如 `2026年3月加入这家公司的未具名人员` 是 `生命体`，`statement中提到的这家公司` 是 `组织`。
+- 弱实体仍然要选择真实语义 type，而不是统一归入 `称呼别名` 或 `角色职业`。例如中文 statement 下 `2026年3月加入这家公司的未具名人员` 是 `生命体`，英文 statement 下应写作 `the unnamed person who joined this company in March 2026`；`statement中提到的这家公司` / `the company mentioned in the statement` 是 `组织`。
 - 复数人物、客户、同事、来访者等集合性弱实体应使用 `群体`，不是 `生命体`。
 - 对 `文档媒体`、`物品设备`、`地点设施`、`组织`、`群体`、`识别联系信息`，尤其避免直接使用泛称 name；如果已有专名、稳定归属、平台、主题、内容、用途、地点、时间或场景限定，应写进 name。
 - `角色职业` 是例外：角色/职业类别本身可以作为实体，例如 `导师`、`程序员`；但具体人物的稳定关系应通过 triplet 或 description 表达。
-- 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定，例如 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`，不要简化成 `小狗`、`账号`，也不要使用 `用户's小狗` 等中英混合形式。
-- 泛化表达不要抽取，例如 `一只狗`、`狗这种动物`。但本二次处理阶段允许抽取有 statement 限定的弱实体，例如 `2026年3月加入这家公司的未具名人员`；不要输出裸泛称 `某个朋友`、`一个账号`、`某个办公室`。
-- `description` 必须跟随输入 `statement_text` 的主要语言。
-- `type` 必须使用上方预定义的中文标签；`type_description` 使用与 `description` 相同的语言说明对应 `type`。
+- 用户本人节点必须命名为 `用户`；用户拥有、归属或关联的实体应使用完整所有格、归属短语或稳定语义限定。中文 statement 使用 `用户的小狗`、`用户的 GitHub 账号`、`用户的公司办公室`、`用户就职的公司`；英文 statement 使用 `the user's dog`、`the user's GitHub account`、`the user's company office`、`the company where the user works`。不要简化成 `小狗`、`账号`、`dog`、`account`，也不要使用 `用户's小狗`、`用户's dog` 等中英混合形式。
+- 泛化表达不要抽取，例如 `一只狗`、`狗这种动物`、`a dog`、`dogs as a species`。但本二次处理阶段允许抽取有 statement 限定的弱实体；中文 statement 可输出 `2026年3月加入这家公司的未具名人员`，英文 statement 必须输出 `the unnamed person who joined this company in March 2026`；不要输出裸泛称 `某个朋友`、`一个账号`、`某个办公室`、`some friend`、`an account`、`some office`。
+- `description` 必须使用 `statement_text` 的主语言。
+- `type` 必须使用上方预定义的中文标签；`type_description` 必须使用 `statement_text` 的主语言说明该预定义 type。
   {% else %}
 - Do not split generic propositions, causal slogans, or value judgments into low-value abstract entities. For example, "effort brings reward" should not create standalone entities for "effort" or "reward" by default.
 - Do not extract ordinary time expressions as entities, including dates, timestamps, "tomorrow", "next week", or "8 PM tonight".
@@ -507,8 +508,8 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 - `角色职业` is an exception: role and occupation categories may themselves be entities, such as `导师` or `程序员`; but stable relations involving specific people should be represented through triplets or descriptions.
 - The user node itself must be named `用户`; entities owned by, affiliated with, or associated with the user should use a complete possessive phrase, affiliation phrase, or stable semantic qualifier, such as `the user's dog`, `the user's GitHub account`, `the user's company office`, or `the company where the user works`. Do not collapse these names to `dog` or `account`, and never use mixed forms such as `用户's dog`.
 - Do not extract generic mentions such as `a dog` or `dogs as a species`. In this second-pass repair stage, weak entities are allowed only when they include statement-specific qualifiers; do not output bare generic names such as `some friend`, `an account`, or `some office`.
-- `description` must follow the primary language of the input `statement_text`.
-- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in the same language as `description`.
+- `description` must be in English.
+- `type` must use the predefined Chinese label above, while `type_description` must explain that predefined type in English.
   {% endif %}
 
 **Same-Name Entity Deduplication:**
@@ -555,9 +556,10 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 {% if language == "zh" %}
 
 - `description` 必须以 `[dialog_at]` 开头，其中 `dialog_at` 直接复制输入中的 `dialog_at` 字段值（ISO 8601 时间点）；如果输入中 `dialog_at` 为空或不存在，则写 `[NULL]`。格式示例：`[2025-03-15T10:00:00Z] 居住在巴黎的说话者`。
+- `description` 的正文语言必须跟随 `statement_text`；如果 statement 是英文，时间戳后必须写英文，例如 `[2025-03-15T10:00:00Z] The speaker who lives in Paris`。
 - `description` 应简洁、直白、与当前上下文相关，并能帮助区分实体。
 - 优先描述实体在当前陈述和必要上下文中的身份、作用、关系、归属和限定信息；在不引入额外推断的前提下，尽量包含与该实体直接相关的上下文限定。
-- 对账号、用户名、编号、邮箱等识别联系信息，`description` 应尽量写清它属于哪个实体、哪个账号/平台或哪种联系方式，例如 `用户的 GitHub 账号的用户名`，不要只写成泛泛的 `用户名`。
+- 对账号、用户名、编号、邮箱等识别联系信息，`description` 应尽量写清它属于哪个实体、哪个账号/平台或哪种联系方式；中文 statement 可写 `用户的 GitHub 账号的用户名`，英文 statement 必须写 `the username of the user's GitHub account`，不要只写成泛泛的 `用户名` / `username`。
 - `description` 只保留适合长期附着在该实体上的描述，例如稳定身份、稳定关系、长期偏好/兴趣/习惯、较稳定认知倾向或可用于区分实体的持久特征。
 - 不要把短期状态、一次性事件、临时计划、当前情绪、具体时间锚点，或只在当前句子里短暂成立的信息写进 `description`。
 - 如果实体应保留，但当前 statement 中没有适合长期附着在该实体上的稳定描述，则 `description` 仍必须保留时间戳前缀，可写为 `[dialog_at]` 或 `[NULL]`，不要输出空字符串。
@@ -573,7 +575,7 @@ Each relation class now keeps only one canonical `covered_predicates` value. Onc
 
 **Type Description (`type_description`):**
 
-- {% if language == "zh" %}`type_description` 必须直接复用对应 `type` 的中文定义。{% else %}`type_description` must restate the corresponding `type` definition in English, while keeping the underlying `type` label itself in Chinese.{% endif %}
+- `type_description` 必须说明对应 `type` 的定义，但语言跟随 `statement_text`：中文 statement 复用中文定义；英文 statement 用英文解释该预定义 type，同时 `type` 标签本身仍保持中文。
 - {% if language == "zh" %}不要把当前实体实例描述写进 `type_description`。{% else %}Do not put the current entity instance description into `type_description`.{% endif %}
 
 **Type ID (`type_id`):**
@@ -952,16 +954,16 @@ JSON 要求：
 - 不要使用中文引号
 - 字符串值中不要换行
 - `name`、`subject_name`、`object_name` 默认保持原文中的表面形式，但用户自指必须规范成 `用户`，可稳定解析的其他代词必须替换为具体指代实体名
-- `description` 必须跟随输入 `statement_text` 的主要语言，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
-- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用与 `description` 相同的语言说明
+- `description` 必须使用 `statement_text` 的主语言，并且每个实体都必须以输入 `dialog_at` 的方括号时间戳开头；如果 `dialog_at` 为空或不存在，则以 `[NULL]` 开头
+- `type`、`predicate` 必须使用上方预定义的中文标签；`type_description`、`predicate_description` 必须使用 `statement_text` 的主语言说明
 - 每个 entity 都必须包含 `type_id`，且必须与 `type` 的本体 ID 一致
 - 每个 triplet 都必须包含 `predicate_id`，且必须与 `predicate` 的本体 ID 一致
-- 每个 triplet 都必须包含 `predicate_surface`；中文输入下使用中文或原文中的关系表达
+- 每个 triplet 都必须包含 `predicate_surface`；优先使用 `statement_text` 中的原文关系表达，英文 statement 不要翻译成中文
 - 每个 triplet 都必须包含 `valid_at` 和 `invalid_at`，并与输入中的同名字段完全一致
 - 输出必须包含 `resolved`（bool）和 `resolution_note`（string）字段
 - `resolved` 为 true 表示所有关键指代都成功从上下文消解为稳定实体名，false 表示至少一个关键指代使用了描述性弱实体名称
-- 在输出最终 JSON 前必须做一致性检查：如果任一关键实体 `name` 或 `description` 包含 `未具名`、`未知`、`不明`，或 `resolution_note` 中写了“无法稳定解析”“上下文未提供”“未提供其名称”，则 `resolved` 必须是 `false`。
-- 只有当所有关键指代都被替换为不含 `未具名`/`未知`/`不明` 的稳定实体名时，`resolved` 才能是 `true`。
+- 在输出最终 JSON 前必须做一致性检查：如果任一关键实体 `name` 或 `description` 包含 `未具名`、`未知`、`不明`、`unnamed`、`unknown`，或 `resolution_note` 中写了“无法稳定解析”“上下文未提供”“未提供其名称”或英文等价表达，则 `resolved` 必须是 `false`。
+- 只有当所有关键指代都被替换为不含 `未具名`/`未知`/`不明`/`unnamed`/`unknown` 的稳定实体名时，`resolved` 才能是 `true`。
 - `resolution_note` 简要说明消解结果或无法消解的原因
 - 允许 `triplets` 为空；不要为了补救 unresolved 而使用 `关联于`(predicate_id=13) 兜底创建关系
 - 如果 `entities` 中包含弱实体，弱实体名称必须带具体限定，不能是裸代词、裸角色或裸泛称
@@ -973,8 +975,8 @@ JSON 要求：
 - No Chinese quotation marks
 - No line breaks inside string values
 - `name`, `subject_name`, and `object_name` keep their original surface forms by default, but user self-reference must be normalized to `用户` and other stably resolvable references must be replaced by their resolved entity names
-- `description` must follow the primary language of the input `statement_text`, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
-- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in the same language as `description`
+- `description` must be in English, and every entity description must start with the bracketed input `dialog_at` timestamp; if `dialog_at` is empty or absent, start with `[NULL]`
+- `type` and `predicate` must use the predefined Chinese labels above; `type_description` and `predicate_description` must be written in English
 - Every entity must include `type_id`, exactly matching the ontology ID for `type`
 - Every triplet must include `predicate_id`, exactly matching the ontology ID for `predicate`
 - Every triplet must include `predicate_surface`; for English input, use English or the source-text relation expression


### PR DESCRIPTION
- Standardize output language to follow `statement_text` primary language instead of `language` parameter
- Update Chinese prompt to explicitly specify English output translations for statement-level qualifiers and entity naming patterns
- Clarify that `supporting_context` is used only for reference resolution and does not affect output language
- Add English examples for weak entities and possessive constructions (e.g., "the company where the user works", "the unnamed person who joined this company in March 2026")
- Specify that `description`, `type_description`, and other flexible text fields must match statement language, not configuration
- Update English prompt sections to reflect consistent language rules across both Chinese and English statement processing
- Ensure user self-reference entity remains fixed as `用户` regardless of input language, while all other output adapts to statement language

## Summary by Sourcery

在实体抽取提示中澄清并统一语言处理规则，使输出遵循陈述文本的主语言，同时保持本体标签和用户自我实体的一致性。

Documentation:
- 记录一致的规则：自然语言输出应遵循 `statement_text` 的主语言，而不是 `language` 参数，并且 `supporting_context` 仅用于指代消解。
- 明确所有可变文本字段（`description`、`type_description`、`predicate_description`、名称以及谓词表面形式）必须与陈述语言一致，固定的中文本体标签和用户实体名称 `用户` 除外。
- 为弱实体、属格结构和描述性命名模式添加对应的中英文示例，包括对未命名实体和与用户相关资源的指导。
- 更新英文提示部分，使其要求使用英文对类型进行描述和解释，同时保持 `type` 标签为中文；并对齐中英文输出中关于解析成功标准的要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and standardize language-handling rules in the entity extraction prompt so that outputs follow the primary language of the statement text while keeping ontology labels and the user self-entity consistent.

Documentation:
- Document consistent rules that natural-language outputs follow the primary language of `statement_text` rather than the `language` parameter, with `supporting_context` used only for reference resolution.
- Clarify that all flexible text fields (`description`, `type_description`, `predicate_description`, names, and predicate surfaces) must match the statement language, except for fixed Chinese ontology labels and the user entity name `用户`.
- Add parallel Chinese and English examples for weak entities, possessive constructions, and descriptive naming patterns, including guidance for unnamed entities and user-affiliated resources.
- Update English prompt sections to require English descriptions and explanations for types while keeping `type` labels in Chinese, and to align resolution success criteria across Chinese and English outputs.

</details>