### PR TITLE
fix(web): agent kb similarity_threshold

### DIFF
--- a/web/src/components/Knowledge/types.ts
+++ b/web/src/components/Knowledge/types.ts
@@ -35,6 +35,7 @@ export interface KnowledgeConfigForm {
   top_k?: number;
   retrieve_type?: RetrieveType;
   weight?: number;
+  config?: KnowledgeConfigForm;
 }
 
 /**

--- a/web/src/views/ApplicationConfig/Agent.tsx
+++ b/web/src/views/ApplicationConfig/Agent.tsx
@@ -227,14 +227,17 @@ const Agent = forwardRef<AgentRef, { onFeaturesLoad?: (features: FeaturesConfigF
       knowledge_retrieval: knowledge_bases.length > 0 ? {
         ...data.knowledge_retrieval,
         ...knowledgeRest,
-        knowledge_bases: knowledge_bases.map((item: KnowledgeConfigForm) => ({
-          kb_id: item.kb_id || item.id,
-          retrieve_type: item.retrieve_type,
-          top_k: item.top_k,
-          similarity_threshold: item.similarity_threshold,
-          vector_similarity_weight: item.vector_similarity_weight,
-          // ...(item.config || {})
-        }))
+        knowledge_bases: knowledge_bases.map((item: KnowledgeConfigForm) => {
+          const kb_config = item.config || item;
+          return {
+            kb_id: item.kb_id || item.id,
+            retrieve_type: kb_config.retrieve_type,
+            top_k: kb_config.top_k,
+            similarity_threshold: ['participle', 'semantic', 'graph'].includes(kb_config.retrieve_type || '') ? undefined : kb_config.similarity_threshold,
+            vector_similarity_weight: kb_config.vector_similarity_weight,
+            // ...(item.config || {})
+          }
+        })
       } as KnowledgeConfig : null,
       tools: tools.map(vo => {
         if (!vo.operation) {


### PR DESCRIPTION
## Summary by Sourcery

调整代理知识库配置的处理方式，以便能够从嵌套的配置数据中正确推导检索设置和相似度阈值。

Bug Fixes:
- 确保对于使用 participle、semantic 或 graph 检索类型的知识库，不再发送 `similarity_threshold`，以避免不正确的配置。
- 修复代理配置中的知识库映射，在存在嵌套配置对象时，从该嵌套对象中读取检索参数。

Enhancements:
- 扩展 `KnowledgeConfigForm`，以支持可选的嵌套配置字段，从而实现更灵活的知识库配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust agent knowledge base configuration handling to properly derive retrieval settings and similarity thresholds from nested config data.

Bug Fixes:
- Ensure similarity_threshold is not sent for knowledge bases using participle, semantic, or graph retrieval types to avoid incorrect configuration.
- Fix knowledge base mapping in agent config to read retrieval parameters from the nested config object when present.

Enhancements:
- Extend KnowledgeConfigForm to support an optional nested config field for more flexible knowledge base configuration.

</details>