### PR TITLE
fix(rag): clean empty Markdown anchors from chunks

### DIFF
--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -15,6 +15,10 @@ from app.core.rag.nlp import find_codec
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 HEADING_PATTERN = re.compile(r"^(#{1,6})\s+.*$")
 LIST_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+\.\s+).*$")
+EMPTY_HTML_ANCHOR_PATTERN = re.compile(
+    r"<a\b(?=[^>]*(?:\bid\s*=\s*['\"][^'\"]+['\"]|\bname\s*=\s*['\"][^'\"]+['\"]))(?![^>]*\bhref\s*=)[^>]*>\s*</a>",
+    re.IGNORECASE,
+)
 
 
 class StructMarkdownParser(DocumentParser):
@@ -25,7 +29,7 @@ class StructMarkdownParser(DocumentParser):
     def parse_text(self, text: str) -> list[ParsedBlock]:
         self._seq = 0
         self.blocks: list[ParsedBlock] = []
-        self.lines = text.split("\n")
+        self.lines = self._strip_empty_html_anchors_outside_code(text.split("\n"))
 
         index = 0
         while index < len(self.lines):
@@ -60,6 +64,24 @@ class StructMarkdownParser(DocumentParser):
             index = self._append_text(index)
 
         return self.blocks
+
+    def _strip_empty_html_anchors_outside_code(self, lines: list[str]) -> list[str]:
+        cleaned_lines = []
+        in_code = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                cleaned_lines.append(line)
+                in_code = not in_code
+                continue
+            if in_code:
+                cleaned_lines.append(line)
+                continue
+            cleaned_lines.append(self._strip_empty_html_anchors(line))
+        return cleaned_lines
+
+    def _strip_empty_html_anchors(self, line: str) -> str:
+        return EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
 
     def md_to_html(self, text: str):
         if not text:


### PR DESCRIPTION
## Summary
- Remove empty HTML anchors such as `<a id="_Toc003"></a>` before structured Markdown block parsing.
- Preserve visible links, anchors with body text, and content inside fenced code blocks.
- Prevent MinerU/Word TOC anchors from becoming standalone RAG chunks.

## Changes
- `api/app/core/rag/chunk/parser/structured_markdown.py`: strip empty HTML anchors outside fenced code before block detection.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/pytest tests/rag/chunk/test_structured_markdown_parser.py tests/rag/chunk/test_mineru_v3_parser.py tests/rag/chunk/test_block_merger.py -q` -> 15 passed
- [x] Smoke checked official MinerU `full.md`: parsed output contains no `_Toc` and preserves `# **三、记忆增强型 AI 知识库**`.
- [x] `git diff --check -- api/app/core/rag/chunk/parser/structured_markdown.py` -> passed
- [x] `PYTHONPATH=api api/.venv/bin/python -m py_compile api/app/core/rag/chunk/parser/structured_markdown.py` -> passed

## API Key Impact
No API route, schema, permission, workspace, tenant, or response contract changes. API-key users only see cleaner chunk content when the shared RAG parsing pipeline is reused.

## Risk
Existing indexed chunks are not cleaned retroactively. Affected documents need re-parse/re-index to remove previously stored empty anchor chunks.

## Summary by Sourcery

错误修复：
- 去除围栏代码块之外、且不包含 `href` 的空 HTML 锚点，以防它们被当作独立的 RAG 片段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Strip empty non-href HTML anchors outside fenced code blocks to prevent them from becoming standalone RAG chunks.

</details>