### PR TITLE
fix(workflow_file)

### DIFF
--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -4114,6 +4114,49 @@ class WorkflowService:
 
         return f"{settings.FILE_LOCAL_SERVER_URL}/storage/permanent/{file_id}"
 
+    async def _resolve_local_file_async(
+            self,
+            upload_file_id,
+            file_type: str,
+            origin_file_type: str,
+    ) -> dict | None:
+        """resolve_local_file_object_dict 的异步版本，兼容 self.db 为 None 的情况。"""
+        from app.core.workflow.utils.file_processor import resolve_local_file_object_dict, build_file_object_dict_from_meta
+        from app.models.file_metadata_model import FileMetadata
+        from app.core.config import settings
+        import uuid as _uuid
+
+        if self.db is not None:
+            return resolve_local_file_object_dict(self.db, upload_file_id, file_type, origin_file_type)
+
+        try:
+            fid = _uuid.UUID(str(upload_file_id))
+        except ValueError:
+            return None
+
+        async with get_async_db_context() as db:
+            meta = await db.scalar(
+                select(FileMetadata).where(
+                    FileMetadata.id == fid,
+                    FileMetadata.status == "completed",
+                )
+            )
+            if not meta:
+                return None
+
+            url = f"{settings.FILE_LOCAL_SERVER_URL}/storage/permanent/{fid}"
+            return build_file_object_dict_from_meta(
+                file_type=file_type,
+                transfer_method="local_file",
+                origin_file_type=origin_file_type,
+                file_id=str(fid),
+                url=url,
+                file_name=meta.file_name,
+                file_size=meta.file_size,
+                file_ext=meta.file_ext,
+                content_type=meta.content_type,
+            )
+
     async def _resolve_start_node_file_variables(
             self,
             start_node_vars: list[dict[str, Any]],
@@ -4159,7 +4202,7 @@ class WorkflowService:
                 origin_file_type = value.get("file_type") or file_type
 
                 if transfer_method == "local_file" and value.get("upload_file_id"):
-                    fo = resolve_local_file_object_dict(self.db, value["upload_file_id"], file_type, origin_file_type)
+                    fo = await self._resolve_local_file_async(value["upload_file_id"], file_type, origin_file_type)
                     resolved[var_name] = fo or build_file_object_dict_from_meta(
                         file_type=file_type, transfer_method="local_file",
                         origin_file_type=origin_file_type,
@@ -4180,7 +4223,7 @@ class WorkflowService:
                         origin_file_type = item.get("file_type") or file_type
 
                         if transfer_method == "local_file" and item.get("upload_file_id"):
-                            fo = resolve_local_file_object_dict(self.db, item["upload_file_id"], file_type, origin_file_type)
+                            fo = await self._resolve_local_file_async(item["upload_file_id"], file_type, origin_file_type)
                             resolved_list.append(fo or build_file_object_dict_from_meta(
                                 file_type=file_type, transfer_method="local_file",
                                 origin_file_type=origin_file_type,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -4029,10 +4029,7 @@ class WorkflowService:
             variables: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Convert FileInput-format defaults in workflow variables to full FileObject dicts."""
-        from app.core.workflow.utils.file_processor import (
-            resolve_local_file_object_dict,
-            fetch_remote_file_meta,
-        )
+        from app.core.workflow.utils.file_processor import fetch_remote_file_meta
 
         async def _resolve_one(item: dict) -> dict | None:
             if not isinstance(item, dict) or item.get("is_file"):
@@ -4044,7 +4041,7 @@ class WorkflowService:
                 url = item.get("url", "")
                 return await fetch_remote_file_meta(url, file_type, origin_file_type) if url else None
             else:
-                return resolve_local_file_object_dict(self.db, item.get("upload_file_id"), file_type, origin_file_type)
+                return await self._resolve_local_file_async(item.get("upload_file_id"), file_type, origin_file_type)
 
         result = []
         for var_def in variables:
@@ -4067,7 +4064,6 @@ class WorkflowService:
             return []
 
         from app.core.workflow.utils.file_processor import (
-            resolve_local_file_object_dict,
             build_file_object_dict_from_meta,
             fetch_remote_file_meta,
         )
@@ -4079,7 +4075,7 @@ class WorkflowService:
             origin_file_type = file.file_type or file_type
 
             if file.transfer_method.value == "local_file" and file.upload_file_id:
-                fo = resolve_local_file_object_dict(self.db, file.upload_file_id, file_type, origin_file_type)
+                fo = await self._resolve_local_file_async(file.upload_file_id, file_type, origin_file_type)
                 files_struct.append(fo or build_file_object_dict_from_meta(
                     file_type=file_type, transfer_method="local_file",
                     origin_file_type=origin_file_type,
@@ -4120,14 +4116,11 @@ class WorkflowService:
             file_type: str,
             origin_file_type: str,
     ) -> dict | None:
-        """resolve_local_file_object_dict 的异步版本，兼容 self.db 为 None 的情况。"""
-        from app.core.workflow.utils.file_processor import resolve_local_file_object_dict, build_file_object_dict_from_meta
+        """resolve_local_file_object_dict 的异步版本。"""
+        from app.core.workflow.utils.file_processor import build_file_object_dict_from_meta
         from app.models.file_metadata_model import FileMetadata
         from app.core.config import settings
         import uuid as _uuid
-
-        if self.db is not None:
-            return resolve_local_file_object_dict(self.db, upload_file_id, file_type, origin_file_type)
 
         try:
             fid = _uuid.UUID(str(upload_file_id))
@@ -4175,7 +4168,6 @@ class WorkflowService:
             解析后的变量值字典
         """
         from app.core.workflow.utils.file_processor import (
-            resolve_local_file_object_dict,
             build_file_object_dict_from_meta,
             fetch_remote_file_meta,
         )


### PR DESCRIPTION
add async local file resolution in workflow service

## Summary by Sourcery

在工作流服务中添加异步本地文件解析功能，以便在没有同步数据库会话可用时，也能解析开始节点的文件变量。

Bug Fixes:
- 确保在异步工作流中，即使服务的数据库会话为 `None`，基于本地文件的开始节点变量也能被正确解析。

Enhancements:
- 引入一个用于解析本地文件元数据的异步辅助方法，并在开始节点文件变量解析中复用该方法，以与服务的异步执行逻辑保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add asynchronous local file resolution in the workflow service so start node file variables can be resolved when no synchronous DB session is available.

Bug Fixes:
- Ensure local file-based start node variables are correctly resolved in async workflows even when the service DB session is None.

Enhancements:
- Introduce an async helper for resolving local file metadata and reuse it in start node file variable resolution to align with the service’s async execution.

</details>