### PR TITLE
fix(web): tool's number type parameter

### DIFF
--- a/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
+++ b/web/src/views/Workflow/components/Properties/ToolConfig/index.tsx
@@ -230,7 +230,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
       <Form.Item name="tool_id" hidden />
       <Form.Item name={['tool_parameters', 'operation']} hidden />
       {parameters.map((parameter) => {
-        const isIntegerType = parameter.type === 'integer'
+        const isIntegerNumberType = ['integer', 'number'].includes(parameter.type)
         return (
           <div key={parameter.name}>
             <Form.Item
@@ -243,7 +243,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
               </>}
               rules={[
                 { required: parameter.required, message: t('common.pleaseEnter') },
-                ...(isIntegerType ? [{
+                ...(isIntegerNumberType ? [{
                   validator(_: any, value: any) {
                     if (value === undefined || value === null || value === '') return Promise.resolve()
                     if (/^-?\d+(\.\d+)?$/.test(String(value)) || /^\{\{(([^.]+\.[^}]+))\}\}$/.test(String(value))) return Promise.resolve()
@@ -266,7 +266,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
                   height={28}
                   options={getFilterOptions(parameter.type)}
                   placeholder={t('common.pleaseEnter')}
-                  onBlur={isIntegerType ? () => {
+                  onBlur={isIntegerNumberType ? () => {
                     const fieldKey = ['tool_parameters', parameter.name]
                     form.validateFields([fieldKey])
                       .then((values) => {
@@ -279,8 +279,7 @@ const ToolConfig: FC<{ options: Suggestion[]; }> = ({
                         }
                         form.setFieldValue(fieldKey, normalizedValue)
                       })
-                      .catch((err) => {
-                        console.log('isIntegerType', isIntegerType, fieldKey, err)
+                      .catch(() => {
                         form.setFieldValue(fieldKey, null)
                       })
                   } : undefined}


### PR DESCRIPTION
## Summary by Sourcery

调整工具参数验证和规范化逻辑，在工作流工具配置表单中将 `'integer'` 和 `'number'` 类型都视为数值输入。

Bug Fixes:
- 修复数值验证和失焦（blur）处理，使 `type` 为 `'number'` 的参数与 `'integer'` 参数在验证和规范化方式上保持一致。

Enhancements:
- 移除在工具配置表单中数值字段验证失败时不必要的错误日志输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust tool parameter validation and normalization to treat both 'integer' and 'number' types as numeric inputs in the workflow tool configuration form.

Bug Fixes:
- Fix numeric validation and blur handling so that parameters with type 'number' are validated and normalized the same way as 'integer' parameters.

Enhancements:
- Remove unnecessary error logging when numeric field validation fails in the tool configuration form.

</details>