### PR TITLE
feat(memory): add skip_summary option to memory read pipeline

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -109,6 +109,7 @@ async def read_memory_internal(
         search_switch=SearchStrategy(payload.search_switch),
         limit=payload.limit,
         includes=includes,
+        skip_summary=payload.skip_summary
     )
     return success(data={
         "answer": memory.content,

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -380,12 +380,20 @@ class MemoryService:
             history: list | None = None,
             limit: int = 10,
             includes: list | None = None,
+            skip_summary: bool = False,
     ) -> MemorySearchResult:
         if history is None:
             history = []
         if self.ctx.memory_config is None:
             raise RuntimeError("MemoryService.read() 需要 memory_config，但当前实例未加载配置")
-        return await ReadPipeLine(self.ctx).run(query, search_switch, history, limit, includes=includes)
+        return await ReadPipeLine(self.ctx).run(
+            query,
+            search_switch,
+            history,
+            limit,
+            includes=includes,
+            skip_summary=skip_summary
+        )
 
     async def forget(self) -> dict:
         return await ForgettingPipeline(self.ctx).run()

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -46,14 +46,15 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             search_switch: SearchStrategy,
             history: list,
             limit: int = 10,
-            includes=None
+            includes=None,
+            skip_summary=False
     ) -> MemorySearchResult:
         query = QueryPreprocessor.process(query)
         match search_switch:
             case SearchStrategy.DEEP:
-                res = await self._deep_read(query, history, limit, includes=includes)
+                res = await self._deep_read(query, history, limit, includes=includes, skip_summary=skip_summary)
             case SearchStrategy.NORMAL:
-                res = await self._normal_read(query, history, limit, includes=includes)
+                res = await self._normal_read(query, history, limit, includes=includes, skip_summary=skip_summary)
             case SearchStrategy.QUICK:
                 return await self._quick_read(query, limit, includes)
             case SearchStrategy.EXPRESS:
@@ -117,6 +118,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             history: list,
             limit: int,
             includes=None,
+            skip_summary=False
     ) -> MemorySearchResult:
         search_service = await self._get_search_service(includes)
         memory_l0 = await self._user_meta()
@@ -147,12 +149,13 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         results = hybrid_search_res + relation_res
 
         results.memories.sort(key=lambda x: x.score, reverse=True)
-        results.content_str = await RetrievalSummaryProcessor.summary(
-            query,
-            results.content,
-            memory_l0.content if memory_l0 else '',
-            await self._get_llm_client()
-        )
+        if not skip_summary:
+            results.content_str = await RetrievalSummaryProcessor.summary(
+                query,
+                results.content,
+                memory_l0.content if memory_l0 else '',
+                await self._get_llm_client()
+            )
 
         return memory_l0 + results
 
@@ -161,6 +164,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             history: list,
             limit: int,
             includes=None,
+            skip_summary=False
     ) -> MemorySearchResult:
         search_service = await self._get_search_service(includes)
 
@@ -181,12 +185,13 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         ), return_exceptions=True))
         results = _safe_merge_results(all_results, "normal")
         results.memories.sort(key=lambda x: x.score, reverse=True)
-        results.content_str = await RetrievalSummaryProcessor.summary(
-            query,
-            results.content,
-            memory_l0.content if memory_l0 else '',
-            await self._get_llm_client()
-        )
+        if not skip_summary:
+            results.content_str = await RetrievalSummaryProcessor.summary(
+                query,
+                results.content,
+                memory_l0.content if memory_l0 else '',
+                await self._get_llm_client()
+            )
         return memory_l0 + results
 
     async def _express_read(self, query: str, limit: int, includes=None) -> MemorySearchResult:

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -55,6 +55,7 @@ class InternalReadInput(BaseModel):
         description="要包含的 Neo4j 节点类型列表，如 CHUNK, COMMUNITY, DIALOGUE 等。不传则包含全部类型。",
     )
     limit: int = Field(default=10, description="返回的记忆数量上限", ge=1, le=100)
+    skip_summary: bool = Field(default=False, description="跳过摘要")
 
 
 class WriteMessageItem(BaseModel):


### PR DESCRIPTION
- Add skip_summary parameter to MemoryService.read and ReadPipeline methods
- Conditionally skip RetrievalSummaryProcessor.summary when skip_summary is True
- Expose skip_summary in MemoryReadRequest schema and controller
- Allow callers to bypass LLM-based summary for performance

## Summary by Sourcery

在内存读取管道中添加一个可选项，用于绕过基于 LLM 的检索摘要生成，并通过服务和 API 模式对外暴露该选项。

New Features:
- 在内存读取操作中引入 `skip_summary` 标志，允许调用方跳过检索摘要的生成。

Enhancements:
- 在深度和普通内存读取路径中传递 `skip_summary` 标志，使摘要生成能够根据请求条件性地执行。

Documentation:
- 在用于内存读取请求的 `InternalReadInput` 模式中记录新的 `skip_summary` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an option to bypass LLM-based retrieval summaries in the memory read pipeline and expose it through the service and API schema.

New Features:
- Introduce a skip_summary flag to memory read operations to allow callers to skip generation of retrieval summaries.

Enhancements:
- Propagate the skip_summary flag through deep and normal memory read paths so summary generation is conditionally executed based on the request.

Documentation:
- Document the new skip_summary field in the InternalReadInput schema for memory read requests.

</details>