### PR TITLE
feat(memory): add internal memory read endpoint with Neo4j node type filter

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -18,13 +18,13 @@ from app.core.api_key_auth import require_api_key, require_api_key_self_db
 from app.core.api_key_utils import get_current_user_from_api_key, validate_end_user_in_workspace, \
     validate_end_user_in_workspace_async
 from app.core.logging_config import get_business_logger
-from app.core.memory.enums import SearchStrategy
+from app.core.memory.enums import Neo4jNodeType, SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.quota_stub import check_end_user_quota
 from app.core.response_utils import success
 from app.db import get_db, get_async_db_context
 from app.schemas.api_key_schema import ApiKeyAuth
-from app.schemas.memory_agent_schema import Write_UserInput, UserInput
+from app.schemas.memory_agent_schema import Write_UserInput, UserInput, InternalReadInput
 from app.services.memory_config_service import MemoryConfigService
 
 router = APIRouter(prefix="/memory", tags=["V1 - Memory API"])
@@ -68,6 +68,48 @@ async def read_memory_sync(
         end_user_id=payload.end_user_id,
     )
     memory = await service.read(payload.message, search_switch=SearchStrategy(payload.search_switch))
+    return success(data={
+        "answer": memory.content,
+        "intermediate_outputs": [_.model_dump() for _ in memory.memories]
+    })
+
+
+@router.post("/read/internal")
+@require_api_key_self_db(scopes=["memory"])
+async def read_memory_internal(
+        request: Request,
+        api_key_auth: ApiKeyAuth = None,
+        body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
+):
+    """
+    Read memory synchronously (internal).
+
+    Requires API Key with 'memory' scope.
+    Extended version of /read/sync that supports `include` (Neo4j node types filter)
+    and `limit` (max memories to return).
+    """
+    body = await request.json()
+    payload = InternalReadInput(**body)
+    async with get_async_db_context() as db:
+        await validate_end_user_in_workspace_async(db, payload.end_user_id, api_key_auth.workspace_id)
+        config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(payload.end_user_id)
+    logger.info(f"V1 memory read (internal) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
+
+    # Resolve include strings to Neo4jNodeType enum values
+    includes = None
+    if payload.includes:
+        includes = [Neo4jNodeType(t) for t in payload.includes]
+
+    service = await MemoryService.create(
+        config_id,
+        end_user_id=payload.end_user_id,
+    )
+    memory = await service.read(
+        payload.message,
+        search_switch=SearchStrategy(payload.search_switch),
+        limit=payload.limit,
+        includes=includes,
+    )
     return success(data={
         "answer": memory.content,
         "intermediate_outputs": [_.model_dump() for _ in memory.memories]

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -379,12 +379,13 @@ class MemoryService:
             search_switch: SearchStrategy,
             history: list | None = None,
             limit: int = 10,
+            includes: list | None = None,
     ) -> MemorySearchResult:
         if history is None:
             history = []
         if self.ctx.memory_config is None:
             raise RuntimeError("MemoryService.read() 需要 memory_config，但当前实例未加载配置")
-        return await ReadPipeLine(self.ctx).run(query, search_switch, history, limit)
+        return await ReadPipeLine(self.ctx).run(query, search_switch, history, limit, includes=includes)
 
     async def forget(self) -> dict:
         return await ForgettingPipeline(self.ctx).run()

--- a/api/app/core/memory/pipelines/base_pipeline.py
+++ b/api/app/core/memory/pipelines/base_pipeline.py
@@ -20,7 +20,6 @@ class ModelClientMixin(ABC):
                 provider=api_config.provider,
                 capability=api_config.capability,
                 api_key=api_config.api_key,
-                capability=api_config.capability,
                 base_url=api_config.api_base,
                 is_omni=api_config.is_omni
             )

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -5,6 +5,7 @@ import math
 import uuid
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.runnables.config import RunnableConfig, var_child_runnable_config
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -253,36 +254,37 @@ class Neo4jSearchService:
         ]
 
         for _ in range(RELATIONSHIP_LOOP_LIMIT):
-            response: AIMessage = await llm_with_tools.ainvoke(
-                messages,
-                config={
-                    "callbacks": [],
-                }
+            _config_token = var_child_runnable_config.set(
+                RunnableConfig(callbacks=[], tags=[], metadata={})
             )
-            messages.append(response)
+            try:
+                response: AIMessage = await llm_with_tools.ainvoke(messages)
+                messages.append(response)
 
-            if not response.tool_calls:
-                break
+                if not response.tool_calls:
+                    break
 
-            async def run_tool(tc):
-                tool = tool_map[tc["name"]]
-                try:
-                    result = await tool.ainvoke(tc["args"])
-                    return ToolMessage(
-                        content=json.dumps(result, ensure_ascii=False),
-                        tool_call_id=tc["id"],
-                    )
-                except Exception as e:
-                    return ToolMessage(
-                        content=json.dumps({"error": str(e)}),
-                        tool_call_id=tc["id"],
-                    )
+                async def run_tool(tc):
+                    tool = tool_map[tc["name"]]
+                    try:
+                        result = await tool.ainvoke(tc["args"])
+                        return ToolMessage(
+                            content=json.dumps(result, ensure_ascii=False),
+                            tool_call_id=tc["id"],
+                        )
+                    except Exception as e:
+                        return ToolMessage(
+                            content=json.dumps({"error": str(e)}),
+                            tool_call_id=tc["id"],
+                        )
 
-            tool_messages = await asyncio.gather(*[
-                run_tool(tc) for tc in response.tool_calls
-            ])
+                tool_messages = await asyncio.gather(*[
+                    run_tool(tc) for tc in response.tool_calls
+                ])
 
-            messages.extend(tool_messages)
+                messages.extend(tool_messages)
+            finally:
+                var_child_runnable_config.reset(_config_token)
 
         final_message = next(
             (m for m in reversed(messages) if isinstance(m, AIMessage)),

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -43,6 +43,20 @@ class UserInput(BaseModel):
     config_id: Optional[str] = None
 
 
+class InternalReadInput(BaseModel):
+    """Internal read request schema — extends UserInput with include / limit."""
+    message: str
+    search_switch: str
+    end_user_id: str
+    session_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    config_id: Optional[str] = None
+    includes: Optional[List[str]] = Field(
+        default=None,
+        description="要包含的 Neo4j 节点类型列表，如 CHUNK, COMMUNITY, DIALOGUE 等。不传则包含全部类型。",
+    )
+    limit: int = Field(default=10, description="返回的记忆数量上限", ge=1, le=100)
+
+
 class WriteMessageItem(BaseModel):
     """写入记忆的单条消息"""
     role: str = Field(..., description="消息角色: user 或 assistant")


### PR DESCRIPTION
## Summary by Sourcery

添加一个支持 Neo4j 节点类型过滤和可调节结果数量限制的内部内存读取端点，并在整个内存读取流水线中传递这些选项。

New Features:
- 引入 `/memory/read/internal` API，用于同步的内部内存读取，并支持包含过滤器和结果数量限制控制。

Enhancements:
- 扩展 `MemoryService.read` 以及底层读取流水线，以接受可选的 Neo4j 节点类型过滤器和可配置的结果数量上限。
- 清理基础流水线中 LLM 客户端的构建逻辑，移除一个重复的能力参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an internal memory read endpoint that supports Neo4j node type filtering and adjustable limits, and propagate these options through the memory read pipeline.

New Features:
- Introduce /memory/read/internal API for synchronous internal memory reads with support for include filters and limit control.

Enhancements:
- Extend MemoryService.read and underlying read pipeline to accept optional Neo4j node type filters and a configurable result limit.
- Clean up LLM client construction in the base pipeline by removing a duplicated capability parameter.

</details>