### PR TITLE
fix(neo4j): merge duplicate WHERE clauses in entity merge query

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2305,8 +2305,7 @@ SET keeper.name = $merged_name,
     keeper.events = apoc.coll.toSet(coalesce(keeper.events,[]) + coalesce(loser.events,[]))
 WITH keeper, loser
 OPTIONAL MATCH (s:Statement)-[r:REFERENCES_ENTITY]->(loser)
-WHERE s.delete_at IS NULL
-WHERE NOT (s)-[:REFERENCES_ENTITY]->(keeper)
+WHERE s.delete_at IS NULL AND NOT (s)-[:REFERENCES_ENTITY]->(keeper)
 FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
   CREATE (s)-[:REFERENCES_ENTITY]->(keeper)
 )


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过将条件合并到单一的 `WHERE` 子句中，确保实体合并查询在过滤引用“失败者”实体的语句时，能够正确排除那些已经引用“保留者”实体的语句。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the entity merge query correctly filters statements referencing a loser entity without already referencing the keeper by combining conditions into a single WHERE clause.

</details>