### PR TITLE
feat(memory): propagate is_omni and capability fields through LLM client construction

### DIFF
--- a/api/app/core/memory/llm_tools/llm_client.py
+++ b/api/app/core/memory/llm_tools/llm_client.py
@@ -55,6 +55,8 @@ class LLMClient(ABC):
         self.base_url = self.config.base_url
         self.max_retries = self.config.max_retries
         self.timeout = self.config.timeout
+        self.is_omni = self.config.is_omni
+        self.capability = self.config.capability
 
         logger.debug(
             f"初始化 LLM 客户端: provider={self.provider}, "

--- a/api/app/core/memory/llm_tools/openai_client.py
+++ b/api/app/core/memory/llm_tools/openai_client.py
@@ -60,6 +60,8 @@ class OpenAIClient(LLMClient):
                 api_key=self.api_key,
                 base_url=self.base_url,
                 max_retries=self.max_retries,
+                is_omni=self.is_omni,
+                capability=self.capability,
                 timeout=self.timeout,
             ),
             type=type_

--- a/api/app/core/memory/storage_services/reflection_engine/self_reflexion.py
+++ b/api/app/core/memory/storage_services/reflection_engine/self_reflexion.py
@@ -250,6 +250,8 @@ class ReflectionEngine:
                 api_key=model_config.get("api_key"),
                 base_url=model_config.get("base_url"),
                 timeout=model_config.get("timeout", 30),
+                is_omni=model_config.get("is_omni"),
+                capability=model_config.get("capability"),
                 max_retries=model_config.get("max_retries", 2),
                 extra_params=extra_params
             ), type_=model_config.get("type"))

--- a/api/app/core/memory/utils/llm/llm_utils.py
+++ b/api/app/core/memory/utils/llm/llm_utils.py
@@ -75,7 +75,9 @@ class MemoryClientFactory:
                     model_name=model_config.get("model_name"),
                     provider=model_config.get("provider"),
                     api_key=model_config.get("api_key"),
-                    base_url=model_config.get("base_url")
+                    base_url=model_config.get("base_url"),
+                    is_omni=model_config.get("is_omni"),
+                    capability=model_config.get("capability")
                 ),
                 type_=model_config.get("type")
             )
@@ -130,7 +132,9 @@ class MemoryClientFactory:
                     model_name=model_config.get("model_name"),
                     provider=model_config.get("provider"),
                     api_key=model_config.get("api_key"),
-                    base_url=model_config.get("base_url")
+                    base_url=model_config.get("base_url"),
+                    is_omni=model_config.get("is_omni"),
+                    capability=model_config.get("capability")
                 ),
                 type_=model_config.get("type")
             )

--- a/api/app/services/memory_base_service.py
+++ b/api/app/services/memory_base_service.py
@@ -72,6 +72,8 @@ class MemoryTransService:
                         base_url=model_config.get("base_url"),
                         timeout=model_config.get("timeout", 30),
                         max_retries=model_config.get("max_retries", 3),
+                        is_omni=model_config.get("is_omni"),
+                        capability=model_config.get("capability"),
                         extra_params=extra_params
                     ),
                     type_=model_config.get("type")

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -661,11 +661,13 @@ class MemoryConfigService:
             "model_name": api_config.model_name,
             "provider": api_config.provider,
             "api_key": api_config.api_key,
+            "capability": api_config.capability,
             "base_url": api_config.api_base,
             "model_config_id": str(config.id),
             "type": config.type,
             "timeout": settings.LLM_TIMEOUT,
             "max_retries": settings.LLM_MAX_RETRIES,
+            "is_omni": api_config.is_omni,
         }
 
     def get_embedder_config(self, embedding_id: str, tenant_id: UUID | None = None) -> dict:


### PR DESCRIPTION
## Summary by Sourcery

在与内存相关的 LLM 客户端构建和配置过程中，向下传递模型能力（capability）和 omni 模式标志（omni-mode）。

新功能：
- 在 LLM 客户端实例上暴露 `is_omni` 和 `capability` 字段，并将它们传递给底层的 OpenAI 客户端。
- 在 `memory_config_service` 返回的模型配置中包含 `capability` 和 `is_omni` 属性。

增强：
- 确保所有内存与反射引擎的 LLM / reranker 客户端工厂会从已存储的模型配置中转发 `is_omni` 和 `capability` 设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate model capability and omni-mode flags through memory-related LLM client construction and configuration.

New Features:
- Expose is_omni and capability fields on LLM client instances and pass them through to the underlying OpenAI client.
- Include capability and is_omni attributes in model configuration returned by memory_config_service.

Enhancements:
- Ensure all memory and reflection engine LLM/reranker client factories forward is_omni and capability settings from stored model configuration.

</details>