### PR TITLE
feat(web): MinerUTool hide api_key

### DIFF
--- a/web/src/views/ToolManagement/components/InnerToolModal.tsx
+++ b/web/src/views/ToolManagement/components/InnerToolModal.tsx
@@ -100,7 +100,7 @@ const InnerToolModal = forwardRef<InnerToolModalRef, InnerToolModalProps>(({
       confirmLoading={loading}
     >
       {editVo?.config_data?.tool_class && config && <>
-        {editVo?.config_data?.tool_class !== 'DatabaseTool' &&
+        {!['DatabaseTool', 'MinerUTool'].includes(editVo?.config_data?.tool_class) &&
           <RbAlert className="rb:mb-3!">
             <div>
               <div className="rb:text-[14px] rb:font-medium">{t('tool.configDesc')}</div>
@@ -159,7 +159,7 @@ const InnerToolModal = forwardRef<InnerToolModalRef, InnerToolModalProps>(({
               </FormItem>
             )
           })}
-      </Form>
+        </Form>
       </>}
     </RbModal>
   );

--- a/web/src/views/ToolManagement/constant.ts
+++ b/web/src/views/ToolManagement/constant.ts
@@ -73,11 +73,11 @@ export const InnerConfigData: Record<string, InnerConfigItem> = {
           { required: true, message: 'common.pleaseEnter' }
         ]
       },
-      api_key: {
-        name: ['config', 'parameters', 'api_key'],
-        type: 'input',
-        desc: 'MinerUTool_api_key_desc',
-      },
+      // api_key: {
+      //   name: ['config', 'parameters', 'api_key'],
+      //   type: 'input',
+      //   desc: 'MinerUTool_api_key_desc',
+      // },
     },
     features: [
       'pdfParser',


### PR DESCRIPTION
## Summary by Sourcery

隐藏 MinerUTool API 密钥配置字段，并相应调整内部工具弹窗的行为。

新功能：
- 支持在工具管理 UI 中隐藏 MinerUTool 专用的 API 密钥配置。

增强改进：
- 将 MinerUTool 排除在通用配置说明提示之外，以符合其专门化的处理方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Hide MinerUTool API key configuration field and adjust inner tool modal behavior accordingly.

New Features:
- Support hiding MinerUTool-specific API key configuration from the tool management UI.

Enhancements:
- Exclude MinerUTool from the generic configuration description alert to align with its specialized handling.

</details>