### PR TITLE
fix(rag): skip rerank for empty hybrid results

### DIFF
--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1243,6 +1243,23 @@ class KnowledgeRetrievalService:
             return vector_chunks, full_text_chunks, unique_chunks
 
         vector_chunks, full_text_chunks, unique_chunks = await asyncio.to_thread(retrieve_candidates)
+        if not unique_chunks:
+            if log_id:
+                logger.info(
+                    "[Retrieval] target_done %s",
+                    cls._format_log_fields(cls._build_target_done_log_fields(
+                        log_id=log_id,
+                        target=target,
+                        target_position=target_position,
+                        vector_count=len(vector_chunks),
+                        full_text_count=len(full_text_chunks),
+                        merged_count=0,
+                        result_count=0,
+                        elapsed_ms=cls._elapsed_ms(started_at),
+                        local_rerank=False,
+                    )),
+                )
+            return []
         chunks = await cls.rerank_documents_async(
             db=db,
             rerank_id=request.rerank_id,
@@ -1364,6 +1381,23 @@ class KnowledgeRetrievalService:
             topk=target.params.top_n,
         )
         unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+        if not unique_chunks:
+            if log_id:
+                logger.info(
+                    "[Retrieval] target_done %s",
+                    cls._format_log_fields(cls._build_target_done_log_fields(
+                        log_id=log_id,
+                        target=target,
+                        target_position=target_position,
+                        vector_count=len(vector_chunks),
+                        full_text_count=len(full_text_chunks),
+                        merged_count=0,
+                        result_count=0,
+                        elapsed_ms=cls._elapsed_ms(started_at),
+                        local_rerank=False,
+                    )),
+                )
+            return []
         # if len(unique_chunks) <= target.params.top_k:
         #     return unique_chunks
         if use_request_rerank and request.rerank_id:


### PR DESCRIPTION
## Business Background

Single-knowledge-base HYBRID retrieval with a request-level `rerank_id` passed an empty candidate list to the reranker when both vector and full-text recall returned no matches. The reranker rejected the empty list and failed the retrieval chain instead of returning a normal empty result.

## Summary

- Short-circuit synchronous HYBRID retrieval when deduplicated candidates are empty.
- Apply the same behavior to the asynchronous single-HYBRID request-rerank path.
- Preserve target completion logging and record that local rerank was not executed.
- Keep the existing `rerank_documents*` input validation contract unchanged.

## Changes

- `api/app/services/knowledge_retrieval_service.py`: 34 insertions.

## Impact

Workflow knowledge nodes, agent draft retrieval, and the internal chunk retrieval endpoint now return an empty result for zero-hit HYBRID searches instead of failing with `ValueError("retrieval chunks cannot be empty")`.

## Risk

Low. The new branches run only when deduplicated HYBRID candidates are empty. Non-empty retrieval and rerank behavior is unchanged.

## Test Plan

- [x] Sync zero-hit HYBRID harness returns `[]` with zero rerank calls.
- [x] Async zero-hit HYBRID harness returns `[]` with zero rerank calls.
- [x] Non-empty sync and async control harnesses still invoke rerank once and return the hit.
- [x] `PYTHONPATH=. .venv/bin/python -m compileall -q app/services/knowledge_retrieval_service.py`.
- [x] `git diff --check origin/release/v0.3.12..HEAD`.

## External API Key Impact

No route, authorization, workspace, schema, or response-shape changes were made in `app/controllers/service/rag_api_*_controller.py`. Any external caller that reuses the unified retrieval service receives the same compatible behavior improvement: empty results instead of an exception.

## Summary by Sourcery

通过在未找到去重分块时提前终止 HYBRID 候选重排来处理零命中 HYBRID 检索，在保留目标补全日志记录的同时返回空结果。

Bug Fixes:
- 当单目标 HYBRID 检索未产生向量或全文命中时，通过返回空结果而不是抛出异常来防止失败。
- 将零命中处理一致地应用于同步和异步的 HYBRID 请求重排路径。

Enhancements:
- 为零命中 HYBRID 检索记录目标补全日志，包括本地重排未执行的事实。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle zero-hit HYBRID retrievals by short-circuiting HYBRID candidate reranking when no deduplicated chunks are found, returning empty results while preserving target completion logging.

Bug Fixes:
- Prevent failures when single-target HYBRID retrieval produces no vector or full-text hits by returning an empty result instead of raising an exception.
- Apply the zero-hit handling consistently to both synchronous and asynchronous HYBRID request rerank paths.

Enhancements:
- Record target completion logs for zero-hit HYBRID retrievals, including that local rerank was not executed.

</details>