### PR TITLE
feat(rag): migrate knowledge retrieval to native async

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -17,6 +17,7 @@ from app.core.logging_config import get_api_logger
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.models import RetrievalPrincipal
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
 from app.db import get_async_db
@@ -1017,8 +1018,7 @@ def get_retrieve_types():
 
 async def retrieve_chunks_with_caller(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: Session | AsyncSession,
-        current_user: User,
+        principal: RetrievalPrincipal | None,
         caller: chunk_schema.KnowledgeRetrievalCaller,
 ):
     """
@@ -1028,7 +1028,7 @@ async def retrieve_chunks_with_caller(
         "retrieve chunk request received: username=%s, caller=%s, query_len=%s, kb_count=%s, "
         "ex_id_count=%s, retrieve_type=%s, top_k=%s, "
         "metadata_mode=%s, metadata_filter_groups=%s",
-        current_user.username,
+        principal.username if principal and principal.username else "anonymous",
         caller,
         len(retrieve_data.query or ""),
         len(retrieve_data.kb_ids or []),
@@ -1044,9 +1044,8 @@ async def retrieve_chunks_with_caller(
         retrieval_payload["caller"] = caller
         request = KnowledgeRetrievalRequest(**retrieval_payload)
         result = await KnowledgeRetrievalService.retrieve_async(
-            db=db,
             request=request,
-            current_user=current_user,
+            principal=principal,
         )
     except KnowledgeRetrievalAccessDenied as exc:
         raise HTTPException(
@@ -1060,12 +1059,10 @@ async def retrieve_chunks_with_caller(
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
-        db: AsyncSession = Depends(get_async_db),
         current_user: User = Depends(get_current_user_async)
 ):
     return await retrieve_chunks_with_caller(
         retrieve_data=retrieve_data,
-        db=db,
-        current_user=current_user,
+        principal=RetrievalPrincipal.from_user(current_user),
         caller=chunk_schema.KnowledgeRetrievalCaller.IN_API,
     )

--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -3,7 +3,7 @@
 from typing import Any, Optional, Union
 import uuid
 
-from fastapi import APIRouter, Body, Depends, File, Request, status, Query, UploadFile
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Request, status, Query, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.controllers import chunk_controller
@@ -17,6 +17,8 @@ from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
+from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied
+from app.services.rag_access_service import get_api_key_retrieval_principal_async
 
 
 router = APIRouter(prefix="/chunks", tags=["V1 - RAG API"])
@@ -232,7 +234,6 @@ def get_retrieve_types():
 async def retrieve_chunks(
     request: Request,
     api_key_auth: ApiKeyAuth = None,
-    db: AsyncSession = Depends(get_async_db),
     query: str = Body(..., description="question"),
 ):
     """
@@ -240,17 +241,18 @@ async def retrieve_chunks(
     """
     body = await request.json()
     retrieve_data = chunk_schema.ChunkRetrieve(**body)
-    # 0. Obtain the creator of the api key
-    api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
-
-    return await chunk_controller.retrieve_chunks_with_caller(
-        retrieve_data=retrieve_data,
-        db=db,
-        current_user=current_user,
-        caller=chunk_schema.KnowledgeRetrievalCaller.EX_API,
-    )
+    try:
+        principal = await get_api_key_retrieval_principal_async(api_key_auth)
+        return await chunk_controller.retrieve_chunks_with_caller(
+            retrieve_data=retrieve_data,
+            principal=principal,
+            caller=chunk_schema.KnowledgeRetrievalCaller.EX_API,
+        )
+    except KnowledgeRetrievalAccessDenied as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
 
 
 @router.post("/{kb_id}/import_qa", response_model=ApiResponse)

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -83,6 +83,9 @@ class Settings:
     ELASTICSEARCH_RETRY_ON_TIMEOUT: bool = os.getenv("ELASTICSEARCH_RETRY_ON_TIMEOUT", "True").lower() == "true"
     ELASTICSEARCH_MAX_RETRIES: int = int(os.getenv("ELASTICSEARCH_MAX_RETRIES", "10"))
     KNOWLEDGE_RETRIEVAL_MAX_WORKERS: int = int(os.getenv("KNOWLEDGE_RETRIEVAL_MAX_WORKERS", "3"))
+    KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY: int = int(
+        os.getenv("KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY", "2")
+    )
 
     # Xinference configuration
     XINFERENCE_URL: str = os.getenv("XINFERENCE_URL", "http://127.0.0.1")

--- a/api/app/core/rag/retrieval/__init__.py
+++ b/api/app/core/rag/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Immutable contracts for retrieval execution."""

--- a/api/app/core/rag/retrieval/async_elasticsearch.py
+++ b/api/app/core/rag/retrieval/async_elasticsearch.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import time
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
@@ -22,7 +23,11 @@ from app.core.rag.retrieval.elasticsearch_queries import (
     resolve_vector_search_mode,
     vector_hits_to_chunks,
 )
-from app.core.rag.retrieval.models import ModelRuntimeSnapshot, RetrievalSearchOptions
+from app.core.rag.retrieval.models import (
+    ModelRuntimeSnapshot,
+    RetrievalSearchOptions,
+    RetrievalTimings,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -74,9 +79,15 @@ class AsyncElasticsearchClientProvider:
 
 
 class AsyncElasticSearchRetrieval:
-    def __init__(self, client: AsyncElasticsearch, models: AsyncEmbeddingClient) -> None:
+    def __init__(
+        self,
+        client: AsyncElasticsearch,
+        models: AsyncEmbeddingClient,
+        timings: RetrievalTimings | None = None,
+    ) -> None:
         self._client = client
         self._models = models
+        self._timings = timings
 
     async def search_by_vector(
         self,
@@ -84,7 +95,11 @@ class AsyncElasticSearchRetrieval:
         query: str,
         options: RetrievalSearchOptions,
     ) -> list[DocumentChunk]:
-        query_vector = normalize_vector(await self._models.embed_query(embedding, query))
+        embedding_started_at = time.perf_counter()
+        try:
+            query_vector = normalize_vector(await self._models.embed_query(embedding, query))
+        finally:
+            self._record_elapsed("embedding_ms", embedding_started_at)
         filters = build_vector_filter_clauses(
             options.file_names_filter,
             options.document_ids_include,
@@ -92,16 +107,20 @@ class AsyncElasticSearchRetrieval:
 
         if resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:
             try:
-                result = await self._client.search(
-                    index=options.indices,
-                    size=options.top_k,
-                    knn=build_knn_query(
-                        query_vector,
-                        options.top_k,
-                        filters,
-                        options.knn_num_candidates,
-                    ),
-                )
+                vector_search_started_at = time.perf_counter()
+                try:
+                    result = await self._client.search(
+                        index=options.indices,
+                        size=options.top_k,
+                        knn=build_knn_query(
+                            query_vector,
+                            options.top_k,
+                            filters,
+                            options.knn_num_candidates,
+                        ),
+                    )
+                finally:
+                    self._record_elapsed("es_vector_ms", vector_search_started_at)
                 return await self._resolve_vector_result(
                     result,
                     options,
@@ -112,12 +131,16 @@ class AsyncElasticSearchRetrieval:
                     raise
                 logger.warning("[ES search_by_vector] KNN search failed; using script score: %s", exc)
 
-        result = await self._client.search(
-            index=options.indices,
-            from_=0,
-            size=options.top_k,
-            query=build_vector_script_query(query_vector, filters),
-        )
+        vector_search_started_at = time.perf_counter()
+        try:
+            result = await self._client.search(
+                index=options.indices,
+                from_=0,
+                size=options.top_k,
+                query=build_vector_script_query(query_vector, filters),
+            )
+        finally:
+            self._record_elapsed("es_vector_ms", vector_search_started_at)
         return await self._resolve_vector_result(
             result,
             options,
@@ -129,16 +152,20 @@ class AsyncElasticSearchRetrieval:
         query: str,
         options: RetrievalSearchOptions,
     ) -> list[DocumentChunk]:
-        result = await self._client.search(
-            index=options.indices,
-            from_=0,
-            size=options.top_k,
-            query=build_full_text_query(
-                query,
-                options.file_names_filter,
-                options.document_ids_include,
-            ),
-        )
+        full_text_search_started_at = time.perf_counter()
+        try:
+            result = await self._client.search(
+                index=options.indices,
+                from_=0,
+                size=options.top_k,
+                query=build_full_text_query(
+                    query,
+                    options.file_names_filter,
+                    options.document_ids_include,
+                ),
+            )
+        finally:
+            self._record_elapsed("es_fulltext_ms", full_text_search_started_at)
         raise_on_shard_failures(result, "full text search")
         docs = full_text_hits_to_chunks(result, options.score_threshold)
         return await self.resolve_parent_chunks(docs, index=options.indices)
@@ -159,6 +186,7 @@ class AsyncElasticSearchRetrieval:
         if not parent_ids:
             return chunks
 
+        parent_resolution_started_at = time.perf_counter()
         try:
             result = await self._client.search(
                 index=index,
@@ -168,7 +196,18 @@ class AsyncElasticSearchRetrieval:
         except Exception as exc:
             logger.warning("Failed to resolve parent chunks: %s", exc)
             return chunks
+        finally:
+            self._record_elapsed("parent_resolution_ms", parent_resolution_started_at)
         return merge_parent_chunks(chunks, result.get("hits", {}).get("hits", []))
+
+    def _record_elapsed(self, field_name: str, started_at: float) -> None:
+        if self._timings is None:
+            return
+        setattr(
+            self._timings,
+            field_name,
+            getattr(self._timings, field_name) + max(0, int((time.perf_counter() - started_at) * 1000)),
+        )
 
     async def _resolve_vector_result(
         self,

--- a/api/app/core/rag/retrieval/async_elasticsearch.py
+++ b/api/app/core/rag/retrieval/async_elasticsearch.py
@@ -1,0 +1,186 @@
+import asyncio
+import logging
+import os
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+from elasticsearch import AsyncElasticsearch
+
+from app.core.config import settings
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.elasticsearch_queries import (
+    VECTOR_SEARCH_MODE_KNN,
+    build_full_text_query,
+    build_knn_query,
+    build_parent_lookup_query,
+    build_vector_filter_clauses,
+    build_vector_script_query,
+    full_text_hits_to_chunks,
+    merge_parent_chunks,
+    normalize_vector,
+    raise_on_shard_failures,
+    resolve_vector_search_mode,
+    vector_hits_to_chunks,
+)
+from app.core.rag.retrieval.models import ModelRuntimeSnapshot, RetrievalSearchOptions
+
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncEmbeddingClient(Protocol):
+    async def embed_query(
+        self,
+        embedding: ModelRuntimeSnapshot,
+        query: str,
+    ) -> list[float]: ...
+
+
+def build_async_elasticsearch_client_config() -> dict[str, Any]:
+    parsed = urlparse(settings.ELASTICSEARCH_HOST)
+    scheme = parsed.scheme or "https"
+    hostname = parsed.hostname or settings.ELASTICSEARCH_HOST
+    config: dict[str, Any] = {
+        "hosts": [f"{scheme}://{hostname}:{settings.ELASTICSEARCH_PORT}"],
+        "basic_auth": (settings.ELASTICSEARCH_USERNAME, settings.ELASTICSEARCH_PASSWORD),
+        "request_timeout": settings.ELASTICSEARCH_REQUEST_TIMEOUT,
+        "retry_on_timeout": settings.ELASTICSEARCH_RETRY_ON_TIMEOUT,
+        "max_retries": settings.ELASTICSEARCH_MAX_RETRIES,
+        "connections_per_node": int(os.getenv("ELASTICSEARCH_CONNECTIONS_PER_NODE", "10")),
+    }
+    if scheme == "https":
+        config["verify_certs"] = settings.ELASTICSEARCH_VERIFY_CERTS
+        if settings.ELASTICSEARCH_CA_CERTS:
+            config["ca_certs"] = settings.ELASTICSEARCH_CA_CERTS
+    return config
+
+
+class AsyncElasticsearchClientProvider:
+    _client: AsyncElasticsearch | None = None
+    _lock = asyncio.Lock()
+
+    @classmethod
+    async def get_shared_client(cls) -> AsyncElasticsearch:
+        async with cls._lock:
+            if cls._client is None:
+                cls._client = AsyncElasticsearch(**build_async_elasticsearch_client_config())
+            return cls._client
+
+    @classmethod
+    async def aclose(cls) -> None:
+        if cls._client is not None:
+            await cls._client.close()
+            cls._client = None
+
+
+class AsyncElasticSearchRetrieval:
+    def __init__(self, client: AsyncElasticsearch, models: AsyncEmbeddingClient) -> None:
+        self._client = client
+        self._models = models
+
+    async def search_by_vector(
+        self,
+        embedding: ModelRuntimeSnapshot,
+        query: str,
+        options: RetrievalSearchOptions,
+    ) -> list[DocumentChunk]:
+        query_vector = normalize_vector(await self._models.embed_query(embedding, query))
+        filters = build_vector_filter_clauses(
+            options.file_names_filter,
+            options.document_ids_include,
+        )
+
+        if resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:
+            try:
+                result = await self._client.search(
+                    index=options.indices,
+                    size=options.top_k,
+                    knn=build_knn_query(
+                        query_vector,
+                        options.top_k,
+                        filters,
+                        options.knn_num_candidates,
+                    ),
+                )
+                return await self._resolve_vector_result(
+                    result,
+                    options,
+                    normalize_script_score=False,
+                )
+            except Exception as exc:
+                if "Elasticsearch shard failures" in str(exc):
+                    raise
+                logger.warning("[ES search_by_vector] KNN search failed; using script score: %s", exc)
+
+        result = await self._client.search(
+            index=options.indices,
+            from_=0,
+            size=options.top_k,
+            query=build_vector_script_query(query_vector, filters),
+        )
+        return await self._resolve_vector_result(
+            result,
+            options,
+            normalize_script_score=True,
+        )
+
+    async def search_by_full_text(
+        self,
+        query: str,
+        options: RetrievalSearchOptions,
+    ) -> list[DocumentChunk]:
+        result = await self._client.search(
+            index=options.indices,
+            from_=0,
+            size=options.top_k,
+            query=build_full_text_query(
+                query,
+                options.file_names_filter,
+                options.document_ids_include,
+            ),
+        )
+        raise_on_shard_failures(result, "full text search")
+        docs = full_text_hits_to_chunks(result, options.score_threshold)
+        return await self.resolve_parent_chunks(docs, index=options.indices)
+
+    async def resolve_parent_chunks(
+        self,
+        chunks: list[DocumentChunk],
+        index: str,
+    ) -> list[DocumentChunk]:
+        parent_ids = list(
+            {
+                doc.metadata.get("parent_id", "")
+                for doc in chunks
+                if (doc.metadata or {}).get("chunk_type") == "child"
+                and doc.metadata.get("parent_id")
+            }
+        )
+        if not parent_ids:
+            return chunks
+
+        try:
+            result = await self._client.search(
+                index=index,
+                size=len(parent_ids),
+                query=build_parent_lookup_query(parent_ids),
+            )
+        except Exception as exc:
+            logger.warning("Failed to resolve parent chunks: %s", exc)
+            return chunks
+        return merge_parent_chunks(chunks, result.get("hits", {}).get("hits", []))
+
+    async def _resolve_vector_result(
+        self,
+        result: dict[str, Any],
+        options: RetrievalSearchOptions,
+        *,
+        normalize_script_score: bool,
+    ) -> list[DocumentChunk]:
+        raise_on_shard_failures(result, "vector search")
+        docs = vector_hits_to_chunks(
+            result,
+            options.score_threshold,
+            normalize_script_score=normalize_script_score,
+        )
+        return await self.resolve_parent_chunks(docs, index=options.indices)

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import logging
 import os
@@ -10,7 +11,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Any, Protocol
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import httpx
 from botocore.auth import SigV4Auth
@@ -111,9 +112,7 @@ class AsyncRetrievalModelGateway:
             response = await client.embeddings.create(model=embedding.model_name, input=query)
             return _embedding_from_openai_response(response)
         if provider == ModelProvider.OLLAMA.value:
-            client = self._ollama_client(embedding)
-            response = await client.embed(model=embedding.model_name, input=[query])
-            return _embedding_from_ollama_response(response)
+            return await self._embed_with_ollama(embedding, query)
         if provider == ModelProvider.VOLCANO.value:
             client = await self._ark_client(embedding)
             response = await client.multimodal_embeddings.create(
@@ -214,13 +213,11 @@ class AsyncRetrievalModelGateway:
             )
             return _metadata_content_from_openai_response(response)
         if provider == ModelProvider.OLLAMA.value:
-            client = self._ollama_client(model)
-            response = await client.chat(
-                model=model.model_name,
-                messages=provider_messages,
-                options=_ollama_metadata_generation_options(generation_options),
+            return await self._metadata_with_ollama(
+                model,
+                provider_messages,
+                generation_options,
             )
-            return _metadata_content_from_ollama_response(response)
         if provider == ModelProvider.VOLCANO.value:
             client = await self._ark_client(model)
             response = await client.chat.completions.create(
@@ -259,13 +256,36 @@ class AsyncRetrievalModelGateway:
             http_client=await AsyncRetrievalHttpClientProvider.get_client(),
         )
 
-    def _ollama_client(self, model: ModelRuntimeSnapshot) -> Any:
-        from ollama import AsyncClient
-
-        return AsyncClient(
-            host=model.api_base or "http://localhost:11434",
-            timeout=_build_timeout(),
+    async def _embed_with_ollama(self, model: ModelRuntimeSnapshot, query: str) -> list[float]:
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        response = await client.post(
+            _ollama_endpoint(model, "api/embed"),
+            headers=_ollama_headers(),
+            json={"model": model.model_name, "input": [query]},
         )
+        response.raise_for_status()
+        return _embedding_from_ollama_response(response.json())
+
+    async def _metadata_with_ollama(
+        self,
+        model: ModelRuntimeSnapshot,
+        messages: Sequence[dict[str, str]],
+        generation_options: Mapping[str, Any] | None,
+    ) -> str:
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        response = await client.post(
+            _ollama_endpoint(model, "api/chat"),
+            headers=_ollama_headers(),
+            json={
+                "model": model.model_name,
+                "messages": messages,
+                "tools": [],
+                "stream": False,
+                "options": _ollama_metadata_generation_options(generation_options),
+            },
+        )
+        response.raise_for_status()
+        return _metadata_content_from_ollama_response(response.json())
 
     async def _ark_client(self, model: ModelRuntimeSnapshot) -> Any:
         from volcenginesdkarkruntime import AsyncArk
@@ -613,6 +633,43 @@ def normalize_jina_rerank_url(base_url: str | None) -> str:
     if normalized.endswith("/v1"):
         return f"{normalized}/rerank"
     return f"{normalized}/v1/rerank"
+
+
+def _ollama_endpoint(model: ModelRuntimeSnapshot, path: str) -> str:
+    base_url = _normalize_ollama_base_url(model.api_base or "http://localhost:11434")
+    return f"{base_url}/{path.lstrip('/')}"
+
+
+def _normalize_ollama_base_url(base_url: str) -> str:
+    default_port = 11434
+    scheme, _, hostport = base_url.partition("://")
+    if not hostport:
+        scheme, hostport = "http", base_url
+    elif scheme == "http":
+        default_port = 80
+    elif scheme == "https":
+        default_port = 443
+
+    parsed = urlsplit(f"{scheme}://{hostport}")
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or default_port
+    try:
+        if isinstance(ipaddress.ip_address(host), ipaddress.IPv6Address):
+            host = f"[{host}]"
+    except ValueError:
+        pass
+
+    path = parsed.path.strip("/")
+    if path:
+        return f"{scheme}://{host}:{port}/{path}"
+    return f"{scheme}://{host}:{port}"
+
+
+def _ollama_headers() -> dict[str, str]:
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    if api_key := os.getenv("OLLAMA_API_KEY"):
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
 
 
 def _build_timeout() -> httpx.Timeout:

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -148,16 +148,25 @@ class AsyncRetrievalModelGateway:
             )
             return _rerank_fallback(docs, top_k)
 
-    def metadata_llm(self, model: ModelRuntimeSnapshot) -> AsyncMetadataLLM:
+    def metadata_llm(
+        self,
+        model: ModelRuntimeSnapshot,
+        generation_options: Mapping[str, Any] | None = None,
+    ) -> AsyncMetadataLLM:
         """Expose a model snapshot as the async LLM adapter metadata filtering needs."""
 
-        return _GatewayMetadataLLM(gateway=self, model=model)
+        return _GatewayMetadataLLM(
+            gateway=self,
+            model=model,
+            generation_options=generation_options,
+        )
 
     async def generate_metadata_filters(
         self,
         query: str,
         metadata_defs: Mapping[str, Mapping[str, Any]],
         model: ModelRuntimeSnapshot,
+        generation_options: Mapping[str, Any] | None = None,
     ) -> list[Any]:
         """Generate normalized metadata filters through the native async adapter."""
 
@@ -166,10 +175,15 @@ class AsyncRetrievalModelGateway:
         return await MetadataAutoFilterService.generate_filter_groups_async(
             query=query,
             metadata_defs=dict(metadata_defs),
-            llm=self.metadata_llm(model),
+            llm=self.metadata_llm(model, generation_options),
         )
 
-    async def invoke_metadata(self, model: ModelRuntimeSnapshot, messages: Sequence[BaseMessage]) -> str:
+    async def invoke_metadata(
+        self,
+        model: ModelRuntimeSnapshot,
+        messages: Sequence[BaseMessage],
+        generation_options: Mapping[str, Any] | None = None,
+    ) -> str:
         """Generate metadata-filter JSON through a provider-native async client."""
 
         provider = _provider_name(model)
@@ -181,7 +195,7 @@ class AsyncRetrievalModelGateway:
             response = await client.chat.completions.create(
                 model=model.model_name,
                 messages=provider_messages,
-                temperature=0,
+                **_openai_metadata_generation_options(model, generation_options),
             )
             return _metadata_content_from_openai_response(response)
         if provider == ModelProvider.OLLAMA.value:
@@ -189,7 +203,7 @@ class AsyncRetrievalModelGateway:
             response = await client.chat(
                 model=model.model_name,
                 messages=provider_messages,
-                options={"temperature": 0},
+                options=_ollama_metadata_generation_options(generation_options),
             )
             return _metadata_content_from_ollama_response(response)
         if provider == ModelProvider.VOLCANO.value:
@@ -197,11 +211,15 @@ class AsyncRetrievalModelGateway:
             response = await client.chat.completions.create(
                 model=model.model_name,
                 messages=provider_messages,
-                temperature=0,
+                **_openai_metadata_generation_options(model, generation_options),
             )
             return _metadata_content_from_openai_response(response)
         if provider == ModelProvider.DASHSCOPE.value:
-            return await self._metadata_with_dashscope(model, provider_messages)
+            return await self._metadata_with_dashscope(
+                model,
+                provider_messages,
+                generation_options,
+            )
         if provider == ModelProvider.BEDROCK.value:
             raise KnowledgeRetrievalConfigError(
                 "Bedrock metadata filtering requires a native async SDK, which is not installed"
@@ -294,15 +312,16 @@ class AsyncRetrievalModelGateway:
         self,
         model: ModelRuntimeSnapshot,
         messages: list[dict[str, str]],
+        generation_options: Mapping[str, Any] | None = None,
     ) -> str:
         client = await AsyncRetrievalHttpClientProvider.get_client()
         response = await client.post(
             _dashscope_endpoint(model, "services/aigc/text-generation/generation"),
-            headers=_bearer_headers(model.api_key),
+            headers=_metadata_headers(model.api_key, generation_options),
             json={
                 "model": model.model_name,
                 "input": {"messages": messages},
-                "parameters": {"result_format": "message", "temperature": 0},
+                "parameters": _dashscope_metadata_generation_options(generation_options),
             },
         )
         response.raise_for_status()
@@ -324,15 +343,154 @@ class AsyncRetrievalModelGateway:
 class _GatewayMetadataLLM:
     gateway: AsyncRetrievalModelGateway
     model: ModelRuntimeSnapshot
+    generation_options: Mapping[str, Any] | None = None
 
     async def invoke(self, messages: Sequence[BaseMessage]) -> str:
-        return await self.gateway.invoke_metadata(self.model, messages)
+        return await self.gateway.invoke_metadata(
+            self.model,
+            messages,
+            self.generation_options,
+        )
 
 
 @dataclass(frozen=True)
 class _RerankResult:
     index: int
     relevance_score: float
+
+
+def _metadata_generation_values(
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if generation_options is None:
+        return {"temperature": 0}
+    return {
+        key: value
+        for key, value in generation_options.items()
+        if isinstance(key, str) and value is not None
+    }
+
+
+def _openai_metadata_generation_options(
+    model: ModelRuntimeSnapshot,
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    values = _metadata_generation_values(generation_options)
+    allowed = {
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "seed",
+        "frequency_penalty",
+        "presence_penalty",
+        "stop",
+        "response_format",
+    }
+    request_options = {
+        key: value
+        for key, value in values.items()
+        if key in allowed
+    }
+    default_headers = values.get("default_headers")
+    if isinstance(default_headers, Mapping):
+        request_options["extra_headers"] = {
+            str(key): str(value)
+            for key, value in default_headers.items()
+        }
+    _apply_openai_thinking_options(model, values, request_options)
+    return request_options
+
+
+def _apply_openai_thinking_options(
+    model: ModelRuntimeSnapshot,
+    values: Mapping[str, Any],
+    request_options: dict[str, Any],
+) -> None:
+    if "deep_thinking" not in values or "thinking" not in model.capability:
+        return
+
+    enabled = bool(values["deep_thinking"])
+    budget = values.get("thinking_budget_tokens")
+    provider = _provider_name(model)
+    if provider == ModelProvider.VOLCANO.value:
+        request_options["extra_body"] = {"thinking": {"type": "enabled" if enabled else "disabled"}}
+        effort = _reasoning_effort(budget)
+        if enabled and effort is not None:
+            request_options["reasoning_effort"] = effort
+        return
+    if provider == ModelProvider.SPEEDBEAR.value:
+        if not enabled:
+            request_options["reasoning_effort"] = "none"
+            return
+        request_options["reasoning_effort"] = _reasoning_effort(budget) or "minimal"
+        return
+
+    extra_body: dict[str, Any] = {"enable_thinking": enabled}
+    if enabled and budget is not None:
+        extra_body["thinking_budget"] = budget
+    request_options["extra_body"] = extra_body
+
+
+def _ollama_metadata_generation_options(
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    values = _metadata_generation_values(generation_options)
+    options = {
+        key: values[key]
+        for key in ("temperature", "top_p", "top_k", "seed", "stop")
+        if key in values
+    }
+    if "max_tokens" in values:
+        options["num_predict"] = values["max_tokens"]
+    if "repetition_penalty" in values:
+        options["repeat_penalty"] = values["repetition_penalty"]
+    return options
+
+
+def _dashscope_metadata_generation_options(
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    values = _metadata_generation_values(generation_options)
+    options = {"result_format": "message"}
+    for key in (
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "top_k",
+        "seed",
+        "repetition_penalty",
+        "enable_search",
+        "stop",
+    ):
+        if key in values:
+            options[key] = values[key]
+    if "deep_thinking" in values:
+        options["enable_thinking"] = bool(values["deep_thinking"])
+    if values.get("deep_thinking") and "thinking_budget_tokens" in values:
+        options["thinking_budget"] = values["thinking_budget_tokens"]
+    return options
+
+
+def _metadata_headers(
+    api_key: str,
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    headers = _bearer_headers(api_key)
+    values = _metadata_generation_values(generation_options)
+    default_headers = values.get("default_headers")
+    if isinstance(default_headers, Mapping):
+        headers.update({str(key): str(value) for key, value in default_headers.items()})
+    return headers
+
+
+def _reasoning_effort(budget: Any) -> str | None:
+    if not isinstance(budget, int):
+        return None
+    if budget <= 2048:
+        return "low"
+    if budget <= 4096:
+        return "medium"
+    return "high"
 
 
 def normalize_jina_rerank_url(base_url: str | None) -> str:

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -5,15 +5,26 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from io import BytesIO
 from typing import Any, Protocol
+from urllib.parse import quote
 
 import httpx
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from botocore.loaders import create_loader
+from botocore.regions import EndpointResolver
+from langchain_aws.chat_models.bedrock import ChatPromptAdapter
+from langchain_aws.llms.bedrock import LLMInputOutputAdapter
 from langchain_core.messages import BaseMessage
 from openai import AsyncOpenAI
 
 from app.core.config import settings
+from app.core.models.bedrock_model_mapper import normalize_bedrock_model_id
 from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
 from app.core.rag.retrieval.exceptions import KnowledgeRetrievalConfigError
 from app.core.rag.retrieval.models import ModelRuntimeSnapshot
@@ -39,6 +50,11 @@ _JINA_RERANK_PROVIDERS = frozenset(
 _DEFAULT_DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/api/v1"
 _DEFAULT_DASHSCOPE_COMPATIBLE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 _DEFAULT_JINA_RERANK_URL = "https://api.jina.ai/v1/rerank"
+_BEDROCK_ENDPOINT_RESOLVER = EndpointResolver(create_loader().load_data("endpoints"))
+_BEDROCK_RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+_BEDROCK_CROSS_REGION_PREFIXES = frozenset(
+    {"eu", "us", "us-gov", "apac", "sa", "amer", "global", "jp", "au"}
+)
 
 
 class AsyncMetadataLLM(Protocol):
@@ -109,9 +125,7 @@ class AsyncRetrievalModelGateway:
         if provider == ModelProvider.DASHSCOPE.value:
             return await self._embed_with_dashscope(embedding, query)
         if provider == ModelProvider.BEDROCK.value:
-            raise KnowledgeRetrievalConfigError(
-                "Bedrock retrieval embedding requires a native async SDK, which is not installed"
-            )
+            return await self._embed_with_bedrock(embedding, query)
         raise KnowledgeRetrievalConfigError(f"Unsupported retrieval embedding provider: {provider}")
 
     async def rerank(
@@ -222,8 +236,10 @@ class AsyncRetrievalModelGateway:
                 generation_options,
             )
         if provider == ModelProvider.BEDROCK.value:
-            raise KnowledgeRetrievalConfigError(
-                "Bedrock metadata filtering requires a native async SDK, which is not installed"
+            return await self._metadata_with_bedrock(
+                model,
+                messages,
+                generation_options,
             )
         raise KnowledgeRetrievalConfigError(f"Unsupported metadata-filter provider: {provider}")
 
@@ -280,6 +296,24 @@ class AsyncRetrievalModelGateway:
         except (KeyError, IndexError, TypeError) as exc:
             raise KnowledgeRetrievalConfigError("DashScope returned an invalid embedding response") from exc
         return _float_vector(embedding)
+
+    async def _embed_with_bedrock(self, model: ModelRuntimeSnapshot, query: str) -> list[float]:
+        model_id = normalize_bedrock_model_id(model.model_name)
+        provider = _bedrock_provider(model_id)
+        if provider == "cohere":
+            payload = {"input_type": "search_query", "texts": [query]}
+        elif provider == "amazon" and "nova" in model_id and "embed" in model_id:
+            payload = {
+                "taskType": "SINGLE_EMBEDDING",
+                "singleEmbeddingParams": {
+                    "embeddingPurpose": "GENERIC_INDEX",
+                    "text": {"truncationMode": "END", "value": query},
+                },
+            }
+        else:
+            payload = {"inputText": query}
+        response = await self._bedrock_request(model, model_id, "invoke", payload)
+        return _embedding_from_bedrock_response(response)
 
     async def _request_rerank(
         self,
@@ -345,6 +379,68 @@ class AsyncRetrievalModelGateway:
         except (KeyError, IndexError, TypeError) as exc:
             raise KnowledgeRetrievalConfigError("DashScope returned an invalid metadata response") from exc
         return content if isinstance(content, str) else ""
+
+    async def _metadata_with_bedrock(
+        self,
+        model: ModelRuntimeSnapshot,
+        messages: Sequence[BaseMessage],
+        generation_options: Mapping[str, Any] | None = None,
+    ) -> str:
+        model_id = normalize_bedrock_model_id(model.model_name)
+        provider = _bedrock_provider(model_id)
+        response = await self._bedrock_request(
+            model,
+            model_id,
+            "invoke",
+            _bedrock_metadata_payload(provider, model_id, messages, generation_options),
+        )
+        return _metadata_content_from_bedrock_response(provider, response)
+
+    async def _bedrock_request(
+        self,
+        model: ModelRuntimeSnapshot,
+        model_id: str,
+        operation: str,
+        payload: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        credentials = _bedrock_credentials(model.api_key)
+        region = _bedrock_region(model.api_base)
+        endpoint = _bedrock_runtime_endpoint(region)
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        max_retries = _bedrock_max_retries()
+        for attempt in range(max_retries + 1):
+            request = AWSRequest(
+                method="POST",
+                url=f"{endpoint}/model/{quote(model_id, safe=':.')}/{operation}",
+                data=body,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+            )
+            SigV4Auth(credentials, "bedrock", region).add_auth(request)
+            try:
+                response = await client.post(
+                    request.url,
+                    headers=dict(request.headers.items()),
+                    content=body,
+                )
+            except httpx.TransportError:
+                if attempt >= max_retries:
+                    raise
+                await asyncio.sleep(_bedrock_retry_delay(attempt))
+                continue
+            if response.status_code in _BEDROCK_RETRYABLE_STATUS_CODES and attempt < max_retries:
+                await response.aclose()
+                await asyncio.sleep(_bedrock_retry_delay(attempt))
+                continue
+            response.raise_for_status()
+            try:
+                result = response.json()
+            except json.JSONDecodeError as exc:
+                raise KnowledgeRetrievalConfigError("Bedrock returned an invalid JSON response") from exc
+            if not isinstance(result, Mapping):
+                raise KnowledgeRetrievalConfigError("Bedrock returned an invalid response")
+            return result
+        raise RuntimeError("Bedrock native async request exhausted without a response")
 
 
 @dataclass(frozen=True)
@@ -526,6 +622,140 @@ def _build_timeout() -> httpx.Timeout:
 
 def _provider_name(model: ModelRuntimeSnapshot) -> str:
     return model.provider.lower().strip()
+
+
+def _bedrock_provider(model_id: str) -> str:
+    parts = model_id.split(".", 2)
+    if len(parts) > 1 and parts[0].lower() in _BEDROCK_CROSS_REGION_PREFIXES:
+        return parts[1].lower()
+    return parts[0].lower()
+
+
+def _bedrock_credentials(api_key: str) -> Credentials:
+    credentials = api_key.split(":", 2)
+    if len(credentials) < 2 or not credentials[0] or not credentials[1]:
+        raise KnowledgeRetrievalConfigError(
+            "Bedrock native async retrieval requires api_key formatted as "
+            "access_key_id:secret_access_key[:session_token]"
+        )
+    session_token = credentials[2] if len(credentials) == 3 and credentials[2] else None
+    return Credentials(credentials[0], credentials[1], session_token)
+
+
+def _bedrock_region(api_base: str | None) -> str:
+    region = (api_base or "us-east-1").strip()
+    if not region or "://" in region or "/" in region:
+        raise KnowledgeRetrievalConfigError("Bedrock api_base must be an AWS region")
+    return region
+
+
+def _bedrock_max_retries() -> int:
+    try:
+        return max(0, int(os.getenv("BEDROCK_MAX_RETRIES", "2")))
+    except ValueError:
+        return 2
+
+
+def _bedrock_retry_delay(attempt: int) -> float:
+    return min(0.25 * (2**attempt), 2.0)
+
+
+def _bedrock_runtime_endpoint(region: str) -> str:
+    endpoint = _BEDROCK_ENDPOINT_RESOLVER.construct_endpoint(
+        "bedrock-runtime",
+        region,
+    )
+    hostname = endpoint.get("hostname") if endpoint else None
+    if not isinstance(hostname, str) or not hostname:
+        raise KnowledgeRetrievalConfigError(f"Bedrock does not support region={region}")
+    return f"https://{hostname}"
+
+
+def _bedrock_metadata_payload(
+    provider: str,
+    model_id: str,
+    messages: Sequence[BaseMessage],
+    generation_options: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    values = _metadata_generation_values(generation_options)
+    model_kwargs = {
+        key: values[key]
+        for key in ("top_p", "top_k", "seed", "response_format")
+        if key in values
+    }
+    if "stop" in values:
+        model_kwargs["stop_sequences"] = values["stop"]
+    if values.get("deep_thinking"):
+        thinking: dict[str, Any] = {"type": "enabled"}
+        if "thinking_budget_tokens" in values:
+            thinking["budget_tokens"] = values["thinking_budget_tokens"]
+        model_kwargs["thinking"] = thinking
+
+    max_tokens = values.get("max_tokens")
+    temperature = values.get("temperature")
+    normalized_messages = list(messages)
+    prompt: str | None = None
+    system: str | list[dict[str, Any]] | None = None
+    formatted_messages: list[dict[str, Any]] | None = None
+    if provider == "anthropic":
+        formatted = ChatPromptAdapter.format_messages(provider, normalized_messages)
+        if not isinstance(formatted, tuple):
+            raise KnowledgeRetrievalConfigError("Bedrock returned an invalid Anthropic message adapter")
+        system, formatted_messages = formatted
+    elif provider in {"openai", "qwen"}:
+        formatted = ChatPromptAdapter.format_messages(provider, normalized_messages)
+        if not isinstance(formatted, list):
+            raise KnowledgeRetrievalConfigError("Bedrock returned an invalid message adapter")
+        formatted_messages = formatted
+    else:
+        prompt = ChatPromptAdapter.convert_messages_to_prompt(
+            provider,
+            normalized_messages,
+            model_id,
+        )
+
+    try:
+        payload = LLMInputOutputAdapter.prepare_input(
+            provider=provider,
+            model_kwargs=model_kwargs,
+            prompt=prompt,
+            system=system,
+            messages=formatted_messages,
+            max_tokens=max_tokens if isinstance(max_tokens, int) else None,
+            temperature=temperature if isinstance(temperature, (int, float)) else None,
+        )
+    except (NotImplementedError, TypeError, ValueError) as exc:
+        raise KnowledgeRetrievalConfigError(
+            f"Bedrock metadata filtering does not support model provider={provider}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise KnowledgeRetrievalConfigError("Bedrock returned an invalid metadata request adapter")
+    return payload
+
+
+def _embedding_from_bedrock_response(response: Mapping[str, Any]) -> list[float]:
+    try:
+        direct_embedding = response.get("embedding")
+        if direct_embedding is not None:
+            return _float_vector(direct_embedding)
+        embeddings = response.get("embeddings")
+        if isinstance(embeddings, Mapping):
+            return _float_vector(embeddings["float"][0])
+        return _float_vector(embeddings[0]["embedding"] if isinstance(embeddings[0], Mapping) else embeddings[0])
+    except (KeyError, IndexError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("Bedrock returned an invalid embedding response") from exc
+
+
+def _metadata_content_from_bedrock_response(provider: str, response: Mapping[str, Any]) -> str:
+    try:
+        parsed = LLMInputOutputAdapter.prepare_output(
+            provider,
+            {"body": BytesIO(json.dumps(response).encode("utf-8"))},
+        )
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError) as exc:
+        raise KnowledgeRetrievalConfigError("Bedrock returned an invalid metadata response") from exc
+    content = parsed.get("text")
+    return content if isinstance(content, str) else ""
 
 
 def _dashscope_endpoint(model: ModelRuntimeSnapshot, path: str) -> str:

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -633,13 +633,22 @@ def _bedrock_provider(model_id: str) -> str:
 
 def _bedrock_credentials(api_key: str) -> Credentials:
     credentials = api_key.split(":", 2)
-    if len(credentials) < 2 or not credentials[0] or not credentials[1]:
-        raise KnowledgeRetrievalConfigError(
-            "Bedrock native async retrieval requires api_key formatted as "
-            "access_key_id:secret_access_key[:session_token]"
+    if len(credentials) >= 2 and credentials[0] and credentials[1]:
+        session_token = credentials[2] if len(credentials) == 3 and credentials[2] else None
+        return Credentials(credentials[0], credentials[1], session_token)
+
+    access_key_id = api_key or os.getenv("AWS_ACCESS_KEY_ID")
+    secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    if access_key_id and secret_access_key:
+        return Credentials(
+            access_key_id,
+            secret_access_key,
+            os.getenv("AWS_SESSION_TOKEN"),
         )
-    session_token = credentials[2] if len(credentials) == 3 and credentials[2] else None
-    return Credentials(credentials[0], credentials[1], session_token)
+    raise KnowledgeRetrievalConfigError(
+        "Bedrock native async retrieval requires api_key formatted as "
+        "access_key_id:secret_access_key[:session_token] or static AWS environment credentials"
+    )
 
 
 def _bedrock_region(api_base: str | None) -> str:

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -37,6 +37,7 @@ _JINA_RERANK_PROVIDERS = frozenset(
     }
 )
 _DEFAULT_DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/api/v1"
+_DEFAULT_DASHSCOPE_COMPATIBLE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 _DEFAULT_JINA_RERANK_URL = "https://api.jina.ai/v1/rerank"
 
 
@@ -227,9 +228,16 @@ class AsyncRetrievalModelGateway:
         raise KnowledgeRetrievalConfigError(f"Unsupported metadata-filter provider: {provider}")
 
     async def _openai_client(self, model: ModelRuntimeSnapshot) -> AsyncOpenAI:
+        base_url = model.api_base
+        if (
+            _provider_name(model) == ModelProvider.DASHSCOPE.value
+            and model.is_omni
+            and not base_url
+        ):
+            base_url = _DEFAULT_DASHSCOPE_COMPATIBLE_BASE_URL
         return AsyncOpenAI(
             api_key=model.api_key or "not-needed",
-            base_url=model.api_base,
+            base_url=base_url,
             timeout=_build_timeout(),
             max_retries=settings.LLM_MAX_RETRIES,
             http_client=await AsyncRetrievalHttpClientProvider.get_client(),
@@ -391,6 +399,8 @@ def _openai_metadata_generation_options(
         for key, value in values.items()
         if key in allowed
     }
+    if _provider_name(model) == ModelProvider.VOLCANO.value:
+        request_options.pop("seed", None)
     default_headers = values.get("default_headers")
     if isinstance(default_headers, Mapping):
         request_options["extra_headers"] = {
@@ -468,6 +478,9 @@ def _dashscope_metadata_generation_options(
         options["enable_thinking"] = bool(values["deep_thinking"])
     if values.get("deep_thinking") and "thinking_budget_tokens" in values:
         options["thinking_budget"] = values["thinking_budget_tokens"]
+    response_format = values.get("response_format")
+    if isinstance(response_format, Mapping):
+        options["response_format"] = dict(response_format)
     return options
 
 

--- a/api/app/core/rag/retrieval/async_models.py
+++ b/api/app/core/rag/retrieval/async_models.py
@@ -1,0 +1,450 @@
+"""Native asynchronous model adapters used by the retrieval pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import httpx
+from langchain_core.messages import BaseMessage
+from openai import AsyncOpenAI
+
+from app.core.config import settings
+from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
+from app.core.rag.retrieval.exceptions import KnowledgeRetrievalConfigError
+from app.core.rag.retrieval.models import ModelRuntimeSnapshot
+from app.models.models_model import ModelProvider
+
+logger = logging.getLogger(__name__)
+
+_OPENAI_COMPATIBLE_PROVIDERS = frozenset(
+    {
+        ModelProvider.OPENAI.value,
+        ModelProvider.XINFERENCE.value,
+        ModelProvider.GPUSTACK.value,
+        ModelProvider.SPEEDBEAR.value,
+    }
+)
+_JINA_RERANK_PROVIDERS = frozenset(
+    {
+        ModelProvider.XINFERENCE.value,
+        ModelProvider.GPUSTACK.value,
+        ModelProvider.SPEEDBEAR.value,
+    }
+)
+_DEFAULT_DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/api/v1"
+_DEFAULT_JINA_RERANK_URL = "https://api.jina.ai/v1/rerank"
+
+
+class AsyncMetadataLLM(Protocol):
+    """Minimal native-async LLM interface for metadata filtering."""
+
+    async def invoke(self, messages: Sequence[BaseMessage]) -> str:
+        """Return the generated message content."""
+
+
+class AsyncRetrievalHttpClientProvider:
+    """Own the shared async HTTP client used by native retrieval adapters."""
+
+    _client: httpx.AsyncClient | None = None
+    _lock: asyncio.Lock | None = None
+
+    @classmethod
+    async def get_client(cls) -> httpx.AsyncClient:
+        client = cls._client
+        if client is not None and not client.is_closed:
+            return client
+
+        if cls._lock is None:
+            cls._lock = asyncio.Lock()
+        async with cls._lock:
+            client = cls._client
+            if client is None or client.is_closed:
+                timeout = _build_timeout()
+                cls._client = httpx.AsyncClient(
+                    timeout=timeout,
+                    follow_redirects=True,
+                    limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+                )
+            return cls._client
+
+    @classmethod
+    async def aclose(cls) -> None:
+        """Close the process-level client during application shutdown."""
+
+        client = cls._client
+        cls._client = None
+        if client is not None and not client.is_closed:
+            await client.aclose()
+
+
+class AsyncRetrievalModelGateway:
+    """Dispatch retrieval model calls to provider-native asynchronous clients."""
+
+    async def embed_query(self, embedding: ModelRuntimeSnapshot, query: str) -> list[float]:
+        """Embed one retrieval query without a synchronous compatibility fallback."""
+
+        provider = _provider_name(embedding)
+        if provider in _OPENAI_COMPATIBLE_PROVIDERS:
+            client = await self._openai_client(embedding)
+            response = await client.embeddings.create(model=embedding.model_name, input=query)
+            return _embedding_from_openai_response(response)
+        if provider == ModelProvider.OLLAMA.value:
+            client = self._ollama_client(embedding)
+            response = await client.embed(model=embedding.model_name, input=[query])
+            return _embedding_from_ollama_response(response)
+        if provider == ModelProvider.VOLCANO.value:
+            client = await self._ark_client(embedding)
+            response = await client.multimodal_embeddings.create(
+                model=embedding.model_name,
+                input=[{"type": "text", "text": query}],
+                encoding_format="float",
+            )
+            return _embedding_from_volcano_response(response)
+        if provider == ModelProvider.DASHSCOPE.value:
+            return await self._embed_with_dashscope(embedding, query)
+        if provider == ModelProvider.BEDROCK.value:
+            raise KnowledgeRetrievalConfigError(
+                "Bedrock retrieval embedding requires a native async SDK, which is not installed"
+            )
+        raise KnowledgeRetrievalConfigError(f"Unsupported retrieval embedding provider: {provider}")
+
+    async def rerank(
+        self,
+        reranker: ModelRuntimeSnapshot,
+        query: str,
+        docs: Sequence[DocumentChunk],
+        top_k: int,
+    ) -> list[DocumentChunk]:
+        """Rerank documents and retain the legacy degradation behavior on failure."""
+
+        if top_k <= 0 or not docs:
+            return []
+        try:
+            results = await self._request_rerank(reranker, query, docs, top_k)
+            reranked: list[DocumentChunk] = []
+            for result in sorted(results, key=lambda item: item.relevance_score, reverse=True):
+                if not 0 <= result.index < len(docs):
+                    continue
+                document = docs[result.index]
+                if document.metadata is None:
+                    document.metadata = {}
+                document.metadata["score"] = result.relevance_score
+                reranked.append(document)
+                if len(reranked) >= top_k:
+                    break
+            return reranked
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[AsyncRetrieval] rerank failed; using retrieval order provider=%s error_type=%s",
+                _provider_name(reranker),
+                type(exc).__name__,
+            )
+            return _rerank_fallback(docs, top_k)
+
+    def metadata_llm(self, model: ModelRuntimeSnapshot) -> AsyncMetadataLLM:
+        """Expose a model snapshot as the async LLM adapter metadata filtering needs."""
+
+        return _GatewayMetadataLLM(gateway=self, model=model)
+
+    async def generate_metadata_filters(
+        self,
+        query: str,
+        metadata_defs: Mapping[str, Mapping[str, Any]],
+        model: ModelRuntimeSnapshot,
+    ) -> list[Any]:
+        """Generate normalized metadata filters through the native async adapter."""
+
+        from app.services.metadata_auto_filter_service import MetadataAutoFilterService
+
+        return await MetadataAutoFilterService.generate_filter_groups_async(
+            query=query,
+            metadata_defs=dict(metadata_defs),
+            llm=self.metadata_llm(model),
+        )
+
+    async def invoke_metadata(self, model: ModelRuntimeSnapshot, messages: Sequence[BaseMessage]) -> str:
+        """Generate metadata-filter JSON through a provider-native async client."""
+
+        provider = _provider_name(model)
+        provider_messages = _provider_messages(messages)
+        if provider in _OPENAI_COMPATIBLE_PROVIDERS or (
+            provider == ModelProvider.DASHSCOPE.value and model.is_omni
+        ):
+            client = await self._openai_client(model)
+            response = await client.chat.completions.create(
+                model=model.model_name,
+                messages=provider_messages,
+                temperature=0,
+            )
+            return _metadata_content_from_openai_response(response)
+        if provider == ModelProvider.OLLAMA.value:
+            client = self._ollama_client(model)
+            response = await client.chat(
+                model=model.model_name,
+                messages=provider_messages,
+                options={"temperature": 0},
+            )
+            return _metadata_content_from_ollama_response(response)
+        if provider == ModelProvider.VOLCANO.value:
+            client = await self._ark_client(model)
+            response = await client.chat.completions.create(
+                model=model.model_name,
+                messages=provider_messages,
+                temperature=0,
+            )
+            return _metadata_content_from_openai_response(response)
+        if provider == ModelProvider.DASHSCOPE.value:
+            return await self._metadata_with_dashscope(model, provider_messages)
+        if provider == ModelProvider.BEDROCK.value:
+            raise KnowledgeRetrievalConfigError(
+                "Bedrock metadata filtering requires a native async SDK, which is not installed"
+            )
+        raise KnowledgeRetrievalConfigError(f"Unsupported metadata-filter provider: {provider}")
+
+    async def _openai_client(self, model: ModelRuntimeSnapshot) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            api_key=model.api_key or "not-needed",
+            base_url=model.api_base,
+            timeout=_build_timeout(),
+            max_retries=settings.LLM_MAX_RETRIES,
+            http_client=await AsyncRetrievalHttpClientProvider.get_client(),
+        )
+
+    def _ollama_client(self, model: ModelRuntimeSnapshot) -> Any:
+        from ollama import AsyncClient
+
+        return AsyncClient(
+            host=model.api_base or "http://localhost:11434",
+            timeout=_build_timeout(),
+        )
+
+    async def _ark_client(self, model: ModelRuntimeSnapshot) -> Any:
+        from volcenginesdkarkruntime import AsyncArk
+
+        return AsyncArk(
+            api_key=model.api_key,
+            base_url=model.api_base,
+            timeout=_build_timeout(),
+            max_retries=settings.LLM_MAX_RETRIES,
+            http_client=await AsyncRetrievalHttpClientProvider.get_client(),
+        )
+
+    async def _embed_with_dashscope(self, model: ModelRuntimeSnapshot, query: str) -> list[float]:
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        response = await client.post(
+            _dashscope_endpoint(model, "services/embeddings/text-embedding/text-embedding"),
+            headers=_bearer_headers(model.api_key),
+            json={
+                "model": model.model_name,
+                "input": {"texts": [query]},
+                "parameters": {"text_type": "query"},
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        try:
+            embedding = payload["output"]["embeddings"][0]["embedding"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise KnowledgeRetrievalConfigError("DashScope returned an invalid embedding response") from exc
+        return _float_vector(embedding)
+
+    async def _request_rerank(
+        self,
+        reranker: ModelRuntimeSnapshot,
+        query: str,
+        docs: Sequence[DocumentChunk],
+        top_k: int,
+    ) -> list["_RerankResult"]:
+        provider = _provider_name(reranker)
+        documents = [chunk_retrieval_content(doc) for doc in docs]
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        if provider in _JINA_RERANK_PROVIDERS:
+            response = await client.post(
+                normalize_jina_rerank_url(reranker.api_base),
+                headers=_bearer_headers(reranker.api_key),
+                json={"model": reranker.model_name, "query": query, "documents": documents, "top_n": top_k},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            return _parse_rerank_results(payload.get("results"))
+        if provider == ModelProvider.DASHSCOPE.value:
+            response = await client.post(
+                _dashscope_endpoint(reranker, "services/rerank/text-rerank/text-rerank"),
+                headers=_bearer_headers(reranker.api_key),
+                json={
+                    "model": reranker.model_name,
+                    "input": {"query": query, "documents": documents},
+                    "parameters": {"top_n": top_k, "return_documents": False},
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            output = payload.get("output") if isinstance(payload, dict) else None
+            return _parse_rerank_results(output.get("results") if isinstance(output, dict) else None)
+        raise KnowledgeRetrievalConfigError(f"Unsupported retrieval rerank provider: {provider}")
+
+    async def _metadata_with_dashscope(
+        self,
+        model: ModelRuntimeSnapshot,
+        messages: list[dict[str, str]],
+    ) -> str:
+        client = await AsyncRetrievalHttpClientProvider.get_client()
+        response = await client.post(
+            _dashscope_endpoint(model, "services/aigc/text-generation/generation"),
+            headers=_bearer_headers(model.api_key),
+            json={
+                "model": model.model_name,
+                "input": {"messages": messages},
+                "parameters": {"result_format": "message", "temperature": 0},
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        try:
+            output = payload["output"]
+            choices = output.get("choices") if isinstance(output, dict) else None
+            if isinstance(choices, list) and choices:
+                message = choices[0].get("message", {})
+                content = message.get("content") if isinstance(message, dict) else None
+            else:
+                content = output.get("text") if isinstance(output, dict) else None
+        except (KeyError, IndexError, TypeError) as exc:
+            raise KnowledgeRetrievalConfigError("DashScope returned an invalid metadata response") from exc
+        return content if isinstance(content, str) else ""
+
+
+@dataclass(frozen=True)
+class _GatewayMetadataLLM:
+    gateway: AsyncRetrievalModelGateway
+    model: ModelRuntimeSnapshot
+
+    async def invoke(self, messages: Sequence[BaseMessage]) -> str:
+        return await self.gateway.invoke_metadata(self.model, messages)
+
+
+@dataclass(frozen=True)
+class _RerankResult:
+    index: int
+    relevance_score: float
+
+
+def normalize_jina_rerank_url(base_url: str | None) -> str:
+    """Return a request-local Jina-compatible rerank endpoint."""
+
+    if not base_url:
+        return _DEFAULT_JINA_RERANK_URL
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/v1/rerank"):
+        return normalized
+    if normalized.endswith("/v1"):
+        return f"{normalized}/rerank"
+    return f"{normalized}/v1/rerank"
+
+
+def _build_timeout() -> httpx.Timeout:
+    timeout = float(settings.LLM_TIMEOUT)
+    return httpx.Timeout(timeout=timeout, connect=min(timeout, 60.0))
+
+
+def _provider_name(model: ModelRuntimeSnapshot) -> str:
+    return model.provider.lower().strip()
+
+
+def _dashscope_endpoint(model: ModelRuntimeSnapshot, path: str) -> str:
+    base_url = (model.api_base or _DEFAULT_DASHSCOPE_BASE_URL).rstrip("/")
+    return f"{base_url}/{path.lstrip('/')}"
+
+
+def _bearer_headers(api_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+
+def _float_vector(value: Any) -> list[float]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise KnowledgeRetrievalConfigError("Embedding provider returned an invalid vector")
+    try:
+        return [float(item) for item in value]
+    except (TypeError, ValueError) as exc:
+        raise KnowledgeRetrievalConfigError("Embedding provider returned an invalid vector") from exc
+
+
+def _embedding_from_openai_response(response: Any) -> list[float]:
+    try:
+        return _float_vector(response.data[0].embedding)
+    except (AttributeError, IndexError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("OpenAI-compatible provider returned an invalid embedding response") from exc
+
+
+def _embedding_from_ollama_response(response: Any) -> list[float]:
+    try:
+        embeddings = response["embeddings"] if isinstance(response, Mapping) else response.embeddings
+        return _float_vector(embeddings[0])
+    except (AttributeError, KeyError, IndexError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("Ollama returned an invalid embedding response") from exc
+
+
+def _embedding_from_volcano_response(response: Any) -> list[float]:
+    try:
+        return _float_vector(response.data.embedding)
+    except (AttributeError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("Volcano returned an invalid embedding response") from exc
+
+
+def _parse_rerank_results(value: Any) -> list[_RerankResult]:
+    if not isinstance(value, list):
+        raise KnowledgeRetrievalConfigError("Rerank provider returned an invalid response")
+    parsed: list[_RerankResult] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            parsed.append(
+                _RerankResult(index=int(item["index"]), relevance_score=float(item["relevance_score"]))
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return parsed
+
+
+def _rerank_fallback(docs: Sequence[DocumentChunk], top_k: int) -> list[DocumentChunk]:
+    fallback = list(docs[:top_k])
+    for document in fallback:
+        if document.metadata is None:
+            document.metadata = {}
+        document.metadata.setdefault("score", 0.5)
+    return fallback
+
+
+def _provider_messages(messages: Sequence[BaseMessage]) -> list[dict[str, str]]:
+    role_mapping = {"human": "user", "ai": "assistant", "system": "system"}
+    converted: list[dict[str, str]] = []
+    for message in messages:
+        content = message.content
+        if not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False)
+        converted.append({"role": role_mapping.get(message.type, "user"), "content": content})
+    return converted
+
+
+def _metadata_content_from_openai_response(response: Any) -> str:
+    try:
+        content = response.choices[0].message.content
+    except (AttributeError, IndexError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("OpenAI-compatible provider returned an invalid metadata response") from exc
+    return content if isinstance(content, str) else ""
+
+
+def _metadata_content_from_ollama_response(response: Any) -> str:
+    try:
+        message = response["message"] if isinstance(response, Mapping) else response.message
+        content = message["content"] if isinstance(message, Mapping) else message.content
+    except (AttributeError, KeyError, TypeError) as exc:
+        raise KnowledgeRetrievalConfigError("Ollama returned an invalid metadata response") from exc
+    return content if isinstance(content, str) else ""

--- a/api/app/core/rag/retrieval/elasticsearch_queries.py
+++ b/api/app/core/rag/retrieval/elasticsearch_queries.py
@@ -1,0 +1,271 @@
+import logging
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.vdb.field import Field
+
+
+logger = logging.getLogger(__name__)
+
+VECTOR_SEARCH_MODE_ENV = "ELASTICSEARCH_VECTOR_SEARCH_MODE"
+VECTOR_SEARCH_MODE_KNN = "knn"
+VECTOR_SEARCH_MODE_SCRIPT_SCORE = "script_score"
+
+
+def normalize_vector(vector: Any) -> list[float]:
+    if hasattr(vector, "tolist"):
+        return vector.tolist()
+    return list(vector)
+
+
+def _build_filter_clauses(
+    file_names_filter: Sequence[str] | None,
+    document_ids_include: Sequence[str] | None,
+    *,
+    require_vector: bool,
+) -> list[dict[str, Any]]:
+    filters: list[dict[str, Any]] = [{"term": {"metadata.status": 1}}]
+    if require_vector:
+        filters.append({"exists": {"field": Field.VECTOR.value}})
+    if file_names_filter:
+        filters.append({"terms": {"metadata.file_name": list(file_names_filter)}})
+    if document_ids_include:
+        filters.append({"terms": {Field.DOCUMENT_ID.value: list(document_ids_include)}})
+    return filters
+
+
+def build_vector_filter_clauses(
+    file_names_filter: Sequence[str] | None,
+    document_ids_include: Sequence[str] | None,
+) -> list[dict[str, Any]]:
+    return _build_filter_clauses(
+        file_names_filter,
+        document_ids_include,
+        require_vector=True,
+    )
+
+
+def build_full_text_query(
+    query: str,
+    file_names_filter: Sequence[str] | None,
+    document_ids_include: Sequence[str] | None,
+) -> dict[str, Any]:
+    return {
+        "bool": {
+            "must": {
+                "multi_match": {
+                    "query": query,
+                    "fields": [Field.CONTENT_KEY.value, Field.VISION_TEXT.value],
+                    "analyzer": "ik_max_word",
+                }
+            },
+            "filter": _build_filter_clauses(
+                file_names_filter,
+                document_ids_include,
+                require_vector=False,
+            ),
+        }
+    }
+
+
+def resolve_knn_num_candidates(top_k: int, configured: Any = None) -> int:
+    raw_value = configured if configured is not None else os.getenv("ELASTICSEARCH_KNN_NUM_CANDIDATES")
+    if raw_value is not None:
+        try:
+            return max(int(raw_value), top_k)
+        except (TypeError, ValueError):
+            logger.warning("Invalid ELASTICSEARCH_KNN_NUM_CANDIDATES value: %s", raw_value)
+    return max(top_k * 10, 100)
+
+
+def resolve_vector_search_mode() -> str:
+    raw_value = os.getenv(VECTOR_SEARCH_MODE_ENV, VECTOR_SEARCH_MODE_SCRIPT_SCORE)
+    mode = raw_value.strip().lower()
+    if mode == VECTOR_SEARCH_MODE_KNN:
+        return VECTOR_SEARCH_MODE_KNN
+    if mode in ("", VECTOR_SEARCH_MODE_SCRIPT_SCORE):
+        return VECTOR_SEARCH_MODE_SCRIPT_SCORE
+
+    logger.warning("Invalid %s value: %s, using script_score", VECTOR_SEARCH_MODE_ENV, raw_value)
+    return VECTOR_SEARCH_MODE_SCRIPT_SCORE
+
+
+def build_vector_script_query(
+    query_vector: Sequence[float],
+    filters: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "bool": {
+            "must": {
+                "script_score": {
+                    "query": {"match_all": {}},
+                    "script": {
+                        "source": f"cosineSimilarity(params.query_vector, '{Field.VECTOR.value}') + 1.0",
+                        "params": {"query_vector": list(query_vector)},
+                    },
+                }
+            },
+            "filter": list(filters),
+        }
+    }
+
+
+def build_knn_query(
+    query_vector: Sequence[float],
+    top_k: int,
+    filters: Sequence[dict[str, Any]],
+    knn_num_candidates: Any = None,
+) -> dict[str, Any]:
+    return {
+        "field": Field.VECTOR.value,
+        "query_vector": list(query_vector),
+        "k": top_k,
+        "num_candidates": resolve_knn_num_candidates(top_k, knn_num_candidates),
+        "filter": list(filters),
+    }
+
+
+def raise_on_shard_failures(result: Mapping[str, Any], context: str) -> None:
+    shards = result.get("_shards") or {}
+    failed = int(shards.get("failed") or 0)
+    if failed <= 0:
+        return
+
+    failures = shards.get("failures") or []
+    failure_summary = []
+    for failure in failures[:3]:
+        index = failure.get("index")
+        reason = failure.get("reason") or {}
+        reason_type = reason.get("type")
+        reason_text = reason.get("reason")
+        failure_summary.append(f"index={index}, type={reason_type}, reason={reason_text}")
+    raise ValueError(
+        f"Elasticsearch shard failures during {context}: failed={failed}, "
+        f"failures={failure_summary}"
+    )
+
+
+def vector_hits_to_chunks(
+    result: Mapping[str, Any],
+    score_threshold: float | None,
+    *,
+    normalize_script_score: bool,
+) -> list[DocumentChunk]:
+    if "errors" in result:
+        raise ValueError(f"Error during query: {result['errors']}")
+
+    docs: list[DocumentChunk] = []
+    for hit in result["hits"]["hits"]:
+        source = hit["_source"]
+        page_content = source.get(Field.CONTENT_KEY.value)
+        metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        chunk_type = source.get(Field.CHUNK_TYPE.value)
+        score = hit["_score"] / 2 if normalize_script_score else hit["_score"]
+
+        if chunk_type == "qa":
+            question = source.get(Field.QUESTION.value, "")
+            answer = source.get(Field.ANSWER.value, "")
+            page_content = f"question: {question}\nanswer: {answer}"
+            metadata["chunk_type"] = "qa"
+            metadata["question"] = question
+            metadata["answer"] = answer
+
+        if score_threshold is None or score > score_threshold:
+            metadata["score"] = score
+            docs.append(DocumentChunk(page_content=page_content, metadata=metadata))
+    return docs
+
+
+def full_text_hits_to_chunks(
+    result: Mapping[str, Any],
+    score_threshold: float | None,
+) -> list[DocumentChunk]:
+    if "errors" in result:
+        raise ValueError(f"Error during query: {result['errors']}")
+
+    hits = result["hits"]
+    max_score = hits["max_score"] or 1.0
+    docs: list[DocumentChunk] = []
+    for hit in hits["hits"]:
+        source = hit["_source"]
+        page_content = source.get(Field.CONTENT_KEY.value)
+        metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        chunk_type = source.get(Field.CHUNK_TYPE.value)
+
+        if chunk_type == "qa":
+            question = source.get(Field.QUESTION.value, "")
+            answer = source.get(Field.ANSWER.value, "")
+            page_content = f"question: {question}\nanswer: {answer}"
+            metadata["chunk_type"] = "qa"
+            metadata["question"] = question
+            metadata["answer"] = answer
+
+        normalized_score = hit["_score"] / max_score
+        if score_threshold is None or normalized_score > score_threshold:
+            metadata["score"] = normalized_score
+            docs.append(DocumentChunk(page_content=page_content, metadata=metadata))
+    return docs
+
+
+def build_parent_lookup_query(parent_ids: Sequence[str]) -> dict[str, Any]:
+    return {
+        "bool": {
+            "must": [
+                {"terms": {Field.DOC_ID.value: list(parent_ids)}},
+            ]
+        }
+    }
+
+
+def merge_parent_chunks(
+    chunks: list[DocumentChunk],
+    parent_hits: Sequence[Mapping[str, Any]],
+) -> list[DocumentChunk]:
+    child_results = []
+    other_results = []
+    for doc in chunks:
+        if (doc.metadata or {}).get("chunk_type") == "child":
+            child_results.append(doc)
+        else:
+            other_results.append(doc)
+
+    if not child_results:
+        return chunks
+    if not any(doc.metadata.get("parent_id") for doc in child_results):
+        return chunks
+
+    parent_map: dict[str, DocumentChunk] = {}
+    for hit in parent_hits:
+        source = hit["_source"]
+        metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        parent_doc_id = metadata.get("doc_id", "")
+        parent_map[parent_doc_id] = DocumentChunk(
+            page_content=source.get(Field.CONTENT_KEY.value, ""),
+            metadata=metadata,
+        )
+
+    seen_parents: dict[str, DocumentChunk] = {}
+    for doc in child_results:
+        parent_id = doc.metadata.get("parent_id", "")
+        if parent_id in seen_parents:
+            existing = seen_parents[parent_id]
+            if doc.metadata.get("score", 0) > existing.metadata.get("score", 0):
+                seen_parents[parent_id] = DocumentChunk(
+                    page_content=existing.page_content,
+                    metadata={**existing.metadata, "score": doc.metadata.get("score", 0)},
+                )
+            continue
+
+        parent = parent_map.get(parent_id)
+        if parent:
+            score = doc.metadata.get("score", 0)
+            seen_parents[parent_id] = DocumentChunk(
+                page_content=parent.page_content,
+                metadata={**parent.metadata, "score": score, "chunk_type": "parent"},
+            )
+        else:
+            seen_parents[parent_id] = doc
+
+    return list(seen_parents.values()) + other_results

--- a/api/app/core/rag/retrieval/exceptions.py
+++ b/api/app/core/rag/retrieval/exceptions.py
@@ -1,0 +1,2 @@
+class KnowledgeRetrievalConfigError(Exception):
+    """Raised when retrieval preparation cannot resolve required configuration."""

--- a/api/app/core/rag/retrieval/graph_bridge.py
+++ b/api/app/core/rag/retrieval/graph_bridge.py
@@ -1,0 +1,104 @@
+import asyncio
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import ClassVar
+
+from app.core.config import settings
+from app.core.rag.llm.chat_model import Base
+from app.core.rag.llm.embedding_model import OpenAIEmbed
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.models import GraphRetrievalSnapshot, ModelRuntimeSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class GraphRetrievalBridge:
+    _executor: ClassVar[ThreadPoolExecutor | None] = None
+    _semaphore: ClassVar[asyncio.Semaphore | None] = None
+
+    @classmethod
+    def _get_executor(cls) -> ThreadPoolExecutor:
+        if cls._executor is None:
+            cls._executor = ThreadPoolExecutor(
+                max_workers=settings.KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY,
+                thread_name_prefix="knowledge-graph-retrieval",
+            )
+        return cls._executor
+
+    @classmethod
+    def _get_semaphore(cls) -> asyncio.Semaphore:
+        if cls._semaphore is None:
+            cls._semaphore = asyncio.Semaphore(settings.KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY)
+        return cls._semaphore
+
+    @classmethod
+    async def retrieve(cls, snapshot: GraphRetrievalSnapshot) -> DocumentChunk | None:
+        if not isinstance(snapshot, GraphRetrievalSnapshot):
+            raise TypeError("GraphRetrievalBridge requires a GraphRetrievalSnapshot")
+
+        started_at = time.perf_counter()
+        async with cls._get_semaphore():
+            loop = asyncio.get_running_loop()
+            future = loop.run_in_executor(cls._get_executor(), cls._retrieve_sync, snapshot)
+            try:
+                document = await future
+            except asyncio.CancelledError:
+                logger.info(
+                    "[Retrieval] graph_cancelled graph_async_mode=thread_bridge "
+                    "wait_ms=%s running_worker_not_stopped=true",
+                    cls._elapsed_ms(started_at),
+                )
+                raise
+
+        logger.info(
+            "[Retrieval] graph_done graph_async_mode=thread_bridge graph_ms=%s",
+            cls._elapsed_ms(started_at),
+        )
+        return document
+
+    @staticmethod
+    def _retrieve_sync(snapshot: GraphRetrievalSnapshot) -> DocumentChunk | None:
+        from app.core.rag.common.settings import kg_retriever
+
+        document = kg_retriever.retrieval(
+            question=snapshot.query,
+            workspace_ids=list(snapshot.workspace_ids),
+            kb_ids=list(snapshot.knowledge_ids),
+            emb_mdl=GraphRetrievalBridge._build_embedding_model(snapshot.embedding),
+            llm=GraphRetrievalBridge._build_chat_model(snapshot.llm),
+        )
+        if not document or not str(document.get("page_content", "")).strip():
+            return None
+
+        return DocumentChunk(
+            page_content=document.get("page_content", ""),
+            metadata=dict(document.get("metadata") or {}),
+        )
+
+    @staticmethod
+    def _build_chat_model(snapshot: ModelRuntimeSnapshot) -> Base:
+        return Base(
+            key=snapshot.api_key,
+            model_name=snapshot.model_name,
+            base_url=snapshot.api_base,
+        )
+
+    @staticmethod
+    def _build_embedding_model(snapshot: ModelRuntimeSnapshot) -> OpenAIEmbed:
+        return OpenAIEmbed(
+            key=snapshot.api_key,
+            model_name=snapshot.model_name,
+            base_url=snapshot.api_base,
+        )
+
+    @classmethod
+    def shutdown(cls) -> None:
+        if cls._executor is not None:
+            cls._executor.shutdown(wait=False, cancel_futures=False)
+            cls._executor = None
+        cls._semaphore = None
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return max(0, int((time.perf_counter() - started_at) * 1000))

--- a/api/app/core/rag/retrieval/graph_bridge.py
+++ b/api/app/core/rag/retrieval/graph_bridge.py
@@ -8,7 +8,11 @@ from app.core.config import settings
 from app.core.rag.llm.chat_model import Base
 from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.models.chunk import DocumentChunk
-from app.core.rag.retrieval.models import GraphRetrievalSnapshot, ModelRuntimeSnapshot
+from app.core.rag.retrieval.models import (
+    GraphRetrievalSnapshot,
+    ModelRuntimeSnapshot,
+    RetrievalTimings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,13 +37,21 @@ class GraphRetrievalBridge:
         return cls._semaphore
 
     @classmethod
-    async def retrieve(cls, snapshot: GraphRetrievalSnapshot) -> DocumentChunk | None:
+    async def retrieve(
+        cls,
+        snapshot: GraphRetrievalSnapshot,
+        timings: RetrievalTimings | None = None,
+    ) -> DocumentChunk | None:
         if not isinstance(snapshot, GraphRetrievalSnapshot):
             raise TypeError("GraphRetrievalBridge requires a GraphRetrievalSnapshot")
 
-        started_at = time.perf_counter()
+        wait_started_at = time.perf_counter()
         semaphore = cls._get_semaphore()
         await semaphore.acquire()
+        wait_ms = cls._elapsed_ms(wait_started_at)
+        if timings is not None:
+            timings.graph_wait_ms += wait_ms
+        graph_started_at = time.perf_counter()
         try:
             loop = asyncio.get_running_loop()
             future = loop.run_in_executor(cls._get_executor(), cls._retrieve_sync, snapshot)
@@ -54,13 +66,17 @@ class GraphRetrievalBridge:
             logger.info(
                 "[Retrieval] graph_cancelled graph_async_mode=thread_bridge "
                 "wait_ms=%s running_worker_not_stopped=true capacity_release=worker_done",
-                cls._elapsed_ms(started_at),
+                wait_ms,
             )
             raise
 
+        graph_ms = cls._elapsed_ms(graph_started_at)
+        if timings is not None:
+            timings.graph_ms += graph_ms
         logger.info(
-            "[Retrieval] graph_done graph_async_mode=thread_bridge graph_ms=%s",
-            cls._elapsed_ms(started_at),
+            "[Retrieval] graph_done graph_async_mode=thread_bridge graph_wait_ms=%s graph_ms=%s",
+            wait_ms,
+            graph_ms,
         )
         return document
 

--- a/api/app/core/rag/retrieval/graph_bridge.py
+++ b/api/app/core/rag/retrieval/graph_bridge.py
@@ -38,18 +38,25 @@ class GraphRetrievalBridge:
             raise TypeError("GraphRetrievalBridge requires a GraphRetrievalSnapshot")
 
         started_at = time.perf_counter()
-        async with cls._get_semaphore():
+        semaphore = cls._get_semaphore()
+        await semaphore.acquire()
+        try:
             loop = asyncio.get_running_loop()
             future = loop.run_in_executor(cls._get_executor(), cls._retrieve_sync, snapshot)
-            try:
-                document = await future
-            except asyncio.CancelledError:
-                logger.info(
-                    "[Retrieval] graph_cancelled graph_async_mode=thread_bridge "
-                    "wait_ms=%s running_worker_not_stopped=true",
-                    cls._elapsed_ms(started_at),
-                )
-                raise
+        except BaseException:
+            semaphore.release()
+            raise
+
+        future.add_done_callback(lambda _future: semaphore.release())
+        try:
+            document = await asyncio.shield(future)
+        except asyncio.CancelledError:
+            logger.info(
+                "[Retrieval] graph_cancelled graph_async_mode=thread_bridge "
+                "wait_ms=%s running_worker_not_stopped=true capacity_release=worker_done",
+                cls._elapsed_ms(started_at),
+            )
+            raise
 
         logger.info(
             "[Retrieval] graph_done graph_async_mode=thread_bridge graph_ms=%s",

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -110,7 +110,11 @@ class ModelRuntimeSnapshot:
     model_type: str | None = None
 
     @classmethod
-    def from_api_key(cls, api_key: Any) -> "ModelRuntimeSnapshot":
+    def from_api_key(
+        cls,
+        api_key: Any,
+        model_type: str | None = None,
+    ) -> "ModelRuntimeSnapshot":
         return cls(
             model_name=api_key.model_name,
             provider=api_key.provider,
@@ -118,7 +122,7 @@ class ModelRuntimeSnapshot:
             api_base=api_key.api_base,
             capability=tuple(api_key.capability or ()),
             is_omni=bool(api_key.is_omni),
-            model_type=getattr(api_key, "model_type", None),
+            model_type=model_type if model_type is not None else getattr(api_key, "model_type", None),
         )
 
 
@@ -192,6 +196,7 @@ class RetrievalPreparation:
     common_metadata_defs: FrozenMetadataDefinitions
     metadata_llm: ModelRuntimeSnapshot | None
     graph: GraphRetrievalSnapshot | None
+    request_reranker: ModelRuntimeSnapshot | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -1,8 +1,7 @@
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
-from typing import Any, TypeAlias
+from typing import Any, NoReturn, TypeAlias
 
 from app.schemas.chunk_schema import RetrieveType
 
@@ -17,6 +16,42 @@ FrozenMetadataValue: TypeAlias = (
 FrozenMetadataFieldDefinition: TypeAlias = Mapping[str, FrozenMetadataValue]
 FrozenMetadataDefinitions: TypeAlias = Mapping[str, FrozenMetadataFieldDefinition]
 FrozenMetadataDefinitionsByKnowledge: TypeAlias = Mapping[uuid.UUID, FrozenMetadataDefinitions]
+
+
+class FrozenMetadataMapping(dict[object, object]):
+    __slots__ = ()
+
+    def __new__(cls, *args: object, **kwargs: object) -> "FrozenMetadataMapping":
+        mapping = dict.__new__(cls)
+        dict.__init__(mapping, *args, **kwargs)
+        return mapping
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        self._reject_mutation()
+
+    def __delattr__(self, name: str) -> NoReturn:
+        self._reject_mutation()
+
+    def _reject_mutation(self, *args: object, **kwargs: object) -> NoReturn:
+        raise TypeError("Frozen metadata mappings cannot be mutated")
+
+    __setitem__ = _reject_mutation
+    __delitem__ = _reject_mutation
+    clear = _reject_mutation
+    pop = _reject_mutation
+    popitem = _reject_mutation
+    setdefault = _reject_mutation
+    update = _reject_mutation
+    __ior__ = _reject_mutation
+
+    def __reduce__(self) -> tuple[type["FrozenMetadataMapping"], tuple[dict[object, object]]]:
+        return type(self), (dict(self),)
+
+    def __reduce_ex__(self, protocol: int) -> tuple[type["FrozenMetadataMapping"], tuple[dict[object, object]]]:
+        return self.__reduce__()
 
 
 def _freeze_metadata_value(value: object) -> FrozenMetadataValue:
@@ -37,7 +72,7 @@ def _freeze_metadata_mapping(value: Mapping[object, object]) -> FrozenMetadataFi
         if not isinstance(key, str):
             raise TypeError("Metadata mapping keys must be strings")
         frozen[key] = _freeze_metadata_value(nested_value)
-    return MappingProxyType(frozen)
+    return FrozenMetadataMapping(frozen)
 
 
 def _freeze_metadata_definitions(value: Mapping[object, object]) -> FrozenMetadataDefinitions:
@@ -48,7 +83,7 @@ def _freeze_metadata_definitions(value: Mapping[object, object]) -> FrozenMetada
         if not isinstance(field_definition, Mapping):
             raise TypeError("Metadata field definitions must be mappings")
         frozen[field_name] = _freeze_metadata_mapping(field_definition)
-    return MappingProxyType(frozen)
+    return FrozenMetadataMapping(frozen)
 
 
 def _freeze_metadata_definitions_by_knowledge(
@@ -61,7 +96,7 @@ def _freeze_metadata_definitions_by_knowledge(
         if not isinstance(field_definitions, Mapping):
             raise TypeError("Knowledge metadata definitions must be mappings")
         frozen[knowledge_id] = _freeze_metadata_definitions(field_definitions)
-    return MappingProxyType(frozen)
+    return FrozenMetadataMapping(frozen)
 
 
 @dataclass(frozen=True)

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -1,0 +1,101 @@
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.schemas.chunk_schema import RetrieveType
+
+
+@dataclass(frozen=True)
+class ModelRuntimeSnapshot:
+    model_name: str
+    provider: str
+    api_key: str = field(repr=False)
+    api_base: str | None = None
+    capability: tuple[str, ...] = ()
+    is_omni: bool = False
+    model_type: str | None = None
+
+    @classmethod
+    def from_api_key(cls, api_key: Any) -> "ModelRuntimeSnapshot":
+        return cls(
+            model_name=api_key.model_name,
+            provider=api_key.provider,
+            api_key=api_key.api_key,
+            api_base=api_key.api_base,
+            capability=tuple(api_key.capability or ()),
+            is_omni=bool(api_key.is_omni),
+            model_type=getattr(api_key, "model_type", None),
+        )
+
+
+@dataclass(frozen=True)
+class RetrievalPrincipal:
+    id: uuid.UUID | None
+    username: str | None
+    tenant_id: uuid.UUID | None
+    current_workspace_id: uuid.UUID | None
+    is_superuser: bool
+
+    @classmethod
+    def from_user(cls, user: Any) -> "RetrievalPrincipal | None":
+        if user is None:
+            return None
+        if isinstance(user, cls):
+            return user
+        return cls(
+            id=getattr(user, "id", None),
+            username=getattr(user, "username", None),
+            tenant_id=getattr(user, "tenant_id", None),
+            current_workspace_id=getattr(user, "current_workspace_id", None),
+            is_superuser=bool(getattr(user, "is_superuser", False)),
+        )
+
+
+@dataclass(frozen=True)
+class RetrievalParams:
+    similarity_threshold: float
+    vector_similarity_weight: float | None
+    top_k: int
+    top_n: int
+    retrieve_type: RetrieveType
+    rerank_score_threshold: float = 0.1
+
+
+@dataclass(frozen=True)
+class RetrievalTarget:
+    knowledge_id: uuid.UUID
+    workspace_id: uuid.UUID
+    index_name: str
+    params: RetrievalParams
+    embedding: ModelRuntimeSnapshot
+    reranker: ModelRuntimeSnapshot | None
+
+
+@dataclass(frozen=True)
+class RetrievalSearchOptions:
+    indices: str
+    top_k: int
+    score_threshold: float | None
+    file_names_filter: tuple[str, ...]
+    document_ids_include: tuple[str, ...] | None
+    knn_num_candidates: int | None
+
+
+@dataclass(frozen=True)
+class GraphRetrievalSnapshot:
+    query: str
+    workspace_ids: tuple[str, ...]
+    knowledge_ids: tuple[str, ...]
+    llm: ModelRuntimeSnapshot
+    embedding: ModelRuntimeSnapshot
+
+
+@dataclass(frozen=True)
+class RetrievalPreparation:
+    targets: tuple[RetrievalTarget, ...]
+    tenant_id: uuid.UUID | None
+    metadata_defs_by_kb: Mapping[uuid.UUID, Mapping[str, dict[str, Any]]]
+    common_metadata_defs: Mapping[str, dict[str, Any]]
+    metadata_llm: ModelRuntimeSnapshot | None
+    graph: GraphRetrievalSnapshot | None

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -1,9 +1,67 @@
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from types import MappingProxyType
+from typing import Any, TypeAlias
 
 from app.schemas.chunk_schema import RetrieveType
+
+
+MetadataScalar: TypeAlias = str | bytes | int | float | bool | None | uuid.UUID
+FrozenMetadataValue: TypeAlias = (
+    MetadataScalar
+    | tuple["FrozenMetadataValue", ...]
+    | frozenset["FrozenMetadataValue"]
+    | Mapping[str, "FrozenMetadataValue"]
+)
+FrozenMetadataFieldDefinition: TypeAlias = Mapping[str, FrozenMetadataValue]
+FrozenMetadataDefinitions: TypeAlias = Mapping[str, FrozenMetadataFieldDefinition]
+FrozenMetadataDefinitionsByKnowledge: TypeAlias = Mapping[uuid.UUID, FrozenMetadataDefinitions]
+
+
+def _freeze_metadata_value(value: object) -> FrozenMetadataValue:
+    if isinstance(value, Mapping):
+        return _freeze_metadata_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_metadata_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_metadata_value(item) for item in value)
+    if value is None or isinstance(value, (str, bytes, int, float, uuid.UUID)):
+        return value
+    raise TypeError(f"Unsupported metadata snapshot value: {type(value).__name__}")
+
+
+def _freeze_metadata_mapping(value: Mapping[object, object]) -> FrozenMetadataFieldDefinition:
+    frozen: dict[str, FrozenMetadataValue] = {}
+    for key, nested_value in value.items():
+        if not isinstance(key, str):
+            raise TypeError("Metadata mapping keys must be strings")
+        frozen[key] = _freeze_metadata_value(nested_value)
+    return MappingProxyType(frozen)
+
+
+def _freeze_metadata_definitions(value: Mapping[object, object]) -> FrozenMetadataDefinitions:
+    frozen: dict[str, FrozenMetadataFieldDefinition] = {}
+    for field_name, field_definition in value.items():
+        if not isinstance(field_name, str):
+            raise TypeError("Metadata field names must be strings")
+        if not isinstance(field_definition, Mapping):
+            raise TypeError("Metadata field definitions must be mappings")
+        frozen[field_name] = _freeze_metadata_mapping(field_definition)
+    return MappingProxyType(frozen)
+
+
+def _freeze_metadata_definitions_by_knowledge(
+    value: Mapping[object, object],
+) -> FrozenMetadataDefinitionsByKnowledge:
+    frozen: dict[uuid.UUID, FrozenMetadataDefinitions] = {}
+    for knowledge_id, field_definitions in value.items():
+        if not isinstance(knowledge_id, uuid.UUID):
+            raise TypeError("Metadata knowledge IDs must be UUIDs")
+        if not isinstance(field_definitions, Mapping):
+            raise TypeError("Knowledge metadata definitions must be mappings")
+        frozen[knowledge_id] = _freeze_metadata_definitions(field_definitions)
+    return MappingProxyType(frozen)
 
 
 @dataclass(frozen=True)
@@ -95,7 +153,19 @@ class GraphRetrievalSnapshot:
 class RetrievalPreparation:
     targets: tuple[RetrievalTarget, ...]
     tenant_id: uuid.UUID | None
-    metadata_defs_by_kb: Mapping[uuid.UUID, Mapping[str, dict[str, Any]]]
-    common_metadata_defs: Mapping[str, dict[str, Any]]
+    metadata_defs_by_kb: FrozenMetadataDefinitionsByKnowledge
+    common_metadata_defs: FrozenMetadataDefinitions
     metadata_llm: ModelRuntimeSnapshot | None
     graph: GraphRetrievalSnapshot | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "metadata_defs_by_kb",
+            _freeze_metadata_definitions_by_knowledge(self.metadata_defs_by_kb),
+        )
+        object.__setattr__(
+            self,
+            "common_metadata_defs",
+            _freeze_metadata_definitions(self.common_metadata_defs),
+        )

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -179,6 +179,38 @@ class RetrievalSearchOptions:
     knn_num_candidates: int | None
 
 
+@dataclass
+class RetrievalTimings:
+    """Mutable request-local phase timings for retrieval observability."""
+
+    db_snapshot_ms: int = 0
+    metadata_llm_ms: int = 0
+    metadata_query_ms: int = 0
+    embedding_ms: int = 0
+    es_vector_ms: int = 0
+    es_fulltext_ms: int = 0
+    parent_resolution_ms: int = 0
+    local_rerank_ms: int = 0
+    global_rerank_ms: int = 0
+    graph_wait_ms: int = 0
+    graph_ms: int = 0
+
+    def as_log_fields(self) -> dict[str, int]:
+        return {
+            "db_snapshot_ms": self.db_snapshot_ms,
+            "metadata_llm_ms": self.metadata_llm_ms,
+            "metadata_query_ms": self.metadata_query_ms,
+            "embedding_ms": self.embedding_ms,
+            "es_vector_ms": self.es_vector_ms,
+            "es_fulltext_ms": self.es_fulltext_ms,
+            "parent_resolution_ms": self.parent_resolution_ms,
+            "local_rerank_ms": self.local_rerank_ms,
+            "global_rerank_ms": self.global_rerank_ms,
+            "graph_wait_ms": self.graph_wait_ms,
+            "graph_ms": self.graph_ms,
+        }
+
+
 @dataclass(frozen=True)
 class GraphRetrievalSnapshot:
     query: str

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import threading
 from dataclasses import dataclass
@@ -22,15 +21,28 @@ from app.models.models_model import ModelApiKey
 from app.services.model_service import ModelApiKeyService
 
 from app.models.knowledge_model import Knowledge
+from app.core.rag.retrieval.elasticsearch_queries import (
+    VECTOR_SEARCH_MODE_ENV as VECTOR_SEARCH_MODE_ENV,
+    VECTOR_SEARCH_MODE_KNN as VECTOR_SEARCH_MODE_KNN,
+    VECTOR_SEARCH_MODE_SCRIPT_SCORE as VECTOR_SEARCH_MODE_SCRIPT_SCORE,
+    build_full_text_query,
+    build_knn_query,
+    build_parent_lookup_query,
+    build_vector_filter_clauses,
+    build_vector_script_query,
+    full_text_hits_to_chunks,
+    merge_parent_chunks,
+    normalize_vector,
+    raise_on_shard_failures,
+    resolve_vector_search_mode,
+    vector_hits_to_chunks,
+)
 from app.core.rag.vdb.field import Field
 from app.core.rag.vdb.vector_base import BaseVector
 from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
 
 logger = logging.getLogger(__name__)
 
-VECTOR_SEARCH_MODE_ENV = "ELASTICSEARCH_VECTOR_SEARCH_MODE"
-VECTOR_SEARCH_MODE_KNN = "knn"
-VECTOR_SEARCH_MODE_SCRIPT_SCORE = "script_score"
 DEFAULT_INDEX_REFRESH_INTERVAL = "1s"
 
 
@@ -488,66 +500,7 @@ class ElasticSearchVector(BaseVector):
 
     @staticmethod
     def _normalize_vector(vector: Any) -> list[float]:
-        if hasattr(vector, "tolist"):
-            return vector.tolist()
-        return list(vector)
-
-    @staticmethod
-    def _build_vector_filter_clauses(
-        file_names_filter: list[str] | None,
-        document_ids_include: list[str] | None,
-    ) -> list[dict[str, Any]]:
-        filters: list[dict[str, Any]] = [
-            {"term": {"metadata.status": 1}},
-            {"exists": {"field": Field.VECTOR.value}},
-        ]
-        if file_names_filter:
-            filters.append({"terms": {"metadata.file_name": file_names_filter}})
-        if document_ids_include:
-            filters.append({"terms": {Field.DOCUMENT_ID.value: document_ids_include}})
-        return filters
-
-    @staticmethod
-    def _resolve_knn_num_candidates(top_k: int, configured: Any = None) -> int:
-        raw_value = configured if configured is not None else os.getenv("ELASTICSEARCH_KNN_NUM_CANDIDATES")
-        if raw_value is not None:
-            try:
-                return max(int(raw_value), top_k)
-            except (TypeError, ValueError):
-                logger.warning(f"Invalid ELASTICSEARCH_KNN_NUM_CANDIDATES value: {raw_value}")
-        return max(top_k * 10, 100)
-
-    @staticmethod
-    def _resolve_vector_search_mode() -> str:
-        raw_value = os.getenv(VECTOR_SEARCH_MODE_ENV, VECTOR_SEARCH_MODE_SCRIPT_SCORE)
-        mode = raw_value.strip().lower()
-        if mode == VECTOR_SEARCH_MODE_KNN:
-            return VECTOR_SEARCH_MODE_KNN
-        if mode in ("", VECTOR_SEARCH_MODE_SCRIPT_SCORE):
-            return VECTOR_SEARCH_MODE_SCRIPT_SCORE
-
-        logger.warning(f"Invalid {VECTOR_SEARCH_MODE_ENV} value: {raw_value}, using script_score")
-        return VECTOR_SEARCH_MODE_SCRIPT_SCORE
-
-    @staticmethod
-    def _build_vector_script_query(
-        query_vector: list[float],
-        filters: list[dict[str, Any]],
-    ) -> dict[str, Any]:
-        return {
-            "bool": {
-                "must": {
-                    "script_score": {
-                        "query": {"match_all": {}},
-                        "script": {
-                            "source": f"cosineSimilarity(params.query_vector, '{Field.VECTOR.value}') + 1.0",
-                            "params": {"query_vector": query_vector},
-                        },
-                    }
-                },
-                "filter": filters,
-            }
-        }
+        return normalize_vector(vector)
 
     def _search_by_knn(
         self,
@@ -557,17 +510,10 @@ class ElasticSearchVector(BaseVector):
         filters: list[dict[str, Any]],
         knn_num_candidates: Any = None,
     ):
-        num_candidates = self._resolve_knn_num_candidates(top_k, knn_num_candidates)
-        knn_query = {
-            "field": Field.VECTOR.value,
-            "query_vector": query_vector,
-            "k": top_k,
-            "num_candidates": num_candidates,
-            "filter": filters,
-        }
+        knn_query = build_knn_query(query_vector, top_k, filters, knn_num_candidates)
         logger.debug(
             f"[ES search_by_vector] mode=knn indices={indices} top_k={top_k} "
-            f"num_candidates={num_candidates} vector_dims={len(query_vector)} filter_count={len(filters)}"
+            f"num_candidates={knn_query['num_candidates']} vector_dims={len(query_vector)} filter_count={len(filters)}"
         )
         return self._client.search(
             index=indices,
@@ -582,7 +528,7 @@ class ElasticSearchVector(BaseVector):
         top_k: int,
         filters: list[dict[str, Any]],
     ):
-        query_str = self._build_vector_script_query(query_vector, filters)
+        query_str = build_vector_script_query(query_vector, filters)
         logger.debug(
             f"[ES search_by_vector] mode=script_score indices={indices} top_k={top_k} "
             f"vector_dims={len(query_vector)} filter_count={len(filters)}"
@@ -603,51 +549,17 @@ class ElasticSearchVector(BaseVector):
         resolve_parents: bool,
         indices: str | None = None,
     ) -> list[DocumentChunk]:
-        self._raise_on_shard_failures(result, "vector search")
-        if "errors" in result:
-            raise ValueError(f"Error during query: {result['errors']}")
-
-        docs: list[DocumentChunk] = []
-        for res in result["hits"]["hits"]:
-            source = res["_source"]
-            page_content = source.get(Field.CONTENT_KEY.value)
-            metadata = source.get(Field.METADATA_KEY.value) or {}
-            chunk_type = source.get(Field.CHUNK_TYPE.value)
-            score = res["_score"] / 2 if normalize_script_score else res["_score"]
-
-            # QA chunk returns question and answer together as retrieval context.
-            if chunk_type == "qa":
-                question = source.get(Field.QUESTION.value, "")
-                answer = source.get(Field.ANSWER.value, "")
-                page_content = f"question: {question}\nanswer: {answer}"
-                metadata["chunk_type"] = "qa"
-                metadata["question"] = question
-                metadata["answer"] = answer
-
-            if score_threshold is None or score > score_threshold:
-                metadata["score"] = score
-                docs.append(DocumentChunk(page_content=page_content, metadata=metadata))
-
+        raise_on_shard_failures(result, "vector search")
+        docs = vector_hits_to_chunks(
+            result,
+            score_threshold,
+            normalize_script_score=normalize_script_score,
+        )
         return self.resolve_parent_chunks(docs, indices=indices) if resolve_parents else docs
 
     @staticmethod
     def _raise_on_shard_failures(result: dict[str, Any], context: str) -> None:
-        shards = result.get("_shards") or {}
-        failed = int(shards.get("failed") or 0)
-        if failed <= 0:
-            return
-        failures = shards.get("failures") or []
-        failure_summary = []
-        for failure in failures[:3]:
-            index = failure.get("index")
-            reason = failure.get("reason") or {}
-            reason_type = reason.get("type")
-            reason_text = reason.get("reason")
-            failure_summary.append(f"index={index}, type={reason_type}, reason={reason_text}")
-        raise ValueError(
-            f"Elasticsearch shard failures during {context}: failed={failed}, "
-            f"failures={failure_summary}"
-        )
+        raise_on_shard_failures(result, context)
 
     def search_by_vector(self, query: str, resolve_parents: bool = True, **kwargs: Any) -> list[DocumentChunk]:
         """Search the nearest neighbors to a vector."""
@@ -666,7 +578,7 @@ class ElasticSearchVector(BaseVector):
         document_ids_include = kwargs.get("document_ids_include")
         if document_ids_include is None:
             document_ids_include = kwargs.get("document_ids_filter")
-        filters = self._build_vector_filter_clauses(file_names_filter, document_ids_include)
+        filters = build_vector_filter_clauses(file_names_filter, document_ids_include)
 
         logger.info(
             "[ES vector_search] indices=%s top_k=%s score_threshold=%s "
@@ -678,7 +590,7 @@ class ElasticSearchVector(BaseVector):
             len(document_ids_include or []),
         )
 
-        if self._resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:
+        if resolve_vector_search_mode() == VECTOR_SEARCH_MODE_KNN:
             try:
                 result = self._search_by_knn(
                     indices=indices,
@@ -739,42 +651,11 @@ class ElasticSearchVector(BaseVector):
         indices = kwargs.get("indices", self._collection_name)  # Default single index, multiple indexes are also supported, such as "index1, index2, index3"
         file_names_filter = kwargs.get("file_names_filter") # ["doc1", "doc2", "doc3"]
 
-        # Basic Query（BM25）
-        content_match_query = {
-            "multi_match": {
-                "query": query,
-                "fields": [Field.CONTENT_KEY.value, Field.VISION_TEXT.value],
-                "analyzer": "ik_max_word",
-            }
-        }
-        query_str: dict[str, Any] = {
-            "bool": {
-                "must": content_match_query,
-                "filter": [
-                    {"term": {"metadata.status": 1}},
-                ]
-            }
-        }
-
-        # If file_names_filter is passed in, merge the filtering conditions
-        if file_names_filter:
-            query_str = {
-                "bool": {
-                    "must": content_match_query,
-                    "filter": [
-                        {"term": {"metadata.status": 1}},
-                        {"terms": {"metadata.file_name": file_names_filter}},
-                    ],
-                }
-            }
-
         document_ids_include = kwargs.get("document_ids_include")
         if document_ids_include is None:
             document_ids_include = kwargs.get("document_ids_filter")
+        query_str = build_full_text_query(query, file_names_filter, document_ids_include)
         if document_ids_include:
-            query_str["bool"]["filter"].append({
-                "terms": {Field.DOCUMENT_ID.value: document_ids_include}
-            })
             logger.info(
                 "[ES full_text_search] indices=%s top_k=%s score_threshold=%s "
                 "file_filter_count=%s document_filter_count=%s",
@@ -804,39 +685,8 @@ class ElasticSearchVector(BaseVector):
         )
         # logger.info(result)
 
-        self._raise_on_shard_failures(result, "full text search")
-        if "errors" in result:
-            raise ValueError(f"Error during query: {result['errors']}")
-
-        docs_and_scores = []
-        max_score = result["hits"]["max_score"] or 1.0  # Get the maximum score. If it is None, use 1.0
-        for res in result["hits"]["hits"]:
-            source = res["_source"]
-            page_content = source.get(Field.CONTENT_KEY.value)
-            metadata = source.get(Field.METADATA_KEY.value, {})
-            chunk_type = source.get(Field.CHUNK_TYPE.value)
-
-            # QA chunk: 返回 Q+A 拼接作为上下文
-            if chunk_type == "qa":
-                question = source.get(Field.QUESTION.value, "")
-                answer = source.get(Field.ANSWER.value, "")
-                page_content = f"question: {question}\nanswer: {answer}"
-                metadata["chunk_type"] = "qa"
-                metadata["question"] = question
-                metadata["answer"] = answer
-
-            # Normalize the score to the [0,1] interval
-            normalized_score = res["_score"] / max_score
-            docs_and_scores.append((DocumentChunk(page_content=page_content, metadata=metadata), normalized_score))
-
-        # docs = [doc for doc, score in docs_and_scores]
-        docs = []
-        for doc, score in docs_and_scores:
-            # check score threshold
-            if score_threshold is None or score > score_threshold:
-                if doc.metadata is not None:
-                    doc.metadata["score"] = score
-                    docs.append(doc)
+        raise_on_shard_failures(result, "full text search")
+        docs = full_text_hits_to_chunks(result, score_threshold)
 
         logger.debug(
             "[ES full_text_search] hits=%s returned_docs=%s score_threshold=%s",
@@ -855,12 +705,9 @@ class ElasticSearchVector(BaseVector):
         Non-child chunks (regular "chunk", "qa") pass through unchanged.
         """
         child_results = []
-        other_results = []
         for doc in chunks:
             if (doc.metadata or {}).get("chunk_type") == "child":
                 child_results.append(doc)
-            else:
-                other_results.append(doc)
 
         if not child_results:
             return chunks
@@ -870,60 +717,18 @@ class ElasticSearchVector(BaseVector):
         if not parent_ids:
             return chunks
 
-        # Batch-fetch parent chunks from ES by doc_id
-        parent_map = {}
         try:
             result = self._client.search(
                 index=indices or self._collection_name,
                 body={
-                    "query": {
-                        "bool": {
-                            "must": [
-                                {"terms": {"metadata.doc_id": parent_ids}}
-                            ]
-                        }
-                    }
+                    "query": build_parent_lookup_query(parent_ids),
                 },
                 size=len(parent_ids),
             )
-            for hit in result.get("hits", {}).get("hits", []):
-                source = hit["_source"]
-                parent_doc_id = source.get("metadata", {}).get("doc_id", "")
-                parent_map[parent_doc_id] = DocumentChunk(
-                    page_content=source.get(Field.CONTENT_KEY.value, ""),
-                    metadata=source.get(Field.METADATA_KEY.value, {}),
-                )
         except Exception as e:
             logger.warning(f"Failed to resolve parent chunks: {e}")
             return chunks
-
-        # Replace child content with parent content, dedup by parent_id
-        seen_parents: dict[str, DocumentChunk] = {}
-        for doc in child_results:
-            parent_id = doc.metadata.get("parent_id", "")
-            if parent_id in seen_parents:
-                existing = seen_parents[parent_id]
-                if doc.metadata.get("score", 0) > existing.metadata.get("score", 0):
-                    seen_parents[parent_id] = DocumentChunk(
-                        page_content=existing.page_content,
-                        metadata={**existing.metadata, "score": doc.metadata.get("score", 0)},
-                    )
-                continue
-
-            parent = parent_map.get(parent_id)
-            if parent:
-                # Replace page_content with parent's, preserve child's score
-                score = doc.metadata.get("score", 0)
-                merged_metadata = {**parent.metadata, "score": score, "chunk_type": "parent"}
-                seen_parents[parent_id] = DocumentChunk(
-                    page_content=parent.page_content,
-                    metadata=merged_metadata,
-                )
-            else:
-                # Parent not found, keep child as-is
-                seen_parents[parent_id] = doc
-
-        return list(seen_parents.values()) + other_results
+        return merge_parent_chunks(chunks, result.get("hits", {}).get("hits", []))
 
     def rerank(self, query: str, docs: list[DocumentChunk], top_k: int) -> list[DocumentChunk]:
         """

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 import re
@@ -15,7 +14,6 @@ from app.core.workflow.nodes.base_node import BaseNode
 from app.core.workflow.nodes.knowledge import KnowledgeRetrievalNodeConfig
 from app.core.workflow.nodes.llm.config import strip_unsupported_llm_params
 from app.core.workflow.variable.base_variable import VariableType
-from app.db import get_async_db_context, get_db_read
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.models import ModelType
 from app.models.models_model import ModelCapability
@@ -351,26 +349,19 @@ class KnowledgeRetrievalNode(BaseNode):
         return filter_groups
 
     async def _extract_auto_filter_groups_async(self, query: str) -> list:
-        async with get_async_db_context() as db:
-            prepared = await db.run_sync(lambda sync_db: self._prepare_auto_filter_state_sync(sync_db))
-
-        if not prepared:
-            return []
-
-        common_metadata_defs, llm = prepared
-        return await asyncio.to_thread(
-            self._extract_auto_filter_groups,
-            query,
-            common_metadata_defs,
-            llm,
+        del query
+        logger.info(
+            "node: %s auto filter is delegated to native knowledge retrieval",
+            self.node_id,
         )
+        return []
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
         """
         Execute the knowledge retrieval workflow node.
 
         Delegates all retrieval and metadata filtering to the unified
-        KnowledgeRetrievalService.retrieve entry point, as specified in
+        KnowledgeRetrievalService.retrieve_async entry point, as specified in
         the knowledge retrieval API convention document.
 
         Args:
@@ -426,13 +417,10 @@ class KnowledgeRetrievalNode(BaseNode):
         )
 
         # 4. Call unified retrieval service
-        with get_db_read() as db:
-            result = await asyncio.to_thread(
-                KnowledgeRetrievalService.retrieve,
-                db=db,
-                request=request,
-                current_user=None,  # workflow nodes have no user context
-            )
+        result = await KnowledgeRetrievalService.retrieve_async(
+            request=request,
+            principal=None,
+        )
 
         # 5. Assemble return format
         chunks = result.chunks

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -252,6 +252,10 @@ class KnowledgeRetrievalNode(BaseNode):
                 and params.response_format.value == "json_object"
             ))
             and ModelCapability.JSON_OUTPUT in set(model.capability)
+            and not (
+                params.thinking.enable
+                and ModelCapability.THINKING in set(model.capability)
+            )
         ):
             options["response_format"] = {"type": "json_object"}
         if params.extra_headers.enable and params.extra_headers.value:

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -3,26 +3,24 @@ import logging
 import re
 from typing import Any
 
-from sqlalchemy.orm import Session
-
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
-from app.core.models import RedBearLLM, RedBearModelConfig
+from app.core.rag.retrieval.async_models import AsyncRetrievalModelGateway
+from app.core.rag.retrieval.models import ModelRuntimeSnapshot
 from app.core.workflow.engine.state_manager import WorkflowState
 from app.core.workflow.engine.variable_pool import VariablePool
 from app.core.workflow.nodes.base_node import BaseNode
 from app.core.workflow.nodes.knowledge import KnowledgeRetrievalNodeConfig
 from app.core.workflow.nodes.llm.config import strip_unsupported_llm_params
 from app.core.workflow.variable.base_variable import VariableType
+from app.db import get_async_db_context
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
-from app.models import ModelType
 from app.models.models_model import ModelCapability
 from app.schemas.knowledge_metadata_schema import FilterCondition, FilterGroup, MetadataFilterMode
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
-from app.schemas.model_schema import ModelInfo
 from app.services.knowledge_metadata_service import KnowledgeMetadataService
+from app.services.knowledge_retrieval_preparation import KnowledgeRetrievalPreparation
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
-from app.services.metadata_auto_filter_service import MetadataAutoFilterService
 from app.services.model_service import ModelConfigService
 
 logger = logging.getLogger(__name__)
@@ -163,198 +161,151 @@ class KnowledgeRetrievalNode(BaseNode):
                 })
         return citations
 
-    def _build_auto_filter_llm(self, db) -> RedBearLLM:
-        """auto 模式：照搬 LLM 节点 _prepare_llm 的构造方式，用 RedBearLLM + extra_params。
-
-        参数折叠进 RedBearModelConfig.extra_params，经 strip_unsupported_llm_params 按 provider
-        剔除不支持的键并打 warning；stop 等经 RedBearModelFactory.get_model_params 路由到顶层，
-        provider 真正认（旧 chat_model.Base 路径下 stop 不生效的根因即在此）。与
-        MetadataAutoFilterService.generate_filter_groups 期望的 llm.invoke() 接口一致。
-
-        api-key 选取沿用旧 chat_model.Base 路径的 model_balance（取 config.api_keys[0]，直接用
-        其 api_base），不切到 get_runtime_api_config：后者对 SpeedBear 公共模型会走
-        _build_speedbear_runtime_api_key，base_url 指向 SPEEDBEAR_BASE_URL 网关，本地开发网络下
-        不可达会触发 Connection error。stop 修复只依赖 RedBearLLM 构造，与 api-key 来源无关。
-        """
-        model_cfg = self.typed_config.metadata_model
-        config = ModelConfigService.get_model_by_id(db=db, model_id=model_cfg.model_id)
-        if not config:
-            raise BusinessException(
-                "auto 模式配置的模型不存在", code=BizCode.NOT_FOUND
-            )
-        api_key = self.model_balance(config)
-        model_info = ModelInfo(
-            model_name=api_key.model_name,
-            model_type=ModelType(config.type),
-            api_key=api_key.api_key,
-            api_base=api_key.api_base,
-            provider=api_key.provider or config.provider,
-            is_omni=api_key.is_omni if api_key.is_omni is not None else config.is_omni,
-            capability=api_key.capability or config.capability or [],
-        )
-
-        p = model_cfg.completion_params
-        extra_params: dict[str, Any] = {}
-        # enable 门与 LLM 节点完全一致：temperature/max_tokens 无 enable 门，其余需 enable=true
-        if p.temperature is not None:
-            extra_params["temperature"] = p.temperature
-        if p.max_tokens is not None:
-            extra_params["max_tokens"] = p.max_tokens
-        if p.top_p.enable and p.top_p.value is not None:
-            extra_params["top_p"] = p.top_p.value
-        if p.top_k.enable and p.top_k.value is not None:
-            extra_params["top_k"] = p.top_k.value
-        if p.seed.enable and p.seed.value is not None:
-            extra_params["seed"] = p.seed.value
-        if p.repetition_penalty.enable and p.repetition_penalty.value is not None:
-            extra_params["repetition_penalty"] = p.repetition_penalty.value
-        if p.frequency_penalty.enable and p.frequency_penalty.value is not None:
-            extra_params["frequency_penalty"] = p.frequency_penalty.value
-        if p.presence_penalty.enable and p.presence_penalty.value is not None:
-            extra_params["presence_penalty"] = p.presence_penalty.value
-        if p.stop.enable and p.stop.value:
-            extra_params["stop"] = p.stop.value[:4]
-        if p.search:
-            extra_params["enable_search"] = True
-
-        deep_thinking = p.thinking.enable
-        thinking_budget_tokens = p.thinking.budget.value if (
-            p.thinking.budget.enable and p.thinking.budget.value is not None
-        ) else None
-
-        capability_set = set(model_info.capability or [])
-        json_output = bool(p.json_output)
-        if (
-            p.response_format.enable
-            and p.response_format.value == "json_object"
-            and ModelCapability.JSON_OUTPUT in capability_set
-        ):
-            extra_params["response_format"] = {"type": "json_object"}
-
-        if p.extra_headers.enable and p.extra_headers.value:
-            try:
-                extra_params["default_headers"] = json.loads(p.extra_headers.value)
-            except (ValueError, TypeError) as e:
-                logger.warning(
-                    f"node: {self.node_id} auto filter: extra_headers JSON parse failed: {e}"
+    async def _prepare_auto_filter_state_async(
+        self,
+    ) -> tuple[dict[str, Any], ModelRuntimeSnapshot, dict[str, Any]] | None:
+        """Snapshot the Workflow AUTO filter inputs in a short async DB context."""
+        cfg = self._get_typed_config()
+        async with get_async_db_context() as db:
+            metadata_defs_by_kb = {
+                kb.kb_id: await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(
+                    db,
+                    kb.kb_id,
                 )
+                for kb in cfg.knowledge_bases
+            }
+            common_metadata_defs = KnowledgeRetrievalPreparation._get_common_metadata_defs(
+                metadata_defs_by_kb,
+            )
+            if not common_metadata_defs:
+                logger.info(
+                    "node: %s auto filter skipped because no common metadata fields exist",
+                    self.node_id,
+                )
+                return None
 
-        # 按 provider 剔除不支持的参数并打 warning（与 LLM 节点 strip_unsupported_llm_params 一致）
-        extra_params, strip_warnings = strip_unsupported_llm_params(
-            extra_params, model_info.provider or "", model_info.is_omni
+            model_cfg = cfg.metadata_model
+            if not model_cfg or not model_cfg.model_id:
+                raise BusinessException(
+                    "auto 模式必须配置 metadata_model.model_id",
+                    code=BizCode.INVALID_PARAMETER,
+                )
+            model_config = await ModelConfigService.get_model_by_id_async(
+                db,
+                model_cfg.model_id,
+            )
+            api_key = self.model_balance(model_config)
+            model = ModelRuntimeSnapshot(
+                model_name=api_key.model_name,
+                provider=api_key.provider or model_config.provider,
+                api_key=api_key.api_key,
+                api_base=api_key.api_base,
+                capability=tuple(api_key.capability or model_config.capability or ()),
+                is_omni=(
+                    api_key.is_omni
+                    if api_key.is_omni is not None
+                    else bool(model_config.is_omni)
+                ),
+                model_type=model_config.type,
+            )
+
+        return (
+            common_metadata_defs,
+            model,
+            self._build_auto_filter_generation_options(model),
         )
-        for w in strip_warnings:
+
+    def _build_auto_filter_generation_options(
+        self,
+        model: ModelRuntimeSnapshot,
+    ) -> dict[str, Any]:
+        """Normalize Workflow completion parameters for the native metadata adapter."""
+        params = self._get_typed_config().metadata_model.completion_params
+        options: dict[str, Any] = {}
+        if params.temperature is not None:
+            options["temperature"] = params.temperature
+        if params.max_tokens is not None:
+            options["max_tokens"] = params.max_tokens
+        if params.top_p.enable and params.top_p.value is not None:
+            options["top_p"] = params.top_p.value
+        if params.top_k.enable and params.top_k.value is not None:
+            options["top_k"] = params.top_k.value
+        if params.seed.enable and params.seed.value is not None:
+            options["seed"] = params.seed.value
+        if params.repetition_penalty.enable and params.repetition_penalty.value is not None:
+            options["repetition_penalty"] = params.repetition_penalty.value
+        if params.frequency_penalty.enable and params.frequency_penalty.value is not None:
+            options["frequency_penalty"] = params.frequency_penalty.value
+        if params.presence_penalty.enable and params.presence_penalty.value is not None:
+            options["presence_penalty"] = params.presence_penalty.value
+        if params.stop.enable and params.stop.value:
+            options["stop"] = params.stop.value[:4]
+        if params.search:
+            options["enable_search"] = True
+        if params.thinking.enable:
+            options["deep_thinking"] = True
+            if params.thinking.budget.enable and params.thinking.budget.value is not None:
+                options["thinking_budget_tokens"] = params.thinking.budget.value
+        if (
+            (params.json_output or (
+                params.response_format.enable
+                and params.response_format.value == "json_object"
+            ))
+            and ModelCapability.JSON_OUTPUT in set(model.capability)
+        ):
+            options["response_format"] = {"type": "json_object"}
+        if params.extra_headers.enable and params.extra_headers.value:
+            try:
+                decoded_headers = json.loads(params.extra_headers.value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "node: %s auto filter ignored invalid extra headers JSON",
+                    self.node_id,
+                )
+            else:
+                if isinstance(decoded_headers, dict):
+                    options["default_headers"] = decoded_headers
+                else:
+                    logger.warning(
+                        "node: %s auto filter ignored non-object extra headers",
+                        self.node_id,
+                    )
+
+        options, strip_warnings = strip_unsupported_llm_params(
+            options,
+            model.provider,
+            model.is_omni,
+        )
+        for warning in strip_warnings:
             logger.warning(
-                f"节点 {self.node_id} auto filter 参数安全剥离: {w} "
-                f"(模型={model_info.model_name}, 提供商={model_info.provider})"
-            )
-
-        logger.info(
-            f"节点 {self.node_id} auto filter: provider={model_info.provider}, "
-            f"model={model_info.model_name}, is_omni={model_info.is_omni}, "
-            f"is_public={getattr(config, 'is_public', None)}, "
-            f"base_url={model_info.api_base!r}, api_key_set={bool(model_info.api_key)}, "
-            f"extra_params={extra_params}"
-        )
-
-        return RedBearLLM(
-            RedBearModelConfig(
-                model_name=model_info.model_name,
-                provider=model_info.provider,
-                api_key=model_info.api_key,
-                base_url=model_info.api_base,
-                is_omni=model_info.is_omni,
-                capability=model_info.capability,
-                deep_thinking=deep_thinking,
-                thinking_budget_tokens=thinking_budget_tokens,
-                json_output=json_output,
-                extra_params=extra_params,
-            ),
-            type=model_info.model_type,
-        )
-
-    def _prepare_auto_filter_state_sync(
-        self,
-        db: Session,
-    ) -> tuple[dict[str, Any], RedBearLLM] | None:
-        cfg = self._get_typed_config()
-        metadata_defs_by_kb = {
-            kb.kb_id: KnowledgeMetadataService.get_metadata_defs_for_filtering(db, kb.kb_id)
-            for kb in cfg.knowledge_bases
-        }
-        common_metadata_defs = KnowledgeRetrievalService._get_common_metadata_defs(metadata_defs_by_kb)
-
-        if not common_metadata_defs:
-            logger.info(
-                "node: %s auto filter: no common metadata fields, skip extraction",
+                "node: %s auto filter parameter stripped: %s",
                 self.node_id,
+                warning,
             )
-            return None
+        return options
 
-        return common_metadata_defs, self._build_auto_filter_llm(db)
+    async def _extract_auto_filter_groups_async(self, query: str) -> list[FilterGroup]:
+        prepared = await self._prepare_auto_filter_state_async()
+        if prepared is None:
+            return []
 
-    def _extract_auto_filter_groups(
-        self,
-        query: str,
-        common_metadata_defs: dict[str, Any],
-        llm: RedBearLLM,
-    ) -> list:
-        """auto 模式：用配置好的模型 + 参数，调用 LLM 提取出源数据过滤条件。
-
-        产出 list[FilterGroup]（配置层类型），直接放进 metadata_filters 交给 service；
-        service 再经 _build_common_filter_groups 转成引擎层类型做真正的过滤。
-        """
-        cfg = self._get_typed_config()
-        model_cfg = cfg.metadata_model
-        if not model_cfg or not model_cfg.model_id:
-            raise BusinessException(
-                "auto 模式必须配置 metadata_model.model_id",
-                code=BizCode.INVALID_PARAMETER,
-            )
-
-        # 3. 调用提取方法（参数已在 llm 实例上，不再单独传 gen_conf）
-        logger.info(
-            "node: %s auto filter: query=%r, fields=%s",
-            self.node_id, query, list(common_metadata_defs.keys()),
-        )
-        filter_groups = MetadataAutoFilterService.generate_filter_groups(
+        common_metadata_defs, model, generation_options = prepared
+        filter_groups = await AsyncRetrievalModelGateway().generate_metadata_filters(
             query=query,
             metadata_defs=common_metadata_defs,
-            llm=llm,
+            model=model,
+            generation_options=generation_options,
         )
-        # generate_filter_groups 返回引擎层 EngineFilterGroup；metadata_filters 字段装的是配置层 FilterGroup，
-        # 这里无损转成配置层类型（引擎层 logic 大写，由 config 校验器统一转小写）。
-        filter_groups = [
+        return [
             FilterGroup(
                 conditions=[
-                    FilterCondition(field=c.field, operator=c.operator, value=c.value)
-                    for c in (g.conditions or [])
+                    FilterCondition(field=condition.field, operator=condition.operator, value=condition.value)
+                    for condition in (group.conditions or [])
                 ],
-                logic=g.logic,
+                logic=group.logic,
             )
-            for g in (filter_groups or [])
+            for group in (filter_groups or [])
         ]
-        # 打印提取出的过滤条件（即交接给知识库工程师做真正过滤的内容）
-        logger.info(
-            "node: %s auto filter extracted: %s",
-            self.node_id,
-            [
-                {
-                    "logic": group.logic,
-                    "conditions": [cond.model_dump() for cond in (group.conditions or [])],
-                }
-                for group in (filter_groups or [])
-            ],
-        )
-        return filter_groups
-
-    async def _extract_auto_filter_groups_async(self, query: str) -> list:
-        del query
-        logger.info(
-            "node: %s auto filter is delegated to native knowledge retrieval",
-            self.node_id,
-        )
-        return []
 
     async def execute(self, state: WorkflowState, variable_pool: VariablePool) -> Any:
         """
@@ -413,8 +364,14 @@ class KnowledgeRetrievalNode(BaseNode):
             retrieve_type=first_kb.retrieve_type,
             rerank_id=self.typed_config.reranker_id,
             metadata_filter_mode=self.typed_config.metadata_filter_mode,
-            metadata_filters=auto_filter_groups or ([rendered_filters] if rendered_filters else []),
+            metadata_filters=(
+                auto_filter_groups
+                if self.typed_config.metadata_filter_mode == MetadataFilterMode.AUTO
+                else ([rendered_filters] if rendered_filters else [])
+            ),
         )
+        if self.typed_config.metadata_filter_mode == MetadataFilterMode.AUTO:
+            request.mark_metadata_filters_prepared()
 
         # 4. Call unified retrieval service
         result = await KnowledgeRetrievalService.retrieve_async(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -118,6 +118,12 @@ async def lifespan(app: FastAPI):
     await close_http_client()
     from app.repositories.neo4j.neo4j_connector import Neo4jConnector
     await Neo4jConnector.shutdown()
+    from app.core.rag.retrieval.async_elasticsearch import AsyncElasticsearchClientProvider
+    from app.core.rag.retrieval.async_models import AsyncRetrievalHttpClientProvider
+    from app.core.rag.retrieval.graph_bridge import GraphRetrievalBridge
+    await AsyncElasticsearchClientProvider.aclose()
+    await AsyncRetrievalHttpClientProvider.aclose()
+    GraphRetrievalBridge.shutdown()
     logger.info("应用程序正在关闭")
 
 

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -1,7 +1,7 @@
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 from app.schemas.chunk_schema import KnowledgeBaseConfig, KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
@@ -23,6 +23,16 @@ class KnowledgeRetrievalRequest(BaseModel):
     rerank_score_threshold: float | None = Field(default=None, ge=0, le=1)
     metadata_filters: list[FilterGroup] = Field(default_factory=list)
     metadata_filter_mode: MetadataFilterMode = MetadataFilterMode.MANUAL
+    _metadata_filters_prepared: bool = PrivateAttr(default=False)
+
+    def mark_metadata_filters_prepared(self) -> None:
+        """Record that an internal caller already evaluated AUTO filters."""
+        self._metadata_filters_prepared = True
+
+    @property
+    def metadata_filters_prepared(self) -> bool:
+        """Whether AUTO filtering was already evaluated by an internal adapter."""
+        return self._metadata_filters_prepared
 
     @field_validator("query")
     @classmethod

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -26,7 +26,7 @@ from app.core.logging_config import get_business_logger
 from app.schemas.chunk_schema import KnowledgeRetrievalCaller, RetrieveType
 from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalService
-from app.db import get_db_context, get_async_db_context
+from app.db import get_async_db_context
 from app.models import App, AgentConfig, ModelConfig, Message, Conversation, Knowledge
 from app.models.agent_execution_model import AgentExecution
 from app.models.annotation_model import AppAnnotation, AppAnnotationHitLog, AppAnnotationSetting

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -105,7 +105,7 @@ def create_web_search_tool(web_search_config: Dict[str, Any]):
     return web_search_tool
 
 
-def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
+async def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list:
     """标准化知识库检索：走 KnowledgeRetrievalService + KnowledgeRetrievalRequest。
 
     读取 agent 的 ``knowledge_retrieval`` 配置（top_k / similarity_threshold /
@@ -162,9 +162,7 @@ def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -> list
         rerank_id=rerank_id,
     )
 
-    # ToolOrchestrator runs sync tools in a worker thread, so keep this DB session on that thread.
-    with get_db_context() as db:
-        result = KnowledgeRetrievalService.retrieve(db=db, request=request, current_user=None)
+    result = await KnowledgeRetrievalService.retrieve_async(request=request, principal=None)
 
     return result.chunks
 
@@ -185,7 +183,7 @@ def create_knowledge_retrieval_tool(kb_config, kb_ids, user_id, citations_collec
     logger.info(f"创建知识库检索工具，用户：{user_id}")
 
     @tool(args_schema=KnowledgeRetrievalInput)
-    def knowledge_retrieval_tool(query: str) -> str:
+    async def knowledge_retrieval_tool(query: str) -> str:
         """从知识库中检索相关信息。当用户的问题需要参考知识库、文档或历史记录时，使用此工具进行检索。
 
         Args:
@@ -197,7 +195,7 @@ def create_knowledge_retrieval_tool(kb_config, kb_ids, user_id, citations_collec
 
         try:
 
-            retrieve_chunks_result = _retrieve_chunks_via_standard(query, kb_config)
+            retrieve_chunks_result = await _retrieve_chunks_via_standard(query, kb_config)
             if retrieve_chunks_result:
                 retrieval_knowledge = [i.page_content for i in retrieve_chunks_result]
                 context = '\n\n'.join(retrieval_knowledge)

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -1,0 +1,540 @@
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.rag.metadata.filter_engine import FilterGroup as EngineFilterGroup, MetadataFilterEngine
+from app.core.rag.retrieval.exceptions import KnowledgeRetrievalConfigError
+from app.core.rag.retrieval.models import (
+    GraphRetrievalSnapshot,
+    ModelRuntimeSnapshot,
+    RetrievalParams,
+    RetrievalPreparation,
+    RetrievalPrincipal,
+    RetrievalTarget,
+)
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorIndexOps
+from app.db import get_async_db_context
+from app.models import knowledge_model, knowledgeshare_model
+from app.models.models_model import ModelConfig
+from app.repositories import knowledge_repository
+from app.schemas.chunk_schema import KnowledgeBaseConfig, RetrieveType
+from app.schemas.knowledge_metadata_schema import MetadataFilterMode
+from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest
+from app.services import knowledge_service, knowledgeshare_service
+from app.services.knowledge_metadata_service import KnowledgeMetadataService
+from app.services.model_service import ModelApiKeyService
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _KnowledgeRetrievalRef:
+    knowledge: Any
+    config: KnowledgeBaseConfig | None
+
+
+class KnowledgeRetrievalPreparation:
+    @classmethod
+    async def prepare(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None,
+    ) -> RetrievalPreparation:
+        async with get_async_db_context() as db:
+            return await cls._prepare_with_db(db, request, principal)
+
+    @classmethod
+    async def resolve_metadata_document_ids(
+        cls,
+        preparation: RetrievalPreparation,
+        filter_groups: list[EngineFilterGroup],
+    ) -> list[str] | None:
+        if not filter_groups:
+            return None
+        async with get_async_db_context() as db:
+            return await cls._query_document_ids(db, preparation, filter_groups)
+
+    @classmethod
+    async def _prepare_with_db(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None,
+    ) -> RetrievalPreparation:
+        refs = await cls._resolve_retrievable_knowledge_refs_async(db, request, principal)
+        targets, tenant_id = await cls._resolve_retrieval_targets_async(
+            db,
+            request,
+            principal,
+            refs=refs,
+        )
+        if not targets:
+            return RetrievalPreparation(
+                targets=(),
+                tenant_id=None,
+                metadata_defs_by_kb={},
+                common_metadata_defs={},
+                metadata_llm=None,
+                graph=None,
+            )
+
+        metadata_defs_by_kb = {
+            target.knowledge_id: await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(
+                db,
+                target.knowledge_id,
+            )
+            for target in targets
+        }
+        common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
+        request_reranker = await cls._snapshot_model_runtime(
+            db,
+            request.rerank_id,
+            tenant_id,
+        )
+        metadata_llm = await cls._build_metadata_llm_snapshot(
+            db,
+            request,
+            refs[0].knowledge,
+            common_metadata_defs,
+            tenant_id,
+        )
+        graph = await cls._build_graph_snapshot(
+            db,
+            request,
+            refs,
+            targets,
+            tenant_id,
+        )
+        return RetrievalPreparation(
+            targets=tuple(targets),
+            tenant_id=tenant_id,
+            metadata_defs_by_kb=metadata_defs_by_kb,
+            common_metadata_defs=common_metadata_defs,
+            metadata_llm=metadata_llm,
+            graph=graph,
+            request_reranker=request_reranker,
+        )
+
+    @classmethod
+    async def _query_document_ids(
+        cls,
+        db: AsyncSession,
+        preparation: RetrievalPreparation,
+        filter_groups: list[EngineFilterGroup],
+    ) -> list[str]:
+        del cls
+        document_ids: set[uuid.UUID] = set()
+        engine = MetadataFilterEngine(db)
+        for target in preparation.targets:
+            metadata_defs = preparation.metadata_defs_by_kb.get(target.knowledge_id)
+            if metadata_defs is None:
+                continue
+            matched_ids = await engine.execute_async(
+                knowledge_id=target.knowledge_id,
+                filter_groups=filter_groups,
+                metadata_defs=metadata_defs,
+            )
+            document_ids.update(matched_ids)
+        return [str(document_id) for document_id in document_ids]
+
+    @classmethod
+    async def _resolve_retrieval_targets_async(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None = None,
+        *,
+        refs: list[_KnowledgeRetrievalRef] | None = None,
+    ) -> tuple[list[RetrievalTarget], uuid.UUID | None]:
+        if refs is None:
+            refs = await cls._resolve_retrievable_knowledge_refs_async(db, request, principal)
+        if not refs:
+            return [], None
+
+        tenant_id = await cls._resolve_tenant_id_async(
+            db,
+            principal,
+            getattr(refs[0].knowledge, "workspace_id", None),
+        )
+        targets = [
+            await cls._build_retrieval_target_async(db, request, ref, tenant_id)
+            for ref in refs
+        ]
+        return targets, tenant_id
+
+    @staticmethod
+    async def _resolve_tenant_id_async(
+        db: AsyncSession,
+        principal: RetrievalPrincipal | None = None,
+        workspace_id: uuid.UUID | None = None,
+    ) -> uuid.UUID | None:
+        if principal is not None:
+            if principal.tenant_id:
+                return principal.tenant_id
+            workspace_id = workspace_id or principal.current_workspace_id
+
+        if not workspace_id:
+            return None
+        from app.models.workspace_model import Workspace
+
+        workspace = await db.get(Workspace, workspace_id)
+        return workspace.tenant_id if workspace else None
+
+    @classmethod
+    async def _build_retrieval_target_async(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        ref: _KnowledgeRetrievalRef,
+        tenant_id: uuid.UUID | None,
+    ) -> RetrievalTarget:
+        knowledge = ref.knowledge
+        if not knowledge.embedding_id:
+            raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
+        if not knowledge.reranker_id:
+            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+
+        embedding = await cls._snapshot_model_runtime(db, knowledge.embedding_id, tenant_id)
+        reranker = await cls._snapshot_model_runtime(db, knowledge.reranker_id, tenant_id)
+        if not embedding:
+            raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
+        if not reranker:
+            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+
+        return RetrievalTarget(
+            knowledge_id=knowledge.id,
+            workspace_id=knowledge.workspace_id,
+            index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
+            params=cls._build_retrieval_params(request, ref.config),
+            embedding=embedding,
+            reranker=reranker,
+        )
+
+    @staticmethod
+    def _resolve_rerank_score_threshold(
+        request: KnowledgeRetrievalRequest,
+        config: KnowledgeBaseConfig | None = None,
+    ) -> float:
+        explicit_fields = config.model_fields_set if config else set()
+        if config and "rerank_score_threshold" in explicit_fields and config.rerank_score_threshold is not None:
+            return config.rerank_score_threshold
+        if config and "vector_similarity_weight" in explicit_fields and config.vector_similarity_weight is not None:
+            return config.vector_similarity_weight
+        if request.rerank_score_threshold is not None:
+            return request.rerank_score_threshold
+        if request.vector_similarity_weight is not None:
+            return request.vector_similarity_weight
+        return 0.1
+
+    @classmethod
+    def _build_retrieval_params(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        config: KnowledgeBaseConfig | None = None,
+    ) -> RetrievalParams:
+        explicit_fields = config.model_fields_set if config else set()
+        top_k = config.top_k if config and "top_k" in explicit_fields else request.top_k
+        retrieve_type = config.retrieve_type if config and "retrieve_type" in explicit_fields else request.retrieve_type
+        similarity_threshold = (
+            config.similarity_threshold
+            if config and "similarity_threshold" in explicit_fields
+            else request.similarity_threshold
+        )
+        vector_similarity_weight = (
+            config.vector_similarity_weight
+            if config and "vector_similarity_weight" in explicit_fields
+            else request.vector_similarity_weight
+        )
+        rerank_score_threshold = cls._resolve_rerank_score_threshold(request, config)
+        top_n = max(top_k, request.top_n or top_k)
+        return RetrievalParams(
+            similarity_threshold=similarity_threshold,
+            vector_similarity_weight=vector_similarity_weight,
+            top_k=top_k,
+            top_n=top_n,
+            retrieve_type=retrieve_type,
+            rerank_score_threshold=rerank_score_threshold,
+        )
+
+    @classmethod
+    async def _resolve_retrievable_knowledge_refs_async(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None = None,
+    ) -> list[_KnowledgeRetrievalRef]:
+        requested_kb_ids, explicit_configs = await cls._resolve_requested_kb_ids_and_configs_async(
+            db,
+            request,
+            principal,
+        )
+        if not requested_kb_ids:
+            return []
+
+        refs: list[_KnowledgeRetrievalRef] = []
+        ref_positions: dict[uuid.UUID, int] = {}
+
+        def append_refs(items: list[_KnowledgeRetrievalRef]) -> None:
+            for item in items:
+                knowledge_id = item.knowledge.id
+                if knowledge_id in ref_positions:
+                    if item.config is not None:
+                        refs[ref_positions[knowledge_id]] = item
+                    continue
+                ref_positions[knowledge_id] = len(refs)
+                refs.append(item)
+
+        if principal is None:
+            result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            knowledge_by_id = {knowledge.id: knowledge for knowledge in result.scalars().all()}
+            for knowledge_id in requested_kb_ids:
+                knowledge = knowledge_by_id.get(knowledge_id)
+                if not knowledge:
+                    continue
+                append_refs(
+                    await cls._expand_knowledge_to_leaf_refs_async(
+                        db,
+                        knowledge,
+                        explicit_configs.get(knowledge_id),
+                        explicit_configs,
+                    )
+                )
+            return refs
+
+        for knowledge_id in requested_kb_ids:
+            private_result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id == knowledge_id,
+                    knowledge_model.Knowledge.workspace_id == principal.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            private_target = private_result.scalars().first()
+            if private_target:
+                append_refs(
+                    await cls._expand_knowledge_to_leaf_refs_async(
+                        db,
+                        private_target,
+                        explicit_configs.get(knowledge_id),
+                        explicit_configs,
+                    )
+                )
+                continue
+
+            share_result = await db.execute(
+                select(knowledge_model.Knowledge).where(
+                    knowledge_model.Knowledge.id == knowledge_id,
+                    knowledge_model.Knowledge.workspace_id == principal.current_workspace_id,
+                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
+                    knowledge_model.Knowledge.status == 1,
+                )
+            )
+            share_target = share_result.scalars().first()
+            if not share_target:
+                continue
+
+            filters = [
+                knowledgeshare_model.KnowledgeShare.target_kb_id == share_target.id,
+                knowledgeshare_model.KnowledgeShare.target_workspace_id == principal.current_workspace_id,
+            ]
+            share_items = await knowledgeshare_service.get_source_kb_ids_by_target_kb_id_async(
+                db=db,
+                filters=filters,
+                current_user=principal,
+            )
+            for source_knowledge_id, _source_workspace_id in share_items:
+                source_knowledge = await knowledge_repository.get_knowledge_by_id_async(
+                    db,
+                    source_knowledge_id,
+                )
+                append_refs(
+                    await cls._expand_knowledge_to_leaf_refs_async(
+                        db,
+                        source_knowledge,
+                        explicit_configs.get(knowledge_id),
+                        explicit_configs,
+                    )
+                )
+
+        return refs
+
+    @classmethod
+    async def _resolve_requested_kb_ids_and_configs_async(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None = None,
+    ) -> tuple[list[uuid.UUID], dict[uuid.UUID, KnowledgeBaseConfig]]:
+        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig] = {}
+        requested_kb_ids = list(request.kb_ids)
+
+        if request.ex_ids:
+            if principal is None:
+                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
+            resolved_ids = await knowledge_service.get_knowledge_ids_by_external_ids_async(
+                db=db,
+                external_ids=request.ex_ids,
+                workspace_id=principal.current_workspace_id,
+                current_user=principal,
+            )
+            requested_kb_ids.extend(resolved_ids)
+
+        for config in request.knowledge_bases:
+            if config.kb_id in explicit_configs:
+                logger.warning("Duplicate KnowledgeBaseConfig found, using the last one: kb_id=%s", config.kb_id)
+            explicit_configs[config.kb_id] = config
+            requested_kb_ids.append(config.kb_id)
+
+        return cls._unique_ids(requested_kb_ids), explicit_configs
+
+    @classmethod
+    async def _expand_knowledge_to_leaf_refs_async(
+        cls,
+        db: AsyncSession,
+        knowledge: Any,
+        inherited_config: KnowledgeBaseConfig | None,
+        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig],
+        visited: set[uuid.UUID] | None = None,
+    ) -> list[_KnowledgeRetrievalRef]:
+        if not knowledge or not knowledge.is_active:
+            return []
+        current_config = explicit_configs.get(knowledge.id) or inherited_config
+        if knowledge.is_retrievable_leaf:
+            return [_KnowledgeRetrievalRef(knowledge=knowledge, config=current_config)]
+        if not knowledge.is_folder:
+            return []
+
+        if visited is None:
+            visited = set()
+        if knowledge.id in visited:
+            logger.warning(
+                "Detected cyclic knowledge folder while expanding retrieval targets: knowledge_id=%s",
+                knowledge.id,
+            )
+            return []
+        visited.add(knowledge.id)
+
+        refs: list[_KnowledgeRetrievalRef] = []
+        children = await knowledge_repository.get_knowledges_by_parent_id_async(db, knowledge.id)
+        for child in children:
+            if child.workspace_id != knowledge.workspace_id:
+                logger.warning(
+                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
+                    knowledge.id,
+                    child.id,
+                )
+                continue
+            refs.extend(
+                await cls._expand_knowledge_to_leaf_refs_async(
+                    db,
+                    child,
+                    current_config,
+                    explicit_configs,
+                    visited,
+                )
+            )
+        return refs
+
+    @staticmethod
+    def _unique_ids(values: list[uuid.UUID]) -> list[uuid.UUID]:
+        return list(dict.fromkeys(values))
+
+    @staticmethod
+    def _get_common_metadata_defs(
+        metadata_defs_by_kb: dict[uuid.UUID, dict[str, dict]],
+    ) -> dict[str, dict]:
+        field_names = set()
+        for metadata_defs in metadata_defs_by_kb.values():
+            field_names.update(metadata_defs.keys())
+
+        common_defs: dict[str, dict] = {}
+        for field_name in field_names:
+            common_type = None
+            common_def = None
+            for metadata_defs in metadata_defs_by_kb.values():
+                field_def = metadata_defs.get(field_name)
+                if not field_def:
+                    common_def = None
+                    break
+                if common_type is None:
+                    common_type = field_def["type"]
+                    common_def = field_def
+                elif common_type != field_def["type"]:
+                    common_def = None
+                    break
+            if common_def:
+                common_defs[field_name] = dict(common_def)
+        return common_defs
+
+    @classmethod
+    async def _snapshot_model_runtime(
+        cls,
+        db: AsyncSession,
+        model_id: uuid.UUID | None,
+        tenant_id: uuid.UUID | None,
+    ) -> ModelRuntimeSnapshot | None:
+        del cls
+        if model_id is None:
+            return None
+        model_config = await db.get(ModelConfig, model_id)
+        if not model_config:
+            return None
+        api_key = await ModelApiKeyService.get_available_api_key_async(
+            db,
+            model_id,
+            tenant_id=tenant_id,
+        )
+        if not api_key:
+            return None
+        return ModelRuntimeSnapshot.from_api_key(api_key, model_type=model_config.type)
+
+    @classmethod
+    async def _build_metadata_llm_snapshot(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        knowledge: Any,
+        common_metadata_defs: dict[str, dict],
+        tenant_id: uuid.UUID | None,
+    ) -> ModelRuntimeSnapshot | None:
+        if (
+            request.metadata_filter_mode != MetadataFilterMode.AUTO
+            or request.metadata_filters
+            or not common_metadata_defs
+        ):
+            return None
+        return await cls._snapshot_model_runtime(db, knowledge.llm_id, tenant_id)
+
+    @classmethod
+    async def _build_graph_snapshot(
+        cls,
+        db: AsyncSession,
+        request: KnowledgeRetrievalRequest,
+        refs: list[_KnowledgeRetrievalRef],
+        targets: list[RetrievalTarget],
+        tenant_id: uuid.UUID | None,
+    ) -> GraphRetrievalSnapshot | None:
+        if not any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
+            return None
+        llm = await cls._snapshot_model_runtime(db, refs[0].knowledge.llm_id, tenant_id)
+        if not llm:
+            raise KnowledgeRetrievalConfigError(
+                f"No LLM api key found for knowledge {refs[0].knowledge.id}",
+            )
+        return GraphRetrievalSnapshot(
+            query=request.query,
+            workspace_ids=tuple(str(target.workspace_id) for target in targets),
+            knowledge_ids=tuple(str(target.knowledge_id) for target in targets),
+            llm=llm,
+            embedding=targets[0].embedding,
+        )

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -27,6 +27,7 @@ from app.core.rag.retrieval.models import (
     RetrievalPrincipal,
     RetrievalSearchOptions,
     RetrievalTarget,
+    RetrievalTimings,
 )
 from app.schemas.chunk_schema import RetrieveType
 from app.schemas.knowledge_metadata_schema import MetadataFilterMode
@@ -93,8 +94,9 @@ class KnowledgeRetrievalService:
         log_id: str,
         request: KnowledgeRetrievalRequest,
         principal: RetrievalPrincipal | None,
+        timings: RetrievalTimings,
     ) -> dict[str, Any]:
-        return {
+        fields: dict[str, Any] = {
             "id": log_id,
             "user": (
                 principal.username
@@ -111,6 +113,8 @@ class KnowledgeRetrievalService:
             "metadata_mode": request.metadata_filter_mode,
             "async_mode": "native",
         }
+        fields.update(timings.as_log_fields())
+        return fields
 
     @classmethod
     async def retrieve_async(
@@ -123,18 +127,19 @@ class KnowledgeRetrievalService:
         principal = RetrievalPrincipal.from_user(principal)
         log_id = cls._new_retrieval_log_id()
         started_at = time.perf_counter()
+        timings = RetrievalTimings()
         logger.info(
             "[Retrieval] start %s",
             cls._format_log_fields(
-                cls._build_retrieval_start_log_fields(log_id, request, principal)
+                cls._build_retrieval_start_log_fields(log_id, request, principal, timings)
             ),
         )
 
         snapshot_started_at = time.perf_counter()
         preparation = await KnowledgeRetrievalPreparation.prepare(request, principal)
-        snapshot_ms = cls._elapsed_ms(snapshot_started_at)
+        timings.db_snapshot_ms = cls._elapsed_ms(snapshot_started_at)
         if not preparation.targets:
-            return cls._finish_empty(log_id, started_at, "no_targets", snapshot_ms)
+            return cls._finish_empty(log_id, started_at, "no_targets", timings)
 
         models = AsyncRetrievalModelGateway()
         metadata_started_at = time.perf_counter()
@@ -143,14 +148,14 @@ class KnowledgeRetrievalService:
             preparation,
             models,
         )
-        metadata_llm_ms = cls._elapsed_ms(metadata_started_at)
+        timings.metadata_llm_ms = cls._elapsed_ms(metadata_started_at)
 
         metadata_query_started_at = time.perf_counter()
         document_ids_include = await KnowledgeRetrievalPreparation.resolve_metadata_document_ids(
             preparation,
             filter_groups,
         )
-        metadata_query_ms = cls._elapsed_ms(metadata_query_started_at)
+        timings.metadata_query_ms = cls._elapsed_ms(metadata_query_started_at)
         cls._log_metadata_filter(
             log_id,
             request,
@@ -163,13 +168,11 @@ class KnowledgeRetrievalService:
                 log_id,
                 started_at,
                 "metadata_filter_empty",
-                snapshot_ms,
-                metadata_llm_ms,
-                metadata_query_ms,
+                timings,
             )
 
         client = await AsyncElasticsearchClientProvider.get_shared_client()
-        store = AsyncElasticSearchRetrieval(client, models)
+        store = AsyncElasticSearchRetrieval(client, models, timings)
         chunks = await cls._retrieve_targets(
             request,
             preparation,
@@ -177,9 +180,10 @@ class KnowledgeRetrievalService:
             store,
             models,
             log_id,
+            timings,
         )
         if preparation.graph:
-            graph_document = await GraphRetrievalBridge.retrieve(preparation.graph)
+            graph_document = await GraphRetrievalBridge.retrieve(preparation.graph, timings)
             if graph_document:
                 chunks.insert(0, graph_document)
 
@@ -193,12 +197,10 @@ class KnowledgeRetrievalService:
                     "target_count": len(preparation.targets),
                     "document_filter_count": len(document_ids_include or []),
                     "final_count": len(chunks),
-                    "db_snapshot_ms": snapshot_ms,
-                    "metadata_llm_ms": metadata_llm_ms,
-                    "metadata_query_ms": metadata_query_ms,
                     "elapsed_ms": cls._elapsed_ms(started_at),
                     "async_mode": "native",
                 }
+                | timings.as_log_fields()
             ),
         )
         return KnowledgeRetrievalResult(chunks=chunks)
@@ -253,6 +255,7 @@ class KnowledgeRetrievalService:
         store: AsyncElasticSearchRetrieval,
         models: AsyncRetrievalModelGateway,
         log_id: str,
+        timings: RetrievalTimings | None = None,
     ) -> list[DocumentChunk]:
         targets = preparation.targets
         if not targets:
@@ -272,6 +275,7 @@ class KnowledgeRetrievalService:
                     "target_kbs": cls._compact_ids([target.knowledge_id for target in targets]),
                     "async_mode": "native",
                 }
+                | cls._timing_log_fields(timings)
             ),
         )
         semaphore = asyncio.Semaphore(max_workers)
@@ -293,6 +297,7 @@ class KnowledgeRetrievalService:
                         and target.params.retrieve_type == RetrieveType.HYBRID
                     ),
                     request_reranker=preparation.request_reranker,
+                    timings=timings,
                 )
                 return index, chunks
 
@@ -318,6 +323,7 @@ class KnowledgeRetrievalService:
             candidates,
             models,
             log_id,
+            timings,
         )
 
     @classmethod
@@ -331,6 +337,7 @@ class KnowledgeRetrievalService:
         *,
         use_request_reranker: bool,
         request_reranker: Any,
+        timings: RetrievalTimings | None = None,
     ) -> list[DocumentChunk]:
         started_at = time.perf_counter()
         target_type = target.params.retrieve_type
@@ -347,7 +354,7 @@ class KnowledgeRetrievalService:
         )
         if target_type == RetrieveType.PARTICIPLE:
             chunks = await store.search_by_full_text(request.query, full_text_options)
-            cls._log_target_done(target, 0, len(chunks), len(chunks), len(chunks), started_at)
+            cls._log_target_done(target, 0, len(chunks), len(chunks), len(chunks), started_at, timings=timings)
             return chunks
 
         vector_options = cls._search_options(
@@ -359,7 +366,7 @@ class KnowledgeRetrievalService:
         )
         if target_type == RetrieveType.SEMANTIC:
             chunks = await store.search_by_vector(target.embedding, request.query, vector_options)
-            cls._log_target_done(target, len(chunks), 0, len(chunks), len(chunks), started_at)
+            cls._log_target_done(target, len(chunks), 0, len(chunks), len(chunks), started_at, timings=timings)
             return chunks
 
         vector_task = asyncio.create_task(
@@ -384,22 +391,26 @@ class KnowledgeRetrievalService:
             raise
         candidates = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         reranker = request_reranker if use_request_reranker else target.reranker
-        if candidates and reranker:
-            ranked = await models.rerank(
-                reranker,
-                request.query,
-                candidates,
-                target.params.top_k,
-            )
-        elif candidates and use_request_reranker:
-            ranked = cls._apply_rerank_fallback(candidates, target.params.top_k)
-        else:
-            ranked = candidates[:target.params.top_k]
-        chunks = [
-            chunk
-            for chunk in ranked
-            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
-        ]
+        local_rerank_started_at = time.perf_counter()
+        try:
+            if candidates and reranker:
+                ranked = await models.rerank(
+                    reranker,
+                    request.query,
+                    candidates,
+                    target.params.top_k,
+                )
+            elif candidates and use_request_reranker:
+                ranked = cls._apply_rerank_fallback(candidates, target.params.top_k)
+            else:
+                ranked = candidates[:target.params.top_k]
+            chunks = [
+                chunk
+                for chunk in ranked
+                if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
+            ]
+        finally:
+            cls._record_timing(timings, "local_rerank_ms", local_rerank_started_at)
         cls._log_target_done(
             target,
             len(vector_chunks),
@@ -408,6 +419,7 @@ class KnowledgeRetrievalService:
             len(chunks),
             started_at,
             local_rerank=True,
+            timings=timings,
         )
         return chunks
 
@@ -419,6 +431,7 @@ class KnowledgeRetrievalService:
         chunks: list[DocumentChunk],
         models: AsyncRetrievalModelGateway,
         log_id: str,
+        timings: RetrievalTimings | None = None,
     ) -> list[DocumentChunk]:
         candidates_count = len(chunks)
         unique_chunks = cls._deduplicate_chunks(chunks)
@@ -435,26 +448,30 @@ class KnowledgeRetrievalService:
             request.rerank_id is not None and not single_hybrid_uses_request_rerank
         )
         if needs_global_rerank:
-            reranker = (
-                preparation.request_reranker
-                if request.rerank_id is not None
-                else targets[0].reranker
-            )
-            if reranker:
-                ranked_chunks = await models.rerank(
-                    reranker,
-                    request.query,
-                    unique_chunks,
-                    request.top_k,
+            global_rerank_started_at = time.perf_counter()
+            try:
+                reranker = (
+                    preparation.request_reranker
+                    if request.rerank_id is not None
+                    else targets[0].reranker
                 )
-            else:
-                ranked_chunks = cls._apply_rerank_fallback(unique_chunks, request.top_k)
-            threshold: float | None = cls._resolve_rerank_score_threshold(request)
-            filtered_chunks = [
-                chunk
-                for chunk in ranked_chunks
-                if (chunk.metadata or {}).get("score", 0) > threshold
-            ]
+                if reranker:
+                    ranked_chunks = await models.rerank(
+                        reranker,
+                        request.query,
+                        unique_chunks,
+                        request.top_k,
+                    )
+                else:
+                    ranked_chunks = cls._apply_rerank_fallback(unique_chunks, request.top_k)
+                threshold: float | None = cls._resolve_rerank_score_threshold(request)
+                filtered_chunks = [
+                    chunk
+                    for chunk in ranked_chunks
+                    if (chunk.metadata or {}).get("score", 0) > threshold
+                ]
+            finally:
+                cls._record_timing(timings, "global_rerank_ms", global_rerank_started_at)
         else:
             ranked_chunks = sorted(
                 unique_chunks,
@@ -476,6 +493,7 @@ class KnowledgeRetrievalService:
                     "result_count": len(result),
                     "async_mode": "native",
                 }
+                | cls._timing_log_fields(timings)
             ),
         )
         return result
@@ -506,9 +524,7 @@ class KnowledgeRetrievalService:
         log_id: str,
         started_at: float,
         reason: str,
-        snapshot_ms: int,
-        metadata_llm_ms: int = 0,
-        metadata_query_ms: int = 0,
+        timings: RetrievalTimings,
     ) -> KnowledgeRetrievalResult:
         logger.info(
             "[Retrieval] finish %s",
@@ -518,12 +534,10 @@ class KnowledgeRetrievalService:
                     "reason": reason,
                     "target_count": 0,
                     "final_count": 0,
-                    "db_snapshot_ms": snapshot_ms,
-                    "metadata_llm_ms": metadata_llm_ms,
-                    "metadata_query_ms": metadata_query_ms,
                     "elapsed_ms": cls._elapsed_ms(started_at),
                     "async_mode": "native",
                 }
+                | timings.as_log_fields()
             ),
         )
         return KnowledgeRetrievalResult(chunks=[])
@@ -539,6 +553,7 @@ class KnowledgeRetrievalService:
         started_at: float,
         *,
         local_rerank: bool = False,
+        timings: RetrievalTimings | None = None,
     ) -> None:
         logger.info(
             "[Retrieval] target_done %s",
@@ -555,7 +570,26 @@ class KnowledgeRetrievalService:
                     "elapsed_ms": cls._elapsed_ms(started_at),
                     "async_mode": "native",
                 }
+                | cls._timing_log_fields(timings)
             ),
+        )
+
+    @staticmethod
+    def _timing_log_fields(timings: RetrievalTimings | None) -> dict[str, int]:
+        return timings.as_log_fields() if timings is not None else RetrievalTimings().as_log_fields()
+
+    @staticmethod
+    def _record_timing(
+        timings: RetrievalTimings | None,
+        field_name: str,
+        started_at: float,
+    ) -> None:
+        if timings is None:
+            return
+        setattr(
+            timings,
+            field_name,
+            getattr(timings, field_name) + KnowledgeRetrievalService._elapsed_ms(started_at),
         )
 
     @classmethod

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -227,7 +227,7 @@ class KnowledgeRetrievalService:
                 set(preparation.common_metadata_defs.keys()),
             )
         if request.metadata_filter_mode == MetadataFilterMode.AUTO:
-            if request.metadata_filters:
+            if request.metadata_filters or request.metadata_filters_prepared:
                 return cls._build_common_filter_groups(
                     request.metadata_filters,
                     set(preparation.common_metadata_defs.keys()),

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -362,10 +362,26 @@ class KnowledgeRetrievalService:
             cls._log_target_done(target, len(chunks), 0, len(chunks), len(chunks), started_at)
             return chunks
 
-        vector_chunks, full_text_chunks = await asyncio.gather(
-            store.search_by_vector(target.embedding, request.query, vector_options),
-            store.search_by_full_text(request.query, full_text_options),
+        vector_task = asyncio.create_task(
+            store.search_by_vector(target.embedding, request.query, vector_options)
         )
+        full_text_task = asyncio.create_task(
+            store.search_by_full_text(request.query, full_text_options)
+        )
+        try:
+            vector_chunks, full_text_chunks = await asyncio.gather(
+                vector_task,
+                full_text_task,
+            )
+        except BaseException:
+            vector_task.cancel()
+            full_text_task.cancel()
+            await asyncio.gather(
+                vector_task,
+                full_text_task,
+                return_exceptions=True,
+            )
+            raise
         candidates = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
         reranker = request_reranker if use_request_reranker else target.reranker
         if candidates and reranker:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -375,6 +375,8 @@ class KnowledgeRetrievalService:
                 candidates,
                 target.params.top_k,
             )
+        elif candidates and use_request_reranker:
+            ranked = cls._apply_rerank_fallback(candidates, target.params.top_k)
         else:
             ranked = candidates[:target.params.top_k]
         chunks = [

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -2,125 +2,52 @@ import asyncio
 import logging
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
-
-from langchain_core.documents import Document
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
+from typing import Any, Sequence
 
 from app.core.config import settings
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
-from app.core.models import RedBearLLM, RedBearRerank
-from app.core.models.base import RedBearModelConfig
-from app.core.rag.llm.chat_model import Base
-from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.metadata.filter_engine import (
     FilterCondition as EngineFilterCondition,
     FilterGroup as EngineFilterGroup,
-    MetadataFilterEngine,
 )
-from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
-from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
-    ElasticSearchVector,
-    ElasticSearchVectorFactory,
-    ElasticSearchVectorIndexOps,
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.async_elasticsearch import (
+    AsyncElasticSearchRetrieval,
+    AsyncElasticsearchClientProvider,
 )
-from app.db import get_db_context
-from app.models import ModelType, knowledge_model, knowledgeshare_model
-from app.models.models_model import ModelApiKey, ModelConfig
-from app.repositories import knowledge_repository
-from app.repositories.tool_repository import ToolRepository
-from app.schemas.chunk_schema import KnowledgeBaseConfig, RetrieveType
+from app.core.rag.retrieval.async_models import AsyncRetrievalModelGateway
+from app.core.rag.retrieval.exceptions import KnowledgeRetrievalConfigError
+from app.core.rag.retrieval.graph_bridge import GraphRetrievalBridge
+from app.core.rag.retrieval.models import (
+    ModelRuntimeSnapshot,
+    RetrievalParams,
+    RetrievalPreparation,
+    RetrievalPrincipal,
+    RetrievalSearchOptions,
+    RetrievalTarget,
+)
+from app.schemas.chunk_schema import RetrieveType
 from app.schemas.knowledge_metadata_schema import MetadataFilterMode
-from app.schemas.knowledge_retrieval_schema import KnowledgeRetrievalRequest, KnowledgeRetrievalResult
-from app.services import knowledge_service, knowledgeshare_service
-from app.services.knowledge_metadata_service import KnowledgeMetadataService
-from app.services.metadata_auto_filter_service import MetadataAutoFilterService
-from app.services.model_service import ModelApiKeyService, ModelConfigService
+from app.schemas.knowledge_retrieval_schema import (
+    KnowledgeRetrievalRequest,
+    KnowledgeRetrievalResult,
+)
+from app.services.knowledge_retrieval_preparation import KnowledgeRetrievalPreparation
 
 logger = logging.getLogger(__name__)
+
+ModelApiKeySnapshot = ModelRuntimeSnapshot
 
 
 class KnowledgeRetrievalAccessDenied(Exception):
     pass
 
 
-class KnowledgeRetrievalConfigError(Exception):
-    pass
-
-
-@dataclass(frozen=True)
-class ModelApiKeySnapshot:
-    model_name: str
-    provider: str
-    api_key: str
-    api_base: str | None
-
-    @classmethod
-    def from_api_key(cls, api_key: ModelApiKey) -> "ModelApiKeySnapshot":
-        return cls(
-            model_name=api_key.model_name,
-            provider=api_key.provider,
-            api_key=api_key.api_key,
-            api_base=api_key.api_base,
-        )
-
-
-@dataclass(frozen=True)
-class RetrievalPrincipal:
-    id: Any
-    username: str | None
-    tenant_id: Any
-    current_workspace_id: Any
-    is_superuser: bool
-
-    @classmethod
-    def from_user(cls, user: Any) -> "RetrievalPrincipal | None":
-        if user is None:
-            return None
-        if isinstance(user, cls):
-            return user
-        return cls(
-            id=getattr(user, "id", None),
-            username=getattr(user, "username", None),
-            tenant_id=getattr(user, "tenant_id", None),
-            current_workspace_id=getattr(user, "current_workspace_id", None),
-            is_superuser=bool(getattr(user, "is_superuser", False)),
-        )
-
-
-@dataclass(frozen=True)
-class RetrievalParams:
-    similarity_threshold: float
-    vector_similarity_weight: float | None
-    top_k: int
-    top_n: int
-    retrieve_type: RetrieveType
-    rerank_score_threshold: float = 0.1
-
-
-@dataclass(frozen=True)
-class KnowledgeRetrievalRef:
-    knowledge: Any
-    config: KnowledgeBaseConfig | None
-
-
-@dataclass(frozen=True)
-class RetrievalTarget:
-    knowledge_id: uuid.UUID
-    workspace_id: uuid.UUID
-    index_name: str
-    params: RetrievalParams
-    embedding_config: ModelApiKeySnapshot
-    reranker_config: ModelApiKeySnapshot
-
-
 class KnowledgeRetrievalService:
+    """Native asynchronous knowledge-base retrieval facade."""
+
     @staticmethod
     def _new_retrieval_log_id() -> str:
         return uuid.uuid4().hex[:8]
@@ -135,7 +62,7 @@ class KnowledgeRetrievalService:
         return text[:8] if len(text) > 8 else text
 
     @classmethod
-    def _compact_ids(cls, values: list[Any], limit: int = 10) -> list[str]:
+    def _compact_ids(cls, values: Sequence[Any], limit: int = 10) -> list[str]:
         compacted = [cls._compact_id(value) for value in values[:limit]]
         if len(values) > limit:
             compacted.append(f"+{len(values) - limit}")
@@ -162,486 +89,487 @@ class KnowledgeRetrievalService:
 
     @classmethod
     def _build_retrieval_start_log_fields(
-            cls,
-            log_id: str,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
+        cls,
+        log_id: str,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None,
     ) -> dict[str, Any]:
         return {
             "id": log_id,
-            "user": getattr(current_user, "username", None) or getattr(current_user, "id", None) or "anonymous",
+            "user": (
+                principal.username
+                if principal and principal.username
+                else principal.id if principal else "anonymous"
+            ),
             "kb_count": len(request.kb_ids or []),
             "ex_id_count": len(request.ex_ids or []),
             "knowledge_base_count": len(request.knowledge_bases or []),
             "query_len": len(request.query or ""),
-            "type": request.retrieve_type.value,
+            "type": request.retrieve_type,
             "top_k": request.top_k,
             "top_n": request.top_n,
-            "similarity_threshold": request.similarity_threshold,
-            "vector_weight": request.vector_similarity_weight,
-            "rerank_threshold": request.rerank_score_threshold,
-            "metadata_mode": request.metadata_filter_mode.value,
-            "metadata_filter_groups": len(request.metadata_filters or []),
-            "file_filter_count": len(request.file_names_filter or []),
+            "metadata_mode": request.metadata_filter_mode,
+            "async_mode": "native",
         }
-
-    @classmethod
-    def _build_targets_log_fields(
-            cls,
-            log_id: str,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            max_workers: int,
-    ) -> dict[str, Any]:
-        return {
-            "id": log_id,
-            "requested_kb_count": len(request.kb_ids or []) + len(request.knowledge_bases or []),
-            "target_count": len(targets),
-            "max_workers": max_workers,
-            "target_kbs": cls._compact_ids([target.knowledge_id for target in targets]),
-        }
-
-    @staticmethod
-    def _build_metadata_filter_log_fields(
-            log_id: str,
-            request: KnowledgeRetrievalRequest,
-            effective: bool,
-            reason: str,
-            document_count: int | None,
-            common_fields: int | None = None,
-            effective_groups: int | None = None,
-    ) -> dict[str, Any]:
-        fields = {
-            "id": log_id,
-            "mode": request.metadata_filter_mode.value,
-            "provided_groups": len(request.metadata_filters or []),
-            "effective": effective,
-            "reason": reason,
-            "matched_documents": document_count if document_count is not None else "none",
-        }
-        if common_fields is not None:
-            fields["common_fields"] = common_fields
-        if effective_groups is not None:
-            fields["effective_groups"] = effective_groups
-        return fields
-
-    @classmethod
-    def _build_target_done_log_fields(
-            cls,
-            log_id: str,
-            target: RetrievalTarget,
-            target_position: int,
-            vector_count: int,
-            full_text_count: int,
-            merged_count: int,
-            result_count: int,
-            elapsed_ms: int,
-            local_rerank: bool,
-    ) -> dict[str, Any]:
-        return {
-            "id": log_id,
-            "target": target_position,
-            "kb_id": cls._compact_id(target.knowledge_id),
-            "index": target.index_name,
-            "type": target.params.retrieve_type.value,
-            "top_k": target.params.top_k,
-            "top_n": target.params.top_n,
-            "vector_kept": vector_count,
-            "fulltext_kept": full_text_count,
-            "merged": merged_count,
-            "local_rerank": local_rerank,
-            "result_count": result_count,
-            "elapsed_ms": elapsed_ms,
-        }
-
-    @staticmethod
-    def _resolve_tenant_id(
-            db: Session,
-            current_user: Any = None,
-            workspace_id: uuid.UUID | None = None,
-    ) -> uuid.UUID | None:
-        if current_user is not None:
-            tenant_id = getattr(current_user, "tenant_id", None)
-            if tenant_id:
-                return tenant_id
-            workspace_id = workspace_id or getattr(current_user, "current_workspace_id", None)
-
-        if not workspace_id:
-            return None
-        return ToolRepository.get_tenant_id_by_workspace_id(db, str(workspace_id))
-
-    @classmethod
-    def retrieve(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> KnowledgeRetrievalResult:
-        log_id = cls._new_retrieval_log_id()
-        started_at = time.perf_counter()
-        logger.info(
-            "[Retrieval] start %s",
-            cls._format_log_fields(cls._build_retrieval_start_log_fields(log_id, request, current_user)),
-        )
-        targets, tenant_id = cls._resolve_retrieval_targets(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not targets:
-            logger.info(
-                "[Retrieval] finish %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "reason": "no_targets",
-                    "target_count": 0,
-                    "final_count": 0,
-                    "elapsed_ms": cls._elapsed_ms(started_at),
-                }),
-            )
-            return KnowledgeRetrievalResult(chunks=[])
-
-        knowledge_ids = [target.knowledge_id for target in targets]
-        workspace_ids = [target.workspace_id for target in targets]
-        db_knowledge = cls._get_first_knowledge(
-            db=db,
-            knowledge_id=targets[0].knowledge_id,
-            current_user=current_user,
-        )
-        if not db_knowledge:
-            raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
-
-        document_ids_include = cls._build_metadata_document_filter(
-            db=db,
-            request=request,
-            knowledge_ids=knowledge_ids,
-            tenant_id=tenant_id,
-            log_id=log_id,
-        )
-        if document_ids_include == []:
-            logger.info(
-                "[Retrieval] finish %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "reason": "metadata_filter_empty",
-                    "target_count": len(targets),
-                    "final_count": 0,
-                    "elapsed_ms": cls._elapsed_ms(started_at),
-                }),
-            )
-            return KnowledgeRetrievalResult(chunks=[])
-
-        chunks = cls._retrieve_targets(
-            db=db,
-            request=request,
-            targets=targets,
-            document_ids_include=document_ids_include,
-            tenant_id=tenant_id,
-            log_id=log_id,
-        )
-        if any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
-            graph_doc = cls._retrieve_graph(
-                db=db,
-                request=request,
-                knowledge_ids=knowledge_ids,
-                workspace_ids=workspace_ids,
-                db_knowledge=db_knowledge,
-                tenant_id=tenant_id,
-            )
-            if graph_doc:
-                chunks.insert(0, graph_doc)
-        chunks = cls._include_document_ids(chunks, document_ids_include)
-        logger.info(
-            "[Retrieval] finish %s",
-            cls._format_log_fields({
-                "id": log_id,
-                "reason": "ok",
-                "target_count": len(targets),
-                "document_filter_count": len(document_ids_include or []),
-                "final_count": len(chunks),
-                "elapsed_ms": cls._elapsed_ms(started_at),
-            }),
-        )
-        return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
     async def retrieve_async(
-            cls,
-            db: Session | AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
+        cls,
+        request: KnowledgeRetrievalRequest,
+        principal: RetrievalPrincipal | None = None,
     ) -> KnowledgeRetrievalResult:
-        """Async retrieval entrypoint for async request chains."""
-        principal = RetrievalPrincipal.from_user(current_user)
-        if isinstance(db, AsyncSession):
-            return await cls._retrieve_with_async_session(db, request, principal)
-        if isinstance(db, Session):
-            return await asyncio.to_thread(
-                cls._retrieve_with_sync_session,
-                request,
-                principal,
-            )
-        raise TypeError("retrieve_async requires Session or AsyncSession")
+        """Retrieve with short database snapshots and native asynchronous I/O."""
 
-    @classmethod
-    def _retrieve_with_sync_session(
-            cls,
-            request: KnowledgeRetrievalRequest,
-            current_user: RetrievalPrincipal | None,
-    ) -> KnowledgeRetrievalResult:
-        with get_db_context() as thread_db:
-            return cls.retrieve(thread_db, request, current_user)
-
-    @classmethod
-    async def _retrieve_with_async_session(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            current_user: RetrievalPrincipal | None = None,
-    ) -> KnowledgeRetrievalResult:
-
+        principal = RetrievalPrincipal.from_user(principal)
         log_id = cls._new_retrieval_log_id()
         started_at = time.perf_counter()
         logger.info(
             "[Retrieval] start %s",
-            cls._format_log_fields(cls._build_retrieval_start_log_fields(log_id, request, current_user)),
+            cls._format_log_fields(
+                cls._build_retrieval_start_log_fields(log_id, request, principal)
+            ),
         )
-        targets, tenant_id = await cls._resolve_retrieval_targets_async(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not targets:
-            logger.info(
-                "[Retrieval] finish %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "reason": "no_targets",
-                    "target_count": 0,
-                    "final_count": 0,
-                    "elapsed_ms": cls._elapsed_ms(started_at),
-                }),
-            )
-            return KnowledgeRetrievalResult(chunks=[])
 
-        knowledge_ids = [target.knowledge_id for target in targets]
-        workspace_ids = [target.workspace_id for target in targets]
-        db_knowledge = await cls._get_first_knowledge_async(
-            db=db,
-            knowledge_id=targets[0].knowledge_id,
-            current_user=current_user,
-        )
-        if not db_knowledge:
-            raise KnowledgeRetrievalAccessDenied("The knowledge base does not exist or access is denied")
+        snapshot_started_at = time.perf_counter()
+        preparation = await KnowledgeRetrievalPreparation.prepare(request, principal)
+        snapshot_ms = cls._elapsed_ms(snapshot_started_at)
+        if not preparation.targets:
+            return cls._finish_empty(log_id, started_at, "no_targets", snapshot_ms)
 
-        document_ids_include = await cls._build_metadata_document_filter_async(
-            db=db,
-            request=request,
-            knowledge_ids=knowledge_ids,
-            tenant_id=tenant_id,
-            log_id=log_id,
+        models = AsyncRetrievalModelGateway()
+        metadata_started_at = time.perf_counter()
+        filter_groups = await cls._build_metadata_filter_groups(
+            request,
+            preparation,
+            models,
+        )
+        metadata_llm_ms = cls._elapsed_ms(metadata_started_at)
+
+        metadata_query_started_at = time.perf_counter()
+        document_ids_include = await KnowledgeRetrievalPreparation.resolve_metadata_document_ids(
+            preparation,
+            filter_groups,
+        )
+        metadata_query_ms = cls._elapsed_ms(metadata_query_started_at)
+        cls._log_metadata_filter(
+            log_id,
+            request,
+            preparation,
+            filter_groups,
+            document_ids_include,
         )
         if document_ids_include == []:
-            logger.info(
-                "[Retrieval] finish %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "reason": "metadata_filter_empty",
-                    "target_count": len(targets),
-                    "final_count": 0,
-                    "elapsed_ms": cls._elapsed_ms(started_at),
-                }),
+            return cls._finish_empty(
+                log_id,
+                started_at,
+                "metadata_filter_empty",
+                snapshot_ms,
+                metadata_llm_ms,
+                metadata_query_ms,
             )
-            return KnowledgeRetrievalResult(chunks=[])
 
-        chunks = await cls._retrieve_targets_async(
-            db=db,
-            request=request,
-            targets=targets,
-            document_ids_include=document_ids_include,
-            tenant_id=tenant_id,
-            log_id=log_id,
+        client = await AsyncElasticsearchClientProvider.get_shared_client()
+        store = AsyncElasticSearchRetrieval(client, models)
+        chunks = await cls._retrieve_targets(
+            request,
+            preparation,
+            document_ids_include,
+            store,
+            models,
+            log_id,
         )
-        if any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
-            graph_doc = await cls._retrieve_graph_async(
-                db=db,
-                request=request,
-                knowledge_ids=knowledge_ids,
-                workspace_ids=workspace_ids,
-                db_knowledge=db_knowledge,
-                tenant_id=tenant_id,
-            )
-            if graph_doc:
-                chunks.insert(0, graph_doc)
+        if preparation.graph:
+            graph_document = await GraphRetrievalBridge.retrieve(preparation.graph)
+            if graph_document:
+                chunks.insert(0, graph_document)
+
         chunks = cls._include_document_ids(chunks, document_ids_include)
         logger.info(
             "[Retrieval] finish %s",
-            cls._format_log_fields({
-                "id": log_id,
-                "reason": "ok",
-                "target_count": len(targets),
-                "document_filter_count": len(document_ids_include or []),
-                "final_count": len(chunks),
-                "elapsed_ms": cls._elapsed_ms(started_at),
-            }),
+            cls._format_log_fields(
+                {
+                    "id": log_id,
+                    "reason": "ok",
+                    "target_count": len(preparation.targets),
+                    "document_filter_count": len(document_ids_include or []),
+                    "final_count": len(chunks),
+                    "db_snapshot_ms": snapshot_ms,
+                    "metadata_llm_ms": metadata_llm_ms,
+                    "metadata_query_ms": metadata_query_ms,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                    "async_mode": "native",
+                }
+            ),
         )
         return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
-    def _resolve_retrieval_targets(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> tuple[list[RetrievalTarget], uuid.UUID | None]:
-        refs = cls._resolve_retrievable_knowledge_refs(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not refs:
-            return [], None
+    def retrieve(cls, *args: Any, **kwargs: Any) -> KnowledgeRetrievalResult:
+        """Compatibility marker for callers that still need migration."""
 
-        tenant_id = cls._resolve_tenant_id(
-            db=db,
-            current_user=current_user,
-            workspace_id=getattr(refs[0].knowledge, "workspace_id", None),
-        )
-        targets = [
-            cls._build_retrieval_target(
-                db=db,
-                request=request,
-                ref=ref,
-                tenant_id=tenant_id,
-            )
-            for ref in refs
-        ]
-        return targets, tenant_id
+        del cls, args, kwargs
+        raise RuntimeError("Synchronous knowledge retrieval is no longer supported")
 
     @classmethod
-    async def _resolve_retrieval_targets_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> tuple[list[RetrievalTarget], uuid.UUID | None]:
-        refs = await cls._resolve_retrievable_knowledge_refs_async(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not refs:
-            return [], None
-
-        tenant_id = await cls._resolve_tenant_id_async(
-            db=db,
-            current_user=current_user,
-            workspace_id=getattr(refs[0].knowledge, "workspace_id", None),
-        )
-        targets = [
-            await cls._build_retrieval_target_async(
-                db=db,
-                request=request,
-                ref=ref,
-                tenant_id=tenant_id,
+    async def _build_metadata_filter_groups(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        preparation: RetrievalPreparation,
+        models: AsyncRetrievalModelGateway,
+    ) -> list[EngineFilterGroup]:
+        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
+            return []
+        if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
+            if not request.metadata_filters:
+                return []
+            return cls._build_common_filter_groups(
+                request.metadata_filters,
+                set(preparation.common_metadata_defs.keys()),
             )
-            for ref in refs
+        if request.metadata_filter_mode == MetadataFilterMode.AUTO:
+            if request.metadata_filters:
+                return cls._build_common_filter_groups(
+                    request.metadata_filters,
+                    set(preparation.common_metadata_defs.keys()),
+                )
+            if not preparation.common_metadata_defs or not preparation.metadata_llm:
+                return []
+            return await models.generate_metadata_filters(
+                request.query,
+                preparation.common_metadata_defs,
+                preparation.metadata_llm,
+            )
+        raise BusinessException(
+            f"metadata_filter_mode 不支持: {request.metadata_filter_mode}",
+            code=BizCode.INVALID_PARAMETER,
+        )
+
+    @classmethod
+    async def _retrieve_targets(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        preparation: RetrievalPreparation,
+        document_ids_include: list[str] | None,
+        store: AsyncElasticSearchRetrieval,
+        models: AsyncRetrievalModelGateway,
+        log_id: str,
+    ) -> list[DocumentChunk]:
+        targets = preparation.targets
+        if not targets:
+            return []
+
+        max_workers = max(
+            1,
+            min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3),
+        )
+        logger.info(
+            "[Retrieval] targets %s",
+            cls._format_log_fields(
+                {
+                    "id": log_id,
+                    "target_count": len(targets),
+                    "max_workers": max_workers,
+                    "target_kbs": cls._compact_ids([target.knowledge_id for target in targets]),
+                    "async_mode": "native",
+                }
+            ),
+        )
+        semaphore = asyncio.Semaphore(max_workers)
+
+        async def retrieve_one(
+            index: int,
+            target: RetrievalTarget,
+        ) -> tuple[int, list[DocumentChunk]]:
+            async with semaphore:
+                chunks = await cls._retrieve_single_target(
+                    request,
+                    target,
+                    document_ids_include,
+                    store,
+                    models,
+                    use_request_reranker=(
+                        request.rerank_id is not None
+                        and len(targets) == 1
+                        and target.params.retrieve_type == RetrieveType.HYBRID
+                    ),
+                    request_reranker=preparation.request_reranker,
+                )
+                return index, chunks
+
+        tasks = [
+            asyncio.create_task(retrieve_one(index, target))
+            for index, target in enumerate(targets)
         ]
-        return targets, tenant_id
+        try:
+            retrieved = await asyncio.gather(*tasks)
+        except BaseException:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
+        chunks_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
+        for index, target_chunks in retrieved:
+            chunks_by_index[index] = target_chunks
+        candidates = [chunk for target_chunks in chunks_by_index for chunk in target_chunks]
+        return await cls._finalize_retrieval_chunks(
+            request,
+            preparation,
+            candidates,
+            models,
+            log_id,
+        )
+
+    @classmethod
+    async def _retrieve_single_target(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        target: RetrievalTarget,
+        document_ids_include: list[str] | None,
+        store: AsyncElasticSearchRetrieval,
+        models: AsyncRetrievalModelGateway,
+        *,
+        use_request_reranker: bool,
+        request_reranker: Any,
+    ) -> list[DocumentChunk]:
+        started_at = time.perf_counter()
+        target_type = target.params.retrieve_type
+        full_text_options = cls._search_options(
+            target,
+            request,
+            document_ids_include,
+            top_k=target.params.top_k if target_type == RetrieveType.PARTICIPLE else target.params.top_n,
+            score_threshold=(
+                None
+                if target_type == RetrieveType.PARTICIPLE
+                else target.params.similarity_threshold
+            ),
+        )
+        if target_type == RetrieveType.PARTICIPLE:
+            chunks = await store.search_by_full_text(request.query, full_text_options)
+            cls._log_target_done(target, 0, len(chunks), len(chunks), len(chunks), started_at)
+            return chunks
+
+        vector_options = cls._search_options(
+            target,
+            request,
+            document_ids_include,
+            top_k=target.params.top_k if target_type == RetrieveType.SEMANTIC else target.params.top_n,
+            score_threshold=target.params.vector_similarity_weight,
+        )
+        if target_type == RetrieveType.SEMANTIC:
+            chunks = await store.search_by_vector(target.embedding, request.query, vector_options)
+            cls._log_target_done(target, len(chunks), 0, len(chunks), len(chunks), started_at)
+            return chunks
+
+        vector_chunks, full_text_chunks = await asyncio.gather(
+            store.search_by_vector(target.embedding, request.query, vector_options),
+            store.search_by_full_text(request.query, full_text_options),
+        )
+        candidates = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+        reranker = request_reranker if use_request_reranker else target.reranker
+        if candidates and reranker:
+            ranked = await models.rerank(
+                reranker,
+                request.query,
+                candidates,
+                target.params.top_k,
+            )
+        else:
+            ranked = candidates[:target.params.top_k]
+        chunks = [
+            chunk
+            for chunk in ranked
+            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
+        ]
+        cls._log_target_done(
+            target,
+            len(vector_chunks),
+            len(full_text_chunks),
+            len(candidates),
+            len(chunks),
+            started_at,
+            local_rerank=True,
+        )
+        return chunks
+
+    @classmethod
+    async def _finalize_retrieval_chunks(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        preparation: RetrievalPreparation,
+        chunks: list[DocumentChunk],
+        models: AsyncRetrievalModelGateway,
+        log_id: str,
+    ) -> list[DocumentChunk]:
+        candidates_count = len(chunks)
+        unique_chunks = cls._deduplicate_chunks(chunks)
+        if not unique_chunks:
+            return []
+
+        targets = preparation.targets
+        single_hybrid_uses_request_rerank = (
+            request.rerank_id is not None
+            and len(targets) == 1
+            and targets[0].params.retrieve_type == RetrieveType.HYBRID
+        )
+        needs_global_rerank = len(targets) > 1 or (
+            request.rerank_id is not None and not single_hybrid_uses_request_rerank
+        )
+        if needs_global_rerank:
+            reranker = (
+                preparation.request_reranker
+                if request.rerank_id is not None
+                else targets[0].reranker
+            )
+            if reranker:
+                ranked_chunks = await models.rerank(
+                    reranker,
+                    request.query,
+                    unique_chunks,
+                    request.top_k,
+                )
+            else:
+                ranked_chunks = cls._apply_rerank_fallback(unique_chunks, request.top_k)
+            threshold: float | None = cls._resolve_rerank_score_threshold(request)
+            filtered_chunks = [
+                chunk
+                for chunk in ranked_chunks
+                if (chunk.metadata or {}).get("score", 0) > threshold
+            ]
+        else:
+            ranked_chunks = sorted(
+                unique_chunks,
+                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
+                reverse=True,
+            )
+            threshold = None
+            filtered_chunks = ranked_chunks
+        result = filtered_chunks[:request.top_k]
+        logger.info(
+            "[Retrieval] finalize %s",
+            cls._format_log_fields(
+                {
+                    "id": log_id,
+                    "candidates": candidates_count,
+                    "deduped": len(unique_chunks),
+                    "global_rerank": needs_global_rerank,
+                    "threshold": threshold if threshold is not None else "none",
+                    "result_count": len(result),
+                    "async_mode": "native",
+                }
+            ),
+        )
+        return result
 
     @staticmethod
-    async def _resolve_tenant_id_async(
-            db: AsyncSession,
-            current_user: Any = None,
-            workspace_id: uuid.UUID | None = None,
-    ) -> uuid.UUID | None:
-        if current_user is not None:
-            tenant_id = getattr(current_user, "tenant_id", None)
-            if tenant_id:
-                return tenant_id
-            workspace_id = workspace_id or getattr(current_user, "current_workspace_id", None)
-
-        if not workspace_id:
-            return None
-        from app.models.workspace_model import Workspace
-
-        workspace = await db.get(Workspace, workspace_id)
-        return workspace.tenant_id if workspace else None
-
-    @classmethod
-    def _build_retrieval_target(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            ref: KnowledgeRetrievalRef,
-            tenant_id: uuid.UUID | None,
-    ) -> RetrievalTarget:
-        knowledge = ref.knowledge
-        if not knowledge.embedding_id:
-            raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
-        if not knowledge.reranker_id:
-            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
-
-        embedding_config = ModelApiKeyService.get_available_api_key(db, knowledge.embedding_id, tenant_id=tenant_id)
-        reranker_config = ModelApiKeyService.get_available_api_key(db, knowledge.reranker_id, tenant_id=tenant_id)
-        if not embedding_config:
-            raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
-        if not reranker_config:
-            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
-
-        return RetrievalTarget(
-            knowledge_id=knowledge.id,
-            workspace_id=knowledge.workspace_id,
-            index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
-            params=cls._build_retrieval_params(request, ref.config),
-            embedding_config=ModelApiKeySnapshot.from_api_key(embedding_config),
-            reranker_config=ModelApiKeySnapshot.from_api_key(reranker_config),
+    def _search_options(
+        target: RetrievalTarget,
+        request: KnowledgeRetrievalRequest,
+        document_ids_include: list[str] | None,
+        *,
+        top_k: int,
+        score_threshold: float | None,
+    ) -> RetrievalSearchOptions:
+        return RetrievalSearchOptions(
+            indices=target.index_name,
+            top_k=top_k,
+            score_threshold=score_threshold,
+            file_names_filter=tuple(request.file_names_filter),
+            document_ids_include=(
+                tuple(document_ids_include) if document_ids_include is not None else None
+            ),
+            knn_num_candidates=None,
         )
 
     @classmethod
-    async def _build_retrieval_target_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            ref: KnowledgeRetrievalRef,
-            tenant_id: uuid.UUID | None,
-    ) -> RetrievalTarget:
-        knowledge = ref.knowledge
-        if not knowledge.embedding_id:
-            raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
-        if not knowledge.reranker_id:
-            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+    def _finish_empty(
+        cls,
+        log_id: str,
+        started_at: float,
+        reason: str,
+        snapshot_ms: int,
+        metadata_llm_ms: int = 0,
+        metadata_query_ms: int = 0,
+    ) -> KnowledgeRetrievalResult:
+        logger.info(
+            "[Retrieval] finish %s",
+            cls._format_log_fields(
+                {
+                    "id": log_id,
+                    "reason": reason,
+                    "target_count": 0,
+                    "final_count": 0,
+                    "db_snapshot_ms": snapshot_ms,
+                    "metadata_llm_ms": metadata_llm_ms,
+                    "metadata_query_ms": metadata_query_ms,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                    "async_mode": "native",
+                }
+            ),
+        )
+        return KnowledgeRetrievalResult(chunks=[])
 
-        embedding_config = await ModelApiKeyService.get_available_api_key_async(db, knowledge.embedding_id, tenant_id=tenant_id)
-        reranker_config = await ModelApiKeyService.get_available_api_key_async(db, knowledge.reranker_id, tenant_id=tenant_id)
-        if not embedding_config:
-            raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
-        if not reranker_config:
-            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+    @classmethod
+    def _log_target_done(
+        cls,
+        target: RetrievalTarget,
+        vector_count: int,
+        full_text_count: int,
+        merged_count: int,
+        result_count: int,
+        started_at: float,
+        *,
+        local_rerank: bool = False,
+    ) -> None:
+        logger.info(
+            "[Retrieval] target_done %s",
+            cls._format_log_fields(
+                {
+                    "kb_id": cls._compact_id(target.knowledge_id),
+                    "index": target.index_name,
+                    "type": target.params.retrieve_type,
+                    "vector_kept": vector_count,
+                    "fulltext_kept": full_text_count,
+                    "merged": merged_count,
+                    "local_rerank": local_rerank,
+                    "result_count": result_count,
+                    "elapsed_ms": cls._elapsed_ms(started_at),
+                    "async_mode": "native",
+                }
+            ),
+        )
 
-        return RetrievalTarget(
-            knowledge_id=knowledge.id,
-            workspace_id=knowledge.workspace_id,
-            index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
-            params=cls._build_retrieval_params(request, ref.config),
-            embedding_config=ModelApiKeySnapshot.from_api_key(embedding_config),
-            reranker_config=ModelApiKeySnapshot.from_api_key(reranker_config),
+    @classmethod
+    def _log_metadata_filter(
+        cls,
+        log_id: str,
+        request: KnowledgeRetrievalRequest,
+        preparation: RetrievalPreparation,
+        filter_groups: list[EngineFilterGroup],
+        document_ids_include: list[str] | None,
+    ) -> None:
+        logger.info(
+            "[Retrieval] metadata_filter %s",
+            cls._format_log_fields(
+                {
+                    "id": log_id,
+                    "mode": request.metadata_filter_mode,
+                    "effective": bool(filter_groups),
+                    "common_fields": len(preparation.common_metadata_defs),
+                    "effective_groups": len(filter_groups),
+                    "matched_documents": (
+                        len(document_ids_include)
+                        if document_ids_include is not None
+                        else "none"
+                    ),
+                    "async_mode": "native",
+                }
+            ),
         )
 
     @staticmethod
-    def _resolve_rerank_score_threshold(
-            request: KnowledgeRetrievalRequest,
-            config: KnowledgeBaseConfig | None = None,
-    ) -> float:
-        explicit_fields = config.model_fields_set if config else set()
-        if (
-                config
-                and "rerank_score_threshold" in explicit_fields
-                and config.rerank_score_threshold is not None
-        ):
-            return config.rerank_score_threshold
-        if config and "vector_similarity_weight" in explicit_fields and config.vector_similarity_weight is not None:
-            return config.vector_similarity_weight
+    def _resolve_rerank_score_threshold(request: KnowledgeRetrievalRequest) -> float:
         if request.rerank_score_threshold is not None:
             return request.rerank_score_threshold
         if request.vector_similarity_weight is not None:
@@ -650,1674 +578,52 @@ class KnowledgeRetrievalService:
 
     @staticmethod
     def _build_retrieval_params(
-            request: KnowledgeRetrievalRequest,
-            config: KnowledgeBaseConfig | None = None,
+        request: KnowledgeRetrievalRequest,
+        config: Any = None,
     ) -> RetrievalParams:
-        explicit_fields = config.model_fields_set if config else set()
-        top_k = config.top_k if config and "top_k" in explicit_fields else request.top_k
-        retrieve_type = config.retrieve_type if config and "retrieve_type" in explicit_fields else request.retrieve_type
-        similarity_threshold = (
-            config.similarity_threshold
-            if config and "similarity_threshold" in explicit_fields
-            else request.similarity_threshold
-        )
-        vector_similarity_weight = (
-            config.vector_similarity_weight
-            if config and "vector_similarity_weight" in explicit_fields
-            else request.vector_similarity_weight
-        )
-        rerank_score_threshold = KnowledgeRetrievalService._resolve_rerank_score_threshold(request, config)
-        top_n = max(top_k, request.top_n or top_k)
-        return RetrievalParams(
-            similarity_threshold=similarity_threshold,
-            vector_similarity_weight=vector_similarity_weight,
-            top_k=top_k,
-            top_n=top_n,
-            retrieve_type=retrieve_type,
-            rerank_score_threshold=rerank_score_threshold,
-        )
+        """Keep configuration precedence available to compatibility callers."""
 
-    @staticmethod
-    def _is_single_target_type(targets: list[RetrievalTarget], retrieve_type: RetrieveType) -> bool:
-        return len(targets) == 1 and targets[0].params.retrieve_type == retrieve_type
-
-    @classmethod
-    def _single_hybrid_uses_request_rerank(
-            cls,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-    ) -> bool:
-        return request.rerank_id is not None and cls._is_single_target_type(targets, RetrieveType.HYBRID)
-
-    @classmethod
-    def _resolve_retrievable_knowledge_refs(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> list[KnowledgeRetrievalRef]:
-        requested_kb_ids, explicit_configs = cls._resolve_requested_kb_ids_and_configs(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not requested_kb_ids:
-            return []
-
-        refs: list[KnowledgeRetrievalRef] = []
-        ref_positions: dict[uuid.UUID, int] = {}
-
-        def append_refs(items: list[KnowledgeRetrievalRef]) -> None:
-            for item in items:
-                knowledge_id = item.knowledge.id
-                if knowledge_id in ref_positions:
-                    if item.config is not None:
-                        refs[ref_positions[knowledge_id]] = item
-                    continue
-                ref_positions[knowledge_id] = len(refs)
-                refs.append(item)
-
-        if current_user is None:
-            knowledges = (
-                db.query(knowledge_model.Knowledge)
-                .filter(
-                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
-                    knowledge_model.Knowledge.status == 1,
-                )
-                .all()
-            )
-            knowledge_by_id = {knowledge.id: knowledge for knowledge in knowledges}
-            for kb_id in requested_kb_ids:
-                knowledge = knowledge_by_id.get(kb_id)
-                if not knowledge:
-                    continue
-                append_refs(cls._expand_knowledge_to_leaf_refs(
-                    db=db,
-                    knowledge=knowledge,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-            return refs
-
-        for kb_id in requested_kb_ids:
-            private_target = (
-                db.query(knowledge_model.Knowledge)
-                .filter(
-                    knowledge_model.Knowledge.id == kb_id,
-                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
-                    knowledge_model.Knowledge.status == 1,
-                )
-                .first()
-            )
-            if private_target:
-                append_refs(cls._expand_knowledge_to_leaf_refs(
-                    db=db,
-                    knowledge=private_target,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-                continue
-
-            share_target = (
-                db.query(knowledge_model.Knowledge)
-                .filter(
-                    knowledge_model.Knowledge.id == kb_id,
-                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
-                    knowledge_model.Knowledge.status == 1,
-                )
-                .first()
-            )
-            if not share_target:
-                continue
-
-            filters = [
-                knowledgeshare_model.KnowledgeShare.target_kb_id == share_target.id,
-                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
-            ]
-            share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
-                db=db,
-                filters=filters,
-                current_user=current_user,
-            )
-            for source_kb_id, _source_workspace_id in share_items:
-                source_knowledge = knowledge_repository.get_knowledge_by_id(
-                    db=db,
-                    knowledge_id=source_kb_id,
-                )
-                append_refs(cls._expand_knowledge_to_leaf_refs(
-                    db=db,
-                    knowledge=source_knowledge,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-
-        return refs
-
-    @classmethod
-    async def _resolve_retrievable_knowledge_refs_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> list[KnowledgeRetrievalRef]:
-        requested_kb_ids, explicit_configs = await cls._resolve_requested_kb_ids_and_configs_async(
-            db=db,
-            request=request,
-            current_user=current_user,
-        )
-        if not requested_kb_ids:
-            return []
-
-        refs: list[KnowledgeRetrievalRef] = []
-        ref_positions: dict[uuid.UUID, int] = {}
-
-        def append_refs(items: list[KnowledgeRetrievalRef]) -> None:
-            for item in items:
-                knowledge_id = item.knowledge.id
-                if knowledge_id in ref_positions:
-                    if item.config is not None:
-                        refs[ref_positions[knowledge_id]] = item
-                    continue
-                ref_positions[knowledge_id] = len(refs)
-                refs.append(item)
-
-        if current_user is None:
-            result = await db.execute(
-                select(knowledge_model.Knowledge).where(
-                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
-                    knowledge_model.Knowledge.status == 1,
-                )
-            )
-            knowledge_by_id = {knowledge.id: knowledge for knowledge in result.scalars().all()}
-            for kb_id in requested_kb_ids:
-                knowledge = knowledge_by_id.get(kb_id)
-                if not knowledge:
-                    continue
-                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
-                    db=db,
-                    knowledge=knowledge,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-            return refs
-
-        for kb_id in requested_kb_ids:
-            private_result = await db.execute(
-                select(knowledge_model.Knowledge).where(
-                    knowledge_model.Knowledge.id == kb_id,
-                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
-                    knowledge_model.Knowledge.status == 1,
-                )
-            )
-            private_target = private_result.scalars().first()
-            if private_target:
-                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
-                    db=db,
-                    knowledge=private_target,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-                continue
-
-            share_result = await db.execute(
-                select(knowledge_model.Knowledge).where(
-                    knowledge_model.Knowledge.id == kb_id,
-                    knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                    knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
-                    knowledge_model.Knowledge.status == 1,
-                )
-            )
-            share_target = share_result.scalars().first()
-            if not share_target:
-                continue
-
-            filters = [
-                knowledgeshare_model.KnowledgeShare.target_kb_id == share_target.id,
-                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
-            ]
-            share_items = await knowledgeshare_service.get_source_kb_ids_by_target_kb_id_async(
-                db=db,
-                filters=filters,
-                current_user=current_user,
-            )
-            for source_kb_id, _source_workspace_id in share_items:
-                source_knowledge = await knowledge_repository.get_knowledge_by_id_async(
-                    db=db,
-                    knowledge_id=source_kb_id,
-                )
-                append_refs(await cls._expand_knowledge_to_leaf_refs_async(
-                    db=db,
-                    knowledge=source_knowledge,
-                    inherited_config=explicit_configs.get(kb_id),
-                    explicit_configs=explicit_configs,
-                ))
-
-        return refs
-
-    @classmethod
-    def _resolve_requested_kb_ids_and_configs(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> tuple[list[uuid.UUID], dict[uuid.UUID, KnowledgeBaseConfig]]:
-        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig] = {}
-        requested_kb_ids = list(request.kb_ids)
-
-        if request.ex_ids:
-            if current_user is None:
-                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
-            resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
-                db=db,
-                external_ids=request.ex_ids,
-                workspace_id=current_user.current_workspace_id,
-                current_user=current_user,
-            )
-            requested_kb_ids.extend(resolved_ids)
-
-        for config in request.knowledge_bases:
-            if config.kb_id in explicit_configs:
-                logger.warning("Duplicate KnowledgeBaseConfig found, using the last one: kb_id=%s", config.kb_id)
-            explicit_configs[config.kb_id] = config
-            requested_kb_ids.append(config.kb_id)
-
-        return cls._unique_ids(requested_kb_ids), explicit_configs
-
-    @classmethod
-    async def _resolve_requested_kb_ids_and_configs_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> tuple[list[uuid.UUID], dict[uuid.UUID, KnowledgeBaseConfig]]:
-        explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig] = {}
-        requested_kb_ids = list(request.kb_ids)
-
-        if request.ex_ids:
-            if current_user is None:
-                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
-            resolved_ids = await knowledge_service.get_knowledge_ids_by_external_ids_async(
-                db=db,
-                external_ids=request.ex_ids,
-                workspace_id=current_user.current_workspace_id,
-                current_user=current_user,
-            )
-            requested_kb_ids.extend(resolved_ids)
-
-        for config in request.knowledge_bases:
-            if config.kb_id in explicit_configs:
-                logger.warning("Duplicate KnowledgeBaseConfig found, using the last one: kb_id=%s", config.kb_id)
-            explicit_configs[config.kb_id] = config
-            requested_kb_ids.append(config.kb_id)
-
-        return cls._unique_ids(requested_kb_ids), explicit_configs
-
-    @classmethod
-    def _expand_knowledge_to_leaf_refs(
-            cls,
-            db: Session,
-            knowledge: Any,
-            inherited_config: KnowledgeBaseConfig | None,
-            explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig],
-            visited: set[uuid.UUID] | None = None,
-    ) -> list[KnowledgeRetrievalRef]:
-        if not knowledge or not knowledge.is_active:
-            return []
-        current_config = explicit_configs.get(knowledge.id) or inherited_config
-        if knowledge.is_retrievable_leaf:
-            return [KnowledgeRetrievalRef(knowledge=knowledge, config=current_config)]
-        if not knowledge.is_folder:
-            return []
-
-        if visited is None:
-            visited = set()
-        if knowledge.id in visited:
-            logger.warning(
-                "Detected cyclic knowledge folder while expanding retrieval targets: knowledge_id=%s",
-                knowledge.id,
-            )
-            return []
-        visited.add(knowledge.id)
-
-        refs = []
-        children = knowledge_repository.get_knowledges_by_parent_id(db=db, parent_id=knowledge.id)
-        for child in children:
-            if child.workspace_id != knowledge.workspace_id:
-                logger.warning(
-                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
-                    knowledge.id,
-                    child.id,
-                )
-                continue
-            refs.extend(cls._expand_knowledge_to_leaf_refs(
-                db=db,
-                knowledge=child,
-                inherited_config=current_config,
-                explicit_configs=explicit_configs,
-                visited=visited,
-            ))
-        return refs
-
-    @classmethod
-    async def _expand_knowledge_to_leaf_refs_async(
-            cls,
-            db: AsyncSession,
-            knowledge: Any,
-            inherited_config: KnowledgeBaseConfig | None,
-            explicit_configs: dict[uuid.UUID, KnowledgeBaseConfig],
-            visited: set[uuid.UUID] | None = None,
-    ) -> list[KnowledgeRetrievalRef]:
-        if not knowledge or not knowledge.is_active:
-            return []
-        current_config = explicit_configs.get(knowledge.id) or inherited_config
-        if knowledge.is_retrievable_leaf:
-            return [KnowledgeRetrievalRef(knowledge=knowledge, config=current_config)]
-        if not knowledge.is_folder:
-            return []
-
-        if visited is None:
-            visited = set()
-        if knowledge.id in visited:
-            logger.warning(
-                "Detected cyclic knowledge folder while expanding retrieval targets: knowledge_id=%s",
-                knowledge.id,
-            )
-            return []
-        visited.add(knowledge.id)
-
-        refs = []
-        children = await knowledge_repository.get_knowledges_by_parent_id_async(db=db, parent_id=knowledge.id)
-        for child in children:
-            if child.workspace_id != knowledge.workspace_id:
-                logger.warning(
-                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
-                    knowledge.id,
-                    child.id,
-                )
-                continue
-            refs.extend(await cls._expand_knowledge_to_leaf_refs_async(
-                db=db,
-                knowledge=child,
-                inherited_config=current_config,
-                explicit_configs=explicit_configs,
-                visited=visited,
-            ))
-        return refs
-
-    @classmethod
-    def _retrieve_targets(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            document_ids_include: list[str] | None,
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[Any]:
-        if not targets:
-            return []
-
-        max_workers = max(1, min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3))
-        if log_id:
-            logger.info(
-                "[Retrieval] targets %s",
-                cls._format_log_fields(cls._build_targets_log_fields(log_id, request, targets, max_workers)),
-            )
-        if cls._single_hybrid_uses_request_rerank(request, targets):
-            candidates = cls._retrieve_single_target(
-                request=request,
-                target=targets[0],
-                document_ids_include=document_ids_include,
-                log_id=log_id,
-                target_position=1,
-                db=db,
-                tenant_id=tenant_id,
-                use_request_rerank=True,
-            )
-            return cls._finalize_retrieval_chunks(
-                db=db,
-                request=request,
-                targets=targets,
-                chunks=candidates,
-                tenant_id=tenant_id,
-                log_id=log_id,
-            )
-
-        results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
-        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="knowledge-retrieval") as executor:
-            futures = {
-                executor.submit(
-                    cls._retrieve_single_target,
-                    request,
-                    target,
-                    document_ids_include,
-                    log_id,
-                    index + 1,
-                ): index
-                for index, target in enumerate(targets)
-            }
-            for future in as_completed(futures):
-                index = futures[future]
-                target = targets[index]
-                try:
-                    results_by_index[index] = future.result()
-                except Exception:
-                    logger.exception(
-                        "Knowledge retrieval target failed: knowledge_id=%s index=%s retrieve_type=%s",
-                        target.knowledge_id,
-                        target.index_name,
-                        target.params.retrieve_type,
-                    )
-                    raise
-
-        candidates = [chunk for target_chunks in results_by_index for chunk in target_chunks]
-        return cls._finalize_retrieval_chunks(
-            db=db,
-            request=request,
-            targets=targets,
-            chunks=candidates,
-            tenant_id=tenant_id,
-            log_id=log_id,
-        )
-
-    @classmethod
-    async def _retrieve_targets_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            document_ids_include: list[str] | None,
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[Any]:
-        if not targets:
-            return []
-
-        max_workers = max(1, min(len(targets), settings.KNOWLEDGE_RETRIEVAL_MAX_WORKERS or 3))
-        if log_id:
-            logger.info(
-                "[Retrieval] targets %s",
-                cls._format_log_fields(cls._build_targets_log_fields(log_id, request, targets, max_workers)),
-            )
-
-        if cls._single_hybrid_uses_request_rerank(request, targets):
-            candidates = await cls._retrieve_single_hybrid_with_request_rerank_async(
-                db=db,
-                request=request,
-                target=targets[0],
-                document_ids_include=document_ids_include,
-                tenant_id=tenant_id,
-                log_id=log_id,
-                target_position=1,
-            )
-            return await cls._finalize_retrieval_chunks_async(
-                db=db,
-                request=request,
-                targets=targets,
-                chunks=candidates,
-                tenant_id=tenant_id,
-                log_id=log_id,
-            )
-
-        semaphore = asyncio.Semaphore(max_workers)
-        results_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
-
-        async def retrieve_one(index: int, target: RetrievalTarget) -> None:
-            async with semaphore:
-                try:
-                    results_by_index[index] = await asyncio.to_thread(
-                        cls._retrieve_single_target,
-                        request,
-                        target,
-                        document_ids_include,
-                        log_id,
-                        index + 1,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Knowledge retrieval target failed: knowledge_id=%s index=%s retrieve_type=%s",
-                        target.knowledge_id,
-                        target.index_name,
-                        target.params.retrieve_type,
-                    )
-                    raise
-
-        await asyncio.gather(
-            *(retrieve_one(index, target) for index, target in enumerate(targets))
-        )
-
-        candidates = [chunk for target_chunks in results_by_index for chunk in target_chunks]
-        return await cls._finalize_retrieval_chunks_async(
-            db=db,
-            request=request,
-            targets=targets,
-            chunks=candidates,
-            tenant_id=tenant_id,
-            log_id=log_id,
-        )
-
-    @classmethod
-    async def _retrieve_single_hybrid_with_request_rerank_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            target: RetrievalTarget,
-            document_ids_include: list[str] | None,
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-            target_position: int = 0,
-    ) -> list[DocumentChunk]:
-        started_at = time.perf_counter()
-
-        def retrieve_candidates() -> tuple[list[DocumentChunk], list[DocumentChunk], list[DocumentChunk]]:
-            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
-                index_name=target.index_name,
-                embedding_config=target.embedding_config,
-                reranker_config=target.reranker_config,
-            )
-            local_request = request.model_copy(update={
-                "similarity_threshold": target.params.similarity_threshold,
-                "vector_similarity_weight": target.params.vector_similarity_weight,
-                "top_k": target.params.top_k,
-                "top_n": target.params.top_n,
-                "retrieve_type": target.params.retrieve_type,
-            })
-            vector_chunks = cls._search_vector(
-                vector_service,
-                local_request,
-                target.index_name,
-                document_ids_include,
-                topk=target.params.top_n,
-            )
-            full_text_chunks = cls._search_full_text(
-                vector_service,
-                local_request,
-                target.index_name,
-                document_ids_include,
-                topk=target.params.top_n,
-            )
-            unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
-            return vector_chunks, full_text_chunks, unique_chunks
-
-        vector_chunks, full_text_chunks, unique_chunks = await asyncio.to_thread(retrieve_candidates)
-        chunks = await cls.rerank_documents_async(
-            db=db,
-            rerank_id=request.rerank_id,
-            query=request.query,
-            docs=unique_chunks,
-            top_k=target.params.top_k,
-            tenant_id=tenant_id,
-        )
-        chunks = [
-            chunk
-            for chunk in chunks
-            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
-        ]
-        if log_id:
-            logger.info(
-                "[Retrieval] target_done %s",
-                cls._format_log_fields(cls._build_target_done_log_fields(
-                    log_id=log_id,
-                    target=target,
-                    target_position=target_position,
-                    vector_count=len(vector_chunks),
-                    full_text_count=len(full_text_chunks),
-                    merged_count=len(unique_chunks),
-                    result_count=len(chunks),
-                    elapsed_ms=cls._elapsed_ms(started_at),
-                    local_rerank=True,
-                )),
-            )
-        return chunks
-
-    @classmethod
-    def _retrieve_single_target(
-            cls,
-            request: KnowledgeRetrievalRequest,
-            target: RetrievalTarget,
-            document_ids_include: list[str] | None,
-            log_id: str | None = None,
-            target_position: int = 0,
-            db: Session | None = None,
-            tenant_id: uuid.UUID | None = None,
-            use_request_rerank: bool = False,
-    ) -> list[DocumentChunk]:
-        started_at = time.perf_counter()
-        vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
-            index_name=target.index_name,
-            embedding_config=target.embedding_config,
-            reranker_config=target.reranker_config,
-        )
-        local_request = request.model_copy(update={
-            "similarity_threshold": target.params.similarity_threshold,
-            "vector_similarity_weight": target.params.vector_similarity_weight,
-            "top_k": target.params.top_k,
-            "top_n": target.params.top_n,
-            "retrieve_type": target.params.retrieve_type,
-        })
-
-        if target.params.retrieve_type == RetrieveType.PARTICIPLE:
-            chunks = cls._search_full_text(
-                vector_service,
-                local_request,
-                target.index_name,
-                document_ids_include,
-                topk=target.params.top_k,
-                apply_score_threshold=False,
-            )
-            if log_id:
-                logger.info(
-                    "[Retrieval] target_done %s",
-                    cls._format_log_fields(cls._build_target_done_log_fields(
-                        log_id=log_id,
-                        target=target,
-                        target_position=target_position,
-                        vector_count=0,
-                        full_text_count=len(chunks),
-                        merged_count=len(chunks),
-                        result_count=len(chunks),
-                        elapsed_ms=cls._elapsed_ms(started_at),
-                        local_rerank=False,
-                    )),
-                )
-            return chunks
-        if target.params.retrieve_type == RetrieveType.SEMANTIC:
-            chunks = cls._search_vector(
-                vector_service,
-                local_request,
-                target.index_name,
-                document_ids_include,
-                topk=target.params.top_k,
-            )
-            if log_id:
-                logger.info(
-                    "[Retrieval] target_done %s",
-                    cls._format_log_fields(cls._build_target_done_log_fields(
-                        log_id=log_id,
-                        target=target,
-                        target_position=target_position,
-                        vector_count=len(chunks),
-                        full_text_count=0,
-                        merged_count=len(chunks),
-                        result_count=len(chunks),
-                        elapsed_ms=cls._elapsed_ms(started_at),
-                        local_rerank=False,
-                    )),
-                )
-            return chunks
-
-        vector_chunks = cls._search_vector(
-            vector_service,
-            local_request,
-            target.index_name,
-            document_ids_include,
-            topk=target.params.top_n,
-        )
-        full_text_chunks = cls._search_full_text(
-            vector_service,
-            local_request,
-            target.index_name,
-            document_ids_include,
-            topk=target.params.top_n,
-        )
-        unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
-        # if len(unique_chunks) <= target.params.top_k:
-        #     return unique_chunks
-        if use_request_rerank and request.rerank_id:
-            chunks = cls.rerank_documents(
-                db=db,
-                rerank_id=request.rerank_id,
-                query=request.query,
-                docs=unique_chunks,
-                top_k=target.params.top_k,
-                tenant_id=tenant_id,
-            )
-        else:
-            chunks = vector_service.rerank(
-                query=request.query,
-                docs=unique_chunks,
-                top_k=target.params.top_k,
-            )
-        chunks = [
-            chunk
-            for chunk in chunks
-            if (chunk.metadata or {}).get("score", 0) > target.params.rerank_score_threshold
-        ]
-        if log_id:
-            logger.info(
-                "[Retrieval] target_done %s",
-                cls._format_log_fields(cls._build_target_done_log_fields(
-                    log_id=log_id,
-                    target=target,
-                    target_position=target_position,
-                    vector_count=len(vector_chunks),
-                    full_text_count=len(full_text_chunks),
-                    merged_count=len(unique_chunks),
-                    result_count=len(chunks),
-                    elapsed_ms=cls._elapsed_ms(started_at),
-                    local_rerank=True,
-                )),
-            )
-        return chunks
-
-    @classmethod
-    def _finalize_retrieval_chunks(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            chunks: list[DocumentChunk],
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[DocumentChunk]:
-        candidate_count = len(chunks)
-        unique_chunks = cls._deduplicate_chunks(chunks)
-        if not unique_chunks:
-            if log_id:
-                logger.info(
-                    "[Retrieval] finalize %s",
-                    cls._format_log_fields({
-                        "id": log_id,
-                        "candidates": candidate_count,
-                        "deduped": 0,
-                        "global_rerank": False,
-                        "threshold": "none",
-                        "filtered": 0,
-                        "result_count": 0,
-                    }),
-                )
-            return []
-
-        single_hybrid_uses_request_rerank = cls._single_hybrid_uses_request_rerank(request, targets)
-        needs_global_rerank = len(targets) > 1 or (
-                request.rerank_id is not None and not single_hybrid_uses_request_rerank
-        )
-        if request.rerank_id and not single_hybrid_uses_request_rerank:
-            ranked_chunks = cls.rerank_documents(
-                db=db,
-                rerank_id=request.rerank_id,
-                query=request.query,
-                docs=unique_chunks,
-                top_k=request.top_k,
-                tenant_id=tenant_id,
-            )
-        elif needs_global_rerank:
-            first_target = targets[0]
-            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
-                index_name=first_target.index_name,
-                embedding_config=first_target.embedding_config,
-                reranker_config=first_target.reranker_config,
-            )
-            ranked_chunks = vector_service.rerank(
-                query=request.query,
-                docs=unique_chunks,
-                top_k=request.top_k,
-            )
-        else:
-            ranked_chunks = sorted(
-                unique_chunks,
-                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
-                reverse=True,
-            )
-
-        if needs_global_rerank:
-            threshold = cls._resolve_rerank_score_threshold(request)
-            filtered_chunks = [
-                chunk
-                for chunk in ranked_chunks
-                if (chunk.metadata or {}).get("score", 0) > threshold
-            ]
-        else:
-            threshold = None
-            filtered_chunks = ranked_chunks
-        result_chunks = filtered_chunks[:request.top_k]
-        if log_id:
-            logger.info(
-                "[Retrieval] finalize %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "candidates": candidate_count,
-                    "deduped": len(unique_chunks),
-                    "global_rerank": needs_global_rerank,
-                    "ranked": len(ranked_chunks),
-                    "threshold": threshold if threshold is not None else "none",
-                    "filtered": len(filtered_chunks),
-                    "result_count": len(result_chunks),
-                }),
-            )
-        return result_chunks
-
-    @classmethod
-    async def _finalize_retrieval_chunks_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            chunks: list[DocumentChunk],
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[DocumentChunk]:
-        candidate_count = len(chunks)
-        unique_chunks = cls._deduplicate_chunks(chunks)
-        if not unique_chunks:
-            if log_id:
-                logger.info(
-                    "[Retrieval] finalize %s",
-                    cls._format_log_fields({
-                        "id": log_id,
-                        "candidates": candidate_count,
-                        "deduped": 0,
-                        "global_rerank": False,
-                        "threshold": "none",
-                        "filtered": 0,
-                        "result_count": 0,
-                    }),
-                )
-            return []
-
-        single_hybrid_uses_request_rerank = cls._single_hybrid_uses_request_rerank(request, targets)
-        needs_global_rerank = len(targets) > 1 or (
-                request.rerank_id is not None and not single_hybrid_uses_request_rerank
-        )
-        if request.rerank_id and not single_hybrid_uses_request_rerank:
-            ranked_chunks = await cls.rerank_documents_async(
-                db=db,
-                rerank_id=request.rerank_id,
-                query=request.query,
-                docs=unique_chunks,
-                top_k=request.top_k,
-                tenant_id=tenant_id,
-            )
-        elif needs_global_rerank:
-            first_target = targets[0]
-            vector_service = ElasticSearchVectorFactory.init_vector_from_configs(
-                index_name=first_target.index_name,
-                embedding_config=first_target.embedding_config,
-                reranker_config=first_target.reranker_config,
-            )
-            ranked_chunks = await asyncio.to_thread(
-                vector_service.rerank,
-                query=request.query,
-                docs=unique_chunks,
-                top_k=request.top_k,
-            )
-        else:
-            ranked_chunks = sorted(
-                unique_chunks,
-                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
-                reverse=True,
-            )
-
-        if needs_global_rerank:
-            threshold = cls._resolve_rerank_score_threshold(request)
-            filtered_chunks = [
-                chunk
-                for chunk in ranked_chunks
-                if (chunk.metadata or {}).get("score", 0) > threshold
-            ]
-        else:
-            threshold = None
-            filtered_chunks = ranked_chunks
-        result_chunks = filtered_chunks[:request.top_k]
-        if log_id:
-            logger.info(
-                "[Retrieval] finalize %s",
-                cls._format_log_fields({
-                    "id": log_id,
-                    "candidates": candidate_count,
-                    "deduped": len(unique_chunks),
-                    "global_rerank": needs_global_rerank,
-                    "ranked": len(ranked_chunks),
-                    "threshold": threshold if threshold is not None else "none",
-                    "filtered": len(filtered_chunks),
-                    "result_count": len(result_chunks),
-                }),
-            )
-        return result_chunks
+        return KnowledgeRetrievalPreparation._build_retrieval_params(request, config)
 
     @staticmethod
     def _resolve_global_score_threshold(
-            request: KnowledgeRetrievalRequest,
-            targets: list[RetrievalTarget],
-            used_rerank: bool,
+        request: KnowledgeRetrievalRequest,
+        targets: Sequence[RetrievalTarget],
+        used_rerank: bool,
     ) -> float:
         if used_rerank:
             return KnowledgeRetrievalService._resolve_rerank_score_threshold(request)
-
         retrieve_types = {target.params.retrieve_type for target in targets}
         if retrieve_types == {RetrieveType.PARTICIPLE}:
             return request.similarity_threshold
         if retrieve_types == {RetrieveType.SEMANTIC}:
-            return request.vector_similarity_weight
-        return min(request.similarity_threshold, request.vector_similarity_weight)
-
-    @classmethod
-    def _retrieve_by_type(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            workspace_ids: list[uuid.UUID],
-            db_knowledge: Any,
-            document_ids_include: list[str] | None,
-            tenant_id: uuid.UUID | None,
-    ) -> list[Any]:
-        vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-        indices = ",".join(f"Vector_index_{knowledge_id}_Node".lower() for knowledge_id in knowledge_ids)
-
-        top_n = request.top_k
-
-        if request.retrieve_type == RetrieveType.PARTICIPLE:
-            return cls._search_full_text(vector_service, request, indices, document_ids_include, topk=top_n)
-        if request.retrieve_type == RetrieveType.SEMANTIC:
-            return cls._search_vector(vector_service, request, indices, document_ids_include, topk=top_n)
-
-        top_n = request.top_n
-
-        vector_chunks = cls._search_vector(vector_service, request, indices, document_ids_include, topk=top_n)
-        full_text_chunks = cls._search_full_text(vector_service, request, indices, document_ids_include, topk=top_n)
-        unique_chunks = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
-        logger.debug(f"Retrieved {len(unique_chunks)} chunks")
-        if not unique_chunks:
-            chunks = []
-        else:
-            chunks = cls._rerank_hybrid_chunks(db, request, vector_service, unique_chunks, tenant_id=tenant_id)
-
-        if request.retrieve_type == RetrieveType.Graph:
-            graph_doc = cls._retrieve_graph(
-                db=db,
-                request=request,
-                knowledge_ids=knowledge_ids,
-                workspace_ids=workspace_ids,
-                db_knowledge=db_knowledge,
-                tenant_id=tenant_id,
-            )
-            if graph_doc:
-                chunks.insert(0, graph_doc)
-
-        return chunks
+            return request.vector_similarity_weight or 0.0
+        return min(
+            request.similarity_threshold,
+            request.vector_similarity_weight or 0.0,
+        )
 
     @staticmethod
-    def _search_vector(
-            vector_service: ElasticSearchVector,
-            request: KnowledgeRetrievalRequest,
-            indices: str,
-            document_ids_include: list[str] | None,
-            topk: Optional[int] = -1,
-            apply_score_threshold: bool = True,
+    def _apply_rerank_fallback(
+        chunks: Sequence[DocumentChunk],
+        top_k: int,
     ) -> list[DocumentChunk]:
-        return vector_service.search_by_vector(
-            query=request.query,
-            top_k=topk,
-            indices=indices,
-            score_threshold=request.vector_similarity_weight if apply_score_threshold else None,
-            document_ids_include=document_ids_include,
-            file_names_filter=request.file_names_filter,
-            resolve_parents=True,
-        )
+        fallback = list(chunks[:top_k])
+        for chunk in fallback:
+            if chunk.metadata is None:
+                chunk.metadata = {}
+            chunk.metadata.setdefault("score", 0.5)
+        return fallback
 
     @staticmethod
-    def _search_full_text(
-            vector_service: ElasticSearchVector,
-            request: KnowledgeRetrievalRequest,
-            indices: str,
-            document_ids_include: list[str] | None,
-            topk: Optional[int] = -1,
-            apply_score_threshold: bool = True,
-    ) -> list[DocumentChunk]:
-        return vector_service.search_by_full_text(
-            query=request.query,
-            top_k=topk,
-            indices=indices,
-            score_threshold=request.similarity_threshold if apply_score_threshold else None,
-            document_ids_include=document_ids_include,
-            file_names_filter=request.file_names_filter,
-            resolve_parents=True,
-        )
-
-    @classmethod
-    def _rerank_hybrid_chunks(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            vector_service: ElasticSearchVector,
-            chunks: list[DocumentChunk],
-            tenant_id: uuid.UUID | None,
-    ) -> list[DocumentChunk]:
-        if request.rerank_id:
-            reranked_chunks = cls.rerank_documents(
-                db=db,
-                rerank_id=request.rerank_id,
-                query=request.query,
-                docs=chunks,
-                top_k=request.top_k,
-                tenant_id=tenant_id,
-            )
-        else:
-            reranked_chunks = vector_service.rerank(
-                query=request.query,
-                docs=chunks,
-                top_k=request.top_k,
-            )
-
-        logger.debug(f"[rerank]rerank_id:{request.rerank_id}, returned {len(reranked_chunks)} docs")
-
-        rerank_score_threshold = cls._resolve_rerank_score_threshold(request)
-
-        filtered_chunks = [
-            chunk
-            for chunk in reranked_chunks
-            if (chunk.metadata or {}).get("score", 0) > rerank_score_threshold
-        ]
-        return filtered_chunks[:request.top_k]
-
-    @staticmethod
-    def _retrieve_graph(
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            workspace_ids: list[uuid.UUID],
-            db_knowledge: Any,
-            tenant_id: uuid.UUID | None,
-    ) -> Any | None:
-        from app.core.rag.common.settings import kg_retriever
-
-        llm_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.llm_id, tenant_id=tenant_id)
-        emb_key = ModelApiKeyService.get_available_api_key(db, db_knowledge.embedding_id, tenant_id=tenant_id)
-        doc = kg_retriever.retrieval(
-            question=request.query,
-            workspace_ids=[str(workspace_id) for workspace_id in workspace_ids],
-            kb_ids=[str(knowledge_id) for knowledge_id in knowledge_ids],
-            emb_mdl=KnowledgeRetrievalService._build_embedding_model(emb_key),
-            llm=KnowledgeRetrievalService._build_chat_model(llm_key),
-        )
-        if doc and str(doc.get("page_content", "")).strip():
-            return doc
-        return None
-
-    @staticmethod
-    async def _retrieve_graph_async(
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            workspace_ids: list[uuid.UUID],
-            db_knowledge: Any,
-            tenant_id: uuid.UUID | None,
-    ) -> Any | None:
-        from app.core.rag.common.settings import kg_retriever
-
-        llm_key = await ModelApiKeyService.get_available_api_key_async(db, db_knowledge.llm_id, tenant_id=tenant_id)
-        emb_key = await ModelApiKeyService.get_available_api_key_async(db, db_knowledge.embedding_id, tenant_id=tenant_id)
-        doc = await asyncio.to_thread(
-            kg_retriever.retrieval,
-            question=request.query,
-            workspace_ids=[str(workspace_id) for workspace_id in workspace_ids],
-            kb_ids=[str(knowledge_id) for knowledge_id in knowledge_ids],
-            emb_mdl=KnowledgeRetrievalService._build_embedding_model(emb_key),
-            llm=KnowledgeRetrievalService._build_chat_model(llm_key),
-        )
-        if doc and str(doc.get("page_content", "")).strip():
-            return doc
-        return None
-
-    @classmethod
-    def _resolve_retrievable_knowledge_ids(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            current_user: Any = None,
-    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        requested_kb_ids = cls._unique_ids(request.kb_ids)
-        if request.ex_ids:
-            if current_user is None:
-                raise KnowledgeRetrievalConfigError("current_user is required to resolve ex_ids")
-            resolved_ids = knowledge_service.get_knowledge_ids_by_external_ids(
-                db=db,
-                external_ids=request.ex_ids,
-                workspace_id=current_user.current_workspace_id,
-                current_user=current_user,
-            )
-            requested_kb_ids = cls._unique_ids(requested_kb_ids + resolved_ids)
-
-        if not requested_kb_ids:
-            return [], []
-
-        if current_user is None:
-            knowledges = (
-                db.query(knowledge_model.Knowledge)
-                .filter(
-                    knowledge_model.Knowledge.id.in_(requested_kb_ids),
-                    knowledge_model.Knowledge.status == 1,
-                )
-                .all()
-            )
-            return cls._expand_knowledges_to_leaf_kbs(db=db, knowledges=knowledges)
-
-        return cls._resolve_accessible_chunk_kbs(
-            db=db,
-            kb_ids=requested_kb_ids,
-            current_user=current_user,
-        )
-
-    @staticmethod
-    def _unique_ids(values: list[uuid.UUID]) -> list[uuid.UUID]:
-        return list(dict.fromkeys(values))
-
-    @classmethod
-    def _expand_knowledges_to_leaf_kbs(
-            cls,
-            db: Session,
-            knowledges: list[Any],
-    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        knowledge_ids = []
-        workspace_ids = []
-        for knowledge in knowledges:
-            expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
-                db=db,
-                knowledge=knowledge,
-            )
-            knowledge_ids.extend(expanded_ids)
-            workspace_ids.extend(expanded_workspace_ids)
-        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
-
-    @classmethod
-    def _expand_folder_to_leaf_kbs(
-            cls,
-            db: Session,
-            knowledge: Any,
-            visited: set[uuid.UUID] | None = None,
-    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        if not knowledge or not knowledge.is_active:
-            return [], []
-        if knowledge.is_retrievable_leaf:
-            return [knowledge.id], [knowledge.workspace_id]
-        if not knowledge.is_folder:
-            return [], []
-
-        if visited is None:
-            visited = set()
-        if knowledge.id in visited:
-            logger.warning(
-                "Detected cyclic knowledge folder while expanding retrieval candidates: knowledge_id=%s",
-                knowledge.id,
-            )
-            return [], []
-        visited.add(knowledge.id)
-
-        knowledge_ids = []
-        workspace_ids = []
-        children = knowledge_repository.get_knowledges_by_parent_id(db=db, parent_id=knowledge.id)
-        for child in children:
-            if child.workspace_id != knowledge.workspace_id:
-                logger.warning(
-                    "Skipping child knowledge from another workspace while expanding folder: folder_id=%s, child_id=%s",
-                    knowledge.id,
-                    child.id,
-                )
-                continue
-            expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
-                db=db,
-                knowledge=child,
-                visited=visited,
-            )
-            knowledge_ids.extend(expanded_ids)
-            workspace_ids.extend(expanded_workspace_ids)
-
-        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
-
-    @staticmethod
-    def _deduplicate_knowledge_pairs(
-            knowledge_ids: list[uuid.UUID],
-            workspace_ids: list[uuid.UUID],
-    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        seen = set()
-        deduplicated_ids = []
-        deduplicated_workspace_ids = []
-        for knowledge_id, workspace_id in zip(knowledge_ids, workspace_ids):
-            if knowledge_id in seen:
-                continue
-            seen.add(knowledge_id)
-            deduplicated_ids.append(knowledge_id)
-            deduplicated_workspace_ids.append(workspace_id)
-        return deduplicated_ids, deduplicated_workspace_ids
-
-    @classmethod
-    def _resolve_accessible_chunk_kbs(
-            cls,
-            db: Session,
-            kb_ids: list[uuid.UUID],
-            current_user: Any,
-    ) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
-        private_targets = (
-            db.query(knowledge_model.Knowledge)
-            .filter(
-                knowledge_model.Knowledge.id.in_(kb_ids),
-                knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Private,
-                knowledge_model.Knowledge.status == 1,
-            )
-            .all()
-        )
-        knowledge_ids, workspace_ids = cls._expand_knowledges_to_leaf_kbs(
-            db=db,
-            knowledges=private_targets,
-        )
-
-        share_targets = (
-            db.query(knowledge_model.Knowledge)
-            .filter(
-                knowledge_model.Knowledge.id.in_(kb_ids),
-                knowledge_model.Knowledge.workspace_id == current_user.current_workspace_id,
-                knowledge_model.Knowledge.permission_id == knowledge_model.PermissionType.Share,
-                knowledge_model.Knowledge.status == 1,
-            )
-            .all()
-        )
-        if share_targets:
-            share_target_ids = [target.id for target in share_targets]
-            filters = [
-                knowledgeshare_model.KnowledgeShare.target_kb_id.in_(share_target_ids),
-                knowledgeshare_model.KnowledgeShare.target_workspace_id == current_user.current_workspace_id,
-            ]
-            share_items = knowledgeshare_service.get_source_kb_ids_by_target_kb_id(
-                db=db,
-                filters=filters,
-                current_user=current_user,
-            )
-            for source_kb_id, _source_workspace_id in share_items:
-                source_knowledge = knowledge_repository.get_knowledge_by_id(
-                    db=db,
-                    knowledge_id=source_kb_id,
-                )
-                expanded_ids, expanded_workspace_ids = cls._expand_folder_to_leaf_kbs(
-                    db=db,
-                    knowledge=source_knowledge,
-                )
-                knowledge_ids.extend(expanded_ids)
-                workspace_ids.extend(expanded_workspace_ids)
-
-        return cls._deduplicate_knowledge_pairs(knowledge_ids, workspace_ids)
-
-    @staticmethod
-    def _get_first_knowledge(
-            db: Session,
-            knowledge_id: uuid.UUID,
-            current_user: Any = None,
-    ) -> Any:
-        if current_user is not None:
-            return knowledge_service.get_knowledge_by_id(
-                db=db,
-                knowledge_id=knowledge_id,
-                current_user=current_user,
-            )
-        return knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
-
-    @staticmethod
-    async def _get_first_knowledge_async(
-            db: AsyncSession,
-            knowledge_id: uuid.UUID,
-            current_user: Any = None,
-    ) -> Any:
-        if current_user is not None:
-            return await knowledge_service.get_knowledge_by_id_async(
-                db=db,
-                knowledge_id=knowledge_id,
-                current_user=current_user,
-            )
-        return await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
-
-    @classmethod
-    def _build_metadata_document_filter(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[str] | None:
-        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="mode_disabled",
-                        document_count=None,
-                    )),
-                )
-            return None
-
-        if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="no_filters",
-                        document_count=None,
-                    )),
-                )
-            return None
-
-        metadata_defs_by_kb = {
-            knowledge_id: KnowledgeMetadataService.get_metadata_defs_for_filtering(db, knowledge_id)
-            for knowledge_id in knowledge_ids
-        }
-        common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
-        filter_groups = cls._build_metadata_filter_groups(
-            db=db,
-            request=request,
-            knowledge_ids=knowledge_ids,
-            common_metadata_defs=common_metadata_defs,
-                tenant_id=tenant_id,
-        )
-        if not filter_groups:
-            logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="no_effective_groups",
-                        document_count=None,
-                        common_fields=len(common_metadata_defs),
-                        effective_groups=0,
-                    )),
-                )
-            return None
-
-        document_ids = set()
-        engine = MetadataFilterEngine(db)
-        for knowledge_id in knowledge_ids:
-            matched_ids = engine.execute(
-                knowledge_id=knowledge_id,
-                filter_groups=filter_groups,
-                metadata_defs=metadata_defs_by_kb[knowledge_id],
-            )
-            document_ids.update(matched_ids)
-        if log_id:
-            logger.info(
-                "[Retrieval] metadata_filter %s",
-                cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                    log_id=log_id,
-                    request=request,
-                    effective=True,
-                    reason="matched",
-                    document_count=len(document_ids),
-                    common_fields=len(common_metadata_defs),
-                    effective_groups=len(filter_groups),
-                )),
-            )
-        return [str(document_id) for document_id in document_ids]
-
-    @classmethod
-    async def _build_metadata_document_filter_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            tenant_id: uuid.UUID | None,
-            log_id: str | None = None,
-    ) -> list[str] | None:
-        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="mode_disabled",
-                        document_count=None,
-                    )),
-                )
-            return None
-
-        if request.metadata_filter_mode == MetadataFilterMode.MANUAL and not request.metadata_filters:
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="no_filters",
-                        document_count=None,
-                    )),
-                )
-            return None
-
-        metadata_defs_by_kb = {
-            knowledge_id: await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(db, knowledge_id)
-            for knowledge_id in knowledge_ids
-        }
-        common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
-        filter_groups = await cls._build_metadata_filter_groups_async(
-            db=db,
-            request=request,
-            knowledge_ids=knowledge_ids,
-            common_metadata_defs=common_metadata_defs,
-            tenant_id=tenant_id,
-        )
-        if not filter_groups:
-            logger.warning("[MetadataFilter] No common metadata fields matched; skipping metadata filter")
-            if log_id:
-                logger.info(
-                    "[Retrieval] metadata_filter %s",
-                    cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                        log_id=log_id,
-                        request=request,
-                        effective=False,
-                        reason="no_effective_groups",
-                        document_count=None,
-                        common_fields=len(common_metadata_defs),
-                        effective_groups=0,
-                    )),
-                )
-            return None
-
-        document_ids = set()
-        engine = MetadataFilterEngine(db)
-        for knowledge_id in knowledge_ids:
-            matched_ids = await engine.execute_async(
-                knowledge_id=knowledge_id,
-                filter_groups=filter_groups,
-                metadata_defs=metadata_defs_by_kb[knowledge_id],
-            )
-            document_ids.update(matched_ids)
-        if log_id:
-            logger.info(
-                "[Retrieval] metadata_filter %s",
-                cls._format_log_fields(cls._build_metadata_filter_log_fields(
-                    log_id=log_id,
-                    request=request,
-                    effective=True,
-                    reason="matched",
-                    document_count=len(document_ids),
-                    common_fields=len(common_metadata_defs),
-                    effective_groups=len(filter_groups),
-                )),
-            )
-        return [str(document_id) for document_id in document_ids]
-
-    @classmethod
-    def _build_metadata_filter_groups(
-            cls,
-            db: Session,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            common_metadata_defs: dict[str, dict],
-            tenant_id: uuid.UUID | None,
-    ) -> list[EngineFilterGroup]:
-        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
-            return []
-
-        if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
-            if not request.metadata_filters:
-                return []
-            return cls._build_common_filter_groups(
-                request.metadata_filters,
-                set(common_metadata_defs.keys()),
-            )
-
-        if request.metadata_filter_mode == MetadataFilterMode.AUTO:
-            # 节点（knowledge node）在 auto 模式下已用配置好的模型提取出过滤条件，
-            # 直接采用，跳过 service 用 knowledge.llm_id 的重复提取。
-            if request.metadata_filters:
-                return cls._build_common_filter_groups(
-                    request.metadata_filters,
-                    set(common_metadata_defs.keys()),
-                )
-
-            if not common_metadata_defs:
-                return []
-            llm = cls._build_metadata_auto_filter_llm(
-                db=db,
-                knowledge_id=knowledge_ids[0],
-                tenant_id=tenant_id,
-            )
-            if not llm:
-                logger.warning("[MetadataAutoFilter] LLM is unavailable; skipping metadata filter")
-                return []
-            return MetadataAutoFilterService.generate_filter_groups(
-                query=request.query,
-                metadata_defs=common_metadata_defs,
-                llm=llm,
-            )
-
-        raise BusinessException(
-            f"metadata_filter_mode 不支持: {request.metadata_filter_mode}",
-            code=BizCode.INVALID_PARAMETER,
-        )
-
-    @classmethod
-    async def _build_metadata_filter_groups_async(
-            cls,
-            db: AsyncSession,
-            request: KnowledgeRetrievalRequest,
-            knowledge_ids: list[uuid.UUID],
-            common_metadata_defs: dict[str, dict],
-            tenant_id: uuid.UUID | None,
-    ) -> list[EngineFilterGroup]:
-        if request.metadata_filter_mode == MetadataFilterMode.DISABLED:
-            return []
-
-        if request.metadata_filter_mode == MetadataFilterMode.MANUAL:
-            if not request.metadata_filters:
-                return []
-            return cls._build_common_filter_groups(
-                request.metadata_filters,
-                set(common_metadata_defs.keys()),
-            )
-
-        if request.metadata_filter_mode == MetadataFilterMode.AUTO:
-            if request.metadata_filters:
-                return cls._build_common_filter_groups(
-                    request.metadata_filters,
-                    set(common_metadata_defs.keys()),
-                )
-
-            if not common_metadata_defs:
-                return []
-            llm = await cls._build_metadata_auto_filter_llm_async(
-                db=db,
-                knowledge_id=knowledge_ids[0],
-                tenant_id=tenant_id,
-            )
-            if not llm:
-                logger.warning("[MetadataAutoFilter] LLM is unavailable; skipping metadata filter")
-                return []
-            return await asyncio.to_thread(
-                MetadataAutoFilterService.generate_filter_groups,
-                query=request.query,
-                metadata_defs=common_metadata_defs,
-                llm=llm,
-            )
-
-        raise BusinessException(
-            f"metadata_filter_mode 不支持: {request.metadata_filter_mode}",
-            code=BizCode.INVALID_PARAMETER,
-        )
-
-    @classmethod
-    def _build_metadata_auto_filter_llm(
-            cls,
-            db: Session,
-            knowledge_id: uuid.UUID,
-            tenant_id: uuid.UUID | None,
-    ) -> RedBearLLM | None:
-        knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
-        if not knowledge or not knowledge.llm_id:
-            return None
-
-        try:
-            config = ModelConfigService.get_model_by_id(db=db, model_id=knowledge.llm_id)
-        except BusinessException:
-            return None
-
-        api_key = ModelApiKeyService.get_available_api_key(db, knowledge.llm_id, tenant_id=tenant_id)
-        if not api_key:
-            return None
-
-        # 参数折叠进 RedBearModelConfig.extra_params（与 knowledge 节点 auto 模式、LLM 节点一致）。
-        # 此兜底路径用知识库 llm_id、无 completion_params，保留原默认 temperature=0 行为。
-        rb_config = RedBearModelConfig(
-            model_name=api_key.model_name,
-            provider=api_key.provider,
-            api_key=api_key.api_key,
-            base_url=api_key.api_base,
-            is_omni=api_key.is_omni,
-            capability=api_key.capability or [],
-            extra_params={"temperature": 0},
-        )
-        return RedBearLLM(rb_config, type=ModelType(config.type))
-
-    @classmethod
-    async def _build_metadata_auto_filter_llm_async(
-            cls,
-            db: AsyncSession,
-            knowledge_id: uuid.UUID,
-            tenant_id: uuid.UUID | None,
-    ) -> RedBearLLM | None:
-        knowledge = await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
-        if not knowledge or not knowledge.llm_id:
-            return None
-
-        config = await db.get(ModelConfig, knowledge.llm_id)
-        if not config:
-            return None
-
-        api_key = await ModelApiKeyService.get_available_api_key_async(db, knowledge.llm_id, tenant_id=tenant_id)
-        if not api_key:
-            return None
-
-        rb_config = RedBearModelConfig(
-            model_name=api_key.model_name,
-            provider=api_key.provider,
-            api_key=api_key.api_key,
-            base_url=api_key.api_base,
-            is_omni=api_key.is_omni,
-            capability=api_key.capability or [],
-            extra_params={"temperature": 0},
-        )
-        return RedBearLLM(rb_config, type=ModelType(config.type))
-
-    @staticmethod
-    def _get_common_metadata_defs(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> dict[str, dict]:
+    def _get_common_metadata_defs(
+        metadata_defs_by_kb: dict[Any, dict[str, dict]],
+    ) -> dict[str, dict]:
         field_names = set()
         for metadata_defs in metadata_defs_by_kb.values():
             field_names.update(metadata_defs.keys())
 
-        common_defs = {}
+        common_defs: dict[str, dict] = {}
         for field_name in field_names:
             common_type = None
             common_def = None
@@ -2337,24 +643,29 @@ class KnowledgeRetrievalService:
         return common_defs
 
     @staticmethod
-    def _get_common_metadata_fields(metadata_defs_by_kb: dict[Any, dict[str, dict]]) -> set[str]:
-        return set(KnowledgeRetrievalService._get_common_metadata_defs(metadata_defs_by_kb).keys())
-
-    @staticmethod
-    def _build_common_filter_groups(metadata_filters: list[Any], common_fields: set[str]) -> list[EngineFilterGroup]:
+    def _build_common_filter_groups(
+        metadata_filters: list[Any],
+        common_fields: set[str],
+    ) -> list[EngineFilterGroup]:
         filter_groups = []
         for group in metadata_filters:
             conditions = [
-                EngineFilterCondition(field=condition.field, operator=condition.operator, value=condition.value)
+                EngineFilterCondition(
+                    field=condition.field,
+                    operator=condition.operator,
+                    value=condition.value,
+                )
                 for condition in group.conditions
                 if condition.field in common_fields
             ]
             if conditions:
-                filter_groups.append(EngineFilterGroup(conditions=conditions, logic=group.logic))
+                filter_groups.append(
+                    EngineFilterGroup(conditions=conditions, logic=group.logic)
+                )
         return filter_groups
 
     @staticmethod
-    def _deduplicate_chunks(chunks: list[DocumentChunk]) -> list[DocumentChunk]:
+    def _deduplicate_chunks(chunks: Sequence[DocumentChunk]) -> list[DocumentChunk]:
         seen_keys = set()
         result = []
         for chunk in chunks:
@@ -2376,144 +687,14 @@ class KnowledgeRetrievalService:
 
     @staticmethod
     def _include_document_ids(
-            chunks: list[Any],
-            document_ids_include: list[str] | None,
-    ) -> list[Any]:
+        chunks: Sequence[DocumentChunk],
+        document_ids_include: list[str] | None,
+    ) -> list[DocumentChunk]:
         if document_ids_include is None:
-            return chunks
+            return list(chunks)
         include_ids = set(document_ids_include)
         return [
             chunk
             for chunk in chunks
-            if chunk.metadata.get("document_id") in include_ids
+            if (chunk.metadata or {}).get("document_id") in include_ids
         ]
-
-    @staticmethod
-    def _exclude_document_ids(
-            chunks: list[Any],
-            document_ids_filter: list[str] | None,
-    ) -> list[Any]:
-        return KnowledgeRetrievalService._include_document_ids(chunks, document_ids_filter)
-
-    @staticmethod
-    def _build_chat_model(api_key: ModelApiKey) -> Base:
-        return Base(
-            key=api_key.api_key,
-            model_name=api_key.model_name,
-            base_url=api_key.api_base,
-        )
-
-    @staticmethod
-    def _build_embedding_model(api_key: ModelApiKey) -> OpenAIEmbed:
-        return OpenAIEmbed(
-            key=api_key.api_key,
-            model_name=api_key.model_name,
-            base_url=api_key.api_base,
-        )
-
-    @staticmethod
-    def rerank_documents(
-            db: Session,
-            rerank_id: uuid.UUID,
-            query: str,
-            docs: list[DocumentChunk],
-            top_k: int,
-            tenant_id: uuid.UUID | None = None,
-    ) -> list[DocumentChunk]:
-        if not docs:
-            raise ValueError("retrieval chunks cannot be empty")
-        if top_k <= 0:
-            raise ValueError("top_k must be a positive integer")
-        try:
-            api_config = ModelApiKeyService.get_available_api_key(db, rerank_id, tenant_id=tenant_id)
-            if not api_config:
-                raise ValueError("模型配置缺少 API Key")
-            reranker = RedBearRerank(
-                RedBearModelConfig(
-                    model_name=api_config.model_name,
-                    provider=api_config.provider,
-                    api_key=api_config.api_key,
-                    base_url=api_config.api_base,
-                )
-            )
-            documents = [
-                Document(
-                    page_content=chunk_retrieval_content(doc),
-                    metadata=doc.metadata or {},
-                )
-                for doc in docs
-            ]
-            reranked_docs = list(reranker.compress_documents(documents, query, top_n=top_k))
-            reranked_docs.sort(
-                key=lambda item: item.metadata.get("relevance_score", 0),
-                reverse=True,
-            )
-            result = []
-            for item in reranked_docs[:top_k]:
-                for doc in docs:
-                    if doc.metadata['doc_id'] == item.metadata['doc_id']:
-                        doc.metadata["score"] = item.metadata["relevance_score"]
-                        result.append(doc)
-            return result
-        except Exception as exc:
-            logger.warning(f"Rerank failed, falling back to original results: {str(exc)}")
-            for doc in docs[:top_k]:
-                if doc.metadata is not None and "score" not in doc.metadata:
-                    doc.metadata["score"] = 0.5
-            return docs[:top_k]
-
-    @staticmethod
-    async def rerank_documents_async(
-            db: AsyncSession,
-            rerank_id: uuid.UUID,
-            query: str,
-            docs: list[DocumentChunk],
-            top_k: int,
-            tenant_id: uuid.UUID | None = None,
-    ) -> list[DocumentChunk]:
-        """Async DB wrapper around the synchronous rerank provider."""
-        if not docs:
-            raise ValueError("retrieval chunks cannot be empty")
-        if top_k <= 0:
-            raise ValueError("top_k must be a positive integer")
-        try:
-            api_config = await ModelApiKeyService.get_available_api_key_async(db, rerank_id, tenant_id=tenant_id)
-            if not api_config:
-                raise ValueError("模型配置缺少 API Key")
-
-            def run_rerank() -> list[DocumentChunk]:
-                reranker = RedBearRerank(
-                    RedBearModelConfig(
-                        model_name=api_config.model_name,
-                        provider=api_config.provider,
-                        api_key=api_config.api_key,
-                        base_url=api_config.api_base,
-                    )
-                )
-                documents = [
-                    Document(
-                        page_content=chunk_retrieval_content(doc),
-                        metadata=doc.metadata or {},
-                    )
-                    for doc in docs
-                ]
-                reranked_docs = list(reranker.compress_documents(documents, query, top_n=top_k))
-                reranked_docs.sort(
-                    key=lambda item: item.metadata.get("relevance_score", 0),
-                    reverse=True,
-                )
-                result = []
-                for item in reranked_docs[:top_k]:
-                    for doc in docs:
-                        if doc.metadata['doc_id'] == item.metadata['doc_id']:
-                            doc.metadata["score"] = item.metadata["relevance_score"]
-                            result.append(doc)
-                return result
-
-            return await asyncio.to_thread(run_rerank)
-        except Exception as exc:
-            logger.warning(f"Rerank failed, falling back to original results: {str(exc)}")
-            for doc in docs[:top_k]:
-                if doc.metadata is not None and "score" not in doc.metadata:
-                    doc.metadata["score"] = 0.5
-            return docs[:top_k]

--- a/api/app/services/metadata_auto_filter_service.py
+++ b/api/app/services/metadata_auto_filter_service.py
@@ -1,9 +1,11 @@
+import asyncio
 import json
 import logging
-from typing import Any
+from collections.abc import Sequence
+from typing import Any, Protocol
 
 import json_repair
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 
 from app.core.rag.metadata.filter_engine import (
     FilterCondition as EngineFilterCondition,
@@ -12,6 +14,13 @@ from app.core.rag.metadata.filter_engine import (
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive
 
 logger = logging.getLogger(__name__)
+
+
+class AsyncMetadataLLM(Protocol):
+    """Minimal native asynchronous LLM contract for metadata filtering."""
+
+    async def invoke(self, messages: Sequence[BaseMessage]) -> str:
+        """Return generated content for the supplied messages."""
 
 
 class MetadataAutoFilterService:
@@ -112,6 +121,38 @@ class MetadataAutoFilterService:
         return [EngineFilterGroup(conditions=conditions, logic="AND")]
 
     @classmethod
+    async def generate_filter_groups_async(
+        cls,
+        query: str,
+        metadata_defs: dict[str, dict],
+        llm: AsyncMetadataLLM,
+    ) -> list[EngineFilterGroup]:
+        """Generate metadata filters without blocking the request event loop."""
+
+        if not metadata_defs:
+            return []
+
+        raw_conditions = await cls._extract_metadata_conditions_async(
+            query=query,
+            metadata_defs=metadata_defs,
+            llm=llm,
+        )
+        conditions = []
+        for raw_condition in raw_conditions:
+            condition = cls._normalize_condition(raw_condition, metadata_defs)
+            if condition:
+                conditions.append(condition)
+
+        logger.info(
+            "[MetadataAutoFilter] async extracted %s valid conditions from %s candidates",
+            len(conditions),
+            len(raw_conditions),
+        )
+        if not conditions:
+            return []
+        return [EngineFilterGroup(conditions=conditions, logic="AND")]
+
+    @classmethod
     def _extract_metadata_conditions(
         cls,
         query: str,
@@ -130,19 +171,49 @@ class MetadataAutoFilterService:
         ]
         try:
             response = llm.invoke(messages)
-        except Exception as e:
-            base_url = getattr(getattr(llm, "_config", None), "base_url", None)
+        except Exception as exc:
             logger.warning(
-                "[MetadataAutoFilter] LLM invoke failed (base_url=%r): %r",
-                base_url, e,
+                "[MetadataAutoFilter] LLM invoke failed error_type=%s",
+                type(exc).__name__,
             )
             return []
         content = response.content if hasattr(response, "content") else str(response)
-        logger.info("[MetadataAutoFilter] LLM raw output: %s", content)
+        logger.info("[MetadataAutoFilter] LLM response received length=%s", len(str(content)))
         if not content:
             logger.warning("[MetadataAutoFilter] LLM returned no usable content")
             return []
         return cls._parse_llm_response(str(content))
+
+    @classmethod
+    async def _extract_metadata_conditions_async(
+        cls,
+        query: str,
+        metadata_defs: dict[str, dict],
+        llm: AsyncMetadataLLM,
+    ) -> list[dict[str, Any]]:
+        system_prompt = (
+            "You are a text metadata extract engine. Extract only metadata filters that are clearly "
+            "present in the user's input and only use fields from the provided metadata list."
+        )
+        messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=cls._build_prompt(query=query, metadata_defs=metadata_defs)),
+        ]
+        try:
+            content = await llm.invoke(messages)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[MetadataAutoFilter] async LLM invoke failed error_type=%s",
+                type(exc).__name__,
+            )
+            return []
+        if not content:
+            logger.warning("[MetadataAutoFilter] async LLM returned no usable content")
+            return []
+        logger.info("[MetadataAutoFilter] async LLM response received length=%s", len(content))
+        return cls._parse_llm_response(content)
 
     @staticmethod
     def _build_prompt(query: str, metadata_defs: dict[str, dict]) -> str:

--- a/api/app/services/rag_access_service.py
+++ b/api/app/services/rag_access_service.py
@@ -4,10 +4,43 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
+from app.core.rag.retrieval.models import RetrievalPrincipal
+from app.db import get_async_db_context
+from app.models.api_key_model import ApiKey
 from app.models import document_model, knowledge_model
 from app.models.user_model import User
 from app.models.workspace_model import Workspace, WorkspaceMember
 from app.repositories import workspace_repository
+from app.schemas.api_key_schema import ApiKeyAuth
+from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied
+
+
+async def get_api_key_retrieval_principal_async(
+    api_key_auth: ApiKeyAuth,
+) -> RetrievalPrincipal:
+    """Read the API Key creator into a retrieval-safe principal snapshot."""
+
+    async with get_async_db_context() as db:
+        result = await db.execute(
+            select(User.id, User.username, User.tenant_id, User.is_superuser)
+            .join(ApiKey, ApiKey.created_by == User.id)
+            .where(
+                ApiKey.id == api_key_auth.api_key_id,
+                ApiKey.workspace_id == api_key_auth.workspace_id,
+            )
+        )
+        creator = result.one_or_none()
+
+    if creator is None:
+        raise KnowledgeRetrievalAccessDenied("API Key creator is unavailable")
+
+    return RetrievalPrincipal(
+        id=creator.id,
+        username=creator.username,
+        tenant_id=creator.tenant_id,
+        current_workspace_id=api_key_auth.workspace_id,
+        is_superuser=bool(creator.is_superuser),
+    )
 
 
 def has_current_workspace_access(

--- a/api/app/services/tool_orchestrator.py
+++ b/api/app/services/tool_orchestrator.py
@@ -251,6 +251,10 @@ class ToolOrchestrator:
             return f"{original_system_prompt}\n\n{react_block}"
         return react_block
 
+    async def _call_sync_tool(self, tool: Any, input_dict: dict) -> Any:
+        """Run legacy synchronous tools without blocking the event loop."""
+        return await asyncio.to_thread(tool.func, **input_dict)
+
     async def _call_tool(self, name: str, input_dict: dict) -> dict:
         """执行单个工具调用"""
         # 单次调用工具超过1次直接提示换工具
@@ -266,7 +270,7 @@ class ToolOrchestrator:
                 result = await tool.ainvoke(input_dict)
             # LangchainToolWrapper 使用 _arun，@tool 装饰器生成的工具使用 func
             elif hasattr(tool, 'func') and callable(tool.func):
-                result = tool.func(**input_dict)
+                result = await self._call_sync_tool(tool, input_dict)
             else:
                 # LangchainToolWrapper: 工具名可能含 operation 后缀（如 datetime_tool_now）
                 # 需要从工具名中提取 operation 并注入参数

--- a/api/app/services/tool_orchestrator.py
+++ b/api/app/services/tool_orchestrator.py
@@ -262,9 +262,11 @@ class ToolOrchestrator:
         if not tool:
             return {"success": False, "output": "", "error": f"工具 '{name}' 不存在"}
         try:
+            if getattr(tool, "coroutine", None):
+                result = await tool.ainvoke(input_dict)
             # LangchainToolWrapper 使用 _arun，@tool 装饰器生成的工具使用 func
-            if hasattr(tool, 'func') and callable(tool.func):
-                result = await asyncio.to_thread(tool.func, **input_dict)
+            elif hasattr(tool, 'func') and callable(tool.func):
+                result = tool.func(**input_dict)
             else:
                 # LangchainToolWrapper: 工具名可能含 operation 后缀（如 datetime_tool_now）
                 # 需要从工具名中提取 operation 并注入参数


### PR DESCRIPTION
## Business Background

Knowledge-base retrieval still mixed synchronous database, model, and Elasticsearch work with thread offloading. Under slow or failing model calls, this could occupy request capacity and made database-session lifetimes difficult to reason about. This change moves standard online retrieval to native async I/O while retaining GraphRAG as the explicitly bounded transitional exception.

## Summary

- Converge the internal HTTP route, API-key route, workflow node, and agent tool on `KnowledgeRetrievalService.retrieve_async`.
- Snapshot permissions, model configuration, metadata, and API-key state in short async database contexts before external I/O.
- Use native async Elasticsearch, embedding, rerank, and metadata-model adapters for standard retrieval.
- Isolate GraphRAG in a dedicated bounded executor and close shared async clients during application shutdown.
- Preserve retrieval ordering, thresholds, AUTO metadata behavior, API-key principal semantics, and sibling-task cancellation cleanup.

## Impact Scope

- Internal `/api/chunks/retrieval`
- API-key `/v1/chunks/retrieval`
- Workflow knowledge retrieval node
- Agent knowledge-base tool
- 20 backend files changed; no test, documentation, or frontend files are included in the PR

## Risks

- GraphRAG remains synchronous inside a dedicated thread bridge. Caller cancellation does not stop an already-running worker; its configured capacity remains occupied until that worker finishes. A stuck GraphRAG call can therefore hold a slot indefinitely and make later graph requests wait.
- Native async prevents model and Elasticsearch waits from blocking the event loop, but it does not impose an aggregate request-wide deadline. Model calls retain per-call `LLM_TIMEOUT` (default `120s`) and `LLM_MAX_RETRIES` (default `2`), while async Elasticsearch inherits `request_timeout=100000`, `retry_on_timeout=True`, and `max_retries=10`. Repeated provider or Elasticsearch failures can therefore still keep an individual retrieval request open for a long time.
- The agent orchestrator retains a generic thread fallback for unrelated legacy synchronous tools. The migrated knowledge-retrieval tool uses `ainvoke` and does not use that fallback.
- Existing synchronous Elasticsearch/model classes remain for write-side and other out-of-scope legacy paths.
- The old memory-RAG caller is outside this change.
- No request or response schema change is intended.

## External API Key Impact

- `/v1/chunks/retrieval` keeps the same request/response contract and `rag` permission scope.
- Authentication now builds a detached retrieval-principal snapshot in a short async database context and delegates to the same native async retrieval service as the internal route.
- Access denial remains mapped to HTTP 404.
- No new API-key endpoint or scope is introduced.

## Validation

- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/rag/test_knowledge_retrieval_async.py tests/rag/test_knowledge_retrieval_dual_session.py tests/rag/test_knowledge_retrieval_config.py tests/rag/test_knowledge_retrieval_preparation.py tests/rag/test_async_elasticsearch_retrieval.py tests/rag/test_async_retrieval_models.py tests/rag/test_graph_retrieval_bridge.py tests/rag/test_api_key_retrieval_principal.py tests/rag/test_tool_orchestrator_async.py tests/rag/test_retrieval_async_static_boundaries.py tests/services/test_knowledge_retrieval_logging.py` — 65 passed, 51 warnings
- `PYTHONPATH=. .venv/bin/python -m compileall app/core/rag/retrieval app/services/knowledge_retrieval_service.py app/services/knowledge_retrieval_preparation.py app/controllers/chunk_controller.py app/controllers/service/rag_api_chunk_controller.py app/core/workflow/nodes/knowledge/node.py app/services/draft_run_service.py app/services/tool_orchestrator.py app/main.py` — passed
- `git diff --check origin/develop...HEAD` — passed
- Static caller scan found no remaining `KnowledgeRetrievalService.retrieve(...)` usage in the four migrated entrypoint families
- Thread-offload scan found only the dedicated GraphRAG bridge in the retrieval core; unrelated existing annotation/TTS adapters and the generic sync-tool fallback remain outside the migrated knowledge-base retrieval path
- `PYTHONPATH=. .venv/bin/python scripts/rag_retrieval_benchmark.py --help` — passed; the local benchmark helper is intentionally not included in the PR
