### PR TITLE
fix(rag): resolve knowledge model api keys through service

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -26,11 +26,32 @@ from app.schemas.response_schema import ApiResponse
 from app.services import knowledge_service, document_service, file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service, generate_kb_file_key
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied, KnowledgeRetrievalService
+from app.services.model_service import ModelApiKeyService
 from app.core.rag.utils.preview_utils import _build_preview_hierarchy
 from app.core.utils.datetime_utils import to_timestamp_ms
 
 # Obtain a dedicated API logger
 api_logger = get_api_logger()
+
+
+def _build_image2text_vision_model(db: Session, image2text_id: uuid.UUID, tenant_id: uuid.UUID):
+    if not image2text_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="image2text model config is unavailable",
+        )
+    api_key = ModelApiKeyService.get_available_api_key(db, image2text_id, tenant_id=tenant_id)
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No available image2text api key found",
+        )
+    return QWenCV(
+        key=api_key.api_key,
+        model_name=api_key.model_name,
+        lang="Chinese",
+        base_url=api_key.api_base,
+    )
 
 
 router = APIRouter(
@@ -109,12 +130,7 @@ async def get_preview_chunks(
     def progress_callback(prog=None, msg=None):
         print(f"prog: {prog} msg: {msg}\n")
     # Prepare to configure vision_model information
-    vision_model = QWenCV(
-            key=db_knowledge.image2text.api_keys[0].api_key,
-            model_name=db_knowledge.image2text.api_keys[0].model_name,
-            lang="Chinese",
-            base_url=db_knowledge.image2text.api_keys[0].api_base
-        )
+    vision_model = _build_image2text_vision_model(db, db_knowledge.image2text_id, current_user.tenant_id)
     from app.core.rag.chunk import chunk_pipeline as chunk
     from app.core.rag.chunk.context import ChunkOutputMode
     parent_child_mode = db_document.is_parent_child_mode
@@ -305,12 +321,7 @@ async def get_preview_chunks_hierarchy(
     def progress_callback(prog=None, msg=None):
         print(f"prog: {prog} msg: {msg}\n")
 
-    vision_model = QWenCV(
-        key=db_knowledge.image2text.api_keys[0].api_key,
-        model_name=db_knowledge.image2text.api_keys[0].model_name,
-        lang="Chinese",
-        base_url=db_knowledge.image2text.api_keys[0].api_base
-    )
+    vision_model = _build_image2text_vision_model(db, db_knowledge.image2text_id, current_user.tenant_id)
     from app.core.rag.chunk import chunk_pipeline as chunk
     from app.core.rag.chunk.context import ChunkOutputMode
 

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -16,7 +16,9 @@ from langchain_core.documents import Document
 from app.core.models.base import RedBearModelConfig
 from app.core.models import RedBearRerank
 from app.core.models.embedding import RedBearEmbeddings
-from app.models.models_model import ModelApiKey, ModelProvider
+from app.db import get_db_context
+from app.models.models_model import ModelApiKey
+from app.services.model_service import ModelApiKeyService
 
 from app.models.knowledge_model import Knowledge
 from app.core.rag.vdb.field import Field
@@ -1226,15 +1228,15 @@ class ElasticSearchVectorFactory:
         client = ElasticSearchVectorClientProvider.get_shared_client()
         collection_name = ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id)
 
-        if knowledge.embedding is None:
-            raise ValueError(f"embedding_id config error: {str(knowledge.embedding_id)}")
-        if knowledge.reranker is None:
-            raise ValueError(f"reranker_id config error: {str(knowledge.reranker_id)}")
+        if not knowledge.embedding_id:
+            raise ValueError(f"embedding_id config error: {str(knowledge.id)}")
+        if not knowledge.reranker_id:
+            raise ValueError(f"reranker_id config error: {str(knowledge.id)}")
 
         tenant_id = cls._resolve_tenant_id(knowledge)
 
-        embedding_config = cls._resolve_api_key(knowledge.embedding, knowledge.id, "embedding", tenant_id)
-        reranker_config = cls._resolve_api_key(knowledge.reranker, knowledge.id, "reranker", tenant_id)
+        embedding_config = cls._resolve_api_key(knowledge.embedding_id, knowledge.id, "embedding", tenant_id)
+        reranker_config = cls._resolve_api_key(knowledge.reranker_id, knowledge.id, "reranker", tenant_id)
 
         return ElasticSearchVector(
             index_name=collection_name,
@@ -1261,31 +1263,16 @@ class ElasticSearchVectorFactory:
     @staticmethod
     def _resolve_tenant_id(knowledge: Knowledge):
         """Look up tenant_id via the knowledge's workspace."""
-        from app.db import get_db_context
         from app.models.workspace_model import Workspace
         with get_db_context() as db:
             ws = db.query(Workspace).filter(Workspace.id == knowledge.workspace_id).first()
             return ws.tenant_id if ws else None
 
     @staticmethod
-    def _resolve_api_key(model_config, knowledge_id, role: str, tenant_id) -> ModelApiKey:
-        """Resolve ModelApiKey, handling public SpeedBear models that have no stored api_keys."""
-        is_public_speedbear = (
-            model_config.provider == ModelProvider.SPEEDBEAR
-            and bool(model_config.is_public)
-        )
-        if is_public_speedbear:
-            from app.db import get_db_context
-            from app.services.model_service import ModelApiKeyService
-            with get_db_context() as db:
-                api_key = ModelApiKeyService.get_available_api_key(db, model_config.id, tenant_id)
-            if not api_key:
-                raise ValueError(
-                    f"No {role} api key found for knowledge {knowledge_id} "
-                    f"(SpeedBear tenant binding missing)"
-                )
-            return api_key
-
-        if not model_config.api_keys:
+    def _resolve_api_key(model_config_id, knowledge_id, role: str, tenant_id) -> ModelApiKey:
+        """Resolve ModelApiKey through the shared model-key selector."""
+        with get_db_context() as db:
+            api_key = ModelApiKeyService.get_available_api_key(db, model_config_id, tenant_id=tenant_id)
+        if not api_key:
             raise ValueError(f"No {role} api key found for knowledge {knowledge_id}")
-        return model_config.api_keys[0]
+        return api_key

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -58,6 +58,7 @@ from app.repositories.end_user_repository import get_end_users_by_workspace
 from app.schemas import document_schema, file_schema
 from app.services.memory_config_service import MemoryConfigService
 from app.services.memory_forget_service import MemoryForgetService
+from app.services.model_service import ModelApiKeyService
 from app.utils.redis_lock import RedisFairLock
 
 logger = get_logger(__name__)
@@ -80,6 +81,42 @@ EMBEDDING_MAX_WORKERS = int(os.getenv("EMBEDDING_MAX_WORKERS", "3"))
 AUTO_QUESTIONS_MAX_WORKERS = int(os.getenv("AUTO_QUESTIONS_MAX_WORKERS", "5"))
 # 文档解析页数上限
 MAX_DOCUMENT_PAGES = int(os.getenv("MAX_DOCUMENT_PAGES", "200"))
+
+
+def _resolve_model_api_key(db, model_config_id, tenant_id, role: str):
+    if not model_config_id:
+        raise RuntimeError(f"{role} model config is unavailable")
+    api_key = ModelApiKeyService.get_available_api_key(db, model_config_id, tenant_id=tenant_id)
+    if not api_key:
+        raise RuntimeError(f"No available {role} api key found")
+    return api_key
+
+
+def _build_llm_config(db, llm_id, tenant_id):
+    llm_key = _resolve_model_api_key(db, llm_id, tenant_id, "llm")
+    return {
+        "key": llm_key.api_key,
+        "model_name": llm_key.model_name,
+        "base_url": llm_key.api_base,
+    }
+
+
+def _build_chat_model(db, llm_id, tenant_id):
+    llm_key = _resolve_model_api_key(db, llm_id, tenant_id, "llm")
+    return Base(
+        key=llm_key.api_key,
+        model_name=llm_key.model_name,
+        base_url=llm_key.api_base,
+    )
+
+
+def _build_embedding_model(db, embedding_id, tenant_id):
+    embedding_key = _resolve_model_api_key(db, embedding_id, tenant_id, "embedding")
+    return OpenAIEmbed(
+        key=embedding_key.api_key,
+        model_name=embedding_key.model_name,
+        base_url=embedding_key.api_base,
+    )
 
 
 def _get_estimated_pages(file_name: str, file_binary: bytes) -> int | None:
@@ -316,7 +353,7 @@ def process_item(item: dict):
     return result
 
 
-def _build_vision_model(file_path: str, db_knowledge):
+def _build_vision_model(file_path: str, db, image2text_id, tenant_id):
     """根据文件类型选择合适的视觉/音频模型，避免冗余初始化。"""
     if AUDIO_PATTERN.search(file_path):
         omni_key = os.getenv("QWEN3_OMNI_API_KEY", "")
@@ -339,11 +376,12 @@ def _build_vision_model(file_path: str, db_knowledge):
             base_url=omni_base,
         )
     # 默认：使用知识库配置的 image2text 模型
+    image2text_key = _resolve_model_api_key(db, image2text_id, tenant_id, "image2text")
     return QWenCV(
-        key=db_knowledge.image2text.api_keys[0].api_key,
-        model_name=db_knowledge.image2text.api_keys[0].model_name,
+        key=image2text_key.api_key,
+        model_name=image2text_key.model_name,
         lang=DEFAULT_PARSE_LANGUAGE,
-        base_url=db_knowledge.image2text.api_keys[0].api_base,
+        base_url=image2text_key.api_base,
     )
 
 
@@ -426,18 +464,15 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                 "workspace_id": str(db_knowledge.workspace_id),
                 "parent_child_mode": bool(db_document.is_parent_child_mode),
             }
+            tenant_id = db_workspace.tenant_id
             llm_config = None
             if auto_questions_topn:
-                llm_config = {
-                    "key": db_knowledge.llm.api_keys[0].api_key,
-                    "model_name": db_knowledge.llm.api_keys[0].model_name,
-                    "base_url": db_knowledge.llm.api_keys[0].api_base,
-                }
+                llm_config = _build_llm_config(db, db_knowledge.llm_id, tenant_id)
             knowledge_id = str(db_knowledge.id)
             use_graphrag = bool(
                 knowledge_parser_config.get("graphrag", {}).get("use_graphrag", False)
             )
-            vision_model = _build_vision_model(file_name, db_knowledge)
+            vision_model = _build_vision_model(file_name, db, db_knowledge.image2text_id, tenant_id)
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
             progress_lines.append(f"{_progress_ts()} Start to parse.")
@@ -879,8 +914,13 @@ def build_graphrag_for_kb(kb_id: uuid.UUID):
             if db_knowledge is None:
                 logger.error(f"[GraphRAG-KB] knowledge={kb_id} not found")
                 return "build knowledge graph failed: knowledge not found"
+            db_workspace = db.query(Workspace).filter(Workspace.id == db_knowledge.workspace_id).first()
+            if db_workspace is None:
+                logger.error(f"[GraphRAG-KB] workspace={db_knowledge.workspace_id} not found")
+                return "build knowledge graph failed: workspace not found"
 
             kb_name = db_knowledge.name
+            tenant_id = db_workspace.tenant_id
             parser_config = db_knowledge.parser_config or {}
             graphrag_conf = parser_config.get("graphrag", {})
             if not graphrag_conf.get("use_graphrag", False):
@@ -889,16 +929,8 @@ def build_graphrag_for_kb(kb_id: uuid.UUID):
             db_documents = db.query(Document).filter(Document.kb_id == kb_id).all()
             document_ids = [str(doc.id) for doc in db_documents]
 
-            chat_model = Base(
-                key=db_knowledge.llm.api_keys[0].api_key,
-                model_name=db_knowledge.llm.api_keys[0].model_name,
-                base_url=db_knowledge.llm.api_keys[0].api_base,
-            )
-            embedding_model = OpenAIEmbed(
-                key=db_knowledge.embedding.api_keys[0].api_key,
-                model_name=db_knowledge.embedding.api_keys[0].model_name,
-                base_url=db_knowledge.embedding.api_keys[0].api_base,
-            )
+            chat_model = _build_chat_model(db, db_knowledge.llm_id, tenant_id)
+            embedding_model = _build_embedding_model(db, db_knowledge.embedding_id, tenant_id)
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
             with_resolution = graphrag_conf.get("resolution", False)
@@ -963,22 +995,19 @@ def build_graphrag_for_document(document_id: str, knowledge_id: str):
             if db_document is None or db_knowledge is None:
                 logger.error(f"[GraphRAG] document={document_id} or knowledge={knowledge_id} not found")
                 return "build_graphrag_for_document failed: record not found"
+            db_workspace = db.query(Workspace).filter(Workspace.id == db_knowledge.workspace_id).first()
+            if db_workspace is None:
+                logger.error(f"[GraphRAG] workspace={db_knowledge.workspace_id} not found")
+                return "build_graphrag_for_document failed: workspace not found"
 
+            tenant_id = db_workspace.tenant_id
             parser_config = db_knowledge.parser_config or {}
             graphrag_conf = parser_config.get("graphrag", {})
             with_resolution = graphrag_conf.get("resolution", False)
             with_community = graphrag_conf.get("community", False)
 
-            chat_model = Base(
-                key=db_knowledge.llm.api_keys[0].api_key,
-                model_name=db_knowledge.llm.api_keys[0].model_name,
-                base_url=db_knowledge.llm.api_keys[0].api_base,
-            )
-            embedding_model = OpenAIEmbed(
-                key=db_knowledge.embedding.api_keys[0].api_key,
-                model_name=db_knowledge.embedding.api_keys[0].model_name,
-                base_url=db_knowledge.embedding.api_keys[0].api_base,
-            )
+            chat_model = _build_chat_model(db, db_knowledge.llm_id, tenant_id)
+            embedding_model = _build_embedding_model(db, db_knowledge.embedding_id, tenant_id)
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
             task = {


### PR DESCRIPTION
## Business Background
Knowledge parsing and retrieval paths should not read model API keys directly from the `knowledges` model relationship snapshots. API key selection must go through the unified `ModelApiKeyService.get_available_api_key()` entrypoint so tenant-aware availability, disabled keys, and key rotation are respected consistently.

## Impact Scope
- Updates document parsing model initialization in `api/app/tasks.py` for image-to-text, auto-question LLM, GraphRAG LLM, and GraphRAG embedding usage.
- Updates chunk preview image-to-text model initialization in `api/app/controllers/chunk_controller.py`.
- Updates Elasticsearch vector initialization in `api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py` so embedding and reranker keys are resolved through the service.
- No database schema, API response schema, or external route changes are introduced.

## Risk Points
- Parsing or retrieval will now fail earlier when a configured model has no available API key for the tenant, instead of using the first stored relationship key.
- The touched paths depend on `model_config_id` and `tenant_id` being present and correct for the configured knowledge models.

## Verification Commands and Results
- `cd api && PYTHONPATH=. ../api/.venv/bin/python -m pytest tests/tasks/test_parse_document_model_api_key_resolution.py -q` -> passed, 5 passed.
- `cd api && PYTHONPATH=. ../api/.venv/bin/python -m py_compile app/tasks.py app/controllers/chunk_controller.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py` -> passed.
- `git diff --check -- api/app/tasks.py api/app/controllers/chunk_controller.py api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py` -> passed.
- `rg -n "db_knowledge\\..*api_keys\\[0\\]|db_knowledge\\.(llm|embedding|reranker|image2text)\\.api_keys|knowledge\\.(embedding|reranker)\\.api_keys\\[0\\]" api/app -g '*.py'` -> passed, no results.
- `cd api && PYTHONPATH=. ../api/.venv/bin/python -m pytest tests/rag/test_knowledge_retrieval_config.py -q` -> currently has 2 pre-existing unrelated failures in knowledge retrieval config coverage.

## External API Key Interface Impact Assessment
This PR does not modify `app/controllers/service/rag_api_*_controller.py`, does not add external API Key routes, and does not change request or response schemas for API Key users. The runtime behavior change is internal model API key resolution for existing knowledge parsing and retrieval-related paths.

## Summary by Sourcery

通过集中式的 ModelApiKeyService 路由 RAG 解析和检索模型的 API Key 解析，在文档解析、分块预览以及 Elasticsearch 向量操作中实现支持租户感知的密钥选择。

Enhancements:
- 引入共享的辅助方法，通过 ModelApiKeyService 构建 LLM、embedding 和 vision 模型配置，而不再直接读取知识模型的 API Key。
- 更新文档解析、GraphRAG 知识/文档构建任务以及分块预览控制器，使其通过 model_config_id 和 tenant_id 来解析模型配置。
- 简化 Elasticsearch 向量 embedding 和 reranker 的密钥解析逻辑，使用统一的 API Key 查询路径，并对已配置模型 ID 进行更严格的校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route RAG parsing and retrieval model API key resolution through the centralized ModelApiKeyService for tenant-aware key selection in document parsing, chunk previews, and Elasticsearch vector operations.

Enhancements:
- Introduce shared helpers to build LLM, embedding, and vision model configs using ModelApiKeyService instead of reading knowledge model API keys directly.
- Update document parsing, GraphRAG knowledge/document build tasks, and chunk preview controllers to resolve model configs by model_config_id and tenant_id.
- Simplify Elasticsearch vector embedding and reranker key resolution to use a unified API-key lookup path and stricter validation of configured model IDs.

</details>