### PR TITLE
fix(rag): set explicit ES index refresh interval

### DIFF
--- a/api/app/core/rag/res/mapping.json
+++ b/api/app/core/rag/res/mapping.json
@@ -3,7 +3,7 @@
     "index": {
       "number_of_shards": 2,
       "number_of_replicas": 0,
-      "refresh_interval": "1000ms"
+      "refresh_interval": "1s"
     },
     "similarity": {
       "scripted_sim": {

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 VECTOR_SEARCH_MODE_ENV = "ELASTICSEARCH_VECTOR_SEARCH_MODE"
 VECTOR_SEARCH_MODE_KNN = "knn"
 VECTOR_SEARCH_MODE_SCRIPT_SCORE = "script_score"
+DEFAULT_INDEX_REFRESH_INTERVAL = "1s"
 
 
 class ElasticSearchVector(BaseVector):
@@ -951,6 +952,11 @@ class ElasticSearchVector(BaseVector):
     ):
         if not self._client.indices.exists(index=self._collection_name):
             index_mapping = {
+                "settings": {
+                    "index": {
+                        "refresh_interval": DEFAULT_INDEX_REFRESH_INTERVAL,
+                    },
+                },
                 "mappings": {
                     "properties": {
                         Field.CONTENT_KEY.value: {


### PR DESCRIPTION
## Summary
- Set refresh_interval to 1s when creating knowledge base Elasticsearch vector indexes.
- Normalize the legacy RAG Elasticsearch mapping refresh interval from 1000ms to 1s.

## Changes
api/app/core/rag/res/mapping.json                          | 4 ++--
api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py | 6 ++++++
2 files changed, 8 insertions(+), 2 deletions(-)

## Test Plan
- [x] PYTHONPATH=. ./.venv/bin/python inline refresh_interval assertion
- [x] PYTHONPATH=. ./.venv/bin/python -m compileall app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
- [x] ./.venv/bin/python -m json.tool app/core/rag/res/mapping.json
- [x] git diff --check origin/develop..HEAD

## Summary by Sourcery

在 RAG 索引创建和遗留映射中，将 Elasticsearch 向量索引的刷新间隔统一为 1 秒设置。

Enhancements:
- 为 RAG 子系统中新创建的 Elasticsearch 向量索引显式设置 `refresh_interval` 为 1 秒。
- 将遗留的 RAG Elasticsearch 索引映射中 `refresh_interval` 从 1000ms 规范化为等效的 1 秒值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize Elasticsearch vector index refresh intervals to a 1s setting across RAG index creation and legacy mappings.

Enhancements:
- Set an explicit 1s refresh_interval for newly created Elasticsearch vector indexes in the RAG subsystem.
- Normalize legacy RAG Elasticsearch index mappings from a 1000ms refresh_interval to the equivalent 1s value.

</details>