### PR TITLE
feat(rag): async knowledge database retrieval phase one

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status, Query, Uplo
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
@@ -18,8 +19,8 @@ from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
-from app.db import get_async_db
-from app.dependencies import get_current_user_async
+from app.db import get_async_db, get_db
+from app.dependencies import get_current_user_async, get_current_user
 from app.models.document_model import Document
 from app.models.file_model import File as FileModel
 from app.models.user_model import User
@@ -1005,7 +1006,7 @@ def get_retrieve_types():
 
 async def retrieve_chunks_with_caller(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: AsyncSession,
+        db: Session | AsyncSession,
         current_user: User,
         caller: chunk_schema.KnowledgeRetrievalCaller,
 ):
@@ -1048,8 +1049,8 @@ async def retrieve_chunks_with_caller(
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: AsyncSession = Depends(get_async_db),
-        current_user: User = Depends(get_current_user_async)
+        db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user)
 ):
     return await retrieve_chunks_with_caller(
         retrieve_data=retrieve_data,

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import csv
@@ -7,7 +8,8 @@ import uuid
 
 from fastapi import APIRouter, Body, Depends, HTTPException, status, Query, UploadFile, File
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
@@ -16,14 +18,15 @@ from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
-from app.db import get_db
-from app.dependencies import get_current_user
+from app.db import get_async_db
+from app.dependencies import get_current_user_async
 from app.models.document_model import Document
+from app.models.file_model import File as FileModel
 from app.models.user_model import User
 from app.schemas import chunk_schema
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.schemas.response_schema import ApiResponse
-from app.services import knowledge_service, document_service, file_service
+from app.services import knowledge_service, document_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service, generate_kb_file_key
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied, KnowledgeRetrievalService
 from app.core.rag.utils.preview_utils import _build_preview_hierarchy
@@ -36,7 +39,7 @@ api_logger = get_api_logger()
 router = APIRouter(
     prefix="/chunks",
     tags=["chunks"],
-    dependencies=[Depends(get_current_user)]  # Apply auth to all routes in this controller
+    dependencies=[Depends(get_current_user_async)]  # Apply auth to all routes in this controller
 )
 
 
@@ -47,8 +50,8 @@ async def get_preview_chunks(
         page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
         pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
         keywords: Optional[str] = Query(None, description="The keywords used to match chunk content"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Paged query document block preview list
@@ -65,14 +68,14 @@ async def get_preview_chunks(
         )
 
     # 2. Obtain knowledge base information
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
     # 3. Check if the document exists
-    db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
     if not db_document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -80,7 +83,7 @@ async def get_preview_chunks(
         )
 
     # 4. Check if the file exists
-    db_file = file_service.get_file_by_id(db, file_id=db_document.file_id)
+    db_file = await db.get(FileModel, db_document.file_id)
     if not db_file:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -120,7 +123,8 @@ async def get_preview_chunks(
     parent_child_mode = db_document.is_parent_child_mode
     api_logger.debug(f"当前文档分块模式：{db_document.is_parent_child_mode}")
     if parent_child_mode:
-        child_res, parent_res, parent_id_map = chunk(
+        child_res, parent_res, parent_id_map = await asyncio.to_thread(
+            chunk,
             filename=db_file.file_name,
             binary=file_binary,
             from_page=0,
@@ -182,20 +186,23 @@ async def get_preview_chunks(
             )
         res = all_preview
     else:
-        res = chunk(filename=db_file.file_name,
-                    binary=file_binary,
-                    from_page=0,
-                    to_page=5,
-                    callback=progress_callback,
-                    vision_model=vision_model,
-                    parser_config=db_document.parser_config,
-                    is_root=False,
-                    tenant_id=str(current_user.tenant_id),
-                    workspace_id=str(db_knowledge.workspace_id),
-                    knowledge_id=str(db_document.kb_id),
-                    document_id=str(db_document.id),
-                    source_file_id=str(db_document.file_id),
-                    source_file_name=db_file.file_name)
+        res = await asyncio.to_thread(
+            chunk,
+            filename=db_file.file_name,
+            binary=file_binary,
+            from_page=0,
+            to_page=5,
+            callback=progress_callback,
+            vision_model=vision_model,
+            parser_config=db_document.parser_config,
+            is_root=False,
+            tenant_id=str(current_user.tenant_id),
+            workspace_id=str(db_knowledge.workspace_id),
+            knowledge_id=str(db_document.kb_id),
+            document_id=str(db_document.id),
+            source_file_id=str(db_document.file_id),
+            source_file_name=db_file.file_name,
+        )
 
     start_index = (page - 1) * pagesize
     end_index = start_index + pagesize
@@ -247,8 +254,8 @@ async def get_preview_chunks_hierarchy(
         pagesize: int = Query(20, gt=0, le=100),
         keywords: Optional[str] = Query(None, description="The keywords used to match chunk content"),
         parser_config_param: Optional[dict] = Body(None, description="Parser config overrides, e.g. {\"layout_recognize\":\"mineru\",\"chunk_token_num\":130,\"parent_child_mode\":true,\"parent_chunk_mode\":\"full-doc\"}"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Paged query document chunk preview (nested structure)
@@ -264,21 +271,21 @@ async def get_preview_chunks_hierarchy(
             detail="The paging parameter must be greater than 0"
         )
 
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
 
-    db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
     if not db_document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The document does not exist or you do not have permission to access it"
         )
 
-    db_file = file_service.get_file_by_id(db, file_id=db_document.file_id)
+    db_file = await db.get(FileModel, db_document.file_id)
     if not db_file:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -330,7 +337,8 @@ async def get_preview_chunks_hierarchy(
 
     try:
         if chunk_mode == "parent_child":
-            child_res, parent_res, parent_id_map = chunk(
+            child_res, parent_res, parent_id_map = await asyncio.to_thread(
+                chunk,
                 filename=db_file.file_name,
                 binary=file_binary,
                 from_page=0,
@@ -354,7 +362,8 @@ async def get_preview_chunks_hierarchy(
                 parent_id_map=parent_id_map,
             )
         elif chunk_mode == "qa":
-            res = chunk(
+            res = await asyncio.to_thread(
+                chunk,
                 filename=db_file.file_name,
                 binary=file_binary,
                 from_page=0,
@@ -372,7 +381,8 @@ async def get_preview_chunks_hierarchy(
             )
             hierarchy = _build_preview_hierarchy(res, chunk_mode="qa")
         else:
-            res = chunk(
+            res = await asyncio.to_thread(
+                chunk,
                 filename=db_file.file_name,
                 binary=file_binary,
                 from_page=0,
@@ -421,8 +431,8 @@ async def get_chunks(
         page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
         pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
         keywords: Optional[str] = Query(None, description="The keywords used to match chunk content"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Paged query document chunk list
@@ -440,7 +450,7 @@ async def get_chunks(
         )
 
     # 2. Obtain knowledge base information
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -448,7 +458,7 @@ async def get_chunks(
         )
 
     # 3. 获取文档并判断分块模式
-    db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
     if not db_document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -485,11 +495,12 @@ async def get_chunks(
     # 4. Execute paged query
     try:
         api_logger.debug("Start executing document chunk query")
-        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+        vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
         if db_document.is_parent_child_mode:
             # 方案 1：两次查询 + parent 级分页
             # 4.1 查询 parent chunks（按 sort_id 排序，分页）
-            total_parents, parent_items = vector_service.search_by_segment(
+            total_parents, parent_items = await asyncio.to_thread(
+                vector_service.search_by_segment,
                 document_id=str(document_id),
                 query=keywords,
                 pagesize=pagesize,
@@ -501,7 +512,8 @@ async def get_chunks(
             # fallback：如果 parent 查询为空（旧数据或 chunk_type 缺失），查所有 chunks 在内存中区分
             if not parent_items and total_parents == 0:
                 api_logger.debug("Parent query returned empty, falling back to query all chunks")
-                total_all, all_items = vector_service.search_by_segment(
+                total_all, all_items = await asyncio.to_thread(
+                    vector_service.search_by_segment,
                     document_id=str(document_id),
                     query=keywords,
                     pagesize=10000,
@@ -535,7 +547,8 @@ async def get_chunks(
             parent_doc_ids = [p.metadata["doc_id"] for p in parent_items]
 
             # 4.2 查询这些 parent 下的所有 child chunks（按 sort_id 排序，不分页）
-            _, child_items = vector_service.search_by_segment(
+            _, child_items = await asyncio.to_thread(
+                vector_service.search_by_segment,
                 document_id=str(document_id),
                 pagesize=10000,
                 page=1,
@@ -548,7 +561,8 @@ async def get_chunks(
             result = _build_nested_result(parent_items, child_items, page, pagesize, total_parents)
         else:
             # 普通分块模式：原有逻辑
-            total, items = vector_service.search_by_segment(
+            total, items = await asyncio.to_thread(
+                vector_service.search_by_segment,
                 document_id=str(document_id),
                 query=keywords,
                 pagesize=pagesize,
@@ -581,8 +595,8 @@ async def create_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
         create_data: chunk_schema.ChunkCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     create chunk
@@ -592,14 +606,14 @@ async def create_chunk(
     api_logger.info(f"Create chunk request: kb_id={kb_id}, document_id={document_id}, content={content}, username: {current_user.username}")
 
     # 1. Obtain knowledge base information
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
     # 1. Obtain document information
-    db_document = db.query(Document).filter(Document.id == document_id).first()
+    db_document = await db.get(Document, document_id)
     if not db_document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -625,11 +639,11 @@ async def create_chunk(
                 detail="当前文档未启用父子分块模式，不允许创建 parent/child 类型块"
             )
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+    vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
 
     # 2. Get the sort ID
     sort_id = 0
-    total, items = vector_service.search_by_segment(document_id=str(document_id), pagesize=1, page=1, asc=False)
+    total, items = await asyncio.to_thread(vector_service.search_by_segment, document_id=str(document_id), pagesize=1, page=1, asc=False)
     if items:
         sort_id = items[0].metadata["sort_id"]
     sort_id = sort_id + 1
@@ -651,11 +665,11 @@ async def create_chunk(
         metadata.update(create_data.qa_metadata)
     chunk = DocumentChunk(page_content=content, metadata=metadata)
     # 3. Segmented vector storage
-    vector_service.add_chunks([chunk])
+    await asyncio.to_thread(vector_service.add_chunks, [chunk])
 
     # 4.update chunk_num
     db_document.chunk_num += 1
-    db.commit()
+    await db.commit()
 
     return success(data=jsonable_encoder(chunk), msg="Document chunk creation successful")
 
@@ -665,8 +679,8 @@ async def create_chunks_batch(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
         batch_data: chunk_schema.ChunkBatchCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Batch create chunks (max 8)
@@ -679,14 +693,17 @@ async def create_chunks_batch(
             detail=f"Batch size exceeds limit: max {settings.MAX_CHUNK_BATCH_SIZE}, got {len(batch_data.items)}"
         )
 
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The knowledge base does not exist or access is denied")
 
-    db_document = db.query(Document).filter(
-        Document.id == document_id,
-        Document.kb_id == kb_id
-    ).first()
+    result = await db.execute(
+        select(Document).where(
+            Document.id == document_id,
+            Document.kb_id == kb_id,
+        )
+    )
+    db_document = result.scalars().first()
     if not db_document:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The document does not exist or you do not have permission to access it")
 
@@ -711,11 +728,11 @@ async def create_chunks_batch(
                     detail="当前文档未启用父子分块模式，不允许创建 parent/child 类型块"
                 )
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+    vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
 
     # Get current max sort_id
     sort_id = 0
-    total, items = vector_service.search_by_segment(document_id=str(document_id), pagesize=1, page=1, asc=False)
+    total, items = await asyncio.to_thread(vector_service.search_by_segment, document_id=str(document_id), pagesize=1, page=1, asc=False)
     if items:
         sort_id = items[0].metadata["sort_id"]
 
@@ -738,10 +755,10 @@ async def create_chunks_batch(
             metadata.update(create_data.qa_metadata)
         chunks.append(DocumentChunk(page_content=create_data.chunk_content, metadata=metadata))
 
-    vector_service.add_chunks(chunks)
+    await asyncio.to_thread(vector_service.add_chunks, chunks)
 
     db_document.chunk_num += len(chunks)
-    db.commit()
+    await db.commit()
 
     return success(data=jsonable_encoder(chunks), msg=f"Batch created {len(chunks)} chunks successfully")
 
@@ -751,8 +768,8 @@ async def import_qa_new_doc(
         kb_id: uuid.UUID,
         file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
         parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
     """
@@ -768,7 +785,7 @@ async def import_qa_new_doc(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="仅支持 CSV (.csv) 或 Excel (.xlsx) 格式")
 
     # 2. 校验知识库
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="知识库不存在或无权访问")
 
@@ -787,7 +804,13 @@ async def import_qa_new_doc(
         parent_id=parent_id,
         file_name=filename, file_ext=file_ext, file_size=file_size,
     )
-    db_file = file_service.create_file(db=db, file=file_data, current_user=current_user)
+    file_data.created_by = current_user.id
+    if file_data.parent_id is None:
+        file_data.parent_id = kb_id
+    db_file = FileModel(**file_data.model_dump())
+    db.add(db_file)
+    await db.commit()
+    await db.refresh(db_file)
 
     # 5. 上传文件到存储后端
     file_key = generate_kb_file_key(kb_id=kb_id, file_id=db_file.id, file_ext=file_ext)
@@ -798,8 +821,8 @@ async def import_qa_new_doc(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"文件存储失败: {str(e)}")
 
     db_file.file_key = file_key
-    db.commit()
-    db.refresh(db_file)
+    await db.commit()
+    await db.refresh(db_file)
 
     # 6. 创建 Document 记录（标记为 QA 类型）
     doc_data = document_schema.DocumentCreate(
@@ -808,7 +831,7 @@ async def import_qa_new_doc(
         file_meta={}, parser_id="qa",
         parser_config={"doc_type": "qa", "auto_questions": 0}
     )
-    db_document = document_service.create_document(db=db, document=doc_data, current_user=current_user)
+    db_document = await document_service.create_document_async(db=db, document=doc_data, current_user=current_user)
 
     api_logger.info(f"Created doc for QA import: file_id={db_file.id}, document_id={db_document.id}, file_key={file_key}")
 
@@ -832,8 +855,8 @@ async def import_qa_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
         file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     导入 QA 问答对（CSV/Excel），异步处理
@@ -846,11 +869,11 @@ async def import_qa_chunks(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="仅支持 CSV (.csv) 或 Excel (.xlsx) 格式")
 
     # 2. 校验知识库和文档
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="知识库不存在或无权访问")
 
-    db_document = db.query(Document).filter(Document.id == document_id).first()
+    db_document = await db.get(Document, document_id)
     if not db_document:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="文档不存在或无权访问")
 
@@ -872,8 +895,8 @@ async def get_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
         doc_id: str,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Retrieve document chunk information based on doc_id
@@ -881,15 +904,15 @@ async def get_chunk(
     api_logger.info(f"Obtain document chunk information: kb_id={kb_id}, document_id={document_id}, doc_id={doc_id}, username: {current_user.username}")
 
     # 1. Obtain knowledge base information
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-    total, items = vector_service.get_by_segment(doc_id=doc_id)
+    vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
+    total, items = await asyncio.to_thread(vector_service.get_by_segment, doc_id=doc_id)
     if total:
         return success(data=jsonable_encoder(items[0]), msg="Document chunk query successful")
     else:
@@ -905,8 +928,8 @@ async def update_chunk(
         document_id: uuid.UUID,
         doc_id: str,
         update_data: chunk_schema.ChunkUpdate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Update document chunk content
@@ -915,22 +938,22 @@ async def update_chunk(
     content = update_data.chunk_content
     api_logger.info(f"Update document chunk content: kb_id={kb_id}, document_id={document_id}, doc_id={doc_id}, content={content}, username: {current_user.username}")
 
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-    total, items = vector_service.get_by_segment(doc_id=doc_id)
+    vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
+    total, items = await asyncio.to_thread(vector_service.get_by_segment, doc_id=doc_id)
     if total:
         chunk = items[0]
         chunk.page_content = content
         # QA chunk: 更新 metadata 中的 question/answer
         if update_data.is_qa:
             chunk.metadata.update(update_data.qa_metadata)
-        vector_service.update_by_segment(chunk)
+        await asyncio.to_thread(vector_service.update_by_segment, chunk)
         return success(data=jsonable_encoder(chunk), msg="The document chunk has been successfully updated")
     else:
         raise HTTPException(
@@ -945,28 +968,28 @@ async def delete_chunk(
         document_id: uuid.UUID,
         doc_id: str,
         force_refresh: bool = Query(False, description="Force Elasticsearch refresh after deletion"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     delete document chunk
     """
     api_logger.info(f"Request to delete document chunk: kb_id={kb_id}, document_id={document_id}, doc_id={doc_id}, username: {current_user.username}")
 
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The knowledge base does not exist or access is denied"
         )
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-    if vector_service.text_exists(doc_id):
-        vector_service.delete_by_ids([doc_id], refresh=force_refresh)
+    vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
+    if await asyncio.to_thread(vector_service.text_exists, doc_id):
+        await asyncio.to_thread(vector_service.delete_by_ids, [doc_id], refresh=force_refresh)
         # 更新 chunk_num
-        db_document = db.query(Document).filter(Document.id == document_id).first()
+        db_document = await db.get(Document, document_id)
         db_document.chunk_num -= 1
-        db.commit()
+        await db.commit()
         return success(msg="The document chunk has been successfully deleted")
     else:
         raise HTTPException(
@@ -982,7 +1005,7 @@ def get_retrieve_types():
 
 async def retrieve_chunks_with_caller(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: Session,
+        db: AsyncSession,
         current_user: User,
         caller: chunk_schema.KnowledgeRetrievalCaller,
 ):
@@ -1008,7 +1031,7 @@ async def retrieve_chunks_with_caller(
         retrieval_payload = retrieve_data.model_dump(exclude_none=True)
         retrieval_payload["caller"] = caller
         request = KnowledgeRetrievalRequest(**retrieval_payload)
-        result = KnowledgeRetrievalService.retrieve(
+        result = await KnowledgeRetrievalService.retrieve_async(
             db=db,
             request=request,
             current_user=current_user,
@@ -1025,8 +1048,8 @@ async def retrieve_chunks_with_caller(
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     return await retrieve_chunks_with_caller(
         retrieve_data=retrieve_data,

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -19,8 +19,8 @@ from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
-from app.db import get_async_db, get_db
-from app.dependencies import get_current_user_async, get_current_user
+from app.db import get_async_db
+from app.dependencies import get_current_user_async
 from app.models.document_model import Document
 from app.models.file_model import File as FileModel
 from app.models.user_model import User
@@ -1049,8 +1049,8 @@ async def retrieve_chunks_with_caller(
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     return await retrieve_chunks_with_caller(
         retrieve_data=retrieve_data,

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import os
 from typing import Optional
@@ -5,12 +6,12 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Body
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
-from app.controllers import file_controller
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
 from app.core.rag.utils.redis_conn import REDIS_CONN
@@ -21,14 +22,15 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
 from app.core.response_utils import success
-from app.db import get_db
-from app.dependencies import get_current_user
+from app.db import get_async_db
+from app.dependencies import get_current_user_async
 from app.models import document_model
+from app.models import file_model
 from app.models.user_model import User
 from app.schemas import document_schema
 from app.schemas.response_schema import ApiResponse
-from app.services import document_service, file_service, knowledge_service
-from app.services.rag_access_service import require_current_workspace_document
+from app.services import document_service, knowledge_service
+from app.services.rag_access_service import require_current_workspace_document_async
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.schemas import knowledge_metadata_schema as metadata_schema
 from app.services.knowledge_metadata_service import KnowledgeMetadataService
@@ -46,8 +48,40 @@ _PARSE_CANCEL_TTL = 60  # 1 minute
 router = APIRouter(
     prefix="/documents",
     tags=["documents"],
-    dependencies=[Depends(get_current_user)]  # Apply auth to all routes in this controller
+    dependencies=[Depends(get_current_user_async)]  # Apply auth to all routes in this controller
 )
+
+
+async def _delete_file_record_async(
+        db: AsyncSession,
+        file_id: uuid.UUID,
+        storage_service: FileStorageService,
+) -> None:
+    db_file = await db.get(file_model.File, file_id)
+    if not db_file:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+
+    if db_file.file_ext == "folder":
+        result = await db.execute(
+            select(file_model.File).where(file_model.File.parent_id == db_file.id)
+        )
+        child_files = list(result.scalars().all())
+        for child in child_files:
+            if child.file_key:
+                try:
+                    await storage_service.delete_file(child.file_key)
+                except Exception as e:
+                    api_logger.warning(f"Failed to delete child file from storage: {child.file_key} - {e}")
+            await db.delete(child)
+    else:
+        if db_file.file_key:
+            try:
+                await storage_service.delete_file(db_file.file_key)
+            except Exception as e:
+                api_logger.warning(f"Failed to delete file from storage: {db_file.file_key} - {e}")
+
+    await db.delete(db_file)
+    await db.commit()
 
 
 @router.get("/{kb_id}/documents", response_model=ApiResponse)
@@ -60,8 +94,8 @@ async def get_documents(
         desc: Optional[bool] = Query(False, description="Is it descending order"),
         keywords: Optional[str] = Query(None, description="Search keywords (file name)"),
         document_ids: Optional[str] = Query(None, description="document ids, separated by commas"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Paged query document list
@@ -85,7 +119,10 @@ async def get_documents(
     ]
 
     if parent_id:
-        files = file_service.get_files_by_parent_id(db=db, parent_id=parent_id, current_user=current_user)
+        file_result = await db.execute(
+            select(file_model.File).where(file_model.File.parent_id == parent_id)
+        )
+        files = list(file_result.scalars().all())
         files_ids = [item.id for item in files]
         filters.append(document_model.Document.file_id.in_(files_ids))
 
@@ -100,7 +137,7 @@ async def get_documents(
     # 3. Execute paged query
     try:
         api_logger.debug("Start executing document paging query")
-        total, items = document_service.get_documents_paginated(
+        total, items = await document_service.get_documents_paginated_async(
             db=db,
             filters=filters,
             page=page,
@@ -133,8 +170,8 @@ async def get_documents(
 @router.post("/document", response_model=ApiResponse)
 async def create_document(
         create_data: document_schema.DocumentCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     create document
@@ -143,7 +180,7 @@ async def create_document(
 
     try:
         api_logger.debug(f"Start creating a document: {create_data.file_name}")
-        db_document = document_service.create_document(db=db, document=create_data, current_user=current_user)
+        db_document = await document_service.create_document_async(db=db, document=create_data, current_user=current_user)
         api_logger.info(f"Document created successfully: {db_document.file_name} (ID: {db_document.id})")
         return success(data=jsonable_encoder(document_schema.Document.model_validate(db_document)), msg="Document creation successful")
     except Exception as e:
@@ -154,8 +191,8 @@ async def create_document(
 @router.get("/{document_id}", response_model=ApiResponse)
 async def get_document(
         document_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Retrieve document information based on document_id
@@ -165,7 +202,7 @@ async def get_document(
     try:
         # 1. Query document information from the database
         api_logger.debug(f"query documentation: {document_id}")
-        db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+        db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
         if not db_document:
             api_logger.warning(f"The document does not exist or you do not have access: document_id={document_id}")
             raise HTTPException(
@@ -186,15 +223,15 @@ async def get_document(
 async def update_document(
         document_id: uuid.UUID,
         update_data: document_schema.DocumentUpdate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Update document information
     """
     # 1. Check if the document exists
     api_logger.debug(f"Query the document to be updated: {document_id}")
-    db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
 
     if not db_document:
         api_logger.warning(f"The document does not exist or you do not have permission to access it: document_id={document_id}")
@@ -203,7 +240,7 @@ async def update_document(
             detail="The document does not exist or you do not have permission to access it"
         )
 
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=db_document.kb_id, current_user=current_user)
 
     # 2. 校验并处理 parser_config 更新
     update_dict = update_data.dict(exclude_unset=True)
@@ -235,7 +272,8 @@ async def update_document(
     if "status" in update_dict:
         new_status = update_dict["status"]
         if new_status != db_document.status:
-            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).change_document_status(
+            await asyncio.to_thread(
+                ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).change_document_status,
                 document_id=str(document_id),
                 status=new_status,
             )
@@ -258,11 +296,11 @@ async def update_document(
 
     # 4. Save to database
     try:
-        db.commit()
-        db.refresh(db_document)
+        await db.commit()
+        await db.refresh(db_document)
         api_logger.info(f"The document has been successfully updated: {db_document.file_name} (ID: {db_document.id})")
     except Exception as e:
-        db.rollback()
+        await db.rollback()
         api_logger.error(f"Document update failed: document_id={document_id} - {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -276,8 +314,8 @@ async def update_document(
 @router.delete("/{document_id}", response_model=ApiResponse)
 async def delete_document(
         document_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user),
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
     """
@@ -288,7 +326,7 @@ async def delete_document(
     try:
         # 1. Check if the document exists
         api_logger.debug(f"Check whether the document exists: {document_id}")
-        db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+        db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
 
         if not db_document:
             api_logger.warning(f"The document does not exist or you do not have permission to access it: document_id={document_id}")
@@ -316,23 +354,24 @@ async def delete_document(
         REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
 
         # 3. Delete vector index (non-404 failures raise, caught by except below)
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=kb_id, current_user=current_user)
-        ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field(
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
+        await asyncio.to_thread(
+            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
             key="document_id",
             value=str(document_id),
         )
 
         # 4. Delete file (storage errors are swallowed internally)
-        await file_controller._delete_file(db=db, file_id=file_id, current_user=current_user, storage_service=storage_service)
+        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
 
         # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
         api_logger.debug(f"Delete metadata bindings for document: {document_id}")
-        KnowledgeMetadataService.delete_document_metadata(db, document_id)
+        await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
 
         # 6. Delete document from DB (last — if DB fails, external resources are already cleaned)
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
-        db.delete(db_document)
-        db.commit()
+        await db.delete(db_document)
+        await db.commit()
 
         api_logger.info(f"The document has been successfully deleted: {db_document.file_name} (ID: {document_id})")
         return success(msg="The document has been successfully deleted")
@@ -344,8 +383,8 @@ async def delete_document(
 @router.post("/{document_id}/chunks", response_model=ApiResponse)
 async def parse_documents(
         document_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     parse document
@@ -355,7 +394,7 @@ async def parse_documents(
     try:
         # 1. Check if the document exists
         api_logger.debug(f"Check whether the document exists: {document_id}")
-        db_document = document_service.get_document_by_id(db, document_id=document_id, current_user=current_user)
+        db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
 
         if not db_document:
             api_logger.warning(f"The document does not exist or you do not have permission to access it: document_id={document_id}")
@@ -366,7 +405,7 @@ async def parse_documents(
 
         # 2. Check if the file exists
         api_logger.debug(f"Check whether the file exists: {db_document.file_id}")
-        db_file = file_service.get_file_by_id(db, file_id=db_document.file_id)
+        db_file = await db.get(file_model.File, db_document.file_id)
 
         if not db_file:
             api_logger.warning(f"The file does not exist or you do not have permission to access it: file_id={db_document.file_id}")
@@ -394,7 +433,7 @@ async def parse_documents(
 
         # 5. Obtain knowledge base information
         api_logger.info(f"Obtain details of the knowledge base: knowledge_id={db_document.kb_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=db_document.kb_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=db_document.kb_id, current_user=current_user)
         if not db_knowledge:
             # Rollback Redis claim on failure
             REDIS_CONN.delete(task_key)
@@ -426,8 +465,8 @@ async def parse_documents(
 @router.post("/metadata/batch", response_model=ApiResponse)
 async def batch_update_document_metadata(
     data: metadata_schema.BatchUpdateMetadataRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """
     批量更新文档元数据
@@ -440,7 +479,7 @@ async def batch_update_document_metadata(
 
     # 1. 校验所有文档的权限和归属（必须属于当前 workspace）
     for item in data.items:
-        db_document = require_current_workspace_document(
+        db_document = await require_current_workspace_document_async(
             db=db,
             document_id=item.document_id,
             current_user=current_user,
@@ -459,7 +498,7 @@ async def batch_update_document_metadata(
         for item in data.items
     ]
 
-    result = KnowledgeMetadataService.batch_update_document_metadata(
+    result = await KnowledgeMetadataService.batch_update_document_metadata_async(
         db=db,
         items=items,
         tenant_id=current_user.tenant_id,
@@ -473,8 +512,8 @@ async def batch_update_document_metadata(
 async def update_document_metadata(
     document_id: uuid.UUID,
     data: metadata_schema.DocumentMetadataUpdateRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """
     更新单个文档的元数据
@@ -486,7 +525,7 @@ async def update_document_metadata(
     )
 
     # 1. 校验文档存在且有权访问
-    db_document = require_current_workspace_document(
+    db_document = await require_current_workspace_document_async(
         db=db,
         document_id=document_id,
         current_user=current_user
@@ -498,7 +537,7 @@ async def update_document_metadata(
         )
 
     # 2. 调用 Service 更新
-    result = KnowledgeMetadataService.update_document_metadata(
+    result = await KnowledgeMetadataService.update_document_metadata_async(
         db=db,
         document_id=document_id,
         metadata=data.metadata,
@@ -515,8 +554,8 @@ async def update_document_metadata(
 @router.get("/{document_id}/metadata", response_model=ApiResponse)
 async def get_document_metadata(
     document_id: uuid.UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """获取单个文档的元数据"""
     api_logger.info(
@@ -524,7 +563,7 @@ async def get_document_metadata(
     )
 
     # 校验文档存在且有权访问
-    db_document = require_current_workspace_document(
+    db_document = await require_current_workspace_document_async(
         db=db,
         document_id=document_id,
         current_user=current_user
@@ -535,7 +574,7 @@ async def get_document_metadata(
             detail="The document does not exist or you do not have permission to access it"
         )
 
-    result = KnowledgeMetadataService.get_document_metadata(
+    result = await KnowledgeMetadataService.get_document_metadata_async(
         db=db,
         document_id=document_id,
     )
@@ -550,8 +589,8 @@ async def get_document_metadata(
 async def delete_document_metadata(
     document_id: uuid.UUID,
     data: metadata_schema.DocumentMetadataDeleteRequest | None = Body(None),
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """
     删除单个文档的元数据
@@ -563,7 +602,7 @@ async def delete_document_metadata(
     )
 
     # 校验文档存在且有权访问
-    db_document = require_current_workspace_document(
+    db_document = await require_current_workspace_document_async(
         db=db,
         document_id=document_id,
         current_user=current_user
@@ -576,7 +615,7 @@ async def delete_document_metadata(
 
     field_names = data.field_names if data else None
 
-    result = KnowledgeMetadataService.delete_document_metadata(
+    result = await KnowledgeMetadataService.delete_document_metadata_async(
         db=db,
         document_id=document_id,
         field_names=field_names,

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -1,4 +1,5 @@
 import csv as csv_module
+import asyncio
 import datetime
 import io
 import json
@@ -8,8 +9,8 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
-from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
@@ -28,8 +29,8 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorIndexOps,
 )
 from app.core.response_utils import success, fail
-from app.db import get_db, get_db_context
-from app.dependencies import get_current_user
+from app.db import get_async_db, get_async_db_context
+from app.dependencies import get_current_user_async
 from app.models import knowledge_model
 from app.models import file_model
 from app.models.document_model import Document
@@ -40,9 +41,8 @@ from app.schemas.response_schema import ApiResponse
 from app.repositories import knowledge_repository, knowledgeshare_repository
 from app.services import knowledge_service, document_service
 from app.services import file_service
-from app.services.file_service import _is_qa_doc
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
-from app.services.model_service import ModelConfigService
+from app.repositories.model_repository import ModelConfigRepository
 from app.services.qa_export_service import iter_qa_csv_chunks, make_qa_export_filename
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -63,7 +63,7 @@ _SHARE_MIRRORED_MODEL_FIELDS = (
 router = APIRouter(
     prefix="/knowledges",
     tags=["knowledges"],
-    dependencies=[Depends(get_current_user)]  # Apply auth to all routes in this controller
+    dependencies=[Depends(get_current_user_async)]  # Apply auth to all routes in this controller
 )
 
 
@@ -104,19 +104,22 @@ def _build_qa_export_content(vector_service: Any, document_id: uuid.UUID | str, 
     return text_output.getvalue().encode("utf-8-sig")
 
 
-def _dispatch_reparse_tasks_for_knowledge(db: Session, knowledge_id: uuid.UUID) -> dict[str, int]:
-    """Dispatch parse tasks for all active documents in a knowledge base."""
+async def _dispatch_reparse_tasks_for_knowledge_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+) -> dict[str, int]:
+    """Dispatch parse tasks for all active documents in a knowledge base using async DB reads."""
     result = {"queued": 0, "skipped": 0, "already_running": 0, "failed": 0}
 
-    rows = (
-        db.query(Document, file_model.File)
+    rows_result = await db.execute(
+        select(Document, file_model.File)
         .join(file_model.File, Document.file_id == file_model.File.id)
-        .filter(
+        .where(
             Document.kb_id == knowledge_id,
             Document.status == 1,
         )
-        .all()
     )
+    rows = rows_result.all()
 
     for db_document, db_file in rows:
         file_key = getattr(db_file, "file_key", None)
@@ -188,15 +191,15 @@ def _dispatch_reparse_tasks_for_knowledge(db: Session, knowledge_id: uuid.UUID) 
     return result
 
 
-def _build_knowledge_detail_data(
-        db: Session,
-        db_knowledge: knowledge_model.Knowledge
+async def _build_knowledge_detail_data_async(
+        db: AsyncSession,
+        db_knowledge: knowledge_model.Knowledge,
 ) -> dict:
     data = jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge))
     if db_knowledge.permission_id != knowledge_model.PermissionType.Share:
         return data
 
-    knowledgeshare = knowledgeshare_repository.get_knowledgeshare_by_id(db, db_knowledge.id)
+    knowledgeshare = await knowledgeshare_repository.get_knowledgeshare_by_id_async(db, db_knowledge.id)
     if not knowledgeshare:
         api_logger.warning(
             "Share relation not found when mirroring knowledge model fields: knowledge_id=%s",
@@ -204,7 +207,7 @@ def _build_knowledge_detail_data(
         )
         return data
 
-    source_knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledgeshare.source_kb_id)
+    source_knowledge = await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledgeshare.source_kb_id)
     if not source_knowledge or source_knowledge.status == 2:
         api_logger.warning(
             "Source knowledge not available when mirroring share model fields: "
@@ -240,8 +243,8 @@ def get_parser_types():
 async def get_knowledge_graph_entity_types(
         llm_id: uuid.UUID,
         scenario: str,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     get knowledge graph entity types based on llm_id
@@ -251,7 +254,7 @@ async def get_knowledge_graph_entity_types(
     try:
         # 1. Check whether the model exists
         api_logger.debug(f"Check whether the model exists: {llm_id}")
-        config = ModelConfigService.get_model_by_id(db=db, model_id=llm_id)
+        config = await ModelConfigRepository.get_by_id_async(db=db, model_id=llm_id)
 
         if not config:
             api_logger.warning(
@@ -284,8 +287,8 @@ async def get_knowledges(
         desc: Optional[bool] = Query(False, description="Is it descending order"),
         keywords: Optional[str] = Query(None, description="Search keywords (knowledge base name)"),
         kb_ids: Optional[str] = Query(None, description="Knowledge base ids, separated by commas"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Query the knowledge base list in pages
@@ -331,7 +334,7 @@ async def get_knowledges(
     # 3. Execute paged query
     try:
         api_logger.debug("Start executing knowledge base paging query")
-        total, items = knowledge_service.get_knowledges_paginated(
+        total, items = await knowledge_service.get_knowledges_paginated_async(
             db=db,
             filters=filters,
             page=page,
@@ -365,8 +368,8 @@ async def get_knowledges(
 @check_knowledge_capacity_quota
 async def create_knowledge(
         create_data: knowledge_schema.KnowledgeCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     create knowledge
@@ -376,14 +379,14 @@ async def create_knowledge(
     try:
         api_logger.debug(f"Start creating the knowledge base: {create_data.name}")
         # 1. Check if the knowledge base name already exists
-        db_knowledge_exist = knowledge_service.get_knowledge_by_name(db, name=create_data.name, current_user=current_user)
+        db_knowledge_exist = await knowledge_service.get_knowledge_by_name_async(db, name=create_data.name, current_user=current_user)
         if db_knowledge_exist:
             api_logger.warning(f"The knowledge base name already exists: {create_data.name}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"The knowledge base name already exists: {create_data.name}"
             )
-        db_knowledge = knowledge_service.create_knowledge(db=db, knowledge=create_data, current_user=current_user)
+        db_knowledge = await knowledge_service.create_knowledge_async(db=db, knowledge=create_data, current_user=current_user)
         api_logger.info(f"The knowledge base has been successfully created: {db_knowledge.name} (ID: {db_knowledge.id})")
         return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="The knowledge base has been successfully created")
     except Exception as e:
@@ -394,8 +397,8 @@ async def create_knowledge(
 @router.get("/{knowledge_id}", response_model=ApiResponse)
 async def get_knowledge(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Retrieve knowledge base information based on knowledge_id
@@ -405,7 +408,7 @@ async def get_knowledge(
     try:
         # 1. Query knowledge base information from the database
         api_logger.debug(f"Query knowledge base: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or access is denied: knowledge_id={knowledge_id}")
             raise HTTPException(
@@ -414,7 +417,7 @@ async def get_knowledge(
             )
 
         api_logger.info(f"Knowledge base query successful: {db_knowledge.name} (ID: {db_knowledge.id})")
-        return success(data=_build_knowledge_detail_data(db, db_knowledge), msg="Successfully obtained knowledge base information")
+        return success(data=await _build_knowledge_detail_data_async(db, db_knowledge), msg="Successfully obtained knowledge base information")
     except HTTPException:
         raise
     except Exception as e:
@@ -425,8 +428,8 @@ async def get_knowledge(
 @router.get("/{knowledge_id}/chunk-policy", response_model=ApiResponse)
 async def get_knowledge_chunk_policy(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     查询知识库的分块策略锁定状态
@@ -437,7 +440,7 @@ async def get_knowledge_chunk_policy(
     api_logger.info(f"Query knowledge base chunk policy: knowledge_id={knowledge_id}, username: {current_user.username}")
 
     # 1. 验证知识库存在
-    db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -461,8 +464,8 @@ async def get_knowledge_chunk_policy(
 async def update_knowledge(
         knowledge_id: uuid.UUID,
         update_data: knowledge_schema.KnowledgeUpdate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     api_logger.info(f"Update knowledge base request: knowledge_id={knowledge_id}, username: {current_user.username}")
     db_knowledge = await _update_knowledge(knowledge_id=knowledge_id, update_data=update_data, db=db, current_user=current_user)
@@ -472,13 +475,13 @@ async def update_knowledge(
 @router.get("/{kb_id}/qa/export")
 async def export_knowledge_qa_csv(
         kb_id: uuid.UUID,
-        current_user: User = Depends(get_current_user),
+        current_user: User = Depends(get_current_user_async),
 ):
     """Export all active QA pairs in a knowledge base as a two-column CSV."""
     api_logger.info(f"KB QA CSV export: kb_id={kb_id}, username={current_user.username}")
 
-    with get_db_context() as db:
-        db_knowledge = knowledge_service.get_knowledge_by_id(
+    async with get_async_db_context() as db:
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(
             db, knowledge_id=kb_id, current_user=current_user
         )
         if not db_knowledge:
@@ -502,25 +505,28 @@ async def export_knowledge_qa_csv(
 @router.post("/{kb_id}/batch-download")
 async def kb_batch_download(
         kb_id: uuid.UUID,
-        current_user: User = Depends(get_current_user),
+        current_user: User = Depends(get_current_user_async),
         storage_service: FileStorageService = Depends(get_file_storage_service),
         request_body: file_schema.KBBatchDownloadRequest = file_schema.KBBatchDownloadRequest(),
 ):
     """知识库文件一键下载 — 将该知识库下所有文件打包为 ZIP 流式下载"""
     api_logger.info(f"KB batch download: kb_id={kb_id}, username={current_user.username}")
 
-    with get_db_context() as db:
-        db_knowledge = knowledge_service.get_knowledge_by_id(
+    async with get_async_db_context() as db:
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(
             db, knowledge_id=kb_id, current_user=current_user
         )
         if not db_knowledge:
             raise BusinessException("知识库不存在或无权访问", BizCode.NOT_FOUND)
 
-        files = db.query(file_model.File).filter(
-            file_model.File.kb_id == kb_id,
-            file_model.File.file_key.isnot(None),
-            file_model.File.file_key != "",
-        ).all()
+        files_result = await db.execute(
+            select(file_model.File).where(
+                file_model.File.kb_id == kb_id,
+                file_model.File.file_key.isnot(None),
+                file_model.File.file_key != "",
+            )
+        )
+        files = list(files_result.scalars().all())
 
         if not files:
             raise BusinessException("该知识库下没有可下载的文件", BizCode.NOT_FOUND)
@@ -528,11 +534,12 @@ async def kb_batch_download(
         qa_export_specs = []
         qa_vector_service = None
         for f in files:
-            if _is_qa_doc(db, f.id):
-                doc = db.query(Document).filter(Document.file_id == f.id).first()
+            doc_result = await db.execute(select(Document).where(Document.file_id == f.id))
+            doc = doc_result.scalars().first()
+            if doc and (doc.parser_config or {}).get("doc_type") == "qa":
                 if doc:
                     if qa_vector_service is None:
-                        qa_vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
+                        qa_vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
                     qa_export_specs.append((f.file_key, f.file_ext, doc.id, qa_vector_service))
 
         entries = file_service.build_zip_arcnames(files)
@@ -542,7 +549,7 @@ async def kb_batch_download(
     # Prefetch QA document content before streaming so the generator does not hold a DB session.
     pre_fetched: dict[str, bytes] = {}
     for file_key, file_ext, document_id, vector_service in qa_export_specs:
-        content = _build_qa_export_content(vector_service, document_id, file_ext)
+        content = await asyncio.to_thread(_build_qa_export_content, vector_service, document_id, file_ext)
         if content:
             pre_fetched[file_key] = content
 
@@ -560,8 +567,8 @@ async def kb_batch_download(
 async def _update_knowledge(
         knowledge_id: uuid.UUID,
         update_data: knowledge_schema.KnowledgeUpdate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ) -> knowledge_schema.Knowledge:
     """
     Update knowledge base information
@@ -569,7 +576,7 @@ async def _update_knowledge(
     try:
         # 1. Check whether the knowledge base exists
         api_logger.debug(f"Query the knowledge base to be updated: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
 
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or you do not have permission to access it: knowledge_id={knowledge_id}")
@@ -585,7 +592,7 @@ async def _update_knowledge(
             name = update_dict["name"]
             if name != db_knowledge.name:
                 # Check if the knowledge base name already exists
-                db_knowledge_exist = knowledge_service.get_knowledge_by_name(db, name=name, current_user=current_user)
+                db_knowledge_exist = await knowledge_service.get_knowledge_by_name_async(db, name=name, current_user=current_user)
                 if db_knowledge_exist:
                     api_logger.warning(f"The knowledge base name already exists: {name}")
                     raise HTTPException(
@@ -597,8 +604,8 @@ async def _update_knowledge(
             if embedding_id != db_knowledge.embedding_id:
                 embedding_changed = True
                 if db_knowledge.embedding_id and db_knowledge.reranker_id:
-                    ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_index()
-                document_service.reset_documents_progress_by_kb_id(db, kb_id=db_knowledge.id, current_user=current_user)
+                    await asyncio.to_thread(ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_index)
+                await document_service.reset_documents_progress_by_kb_id_async(db, kb_id=db_knowledge.id, current_user=current_user)
 
         # 2. Update fields (only update non-null fields)
         api_logger.debug(f"Start updating the knowledge base fields: {knowledge_id}")
@@ -622,13 +629,13 @@ async def _update_knowledge(
         db_knowledge.updated_at = utcnow_naive()
 
         # 3. Save to database
-        db.commit()
-        db.refresh(db_knowledge)
+        await db.commit()
+        await db.refresh(db_knowledge)
         api_logger.info(f"The knowledge base has been successfully updated: {db_knowledge.name} (ID: {db_knowledge.id})")
 
         if embedding_changed:
             try:
-                dispatch_result = _dispatch_reparse_tasks_for_knowledge(db=db, knowledge_id=db_knowledge.id)
+                dispatch_result = await _dispatch_reparse_tasks_for_knowledge_async(db=db, knowledge_id=db_knowledge.id)
                 api_logger.info(
                     "Knowledge base embedding changed, document reparse tasks dispatched",
                     extra={
@@ -650,7 +657,7 @@ async def _update_knowledge(
     except HTTPException:
         raise
     except Exception as e:
-        db.rollback()
+        await db.rollback()
         api_logger.error(f"Knowledge base update failed: knowledge_id={knowledge_id} - {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -661,8 +668,8 @@ async def _update_knowledge(
 @router.delete("/{knowledge_id}", response_model=ApiResponse)
 async def delete_knowledge(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Soft-delete knowledge base
@@ -672,7 +679,7 @@ async def delete_knowledge(
     try:
         # 1. Check whether the knowledge base exists
         api_logger.debug(f"Check whether the knowledge base exists: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
 
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or you do not have permission to access it: knowledge_id={knowledge_id}")
@@ -685,7 +692,7 @@ async def delete_knowledge(
         api_logger.debug(f"Perform a soft delete: {db_knowledge.name} (ID: {knowledge_id})")
         db_knowledge.status = 2
         db_knowledge.updated_at = utcnow_naive()
-        db.commit()
+        await db.commit()
         api_logger.info(f"The knowledge base has been successfully deleted: {db_knowledge.name} (ID: {knowledge_id})")
         return success(msg="The knowledge base has been successfully deleted")
     except Exception as e:
@@ -696,8 +703,8 @@ async def delete_knowledge(
 @router.get("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
 async def get_knowledge_graph(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Retrieve knowledge_graph base information based on knowledge_id
@@ -707,7 +714,7 @@ async def get_knowledge_graph(
     try:
         # 1. Query knowledge base information from the database
         api_logger.debug(f"Query knowledge base: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or access is denied: knowledge_id={knowledge_id}")
             raise HTTPException(
@@ -721,9 +728,19 @@ async def get_knowledge_graph(
         }
 
         obj = {"graph": {}, "mind_map": {}}
-        if not settings.docStoreConn.indexExist(search.index_name(str(db_knowledge.workspace_id)), str(db_knowledge.id)):
+        index_exists = await asyncio.to_thread(
+            settings.docStoreConn.indexExist,
+            search.index_name(str(db_knowledge.workspace_id)),
+            str(db_knowledge.id),
+        )
+        if not index_exists:
             return success(data=obj, msg="Successfully obtained knowledge graph information")
-        sres = settings.retriever.search(req, search.index_name(str(db_knowledge.workspace_id)), [str(db_knowledge.id)])
+        sres = await asyncio.to_thread(
+            settings.retriever.search,
+            req,
+            search.index_name(str(db_knowledge.workspace_id)),
+            [str(db_knowledge.id)],
+        )
         if not len(sres.ids):
             return success(data=obj, msg="Successfully obtained knowledge graph information")
 
@@ -753,8 +770,8 @@ async def get_knowledge_graph(
 @router.delete("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
 async def delete_knowledge_graph(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     delete knowledge graph
@@ -764,7 +781,7 @@ async def delete_knowledge_graph(
     try:
         # 1. Check whether the knowledge base exists
         api_logger.debug(f"Check whether the knowledge base exists: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
 
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or you do not have permission to access it: knowledge_id={knowledge_id}")
@@ -774,7 +791,12 @@ async def delete_knowledge_graph(
             )
 
         # 2. delete knowledge graph
-        settings.docStoreConn.delete({"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]}, search.index_name(str(db_knowledge.workspace_id)), str(db_knowledge.id))
+        await asyncio.to_thread(
+            settings.docStoreConn.delete,
+            {"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]},
+            search.index_name(str(db_knowledge.workspace_id)),
+            str(db_knowledge.id),
+        )
         api_logger.info(f"The knowledge graph has been successfully deleted: {db_knowledge.name} (ID: {knowledge_id})")
         return success(msg="The knowledge graph has been successfully deleted")
     except Exception as e:
@@ -785,8 +807,8 @@ async def delete_knowledge_graph(
 @router.post("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
 async def rebuild_knowledge_graph(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     rebuild knowledge graph
@@ -796,7 +818,7 @@ async def rebuild_knowledge_graph(
     try:
         # 1. Check whether the knowledge base exists
         api_logger.debug(f"Check whether the knowledge base exists: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
 
         if not db_knowledge:
             api_logger.warning(
@@ -807,7 +829,12 @@ async def rebuild_knowledge_graph(
             )
 
         # 2. delete knowledge graph
-        settings.docStoreConn.delete({"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]}, search.index_name(str(db_knowledge.workspace_id)), str(db_knowledge.id))
+        await asyncio.to_thread(
+            settings.docStoreConn.delete,
+            {"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]},
+            search.index_name(str(db_knowledge.workspace_id)),
+            str(db_knowledge.id),
+        )
 
         # 3. build knowledge graph
         # from app.tasks import build_graphrag_for_kb
@@ -826,8 +853,8 @@ async def rebuild_knowledge_graph(
 async def check_yuque_auth(
         yuque_user_id: str,
         yuque_token: str,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     check yuque auth info
@@ -856,8 +883,8 @@ async def check_feishu_auth(
         feishu_app_id: str,
         feishu_app_secret: str,
         feishu_folder_token: str,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     check feishu auth info
@@ -884,8 +911,8 @@ async def check_feishu_auth(
 @router.post("/{knowledge_id}/sync", response_model=ApiResponse)
 async def sync_knowledge(
         knowledge_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     sync knowledge base information based on knowledge_id
@@ -895,7 +922,7 @@ async def sync_knowledge(
     try:
         # 1. Query knowledge base information from the database
         api_logger.debug(f"Query knowledge base: {knowledge_id}")
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=knowledge_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=knowledge_id, current_user=current_user)
         if not db_knowledge:
             api_logger.warning(f"The knowledge base does not exist or access is denied: knowledge_id={knowledge_id}")
             raise HTTPException(

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -42,7 +42,7 @@ from app.repositories import knowledge_repository, knowledgeshare_repository
 from app.services import knowledge_service, document_service
 from app.services import file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
-from app.repositories.model_repository import ModelConfigRepository
+from app.services.model_service import ModelConfigService
 from app.services.qa_export_service import iter_qa_csv_chunks, make_qa_export_filename
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -254,15 +254,7 @@ async def get_knowledge_graph_entity_types(
     try:
         # 1. Check whether the model exists
         api_logger.debug(f"Check whether the model exists: {llm_id}")
-        config = await ModelConfigRepository.get_by_id_async(db=db, model_id=llm_id)
-
-        if not config:
-            api_logger.warning(
-                f"The model does not exist or you do not have permission to access it: llm_id={llm_id}")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="The model does not exist or you do not have permission to access it"
-            )
+        config = await ModelConfigService.get_model_by_id_async(db=db, model_id=llm_id)
         # 2. Prepare to configure chat_mdl information
         chat_model = Base(
             key=config.api_keys[0].api_key,

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -652,8 +652,8 @@ async def _update_knowledge(
                     },
                 )
 
-        # 4. Return the updated knowledge base
-        return db_knowledge
+        # 4. Return the updated knowledge base with async-safe relationships loaded
+        return await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=db_knowledge.id) or db_knowledge
     except HTTPException:
         raise
     except Exception as e:

--- a/api/app/controllers/knowledge_metadata_controller.py
+++ b/api/app/controllers/knowledge_metadata_controller.py
@@ -1,12 +1,12 @@
 import uuid
 from fastapi import APIRouter, Depends, Body
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.response_utils import success
 from app.core.logging_config import get_api_logger
 from app.core.exceptions import ResourceNotFoundException
-from app.db import get_db
-from app.dependencies import get_current_user
-from app.services.rag_access_service import require_current_workspace_knowledge
+from app.db import get_async_db
+from app.dependencies import get_current_user_async
+from app.services.rag_access_service import require_current_workspace_knowledge_async
 from app.models.user_model import User
 from app.schemas import knowledge_metadata_schema as schemas
 from app.schemas.response_schema import ApiResponse
@@ -17,7 +17,7 @@ api_logger = get_api_logger()
 router = APIRouter(
     prefix="/knowledges",
     tags=["knowledge-metadata"],
-    dependencies=[Depends(get_current_user)]
+    dependencies=[Depends(get_current_user_async)]
 )
 
 
@@ -76,15 +76,15 @@ def _format_common_metadata_fields_result(result: dict) -> dict:
 @router.post("/metadata/fields", response_model=ApiResponse)
 async def list_common_metadata_fields(
     data: schemas.KnowledgeMetadataFieldsRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """List common metadata fields across knowledge bases."""
     kb_ids = list(dict.fromkeys(data.kb_ids))
     api_logger.info(f"List common metadata fields: kb_ids={kb_ids}, user={current_user.username}")
 
     for kb_id in kb_ids:
-        db_knowledge = require_current_workspace_knowledge(
+        db_knowledge = await require_current_workspace_knowledge_async(
             db=db,
             knowledge_id=kb_id,
             current_user=current_user,
@@ -92,7 +92,7 @@ async def list_common_metadata_fields(
         if not db_knowledge:
             raise ResourceNotFoundException("知识库", str(kb_id))
 
-    result = KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids(
+    result = await KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids_async(
         db,
         kb_ids,
         include_counts=False,
@@ -104,14 +104,14 @@ async def list_common_metadata_fields(
 @router.get("/{kb_id}/metadata", response_model=ApiResponse)
 async def list_metadata_fields(
     kb_id: uuid.UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """获取元数据字段列表（自定义 + 内置）"""
     api_logger.info(f"List metadata fields: kb_id={kb_id}, user={current_user.username}")
 
     # 校验知识库权限
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -119,7 +119,7 @@ async def list_metadata_fields(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    result = KnowledgeMetadataService.list_metadata_fields(db, kb_id)
+    result = await KnowledgeMetadataService.list_metadata_fields_async(db, kb_id)
 
     return success(data=_format_metadata_fields_result(result))
 
@@ -128,13 +128,13 @@ async def list_metadata_fields(
 async def create_metadata_field(
     kb_id: uuid.UUID,
     data: schemas.KnowledgeMetadataCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """创建自定义元数据字段"""
     api_logger.info(f"Create metadata field: kb_id={kb_id}, name={data.name}, type={data.type}")
 
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -142,7 +142,7 @@ async def create_metadata_field(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    field = KnowledgeMetadataService.create_metadata_field(
+    field = await KnowledgeMetadataService.create_metadata_field_async(
         db=db,
         knowledge_id=kb_id,
         name=data.name,
@@ -162,13 +162,13 @@ async def update_metadata_field(
     kb_id: uuid.UUID,
     metadata_id: uuid.UUID,
     data: schemas.KnowledgeMetadataUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """更新自定义元数据字段"""
     api_logger.info(f"Update metadata field: kb_id={kb_id}, metadata_id={metadata_id}")
 
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -176,7 +176,7 @@ async def update_metadata_field(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    field = KnowledgeMetadataService.update_metadata_field(
+    field = await KnowledgeMetadataService.update_metadata_field_async(
         db=db,
         metadata_id=metadata_id,
         knowledge_id=kb_id,
@@ -194,13 +194,13 @@ async def update_metadata_field(
 async def delete_metadata_field(
     kb_id: uuid.UUID,
     metadata_id: uuid.UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """删除自定义元数据字段"""
     api_logger.info(f"Delete metadata field: kb_id={kb_id}, metadata_id={metadata_id}")
 
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -208,7 +208,7 @@ async def delete_metadata_field(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    KnowledgeMetadataService.delete_metadata_field(db, metadata_id, kb_id)
+    await KnowledgeMetadataService.delete_metadata_field_async(db, metadata_id, kb_id)
 
     return success(msg="字段删除成功")
 
@@ -216,13 +216,13 @@ async def delete_metadata_field(
 @router.get("/{kb_id}/metadata/builtin", response_model=ApiResponse)
 async def get_builtin_metadata_fields(
     kb_id: uuid.UUID,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """获取内置元数据字段列表"""
     api_logger.info(f"Get builtin metadata fields: kb_id={kb_id}")
 
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -230,7 +230,7 @@ async def get_builtin_metadata_fields(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    result = KnowledgeMetadataService.get_builtin_fields(db, kb_id)
+    result = await KnowledgeMetadataService.get_builtin_fields_async(db, kb_id)
 
     return success(data=schemas.BuiltinMetadataListResponse(
         enabled=result["enabled"],
@@ -242,13 +242,13 @@ async def get_builtin_metadata_fields(
 async def toggle_builtin_metadata(
     kb_id: uuid.UUID,
     data: schemas.BuiltinMetadataEnableRequest,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user_async),
 ):
     """更新内置元数据开关"""
     api_logger.info(f"Toggle builtin metadata: kb_id={kb_id}, enabled={data.enabled}")
 
-    db_knowledge = require_current_workspace_knowledge(
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=kb_id,
         current_user=current_user,
@@ -256,6 +256,6 @@ async def toggle_builtin_metadata(
     if not db_knowledge:
         raise ResourceNotFoundException("知识库", str(kb_id))
 
-    enabled = KnowledgeMetadataService.set_builtin_metadata_enabled(db, kb_id, data.enabled)
+    enabled = await KnowledgeMetadataService.set_builtin_metadata_enabled_async(db, kb_id, data.enabled)
 
     return success(data={"enabled": enabled}, msg="内置元数据开关更新成功")

--- a/api/app/controllers/knowledgeshare_controller.py
+++ b/api/app/controllers/knowledgeshare_controller.py
@@ -1,10 +1,10 @@
 from typing import Optional
 import uuid
 from fastapi import APIRouter, Depends, HTTPException, status, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import get_db
-from app.dependencies import get_current_user
+from app.db import get_async_db
+from app.dependencies import get_current_user_async
 from app.models.user_model import User
 from app.models import knowledgeshare_model, knowledge_model
 from app.schemas import knowledgeshare_schema, knowledge_schema
@@ -19,7 +19,7 @@ api_logger = get_api_logger()
 router = APIRouter(
     prefix="/knowledgeshares",
     tags=["knowledgeshares"],
-    dependencies=[Depends(get_current_user)]  # Apply auth to all routes in this controller
+    dependencies=[Depends(get_current_user_async)]  # Apply auth to all routes in this controller
 )
 
 
@@ -30,8 +30,8 @@ async def get_knowledgeshares(
         pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
         orderby: Optional[str] = Query(None, description="Sort fields, such as: created_at,updated_at"),
         desc: Optional[bool] = Query(False, description="Is it descending order"),
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Paged query knowledge base sharing list
@@ -59,7 +59,7 @@ async def get_knowledgeshares(
     # 3. Execute paged query
     try:
         api_logger.debug("Start executing knowledge base sharing and paging query")
-        total, items = knowledgeshare_service.get_knowledgeshares_paginated(
+        total, items = await knowledgeshare_service.get_knowledgeshares_paginated_async(
             db=db,
             filters=filters,
             page=page,
@@ -92,8 +92,8 @@ async def get_knowledgeshares(
 @router.post("/knowledgeshare", response_model=ApiResponse)
 async def create_knowledgeshare(
         create_data: knowledgeshare_schema.KnowledgeShareCreate,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     create knowledgeshare
@@ -103,7 +103,7 @@ async def create_knowledgeshare(
 
     try:
         # 1.Create a knowledge base with permission_id=knowledge_model.PermissionType.Share
-        db_knowledge = knowledge_service.get_knowledge_by_id(db, knowledge_id=create_data.source_kb_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=create_data.source_kb_id, current_user=current_user)
         knowledge = knowledge_schema.KnowledgeCreate(
             workspace_id=create_data.target_workspace_id,
             created_by=current_user.id,
@@ -122,11 +122,11 @@ async def create_knowledgeshare(
             parser_id=db_knowledge.parser_id,
             parser_config=db_knowledge.parser_config
         )
-        db_knowledge = knowledge_service.create_knowledge(db=db, knowledge=knowledge, current_user=current_user)
+        db_knowledge = await knowledge_service.create_knowledge_async(db=db, knowledge=knowledge, current_user=current_user)
         # 2. Create a knowledge base for sharing
         api_logger.debug(f"Start creating the knowledge base sharing: {db_knowledge.name}")
         create_data.target_kb_id = db_knowledge.id
-        db_knowledgeshare = knowledgeshare_service.create_knowledgeshare(db=db, knowledgeshare=create_data, current_user=current_user)
+        db_knowledgeshare = await knowledgeshare_service.create_knowledgeshare_async(db=db, knowledgeshare=create_data, current_user=current_user)
         api_logger.info(f"The knowledge base sharing has been successfully created: (ID: {db_knowledgeshare.id})")
         return success(data=knowledgeshare_schema.KnowledgeShare.model_validate(db_knowledgeshare), msg="The knowledge base sharing has been successfully created")
     except Exception as e:
@@ -137,8 +137,8 @@ async def create_knowledgeshare(
 @router.get("/{knowledgeshare_id}", response_model=ApiResponse)
 async def get_knowledgeshare(
         knowledgeshare_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Retrieve knowledge base sharing information based on knowledgeshare_id
@@ -148,7 +148,7 @@ async def get_knowledgeshare(
     try:
         # 1. Query knowledge base sharing information from the database
         api_logger.debug(f"Query knowledge base sharing: {knowledgeshare_id}")
-        db_knowledgeshare = knowledgeshare_service.get_knowledgeshare_by_id(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
+        db_knowledgeshare = await knowledgeshare_service.get_knowledgeshare_by_id_async(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
         if not db_knowledgeshare:
             api_logger.warning(f"The knowledge base sharing does not exist or access is denied: knowledgeshare_id={knowledgeshare_id}")
             raise HTTPException(
@@ -168,8 +168,8 @@ async def get_knowledgeshare(
 @router.delete("/{knowledgeshare_id}", response_model=ApiResponse)
 async def delete_knowledgeshare(
         knowledgeshare_id: uuid.UUID,
-        db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user)
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user_async)
 ):
     """
     Delete knowledge base sharing
@@ -179,7 +179,7 @@ async def delete_knowledgeshare(
     try:
         # 1. Query knowledge base sharing information from the database
         api_logger.debug(f"Query knowledge base sharing: {knowledgeshare_id}")
-        db_knowledgeshare = knowledgeshare_service.get_knowledgeshare_by_id(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
+        db_knowledgeshare = await knowledgeshare_service.get_knowledgeshare_by_id_async(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
         if not db_knowledgeshare:
             api_logger.warning(f"The knowledge base sharing does not exist or access is denied: knowledgeshare_id={knowledgeshare_id}")
             raise HTTPException(
@@ -187,11 +187,11 @@ async def delete_knowledgeshare(
                 detail="The knowledge base sharing does not exist or access is denied"
             )
         # 2. Deleting shared knowledge base
-        knowledge_service.delete_knowledge_by_id(db, knowledge_id=db_knowledgeshare.target_kb_id ,current_user=current_user)
+        await knowledge_service.delete_knowledge_by_id_async(db, knowledge_id=db_knowledgeshare.target_kb_id ,current_user=current_user)
         # 3. Delete knowledge base sharing
         api_logger.debug(f"perform knowledge base sharing delete: (ID: {knowledgeshare_id})")
 
-        knowledgeshare_service.delete_knowledgeshare_by_id(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
+        await knowledgeshare_service.delete_knowledgeshare_by_id_async(db, knowledgeshare_id=knowledgeshare_id, current_user=current_user)
         api_logger.info(f"The knowledge base sharing has been successfully deleted: (ID: {knowledgeshare_id})")
         return success(msg="The knowledge base sharing has been successfully deleted")
     except Exception as e:

--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -4,14 +4,14 @@ from typing import Any, Optional, Union
 import uuid
 
 from fastapi import APIRouter, Body, Depends, File, Request, status, Query, UploadFile
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controllers import chunk_controller
-from app.core.api_key_auth import require_api_key
+from app.core.api_key_auth import require_api_key_self_db
 from app.core.logging_config import get_business_logger
 from app.core.rag.models.chunk import QAChunk
 from app.core.response_utils import success
-from app.db import get_db
+from app.db import get_async_db
 from app.schemas import chunk_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
@@ -24,13 +24,13 @@ api_logger = get_business_logger()
 
 
 @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_preview_chunks(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
     pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
     keywords: Optional[str] = Query(None, description="The keywords used to match chunk content")
@@ -42,7 +42,7 @@ async def get_preview_chunks(
     - Return paging metadata + file list
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -56,13 +56,13 @@ async def get_preview_chunks(
 
 
 @router.get("/{kb_id}/{document_id}/chunks", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_chunks(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
     pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
     keywords: Optional[str] = Query(None, description="The keywords used to match chunk content")
@@ -74,7 +74,7 @@ async def get_chunks(
     - Return paging metadata + file list
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -88,13 +88,13 @@ async def get_chunks(
 
 
 @router.post("/{kb_id}/{document_id}/chunk", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def create_chunk(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     content: Union[str, QAChunk] = Body(..., description="Content can be either a string or a QAChunk object"),
 ):
     """
@@ -103,7 +103,7 @@ async def create_chunk(
     body = await request.json()
     create_data = chunk_schema.ChunkCreate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -115,13 +115,13 @@ async def create_chunk(
 
 
 @router.post("/{kb_id}/{document_id}/chunk/batch", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def create_chunks_batch(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     items: list = Body(..., description="chunk items list"),
 ):
     """
@@ -130,7 +130,7 @@ async def create_chunks_batch(
     body = await request.json()
     batch_data = chunk_schema.ChunkBatchCreate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -142,20 +142,20 @@ async def create_chunks_batch(
 
 
 @router.get("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_chunk(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     doc_id: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Retrieve document chunk information based on doc_id
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -167,14 +167,14 @@ async def get_chunk(
 
 
 @router.put("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def update_chunk(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     doc_id: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     content: Union[str, QAChunk] = Body(..., description="Content can be either a string or a QAChunk object"),
 ):
     """
@@ -183,7 +183,7 @@ async def update_chunk(
     body = await request.json()
     update_data = chunk_schema.ChunkUpdate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -196,21 +196,21 @@ async def update_chunk(
 
 
 @router.delete("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def delete_chunk(
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     doc_id: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     force_refresh: bool = Query(False, description="Force Elasticsearch refresh after deletion"),
 ):
     """
     delete document chunk
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -228,11 +228,11 @@ def get_retrieve_types():
 
 
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def retrieve_chunks(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     query: str = Body(..., description="question"),
 ):
     """
@@ -241,7 +241,7 @@ async def retrieve_chunks(
     body = await request.json()
     retrieve_data = chunk_schema.ChunkRetrieve(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -254,20 +254,20 @@ async def retrieve_chunks(
 
 
 @router.post("/{kb_id}/import_qa", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def import_qa_new_doc(
     kb_id: uuid.UUID,
     request: Request,
     file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
     api_key_auth: ApiKeyAuth = None,
     parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
     """
     导入 QA 问答对并新建文档（CSV/Excel），异步处理（API Key 认证）
     """
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 

--- a/api/app/controllers/service/rag_api_document_controller.py
+++ b/api/app/controllers/service/rag_api_document_controller.py
@@ -4,12 +4,12 @@ from typing import Optional
 import uuid
 
 from fastapi import APIRouter, Body, Depends, Request, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controllers import document_controller
-from app.core.api_key_auth import require_api_key
+from app.core.api_key_auth import require_api_key_self_db
 from app.core.logging_config import get_business_logger
-from app.db import get_db
+from app.db import get_async_db
 from app.schemas import document_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
@@ -21,12 +21,12 @@ api_logger = get_business_logger()
 
 
 @router.get("/{kb_id}/documents", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_documents(
     kb_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id when type is Folder"),
     page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
     pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
@@ -43,7 +43,7 @@ async def get_documents(
     - Return paging metadata + file list
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -60,11 +60,11 @@ async def get_documents(
 
 
 @router.post("/document", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def create_document(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     kb_id: uuid.UUID = Body(..., description="kb id"),
     file_name: str = Body(..., description="file name"),
 ):
@@ -74,7 +74,7 @@ async def create_document(
     body = await request.json()
     create_data = document_schema.DocumentCreate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -84,18 +84,18 @@ async def create_document(
 
 
 @router.get("/{document_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_document(
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Retrieve document information based on document_id
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -105,12 +105,12 @@ async def get_document(
 
 
 @router.put("/{document_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def update_document(
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     file_name: str = Body(None, description="file name (optional)"),
 ):
     """
@@ -119,7 +119,7 @@ async def update_document(
     body = await request.json()
     update_data = document_schema.DocumentUpdate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -130,18 +130,18 @@ async def update_document(
 
 
 @router.delete("/{document_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def delete_document(
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Delete document
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -151,18 +151,18 @@ async def delete_document(
 
 
 @router.post("/{document_id}/chunks", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def parse_documents(
     document_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     parse document
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 

--- a/api/app/controllers/service/rag_api_knowledge_controller.py
+++ b/api/app/controllers/service/rag_api_knowledge_controller.py
@@ -1,16 +1,16 @@
 """RAG 服务接口 - 基于 API Key 认证"""
 
-from typing import Optional, Dict
+from typing import Optional
 import uuid
 
 from fastapi import APIRouter, Body, Depends, Request, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controllers import knowledge_controller
-from app.core.api_key_auth import require_api_key
+from app.core.api_key_auth import require_api_key_self_db
 from app.core.logging_config import get_business_logger
 from app.core.response_utils import success
-from app.db import get_db
+from app.db import get_async_db
 from app.models import knowledge_model
 from app.schemas import knowledge_schema
 from app.schemas.api_key_schema import ApiKeyAuth
@@ -38,19 +38,19 @@ def get_parser_types():
 
 
 @router.get("/knowledge_graph_entity_types", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_knowledge_graph_entity_types(
     llm_id: uuid.UUID,
     scenario: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     get knowledge graph entity types based on llm_id
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -61,11 +61,11 @@ async def get_knowledge_graph_entity_types(
 
 
 @router.get("/knowledges", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_knowledges(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
     page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
     pagesize: int = Query(20, gt=0, le=100),  # Default: 20 items per page, maximum: 100 items
@@ -82,7 +82,7 @@ async def get_knowledges(
     - Return paging metadata + file list
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -98,11 +98,11 @@ async def get_knowledges(
 
 
 @router.post("/knowledge", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def create_knowledge(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     name: str = Body(..., description="KB name"),
 ):
     """
@@ -111,7 +111,7 @@ async def create_knowledge(
     body = await request.json()
     create_data = knowledge_schema.KnowledgeCreate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -121,18 +121,18 @@ async def create_knowledge(
 
 
 @router.get("/{knowledge_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_knowledge(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Retrieve knowledge base information based on knowledge_id
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -142,18 +142,18 @@ async def get_knowledge(
 
 
 @router.put("/{knowledge_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def update_knowledge(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
     name: str = Body(None, description="KB name (optional)"),
 ):
     body = await request.json()
     update_data = knowledge_schema.KnowledgeUpdate(**body)
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -164,18 +164,18 @@ async def update_knowledge(
 
 
 @router.delete("/{knowledge_id}", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def delete_knowledge(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Soft-delete knowledge base
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -185,18 +185,18 @@ async def delete_knowledge(
 
 
 @router.get("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def get_knowledge_graph(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     Retrieve knowledge_graph base information based on knowledge_id
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -206,18 +206,18 @@ async def get_knowledge_graph(
 
 
 @router.delete("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def delete_knowledge_graph(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     delete knowledge graph
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -227,18 +227,18 @@ async def delete_knowledge_graph(
 
 
 @router.post("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def rebuild_knowledge_graph(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     rebuild knowledge graph
     """
     # 0. Obtain the creator of the api key
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -248,18 +248,18 @@ async def rebuild_knowledge_graph(
 
 
 @router.get("/check/yuque/auth", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def check_yuque_auth(
     yuque_user_id: str,
     yuque_token: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     check yuque auth info
     """
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -272,19 +272,19 @@ async def check_yuque_auth(
 
 
 @router.get("/check/feishu/auth", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def check_feishu_auth(
     feishu_app_id: str,
     feishu_app_secret: str,
     feishu_folder_token: str,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     check feishu auth info
     """
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
@@ -298,21 +298,20 @@ async def check_feishu_auth(
 
 
 @router.post("/{knowledge_id}/sync", response_model=ApiResponse)
-@require_api_key(scopes=["rag"])
+@require_api_key_self_db(scopes=["rag"])
 async def sync_knowledge(
     knowledge_id: uuid.UUID,
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ):
     """
     sync knowledge base information based on knowledge_id
     """
-    api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
+    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
     current_user = api_key.creator
     current_user.current_workspace_id = api_key_auth.workspace_id
 
     return await knowledge_controller.sync_knowledge(knowledge_id=knowledge_id,
                                                      db=db,
                                                      current_user=current_user)
-

--- a/api/app/core/quota_manager.py
+++ b/api/app/core/quota_manager.py
@@ -98,6 +98,11 @@ def _get_tenant_id_from_kwargs(db: Session, kwargs: dict):
     return None
 
 
+async def _get_tenant_id_from_kwargs_async(db: AsyncSession, kwargs: dict):
+    """Resolve tenant context through AsyncSession without sync DB access in the event loop."""
+    return await db.run_sync(lambda sync_db: _get_tenant_id_from_kwargs(sync_db, kwargs))
+
+
 def _get_quota_config(db: Session, tenant_id: UUID) -> Optional[Dict[str, Any]]:
     """
     获取租户的配额配置
@@ -363,6 +368,27 @@ def _check_quota(
         raise
 
 
+async def _check_quota_async(
+        db: AsyncSession,
+        tenant_id: UUID,
+        quota_type: str,
+        resource_name: str,
+        usage_func: Optional[Callable] = None,
+        workspace_id: Optional[UUID] = None,
+) -> None:
+    """Run the existing quota semantics through an AsyncSession greenlet context."""
+    await db.run_sync(
+        lambda sync_db: _check_quota(
+            sync_db,
+            tenant_id,
+            quota_type,
+            resource_name,
+            usage_func,
+            workspace_id,
+        )
+    )
+
+
 # ─── 具名装饰器 ────────────────────────────────────────────────────────────
 
 def check_workspace_quota(func: Callable) -> Callable:
@@ -448,11 +474,14 @@ def check_app_quota(func: Callable) -> Callable:
 def check_knowledge_capacity_quota(func: Callable) -> Callable:
     @wraps(func)
     async def async_wrapper(*args, **kwargs):
-        db: Session = kwargs.get("db")
+        db: Session | AsyncSession = kwargs.get("db")
         if not db:
             logger.error(f"配额检查失败：{func.__name__} 缺少 db 参数，拒绝请求")
             raise InternalServerError()
-        tenant_id = _get_tenant_id_from_kwargs(db, kwargs)
+        if isinstance(db, AsyncSession):
+            tenant_id = await _get_tenant_id_from_kwargs_async(db, kwargs)
+        else:
+            tenant_id = _get_tenant_id_from_kwargs(db, kwargs)
         if not tenant_id:
             logger.error(f"配额检查失败：{func.__name__} 无法获取 tenant_id，拒绝请求")
             raise InternalServerError()
@@ -460,7 +489,22 @@ def check_knowledge_capacity_quota(func: Callable) -> Callable:
         if not workspace_id:
             logger.error(f"配额检查失败：{func.__name__} 无法获取 workspace_id，拒绝请求")
             raise InternalServerError()
-        _check_quota(db, tenant_id, "knowledge_capacity_quota", "knowledge_capacity", workspace_id=workspace_id)
+        if isinstance(db, AsyncSession):
+            await _check_quota_async(
+                db,
+                tenant_id,
+                "knowledge_capacity_quota",
+                "knowledge_capacity",
+                workspace_id=workspace_id,
+            )
+        else:
+            _check_quota(
+                db,
+                tenant_id,
+                "knowledge_capacity_quota",
+                "knowledge_capacity",
+                workspace_id=workspace_id,
+            )
         return await func(*args, **kwargs)
 
     @wraps(func)

--- a/api/app/core/rag/metadata/filter_engine.py
+++ b/api/app/core/rag/metadata/filter_engine.py
@@ -1,6 +1,8 @@
 import uuid
 import logging
 from typing import Any
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, exists, or_
 from app.core.exceptions import BusinessException
@@ -38,7 +40,7 @@ class FilterGroup:
 class MetadataFilterEngine:
     """元数据过滤引擎：将多条件过滤转化为 SQLAlchemy 查询"""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: Session | AsyncSession):
         self.db = db
         self._strategies = {
             "string": StringFilterStrategy(),
@@ -108,10 +110,69 @@ class MetadataFilterEngine:
         )
         return query
 
+    def build_statement(
+        self,
+        knowledge_id: uuid.UUID,
+        filter_groups: list[FilterGroup],
+        metadata_defs: dict[str, dict],
+    ):
+        """Build an async-compatible SQLAlchemy select statement."""
+        stmt = select(Document.id).where(Document.kb_id == knowledge_id)
+
+        group_conditions = []
+        for group in filter_groups:
+            conditions = []
+            for cond in group.conditions:
+                field_def = metadata_defs.get(cond.field)
+                if not field_def:
+                    raise BusinessException(
+                        f"未知元数据字段: {cond.field}",
+                        code=BizCode.METADATA_FIELD_NOT_FOUND,
+                    )
+
+                is_builtin = field_def.get("is_builtin", False)
+
+                if is_builtin:
+                    filter_expr = self._build_builtin_filter(cond, field_def)
+                else:
+                    strategy = self._strategies[field_def["type"]]
+                    if cond.operator not in ("is_missing", "not_missing") and not strategy.supports(cond.operator):
+                        raise BusinessException(
+                            f"字段 '{cond.field}' (类型 {field_def['type']}) "
+                            f"不支持操作符 '{cond.operator}'",
+                            code=BizCode.METADATA_INVALID_OPERATOR,
+                        )
+                    filter_expr = self._build_custom_filter(cond, field_def, strategy)
+
+                conditions.append(filter_expr)
+
+            if not conditions:
+                continue
+
+            if group.logic == "OR":
+                group_conditions.append(or_(*conditions))
+            else:
+                group_conditions.append(and_(*conditions))
+
+        if group_conditions:
+            stmt = stmt.where(and_(*group_conditions))
+
+        logger.debug(
+            "[MetadataFilterEngine] built statement: %s",
+            str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        )
+        return stmt
+
     def execute(self, *args, **kwargs) -> list[uuid.UUID]:
         """执行过滤，返回符合条件的 document_id 列表"""
         query = self.build_query(*args, **kwargs)
         return [row[0] for row in query.all()]
+
+    async def execute_async(self, *args, **kwargs) -> list[uuid.UUID]:
+        """Async version of execute."""
+        stmt = self.build_statement(*args, **kwargs)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
 
     def _build_custom_filter(self, cond: FilterCondition, field_def: dict, strategy):
         metadata_id = field_def.get("id")

--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -4,10 +4,13 @@ from functools import wraps
 
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 from jose import jwt, JWTError
 
-from app.db import get_db, get_db_read, SessionLocal
+from app.db import get_async_db, get_db, get_db_read, SessionLocal
 from app.models import App
 from app.schemas import token_schema
 from app.core.config import settings
@@ -147,6 +150,92 @@ async def get_current_user(
         auth_logger.info(f"用户认证成功: {user.username} (ID: {user.id})")
         return user
 
+    except Exception as e:
+        auth_logger.error(f"查询用户信息时发生错误: {str(e)}")
+        raise credentials_exception
+
+
+async def get_current_user_async(
+        token: str = Depends(oauth2_scheme),
+        db: AsyncSession = Depends(get_async_db)
+) -> User:
+    """
+    Async version of get_current_user for async request chains.
+    """
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    try:
+        auth_logger.debug("开始解析JWT token")
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        user_id: str = payload.get("sub")
+
+        if user_id is None:
+            auth_logger.warning("JWT token中缺少用户ID")
+            raise credentials_exception
+
+        token_data = token_schema.TokenData(userId=user_id)
+        auth_logger.debug(f"JWT解析成功，用户ID: {user_id}")
+
+    except JWTError as e:
+        auth_logger.warning(f"JWT解析失败: {str(e)}")
+        raise credentials_exception
+
+    try:
+        auth_logger.debug("检查单点登录黑名单")
+        token_id = get_token_id(token)
+        session_service = SessionService()
+
+        if await session_service.is_token_blacklisted(token_id):
+            auth_logger.warning(f"Token已被列入黑名单: {token_id}")
+            raise credentials_exception
+
+        invalidation_time_str = await session_service.get_user_token_invalidation_time(user_id)
+        if invalidation_time_str:
+            from datetime import datetime, timezone
+            invalidation_time = datetime.fromisoformat(invalidation_time_str)
+            token_issued_at = datetime.fromtimestamp(payload.get("iat", 0), tz=timezone.utc) if payload.get(
+                "iat") else None
+
+            if token_issued_at and token_issued_at < invalidation_time:
+                auth_logger.warning(f"Token在密码重置前签发，已失效: user_id={user_id}")
+                raise credentials_exception
+
+        auth_logger.debug("单点登录检查通过")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        auth_logger.error(f"检查token有效性时发生错误: {str(e)}")
+        raise credentials_exception
+
+    try:
+        auth_logger.debug(f"查询用户信息: {token_data.userId}")
+        result = await db.execute(
+            select(User)
+            .options(joinedload(User.tenant))
+            .where(User.id == token_data.userId, User.is_active.is_(True))
+        )
+        user = result.scalars().first()
+
+        if user is None:
+            auth_logger.warning(f"用户不存在: {token_data.userId}")
+            raise credentials_exception
+        if user.tenant and not user.tenant.is_active:
+            auth_logger.warning(f"用户 {user.username} (ID: {user.id}) 所属租户 {user.tenant_id} 已被禁用")
+            raise credentials_exception
+        if not user.is_active:
+            auth_logger.warning(f"用户已被停用: {user.username} (ID: {user.id})")
+            raise credentials_exception
+
+        auth_logger.info(f"用户认证成功: {user.username} (ID: {user.id})")
+        return user
+
+    except HTTPException:
+        raise
     except Exception as e:
         auth_logger.error(f"查询用户信息时发生错误: {str(e)}")
         raise credentials_exception
@@ -632,5 +721,4 @@ async def get_app_or_workspace(
     except Exception as e:
         auth_logger.error(f"Error validating API Key: {str(e)}", exc_info=True)
         raise credentials_exception
-
 

--- a/api/app/repositories/api_key_repository.py
+++ b/api/app/repositories/api_key_repository.py
@@ -3,7 +3,7 @@ import uuid
 import datetime
 from typing import Optional, List, Tuple
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_
 
@@ -27,6 +27,13 @@ class ApiKeyRepository:
     def get_by_id(db: Session, api_key_id: uuid.UUID) -> Optional[ApiKey]:
         """根据 ID 获取 API Key"""
         return db.get(ApiKey, api_key_id)
+
+    @staticmethod
+    async def get_by_id_async(db: AsyncSession, api_key_id: uuid.UUID) -> Optional[ApiKey]:
+        """Async version of get_by_id with creator eager-loaded."""
+        stmt = select(ApiKey).options(joinedload(ApiKey.creator)).where(ApiKey.id == api_key_id)
+        result = await db.execute(stmt)
+        return result.scalars().first()
 
     @staticmethod
     def get_by_api_key(db: Session, api_key: str) -> Optional[ApiKey]:

--- a/api/app/repositories/document_repository.py
+++ b/api/app/repositories/document_repository.py
@@ -1,4 +1,6 @@
 import uuid
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.core.utils.datetime_utils import to_iso_z, utcnow, utcnow_naive
 from app.models.document_model import Document
@@ -57,6 +59,48 @@ def get_documents_paginated(
         raise
 
 
+async def get_documents_paginated_async(
+        db: AsyncSession,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    """Async version of get_documents_paginated."""
+    db_logger.debug(
+        f"Query documents in pages (async): page={page}, pagesize={pagesize}, "
+        f"orderby={orderby}, desc={desc}, filters_count={len(filters)}"
+    )
+
+    try:
+        stmt = select(Document)
+        for filter_cond in filters:
+            stmt = stmt.where(filter_cond)
+
+        total_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+        total = total_result.scalar_one()
+
+        if orderby:
+            order_attr = getattr(Document, orderby, None)
+            if order_attr is not None:
+                stmt = stmt.order_by(order_attr.desc() if desc else order_attr.asc())
+
+        stmt = stmt.offset((page - 1) * pagesize).limit(pagesize)
+        result = await db.execute(stmt)
+        items = result.scalars().all()
+        db_logger.info(
+            f"The document paging query has been successful (async): "
+            f"total={total}, Number of current page={len(items)}"
+        )
+        return total, [document_schema.Document.model_validate(item) for item in items]
+    except Exception as e:
+        db_logger.error(
+            f"Querying document pagination failed (async): page={page}, pagesize={pagesize} - {str(e)}"
+        )
+        raise
+
+
 def create_document(db: Session, document: document_schema.DocumentCreate) -> Document:
     db_logger.debug(f"Create a document record: file_name={document.file_name}")
     
@@ -72,6 +116,23 @@ def create_document(db: Session, document: document_schema.DocumentCreate) -> Do
         raise
 
 
+async def create_document_async(db: AsyncSession, document: document_schema.DocumentCreate) -> Document:
+    """Async version of create_document."""
+    db_logger.debug(f"Create a document record (async): file_name={document.file_name}")
+
+    try:
+        db_document = Document(**document.model_dump())
+        db.add(db_document)
+        await db.commit()
+        await db.refresh(db_document)
+        db_logger.info(f"Document record created successfully (async): {document.file_name} (ID: {db_document.id})")
+        return db_document
+    except Exception as e:
+        db_logger.error(f"Failed to create a document record (async): title={document.file_name} - {str(e)}")
+        await db.rollback()
+        raise
+
+
 def get_document_by_id(db: Session, document_id: uuid.UUID) -> Document | None:
     db_logger.debug(f"Query documents based on ID: document_id={document_id}")
     
@@ -84,6 +145,17 @@ def get_document_by_id(db: Session, document_id: uuid.UUID) -> Document | None:
         return document
     except Exception as e:
         db_logger.error(f"Failed to query the document based on the ID: document_id={document_id} - {str(e)}")
+        raise
+
+
+async def get_document_by_id_async(db: AsyncSession, document_id: uuid.UUID) -> Document | None:
+    """Async version of get_document_by_id."""
+    try:
+        stmt = select(Document).where(Document.id == document_id)
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(f"Failed to query document by ID (async): document_id={document_id} - {str(e)}")
         raise
 
 
@@ -132,6 +204,32 @@ def reset_documents_progress_by_kb_id(db: Session, kb_id: uuid.UUID) -> int:
         raise
 
 
+async def reset_documents_progress_by_kb_id_async(db: AsyncSession, kb_id: uuid.UUID) -> int:
+    """Async version of reset_documents_progress_by_kb_id."""
+    db_logger.debug(f"Reset document processing progress by knowledge base (async): kb_id={kb_id}")
+    try:
+        update_data = {
+            Document.chunk_num: 0,
+            Document.progress: 0,
+            Document.progress_msg: _pending_progress_msg(),
+            Document.process_duration: 0,
+            Document.run: 0,
+            Document.updated_at: utcnow_naive(),
+        }
+        result = await db.execute(
+            update(Document)
+            .where(Document.kb_id == kb_id)
+            .values(update_data)
+            .execution_options(synchronize_session=False)
+        )
+        await db.commit()
+        return result.rowcount or 0
+    except Exception as e:
+        await db.rollback()
+        db_logger.error(f"Failed to reset document progress by KB (async): kb_id={kb_id} - {str(e)}")
+        raise
+
+
 
 def delete_document_by_id(db: Session, document_id: uuid.UUID):
     db_logger.debug(f"Delete document record: document_id={document_id}")
@@ -154,4 +252,23 @@ def delete_document_by_id(db: Session, document_id: uuid.UUID):
     except Exception as e:
         db_logger.error(f"Failed to delete document record: document_id={document_id} - {str(e)}")
         db.rollback()
+        raise
+
+
+async def delete_document_by_id_async(db: AsyncSession, document_id: uuid.UUID):
+    """Async version of delete_document_by_id."""
+    try:
+        document = await get_document_by_id_async(db, document_id)
+        file_name = document.file_name if document else "unknown"
+
+        result = await db.execute(delete(Document).where(Document.id == document_id))
+        await db.commit()
+
+        if result.rowcount and result.rowcount > 0:
+            db_logger.info(f"Document record deleted successfully (async): {file_name} (ID: {document_id})")
+        else:
+            db_logger.warning(f"The document record does not exist, and cannot be deleted (async): document_id={document_id}")
+    except Exception as e:
+        db_logger.error(f"Failed to delete document record (async): document_id={document_id} - {str(e)}")
+        await db.rollback()
         raise

--- a/api/app/repositories/knowledge_metadata_repository.py
+++ b/api/app/repositories/knowledge_metadata_repository.py
@@ -1,6 +1,7 @@
 import uuid
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-from sqlalchemy import and_, delete, update, func
+from sqlalchemy import and_, delete, select, update, func
 from app.models.knowledge_metadata_model import KnowledgeMetadata, KnowledgeMetadataBinding
 from app.core.logging_config import get_db_logger
 
@@ -18,8 +19,20 @@ class KnowledgeMetadataRepository:
         return obj
 
     @staticmethod
+    async def create_async(db: AsyncSession, obj: KnowledgeMetadata) -> KnowledgeMetadata:
+        db.add(obj)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+
+    @staticmethod
     def get_by_id(db: Session, metadata_id: uuid.UUID) -> KnowledgeMetadata | None:
         return db.query(KnowledgeMetadata).filter(KnowledgeMetadata.id == metadata_id).first()
+
+    @staticmethod
+    async def get_by_id_async(db: AsyncSession, metadata_id: uuid.UUID) -> KnowledgeMetadata | None:
+        result = await db.execute(select(KnowledgeMetadata).where(KnowledgeMetadata.id == metadata_id))
+        return result.scalars().first()
 
     @staticmethod
     def get_by_knowledge_id(db: Session, knowledge_id: uuid.UUID) -> list[KnowledgeMetadata]:
@@ -28,12 +41,28 @@ class KnowledgeMetadataRepository:
         ).all()
 
     @staticmethod
+    async def get_by_knowledge_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -> list[KnowledgeMetadata]:
+        result = await db.execute(
+            select(KnowledgeMetadata).where(KnowledgeMetadata.knowledge_id == knowledge_id)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
     def get_by_knowledge_ids(db: Session, knowledge_ids: list[uuid.UUID]) -> list[KnowledgeMetadata]:
         if not knowledge_ids:
             return []
         return db.query(KnowledgeMetadata).filter(
             KnowledgeMetadata.knowledge_id.in_(knowledge_ids)
         ).all()
+
+    @staticmethod
+    async def get_by_knowledge_ids_async(db: AsyncSession, knowledge_ids: list[uuid.UUID]) -> list[KnowledgeMetadata]:
+        if not knowledge_ids:
+            return []
+        result = await db.execute(
+            select(KnowledgeMetadata).where(KnowledgeMetadata.knowledge_id.in_(knowledge_ids))
+        )
+        return list(result.scalars().all())
 
     @staticmethod
     def get_by_name(db: Session, knowledge_id: uuid.UUID, name: str) -> KnowledgeMetadata | None:
@@ -45,12 +74,30 @@ class KnowledgeMetadataRepository:
         ).first()
 
     @staticmethod
+    async def get_by_name_async(db: AsyncSession, knowledge_id: uuid.UUID, name: str) -> KnowledgeMetadata | None:
+        result = await db.execute(
+            select(KnowledgeMetadata).where(
+                KnowledgeMetadata.knowledge_id == knowledge_id,
+                KnowledgeMetadata.name == name,
+            )
+        )
+        return result.scalars().first()
+
+    @staticmethod
     def update(db: Session, metadata_id: uuid.UUID, update_data: dict) -> int:
         result = db.query(KnowledgeMetadata).filter(
             KnowledgeMetadata.id == metadata_id
         ).update(update_data)
         db.commit()
         return result
+
+    @staticmethod
+    async def update_async(db: AsyncSession, metadata_id: uuid.UUID, update_data: dict) -> int:
+        result = await db.execute(
+            update(KnowledgeMetadata).where(KnowledgeMetadata.id == metadata_id).values(update_data)
+        )
+        await db.commit()
+        return result.rowcount or 0
 
     @staticmethod
     def delete(db: Session, metadata_id: uuid.UUID) -> int:
@@ -61,12 +108,24 @@ class KnowledgeMetadataRepository:
         return result
 
     @staticmethod
+    async def delete_async(db: AsyncSession, metadata_id: uuid.UUID) -> int:
+        result = await db.execute(delete(KnowledgeMetadata).where(KnowledgeMetadata.id == metadata_id))
+        await db.commit()
+        return result.rowcount or 0
+
+    @staticmethod
     def delete_by_knowledge_id(db: Session, knowledge_id: uuid.UUID) -> int:
         result = db.query(KnowledgeMetadata).filter(
             KnowledgeMetadata.knowledge_id == knowledge_id
         ).delete()
         db.commit()
         return result
+
+    @staticmethod
+    async def delete_by_knowledge_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -> int:
+        result = await db.execute(delete(KnowledgeMetadata).where(KnowledgeMetadata.knowledge_id == knowledge_id))
+        await db.commit()
+        return result.rowcount or 0
 
     # === Binding Operations ===
 
@@ -78,16 +137,43 @@ class KnowledgeMetadataRepository:
         return obj
 
     @staticmethod
+    async def create_binding_async(db: AsyncSession, obj: KnowledgeMetadataBinding) -> KnowledgeMetadataBinding:
+        db.add(obj)
+        await db.commit()
+        await db.refresh(obj)
+        return obj
+
+    @staticmethod
     def get_bindings_by_metadata_id(db: Session, metadata_id: uuid.UUID) -> list[KnowledgeMetadataBinding]:
         return db.query(KnowledgeMetadataBinding).filter(
             KnowledgeMetadataBinding.metadata_id == metadata_id
         ).all()
 
     @staticmethod
+    async def get_bindings_by_metadata_id_async(
+        db: AsyncSession,
+        metadata_id: uuid.UUID,
+    ) -> list[KnowledgeMetadataBinding]:
+        result = await db.execute(
+            select(KnowledgeMetadataBinding).where(KnowledgeMetadataBinding.metadata_id == metadata_id)
+        )
+        return list(result.scalars().all())
+
+    @staticmethod
     def get_bindings_by_document_id(db: Session, document_id: uuid.UUID) -> list[KnowledgeMetadataBinding]:
         return db.query(KnowledgeMetadataBinding).filter(
             KnowledgeMetadataBinding.document_id == document_id
         ).all()
+
+    @staticmethod
+    async def get_bindings_by_document_id_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+    ) -> list[KnowledgeMetadataBinding]:
+        result = await db.execute(
+            select(KnowledgeMetadataBinding).where(KnowledgeMetadataBinding.document_id == document_id)
+        )
+        return list(result.scalars().all())
 
     @staticmethod
     def delete_bindings_by_metadata_id(db: Session, metadata_id: uuid.UUID) -> int:
@@ -98,12 +184,28 @@ class KnowledgeMetadataRepository:
         return result
 
     @staticmethod
+    async def delete_bindings_by_metadata_id_async(db: AsyncSession, metadata_id: uuid.UUID) -> int:
+        result = await db.execute(
+            delete(KnowledgeMetadataBinding).where(KnowledgeMetadataBinding.metadata_id == metadata_id)
+        )
+        await db.commit()
+        return result.rowcount or 0
+
+    @staticmethod
     def delete_bindings_by_document_id(db: Session, document_id: uuid.UUID) -> int:
         result = db.query(KnowledgeMetadataBinding).filter(
             KnowledgeMetadataBinding.document_id == document_id
         ).delete()
         db.commit()
         return result
+
+    @staticmethod
+    async def delete_bindings_by_document_id_async(db: AsyncSession, document_id: uuid.UUID) -> int:
+        result = await db.execute(
+            delete(KnowledgeMetadataBinding).where(KnowledgeMetadataBinding.document_id == document_id)
+        )
+        await db.commit()
+        return result.rowcount or 0
 
     @staticmethod
     def binding_exists(db: Session, knowledge_id: uuid.UUID, metadata_id: uuid.UUID, document_id: uuid.UUID) -> bool:
@@ -114,6 +216,22 @@ class KnowledgeMetadataRepository:
                 KnowledgeMetadataBinding.document_id == document_id,
             )
         ).first() is not None
+
+    @staticmethod
+    async def binding_exists_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+        metadata_id: uuid.UUID,
+        document_id: uuid.UUID,
+    ) -> bool:
+        result = await db.execute(
+            select(KnowledgeMetadataBinding.id).where(
+                KnowledgeMetadataBinding.knowledge_id == knowledge_id,
+                KnowledgeMetadataBinding.metadata_id == metadata_id,
+                KnowledgeMetadataBinding.document_id == document_id,
+            )
+        )
+        return result.scalar_one_or_none() is not None
 
     @staticmethod
     def count_active_bindings_by_metadata_ids(
@@ -139,3 +257,28 @@ class KnowledgeMetadataRepository:
             .all()
         )
         return {metadata_id: int(count) for metadata_id, count in rows}
+
+    @staticmethod
+    async def count_active_bindings_by_metadata_ids_async(
+        db: AsyncSession,
+        metadata_ids: list[uuid.UUID],
+    ) -> dict[uuid.UUID, int]:
+        if not metadata_ids:
+            return {}
+
+        from app.models.document_model import Document
+
+        stmt = (
+            select(
+                KnowledgeMetadataBinding.metadata_id,
+                func.count(KnowledgeMetadataBinding.document_id),
+            )
+            .join(Document, Document.id == KnowledgeMetadataBinding.document_id)
+            .where(
+                KnowledgeMetadataBinding.metadata_id.in_(metadata_ids),
+                Document.status == 1,
+            )
+            .group_by(KnowledgeMetadataBinding.metadata_id)
+        )
+        result = await db.execute(stmt)
+        return {metadata_id: int(count) for metadata_id, count in result.all()}

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session, selectinload
 from app.models.document_model import Document
 from app.models.knowledge_model import Knowledge, PermissionType
+from app.models.models_model import ModelApiKey, ModelConfig
 from app.schemas import knowledge_schema
 from app.core.logging_config import get_db_logger
 
@@ -12,12 +13,20 @@ db_logger = get_db_logger()
 
 
 def _knowledge_relationship_load_options():
+    def model_config_options(relationship_attr):
+        return (
+            selectinload(relationship_attr).selectinload(ModelConfig.model_base),
+            selectinload(relationship_attr)
+            .selectinload(ModelConfig.api_keys)
+            .selectinload(ModelApiKey.model_configs),
+        )
+
     return (
         selectinload(Knowledge.created_user),
-        selectinload(Knowledge.embedding),
-        selectinload(Knowledge.reranker),
-        selectinload(Knowledge.llm),
-        selectinload(Knowledge.image2text),
+        *model_config_options(Knowledge.embedding),
+        *model_config_options(Knowledge.reranker),
+        *model_config_options(Knowledge.llm),
+        *model_config_options(Knowledge.image2text),
     )
 
 

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -12,7 +12,7 @@ from app.core.logging_config import get_db_logger
 db_logger = get_db_logger()
 
 
-def _knowledge_relationship_load_options():
+def knowledge_schema_load_options():
     def model_config_options(relationship_attr):
         return (
             selectinload(relationship_attr).selectinload(ModelConfig.model_base),
@@ -89,7 +89,7 @@ async def get_knowledges_paginated_async(
     )
 
     try:
-        stmt = select(Knowledge).options(*_knowledge_relationship_load_options())
+        stmt = select(Knowledge).options(*knowledge_schema_load_options())
         for filter_cond in filters:
             stmt = stmt.where(filter_cond)
 
@@ -214,7 +214,7 @@ async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -
     db_logger.debug(f"Query knowledge base based on ID (async): knowledge_id={knowledge_id}")
 
     try:
-        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(Knowledge.id == knowledge_id)
+        stmt = select(Knowledge).options(*knowledge_schema_load_options()).where(Knowledge.id == knowledge_id)
         result = await db.execute(stmt)
         knowledge = result.scalars().first()
         if knowledge:
@@ -253,7 +253,7 @@ async def get_knowledge_by_external_id_async(
 ) -> Knowledge | None:
     """Async version of get_knowledge_by_external_id."""
     try:
-        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(
+        stmt = select(Knowledge).options(*knowledge_schema_load_options()).where(
             Knowledge.external_id == external_id,
             Knowledge.workspace_id == workspace_id,
             Knowledge.status == 1,
@@ -370,7 +370,7 @@ async def get_knowledges_by_parent_ids_async(
         return []
 
     try:
-        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(
+        stmt = select(Knowledge).options(*knowledge_schema_load_options()).where(
             Knowledge.parent_id.in_(parent_ids),
             Knowledge.workspace_id == workspace_id,
             Knowledge.status != 2,
@@ -465,7 +465,7 @@ async def get_knowledge_by_name_async(db: AsyncSession, name: str, workspace_id:
     try:
         stmt = (
             select(Knowledge)
-            .options(*_knowledge_relationship_load_options())
+            .options(*knowledge_schema_load_options())
             .where(Knowledge.name == name, Knowledge.workspace_id == workspace_id, Knowledge.status == 1)
         )
         result = await db.execute(stmt)

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -1,7 +1,7 @@
 import uuid
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from app.models.document_model import Document
 from app.models.knowledge_model import Knowledge, PermissionType
 from app.schemas import knowledge_schema
@@ -9,6 +9,16 @@ from app.core.logging_config import get_db_logger
 
 # Obtain a dedicated logger for the database
 db_logger = get_db_logger()
+
+
+def _knowledge_relationship_load_options():
+    return (
+        selectinload(Knowledge.created_user),
+        selectinload(Knowledge.embedding),
+        selectinload(Knowledge.reranker),
+        selectinload(Knowledge.llm),
+        selectinload(Knowledge.image2text),
+    )
 
 
 def get_knowledges_paginated(
@@ -70,7 +80,7 @@ async def get_knowledges_paginated_async(
     )
 
     try:
-        stmt = select(Knowledge)
+        stmt = select(Knowledge).options(*_knowledge_relationship_load_options())
         for filter_cond in filters:
             stmt = stmt.where(filter_cond)
 
@@ -166,8 +176,9 @@ async def create_knowledge_async(db: AsyncSession, knowledge: knowledge_schema.K
         db.add(db_knowledge)
         await db.commit()
         await db.refresh(db_knowledge)
+        loaded_knowledge = await get_knowledge_by_id_async(db, db_knowledge.id)
         db_logger.info(f"knowledge base record created successfully (async): {knowledge.name} (ID: {db_knowledge.id})")
-        return db_knowledge
+        return loaded_knowledge or db_knowledge
     except Exception as e:
         db_logger.error(f"Failed to create a knowledge base record (async): name={knowledge.name} - {str(e)}")
         await db.rollback()
@@ -194,7 +205,7 @@ async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -
     db_logger.debug(f"Query knowledge base based on ID (async): knowledge_id={knowledge_id}")
 
     try:
-        stmt = select(Knowledge).where(Knowledge.id == knowledge_id)
+        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(Knowledge.id == knowledge_id)
         result = await db.execute(stmt)
         knowledge = result.scalars().first()
         if knowledge:
@@ -233,7 +244,7 @@ async def get_knowledge_by_external_id_async(
 ) -> Knowledge | None:
     """Async version of get_knowledge_by_external_id."""
     try:
-        stmt = select(Knowledge).where(
+        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(
             Knowledge.external_id == external_id,
             Knowledge.workspace_id == workspace_id,
             Knowledge.status == 1,
@@ -350,7 +361,7 @@ async def get_knowledges_by_parent_ids_async(
         return []
 
     try:
-        stmt = select(Knowledge).where(
+        stmt = select(Knowledge).options(*_knowledge_relationship_load_options()).where(
             Knowledge.parent_id.in_(parent_ids),
             Knowledge.workspace_id == workspace_id,
             Knowledge.status != 2,
@@ -445,6 +456,7 @@ async def get_knowledge_by_name_async(db: AsyncSession, name: str, workspace_id:
     try:
         stmt = (
             select(Knowledge)
+            .options(*_knowledge_relationship_load_options())
             .where(Knowledge.name == name, Knowledge.workspace_id == workspace_id, Knowledge.status == 1)
         )
         result = await db.execute(stmt)

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.models.document_model import Document
@@ -55,6 +55,48 @@ def get_knowledges_paginated(
         raise
 
 
+async def get_knowledges_paginated_async(
+        db: AsyncSession,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    """Async version of get_knowledges_paginated."""
+    db_logger.debug(
+        f"Query knowledge base in pages (async): page={page}, pagesize={pagesize}, "
+        f"orderby={orderby}, desc={desc}, filters_count={len(filters)}"
+    )
+
+    try:
+        stmt = select(Knowledge)
+        for filter_cond in filters:
+            stmt = stmt.where(filter_cond)
+
+        total_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+        total = total_result.scalar_one()
+
+        if orderby:
+            order_attr = getattr(Knowledge, orderby, None)
+            if order_attr is not None:
+                stmt = stmt.order_by(order_attr.desc() if desc else order_attr.asc())
+
+        stmt = stmt.offset((page - 1) * pagesize).limit(pagesize)
+        result = await db.execute(stmt)
+        items = result.scalars().all()
+        db_logger.info(
+            f"The knowledge base paging query has been successful (async): "
+            f"total={total}, Number of current page={len(items)}"
+        )
+        return total, [knowledge_schema.Knowledge.model_validate(item) for item in items]
+    except Exception as e:
+        db_logger.error(
+            f"Querying knowledge base pagination failed (async): page={page}, pagesize={pagesize} - {str(e)}"
+        )
+        raise
+
+
 def get_chunked_knowledgeids(
         db: Session,
         filters: list
@@ -84,6 +126,22 @@ def get_chunked_knowledgeids(
         raise
 
 
+async def get_chunked_knowledgeids_async(
+        db: AsyncSession,
+        filters: list
+) -> list:
+    """Async version of get_chunked_knowledgeids."""
+    try:
+        stmt = select(Knowledge.id, Knowledge.workspace_id)
+        for filter_cond in filters:
+            stmt = stmt.where(filter_cond)
+        result = await db.execute(stmt)
+        return result.all()
+    except Exception as e:
+        db_logger.error(f"Querying vectorized knowledge IDs failed (async): {str(e)}")
+        raise
+
+
 def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -> Knowledge:
     db_logger.debug(f"Create a knowledge base record: name={knowledge.name}")
     
@@ -96,6 +154,23 @@ def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -
     except Exception as e:
         db_logger.error(f"Failed to create a knowledge base record: name={knowledge.name} - {str(e)}")
         db.rollback()
+        raise
+
+
+async def create_knowledge_async(db: AsyncSession, knowledge: knowledge_schema.KnowledgeCreate) -> Knowledge:
+    """Async version of create_knowledge."""
+    db_logger.debug(f"Create a knowledge base record (async): name={knowledge.name}")
+
+    try:
+        db_knowledge = Knowledge(**knowledge.model_dump())
+        db.add(db_knowledge)
+        await db.commit()
+        await db.refresh(db_knowledge)
+        db_logger.info(f"knowledge base record created successfully (async): {knowledge.name} (ID: {db_knowledge.id})")
+        return db_knowledge
+    except Exception as e:
+        db_logger.error(f"Failed to create a knowledge base record (async): name={knowledge.name} - {str(e)}")
+        await db.rollback()
         raise
 
 
@@ -151,6 +226,25 @@ def get_knowledge_by_external_id(db: Session, external_id: str, workspace_id: uu
         raise
 
 
+async def get_knowledge_by_external_id_async(
+        db: AsyncSession,
+        external_id: str,
+        workspace_id: uuid.UUID
+) -> Knowledge | None:
+    """Async version of get_knowledge_by_external_id."""
+    try:
+        stmt = select(Knowledge).where(
+            Knowledge.external_id == external_id,
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status == 1,
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(f"Failed to query knowledge by external_id (async): external_id={external_id} - {str(e)}")
+        raise
+
+
 def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], workspace_id: uuid.UUID) -> list[uuid.UUID]:
     """解析 external_ids 为 knowledge UUID 列表（仅返回存在的）"""
     db_logger.debug(f"Resolve external_ids to knowledge UUIDs: external_ids={external_ids}, workspace_id={workspace_id}")
@@ -169,6 +263,25 @@ def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], work
         raise
 
 
+async def get_knowledge_ids_by_external_ids_async(
+        db: AsyncSession,
+        external_ids: list[str],
+        workspace_id: uuid.UUID
+) -> list[uuid.UUID]:
+    """Async version of get_knowledge_ids_by_external_ids."""
+    try:
+        stmt = select(Knowledge.id).where(
+            Knowledge.external_id.in_(external_ids),
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status == 1,
+        )
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+    except Exception as e:
+        db_logger.error(f"Failed to resolve external_ids (async): external_ids={external_ids} - {str(e)}")
+        raise
+
+
 def get_knowledges_by_parent_id(db: Session, parent_id: uuid.UUID) -> list[Knowledge]:
     db_logger.debug(f"Query knowledge bases based on parent ID: parent_id={parent_id}")
     try:
@@ -180,6 +293,17 @@ def get_knowledges_by_parent_id(db: Session, parent_id: uuid.UUID) -> list[Knowl
         return knowledges
     except Exception as e:
         db_logger.error(f"Failed to query the knowledge bases based on parent ID: parent_id={parent_id} - {str(e)}")
+        raise
+
+
+async def get_knowledges_by_parent_id_async(db: AsyncSession, parent_id: uuid.UUID) -> list[Knowledge]:
+    """Async version of get_knowledges_by_parent_id."""
+    try:
+        stmt = select(Knowledge).where(Knowledge.parent_id == parent_id, Knowledge.status == 1)
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+    except Exception as e:
+        db_logger.error(f"Failed to query knowledge bases by parent ID (async): parent_id={parent_id} - {str(e)}")
         raise
 
 
@@ -216,6 +340,29 @@ def get_knowledges_by_parent_ids(
         raise
 
 
+async def get_knowledges_by_parent_ids_async(
+        db: AsyncSession,
+        parent_ids: list[uuid.UUID],
+        workspace_id: uuid.UUID,
+) -> list[knowledge_schema.Knowledge]:
+    """Async version of get_knowledges_by_parent_ids."""
+    if not parent_ids:
+        return []
+
+    try:
+        stmt = select(Knowledge).where(
+            Knowledge.parent_id.in_(parent_ids),
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status != 2,
+            Knowledge.permission_id != PermissionType.Memory,
+        )
+        result = await db.execute(stmt)
+        return [knowledge_schema.Knowledge.model_validate(item) for item in result.scalars().all()]
+    except Exception as e:
+        db_logger.error(f"Failed to batch query knowledge bases by parent IDs (async): workspace_id={workspace_id} - {str(e)}")
+        raise
+
+
 def get_document_counts_by_knowledge_ids(
         db: Session,
         knowledge_ids: list[uuid.UUID],
@@ -246,6 +393,31 @@ def get_document_counts_by_knowledge_ids(
         db_logger.error(
             f"Failed to query document counts by knowledge IDs: {str(e)}"
         )
+        raise
+
+
+async def get_document_counts_by_knowledge_ids_async(
+        db: AsyncSession,
+        knowledge_ids: list[uuid.UUID],
+) -> dict[uuid.UUID, int]:
+    """Async version of get_document_counts_by_knowledge_ids."""
+    if not knowledge_ids:
+        return {}
+
+    unique_knowledge_ids = list(dict.fromkeys(knowledge_ids))
+    try:
+        stmt = (
+            select(Document.kb_id, func.count(Document.id))
+            .where(
+                Document.kb_id.in_(unique_knowledge_ids),
+                Document.status == 1,
+            )
+            .group_by(Document.kb_id)
+        )
+        result = await db.execute(stmt)
+        return {kb_id: int(count) for kb_id, count in result.all()}
+    except Exception as e:
+        db_logger.error(f"Failed to query document counts by knowledge IDs (async): {str(e)}")
         raise
 
 
@@ -308,6 +480,25 @@ def delete_knowledge_by_id(db: Session, knowledge_id: uuid.UUID):
     except Exception as e:
         db_logger.error(f"Failed to delete knowledge base record: knowledge_id={knowledge_id} - {str(e)}")
         db.rollback()
+        raise
+
+
+async def delete_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID):
+    """Async version of delete_knowledge_by_id."""
+    try:
+        knowledge = await get_knowledge_by_id_async(db, knowledge_id)
+        knowledge_name = knowledge.name if knowledge else "unknown"
+
+        result = await db.execute(delete(Knowledge).where(Knowledge.id == knowledge_id))
+        await db.commit()
+
+        if result.rowcount and result.rowcount > 0:
+            db_logger.info(f"knowledge base record deleted successfully (async): {knowledge_name} (ID: {knowledge_id})")
+        else:
+            db_logger.warning(f"The knowledge base record does not exist, and cannot be deleted (async): knowledge_id={knowledge_id}")
+    except Exception as e:
+        db_logger.error(f"Failed to delete knowledge base record (async): knowledge_id={knowledge_id} - {str(e)}")
+        await db.rollback()
         raise
 
 

--- a/api/app/repositories/knowledgeshare_repository.py
+++ b/api/app/repositories/knowledgeshare_repository.py
@@ -1,15 +1,22 @@
 import uuid
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 from app.models.knowledgeshare_model import KnowledgeShare
+from app.repositories.knowledge_repository import knowledge_schema_load_options
 from app.schemas import knowledgeshare_schema
 from app.core.logging_config import get_db_logger
-from sqlalchemy.orm import joinedload
-from sqlalchemy import or_
 
 # Obtain a dedicated logger for the database
 db_logger = get_db_logger()
+
+
+def _knowledgeshare_schema_load_options():
+    return (
+        selectinload(KnowledgeShare.target_kb).options(*knowledge_schema_load_options()),
+        selectinload(KnowledgeShare.target_workspace),
+        selectinload(KnowledgeShare.shared_user),
+    )
 
 
 def get_knowledgeshares_paginated(
@@ -67,7 +74,7 @@ async def get_knowledgeshares_paginated_async(
 ) -> tuple[int, list]:
     """Async version of get_knowledgeshares_paginated."""
     try:
-        stmt = select(KnowledgeShare)
+        stmt = select(KnowledgeShare).options(*_knowledgeshare_schema_load_options())
         for filter_cond in filters:
             stmt = stmt.where(filter_cond)
 
@@ -158,7 +165,8 @@ async def create_knowledgeshare_async(
         db.add(db_knowledgeshare)
         await db.commit()
         await db.refresh(db_knowledgeshare)
-        return db_knowledgeshare
+        loaded_share = await get_knowledgeshare_by_id_async(db, db_knowledgeshare.id)
+        return loaded_share or db_knowledgeshare
     except Exception as e:
         db_logger.error(
             f"Failed to create a knowledge base sharing record (async): "
@@ -191,7 +199,7 @@ def get_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID) -> Knowl
 async def get_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uuid.UUID) -> KnowledgeShare | None:
     """Async version of get_knowledgeshare_by_id."""
     try:
-        stmt = select(KnowledgeShare).where(
+        stmt = select(KnowledgeShare).options(*_knowledgeshare_schema_load_options()).where(
             or_(
                 KnowledgeShare.id == knowledgeshare_id,
                 KnowledgeShare.target_kb_id == knowledgeshare_id,

--- a/api/app/repositories/knowledgeshare_repository.py
+++ b/api/app/repositories/knowledgeshare_repository.py
@@ -1,4 +1,6 @@
 import uuid
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.models.knowledgeshare_model import KnowledgeShare
 from app.schemas import knowledgeshare_schema
@@ -55,6 +57,36 @@ def get_knowledgeshares_paginated(
         raise
 
 
+async def get_knowledgeshares_paginated_async(
+        db: AsyncSession,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    """Async version of get_knowledgeshares_paginated."""
+    try:
+        stmt = select(KnowledgeShare)
+        for filter_cond in filters:
+            stmt = stmt.where(filter_cond)
+
+        total_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+        total = total_result.scalar_one()
+
+        if orderby:
+            order_attr = getattr(KnowledgeShare, orderby, None)
+            if order_attr is not None:
+                stmt = stmt.order_by(order_attr.desc() if desc else order_attr.asc())
+
+        result = await db.execute(stmt.offset((page - 1) * pagesize).limit(pagesize))
+        items = result.scalars().all()
+        return total, [knowledgeshare_schema.KnowledgeShare.model_validate(item) for item in items]
+    except Exception as e:
+        db_logger.error(f"Querying knowledge base sharing pagination failed (async): page={page}, pagesize={pagesize} - {str(e)}")
+        raise
+
+
 def get_source_kb_ids_by_target_kb_id(
         db: Session,
         filters: list
@@ -85,6 +117,22 @@ def get_source_kb_ids_by_target_kb_id(
         raise
 
 
+async def get_source_kb_ids_by_target_kb_id_async(
+        db: AsyncSession,
+        filters: list
+) -> list:
+    """Async version of get_source_kb_ids_by_target_kb_id."""
+    try:
+        stmt = select(KnowledgeShare.source_kb_id, KnowledgeShare.source_workspace_id)
+        for filter_cond in filters:
+            stmt = stmt.where(filter_cond)
+        result = await db.execute(stmt)
+        return result.all()
+    except Exception as e:
+        db_logger.error(f"Failed to query source KB IDs through knowledge share (async): {str(e)}")
+        raise
+
+
 def create_knowledgeshare(db: Session, knowledgeshare: knowledgeshare_schema.KnowledgeShareCreate) -> KnowledgeShare:
     db_logger.debug(f"Create a knowledge base sharing record: source_kb_id={knowledgeshare.source_kb_id}")
 
@@ -97,6 +145,26 @@ def create_knowledgeshare(db: Session, knowledgeshare: knowledgeshare_schema.Kno
     except Exception as e:
         db_logger.error(f"Failed to create a knowledge base sharing record: source_kb_id={knowledgeshare.source_kb_id} - {str(e)}")
         db.rollback()
+        raise
+
+
+async def create_knowledgeshare_async(
+        db: AsyncSession,
+        knowledgeshare: knowledgeshare_schema.KnowledgeShareCreate
+) -> KnowledgeShare:
+    """Async version of create_knowledgeshare."""
+    try:
+        db_knowledgeshare = KnowledgeShare(**knowledgeshare.model_dump())
+        db.add(db_knowledgeshare)
+        await db.commit()
+        await db.refresh(db_knowledgeshare)
+        return db_knowledgeshare
+    except Exception as e:
+        db_logger.error(
+            f"Failed to create a knowledge base sharing record (async): "
+            f"source_kb_id={knowledgeshare.source_kb_id} - {str(e)}"
+        )
+        await db.rollback()
         raise
 
 
@@ -120,6 +188,22 @@ def get_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID) -> Knowl
         raise
 
 
+async def get_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uuid.UUID) -> KnowledgeShare | None:
+    """Async version of get_knowledgeshare_by_id."""
+    try:
+        stmt = select(KnowledgeShare).where(
+            or_(
+                KnowledgeShare.id == knowledgeshare_id,
+                KnowledgeShare.target_kb_id == knowledgeshare_id,
+            )
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(f"Failed to query knowledge share by ID (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
+        raise
+
+
 def delete_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID):
     db_logger.debug(f"Delete knowledge base sharing record: knowledgeshare_id={knowledgeshare_id}")
 
@@ -139,4 +223,26 @@ def delete_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID):
     except Exception as e:
         db_logger.error(f"Failed to delete knowledge base sharing record: knowledgeshare_id={knowledgeshare_id} - {str(e)}")
         db.rollback()
+        raise
+
+
+async def delete_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uuid.UUID):
+    """Async version of delete_knowledgeshare_by_id."""
+    try:
+        result = await db.execute(
+            delete(KnowledgeShare).where(
+                or_(
+                    KnowledgeShare.id == knowledgeshare_id,
+                    KnowledgeShare.target_kb_id == knowledgeshare_id,
+                )
+            )
+        )
+        await db.commit()
+        if result.rowcount and result.rowcount > 0:
+            db_logger.info(f"knowledge base sharing record deleted successfully (async): (ID: {knowledgeshare_id})")
+        else:
+            db_logger.warning(f"The knowledge base sharing record does not exist, and cannot be deleted (async): knowledgeshare_id={knowledgeshare_id}")
+    except Exception as e:
+        db_logger.error(f"Failed to delete knowledge share record (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
+        await db.rollback()
         raise

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -157,6 +157,22 @@ class ApiKeyService:
         return api_key
 
     @staticmethod
+    async def get_api_key_async(
+            db: AsyncSession,
+            api_key_id: uuid.UUID,
+            workspace_id: uuid.UUID
+    ) -> ApiKey:
+        """Async version of get_api_key."""
+        api_key = await ApiKeyRepository.get_by_id_async(db, api_key_id)
+        if not api_key:
+            raise BusinessException(f"API Key {api_key_id} 不存在", BizCode.API_KEY_NOT_FOUND)
+
+        if api_key.workspace_id != workspace_id:
+            raise BusinessException("无权访问此 API Key", BizCode.FORBIDDEN)
+
+        return api_key
+
+    @staticmethod
     def list_api_keys(
             db: Session,
             workspace_id: uuid.UUID,

--- a/api/app/services/document_service.py
+++ b/api/app/services/document_service.py
@@ -1,4 +1,5 @@
 import uuid
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.models.user_model import User
 from app.models.document_model import Document
@@ -37,6 +38,39 @@ def get_documents_paginated(
         raise
 
 
+async def get_documents_paginated_async(
+        db: AsyncSession,
+        current_user: User,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    business_logger.debug(
+        f"Query document in pages (async): username={current_user.username}, "
+        f"page={page}, pagesize={pagesize}, orderby={orderby}, desc={desc}"
+    )
+
+    try:
+        total, items = await document_repository.get_documents_paginated_async(
+            db=db,
+            filters=filters,
+            page=page,
+            pagesize=pagesize,
+            orderby=orderby,
+            desc=desc,
+        )
+        business_logger.info(
+            f"The document paging query has been successful (async): username={current_user.username}, "
+            f"total={total}, Number of current page={len(items)}"
+        )
+        return total, items
+    except Exception as e:
+        business_logger.error(f"Querying document pagination failed (async): username={current_user.username} - {str(e)}")
+        raise
+
+
 def create_document(
         db: Session, document: DocumentCreate, current_user: User
 ) -> Document:
@@ -51,6 +85,26 @@ def create_document(
         return db_document
     except Exception as e:
         business_logger.error(f"Failed to create a document: {document.file_name} - {str(e)}")
+        raise
+
+
+async def create_document_async(
+        db: AsyncSession, document: DocumentCreate, current_user: User
+) -> Document:
+    business_logger.info(f"Create a document (async): {document.file_name}, creator: {current_user.username}")
+
+    try:
+        document.created_by = current_user.id
+        db_document = await document_repository.create_document_async(
+            db=db, document=document
+        )
+        business_logger.info(
+            f"The document has been successfully created (async): "
+            f"{document.file_name} (ID: {db_document.id}), creator: {current_user.username}"
+        )
+        return db_document
+    except Exception as e:
+        business_logger.error(f"Failed to create a document (async): {document.file_name} - {str(e)}")
         raise
 
 
@@ -69,9 +123,31 @@ def get_document_by_id(db: Session, document_id: uuid.UUID, current_user: User) 
         raise
 
 
+async def get_document_by_id_async(db: AsyncSession, document_id: uuid.UUID, current_user: User) -> Document | None:
+    business_logger.debug(f"Query document based on ID (async): document_id={document_id}, username: {current_user.username}")
+
+    try:
+        document = await document_repository.get_document_by_id_async(db=db, document_id=document_id)
+        if document:
+            business_logger.info(f"document query successful (async): {document.file_name} (ID: {document_id})")
+        else:
+            business_logger.warning(f"document does not exist (async): document_id={document_id}")
+        return document
+    except Exception as e:
+        business_logger.error(f"Failed to query document by ID (async): document_id={document_id} - {str(e)}")
+        raise
+
+
 def reset_documents_progress_by_kb_id(db: Session, kb_id: uuid.UUID, current_user: User) -> int:
     business_logger.debug(f"Reset the processing progress of all documents under the specified knowledge base: kb_id=={kb_id}, username: {current_user.username}")
     return document_repository.reset_documents_progress_by_kb_id(db=db, kb_id=kb_id)
+
+
+async def reset_documents_progress_by_kb_id_async(db: AsyncSession, kb_id: uuid.UUID, current_user: User) -> int:
+    business_logger.debug(
+        f"Reset processing progress for documents under KB (async): kb_id={kb_id}, username={current_user.username}"
+    )
+    return await document_repository.reset_documents_progress_by_kb_id_async(db=db, kb_id=kb_id)
 
 
 def delete_document_by_id(db: Session, document_id: uuid.UUID, current_user: User) -> None:
@@ -82,4 +158,15 @@ def delete_document_by_id(db: Session, document_id: uuid.UUID, current_user: Use
         business_logger.info(f"document deleted successfully: document_id={document_id}, operator: {current_user.username}")
     except Exception as e:
         business_logger.error(f"Failed to delete document: document_id={document_id} - {str(e)}")
+        raise
+
+
+async def delete_document_by_id_async(db: AsyncSession, document_id: uuid.UUID, current_user: User) -> None:
+    business_logger.info(f"Delete document (async): document_id={document_id}, operator: {current_user.username}")
+
+    try:
+        await document_repository.delete_document_by_id_async(db=db, document_id=document_id)
+        business_logger.info(f"document deleted successfully (async): document_id={document_id}, operator: {current_user.username}")
+    except Exception as e:
+        business_logger.error(f"Failed to delete document (async): document_id={document_id} - {str(e)}")
         raise

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -8,6 +8,7 @@ import datetime
 import json
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from langchain.tools import tool
@@ -25,7 +26,7 @@ from app.core.logging_config import get_business_logger
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
-from app.db import get_db_context
+from app.db import get_async_db_context, get_db_context
 from app.models import App, AgentConfig, ModelConfig, Message
 from app.models.agent_execution_model import AgentExecution
 from app.models.models_model import ModelCapability, ModelType
@@ -55,6 +56,16 @@ class KnowledgeRetrievalInput(BaseModel):
 class WebSearchInput(BaseModel):
     """网络搜索工具输入参数"""
     query: str = Field(description="需要搜索的问题或关键词")
+
+
+def _run_async_blocking(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(coro)).result()
 
 
 def create_web_search_tool(web_search_config: Dict[str, Any]):
@@ -101,7 +112,7 @@ def create_web_search_tool(web_search_config: Dict[str, Any]):
     return web_search_tool
 
 
-def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
+async def _retrieve_chunks_via_standard_async(query: str, kb_config: Dict[str, Any]) -> list:
     """标准化知识库检索：走 KnowledgeRetrievalService + KnowledgeRetrievalRequest。
 
     读取 agent 的 ``knowledge_retrieval`` 配置（top_k / similarity_threshold /
@@ -152,10 +163,51 @@ def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list
         rerank_id=rerank_id,
     )
 
-    with get_db_context() as db:
-        result = KnowledgeRetrievalService.retrieve(db=db, request=request, current_user=None)
+    async with get_async_db_context() as db:
+        result = await KnowledgeRetrievalService.retrieve_async(db=db, request=request, current_user=None)
 
     return result.chunks
+
+
+def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
+    return _run_async_blocking(_retrieve_chunks_via_standard_async(query, kb_config))
+
+
+async def _load_knowledge_retrieval_kb_names_async(kb_ids: List[str]) -> List[Dict[str, str]]:
+    valid_kb_ids = []
+    for kid in kb_ids:
+        try:
+            valid_kb_ids.append(kid if isinstance(kid, uuid.UUID) else uuid.UUID(str(kid)))
+        except (TypeError, ValueError):
+            continue
+
+    if not valid_kb_ids:
+        return []
+
+    from app.models import Knowledge
+    from app.models.knowledgeshare_model import KnowledgeShare
+
+    async with get_async_db_context() as db:
+        rows_result = await db.execute(
+            select(Knowledge.id, Knowledge.name).where(Knowledge.id.in_(valid_kb_ids))
+        )
+        rows = rows_result.all()
+        kb_names = [{"id": str(kb_id), "name": name} for kb_id, name in rows]
+
+        share_result = await db.execute(
+            select(KnowledgeShare.source_kb_id, KnowledgeShare.target_kb_id).where(
+                KnowledgeShare.target_kb_id.in_(valid_kb_ids)
+            )
+        )
+        share_rows = share_result.all()
+        if share_rows:
+            id_to_name = {str(kb_id): name for kb_id, name in rows}
+            for source_kb_id, target_kb_id in share_rows:
+                source_name = id_to_name.get(str(target_kb_id))
+                if source_name:
+                    kb_names.append({"id": str(source_kb_id), "name": source_name})
+
+    return kb_names
 
 
 def create_knowledge_retrieval_tool(kb_config, kb_ids, user_id, citations_collector: Optional[List[Citation]] = None, kb_names: Optional[List[Dict]] = None):
@@ -550,27 +602,7 @@ class AgentRunService:
             # 查询知识库名称
             kb_names = []
             try:
-                from app.models import Knowledge
-                rows = self.db.query(Knowledge.id, Knowledge.name).filter(
-                    Knowledge.id.in_(kb_ids)
-                ).all()
-                kb_names = [{"id": str(r.id), "name": r.name} for r in rows]
-
-                # 对于共享知识库，chunk元数据中的knowledge_id是source_kb_id，
-                # 需要将source_kb_id也映射到名称，否则会显示为ID
-                from app.models.knowledgeshare_model import KnowledgeShare
-                target_kb_ids = [uuid.UUID(kid) for kid in kb_ids]
-                share_rows = self.db.query(
-                    KnowledgeShare.source_kb_id, KnowledgeShare.target_kb_id
-                ).filter(
-                    KnowledgeShare.target_kb_id.in_(target_kb_ids)
-                ).all()
-                if share_rows:
-                    id_to_name = {str(r.id): r.name for r in rows}
-                    for sr in share_rows:
-                        source_name = id_to_name.get(str(sr.target_kb_id))
-                        if source_name:
-                            kb_names.append({"id": str(sr.source_kb_id), "name": source_name})
+                kb_names = _run_async_blocking(_load_knowledge_retrieval_kb_names_async(kb_ids))
             except Exception:
                 kb_names = [{"id": kid, "name": kid} for kid in kb_ids]
 

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -8,7 +8,6 @@ import datetime
 import json
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from langchain.tools import tool
@@ -26,7 +25,7 @@ from app.core.logging_config import get_business_logger
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
-from app.db import get_async_db_context, get_db_context
+from app.db import get_db_context
 from app.models import App, AgentConfig, ModelConfig, Message
 from app.models.agent_execution_model import AgentExecution
 from app.models.models_model import ModelCapability, ModelType
@@ -56,16 +55,6 @@ class KnowledgeRetrievalInput(BaseModel):
 class WebSearchInput(BaseModel):
     """网络搜索工具输入参数"""
     query: str = Field(description="需要搜索的问题或关键词")
-
-
-def _run_async_blocking(coro):
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        return executor.submit(lambda: asyncio.run(coro)).result()
 
 
 def create_web_search_tool(web_search_config: Dict[str, Any]):
@@ -112,7 +101,7 @@ def create_web_search_tool(web_search_config: Dict[str, Any]):
     return web_search_tool
 
 
-async def _retrieve_chunks_via_standard_async(query: str, kb_config: Dict[str, Any]) -> list:
+def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
     """标准化知识库检索：走 KnowledgeRetrievalService + KnowledgeRetrievalRequest。
 
     读取 agent 的 ``knowledge_retrieval`` 配置（top_k / similarity_threshold /
@@ -163,51 +152,11 @@ async def _retrieve_chunks_via_standard_async(query: str, kb_config: Dict[str, A
         rerank_id=rerank_id,
     )
 
-    async with get_async_db_context() as db:
-        result = await KnowledgeRetrievalService.retrieve_async(db=db, request=request, current_user=None)
+    # ToolOrchestrator runs sync tools in a worker thread, so keep this DB session on that thread.
+    with get_db_context() as db:
+        result = KnowledgeRetrievalService.retrieve(db=db, request=request, current_user=None)
 
     return result.chunks
-
-
-def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
-    return _run_async_blocking(_retrieve_chunks_via_standard_async(query, kb_config))
-
-
-async def _load_knowledge_retrieval_kb_names_async(kb_ids: List[str]) -> List[Dict[str, str]]:
-    valid_kb_ids = []
-    for kid in kb_ids:
-        try:
-            valid_kb_ids.append(kid if isinstance(kid, uuid.UUID) else uuid.UUID(str(kid)))
-        except (TypeError, ValueError):
-            continue
-
-    if not valid_kb_ids:
-        return []
-
-    from app.models import Knowledge
-    from app.models.knowledgeshare_model import KnowledgeShare
-
-    async with get_async_db_context() as db:
-        rows_result = await db.execute(
-            select(Knowledge.id, Knowledge.name).where(Knowledge.id.in_(valid_kb_ids))
-        )
-        rows = rows_result.all()
-        kb_names = [{"id": str(kb_id), "name": name} for kb_id, name in rows]
-
-        share_result = await db.execute(
-            select(KnowledgeShare.source_kb_id, KnowledgeShare.target_kb_id).where(
-                KnowledgeShare.target_kb_id.in_(valid_kb_ids)
-            )
-        )
-        share_rows = share_result.all()
-        if share_rows:
-            id_to_name = {str(kb_id): name for kb_id, name in rows}
-            for source_kb_id, target_kb_id in share_rows:
-                source_name = id_to_name.get(str(target_kb_id))
-                if source_name:
-                    kb_names.append({"id": str(source_kb_id), "name": source_name})
-
-    return kb_names
 
 
 def create_knowledge_retrieval_tool(kb_config, kb_ids, user_id, citations_collector: Optional[List[Citation]] = None, kb_names: Optional[List[Dict]] = None):
@@ -602,7 +551,27 @@ class AgentRunService:
             # 查询知识库名称
             kb_names = []
             try:
-                kb_names = _run_async_blocking(_load_knowledge_retrieval_kb_names_async(kb_ids))
+                from app.models import Knowledge
+                rows = self.db.query(Knowledge.id, Knowledge.name).filter(
+                    Knowledge.id.in_(kb_ids)
+                ).all()
+                kb_names = [{"id": str(r.id), "name": r.name} for r in rows]
+
+                # 对于共享知识库，chunk元数据中的knowledge_id是source_kb_id，
+                # 需要将source_kb_id也映射到名称，否则会显示为ID
+                from app.models.knowledgeshare_model import KnowledgeShare
+                target_kb_ids = [uuid.UUID(kid) for kid in kb_ids]
+                share_rows = self.db.query(
+                    KnowledgeShare.source_kb_id, KnowledgeShare.target_kb_id
+                ).filter(
+                    KnowledgeShare.target_kb_id.in_(target_kb_ids)
+                ).all()
+                if share_rows:
+                    id_to_name = {str(r.id): r.name for r in rows}
+                    for sr in share_rows:
+                        source_name = id_to_name.get(str(sr.target_kb_id))
+                        if source_name:
+                            kb_names.append({"id": str(sr.source_kb_id), "name": source_name})
             except Exception:
                 kb_names = [{"id": kid, "name": kid} for kid in kb_ids]
 

--- a/api/app/services/knowledge_metadata_service.py
+++ b/api/app/services/knowledge_metadata_service.py
@@ -1,5 +1,7 @@
 import uuid
 from typing import Any
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 from app.core.utils.datetime_utils import (
@@ -35,6 +37,16 @@ class KnowledgeMetadataService:
         Returns: {"custom": [...], "builtin_enabled": bool, "builtin_fields": [...]}
         """
         return KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids(
+            db=db,
+            knowledge_ids=[knowledge_id],
+            include_builtin_when_disabled=True,
+            preserve_single_ids=True,
+        )
+
+    @staticmethod
+    async def list_metadata_fields_async(db: AsyncSession, knowledge_id: uuid.UUID) -> dict:
+        """Async version of list_metadata_fields."""
+        return await KnowledgeMetadataService.list_metadata_fields_for_knowledge_ids_async(
             db=db,
             knowledge_ids=[knowledge_id],
             include_builtin_when_disabled=True,
@@ -82,6 +94,58 @@ class KnowledgeMetadataService:
         builtin_enabled_by_kb = {
             row[0]: row[1] == 1
             for row in knowledge_rows
+        }
+        for knowledge_id in unique_knowledge_ids:
+            builtin_enabled_by_kb.setdefault(knowledge_id, False)
+
+        return KnowledgeMetadataService._build_common_metadata_fields_response(
+            fields_by_kb=fields_by_kb,
+            builtin_enabled_by_kb=builtin_enabled_by_kb,
+            counts_by_metadata_id=counts_by_metadata_id,
+            include_builtin_when_disabled=include_builtin_when_disabled,
+            preserve_single_ids=preserve_single_ids,
+        )
+
+    @staticmethod
+    async def list_metadata_fields_for_knowledge_ids_async(
+        db: AsyncSession,
+        knowledge_ids: list[uuid.UUID],
+        *,
+        include_builtin_when_disabled: bool = False,
+        preserve_single_ids: bool = False,
+        include_counts: bool = True,
+    ) -> dict:
+        """Async version of list_metadata_fields_for_knowledge_ids."""
+        from app.models.knowledge_model import Knowledge
+
+        unique_knowledge_ids = list(dict.fromkeys(knowledge_ids))
+        if not unique_knowledge_ids:
+            return {
+                "custom": [],
+                "builtin_enabled": False,
+                "builtin_fields": [],
+            }
+
+        custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_ids_async(db, unique_knowledge_ids)
+        fields_by_kb = {knowledge_id: [] for knowledge_id in unique_knowledge_ids}
+        for field in custom_fields:
+            fields_by_kb.setdefault(field.knowledge_id, []).append(field)
+
+        counts_by_metadata_id = {}
+        if include_counts:
+            metadata_ids = [field.id for field in custom_fields]
+            counts_by_metadata_id = await KnowledgeMetadataRepository.count_active_bindings_by_metadata_ids_async(
+                db,
+                metadata_ids,
+            )
+
+        result = await db.execute(
+            select(Knowledge.id, Knowledge.builtin_metadata_enabled)
+            .where(Knowledge.id.in_(unique_knowledge_ids))
+        )
+        builtin_enabled_by_kb = {
+            row[0]: row[1] == 1
+            for row in result.all()
         }
         for knowledge_id in unique_knowledge_ids:
             builtin_enabled_by_kb.setdefault(knowledge_id, False)
@@ -189,6 +253,36 @@ class KnowledgeMetadataService:
         return KnowledgeMetadataRepository.create(db, metadata_field)
 
     @staticmethod
+    async def create_metadata_field_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+        name: str,
+        field_type: str,
+        tenant_id: uuid.UUID,
+        created_by: uuid.UUID,
+    ) -> KnowledgeMetadata:
+        """Async version of create_metadata_field."""
+        if name in KnowledgeMetadataService.BUILTIN_FIELD_NAMES:
+            raise ValidationException(
+                f"字段名 '{name}' 与内置字段冲突",
+                field="name",
+            )
+
+        existing = await KnowledgeMetadataRepository.get_by_name_async(db, knowledge_id, name)
+        if existing:
+            raise DuplicateResourceException(f"字段 '{name}' 已存在")
+
+        metadata_field = KnowledgeMetadata(
+            tenant_id=tenant_id,
+            knowledge_id=knowledge_id,
+            name=name,
+            type=field_type,
+            created_by=created_by,
+            updated_by=created_by,
+        )
+        return await KnowledgeMetadataRepository.create_async(db, metadata_field)
+
+    @staticmethod
     def update_metadata_field(
         db: Session,
         metadata_id: uuid.UUID,
@@ -215,6 +309,35 @@ class KnowledgeMetadataService:
 
         KnowledgeMetadataRepository.update(db, metadata_id, update_data)
         db.refresh(field)
+        return field
+
+    @staticmethod
+    async def update_metadata_field_async(
+        db: AsyncSession,
+        metadata_id: uuid.UUID,
+        knowledge_id: uuid.UUID,
+        name: str | None,
+        updated_by: uuid.UUID,
+    ) -> KnowledgeMetadata:
+        """Async version of update_metadata_field."""
+        field = await KnowledgeMetadataRepository.get_by_id_async(db, metadata_id)
+        if not field or field.knowledge_id != knowledge_id:
+            raise ResourceNotFoundException("元数据字段", str(metadata_id))
+
+        update_data = {"updated_by": updated_by}
+        if name and name != field.name:
+            if name in KnowledgeMetadataService.BUILTIN_FIELD_NAMES:
+                raise ValidationException(
+                    f"字段名 '{name}' 与内置字段冲突",
+                    field="name",
+                )
+            existing = await KnowledgeMetadataRepository.get_by_name_async(db, knowledge_id, name)
+            if existing and existing.id != metadata_id:
+                raise DuplicateResourceException(f"字段 '{name}' 已存在")
+            update_data["name"] = name
+
+        await KnowledgeMetadataRepository.update_async(db, metadata_id, update_data)
+        await db.refresh(field)
         return field
 
     @staticmethod
@@ -247,11 +370,58 @@ class KnowledgeMetadataService:
         api_logger.info(f"Deleted metadata field '{field_name}' and cleaned up document metadata")
 
     @staticmethod
+    async def delete_metadata_field_async(
+        db: AsyncSession,
+        metadata_id: uuid.UUID,
+        knowledge_id: uuid.UUID,
+    ) -> None:
+        """Async version of delete_metadata_field."""
+        field = await KnowledgeMetadataRepository.get_by_id_async(db, metadata_id)
+        if not field or field.knowledge_id != knowledge_id:
+            raise ResourceNotFoundException("元数据字段", str(metadata_id))
+
+        field_name = field.name
+        try:
+            await db.execute(
+                delete(KnowledgeMetadataBinding).where(
+                    KnowledgeMetadataBinding.metadata_id == metadata_id
+                )
+            )
+            await db.execute(
+                update(Document)
+                .where(Document.kb_id == knowledge_id)
+                .values({Document.meta_data: Document.meta_data.op("-")(field_name)})
+                .execution_options(synchronize_session=False)
+            )
+            await db.execute(
+                delete(KnowledgeMetadata).where(KnowledgeMetadata.id == metadata_id)
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+        api_logger.info(f"Deleted metadata field '{field_name}' and cleaned up document metadata")
+
+    @staticmethod
     def get_builtin_fields(db: Session, knowledge_id: uuid.UUID) -> dict:
         """获取内置元数据字段列表及开关状态"""
         from app.models.knowledge_model import Knowledge
 
         knowledge = db.query(Knowledge).filter(Knowledge.id == knowledge_id).first()
+        enabled = knowledge.builtin_metadata_enabled == 1 if knowledge else False
+
+        return {
+            "enabled": enabled,
+            "fields": BuiltinFieldResolver.get_all(),
+        }
+
+    @staticmethod
+    async def get_builtin_fields_async(db: AsyncSession, knowledge_id: uuid.UUID) -> dict:
+        """Async version of get_builtin_fields."""
+        from app.models.knowledge_model import Knowledge
+
+        knowledge = await db.get(Knowledge, knowledge_id)
         enabled = knowledge.builtin_metadata_enabled == 1 if knowledge else False
 
         return {
@@ -275,6 +445,25 @@ class KnowledgeMetadataService:
         knowledge.builtin_metadata_enabled = 1 if enabled else 0
         db.commit()
         db.refresh(knowledge)
+
+        return enabled
+
+    @staticmethod
+    async def set_builtin_metadata_enabled_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+        enabled: bool,
+    ) -> bool:
+        """Async version of set_builtin_metadata_enabled."""
+        from app.models.knowledge_model import Knowledge
+
+        knowledge = await db.get(Knowledge, knowledge_id)
+        if not knowledge:
+            raise ResourceNotFoundException("知识库", str(knowledge_id))
+
+        knowledge.builtin_metadata_enabled = 1 if enabled else 0
+        await db.commit()
+        await db.refresh(knowledge)
 
         return enabled
 
@@ -386,6 +575,101 @@ class KnowledgeMetadataService:
         return {"success_count": success_count, "failed_items": []}
 
     @staticmethod
+    async def batch_update_document_metadata_async(
+        db: AsyncSession,
+        items: list[dict],
+        tenant_id: uuid.UUID,
+        created_by: uuid.UUID,
+    ) -> dict:
+        """Async version of batch_update_document_metadata."""
+        if not items:
+            return {"success_count": 0, "failed_items": []}
+
+        document_ids = [item["document_id"] for item in items]
+        result = await db.execute(select(Document).where(Document.id.in_(document_ids)))
+        documents = list(result.scalars().all())
+        doc_map = {doc.id: doc for doc in documents}
+
+        if len(documents) != len(document_ids):
+            missing = set(document_ids) - set(doc_map.keys())
+            raise ResourceNotFoundException("文档", str(list(missing)[0]))
+
+        kb_ids = {doc.kb_id for doc in documents}
+        if len(kb_ids) != 1:
+            raise BusinessException(
+                "批量更新的文档必须属于同一知识库",
+                code=BizCode.METADATA_CROSS_KB_BATCH,
+            )
+
+        knowledge_id = list(kb_ids)[0]
+        custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_id_async(db, knowledge_id)
+        field_defs = {f.name: f for f in custom_fields}
+
+        failed_items = []
+        for item in items:
+            doc_id = item["document_id"]
+            metadata = item["metadata"]
+            doc = doc_map.get(doc_id)
+
+            if not doc:
+                failed_items.append({"document_id": str(doc_id), "error": "文档不存在"})
+                continue
+
+            for field_name, value in metadata.items():
+                field_def = field_defs.get(field_name)
+                if not field_def:
+                    failed_items.append({
+                        "document_id": str(doc_id),
+                        "error": f"字段 '{field_name}' 未在知识库中定义",
+                    })
+                elif not KnowledgeMetadataService._validate_value_type(field_def.type, value):
+                    failed_items.append({
+                        "document_id": str(doc_id),
+                        "error": f"字段 '{field_name}' 的值类型不匹配，期望 {field_def.type}",
+                    })
+
+        if failed_items:
+            return {"success_count": 0, "failed_items": failed_items}
+
+        success_count = 0
+        try:
+            for item in items:
+                doc_id = item["document_id"]
+                metadata = item["metadata"]
+                doc = doc_map[doc_id]
+                normalized_metadata = KnowledgeMetadataService._normalize_metadata_for_storage(
+                    metadata,
+                    field_defs,
+                )
+                doc.meta_data = doc.meta_data or {}
+                doc.meta_data.update(normalized_metadata)
+                flag_modified(doc, "meta_data")
+                doc.updated_at = utcnow_naive()
+
+                for field_name in metadata.keys():
+                    field_def = field_defs[field_name]
+                    if not await KnowledgeMetadataRepository.binding_exists_async(
+                        db, knowledge_id, field_def.id, doc_id
+                    ):
+                        binding = KnowledgeMetadataBinding(
+                            tenant_id=tenant_id,
+                            knowledge_id=knowledge_id,
+                            metadata_id=field_def.id,
+                            document_id=doc_id,
+                            created_by=created_by,
+                        )
+                        db.add(binding)
+
+                success_count += 1
+
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+        return {"success_count": success_count, "failed_items": []}
+
+    @staticmethod
     def update_document_metadata(
         db: Session,
         document_id: uuid.UUID,
@@ -457,6 +741,64 @@ class KnowledgeMetadataService:
         return KnowledgeMetadataService.get_document_metadata(db, document_id)
 
     @staticmethod
+    async def update_document_metadata_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+        metadata: dict[str, Any],
+        tenant_id: uuid.UUID,
+        created_by: uuid.UUID,
+    ) -> dict:
+        """Async version of update_document_metadata."""
+        doc = await db.get(Document, document_id)
+        if not doc:
+            raise ResourceNotFoundException("文档", str(document_id))
+
+        knowledge_id = doc.kb_id
+        custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_id_async(db, knowledge_id)
+        field_defs = {f.name: f for f in custom_fields}
+
+        for field_name, value in metadata.items():
+            field_def = field_defs.get(field_name)
+            if not field_def:
+                raise ValidationException(
+                    f"字段 '{field_name}' 未在知识库中定义",
+                    field=field_name,
+                )
+
+            if not KnowledgeMetadataService._validate_value_type(field_def.type, value):
+                raise ValidationException(
+                    f"字段 '{field_name}' 的值类型不匹配，期望 {field_def.type}",
+                    field=field_name,
+                )
+
+        normalized_metadata = KnowledgeMetadataService._normalize_metadata_for_storage(
+            metadata,
+            field_defs,
+        )
+        doc.meta_data = doc.meta_data or {}
+        doc.meta_data.update(normalized_metadata)
+        flag_modified(doc, "meta_data")
+        doc.updated_at = utcnow_naive()
+
+        for field_name in metadata.keys():
+            field_def = field_defs[field_name]
+            if not await KnowledgeMetadataRepository.binding_exists_async(
+                db, knowledge_id, field_def.id, document_id
+            ):
+                binding = KnowledgeMetadataBinding(
+                    tenant_id=tenant_id,
+                    knowledge_id=knowledge_id,
+                    metadata_id=field_def.id,
+                    document_id=document_id,
+                    created_by=created_by,
+                )
+                db.add(binding)
+
+        await db.commit()
+        await db.refresh(doc)
+        return await KnowledgeMetadataService.get_document_metadata_async(db, document_id)
+
+    @staticmethod
     def get_document_metadata(
         db: Session,
         document_id: uuid.UUID,
@@ -475,6 +817,45 @@ class KnowledgeMetadataService:
 
         # 获取字段定义
         custom_fields = KnowledgeMetadataRepository.get_by_knowledge_id(db, doc.kb_id)
+        field_map = {f.id: f for f in custom_fields}
+        field_defs_by_name = {f.name: f for f in custom_fields}
+        metadata = KnowledgeMetadataService._serialize_metadata_for_response(
+            doc.meta_data or {},
+            field_defs_by_name,
+        )
+
+        result = {
+            "document_id": str(document_id),
+            "metadata": metadata,
+            "fields": [],
+        }
+
+        for metadata_id, binding in binding_fields.items():
+            field_def = field_map.get(metadata_id)
+            if field_def:
+                result["fields"].append({
+                    "field_id": str(field_def.id),
+                    "name": field_def.name,
+                    "type": field_def.type,
+                    "value": metadata.get(field_def.name),
+                })
+
+        return result
+
+    @staticmethod
+    async def get_document_metadata_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+    ) -> dict:
+        """Async version of get_document_metadata."""
+        doc = await db.get(Document, document_id)
+        if not doc:
+            raise ResourceNotFoundException("文档", str(document_id))
+
+        bindings = await KnowledgeMetadataRepository.get_bindings_by_document_id_async(db, document_id)
+        binding_fields = {b.metadata_id: b for b in bindings}
+
+        custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_id_async(db, doc.kb_id)
         field_map = {f.id: f for f in custom_fields}
         field_defs_by_name = {f.name: f for f in custom_fields}
         metadata = KnowledgeMetadataService._serialize_metadata_for_response(
@@ -563,6 +944,70 @@ class KnowledgeMetadataService:
 
         db.commit()
         db.refresh(doc)
+
+        return {
+            "document_id": str(document_id),
+            "deleted_fields": deleted_fields,
+        }
+
+    @staticmethod
+    async def delete_document_metadata_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+        field_names: list[str] | None = None,
+    ) -> dict:
+        """Async version of delete_document_metadata."""
+        doc = await db.get(Document, document_id)
+        if not doc:
+            raise ResourceNotFoundException("文档", str(document_id))
+
+        doc.meta_data = doc.meta_data or {}
+        knowledge_id = doc.kb_id
+        deleted_fields = []
+
+        if field_names is None or len(field_names) == 0:
+            deleted_fields = list(doc.meta_data.keys()) if doc.meta_data else []
+            doc.meta_data = {}
+            flag_modified(doc, "meta_data")
+            await db.execute(
+                delete(KnowledgeMetadataBinding).where(
+                    KnowledgeMetadataBinding.document_id == document_id
+                )
+            )
+        else:
+            custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_id_async(db, knowledge_id)
+            field_defs = {f.name: f for f in custom_fields}
+            skipped_fields = []
+
+            for field_name in field_names:
+                field_def = field_defs.get(field_name)
+                if field_name not in doc.meta_data and not field_def:
+                    skipped_fields.append(field_name)
+                    continue
+
+                if field_name in doc.meta_data:
+                    del doc.meta_data[field_name]
+                    deleted_fields.append(field_name)
+
+                if field_def:
+                    await db.execute(
+                        delete(KnowledgeMetadataBinding).where(
+                            KnowledgeMetadataBinding.document_id == document_id,
+                            KnowledgeMetadataBinding.metadata_id == field_def.id,
+                        )
+                    )
+
+            if deleted_fields:
+                flag_modified(doc, "meta_data")
+            if skipped_fields:
+                api_logger.warning(
+                    "Skipped unknown document metadata fields: "
+                    f"document_id={document_id}, knowledge_id={knowledge_id}, "
+                    f"field_names={skipped_fields}"
+                )
+
+        await db.commit()
+        await db.refresh(doc)
 
         return {
             "document_id": str(document_id),
@@ -673,6 +1118,27 @@ class KnowledgeMetadataService:
 
         # 内置字段（如果开启）
         knowledge = db.query(Knowledge).filter(Knowledge.id == knowledge_id).first()
+        if knowledge and knowledge.builtin_metadata_enabled == 1:
+            for bf in BuiltinFieldResolver.get_all():
+                result[bf.name] = {"type": bf.type, "is_builtin": True}
+
+        return result
+
+    @staticmethod
+    async def get_metadata_defs_for_filtering_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+    ) -> dict[str, dict]:
+        """Async version of get_metadata_defs_for_filtering."""
+        from app.models.knowledge_model import Knowledge
+
+        result = {}
+
+        custom_fields = await KnowledgeMetadataRepository.get_by_knowledge_id_async(db, knowledge_id)
+        for f in custom_fields:
+            result[f.name] = {"id": f.id, "type": f.type, "is_builtin": False}
+
+        knowledge = await db.get(Knowledge, knowledge_id)
         if knowledge and knowledge.builtin_metadata_enabled == 1:
             for bf in BuiltinFieldResolver.get_all():
                 result[bf.name] = {"type": bf.type, "is_builtin": True}

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -30,6 +30,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
     ElasticSearchVectorIndexOps,
 )
+from app.db import get_db_context
 from app.models import ModelType, knowledge_model, knowledgeshare_model
 from app.models.models_model import ModelApiKey, ModelConfig
 from app.repositories import knowledge_repository
@@ -67,6 +68,29 @@ class ModelApiKeySnapshot:
             provider=api_key.provider,
             api_key=api_key.api_key,
             api_base=api_key.api_base,
+        )
+
+
+@dataclass(frozen=True)
+class RetrievalPrincipal:
+    id: Any
+    username: str | None
+    tenant_id: Any
+    current_workspace_id: Any
+    is_superuser: bool
+
+    @classmethod
+    def from_user(cls, user: Any) -> "RetrievalPrincipal | None":
+        if user is None:
+            return None
+        if isinstance(user, cls):
+            return user
+        return cls(
+            id=getattr(user, "id", None),
+            username=getattr(user, "username", None),
+            tenant_id=getattr(user, "tenant_id", None),
+            current_workspace_id=getattr(user, "current_workspace_id", None),
+            is_superuser=bool(getattr(user, "is_superuser", False)),
         )
 
 
@@ -343,13 +367,38 @@ class KnowledgeRetrievalService:
     @classmethod
     async def retrieve_async(
             cls,
-            db: AsyncSession,
+            db: Session | AsyncSession,
             request: KnowledgeRetrievalRequest,
             current_user: Any = None,
     ) -> KnowledgeRetrievalResult:
         """Async retrieval entrypoint for async request chains."""
-        if not isinstance(db, AsyncSession):
-            return await asyncio.to_thread(cls.retrieve, db, request, current_user)
+        principal = RetrievalPrincipal.from_user(current_user)
+        if isinstance(db, AsyncSession):
+            return await cls._retrieve_with_async_session(db, request, principal)
+        if isinstance(db, Session):
+            return await asyncio.to_thread(
+                cls._retrieve_with_sync_session,
+                request,
+                principal,
+            )
+        raise TypeError("retrieve_async requires Session or AsyncSession")
+
+    @classmethod
+    def _retrieve_with_sync_session(
+            cls,
+            request: KnowledgeRetrievalRequest,
+            current_user: RetrievalPrincipal | None,
+    ) -> KnowledgeRetrievalResult:
+        with get_db_context() as thread_db:
+            return cls.retrieve(thread_db, request, current_user)
+
+    @classmethod
+    async def _retrieve_with_async_session(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            current_user: RetrievalPrincipal | None = None,
+    ) -> KnowledgeRetrievalResult:
 
         log_id = cls._new_retrieval_log_id()
         started_at = time.perf_counter()

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 import uuid
@@ -7,6 +8,8 @@ from enum import Enum
 from typing import Any, Optional
 
 from langchain_core.documents import Document
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -28,7 +31,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorIndexOps,
 )
 from app.models import ModelType, knowledge_model, knowledgeshare_model
-from app.models.models_model import ModelApiKey
+from app.models.models_model import ModelApiKey, ModelConfig
 from app.repositories import knowledge_repository
 from app.repositories.tool_repository import ToolRepository
 from app.schemas.chunk_schema import KnowledgeBaseConfig, RetrieveType
@@ -338,6 +341,104 @@ class KnowledgeRetrievalService:
         return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
+    async def retrieve_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> KnowledgeRetrievalResult:
+        """Async retrieval entrypoint for async request chains."""
+        if not isinstance(db, AsyncSession):
+            return await asyncio.to_thread(cls.retrieve, db, request, current_user)
+
+        log_id = cls._new_retrieval_log_id()
+        started_at = time.perf_counter()
+        logger.info(
+            "[Retrieval] start %s",
+            cls._format_log_fields(cls._build_retrieval_start_log_fields(log_id, request, current_user)),
+        )
+        targets, tenant_id = await cls._resolve_retrieval_targets_async(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not targets:
+            logger.info(
+                "[Retrieval] finish %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "reason": "no_targets",
+                    "target_count": 0,
+                    "final_count": 0,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                }),
+            )
+            return KnowledgeRetrievalResult(chunks=[])
+
+        knowledge_ids = [target.knowledge_id for target in targets]
+        workspace_ids = [target.workspace_id for target in targets]
+        db_knowledge = await cls._get_first_knowledge_async(
+            db=db,
+            knowledge_id=targets[0].knowledge_id,
+            current_user=current_user,
+        )
+        if not db_knowledge:
+            raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
+
+        document_ids_include = await cls._build_metadata_document_filter_async(
+            db=db,
+            request=request,
+            knowledge_ids=knowledge_ids,
+            tenant_id=tenant_id,
+            log_id=log_id,
+        )
+        if document_ids_include == []:
+            logger.info(
+                "[Retrieval] finish %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "reason": "metadata_filter_empty",
+                    "target_count": len(targets),
+                    "final_count": 0,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                }),
+            )
+            return KnowledgeRetrievalResult(chunks=[])
+
+        chunks = await cls._retrieve_targets_async(
+            db=db,
+            request=request,
+            targets=targets,
+            document_ids_include=document_ids_include,
+            tenant_id=tenant_id,
+            log_id=log_id,
+        )
+        if any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
+            graph_doc = await cls._retrieve_graph_async(
+                db=db,
+                request=request,
+                knowledge_ids=knowledge_ids,
+                workspace_ids=workspace_ids,
+                db_knowledge=db_knowledge,
+                tenant_id=tenant_id,
+            )
+            if graph_doc:
+                chunks.insert(0, graph_doc)
+        chunks = cls._include_document_ids(chunks, document_ids_include)
+        logger.info(
+            "[Retrieval] finish %s",
+            cls._format_log_fields({
+                "id": log_id,
+                "reason": "ok",
+                "target_count": len(targets),
+                "document_filter_count": len(document_ids_include or []),
+                "final_count": len(chunks),
+                "elapsed_ms": cls._elapsed_ms(started_at),
+            }),
+        )
+        return KnowledgeRetrievalResult(chunks=chunks)
+
+    @classmethod
     def _resolve_retrieval_targets(
             cls,
             db: Session,
@@ -369,6 +470,56 @@ class KnowledgeRetrievalService:
         return targets, tenant_id
 
     @classmethod
+    async def _resolve_retrieval_targets_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> tuple[list[RetrievalTarget], uuid.UUID | None]:
+        refs = await cls._resolve_retrievable_knowledge_refs_async(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not refs:
+            return [], None
+
+        tenant_id = await cls._resolve_tenant_id_async(
+            db=db,
+            current_user=current_user,
+            workspace_id=getattr(refs[0].knowledge, "workspace_id", None),
+        )
+        targets = [
+            await cls._build_retrieval_target_async(
+                db=db,
+                request=request,
+                ref=ref,
+                tenant_id=tenant_id,
+            )
+            for ref in refs
+        ]
+        return targets, tenant_id
+
+    @staticmethod
+    async def _resolve_tenant_id_async(
+            db: AsyncSession,
+            current_user: Any = None,
+            workspace_id: uuid.UUID | None = None,
+    ) -> uuid.UUID | None:
+        if current_user is not None:
+            tenant_id = getattr(current_user, "tenant_id", None)
+            if tenant_id:
+                return tenant_id
+            workspace_id = workspace_id or getattr(current_user, "current_workspace_id", None)
+
+        if not workspace_id:
+            return None
+        from app.models.workspace_model import Workspace
+
+        workspace = await db.get(Workspace, workspace_id)
+        return workspace.tenant_id if workspace else None
+
+    @classmethod
     def _build_retrieval_target(
             cls,
             db: Session,
@@ -384,6 +535,36 @@ class KnowledgeRetrievalService:
 
         embedding_config = ModelApiKeyService.get_available_api_key(db, knowledge.embedding_id, tenant_id=tenant_id)
         reranker_config = ModelApiKeyService.get_available_api_key(db, knowledge.reranker_id, tenant_id=tenant_id)
+        if not embedding_config:
+            raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
+        if not reranker_config:
+            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+
+        return RetrievalTarget(
+            knowledge_id=knowledge.id,
+            workspace_id=knowledge.workspace_id,
+            index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
+            params=cls._build_retrieval_params(request, ref.config),
+            embedding_config=ModelApiKeySnapshot.from_api_key(embedding_config),
+            reranker_config=ModelApiKeySnapshot.from_api_key(reranker_config),
+        )
+
+    @classmethod
+    async def _build_retrieval_target_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            ref: KnowledgeRetrievalRef,
+            tenant_id: uuid.UUID | None,
+    ) -> RetrievalTarget:
+        knowledge = ref.knowledge
+        if not knowledge.embedding_id:
+            raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
+        if not knowledge.reranker_id:
+            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+
+        embedding_config = await ModelApiKeyService.get_available_api_key_async(db, knowledge.embedding_id, tenant_id=tenant_id)
+        reranker_config = await ModelApiKeyService.get_available_api_key_async(db, knowledge.reranker_id, tenant_id=tenant_id)
         if not embedding_config:
             raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
         if not reranker_config:
@@ -566,6 +747,108 @@ class KnowledgeRetrievalService:
         return refs
 
     @classmethod
+    async def _resolve_retrievable_knowledge_refs_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> list[KnowledgeRetrievalRef]:
+        requested_kb_ids, explicit_configs = await cls._resolve_requested_kb_ids_and_configs_async(
+            db=db,
+            request=request,
+            current_user=current_user,
+        )
+        if not requested_kb_ids:
+            return []
+
+        refs: list[KnowledgeRetrievalRef] = []
+        ref_positions: dict[uuid.UUID, int] = {}
+
+        def append_refs(items: list[KnowledgeRetrievalRef]) -> None:
+            for item in items:
+                knowledge_id = item.knowledge.id
+                if knowledge_id in ref_positions:
+                    if item.config is not None:
+                        refs[ref_positions[knowledge_id]] = item
+                    continue
+                ref_positions[knowledge_id] = len(refs)
+                refs.append(item)
+
+        if current_user is None:
+            result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            knowledge_by_id = {knowledge.id: knowledge for knowledge in result.scalars().all()}
+            for kb_id in requested_kb_ids:
+                knowledge = knowledge_by_id.get(kb_id)
+                if not knowledge:
+                    continue
+                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
+                    db=db,
+                    knowledge=knowledge,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+            return refs
+
+        for kb_id in requested_kb_ids:
+            private_result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id == kb_id,
+                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            private_target = private_result.scalars().first()
+            if private_target:
+                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
+                    db=db,
+                    knowledge=private_target,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+                continue
+
+            share_result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id == kb_id,
+                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            share_target = share_result.scalars().first()
+            if not share_target:
+                continue
+
+            filters = [
+                knowledgeshare_model.KnowledgeShare.target_kb_id == share_target.id,
+                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
+            ]
+            share_items = await knowledgeshare_service.get_source_kb_ids_by_target_kb_id_async(
+                db=db,
+                filters=filters,
+                current_user=current_user,
+            )
+            for source_kb_id, _source_workspace_id in share_items:
+                source_knowledge = await knowledge_repository.get_knowledge_by_id_async(
+                    db=db,
+                    knowledge_id=source_kb_id,
+                )
+                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
+                    db=db,
+                    knowledge=source_knowledge,
+                    inherited_config=explicit_configs.get(kb_id),
+                    explicit_configs=explicit_configs,
+                ))
+
+        return refs
+
+    @classmethod
     def _resolve_requested_kb_ids_and_configs(
             cls,
             db: Session,
@@ -579,6 +862,35 @@ class KnowledgeRetrievalService:
             if current_user is None:
                 raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
             resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
+                db=db,
+                external_ids=request.ex_ids,
+                workspace_id=current_user.current_workspace_id,
+                current_user=current_user,
+            )
+            requested_kb_ids.extend(resolved_ids)
+
+        for config in request.knowledge_bases:
+            if config.kb_id in explicit_configs:
+                logger.warning("Duplicate KnowledgeBaseConfig found, using the last one: kb_id=%s", config.kb_id)
+            explicit_configs[config.kb_id] = config
+            requested_kb_ids.append(config.kb_id)
+
+        return cls._unique_ids(requested_kb_ids), explicit_configs
+
+    @classmethod
+    async def _resolve_requested_kb_ids_and_configs_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            current_user: Any = None,
+    ) -> tuple[list[uuid.UUID], dict[uuid.UUID, KnowledgeBaseConfig]]:
+        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig] = {}
+        requested_kb_ids = list(request.kb_ids)
+
+        if request.ex_ids:
+            if current_user is None:
+                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
+            resolved_ids = await knowledge_service.get_knowledge_ids_by_external_ids_async(
                 db=db,
                 external_ids=request.ex_ids,
                 workspace_id=current_user.current_workspace_id,
@@ -632,6 +944,52 @@ class KnowledgeRetrievalService:
                 )
                 continue
             refs.extend(cls._expand_knowledge_to_leaf_refs(
+                db=db,
+                knowledge=child,
+                inherited_config=current_config,
+                explicit_configs=explicit_configs,
+                visited=visited,
+            ))
+        return refs
+
+    @classmethod
+    async def _expand_knowledge_to_leaf_refs_async(
+            cls,
+            db: AsyncSession,
+            knowledge: Any,
+            inherited_config: KnowledgeBaseConfig | None,
+            explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig],
+            visited: set[uuid.UUID] | None = None,
+    ) -> list[KnowledgeRetrievalRef]:
+        if not knowledge or not knowledge.is_active:
+            return []
+        current_config = explicit_configs.get(knowledge.id) or inherited_config
+        if knowledge.is_retrievable_leaf:
+            return [KnowledgeRetrievalRef(knowledge=knowledge, config=current_config)]
+        if not knowledge.is_folder:
+            return []
+
+        if visited is None:
+            visited = set()
+        if knowledge.id in visited:
+            logger.warning(
+                "Detected cyclic knowledge folder while expanding retrieval targets: knowledge_id=%s",
+                knowledge.id,
+            )
+            return []
+        visited.add(knowledge.id)
+
+        refs = []
+        children = await knowledge_repository.get_knowledges_by_parent_id_async(db=db, parent_id=knowledge.id)
+        for child in children:
+            if child.workspace_id != knowledge.workspace_id:
+                logger.warning(
+                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
+                    knowledge.id,
+                    child.id,
+                )
+                continue
+            refs.extend(await cls._expand_knowledge_to_leaf_refs_async(
                 db=db,
                 knowledge=child,
                 inherited_config=current_config,
@@ -715,6 +1073,156 @@ class KnowledgeRetrievalService:
             tenant_id=tenant_id,
             log_id=log_id,
         )
+
+    @classmethod
+    async def _retrieve_targets_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            document_ids_include: list[str] | None,
+            tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
+    ) -> list[Any]:
+        if not targets:
+            return []
+
+        max_workers = max(1, min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3))
+        if log_id:
+            logger.info(
+                "[Retrieval] targets %s",
+                cls._format_log_fields(cls._build_targets_log_fields(log_id, request, targets, max_workers)),
+            )
+
+        if cls._single_hybrid_uses_request_rerank(request, targets):
+            candidates = await cls._retrieve_single_hybrid_with_request_rerank_async(
+                db=db,
+                request=request,
+                target=targets[0],
+                document_ids_include=document_ids_include,
+                tenant_id=tenant_id,
+                log_id=log_id,
+                target_position=1,
+            )
+            return await cls._finalize_retrieval_chunks_async(
+                db=db,
+                request=request,
+                targets=targets,
+                chunks=candidates,
+                tenant_id=tenant_id,
+                log_id=log_id,
+            )
+
+        semaphore = asyncio.Semaphore(max_workers)
+        results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
+
+        async def retrieve_one(index: int, target: RetrievalTarget) -> None:
+            async with semaphore:
+                try:
+                    results_by_index[index] = await asyncio.to_thread(
+                        cls._retrieve_single_target,
+                        request,
+                        target,
+                        document_ids_include,
+                        log_id,
+                        index + 1,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Knowledge retrieval target failed: knowledge_id=%s index=%s retrieve_type=%s",
+                        target.knowledge_id,
+                        target.index_name,
+                        target.params.retrieve_type,
+                    )
+                    raise
+
+        await asyncio.gather(
+            *(retrieve_one(index, target) for index, target in enumerate(targets))
+        )
+
+        candidates = [chunk for target_chunks in results_by_index for chunk in target_chunks]
+        return await cls._finalize_retrieval_chunks_async(
+            db=db,
+            request=request,
+            targets=targets,
+            chunks=candidates,
+            tenant_id=tenant_id,
+            log_id=log_id,
+        )
+
+    @classmethod
+    async def _retrieve_single_hybrid_with_request_rerank_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            target: RetrievalTarget,
+            document_ids_include: list[str] | None,
+            tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
+            target_position: int = 0,
+    ) -> list[DocumentChunk]:
+        started_at = time.perf_counter()
+
+        def retrieve_candidates() -> tuple[list[DocumentChunk], list[DocumentChunk], list[DocumentChunk]]:
+            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
+                index_name=target.index_name,
+                embedding_config=target.embedding_config,
+                reranker_config=target.reranker_config,
+            )
+            local_request = request.model_copy(update={
+                "similarity_threshold": target.params.similarity_threshold,
+                "vector_similarity_weight": target.params.vector_similarity_weight,
+                "top_k": target.params.top_k,
+                "top_n": target.params.top_n,
+                "retrieve_type": target.params.retrieve_type,
+            })
+            vector_chunks = cls._search_vector(
+                vector_service,
+                local_request,
+                target.index_name,
+                document_ids_include,
+                topk=target.params.top_n,
+            )
+            full_text_chunks = cls._search_full_text(
+                vector_service,
+                local_request,
+                target.index_name,
+                document_ids_include,
+                topk=target.params.top_n,
+            )
+            unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+            return vector_chunks, full_text_chunks, unique_chunks
+
+        vector_chunks, full_text_chunks, unique_chunks = await asyncio.to_thread(retrieve_candidates)
+        chunks = await cls.rerank_documents_async(
+            db=db,
+            rerank_id=request.rerank_id,
+            query=request.query,
+            docs=unique_chunks,
+            top_k=target.params.top_k,
+            tenant_id=tenant_id,
+        )
+        chunks = [
+            chunk
+            for chunk in chunks
+            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
+        ]
+        if log_id:
+            logger.info(
+                "[Retrieval] target_done %s",
+                cls._format_log_fields(cls._build_target_done_log_fields(
+                    log_id=log_id,
+                    target=target,
+                    target_position=target_position,
+                    vector_count=len(vector_chunks),
+                    full_text_count=len(full_text_chunks),
+                    merged_count=len(unique_chunks),
+                    result_count=len(chunks),
+                    elapsed_ms=cls._elapsed_ms(started_at),
+                    local_rerank=True,
+                )),
+            )
+        return chunks
 
     @classmethod
     def _retrieve_single_target(
@@ -933,6 +1441,94 @@ class KnowledgeRetrievalService:
             )
         return result_chunks
 
+    @classmethod
+    async def _finalize_retrieval_chunks_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            targets: list[RetrievalTarget],
+            chunks: list[DocumentChunk],
+            tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
+    ) -> list[DocumentChunk]:
+        candidate_count = len(chunks)
+        unique_chunks = cls._deduplicate_chunks(chunks)
+        if not unique_chunks:
+            if log_id:
+                logger.info(
+                    "[Retrieval] finalize %s",
+                    cls._format_log_fields({
+                        "id": log_id,
+                        "candidates": candidate_count,
+                        "deduped": 0,
+                        "global_rerank": False,
+                        "threshold": "none",
+                        "filtered": 0,
+                        "result_count": 0,
+                    }),
+                )
+            return []
+
+        single_hybrid_uses_request_rerank = cls._single_hybrid_uses_request_rerank(request, targets)
+        needs_global_rerank = len(targets) > 1 or (
+                request.rerank_id is not None and not single_hybrid_uses_request_rerank
+        )
+        if request.rerank_id and not single_hybrid_uses_request_rerank:
+            ranked_chunks = await cls.rerank_documents_async(
+                db=db,
+                rerank_id=request.rerank_id,
+                query=request.query,
+                docs=unique_chunks,
+                top_k=request.top_k,
+                tenant_id=tenant_id,
+            )
+        elif needs_global_rerank:
+            first_target = targets[0]
+            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
+                index_name=first_target.index_name,
+                embedding_config=first_target.embedding_config,
+                reranker_config=first_target.reranker_config,
+            )
+            ranked_chunks = await asyncio.to_thread(
+                vector_service.rerank,
+                query=request.query,
+                docs=unique_chunks,
+                top_k=request.top_k,
+            )
+        else:
+            ranked_chunks = sorted(
+                unique_chunks,
+                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
+                reverse=True,
+            )
+
+        if needs_global_rerank:
+            threshold = cls._resolve_rerank_score_threshold(request)
+            filtered_chunks = [
+                chunk
+                for chunk in ranked_chunks
+                if (chunk.metadata or {}).get("score", 0) > threshold
+            ]
+        else:
+            threshold = None
+            filtered_chunks = ranked_chunks
+        result_chunks = filtered_chunks[:request.top_k]
+        if log_id:
+            logger.info(
+                "[Retrieval] finalize %s",
+                cls._format_log_fields({
+                    "id": log_id,
+                    "candidates": candidate_count,
+                    "deduped": len(unique_chunks),
+                    "global_rerank": needs_global_rerank,
+                    "ranked": len(ranked_chunks),
+                    "threshold": threshold if threshold is not None else "none",
+                    "filtered": len(filtered_chunks),
+                    "result_count": len(result_chunks),
+                }),
+            )
+        return result_chunks
+
     @staticmethod
     def _resolve_global_score_threshold(
             request: KnowledgeRetrievalRequest,
@@ -1083,6 +1679,31 @@ class KnowledgeRetrievalService:
         llm_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.llm_id, tenant_id=tenant_id)
         emb_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.embedding_id, tenant_id=tenant_id)
         doc = kg_retriever.retrieval(
+            question=request.query,
+            workspace_ids=[str(workspace_id) for workspace_id in workspace_ids],
+            kb_ids=[str(knowledge_id) for knowledge_id in knowledge_ids],
+            emb_mdl=KnowledgeRetrievalService._build_embedding_model(emb_key),
+            llm=KnowledgeRetrievalService._build_chat_model(llm_key),
+        )
+        if doc and str(doc.get("page_content", "")).strip():
+            return doc
+        return None
+
+    @staticmethod
+    async def _retrieve_graph_async(
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            workspace_ids: list[uuid.UUID],
+            db_knowledge: Any,
+            tenant_id: uuid.UUID | None,
+    ) -> Any | None:
+        from app.core.rag.common.settings import kg_retriever
+
+        llm_key = await ModelApiKeyService.get_available_api_key_async(db, db_knowledge.llm_id, tenant_id=tenant_id)
+        emb_key = await ModelApiKeyService.get_available_api_key_async(db, db_knowledge.embedding_id, tenant_id=tenant_id)
+        doc = await asyncio.to_thread(
+            kg_retriever.retrieval,
             question=request.query,
             workspace_ids=[str(workspace_id) for workspace_id in workspace_ids],
             kb_ids=[str(knowledge_id) for knowledge_id in knowledge_ids],
@@ -1285,6 +1906,20 @@ class KnowledgeRetrievalService:
             )
         return knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
 
+    @staticmethod
+    async def _get_first_knowledge_async(
+            db: AsyncSession,
+            knowledge_id: uuid.UUID,
+            current_user: Any = None,
+    ) -> Any:
+        if current_user is not None:
+            return await knowledge_service.get_knowledge_by_id_async(
+                db=db,
+                knowledge_id=knowledge_id,
+                current_user=current_user,
+            )
+        return await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
+
     @classmethod
     def _build_metadata_document_filter(
             cls,
@@ -1376,6 +2011,96 @@ class KnowledgeRetrievalService:
         return [str(document_id) for document_id in document_ids]
 
     @classmethod
+    async def _build_metadata_document_filter_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            tenant_id: uuid.UUID | None,
+            log_id: str | None = None,
+    ) -> list[str] | None:
+        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="mode_disabled",
+                        document_count=None,
+                    )),
+                )
+            return None
+
+        if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="no_filters",
+                        document_count=None,
+                    )),
+                )
+            return None
+
+        metadata_defs_by_kb = {
+            knowledge_id: await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(db, knowledge_id)
+            for knowledge_id in knowledge_ids
+        }
+        common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
+        filter_groups = await cls._build_metadata_filter_groups_async(
+            db=db,
+            request=request,
+            knowledge_ids=knowledge_ids,
+            common_metadata_defs=common_metadata_defs,
+            tenant_id=tenant_id,
+        )
+        if not filter_groups:
+            logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
+            if log_id:
+                logger.info(
+                    "[Retrieval] metadata_filter %s",
+                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                        log_id=log_id,
+                        request=request,
+                        effective=False,
+                        reason="no_effective_groups",
+                        document_count=None,
+                        common_fields=len(common_metadata_defs),
+                        effective_groups=0,
+                    )),
+                )
+            return None
+
+        document_ids = set()
+        engine = MetadataFilterEngine(db)
+        for knowledge_id in knowledge_ids:
+            matched_ids = await engine.execute_async(
+                knowledge_id=knowledge_id,
+                filter_groups=filter_groups,
+                metadata_defs=metadata_defs_by_kb[knowledge_id],
+            )
+            document_ids.update(matched_ids)
+        if log_id:
+            logger.info(
+                "[Retrieval] metadata_filter %s",
+                cls._format_log_fields(cls._build_metadata_filter_log_fields(
+                    log_id=log_id,
+                    request=request,
+                    effective=True,
+                    reason="matched",
+                    document_count=len(document_ids),
+                    common_fields=len(common_metadata_defs),
+                    effective_groups=len(filter_groups),
+                )),
+            )
+        return [str(document_id) for document_id in document_ids]
+
+    @classmethod
     def _build_metadata_filter_groups(
             cls,
             db: Session,
@@ -1426,6 +2151,55 @@ class KnowledgeRetrievalService:
         )
 
     @classmethod
+    async def _build_metadata_filter_groups_async(
+            cls,
+            db: AsyncSession,
+            request: KnowledgeRetrievalRequest,
+            knowledge_ids: list[uuid.UUID],
+            common_metadata_defs: dict[str, dict],
+            tenant_id: uuid.UUID | None,
+    ) -> list[EngineFilterGroup]:
+        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            return []
+
+        if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
+            if not request.metadata_filters:
+                return []
+            return cls._build_common_filter_groups(
+                request.metadata_filters,
+                set(common_metadata_defs.keys()),
+            )
+
+        if request.metadata_filter_mode == MetadataFilterMode.AUTO:
+            if request.metadata_filters:
+                return cls._build_common_filter_groups(
+                    request.metadata_filters,
+                    set(common_metadata_defs.keys()),
+                )
+
+            if not common_metadata_defs:
+                return []
+            llm = await cls._build_metadata_auto_filter_llm_async(
+                db=db,
+                knowledge_id=knowledge_ids[0],
+                tenant_id=tenant_id,
+            )
+            if not llm:
+                logger.warning("[MetadataAutoFilter] LLM is unavailable; skipping metadata filter")
+                return []
+            return await asyncio.to_thread(
+                MetadataAutoFilterService.generate_filter_groups,
+                query=request.query,
+                metadata_defs=common_metadata_defs,
+                llm=llm,
+            )
+
+        raise BusinessException(
+            f"metadata_filter_mode 不支持: {request.metadata_filter_mode}",
+            code=BizCode.INVALID_PARAMETER,
+        )
+
+    @classmethod
     def _build_metadata_auto_filter_llm(
             cls,
             db: Session,
@@ -1447,6 +2221,36 @@ class KnowledgeRetrievalService:
 
         # 参数折叠进 RedBearModelConfig.extra_params（与 knowledge 节点 auto 模式、LLM 节点一致）。
         # 此兜底路径用知识库 llm_id、无 completion_params，保留原默认 temperature=0 行为。
+        rb_config = RedBearModelConfig(
+            model_name=api_key.model_name,
+            provider=api_key.provider,
+            api_key=api_key.api_key,
+            base_url=api_key.api_base,
+            is_omni=api_key.is_omni,
+            capability=api_key.capability or [],
+            extra_params={"temperature": 0},
+        )
+        return RedBearLLM(rb_config, type=ModelType(config.type))
+
+    @classmethod
+    async def _build_metadata_auto_filter_llm_async(
+            cls,
+            db: AsyncSession,
+            knowledge_id: uuid.UUID,
+            tenant_id: uuid.UUID | None,
+    ) -> RedBearLLM | None:
+        knowledge = await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
+        if not knowledge or not knowledge.llm_id:
+            return None
+
+        config = await db.get(ModelConfig, knowledge.llm_id)
+        if not config:
+            return None
+
+        api_key = await ModelApiKeyService.get_available_api_key_async(db, knowledge.llm_id, tenant_id=tenant_id)
+        if not api_key:
+            return None
+
         rb_config = RedBearModelConfig(
             model_name=api_key.model_name,
             provider=api_key.provider,
@@ -1602,6 +2406,62 @@ class KnowledgeRetrievalService:
                         doc.metadata["score"] = item.metadata["relevance_score"]
                         result.append(doc)
             return result
+        except Exception as exc:
+            logger.warning(f"Rerank failed, falling back to original results: {str(exc)}")
+            for doc in docs[:top_k]:
+                if doc.metadata is not None and "score" not in doc.metadata:
+                    doc.metadata["score"] = 0.5
+            return docs[:top_k]
+
+    @staticmethod
+    async def rerank_documents_async(
+            db: AsyncSession,
+            rerank_id: uuid.UUID,
+            query: str,
+            docs: list[DocumentChunk],
+            top_k: int,
+            tenant_id: uuid.UUID | None = None,
+    ) -> list[DocumentChunk]:
+        """Async DB wrapper around the synchronous rerank provider."""
+        if not docs:
+            raise ValueError("retrieval chunks cannot be empty")
+        if top_k <= 0:
+            raise ValueError("top_k must be a positive integer")
+        try:
+            api_config = await ModelApiKeyService.get_available_api_key_async(db, rerank_id, tenant_id=tenant_id)
+            if not api_config:
+                raise ValueError("模型配置缺少 API Key")
+
+            def run_rerank() -> list[DocumentChunk]:
+                reranker = RedBearRerank(
+                    RedBearModelConfig(
+                        model_name=api_config.model_name,
+                        provider=api_config.provider,
+                        api_key=api_config.api_key,
+                        base_url=api_config.api_base,
+                    )
+                )
+                documents = [
+                    Document(
+                        page_content=chunk_retrieval_content(doc),
+                        metadata=doc.metadata or {},
+                    )
+                    for doc in docs
+                ]
+                reranked_docs = list(reranker.compress_documents(documents, query, top_n=top_k))
+                reranked_docs.sort(
+                    key=lambda item: item.metadata.get("relevance_score", 0),
+                    reverse=True,
+                )
+                result = []
+                for item in reranked_docs[:top_k]:
+                    for doc in docs:
+                        if doc.metadata['doc_id'] == item.metadata['doc_id']:
+                            doc.metadata["score"] = item.metadata["relevance_score"]
+                            result.append(doc)
+                return result
+
+            return await asyncio.to_thread(run_rerank)
         except Exception as exc:
             logger.warning(f"Rerank failed, falling back to original results: {str(exc)}")
             for doc in docs[:top_k]:

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Any
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.models.user_model import User
 from app.models.knowledge_model import Knowledge, KnowledgeType
@@ -117,6 +119,106 @@ def _build_knowledge_items_with_folder_trees(
     ]
 
 
+async def _build_knowledge_items_with_folder_trees_async(
+        db: AsyncSession,
+        items: list,
+        workspace_id: uuid.UUID,
+) -> list[dict[str, Any]]:
+    knowledge_items = [
+        knowledge_schema.Knowledge.model_validate(item)
+        for item in items
+    ]
+    folder_ids = [
+        item.id for item in knowledge_items
+        if item.type == KnowledgeType.FOLDER
+    ]
+    if not folder_ids:
+        return [item.model_dump(mode="json") for item in knowledge_items]
+
+    children_by_parent: dict[uuid.UUID, list[knowledge_schema.Knowledge]] = {}
+    pending_parent_ids = list(folder_ids)
+    visited_parent_ids: set[uuid.UUID] = set()
+    all_folder_ids = list(folder_ids)
+
+    while pending_parent_ids:
+        current_parent_ids = [
+            parent_id for parent_id in pending_parent_ids
+            if parent_id not in visited_parent_ids
+        ]
+        if not current_parent_ids:
+            break
+
+        visited_parent_ids.update(current_parent_ids)
+        children = await knowledge_repository.get_knowledges_by_parent_ids_async(
+            db=db,
+            parent_ids=current_parent_ids,
+            workspace_id=workspace_id,
+        )
+        pending_parent_ids = []
+
+        for child in children:
+            children_by_parent.setdefault(child.parent_id, []).append(child)
+            if child.type == KnowledgeType.FOLDER:
+                all_folder_ids.append(child.id)
+                pending_parent_ids.append(child.id)
+
+    all_folder_ids = list(dict.fromkeys(all_folder_ids))
+    knowledge_ids_by_folder: dict[uuid.UUID, set[uuid.UUID]] = {}
+
+    def collect_knowledge_ids(folder_id: uuid.UUID, ancestors: set[uuid.UUID]) -> set[uuid.UUID]:
+        if folder_id in knowledge_ids_by_folder:
+            return knowledge_ids_by_folder[folder_id]
+        if folder_id in ancestors:
+            return set()
+
+        knowledge_ids = {folder_id}
+        next_ancestors = ancestors | {folder_id}
+        for child in children_by_parent.get(folder_id, []):
+            if child.id in next_ancestors:
+                continue
+            knowledge_ids.add(child.id)
+            if child.type == KnowledgeType.FOLDER:
+                knowledge_ids.update(collect_knowledge_ids(child.id, next_ancestors))
+
+        knowledge_ids_by_folder[folder_id] = knowledge_ids
+        return knowledge_ids
+
+    for folder_id in all_folder_ids:
+        collect_knowledge_ids(folder_id, set())
+
+    counted_knowledge_ids = list({
+        knowledge_id
+        for knowledge_ids in knowledge_ids_by_folder.values()
+        for knowledge_id in knowledge_ids
+    })
+    document_counts = await knowledge_repository.get_document_counts_by_knowledge_ids_async(
+        db=db,
+        knowledge_ids=counted_knowledge_ids,
+    )
+    doc_counts = {
+        folder_id: sum(document_counts.get(knowledge_id, 0) for knowledge_id in knowledge_ids)
+        for folder_id, knowledge_ids in knowledge_ids_by_folder.items()
+    }
+
+    def build_item(item: knowledge_schema.Knowledge, ancestors: set[uuid.UUID]) -> dict[str, Any]:
+        data = item.model_dump(mode="json")
+        if item.id in doc_counts:
+            data["doc_num"] = doc_counts[item.id]
+        if item.type == KnowledgeType.FOLDER:
+            next_ancestors = ancestors | {item.id}
+            data["children"] = [
+                build_item(child, next_ancestors)
+                for child in children_by_parent.get(item.id, [])
+                if child.id not in next_ancestors
+            ]
+        return data
+
+    return [
+        build_item(item, set())
+        for item in knowledge_items
+    ]
+
+
 def get_knowledges_paginated(
         db: Session,
         current_user: User,
@@ -149,6 +251,40 @@ def get_knowledges_paginated(
         raise
 
 
+async def get_knowledges_paginated_async(
+        db: AsyncSession,
+        current_user: User,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    business_logger.debug(
+        f"Query knowledge base in pages (async): username={current_user.username}, "
+        f"page={page}, pagesize={pagesize}, orderby={orderby}, desc={desc}"
+    )
+
+    try:
+        total, items = await knowledge_repository.get_knowledges_paginated_async(
+            db=db,
+            filters=filters,
+            page=page,
+            pagesize=pagesize,
+            orderby=orderby,
+            desc=desc,
+        )
+        items = await _build_knowledge_items_with_folder_trees_async(
+            db=db,
+            items=items,
+            workspace_id=current_user.current_workspace_id,
+        )
+        return total, items
+    except Exception as e:
+        business_logger.error(f"Querying knowledge pagination failed (async): username={current_user.username} - {str(e)}")
+        raise
+
+
 def get_chunked_knowledgeids(
         db: Session,
         current_user: User,
@@ -165,6 +301,18 @@ def get_chunked_knowledgeids(
         return items
     except Exception as e:
         business_logger.error(f"Querying the vectorized knowledge base id list failed: username={current_user.username} - {str(e)}")
+        raise
+
+
+async def get_chunked_knowledgeids_async(
+        db: AsyncSession,
+        current_user: User,
+        filters: list
+) -> list:
+    try:
+        return await knowledge_repository.get_chunked_knowledgeids_async(db=db, filters=filters)
+    except Exception as e:
+        business_logger.error(f"Querying vectorized knowledge base id list failed (async): username={current_user.username} - {str(e)}")
         raise
 
 
@@ -239,6 +387,86 @@ def create_knowledge(
         raise
 
 
+async def create_knowledge_async(
+        db: AsyncSession, knowledge: KnowledgeCreate, current_user: User
+) -> Knowledge:
+    business_logger.info(f"Create a knowledge base (async): {knowledge.name}, creator: {current_user.username}")
+
+    try:
+        knowledge.created_by = current_user.id
+        if knowledge.workspace_id is None:
+            knowledge.workspace_id = current_user.current_workspace_id
+        if knowledge.parent_id is None:
+            knowledge.parent_id = knowledge.workspace_id
+
+        if knowledge.external_id:
+            if not (1 <= len(knowledge.external_id) <= 36):
+                raise BusinessException(
+                    "external_id must be between 1 and 36 characters",
+                    code=BizCode.VALIDATION_FAILED,
+                )
+            existing = await knowledge_repository.get_knowledge_by_external_id_async(
+                db, knowledge.external_id, knowledge.workspace_id
+            )
+            if existing:
+                raise BusinessException(
+                    f"external_id already exists in this workspace: {knowledge.external_id}",
+                    code=BizCode.VALIDATION_FAILED,
+                )
+
+        workspace = await db.get(Workspace, knowledge.workspace_id)
+        if not workspace:
+            raise Exception(f"Workspace {knowledge.workspace_id} not found")
+
+        tenant_id = workspace.tenant_id
+
+        if not knowledge.embedding_id:
+            if not workspace.embedding:
+                raise Exception("工作空间未配置 Embedding 模型，请先完善工作空间配置后重试")
+            knowledge.embedding_id = workspace.embedding
+
+        if not knowledge.reranker_id:
+            if not workspace.rerank:
+                raise Exception("工作空间未配置 Rerank 模型，请先完善工作空间配置后重试")
+            knowledge.reranker_id = workspace.rerank
+
+        if not knowledge.llm_id:
+            if not workspace.llm:
+                raise Exception("工作空间未配置 LLM 模型，请先完善工作空间配置后重试")
+            knowledge.llm_id = workspace.llm
+
+        if not knowledge.image2text_id:
+            stmt = (
+                select(ModelConfig)
+                .where(
+                    ModelConfig.tenant_id == tenant_id,
+                    ModelConfig.type.in_([ModelType.CHAT.value, ModelType.LLM.value]),
+                    ModelConfig.capability.contains(["vision"]),
+                    ModelConfig.is_active == True,
+                )
+                .order_by(ModelConfig.created_at.desc())
+                .limit(1)
+            )
+            result = await db.execute(stmt)
+            model = result.scalars().first()
+            if not model:
+                raise Exception("租户下没有可用的视觉模型，创建知识库失败")
+            knowledge.image2text_id = model.id
+            business_logger.debug(f"Auto-bind image2text model: {model.id}")
+
+        db_knowledge = await knowledge_repository.create_knowledge_async(
+            db=db, knowledge=knowledge
+        )
+        business_logger.info(
+            f"The knowledge base has been successfully created (async): "
+            f"{knowledge.name} (ID: {db_knowledge.id}), creator: {current_user.username}"
+        )
+        return db_knowledge
+    except Exception as e:
+        business_logger.error(f"Failed to create a knowledge base (async): {knowledge.name} - {str(e)}")
+        raise
+
+
 def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: User) -> Knowledge | None:
     business_logger.debug(f"Query knowledge base based on ID: knowledge_id={knowledge_id}, username: {current_user.username}")
     
@@ -251,6 +479,16 @@ def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: User
         return knowledge
     except Exception as e:
         business_logger.error(f"Failed to query the knowledge base based on the ID: knowledge_id={knowledge_id} - {str(e)}")
+        raise
+
+
+async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID, current_user: User) -> Knowledge | None:
+    business_logger.debug(f"Query knowledge base by ID (async): knowledge_id={knowledge_id}, username: {current_user.username}")
+
+    try:
+        return await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
+    except Exception as e:
+        business_logger.error(f"Failed to query knowledge by ID (async): knowledge_id={knowledge_id} - {str(e)}")
         raise
 
 
@@ -269,6 +507,23 @@ def get_knowledge_by_external_id(db: Session, external_id: str, workspace_id: uu
         raise
 
 
+async def get_knowledge_by_external_id_async(
+        db: AsyncSession,
+        external_id: str,
+        workspace_id: uuid.UUID,
+        current_user: User
+) -> Knowledge | None:
+    try:
+        return await knowledge_repository.get_knowledge_by_external_id_async(
+            db=db,
+            external_id=external_id,
+            workspace_id=workspace_id,
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to query knowledge by external_id (async): external_id={external_id} - {str(e)}")
+        raise
+
+
 def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], workspace_id: uuid.UUID, current_user: User) -> list[uuid.UUID]:
     business_logger.debug(f"Resolve external_ids to knowledge UUIDs: external_ids={external_ids}, username: {current_user.username}")
 
@@ -278,6 +533,23 @@ def get_knowledge_ids_by_external_ids(db: Session, external_ids: list[str], work
         return ids
     except Exception as e:
         business_logger.error(f"Failed to resolve external_ids: external_ids={external_ids} - {str(e)}")
+        raise
+
+
+async def get_knowledge_ids_by_external_ids_async(
+        db: AsyncSession,
+        external_ids: list[str],
+        workspace_id: uuid.UUID,
+        current_user: User
+) -> list[uuid.UUID]:
+    try:
+        return await knowledge_repository.get_knowledge_ids_by_external_ids_async(
+            db=db,
+            external_ids=external_ids,
+            workspace_id=workspace_id,
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to resolve external_ids (async): external_ids={external_ids} - {str(e)}")
         raise
 
 
@@ -296,6 +568,18 @@ def get_knowledge_by_name(db: Session, name: str, current_user: User) -> Knowled
         raise
 
 
+async def get_knowledge_by_name_async(db: AsyncSession, name: str, current_user: User) -> Knowledge | None:
+    try:
+        return await knowledge_repository.get_knowledge_by_name_async(
+            db=db,
+            name=name,
+            workspace_id=current_user.current_workspace_id,
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to query knowledge by name (async): name={name} - {str(e)}")
+        raise
+
+
 def delete_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: User) -> None:
     business_logger.info(f"Delete knowledge base: knowledge_id={knowledge_id}, operator: {current_user.username}")
     
@@ -311,4 +595,15 @@ def delete_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: U
         business_logger.info(f"knowledge base record deleted successfully: knowledge_id={knowledge_id}, operator: {current_user.username}")
     except Exception as e:
         business_logger.error(f"Failed to delete knowledge base: knowledge_id={knowledge_id} - {str(e)}")
+        raise
+
+
+async def delete_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID, current_user: User) -> None:
+    business_logger.info(f"Delete knowledge base (async): knowledge_id={knowledge_id}, operator: {current_user.username}")
+
+    try:
+        await knowledge_repository.delete_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
+        business_logger.info(f"knowledge base record deleted successfully (async): knowledge_id={knowledge_id}, operator: {current_user.username}")
+    except Exception as e:
+        business_logger.error(f"Failed to delete knowledge base (async): knowledge_id={knowledge_id} - {str(e)}")
         raise

--- a/api/app/services/knowledgeshare_service.py
+++ b/api/app/services/knowledgeshare_service.py
@@ -1,4 +1,5 @@
 import uuid
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.models.user_model import User
 from app.models.knowledgeshare_model import KnowledgeShare
@@ -37,6 +38,34 @@ def get_knowledgeshares_paginated(
         raise
 
 
+async def get_knowledgeshares_paginated_async(
+        db: AsyncSession,
+        current_user: User,
+        filters: list,
+        page: int,
+        pagesize: int,
+        orderby: str = None,
+        desc: bool = False
+) -> tuple[int, list]:
+    business_logger.debug(
+        f"Query knowledge base sharing in pages (async): username={current_user.username}, "
+        f"page={page}, pagesize={pagesize}, orderby={orderby}, desc={desc}"
+    )
+
+    try:
+        return await knowledgeshare_repository.get_knowledgeshares_paginated_async(
+            db=db,
+            filters=filters,
+            page=page,
+            pagesize=pagesize,
+            orderby=orderby,
+            desc=desc,
+        )
+    except Exception as e:
+        business_logger.error(f"Querying knowledge base sharing pagination failed (async): username={current_user.username} - {str(e)}")
+        raise
+
+
 def get_source_kb_ids_by_target_kb_id(
         db: Session,
         current_user: User,
@@ -53,6 +82,24 @@ def get_source_kb_ids_by_target_kb_id(
         return items
     except Exception as e:
         business_logger.error(f"Failed to query the original knowledge base ID list through knowledge base sharing: username={current_user.username} - {str(e)}")
+        raise
+
+
+async def get_source_kb_ids_by_target_kb_id_async(
+        db: AsyncSession,
+        current_user: User,
+        filters: list
+) -> list:
+    try:
+        return await knowledgeshare_repository.get_source_kb_ids_by_target_kb_id_async(
+            db=db,
+            filters=filters,
+        )
+    except Exception as e:
+        business_logger.error(
+            f"Failed to query source KB ID list through knowledge share (async): "
+            f"username={current_user.username} - {str(e)}"
+        )
         raise
 
 
@@ -75,6 +122,22 @@ def create_knowledgeshare(
         raise
 
 
+async def create_knowledgeshare_async(
+        db: AsyncSession, knowledgeshare: KnowledgeShareCreate, current_user: User
+) -> KnowledgeShare:
+    business_logger.info(f"Create a knowledge base sharing (async): creator: {current_user.username}")
+
+    try:
+        knowledgeshare.source_workspace_id = current_user.current_workspace_id
+        knowledgeshare.shared_by = current_user.id
+        return await knowledgeshare_repository.create_knowledgeshare_async(
+            db=db, knowledgeshare=knowledgeshare
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to create knowledge base sharing (async) - {str(e)}")
+        raise
+
+
 def get_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID, current_user: User) -> KnowledgeShare | None:
     business_logger.debug(f"Query knowledge base sharing based on ID: knowledgeshare_id={knowledgeshare_id}, username: {current_user.username}")
 
@@ -87,6 +150,21 @@ def get_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID, current_
         return knowledgeshare
     except Exception as e:
         business_logger.error(f"Failed to query the knowledge base sharing: knowledgeshare_id={knowledgeshare_id} - {str(e)}")
+        raise
+
+
+async def get_knowledgeshare_by_id_async(
+        db: AsyncSession,
+        knowledgeshare_id: uuid.UUID,
+        current_user: User
+) -> KnowledgeShare | None:
+    try:
+        return await knowledgeshare_repository.get_knowledgeshare_by_id_async(
+            db=db,
+            knowledgeshare_id=knowledgeshare_id,
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to query knowledge share (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
         raise
 
 
@@ -105,4 +183,21 @@ def delete_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID, curre
         business_logger.info(f"knowledge base sharing deleted successfully: knowledgeshare_id={knowledgeshare_id}, operator: {current_user.username}")
     except Exception as e:
         business_logger.error(f"Failed to delete knowledge base sharing: knowledgeshare_id={knowledgeshare_id} - {str(e)}")
+        raise
+
+
+async def delete_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uuid.UUID, current_user: User) -> None:
+    business_logger.info(f"Delete knowledge base sharing (async): knowledgeshare_id={knowledgeshare_id}, operator: {current_user.username}")
+
+    try:
+        await knowledgeshare_repository.delete_knowledgeshare_by_id_async(
+            db=db,
+            knowledgeshare_id=knowledgeshare_id,
+        )
+        business_logger.info(
+            f"knowledge base sharing deleted successfully (async): "
+            f"knowledgeshare_id={knowledgeshare_id}, operator: {current_user.username}"
+        )
+    except Exception as e:
+        business_logger.error(f"Failed to delete knowledge base sharing (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
         raise

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -41,6 +41,23 @@ class ModelConfigService:
         return model
 
     @staticmethod
+    async def get_model_by_id_async(
+            db: AsyncSession,
+            model_id: uuid.UUID,
+            tenant_id: uuid.UUID | None = None,
+    ) -> ModelConfig:
+        """Async version of get_model_by_id with the same availability checks."""
+        model = await ModelConfigRepository.get_by_id_async(db, model_id, tenant_id=tenant_id)
+        if not model:
+            raise BusinessException("模型配置不存在", BizCode.MODEL_NOT_FOUND)
+        if model.model_base and model.model_base.is_deprecated:
+            raise BusinessException(
+                f"模型 '{model.name}' 已弃用，请在模型配置中更换为其他模型",
+                BizCode.MODEL_DEPRECATED,
+            )
+        return model
+
+    @staticmethod
     def get_model_list(db: Session, query: ModelConfigQuery, tenant_id: uuid.UUID | None = None) -> PageData:
         """获取模型配置列表"""
         models, total = ModelConfigRepository.get_list(db, query, tenant_id=tenant_id)

--- a/api/app/services/rag_access_service.py
+++ b/api/app/services/rag_access_service.py
@@ -1,9 +1,12 @@
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models import document_model, knowledge_model
 from app.models.user_model import User
+from app.models.workspace_model import Workspace, WorkspaceMember
 from app.repositories import workspace_repository
 
 
@@ -33,6 +36,31 @@ def has_current_workspace_access(
     return member is not None
 
 
+async def has_current_workspace_access_async(
+    db: AsyncSession,
+    current_user: User,
+) -> bool:
+    """Async version of has_current_workspace_access."""
+    if not current_user.current_workspace_id:
+        return False
+
+    workspace = await db.get(Workspace, current_user.current_workspace_id)
+    if not workspace:
+        return False
+
+    if current_user.is_superuser:
+        return current_user.tenant_id == workspace.tenant_id
+
+    result = await db.execute(
+        select(WorkspaceMember.id).where(
+            WorkspaceMember.user_id == current_user.id,
+            WorkspaceMember.workspace_id == current_user.current_workspace_id,
+            WorkspaceMember.is_active.is_(True),
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
 def require_current_workspace_knowledge(
     db: Session,
     knowledge_id: uuid.UUID,
@@ -52,6 +80,24 @@ def require_current_workspace_knowledge(
     )
 
 
+async def require_current_workspace_knowledge_async(
+    db: AsyncSession,
+    knowledge_id: uuid.UUID,
+    current_user: User,
+):
+    """Async version of require_current_workspace_knowledge."""
+    if not await has_current_workspace_access_async(db=db, current_user=current_user):
+        return None
+
+    result = await db.execute(
+        select(knowledge_model.Knowledge).where(
+            knowledge_model.Knowledge.id == knowledge_id,
+            knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
+        )
+    )
+    return result.scalars().first()
+
+
 def require_current_workspace_document(
     db: Session,
     document_id: uuid.UUID,
@@ -63,6 +109,30 @@ def require_current_workspace_document(
         return None
 
     db_knowledge = require_current_workspace_knowledge(
+        db=db,
+        knowledge_id=db_document.kb_id,
+        current_user=current_user,
+    )
+    if not db_knowledge:
+        return None
+
+    return db_document
+
+
+async def require_current_workspace_document_async(
+    db: AsyncSession,
+    document_id: uuid.UUID,
+    current_user: User,
+):
+    """Async version of require_current_workspace_document."""
+    result = await db.execute(
+        select(document_model.Document).where(document_model.Document.id == document_id)
+    )
+    db_document = result.scalars().first()
+    if not db_document:
+        return None
+
+    db_knowledge = await require_current_workspace_knowledge_async(
         db=db,
         knowledge_id=db_document.kb_id,
         current_user=current_user,


### PR DESCRIPTION
## Background

Knowledge-base request paths still performed synchronous SQLAlchemy work inside async FastAPI chains, which could block the event loop and reduce request concurrency. This phase introduces async database access across the main knowledge-base HTTP paths while preserving compatibility for legacy synchronous retrieval callers.

## Summary

- Migrate knowledge, document, metadata, knowledge-share, and related API Key RAG request paths to `AsyncSession` repositories and services.
- Add a dual-session `retrieve_async()` facade: `AsyncSession` uses the native async path, while `Session` uses the synchronous retrieval path in a worker thread with a thread-owned short Session.
- Snapshot user authorization fields before crossing the thread boundary.
- Eager-load Knowledge and nested model-config relationships required by response serialization to prevent `MissingGreenlet` failures.
- Keep task execution and workflow knowledge nodes unchanged in this phase.

## Changes

```text
api/app/controllers/chunk_controller.py            | 208 ++---
api/app/controllers/document_controller.py         | 149 ++--
api/app/controllers/knowledge_controller.py        | 203 +++--
api/app/controllers/knowledge_metadata_controller.py | 66 +-
api/app/controllers/knowledgeshare_controller.py   | 40 +-
api/app/controllers/service/rag_api_chunk_controller.py | 60 +-
api/app/controllers/service/rag_api_document_controller.py | 42 +-
api/app/controllers/service/rag_api_knowledge_controller.py | 81 +-
api/app/core/rag/metadata/filter_engine.py          | 63 +-
api/app/dependencies.py                             | 92 ++-
api/app/repositories/api_key_repository.py          | 9 +-
api/app/repositories/document_repository.py         | 117 +++
api/app/repositories/knowledge_metadata_repository.py | 145 +++-
api/app/repositories/knowledge_repository.py        | 218 ++++-
api/app/repositories/knowledgeshare_repository.py   | 106 +++
api/app/services/api_key_service.py                 | 16 +
api/app/services/document_service.py                | 87 ++
api/app/services/draft_run_service.py               | 82 +-
api/app/services/knowledge_metadata_service.py      | 466 +++++++++++
api/app/services/knowledge_retrieval_service.py     | 905 ++++++++++++++++++++-
api/app/services/knowledge_service.py               | 295 +++++++
api/app/services/knowledgeshare_service.py          | 95 +++
api/app/services/rag_access_service.py              | 70 ++
23 files changed, 3161 insertions(+), 454 deletions(-)
```

## Impact

- Internal knowledge-base controllers use async DB access, except the internal chunk retrieval endpoint which deliberately retains the synchronous compatibility path behind `to_thread`.
- Agent retrieval continues through the shared async retrieval facade.
- Workflow knowledge nodes and background tasks are unchanged.
- Request and response schemas remain unchanged.

## Risks

- Native async ORM paths require explicit eager loading for every relationship accessed during serialization.
- The synchronous compatibility path is bounded by the process thread pool and can briefly hold both the caller Session and a thread-owned retrieval Session.
- Sync and native async retrieval implementations must remain behaviorally aligned when retrieval rules change.

## External API Key Impact

- Existing API Key route schemas, scopes, workspace checks, and response formats are unchanged.
- External chunk retrieval keeps `AsyncSession` and uses the native async retrieval path.
- External knowledge and document routes now use their async repository/service variants.

## Test Plan

- [x] `cd api && PYTHONPATH=. uv run --frozen pytest tests/rag/test_knowledge_retrieval_dual_session.py tests/rag/test_knowledge_retrieval_config.py tests/rag/test_metadata_time_response_format.py tests/rag/test_qa_csv_export.py -q` (`26 passed`)
- [x] `cd api && PYTHONPATH=. uv run --frozen python -m compileall app/services/knowledge_retrieval_service.py app/controllers/chunk_controller.py app/controllers/service/rag_api_chunk_controller.py app/services/draft_run_service.py app/repositories/knowledge_repository.py app/repositories/knowledgeshare_repository.py`
- [x] `git diff --check origin/develop..HEAD`
