### PR TITLE
feat(memory): implement forgetting pipeline with candidate scan and soft-delete

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -130,6 +130,8 @@ celery_app.conf.update(
         # Memory-heavy tasks → memory_heavy_tasks queue (prefork worker, CPU-bound + beat long tasks)
         'app.tasks.scan_refresh_insight_summary_cache': {'queue': 'periodic_tasks'}, # NOTE：扫描器，仅枚举+派发，轻量
         'app.tasks.do_refresh_insight_summary_cache': {'queue': 'memory_heavy_tasks'}, # NOTE：单用户生成记忆洞察、用户摘要缓存
+        'app.tasks.scan_forget_candidates': {'queue': 'periodic_tasks'},
+        'app.tasks.do_forget_for_user': {'queue': 'memory_heavy_tasks'},
         'app.tasks.run_forgetting_cycle_task': {'queue': 'memory_heavy_tasks'},# NOTE：定时任务，跑遗忘 可以暂时关闭
         'app.tasks.write_all_workspaces_memory_task': {'queue': 'memory_heavy_tasks'}, #NOTE：定时任务，记忆增量统计
         'app.tasks.update_implicit_emotions_storage': {'queue': 'memory_heavy_tasks'},
@@ -183,6 +185,7 @@ layer2_dedup_full_scan_schedule = crontab(hour=settings.LAYER2_DEDUP_FULL_SCAN_H
 reflection_retry_schedule = timedelta(minutes=settings.REFLECTION_RETRY_SCAN_INTERVAL_MINUTES)
 hot_memory_tags_refresh_schedule = crontab(hour=settings.HOT_MEMORY_TAGS_REFRESH_HOUR, minute=0)
 draft_data_clean_schedule = crontab(hour=settings.DRAFT_DATA_CLEAN_HOUR, minute=0)
+forget_scan_schedule = crontab(minute=settings.FORGET_SCAN_INTERVAL_MINUTES)
 # 构建定时任务配置
 beat_schedule_config = {
     # "run-workspace-reflection": {
@@ -195,13 +198,17 @@ beat_schedule_config = {
         "schedule": memory_cache_regeneration_schedule,
         "args": (),
     },
-    "run-forgetting-cycle": {
-        "task": "app.tasks.run_forgetting_cycle_task",
-        "schedule": forgetting_cycle_schedule,
-        "kwargs": {
-            "config_id": None,  # 使用默认配置，可以通过环境变量配置
-        },
+    "scan-forget-candidates": {
+        "task": "app.tasks.scan_forget_candidates",
+        "schedule": forget_scan_schedule,
     },
+    # "run-forgetting-cycle": {
+    #     "task": "app.tasks.run_forgetting_cycle_task",
+    #     "schedule": forgetting_cycle_schedule,
+    #     "kwargs": {
+    #         "config_id": None,  # 使用默认配置，可以通过环境变量配置
+    #     },
+    # },
     "write-all-workspaces-memory": {
         "task": "app.tasks.write_all_workspaces_memory_task",
         "schedule": memory_increment_schedule,

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -303,6 +303,11 @@ class Settings:
         Annotated[int, Field(ge=0, le=59, description="forgetting cycle cron minute [0, 59]")]
     ).validate_python(int(os.getenv("FORGETTING_CYCLE_MINUTE", "0")))
 
+    # scan-forget-candidates 定时任务扫描间隔（分钟）
+    FORGET_SCAN_INTERVAL_MINUTES: int = TypeAdapter(
+        Annotated[int, Field(ge=1, description="forget candidates scan interval in minutes, must be >= 1")]
+    ).validate_python(int(os.getenv("FORGET_SCAN_INTERVAL_MINUTES", "5")))
+
     IMPLICIT_EMOTIONS_UPDATE_HOUR: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_HOUR", "2"))
     # implicit_emotions_update: 每天几分执行（分钟，0-59）
     IMPLICIT_EMOTIONS_UPDATE_MINUTE: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_MINUTE", "0"))  

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from app.core.memory.enums import SearchStrategy, StorageType
 from app.core.memory.models.message_models import DialogData
 from app.core.memory.models.service_models import LongTermMemoryInput, MemoryContext, MemorySearchResult
+from app.core.memory.pipelines.forgetting_pipeline import ForgettingPipeline
 from app.core.memory.pipelines.memory_read import ReadPipeLine
 from app.core.memory.pipelines.pilot_write_pipeline import PilotWriteResult
 from app.core.memory.pipelines.write_pipeline import WriteResult
@@ -385,11 +386,8 @@ class MemoryService:
             raise RuntimeError("MemoryService.read() 需要 memory_config，但当前实例未加载配置")
         return await ReadPipeLine(self.ctx).run(query, search_switch, history, limit)
 
-    async def forget(
-            self, max_batch: int = 100, min_days: int = 30
-    ) -> dict:
-        """遗忘：识别低激活节点并融合"""
-        raise NotImplementedError("ForgettingPipeline 尚未实现")
+    async def forget(self) -> dict:
+        return await ForgettingPipeline(self.ctx).run()
 
     async def run_reflection_layer2(self, language: str = "zh") -> dict:
         """反思引擎 Layer 2 离线巡检

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -4,7 +4,7 @@ from app.core.memory.pipelines.base_pipeline import BasePipeline
 from app.core.memory.storage_services.forgetting_engine.forget_service import ForgetService
 from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.core.quota_manager import get_end_user_memory_limit
-from app.db import get_db_read, get_db_context
+from app.db import get_db_context
 from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
 from app.repositories.neo4j.cypher_queries import DELETE_NODE_BY_ELEMENT_ID
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -12,7 +12,7 @@ from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 class ForgettingPipeline(BasePipeline):
     async def run(self):
-        with get_db_read() as db:
+        with get_db_context() as db:
             tenant_id = get_tenant_id_by_end_user_id(db, uuid.UUID(self.ctx.end_user_id))
             if tenant_id is None:
                 raise Exception(f"End user not found. - User ID:{self.ctx.end_user_id}")
@@ -20,11 +20,12 @@ class ForgettingPipeline(BasePipeline):
             if memory_limit is None:
                 raise Exception(f"Memory limit not found. - Tenant ID:{tenant_id}")
         if memory_limit <= 0:
-            return
-        await ForgetService(self.ctx, memory_limit).run()
+            return {"skipped": True, "reason": "memory_limit <= 0"}
+        res = await ForgetService(self.ctx, memory_limit).run()
 
         async with Neo4jConnector() as connector:
             await sync_end_user_memory_count_from_neo4j(self.ctx.end_user_id, connector)
+        return res
 
     @staticmethod
     async def delete_node_by_element_id(element_id: str, end_user_id: str) -> bool:

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -1,25 +1,131 @@
+import logging
+from typing import Any
+
 from app.core.memory.models.service_models import MemoryContext
-from app.repositories.neo4j import Neo4jConnector
+from app.core.utils.datetime_utils import utcnow, to_iso_z
+from app.repositories.neo4j.graph_search import (
+    forget_count_active_nodes,
+    forget_get_mixed_candidates,
+    forget_soft_delete_by_element_ids,
+)
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = logging.getLogger(__name__)
 
 
 class ForgetService:
-    def __init__(
-            self,
-            ctx: MemoryContext,
-            memory_limit: int,
-    ):
+    BATCH_SIZE = 50
+    ENTITY_PROTECTION_THRESHOLD = 10
+
+    def __init__(self, ctx: MemoryContext, memory_limit: int) -> None:
         self.ctx = ctx
-        self.memory_limit = memory_limit
+        self.trigger_count = memory_limit
+        self._connector: Neo4jConnector | None = None
+        self._audit: list[dict[str, Any]] = []
+        self.target_ratio = (1 - self.ctx.memory_config.lambda_mem)
+        self.target_count = max(int(memory_limit * self.target_ratio), 50)
 
-    async def run(self):
+    async def run(self) -> dict[str, Any]:
+        self._audit = []
         async with Neo4jConnector() as connector:
-            pass
+            self._connector = connector
 
-    def important_rank(self):
-        pass
+            active_count = await forget_count_active_nodes(connector, self.ctx.end_user_id)
+            summary = {
+                "end_user_id": self.ctx.end_user_id,
+                "trigger": self.trigger_count,
+                "target": self.target_count,
+                "protection_threshold": self.ENTITY_PROTECTION_THRESHOLD,
+                "initial_count": active_count,
+            }
 
-    async def chunk_stmt_clean(self):
-        pass
+            if active_count <= self.trigger_count:
+                logger.info(
+                    "ForgetService skip — active=%d <= trigger=%d",
+                    active_count, self.trigger_count,
+                )
+                summary["deleted"] = 0
+                summary["final_count"] = active_count
+                return summary
 
-    async def entity_clean(self):
-        pass
+            budget = active_count - self.target_count
+            logger.info(
+                "ForgetService start — active=%d trigger=%d target=%d budget=%d "
+                "protection_threshold=%d",
+                active_count, self.trigger_count, self.target_count, budget,
+                self.ENTITY_PROTECTION_THRESHOLD,
+            )
+
+            budget = await self._mixed_clean(budget)
+
+            final_count = await forget_count_active_nodes(connector, self.ctx.end_user_id)
+            deleted = summary["initial_count"] - final_count
+
+            summary["deleted"] = deleted
+            summary["budget"] = max(budget, 0)
+            summary["final_count"] = final_count
+
+            logger.info(
+                "ForgetService done — deleted=%d final=%d remaining_budget=%d",
+                deleted, final_count, summary["budget"],
+            )
+            return summary
+
+    async def _mixed_clean(self, budget: int) -> int:
+        if budget <= 0:
+            return budget
+
+        connector = self._connector
+        total_deleted = 0
+
+        while budget > 0:
+            batch_size = min(self.BATCH_SIZE, budget)
+            candidates = await forget_get_mixed_candidates(
+                connector, self.ctx.end_user_id, batch_size,
+                self.ENTITY_PROTECTION_THRESHOLD,
+            )
+
+            if not candidates:
+                break
+
+            element_ids = [row["element_id"] for row in candidates]
+            now = utcnow()
+
+            deleted_in_batch = await forget_soft_delete_by_element_ids(
+                connector, self.ctx.end_user_id, element_ids, to_iso_z(now),
+            )
+
+            total_deleted += deleted_in_batch
+            budget -= deleted_in_batch
+
+            for row in candidates:
+                node_type = row.get("node_type", "unknown")
+                entry: dict[str, Any] = {
+                    "node_id": row.get("node_id"),
+                    "node_type": node_type,
+                    "user_id": self.ctx.end_user_id,
+                    "delete_at": now,
+                    "delete_reason": "mixed_time_asc",
+                    "sort_time": row.get("sort_time"),
+                    "extraction_count": row.get("extraction_count"),
+                }
+                self._audit.append(entry)
+
+            logger.info(
+                "ForgetService mixed: batch=%d deleted=%d/%d remaining_budget=%d "
+                "types=%s",
+                len(element_ids), deleted_in_batch, total_deleted, budget,
+                {t: sum(1 for r in candidates if r.get("node_type") == t)
+                 for t in ("chunk", "statement", "entity")},
+            )
+
+            if deleted_in_batch < len(element_ids):
+                break
+
+        active_count = await forget_count_active_nodes(connector, self.ctx.end_user_id)
+        new_budget = max(0, active_count - self.target_count)
+        logger.info(
+            "ForgetService mixed done: total_deleted=%d budget_before=%d budget_after=%d",
+            total_deleted, budget + total_deleted, new_budget,
+        )
+        return new_budget

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -2,9 +2,12 @@ import asyncio
 import logging
 from uuid import UUID
 
+from app.aioRedis import get_thread_safe_redis
+from app.core.quota_manager import get_end_user_memory_limit
 from app.db import get_db_context
-from app.repositories.end_user_repository import EndUserRepository
+from app.repositories.end_user_repository import EndUserRepository, get_tenant_id_by_end_user_id
 from app.repositories.memory_config_repository import MemoryConfigRepository
+from app.repositories.neo4j.graph_search import forget_count_active_nodes
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 _logger = logging.getLogger(__name__)
@@ -12,8 +15,8 @@ _LOG_PREFIX = "[MEMORY_COUNT_SYNC]"
 
 
 async def sync_end_user_memory_count_from_neo4j(
-    end_user_id: str,
-    connector: Neo4jConnector,
+        end_user_id: str,
+        connector: Neo4jConnector,
 ) -> int:
     """
     Sync one end user's Neo4j memory node count to PostgreSQL.
@@ -29,8 +32,20 @@ async def sync_end_user_memory_count_from_neo4j(
     )
     node_count = int(result[0]["total"]) if result else 0
 
+    memory_node_count = await forget_count_active_nodes(connector, end_user_id)
     with get_db_context() as db:
         EndUserRepository(db).update_memory_count(UUID(end_user_id), node_count)
+        tenant_id = get_tenant_id_by_end_user_id(db, end_user_id)
+        memory_limit = get_end_user_memory_limit(db, tenant_id)
+    redis_client = get_thread_safe_redis()
+    if memory_node_count > memory_limit:
+        await redis_client.sadd("forget:candidates", end_user_id)
+        _logger.info(
+            f"{_LOG_PREFIX} 加入遗忘候选: end_user_id={end_user_id}, "
+            f"count={memory_node_count}, limit={memory_limit}"
+        )
+    else:
+        await redis_client.srem("forget:candidates", end_user_id)
 
     _logger.info(f"{_LOG_PREFIX} 同步完成: end_user_id={end_user_id}, count={node_count}")
     return node_count
@@ -43,6 +58,7 @@ def sync_memory_count_neo4j(end_user_id: str) -> None:
     Uses asyncio.run() which creates a fresh event loop, runs the coroutine,
     and closes the loop automatically — no resource leaks.
     """
+
     async def _run():
         connector = Neo4jConnector()
         try:

--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -38,14 +38,15 @@ async def sync_end_user_memory_count_from_neo4j(
         tenant_id = get_tenant_id_by_end_user_id(db, end_user_id)
         memory_limit = get_end_user_memory_limit(db, tenant_id)
     redis_client = get_thread_safe_redis()
-    if memory_node_count > memory_limit:
-        await redis_client.sadd("forget:candidates", end_user_id)
-        _logger.info(
-            f"{_LOG_PREFIX} 加入遗忘候选: end_user_id={end_user_id}, "
-            f"count={memory_node_count}, limit={memory_limit}"
-        )
-    else:
-        await redis_client.srem("forget:candidates", end_user_id)
+    if redis_client:
+        if memory_node_count > memory_limit:
+            await redis_client.sadd("forget:candidates", end_user_id)
+            _logger.info(
+                f"{_LOG_PREFIX} 加入遗忘候选: end_user_id={end_user_id}, "
+                f"count={memory_node_count}, limit={memory_limit}"
+            )
+        else:
+            await redis_client.srem("forget:candidates", end_user_id)
 
     _logger.info(f"{_LOG_PREFIX} 同步完成: end_user_id={end_user_id}, count={node_count}")
     return node_count

--- a/api/app/core/models/llm.py
+++ b/api/app/core/models/llm.py
@@ -298,11 +298,11 @@ class RedBearLLM(BaseLLM):
         try:
             chain = self.with_structured_output(schema, **kwargs)
             return await chain.ainvoke(input)
-        except NotImplementedError:
+        except Exception:
             _logger.warning(
                 "call_structured: with_structured_output not supported by %s, "
                 "falling back to ainvoke + StructResponse",
-                type(self._model).__name__,
+                type(self._model).__name__, exc_info=True
             )
 
         response = await self.ainvoke(input)

--- a/api/app/core/quota_manager.py
+++ b/api/app/core/quota_manager.py
@@ -11,6 +11,7 @@ from typing import Optional, Callable, Dict, Any
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_auth_logger
@@ -129,7 +130,7 @@ def _get_quota_config(db: Session, tenant_id: UUID) -> Optional[Dict[str, Any]]:
         return None
 
 
-async def _get_quota_config_async(db, tenant_id: UUID) -> Optional[Dict[str, Any]]:
+async def _get_quota_config_async(db: AsyncSession, tenant_id: UUID) -> Optional[Dict[str, Any]]:
     """Async version of _get_quota_config.
 
     Community edition: db is unused (falls through to DEFAULT_FREE_PLAN).
@@ -185,7 +186,7 @@ async def get_api_ops_rate_limit_async(db, tenant_id: UUID) -> Optional[int]:
 def get_end_user_memory_limit(db: Session, tenant_id: UUID) -> Optional[int]:
     quota_config = _get_quota_config(db, tenant_id)
     if quota_config:
-        return quota_config.get("end_user_memory_limit")
+        return quota_config.get("end_user_memory_limit", 300)
     return None
 
 

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1262,15 +1262,23 @@ async def get_end_user_by_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> 
 
 
 def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
-    """根据 end_user_id 查询对应的 tenant_id，单次 JOIN 查询，不加载 ORM 对象"""
-    from app.models.workspace_model import Workspace
-
-    return (
-        db.query(Workspace.tenant_id)
+    stmt = (
+        select(Workspace.tenant_id)
         .join(EndUser, EndUser.workspace_id == Workspace.id)
         .filter(EndUser.id == end_user_id, EndUser.is_active == True)
-        .scalar()
     )
+    result = db.execute(stmt)
+    return result.scalar()
+
+
+async def get_tenant_id_by_end_user_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
+    stmt = (
+        select(Workspace.tenant_id)
+        .join(EndUser, EndUser.workspace_id == Workspace.id)
+        .filter(EndUser.id == end_user_id, EndUser.is_active == True)
+    )
+    result = await db.execute(stmt)
+    return result.scalar()
 
 
 # 新增的缓存操作函数（保持与类方法一致的接口）

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -53,35 +53,35 @@ class MemoryConfigRepository:
 
     # Chunk count by group
     SEARCH_FOR_CHUNK = """
-    MATCH (n:Chunk) WHERE n.end_user_id = $end_user_id RETURN COUNT(n) AS num
+    MATCH (n:Chunk) WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL RETURN COUNT(n) AS num
     """
 
     # Statement count by group
     SEARCH_FOR_STATEMENT = """
-    MATCH (n:Statement) WHERE n.end_user_id = $end_user_id RETURN COUNT(n) AS num
+    MATCH (n:Statement) WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL RETURN COUNT(n) AS num
     """
 
     # ExtractedEntity count by group
     SEARCH_FOR_ENTITY = """
-    MATCH (n:ExtractedEntity) WHERE n.end_user_id = $end_user_id RETURN COUNT(n) AS num
+    MATCH (n:ExtractedEntity) WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL RETURN COUNT(n) AS num
     """
 
     # All counts by label and total
     SEARCH_FOR_ALL = """
     OPTIONAL MATCH (n:Dialogue) WHERE n.end_user_id = $end_user_id RETURN 'Dialogue' AS Label, COUNT(n) AS Count
     UNION ALL
-    OPTIONAL MATCH (n:Chunk) WHERE n.end_user_id = $end_user_id RETURN 'Chunk' AS Label, COUNT(n) AS Count
+    OPTIONAL MATCH (n:Chunk) WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL RETURN 'Chunk' AS Label, COUNT(n) AS Count
     UNION ALL
-    OPTIONAL MATCH (n:Statement) WHERE n.end_user_id = $end_user_id RETURN 'Statement' AS Label, COUNT(n) AS Count
+    OPTIONAL MATCH (n:Statement) WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL RETURN 'Statement' AS Label, COUNT(n) AS Count
     UNION ALL
-    OPTIONAL MATCH (n:ExtractedEntity) WHERE n.end_user_id = $end_user_id RETURN 'ExtractedEntity' AS Label, COUNT(n) AS Count
+    OPTIONAL MATCH (n:ExtractedEntity) WHERE n.end_user_id = $end_user_id  AND n.delete_at is NULL RETURN 'ExtractedEntity' AS Label, COUNT(n) AS Count
     UNION ALL
-    OPTIONAL MATCH (n) WHERE n.end_user_id = $end_user_id RETURN 'ALL' AS Label, COUNT(n) AS Count
+    OPTIONAL MATCH (n) WHERE n.end_user_id = $end_user_id  AND n.delete_at is NULL RETURN 'ALL' AS Label, COUNT(n) AS Count
     """
 
     # 批量查询多个用户的记忆数量（简化版本，只返回total）
     SEARCH_FOR_ALL_BATCH = """
-    MATCH (n) WHERE n.end_user_id IN $end_user_ids
+    MATCH (n) WHERE n.end_user_id IN $end_user_ids AND n.delete_at is NULL
     RETURN 
         n.end_user_id as user_id,
         count(n) as total
@@ -91,7 +91,7 @@ class MemoryConfigRepository:
     # Extracted entity details within group/app/user
     SEARCH_FOR_DETIALS = """
     MATCH (n:ExtractedEntity)
-    WHERE n.end_user_id = $end_user_id
+    WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL
     RETURN n.entity_idx AS entity_idx, 
         n.connect_strength AS connect_strength, 
         n.description AS description, 
@@ -108,7 +108,7 @@ class MemoryConfigRepository:
     # Edges between extracted entities within group/app/user
     SEARCH_FOR_EDGES = """
     MATCH (n:ExtractedEntity)-[r]->(m:ExtractedEntity)
-    WHERE n.end_user_id = $end_user_id
+    WHERE n.end_user_id = $end_user_id AND n.delete_at is NULL
     RETURN
       r.end_user_id AS end_user_id,
       r.apply_id AS apply_id,

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -39,7 +39,6 @@ RANGE_DEFS: List[Tuple[str, str]] = [
     ("user_conversation", "Conversation"),
 ]
 
-# 复合索引 (end_user_id, id)
 COMPOSITE_DEFS: List[Tuple[str, str, str]] = [
     ("user_statement_id", "Statement", "id"),
     ("user_entity_id", "ExtractedEntity", "id"),
@@ -47,6 +46,12 @@ COMPOSITE_DEFS: List[Tuple[str, str, str]] = [
     ("user_summary_id", "MemorySummary", "id"),
     ("user_perceptual_id", "Perceptual", "id"),
     ("user_community_id", "Community", "community_id"),
+]
+
+DELETE_AT_DEFS: List[Tuple[str, str, str]] = [
+    ("user_statement_delete_at", "Statement", "delete_at"),
+    ("user_entity_delete_at", "ExtractedEntity", "delete_at"),
+    ("user_chunk_delete_at", "Chunk", "delete_at"),
 ]
 
 # 旧的单列 end_user_id 索引名称（已被复合索引替代，创建复合索引前需先删除）
@@ -377,9 +382,8 @@ async def create_composite_indexes():
                 except Exception as e:
                     logger.warning(f"[Index] 删除旧单列索引失败 {name}: {e}")
 
-        # 2. Smart upsert 复合索引
         desired: List[Dict[str, Any]] = []
-        for name, label, id_prop in COMPOSITE_DEFS:
+        for name, label, id_prop in COMPOSITE_DEFS + DELETE_AT_DEFS:
             desired.append({
                 "name": name,
                 "label": label,

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -17,7 +17,8 @@ DIALOGUE_NODE_SAVE = """
 STATEMENT_NODE_SAVE = """
 UNWIND $statements AS statement
 MERGE (s:Statement {id: statement.id})
-SET s += {
+SET s.delete_at = null,
+    s += {
     id: statement.id,
     run_id: statement.run_id,
     chunk_id: statement.chunk_id,
@@ -50,6 +51,7 @@ RETURN s.id AS uuid
 STATEMENT_EMOTION_UPDATE = """
 UNWIND $items AS item
 MATCH (s:Statement {id: item.statement_id})
+WHERE s.delete_at IS NULL
 SET s.emotion_type = item.emotion_type,
     s.emotion_intensity = item.emotion_intensity,
     s.emotion_keywords = item.emotion_keywords
@@ -59,7 +61,8 @@ RETURN s.id AS uuid
 CHUNK_NODE_SAVE = """
 UNWIND $chunks AS chunk
 MERGE (c:Chunk {id: chunk.id})
-SET c += {
+SET c.delete_at = null,
+    c += {
     id: chunk.id,
     name: chunk.name,
     end_user_id: chunk.end_user_id,
@@ -80,6 +83,7 @@ EXTRACTED_ENTITY_NODE_SAVE = """
 // Upsert entity nodes safely: preserve existing non-empty fields when incoming is empty
 UNWIND $entities AS entity
 MERGE (e:ExtractedEntity {id: entity.id})
+SET e.delete_at = null
 SET e.name = CASE WHEN entity.name IS NOT NULL AND entity.name <> '' THEN entity.name ELSE e.name END,
     e.end_user_id = CASE WHEN entity.end_user_id IS NOT NULL AND entity.end_user_id <> '' THEN entity.end_user_id ELSE e.end_user_id END,
     e.run_id = CASE WHEN entity.run_id IS NOT NULL AND entity.run_id <> '' THEN entity.run_id ELSE e.run_id END,
@@ -134,13 +138,15 @@ SET e.name = CASE WHEN entity.name IS NOT NULL AND entity.name <> '' THEN entity
     e.last_access_time = CASE WHEN entity.last_access_time IS NOT NULL THEN entity.last_access_time ELSE e.last_access_time END,
     e.access_count = CASE WHEN entity.access_count IS NOT NULL THEN entity.access_count ELSE coalesce(e.access_count, 0) END,
     e.is_explicit_memory = CASE WHEN entity.is_explicit_memory IS NOT NULL THEN entity.is_explicit_memory ELSE coalesce(e.is_explicit_memory, false) END,
-    e.extraction_count = CASE WHEN entity.extraction_count IS NOT NULL THEN entity.extraction_count + coalesce(e.extraction_count, 0) ELSE coalesce(e.extraction_count, 1) END
+    e.extraction_count = CASE WHEN entity.extraction_count IS NOT NULL THEN entity.extraction_count + coalesce(e.extraction_count, 0) ELSE coalesce(e.extraction_count, 1) END,
+    e.delete_at = null
 RETURN e.id AS uuid
 """
 
 # ── 查询用户实体已有的元数据（供增量提取时去重） ──
 ENTITY_METADATA_QUERY = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 RETURN e.core_facts AS core_facts,
        e.traits AS traits,
        e.relations AS relations,
@@ -165,6 +171,7 @@ RETURN e.core_facts AS core_facts,
 #      上层调用方对未变更字段传空数组即可，避免 Cypher 内部出现 NULL 分支。
 ENTITY_METADATA_PATCH = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 
 // ── core_facts ──
 WITH e,
@@ -254,7 +261,9 @@ ENTITY_RELATIONSHIP_SAVE = """
 UNWIND $relationships AS rel
 // Match entities by stable id within end_user_id, do not constrain by run_id
 MATCH (subject:ExtractedEntity {id: rel.source_id, end_user_id: rel.end_user_id})
+WHERE subject.delete_at IS NULL
 MATCH (object:ExtractedEntity {id: rel.target_id, end_user_id: rel.end_user_id})
+WHERE object.delete_at IS NULL
 // Avoid duplicate edges across runs for the same endpoints
 MERGE (subject)-[r:EXTRACTED_RELATIONSHIP]->(object)
 SET r.predicate = rel.predicate,
@@ -278,7 +287,8 @@ RETURN elementId(r) AS uuid
 WEAK_ENTITY_NODE_SAVE = """
 UNWIND $weak_entities AS entity
 MERGE (e:ExtractedEntity {id: entity.id, run_id: entity.run_id})
-SET e += {
+SET e.delete_at = null,
+    e += {
     name: entity.name,
     end_user_id: entity.end_user_id,
     run_id: entity.run_id,
@@ -295,11 +305,13 @@ RETURN e.id AS id
 SAVE_STRONG_TRIPLE_ENTITIES = """
 UNWIND $items AS item
 MERGE (s:ExtractedEntity {id: item.source_id, run_id: item.run_id})
-SET s += {name: item.subject, end_user_id: item.end_user_id, run_id: item.run_id}
+SET s.delete_at = null,
+    s += {name: item.subject, end_user_id: item.end_user_id, run_id: item.run_id}
 // Independent strong flag
 SET s.is_strong = true
 MERGE (o:ExtractedEntity {id: item.target_id, run_id: item.run_id})
-SET o += {name: item.object, end_user_id: item.end_user_id, run_id: item.run_id}
+SET o.delete_at = null,
+    o += {name: item.object, end_user_id: item.end_user_id, run_id: item.run_id}
 // Independent strong flag
 SET o.is_strong = true
 """
@@ -310,6 +322,7 @@ DIALOGUE_STATEMENT_EDGE_SAVE = """
     MATCH (dialogue:Dialogue)
     WHERE dialogue.uuid = edge.source OR dialogue.ref_id = edge.source
     MATCH (statement:Statement {id: edge.target})
+    WHERE statement.delete_at IS NULL
     // 仅按端点去重，关系属性可更新
     MERGE (dialogue)-[e:MENTIONS]->(statement)
     SET e.uuid = edge.id,
@@ -324,7 +337,9 @@ DIALOGUE_STATEMENT_EDGE_SAVE = """
 CHUNK_STATEMENT_EDGE_SAVE = """
     UNWIND $chunk_statement_edges AS edge
     MATCH (statement:Statement {id: edge.source, run_id: edge.run_id})
+    WHERE statement.delete_at IS NULL
     MATCH (chunk:Chunk {id: edge.target, run_id: edge.run_id})
+    WHERE chunk.delete_at IS NULL
     MERGE (chunk)-[e:CONTAINS {id: edge.id}]->(statement)
     SET e.end_user_id = edge.end_user_id,
         e.run_id = edge.run_id,
@@ -336,8 +351,10 @@ STATEMENT_ENTITY_EDGE_SAVE = """
 UNWIND $relationships AS rel
 // Statement nodes are per-run; keep run_id constraint on statements
 MATCH (statement:Statement {id: rel.source, run_id: rel.run_id})
+WHERE statement.delete_at IS NULL
 // Entities are shared across runs within end_user_id; do not constrain by run_id
 MATCH (entity:ExtractedEntity {id: rel.target, end_user_id: rel.end_user_id})
+WHERE entity.delete_at IS NULL
 // Avoid duplicate edges across runs for same endpoints
 MERGE (statement)-[r:REFERENCES_ENTITY]->(entity)
 SET r.end_user_id = rel.end_user_id,
@@ -352,6 +369,7 @@ CALL db.index.vector.queryNodes('entity_embedding_index', $limit * 100, $embeddi
 YIELD node AS e, score
 WHERE e.name_embedding IS NOT NULL
   AND ($end_user_id IS NULL OR e.end_user_id = $end_user_id)
+  AND e.delete_at IS NULL
 RETURN e.id AS id,
        e.name AS name,
        e.end_user_id AS end_user_id,
@@ -370,6 +388,7 @@ CALL db.index.vector.queryNodes('statement_embedding_index', $limit * 100, $embe
 YIELD node AS s, score
 WHERE s.statement_embedding IS NOT NULL
   AND ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+  AND s.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
        s.end_user_id AS end_user_id,
@@ -392,6 +411,7 @@ CALL db.index.vector.queryNodes('chunk_embedding_index', $limit * 100, $embeddin
 YIELD node AS c, score
 WHERE c.chunk_embedding IS NOT NULL
   AND ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+  AND c.delete_at IS NULL
 RETURN c.id AS chunk_id,
        c.end_user_id AS end_user_id,
        c.content AS content,
@@ -407,8 +427,11 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_KEYWORD = """
 CALL db.index.fulltext.queryNodes("statementsFulltext", $query) YIELD node AS s, score
 WHERE ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+  AND s.delete_at IS NULL
 OPTIONAL MATCH (c:Chunk)-[:CONTAINS]->(s)
+WHERE c.delete_at IS NULL
 OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(e:ExtractedEntity)
+WHERE e.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
        s.end_user_id AS end_user_id,
@@ -430,17 +453,19 @@ LIMIT $limit
 SEARCH_ENTITIES_BY_NAME_OR_ALIAS = """
 CALL db.index.fulltext.queryNodes("entitiesFulltext", $query) YIELD node AS e, score
 WHERE ($end_user_id IS NULL OR e.end_user_id = $end_user_id)
+  AND e.delete_at IS NULL
 WITH e, score
 With collect({entity: e, score: score}) AS fulltextResults
 
 OPTIONAL MATCH (ae:ExtractedEntity)
 WHERE ($end_user_id IS NULL OR ae.end_user_id = $end_user_id)
+  AND ae.delete_at IS NULL
   AND ae.aliases IS NOT NULL
   AND ANY(alias IN ae.aliases WHERE toLower(alias) CONTAINS toLower($query))
 WITH fulltextResults, collect(ae) AS aliasEntities
 
 UNWIND (fulltextResults + [x IN aliasEntities | {entity: x, score:
-     CASE 
+     CASE
        WHEN ANY(alias IN x.aliases WHERE toLower(alias) = toLower($query)) THEN 1.0
        WHEN ANY(alias IN x.aliases WHERE toLower(alias) STARTS WITH toLower($query)) THEN 0.9
        ELSE 0.8
@@ -449,7 +474,9 @@ UNWIND (fulltextResults + [x IN aliasEntities | {entity: x, score:
 WITH row.entity AS e, row.score AS score
 WITH DISTINCT e, MAX(score) AS score
 OPTIONAL MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e)
+WHERE s.delete_at IS NULL
 OPTIONAL MATCH (c:Chunk)-[:CONTAINS]->(s)
+WHERE c.delete_at IS NULL
 RETURN e.id AS id,
        e.name AS name,
        e.end_user_id AS end_user_id,
@@ -477,8 +504,11 @@ LIMIT $limit
 SEARCH_CHUNKS_BY_CONTENT = """
 CALL db.index.fulltext.queryNodes("chunksFulltext", $query) YIELD node AS c, score
 WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+  AND c.delete_at IS NULL
 OPTIONAL MATCH (c)-[:CONTAINS]->(s:Statement)
+WHERE s.delete_at IS NULL
 OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(e:ExtractedEntity)
+WHERE e.delete_at IS NULL
 RETURN c.id AS chunk_id,
        c.end_user_id AS end_user_id,
        c.content AS content,
@@ -555,6 +585,7 @@ LIMIT $limit
 SEARCH_CHUNK_BY_CHUNK_ID = """
 MATCH (c:Chunk)
 WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+  AND c.delete_at IS NULL
   AND c.id = $chunk_id
 RETURN c.id AS chunk_id,
        c.end_user_id AS end_user_id,
@@ -569,6 +600,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_TEMPORAL = """
 MATCH (s:Statement)
 WHERE ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+  AND s.delete_at IS NULL
   AND ((($start_date IS NULL OR datetime(s.created_at) >= datetime($start_date))
   AND ($end_date IS NULL OR datetime(s.created_at) <= datetime($end_date)))
   OR (($valid_date IS NULL OR (s.valid_at IS NOT NULL AND datetime(s.valid_at) >= datetime($valid_date)))
@@ -592,12 +624,15 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_KEYWORD_TEMPORAL = """
 CALL db.index.fulltext.queryNodes("statementsFulltext", $query) YIELD node AS s, score
 WHERE ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+  AND s.delete_at IS NULL
   AND ((($start_date IS NULL OR (s.created_at IS NOT NULL AND datetime(s.created_at) >= datetime($start_date)))
   AND ($end_date IS NULL OR (s.created_at IS NOT NULL AND datetime(s.created_at) <= datetime($end_date))))
   OR (($valid_date IS NULL OR (s.valid_at IS NOT NULL AND datetime(s.valid_at) >= datetime($valid_date)))
   AND ($invalid_date IS NULL OR (s.invalid_at IS NOT NULL AND datetime(s.invalid_at) <= datetime($invalid_date)))))
 OPTIONAL MATCH (c:Chunk)-[:CONTAINS]->(s)
+WHERE c.delete_at IS NULL
 OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(e:ExtractedEntity)
+WHERE e.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
        s.end_user_id AS end_user_id,
@@ -619,6 +654,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_CREATED_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($created_at IS NOT NULL AND date(substring(n.created_at, 0, 10)) = date($created_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -635,6 +671,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_VALID_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($valid_at IS NOT NULL AND date(substring(n.valid_at, 0, 10)) = date($valid_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -651,6 +688,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_G_CREATED_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($created_at IS NOT NULL AND date(substring(n.created_at, 0, 19)) = date($created_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -667,6 +705,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_L_CREATED_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($created_at IS NOT NULL AND date(substring(n.created_at, 0, 19)) < date($created_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -683,6 +722,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_G_VALID_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($valid_at IS NOT NULL AND date(substring(n.valid_at, 0, 10)) > date($valid_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -699,6 +739,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_L_VALID_AT = """
 MATCH (n:Statement)
 WHERE ($end_user_id IS NULL OR n.end_user_id = $end_user_id)
+  AND n.delete_at IS NULL
   AND ($valid_at IS NOT NULL AND date(substring(n.valid_at, 0, 10)) < date($valid_at))
 RETURN n.id AS id,
        n.statement AS statement,
@@ -761,6 +802,7 @@ LIMIT $limit
 # 根据id修改句子的invalid_at的值
 UPDATE_STATEMENT_INVALID_AT = """
 MATCH (n:Statement {end_user_id: $end_user_id, id: $id})
+WHERE n.delete_at IS NULL
 SET n.invalid_at = $new_invalid_at
 """
 
@@ -792,7 +834,9 @@ MEMORY_SUMMARY_STATEMENT_EDGE_SAVE = """
 UNWIND $edges AS e
 MATCH (ms:MemorySummary {id: e.summary_id, run_id: e.run_id})
 MATCH (c:Chunk {id: e.chunk_id, run_id: e.run_id})
+WHERE c.delete_at IS NULL
 MATCH (c)-[:CONTAINS]->(s:Statement {run_id: e.run_id})
+WHERE s.delete_at IS NULL
 MERGE (ms)-[r:DERIVED_FROM_STATEMENT]->(s)
 SET r.end_user_id = e.end_user_id,
     r.run_id = e.run_id,
@@ -803,7 +847,9 @@ RETURN elementId(r) AS uuid
 # Entity Merge Query
 MERGE_ENTITIES = """
 MATCH (canonical:ExtractedEntity {id: $canonical_id})
+WHERE canonical.delete_at IS NULL
 MATCH (losing:ExtractedEntity {id: $losing_id})
+WHERE losing.delete_at IS NULL
 
 // 更新canonical实体的aliases
 SET canonical.aliases = $merged_aliases
@@ -859,9 +905,10 @@ RETURN count(losing) as deleted
 
 neo4j_statement_part = '''
 MATCH (n:Statement)
-WHERE n.end_user_id = "{}" 
+WHERE n.end_user_id = "{}"
+  AND n.delete_at IS NULL
   AND datetime(n.created_at) >= datetime() - duration('P3D')
-RETURN 
+RETURN
   n.statement as statement_name,
   n.id as statement_id,
    n.created_at as   statement_created_at
@@ -869,19 +916,23 @@ RETURN
 '''
 neo4j_statement_all = '''
 MATCH (n:Statement)
-WHERE n.end_user_id = "{}" 
-RETURN 
+WHERE n.end_user_id = "{}"
+  AND n.delete_at IS NULL
+RETURN
   n.statement as statement_name,
   n.id as statement_id
 
 '''
 neo4j_query_part = """
             MATCH (n)-[r]-(m:ExtractedEntity)
-            WHERE n.end_user_id = "{}" 
+            WHERE n.end_user_id = "{}"
+            AND n.delete_at IS NULL
+            AND m.delete_at IS NULL
             AND datetime(n.created_at) >= datetime() - duration('P3D')
             WITH DISTINCT m
             OPTIONAL MATCH (m)-[rel]-(other:ExtractedEntity)
-            RETURN 
+            WHERE other.delete_at IS NULL
+            RETURN
              elementId(m) as id,
             m.name as entity1_name,
             m.description as description,
@@ -897,10 +948,13 @@ neo4j_query_part = """
                           """
 neo4j_query_all = """
                 MATCH (n)-[r]-(m:ExtractedEntity)
-                WHERE n.end_user_id = "{}" 
+                WHERE n.end_user_id = "{}"
+                AND n.delete_at IS NULL
+                AND m.delete_at IS NULL
                 WITH DISTINCT m
                 OPTIONAL MATCH (m)-[rel]-(other:ExtractedEntity)
-                RETURN 
+                WHERE other.delete_at IS NULL
+                RETURN
                  elementId(m) as id,
                 m.name as entity1_name,
                 m.description as description,
@@ -919,6 +973,7 @@ neo4j_query_all = """
 Memory_Timeline_Entity_Events = """
 MATCH (e:ExtractedEntity)
 WHERE elementId(e) = $id
+  AND e.delete_at IS NULL
 RETURN e.name AS entity_name,
        e.entity_type AS entity_type,
        e.description_summary AS description_summary,
@@ -930,6 +985,8 @@ Memory_Timeline_ExtractedEntity = """
 MATCH (n)-[r1]-(e)-[r2]-(ms)
 WHERE elementId(n) = $id
   AND (ms:ExtractedEntity OR ms:MemorySummary)
+  AND n.delete_at IS NULL
+  AND e.delete_at IS NULL
 
 RETURN
   collect(
@@ -938,7 +995,7 @@ RETURN
       WHEN ms:ExtractedEntity THEN {
         text: ms.name,
         created_at: ms.created_at,
-     type: "情景记忆" 
+     type: "情景记忆"
       }
     END
   ) AS ExtractedEntity,
@@ -949,7 +1006,7 @@ RETURN
       WHEN ms:MemorySummary THEN {
         text: ms.content,
         created_at: ms.created_at,
-       type: "长期沉淀" 
+       type: "长期沉淀"
       }
     END
   ) AS MemorySummary,
@@ -958,16 +1015,18 @@ RETURN
     DISTINCT {
       text: e.statement,
       created_at: e.created_at,
-      type: "情绪记忆" 
+      type: "情绪记忆"
     }
   ) AS statement;
 
 
 """
-Memory_Timeline_MemorySummary = """ 
+Memory_Timeline_MemorySummary = """
 MATCH (n)-[r1]-(e)-[r2]-(ms)
 WHERE elementId(n) =$id
   AND (ms:MemorySummary OR ms:ExtractedEntity)
+  AND n.delete_at IS NULL
+  AND e.delete_at IS NULL
 RETURN
   collect(
     DISTINCT
@@ -975,7 +1034,7 @@ RETURN
       WHEN ms:ExtractedEntity THEN {
         text: ms.name,
         created_at: ms.created_at,
-        type: "情景记忆" 
+        type: "情景记忆"
       }
     END
   ) AS ExtractedEntity,
@@ -986,7 +1045,7 @@ RETURN
       WHEN n:MemorySummary THEN {
         text: n.content,
         created_at: n.created_at,
-        type: "长期沉淀" 
+        type: "长期沉淀"
       }
     END
   ) AS MemorySummary,
@@ -995,36 +1054,39 @@ RETURN
     DISTINCT {
       text: e.statement,
       created_at: e.created_at,
-      type: "情绪记忆" 
+      type: "情绪记忆"
     }
   ) AS statement;
 """
 Memory_Timeline_Statement = """
 MATCH (n)
 WHERE elementId(n) = $id
+  AND n.delete_at IS NULL
 
-CALL {
+CALL () {
   WITH n
   MATCH (n)-[]-(m:ExtractedEntity)
   WHERE NOT m:MemorySummary AND NOT m:Chunk
+    AND m.delete_at IS NULL
   RETURN collect(
     DISTINCT {
       text: m.name,
       created_at: m.created_at,
-      type: "情景记忆" 
+      type: "情景记忆"
     }
   ) AS ExtractedEntity
 }
 
-CALL {
+CALL () {
   WITH n
   MATCH (n)-[]-(m:MemorySummary)
   WHERE NOT m:Chunk
+    AND m.delete_at IS NULL
   RETURN collect(
     DISTINCT {
       text: m.content,
       created_at: m.created_at,
-       type: "长期沉淀" 
+       type: "长期沉淀"
     }
   ) AS MemorySummary
 }
@@ -1035,7 +1097,7 @@ RETURN
   {
     text: n.statement,
     created_at: n.created_at,
-     type: "情绪记忆" 
+     type: "情绪记忆"
   } AS statement;
 
 
@@ -1045,6 +1107,7 @@ RETURN
 Memory_Space_Emotion_Statement = """
 MATCH (n)
 WHERE elementId(n) = $id
+  AND n.delete_at IS NULL
 RETURN
   n.emotion_intensity AS emotion_intensity,
   n.created_at        AS created_at,
@@ -1055,9 +1118,12 @@ RETURN
 Memory_Space_Emotion_MemorySummary = """
 MATCH (n)-[]-(e)
 WHERE elementId(n) = $id
+  AND n.delete_at IS NULL
+  AND e.delete_at IS NULL
   AND EXISTS {
     MATCH (e)-[]-(ms)
-    WHERE ms:MemorySummary OR ms:ExtractedEntity
+    WHERE (ms:MemorySummary OR ms:ExtractedEntity)
+      AND ms.delete_at IS NULL
   }
 RETURN DISTINCT
   e.emotion_intensity AS emotion_intensity,
@@ -1068,8 +1134,11 @@ RETURN DISTINCT
 Memory_Space_Emotion_ExtractedEntity = """
 MATCH (n)-[]-(e)
 WHERE elementId(n) = $id
+  AND n.delete_at IS NULL
+  AND e.delete_at IS NULL
   AND EXISTS {
     MATCH (e)-[]-(ms:ExtractedEntity)
+    WHERE ms.delete_at IS NULL
   }
 RETURN DISTINCT
   e.emotion_intensity AS emotion_intensity,
@@ -1080,12 +1149,16 @@ RETURN DISTINCT
 
 Memory_Space_User = """
 MATCH (n)-[r]->(m)
-WHERE n.end_user_id = $end_user_id  AND m.name="用户" 
+WHERE n.end_user_id = $end_user_id  AND m.name="用户"
+  AND n.delete_at IS NULL
+  AND m.delete_at IS NULL
 return DISTINCT elementId(m) as id
 """
 Memory_Space_Entity = """
 MATCH (n)-[]-(m)
 WHERE elementId(m) = $id AND  m.entity_type = "Person"
+  AND n.delete_at IS NULL
+  AND m.delete_at IS NULL
 RETURN
 DISTINCT m.name as name,m.end_user_id as end_user_id
 """
@@ -1093,6 +1166,9 @@ Memory_Space_Associative = """
 MATCH (u)-[]-(x)-[]-(h)
 WHERE elementId(u) = $user_id
   AND elementId(h) = $id
+  AND u.delete_at IS NULL
+  AND x.delete_at IS NULL
+  AND h.delete_at IS NULL
 RETURN DISTINCT
  x.statement as statement,x.created_at as created_at
 """
@@ -1140,6 +1216,7 @@ def build_graph_nodes_by_type_query(node_type: str) -> str:
 // GRAPH_NODES_BY_TYPE_LIMITS({node_type})
 MATCH (n:{node_type})
 WHERE n.end_user_id = $end_user_id
+  AND n.delete_at IS NULL
 RETURN
     elementId(n)        AS id,
     labels(n)           AS labels,
@@ -1171,6 +1248,7 @@ def build_graph_total_count_by_type_query(node_type: str) -> str:
 // GRAPH_NODES_TOTAL_COUNT_BY_TYPE({node_type})
 MATCH (n:{node_type})
 WHERE n.end_user_id = $end_user_id
+  AND n.delete_at IS NULL
 RETURN count(n) AS total
 """
 
@@ -1190,6 +1268,7 @@ GRAPH_NODES_REL_COUNT_BATCH = """
 // GRAPH_NODES_REL_COUNT_BATCH
 UNWIND $node_ids AS nid
 MATCH (n) WHERE elementId(n) = nid
+  AND n.delete_at IS NULL
 RETURN nid AS id, COUNT { (n)--() } AS rel_count
 """
 
@@ -1199,13 +1278,14 @@ RETURN nid AS id, COUNT { (n)--() } AS rel_count
 Graph_Node_query = """
 MATCH (n:MemorySummary)
 WHERE n.end_user_id = $end_user_id
+  AND n.delete_at IS NULL
 RETURN
   elementId(n) AS id,
   labels(n) AS labels,
   properties(n) AS properties,
   0 AS priority
 LIMIT $limit
-                
+
 UNION ALL
 
 MATCH (n:Dialogue)
@@ -1221,6 +1301,7 @@ UNION ALL
 
 MATCH (n:Statement)
 WHERE n.end_user_id =  $end_user_id
+  AND n.delete_at IS NULL
 RETURN
   elementId(n) AS id,
   labels(n) AS labels,
@@ -1232,6 +1313,7 @@ UNION ALL
 
 MATCH (n:ExtractedEntity)
 WHERE n.end_user_id =  $end_user_id
+  AND n.delete_at IS NULL
 RETURN
   elementId(n) AS id,
   labels(n) AS labels,
@@ -1243,6 +1325,7 @@ UNION ALL
 
 MATCH (n:Chunk)
 WHERE n.end_user_id =  $end_user_id
+  AND n.delete_at IS NULL
 RETURN
   elementId(n) AS id,
   labels(n) AS labels,
@@ -1278,6 +1361,7 @@ RETURN c.community_id AS community_id
 
 ENTITY_JOIN_COMMUNITY = """
 MATCH (e:ExtractedEntity {id: $entity_id, end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 MATCH (c:Community {community_id: $community_id, end_user_id: $end_user_id})
 MERGE (e)-[:BELONGS_TO_COMMUNITY]->(c)
 SET c.updated_at = datetime()
@@ -1286,20 +1370,25 @@ RETURN e.id AS entity_id, c.community_id AS community_id
 
 ENTITY_LEAVE_ALL_COMMUNITIES = """
 MATCH (e:ExtractedEntity {id: $entity_id, end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 MATCH (e)-[r:BELONGS_TO_COMMUNITY]->(:Community)
 DELETE r
 """
 
 GET_ENTITY_NEIGHBORS = """
 MATCH (e:ExtractedEntity {id: $entity_id, end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 
 // 来源一：直接关系邻居（EXTRACTED_RELATIONSHIP 边）
 OPTIONAL MATCH (e)-[:EXTRACTED_RELATIONSHIP]-(nb1:ExtractedEntity {end_user_id: $end_user_id})
+WHERE nb1.delete_at IS NULL
 
 // 来源二：同 Statement 共现邻居（REFERENCES_ENTITY 边）
 OPTIONAL MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e)
+WHERE s.delete_at IS NULL
 OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(nb2:ExtractedEntity {end_user_id: $end_user_id})
 WHERE nb2.id <> e.id
+  AND nb2.delete_at IS NULL
 
 WITH collect(DISTINCT nb1) + collect(DISTINCT nb2) AS all_neighbors
 UNWIND all_neighbors AS nb
@@ -1314,6 +1403,7 @@ RETURN DISTINCT
 
 GET_ALL_ENTITIES_FOR_USER = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
@@ -1323,16 +1413,19 @@ RETURN e.id AS id,
 
 GET_ENTITY_COUNT_FOR_USER = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 RETURN count(e) AS entity_count
 """
 
 GET_ALL_ENTITY_IDS_FOR_USER = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 RETURN e.id AS id
 """
 
 GET_COMMUNITY_MEMBERS = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
+WHERE e.delete_at IS NULL
 RETURN e.id AS id, e.name AS name, e.entity_type AS entity_type,
        e.importance_score AS importance_score,
        e.name_embedding AS name_embedding,
@@ -1343,7 +1436,9 @@ ORDER BY coalesce(e.importance_score, 0) DESC
 
 GET_COMMUNITY_RELATIONSHIPS = """
 MATCH (e1:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
+WHERE e1.delete_at IS NULL
 MATCH (e2:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e2.delete_at IS NULL
 MATCH (e1)-[r:EXTRACTED_RELATIONSHIP]->(e2)
 RETURN e1.name AS subject, r.predicate AS predicate, e2.name AS object
 ORDER BY e1.name, r.predicate, e2.name
@@ -1354,6 +1449,7 @@ LIMIT 20
 BATCH_ASSIGN_ENTITIES_TO_COMMUNITIES = """
 UNWIND $assignments AS row
 MATCH (e:ExtractedEntity {id: row.entity_id, end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 OPTIONAL MATCH (e)-[old_r:BELONGS_TO_COMMUNITY]->(:Community)
 DELETE old_r
 WITH e, row
@@ -1369,6 +1465,7 @@ GET_COMMUNITY_AVG_EMBEDDINGS_BATCH = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
       -[:BELONGS_TO_COMMUNITY]->(c:Community)
 WHERE c.community_id IN $community_ids
+  AND e.delete_at IS NULL
   AND e.name_embedding IS NOT NULL
 WITH c.community_id AS cid,
      count(e) AS member_count,
@@ -1391,6 +1488,7 @@ RETURN count(c) AS community_count
 
 UPDATE_COMMUNITY_MEMBER_COUNT = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c:Community {community_id: $community_id})
+WHERE e.delete_at IS NULL
 WITH c, count(e) AS cnt
 SET c.member_count = cnt
 RETURN c.community_id AS community_id, cnt AS member_count
@@ -1409,6 +1507,7 @@ RETURN count(c) AS deleted
 RECONCILE_REFRESH_ALL_MEMBER_COUNTS = """
 MATCH (c:Community {end_user_id: $end_user_id})
 OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
 WITH c, count(e) AS cnt
 SET c.member_count = cnt
 RETURN count(c) AS refreshed
@@ -1419,6 +1518,7 @@ RECONCILE_REFRESH_MEMBER_COUNTS_SCOPED = """
 MATCH (c:Community {end_user_id: $end_user_id})
 WHERE c.community_id IN $community_ids
 OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
 WITH c, count(e) AS cnt
 SET c.member_count = cnt
 RETURN count(c) AS refreshed
@@ -1449,6 +1549,7 @@ RETURN c.community_id AS community_id
 
 GET_ENTITIES_PAGE = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
 OPTIONAL MATCH (e)-[:BELONGS_TO_COMMUNITY]->(c:Community)
 RETURN e.id AS id,
        e.name AS name,
@@ -1461,11 +1562,16 @@ SKIP $skip LIMIT $limit
 GET_ENTITY_NEIGHBORS_BATCH_FOR_IDS = """
 // 批量拉取指定实体列表的邻居（用于分批全量聚类）
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
-WHERE e.id IN $entity_ids
+WHERE e.delete_at IS NULL
+  AND e.id IN $entity_ids
+  AND e.delete_at IS NULL
 OPTIONAL MATCH (e)-[:EXTRACTED_RELATIONSHIP]-(nb1:ExtractedEntity {end_user_id: $end_user_id})
+WHERE nb1.delete_at IS NULL
 OPTIONAL MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e)
+WHERE s.delete_at IS NULL
 OPTIONAL MATCH (s)-[:REFERENCES_ENTITY]->(nb2:ExtractedEntity {end_user_id: $end_user_id})
 WHERE nb2.id <> e.id
+  AND nb2.delete_at IS NULL
 WITH e, collect(DISTINCT nb1) + collect(DISTINCT nb2) AS all_neighbors
 UNWIND all_neighbors AS nb
 WITH e, nb WHERE nb IS NOT NULL
@@ -1481,7 +1587,9 @@ RETURN DISTINCT
 GET_COMMUNITY_GRAPH_DATA = """
 MATCH (c:Community {end_user_id: $end_user_id})
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})-[b:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
 OPTIONAL MATCH (e)-[r:EXTRACTED_RELATIONSHIP]-(e2:ExtractedEntity {end_user_id: $end_user_id})
+WHERE e2.delete_at IS NULL
 RETURN
     elementId(c)          AS c_id,
     properties(c)         AS c_props,
@@ -1536,8 +1644,10 @@ RETURN c.community_id AS community_id
 EXPAND_COMMUNITY_STATEMENTS = """
 MATCH (c:Community {community_id: $community_id})
 MATCH (e:ExtractedEntity)-[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
 MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e)
 WHERE s.end_user_id = $end_user_id
+  AND s.delete_at IS NULL
 RETURN s.statement AS statement,
        s.id AS id,
        s.end_user_id AS end_user_id,
@@ -1579,6 +1689,7 @@ PERCEPTUAL_CHUNK_EDGE_SAVE = """
 UNWIND $edges AS edge
 MATCH (p:Perceptual {id: edge.perceptual_id, end_user_id: edge.end_user_id})
 MATCH (c:Chunk {id: edge.chunk_id, end_user_id: edge.end_user_id})
+WHERE c.delete_at IS NULL
 MERGE (c)-[r:HAS_PERCEPTUAL]->(p)
 ON CREATE SET r.end_user_id = edge.end_user_id,
     r.created_at = edge.created_at
@@ -1600,6 +1711,7 @@ LIMIT $batch_size
 SEARCH_STATEMENTS_BY_USER_ID = """
 MATCH (s:Statement)
 WHERE s.end_user_id = $end_user_id AND s.id > $last_id
+  AND s.delete_at IS NULL
 RETURN s.id AS id,
        s.statement_embedding AS embedding
 ORDER BY s.id
@@ -1609,6 +1721,7 @@ LIMIT $batch_size
 SEARCH_ENTITIES_BY_USER_ID = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id AND e.id > $last_id
+  AND e.delete_at IS NULL
 RETURN e.id AS id,
        e.name_embedding AS embedding
 ORDER BY e.id
@@ -1618,6 +1731,7 @@ LIMIT $batch_size
 SEARCH_CHUNKS_BY_USER_ID = """
 MATCH (c:Chunk)
 WHERE c.end_user_id = $end_user_id AND c.id > $last_id
+  AND c.delete_at IS NULL
 RETURN c.id AS id,
        c.chunk_embedding AS embedding
 ORDER BY c.id
@@ -1665,6 +1779,7 @@ RETURN p.id AS id,
 SEARCH_STATEMENTS_BY_IDS = """
 MATCH (s:Statement)
 WHERE s.id IN $ids
+  AND s.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
        s.end_user_id AS end_user_id,
@@ -1682,6 +1797,7 @@ RETURN s.id AS id,
 SEARCH_CHUNKS_BY_IDS = """
 MATCH (c:Chunk)
 WHERE c.id IN $ids
+  AND c.delete_at IS NULL
 RETURN c.id AS id,
        c.end_user_id AS end_user_id,
        c.content AS content,
@@ -1694,6 +1810,7 @@ RETURN c.id AS id,
 SEARCH_ENTITIES_BY_IDS = """
 MATCH (e:ExtractedEntity)
 WHERE e.id IN $ids
+  AND e.delete_at IS NULL
 RETURN e.id AS id,
        e.name AS name,
        COALESCE(e.aliases, []) AS aliases,
@@ -1761,6 +1878,7 @@ LIMIT $limit
 SEARCH_STATEMENTS_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("statementsFulltext", $query) YIELD node AS s, score
 WHERE ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+  AND s.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
        s.end_user_id AS end_user_id,
@@ -1781,6 +1899,7 @@ LIMIT $limit
 SEARCH_ENTITIES_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("entitiesFulltext", $query) YIELD node AS e, score
 WHERE ($end_user_id IS NULL OR e.end_user_id = $end_user_id)
+  AND e.delete_at IS NULL
 RETURN e.id AS id,
        e.name AS name,
        COALESCE(e.aliases, []) AS aliases,
@@ -1797,6 +1916,7 @@ LIMIT $limit
 SEARCH_CHUNKS_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("chunksFulltext", $query) YIELD node AS c, score
 WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+  AND c.delete_at IS NULL
 RETURN c.id AS id,
        c.content AS content,
        COALESCE(c.activation_value, 0.5) AS activation_value,
@@ -1844,6 +1964,8 @@ LIMIT $limit
 SEARCH_ENITITES_BY_RELATIONSHIP = """
 MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
 WHERE (n.end_user_id = $end_user_id AND n.id = $source_id AND r.predicate_id IN $predicates)
+  AND n.delete_at IS NULL
+  AND m.delete_at IS NULL
 RETURN m.id AS id,
        n.name AS source_name,
        r.predicate AS relation_predicate,
@@ -1853,6 +1975,8 @@ RETURN m.id AS id,
 SEARCH_RELATION_BETWEEN_ENTITIES = """
 MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
 WHERE n.end_user_id = $end_user_id AND n.id = $source_id AND m.id = $target_id
+  AND n.delete_at IS NULL
+  AND m.delete_at IS NULL
 RETURN n.id AS source_id,
        n.name AS source_name,
        r.predicate AS relation_predicate,
@@ -1864,6 +1988,8 @@ SEARCH_RELATIONS_BETWEEN_ENTITY_PAIRS = """
 UNWIND $pairs AS pair
 MATCH (n:ExtractedEntity)-[r]-(m:ExtractedEntity)
 WHERE n.end_user_id = $end_user_id AND n.id = pair.source_id AND m.id = pair.target_id
+  AND n.delete_at IS NULL
+  AND m.delete_at IS NULL
 RETURN n.id AS source_id,
        n.name AS source_name,
        r.predicate AS relation_predicate,
@@ -1874,6 +2000,7 @@ RETURN n.id AS source_id,
 SEARCH_USER_METADATA = """
 MATCH (n:ExtractedEntity)
 WHERE (n.end_user_id = $end_user_id AND n.entity_type ='用户')
+  AND n.delete_at IS NULL
 RETURN n.description AS description,
        n.aliases AS aliases,
        n.anchors AS anchors,
@@ -1891,6 +2018,7 @@ RETURN n.description AS description,
 USER_ENTITY_FOR_METADATA = """
 MATCH (n:ExtractedEntity)
 WHERE n.end_user_id = $end_user_id
+  AND n.delete_at IS NULL
   AND (n.entity_type = '用户' OR toLower(n.name) IN ['用户', '我', 'user', 'i'])
 RETURN n.id AS entity_id,
        n.name AS entity_name,
@@ -2016,6 +2144,7 @@ RETURN elementId(r) AS uuid
 REFLECTION_DESC_MERGE_CANDIDATES = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id
+  AND e.delete_at IS NULL
   AND e.description IS NOT NULL
   AND e.description <> ""
   AND size(split(e.description, '；')) >= $min_fragments
@@ -2034,6 +2163,7 @@ LIMIT $batch_size
 # Clear description, write summary, timeline and event_timeline
 REFLECTION_DESC_UPDATE = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 SET e.description = "",
     e.description_summary = $summary,
     e.description_timeline = $timeline,
@@ -2045,17 +2175,20 @@ RETURN e.id
 REFLECTION_RENAME_CHECK_CONFLICT = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id, name: $suggested_name})
 WHERE e.id <> $current_entity_id
+  AND e.delete_at IS NULL
 RETURN count(e) AS conflict_count
 """
 
 REFLECTION_RENAME_ENTITY = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 SET e.name = $new_name
 RETURN e.id
 """
 
 REFLECTION_UPDATE_NAME_EMBEDDING = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 SET e.name_embedding = $name_embedding
 RETURN e.id
 """
@@ -2064,10 +2197,12 @@ RETURN e.id
 DEDUP_CANDIDATES_BY_NAME = """
 MATCH (e1:ExtractedEntity)
 WHERE e1.end_user_id = $end_user_id
+  AND e1.delete_at IS NULL
   AND NOT toLower(e1.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
 WITH e1
 MATCH (e2:ExtractedEntity)
 WHERE e2.end_user_id = $end_user_id
+  AND e2.delete_at IS NULL
   AND e2.entity_type = e1.entity_type
   AND elementId(e1) < elementId(e2)
   AND NOT toLower(e2.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
@@ -2095,11 +2230,13 @@ LIMIT $candidate_cap
 DEDUP_CANDIDATES_BY_EMBED = """
 MATCH (e1:ExtractedEntity)
 WHERE e1.end_user_id = $end_user_id
+  AND e1.delete_at IS NULL
   AND e1.name_embedding IS NOT NULL
   AND NOT toLower(e1.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
 CALL db.index.vector.queryNodes('entity_embedding_index', $top_k, e1.name_embedding)
 YIELD node AS e2, score
 WHERE e2.end_user_id = $end_user_id
+  AND e2.delete_at IS NULL
   AND e2.entity_type = e1.entity_type
   AND elementId(e1) < elementId(e2)
   AND score >= $theta_embed_floor
@@ -2117,21 +2254,25 @@ LIMIT $candidate_cap
 # 查两个实体各自度数（用于超级节点保护）
 ENTITY_DEGREE_COUNT = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
-WHERE e.id IN [$id_a, $id_b]
+WHERE e.delete_at IS NULL
+  AND e.id IN [$id_a, $id_b]
 RETURN e.id AS id, COUNT{ (e)--() } AS degree
 """
 
 # 批量查多个实体度数（方案B 桶内同名直合用）
 ENTITY_DEGREES_BY_IDS = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
-WHERE e.id IN $ids
+WHERE e.delete_at IS NULL
+  AND e.id IN $ids
 RETURN e.id AS id, COUNT{ (e)--() } AS degree
 """
 
 # 去重两个实体合并
 DEDUP_MERGE_ENTITIES = """
 MATCH (keeper:ExtractedEntity {id: $keeper_id, end_user_id: $end_user_id})
+WHERE keeper.delete_at IS NULL
 MATCH (loser:ExtractedEntity {id: $loser_id, end_user_id: $end_user_id})
+WHERE loser.delete_at IS NULL
 SET keeper.name = $merged_name,
     keeper.aliases = $merged_aliases,
     keeper.description = CASE
@@ -2164,6 +2305,7 @@ SET keeper.name = $merged_name,
     keeper.events = apoc.coll.toSet(coalesce(keeper.events,[]) + coalesce(loser.events,[]))
 WITH keeper, loser
 OPTIONAL MATCH (s:Statement)-[r:REFERENCES_ENTITY]->(loser)
+WHERE s.delete_at IS NULL
 WHERE NOT (s)-[:REFERENCES_ENTITY]->(keeper)
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
   CREATE (s)-[:REFERENCES_ENTITY]->(keeper)
@@ -2191,6 +2333,7 @@ RETURN keeper.id AS merged_id
 DEDUP_FULL_SCAN_ENTITIES = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id
+  AND e.delete_at IS NULL
   AND e.entity_type = $entity_type
   AND NOT toLower(e.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
 RETURN e.id AS entity_id, e.name AS name, e.entity_type AS entity_type,
@@ -2203,6 +2346,7 @@ ORDER BY e.created_at
 DEDUP_FULL_SCAN_NEW_COUNT = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id
+  AND e.delete_at IS NULL
   AND e.entity_type = $entity_type
   AND e.created_at > $last_scan_time
   AND NOT toLower(e.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
@@ -2213,6 +2357,7 @@ RETURN count(e) AS new_count
 DEDUP_FULL_SCAN_ENTITY_TYPES = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id
+  AND e.delete_at IS NULL
   AND NOT toLower(e.name) IN ['用户', '我', 'user', 'ai助手', '助手', '助理', 'ai', 'assistant', 'ai回复']
 RETURN DISTINCT e.entity_type AS entity_type, count(e) AS count
 """
@@ -2222,6 +2367,7 @@ RETURN DISTINCT e.entity_type AS entity_type, count(e) AS count
 UNRESOLVED_STATEMENT_CANDIDATES = """
 MATCH (s:Statement)
 WHERE s.end_user_id = $end_user_id
+  AND s.delete_at IS NULL
   AND s.has_unsolved_reference = true
 RETURN s.id AS statement_id,
        s.statement AS statement_text,
@@ -2239,8 +2385,10 @@ LIMIT $batch_size
 
 UNRESOLVED_CONTEXT_CHUNKS = """
 MATCH (c:Chunk {id: $chunk_id})
+WHERE c.delete_at IS NULL
 MATCH (nearby:Chunk {end_user_id: $end_user_id})
 WHERE nearby.id <> c.id
+  AND nearby.delete_at IS NULL
 WITH c, nearby,
      abs(duration.between(datetime(nearby.created_at), datetime(c.created_at)).days * 86400
        + duration.between(datetime(nearby.created_at), datetime(c.created_at)).seconds) AS diff_sec
@@ -2259,6 +2407,7 @@ MERGE (e:ExtractedEntity {
   entity_type: $entity_type
 })
 ON CREATE SET
+  e.delete_at = null,
   e.id = randomUUID(),
   e.description = $description,
   e.example = "",
@@ -2279,6 +2428,7 @@ ON CREATE SET
   e.created_at = $created_at,
   e.extraction_count = 1
 ON MATCH SET
+  e.delete_at = null,
   e.description = CASE
     WHEN e.description IS NULL OR e.description = "" THEN $description
     ELSE e.description + '；' + $description
@@ -2294,6 +2444,7 @@ RETURN e.id AS entity_id, e.name AS name
 
 UNRESOLVED_UPDATE_NAME_EMBEDDING = """
 MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
 SET e.name_embedding = $name_embedding
 RETURN e.id
 """
@@ -2303,6 +2454,7 @@ RETURN e.id
 # 历史变体的情况；end_user_id 唯一约束保证只命中一个全局用户节点。
 UNRESOLVED_APPEND_USER_INFO = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id, entity_type: '用户'})
+WHERE e.delete_at IS NULL
 SET e.description = CASE
     WHEN $description IS NULL OR $description = '' THEN e.description
     WHEN e.description IS NULL OR e.description = '' THEN $description
@@ -2313,7 +2465,9 @@ RETURN e.id AS entity_id
 
 UNRESOLVED_CREATE_RELATIONSHIP = """
 MATCH (subj:ExtractedEntity {end_user_id: $end_user_id, name: $subject_name})
+WHERE subj.delete_at IS NULL
 MATCH (obj:ExtractedEntity {end_user_id: $end_user_id, name: $object_name})
+WHERE obj.delete_at IS NULL
 CREATE (subj)-[r:EXTRACTED_RELATIONSHIP {
   predicate: $predicate,
   predicate_id: $predicate_id,
@@ -2333,7 +2487,9 @@ RETURN r.predicate AS predicate
 
 UNRESOLVED_CREATE_STATEMENT_ENTITY_EDGE = """
 MATCH (s:Statement {id: $statement_id})
+WHERE s.delete_at IS NULL
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id, name: $entity_name})
+WHERE e.delete_at IS NULL
 MERGE (s)-[r:REFERENCES_ENTITY]->(e)
 SET r.end_user_id = $end_user_id,
     r.run_id = $run_id,
@@ -2344,6 +2500,7 @@ RETURN s.id AS statement_id
 
 UNRESOLVED_UPDATE_STATEMENT_FLAG = """
 MATCH (s:Statement {id: $statement_id})
+WHERE s.delete_at IS NULL
 SET s.has_unsolved_reference = false
 RETURN s.id AS statement_id
 """
@@ -2364,6 +2521,8 @@ MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})
       -[r:EXTRACTED_RELATIONSHIP {predicate: '别名属于'}]->
       (target:ExtractedEntity {end_user_id: $end_user_id})
 WHERE alias.id <> target.id
+  AND alias.delete_at IS NULL
+  AND target.delete_at IS NULL
 RETURN alias.id   AS alias_id,
        alias.name AS alias_name,
        alias.entity_type AS alias_entity_type,
@@ -2387,6 +2546,8 @@ MERGE_ALIAS_BELONGS_TO = """
 // 再一次性 SET，避免多条 别名属于 边对同一 target 反复覆盖。
 MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
 WHERE r.predicate = '别名属于' AND source.id IN $alias_ids
+  AND source.delete_at IS NULL
+  AND target.delete_at IS NULL
 WITH target,
      coalesce(target.aliases, []) AS existing_aliases,
      coalesce(target.description, '') AS tgt_desc,
@@ -2417,12 +2578,12 @@ RETURN target.name AS target_name, new_aliases AS updated_aliases, size(new_alia
 # 处理两类边：
 #   1. EXTRACTED_RELATIONSHIP：其他实体 → 别名节点 或 别名节点 → 其他实体
 #   2. STATEMENT_ENTITY：陈述句 → 别名节点
-# 三段用独立 CALL {} 子查询隔离，避免空输入时分组聚合丢行导致后续段被跳过。
+# 三段用独立 CALL () {} 子查询隔离，避免空输入时分组聚合丢行导致后续段被跳过。
 REDIRECT_ALIAS_EDGES = """
 // 1. 入边：其他实体 → 别名节点，重定向到 target
-CALL {
+CALL () {
   MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-  WHERE ar.predicate = '别名属于' AND alias.id IN $alias_ids
+  WHERE ar.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user.delete_at IS NULL
   WITH DISTINCT alias, user
   MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias)
   WHERE r.predicate <> '别名属于' AND other.id <> user.id
@@ -2432,9 +2593,9 @@ CALL {
   RETURN count(*) AS redirected_incoming
 }
 // 2. 出边：别名节点 → 其他实体，重定向到 target
-CALL {
+CALL () {
   MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
-  WHERE ar2.predicate = '别名属于' AND alias.id IN $alias_ids
+  WHERE ar2.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user2.delete_at IS NULL
   WITH DISTINCT alias, user2
   MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
   WHERE r.predicate <> '别名属于' AND other.id <> user2.id
@@ -2444,9 +2605,9 @@ CALL {
   RETURN count(*) AS redirected_outgoing
 }
 // 3. 陈述句 → 别名节点，重定向到 target
-CALL {
+CALL () {
   MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
-  WHERE ar3.predicate = '别名属于' AND alias.id IN $alias_ids
+  WHERE ar3.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user3.delete_at IS NULL
   WITH DISTINCT alias, user3
   MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
   CREATE (stmt)-[nr:STATEMENT_ENTITY]->(user3)
@@ -2463,7 +2624,7 @@ RETURN redirected_incoming, redirected_outgoing, redirected_stmt
 # 使用 DETACH DELETE 一并删除节点和该关系。
 DELETE_ALIAS_NODES = """
 MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
-WHERE r.predicate = '别名属于' AND alias.id IN $alias_ids
+WHERE r.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user.delete_at IS NULL
 WITH alias, count(r) AS rel_count
 DETACH DELETE alias
 RETURN count(alias) AS deleted_count
@@ -2475,6 +2636,8 @@ MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})
       -[r:EXTRACTED_RELATIONSHIP {predicate: '别名属于'}]->
       (target:ExtractedEntity {end_user_id: $end_user_id})
 WHERE alias.id IN $drop_alias_ids
+  AND alias.delete_at IS NULL
+  AND target.delete_at IS NULL
 DELETE r
 RETURN count(r) AS dropped_count
 """
@@ -2485,8 +2648,9 @@ RETURN count(r) AS dropped_count
 # 保持一致：name 命中常见用户称呼，或 entity_type 为 '用户'。
 GET_USER_ENTITY_ALIASES = """
 MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
-WHERE toLower(e.name) IN ['用户', '我', 'user', 'i']
-   OR e.entity_type = '用户'
+WHERE e.delete_at IS NULL
+  AND (toLower(e.name) IN ['用户', '我', 'user', 'i']
+   OR e.entity_type = '用户')
 RETURN e.id AS entity_id, e.name AS name, coalesce(e.aliases, []) AS aliases
 """
 
@@ -2496,6 +2660,7 @@ RETURN e.id AS entity_id, e.name AS name, coalesce(e.aliases, []) AS aliases
 SPECIAL_ENTITY_QUERY = """
 MATCH (e:ExtractedEntity)
 WHERE e.end_user_id = $end_user_id AND toLower(e.name) IN $names
+  AND e.delete_at IS NULL
 RETURN e.id AS id, e.name AS name
 """
 
@@ -2504,4 +2669,54 @@ MATCH (n)
 WHERE elementId(n) = $element_id AND n.end_user_id = $end_user_id
 DETACH DELETE n
 RETURN count(n) AS deleted
+"""
+
+# ── Forgetting engine (soft-delete) ────────────────────────────────────
+
+FORGET_COUNT_ACTIVE_NODES = """
+    MATCH (n {end_user_id: $end_user_id})
+    WHERE n.delete_at IS NULL
+      AND (n:Statement OR n:Chunk OR n:ExtractedEntity)
+    RETURN count(n) AS cnt
+"""
+
+FORGET_SOFT_DELETE_BY_ELEMENT_IDS = """
+    MATCH (n {end_user_id: $end_user_id})
+    WHERE n.delete_at IS NULL
+      AND elementId(n) IN $element_ids
+    SET n.delete_at = datetime($now)
+    RETURN count(n) AS deleted
+"""
+
+FORGET_MIXED_CANDIDATES = """
+CALL () {
+    MATCH (c:Chunk {end_user_id: $end_user_id})
+    WHERE c.delete_at IS NULL
+    RETURN 'chunk' AS node_type, elementId(c) AS element_id, c.id AS node_id,
+           coalesce(c.created_at) AS sort_time, 0 AS extraction_count,
+           null AS name, null AS _type
+    ORDER BY sort_time ASC
+    LIMIT $batch_size
+    UNION ALL
+    MATCH (s:Statement {end_user_id: $end_user_id})
+    WHERE s.delete_at IS NULL
+    RETURN 'statement' AS node_type, elementId(s) AS element_id, s.id AS node_id,
+           coalesce(s.created_at) AS sort_time, 0 AS extraction_count,
+           null AS name, null AS _type
+    ORDER BY sort_time ASC
+    LIMIT $batch_size
+    UNION ALL
+    MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+    WHERE e.delete_at IS NULL
+      AND coalesce(e.extraction_count, 0) < $protection_threshold
+    RETURN 'entity' AS node_type, elementId(e) AS element_id, e.id AS node_id,
+           coalesce(e.created_at) AS sort_time,
+           coalesce(e.extraction_count, 0) AS extraction_count,
+           e.name AS name, e.entity_type AS _type
+    ORDER BY sort_time ASC, extraction_count ASC
+    LIMIT $batch_size
+}
+RETURN *
+ORDER BY CASE WHEN sort_time IS NULL THEN 0 ELSE 1 END, sort_time ASC, extraction_count ASC
+LIMIT $batch_size
 """

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -1,7 +1,6 @@
 import asyncio
 import heapq
 import logging
-import time
 from typing import Any, Dict, List, Optional, Coroutine
 
 import numpy as np
@@ -1092,7 +1091,7 @@ async def search_graph_l_valid_at(
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Temporal search across Statements.
-    
+
     INTEGRATED: Updates activation values for Statement nodes before returning results
 
     - Matches statements valid at valid_at
@@ -1116,3 +1115,55 @@ async def search_graph_l_valid_at(
     )
 
     return results
+
+
+async def forget_count_active_nodes(
+    connector: Neo4jConnector,
+    end_user_id: str,
+) -> int:
+    """Count active nodes (``delete_at IS NULL``) across Chunk, Statement, Entity."""
+    from app.repositories.neo4j.cypher_queries import FORGET_COUNT_ACTIVE_NODES
+    result = await connector.execute_query(
+        FORGET_COUNT_ACTIVE_NODES, end_user_id=end_user_id,
+    )
+    return result[0]["cnt"] if result else 0
+
+
+async def forget_get_mixed_candidates(
+    connector: Neo4jConnector,
+    end_user_id: str,
+    batch_size: int,
+    protection_threshold: int,
+) -> list[dict[str, Any]]:
+    """Return up to *batch_size* oldest candidates across all three types.
+
+    Entity nodes with ``extraction_count >= protection_threshold`` are skipped.
+    Results are sorted by ``sort_time ASC NULLS FIRST, extraction_count ASC``.
+    """
+    from app.repositories.neo4j.cypher_queries import FORGET_MIXED_CANDIDATES
+    return await connector.execute_query(
+        FORGET_MIXED_CANDIDATES,
+        end_user_id=end_user_id,
+        batch_size=batch_size,
+        protection_threshold=protection_threshold,
+    )
+
+
+async def forget_soft_delete_by_element_ids(
+    connector: Neo4jConnector,
+    end_user_id: str,
+    element_ids: list[str],
+    now: str,
+) -> int:
+    """Mark nodes as soft-deleted (``SET delete_at = datetime($now)``).
+
+    Returns the number of nodes actually deleted.
+    """
+    from app.repositories.neo4j.cypher_queries import FORGET_SOFT_DELETE_BY_ELEMENT_IDS
+    result = await connector.execute_query(
+        FORGET_SOFT_DELETE_BY_ELEMENT_IDS,
+        end_user_id=end_user_id,
+        element_ids=element_ids,
+        now=now,
+    )
+    return result[0]["deleted"] if result else 0

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -17,6 +17,7 @@ from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
 from sqlalchemy import select, cast, String
 
+from app.aioRedis import get_thread_safe_redis
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
@@ -1696,8 +1697,7 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
         return f"sync knowledge '{kb_name}' failed: {e}"
 
 
-@celery_app.task(name="app.core.memory.agent.write_message", bind=True, acks_late=True, max_retries=3,
-                 reject_on_worker_lost=True)
+@celery_app.task(name="app.core.memory.agent.write_message", bind=True, acks_late=False, max_retries=0)
 def write_message_task(
         self,
         end_user_id: str,
@@ -3049,6 +3049,138 @@ def run_forgetting_cycle_task(self, config_id: Optional[uuid.UUID] = None) -> Di
             "message": f"任务失败: {str(e)}",
             "duration_seconds": time.time() - start_time
         }
+
+
+_FORGET_CANDIDATES_KEY = "forget:candidates"
+_FORGET_INFLIGHT_KEY = "forget:inflight"
+
+
+@celery_app.task(
+    name="app.tasks.scan_forget_candidates",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+)
+def scan_forget_candidates(self) -> Dict[str, Any]:
+    """扫描 Redis 中超过配额的用户，派发 do_forget_for_user。
+
+    通过 smove 原子地将 end_user_id 从 candidates → inflight，
+    避免重复派发同一个用户。
+    """
+
+    async def _run() -> Dict[str, Any]:
+        from app.aioRedis import get_thread_safe_redis
+
+        start_time = time.time()
+        redis_client = get_thread_safe_redis()
+        if redis_client is None:
+            return {"status": "FAILED", "message": "Redis 不可用"}
+
+        candidates = await redis_client.smembers(_FORGET_CANDIDATES_KEY)
+        print(candidates)
+        if not candidates:
+            return {"status": "SUCCESS", "dispatched": 0}
+
+        dispatched = 0
+        skipped_inflight = 0
+        for uid in candidates:
+            if await redis_client.sismember(_FORGET_INFLIGHT_KEY, uid):
+                await redis_client.srem(_FORGET_CANDIDATES_KEY, uid)
+                skipped_inflight += 1
+                continue
+
+            moved = await redis_client.smove(_FORGET_CANDIDATES_KEY, _FORGET_INFLIGHT_KEY, uid)
+            if not moved:
+                skipped_inflight += 1
+                continue
+            try:
+                do_forget_for_user.apply_async(
+                    kwargs={"end_user_id": uid},
+                    queue="memory_heavy_tasks",
+                )
+                dispatched += 1
+            except Exception as e:
+                await redis_client.smove(_FORGET_INFLIGHT_KEY, _FORGET_CANDIDATES_KEY, uid)
+                logger.error(f"[ForgetScan] 派发失败 user={uid}: {e}")
+
+        logger.info(
+            f"[ForgetScan] 完成: dispatched={dispatched}/{len(candidates)}, "
+            f"skip_inflight={skipped_inflight}, "
+            f"耗时={time.time() - start_time:.1f}s"
+        )
+        return {
+            "status": "SUCCESS",
+            "dispatched": dispatched,
+            "candidates": len(candidates),
+            "skip_inflight": skipped_inflight,
+        }
+
+    return asyncio.run(_run())
+
+
+@celery_app.task(
+    name="app.tasks.do_forget_for_user",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+    time_limit=1200,
+    soft_time_limit=1080,
+)
+def do_forget_for_user(self, end_user_id: str) -> Dict[str, Any]:
+    """对单个用户执行遗忘。由 scan_forget_candidates 派发。
+
+    ForgettingPipeline.run() 内部已调用 sync，sync 会根据最新计数
+    自行决定 sadd / srem。这里只清理 inflight，保证不泄漏。
+    """
+    start_time = time.time()
+
+    async def _run() -> Dict[str, Any]:
+        from app.repositories.end_user_repository import get_by_id as _get_user
+        from app.services.memory_config_service import MemoryConfigService
+        from app.core.memory.memory_service import MemoryService
+        redis_client = get_thread_safe_redis()
+        with get_db_context() as db:
+            end_user = _get_user(db, uuid.UUID(end_user_id))
+            if end_user is None:
+                logger.warning(f"[ForgetDo] 用户不存在: {end_user_id}")
+                if redis_client:
+                    await redis_client.srem(_FORGET_INFLIGHT_KEY, end_user_id)
+                    await redis_client.srem(_FORGET_CANDIDATES_KEY, end_user_id)
+                return {"status": "skipped", "reason": "not_found"}
+
+            config_id = MemoryConfigService(db).get_workspace_active_config_id(end_user.workspace_id)
+            workspace_id = str(end_user.workspace_id)
+
+        service = MemoryService(
+            config_id=config_id,
+            end_user_id=end_user_id,
+            workspace_id=workspace_id,
+        )
+        result = await service.forget()
+
+        if redis_client:
+            await redis_client.srem(_FORGET_INFLIGHT_KEY, end_user_id)
+
+        logger.info(
+            f"[ForgetDo] 完成: end_user_id={end_user_id}, "
+            f"elapsed={time.time() - start_time:.1f}s"
+        )
+        return {"status": "success", "result": result}
+
+    loop = set_asyncio_event_loop()
+    try:
+        result = loop.run_until_complete(_run())
+    except Exception as e:
+        logger.error(f"[ForgetDo] 失败 user={end_user_id}: {e}", exc_info=True)
+        result = {"status": "failed", "error": str(e)}
+    finally:
+        _shutdown_loop_gracefully(loop)
+
+    result["end_user_id"] = end_user_id
+    result["elapsed_time"] = time.time() - start_time
+    return result
 
 
 # =============================================================================

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3078,7 +3078,6 @@ def scan_forget_candidates(self) -> Dict[str, Any]:
             return {"status": "FAILED", "message": "Redis 不可用"}
 
         candidates = await redis_client.smembers(_FORGET_CANDIDATES_KEY)
-        print(candidates)
         if not candidates:
             return {"status": "SUCCESS", "dispatched": 0}
 


### PR DESCRIPTION
- Add ForgetService with batch soft-delete of low-activity nodes
- Introduce scan-forget-candidates Celery beat task and do-forget-for-user task
- Add FORGET_SCAN_INTERVAL_MINUTES configuration
- Add forget_count_active_nodes and forget_get_mixed_candidates Neo4j queries
- Update sync_end_user_memory_count_from_neo4j to enqueue end_user_id when over limit
- Replace placeholder forget() in MemoryService with ForgettingPipeline call
- Fix llm.py exception handler to log stack trace
- Add async variant get_tenant_id_by_end_user_id_async

## Summary by Sourcery

引入基于软删除的遗忘管道（forgetting pipeline）用于处理 memory 节点，通过定时的 Celery 任务和 Redis 协调，在排除已遗忘数据的前提下对 Neo4j 查询和计数实施租户级内存限制。

New Features:
- 增加 ForgetService 和 ForgettingPipeline，用于基于租户配额软删除低活跃的 memory 节点（chunks、statements、entities）。
- 引入基于 Redis 的协调机制，对超过内存配额的用户，通过 `forget:candidates` / `forget:inflight` 集合以及按用户执行 `do_forget_for_user` 进行处理。
- 新增周期性执行的 `scan_forget_candidates` Celery beat 任务以及配置项 `FORGET_SCAN_INTERVAL_MINUTES`，以驱动遗忘工作流。

Enhancements:
- 更新 Neo4j cypher 查询和计数逻辑以遵循 `delete_at` 软删除标记，并添加相应的 `delete_at` 索引。
- 将 `MemoryService.forget()` 接入新的 ForgettingPipeline，并返回结构化结果，同时将内存计数同步回 PostgreSQL。
- 扩展内存计数同步逻辑，对比活跃节点数量与租户配额，并据此将用户加入或移出遗忘候选集合。
- 新增异步辅助函数 `get_tenant_id_by_end_user_id_async`，并对 Redis 客户端进行小幅改动以支持选择不同 DB。
- 改进 LLM 结构化调用的错误处理，通过捕获通用异常并记录堆栈信息，便于调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a soft-delete based forgetting pipeline for memory nodes, with scheduled Celery tasks and Redis coordination to enforce per-tenant memory limits while excluding forgotten data from Neo4j queries and counts.

New Features:
- Add ForgetService and ForgettingPipeline to soft-delete low-activity memory nodes (chunks, statements, entities) based on per-tenant limits.
- Introduce Redis-backed coordination for users exceeding memory quotas via forget:candidates / forget:inflight sets and per-user do_forget_for_user execution.
- Add periodic scan_forget_candidates Celery beat task and configuration FORGET_SCAN_INTERVAL_MINUTES to drive the forgetting workflow.

Enhancements:
- Update Neo4j cypher queries and counting logic to respect delete_at soft-delete flags and add corresponding delete_at indexes.
- Wire MemoryService.forget() to the new ForgettingPipeline and return structured results, with memory counts synchronized back to PostgreSQL.
- Extend memory count sync to compare active node counts against tenant limits and enqueue or remove users from forgetting candidates accordingly.
- Add async helper get_tenant_id_by_end_user_id_async and minor Redis client flexibility for selecting DBs.
- Improve LLM structured call error handling by catching generic exceptions and logging stack traces for easier debugging.

</details>