### PR TITLE
Fix/pruning pilot persist

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -932,7 +932,6 @@ class WritePipeline:
     # ──────────────────────────────────────────────
     # 文件预处理（与旧路径 memory_agent_service._preprocess_files 一脉相承）
     # ──────────────────────────────────────────────
-# 需要重构调整一下，先研究一下感知记忆的内容产生，应用如何产生感知内容，写入如何拿到感知内容。
     async def _preprocess_files(self, messages: List[dict]) -> None:
         """处理消息中附带的文件，生成 Perceptual 记录并注入 summary 到 content。
 

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -360,6 +360,7 @@ class WritePipeline:
                         conversation_id=conversation_id,
                         source=source,
                         language=self.language,
+                        persist=not is_pilot_run,
                     )
 
                     # 拆回三部分
@@ -931,7 +932,7 @@ class WritePipeline:
     # ──────────────────────────────────────────────
     # 文件预处理（与旧路径 memory_agent_service._preprocess_files 一脉相承）
     # ──────────────────────────────────────────────
-
+# 需要重构调整一下，先研究一下感知记忆的内容产生，应用如何产生感知内容，写入如何拿到感知内容。
     async def _preprocess_files(self, messages: List[dict]) -> None:
         """处理消息中附带的文件，生成 Perceptual 记录并注入 summary 到 content。
 

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
@@ -39,6 +39,7 @@ async def prune_messages(
     conversation_id: str = "",
     source: str = "",
     language: str = "zh",
+    persist: bool = True,
 ) -> Tuple[List[dict], list]:
     """对滑动窗口覆盖的所有消息执行剪枝/规整。
 
@@ -49,6 +50,8 @@ async def prune_messages(
         conversation_id: 对话 ID
         source: 写入来源（agent/service_api/mcp/workflow）
         language: 语言
+        persist: 是否将剪枝结果持久化到 DB。试运行(pilot)模式应传 False，
+                 避免污染 PG 中的 pruned_content 字段。
 
     Returns:
         (pruned_messages, pruning_records) 元组：
@@ -64,7 +67,8 @@ async def prune_messages(
         return list(messages), pruning_records
 
     # Step 1: 从 DB 刷新 pruned_content
-    _refresh_pruned_content(messages, conversation_id, end_user_id, source)
+    if persist:
+        _refresh_pruned_content(messages, conversation_id, end_user_id, source)
 
     # Step 2: 遍历消息，收集 LLM 任务
     result: List[Optional[dict]] = [None] * len(messages)
@@ -172,7 +176,8 @@ async def prune_messages(
                 })
 
     # Step 4: 批量回写 DB
-    _batch_write_db(db_updates, conversation_id, end_user_id, source)
+    if persist:
+        _batch_write_db(db_updates, conversation_id, end_user_id, source)
 
     return [m for m in result if m is not None], pruning_records
 

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -76,6 +76,7 @@ CONSTRAINT_DEFS: List[Tuple[str, str, str]] = [
     ("memory_summary_id_unique", "MemorySummary", "id"),
     ("perceptual_id_unique", "Perceptual", "id"),
     ("community_id_unique", "Community", "community_id"),
+    ("user_source_id_unique", "UserSource", "id"),
 ]
 
 


### PR DESCRIPTION
## Summary by Sourcery

通过一个新的标志位来控制修剪（pruning）结果是否持久化到数据库，并确保试运行（pilot runs）不会写入修剪结果，同时在 Neo4j 中为 UserSource 的 ID 添加唯一索引。

New Features:
- 引入一个 `persist` 标志，用于控制是否将修剪结果写回数据库。

Enhancements:
- 将试运行检测逻辑接入修剪管线，使试运行跳过数据库刷新和批量写入。
- 在 Neo4j 中为 `UserSource` 节点的 `id` 字段添加唯一索引，以确保标识符的唯一性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate pruning DB persistence behind a new flag and ensure pilot runs do not write pruning results, while adding a unique index for UserSource IDs in Neo4j.

New Features:
- Introduce a persist flag to control whether pruning results are written back to the database.

Enhancements:
- Wire pilot run detection into the pruning pipeline so trial executions skip DB refresh and batch writes.
- Add a unique index on the UserSource node id field in Neo4j to enforce identifier uniqueness.

</details>