### PR TITLE
fix(api): set reflection_model_id when creating default memory config

### DIFF
--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -828,6 +828,7 @@ class MemoryConfigService:
             config_desc="工作空间创建时自动生成的默认记忆配置",
             workspace_id=workspace.id,
             llm_id=str(workspace.llm) if workspace.llm else None,
+            reflection_model_id=str(workspace.llm) if workspace.llm else None,
             embedding_id=str(workspace.embedding) if workspace.embedding else None,
             rerank_id=str(workspace.rerank) if workspace.rerank else None,
             vision_id=str(workspace.vision) if workspace.vision else None,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在创建工作区默认记忆配置时填充 `reflection_model_id`，以便与该工作区的 LLM 设置保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Populate reflection_model_id when creating a workspace default memory config so it aligns with the workspace LLM setting.

</details>