### PR TITLE
fix(rag): avoid duplicate single hybrid rerank

### DIFF
--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -906,22 +906,16 @@ class KnowledgeRetrievalService:
                 reverse=True,
             )
 
-        skip_score_threshold = cls._is_single_target_type(targets, RetrieveType.PARTICIPLE)
-        if skip_score_threshold:
-            threshold = None
-            filtered_chunks = ranked_chunks
-        else:
-            # Apply the final global score threshold after optional cross-KB rerank.
-            threshold = cls._resolve_global_score_threshold(
-                request=request,
-                targets=targets,
-                used_rerank=needs_global_rerank,
-            )
+        if needs_global_rerank:
+            threshold = cls._resolve_rerank_score_threshold(request)
             filtered_chunks = [
                 chunk
                 for chunk in ranked_chunks
                 if (chunk.metadata or {}).get("score", 0) > threshold
             ]
+        else:
+            threshold = None
+            filtered_chunks = ranked_chunks
         result_chunks = filtered_chunks[:request.top_k]
         if log_id:
             logger.info(

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -447,6 +447,18 @@ class KnowledgeRetrievalService:
             rerank_score_threshold=rerank_score_threshold,
         )
 
+    @staticmethod
+    def _is_single_target_type(targets: list[RetrievalTarget], retrieve_type: RetrieveType) -> bool:
+        return len(targets) == 1 and targets[0].params.retrieve_type == retrieve_type
+
+    @classmethod
+    def _single_hybrid_uses_request_rerank(
+            cls,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+    ) -> bool:
+        return request.rerank_id is not None and cls._is_single_target_type(targets, RetrieveType.HYBRID)
+
     @classmethod
     def _resolve_retrievable_knowledge_refs(
             cls,
@@ -647,6 +659,26 @@ class KnowledgeRetrievalService:
                 "[Retrieval] targets %s",
                 cls._format_log_fields(cls._build_targets_log_fields(log_id, request, targets, max_workers)),
             )
+        if cls._single_hybrid_uses_request_rerank(request, targets):
+            candidates = cls._retrieve_single_target(
+                request=request,
+                target=targets[0],
+                document_ids_include=document_ids_include,
+                log_id=log_id,
+                target_position=1,
+                db=db,
+                tenant_id=tenant_id,
+                use_request_rerank=True,
+            )
+            return cls._finalize_retrieval_chunks(
+                db=db,
+                request=request,
+                targets=targets,
+                chunks=candidates,
+                tenant_id=tenant_id,
+                log_id=log_id,
+            )
+
         results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
         with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="knowledge-retrieval") as executor:
             futures = {
@@ -692,6 +724,9 @@ class KnowledgeRetrievalService:
             document_ids_include: list[str] | None,
             log_id: str | None = None,
             target_position: int = 0,
+            db: Session | None = None,
+            tenant_id: uuid.UUID | None = None,
+            use_request_rerank: bool = False,
     ) -> list[DocumentChunk]:
         started_at = time.perf_counter()
         vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
@@ -774,11 +809,21 @@ class KnowledgeRetrievalService:
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         # if len(unique_chunks) <= target.params.top_k:
         #     return unique_chunks
-        chunks = vector_service.rerank(
-            query=request.query,
-            docs=unique_chunks,
-            top_k=target.params.top_k,
-        )
+        if use_request_rerank and request.rerank_id:
+            chunks = cls.rerank_documents(
+                db=db,
+                rerank_id=request.rerank_id,
+                query=request.query,
+                docs=unique_chunks,
+                top_k=target.params.top_k,
+                tenant_id=tenant_id,
+            )
+        else:
+            chunks = vector_service.rerank(
+                query=request.query,
+                docs=unique_chunks,
+                top_k=target.params.top_k,
+            )
         chunks = [
             chunk
             for chunk in chunks
@@ -829,8 +874,11 @@ class KnowledgeRetrievalService:
                 )
             return []
 
-        needs_global_rerank = request.rerank_id is not None or len(targets) > 1
-        if request.rerank_id:
+        single_hybrid_uses_request_rerank = cls._single_hybrid_uses_request_rerank(request, targets)
+        needs_global_rerank = len(targets) > 1 or (
+                request.rerank_id is not None and not single_hybrid_uses_request_rerank
+        )
+        if request.rerank_id and not single_hybrid_uses_request_rerank:
             ranked_chunks = cls.rerank_documents(
                 db=db,
                 rerank_id=request.rerank_id,
@@ -858,17 +906,22 @@ class KnowledgeRetrievalService:
                 reverse=True,
             )
 
-        # Apply the final global score threshold after optional cross-KB rerank.
-        threshold = cls._resolve_global_score_threshold(
-            request=request,
-            targets=targets,
-            used_rerank=needs_global_rerank,
-        )
-        filtered_chunks = [
-            chunk
-            for chunk in ranked_chunks
-            if (chunk.metadata or {}).get("score", 0) > threshold
-        ]
+        skip_score_threshold = cls._is_single_target_type(targets, RetrieveType.PARTICIPLE)
+        if skip_score_threshold:
+            threshold = None
+            filtered_chunks = ranked_chunks
+        else:
+            # Apply the final global score threshold after optional cross-KB rerank.
+            threshold = cls._resolve_global_score_threshold(
+                request=request,
+                targets=targets,
+                used_rerank=needs_global_rerank,
+            )
+            filtered_chunks = [
+                chunk
+                for chunk in ranked_chunks
+                if (chunk.metadata or {}).get("score", 0) > threshold
+            ]
         result_chunks = filtered_chunks[:request.top_k]
         if log_id:
             logger.info(
@@ -879,7 +932,7 @@ class KnowledgeRetrievalService:
                     "deduped": len(unique_chunks),
                     "global_rerank": needs_global_rerank,
                     "ranked": len(ranked_chunks),
-                    "threshold": threshold,
+                    "threshold": threshold if threshold is not None else "none",
                     "filtered": len(filtered_chunks),
                     "result_count": len(result_chunks),
                 }),


### PR DESCRIPTION
## Background
Single knowledge-base hybrid retrieval could rerank once in the local hybrid stage and rerank again in the final global stage when a request-level reranker was provided. Single knowledge-base participle retrieval also still applied the final score threshold after the full-text channel had already disabled its local threshold.

## Summary
- Use the request-level reranker in the single-target hybrid local rerank path.
- Avoid a second global rerank for single-target hybrid retrieval.
- Skip final score-threshold filtering for single-target participle retrieval while preserving sorting and top_k truncation.

## Changes
- api/app/services/knowledge_retrieval_service.py | 91 +++++++++++++++++++------
- 1 file changed, 72 insertions(+), 19 deletions(-)

## Impact Scope
- Affects the shared KnowledgeRetrievalService retrieval flow used by internal chunk retrieval, API Key chunk retrieval, workflow knowledge nodes, and agent knowledge retrieval.
- Does not change request or response schemas.
- Does not change database models or migrations.

## Risks
- Multi-knowledge-base retrieval behavior is intended to remain unchanged.
- The main behavior change is limited to single-target hybrid rerank selection and single-target participle final filtering.

## External API Key Interface Impact
- The API Key route reuses the same service-layer retrieval path, so runtime behavior changes apply there as well.
- No external API request fields, response fields, permissions, workspace, tenant, or schema contracts are changed.

## Test Plan
- [x] cd api && PYTHONPATH=. uv run pytest tests/rag/test_knowledge_retrieval_config.py -q (18 passed, 4 warnings)
- [x] cd api && PYTHONPATH=. uv run python -m compileall app/services/knowledge_retrieval_service.py

## Summary by Sourcery

调整单目标检索行为，仅在请求级别使用一次重排序器，并放宽分词检索的最终分数阈值过滤。

Bug Fixes:
- 确保单知识库混合检索在本地重排序路径中使用请求级别重排序器，而不是在全局阶段再次重排序。
- 当配置了请求级别重排序器时，避免对单目标混合检索进行重复的全局重排序。
- 在单目标分词检索中跳过最终的全局分数阈值过滤，同时保留排序和 `top_k` 截断。

Enhancements:
- 添加用于检测单目标检索类型的辅助方法，并改进围绕阈值和重排序行为的检索日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust single-target retrieval behavior to use the request-level reranker only once and relax final score-threshold filtering for participle retrieval.

Bug Fixes:
- Ensure single knowledge-base hybrid retrieval uses the request-level reranker in the local rerank path instead of reranking again globally.
- Avoid duplicate global rerank for single-target hybrid retrieval when a request-level reranker is configured.
- Skip final global score-threshold filtering for single-target participle retrieval while preserving sorting and top_k truncation.

Enhancements:
- Add helpers to detect single-target retrieval types and improve retrieval logging around thresholds and rerank behavior.

</details>