### PR TITLE
fix(rag): preserve Unicode chunks and cap QA embedding batches

### DIFF
--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -65,11 +65,40 @@ class TextMerger:
 
     def _hard_split(self, text: str, limit: int) -> list[str]:
         tokens = encoder.encode(text)
-        return [
-            encoder.decode(tokens[index:index + limit])
-            for index in range(0, len(tokens), limit)
-            if tokens[index:index + limit]
-        ]
+        token_bytes = [encoder.decode_single_token_bytes(token) for token in tokens]
+        chunks: list[str] = []
+        start = 0
+
+        def decode_range(begin: int, end: int) -> str:
+            return b"".join(token_bytes[begin:end]).decode("utf-8")
+
+        while start < len(tokens):
+            end = min(start + limit, len(tokens))
+
+            while end > start:
+                try:
+                    chunk = decode_range(start, end)
+                except UnicodeDecodeError:
+                    end -= 1
+                    continue
+                chunks.append(chunk)
+                start = end
+                break
+            else:
+                end = min(start + limit + 1, len(tokens))
+                while True:
+                    try:
+                        chunk = decode_range(start, end)
+                    except UnicodeDecodeError:
+                        if end >= len(tokens):
+                            raise
+                        end += 1
+                        continue
+                    chunks.append(chunk)
+                    start = end
+                    break
+
+        return chunks
 
     @staticmethod
     def _within_limit(text: str, limit: int) -> bool:

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -65,38 +65,28 @@ class TextMerger:
 
     def _hard_split(self, text: str, limit: int) -> list[str]:
         tokens = encoder.encode(text)
-        token_bytes = [encoder.decode_single_token_bytes(token) for token in tokens]
         chunks: list[str] = []
         start = 0
 
-        def decode_range(begin: int, end: int) -> str:
-            return b"".join(token_bytes[begin:end]).decode("utf-8")
+        def find_decodable_boundary(begin: int, end: int, step: int) -> tuple[int, str] | None:
+            while begin < end <= len(tokens):
+                try:
+                    return end, encoder.decode(tokens[begin:end], errors="strict")
+                except UnicodeDecodeError:
+                    end += step
+            return None
 
         while start < len(tokens):
             end = min(start + limit, len(tokens))
+            boundary = find_decodable_boundary(start, end, -1)
+            if boundary is None:
+                boundary = find_decodable_boundary(start, min(start + limit + 1, len(tokens)), 1)
+            if boundary is None:
+                raise RuntimeError(f"Unable to find a valid UTF-8 boundary from token index {start}.")
 
-            while end > start:
-                try:
-                    chunk = decode_range(start, end)
-                except UnicodeDecodeError:
-                    end -= 1
-                    continue
-                chunks.append(chunk)
-                start = end
-                break
-            else:
-                end = min(start + limit + 1, len(tokens))
-                while True:
-                    try:
-                        chunk = decode_range(start, end)
-                    except UnicodeDecodeError:
-                        if end >= len(tokens):
-                            raise
-                        end += 1
-                        continue
-                    chunks.append(chunk)
-                    start = end
-                    break
+            end, chunk = boundary
+            chunks.append(chunk)
+            start = end
 
         return chunks
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1201,7 +1201,7 @@ def import_qa_chunks(
             }
             chunks.append(DocumentChunk(page_content=pair["question"], metadata=metadata))
 
-        batch_size = 50
+        batch_size = min(EMBEDDING_BATCH_SIZE or 10, 20)
         for i in range(0, len(chunks), batch_size):
             batch = chunks[i:i + batch_size]
             vector_service.add_chunks(batch)


### PR DESCRIPTION
## Business context

`TextMerger` falls back to token-based hard splitting when no configured separator can split an oversized text segment. Decoding arbitrary token windows can bisect the UTF-8 bytes of a multi-token Unicode character and replace the original character with U+FFFD.

For example, `范围内产生的二氧化碳排放量` contains 17 `cl100k_base` tokens. With a 10-token limit, the old implementation split the two tokens that encode `氧`, producing `范围内产生的二�` and `�化碳排放量`.

The same release branch also needs QA imports to use the configured embedding batch size while capping each vector-write batch at 20 chunks instead of using a fixed batch size of 50.

## Impact scope

- Preserve complete Unicode characters during `TextMerger` hard splits.
- Keep the current custom delimiter priority, recursive separator order, and delimiter retention behavior unchanged.
- Keep normal chunks within the configured token limit by rolling back to the nearest valid UTF-8 boundary.
- Allow a single-character chunk to exceed an impossible token limit when preserving that character requires more tokens than the configured limit.
- Set QA import vector-write batches to `min(EMBEDDING_BATCH_SIZE or 10, 20)`.
- No database, schema, controller, service route, or frontend changes.

## Risks

- A chunk boundary may move backward by a few tokens to reach a valid UTF-8 boundary, which may change chunk counts for affected documents.
- Existing corrupted chunks require reparsing and re-vectorization; this change only corrects newly generated chunks.
- QA imports may issue more embedding/vector-write batches than before because each batch is capped at 20 chunks.

## Verification

- `.venv/bin/python -m pytest tests/core/rag/chunk/merger/test_text_merger.py -v` — 7 passed.
- `.venv/bin/python -m compileall app/core/rag/chunk/merger/text.py` — passed.
- Unicode/token invariant probe across 20 Chinese, emoji, and ASCII cases — passed.
- Exact reproduction with `！` as the custom delimiter and a 10-token limit now returns `范围内产生的二` and `氧化碳排放量` without replacement characters.
- Fair 17,000-token microbenchmark including tokenization in every implementation: strict decode `4.566473s`, original implementation `4.771789s`, and per-token byte decoding `4.920469s` across 20 runs.

The QA import batch-size commit was supplied independently and was not modified by the Unicode optimization follow-up.

The local regression test is intentionally excluded from the commit because repository policy prohibits committing files under `tests/`.

## External API key impact

No route, authentication, workspace, tenant, schema, or response contract changes. API key consumers that reuse the same parsing pipeline only receive corrected chunk content.
