### PR TITLE
fix(tool): Fix tool enabled state handling logic

### DIFF
--- a/api/app/controllers/tool_controller.py
+++ b/api/app/controllers/tool_controller.py
@@ -145,7 +145,7 @@ async def update_tool(
             description=request.description,
             icon=request.icon,
             config=request.config,
-            is_enabled=request.config.get("is_enabled", None),
+            is_enabled=request.is_enabled,
             tags=request.tags
         )
         if not success_flag:

--- a/api/app/controllers/tool_controller.py
+++ b/api/app/controllers/tool_controller.py
@@ -145,7 +145,7 @@ async def update_tool(
             description=request.description,
             icon=request.icon,
             config=request.config,
-            is_enabled=request.is_enabled,
+            is_enabled=request.config.get("is_enabled", None),
             tags=request.tags
         )
         if not success_flag:

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -229,6 +229,12 @@ class ToolService:
             if name or description or icon:
                 raise ValueError("内置工具不允许修改名称、描述和图标")
         try:
+            effective_is_enabled = is_enabled
+            if config_obj.tool_type == ToolType.BUILTIN.value and is_enabled is None:
+                builtin_config = self.builtin_repo.find_by_tool_id(self.db, config_obj.id)
+                if builtin_config and builtin_config.tool_class == "MinerUTool":
+                    effective_is_enabled = True
+
             if name:
                 self._check_name_duplicate(name, config_obj.tool_type, tenant_id, exclude_id=config_obj.id)
                 config_obj.name = name
@@ -241,8 +247,11 @@ class ToolService:
             if config:
                 config_obj.config_data = config.copy()
 
+                if config_obj.tool_type == ToolType.BUILTIN.value and effective_is_enabled is not None:
+                    config_obj.config_data["is_enabled"] = effective_is_enabled
+
                 # 同步到类型表
-                self._sync_type_config(config_obj, config, is_enabled)
+                self._sync_type_config(config_obj, config, effective_is_enabled)
 
                 # 更新状态逻辑
                 self._update_tool_status(config_obj)
@@ -407,7 +416,7 @@ class ToolService:
                     status=initial_status,
                     config_data={"tool_class": tool_info['tool_class'],
                                  "requires_config": tool_info.get('requires_config', False),
-                                 "is_enabled": False},
+                                 "is_enabled": tool_info.get('enabled', False)},
                     version=tool_info["version"]
                 )
                 self.db.add(tool_config)
@@ -417,6 +426,7 @@ class ToolService:
                     id=tool_config.id,
                     tool_class=tool_info['tool_class'],
                     parameters={},
+                    is_enabled=tool_info.get('enabled', False),
                     requires_config=tool_info.get('requires_config', False)
                 )
                 self.db.add(builtin_config_obj)

--- a/api/app/services/tool_service.py
+++ b/api/app/services/tool_service.py
@@ -230,7 +230,7 @@ class ToolService:
                 raise ValueError("内置工具不允许修改名称、描述和图标")
         try:
             effective_is_enabled = is_enabled
-            if config_obj.tool_type == ToolType.BUILTIN.value and is_enabled is None:
+            if config_obj.tool_type == ToolType.BUILTIN.value:
                 builtin_config = self.builtin_repo.find_by_tool_id(self.db, config_obj.id)
                 if builtin_config and builtin_config.tool_class == "MinerUTool":
                     effective_is_enabled = True


### PR DESCRIPTION
1. Get is_enabled directly from request parameters instead of reading from config
2. Add default enabled state handling for built-in MinerU tool
3. Fix is_enabled field assignment logic during tool initialization
4. Synchronize tool state updates to configuration data and related type tables

## Summary by Sourcery

在控制器、服务和内置初始化之间对工具的启用状态处理方式进行统一，以确保行为和默认状态的一致性。

Bug 修复：
- 在更新工具时，使用顶层请求中的 `is_enabled` 标志，而不是从配置负载中的 `is_enabled` 字段读取。
- 修正更新工具时的启用状态传递逻辑，确保类型配置与 `config_data` 保持同步。
- 修复内置工具初始化逻辑，使其在 `config_data` 和内置类型记录中都尊重每个工具声明的默认启用状态。

功能增强：
- 为 MinerU 内置工具引入默认启用行为：当更新中未显式提供启用标志时，工具将默认启用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align tool enabled-state handling across controller, service, and builtin initialization to ensure consistent behavior and default states.

Bug Fixes:
- Use the top-level request is_enabled flag instead of reading is_enabled from the config payload when updating tools.
- Correct enabled-state propagation when updating tools so that type configuration and config_data stay in sync.
- Fix builtin tool initialization to honor each tool’s declared default enabled state for both config_data and builtin type records.

Enhancements:
- Introduce a default-enabled behavior for the MinerU builtin tool when no explicit enabled flag is provided in updates.

</details>