### PR TITLE
refactor(memory): decouple LLM client injection from extraction engine

### DIFF
--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -70,7 +70,7 @@ class ReflectionPipeline:
     def _lazy_init(self):
         """延迟初始化依赖，避免循环导入和不必要的连接创建"""
         if self._llm_client is None:
-            from app.core.memory.utils.llm.llm_utils import MemoryClientFactory
+            from app.core.memory.pipelines.base_pipeline import ModelClientMixin
             from app.db import get_db_context
 
             llm_id = (
@@ -79,10 +79,10 @@ class ReflectionPipeline:
                 or getattr(self.memory_config, 'llm_id', None)
             )
 
-            with get_db_context() as db:
-                if llm_id:
-                    factory = MemoryClientFactory(db, tenant_id=getattr(self.memory_config, "tenant_id", None))
-                    self._llm_client = factory.get_llm_client(
+            if llm_id:
+                with get_db_context() as db:
+                    self._llm_client = ModelClientMixin.get_llm_client(
+                        db,
                         llm_id,
                         tenant_id=getattr(self.memory_config, "tenant_id", None),
                     )

--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -67,11 +67,11 @@ class ReflectionPipeline:
         # 延迟初始化的客户端
         self._llm_client = None
 
-    def _lazy_init(self):
+    async def _lazy_init(self):
         """延迟初始化依赖，避免循环导入和不必要的连接创建"""
         if self._llm_client is None:
             from app.core.memory.pipelines.base_pipeline import ModelClientMixin
-            from app.db import get_db_context
+            from app.db import get_async_db_context
 
             llm_id = (
                 getattr(self.memory_config, 'reflection_model_id', None)
@@ -80,8 +80,8 @@ class ReflectionPipeline:
             )
 
             if llm_id:
-                with get_db_context() as db:
-                    self._llm_client = ModelClientMixin.get_llm_client(
+                async with get_async_db_context() as db:
+                    self._llm_client = await ModelClientMixin.get_llm_client_async(
                         db,
                         llm_id,
                         tenant_id=getattr(self.memory_config, "tenant_id", None),
@@ -94,9 +94,9 @@ class ReflectionPipeline:
             if embedding_id:
                 try:
                     from app.core.memory.pipelines.base_pipeline import ModelClientMixin
-                    from app.db import get_db_context
-                    with get_db_context() as db:
-                        self._embedding_client = ModelClientMixin.get_embedding_client(
+                    from app.db import get_async_db_context
+                    async with get_async_db_context() as db:
+                        self._embedding_client = await ModelClientMixin.get_embedding_client_async(
                             db,
                             embedding_id,
                             tenant_id=getattr(self.memory_config, "tenant_id", None),
@@ -109,7 +109,7 @@ class ReflectionPipeline:
 
         执行顺序：子问题 1→2→5→3→6→4（当前只实现子问题 3 和 6）
         """
-        self._lazy_init()
+        await self._lazy_init()
 
         if not self._llm_client:
             return {"status": "skipped", "reason": "no llm_id configured"}
@@ -136,7 +136,7 @@ class ReflectionPipeline:
 
     async def run_dedup_full_scan(self, baseline: str = "HYBRID") -> Dict[str, Any]:
         """方案B：低频全量扫描去重 — 由每天一次的定时任务调用"""
-        self._lazy_init()
+        await self._lazy_init()
 
         if not self._llm_client:
             return {"status": "skipped", "reason": "no llm_id configured"}

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
@@ -11,6 +11,7 @@ and runs LLM extraction + patch. Description fragment count is gated by the
 ``min_fragments`` parameter (default 5, shared with description_merge config).
 """
 
+import json
 import logging
 from typing import Any, Dict, List, Tuple
 
@@ -180,9 +181,8 @@ async def extract_metadata_for_user(
 ) -> Dict[str, Any]:
     """对指定用户的 User 实体执行元数据提取 + Neo4j 回写 + PostgreSQL 同步。
 
-    从 Neo4j 中读取当前用户的 User 实体及其 description，
-    调用 MetadataExtractionStep 进行 LLM 结构化提取，
-    将 patch operations 回写 Neo4j 并同步 PostgreSQL。
+    从 Neo4j 中读取当前用户的 User 实体及其 description，直接调 LLM 做
+    结构化元数据提取，将 patch operations 回写 Neo4j 并同步 PostgreSQL。
 
     Args:
         connector: Neo4j 连接器
@@ -196,9 +196,6 @@ async def extract_metadata_for_user(
         {"extracted": N, "failed": N}
     """
     from app.core.memory.models.metadata_models import ALLOWED_METADATA_FIELDS
-    from app.core.memory.models.variate_config import ExtractionPipelineConfig
-    from app.core.memory.storage_services.extraction_engine.steps.base import StepContext
-    from app.core.memory.storage_services.extraction_engine.steps.metadata_step import MetadataExtractionStep
     from app.repositories.neo4j.cypher_queries import (
         ENTITY_METADATA_PATCH,
         ENTITY_METADATA_QUERY,
@@ -240,14 +237,10 @@ async def extract_metadata_for_user(
 
     logger.info(f"[Metadata] 扫描到 {len(candidates)} 个候选 User 实体")
 
-    # ── 2. 构建 step ──
-    pipeline_config = ExtractionPipelineConfig()
-    context = StepContext(
-        llm_client=llm_client,
-        language=language,
-        config=pipeline_config,
-    )
-    step = MetadataExtractionStep(context)
+    # ── 2. 反思侧直接持有 llm_client + language 调 LLM，
+    #      不复用 MetadataExtractionStep：其基类 call_structured 依赖
+    #      llm_client.response_structured（OpenAIClient 接口），与反思注入的
+    #      RedBearLLM 不兼容。模板与 schema 仍复用抽取引擎既有资源。
 
     extracted = 0
     failed = 0
@@ -264,7 +257,8 @@ async def extract_metadata_for_user(
         try:
             patched = await _extract_single_entity(
                 connector=connector,
-                step=step,
+                llm_client=llm_client,
+                language=language,
                 entity_id=entity_id,
                 entity_name=entity_name,
                 descriptions=entity_dict.get("descriptions", []),
@@ -314,9 +308,57 @@ async def extract_metadata_for_user(
     return out
 
 
+async def _run_metadata_llm(
+    llm_client: Any,
+    language: str,
+    inp: "MetadataStepInput",
+) -> "MetadataStepOutput":
+    """反思侧直接调 LLM 完成元数据结构化提取，替代 MetadataExtractionStep.run。
+
+    绕开 MetadataExtractionStep：其基类的 call_structured 依赖
+    llm_client.response_structured（OpenAIClient 接口），反思注入的 RedBearLLM
+    仅提供 call_structured 实例方法。此处复用抽取引擎的模板与 Pydantic schema，
+    仅由反思侧接管调用协议。sidecar 语义：LLM 失败返回空结果、不中断反思。
+    """
+    from app.core.memory.utils.prompt.prompt_utils import prompt_env
+    from app.core.memory.models.metadata_models import MetadataExtractionResponse
+    from app.core.memory.storage_services.extraction_engine.steps.schema import (
+        MetadataStepOutput,
+    )
+
+    template = prompt_env.get_template("extract_user_metadata.jinja2")
+    prompt = template.render(
+        language=language,
+        input_json=json.dumps(
+            {
+                "description": inp.descriptions,
+                "existing_metadata": inp.existing_metadata,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+    )
+
+    try:
+        raw = await llm_client.call_structured(
+            [{"role": "user", "content": prompt}],
+            MetadataExtractionResponse,
+        )
+    except Exception as e:
+        logger.warning(f"[Metadata] LLM 提取失败，返回空 operations: {e}")
+        return MetadataStepOutput(operations=[])
+
+    if raw is None:
+        return MetadataStepOutput(operations=[])
+    operations = list(getattr(raw, "operations", []) or [])
+    dropped = getattr(raw, "_dropped_ops_count", 0) or 0
+    return MetadataStepOutput(operations=operations, dropped_ops_count=dropped)
+
+
 async def _extract_single_entity(
     connector: Any,
-    step: Any,
+    llm_client: Any,
+    language: str,
     entity_id: str,
     entity_name: str,
     descriptions: List[str],
@@ -354,7 +396,7 @@ async def _extract_single_entity(
         descriptions=descriptions,
         existing_metadata=existing,
     )
-    result = await step.run(inp)
+    result = await _run_metadata_llm(llm_client, language, inp)
 
     if not result.has_any():
         logger.debug(f"[Metadata] 实体 {entity_name}({entity_id}) 无新增元数据")

--- a/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
@@ -52,8 +52,6 @@ async def judge_alias_belongs(
         已判定的候选列表，每项：{alias_id, decision("merge"|"drop"), confidence, reason}。
         未拿到有效判定（LLM 异常/缺失/越界/非法分数）的候选不在返回中 —— 调用方据此 skip（保留边）。
     """
-    from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
     if not candidates:
         return []
 
@@ -65,7 +63,7 @@ async def judge_alias_belongs(
             language=language,
         )
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, AliasBatchJudgeOutput)
+        response = await llm_client.call_structured(messages, AliasBatchJudgeOutput)
 
         if not isinstance(response, AliasBatchJudgeOutput):
             logger.warning("[AliasJudge] LLM 返回类型异常，整组按 skip 处理")

--- a/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
@@ -46,8 +46,6 @@ async def merge_description(
         合并后的纯文本摘要，失败返回 None
     """
     try:
-        from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
         template = _prompt_env.get_template("description_merge.jinja2")
         json_schema = json.dumps(DescriptionMergeOutput.model_json_schema(), indent=2)
 
@@ -62,7 +60,7 @@ async def merge_description(
         )
 
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, DescriptionMergeOutput)
+        response = await llm_client.call_structured(messages, DescriptionMergeOutput)
 
         if isinstance(response, DescriptionMergeOutput):
             result = response.merged_description
@@ -207,8 +205,6 @@ async def summarize_extract_and_rename(
         SummarizeExtractRenameOutput 实例，失败返回 None
     """
     try:
-        from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
         template = _prompt_env.get_template("reflection_summary_timeline.prompt.jinja2")
 
         input_data = {
@@ -225,7 +221,7 @@ async def summarize_extract_and_rename(
         )
 
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, SummarizeExtractRenameOutput)
+        response = await llm_client.call_structured(messages, SummarizeExtractRenameOutput)
 
         if isinstance(response, SummarizeExtractRenameOutput):
             result = response

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
@@ -49,8 +49,6 @@ async def judge_batch_dedup(
     Returns:
         [(idx_a, idx_b, confidence, reason), ...] 索引从0开始（内部已转换）
     """
-    from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
     try:
         template = _prompt_env.get_template("entity_dedup_batch.jinja2")
         rendered_prompt = template.render(
@@ -60,7 +58,7 @@ async def judge_batch_dedup(
         )
 
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, BatchDedupOutput)
+        response = await llm_client.call_structured(messages, BatchDedupOutput)
 
         if not isinstance(response, BatchDedupOutput):
             return []

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
@@ -52,8 +52,6 @@ async def judge_pair_for_dedup(
     entity_a/entity_b 需有 name, entity_type, description, description_summary, aliases 属性。
     """
     try:
-        from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
         template = _prompt_env.get_template("entity_dedup_reflection.jinja2")
         rendered_prompt = template.render(
             entity_a={
@@ -75,7 +73,7 @@ async def judge_pair_for_dedup(
         )
 
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, DedupJudgeOutput)
+        response = await llm_client.call_structured(messages, DedupJudgeOutput)
 
         if isinstance(response, DedupJudgeOutput):
             # new_name 为空时回退到 canonical_idx 对应实体名

--- a/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
@@ -116,8 +116,6 @@ async def resolve_unresolved_statement(
 ) -> Optional[UnresolvedResult]:
     """调用 LLM 对 unresolved statement 进行消解 + 三元组提取"""
     try:
-        from app.core.memory.storage_services.extraction_engine.steps.base import call_structured
-
         template = _prompt_env.get_template("resolve_unresolved_triplet.jinja2")
 
         input_json = {
@@ -141,7 +139,7 @@ async def resolve_unresolved_statement(
         )
 
         messages = [{"role": "user", "content": rendered_prompt}]
-        response = await call_structured(llm_client, messages, UnresolvedResult)
+        response = await llm_client.call_structured(messages, UnresolvedResult)
 
         if isinstance(response, UnresolvedResult):
             return response


### PR DESCRIPTION
- Replace MemoryClientFactory dependency with direct ModelClientMixin.get_llm_client call in reflection_pipeline
- Move llm_id validation before database context to reduce scope and avoid unnecessary connections
- Decouple metadata extraction from MetadataExtractionStep; add _run_metadata_llm to handle LLM calls directly
- Replace step-based architecture with direct llm_client invocation in extract_metadata_for_user
- Remove ExtractionPipelineConfig and StepContext dependencies from reflection engine
- Consolidate call_structured usage: remove extraction_engine.steps.base imports, use llm_client methods directly
- Update function signatures to pass llm_client and language directly instead of step objects
- Add json import to extract_metadata_service for prompt rendering
- Simplify error handling: LLM failures return empty operations instead of propagating exceptions
- Reduces circular import risk and aligns reflection engine with injected client interface

## Summary by Sourcery

将反射引擎的元数据提取和 LLM 使用与提取引擎的基于步骤（step-based）架构解耦，使其与注入的 LLM 客户端接口保持一致，并简化错误处理。

增强点：
- 在反射流水线中直接使用 `ModelClientMixin.get_llm_client`，并在打开数据库上下文之前验证 `llm_id`，以降低耦合度并减少不必要的连接。
- 用直接的 LLM 调用辅助方法替换基于 `MetadataExtractionStep` 的元数据提取逻辑，该辅助方法复用现有的提示（prompts）和模式（schemas），但在失败时通过返回空操作集来处理错误。
- 将反射中的 LLM 调用统一为直接使用 `llm_client.call_structured`，而不再依赖提取引擎的共享 `call_structured` 辅助方法，从而减少跨模块依赖并降低循环导入的风险。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple the reflection engine’s metadata extraction and LLM usage from the extraction engine’s step-based architecture, aligning it with the injected LLM client interface and simplifying error handling.

Enhancements:
- Use ModelClientMixin.get_llm_client directly in the reflection pipeline and validate llm_id before opening a DB context to reduce coupling and unnecessary connections.
- Replace MetadataExtractionStep-based metadata extraction with a direct LLM invocation helper that reuses existing prompts and schemas but handles failures by returning empty operations.
- Standardize reflection LLM calls to use llm_client.call_structured directly instead of the extraction engine’s shared call_structured helper, reducing cross-module dependencies and circular import risk.

</details>