### PR TITLE
feat(rag): add MinerU v3 presentation pipeline

### DIFF
--- a/api/app/core/rag/chunk/pipeline/pdf.py
+++ b/api/app/core/rag/chunk/pipeline/pdf.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+from dataclasses import replace
 
 from app.core.rag.chunk.context import ChunkContext, ParseResult
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
@@ -73,12 +74,18 @@ class PdfChunkPipeline(ChunkPipeline):
 
 
 class PresentationChunkPipeline(ChunkPipeline):
+    START_PROGRESS = 0.1
+    CONVERT_PROGRESS = 0.2
+    CHILD_PROGRESS_START = 0.3
+    CHILD_PROGRESS_END = 0.75
+    FINISH_PROGRESS = 0.8
+
     def parse(self, ctx: ChunkContext) -> ParseResult:
-        self._callback(ctx, 0.1, "Start to parse.")
+        self._callback(ctx, self.START_PROGRESS, "Start to parse.")
         if self._file_extension(ctx) == ".pptx":
             try:
                 parse_result = MinerUV3Parser().parse(ctx)
-                self._callback(ctx, 0.8, "Finish parsing.")
+                self._callback(ctx, self.FINISH_PROGRESS, "Finish parsing.")
                 return parse_result
             except Exception as exc:
                 LOGGER.warning(
@@ -86,9 +93,13 @@ class PresentationChunkPipeline(ChunkPipeline):
                     ctx.filename,
                     exc,
                 )
-                self._callback(ctx, 0.78, "MinerU V3 failed, fallback to converted PDF flow.")
+                self._callback(ctx, self.CONVERT_PROGRESS, "MinerU V3 failed, convert presentation to PDF.")
+        else:
+            self._callback(ctx, self.CONVERT_PROGRESS, "Convert presentation to PDF.")
 
-        return self._parse_converted_pdf(ctx)
+        parse_result = self._parse_converted_pdf(ctx)
+        self._callback(ctx, self.FINISH_PROGRESS, "Finish parsing.")
+        return parse_result
 
     def _file_extension(self, ctx: ChunkContext) -> str:
         return os.path.splitext(ctx.filename)[1].lower()
@@ -96,6 +107,26 @@ class PresentationChunkPipeline(ChunkPipeline):
     def _callback(self, ctx: ChunkContext, progress, message: str) -> None:
         if ctx.callback:
             ctx.callback(progress, message)
+
+    def _converted_pdf_context(self, ctx: ChunkContext) -> ChunkContext:
+        if not ctx.callback:
+            return ctx
+
+        def converted_pdf_callback(progress=None, message=None):
+            mapped_progress = self._map_converted_pdf_progress(progress)
+            ctx.callback(mapped_progress, message)
+
+        return replace(ctx, callback=converted_pdf_callback)
+
+    def _map_converted_pdf_progress(self, progress):
+        if not isinstance(progress, (int, float)):
+            return progress
+
+        child_start = self.START_PROGRESS
+        child_end = self.FINISH_PROGRESS
+        ratio = (progress - child_start) / (child_end - child_start)
+        ratio = min(max(ratio, 0), 1)
+        return self.CHILD_PROGRESS_START + ratio * (self.CHILD_PROGRESS_END - self.CHILD_PROGRESS_START)
 
     def _parse_converted_pdf(self, ctx: ChunkContext) -> ParseResult:
         tmp_file = None
@@ -112,10 +143,11 @@ class PresentationChunkPipeline(ChunkPipeline):
 
             future = async_convert_to_pdf(tmp_file.name)
             dest_pdf_path = future.result()
+            child_ctx = self._converted_pdf_context(ctx)
             direct_result = self.run_child(
                 dest_pdf_path,
                 binary=None,
-                ctx=ctx,
+                ctx=child_ctx,
                 is_root=ctx.kwargs.get("is_root", True),
                 vision_model=ctx.vision_model,
             )

--- a/api/app/core/rag/chunk/pipeline/pdf.py
+++ b/api/app/core/rag/chunk/pipeline/pdf.py
@@ -74,6 +74,30 @@ class PdfChunkPipeline(ChunkPipeline):
 
 class PresentationChunkPipeline(ChunkPipeline):
     def parse(self, ctx: ChunkContext) -> ParseResult:
+        self._callback(ctx, 0.1, "Start to parse.")
+        if self._file_extension(ctx) == ".pptx":
+            try:
+                parse_result = MinerUV3Parser().parse(ctx)
+                self._callback(ctx, 0.8, "Finish parsing.")
+                return parse_result
+            except Exception as exc:
+                LOGGER.warning(
+                    "[MinerUV3] presentation parse failed, fallback started: file_name=%s, fallback=converted_pdf, error=%s",
+                    ctx.filename,
+                    exc,
+                )
+                self._callback(ctx, 0.78, "MinerU V3 failed, fallback to converted PDF flow.")
+
+        return self._parse_converted_pdf(ctx)
+
+    def _file_extension(self, ctx: ChunkContext) -> str:
+        return os.path.splitext(ctx.filename)[1].lower()
+
+    def _callback(self, ctx: ChunkContext, progress, message: str) -> None:
+        if ctx.callback:
+            ctx.callback(progress, message)
+
+    def _parse_converted_pdf(self, ctx: ChunkContext) -> ParseResult:
         tmp_file = None
         dest_pdf_path = None
         try:

--- a/api/app/core/rag/chunk/pipeline/pdf.py
+++ b/api/app/core/rag/chunk/pipeline/pdf.py
@@ -112,14 +112,16 @@ class PresentationChunkPipeline(ChunkPipeline):
         if not ctx.callback:
             return ctx
 
-        def converted_pdf_callback(progress=None, message=None):
+        def converted_pdf_callback(*args, **kwargs):
+            progress = args[0] if args else kwargs.get("prog", kwargs.get("progress"))
+            message = args[1] if len(args) > 1 else kwargs.get("msg", kwargs.get("message"))
             mapped_progress = self._map_converted_pdf_progress(progress)
-            ctx.callback(mapped_progress, message)
+            ctx.callback(prog=mapped_progress, msg=message)
 
         return replace(ctx, callback=converted_pdf_callback)
 
     def _map_converted_pdf_progress(self, progress):
-        if not isinstance(progress, (int, float)):
+        if not isinstance(progress, (int, float)) or progress < 0:
             return progress
 
         child_start = self.START_PROGRESS

--- a/api/app/core/rag/chunk/router.py
+++ b/api/app/core/rag/chunk/router.py
@@ -37,4 +37,6 @@ class FileTypeRouter:
             return JsonChunkPipeline()
         if re.search(r"\.doc$", filename, re.IGNORECASE):
             return LegacyDocChunkPipeline()
-        raise NotImplementedError("file type not supported yet(pdf, xlsx, doc, docx, txt supported)")
+        raise NotImplementedError(
+            "file type not supported yet(pdf, ppt, pptx, xlsx, csv, doc, docx, txt, md, html, json supported)"
+        )


### PR DESCRIPTION
## Summary
- Add presentation routing support to the RAG chunk pipeline.
- Parse PPTX directly with MinerU V3 by default, with fallback to the converted-PDF flow.
- Keep legacy PPT files on the existing converted-PDF flow.

## Changes
```
api/app/core/rag/chunk/pipeline/pdf.py | 24 ++++++++++++++++++++++++
api/app/core/rag/chunk/router.py       |  4 +++-
2 files changed, 27 insertions(+), 1 deletion(-)
```

## Test Plan
- [x] `.venv/bin/python -m compileall app/core/rag/chunk`
- [x] `PYTHONPATH=. .venv/bin/pytest tests/rag/chunk/test_mineru_v3_presentation_pipeline.py -k 'not knowledge_base_upload_policy and not file_validator' -v`

## External API Impact
- No changes to `app/controllers/service/rag_api_*_controller.py`.
- This change only updates internal RAG chunk routing and presentation parsing behavior.

## Summary by Sourcery

在 RAG 演示文稿分块管线中添加基于 MinerU V3 的解析能力，并在其失败时回退到现有的 PDF 转换流程，同时更新路由相关消息以反映当前支持的演示文稿文件类型。

新功能：
- 在演示文稿分块管线中引入基于 MinerU V3 的直接 PPTX 解析，并在 MinerU 解析失败时自动回退到现有的 PDF 转换流程。

增强改进：
- 为演示文稿解析流程添加进度回调，用于报告解析开始、完成以及回退等事件。
- 明确分块路由器在遇到不支持文件类型时的错误信息，列出当前所有已支持的文件类型，包括 PPT 和 PPTX 演示文稿。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MinerU V3-based parsing to the RAG presentation chunk pipeline with fallback to the existing converted-PDF flow and update routing messaging to reflect supported presentation file types.

New Features:
- Introduce direct PPTX parsing via MinerU V3 in the presentation chunk pipeline with automatic fallback to the converted-PDF flow when MinerU parsing fails.

Enhancements:
- Add progress callbacks to the presentation parsing flow to report parsing start, completion, and fallback events.
- Clarify the chunk router unsupported-file error message to enumerate all currently supported file types, including PPT and PPTX presentations.

</details>