### PR TITLE
Feature/forget memory zy

### DIFF
--- a/web/install-private.js
+++ b/web/install-private.js
@@ -1,6 +1,6 @@
 const { execSync } = await import('child_process');
 // 企业私有配置（自行替换）
-const PRIVATE_PACKAGE = '@redbear/memory-brick@0.0.15-beta.0';
+const PRIVATE_PACKAGE = '@redbear/memory-brick@0.0.16-beta.0';
 const PRIVATE_REGISTRY = 'http://10.206.16.48:4873';
 
 console.log('🔍 检测内网环境，校验私有模块权限...');

--- a/web/src/views/UserMemoryDetail/Neo4j.tsx
+++ b/web/src/views/UserMemoryDetail/Neo4j.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next';
 import EndUserProfile from './components/EndUserProfile'
 import AboutMe from './components/AboutMe'
 import InterestDistribution from './components/InterestDistribution'
-import NodeStatistics from './components/NodeStatistics'
+import NodeStatistics, { type NodeStatisticsRef } from './components/NodeStatistics'
 import RelationshipNetwork from './components/RelationshipNetwork'
 import MemoryInsight from './components/MemoryInsight'
 import type { EndUserProfileRef, MemoryInsightRef, AboutMeRef, EndUser } from './types'
@@ -29,7 +29,7 @@ import {
 import { useI18n } from '@/store/locale'
 
 import PrivateWrap from '@/components/PrivateWrap'
-import { BrainView, ReflectMemory } from '@redbear/memory-brick'
+import { BrainView, ReflectMemory, type ReflectMemoryRef } from '@redbear/memory-brick'
 import { request } from '@/utils/request'
 
 
@@ -49,6 +49,8 @@ const Neo4j: FC = () => {
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [brainMemories, setBrainMemories] = useState<string[]>([])
   const [regionId, setRegionId] = useState<string | null>(null)
+  const nodeStatisticsRef = useRef<NodeStatisticsRef>(null)
+  const reflectMemoryRef = useRef<ReflectMemoryRef>(null)
 
   /** Handle brain region memory types change */
   const handleBrainMemoriesChange = (memories: string[], regionId: string | null) => {
@@ -195,6 +197,7 @@ const Neo4j: FC = () => {
 
               {isSaas && ReflectMemory &&
                 <ReflectMemory
+                  ref={reflectMemoryRef}
                   request={request}
                   onOpenChange={(e) => onOpenChange(e, 'reflect')}
                   selectedKey={selectedKey}
@@ -212,13 +215,17 @@ const Neo4j: FC = () => {
         </Flex>
 
         <Flex vertical className="rb:flex-1">
-          <NodeStatistics highlightKeys={brainMemories} />
+          <NodeStatistics ref={nodeStatisticsRef} highlightKeys={brainMemories} />
           <RelationshipNetwork
             regionId={regionId}
             setRegionId={setRegionId}
             selectedKey={selectedKey}
             setSelectedKey={setSelectedKey}
             setBrainMemories={setBrainMemories}
+            refresh={() => {
+              // nodeStatisticsRef.current?.getData()
+              reflectMemoryRef.current?.getData()
+            }}
           />
         </Flex>
       </Flex>

--- a/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
+++ b/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
@@ -9,7 +9,7 @@
  * Displays memory node statistics by type with navigation to detail views
  */
 
-import { type FC, useEffect, useState } from 'react'
+import { useEffect, useState, forwardRef, useImperativeHandle } from 'react'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate } from 'react-router-dom'
@@ -37,8 +37,11 @@ const typeList = [
     ]
   },
 ]
+export interface NodeStatisticsRef {
+  getData: () => void
+}
 
-const NodeStatistics: FC<{ highlightKeys?: string[] }> = ({ highlightKeys = [] }) => {
+const NodeStatistics = forwardRef<NodeStatisticsRef, { highlightKeys?: string[] }>(({ highlightKeys = [] }, ref) => {
   const navigate = useNavigate();
   const { t } = useTranslation()
   const { id } = useParams()
@@ -98,6 +101,9 @@ const NodeStatistics: FC<{ highlightKeys?: string[] }> = ({ highlightKeys = [] }
       </Flex>
     )
   }
+  useImperativeHandle(ref, () => ({
+    getData,
+  }))
 
   return (
     <div className="rb:h-22">
@@ -126,5 +132,5 @@ const NodeStatistics: FC<{ highlightKeys?: string[] }> = ({ highlightKeys = [] }
         }
     </div>
   )
-}
+})
 export default NodeStatistics

--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -34,8 +34,9 @@ interface RelationshipNetworkProps {
   setRegionId: Dispatch<SetStateAction<string | null>>;
   setSelectedKey: Dispatch<SetStateAction<string | null>>;
   setBrainMemories: Dispatch<SetStateAction<string[]>>;
+  refresh: () => void
 }
-const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedKey, setRegionId, setBrainMemories, setSelectedKey }) => {
+const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedKey, setRegionId, setBrainMemories, setSelectedKey, refresh }) => {
   const { t } = useTranslation()
   const { id } = useParams()
   const [nodes, setNodes] = useState<Node[]>([])
@@ -296,6 +297,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
         onSuccess={() => {
           setSelectedNode(null)
           getEdgeData()
+          refresh()
         }}
       />
     </div>

--- a/web/src/views/UserMemoryDetail/pages/index.tsx
+++ b/web/src/views/UserMemoryDetail/pages/index.tsx
@@ -19,7 +19,7 @@ import EpisodicDetail from './EpisodicDetail'
 import ExplicitDetail from './ExplicitDetail'
 import WorkingDetail from './WorkingDetail'
 import GraphDetail from './GraphDetail'
-import { ReflectLogList } from '@redbear/memory-brick'
+import { MemoryEvolutionEvent } from '@redbear/memory-brick'
 import { request } from '@/utils/request';
 
 
@@ -76,8 +76,8 @@ const Detail: FC = () => {
     }
   }
 
-  if (type === 'REFLECT_LOGS' && isSaas && ReflectLogList) {
-    return <ReflectLogList request={request} />
+  if (type === 'REFLECT_LOGS' && isSaas && MemoryEvolutionEvent) {
+    return <MemoryEvolutionEvent request={request} />
   } else if (type === 'REFLECT_LOGS') {
     return null;
   }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -41,7 +41,9 @@ const virtualModulePlugin = () => ({
         export const MemoryEngine = FallbackComponent;
         export const DynamicWeightEngine = FallbackComponent;
         export const AssociationEngine = FallbackComponent;
-        export default { BrainView, Provider, ReflectMemory, ReflectLogList, ContextEngine, Account, MemoryEngine, DynamicWeightEngine, AssociationEngine };
+        export const ReflectMemoryRef = {};
+        export const MemoryEvolutionEvent = FallbackComponent;
+        export default { BrainView, Provider, ReflectMemory, ReflectLogList, ContextEngine, Account, MemoryEngine, DynamicWeightEngine, AssociationEngine, ReflectMemoryRef, MemoryEvolutionEvent };
       `
     }
     return null


### PR DESCRIPTION
## Summary by Sourcery

在用户记忆详情视图中添加可刷新的内存统计和反射数据，并更新私有 memory-brick 集成。

新功能：
- 在节点统计上暴露命令式刷新 API，并反射内存组件，将它们连接到关系网络更新。
- 在用户记忆详情页中，用新的内存演化事件视图替换原有的反射日志列表视图。

改进：
- 升级私有的 `@redbear/memory-brick` 包版本，并扩展其 Vite 回退模块以覆盖新的导出内容。

构建：
- 调整 Vite 虚拟模块配置，为新的 memory-brick 组件和 refs 提供回退支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add refreshable memory statistics and reflection data in the user memory detail view and update private memory-brick integration.

New Features:
- Expose imperative refresh APIs on node statistics and reflect memory components and wire them to relationship network updates.
- Replace reflect log list view with a new memory evolution event view in the user memory detail pages.

Enhancements:
- Upgrade the private @redbear/memory-brick package version and extend its Vite fallback module to cover new exports.

Build:
- Adjust Vite virtual module configuration to provide fallbacks for new memory-brick components and refs.

</details>