### PR TITLE
fix(web): MinerUTool add is_enabled config

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -2342,6 +2342,7 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       error_desc: 'API is configured but connection error',
       MinerUTool_available_desc: 'API URL is configured and enabled',
       MinerUTool_unconfigured_desc: 'Need to configure API URL',
+      MinerUTool_configured_disabled_desc: 'API is configured but not enabled',
       DatabaseTool_available_desc: 'Database tool is enabled',
       DatabaseTool_configured_disabled_desc: 'Not enabled',
 

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -2338,6 +2338,7 @@ export const zh = {
       error_desc: 'API 已配置但链接异常',
       MinerUTool_available_desc: 'API URL 已配置并启用',
       MinerUTool_unconfigured_desc: '需要配置 API URL',
+      MinerUTool_configured_disabled_desc: '已配置未启用',
       DatabaseTool_available_desc: '数据库查询已启用',
       DatabaseTool_configured_disabled_desc: '未启用',
       

--- a/web/src/views/ToolManagement/constant.ts
+++ b/web/src/views/ToolManagement/constant.ts
@@ -73,11 +73,11 @@ export const InnerConfigData: Record<string, InnerConfigItem> = {
           { required: true, message: 'common.pleaseEnter' }
         ]
       },
-      // api_key: {
-      //   name: ['config', 'parameters', 'api_key'],
-      //   type: 'input',
-      //   desc: 'MinerUTool_api_key_desc',
-      // },
+      MinerUTool_enable: {
+        name: ['config', 'is_enabled'],
+        type: 'checkbox',
+        defaultValue: true,
+      },
     },
     features: [
       'pdfParser',


### PR DESCRIPTION
## Summary by Sourcery

为 MinerUTool 添加启用/禁用配置，并更新相关状态描述。

新功能：
- 为 MinerUTool 新增 `is_enabled` 复选框配置选项。

文档：
- 在英文和中文的 i18n 字符串中记录 MinerUTool 处于“已配置但被禁用”的状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add enable/disable configuration for MinerUTool and update related status descriptions.

New Features:
- Introduce an is_enabled checkbox configuration option for MinerUTool.

Documentation:
- Document MinerUTool's configured-but-disabled state in English and Chinese i18n strings.

</details>