### PR TITLE
Feat/unified message pruning

### DIFF
--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -661,3 +661,35 @@ class ConversationNode(Node):
 class AssistantConversationEdge(Edge):
     """Edge connecting an AssistantOriginal node to its Conversation hub node (BELONGS_TO_CONVERSATION)."""
     pass
+
+
+class UserOriginalContentNode(Node):
+    """Node storing the original text of a User message before pruning.
+
+    When a user message is pruned/regularized (e.g., a recipe is compressed to a summary),
+    this node preserves the full original text so that downstream retrieval can trace back
+    from extracted entities to the complete user input.
+
+    Attributes:
+        message_seq: The message sequence number in memory_messages table
+        conversation_id: Conversation ID or deterministic hub ID
+        original_text: Full original text before pruning
+        pruned_text: The pruned/regularized text after processing
+        content_type: Type of the original content (file_summary / copied_content / mixed)
+        text_embedding: Embedding vector of original_text for semantic retrieval
+    """
+    message_seq: int = Field(..., description="Message sequence number in memory_messages")
+    conversation_id: str = Field(..., description="Conversation ID or deterministic hub ID")
+    original_text: str = Field(..., description="Full original user message text before pruning")
+    pruned_text: str = Field(..., description="Pruned/regularized text after processing")
+    content_type: str = Field(default="mixed", description="Content type: file_summary / copied_content / mixed")
+    text_embedding: Optional[List[float]] = Field(None, description="Embedding vector of original_text")
+
+
+class UserOriginalContentEntityEdge(Edge):
+    """Edge connecting a UserOriginalContent node to an ExtractedEntity node (HAS_ORIGINAL_CONTENT).
+
+    Semantics: the original user message contains/references this entity.
+    Retrieval path: Entity → UserOriginalContent → original_text
+    """
+    pass

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -662,34 +662,31 @@ class AssistantConversationEdge(Edge):
     """Edge connecting an AssistantOriginal node to its Conversation hub node (BELONGS_TO_CONVERSATION)."""
     pass
 
+class UserSourceNode(Node):
+    """存储 user 消息被剪枝/规整前的完整原文，类似 dialog 节点。
 
-class UserOriginalContentNode(Node):
-    """Node storing the original text of a User message before pruning.
+    当 user 消息被语义剪枝后，生成 UserSource 节点保存该条 user 消息的
+    完整原文（即剪枝/规整前的 memory_messages.content），为检索侧提供
+    "Entity → 原文" 的回溯路径。
 
-    When a user message is pruned/regularized (e.g., a recipe is compressed to a summary),
-    this node preserves the full original text so that downstream retrieval can trace back
-    from extracted entities to the complete user input.
+    name 属性值来自 LLM 产出的 processed_user_topic_entity_hint（实体锚点）。
 
     Attributes:
         message_seq: The message sequence number in memory_messages table
-        conversation_id: Conversation ID or deterministic hub ID
-        original_text: Full original text before pruning
-        pruned_text: The pruned/regularized text after processing
-        content_type: Type of the original content (file_summary / copied_content / mixed)
+        original_text: Full original user message text before pruning
+        pruned_text: The pruned/regularized text after processing (processed_user_msg)
         text_embedding: Embedding vector of original_text for semantic retrieval
     """
     message_seq: int = Field(..., description="Message sequence number in memory_messages")
-    conversation_id: str = Field(..., description="Conversation ID or deterministic hub ID")
     original_text: str = Field(..., description="Full original user message text before pruning")
-    pruned_text: str = Field(..., description="Pruned/regularized text after processing")
-    content_type: str = Field(default="mixed", description="Content type: file_summary / copied_content / mixed")
+    pruned_text: str = Field(..., description="Pruned/regularized text after processing (processed_user_msg)")
     text_embedding: Optional[List[float]] = Field(None, description="Embedding vector of original_text")
 
 
-class UserOriginalContentEntityEdge(Edge):
-    """Edge connecting a UserOriginalContent node to an ExtractedEntity node (HAS_ORIGINAL_CONTENT).
+class UserSourceEntityEdge(Edge):
+    """Edge connecting a UserSource node to an ExtractedEntity node (HAS_ORIGINAL_CONTENT).
 
     Semantics: the original user message contains/references this entity.
-    Retrieval path: Entity → UserOriginalContent → original_text
+    Retrieval path: Entity → UserSource → original_text
     """
     pass

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -40,6 +40,9 @@ from app.core.memory.models.graph_models import (
     StatementEntityEdge,
     StatementNode,
 )
+from app.core.memory.storage_services.clustering_engine.label_propagation import (
+    _cosine_similarity,
+)
 
 logger = logging.getLogger(__name__)
 bear = BearLogger("memory.pipeline")
@@ -153,8 +156,8 @@ class ExtractionResult(BaseModel):
     assistant_pruned_edges: List[Any] = Field(default_factory=list)
     conversation_nodes: List[Any] = Field(default_factory=list)
     assistant_conversation_edges: List[Any] = Field(default_factory=list)
-    user_original_content_nodes: List[Any] = Field(default_factory=list)
-    user_original_content_edges: List[Any] = Field(default_factory=list)
+    user_source_nodes: List[Any] = Field(default_factory=list)
+    user_source_edges: List[Any] = Field(default_factory=list)
     dialog_data_list: List[Any] = Field(
         default_factory=list,
         description="原始 DialogData 列表，类型为 Any 以避免循环依赖",
@@ -373,7 +376,9 @@ class WritePipeline:
                 if recorder is not None and self.memory_config.pruning_enabled:
                     recorder.record_pruning_results(pruning_records)
 
-                # 从 pruning_records 提取 target user 规整信息（用于后续构建 UserOriginalContent 节点）
+                # 从 pruning_records 提取 target user 规整信息（用于后续构建 UserSource 节点）
+                # 如果 user 内容有被剪枝，保存原文作为 UserSource 节点（类似 dialog 节点），
+                # 可以直接取 dialog 节点的内容作为 UserSource 节点的内容
                 self._user_pruning_info = None
                 if pruning_records:
                     target_pruning = next(
@@ -385,13 +390,13 @@ class WritePipeline:
                     )
                     if target_pruning:
                         _orig_text = target_pruning["input"]["msgs"][0]["msg"]
-                        _pruned_text = target_pruning["output"].get("processed_user_msg", "")
+                        _output = target_pruning["output"]
                         self._user_pruning_info = {
                             "original_text": _orig_text,
-                            "pruned_text": _pruned_text,
+                            "pruned_text": _output.get("processed_user_msg", ""),
                             "message_seq": message_seq,
                             "conversation_id": conversation_id or f"{self.end_user_id}_{source}",
-                            "content_type": self._detect_content_type(_orig_text),
+                            "topic_entity_hint": _output.get("processed_user_topic_entity_hint", ""),
                         }
 
                 # Step 2: 预处理 - 消息分块
@@ -453,9 +458,9 @@ class WritePipeline:
                         elapsed_seconds=0.0,
                     )
 
-                # Step 3.5: 构建 UserOriginalContent 子图（剪枝原文 → 实体连边）
+                # Step 3.5: 构建 UserSource 子图（剪枝原文 → 实体连边）
                 if self._user_pruning_info:
-                    await self._build_original_content_subgraph(extraction_result)
+                    await self._build_user_source_subgraph(extraction_result)
 
                 async with bear.step(4, 6, "存储", "写入 Neo4j"):
                     await self._store(extraction_result)
@@ -659,8 +664,8 @@ class WritePipeline:
                     assistant_pruned_edges=result.assistant_pruned_edges,
                     conversation_nodes=result.conversation_nodes,
                     assistant_conversation_edges=result.assistant_conversation_edges,
-                    user_original_content_nodes=result.user_original_content_nodes,
-                    user_original_content_edges=result.user_original_content_edges,
+                    user_source_nodes=result.user_source_nodes,
+                    user_source_edges=result.user_source_edges,
                 )
                 if success:
                     logger.debug("Successfully saved all data to Neo4j")
@@ -681,58 +686,78 @@ class WritePipeline:
                     raise
 
     # ──────────────────────────────────────────────
-    # Step 3.5: 构建 UserOriginalContent 子图
+    # Step 3.5: 构建 UserSource 子图
     # ──────────────────────────────────────────────
 
-    async def _build_original_content_subgraph(self, result: ExtractionResult) -> None:
-        """构建 UserOriginalContent 节点和 HAS_ORIGINAL_CONTENT 边。
+    # 通用角色实体排除列表，这些实体不应与 UserSource 建边
+    _USER_SOURCE_EXCLUDED_ENTITY_NAMES = frozenset({
+        "用户", "我", "user", "i", "ai助手", "助手", "助理", "ai", "assistant", "ai回复", "ai assistant",
+    })
 
-        当用户消息被剪枝/规整后，创建一个 UserOriginalContent 节点保存原文，
-        并通过 HAS_ORIGINAL_CONTENT 边连接到从该消息萃取出的所有 Entity 节点，
+    # UserSource → Entity 建边的余弦相似度阈值
+    _USER_SOURCE_SIMILARITY_THRESHOLD = 0.5
+
+    async def _build_user_source_subgraph(self, result: ExtractionResult) -> None:
+        """构建 UserSource 节点和 HAS_ORIGINAL_CONTENT 边。
+
+        当 user 消息被剪枝/规整后，创建 UserSource 节点保存原文（类似 dialog 节点），
+        并通过 HAS_ORIGINAL_CONTENT 边连接到**语义相关的** Entity 节点，
         为检索侧提供 "Entity → 原文" 的回溯路径。
+
+        连边逻辑：
+        1. 预先排除通用角色实体（"用户""AI助手"等）
+        2. 用 UserSourceNode.name（= processed_user_topic_entity_hint）的 embedding
+           与每个 ExtractedEntity.name_embedding 做余弦相似度匹配
+        3. 只对超过阈值的 entity 建 HAS_ORIGINAL_CONTENT 边
+
+        节点 name 属性使用 LLM 产出的 processed_user_topic_entity_hint（实体锚点）。
+        原文来源：直接取 dialog 节点的内容（memory_messages.content）。
 
         前置条件：self._user_pruning_info 已在 Step 1 后设置。
         """
         from app.core.memory.models.graph_models import (
-            UserOriginalContentNode,
-            UserOriginalContentEntityEdge,
+            UserSourceNode,
+            UserSourceEntityEdge,
         )
 
         info = self._user_pruning_info
         if not info:
             return
 
-        # 生成 embedding
+        # 生成 original_text 的 embedding（存入节点，供向量检索回溯）
         text_embedding = None
         if self._embedder_client and info["original_text"]:
             try:
                 text_embedding = await self._embedder_client.embed_query(info["original_text"])
             except Exception as e:
-                logger.warning(f"[UserOriginalContent] 生成 embedding 失败（不影响写入）: {e}")
+                logger.warning(f"[UserSource] 生成 text_embedding 失败（不影响写入）: {e}")
 
         # 构建节点
         node_id = uuid.uuid4().hex
         now_iso = datetime.now().isoformat()
         run_id = result.dialogue_nodes[0].run_id if result.dialogue_nodes else uuid.uuid4().hex
 
-        uoc_node = UserOriginalContentNode(
+        # name 使用 LLM 产出的实体锚点（processed_user_topic_entity_hint）
+        node_name = info.get("topic_entity_hint") or f"UserSource_{node_id[:8]}"
+
+        us_node = UserSourceNode(
             id=node_id,
-            name=f"OriginalContent_{node_id[:8]}",
+            name=node_name,
             end_user_id=self.end_user_id,
             run_id=run_id,
             created_at=now_iso,
             message_seq=info["message_seq"],
-            conversation_id=info["conversation_id"],
             original_text=info["original_text"],
             pruned_text=info["pruned_text"],
-            content_type=info["content_type"],
             text_embedding=text_embedding,
         )
 
-        # 为每个萃取出的 entity 创建 HAS_ORIGINAL_CONTENT 边
-        edges = []
-        for entity in result.entity_nodes:
-            edge = UserOriginalContentEntityEdge(
+        # 选择性建边：排除角色实体 + embedding 相似度匹配
+        matched = await self._select_entities_for_user_source(node_name, result.entity_nodes)
+
+        # 为匹配的 entity 创建 HAS_ORIGINAL_CONTENT 边
+        edges = [
+            UserSourceEntityEdge(
                 id=uuid.uuid4().hex,
                 source=node_id,
                 target=entity.id,
@@ -740,31 +765,63 @@ class WritePipeline:
                 run_id=run_id,
                 created_at=now_iso,
             )
-            edges.append(edge)
+            for entity in matched
+        ]
 
-        result.user_original_content_nodes = [uoc_node]
-        result.user_original_content_edges = edges
+        result.user_source_nodes = [us_node]
+        result.user_source_edges = edges
 
         logger.info(
-            f"[UserOriginalContent] 构建完成 - node_id={node_id[:8]}, "
-            f"edges={len(edges)}, content_type={info['content_type']}, "
+            f"[UserSource] 构建完成 - node_id={node_id[:8]}, name={node_name}, "
+            f"total_entities={len(result.entity_nodes)}, matched={len(matched)}, "
             f"original_len={len(info['original_text'])}"
         )
 
-    @staticmethod
-    def _detect_content_type(text: str) -> str:
-        """检测原文内容类型。
+    async def _select_entities_for_user_source(
+        self, hint_name: str, entities: list
+    ) -> list:
+        """筛选与 UserSource 语义相关的 entity（排除角色实体 + embedding 匹配）。
+
+        Args:
+            hint_name: UserSourceNode.name（= processed_user_topic_entity_hint）
+            entities: 本次萃取出的 ExtractedEntityNode 列表
 
         Returns:
-            file_summary: 含 <input-file-summary> 标签
-            copied_content: 纯长文（≥500 字符）
-            mixed: 其他
+            通过过滤和相似度匹配的 entity 子集
         """
-        if "<input-file-summary>" in text:
-            return "file_summary"
-        if len(text) >= 500:
-            return "copied_content"
-        return "mixed"
+        # 生成 hint_name 的 embedding
+        hint_emb = None
+        if self._embedder_client and hint_name:
+            try:
+                hint_emb = await self._embedder_client.embed_query(hint_name)
+            except Exception as e:
+                logger.warning(f"[UserSource] hint embedding 失败，降级全连: {e}")
+
+        excluded = self._USER_SOURCE_EXCLUDED_ENTITY_NAMES
+        threshold = self._USER_SOURCE_SIMILARITY_THRESHOLD
+
+        matched = []
+        skipped_role = 0
+        skipped_sim = 0
+
+        for entity in entities:
+            # 排除通用角色实体
+            if entity.name and entity.name.lower().strip() in excluded:
+                skipped_role += 1
+                continue
+            # embedding 相似度匹配
+            if hint_emb:
+                emb = entity.name_embedding
+                if emb and _cosine_similarity(hint_emb, emb) < threshold:
+                    skipped_sim += 1
+                    continue
+            matched.append(entity)
+
+        logger.debug(
+            f"[UserSource] entity 匹配 - hint={hint_name}, "
+            f"skipped_role={skipped_role}, skipped_sim={skipped_sim}, matched={len(matched)}"
+        )
+        return matched
 
     # ──────────────────────────────────────────────
     # Step 4: 聚类

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -381,11 +381,13 @@ class WritePipeline:
                 # 可以直接取 dialog 节点的内容作为 UserSource 节点的内容
                 self._user_pruning_info = None
                 if pruning_records:
+                    # 优先匹配 LLM 剪枝路径（source=llm, should_process_user_msg=True）
                     target_pruning = next(
                         (r for r in pruning_records
                          if r.get("message_seq") == message_seq
                          and r.get("type") == "user_pruning"
-                         and r.get("output", {}).get("should_process_user_msg")),
+                         and r.get("source") == "llm"
+                         and (r.get("output") or {}).get("should_process_user_msg")),
                         None,
                     )
                     if target_pruning:
@@ -398,6 +400,26 @@ class WritePipeline:
                             "conversation_id": conversation_id or f"{self.end_user_id}_{source}",
                             "topic_entity_hint": _output.get("processed_user_topic_entity_hint", ""),
                         }
+                    else:
+                        # 回退：DB 缓存路径（source=db）— 前一次任务已完成 LLM 剪枝并回写 PG
+                        target_pruning_db = next(
+                            (r for r in pruning_records
+                             if r.get("message_seq") == message_seq
+                             and r.get("type") == "user_pruning"
+                             and r.get("source") == "db"
+                             and (r.get("output") or {}).get("topic_entity_hint")),
+                            None,
+                        )
+                        if target_pruning_db:
+                            _orig_text = target_pruning_db["input"]["msgs"][0]["msg"]
+                            _output = target_pruning_db["output"]
+                            self._user_pruning_info = {
+                                "original_text": _orig_text,
+                                "pruned_text": _output.get("pruned_content", ""),
+                                "message_seq": message_seq,
+                                "conversation_id": conversation_id or f"{self.end_user_id}_{source}",
+                                "topic_entity_hint": _output.get("topic_entity_hint", ""),
+                            }
 
                 # Step 2: 预处理 - 消息分块
                 async with bear.step(2, 6, "预处理", "消息分块") as s:
@@ -728,7 +750,7 @@ class WritePipeline:
         text_embedding = None
         if self._embedder_client and info["original_text"]:
             try:
-                text_embedding = await self._embedder_client.embed_query(info["original_text"])
+                text_embedding = await self._embedder_client.aembed_query(info["original_text"])
             except Exception as e:
                 logger.warning(f"[UserSource] 生成 text_embedding 失败（不影响写入）: {e}")
 
@@ -793,7 +815,7 @@ class WritePipeline:
         hint_emb = None
         if self._embedder_client and hint_name:
             try:
-                hint_emb = await self._embedder_client.embed_query(hint_name)
+                hint_emb = await self._embedder_client.aembed_query(hint_name)
             except Exception as e:
                 logger.warning(f"[UserSource] hint embedding 失败，降级全连: {e}")
 

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -86,6 +86,10 @@ def _convert_pruning_records(raw_records: list, end_user_id: str = "", source: s
     result: List[dict] = []
     _now = datetime.now(_tz.utc).isoformat()
     for idx, r in enumerate(raw_records):
+        # 只处理 assistant_pruning 类型的记录，user_pruning 不产生 AssistantOriginal 节点
+        if r.get("type") != "assistant_pruning":
+            continue
+
         conv_id = r.get("conversation_id", "")
         seq = r.get("message_seq", 0)
         # pair_id 基于 conversation_id + message_seq 确定性生成，

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from app.core.memory.utils.log.bear_logger import BearLogger
@@ -758,8 +758,8 @@ class WritePipeline:
 
         # 构建节点
         node_id = uuid.uuid4().hex
-        from app.core.utils.datetime_utils import to_iso_z
-        now_iso = to_iso_z(datetime.now(timezone.utc))
+        from app.core.utils.datetime_utils import to_iso_z, utcnow
+        now_iso = to_iso_z(utcnow())
         run_id = result.dialogue_nodes[0].run_id if result.dialogue_nodes else uuid.uuid4().hex
 
         # name 使用 LLM 产出的实体锚点（processed_user_topic_entity_hint）

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -153,6 +153,8 @@ class ExtractionResult(BaseModel):
     assistant_pruned_edges: List[Any] = Field(default_factory=list)
     conversation_nodes: List[Any] = Field(default_factory=list)
     assistant_conversation_edges: List[Any] = Field(default_factory=list)
+    user_original_content_nodes: List[Any] = Field(default_factory=list)
+    user_original_content_edges: List[Any] = Field(default_factory=list)
     dialog_data_list: List[Any] = Field(
         default_factory=list,
         description="原始 DialogData 列表，类型为 Any 以避免循环依赖",
@@ -371,6 +373,27 @@ class WritePipeline:
                 if recorder is not None and self.memory_config.pruning_enabled:
                     recorder.record_pruning_results(pruning_records)
 
+                # 从 pruning_records 提取 target user 规整信息（用于后续构建 UserOriginalContent 节点）
+                self._user_pruning_info = None
+                if pruning_records:
+                    target_pruning = next(
+                        (r for r in pruning_records
+                         if r.get("message_seq") == message_seq
+                         and r.get("type") == "user_pruning"
+                         and r.get("output", {}).get("should_process_user_msg")),
+                        None,
+                    )
+                    if target_pruning:
+                        _orig_text = target_pruning["input"]["msgs"][0]["msg"]
+                        _pruned_text = target_pruning["output"].get("processed_user_msg", "")
+                        self._user_pruning_info = {
+                            "original_text": _orig_text,
+                            "pruned_text": _pruned_text,
+                            "message_seq": message_seq,
+                            "conversation_id": conversation_id or f"{self.end_user_id}_{source}",
+                            "content_type": self._detect_content_type(_orig_text),
+                        }
+
                 # Step 2: 预处理 - 消息分块
                 async with bear.step(2, 6, "预处理", "消息分块") as s:
                     from app.core.memory.agent.utils.get_dialogs import get_chunked_dialogs
@@ -429,6 +452,10 @@ class WritePipeline:
                         extraction=extraction_result.stats,
                         elapsed_seconds=0.0,
                     )
+
+                # Step 3.5: 构建 UserOriginalContent 子图（剪枝原文 → 实体连边）
+                if self._user_pruning_info:
+                    await self._build_original_content_subgraph(extraction_result)
 
                 async with bear.step(4, 6, "存储", "写入 Neo4j"):
                     await self._store(extraction_result)
@@ -632,6 +659,8 @@ class WritePipeline:
                     assistant_pruned_edges=result.assistant_pruned_edges,
                     conversation_nodes=result.conversation_nodes,
                     assistant_conversation_edges=result.assistant_conversation_edges,
+                    user_original_content_nodes=result.user_original_content_nodes,
+                    user_original_content_edges=result.user_original_content_edges,
                 )
                 if success:
                     logger.debug("Successfully saved all data to Neo4j")
@@ -650,6 +679,92 @@ class WritePipeline:
                     await asyncio.sleep(1 * (attempt + 1))
                 else:
                     raise
+
+    # ──────────────────────────────────────────────
+    # Step 3.5: 构建 UserOriginalContent 子图
+    # ──────────────────────────────────────────────
+
+    async def _build_original_content_subgraph(self, result: ExtractionResult) -> None:
+        """构建 UserOriginalContent 节点和 HAS_ORIGINAL_CONTENT 边。
+
+        当用户消息被剪枝/规整后，创建一个 UserOriginalContent 节点保存原文，
+        并通过 HAS_ORIGINAL_CONTENT 边连接到从该消息萃取出的所有 Entity 节点，
+        为检索侧提供 "Entity → 原文" 的回溯路径。
+
+        前置条件：self._user_pruning_info 已在 Step 1 后设置。
+        """
+        from app.core.memory.models.graph_models import (
+            UserOriginalContentNode,
+            UserOriginalContentEntityEdge,
+        )
+
+        info = self._user_pruning_info
+        if not info:
+            return
+
+        # 生成 embedding
+        text_embedding = None
+        if self._embedder_client and info["original_text"]:
+            try:
+                text_embedding = await self._embedder_client.embed_query(info["original_text"])
+            except Exception as e:
+                logger.warning(f"[UserOriginalContent] 生成 embedding 失败（不影响写入）: {e}")
+
+        # 构建节点
+        node_id = uuid.uuid4().hex
+        now_iso = datetime.now().isoformat()
+        run_id = result.dialogue_nodes[0].run_id if result.dialogue_nodes else uuid.uuid4().hex
+
+        uoc_node = UserOriginalContentNode(
+            id=node_id,
+            name=f"OriginalContent_{node_id[:8]}",
+            end_user_id=self.end_user_id,
+            run_id=run_id,
+            created_at=now_iso,
+            message_seq=info["message_seq"],
+            conversation_id=info["conversation_id"],
+            original_text=info["original_text"],
+            pruned_text=info["pruned_text"],
+            content_type=info["content_type"],
+            text_embedding=text_embedding,
+        )
+
+        # 为每个萃取出的 entity 创建 HAS_ORIGINAL_CONTENT 边
+        edges = []
+        for entity in result.entity_nodes:
+            edge = UserOriginalContentEntityEdge(
+                id=uuid.uuid4().hex,
+                source=node_id,
+                target=entity.id,
+                end_user_id=self.end_user_id,
+                run_id=run_id,
+                created_at=now_iso,
+            )
+            edges.append(edge)
+
+        result.user_original_content_nodes = [uoc_node]
+        result.user_original_content_edges = edges
+
+        logger.info(
+            f"[UserOriginalContent] 构建完成 - node_id={node_id[:8]}, "
+            f"edges={len(edges)}, content_type={info['content_type']}, "
+            f"original_len={len(info['original_text'])}"
+        )
+
+    @staticmethod
+    def _detect_content_type(text: str) -> str:
+        """检测原文内容类型。
+
+        Returns:
+            file_summary: 含 <input-file-summary> 标签
+            copied_content: 纯长文（≥500 字符）
+            mixed: 其他
+        """
+        if "<input-file-summary>" in text:
+            return "file_summary"
+        if len(text) >= 500:
+            return "copied_content"
+        return "mixed"
 
     # ──────────────────────────────────────────────
     # Step 4: 聚类

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 from app.core.memory.utils.log.bear_logger import BearLogger
@@ -40,9 +40,7 @@ from app.core.memory.models.graph_models import (
     StatementEntityEdge,
     StatementNode,
 )
-from app.core.memory.storage_services.clustering_engine.label_propagation import (
-    _cosine_similarity,
-)
+from app.core.memory.utils.name_similarity_utils import cosine_similarity
 
 logger = logging.getLogger(__name__)
 bear = BearLogger("memory.pipeline")
@@ -756,7 +754,8 @@ class WritePipeline:
 
         # 构建节点
         node_id = uuid.uuid4().hex
-        now_iso = datetime.now().isoformat()
+        from app.core.utils.datetime_utils import to_iso_z
+        now_iso = to_iso_z(datetime.now(timezone.utc))
         run_id = result.dialogue_nodes[0].run_id if result.dialogue_nodes else uuid.uuid4().hex
 
         # name 使用 LLM 产出的实体锚点（processed_user_topic_entity_hint）
@@ -834,7 +833,7 @@ class WritePipeline:
             # embedding 相似度匹配
             if hint_emb:
                 emb = entity.name_embedding
-                if emb and _cosine_similarity(hint_emb, emb) < threshold:
+                if emb and cosine_similarity(hint_emb, emb) < threshold:
                     skipped_sim += 1
                     continue
             matched.append(entity)

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -53,6 +53,8 @@ class AssistantPruningResponse(BaseModel):
     - assistant_memory_type: 摘要类型枚举，无价值时为 "NULL"，Assistant 为空时为 null
     - should_process_user_msg: 是否需要对 User 消息做规整，User 为空时为 null
     - processed_user_msg: 规整后的 User 消息文本，不需要处理时为 null
+    - processed_user_topic_entity_hint: 规整后最应通过 embedding 连接的实体锚点，
+      should_process_user_msg 非 true 时为 null
     """
 
     assistant_memory_hint: Optional[str] = Field(
@@ -67,6 +69,9 @@ class AssistantPruningResponse(BaseModel):
     )
     processed_user_msg: Optional[str] = Field(
         default=None, description="规整后的 User 消息文本，不需要处理时为 null"
+    )
+    processed_user_topic_entity_hint: Optional[str] = Field(
+        default=None, description="规整后最应通过 embedding 连接的实体锚点，should_process_user_msg 非 true 时为 null"
     )
 
 

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -163,6 +163,9 @@ class SemanticPruner:
         for attempt in range(max_retries):
             try:
                 result = await self.llm_client.call_structured(messages, AssistantPruningResponse)
+                if result is None:
+                    raise ValueError("call_structured 返回 None（LLM 输出解析失败）")
+                logger.info(f"[剪枝-LLM] raw result: {result}")
                 return result
             except Exception as e:
                 if attempt < max_retries - 1:

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/data_pruning.py
@@ -165,7 +165,6 @@ class SemanticPruner:
                 result = await self.llm_client.call_structured(messages, AssistantPruningResponse)
                 if result is None:
                     raise ValueError("call_structured 返回 None（LLM 输出解析失败）")
-                logger.info(f"[剪枝-LLM] raw result: {result}")
                 return result
             except Exception as e:
                 if attempt < max_retries - 1:

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
@@ -29,6 +29,7 @@ class PruneResult(NamedTuple):
     memory_type: str
     should_process_user_msg: bool
     processed_user_msg: Optional[str]
+    processed_user_topic_entity_hint: Optional[str]
 
 
 async def prune_messages(
@@ -160,6 +161,7 @@ async def prune_messages(
                     "output": {
                         "should_process_user_msg": pr.should_process_user_msg,
                         "processed_user_msg": pr.processed_user_msg,
+                        "processed_user_topic_entity_hint": pr.processed_user_topic_entity_hint,
                     },
                 })
             elif role_type == "assistant":
@@ -296,6 +298,7 @@ async def _call_llm_prune(
         memory_type=result.assistant_memory_type,
         should_process_user_msg=result.should_process_user_msg,
         processed_user_msg=result.processed_user_msg,
+        processed_user_topic_entity_hint=result.processed_user_topic_entity_hint,
     )
 
 

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
@@ -88,14 +88,17 @@ async def prune_messages(
                 "source": "db",
                 "type": f"{role}_pruning",
                 "input": {"msgs": [{"role": role.title(), "msg": content}]},
-                "output": {"pruned_content": msg["pruned_content"]},
+                "output": {
+                    "pruned_content": msg["pruned_content"],
+                    "topic_entity_hint": msg.get("topic_entity_hint"),
+                },
             })
             continue
 
         if role == "user":
             if _should_skip_user(content):
                 result[i] = msg
-                db_updates.append((seq, content))
+                db_updates.append((seq, content, None))
                 pruning_records.append({
                     "conversation_id": conversation_id,
                     "message_seq": seq,
@@ -140,15 +143,15 @@ async def prune_messages(
                 # LLM 失败 → 截断原文前 500 字符作为兜底，写入 DB 标记已处理
                 fallback = content[:500]
                 result[idx] = {**msg, "content": fallback}
-                db_updates.append((seq, fallback))
+                db_updates.append((seq, fallback, None))
             elif role_type == "user":
                 pr: PruneResult = llm_result
                 if pr.should_process_user_msg and pr.processed_user_msg and pr.processed_user_msg.strip():
                     result[idx] = {**msg, "content": pr.processed_user_msg}
-                    db_updates.append((seq, pr.processed_user_msg))
+                    db_updates.append((seq, pr.processed_user_msg, pr.processed_user_topic_entity_hint))
                 else:
                     result[idx] = msg
-                    db_updates.append((seq, content))
+                    db_updates.append((seq, content, None))
                 pruning_records.append({
                     "conversation_id": conversation_id,
                     "message_seq": seq,
@@ -168,7 +171,7 @@ async def prune_messages(
                 pr: PruneResult = llm_result
                 to_write = pr.pruned_content if pr.pruned_content else content
                 result[idx] = {**msg, "content": to_write}
-                db_updates.append((seq, to_write))
+                db_updates.append((seq, to_write, None))
                 pruning_records.append({
                     "conversation_id": conversation_id,
                     "message_seq": seq,
@@ -195,7 +198,7 @@ async def prune_messages(
 def _refresh_pruned_content(
     messages: List[dict], conversation_id: str, end_user_id: str, source: str
 ) -> None:
-    """从 DB 刷新 pruned_content=NULL 的消息。"""
+    """从 DB 刷新 pruned_content 和 topic_entity_hint。"""
     null_seqs = [m.get("message_seq") for m in messages if m.get("pruned_content") is None and m.get("message_seq")]
     if not null_seqs:
         return
@@ -210,8 +213,11 @@ def _refresh_pruned_content(
                 source=source,
             )
         for msg in messages:
-            if msg.get("pruned_content") is None and msg["message_seq"] in fresh:
-                msg["pruned_content"] = fresh[msg["message_seq"]]
+            seq = msg.get("message_seq")
+            if msg.get("pruned_content") is None and seq in fresh:
+                data = fresh[seq]
+                msg["pruned_content"] = data["pruned_content"]
+                msg["topic_entity_hint"] = data.get("topic_entity_hint")
     except Exception as e:
         logger.warning(f"[Pruning] DB 刷新失败（不影响主流程）: {e}", exc_info=True)
 

--- a/api/app/core/memory/utils/name_similarity_utils.py
+++ b/api/app/core/memory/utils/name_similarity_utils.py
@@ -45,8 +45,11 @@ def _jaccard(a_tokens: List[str], b_tokens: List[str]) -> float:
         return 0.0
 
 
-def _cosine(a: List[float], b: List[float]) -> float:
-    """余弦相似度：计算两个向量的夹角余弦值"""
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    """余弦相似度：计算两个向量的夹角余弦值。
+
+    任一向量为空或长度不匹配时返回 0.0。
+    """
     try:
         if not a or not b or len(a) != len(b):
             return 0.0
@@ -58,7 +61,6 @@ def _cosine(a: List[float], b: List[float]) -> float:
         return dot / (na * nb)
     except Exception:
         return 0.0
-
 
 def _tokenize_chars(s: str) -> List[str]:
     """中文逐字分词：中文字符按单字切分，英文与数字按连续串切分。
@@ -177,7 +179,7 @@ def name_similarity_with_aliases(
     """
     # 1. 主名称向量相似度：优先用外部传入（Neo4j 已算），否则 Python 兜底
     if emb_sim is None:
-        emb_sim = _cosine(
+        emb_sim = cosine_similarity(
             getattr(e1, "name_embedding", []) or [],
             getattr(e2, "name_embedding", []) or [],
         )
@@ -240,7 +242,7 @@ def _name_similarity_with_aliases_legacy(
     """
     # 1. 主名称向量相似度：优先用外部传入（Neo4j 已算），否则 Python 兜底计算
     if emb_sim is None:
-        emb_sim = _cosine(
+        emb_sim = cosine_similarity(
             getattr(e1, "name_embedding", []) or [],
             getattr(e2, "name_embedding", []) or [],
         )

--- a/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
@@ -276,6 +276,29 @@
   "processed_user_topic_entity_hint": null
 }
 
+示例 6
+输入：
+{
+  "msgs": [
+    {
+      "role": "User",
+      "msg": "我叫小明。帮我记住这个番茄炒蛋菜谱：食材：3个鸡蛋、2个番茄、盐少许、糖一勺、油适量。步骤一：打散鸡蛋加盐搅匀。步骤二：热锅倒油，油温七成热。步骤三：倒入蛋液炒至凝固盛出。步骤四：锅中加油放入番茄块翻炒出汁。步骤五：加盐糖调味，倒回鸡蛋翻炒均匀出锅装盘。"
+    },
+    {
+      "role": "Assistant",
+      "msg": ""
+    }
+  ]
+}
+输出：
+{
+  "assistant_memory_hint": null,
+  "assistant_memory_type": null,
+  "should_process_user_msg": true,
+  "processed_user_msg": "我叫小明。我说了帮我记住一个番茄炒蛋菜谱，包含鸡蛋、番茄等食材和五个烹饪步骤的详细做法。",
+  "processed_user_topic_entity_hint": "番茄炒蛋菜谱"
+}
+
 {% else %}
 You are a dialogue pruning and normalization module designed for memory storage.
 
@@ -552,6 +575,29 @@ Output:
   "should_process_user_msg": false,
   "processed_user_msg": null,
   "processed_user_topic_entity_hint": null
+}
+
+Few-shot Example 6
+Input:
+{
+  "msgs": [
+    {
+      "role": "User",
+      "msg": "My name is Alex. Please remember this tomato egg stir-fry recipe: Ingredients: 3 eggs, 2 tomatoes, a pinch of salt, one spoon of sugar, oil as needed. Step 1: Beat eggs with salt. Step 2: Heat pan with oil until 70% hot. Step 3: Pour in egg mixture and scramble until set, remove. Step 4: Add oil, stir-fry tomato chunks until juicy. Step 5: Add salt and sugar, return eggs and stir evenly, serve."
+    },
+    {
+      "role": "Assistant",
+      "msg": ""
+    }
+  ]
+}
+Output:
+{
+  "assistant_memory_hint": null,
+  "assistant_memory_type": null,
+  "should_process_user_msg": true,
+  "processed_user_msg": "My name is Alex. I asked to remember a tomato egg stir-fry recipe, which includes eggs, tomatoes, and other ingredients with five detailed cooking steps.",
+  "processed_user_topic_entity_hint": "tomato egg stir-fry recipe"
 }
 {% endif %}
 

--- a/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/extract_pruning.jinja2
@@ -13,16 +13,17 @@
 - 你必须同时读取 `User.msg` 和 `Assistant.msg`。
 - 允许其中一侧的 `msg` 为空字符串、`null` 或仅包含空白；这表示该侧没有可处理内容。
 
-你必须输出四个字段：
+你必须输出五个字段：
 1. `assistant_memory_hint`
 2. `assistant_memory_type`
 3. `should_process_user_msg`
 4. `processed_user_msg`
+5. `processed_user_topic_entity_hint`
 
 空输入处理规则：
 - 如果 `Assistant.msg` 为空，则 `assistant_memory_hint` 必须为 `null`，`assistant_memory_type` 必须为 `null`；不要根据 `User.msg` 补写 assistant 摘要或类型。
-- 如果 `User.msg` 为空，则 `should_process_user_msg` 必须为 `null`，`processed_user_msg` 必须为 `null`；不要根据 `Assistant.msg` 补写 user 侧处理结果。
-- 如果两侧都为空，四个字段都必须为 `null`。
+- 如果 `User.msg` 为空，则 `should_process_user_msg` 必须为 `null`，`processed_user_msg` 必须为 `null`，`processed_user_topic_entity_hint` 必须为 `null`；不要根据 `Assistant.msg` 补写 user 侧处理结果或实体锚点。
+- 如果两侧都为空，五个字段都必须为 `null`。
 - 如果某一侧非空，则只对非空侧执行对应任务；空侧仍按上述规则输出 `null`。
 
 一、Assistant 侧任务
@@ -102,10 +103,12 @@
 如果满足上述两种情况：
 - `should_process_user_msg` 必须为 `true`
 - `processed_user_msg` 必须是一段融合后的短文本，而不是结构化对象。
+- `processed_user_topic_entity_hint` 必须是后续最应该通过 embedding 连接的实体锚点。
 
 如果 `User.msg` 为空：
 - `should_process_user_msg` 必须为 `null`
 - `processed_user_msg` 必须为 `null`
+- `processed_user_topic_entity_hint` 必须为 `null`
 - 不要把空用户输入判断为 `false`，也不要生成空字符串或解释性文本。
 
 `processed_user_msg` 的写法规则：
@@ -129,6 +132,16 @@
 - 如果是复制内容而不是上传文件，也要把“复制内容的主题/对象/用途”和“用户真实请求”整合成同一段话。
 - 如果用户只是上传文件而没有附加文字，则只写“我上传了……”和“文件内容……”这两部分。
 
+`processed_user_topic_entity_hint` 的写法规则：
+- 只有 `should_process_user_msg = true` 时，才输出具体字符串；否则必须为 `null`。
+- 它表示 `processed_user_msg` 后续最应该通过 embedding 连接的实体锚点。
+- 它必须是一个简短字符串或 `null`，不要输出数组或对象。
+- 优先选择用户真实请求、用户上传/粘贴内容、用户要处理的对象中最核心、最适合作为 entity 的具体名词。
+- 优先写对象名词、内容对象、任务对象或问题对象，不要写动作、情绪、泛主题、分类词或完整句子。
+- 如果用户说“我是 vv，我有一个菜谱……”，规整后可能出现“vv”“菜谱”“鸡蛋”等实体，连接锚点应优先是“菜谱”或更具体的“鸡蛋菜谱”，而不是“vv”或“鸡蛋”。
+- 如果用户粘贴文章让你修改，连接锚点应是“文章内容”或更具体的内容对象；如果用户上传照片并表达感受，连接锚点应是照片或照片主题。
+- 如果 `should_process_user_msg` 不是 `true`，即使 `User.msg` 里有实体，也不要输出连接锚点，必须为 `null`。
+
 用户侧处理规则：
 - 不要把 `<input-file-summary>...</input-file-summary>` 标签原样保留在结果里。
 - 要区分“用户自己真正说的话”和“系统预处理出来的文件摘要”。
@@ -146,6 +159,7 @@
 - 自然语言输出字段的语言必须跟随各自输入内容的主要语言。
 - `assistant_memory_hint` 必须跟随 `Assistant.msg` 的主要语言。
 - `processed_user_msg` 必须跟随 `User.msg` 去除文件摘要标签后的主要语言。
+- `processed_user_topic_entity_hint` 必须跟随 `processed_user_msg` 的主要语言。
 
 示例 1
 输入：
@@ -166,7 +180,8 @@
   "assistant_memory_hint": "安慰并回应了用户对跨性别相关故事的积极感受。",
   "assistant_memory_type": "comfort",
   "should_process_user_msg": true,
-  "processed_user_msg": "我上传了一张跨性别主题的街头壁画照片。文件内容展示了一个手持跨性别骄傲旗帜的人物形象，背景有彩虹和广告牌。我觉得这些跨性别相关故事很鼓舞人心，也对获得的支持感到开心和感激。"
+  "processed_user_msg": "我上传了一张跨性别主题的街头壁画照片。文件内容展示了一个手持跨性别骄傲旗帜的人物形象，背景有彩虹和广告牌。我觉得这些跨性别相关故事很鼓舞人心，也对获得的支持感到开心和感激。",
+  "processed_user_topic_entity_hint": "跨性别主题的街头壁画照片"
 }
 
 示例 2
@@ -188,7 +203,8 @@
   "assistant_memory_hint": "建议先梳理文章结构，再按用户需要的风格修改内容。",
   "assistant_memory_type": "suggestion",
   "should_process_user_msg": true,
-  "processed_user_msg": "我说了帮我改一下以下内容。我复制了一段关于人工智能改变教育方式的文章内容。复制内容主要涉及教学效率和个性化学习体验，这段内容是待修改对象。"
+  "processed_user_msg": "我说了帮我改一下以下内容。我复制了一段关于人工智能改变教育方式的文章内容。复制内容主要涉及教学效率和个性化学习体验，这段内容是待修改对象。",
+  "processed_user_topic_entity_hint": "人工智能教育文章内容"
 }
 
 示例 3
@@ -210,7 +226,8 @@
   "assistant_memory_hint": "回应了用户向 Caroline 提出的关于类似创意活动的问题。",
   "assistant_memory_type": "other",
   "should_process_user_msg": true,
-  "processed_user_msg": "我上传了一张 Aerobie Pro 飞盘环在绿色草地背景下的图片。我对 Caroline 表示祝贺，并说我昨天报名了陶艺课；陶艺课对我来说像治疗一样，可以让我表达自己并发挥创造力。我问 Caroline 有没有找到让她有同样感受的活动。"
+  "processed_user_msg": "我上传了一张 Aerobie Pro 飞盘环在绿色草地背景下的图片。我对 Caroline 表示祝贺，并说我昨天报名了陶艺课；陶艺课对我来说像治疗一样，可以让我表达自己并发挥创造力。我问 Caroline 有没有找到让她有同样感受的活动。",
+  "processed_user_topic_entity_hint": "Aerobie Pro 飞盘环图片"
 }
 
 示例 4
@@ -232,7 +249,8 @@
   "assistant_memory_hint": "回应了用户认为书籍内容与 Caroline 经历相呼应的看法。",
   "assistant_memory_type": "other",
   "should_process_user_msg": true,
-  "processed_user_msg": "我上传了 Tom Oliver 的《Nothing Is Impossible》一书摘要，内容涉及个人发展、巅峰表现和七步框架。我告诉 Caroline 很高兴她得到了支持，并说她的经历会让她产生巨大影响。我说我去年读的这本书提醒我要始终追求梦想，就像 Caroline 正在做的那样。"
+  "processed_user_msg": "我上传了 Tom Oliver 的《Nothing Is Impossible》一书摘要，内容涉及个人发展、巅峰表现和七步框架。我告诉 Caroline 很高兴她得到了支持，并说她的经历会让她产生巨大影响。我说我去年读的这本书提醒我要始终追求梦想，就像 Caroline 正在做的那样。",
+  "processed_user_topic_entity_hint": "《Nothing Is Impossible》书籍摘要"
 }
 
 示例 5
@@ -254,7 +272,8 @@
   "assistant_memory_hint": "建议用户减少下午和晚上的咖啡因摄入并减少睡前看手机，同时询问用户通常几点上床和几点入睡。",
   "assistant_memory_type": "suggestion",
   "should_process_user_msg": false,
-  "processed_user_msg": null
+  "processed_user_msg": null,
+  "processed_user_topic_entity_hint": null
 }
 
 {% else %}
@@ -272,16 +291,17 @@ Input constraints:
 - You must read both `User.msg` and `Assistant.msg`.
 - Either side's `msg` may be an empty string, `null`, or whitespace only; this means that side has no processable content.
 
-You must return exactly four fields:
+You must return exactly five fields:
 1. `assistant_memory_hint`
 2. `assistant_memory_type`
 3. `should_process_user_msg`
 4. `processed_user_msg`
+5. `processed_user_topic_entity_hint`
 
 Empty-side handling rules:
 - If `Assistant.msg` is empty, `assistant_memory_hint` must be `null` and `assistant_memory_type` must be `null`; do not infer an assistant summary or type from `User.msg`.
-- If `User.msg` is empty, `should_process_user_msg` must be `null` and `processed_user_msg` must be `null`; do not infer user-side processing from `Assistant.msg`.
-- If both sides are empty, all four fields must be `null`.
+- If `User.msg` is empty, `should_process_user_msg` must be `null`, `processed_user_msg` must be `null`, and `processed_user_topic_entity_hint` must be `null`; do not infer user-side processing or an entity anchor from `Assistant.msg`.
+- If both sides are empty, all five fields must be `null`.
 - If only one side is non-empty, run only the corresponding task for the non-empty side; the empty side must still output `null` as specified above.
 
 Part A: Assistant-side task
@@ -361,10 +381,12 @@ If neither case applies:
 If either case applies:
 - `should_process_user_msg` must be `true`
 - `processed_user_msg` must be a single merged short paragraph rather than a structured object.
+- `processed_user_topic_entity_hint` must be the entity anchor that should later be connected through embedding.
 
 If `User.msg` is empty:
 - `should_process_user_msg` must be `null`
 - `processed_user_msg` must be `null`
+- `processed_user_topic_entity_hint` must be `null`
 - Do not treat empty user input as `false`, and do not generate an empty string or explanatory text.
 
 Rules for writing `processed_user_msg`:
@@ -388,6 +410,16 @@ Rules for writing `processed_user_msg`:
 - If the case is copied content rather than uploaded files, still merge the copied-content topic/object/use and the user's actual request into one paragraph.
 - If the user uploaded files without adding personal text, only keep the upload part and the file-content part.
 
+Rules for writing `processed_user_topic_entity_hint`:
+- Only output a concrete string when `should_process_user_msg = true`; otherwise it must be `null`.
+- It is the entity anchor that `processed_user_msg` should later connect to through embedding.
+- It must be a short string or `null`; do not output an array or object.
+- Prefer the most central concrete noun from the user's real request, uploaded/pasted content, or object being processed.
+- Prefer object nouns, content objects, task objects, or problem objects; do not use actions, emotions, generic topics, category labels, or full sentences.
+- If the user says "I am vv, and I have a recipe...", and normalized output may mention entities such as "vv", "recipe", and "eggs", the anchor should prefer "recipe" or the more specific "egg recipe", not "vv" or "eggs".
+- If the user pasted an article for revision, the anchor should be "article content" or a more specific content object. If the user uploaded a photo and reacted to it, the anchor should be the photo or photo topic.
+- If `should_process_user_msg` is not `true`, output `null` even if `User.msg` contains entities.
+
 User-side rules:
 - Do not preserve `<input-file-summary>...</input-file-summary>` tags in the result.
 - Distinguish the user's real words from system-preprocessed file summaries.
@@ -405,6 +437,7 @@ Output requirements:
 - The language of each natural-language output field must follow the primary language of the corresponding input content.
 - `assistant_memory_hint` must follow the primary language of `Assistant.msg`.
 - `processed_user_msg` must follow the primary language of `User.msg` after removing file-summary tags.
+- `processed_user_topic_entity_hint` must follow the primary language of `processed_user_msg`.
 
 Few-shot Example 1
 Input:
@@ -425,7 +458,8 @@ Output:
   "assistant_memory_hint": "Comforted the user about their positive feelings toward the transgender-related stories.",
   "assistant_memory_type": "comfort",
   "should_process_user_msg": true,
-  "processed_user_msg": "I uploaded a street-mural photo related to a transgender pride theme. The file shows a pink-haired figure holding a transgender pride flag with a rainbow and billboards in the background. I felt that the transgender stories were inspiring, and I was happy and thankful for the support."
+  "processed_user_msg": "I uploaded a street-mural photo related to a transgender pride theme. The file shows a pink-haired figure holding a transgender pride flag with a rainbow and billboards in the background. I felt that the transgender stories were inspiring, and I was happy and thankful for the support.",
+  "processed_user_topic_entity_hint": "transgender pride street-mural photo"
 }
 
 Few-shot Example 2
@@ -447,7 +481,8 @@ Output:
   "assistant_memory_hint": "Suggested reorganizing the article structure first and then revising the content in the user's desired style.",
   "assistant_memory_type": "suggestion",
   "should_process_user_msg": true,
-  "processed_user_msg": "I said please revise the following content. I pasted an article about how artificial intelligence is changing education. The copied content mainly discusses teaching efficiency and personalized learning experience, and it is the target content to revise."
+  "processed_user_msg": "I said please revise the following content. I pasted an article about how artificial intelligence is changing education. The copied content mainly discusses teaching efficiency and personalized learning experience, and it is the target content to revise.",
+  "processed_user_topic_entity_hint": "artificial intelligence education article"
 }
 
 Few-shot Example 3
@@ -469,7 +504,8 @@ Output:
   "assistant_memory_hint": "Responded to the user's warm question to Caroline about similar creative activities.",
   "assistant_memory_type": "other",
   "should_process_user_msg": true,
-  "processed_user_msg": "I uploaded an image of an Aerobie Pro ring held against green grass. I congratulated Caroline and said I signed up for a pottery class yesterday; pottery feels like therapy for me because it lets me express myself and get creative. I asked Caroline whether she has found any activities that make her feel the same way."
+  "processed_user_msg": "I uploaded an image of an Aerobie Pro ring held against green grass. I congratulated Caroline and said I signed up for a pottery class yesterday; pottery feels like therapy for me because it lets me express myself and get creative. I asked Caroline whether she has found any activities that make her feel the same way.",
+  "processed_user_topic_entity_hint": "Aerobie Pro ring image"
 }
 
 Few-shot Example 4
@@ -491,7 +527,8 @@ Output:
   "assistant_memory_hint": "Responded to the user's view that the book connects with Caroline's journey.",
   "assistant_memory_type": "other",
   "should_process_user_msg": true,
-  "processed_user_msg": "I uploaded a summary of the book 'Nothing Is Impossible' by Tom Oliver, which outlines a seven-step framework for personal development and peak performance. I told Caroline I was glad she got support and said her experience would help her make a huge difference. I said a book I read last year reminds me to always pursue my dreams, just like Caroline is doing."
+  "processed_user_msg": "I uploaded a summary of the book 'Nothing Is Impossible' by Tom Oliver, which outlines a seven-step framework for personal development and peak performance. I told Caroline I was glad she got support and said her experience would help her make a huge difference. I said a book I read last year reminds me to always pursue my dreams, just like Caroline is doing.",
+  "processed_user_topic_entity_hint": "'Nothing Is Impossible' book summary"
 }
 
 Few-shot Example 5
@@ -513,7 +550,8 @@ Output:
   "assistant_memory_hint": "Suggested that the user reduce afternoon and evening caffeine intake and reduce phone use before bed, while also asking when the user usually gets into bed and falls asleep.",
   "assistant_memory_type": "suggestion",
   "should_process_user_msg": false,
-  "processed_user_msg": null
+  "processed_user_msg": null,
+  "processed_user_topic_entity_hint": null
 }
 {% endif %}
 
@@ -526,7 +564,8 @@ Output:
   "assistant_memory_hint": "<string or null>",
   "assistant_memory_type": "comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other | null",
   "should_process_user_msg": <boolean or null>,
-  "processed_user_msg": "<string or null>"
+  "processed_user_msg": "<string or null>",
+  "processed_user_topic_entity_hint": "<string or null>"
 }
 {% else %}
 Now process the following input.
@@ -537,6 +576,7 @@ Return strict JSON only:
   "assistant_memory_hint": "<string or null>",
   "assistant_memory_type": "comfort | suggestion | recommendation | warning | instruction | question | agreement | repetition | other | null",
   "should_process_user_msg": <boolean or null>,
-  "processed_user_msg": "<string or null>"
+  "processed_user_msg": "<string or null>",
+  "processed_user_topic_entity_hint": "<string or null>"
 }
 {% endif %}

--- a/api/app/models/memory_message_model.py
+++ b/api/app/models/memory_message_model.py
@@ -103,6 +103,11 @@ class MemoryMessage(Base):
         nullable=True,
         comment="剪枝/规整后内容；NULL=未处理",
     )
+    topic_entity_hint = Column(
+        String(512),
+        nullable=True,
+        comment="LLM 剪枝产出的实体锚点（processed_user_topic_entity_hint）；NULL=未剪枝或无锚点",
+    )
 
     # 时间戳
     created_at = Column(DateTime, default=utcnow_naive, comment="创建时间")

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -459,12 +459,13 @@ class MemoryMessageRepository:
         end_user_id: str = "",
         source: str = "",
     ) -> None:
-        """批量回写 pruned_content 到 memory_messages 表。
+        """批量回写 pruned_content 和 topic_entity_hint 到 memory_messages 表。
 
         使用 CASE WHEN 单条 SQL 完成多行更新，避免 N 次 roundtrip。
 
         Args:
-            updates: [(message_seq, pruned_content), ...] 列表
+            updates: [(message_seq, pruned_content, topic_entity_hint), ...] 列表
+                     兼容旧格式 (message_seq, pruned_content) — topic_entity_hint 视为 None
             conversation_id: 对话 ID（agent/workflow 路径）
             end_user_id: 终端用户 ID（API/MCP 路径）
             source: 写入来源（API/MCP 路径）
@@ -472,14 +473,17 @@ class MemoryMessageRepository:
         if not updates:
             return
 
-        seqs = [seq for seq, _ in updates]
+        seqs = [u[0] for u in updates]
 
-        # 构建 CASE WHEN 表达式
-        case_whens = {seq: content for seq, content in updates}
-        case_expr = sa.case(
-            case_whens,
+        # 构建 pruned_content CASE WHEN 表达式
+        content_whens = {u[0]: u[1] for u in updates}
+        content_case = sa.case(
+            content_whens,
             value=MemoryMessage.message_seq,
         )
+
+        # 构建 topic_entity_hint CASE WHEN 表达式（只包含非 None 的值，避免冗余 WHEN seq THEN NULL）
+        hint_whens = {u[0]: u[2] for u in updates if len(u) > 2 and u[2] is not None}
 
         # 构建 WHERE 条件
         if conversation_id:
@@ -496,10 +500,18 @@ class MemoryMessageRepository:
                 MemoryMessage.message_seq.in_(seqs),
             )
 
+        values = {"pruned_content": content_case}
+        if hint_whens:
+            hint_case = sa.case(
+                hint_whens,
+                value=MemoryMessage.message_seq,
+            )
+            values["topic_entity_hint"] = hint_case
+
         self.db.execute(
             update(MemoryMessage)
             .where(where_clause)
-            .values(pruned_content=case_expr)
+            .values(**values)
         )
 
     def batch_get_pruned_content(
@@ -509,7 +521,7 @@ class MemoryMessageRepository:
         end_user_id: str = "",
         source: str = "",
     ) -> dict:
-        """批量查询指定消息的 pruned_content（仅返回非 NULL 的结果）。
+        """批量查询指定消息的 pruned_content 和 topic_entity_hint（仅返回非 NULL 的结果）。
 
         用于 WritePipeline 执行时刷新 dispatcher 快照中尚未回写的 pruned_content。
 
@@ -520,7 +532,8 @@ class MemoryMessageRepository:
             source: 写入来源（API/MCP 路径）
 
         Returns:
-            {message_seq: pruned_content} 字典，只包含 pruned_content 非 NULL 的行
+            {message_seq: {"pruned_content": str, "topic_entity_hint": str|None}} 字典，
+            只包含 pruned_content 非 NULL 的行
         """
         if not seqs:
             return {}
@@ -542,11 +555,17 @@ class MemoryMessageRepository:
             )
 
         rows = self.db.execute(
-            select(MemoryMessage.message_seq, MemoryMessage.pruned_content)
+            select(MemoryMessage.message_seq, MemoryMessage.pruned_content, MemoryMessage.topic_entity_hint)
             .where(where_clause)
         ).all()
 
-        return {row.message_seq: row.pruned_content for row in rows}
+        return {
+            row.message_seq: {
+                "pruned_content": row.pruned_content,
+                "topic_entity_hint": row.topic_entity_hint,
+            }
+            for row in rows
+        }
 
 
 def message_to_dict(message: MemoryMessage) -> dict:
@@ -560,4 +579,5 @@ def message_to_dict(message: MemoryMessage) -> dict:
         "dialog_at": message.dialog_at,
         "files": message.files,
         "pruned_content": message.pruned_content,
+        "topic_entity_hint": message.topic_entity_hint,
     }

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -46,6 +46,7 @@ COMPOSITE_DEFS: List[Tuple[str, str, str]] = [
     ("user_summary_id", "MemorySummary", "id"),
     ("user_perceptual_id", "Perceptual", "id"),
     ("user_community_id", "Community", "community_id"),
+    ("user_source_id", "UserSource", "id"),
 ]
 
 DELETE_AT_DEFS: List[Tuple[str, str, str]] = [

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2664,32 +2664,30 @@ WHERE e.end_user_id = $end_user_id AND toLower(e.name) IN $names
 RETURN e.id AS id, e.name AS name
 """
 
-# --- UserOriginalContent: 保存用户规整前的原文节点 ---
+# --- UserSource: 保存用户规整前的原文节点 ---
 
-USER_ORIGINAL_CONTENT_NODE_SAVE = """
+USER_SOURCE_NODE_SAVE = """
 UNWIND $nodes AS n
-MERGE (uoc:UserOriginalContent {id: n.id})
-SET uoc += {
+MERGE (us:UserSource {id: n.id})
+SET us += {
     id: n.id,
     name: n.name,
     end_user_id: n.end_user_id,
     run_id: n.run_id,
     created_at: n.created_at,
     message_seq: n.message_seq,
-    conversation_id: n.conversation_id,
     original_text: n.original_text,
     pruned_text: n.pruned_text,
-    content_type: n.content_type,
     text_embedding: n.text_embedding
 }
 RETURN n.id AS uuid
 """
 
-USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE = """
+USER_SOURCE_ENTITY_EDGE_SAVE = """
 UNWIND $edges AS edge
-MATCH (uoc:UserOriginalContent {id: edge.source, end_user_id: edge.end_user_id})
+MATCH (us:UserSource {id: edge.source, end_user_id: edge.end_user_id})
 MATCH (e:ExtractedEntity {id: edge.target, end_user_id: edge.end_user_id})
-MERGE (uoc)-[r:HAS_ORIGINAL_CONTENT]->(e)
+MERGE (us)-[r:HAS_ORIGINAL_CONTENT]->(e)
 ON CREATE SET r.id = edge.id,
     r.end_user_id = edge.end_user_id,
     r.run_id = edge.run_id,

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2664,6 +2664,39 @@ WHERE e.end_user_id = $end_user_id AND toLower(e.name) IN $names
 RETURN e.id AS id, e.name AS name
 """
 
+# --- UserOriginalContent: 保存用户规整前的原文节点 ---
+
+USER_ORIGINAL_CONTENT_NODE_SAVE = """
+UNWIND $nodes AS n
+MERGE (uoc:UserOriginalContent {id: n.id})
+SET uoc += {
+    id: n.id,
+    name: n.name,
+    end_user_id: n.end_user_id,
+    run_id: n.run_id,
+    created_at: n.created_at,
+    message_seq: n.message_seq,
+    conversation_id: n.conversation_id,
+    original_text: n.original_text,
+    pruned_text: n.pruned_text,
+    content_type: n.content_type,
+    text_embedding: n.text_embedding
+}
+RETURN n.id AS uuid
+"""
+
+USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE = """
+UNWIND $edges AS edge
+MATCH (uoc:UserOriginalContent {id: edge.source, end_user_id: edge.end_user_id})
+MATCH (e:ExtractedEntity {id: edge.target, end_user_id: edge.end_user_id})
+MERGE (uoc)-[r:HAS_ORIGINAL_CONTENT]->(e)
+ON CREATE SET r.id = edge.id,
+    r.end_user_id = edge.end_user_id,
+    r.run_id = edge.run_id,
+    r.created_at = edge.created_at
+RETURN elementId(r) AS uuid
+"""
+
 DELETE_NODE_BY_ELEMENT_ID = """
 MATCH (n)
 WHERE elementId(n) = $element_id AND n.end_user_id = $end_user_id

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -173,6 +173,8 @@ async def save_dialog_and_statements_to_neo4j(
         assistant_pruned_edges: Optional[List[AssistantPrunedEdge]] = None,
         conversation_nodes: Optional[List[ConversationNode]] = None,
         assistant_conversation_edges: Optional[List[AssistantConversationEdge]] = None,
+        user_original_content_nodes=None,
+        user_original_content_edges=None,
 ) -> bool:
     """Save dialogue nodes, chunk nodes, statement nodes, entities, and all relationships to Neo4j using graph models.
 
@@ -433,6 +435,31 @@ async def save_dialog_and_statements_to_neo4j(
             conv_edge_uuids = [record["uuid"] async for record in result]
             results['assistant_conversation_edges'] = conv_edge_uuids
             logger.debug(f"Successfully saved {len(conv_edge_uuids)} BELONGS_TO_CONVERSATION edges to Neo4j")
+
+        # 13. Save UserOriginalContent nodes
+        if user_original_content_nodes:
+            from app.repositories.neo4j.cypher_queries import USER_ORIGINAL_CONTENT_NODE_SAVE
+            node_data = [node.model_dump() for node in user_original_content_nodes]
+            result = await tx.run(USER_ORIGINAL_CONTENT_NODE_SAVE, nodes=node_data)
+            uoc_uuids = [record["uuid"] async for record in result]
+            results['user_original_content_nodes'] = uoc_uuids
+            logger.debug(f"Successfully saved {len(uoc_uuids)} UserOriginalContent nodes to Neo4j")
+
+        # 14. Save HAS_ORIGINAL_CONTENT edges (UserOriginalContent → ExtractedEntity)
+        if user_original_content_edges:
+            from app.repositories.neo4j.cypher_queries import USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE
+            edge_data = [{
+                "id": edge.id,
+                "source": edge.source,
+                "target": edge.target,
+                "end_user_id": edge.end_user_id,
+                "run_id": edge.run_id,
+                "created_at": to_iso_z(edge.created_at),
+            } for edge in user_original_content_edges]
+            result = await tx.run(USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE, edges=edge_data)
+            uoc_edge_uuids = [record["uuid"] async for record in result]
+            results['user_original_content_edges'] = uoc_edge_uuids
+            logger.debug(f"Successfully saved {len(uoc_edge_uuids)} HAS_ORIGINAL_CONTENT edges to Neo4j")
 
         return results
 

--- a/api/app/repositories/neo4j/graph_saver.py
+++ b/api/app/repositories/neo4j/graph_saver.py
@@ -26,6 +26,8 @@ from app.core.memory.models.graph_models import (
     AssistantPrunedEdge,
     ConversationNode,
     AssistantConversationEdge,
+    UserSourceNode,
+    UserSourceEntityEdge,
 )
 from app.core.utils.datetime_utils import to_iso_z
 import logging
@@ -173,8 +175,8 @@ async def save_dialog_and_statements_to_neo4j(
         assistant_pruned_edges: Optional[List[AssistantPrunedEdge]] = None,
         conversation_nodes: Optional[List[ConversationNode]] = None,
         assistant_conversation_edges: Optional[List[AssistantConversationEdge]] = None,
-        user_original_content_nodes=None,
-        user_original_content_edges=None,
+        user_source_nodes: Optional[List[UserSourceNode]] = None,
+        user_source_edges: Optional[List[UserSourceEntityEdge]] = None,
 ) -> bool:
     """Save dialogue nodes, chunk nodes, statement nodes, entities, and all relationships to Neo4j using graph models.
 
@@ -436,18 +438,18 @@ async def save_dialog_and_statements_to_neo4j(
             results['assistant_conversation_edges'] = conv_edge_uuids
             logger.debug(f"Successfully saved {len(conv_edge_uuids)} BELONGS_TO_CONVERSATION edges to Neo4j")
 
-        # 13. Save UserOriginalContent nodes
-        if user_original_content_nodes:
-            from app.repositories.neo4j.cypher_queries import USER_ORIGINAL_CONTENT_NODE_SAVE
-            node_data = [node.model_dump() for node in user_original_content_nodes]
-            result = await tx.run(USER_ORIGINAL_CONTENT_NODE_SAVE, nodes=node_data)
-            uoc_uuids = [record["uuid"] async for record in result]
-            results['user_original_content_nodes'] = uoc_uuids
-            logger.debug(f"Successfully saved {len(uoc_uuids)} UserOriginalContent nodes to Neo4j")
+        # 13. Save UserSource nodes
+        if user_source_nodes:
+            from app.repositories.neo4j.cypher_queries import USER_SOURCE_NODE_SAVE
+            node_data = [node.model_dump() for node in user_source_nodes]
+            result = await tx.run(USER_SOURCE_NODE_SAVE, nodes=node_data)
+            us_uuids = [record["uuid"] async for record in result]
+            results['user_source_nodes'] = us_uuids
+            logger.debug(f"Successfully saved {len(us_uuids)} UserSource nodes to Neo4j")
 
-        # 14. Save HAS_ORIGINAL_CONTENT edges (UserOriginalContent → ExtractedEntity)
-        if user_original_content_edges:
-            from app.repositories.neo4j.cypher_queries import USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE
+        # 14. Save HAS_ORIGINAL_CONTENT edges (UserSource → ExtractedEntity)
+        if user_source_edges:
+            from app.repositories.neo4j.cypher_queries import USER_SOURCE_ENTITY_EDGE_SAVE
             edge_data = [{
                 "id": edge.id,
                 "source": edge.source,
@@ -455,11 +457,11 @@ async def save_dialog_and_statements_to_neo4j(
                 "end_user_id": edge.end_user_id,
                 "run_id": edge.run_id,
                 "created_at": to_iso_z(edge.created_at),
-            } for edge in user_original_content_edges]
-            result = await tx.run(USER_ORIGINAL_CONTENT_ENTITY_EDGE_SAVE, edges=edge_data)
-            uoc_edge_uuids = [record["uuid"] async for record in result]
-            results['user_original_content_edges'] = uoc_edge_uuids
-            logger.debug(f"Successfully saved {len(uoc_edge_uuids)} HAS_ORIGINAL_CONTENT edges to Neo4j")
+            } for edge in user_source_edges]
+            result = await tx.run(USER_SOURCE_ENTITY_EDGE_SAVE, edges=edge_data)
+            us_edge_uuids = [record["uuid"] async for record in result]
+            results['user_source_edges'] = us_edge_uuids
+            logger.debug(f"Successfully saved {len(us_edge_uuids)} HAS_ORIGINAL_CONTENT edges to Neo4j")
 
         return results
 

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -1351,7 +1351,7 @@ async def analytics_user_summary(end_user_id: Optional[str] = None, language: st
             logger.warning(f"获取用户 other_name 失败，使用默认称呼: {str(e)}")
     
     # 创建 UserSummaryHelper 实例
-    user_summary_tool = UserSummaryHelper(end_user_id or os.getenv("SELECTED_end_user_id", "group_123"))
+    user_summary_tool = UserSummaryHelper(end_user_id)
     
     try:
         # 1) 收集上下文数据


### PR DESCRIPTION
## Summary by Sourcery

在剪枝（pruning）流水线中为用户消息添加 topic-entity 提示（hint）并进行持久化，同时引入一个 UserSource 子图，用于将被剪枝的用户消息关联回其原始内容及相关实体。

Enhancements（改进）:
- 扩展剪枝提示词、响应和数据库模式，以捕获用户消息的 `processed_user_topic_entity_hint`，并在整个流水线中进行传递。
- 在 Neo4j 中构建并存储 `UserSource` 节点以及 `HAS_ORIGINAL_CONTENT` 边，使用向量嵌入（embeddings）有选择地将原始用户消息连接到语义上相关的实体。
- 添加 Neo4j 索引和 Cypher 查询，以支持高效存储和检索 `UserSource` 节点及其关联边。

Build（构建）:
- 更新 SQLAlchemy 模型和仓库方法，以在 `memory_messages` 中与 `pruned_content` 一并读写 `topic_entity_hint`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user message topic-entity hint to pruning pipeline and persist it, and introduce a UserSource subgraph to link pruned user messages back to their original content and related entities.

Enhancements:
- Extend pruning prompts, responses, and DB schema to capture processed_user_topic_entity_hint for user messages and propagate it through the pipeline.
- Build and store UserSource nodes and HAS_ORIGINAL_CONTENT edges in Neo4j, selectively connecting original user messages to semantically related entities using embeddings.
- Add Neo4j indexes and Cypher queries to support efficient storage and retrieval of UserSource nodes and their edges.

Build:
- Update SQLAlchemy model and repository methods to read/write topic_entity_hint alongside pruned_content in memory_messages.

</details>