### PR TITLE
Fix/index zy

### DIFF
--- a/web/install-private.js
+++ b/web/install-private.js
@@ -1,6 +1,6 @@
 const { execSync } = await import('child_process');
 // 企业私有配置（自行替换）
-const PRIVATE_PACKAGE = '@redbear/memory-brick@0.0.13-beta.1';
+const PRIVATE_PACKAGE = '@redbear/memory-brick';
 const PRIVATE_REGISTRY = 'http://10.206.16.48:4873';
 
 console.log('🔍 检测内网环境，校验私有模块权限...');

--- a/web/src/views/Conversation/components/DesktopLayout.tsx
+++ b/web/src/views/Conversation/components/DesktopLayout.tsx
@@ -25,7 +25,7 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
   const {
     t, conversation_id, historyList, groupHistoryList, hasMore, scrollRef, toolbarCallbackRef, config,
     isShare, chatTitle,
-    getHistory, handleChangeHistory, handleShare,
+    getHistory, handleChangeHistory, handleShare, disabled,
   } = ctx
 
   return (
@@ -45,7 +45,10 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
           </Flex>
 
           <Flex align="center" gap={12}
-            className="rb:cursor-pointer rb:border rb:border-[#155EEF] rb:rounded-xl rb:p-3! rb:mx-4! rb:text-[16px] rb:font-medium rb:text-[#155EEF] rb:h-12! rb:mb-5!"
+            className={clsx("rb:border rb:border-[#155EEF] rb:rounded-xl rb:p-3! rb:mx-4! rb:text-[16px] rb:font-medium rb:text-[#155EEF] rb:h-12! rb:mb-5!", {
+              'rb:cursor-not-allowed rb:opacity-65': disabled,
+              'rb:cursor-pointer': !disabled,
+            })}
             onClick={() => handleChangeHistory(null)}
           >
             <div
@@ -114,6 +117,7 @@ const DesktopLayout: FC<DesktopLayoutProps> = ({ ctx }) => {
             {...buildSharedChatProps(ctx)}
             empty={<Empty url={ChatEmpty} className="rb:h-full" size={[320, 180]} title={t('memoryConversation.chatEmpty')} subTitle={t('memoryConversation.emptyDesc')} />}
             labelFormat={(item) => formatDateTime(item.created_at, 'MMMM D, YYYY [at] h:mm A', 'en')}
+            readOnly={disabled}
           >
             <ChatToolbar
               ref={toolbarCallbackRef}

--- a/web/src/views/Conversation/components/MobileLayout.tsx
+++ b/web/src/views/Conversation/components/MobileLayout.tsx
@@ -25,7 +25,7 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
   const {
     t, conversation_id, historyList, hasMore, scrollRef, toolbarCallbackRef, config,
     isShare, isIframe, isFloatBtn, isSmallScreen, chatTitle, showHistory, setShowHistory,
-    getHistory, handleChangeHistory, handleShare,
+    getHistory, handleChangeHistory, handleShare, disabled,
   } = ctx
 
   return (
@@ -67,8 +67,10 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
               }
               <Tooltip placement="left" title={t('memoryConversation.startANewConversation')}>
                 <div
-                  className={clsx("rb:size-3.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/refresh_dark.svg')]", {
+                  className={clsx("rb:size-3.5 rb:bg-cover rb:bg-[url('@/assets/images/refresh_dark.svg')]", {
                     "rb:bg-[url('@/assets/images/refresh_white.svg')]": isFloatBtn,
+                    'rb:cursor-not-allowed rb:opacity-65': disabled,
+                    'rb:cursor-pointer': !disabled,
                   })}
                   onClick={() => handleChangeHistory(null)}
                 ></div>
@@ -94,6 +96,7 @@ const MobileLayout: FC<MobileLayoutProps> = ({ ctx }) => {
             {...buildSharedChatProps(ctx)}
             empty={isShare ? null : <Empty url={ChatEmpty} className="rb:h-full" size={[320, 180]} title={t('memoryConversation.chatEmpty')} subTitle={t('memoryConversation.emptyDesc')} />}
             labelFormat={(item) => isFloatBtn ? formatDateTime(item.created_at, 'HH:mm') : formatDateTime(item.created_at, 'MMMM D, YYYY [at] h:mm A', 'en')}
+            readOnly={disabled}
           >
             <ChatToolbar
               ref={toolbarCallbackRef}

--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -189,6 +189,7 @@ export function useConversation() {
   }
 
   /** 分页拉取会话历史 */
+  const [disabled, setDisabled] = useState(false)
   const getHistory = (flag: boolean = false) => {
     if (!shareToken || shareToken === '' || (pageLoading || !hasMore) && !flag) return
     setPageLoading(true)
@@ -213,11 +214,15 @@ export function useConversation() {
         setHasMore(response.page.hasnext)
         setLoading(false)
       })
+      .catch(err => {
+        setDisabled(err?.response?.data?.error_code === 'QUOTA_EXCEEDED')
+      })
       .finally(() => setPageLoading(false))
   }
 
   /** 切换会话或开启新会话 */
   const handleChangeHistory = (id: string | null) => {
+    if (disabled && id === null) return
     if (id !== conversation_id) setConversationId(id)
     if (!id) setMessage('')
     abortRef.current?.()
@@ -570,6 +575,7 @@ export function useConversation() {
     handleShare,
     handleFeedback,
     handleFavorite,
+    disabled,
   }
 }
 

--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -224,9 +224,23 @@ export function useConversation() {
   const handleChangeHistory = (id: string | null) => {
     if (disabled && id === null) return
     if (id !== conversation_id) setConversationId(id)
-    if (!id) setMessage('')
+    if (abortRef.current) {
+      getHistory(true)
+    }
     abortRef.current?.()
     abortRef.current = null
+    if (!id) {
+      setMessage('')
+      // 新对话流式输出中 conversation_id 仍为 null，setConversationId 不会触发 useEffect，
+      // 需手动重置聊天列表与流式状态
+      const variables = toolbarRef.current?.getVariables() || []
+      const openingMsg = buildOpeningStatementMessage(features?.opening_statement, {
+        variables,
+        withTimestamp: true,
+        extra: { is_hidden_refresh: true },
+      })
+      setChatList(openingMsg ? [openingMsg] : [])
+    }
   }
 
   const getChatDetail = () => {

--- a/web/src/views/Index/components/TopCardList/index.tsx
+++ b/web/src/views/Index/components/TopCardList/index.tsx
@@ -10,45 +10,21 @@ const list = [
   {
     key: 'models',
     icon: 'rb:bg-[url("@/assets/images/index/models.svg")]',
-    value: '24',
-    // trendValue: '12.5%',
-    trend: 'up',
-    // trendDesc: 'comparedToYesterday',
-    rate:"up",
-    rateValue: '12%',
     background: 'linear-gradient( 136deg, rgba(21,94,239,0.06) 0%, rgba(251,253,255,0) 100%)'
   },
   {
     key: 'spaces',
     icon: 'rb:bg-[url("@/assets/images/index/spaces.svg")]',
-    value: '156',
-    trendValue: '+8',
-    trend: 'down',
-    rate:"up",
-    rateValue: '5.4%',
-    // trendDesc: 'comparedToYesterday',
     background: 'linear-gradient( 134deg, rgba(54,159,33,0.06) 0%, rgba(251,253,255,0) 100%)',
   },
   {
     key: 'users',
     icon: 'rb:bg-[url("@/assets/images/index/users.svg")]',
-    value: '1,248',
-    trendValue: '+42',
-    trend: 'up',
-    rate:"up",
-    rateValue: '12%',
-    // trendDesc: 'thisWeek',
     background: 'linear-gradient( 136deg, rgba(77,168,255,0.06) 0%, rgba(251,253,255,0) 100%)',
   },
   {
     key: 'running_apps',
     icon: 'rb:bg-[url("@/assets/images/index/apps.svg")]',
-    value: '12.8k',
-    trendValue: '98.7%',
-    trend: 'up',
-    rate:"down",
-    rateValue: '2.1%',
-    // trendDesc: 'comparedToYesterday',
     background: 'linear-gradient( 136deg, rgba(156,111,255,0.06) 0%, rgba(251,253,255,0) 100%)',
   },
 ]
@@ -69,8 +45,8 @@ const TopCardList: FC<{data?: DataResponse}> = ({ data }) => {
 
             <div className="rb:mt-5 rb:font-[MiSans-Bold] rb:font-bold rb:text-[24px] rb:leading-8">
               {item.key === 'spaces' && String(data?.active_workspaces || 0)}
-              {item.key === 'running_apps' &&  String(data?.[`${item.key}` as keyof DataResponse] || item.value || 0)}
-              {item.key !== 'spaces' && item.key !== 'running_apps' && String(data?.[`total_${item.key}` as keyof DataResponse] || item.value || 0)}
+              {item.key === 'running_apps' &&  String(data?.[`${item.key}` as keyof DataResponse] || 0)}
+              {item.key !== 'spaces' && item.key !== 'running_apps' && String(data?.[`total_${item.key}` as keyof DataResponse] || 0)}
             </div>
             <div className='rb:flex rb:flex-col rb:items-start rb:mt-2'>
               {item.key === 'models'


### PR DESCRIPTION
## Summary by Sourcery

在会话中处理配额超限状态：通过禁用新的聊天操作并将聊天设为只读，同时清理索引卡片默认值和私有包配置。

新功能：
- 在会话钩子中引入一个“已禁用”状态来表示配额超限条件，并将该状态暴露给各布局使用。
- 在配额超限时阻止开启新会话，并在桌面和移动端的刷新控件中直观地展示禁用状态。

错误修复：
- 确保运行中的应用和其他索引卡片在缺少 API 数据时不再回退到硬编码的默认值。

优化增强：
- 在开启新会话时重置聊天列表和首条消息，以保持串流会话的 UI 一致性。
- 让共享聊天组件在会话操作被禁用时遵守只读模式。

构建：
- 更新私有安装配置，使用最新的 `@redbear/memory-brick` 包名而不再固定到 beta 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle quota-exceeded state in conversations by disabling new chat actions and making the chat read-only, and clean up index card defaults and private package configuration.

New Features:
- Introduce a disabled state in the conversation hook to represent quota-exceeded conditions and expose it to layouts.
- Prevent starting new conversations when quota is exceeded and visually reflect the disabled state in desktop and mobile refresh controls.

Bug Fixes:
- Ensure running apps and other index cards no longer fall back to hardcoded default values when API data is missing.

Enhancements:
- Reset chat list and opening message when starting a new conversation to keep the UI consistent for streaming sessions.
- Make the shared chat components respect a read-only mode when conversation actions are disabled.

Build:
- Update private install configuration to use the latest @redbear/memory-brick package name without a fixed beta version.

</details>