### PR TITLE
refactor(core)

### DIFF
--- a/api/app/core/workflow/nodes/start/node.py
+++ b/api/app/core/workflow/nodes/start/node.py
@@ -109,6 +109,21 @@ class StartNode(BaseNode):
             if var_name in input_variables:
                 value = input_variables[var_name]
 
+                # None 值按类型回退到默认值，避免写入 StringVariable(None) 等报错
+                if value is None:
+                    if var_def.required:
+                        raise ValueError(
+                            f"缺少必需的输入变量: {var_name}"
+                            + (f" ({var_def.description})" if var_def.description else "")
+                        )
+                    value = var_def.default if var_def.default is not None else DEFAULT_VALUE(var_type)
+                    if var_type == VariableType.FILE:
+                        self.output_var_types[var_name] = var_type
+                        continue
+                    processed[var_name] = value
+                    self.output_var_types[var_name] = var_type
+                    continue
+
                 # select: 值必须在 options 列表中
                 if ui_type == "select" and var_def.options:
                     if value not in var_def.options:

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -695,7 +695,7 @@ class AppChatService:
                 "provider": api_key_obj.provider,
             },
         )
-        await self._create_agent_execution(agent_exec_repo, agent_execution)
+        agent_execution_id = await self._create_agent_execution(agent_exec_repo, agent_execution)
 
         try:
             # 调用 Agent（支持多模态）
@@ -710,7 +710,7 @@ class AppChatService:
             elapsed_time = time.time() - start_time
             await self._update_agent_execution(
                 agent_exec_repo,
-                execution_id=agent_execution.id,
+                execution_id=agent_execution_id,
                 steps=[],
                 status="failed",
                 elapsed_time=elapsed_time,
@@ -841,7 +841,7 @@ class AppChatService:
         node_executions = orchestrator_node_executions + result.get("node_executions", [])
         await self._update_agent_execution(
             agent_exec_repo,
-            execution_id=agent_execution.id,
+            execution_id=agent_execution_id,
             steps=node_executions,
             status="completed",
             elapsed_time=elapsed_time,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1821,7 +1821,7 @@ class WorkflowService:
             output_data: dict[str, Any],
             workflow_config: "WorkflowConfig | None" = None,
     ) -> dict[str, Any]:
-        workflow_config = workflow_config or execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        workflow_config = workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
         type_maps = self._build_snapshot_type_maps(workflow_config)
         raw_groups = self._extract_execution_snapshot_raw_groups(
             output_data=output_data,
@@ -2153,7 +2153,7 @@ class WorkflowService:
         )
 
     def _refresh_workflow_debug_state_from_execution(self, execution: WorkflowExecution, workflow_config: WorkflowConfig | None = None) -> None:
-        workflow_config = workflow_config or execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
+        workflow_config = workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
         node_executions = self.node_execution_repo.get_by_execution_id(execution.id)
         output_data = self._serialize_execution_value(execution.output_data or {})
         snapshot = self._build_public_execution_snapshot_record(
@@ -3495,19 +3495,16 @@ class WorkflowService:
             logger.info(f"创建工作流执行记录: execution_id={execution_id}")
             return self._build_execution_ref(execution)
 
-    async def _get_execution_async(self, execution_id: str) -> WorkflowExecution | None:
+    async def _get_execution_async(self, execution_id: str) -> WorkflowExecutionRef | None:
         async with get_async_db_context() as db:
             result = await db.execute(
                 select(WorkflowExecution).where(WorkflowExecution.execution_id == execution_id)
             )
             execution = result.scalar_one_or_none()
             if execution:
-                db.expunge(execution)
-                return execution
+                return self._build_execution_ref(execution)
             runtime_execution = await self._get_runtime_execution_snapshot_async(execution_id)
-            if runtime_execution:
-                return self._build_execution_record_from_ref(runtime_execution)
-            return None
+            return runtime_execution
 
     async def _patch_execution_async(
             self,
@@ -3615,7 +3612,7 @@ class WorkflowService:
             assistant_meta: Optional[dict],
             workflow_output_data: Any,
             token_usage: Any,
-    ) -> WorkflowExecution:
+    ) -> WorkflowExecutionRef:
         async with get_async_db_context() as db:
             started_at = time.perf_counter()
             conversation = await db.get(Conversation, conversation_id)
@@ -3695,8 +3692,7 @@ class WorkflowService:
                 pool_status["usage_percent"],
             )
             await self._delete_runtime_execution_snapshot_async(execution_id)
-            db.expunge(execution)
-            return execution
+            return self._build_execution_ref(execution)
 
     async def _update_message_async(
             self,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -3502,6 +3502,7 @@ class WorkflowService:
             )
             execution = result.scalar_one_or_none()
             if execution:
+                db.expunge(execution)
                 return execution
             runtime_execution = await self._get_runtime_execution_snapshot_async(execution_id)
             if runtime_execution:
@@ -3694,6 +3695,7 @@ class WorkflowService:
                 pool_status["usage_percent"],
             )
             await self._delete_runtime_execution_snapshot_async(execution_id)
+            db.expunge(execution)
             return execution
 
     async def _update_message_async(


### PR DESCRIPTION
expunge workflow execution objects and fix agent execution ID usage

- Expunge workflow execution objects from session to prevent stale state issues
- Use returned agent execution ID instead of object attribute to avoid potential race conditions

## Summary by Sourcery

优化工作流执行处理和代理执行跟踪，以避免状态过期和竞争条件。

Bug Fixes（错误修复）:
- 防止将无效的 `None` 值写入带类型的工作流变量，并强制执行必需输入的校验。
- 确保代理执行更新使用创建操作返回的持久化执行 ID，而不是内存中的对象 ID。
- 通过在检索和最终处理后将工作流执行实体从会话中移除，避免 ORM 状态过期。

Enhancements（增强）:
- 改进工作流起始节点变量的默认值处理，包括在输入缺失时的文件类型输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine workflow execution handling and agent execution tracking to avoid stale state and race conditions.

Bug Fixes:
- Prevent writing invalid None values into typed workflow variables and enforce required input validation.
- Ensure agent execution updates use the persisted execution ID returned from creation rather than the in-memory object ID.
- Avoid stale ORM state by expunging workflow execution entities from the session after retrieval and finalization.

Enhancements:
- Improve default value handling for workflow start node variables, including file-type outputs when inputs are missing.

</details>