### PR TITLE
feat(memory): add forget audit log with operator tracking and recovery support

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -185,7 +185,7 @@ layer2_dedup_full_scan_schedule = crontab(hour=settings.LAYER2_DEDUP_FULL_SCAN_H
 reflection_retry_schedule = timedelta(minutes=settings.REFLECTION_RETRY_SCAN_INTERVAL_MINUTES)
 hot_memory_tags_refresh_schedule = crontab(hour=settings.HOT_MEMORY_TAGS_REFRESH_HOUR, minute=0)
 draft_data_clean_schedule = crontab(hour=settings.DRAFT_DATA_CLEAN_HOUR, minute=0)
-forget_scan_schedule = crontab(minute=settings.FORGET_SCAN_INTERVAL_MINUTES)
+forget_scan_schedule = timedelta(minutes=settings.FORGET_SCAN_INTERVAL_MINUTES)
 # 构建定时任务配置
 beat_schedule_config = {
     # "run-workspace-reflection": {

--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -181,6 +181,7 @@ async def delete_node_api(
         deleted = await MemoryService.delete_node_by_element_id(
             element_id=element_id,
             end_user_id=end_user_id,
+            operator=current_user.id,
         )
 
         if deleted:

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -256,7 +256,11 @@ class MemoryService:
         return dispatch_flush_conversation(conversation_id)
 
     @staticmethod
-    async def delete_node_by_element_id(element_id: str, end_user_id: str) -> bool:
+    async def delete_node_by_element_id(
+        element_id: str,
+        end_user_id: str,
+        operator: uuid.UUID,
+    ) -> bool:
         """通过 elementId 删除 Neo4j 图节点（同时 DETACH DELETE 关联边）。"""
         from app.core.memory.models.service_models import MemoryContext
         from app.core.memory.pipelines.forgetting_pipeline import ForgettingPipeline
@@ -265,6 +269,7 @@ class MemoryService:
         return await pipeline.delete_node_by_element_id(
             element_id=element_id,
             end_user_id=end_user_id,
+            operator=operator,
         )
 
     @staticmethod

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from typing import Self
 
 from pydantic import BaseModel, Field, field_serializer, ConfigDict, computed_field
@@ -133,3 +134,17 @@ class MemorySearchResult(BaseModel):
 
         merged.content_str = other.content_str or self.content_str
         return merged
+
+
+class ForgetLog(BaseModel):
+    node_id: str = Field(...)
+    end_user_id: uuid.UUID = Field(...)
+    node_type: str = Field(...)
+    content: str = Field(...)
+    trigger: int = Field(...)
+    reason: str = Field(...)
+    recoverable: bool = Field(...)
+    operator: uuid.UUID | None = Field(default=None)
+
+    delete_at: datetime = Field(...)
+    is_recovered: bool = Field(default=False)

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -1,11 +1,15 @@
 import uuid
 
+from app.core.memory.models.service_models import ForgetLog
 from app.core.memory.pipelines.base_pipeline import BasePipeline
 from app.core.memory.storage_services.forgetting_engine.forget_service import ForgetService
 from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.core.quota_manager import get_end_user_memory_limit
+from app.core.utils.datetime_utils import utcnow
 from app.db import get_db_context
+from app.models.memory_forget_model import ForgetTrigger
 from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
+from app.repositories.forget_log_repository import ForgetLogRepository
 from app.repositories.neo4j.cypher_queries import DELETE_NODE_BY_ELEMENT_ID
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -28,16 +32,57 @@ class ForgettingPipeline(BasePipeline):
         return res
 
     @staticmethod
-    async def delete_node_by_element_id(element_id: str, end_user_id: str) -> bool:
-        """通过 elementId 删除 Neo4j 图节点（同时 DETACH DELETE 关联边）。"""
+    async def delete_node_by_element_id(
+        element_id: str,
+        end_user_id: str,
+        operator: uuid.UUID,
+    ) -> bool:
+        """通过 elementId 删除 Neo4j 图节点并同步审计日志。
 
+        Args:
+            element_id: Neo4j 内部元素 ID。
+            end_user_id: 终端用户 ID。
+            operator: 执行删除操作的用户 ID。
+        """
         async with Neo4jConnector() as connector:
             result = await connector.execute_query(
                 DELETE_NODE_BY_ELEMENT_ID,
                 element_id=element_id,
                 end_user_id=end_user_id,
             )
-            return result[0]['deleted'] > 0 if result else False
+
+        if not result or result[0]["deleted"] == 0:
+            return False
+
+        row = result[0]
+        labels = row.get("labels", [])
+        node_type = next(
+            (label for label in labels if label != "Memory"), "unknown",
+        )
+
+        content = (
+            row.get("content") or row.get("statement") or row.get("name")
+            or row.get("text") or ""
+        )
+
+        log = ForgetLog(
+            node_id=row["node_id"],
+            end_user_id=uuid.UUID(end_user_id),
+            node_type=node_type,
+            content=content,
+            trigger=ForgetTrigger.Manual.value,
+            reason="manual",
+            recoverable=False,
+            operator=operator,
+            delete_at=utcnow(),
+            is_recovered=False,
+        )
+
+        with get_db_context() as db:
+            ForgetLogRepository.sync_logs(db, [log])
+            db.commit()
+
+        return True
 
     @staticmethod
     async def delete_all_nodes_by_end_user_id(end_user_id: str) -> int:

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -1,8 +1,13 @@
 import logging
+import uuid
 from typing import Any
 
-from app.core.memory.models.service_models import MemoryContext
+from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.models.service_models import MemoryContext, ForgetLog
 from app.core.utils.datetime_utils import utcnow, to_iso_z
+from app.db import get_db_context
+from app.models.memory_forget_model import ForgetTrigger
+from app.repositories.forget_log_repository import ForgetLogRepository
 from app.repositories.neo4j.graph_search import (
     forget_count_active_nodes,
     forget_get_mixed_candidates,
@@ -21,7 +26,7 @@ class ForgetService:
         self.ctx = ctx
         self.trigger_count = memory_limit
         self._connector: Neo4jConnector | None = None
-        self._audit: list[dict[str, Any]] = []
+        self._audit: list[ForgetLog] = []
         self.target_ratio = (1 - self.ctx.memory_config.lambda_mem)
         self.target_count = max(int(memory_limit * self.target_ratio), 50)
 
@@ -100,15 +105,17 @@ class ForgetService:
 
             for row in candidates:
                 node_type = row.get("node_type", "unknown")
-                entry: dict[str, Any] = {
-                    "node_id": row.get("node_id"),
-                    "node_type": node_type,
-                    "user_id": self.ctx.end_user_id,
-                    "delete_at": now,
-                    "delete_reason": "mixed_time_asc",
-                    "sort_time": row.get("sort_time"),
-                    "extraction_count": row.get("extraction_count"),
-                }
+                entry: ForgetLog = ForgetLog(
+                    node_id=row.get("element_id"),
+                    node_type=node_type,
+                    end_user_id=uuid.UUID(self.ctx.end_user_id),
+                    reason="timeout",
+                    recoverable=True,
+                    operator=None,
+                    delete_at=now,
+                    trigger=ForgetTrigger.Scheduled.value,
+                    content=row.get("content")
+                )
                 self._audit.append(entry)
 
             logger.info(
@@ -116,11 +123,14 @@ class ForgetService:
                 "types=%s",
                 len(element_ids), deleted_in_batch, total_deleted, budget,
                 {t: sum(1 for r in candidates if r.get("node_type") == t)
-                 for t in ("chunk", "statement", "entity")},
+                 for t in (Neo4jNodeType.CHUNK, Neo4jNodeType.STATEMENT, Neo4jNodeType.EXTRACTEDENTITY)},
             )
 
             if deleted_in_batch < len(element_ids):
                 break
+        with get_db_context() as db:
+            ForgetLogRepository.sync_logs(db, self._audit)
+            db.commit()
 
         active_count = await forget_count_active_nodes(connector, self.ctx.end_user_id)
         new_budget = max(0, active_count - self.target_count)

--- a/api/app/locales/en/memory.json
+++ b/api/app/locales/en/memory.json
@@ -1,0 +1,13 @@
+{
+  "forget_reason": {
+    "timeout": "Timeout expired",
+    "manual": "User manual"
+  },
+  "default_operator": "Forgetting Engine",
+  "recover_success": "Memory recovered successfully",
+  "errors": {
+    "recover_not_allowed": "This memory cannot be recovered, it may have already been recovered or is of an unrecoverable type",
+    "neo4j_node_not_found": "Neo4j node does not exist or has been deleted",
+    "internal_error": "Failed to recover memory"
+  }
+}

--- a/api/app/locales/zh/memory.json
+++ b/api/app/locales/zh/memory.json
@@ -1,0 +1,13 @@
+{
+  "forget_reason": {
+    "timeout": "超时过期",
+    "manual": "用户手动"
+  },
+  "default_operator": "遗忘引擎",
+  "recover_success": "记忆恢复成功",
+  "errors": {
+    "recover_not_allowed": "该记忆不可恢复，可能已恢复或为不可恢复类型",
+    "neo4j_node_not_found": "Neo4j 节点不存在或已被删除",
+    "internal_error": "恢复记忆失败"
+  }
+}

--- a/api/app/models/memory_forget_model.py
+++ b/api/app/models/memory_forget_model.py
@@ -1,0 +1,30 @@
+from enum import IntEnum
+import uuid
+
+from sqlalchemy import Column, DateTime, Integer, String, Boolean
+from sqlalchemy import ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db import Base
+
+
+class ForgetTrigger(IntEnum):
+    Manual = 1
+    Scheduled = 2
+
+
+class ForgetAuditModel(Base):
+    __tablename__ = 'memory_forget_log'
+
+    id = Column(UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
+    end_user_id = Column(UUID(as_uuid=True), ForeignKey("end_users.id"), index=True, nullable=False)
+    node_id = Column(String, nullable=False, index=True)
+    node_type = Column(String, nullable=False, index=True)
+    content = Column(String, nullable=False)
+    trigger = Column(Integer, nullable=False)
+    reason = Column(String, nullable=False)
+    recoverable = Column(Boolean, nullable=False)
+    operator = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+
+    delete_at = Column(DateTime, nullable=False)
+    is_recovered = Column(Boolean, default=False, nullable=False)

--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -1,6 +1,6 @@
 import uuid
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -135,7 +135,7 @@ class ForgetLogRepository:
         end_user_id: uuid.UUID,
         method: int | None = None,
         memory_type: str | None = None,
-        status: bool | None = None,
+        status: str | None = None,
         page: int = 1,
         pagesize: int = 10,
     ) -> tuple[list[ForgetAuditModel], dict[uuid.UUID, str], int]:
@@ -146,7 +146,7 @@ class ForgetLogRepository:
             end_user_id: 终端用户 ID（必填）。
             method: 遗忘触发方式（1=手动, 2=定时）。
             memory_type: 记忆节点类型过滤。
-            status: 恢复状态（True=已恢复, False=未恢复, None=全部）。
+            status: 恢复状态（"recoverable"=可恢复, "deleted"=已删除, None=全部）。
             page: 页码，从 1 开始。
             pagesize: 每页条数。
 
@@ -158,8 +158,20 @@ class ForgetLogRepository:
             conditions.append(ForgetAuditModel.trigger == method)
         if memory_type is not None:
             conditions.append(ForgetAuditModel.node_type == memory_type)
-        if status is not None:
-            conditions.append(ForgetAuditModel.is_recovered == status)
+        if status == "recoverable":
+            conditions.append(
+                and_(
+                    ForgetAuditModel.is_recovered == False,
+                    ForgetAuditModel.recoverable == True,
+                )
+            )
+        elif status == "deleted":
+            conditions.append(
+                or_(
+                    ForgetAuditModel.is_recovered == False,
+                    ForgetAuditModel.recoverable == False,
+                )
+            )
 
         base_query = select(ForgetAuditModel).where(*conditions)
 

--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_db_logger
+from app.core.utils.datetime_utils import to_iso_z, utcnow
 from app.core.memory.models.service_models import ForgetLog
 from app.models.memory_forget_model import ForgetAuditModel
 from app.models.user_model import User
@@ -112,7 +113,9 @@ class ForgetLogRepository:
             return
 
         async with Neo4jConnector() as connector:
-            recovered = await forget_recover_by_element_id(connector, element_id)
+            recovered = await forget_recover_by_element_id(
+                connector, element_id, now=to_iso_z(utcnow()),
+            )
 
         if recovered is None:
             raise BusinessException(

--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -165,6 +165,13 @@ class ForgetLogRepository:
                     ForgetAuditModel.recoverable == True,
                 )
             )
+        elif status == "recovered":
+            conditions.append(
+                and_(
+                    ForgetAuditModel.is_recovered == True,
+                    ForgetAuditModel.recoverable == True,
+                )
+            )
         elif status == "deleted":
             conditions.append(
                 or_(

--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -1,0 +1,188 @@
+import uuid
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from app.core.exceptions import BusinessException
+from app.core.logging_config import get_db_logger
+from app.core.memory.models.service_models import ForgetLog
+from app.models.memory_forget_model import ForgetAuditModel
+from app.models.user_model import User
+from app.repositories.neo4j.graph_search import forget_recover_by_element_id
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = get_db_logger()
+
+
+class ForgetLogRepository:
+    @staticmethod
+    def sync_logs(db: Session, logs: list[ForgetLog]):
+        """将内存审计日志批量写入数据库（存在则更新，不存在则新增）。
+
+        对每条 ``ForgetLog``，以 ``node_id`` 为键查找已有记录：
+        - 已存在：更新字段
+        - 不存在：新建 ``ForgetAuditModel``
+
+        调用方负责 commit/rollback，适合与其他写入操作共享事务。
+
+        Args:
+            db: SQLAlchemy 同步会话。
+            logs: 待持久化的 ForgetLog 列表。
+        """
+        if not logs:
+            return
+
+        node_ids = [log.node_id for log in logs]
+        existing = db.execute(
+            select(ForgetAuditModel).where(ForgetAuditModel.node_id.in_(node_ids))
+        ).scalars().all()
+        existing_map: dict[str, ForgetAuditModel] = {row.node_id: row for row in existing}
+
+        updated = 0
+        inserted = 0
+
+        for log in logs:
+            if log.node_id in existing_map:
+                record = existing_map[log.node_id]
+                record.end_user_id = log.end_user_id
+                record.node_type = log.node_type
+                record.content = log.content
+                record.trigger = log.trigger
+                record.reason = log.reason
+                record.recoverable = log.recoverable
+                record.operator = log.operator
+                record.delete_at = log.delete_at
+                record.is_recovered = log.is_recovered
+                updated += 1
+            else:
+                db.add(ForgetAuditModel(
+                    node_id=log.node_id,
+                    end_user_id=log.end_user_id,
+                    node_type=log.node_type,
+                    content=log.content,
+                    trigger=log.trigger,
+                    reason=log.reason,
+                    recoverable=log.recoverable,
+                    operator=log.operator,
+                    delete_at=log.delete_at,
+                    is_recovered=log.is_recovered,
+                ))
+                inserted += 1
+
+        db.flush()
+        logger.info(
+            "Synced forget audit logs: inserted=%d updated=%d total=%d",
+            inserted, updated, len(logs),
+        )
+
+    @staticmethod
+    async def recover_memory(db: AsyncSession, element_id: str, operator: uuid.UUID):
+        """恢复被软删除的记忆节点并更新审计日志。
+
+        先查 DB 确认 ``recoverable=True``，通过后再恢复 Neo4j。
+
+        Args:
+            db: SQLAlchemy 异步会话。
+            element_id: Neo4j 内部元素 ID，对应 DB 中 ``node_id`` 字段。
+            operator: 执行恢复操作的用户 ID。
+
+        Raises:
+            ResourceNotFoundException: 未找到可恢复的审计记录或 Neo4j 节点。
+        """
+        result = await db.execute(
+            select(ForgetAuditModel.id, ForgetAuditModel.is_recovered).where(
+                ForgetAuditModel.node_id == element_id,
+                ForgetAuditModel.recoverable == True,
+            )
+        )
+        row = result.one_or_none()
+
+        if row is None:
+            raise BusinessException(
+                "该记忆不可恢复，可能已恢复或不可恢复类型", 400,
+            )
+
+        audit_id, already_recovered = row
+
+        if already_recovered:
+            logger.info(
+                "Memory already recovered (idempotent): element_id=%s", element_id,
+            )
+            return
+
+        async with Neo4jConnector() as connector:
+            recovered = await forget_recover_by_element_id(connector, element_id)
+
+        if recovered is None:
+            raise BusinessException(
+                "Neo4j 节点不存在或已被删除", 400,
+            )
+
+        values = {"is_recovered": True, "operator": operator}
+
+        await db.execute(
+            update(ForgetAuditModel)
+            .where(ForgetAuditModel.id == audit_id)
+            .values(**values)
+        )
+        await db.commit()
+        logger.info("Memory recovered: element_id=%s operator=%s", element_id, operator)
+
+    @staticmethod
+    async def get_forget_logs(
+        db: AsyncSession,
+        end_user_id: uuid.UUID,
+        method: int | None = None,
+        memory_type: str | None = None,
+        status: bool | None = None,
+        page: int = 1,
+        pagesize: int = 10,
+    ) -> tuple[list[ForgetAuditModel], dict[uuid.UUID, str], int]:
+        """分页查询遗忘审计日志。
+
+        Args:
+            db: SQLAlchemy 异步会话。
+            end_user_id: 终端用户 ID（必填）。
+            method: 遗忘触发方式（1=手动, 2=定时）。
+            memory_type: 记忆节点类型过滤。
+            status: 恢复状态（True=已恢复, False=未恢复, None=全部）。
+            page: 页码，从 1 开始。
+            pagesize: 每页条数。
+
+        Returns:
+            (日志列表, operator_id → username 映射, 总记录数) 元组。
+        """
+        conditions = [ForgetAuditModel.end_user_id == end_user_id]
+        if method is not None:
+            conditions.append(ForgetAuditModel.trigger == method)
+        if memory_type is not None:
+            conditions.append(ForgetAuditModel.node_type == memory_type)
+        if status is not None:
+            conditions.append(ForgetAuditModel.is_recovered == status)
+
+        base_query = select(ForgetAuditModel).where(*conditions)
+
+        # 总数
+        count_query = select(func.count()).select_from(ForgetAuditModel).where(*conditions)
+        total_result = await db.execute(count_query)
+        total = total_result.scalar_one()
+
+        page = max(page, 1)
+        offset = (page - 1) * pagesize
+        result = await db.execute(
+            base_query.order_by(ForgetAuditModel.delete_at.desc()).offset(offset).limit(pagesize)
+        )
+        items = list(result.scalars().all())
+
+        # 批量查询 operator 的 username
+        operator_ids = {item.operator for item in items if item.operator is not None}
+        operator_names: dict[uuid.UUID, str] = {}
+        if operator_ids:
+            user_result = await db.execute(
+                select(User.id, User.username).where(User.id.in_(operator_ids))
+            )
+            for row in user_result.all():
+                operator_names[row.id] = row.username
+
+        return items, operator_names, total

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2698,8 +2698,10 @@ RETURN elementId(r) AS uuid
 DELETE_NODE_BY_ELEMENT_ID = """
 MATCH (n)
 WHERE elementId(n) = $element_id AND n.end_user_id = $end_user_id
+WITH n, elementId(n) AS node_id, n.content AS content, n.statement AS statement,
+     n.name AS name, n.text AS text, labels(n) AS labels
 DETACH DELETE n
-RETURN count(n) AS deleted
+RETURN count(n) AS deleted, node_id, content, statement, name, text, labels
 """
 
 # ── Forgetting engine (soft-delete) ────────────────────────────────────
@@ -2719,11 +2721,18 @@ FORGET_SOFT_DELETE_BY_ELEMENT_IDS = """
     RETURN count(n) AS deleted
 """
 
+FORGET_RECOVER_BY_ELEMENT_ID = """
+    MATCH (n)
+    WHERE elementId(n) = $element_id
+    SET n.delete_at = NULL
+    RETURN n.id AS node_id, labels(n) AS labels
+"""
+
 FORGET_MIXED_CANDIDATES = """
 CALL () {
     MATCH (c:Chunk {end_user_id: $end_user_id})
     WHERE c.delete_at IS NULL
-    RETURN 'chunk' AS node_type, elementId(c) AS element_id, c.id AS node_id,
+    RETURN 'Chunk' AS node_type, elementId(c) AS element_id, c.content AS content,
            coalesce(c.created_at) AS sort_time, 0 AS extraction_count,
            null AS name, null AS _type
     ORDER BY sort_time ASC
@@ -2731,7 +2740,7 @@ CALL () {
     UNION ALL
     MATCH (s:Statement {end_user_id: $end_user_id})
     WHERE s.delete_at IS NULL
-    RETURN 'statement' AS node_type, elementId(s) AS element_id, s.id AS node_id,
+    RETURN 'Statement' AS node_type, elementId(s) AS element_id, s.statement AS content,
            coalesce(s.created_at) AS sort_time, 0 AS extraction_count,
            null AS name, null AS _type
     ORDER BY sort_time ASC
@@ -2740,7 +2749,7 @@ CALL () {
     MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
     WHERE e.delete_at IS NULL
       AND coalesce(e.extraction_count, 0) < $protection_threshold
-    RETURN 'entity' AS node_type, elementId(e) AS element_id, e.id AS node_id,
+    RETURN 'ExtractedEntity' AS node_type, elementId(e) AS element_id, e.name AS content,
            coalesce(e.created_at) AS sort_time,
            coalesce(e.extraction_count, 0) AS extraction_count,
            e.name AS name, e.entity_type AS _type

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2724,7 +2724,7 @@ FORGET_SOFT_DELETE_BY_ELEMENT_IDS = """
 FORGET_RECOVER_BY_ELEMENT_ID = """
     MATCH (n)
     WHERE elementId(n) = $element_id
-    SET n.delete_at = NULL
+    SET n.delete_at = NULL, n.created_at = datetime($now)
     RETURN n.id AS node_id, labels(n) AS labels
 """
 

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -1172,6 +1172,7 @@ async def forget_soft_delete_by_element_ids(
 async def forget_recover_by_element_id(
     connector: Neo4jConnector,
     element_id: str,
+    now: str,
 ) -> dict | None:
     """Remove the soft-delete marker from a node, restoring it.
 
@@ -1185,6 +1186,7 @@ async def forget_recover_by_element_id(
     result = await connector.execute_query(
         FORGET_RECOVER_BY_ELEMENT_ID,
         element_id=element_id,
+        now=now,
     )
     return result[0] if result else None
 

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -1167,3 +1167,25 @@ async def forget_soft_delete_by_element_ids(
         now=now,
     )
     return result[0]["deleted"] if result else 0
+
+
+async def forget_recover_by_element_id(
+    connector: Neo4jConnector,
+    element_id: str,
+) -> dict | None:
+    """Remove the soft-delete marker from a node, restoring it.
+
+    ``elementId()`` is globally unique within a Neo4j database, so no
+    additional scoping is required.
+
+    Returns a dict with ``node_id`` and ``labels`` on success, or ``None``
+    if no matching soft-deleted node was found.
+    """
+    from app.repositories.neo4j.cypher_queries import FORGET_RECOVER_BY_ELEMENT_ID
+    result = await connector.execute_query(
+        FORGET_RECOVER_BY_ELEMENT_ID,
+        element_id=element_id,
+    )
+    return result[0] if result else None
+
+


### PR DESCRIPTION
## Summary by Sourcery

为“遗忘”相关的内存操作增加审计和恢复支持，包括对手动删除和定时清理的操作员跟踪，并将其整合到现有的遗忘管线和服务中。

新功能：
- 引入持久化的遗忘审计日志模型，用于跟踪被遗忘的内存节点，并记录触发类型、原因、可恢复性、操作员以及时间戳等元数据。
- 添加 API 和仓储方法，用于持久化遗忘日志、对审计记录进行分页和过滤，并从 Neo4j 中恢复软删除的内存节点（具备幂等处理）。
- 扩展手动节点删除和定时遗忘流程，以记录遗忘日志，包括手动删除的操作员信息以及定时超时操作的可恢复性。

增强改进：
- 调整遗忘引擎查询，使其为块、语句和抽取的实体输出更丰富的元数据，并使用基于枚举的节点类型。
- 修改遗忘扫描的 Celery 调度机制，改为使用基于 `timedelta` 的间隔配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add auditing and recovery support for memory forgetting operations, including operator tracking for manual deletes and scheduled cleanups, and integrate this into the existing forgetting pipeline and services.

New Features:
- Introduce a persistent forget audit log model to track forgotten memory nodes with metadata such as trigger type, reason, recoverability, operator, and timestamps.
- Add APIs and repository methods to persist forget logs, paginate and filter audit records, and recover soft-deleted memory nodes from Neo4j with idempotent handling.
- Extend manual node deletion and scheduled forgetting flows to record forget logs, including operator information for manual deletions and recoverability for scheduled timeouts.

Enhancements:
- Adjust forgetting engine queries to emit richer metadata for chunks, statements, and extracted entities and use enum-based node types.
- Change the forget scanning Celery schedule to use a timedelta-based interval configuration.

</details>