### PR TITLE
fix(web): share chat abort support open new chat

### DIFF
--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -224,9 +224,23 @@ export function useConversation() {
   const handleChangeHistory = (id: string | null) => {
     if (disabled && id === null) return
     if (id !== conversation_id) setConversationId(id)
-    if (!id) setMessage('')
+    if (abortRef.current) {
+      getHistory(true)
+    }
     abortRef.current?.()
     abortRef.current = null
+    if (!id) {
+      setMessage('')
+      // 新对话流式输出中 conversation_id 仍为 null，setConversationId 不会触发 useEffect，
+      // 需手动重置聊天列表与流式状态
+      const variables = toolbarRef.current?.getVariables() || []
+      const openingMsg = buildOpeningStatementMessage(features?.opening_statement, {
+        variables,
+        withTimestamp: true,
+        extra: { is_hidden_refresh: true },
+      })
+      setChatList(openingMsg ? [openingMsg] : [])
+    }
   }
 
   const getChatDetail = () => {


### PR DESCRIPTION
## Summary by Sourcery

确保在开始新会话时，会话历史记录的变化能够正确中止并重置正在进行的流式聊天。

Bug Fixes:
- 通过中止并刷新历史记录，防止在切换或创建新会话时，正在进行的流式聊天继续存在。

Enhancements:
- 当在有活动流的情况下开始新会话时，用开场语重置聊天列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure conversation history changes correctly abort and reset streaming chats when starting a new conversation.

Bug Fixes:
- Prevent ongoing streaming chats from persisting when switching or creating a new conversation by aborting and refreshing history.

Enhancements:
- Reset the chat list with an opening statement when starting a new conversation while a stream is active.

</details>