### PR TITLE
fix(rag): snapshot vector api keys before session closes

### DIFF
--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import threading
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
@@ -32,9 +33,27 @@ VECTOR_SEARCH_MODE_KNN = "knn"
 VECTOR_SEARCH_MODE_SCRIPT_SCORE = "script_score"
 
 
+@dataclass(frozen=True)
+class ModelApiKeyRuntimeConfig:
+    model_name: str
+    provider: str
+    api_key: str
+    api_base: str | None
+
+    @classmethod
+    def from_api_key(cls, api_key: ModelApiKey) -> "ModelApiKeyRuntimeConfig":
+        return cls(
+            model_name=api_key.model_name,
+            provider=api_key.provider,
+            api_key=api_key.api_key,
+            api_base=api_key.api_base,
+        )
+
+
 class ElasticSearchVector(BaseVector):
     def __init__(self, index_name: str, client: Elasticsearch,
-                 embedding_config: ModelApiKey, reranker_config: ModelApiKey):
+                 embedding_config: ModelApiKey | ModelApiKeyRuntimeConfig,
+                 reranker_config: ModelApiKey | ModelApiKeyRuntimeConfig):
         super().__init__(index_name.lower())
 
         # 初始化 Embedding 模型（自动支持火山引擎多模态）
@@ -1249,8 +1268,8 @@ class ElasticSearchVectorFactory:
     def init_vector_from_configs(
         cls,
         index_name: str,
-        embedding_config: ModelApiKey,
-        reranker_config: ModelApiKey,
+        embedding_config: ModelApiKey | ModelApiKeyRuntimeConfig,
+        reranker_config: ModelApiKey | ModelApiKeyRuntimeConfig,
     ) -> ElasticSearchVector:
         """Create a vector service from resolved model config snapshots."""
         client = ElasticSearchVectorClientProvider.get_shared_client()
@@ -1269,10 +1288,10 @@ class ElasticSearchVectorFactory:
             return ws.tenant_id if ws else None
 
     @staticmethod
-    def _resolve_api_key(model_config_id, knowledge_id, role: str, tenant_id) -> ModelApiKey:
+    def _resolve_api_key(model_config_id, knowledge_id, role: str, tenant_id) -> ModelApiKeyRuntimeConfig:
         """Resolve ModelApiKey through the shared model-key selector."""
         with get_db_context() as db:
             api_key = ModelApiKeyService.get_available_api_key(db, model_config_id, tenant_id=tenant_id)
-        if not api_key:
-            raise ValueError(f"No {role} api key found for knowledge {knowledge_id}")
-        return api_key
+            if not api_key:
+                raise ValueError(f"No {role} api key found for knowledge {knowledge_id}")
+            return ModelApiKeyRuntimeConfig.from_api_key(api_key)


### PR DESCRIPTION
## Business Background
PR #1715 moved knowledge parsing and retrieval-related model key resolution to `ModelApiKeyService.get_available_api_key()`. A follow-up review found that the Elasticsearch vector factory could return a DB-backed `ModelApiKey` ORM instance after its short `get_db_context()` had already rolled back and closed, which can trigger detached-instance failures during vector initialization.

## Impact Scope
- Updates `api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py` so `ElasticSearchVectorFactory._resolve_api_key()` copies the resolved embedding/reranker key into a runtime snapshot before leaving the DB context.
- Protects all existing `ElasticSearchVectorFactory.init_vector()` callers that initialize embedding/reranker clients through this shared factory.
- No database schema, API response schema, or route changes are introduced.

## Risk Points
- The runtime snapshot intentionally contains only the fields consumed by `ElasticSearchVector`: `model_name`, `provider`, `api_key`, and `api_base`.
- The factory still raises when no available model API key exists for the configured tenant/model pair.

## Verification Commands and Results
- `cd api && PYTHONPATH=. ../api/.venv/bin/python -m pytest tests/tasks/test_parse_document_model_api_key_resolution.py -q` -> passed, 5 passed. This includes a local regression test that fails when a DB-backed key object is read after its context closes.
- `cd api && PYTHONPATH=. ../api/.venv/bin/python -m py_compile app/core/rag/vdb/elasticsearch/elasticsearch_vector.py app/tasks.py app/controllers/chunk_controller.py` -> passed.
- `git diff --check -- api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py` -> passed.
- `rg -n "db_knowledge\\..*api_keys\\[0\\]|db_knowledge\\.(llm|embedding|reranker|image2text)\\.api_keys|knowledge\\.(embedding|reranker)\\.api_keys\\[0\\]" api/app -g '*.py'` -> passed, no results.

## External API Key Interface Impact Assessment
This PR does not modify `app/controllers/service/rag_api_*_controller.py`, does not add external API Key routes, and does not change request or response schemas for API Key users. The change is internal to Elasticsearch vector model-key initialization.

## Summary by Sourcery

在数据库上下文关闭之前，将 Elasticsearch 向量模型的 API 密钥快照到不可变的运行时配置中，以避免在向量初始化期间出现已分离的 ORM 实例。

Enhancements:
- 引入 `ModelApiKeyRuntimeConfig` 数据类，用于保存模型 API 密钥字段中在运行时安全的子集。
- 更新 `ElasticSearchVector` 及其工厂，使其接受运行时模型密钥配置，并在数据库上下文内完全解析这些配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Snapshot Elasticsearch vector model API keys into immutable runtime configs before DB contexts close to avoid detached ORM instances during vector initialization.

Enhancements:
- Introduce a ModelApiKeyRuntimeConfig dataclass to hold the runtime-safe subset of model API key fields.
- Update ElasticSearchVector and its factory to accept runtime model key configs and resolve them entirely within the DB context.

</details>