### PR TITLE
refactor(scheduler): refactor task scheduler into async module with Redis-backed rate limiting

### DIFF
--- a/api/app/aioRedis.py
+++ b/api/app/aioRedis.py
@@ -6,6 +6,7 @@ import threading
 from typing import Dict, Any, Optional
 
 import redis.asyncio as redis
+import redis as sync_redis
 from redis.asyncio import ConnectionPool
 
 from app.core.config import settings
@@ -76,6 +77,34 @@ def get_thread_safe_redis() -> redis.StrictRedis:
         )
 
     return redis.StrictRedis(connection_pool=_thread_local.pool)
+
+
+# Thread-local storage for sync connection pools (same fork/thread safety semantics).
+_sync_thread_local = threading.local()
+
+
+def get_thread_safe_sync_redis() -> sync_redis.StrictRedis:
+    """Return a **synchronous** Redis client whose connection pool is bound to
+    the current thread and process.
+
+    Designed for use in sync functions (Celery sync tasks, scripts, background
+    threads) that need Redis caching without ``asyncio.run()``.
+    """
+    current_pid = os.getpid()
+
+    if not hasattr(_sync_thread_local, "pool") \
+            or getattr(_sync_thread_local, "pid", None) != current_pid:
+        _sync_thread_local.pid = current_pid
+        _sync_thread_local.pool = sync_redis.ConnectionPool.from_url(
+            _REDIS_URL,
+            db=settings.REDIS_DB,
+            password=settings.REDIS_PASSWORD,
+            decode_responses=True,
+            max_connections=5,
+            health_check_interval=30,
+        )
+
+    return sync_redis.StrictRedis(connection_pool=_sync_thread_local.pool)
 
 
 async def get_redis_connection():

--- a/api/app/celery_task_scheduler/__init__.py
+++ b/api/app/celery_task_scheduler/__init__.py
@@ -1,0 +1,3 @@
+from app.celery_task_scheduler.scheduler import RedisTaskScheduler, scheduler
+
+__all__ = ["RedisTaskScheduler", "scheduler"]

--- a/api/app/celery_task_scheduler/__main__.py
+++ b/api/app/celery_task_scheduler/__main__.py
@@ -1,0 +1,27 @@
+import signal
+import sys
+
+from app.celery_task_scheduler.scheduler import scheduler
+
+
+def _signal_handler(signum, frame):
+    scheduler.shutdown()
+    sys.exit(0)
+
+
+def main():
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    # Migrate legacy per-user queues before serving so pending messages
+    # written by the previous version are not stranded and lost.
+    scheduler.migrate_legacy_queues()
+    # Migrate legacy un-namespaced tracker keys (task_tracker:* ->
+    # scheduler:tracker:*) so in-flight status lookups keep working.
+    scheduler.migrate_legacy_tracker_keys()
+
+    scheduler.run_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/api/app/celery_task_scheduler/lua_scripts/admission.lua
+++ b/api/app/celery_task_scheduler/lua_scripts/admission.lua
@@ -1,0 +1,53 @@
+-- Atomic admission for push_task: enforces per-unit queue-length limit and
+-- per-(task,user) QPS (sliding window), then enqueues and updates bookkeeping.
+--
+-- KEYS:
+--   1 = queue_key
+--   2 = rate-limit zset key (scheduler:rl:{unit_key})
+--   3 = active_units set
+--   4 = ready_set
+--   5 = lock_key (unit_key)
+--   6 = tracker_key
+--
+-- ARGV:
+--   1 = max_len
+--   2 = qps
+--   3 = now_ms
+--   4 = window_ms
+--   5 = msg (serialized task payload)
+--   6 = unit_key
+--   7 = tracker_val
+--   8 = member (msg_id)
+--
+-- Returns: 1 admitted, -1 queue full, -2 rate limited.
+
+local max_len = tonumber(ARGV[1])
+local qps = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local window = tonumber(ARGV[4])
+
+if max_len > 0 and redis.call('LLEN', KEYS[1]) >= max_len then
+    return -1
+end
+
+if qps > 0 then
+    redis.call('ZREMRANGEBYSCORE', KEYS[2], 0, now - window)
+    if redis.call('ZCARD', KEYS[2]) >= qps then
+        return -2
+    end
+end
+
+redis.call('RPUSH', KEYS[1], ARGV[5])
+redis.call('SADD', KEYS[3], ARGV[6])
+redis.call('SET', KEYS[6], ARGV[7], 'EX', 86400)
+
+if qps > 0 then
+    redis.call('ZADD', KEYS[2], now, ARGV[8])
+    redis.call('PEXPIRE', KEYS[2], window)
+end
+
+if redis.call('EXISTS', KEYS[5]) == 0 then
+    redis.call('SADD', KEYS[4], ARGV[6])
+end
+
+return 1

--- a/api/app/celery_task_scheduler/lua_scripts/atomic_lock.lua
+++ b/api/app/celery_task_scheduler/lua_scripts/atomic_lock.lua
@@ -1,0 +1,25 @@
+-- Atomically acquire a per-message dispatch lock, then check that the
+-- underlying task lock (unit_key) is free. Avoids two processes dispatching
+-- the same unit concurrently.
+--
+-- KEYS: 1=dispatch_lock 2=lock_key
+-- ARGV: 1=instance_id 2=dispatch_ttl 3=lock_ttl
+-- Returns: 1 acquired, 0 dispatch contention, -1 already locked.
+
+local dispatch_lock = KEYS[1]
+local lock_key = KEYS[2]
+local instance_id = ARGV[1]
+local dispatch_ttl = tonumber(ARGV[2])
+local lock_ttl = tonumber(ARGV[3])
+
+if redis.call('SET', dispatch_lock, instance_id, 'NX', 'EX', dispatch_ttl) == false then
+    return 0
+end
+
+if redis.call('EXISTS', lock_key) == 1 then
+    redis.call('DEL', dispatch_lock)
+    return -1
+end
+
+redis.call('SET', lock_key, 'dispatching', 'EX', lock_ttl)
+return 1

--- a/api/app/celery_task_scheduler/lua_scripts/migrate_head.lua
+++ b/api/app/celery_task_scheduler/lua_scripts/migrate_head.lua
@@ -1,0 +1,12 @@
+-- Legacy migration helper: atomically move the head message of a source
+-- (per-user) queue into a new per-unit (task_name:user_id) queue.
+--
+-- KEYS: 1=source_queue 2=target_queue
+-- Returns: the moved payload, or false when source is empty.
+
+local raw = redis.call('LPOP', KEYS[1])
+if raw == false then
+    return false
+end
+redis.call('RPUSH', KEYS[2], raw)
+return raw

--- a/api/app/celery_task_scheduler/lua_scripts/migrate_tracker.lua
+++ b/api/app/celery_task_scheduler/lua_scripts/migrate_tracker.lua
@@ -1,0 +1,16 @@
+-- Legacy migration helper: atomically rename a tracker key from the old
+-- prefix (task_tracker:{msg_id}) to the new one (scheduler:tracker:{msg_id}).
+-- RENAME preserves the source key's TTL.
+--
+-- KEYS: 1=old_key 2=new_key
+-- Returns: 1 renamed, 0 dest existed (old deleted), -1 source missing.
+
+if redis.call('EXISTS', KEYS[2]) == 1 then
+    redis.call('DEL', KEYS[1])
+    return 0
+end
+if redis.call('EXISTS', KEYS[1]) == 0 then
+    return -1
+end
+redis.call('RENAME', KEYS[1], KEYS[2])
+return 1

--- a/api/app/celery_task_scheduler/lua_scripts/safe_delete.lua
+++ b/api/app/celery_task_scheduler/lua_scripts/safe_delete.lua
@@ -1,0 +1,11 @@
+-- Conditionally delete a key only when its value matches the expected token.
+-- Used to safely release per-unit locks without races.
+--
+-- KEYS: 1=key
+-- ARGV: 1=expected_value
+-- Returns: 1 deleted, 0 skipped (value mismatch).
+
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0

--- a/api/app/celery_task_scheduler/rate_policy.py
+++ b/api/app/celery_task_scheduler/rate_policy.py
@@ -1,0 +1,141 @@
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from app.core.config import settings
+from app.core.exceptions import RateLimitException
+from app.core.logging_config import get_named_logger
+from app.db import get_async_db_context
+
+logger = get_named_logger("task_scheduler.rate_policy")
+
+_LUA_ADMISSION = (Path(__file__).parent / "lua_scripts" / "admission.lua").read_text()
+
+
+QpsResolver = Callable[[str, str], Awaitable[int | None]]
+_resolvers: dict[str, QpsResolver] = {}
+
+
+def register_qps_resolver(task_name: str, resolver: QpsResolver) -> None:
+    _resolvers[task_name] = resolver
+
+
+async def _resolve_qps(task_name: str, end_user_id: str) -> int | None:
+    resolver = _resolvers.get(task_name)
+    if resolver is None:
+        return None
+    try:
+        return await resolver(task_name, end_user_id)
+    except Exception:
+        logger.warning(
+            "_resolve_qps: resolver failed for task=%s user=%s, falling back",
+            task_name, end_user_id, exc_info=True,
+        )
+        return None
+
+
+async def _write_message_qps_resolver(_task_name: str, end_user_id: str) -> int | None:
+    if not end_user_id:
+        return None
+    from uuid import UUID
+
+    from app.core.quota_manager import get_pre_user_memory_write_ops_limit
+    from app.repositories.end_user_repository import get_tenant_id_by_end_user_id_async
+
+    async with get_async_db_context() as db:
+        tenant_id = await get_tenant_id_by_end_user_id_async(db, UUID(end_user_id))
+        if not tenant_id:
+            logger.warning("write_message_qps_resolver: end_user not found id=%s", end_user_id)
+            return None
+        return await get_pre_user_memory_write_ops_limit(db, tenant_id)
+
+
+register_qps_resolver("app.core.memory.agent.write_message", _write_message_qps_resolver)
+
+
+RATE_LIMIT_PREFIX = "scheduler:rl:"   # sliding-window key prefix
+RATE_WINDOW_MS = 1000                  # sliding-window size in ms
+
+DEFAULT_MAX_QUEUE_LEN = settings.SCHEDULER_MAX_QUEUE_LEN
+DEFAULT_QPS = 0
+
+RATE_POLICY = {}
+
+
+def _resolve_policy(task_name, qps_override=None):
+    """Return (max_queue_len, qps) for a task type. 0 = unlimited."""
+    policy = RATE_POLICY.get(task_name, {})
+    max_len = int(policy.get("max_queue_len", DEFAULT_MAX_QUEUE_LEN) or 0)
+
+    if qps_override is not None:
+        qps = float(qps_override)
+    else:
+        qps = float(policy.get("qps", DEFAULT_QPS) or 0)
+
+    return max_len, qps
+
+
+@dataclass
+class AdmissionCtx:
+    """Bundles task routing keys and payload for enforce_admission."""
+    task_name: str
+    user_id: str
+    msg: str
+    msg_id: str
+    unit_key: str
+    queue_key: str
+    active_units_key: str
+    ready_set_key: str
+    tracker_key: str
+    tracker_val: str
+
+
+async def enforce_admission(redis_client, *, ctx: AdmissionCtx):
+    """Atomically admit or reject a task (queue-length + per-user QPS)."""
+    qps_override = await _resolve_qps(ctx.task_name, ctx.user_id)
+    max_len, qps = _resolve_policy(ctx.task_name, qps_override=qps_override)
+    now_ms = int(time.time() * 1000)
+    rl_key = f"{RATE_LIMIT_PREFIX}{ctx.unit_key}"
+
+    result = redis_client.eval(
+        _LUA_ADMISSION, 6,
+        ctx.queue_key, rl_key, ctx.active_units_key, ctx.ready_set_key, ctx.unit_key, ctx.tracker_key,
+        str(max_len), str(qps), str(now_ms), str(RATE_WINDOW_MS),
+        ctx.msg, ctx.unit_key, ctx.tracker_val, ctx.msg_id,
+    )
+
+    if result == -1:
+        logger.warning("Queue full, rejected: unit=%s max_queue_len=%d", ctx.unit_key, max_len)
+        raise RateLimitException(
+            message=f"任务队列已满，请稍后再试 (task={ctx.task_name})",
+            rate_headers={
+                "Retry-After": "1",
+                "X-RateLimit-Reason": "queue_full",
+                "X-RateLimit-Queue-Limit": str(max_len),
+            },
+            context={
+                "reason": "queue_full",
+                "task_name": ctx.task_name,
+                "user_id": ctx.user_id,
+                "max_queue_len": max_len,
+            },
+        )
+    if result == -2:
+        logger.warning("QPS limited, rejected: unit=%s qps=%s", ctx.unit_key, qps)
+        raise RateLimitException(
+            message=f"请求过于频繁，请稍后再试 (task={ctx.task_name})",
+            rate_headers={
+                "Retry-After": "1",
+                "X-RateLimit-Reason": "qps",
+                "X-RateLimit-QPS-Limit": str(qps),
+            },
+            context={
+                "reason": "qps",
+                "task_name": ctx.task_name,
+                "user_id": ctx.user_id,
+                "qps": qps,
+            },
+        )
+
+    return True

--- a/api/app/celery_task_scheduler/scheduler.py
+++ b/api/app/celery_task_scheduler/scheduler.py
@@ -5,56 +5,50 @@ import socket
 import threading
 import time
 import uuid
+from pathlib import Path
 
 import redis
 
-from app.core.config import settings
-from app.core.logging_config import get_named_logger
 from app.celery_app import celery_app
+from app.core.config import settings
+from app.core.exceptions import RateLimitException
+from app.core.logging_config import get_named_logger
 
 logger = get_named_logger("task_scheduler")
 
-# per-user queue scheduler:uq:{user_id}
+# per-unit queue scheduler:uq:{task_name}:{user_id}
 USER_QUEUE_PREFIX = "scheduler:uq:"
-# User Collection of Pending Messages
-ACTIVE_USERS = "scheduler:active_users"
-# Set of users that can dispatch (ready signal)
-READY_SET = "scheduler:ready_users"
+# Collection of scheduling units (task_name:user_id) with pending messages
+ACTIVE_UNITS = "scheduler:active_units"
+# Set of scheduling units that can dispatch (ready signal)
+READY_SET = "scheduler:ready_units"
 # Metadata of tasks that have been dispatched and are pending completion
 PENDING_HASH = "scheduler:pending_tasks"
 # Dynamic Sharding: Instance Registry
 REGISTRY_KEY = "scheduler:instances"
+# Namespaced task-status tracker (client polling): scheduler:tracker:{msg_id}
+TRACKER_PREFIX = "scheduler:tracker:"
+# Namespaced per-message dispatch lock: scheduler:dispatch_lock:{msg_id}
+DISPATCH_LOCK_PREFIX = "scheduler:dispatch_lock:"
 
 TASK_TIMEOUT = 7800  # Task timeout (seconds), considered lost if exceeded
 HEARTBEAT_INTERVAL = 10  # Heartbeat interval (seconds)
 INSTANCE_TTL = 30  # Instance timeout (seconds)
 
-LUA_ATOMIC_LOCK = """
-local dispatch_lock = KEYS[1]
-local lock_key = KEYS[2]
-local instance_id = ARGV[1]
-local dispatch_ttl = tonumber(ARGV[2])
-local lock_ttl = tonumber(ARGV[3])
+_LUA_DIR = Path(__file__).parent / "lua_scripts"
+_LUA_ATOMIC_LOCK = (_LUA_DIR / "atomic_lock.lua").read_text()
+_LUA_SAFE_DELETE = (_LUA_DIR / "safe_delete.lua").read_text()
+_LUA_MIGRATE_HEAD = (_LUA_DIR / "migrate_head.lua").read_text()
+_LUA_MIGRATE_TRACKER = (_LUA_DIR / "migrate_tracker.lua").read_text()
 
-if redis.call('SET', dispatch_lock, instance_id, 'NX', 'EX', dispatch_ttl) == false then
-    return 0
-end
+# --- Legacy migration (per-user queue -> per-unit queue) ---
+LEGACY_ACTIVE_USERS = "scheduler:active_users"
+LEGACY_READY_SET = "scheduler:ready_users"
+MIGRATION_LOCK = "scheduler:migration:v2_unit_queue"
 
-if redis.call('EXISTS', lock_key) == 1 then
-    redis.call('DEL', dispatch_lock)
-    return -1
-end
-
-redis.call('SET', lock_key, 'dispatching', 'EX', lock_ttl)
-return 1
-"""
-
-LUA_SAFE_DELETE = """
-if redis.call('GET', KEYS[1]) == ARGV[1] then
-    return redis.call('DEL', KEYS[1])
-end
-return 0
-"""
+# --- Legacy migration (task_tracker:{msg_id} -> scheduler:tracker:{msg_id}) ---
+LEGACY_TRACKER_PREFIX = "task_tracker:"
+TRACKER_MIGRATION_LOCK = "scheduler:migration:v2_tracker_keys"
 
 
 def stable_hash(value: str) -> int:
@@ -106,7 +100,8 @@ class RedisTaskScheduler:
         self._shard_count = 1
         self._last_heartbeat = 0.0
 
-    def push_task(self, task_name, user_id, params):
+    async def push_task(self, task_name, user_id, params):
+        from app.celery_task_scheduler.rate_policy import AdmissionCtx, enforce_admission
         try:
             msg_id = str(uuid.uuid4())
             msg = json.dumps({
@@ -116,30 +111,31 @@ class RedisTaskScheduler:
                 "params": json.dumps(params, default=str),
             })
 
-            lock_key = f"{task_name}:{user_id}"
-            queue_key = f"{USER_QUEUE_PREFIX}{user_id}"
-
-            pipe = self.redis.pipeline()
-            pipe.rpush(queue_key, msg)
-            pipe.sadd(ACTIVE_USERS, user_id)
-            pipe.set(
-                f"task_tracker:{msg_id}",
-                json.dumps({"status": "QUEUED", "task_id": None}),
-                ex=86400,
+            ctx = AdmissionCtx(
+                task_name=task_name,
+                user_id=user_id,
+                msg=msg,
+                msg_id=msg_id,
+                unit_key=f"{task_name}:{user_id}",
+                queue_key=f"{USER_QUEUE_PREFIX}{task_name}:{user_id}",
+                active_units_key=ACTIVE_UNITS,
+                ready_set_key=READY_SET,
+                tracker_key=f"{TRACKER_PREFIX}{msg_id}",
+                tracker_val=json.dumps({"status": "QUEUED", "task_id": None}),
             )
-            pipe.execute()
 
-            if not self.redis.exists(lock_key):
-                self.redis.sadd(READY_SET, user_id)
+            await enforce_admission(self.redis, ctx=ctx)
 
             logger.info("Task pushed: msg_id=%s task=%s user=%s", msg_id, task_name, user_id)
             return msg_id
+        except RateLimitException:
+            raise
         except Exception as e:
             logger.error("Push task exception %s", e, exc_info=True)
             raise
 
     def get_task_status(self, msg_id: str) -> dict:
-        raw = self.redis.get(f"task_tracker:{msg_id}")
+        raw = self.redis.get(f"{TRACKER_PREFIX}{msg_id}")
         if raw is None:
             return {"status": "NOT_FOUND"}
 
@@ -179,7 +175,7 @@ class RedisTaskScheduler:
 
         cleanup_pipe = self.redis.pipeline()
         has_cleanup = False
-        ready_user_ids = set()
+        ready_units = set()
 
         for task_id, raw_result in zip(task_ids, results):
             try:
@@ -211,14 +207,14 @@ class RedisTaskScheduler:
                         result_data.get("status", "UNKNOWN") if result_data else "EXPIRED"
                     )
 
-                    self.redis.eval(LUA_SAFE_DELETE, 1, lock_key, task_id)
+                    self.redis.eval(_LUA_SAFE_DELETE, 1, lock_key, task_id)
 
                     cleanup_pipe.hdel(PENDING_HASH, task_id)
 
                     tracker_msg_id = meta.get("msg_id")
                     if tracker_msg_id:
                         cleanup_pipe.set(
-                            f"task_tracker:{tracker_msg_id}",
+                            f"{TRACKER_PREFIX}{tracker_msg_id}",
                             json.dumps({
                                 "status": final_status,
                                 "task_id": task_id,
@@ -228,9 +224,8 @@ class RedisTaskScheduler:
                         )
                     has_cleanup = True
 
-                    parts = lock_key.split(":", 1)
-                    if len(parts) == 2:
-                        ready_user_ids.add(parts[1])
+                    # lock_key == unit_key (task_name:user_id)
+                    ready_units.add(lock_key)
 
             except Exception as e:
                 logger.error("Cleanup error for %s: %s", task_id, e, exc_info=True)
@@ -239,8 +234,8 @@ class RedisTaskScheduler:
         if has_cleanup:
             cleanup_pipe.execute()
 
-        if ready_user_ids:
-            self.redis.sadd(READY_SET, *ready_user_ids)
+        if ready_units:
+            self.redis.sadd(READY_SET, *ready_units)
 
     def _heartbeat(self):
         now = time.time()
@@ -276,9 +271,12 @@ class RedisTaskScheduler:
             self.instance_id, len(alive),
         )
 
-    def _is_mine(self, user_id: str) -> bool:
+    def _is_mine(self, unit_key: str) -> bool:
         if self._shard_count <= 1:
             return True
+        # unit_key == "{task_name}:{user_id}"; shard by user_id so that all
+        # task types of the same user are owned by the same instance.
+        user_id = unit_key.split(":", 1)[1] if ":" in unit_key else unit_key
         return stable_hash(user_id) % self._shard_count == self._shard_index
 
     def _commit_post_dispatch(self, lock_key, task, msg_id, dispatch_lock):
@@ -291,7 +289,7 @@ class RedisTaskScheduler:
         }))
         pipe.delete(dispatch_lock)
         pipe.set(
-            f"task_tracker:{msg_id}",
+            f"{TRACKER_PREFIX}{msg_id}",
             json.dumps({"status": "DISPATCHED", "task_id": task.id}),
             ex=86400,
         )
@@ -303,10 +301,10 @@ class RedisTaskScheduler:
         params = json.loads(msg_data.get("params", "{}"))
 
         lock_key = f"{task_name}:{user_id}"
-        dispatch_lock = f"dispatch:{msg_id}"
+        dispatch_lock = f"{DISPATCH_LOCK_PREFIX}{msg_id}"
 
         result = self.redis.eval(
-            LUA_ATOMIC_LOCK, 2,
+            _LUA_ATOMIC_LOCK, 2,
             dispatch_lock, lock_key,
             self.instance_id, str(300), str(3600),
         )
@@ -345,82 +343,78 @@ class RedisTaskScheduler:
         logger.info("Task dispatched: %s (msg=%s)", task.id, msg_id)
         return True
 
-    def _process_batch(self, user_ids):
-        if not user_ids:
+    def _process_batch(self, unit_keys):
+        if not unit_keys:
             return
 
         pipe = self.redis.pipeline()
-        for uid in user_ids:
-            pipe.lindex(f"{USER_QUEUE_PREFIX}{uid}", 0)
+        for uk in unit_keys:
+            pipe.lindex(f"{USER_QUEUE_PREFIX}{uk}", 0)
         heads = pipe.execute()
 
-        candidates = []  # (user_id, msg_dict)
-        empty_users = []
+        candidates = []  # (unit_key, msg_dict)
+        empty_units = []
 
-        for uid, head in zip(user_ids, heads):
+        for uk, head in zip(unit_keys, heads):
             if head is None:
-                empty_users.append(uid)
+                empty_units.append(uk)
             else:
                 try:
-                    candidates.append((uid, json.loads(head)))
+                    candidates.append((uk, json.loads(head)))
                 except (json.JSONDecodeError, TypeError) as e:
-                    logger.error("Bad message in queue for user %s: %s", uid, e)
-                    self.redis.lpop(f"{USER_QUEUE_PREFIX}{uid}")
+                    logger.error("Bad message in queue for unit %s: %s", uk, e)
+                    self.redis.lpop(f"{USER_QUEUE_PREFIX}{uk}")
 
-        if empty_users:
+        if empty_units:
             pipe = self.redis.pipeline()
-            for uid in empty_users:
-                pipe.srem(ACTIVE_USERS, uid)
+            for uk in empty_units:
+                pipe.srem(ACTIVE_UNITS, uk)
             pipe.execute()
 
         if not candidates:
             return
 
-        for uid, msg in candidates:
-            queue_key = f"{USER_QUEUE_PREFIX}{uid}"
+        for uk, msg in candidates:
+            queue_key = f"{USER_QUEUE_PREFIX}{uk}"
             if self._dispatch(msg["msg_id"], msg):
                 self.redis.lpop(queue_key)
                 if self.redis.llen(queue_key) > 0:
-                    self.redis.sadd(READY_SET, uid)
+                    self.redis.sadd(READY_SET, uk)
 
     def schedule_loop(self):
         self._cleanup_finished()
 
-        ready_users = self.redis.smembers(READY_SET) or set()
-        my_users = [uid for uid in ready_users if self._is_mine(uid)]
-        if my_users:
-            self.redis.srem(READY_SET, *my_users)
+        ready_units = self.redis.smembers(READY_SET) or set()
+        my_units = [uk for uk in ready_units if self._is_mine(uk)]
+        if my_units:
+            self.redis.srem(READY_SET, *my_units)
         else:
             time.sleep(0.5)
             return
 
-        self._process_batch(my_users)
+        self._process_batch(my_units)
         time.sleep(0.1)
 
     def _full_scan(self):
         cursor = 0
-        ready_batch = []
+        ready_batch = []  # unit_key (== lock_key)
         while True:
-            cursor, user_ids = self.redis.sscan(
-                ACTIVE_USERS, cursor=cursor, count=1000,
+            cursor, unit_keys = self.redis.sscan(
+                ACTIVE_UNITS, cursor=cursor, count=1000,
             )
-            if user_ids:
-                my_users = [uid for uid in user_ids if self._is_mine(uid)]
-                if my_users:
+            if unit_keys:
+                my_units = [uk for uk in unit_keys if self._is_mine(uk)]
+                if my_units:
                     pipe = self.redis.pipeline()
-                    for uid in my_users:
-                        pipe.lindex(f"{USER_QUEUE_PREFIX}{uid}", 0)
+                    for uk in my_units:
+                        pipe.lindex(f"{USER_QUEUE_PREFIX}{uk}", 0)
                     heads = pipe.execute()
 
-                    for uid, head in zip(my_users, heads):
+                    for uk, head in zip(my_units, heads):
                         if head is None:
                             continue
-                        try:
-                            msg = json.loads(head)
-                            lock_key = f"{msg['task_name']}:{uid}"
-                            ready_batch.append((uid, lock_key))
-                        except (json.JSONDecodeError, TypeError):
-                            continue
+                        # unit_key already equals the lock_key
+                        ready_batch.append(uk)
 
             if cursor == 0:
                 break
@@ -429,18 +423,144 @@ class RedisTaskScheduler:
             return
 
         pipe = self.redis.pipeline()
-        for _, lock_key in ready_batch:
+        for lock_key in ready_batch:
             pipe.exists(lock_key)
         lock_exists = pipe.execute()
 
-        ready_uids = [
-            uid for (uid, _), locked in zip(ready_batch, lock_exists)
+        ready_units = [
+            uk for uk, locked in zip(ready_batch, lock_exists)
             if not locked
         ]
 
-        if ready_uids:
-            self.redis.sadd(READY_SET, *ready_uids)
-            logger.info("Full scan found %d ready users", len(ready_uids))
+        if ready_units:
+            self.redis.sadd(READY_SET, *ready_units)
+            logger.info("Full scan found %d ready units", len(ready_units))
+
+    def migrate_legacy_queues(self):
+        """One-time migration from per-user queues (scheduler:uq:{user_id})
+        to per-unit queues (scheduler:uq:{task_name}:{user_id}).
+
+        Idempotent and restartable: each message is moved atomically, so a
+        crash mid-run only leaves the remaining messages in the legacy queue
+        to be picked up on the next startup. Guarded by a single-flight lock
+        so only one instance runs it. Call this at process startup BEFORE
+        run_server (and never at import time, since the singleton is also
+        imported by the API process).
+        """
+        # single-flight guard across instances
+        if not self.redis.set(MIGRATION_LOCK, self.instance_id, nx=True, ex=600):
+            logger.info("[Migrate] Another instance holds the migration lock, skip")
+            return
+
+        migrated_msgs = 0
+        migrated_users = 0
+        try:
+            legacy_users = self.redis.smembers(LEGACY_ACTIVE_USERS) or set()
+            if not legacy_users:
+                # Nothing queued under the old scheme; drop any stray ready set.
+                self.redis.delete(LEGACY_READY_SET)
+                logger.info("[Migrate] No legacy per-user queues found")
+                return
+
+            for user_id in legacy_users:
+                legacy_queue = f"{USER_QUEUE_PREFIX}{user_id}"
+                while True:
+                    peek = self.redis.lindex(legacy_queue, 0)
+                    if peek is None:
+                        break
+                    try:
+                        msg = json.loads(peek)
+                        task_name = msg["task_name"]
+                        msg_user = msg.get("user_id", user_id)
+                    except (json.JSONDecodeError, TypeError, KeyError) as e:
+                        logger.error(
+                            "[Migrate] Bad legacy message for %s, dropping: %s",
+                            user_id, e,
+                        )
+                        self.redis.lpop(legacy_queue)  # discard to make progress
+                        continue
+
+                    unit_key = f"{task_name}:{msg_user}"
+                    new_queue = f"{USER_QUEUE_PREFIX}{unit_key}"
+
+                    moved = self.redis.eval(
+                        _LUA_MIGRATE_HEAD, 2, legacy_queue, new_queue,
+                    )
+                    if moved is None:  # queue drained concurrently
+                        break
+
+                    self.redis.sadd(ACTIVE_UNITS, unit_key)
+                    if not self.redis.exists(unit_key):
+                        self.redis.sadd(READY_SET, unit_key)
+                    migrated_msgs += 1
+
+                self.redis.delete(legacy_queue)
+                self.redis.srem(LEGACY_ACTIVE_USERS, user_id)
+                migrated_users += 1
+
+            self.redis.delete(LEGACY_ACTIVE_USERS)
+            self.redis.delete(LEGACY_READY_SET)
+            logger.info(
+                "[Migrate] Legacy migration done: users=%d messages=%d",
+                migrated_users, migrated_msgs,
+            )
+        except Exception as e:
+            logger.error("[Migrate] Legacy migration failed: %s", e, exc_info=True)
+        finally:
+            self.redis.eval(_LUA_SAFE_DELETE, 1, MIGRATION_LOCK, self.instance_id)
+
+    def migrate_legacy_tracker_keys(self):
+        """One-time migration of task-status tracker keys from the old
+        un-namespaced form ``task_tracker:{msg_id}`` to ``scheduler:tracker:{msg_id}``.
+
+        Preserves TTL (via RENAME) and never clobbers a newer value: if the
+        namespaced key already exists (e.g. an in-flight task was dispatched
+        after deploy and wrote the new key), the stale old key is dropped.
+        Idempotent, restartable, and guarded by a single-flight lock.
+
+        The ephemeral ``dispatch:{msg_id}`` lock is intentionally NOT migrated:
+        it lives only during an active dispatch (300s TTL) and any stale entry
+        expires harmlessly on its own.
+        """
+        if not self.redis.set(TRACKER_MIGRATION_LOCK, self.instance_id, nx=True, ex=600):
+            logger.info("[Migrate] Another instance holds the tracker migration lock, skip")
+            return
+
+        renamed = 0
+        dropped = 0
+        prefix_len = len(LEGACY_TRACKER_PREFIX)
+        try:
+            cursor = 0
+            while True:
+                cursor, keys = self.redis.scan(
+                    cursor=cursor, match=f"{LEGACY_TRACKER_PREFIX}*", count=500,
+                )
+                for old_key in keys:
+                    msg_id = old_key[prefix_len:]
+                    new_key = f"{TRACKER_PREFIX}{msg_id}"
+                    try:
+                        res = self.redis.eval(
+                            _LUA_MIGRATE_TRACKER, 2, old_key, new_key,
+                        )
+                    except Exception as e:
+                        logger.error(
+                            "[Migrate] Tracker key migrate failed %s: %s", old_key, e,
+                        )
+                        continue
+                    if res == 1:
+                        renamed += 1
+                    elif res == 0:
+                        dropped += 1
+                if cursor == 0:
+                    break
+            logger.info(
+                "[Migrate] Tracker keys migrated: renamed=%d dropped_stale=%d",
+                renamed, dropped,
+            )
+        except Exception as e:
+            logger.error("[Migrate] Tracker migration failed: %s", e, exc_info=True)
+        finally:
+            self.redis.eval(_LUA_SAFE_DELETE, 1, TRACKER_MIGRATION_LOCK, self.instance_id)
 
     def run_server(self):
         health_check_server(self)
@@ -477,8 +597,8 @@ class RedisTaskScheduler:
     def health(self) -> dict:
         return {
             "running": self.running,
-            "active_users": self.redis.scard(ACTIVE_USERS),
-            "ready_users": self.redis.scard(READY_SET),
+            "active_units": self.redis.scard(ACTIVE_UNITS),
+            "ready_units": self.redis.scard(READY_SET),
             "pending_tasks": self.redis.hlen(PENDING_HASH),
             "dispatched": self.dispatched,
             "errors": self.errors,
@@ -496,18 +616,3 @@ class RedisTaskScheduler:
 
 
 scheduler = RedisTaskScheduler()
-
-if __name__ == "__main__":
-    import signal
-    import sys
-
-
-    def _signal_handler(signum, frame):
-        scheduler.shutdown()
-        sys.exit(0)
-
-
-    signal.signal(signal.SIGTERM, _signal_handler)
-    signal.signal(signal.SIGINT, _signal_handler)
-
-    scheduler.run_server()

--- a/api/app/config/default_free_plan.py
+++ b/api/app/config/default_free_plan.py
@@ -21,7 +21,8 @@ def _get_quota_from_env():
         "ontology_project_quota",
         "model_quota",
         "api_ops_rate_limit",
-        "end_user_memory_limit"
+        "end_user_memory_limit",
+        "pre_user_memory_write_qps_limit"
     ]
     quotas = {}
     for key in quota_keys:
@@ -65,7 +66,8 @@ def _build_default_free_plan():
             "ontology_project_quota": 3,
             "model_quota": 1,
             "api_ops_rate_limit": 50,
-            "end_user_memory_limit": 300
+            "end_user_memory_limit": 300,
+            "pre_user_memory_write_qps_limit": 50
         },
     }
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -255,6 +255,10 @@ class Settings:
     LOG_STREAM_BUFFER_SIZE: int = int(os.getenv("LOG_STREAM_BUFFER_SIZE", "8192"))  # 8KB
     LOG_FILE_MAX_SIZE_MB: int = int(os.getenv("LOG_FILE_MAX_SIZE_MB", "10"))  # 10MB
 
+    # Celery Task Scheduler Configuration
+    # 每个 (task_name, user_id) 队列的最大待处理消息数，0 表示不限制
+    SCHEDULER_MAX_QUEUE_LEN: int = int(os.getenv("SCHEDULER_MAX_QUEUE_LEN", "1000"))
+
     # Celery configuration (internal)
     # NOTE: 变量名不以 CELERY_ 开头，避免被 Celery CLI 的前缀匹配机制劫持
     # 详见 docs/celery-env-bug-report.md

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -250,10 +250,10 @@ class MemoryService:
         )
 
     @staticmethod
-    def dispatch_flush_conversation(conversation_id: str) -> int:
+    async def dispatch_flush_conversation(conversation_id: str) -> int:
         """Flush 兜底任务派发。"""
         from app.core.memory.pipelines.dispatcher import dispatch_flush_conversation
-        return dispatch_flush_conversation(conversation_id)
+        return await dispatch_flush_conversation(conversation_id)
 
     @staticmethod
     async def delete_node_by_element_id(

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -114,7 +114,7 @@ def verify_unmark_safe(conversation_id: str) -> bool:
 # 派发函数：各入口点使用
 # ──────────────────────────────────────────────
 
-def push_write_task(
+async def push_write_task(
     end_user_id: str,
     target_message: dict,
     context_before: List[dict],
@@ -153,7 +153,7 @@ def push_write_task(
     # 记录任务派发时刻，作为 pipeline 内 dialog_at 的第二级兜底
     dispatch_at = datetime.now(timezone.utc).isoformat()
 
-    msg_id = celery_scheduler.push_task(
+    msg_id = await celery_scheduler.push_task(
         "app.core.memory.agent.write_message",
         end_user_id,
         {
@@ -286,7 +286,7 @@ async def dispatch_api_service_async(
             after_end = user_indices[after_user_p] + 1
             context_after = written_mms[idx + 1:after_end]
 
-        msg_id = push_write_task(
+        msg_id = await push_write_task(
             end_user_id=end_user_id,
             target_message=msg,
             context_before=context_before,
@@ -452,7 +452,7 @@ def _resolve_memory_config_id(conversation_id: str) -> "uuid.UUID | None":
         return None
 
 
-def dispatch_flush_conversation(conversation_id: str) -> int:
+async def dispatch_flush_conversation(conversation_id: str) -> int:
     """Flush 兜底任务派发：处理单个对话的所有未写入消息。
 
     仅服务 agent/workflow 路径。API/MCP 消息 conversation_id=NULL 不会被扫到。
@@ -525,7 +525,7 @@ def dispatch_flush_conversation(conversation_id: str) -> int:
                 skipped_non_user += 1
                 continue
 
-            if dispatch_single_message(
+            if await dispatch_single_message(
                 conversation_id=conversation_id,
                 target_seq=target_seq,
                 end_user_id=end_user_id,
@@ -624,7 +624,7 @@ async def check_sliding_window_and_dispatch(
             context_after = [message_to_dict(m) for m in repo.build_context_after(conversation_id, target_seq)]
 
         # 派发写入任务
-        push_write_task(
+        await push_write_task(
             end_user_id=end_user_id,
             target_message=msg,
             context_before=context_before,
@@ -641,7 +641,7 @@ async def check_sliding_window_and_dispatch(
         return
 
 
-def dispatch_single_message(
+async def dispatch_single_message(
     conversation_id: str,
     target_seq: int,
     end_user_id: str,
@@ -673,7 +673,7 @@ def dispatch_single_message(
         )
         return False
 
-    push_write_task(
+    await push_write_task(
         end_user_id=end_user_id,
         target_message=msg_dict,
         context_before=context_before,
@@ -733,7 +733,7 @@ async def dispatch_mcp_write(
     target_msg = written[0]
     target_seq = target_msg["message_seq"]
 
-    msg_id = push_write_task(
+    msg_id = await push_write_task(
         end_user_id=end_user_id,
         target_message=target_msg,
         context_before=[],

--- a/api/app/core/quota_manager.py
+++ b/api/app/core/quota_manager.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_auth_logger
 from app.i18n.exceptions import QuotaExceededError, InternalServerError
+from app.utils.redis_cache import redis_cache
 
 logger = get_auth_logger()
 
@@ -189,10 +190,19 @@ async def get_api_ops_rate_limit_async(db, tenant_id: UUID) -> Optional[int]:
     return None
 
 
+@redis_cache(ttl=300, prefix='quota', skip_args=['db'])
 def get_end_user_memory_limit(db: Session, tenant_id: UUID) -> Optional[int]:
     quota_config = _get_quota_config(db, tenant_id)
     if quota_config:
-        return quota_config.get("end_user_memory_limit", 300)
+        return quota_config.get("end_user_memory_limit")
+    return None
+
+
+@redis_cache(ttl=300, prefix='quota', skip_args=['db'])
+async def get_pre_user_memory_write_ops_limit(db: AsyncSession, tenant_id: UUID) -> Optional[int]:
+    quota_config = await _get_quota_config_async(db, tenant_id)
+    if quota_config:
+        return quota_config.get("pre_user_memory_write_qps_limit")
     return None
 
 

--- a/api/app/services/memory_api_service.py
+++ b/api/app/services/memory_api_service.py
@@ -129,7 +129,7 @@ class MemoryAPIService:
         except Exception as e:
             logger.warning(f"Failed to update memory_config_id for end_user {end_user_id}: {e}")
 
-    def write_memory( #TODO(乐力齐):[910]清除旧有无用代码(v0.3.14)
+    async def write_memory( #TODO(乐力齐):[910]清除旧有无用代码(v0.3.14)
             self,
             workspace_id: uuid.UUID,
             end_user_id: str,
@@ -178,7 +178,7 @@ class MemoryAPIService:
         #     storage_type,
         #     user_rag_memory_id or "",
         # )
-        task_id = scheduler.push_task(
+        task_id = await scheduler.push_task(
             "app.core.memory.agent.write_message",
             end_user_id,
             {

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4102,6 +4102,9 @@ def flush_conversation_task(self) -> None:
     _dispatch_flush = _MS.dispatch_flush_conversation
     from app.models.conversation_model import Conversation
 
+    # Ensure an event loop is available for awaiting the async dispatch function.
+    _loop = set_asyncio_event_loop()
+
     redis_client = get_sync_redis_client()
     if redis_client is None:
         logger.error("[FlushScan] Redis 不可用，跳过本次扫描")
@@ -4215,7 +4218,7 @@ def flush_conversation_task(self) -> None:
 
             # 派发单个对话的兜底写入
             try:
-                _dispatch_flush(conv_id_str)
+                _loop.run_until_complete(_dispatch_flush(conv_id_str))
                 dispatched += 1
                 logger.info(f"[FlushScan] 已处理: conv={conv_id_str}")
             except Exception as e:

--- a/api/app/utils/redis_cache.py
+++ b/api/app/utils/redis_cache.py
@@ -1,0 +1,293 @@
+"""
+Redis 查询结果缓存装饰器
+
+提供 ``@redis_cache`` 装饰器，自动缓存异步函数的返回值到 Redis
+
+用法::
+
+    from app.utils.redis_cache import redis_cache
+
+    # skip_args 支持参数名，db 等连接参数自动跳过
+    @redis_cache(ttl=300, prefix="forget_logs", skip_args=["db"])
+    async def get_forget_logs(db, end_user_id, page=1, pagesize=10):
+        ...
+
+    # 也支持位置索引
+    @redis_cache(ttl=120, prefix="user", skip_args=[0])
+    async def get_user(db, user_id):
+        ...
+
+    # 自定义 key 构建
+    @redis_cache(ttl=60, key_builder=lambda *a, **kw: f"custom:{kw['user_id']}")
+    async def expensive_query(user_id):
+        ...
+
+Key 格式： ``cache:{prefix}:{qualname}:{args_hash}``
+"""
+
+import hashlib
+import inspect
+import json
+import logging
+import uuid
+from enum import Enum
+from functools import wraps
+from typing import Any, Callable
+
+from app.aioRedis import get_thread_safe_redis, get_thread_safe_sync_redis
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL = 300  # 默认 5 分钟
+
+
+def _resolve_skip_indices(
+        func: Callable,
+        skip_args: list[int | str],
+) -> frozenset[int]:
+    """将 ``skip_args`` 中的参数名解析为位置索引，与已有的 int 索引合并。"""
+    indices: set[int] = set()
+    names: set[str] = set()
+    for v in skip_args:
+        if isinstance(v, int):
+            indices.add(v)
+        else:
+            names.add(v)
+
+    if names:
+        try:
+            sig = inspect.signature(func)
+            for i, (pname, _param) in enumerate(sig.parameters.items()):
+                if pname in names:
+                    indices.add(i)
+        except (ValueError, TypeError):
+            pass
+
+    return frozenset(indices)
+
+
+def _default_key_builder(
+        prefix: str,
+        func: Callable,
+        args: tuple,
+        kwargs: dict,
+        skip_indices: frozenset[int],
+) -> str:
+    """默认缓存 key 构建器。
+
+    Key 格式：``cache:{prefix}:{qualname}:{args_hash}``
+    """
+    qualname = getattr(func, "__qualname__", func.__name__)
+    # 跳过标记位置的参数
+    if skip_indices:
+        filtered_args = tuple(
+            v for i, v in enumerate(args) if i not in skip_indices
+        )
+    else:
+        filtered_args = args
+
+    raw = _make_hashable(filtered_args, kwargs)
+    payload = json.dumps(raw, sort_keys=True, ensure_ascii=False, default=str)
+    digest = hashlib.md5(payload.encode()).hexdigest()[:12]
+    return f"cache:{prefix}:{qualname}:{digest}"
+
+
+def _make_hashable(args: tuple, kwargs: dict) -> list:
+    """将 args/kwargs 转为 JSON 可序列化的列表，用于 hash 计算。"""
+    result: list[Any] = []
+    for v in args:
+        result.append(_to_hashable(v))
+    if kwargs:
+        result.append(dict(sorted((k, _to_hashable(v)) for k, v in kwargs.items())))
+    return result
+
+
+def _to_hashable(v: Any) -> Any:
+    """将单个值转为 hash-key"""
+    if isinstance(v, uuid.UUID):
+        return str(v)
+    if isinstance(v, Enum):
+        return v.value
+    if hasattr(v, "model_dump"):
+        try:
+            return v.model_dump(mode="json")
+        except Exception:
+            return str(v)
+    if isinstance(v, (bytes, bytearray)):
+        return v.hex()
+    if isinstance(v, (set, frozenset)):
+        return sorted(_to_hashable(x) for x in v)
+    if isinstance(v, dict):
+        return {str(k): _to_hashable(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_to_hashable(x) for x in v]
+    return v
+
+
+def redis_cache(
+        ttl: int = DEFAULT_TTL,
+        prefix: str = "default",
+        skip_args: list[int | str] | None = None,
+        key_builder: Callable[..., str] | None = None,
+        cache_none: bool = False,
+) -> Callable:
+    """函数返回值 Redis 缓存装饰器，同时支持同步和异步函数。
+
+    Args:
+        ttl: 缓存过期时间（秒），默认 300。
+        prefix: 缓存 key 前缀，最终 key 为 ``cache:{prefix}:...``。
+        skip_args: 不参与 key 计算的参数。支持位置索引 (int) 或参数名 (str)。
+                   例：``skip_args=[0]`` 跳过第一个位置参数；
+                   ``skip_args=["db", "redis"]`` 跳过名为 db、redis 的参数。
+        key_builder: 自定义 key 构建函数，签名为
+                     ``(prefix, func, args, kwargs) -> str``。
+                     提供后忽略 ``skip_args`` 和默认 key 逻辑。
+        cache_none: 是否缓存 ``None`` 返回值。默认 ``False``，避免缓存空结果。
+    """
+
+    def deco(func: Callable):
+        _skip_indices = _resolve_skip_indices(func, skip_args or [])
+
+        def _build_key(fn: Callable, args: tuple, kwargs: dict) -> str:
+            if key_builder is not None:
+                return key_builder(prefix, fn, args, kwargs)
+            return _default_key_builder(prefix, fn, args, kwargs, _skip_indices)
+
+        async def _cache_read_write(cache_key: str, compute):
+            """共享的缓存读取→回退计算→写入逻辑（异步）。"""
+            redis = get_thread_safe_redis()
+
+            # 尝试读取缓存
+            try:
+                cached = await redis.get(cache_key)
+            except Exception:
+                logger.warning("Redis GET failed for key=%s", cache_key, exc_info=True)
+                cached = None
+
+            if cached is not None:
+                try:
+                    result = json.loads(cached)
+                    logger.debug("Cache HIT: %s", cache_key)
+                    return result
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Corrupted cache data for key=%s, will recompute", cache_key,
+                    )
+
+            # 缓存未命中，执行原函数
+            result = await compute()
+
+            # 决定是否写入缓存
+            if result is None and not cache_none:
+                return None
+
+            try:
+                value = json.dumps(result, ensure_ascii=False, default=str)
+                await redis.set(cache_key, value, ex=ttl)
+                logger.debug("Cache SET: %s (ttl=%ds)", cache_key, ttl)
+            except Exception:
+                logger.warning("Redis SET failed for key=%s", cache_key, exc_info=True)
+
+            return result
+
+        if inspect.iscoroutinefunction(func):
+            # async
+            @wraps(func)
+            async def async_wrapper(*args, **kwargs):
+                cache_key = _build_key(func, args, kwargs)
+
+                async def _compute():
+                    return await func(*args, **kwargs)
+
+                return await _cache_read_write(cache_key, _compute)
+
+            async_wrapper._cache_prefix = prefix
+            async_wrapper._cache_ttl = ttl
+            return async_wrapper
+
+        else:
+            # sync
+            @wraps(func)
+            def sync_wrapper(*args, **kwargs):
+                cache_key = _build_key(func, args, kwargs)
+                redis = get_thread_safe_sync_redis()
+
+                # 读取缓存
+                try:
+                    cached = redis.get(cache_key)
+                except Exception:
+                    logger.warning("Redis GET failed for key=%s", cache_key, exc_info=True)
+                    cached = None
+
+                if cached is not None:
+                    try:
+                        result = json.loads(cached)
+                        logger.debug("Cache HIT: %s", cache_key)
+                        return result
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Corrupted cache data for key=%s, will recompute", cache_key,
+                        )
+
+                # 缓存未命中
+                result = func(*args, **kwargs)
+
+                if result is None and not cache_none:
+                    return None
+
+                try:
+                    value = json.dumps(result, ensure_ascii=False, default=str)
+                    redis.set(cache_key, value, ex=ttl)
+                    logger.debug("Cache SET: %s (ttl=%ds)", cache_key, ttl)
+                except Exception:
+                    logger.warning("Redis SET failed for key=%s", cache_key, exc_info=True)
+
+                return result
+
+            sync_wrapper._cache_prefix = prefix
+            sync_wrapper._cache_ttl = ttl
+            return sync_wrapper
+
+    return deco
+
+
+async def invalidate_cache(
+        key: str | None = None,
+        *,
+        prefix: str | None = None,
+        pattern: str | None = None,
+) -> int:
+    """主动删除缓存。
+
+    三种调用方式::
+
+        await invalidate_cache(key="cache:user:get_user:abc123")
+        await invalidate_cache(prefix="user")           # 删除 cache:user:* 开头的所有 key
+        await invalidate_cache(pattern="cache:user:*")  # 自定义 glob 模式
+
+    Returns:
+        已删除的 key 数量。
+
+    Raises:
+        ValueError: 未提供任何匹配条件。
+    """
+    redis = get_thread_safe_redis()
+
+    if key is not None:
+        return await redis.delete(key)
+
+    search = pattern or (f"cache:{prefix}:*" if prefix else None)
+    if search is None:
+        raise ValueError("Provide key=, prefix=, or pattern=")
+
+    deleted = 0
+    cursor = 0
+    while True:
+        cursor, keys = await redis.scan(cursor, match=search, count=500)
+        if keys:
+            deleted += await redis.unlink(*keys)
+        if cursor == 0:
+            break
+
+    logger.info("Invalidated %d cache keys matching '%s'", deleted, search)
+    return deleted


### PR DESCRIPTION
- Extract monolithic celery_task_scheduler.py into a package with LUA scripts
- Add per-unit queue length limit and per-(task,user) QPS sliding window admission
- Introduce redis_cache decorator for async query caching
- Convert dispatcher and related functions from sync to async
- Add pre_user_memory_write_qps_limit to free plan configuration

## 由 Sourcery 提供的摘要

将基于 Redis 的 Celery 任务调度器重构为一个异步、模块化的包，引入基于 Redis/Lua 的限流和旧数据迁移，并更新内存写入流程以使用新的异步调度器和按用户的 QPS 控制。

新功能：
- 引入基于 Redis 的滑动窗口限流，以及按 (任务、用户) 的队列长度限制用于任务准入。
- 添加可复用的 `redis_cache` 装饰器，用于在 Redis 中缓存同步和异步查询结果。
- 通过应用设置暴露调度器的最大队列长度配置。
- 在免费套餐和配额管理器中添加对 `pre_user_memory_write_qps_limit` 配额的支持。

改进：
- 将单体任务调度器拆分为一个带 Lua 脚本的独立包，并使用更清晰的 Redis 键命名空间。
- 将内存写入的派发和刷新路径改为异步，并与新的调度器接口集成。
- 添加线程安全的同步 Redis 客户端支持，用于在非异步场景中进行缓存。
- 改进调度器健康状态上报，并引入针对旧队列和跟踪键的迁移流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Redis-based Celery task scheduler into an async, modular package with Redis/Lua-backed rate limiting and legacy data migration, and update memory write flows to use the new async scheduler and per-user QPS controls.

New Features:
- Introduce Redis-backed sliding-window rate limiting and per-(task,user) queue length limits for task admission.
- Add a reusable redis_cache decorator to cache sync and async query results in Redis.
- Expose scheduler configuration for maximum queue length via application settings.
- Add support for a pre_user_memory_write_qps_limit quota in the free plan and quota manager.

Enhancements:
- Split the monolithic task scheduler into a dedicated package with Lua scripts and clearer Redis key namespaces.
- Convert memory write dispatch and flush paths to async, integrating them with the new scheduler interface.
- Add thread-safe synchronous Redis client support for caching in non-async contexts.
- Improve scheduler health reporting and introduce migration routines for legacy queues and tracker keys.

</details>