### PR TITLE
feat(web): Memory Extraction Engine

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8">
+    <meta name="google" content="notranslate">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">

--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 14:00:06 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-03 11:08:34
+ * @Last Modified time: 2026-07-16 12:24:45
  */
 import { request } from '@/utils/request'
 import type { AxiosRequestConfig } from 'axios'
@@ -24,6 +24,7 @@ import type {
 import type { TestParams } from '@/views/MemoryConversation'
 import type { EndUser } from '@/views/UserMemoryDetail/types'
 import { handleSSE, type SSEMessage } from '@/utils/stream'
+import type { ChatItem } from '@/components/Chat/types'
 
 // Memory conversation
 export const readService = (query: TestParams) => {
@@ -338,7 +339,7 @@ export const updateMemoryExtractionConfig = (values: ExtractionConfigForm) => {
   return request.post('/memory_config/update_config_extracted', values)
 }
 // Memory Extraction Engine - Pilot run
-export const pilotRunMemoryExtractionConfig = (values: { config_id: string | string; dialogue_text: string; custom_text?: string; }, onMessage?: (data: SSEMessage[]) => void, onAbort?: (abort: () => void) => void) => {
+export const pilotRunMemoryExtractionConfig = (values: { config_id: string | string; messages: ChatItem[]; }, onMessage?: (data: SSEMessage[]) => void, onAbort?: (abort: () => void) => void) => {
   return handleSSE('/memory-storage/pilot_run', values, onMessage, undefined, onAbort)
 }
 // Emotion Engine - Get configuration

--- a/web/src/components/Chat/index.tsx
+++ b/web/src/components/Chat/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2025-12-10 16:46:09 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-06-05 19:20:53
+ * @Last Modified time: 2026-07-16 17:18:50
  */
 import { type FC } from 'react'
 import ChatInput from './ChatInput'
@@ -14,11 +14,11 @@ import ChatContent from './ChatContent'
  * Provides complete chat interface functionality, including message display and input interaction
  */
 const Chat: FC<ChatProps> = ({
-  empty,
   data,
   onChange,
   onSend,
   loading,
+  message,
   contentClassName = '',
   children,
   fileList,
@@ -43,6 +43,7 @@ const Chat: FC<ChatProps> = ({
       {!readOnly &&
         <ChatInput
           fileList={fileList}
+          message={message}
           onChange={onChange}
           onSend={onSend}
           loading={loading}

--- a/web/src/components/Chat/types.ts
+++ b/web/src/components/Chat/types.ts
@@ -79,6 +79,8 @@ export interface Intervention {
 export interface ChatProps extends Omit<ChatContentProps, 'onSend'> {
   /** Input content change callback */
   onChange: (message: string) => void;
+  /** Current input message (controlled; clearing it empties the input box) */
+  message?: string;
   /** Send message callback */
   onSend: () => void;
   /** Loading state */

--- a/web/src/i18n/en/space.ts
+++ b/web/src/i18n/en/space.ts
@@ -70,8 +70,8 @@ export const space = {
       extractTheNumberOfEntities: 'Extract the number of entities',
       extractTheNumberOfEntitiesDesc: 'Merge after deduplication: {{num}} (exact: {{exact}}, fuzzy: {{fuzzy}}, LLM: {{llm}})',
 
-      numberOfEntityDisambiguation: 'Number of entity disambiguation',
-      numberOfEntityDisambiguationDesc: 'Total {{num}} times (blocking: {{block_count}})',
+      perceptualMemory: 'Perceptual memory',
+      perceptualMemoryDesc: '{{num}} perceptual memories in total',
 
       memoryFragments: 'Memory fragments',
       memoryFragmentsDesc: 'Split by paragraph + semantics',
@@ -93,6 +93,7 @@ export const space = {
       sentenceChunker: 'Sentence Chunker',
       lateChunker: 'Late Chunker',
       debug: 'Debug',
+      clearChat: 'Clear',
       model: 'Model',
       chunkerStrategy: 'Chunker Strategy',
       chunkerStrategyDesc: 'Choose a partitioning strategy.',
@@ -139,24 +140,6 @@ export const space = {
       extractRelationalTriples: 'Extracted relational triples (partial)',
       extractRelationalTriplesDesc: 'There are a total of {{count}} segments with clear semantic boundaries',
       theEffectOfEntityDisambiguationLLMDriven: 'The effect of entity disambiguation (LLM driven)',
-      exampleText: `Student: What was the root cause of the Song dynasty’s military weakness?
-Memory Bear: The Song dynasty’s military weakness mainly stemmed from institutional factors: the imperial guards were controlled by civil officials, which led to low combat efficiency; the regional armies were poorly equipped; military spending consumed more than half of the national budget for a long time, and constant warfare intensified fiscal pressure, which in turn restricted military development; its foreign strategy was passive, lacking strategic depth and mobility; and the dominance of civil officials suppressed military commanders, dispersing military authority and making it difficult to improve professionalization within the armed forces.
-
-Student: I’m confused about the connection between fiscal pressure and insufficient military strength.
-Memory Bear: Simply put, the Song government spent over half its budget on the military—costs kept rising, but the wars kept going badly. As military expenses dragged down the treasury, the court had to cut equipment and reduce troop numbers, which made the army even weaker. Losing battles meant having to spend more again to recruit troops, creating a vicious cycle.
-
-Student: After the position of chancellor was abolished, what exactly went wrong with the bureaucracy?
-Memory Bear: Abolishing the chancellor led to a rigid bureaucratic system, which manifested in several ways: central decision-making became highly concentrated in the emperor, reducing administrative efficiency; the Six Ministries lost the chancellor as their coordinating hub and lacked mechanisms for inter-departmental cooperation, making policy implementation difficult; surveillance agencies such as the Jinyiwei and the Eastern/Western Depots filled part of the gap, but since their focus was on monitoring and control, they intensified administrative tension; and officials selected through the imperial examination system were mostly scholars lacking systematic administrative training and specialization.
-
-Student: I still don’t fully understand the specific impact of the “lack of coordination among the Six Ministries.”
-Memory Bear: Originally, the chancellor functioned like a modern “prime minister,” and the Six Ministries were like today’s major government departments. Big or small, he coordinated everything. After the position was eliminated, the ministries reported directly to the emperor, but the emperor couldn’t possibly review everything himself, so they started passing responsibility around. For example, in wartime the Ministry of War needed funds, the Ministry of Revenue claimed it had none, and the Ministry of Works said it had no materials for weapons. With no one to make final decisions, military operations stalled.
-
-Student: I’m reviewing the history of the Spring and Autumn and Warring States periods. I’m puzzled as to why Qin was able to unify the Six States, since the others were also strong.
-Memory Bear: Qin succeeded for several reasons: Shang Yang’s reforms were thorough, establishing a legal system, household registration, and a military merit-based rank system that strengthened state capacity; the old aristocracy was weak, which allowed for a high degree of centralization; the Guanzhong region had superior geography—resource-rich, easy to defend, and difficult to invade; and from Duke Xiao to the First Emperor, Qin maintained strong policy continuity.
-
-Student: Then switching to Tang history: after the An Lushan Rebellion, the central government began reforms, so why did regional warlordism (the fanzhen problem) actually get worse?
-Memory Bear: After the rebellion, regional warlordism intensified for several reasons: military governors (jiedushi) held the power to recruit troops, control local finances, and command military forces, effectively becoming regional warlords; the central government’s finances declined due to the breakdown of the equal-field system and the collapse of the tax-labor system, making it increasingly unable to support the army, which pushed military forces to rely on the jiedushi; the recruitment-based military system made soldiers loyal to individual commanders rather than the state; eunuchs controlled the imperial guards, the civil bureaucracy lost influence, and the central government’s ability to balance regional power weakened.
-`,
 
       warning: 'When you modify the configuration items on the left, click [Debug], and the extraction conclusions will be updated in real time here',
       processing: 'Configuration updated, re-extracting sample memory...',
@@ -179,6 +162,9 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       creating_nodes_edges_desc: 'Entity relationship creation completed, {{num}} relationships in total',
       deduplication_desc: 'Deduplication and disambiguation completed, {{count}} unique entities in total',
       custom_text: 'Debug Text',
+      chatPlaceholder: 'Enter debug text and send to view the AI reply',
+      chatEmpty: 'Send a message to start the debug conversation',
+      debugReply: 'Sure, memory has been extracted from this image and text based on the current configuration. Click "Debug" in the top-right corner to view the extraction process and results.',
       ontologyCoverage: 'Ontology Type',
       entity_total: 'Total {{num}} entities',
       scene_type_distribution: 'Scene Type Distribution',
@@ -188,6 +174,32 @@ Memory Bear: After the rebellion, regional warlordism intensified for several re
       Pruned: 'Pruned',
       pruning: 'Pruning',
       pruning_desc: 'Text pruning {{count}} fragments',
+
+      pruning_result_title: 'Pruning',
+      chunking_result_title: 'Chunking',
+      statement_result_title: 'Statement Extraction',
+      triplet_result_title: 'Triple Extraction',
+      perceptual_result_title: ' Perception',
+      dedup_result_title: 'Deduplication',
+      pruning_result_desc: 'Assistant compressed text into {{count}} statements ({{count}} fragments)',
+      chunking_result_desc: 'Chunking into {{count}} chunks(total_chunks), strategy: {{strategy}}',
+      statement_result_desc: 'Extracted {{count}} statements(total_count: {{count}}), completed anaphora resolution and time extraction',
+      triplet_result_desc: 'Identified {{entity}} entities(entity_count: {{entity}}), triplets {{triplet}} triples(triplet_count: {{triplet}})',
+      perceptual_result_desc: 'Multimodal file understanding completed, generated a total of {{count}} nodes(new capability)',
+      dedup_result_desc: 'Merged entities {{before}} → {{after}}(before_count → after_count), merged {{pairs}} pairs',
+      original_preview: 'Original Preview',
+      compressedInto: 'Compressed Into',
+      memory_hint: 'Memory Hint',
+      entities: 'Entities',
+      triplets: 'Triples',
+      merged_pairs: 'Merged Pairs',
+      mergedIntoOne: 'Merged into 1 entity',
+      mergedCount: 'Merged entities {{count}} pairs',
+      perceptualType: 'Perceptual Type',
+      perceptualSummary: 'Summary',
+      perceptualTopic: 'Topic',
+      perceptualDomain: 'Domain',
+      perceptualKeywords: 'Keywords',
 
       processData: 'Process Data',
       finalResult: 'Final Result',

--- a/web/src/i18n/zh/space.ts
+++ b/web/src/i18n/zh/space.ts
@@ -70,8 +70,8 @@ export const space = {
       extractTheNumberOfEntities: '提取实体数量',
       extractTheNumberOfEntitiesDesc: '去重后合并：{{num}}（精确：{{exact}}，模糊：{{fuzzy}}，LLM：{{llm}}）',
 
-      numberOfEntityDisambiguation: '实体消歧数量',
-      numberOfEntityDisambiguationDesc: '总计{{num}}次（阻止：{{block_count}}）',
+      perceptualMemory: '感知记忆',
+      perceptualMemoryDesc: '共{{num}}条感知记忆',
 
       memoryFragments: '记忆片段',
       memoryFragmentsDesc: '按段落+语义分割',
@@ -93,6 +93,7 @@ export const space = {
       sentenceChunker: '句子分块器',
       lateChunker: '延迟分块器',
       debug: '调试',
+      clearChat: '清空',
       model: '模型',
       chunkerStrategy: '分块策略',
       chunkerStrategyDesc: '选择分块策略。',
@@ -139,23 +140,7 @@ export const space = {
       extractRelationalTriples: '提取的关系三元组（部分）',
       extractRelationalTriplesDesc: '共有{{count}}个具有明确语义边界的片段',
       theEffectOfEntityDisambiguationLLMDriven: '实体消歧的效果（LLM驱动）',
-      exampleText: `学生：宋朝军事弱势的根源是什么？
-记忆熊：宋朝军事弱势主要源于制度性因素：禁军由文官控制导致作战效率低下，厢军装备不足；军费长期占财政支出一半以上，持续战争加剧财政压力，反向制约军力发展；对外战略被动，缺乏战略纵深且机动能力弱；文官集团压制武将，军权分散，军事专业化难以提升。
 
-学生：我对财政压力与军力不足的关系表示困惑。
-记忆熊：简单说，宋朝军费占财政一半以上，钱越花越多，仗却越打越输。财政被军费拖垮后，朝廷只能削减装备、裁撤兵员，结果军队更弱，打仗更吃亏，又要再花钱募兵，形成恶性循环。
-
-学生：废除丞相制度后，官僚体系到底出了什么问题？
-记忆熊：废除丞相制度导致官僚体系僵化，主要表现为：中央决策高度集中于皇帝，降低行政效率；六部之间失去丞相作为协调中枢，缺乏协作机制，政令推行困难；厂卫机构如锦衣卫、东厂、西厂填补部分职能，但侧重监督，加剧行政紧张；官员通过科举选拔，多为文士出身，缺乏系统行政训练与专业分工。
-
-学生：我对"六部缺乏协调机制"的具体影响表示理解不足。
-记忆熊：原来丞相相当于"总理"，六部像今天的各部委，大事小情由他统筹。废丞相后，六部直接对皇帝，皇帝一人批不完，部就互相踢皮球。比如打仗，兵部要银子，户部说没有，工部说武器没材料，没人拍板，战事就拖延。
-
-学生：我在复习春秋战国史，对秦国为何能统一六国表示疑问，认为其他国家也较强。
-记忆熊：秦国统一的原因包括：商鞅变法彻底，建立法律、户籍和军功爵制度，提升国家组织能力；旧贵族势力弱，中央集权程度高；关中地理优越，资源丰富且易守难攻；从孝公到秦始皇政策连续性强。
-
-学生：那我换到唐朝史：安史之乱后，中央已开始整顿，为何藩镇割据反而加剧？
-记忆熊：安史之乱后藩镇割据加剧的原因包括：节度使掌握募兵权、财政调度权与军事指挥权，形成地方军阀；中央财政因均田制瓦解和租庸调失效而衰退，难以支撑军队，导致地方军事力量依附节度使；募兵制使士兵效忠个人而非国家；宦官掌控禁军，文官集团失势，中央制衡能力削弱。`,
       warning: '当您修改左侧的配置项后，点击【调试】，提取结论将在此处实时更新',
       processing: '配置已更新，正在重新萃取示例记忆...',
       success: '记忆萃取完成！',
@@ -177,6 +162,9 @@ export const space = {
       creating_nodes_edges_desc: '实体关系创建完成，共{{num}}条关系',
       deduplication_desc: '去重消歧完成，最终{{count}}个唯一实体',
       custom_text: '调试文本',
+      chatPlaceholder: '输入调试文本，发送后查看 AI 回复',
+      chatEmpty: '发送一条消息，开始调试对话',
+      debugReply: '好的,已根据当前配置对该图文进行记忆萃取,点击右上角「调试」查看提取过程与结果。',
       ontologyCoverage: '本体类型',
       entity_total: '一共{{num}}个实体',
       scene_type_distribution: '场景类型',
@@ -186,6 +174,32 @@ export const space = {
       Pruned: '已剪枝',
       pruning: '剪枝',
       pruning_desc: '文本剪枝{{count}}个片段',
+
+      pruning_result_title: '剪枝',
+      chunking_result_title: '分块',
+      statement_result_title: '陈述句提取',
+      triplet_result_title: '三元组提取',
+      perceptual_result_title: '感知记忆提取',
+      dedup_result_title: '去重',
+      pruning_result_desc: 'Assistant 长文本已压缩为 {{count}} 句记忆提示(hint)，共 {{count}} 条',
+      chunking_result_desc: '共切分为 {{count}} 个分块(total_chunks)，策略：{{strategy}}',
+      statement_result_desc: '共提取 {{count}} 条陈述句(total_count: {{count}})，完成指代消融与时间提取',
+      triplet_result_desc: '识别实体 {{entity}} 个(entity_count: {{entity}})，关系三元组 {{triplet}} 条(triplet_count: {{triplet}})',
+      perceptual_result_desc: '多模态文件理解完成，共生成 {{count}} 个感知节点(新能力)',
+      dedup_result_desc: '同一轮对话内实体合并：{{before}} → {{after}}(before_count → after_count)，合并 {{pairs}} 对',
+      original_preview: '原文预览',
+      compressedInto: '压缩为',
+      memory_hint: '记忆提示',
+      entities: '实体',
+      triplets: '三元组',
+      merged_pairs: '合并对',
+      mergedIntoOne: '合并为 1 个实体',
+      mergedCount: '合并 {{count}} 个相似实体',
+      perceptualType: '类型',
+      perceptualSummary: '摘要',
+      perceptualTopic: '主题',
+      perceptualDomain: '领域',
+      perceptualKeywords: '关键词',
 
       processData: '处理数据',
       finalResult: '最终结果',

--- a/web/src/views/MemoryExtractionEngine/components/Result.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/Result.tsx
@@ -1,8 +1,8 @@
 /*
- * @Author: ZhaoYing 
- * @Date: 2026-02-03 17:30:11 
+ * @Author: ZhaoYing
+ * @Date: 2026-02-03 17:30:11
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-04-21 14:54:14
+ * @Last Modified time: 2026-07-16 12:07:14
  */
 /**
  * Result Component
@@ -10,104 +10,61 @@
  * Shows text preprocessing, knowledge extraction, node/edge creation, and deduplication
  */
 
-import { type FC, useState, useRef, useEffect } from 'react'
+import { type FC, useRef, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Space, Button, Progress, Form, Input, Flex } from 'antd'
-import { ExclamationCircleFilled, LoadingOutlined } from '@ant-design/icons'
+import { Space, Button, Progress, Flex } from 'antd'
+import { ExclamationCircleFilled } from '@ant-design/icons'
 import clsx from 'clsx'
-import type { AnyObject } from 'antd/es/_util/type';
 
 import Card from './Card'
 import RbAlert from '@/components/RbAlert'
-import type { TestResult, OntologyCoverage } from '../types'
-import { pilotRunMemoryExtractionConfig } from '@/api/memory'
-import { type SSEMessage } from '@/utils/stream'
-import Tag, { type TagProps } from '@/components/Tag'
-import Markdown from '@/components/Markdown'
-import { groupDataByType } from '../constant'
-import Empty from '@/components/Empty'
-import NoDataIcon from '@/assets/images/empty/noData.png'
-import ResultCard from '@/components/RbCard/ResultCard'
+import type { ResultProps } from './result/types'
+import { useDebugChat } from './result/hooks/useDebugChat'
+import { usePilotRun } from './result/hooks/usePilotRun'
+import DebugChat from './result/DebugChat'
+import ProcessData from './result/ProcessData'
+import FinalResult from './result/FinalResult'
 
-/** Result metric mapping */
-const resultObj = {
-  extractTheNumberOfEntities: 'entities.extracted_count',
-  numberOfEntityDisambiguation: 'disambiguation.block_count',
-  memoryFragments: 'memory.chunks',
-  numberOfRelationalTriples: 'triplets.count'
-}
-/**
- * Component props
- */
-interface ResultProps {
-  loading: boolean;
-  handleSave: () => void;
-  /** 系统默认配置时禁用保存操作 */
-  disabled?: boolean;
-}
-/**
- * Module processing item
- */
-interface ModuleItem {
-  status: 'pending' | 'processing' | 'completed' | 'failed';
-  data: any[],
-  result: any,
-  start_at?: number;
-  end_at?: number;
-}
-/** Tag color mapping by status */
-const tagColors: {
-  [key: string]:  TagProps['color']
-} = {
-  pending: 'warning',
-  processing: 'processing',
-  completed: 'success',
-  failed: 'error'
-}
-/** Initial module state */
-const initObj = {
-  data: [],
-  status: 'pending',
-  result: null
-}
-const initialExpanded = {
-  text_preprocessing: false,
-  knowledge_extraction: false,
-  creating_nodes_edges: false,
-  deduplication: false,
-  dataStatistics: false,
-  entityDeduplicationImpact: false,
-  disambiguation: false,
-  coreEntities: false,
-  triplet_samples: false,
-  ontologyCoverage: false,
-}
-
-const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
+const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false, pruningEnabled = true }) => {
   const { t } = useTranslation();
   const { id } = useParams()
-  const [runLoading, setRunLoading] = useState(false)
-  const [activeTab, setActiveTab] = useState('processData')
-  const [testResult, setTestResult] = useState<TestResult>({} as TestResult)
-  const [coreEntitiesTab, setCoreEntitiesTab] = useState<string | null>(null) 
-  const [textPreprocessing, setTextPreprocessing] = useState<ModuleItem>(initObj as ModuleItem)
-  const [textPreprocessingTab, setTextPreprocessingTab] = useState('chunking')
-  const [knowledgeExtraction, setKnowledgeExtraction] = useState<ModuleItem>(initObj as ModuleItem)
-  const [creatingNodesEdges, setCreatingNodesEdges] = useState<ModuleItem>(initObj as ModuleItem)
-  const [deduplication, setDeduplication] = useState<ModuleItem>(initObj as ModuleItem)
-  const [ontologyCoverage, setOntologyCoverage] = useState<OntologyCoverage>({} as OntologyCoverage)
 
-  const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>(initialExpanded)
-  const toggleCard = (key: string) => {
-    console.log('toggleCard', key)
-    setExpandedCards(prev => ({ ...prev, [key]: !prev[key] }))
-  }
-  console.log('expandedCards', expandedCards)
-
-  const [runForm] = Form.useForm()
-  const customText = Form.useWatch(['custom_text'], runForm)
   const abortRef = useRef<(() => void) | null>(null)
+
+  /** Debug chat logic */
+  const {
+    msg,
+    setMsg,
+    chatList,
+    chatLoading,
+    fileList,
+    setFileList,
+    toolbarRef,
+    streamLoadingRef,
+    handleChatSend,
+    clearChat,
+  } = useDebugChat(id, abortRef)
+
+  /** Pilot run logic */
+  const {
+    runLoading,
+    activeTab,
+    setActiveTab,
+    testResult,
+    coreEntitiesTab,
+    setCoreEntitiesTab,
+    textPreprocessing,
+    chunking,
+    knowledgeExtraction,
+    creatingNodesEdges,
+    deduplication,
+    perceptual,
+    ontologyCoverage,
+    expandedCards,
+    toggleCard,
+    handleRun,
+  } = usePilotRun(id, abortRef, chatList)
 
   useEffect(() => {
     return () => {
@@ -115,163 +72,12 @@ const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
       abortRef.current = null;
     }
   }, [])
-  /** Run pilot test */
-  const handleRun = () => {
-    if(!id) return
-    setActiveTab('processData')
-    setCoreEntitiesTab(null)
-    setTextPreprocessing({...initObj} as ModuleItem)
-    setTextPreprocessingTab('chunking')
-    setKnowledgeExtraction({...initObj} as ModuleItem)
-    setCreatingNodesEdges({...initObj} as ModuleItem)
-    setDeduplication({...initObj} as ModuleItem)
-    setTestResult({} as TestResult)
-    setExpandedCards(initialExpanded)
-    const handleStreamMessage = (list: SSEMessage[]) => {
 
-      list.forEach((data: AnyObject) => {
-        switch(data.event) {
-          case 'text_preprocessing': // Start text preprocessing
-            setTextPreprocessing(prev => ({
-              ...prev,
-              status: 'processing',
-              start_at: data.data.time
-            }))
-            toggleCard('text_preprocessing')
-            break
-          case 'text_preprocessing_result': // Text preprocessing in progress
-            setTextPreprocessing(prev => ({
-              ...prev,
-              data: [...prev.data, data.data?.deleted_messages ? { deleted_messages: data.data?.deleted_messages } : data.data?.data],
-            }))
-            break
-          case 'text_preprocessing_complete': // Text preprocessing complete
-            setTextPreprocessing(prev => ({
-              ...prev,
-              result: data.data?.data,
-              status: 'completed',
-              end_at: data.data.time
-            }))
-            break
-          case 'knowledge_extraction': // Start knowledge extraction
-            setKnowledgeExtraction(prev => ({
-              ...prev,
-              status: 'processing',
-              start_at: data.data.time
-            }))
-            toggleCard('knowledge_extraction')
-            break
-          case 'knowledge_extraction_result': // Knowledge extraction in progress
-            setKnowledgeExtraction(prev => ({
-              ...prev,
-              data: [...prev.data, data.data?.data]
-            }))
-            break
-          case 'knowledge_extraction_complete': // Knowledge extraction complete
-            setKnowledgeExtraction(prev => ({
-              ...prev,
-              result: data.data?.data,
-              status: 'completed',
-              end_at: data.data.time
-            }))
-            break
-          case 'creating_nodes_edges': // Start creating nodes and edges
-            setCreatingNodesEdges(prev => ({
-              ...prev,
-              status: 'processing',
-              start_at: data.data.time
-            }))
-            toggleCard('creating_nodes_edges')
-            break
-          case 'creating_nodes_edges_result': // Creating nodes and edges in progress
-            setCreatingNodesEdges(prev => ({
-              ...prev,
-              data: [...prev.data, data.data?.data]
-            }))
-            break
-          case 'creating_nodes_edges_complete': // Creating nodes and edges complete
-            setCreatingNodesEdges(prev => ({
-              ...prev,
-              result: data.data?.data,
-              status: 'completed',
-              end_at: data.data.time
-            }))
-            break
-          case 'deduplication': // Start deduplication and disambiguation
-            setDeduplication(prev => ({
-              ...prev,
-              status: 'processing',
-              start_at: data.data.time
-            }))
-            toggleCard('deduplication')
-            break
-          case 'dedup_disambiguation_result': // Deduplication and disambiguation in progress
-            setDeduplication(prev => ({
-              ...prev,
-              data: [...prev.data, data.data.data]
-            }))
-            break
-          case 'dedup_disambiguation_complete': // Deduplication and disambiguation complete
-            setDeduplication(prev => ({
-              ...prev,
-              result: data.data?.data,
-              status: 'completed',
-              end_at: data.data.time
-            }))
-            break
-          case 'generating_results': // Generating results
-            break
-          case 'result': // Result
-            setTestResult(data.data?.extracted_result)
-            setOntologyCoverage(data.data?.ontology_coverage)
-            setExpandedCards(prev => ({
-              ...prev,
-              dataStatistics: true,
-              entityDeduplicationImpact: true,
-              disambiguation: true,
-              coreEntities: true,
-              triplet_samples: true,
-              ontologyCoverage: true,
-            }))
-            break
-        }
-      })
-    }
-    setRunLoading(true)
-    abortRef.current?.()
-    abortRef.current = null;
-    pilotRunMemoryExtractionConfig({
-      config_id: id,
-      dialogue_text: t('memoryExtractionEngine.exampleText'),
-      custom_text: runForm.getFieldValue('custom_text')
-    }, handleStreamMessage, (abort) => { abortRef.current = abort })
-      .finally(() => {
-        setRunLoading(false)
-      })
-  }
-  const completedNum = [textPreprocessing, knowledgeExtraction, creatingNodesEdges, deduplication].filter(item => item.status === 'completed').length
-  const deduplicationData = groupDataByType(deduplication.data, 'result_type')
-
-  /** Format status tag */
-  const formatTag = (status: string) => {
-    return (
-      <Tag color={tagColors[status]} className="rb:flex! rb:items-center rb:gap-1 rb:bg-white! rb:border-white!">
-        {status === 'pending' && <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/memory/clock_orange.svg')]"></div>}
-        {status === 'processing' && <LoadingOutlined spin className="rb:mr-1" />}
-        {status === 'completed' && <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/check_green.svg')]"></div>}
-        {t(`memoryExtractionEngine.status.${status}`)}
-      </Tag>
-    )
-  }
-  /** Format processing time */
-  const formatTime = (data: ModuleItem, color?: string) => {
-    if (typeof data.end_at === 'number' && typeof data.start_at === 'number') {
-      return <div className={`rb:text-[${color ?? '#155EEF'}] rb:mb-0.5`}>{t('memoryExtractionEngine.time')}{data.end_at - data.start_at}ms</div>
-    }
-    return null
-  }
-  /** Convert first character to lowercase */
-  const lowercaseFirst = (str: string) => str.charAt(0).toLowerCase() + str.slice(1)
+  const modules = [
+    ...(pruningEnabled ? [textPreprocessing] : []),
+    chunking, knowledgeExtraction, creatingNodesEdges, perceptual, deduplication,
+  ]
+  const completedNum = modules.filter(item => item.status === 'completed').length
 
   return (
     <Card
@@ -280,6 +86,10 @@ const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
       headerClassName="rb:pb-0! rb:pt-4!"
       bodyClassName="rb:h-[calc(100%-50px)]! rb:overflow-y-auto rb:p-[16px_20px]!"
       extra={<Space size={8}>
+        <Button
+          disabled={disabled || runLoading || chatList.length === 0}
+          onClick={clearChat}
+        >{t('memoryExtractionEngine.clearChat')}</Button>
         <Button
           icon={<div className="rb:size-3.5 rb:bg-cover rb:bg-[url('@/assets/images/common/save.svg')]"></div>}
           loading={loading}
@@ -295,22 +105,17 @@ const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
       </Space>}
       className="rb:h-full!"
     >
-      {/* <RbAlert color="orange" icon={<ExclamationCircleFilled />} className="rb:mb-3!">
-        {t('memoryExtractionEngine.warning')}
-      </RbAlert> */}
-      <Form form={runForm} layout="vertical" className="rb:bg-[#F6F6F6]! rb:rounded-xl rb:py-2! rb:mb-4!">
-        <Flex align="center" justify="space-between" className="rb:px-3! rb:mb-2!">
-          <div className="rb:text-[#212332] rb:font-medium rb:leading-5">{t('memoryExtractionEngine.custom_text')}</div>
-          <div className="rb:text-[12px] rb:text-[#5B6167] rb:leading-4.5">{customText?.length || 0}</div>
-        </Flex>
-        <Form.Item
-          name="custom_text"
-          label={t('memoryExtractionEngine.custom_text')}
-          noStyle
-        >
-          <Input.TextArea placeholder={t('common.pleaseEnter')} variant="borderless" />
-        </Form.Item>
-      </Form>
+      <DebugChat
+        chatList={chatList}
+        chatLoading={chatLoading}
+        streamLoading={streamLoadingRef.current}
+        message={msg}
+        fileList={fileList}
+        setFileList={setFileList}
+        toolbarRef={toolbarRef}
+        onChange={setMsg}
+        onSend={handleChatSend}
+      />
 
       {runLoading
         ? <>
@@ -320,9 +125,9 @@ const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
 
               {/* Overall Progress */}
               <Flex gap={13} align="center">
-                <Progress percent={completedNum * 100 / 4} showInfo={false} className="rb:flex-1!" />
+                <Progress percent={completedNum * 100 / modules.length} showInfo={false} className="rb:flex-1!" />
                 <div className="rb:text-[12px] rb:leading-4 rb:font-regular">
-                  {t('memoryExtractionEngine.overallProgress')}{`${(completedNum*100/4).toFixed(0)}%`}
+                  {t('memoryExtractionEngine.overallProgress')}{`${(completedNum*100/modules.length).toFixed(0)}%`}
                 </div>
               </Flex>
             </div>
@@ -350,330 +155,31 @@ const Result: FC<ResultProps> = ({ loading, handleSave, disabled = false }) => {
         ))}
       </Space>
 
-      {activeTab === 'processData' && <Flex vertical gap={12} className="rb:pb-3!">
-        {/* Text Preprocessing */}
-        <ResultCard
-          title={t(`memoryExtractionEngine.text_preprocessing`)}
-          extra={formatTag(textPreprocessing.status)}
-          expanded={expandedCards['text_preprocessing']}
-          handleExpand={() => toggleCard('text_preprocessing')}
-        >
-          {expandedCards['text_preprocessing'] && textPreprocessing.data?.length > 0 &&
-            <Space size={10} className="rb:px-1! rb:mb-3!">
-              {(['chunking', ...(textPreprocessing.data.some(vo => vo.deleted_messages) ? ['pruning'] : [])] as string[]).map(type => (
-                <div
-                  key={type}
-                  className={clsx("rb:rounded-[13px] rb:py-0.5 rb:px-3 rb:leading-5 rb:cursor-pointer", {
-                    'rb:bg-white': textPreprocessingTab !== type,
-                    'rb:bg-[#171719] rb:text-white': textPreprocessingTab === type
-                  })}
-                  onClick={() => setTextPreprocessingTab(type)}
-                >
-                  {t(`memoryExtractionEngine.${type}`)}
-                </div>
-              ))}
-            </Space>
-          }
-          {expandedCards['text_preprocessing'] && textPreprocessing.result &&
-            <RbAlert color="blue" className="rb:mb-2!">
-              <div>
-                <div>{formatTime(textPreprocessing)}</div>
-                {t('memoryExtractionEngine.pruning_desc', { count: textPreprocessing.result.pruning.deleted_count || 0 })},
-                {t('memoryExtractionEngine.text_preprocessing_desc', { count: textPreprocessing.result.total_chunks })},
-                {t('memoryExtractionEngine.chunkerStrategy')}: {t(`memoryExtractionEngine.${lowercaseFirst(textPreprocessing.result.chunker_strategy)}`)}
-              </div>
-            </RbAlert>
-          }
-          {expandedCards['text_preprocessing'] && textPreprocessing.data.map((vo, index) => {
-            if (vo.deleted_messages && textPreprocessingTab === 'pruning') {
-              return <div key={index} className="rb:mb-3 rb:pb-1 rb:border-b rb:border-b-[#EBEBEB]">
-                <div className="rb:font-medium rb:text-[12px] rb:mb-2">{t('memoryExtractionEngine.Pruned')}</div>
-                {vo.deleted_messages.map((msg: any, idx: number) => (
-                  <div key={idx} className="rb:leading-5">
-                    <div className="rb:font-medium">-{t('memoryExtractionEngine.pruning')}{idx}:</div>
-                    <Markdown content={msg.content} />
-                  </div>
-                ))}
-              </div>
-            }
-            if (textPreprocessingTab === 'chunking' && vo.content) {
-              return (
-                <div key={index} className="rb:leading-5">
-                  <div className="rb:font-medium">-{t('memoryExtractionEngine.fragment')}{vo.chunk_index}:</div>
-                  <Markdown content={vo.content.startsWith('\n') ? vo.content : '\n' + vo.content} className="rb:text-[#212332]" />
-                </div>
-              )
-            }
-            return null
-          })}
-        </ResultCard>
-        {/* Knowledge Extraction */}
-        <ResultCard
-          title={t(`memoryExtractionEngine.knowledge_extraction`)}
-          extra={formatTag(knowledgeExtraction.status)}
-          expanded={expandedCards['knowledge_extraction']}
-          handleExpand={() => toggleCard('knowledge_extraction')}
-        >
-          {knowledgeExtraction.result &&
-            <RbAlert color="blue" className="rb:mb-2!">
-              <div>
-                <div>{formatTime(knowledgeExtraction)}</div>
-                {t('memoryExtractionEngine.knowledge_extraction_desc', {
-                  entities: knowledgeExtraction.result.entities_count,
-                  statements: knowledgeExtraction.result.statements_count,
-                  temporal_ranges_count: knowledgeExtraction.result.temporal_ranges_count,
-                  triplets: knowledgeExtraction.result.triplets_count
-                })}
-              </div>
-            </RbAlert>
-          }
-          {knowledgeExtraction.data?.length > 0 &&
-            <ul className="rb:list-disc rb:ml-4 rb:mb-3">
-              {knowledgeExtraction.data.map((vo, index) =>
-                <li key={index} className="rb:leading-6">{vo.statement}</li>
-              )}
-            </ul>
-          }
-        </ResultCard>
-        {/* Creating Entity Relationships */}
-        <ResultCard
-          title={t(`memoryExtractionEngine.creating_nodes_edges`)}
-          extra={formatTag(creatingNodesEdges.status)}
-          expanded={expandedCards['creating_nodes_edges']}
-          handleExpand={() => toggleCard('creating_nodes_edges')}
-        >
-          {creatingNodesEdges.result &&
-            <RbAlert color="blue" className="rb:mb-2!">
-              <div>
-                <div>{formatTime(creatingNodesEdges)}</div>
-                {t('memoryExtractionEngine.creating_nodes_edges_desc', { num: creatingNodesEdges.result.entity_entity_edges_count })}
-              </div>
-            </RbAlert>
-          }
-          {creatingNodesEdges.data?.length > 0 &&
-            <ul className="rb:list-disc rb:ml-4 rb:mb-3">
-              {creatingNodesEdges.data.map((vo, index) =>
-                <li key={index} className="rb:leading-6">
-                  {vo?.result_type === 'entity_nodes_creation'
-                    ? <>{vo.type_display_name}: {vo.entity_names.join(', ')}</>
-                    : <>{vo?.relationship_text}</>
-                  }
-                </li>
-              )}
-            </ul>
-          }
-        </ResultCard>
-        {/* Deduplication and Disambiguation */}
-        <ResultCard
-          title={t(`memoryExtractionEngine.deduplication`)}
-          extra={formatTag(deduplication.status)}
-          expanded={expandedCards['deduplication']}
-          handleExpand={() => toggleCard('deduplication')}
-        >
-          {deduplication.result &&
-            <RbAlert color="blue" className="rb:mb-2!">
-              <div>
-                <div>{formatTime(deduplication)}</div>
-                {t('memoryExtractionEngine.deduplication_desc', { count: deduplication.result.summary.total_merges })}
-              </div>
-            </RbAlert>
-          }
-          {Object.keys(deduplicationData).length > 0 &&
-            <ul className="rb:list-disc rb:ml-4 rb:mb-3">
-              {Object.keys(deduplicationData).map(key => {
-                return deduplicationData[key].map((vo, index) => (
-                  <li key={index} className="rb:leading-6">
-                    {vo.message}
-                  </li>
-                ))
-              })}
-            </ul>
-          }
-        </ResultCard>
-      </Flex>}
+      {activeTab === 'processData' &&
+        <ProcessData
+          textPreprocessing={textPreprocessing}
+          chunking={chunking}
+          knowledgeExtraction={knowledgeExtraction}
+          creatingNodesEdges={creatingNodesEdges}
+          deduplication={deduplication}
+          perceptual={perceptual}
+          pruningEnabled={pruningEnabled}
+          expandedCards={expandedCards}
+          toggleCard={toggleCard}
+        />
+      }
 
-      {activeTab === 'finalResult' && <Flex vertical gap={12} className="rb:pb-3!">
-        {!testResult || Object.keys(testResult).length === 0
-          ? <Empty url={NoDataIcon} />
-          : null
-        }
-
-        {testResult && Object.keys(testResult).length > 0 && resultObj && Object.keys(resultObj).length > 0 &&
-          <ResultCard
-            title={t(`memoryExtractionEngine.dataStatistics`)}
-            expanded={expandedCards['dataStatistics']}
-            handleExpand={() => toggleCard('dataStatistics')}
-          >
-            <div className="rb:grid rb:grid-cols-2 rb:gap-2.5 rb:mb-3">
-              {Object.keys(resultObj).map((key, index) => {
-                const keys = (resultObj as Record<string, string>)[key].split('.')
-                return (
-                  <div key={index} className="rb:bg-white rb:rounded-lg rb:py-2 rb:px-3">
-                    <div className="rb:text-[24px] rb:leading-8 rb:font-bold rb:font-[MiSans-Bold] rb:mb-1">{(testResult?.[keys[0] as keyof TestResult] as any)?.[keys[1]]}</div>
-                    <div className="rb:text-[12px] rb:leading-4 rb:mb-0.5">{t(`memoryExtractionEngine.${key}`)}</div>
-                    <div className="rb:text-[12px] rb:text-[#369F21] rb:leading-4">
-                      {key === 'extractTheNumberOfEntities' && testResult.dedup
-                        ? t(`memoryExtractionEngine.${key}Desc`, {
-                          num: testResult.dedup.total_merged_count,
-                          exact: testResult.dedup.breakdown.exact,
-                          fuzzy: testResult.dedup.breakdown.fuzzy,
-                          llm: testResult.dedup.breakdown.llm,
-                        })
-                        : key === 'numberOfEntityDisambiguation' && testResult.disambiguation
-                          ? t(`memoryExtractionEngine.${key}Desc`, { num: testResult.disambiguation.effects?.length, block_count: testResult.disambiguation.block_count })
-                          : key === 'numberOfRelationalTriples' && testResult.triplets
-                            ? t(`memoryExtractionEngine.${key}Desc`, { num: testResult.triplets.count })
-                            : t(`memoryExtractionEngine.${key}Desc`)
-                      }
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </ResultCard>
-        }
-
-        {testResult?.dedup?.impact && testResult.dedup.impact?.length > 0 &&
-          <ResultCard
-            title={t('memoryExtractionEngine.entityDeduplicationImpact')}
-            expanded={expandedCards['entityDeduplicationImpact']}
-            handleExpand={() => toggleCard('entityDeduplicationImpact')}
-          >
-            <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
-              <RbAlert color="blue" className="rb:mb-2!">
-                {t('memoryExtractionEngine.entityDeduplicationImpactDesc', { count: testResult.dedup.impact.length })}
-              </RbAlert>
-              <div className="rb:font-medium rb:leading-5 rb:mb-2">{t('memoryExtractionEngine.identifyDuplicates')}:</div>
-
-              <ul className="rb:list-disc rb:ml-4">
-                {testResult.dedup.impact.map((item, index) => (
-                  <li key={index} className="rb:leading-6">
-                    {t('memoryExtractionEngine.identifyDuplicatesDesc', { ...item })}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </ResultCard>
-        }
-
-        {testResult?.disambiguation && testResult.disambiguation?.effects?.length > 0 &&
-          <ResultCard
-            title={t('memoryExtractionEngine.theEffectOfEntityDisambiguationLLMDriven')}
-            expanded={expandedCards['disambiguation']}
-            handleExpand={() => toggleCard('disambiguation')}
-          >
-            <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
-              <RbAlert color="blue" className="rb:mb-2!">
-                {t('memoryExtractionEngine.entityDeduplicationImpactDesc', { count: testResult.dedup.impact.length })}
-              </RbAlert>
-              {testResult.disambiguation.effects.map((item, index) => (
-                <div key={index} className={clsx("rb:text-[12px] rb:text-[#5B6167] rb:leading-4", {
-                  'rb:mt-5': index > 0,
-                })}>
-                  <div className="rb:font-medium rb:leading-5 rb:mb-1">{t('memoryExtractionEngine.disagreementCase')} {index + 1}:</div>
-
-                  <ul className="rb:list-disc rb:ml-4">
-                    <li key={index} className="rb:leading-6">
-                      {item.left.name}({item.left.type}) vs {item.right.name}({item.right.type}) → {item.result}
-                    </li>
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </ResultCard>
-        }
-
-        {testResult?.core_entities && testResult?.core_entities.length > 0 &&
-          <ResultCard
-            title={t('memoryExtractionEngine.coreEntitiesAfterDedup')}
-            expanded={expandedCards['coreEntities']}
-            handleExpand={() => toggleCard('coreEntities')}
-          >
-            <Flex gap={10} wrap className="rb:px-1! rb:mb-3! rb:gap-y-2!">
-              {testResult.core_entities.map((item, index) => (
-                <div
-                  key={item.type}
-                  className={clsx("rb:rounded-[13px] rb:py-0.5 rb:px-3 rb:leading-5 rb:cursor-pointer", {
-                    'rb:bg-white': !((coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)),
-                    'rb:bg-[#171719] rb:text-white': (coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)
-                  })}
-                  onClick={() => setCoreEntitiesTab(item.type)}
-                >
-                  {item.type}({item.count})
-                </div>
-              ))}
-            </Flex>
-            <div className="rb:bg-white rb:rounded-lg rb:py-2.5 rb:px-3 rb:mb-3">
-              {testResult.core_entities.filter((item, index) => (coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)).map((item, idx) => (
-                <div key={idx} className="rb:leading-5">
-                  <div className="rb:text-[#155EEF] rb:font-medium rb:mb-2">{item.type}({item.count})</div>
-
-                  <ul className="rb:list-disc rb:ml-4">
-                    {item.entities.map((entity, index) => (
-                      <li key={index} className="rb:leading-6">
-                        {entity}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </ResultCard>
-        }
-
-        {testResult?.triplet_samples && testResult?.triplet_samples.length > 0 &&
-          <ResultCard
-            title={t('memoryExtractionEngine.extractRelationalTriples')}
-            expanded={expandedCards['triplet_samples']}
-            handleExpand={() => toggleCard('triplet_samples')}
-          >
-            <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
-              <RbAlert color="blue"className="rb:mb-2!">
-                {t('memoryExtractionEngine.extractRelationalTriplesDesc', { count: testResult.triplet_samples.length })}
-              </RbAlert>
-              <ul className="rb:list-disc rb:ml-4">
-                {testResult.triplet_samples.map((item, index) => (
-                  <li key={index} className="rb:leading-6">
-                    ({item.subject}, <span className="rb:text-[#155EEF] rb:font-medium">{item.predicate}</span>, {item.object})
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </ResultCard>
-        }
-        {ontologyCoverage && Object.keys(ontologyCoverage).length > 0 &&
-          <ResultCard
-            title={<>{t('memoryExtractionEngine.ontologyCoverage')}({ontologyCoverage.total_entities})</>}
-            expanded={expandedCards['ontologyCoverage']}
-            handleExpand={() => toggleCard('ontologyCoverage')}
-          >
-            <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3 rb:leading-5">
-              <div className="rb:grid rb:grid-cols-1 rb:gap-3">
-                {(['scene_type_distribution', 'general_type_distribution', 'unmatched'] as const).map((key, idx) => {
-                  if (!ontologyCoverage[key]) return null
-                  return (
-                    <div key={idx}>
-                      <div className="rb:text-[#155EEF] rb:font-medium rb:mb-1">{t(`memoryExtractionEngine.${key}`)}({ontologyCoverage[key].type_count})</div>
-                      <div className="rb:text-[#212332] rb:mb-1">{t('memoryExtractionEngine.entity_total', { num: ontologyCoverage[key].entity_total })}</div>
-
-                      <ul className="rb:list-disc rb:ml-4">
-                        {ontologyCoverage[key].types.map((type, index) => {
-                          if (!type.type || type.type === '') return null
-                          return (
-                            <li key={index} className="rb:leading-6 rb:text-[#5B6167]">
-                              {type.type}({type.count})
-                            </li>
-                          )
-                        })}
-                      </ul>
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          </ResultCard>
-        }
-      </Flex>}
+      {activeTab === 'finalResult' &&
+        <FinalResult
+          testResult={testResult}
+          ontologyCoverage={ontologyCoverage}
+          perceptual={perceptual}
+          coreEntitiesTab={coreEntitiesTab}
+          setCoreEntitiesTab={setCoreEntitiesTab}
+          expandedCards={expandedCards}
+          toggleCard={toggleCard}
+        />
+      }
     </Card>
   )
 }

--- a/web/src/views/MemoryExtractionEngine/components/result/DebugChat.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/result/DebugChat.tsx
@@ -1,0 +1,75 @@
+/*
+ * Debug chat panel
+ * Reuses the Chat component, supporting attachment input and streaming AI replies
+ */
+import { type FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import clsx from 'clsx'
+import Chat from '@/components/Chat'
+import Empty from '@/components/Empty'
+import ConversationEmptyIcon from '@/assets/images/conversation/conversationEmpty.svg'
+import ChatToolbar, { type ChatToolbarRef } from '@/components/Chat/ChatToolbar'
+import type { ChatItem } from '@/components/Chat/types'
+import type { FeaturesConfigForm } from '@/views/ApplicationConfig/types'
+import { chatFeatures } from './constants'
+import { formatDateTime } from '@/utils/format'
+
+interface DebugChatProps {
+  chatList: ChatItem[];
+  chatLoading: boolean;
+  streamLoading: boolean;
+  message: string;
+  fileList: any[];
+  setFileList: (list: any[]) => void;
+  toolbarRef: React.RefObject<ChatToolbarRef>;
+  onChange: (msg: string) => void;
+  onSend: (msg?: string) => void;
+}
+
+const DebugChat: FC<DebugChatProps> = ({
+  chatList,
+  chatLoading,
+  streamLoading,
+  message,
+  fileList,
+  setFileList,
+  toolbarRef,
+  onChange,
+  onSend,
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="rb-border rb:rounded-xl rb:px-3 rb:mb-4 rb:h-[300px]">
+      <Chat
+        data={chatList}
+        loading={chatLoading}
+        streamLoading={streamLoading}
+        message={message}
+        labelPosition="bottom"
+        labelFormat={(item) => formatDateTime(item.created_at)}
+        empty={
+          <Empty url={ConversationEmptyIcon} className="rb:h-full!" size={[140, 100]} title={t('memoryExtractionEngine.chatEmpty')} isNeedSubTitle={false} />
+        }
+        contentClassName={clsx({
+          'rb:h-[calc(100%-140px)]': !fileList.length,
+          'rb:h-[calc(100%-208px)]': !!fileList.length,
+        })}
+        fileList={fileList}
+        fileChange={(list) => {
+          setFileList(list || [])
+          toolbarRef.current?.setFiles(list || [])
+        }}
+        onChange={onChange}
+        onSend={onSend}
+      >
+        <ChatToolbar
+          ref={toolbarRef}
+          features={chatFeatures as FeaturesConfigForm}
+          onFilesChange={setFileList}
+        />
+      </Chat>
+    </div>
+  )
+}
+export default DebugChat

--- a/web/src/views/MemoryExtractionEngine/components/result/FinalResult.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/result/FinalResult.tsx
@@ -1,0 +1,236 @@
+/*
+ * Final result panel
+ * Shows data statistics, dedup impact, disambiguation effects, core entities, triplet samples and ontology coverage
+ */
+import { type FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex } from 'antd'
+import clsx from 'clsx'
+import RbAlert from '@/components/RbAlert'
+import Empty from '@/components/Empty'
+import NoDataIcon from '@/assets/images/empty/noData.png'
+import ResultCard from '@/components/RbCard/ResultCard'
+import type { TestResult, OntologyCoverage } from '../../types'
+import type { ModuleItem } from './types'
+import PerceptualNodes from './PerceptualNodes'
+import { resultObj } from './constants'
+
+interface FinalResultProps {
+  testResult: TestResult;
+  ontologyCoverage: OntologyCoverage;
+  perceptual: ModuleItem;
+  coreEntitiesTab: string | null;
+  setCoreEntitiesTab: (tab: string | null) => void;
+  expandedCards: Record<string, boolean>;
+  toggleCard: (key: string) => void;
+}
+
+const FinalResult: FC<FinalResultProps> = ({
+  testResult,
+  ontologyCoverage,
+  perceptual,
+  coreEntitiesTab,
+  setCoreEntitiesTab,
+  expandedCards,
+  toggleCard,
+}) => {
+  const { t } = useTranslation()
+
+  // Perceptual memory nodes (same as "Process data")
+  const perceptualNodes = perceptual.data || []
+
+  return (
+    <Flex vertical gap={12} className="rb:pb-3!">
+      {!testResult || Object.keys(testResult).length === 0
+        ? <Empty url={NoDataIcon} />
+        : null
+      }
+
+      {testResult && Object.keys(testResult).length > 0 && resultObj && Object.keys(resultObj).length > 0 &&
+        <ResultCard
+          title={t(`memoryExtractionEngine.dataStatistics`)}
+          expanded={expandedCards['dataStatistics']}
+          handleExpand={() => toggleCard('dataStatistics')}
+        >
+          <div className="rb:grid rb:grid-cols-2 rb:gap-2.5 rb:mb-3">
+            {Object.keys(resultObj).map((key, index) => {
+              const keys = (resultObj as Record<string, string>)[key].split('.')
+              return (
+                <div key={index} className="rb:bg-white rb:rounded-lg rb:py-2 rb:px-3">
+                  <div className="rb:text-[24px] rb:leading-8 rb:font-bold rb:font-[MiSans-Bold] rb:mb-1">{(testResult?.[keys[0] as keyof TestResult] as any)?.[keys[1]]}</div>
+                  <div className="rb:text-[12px] rb:leading-4 rb:mb-0.5">{t(`memoryExtractionEngine.${key}`)}</div>
+                  <div className="rb:text-[12px] rb:text-[#369F21] rb:leading-4">
+                    {key === 'extractTheNumberOfEntities' && testResult.dedup
+                      ? t(`memoryExtractionEngine.${key}Desc`, {
+                        num: testResult.dedup.total_merged_count,
+                        exact: testResult.dedup.breakdown.exact,
+                        fuzzy: testResult.dedup.breakdown.fuzzy,
+                        llm: testResult.dedup.breakdown.llm,
+                      })
+                      : key === 'perceptualMemory' && testResult.perceptual
+                        ? t(`memoryExtractionEngine.${key}Desc`, { num: testResult.perceptual.count })
+                        : key === 'numberOfRelationalTriples' && testResult.triplets
+                          ? t(`memoryExtractionEngine.${key}Desc`, { num: testResult.triplets.count })
+                          : t(`memoryExtractionEngine.${key}Desc`)
+                    }
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </ResultCard>
+      }
+
+      {testResult?.dedup?.impact && testResult.dedup.impact?.length > 0 &&
+        <ResultCard
+          title={t('memoryExtractionEngine.entityDeduplicationImpact')}
+          expanded={expandedCards['entityDeduplicationImpact']}
+          handleExpand={() => toggleCard('entityDeduplicationImpact')}
+        >
+          <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
+            <RbAlert color="blue" className="rb:mb-2!">
+              {t('memoryExtractionEngine.entityDeduplicationImpactDesc', { count: testResult.dedup.impact.length })}
+            </RbAlert>
+            <div className="rb:font-medium rb:leading-5 rb:mb-2">{t('memoryExtractionEngine.identifyDuplicates')}:</div>
+
+            <ul className="rb:list-disc rb:ml-4">
+              {testResult.dedup.impact.map((item, index) => (
+                <li key={index} className="rb:leading-6">
+                  {t('memoryExtractionEngine.identifyDuplicatesDesc', { ...item })}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </ResultCard>
+      }
+
+      {testResult?.disambiguation && testResult.disambiguation?.effects?.length > 0 &&
+        <ResultCard
+          title={t('memoryExtractionEngine.theEffectOfEntityDisambiguationLLMDriven')}
+          expanded={expandedCards['disambiguation']}
+          handleExpand={() => toggleCard('disambiguation')}
+        >
+          <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
+            <RbAlert color="blue" className="rb:mb-2!">
+              {t('memoryExtractionEngine.entityDeduplicationImpactDesc', { count: testResult.dedup.impact.length })}
+            </RbAlert>
+            {testResult.disambiguation.effects.map((item, index) => (
+              <div key={index} className={clsx("rb:text-[12px] rb:text-[#5B6167] rb:leading-4", {
+                'rb:mt-5': index > 0,
+              })}>
+                <div className="rb:font-medium rb:leading-5 rb:mb-1">{t('memoryExtractionEngine.disagreementCase')} {index + 1}:</div>
+
+                <ul className="rb:list-disc rb:ml-4">
+                  <li key={index} className="rb:leading-6">
+                    {item.left.name}({item.left.type}) vs {item.right.name}({item.right.type}) → {item.result}
+                  </li>
+                </ul>
+              </div>
+            ))}
+          </div>
+        </ResultCard>
+      }
+
+      {testResult?.core_entities && testResult?.core_entities.length > 0 &&
+        <ResultCard
+          title={t('memoryExtractionEngine.coreEntitiesAfterDedup')}
+          expanded={expandedCards['coreEntities']}
+          handleExpand={() => toggleCard('coreEntities')}
+        >
+          <Flex gap={10} wrap className="rb:px-1! rb:mb-3! rb:gap-y-2!">
+            {testResult.core_entities.map((item, index) => (
+              <div
+                key={item.type}
+                className={clsx("rb:rounded-[13px] rb:py-0.5 rb:px-3 rb:leading-5 rb:cursor-pointer", {
+                  'rb:bg-white': !((coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)),
+                  'rb:bg-[#171719] rb:text-white': (coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)
+                })}
+                onClick={() => setCoreEntitiesTab(item.type)}
+              >
+                {item.type}({item.count})
+              </div>
+            ))}
+          </Flex>
+          <div className="rb:bg-white rb:rounded-lg rb:py-2.5 rb:px-3 rb:mb-3">
+            {testResult.core_entities.filter((item, index) => (coreEntitiesTab && item.type === coreEntitiesTab) || (!coreEntitiesTab && index === 0)).map((item, idx) => (
+              <div key={idx} className="rb:leading-5">
+                <div className="rb:text-[#155EEF] rb:font-medium rb:mb-2">{item.type}({item.count})</div>
+
+                <ul className="rb:list-disc rb:ml-4">
+                  {item.entities.map((entity, index) => (
+                    <li key={index} className="rb:leading-6">
+                      {entity}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </ResultCard>
+      }
+
+      {testResult?.triplet_samples && testResult?.triplet_samples.length > 0 &&
+        <ResultCard
+          title={t('memoryExtractionEngine.extractRelationalTriples')}
+          expanded={expandedCards['triplet_samples']}
+          handleExpand={() => toggleCard('triplet_samples')}
+        >
+          <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3">
+            <RbAlert color="blue" className="rb:mb-2!">
+              {t('memoryExtractionEngine.extractRelationalTriplesDesc', { count: testResult.triplet_samples.length })}
+            </RbAlert>
+            <ul className="rb:list-disc rb:ml-4">
+              {testResult.triplet_samples.map((item, index) => (
+                <li key={index} className="rb:leading-6">
+                  ({item.subject}, <span className="rb:text-[#155EEF] rb:font-medium">{item.predicate}</span>, {item.object})
+                </li>
+              ))}
+            </ul>
+          </div>
+        </ResultCard>
+      }
+      {perceptualNodes.length > 0 &&
+        <ResultCard
+          title={t('memoryExtractionEngine.perceptualMemory')}
+          expanded={expandedCards['perceptual']}
+          handleExpand={() => toggleCard('perceptual')}
+        >
+          <PerceptualNodes nodes={perceptualNodes} />
+        </ResultCard>
+      }
+      {ontologyCoverage && Object.keys(ontologyCoverage).length > 0 &&
+        <ResultCard
+          title={<>{t('memoryExtractionEngine.ontologyCoverage')}({ontologyCoverage.total_entities})</>}
+          expanded={expandedCards['ontologyCoverage']}
+          handleExpand={() => toggleCard('ontologyCoverage')}
+        >
+          <div className="rb:bg-white rb:rounded-xl rb:p-3 rb:mb-3 rb:leading-5">
+            <div className="rb:grid rb:grid-cols-1 rb:gap-3">
+              {(['scene_type_distribution', 'general_type_distribution', 'unmatched'] as const).map((key, idx) => {
+                if (!ontologyCoverage[key]) return null
+                return (
+                  <div key={idx}>
+                    <div className="rb:text-[#155EEF] rb:font-medium rb:mb-1">{t(`memoryExtractionEngine.${key}`)}({ontologyCoverage[key].type_count})</div>
+                    <div className="rb:text-[#212332] rb:mb-1">{t('memoryExtractionEngine.entity_total', { num: ontologyCoverage[key].entity_total })}</div>
+
+                    <ul className="rb:list-disc rb:ml-4">
+                      {ontologyCoverage[key].types.map((type, index) => {
+                        if (!type.type || type.type === '') return null
+                        return (
+                          <li key={index} className="rb:leading-6 rb:text-[#5B6167]">
+                            {type.type}({type.count})
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </ResultCard>
+      }
+    </Flex>
+  )
+}
+export default FinalResult

--- a/web/src/views/MemoryExtractionEngine/components/result/PerceptualNodes.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/result/PerceptualNodes.tsx
@@ -1,0 +1,87 @@
+/*
+ * Perceptual memory node list
+ * Shared by the process-data and final-result panels; shows images/audio/video/files with their summary, topic, domain and keywords
+ */
+import { type FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex, Image } from 'antd'
+import AudioPlayer from '@/views/UserMemoryDetail/components/AudioPlayer'
+import VideoPlayer from '@/views/UserMemoryDetail/components/VideoPlayer'
+import Empty from '@/components/Empty'
+
+/** Perceptual memory display fields (see perceptual_retrieve on the conversation page) */
+const PERCEPTUAL_FIELDS = ['summary', 'topic', 'domain', 'keywords'] as const
+
+interface PerceptualNodesProps {
+  nodes: any[];
+}
+
+const PerceptualNodes: FC<PerceptualNodesProps> = ({ nodes }) => {
+  const { t } = useTranslation()
+
+  const handleDownload = (file_path?: string) => {
+    if (!file_path) return
+    window.open(file_path, '_blank')
+  }
+
+  if (!nodes || nodes.length === 0) return null
+
+  return (
+    <Flex vertical gap={12} className="rb:mb-2!">
+      {nodes.map((node: any, index: number) => (
+        <div key={index} className="rb:p-3 rb:bg-white rb:rounded-xl">
+          {node.url
+            ? <>
+              {/(jpg|jpeg|png|gif|webp|svg)$/i.test(node.file_type)
+                ? <Image src={node.url} alt={node.file_name} width={432} className="rb:rounded-xl rb:h-45!" />
+                : /(mp4|webm|ogg|mov)$/i.test(node.file_type)
+                ? <VideoPlayer src={node.url} />
+                : /(mp3|wav|ogg|m4a|aac)$/i.test(node.file_type)
+                ? <AudioPlayer src={node.url} fileName={node.file_name} fileSize='-' />
+                : <Flex gap={11} align="center" justify="space-between" className="rb:bg-[#F6F6F6] rb:min-h-15.5! rb:rounded-xl rb:p-3!">
+                  <Flex gap={12} align="center">
+                    <div className="rb:w-7.5 rb:h-9 rb:bg-cover rb:bg-[url('@/assets/images/userMemory/file.svg')]"></div>
+                    <div>
+                      <div className="rb:leading-5 rb:font-medium rb:mb-1 rb:wrap-break-word rb:line-clamp-1">{node.file_name}</div>
+                      <div className="rb:text-[#5B6167] rb:leading-4.5 rb:text-[12px]">
+                        {node.file_type}
+                      </div>
+                    </div>
+                  </Flex>
+                  <div
+                    className="rb:size-6 rb:bg-cover rb:cursor-pointer rb:bg-[url('@/assets/images/userMemory/download.svg')] rb:hover:bg-[url('@/assets/images/userMemory/download_hover.svg')]"
+                      onClick={() => handleDownload(node.url)}
+                  ></div>
+                </Flex>
+              }
+            </>
+            : <div className="rb:bg-[#F6F6F6] rb:min-h-15.5! rb:rounded-xl rb:p-3!">
+              <Empty size={44} />
+            </div>
+          }
+          <Flex vertical gap={12}>
+            {PERCEPTUAL_FIELDS.map(key => {
+              const value = node[key]
+              if (value == null || (Array.isArray(value) && value.length === 0)) return null
+              return (
+                <div key={key} className="rb:leading-5">
+                  <div className="rb:text-[#5B6167] rb:mb-1">{t(`perceptualDetail.${key}`)}</div>
+                  {Array.isArray(value)
+                    ? <Flex wrap gap={8}>
+                        {value.map((item: string, i: number) => (
+                          <div key={i} className="rb:bg-[#F6F6F6] rb:rounded-[13px] rb:text-[12px] rb:py-1 rb:px-2 rb:leading-4.5">{item}</div>
+                        ))}
+                      </Flex>
+                    : <div className="rb:text-[#212332]">{value}</div>
+                  }
+                </div>
+              )
+            })}
+          </Flex>
+        </div>
+      ))}
+    </Flex>
+  )
+}
+
+export default PerceptualNodes

--- a/web/src/views/MemoryExtractionEngine/components/result/ProcessData.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/result/ProcessData.tsx
@@ -1,0 +1,306 @@
+/*
+ * Process data panel
+ * Six cards: pruning / chunking / statement extraction / triplet extraction / perceptual memory extraction / deduplication
+ */
+import { type FC, type ReactNode, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex } from 'antd'
+import clsx from 'clsx'
+import RbAlert from '@/components/RbAlert'
+import ResultCard from '@/components/RbCard/ResultCard'
+import type { ModuleItem } from './types'
+import { formatTag, formatTime } from './helpers'
+import PerceptualNodes from './PerceptualNodes'
+
+interface ProcessDataProps {
+  textPreprocessing: ModuleItem;
+  chunking: ModuleItem;
+  knowledgeExtraction: ModuleItem;
+  creatingNodesEdges: ModuleItem;
+  deduplication: ModuleItem;
+  perceptual: ModuleItem;
+  /** Whether semantic pruning is enabled; hides the pruning card when false */
+  pruningEnabled?: boolean;
+  expandedCards: Record<string, boolean>;
+  toggleCard: (key: string) => void;
+}
+
+/** Strip the leading [timestamp] prefix from an entity description */
+const cleanDescription = (desc?: string) => (desc || '').replace(/^\[[^\]]*\]\s*/, '')
+
+/** Card title: name + event type badge */
+const CardTitle: FC<{ label: string; }> = ({ label }) => (
+  <span className="rb:inline-flex rb:items-center rb:gap-2">
+    {label}
+  </span>
+)
+
+type PillTone = 'default' | 'green' | 'purple'
+const PILL_TONE: Record<PillTone, string> = {
+  default: 'rb:bg-[#F0F0F1] rb:text-[#5A5C66]',
+  green: 'rb:bg-[#E7F6EC] rb:text-[#12B76A]',
+  purple: 'rb:bg-[#EFE9FC] rb:text-[#7A5AF8]',
+}
+
+/** Tag pill: shows only value when label is empty */
+const Pill: FC<{ label?: string; value: ReactNode; tone?: PillTone }> = ({ label, value, tone = 'default' }) => (
+  <span className={clsx('rb:inline-flex rb:items-center rb:rounded rb:px-2 rb:py-0.5 rb:text-[12px] rb:leading-5 rb:mr-2 rb:mb-1', PILL_TONE[tone])}>
+    {label ? `${label}: ` : ''}{value}
+  </span>
+)
+
+const ProcessData: FC<ProcessDataProps> = ({
+  textPreprocessing,
+  chunking,
+  knowledgeExtraction,
+  creatingNodesEdges,
+  deduplication,
+  perceptual,
+  pruningEnabled = true,
+  expandedCards,
+  toggleCard,
+}) => {
+  const { t } = useTranslation()
+
+  // Triplet card "entities / triplets" toggle
+  const [tripletTab, setTripletTab] = useState('entities')
+
+  // Pruning: text preprocessing result is directly a user_message_changes list
+  const pruningChanges = textPreprocessing.data || []
+
+  // Chunking: each item is { chunk_index, content, ... }
+  const chunks = chunking.data || []
+  const chunkCount = chunking.result?.total_chunks ?? chunks.length
+
+  // Statements
+  const statements = knowledgeExtraction.data || []
+  const statementCount = knowledgeExtraction.result?.statements_count ?? statements.length
+
+  // Triplets: each item carries entity_creation[] / relationship_creation[]; flatten across items then dedupe
+  const cne = creatingNodesEdges.data || []
+  const entities = cne
+    .flatMap((vo: any) => vo?.entity_creation || [])
+  const relationships = cne
+    .flatMap((vo: any) => vo?.relationship_creation || [])
+  const entityCount = creatingNodesEdges.result?.entities_count ?? entities.length
+  const tripletCount = creatingNodesEdges.result?.triplets_count ?? relationships.length
+
+  // Deduplication
+  const merges = deduplication.data || []
+  const mergedPairs = deduplication.result?.merged_pairs || []
+  const dedupBefore = deduplication.result?.entities?.original_count ?? '-'
+  const dedupAfter = deduplication.result?.entities?.final_count ?? '-'
+  const pairCount = mergedPairs.length || merges.length
+
+  // Perceptual memory nodes
+  const perceptualNodes = perceptual.data || []
+
+  return (
+    <Flex vertical gap={12} className="rb:pb-3!">
+      {/* Perceptual memory extraction complete */}
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.perceptual_result_title')} />}
+        extra={formatTag(perceptual.status, t)}
+        expanded={expandedCards['perceptual']}
+        handleExpand={() => toggleCard('perceptual')}
+      >
+        {perceptual.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(perceptual, t)}</div>
+              {t('memoryExtractionEngine.perceptual_result_desc', { count: perceptualNodes.length })}
+            </div>
+          </RbAlert>
+        }
+        {perceptualNodes.length > 0 &&
+          <PerceptualNodes nodes={perceptualNodes} />
+        }
+      </ResultCard>
+
+      {/* Pruning */}
+      {pruningEnabled &&
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.pruning_result_title')} />}
+        extra={formatTag(textPreprocessing.status, t)}
+        expanded={expandedCards['text_preprocessing']}
+        handleExpand={() => toggleCard('text_preprocessing')}
+      >
+        {textPreprocessing.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(textPreprocessing, t)}</div>
+              {t('memoryExtractionEngine.pruning_result_desc', { count: pruningChanges.length })}
+            </div>
+          </RbAlert>
+        }
+        {pruningChanges.length > 0 &&
+          <Flex vertical gap={12} className="rb:mb-2!">
+            {pruningChanges.map((change: any, index: number) => (
+              <div key={index} className="rb:p-3 rb:bg-white rb:rounded-xl">
+                <div className="rb:text-[#5B6167] rb:text-[12px] rb:leading-5 rb:mb-1">{t('memoryExtractionEngine.original_preview')} (original_preview)</div>
+                <div className="rb:leading-5 rb:mb-2">{change.original}</div>
+                <div className="rb:text-center rb:text-[#155EEF] rb:text-[12px] rb:mb-2">↓ {t('memoryExtractionEngine.compressedInto')}</div>
+                <div className="rb:text-[#5B6167] rb:text-[12px] rb:leading-5 rb:mb-1">{t('memoryExtractionEngine.memory_hint')} (memory_hint)</div>
+                <div className="rb:leading-5 rb:mb-2">{change.pruned}</div>
+              </div>
+            ))}
+          </Flex>
+        }
+      </ResultCard>
+      }
+
+      {/* Chunking */}
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.chunking_result_title')} />}
+        extra={formatTag(chunking.status, t)}
+        expanded={expandedCards['chunking']}
+        handleExpand={() => toggleCard('chunking')}
+      >
+        {chunking.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(chunking, t)}</div>
+              {t('memoryExtractionEngine.chunking_result_desc', { count: chunkCount, strategy: chunking.result?.chunker_strategy || '-' })}
+            </div>
+          </RbAlert>
+        }
+        {chunks.length > 0 &&
+          <Flex vertical gap={12} className="rb:mb-2!">
+            {chunks.map((chunk: any, index: number) => (
+              <div key={index} className="rb:p-3 rb:bg-white rb:rounded-xl">
+                <Flex align="center" gap={6} className="rb:mb-1">
+                  <span className="rb:text-[#5B6167] rb:text-[12px]">{t('memoryExtractionEngine.fragment')}{chunk.chunk_index ?? index + 1}</span>
+                </Flex>
+                <div className="rb:text-[#212332] rb:leading-5">{chunk.content}</div>
+              </div>
+            ))}
+          </Flex>
+        }
+      </ResultCard>
+
+      {/* Statement extraction complete */}
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.statement_result_title')} />}
+        extra={formatTag(knowledgeExtraction.status, t)}
+        expanded={expandedCards['knowledge_extraction']}
+        handleExpand={() => toggleCard('knowledge_extraction')}
+      >
+        {knowledgeExtraction.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(knowledgeExtraction, t)}</div>
+              {t('memoryExtractionEngine.statement_result_desc', { count: statementCount })}
+            </div>
+          </RbAlert>
+        }
+        {statements.length > 0 &&
+          <Flex vertical gap={12} className="rb:mb-2!">
+            {statements.map((vo: any, index: number) => (
+              <div key={index} className="rb:p-3 rb:bg-white rb:rounded-xl">
+                <div className="rb:leading-6 rb:text-[#212332]">
+                  <span className="rb:text-[#5B6167] rb:mr-1">[s{index + 1}]</span>
+                  {vo.statement || vo.content}
+                </div>
+              </div>
+            ))}
+          </Flex>
+        }
+      </ResultCard>
+
+      {/* Triplet extraction complete */}
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.triplet_result_title')} />}
+        extra={formatTag(creatingNodesEdges.status, t)}
+        expanded={expandedCards['creating_nodes_edges']}
+        handleExpand={() => toggleCard('creating_nodes_edges')}
+      >
+        {creatingNodesEdges.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(creatingNodesEdges, t)}</div>
+              {t('memoryExtractionEngine.triplet_result_desc', { entity: entityCount, triplet: tripletCount })}
+            </div>
+          </RbAlert>
+        }
+        {(entities.length > 0 || relationships.length > 0) &&
+          <>
+            <Flex gap={10} wrap className="rb:px-1! rb:mb-3! rb:gap-y-2!">
+              {[
+                { value: 'entities', label: `${t('memoryExtractionEngine.entities')} (${entities.length})` },
+                { value: 'triplets', label: `${t('memoryExtractionEngine.triplets')} (${relationships.length})` },
+              ].map((item) => (
+                <div
+                  key={item.value}
+                  className={clsx("rb:rounded-[13px] rb:py-0.5 rb:px-3 rb:leading-5 rb:cursor-pointer", {
+                    'rb:bg-white': tripletTab !== item.value,
+                    'rb:bg-[#171719] rb:text-white': tripletTab === item.value
+                  })}
+                  onClick={() => setTripletTab(item.value)}
+                >
+                  {item.label}
+                </div>
+              ))}
+            </Flex>
+            <div className="rb:p-3 rb:mb-2 rb:bg-white rb:rounded-xl">
+              {tripletTab === 'entities'
+                ? <ul className="rb:list-disc rb:ml-4">
+                    {entities.map((vo: any, index: number) => (
+                      <li key={index} className="rb:leading-6">
+                        <span>{vo.name}</span>
+                        {vo.type && <span className="rb:ml-1"><Pill label="type" value={vo.type} /></span>}
+                        {cleanDescription(vo.description) && <span> — {cleanDescription(vo.description)}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                : <ul className="rb:list-disc rb:ml-4">
+                    {relationships.map((vo: any, index: number) => (
+                      <li key={index} className="rb:leading-6">
+                        {vo.source_entity} —<span className="rb:text-[#155EEF] rb:font-medium">[{vo.relation_type}]</span>→ {vo.target_entity}
+                      </li>
+                    ))}
+                  </ul>
+              }
+            </div>
+          </>
+        }
+      </ResultCard>
+
+      {/* Deduplication complete */}
+      <ResultCard
+        title={<CardTitle label={t('memoryExtractionEngine.dedup_result_title')} />}
+        extra={formatTag(deduplication.status, t)}
+        expanded={expandedCards['deduplication']}
+        handleExpand={() => toggleCard('deduplication')}
+      >
+        {deduplication.result &&
+          <RbAlert color="blue" className="rb:mb-2!">
+            <div>
+              <div>{formatTime(deduplication, t)}</div>
+              {t('memoryExtractionEngine.dedup_result_desc', { before: dedupBefore, after: dedupAfter, pairs: pairCount })}
+            </div>
+          </RbAlert>
+        }
+        {(mergedPairs.length > 0 || merges.length > 0) &&
+          <div className="rb:mb-2 rb:p-3 rb:bg-white rb:rounded-xl">
+            <div className="rb:font-medium rb:mb-1">{t('memoryExtractionEngine.merged_pairs')} (merged_pairs)</div>
+            <ul className="rb:list-disc rb:ml-4">
+              {mergedPairs.length > 0
+                ? mergedPairs.map((pair: any, index: number) => (
+                  <li key={index} className="rb:leading-6">
+                    [{pair.source || pair.a || pair[0]}] ⟷ [{pair.target || pair.b || pair[1]}] → {t('memoryExtractionEngine.mergedIntoOne')}
+                  </li>
+                ))
+                : merges.map((vo: any, index: number) => (
+                  <li key={index} className="rb:leading-6">
+                    [{vo.merged_entity_name}] {t('memoryExtractionEngine.mergedCount', { count: vo.merged_count })} → {t('memoryExtractionEngine.mergedIntoOne')}
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+        }
+      </ResultCard>
+    </Flex>
+  )
+}
+export default ProcessData

--- a/web/src/views/MemoryExtractionEngine/components/result/constants.ts
+++ b/web/src/views/MemoryExtractionEngine/components/result/constants.ts
@@ -1,0 +1,67 @@
+/*
+ * Result module constants
+ */
+import { type TagProps } from '@/components/Tag'
+
+/** Result metric mapping */
+export const resultObj = {
+  extractTheNumberOfEntities: 'entities.extracted_count',
+  perceptualMemory: 'perceptual.count',
+  memoryFragments: 'memory.chunks',
+  numberOfRelationalTriples: 'triplets.count'
+}
+
+/** Tag color mapping by status */
+export const tagColors: {
+  [key: string]: TagProps['color']
+} = {
+  pending: 'warning',
+  processing: 'processing',
+  completed: 'success',
+  failed: 'error'
+}
+
+/** Initial module state */
+export const initObj = {
+  data: [],
+  status: 'pending',
+  result: null
+}
+
+/** Default expanded state of each result card */
+export const initialExpanded = {
+  text_preprocessing: false,
+  chunking: false,
+  knowledge_extraction: false,
+  creating_nodes_edges: false,
+  deduplication: false,
+  perceptual: false,
+  dataStatistics: false,
+  entityDeduplicationImpact: false,
+  disambiguation: false,
+  coreEntities: false,
+  triplet_samples: false,
+  ontologyCoverage: false,
+}
+
+/** Attachment upload reuses the conversation upload API; images and document types are allowed here */
+export const chatFeatures = {
+  file_upload: {
+    enabled: true,
+    allowed_transfer_methods: ['local_file', 'remote_url'],
+    max_file_count: 1,
+    image_enabled: true,
+    image_max_size_mb: 20,
+    image_allowed_extensions: ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg'],
+    audio_enabled: true,
+    audio_max_size_mb: 50,
+    audio_allowed_extensions: ['mp3', 'wav', 'ogg', 'aac', 'flac', 'm4a', 'wma'],
+    document_enabled: true,
+    document_image_recognition: true,
+    document_max_size_mb: 20,
+    document_allowed_extensions: ['txt', 'md', 'pdf', 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx', 'csv', 'json'],
+    video_enabled: true,
+    video_max_size_mb: 100,
+    video_allowed_extensions: ['mp4', 'mov', 'avi', 'mkv', 'webm', 'flv', 'wmv'],
+  },
+}

--- a/web/src/views/MemoryExtractionEngine/components/result/debugChatMock.ts
+++ b/web/src/views/MemoryExtractionEngine/components/result/debugChatMock.ts
@@ -1,0 +1,95 @@
+/*
+ * Sample scripts for the debug chat (not tied to any API, for display/debugging only)
+ * Split by language: Chinese zh / English en
+ */
+ import type { ChatItem } from '@/components/Chat/types'
+
+/** English sample */
+export const debugChatMockEn: ChatItem[] = [
+  {
+    role: 'user',
+    content: "My name is Su Qing. I'm 26 years old and work as a product manager in Hangzhou. Last weekend, I went to West Lake with my college roommate, Lin Yue, and took a beautiful scenery photo near Leifeng Pagoda.",
+    created_at: '2026-07-16 10:00:00',
+    meta_data: {
+    "files": [
+        {
+          "type": "image/png",
+          "transfer_method": "remote_url",
+          "url": "https://myhmars.site/pub/111.png"
+        }
+      ],
+    }
+  },
+  {
+    role: 'assistant',
+    content: "Hello, Su Qing! The scenery at West Lake's Leifeng Pagoda is indeed beautiful 😊. Sunset at Leifeng Pagoda is one of the \"Ten Scenes of West Lake,\" known as \"Leifeng Sunset.\" The pagoda looks particularly spectacular against the evening glow at dusk. From the top of the pagoda, you can also get a full view of \"Three Pools Mirroring the Moon\" and \"Suxi Causeway in the Spring.\"\n\nTraveling with a college roommate is a precious time—after graduation, everyone goes their separate ways, so it's not easy to get together. Autumn in Hangzhou is also the most comfortable season, with the sweet scent of osmanthus and leaves turning vibrant colors.\n\nIf you'd like to:\n\nMake a beautiful travel album out of the photos from this trip\n\nPlan your next weekend getaway with Lin Yue (like Qiandao Lake or Moganshan)\n\nOr chat about other hidden gems in Hangzhou\n\nFeel free to let me know! 🍂",
+    created_at: '2026-07-16 10:00:30',
+  },
+  {
+    role: 'user',
+    content: "Yes! She actually said she wants to come back next spring to see \"Lingering Snow on the Broken Bridge.\" We sat in a lakeside cafe all afternoon, and their osmanthus latte was incredibly delicious.",
+    created_at: '2026-07-16 10:02:00',
+  },
+  {
+    role: 'assistant',
+    content: "\"Lingering Snow on the Broken Bridge\" is a classic winter scene of West Lake! However, seeing actual snow requires a bit of luck—it doesn't snow often in Hangzhou, usually around late January to early February. If she visits next spring, \"Orioles Singing in the Willows\" in March is also beautiful, with peach blossoms and willow trees complementing each other.\n\nA lakeside cafe paired with an osmanthus latte sounds like a cozy autumn afternoon. Hangzhou's cafe culture has developed rapidly over the past few years, with many stylish independent cafes around Nanshan Road and Manjuelong.\n\nIf you'd like to:\n\nBookmark a few West Lake cafes worth revisiting\n\nPlan ahead for your snow-watching route at the Broken Bridge with Lin Yue next spring\n\nOr save \"osmanthus latte\" as your flavor preference\n\nI can save all of these for you 😊",
+    created_at: '2026-07-16 10:02:40',
+  },
+  {
+    role: 'user',
+    content: "Great! Her birthday is on the 15th of next month. I want to host a small birthday gathering for her at that cafe, and invite our other friend, Zhang Wei, to join us.",
+    created_at: '2026-07-16 10:05:00',
+  },
+  {
+    role: 'assistant',
+    content: "Wow, that sounds amazing! The birthday gathering is going to be wonderful.",
+    created_at: '2026-07-16 10:05:20',
+  },
+]
+
+/** Chinese sample */
+export const debugChatMockZh: ChatItem[] = [
+  {
+    role: 'user',
+    content: '我叫苏晴，今年26岁，在杭州做产品经理。上周末我和大学室友林悦一起去了西湖，在雷峰塔那边拍了一张特别好看的风景照。',
+    created_at: '2026-07-16 10:00:00',
+    meta_data: {
+      "files": [
+        {
+          "type": "image/png",
+          "transfer_method": "remote_url",
+          "url": "https://myhmars.site/pub/111.png"
+        }
+      ],
+    }
+  },
+  {
+    role: 'assistant',
+    content: '苏晴你好！西湖雷峰塔的风景确实很美 😊，雷峰塔的日落是西湖十景之一的雷峰夕照，尤其是黄昏时分，塔身在晚霞映衬下特别壮观。从塔顶眺望还能看到三潭印月和苏堤春晓的全貌。\n\n和大学室友一起出游是很珍贵的时光——毕业后大家各奔东西，能约到一起不容易。杭州的秋天也是最舒服的季节，桂花飘香、层林尽染。\n\n如果你想：\n\n把这次出游的照片做成精美的旅行相册\n\n规划下一次和林悦的周末短途旅行（比如千岛湖、莫干山）\n\n或者聊聊杭州还有哪些小众好去处\n\n随时告诉我！🍂',
+    created_at: '2026-07-16 10:00:30',
+  },
+  {
+    role: 'user',
+    content: '对！她当时还说明年春天想再来一次，看断桥残雪的景色。我们在湖边的一家咖啡馆坐了一下午，那里的桂花拿铁特别好喝。',
+    created_at: '2026-07-16 10:02:00',
+  },
+  {
+    role: 'assistant',
+    content: '断桥残雪是西湖冬景的经典！不过要看到真正的雪景需要一点运气——杭州冬天下雪的日子不多，一般在1月底到2月初。如果明年春天来的话，3月的柳浪闻莺也很美，桃花和柳树交相辉映。\n\n湖边咖啡馆配桂花拿铁，听起来是一个很惬意的秋日午后。杭州的咖啡文化这几年发展得很快，南山路和满觉陇那边有不少有调性的独立咖啡馆。\n\n如果你想：\n\n收藏几家西湖周边值得回访的咖啡馆\n\n提前规划明年春天和林悦的断桥赏雪路线\n\n或者记住桂花拿铁这个口味偏好\n\n我都可以帮你记下来 😊',
+    created_at: '2026-07-16 10:02:40',
+  },
+  {
+    role: 'user',
+    content: '好的！她下个月15号生日，我想在那个咖啡馆给她办一个小型生日聚会，到时候再叫上我们的另一个朋友张薇。',
+    created_at: '2026-07-16 10:05:00',
+  },
+  {
+    role: 'assistant',
+    content: '哇，听起来很太棒了！生日聚会一定会很精彩的。',
+    created_at: '2026-07-16 10:05:20',
+  },
+]
+
+/** Select the sample by language (anything other than en falls back to Chinese) */
+export const getDebugChatMock = (language: string): ChatItem[] =>
+  language === 'en' ? debugChatMockEn : debugChatMockZh

--- a/web/src/views/MemoryExtractionEngine/components/result/helpers.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/result/helpers.tsx
@@ -1,0 +1,31 @@
+/*
+ * Shared display helper functions for the Result module
+ */
+import type { TFunction } from 'i18next'
+import { LoadingOutlined } from '@ant-design/icons'
+import Tag from '@/components/Tag'
+import { tagColors } from './constants'
+import type { ModuleItem } from './types'
+
+/** Format status tag */
+export const formatTag = (status: string, t: TFunction) => {
+  return (
+    <Tag color={tagColors[status]} className="rb:flex! rb:items-center rb:gap-1 rb:bg-white! rb:border-white!">
+      {status === 'pending' && <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/memory/clock_orange.svg')]"></div>}
+      {status === 'processing' && <LoadingOutlined spin className="rb:mr-1" />}
+      {status === 'completed' && <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/check_green.svg')]"></div>}
+      {t(`memoryExtractionEngine.status.${status}`)}
+    </Tag>
+  )
+}
+
+/** Format processing time */
+export const formatTime = (data: ModuleItem, t: TFunction, color?: string) => {
+  if (typeof data.end_at === 'number' && typeof data.start_at === 'number') {
+    return <div className={`rb:text-[${color ?? '#155EEF'}] rb:mb-0.5`}>{t('memoryExtractionEngine.time')}{data.end_at - data.start_at}ms</div>
+  }
+  return null
+}
+
+/** Convert first character to lowercase */
+export const lowercaseFirst = (str: string) => str.charAt(0).toLowerCase() + str.slice(1)

--- a/web/src/views/MemoryExtractionEngine/components/result/hooks/useDebugChat.ts
+++ b/web/src/views/MemoryExtractionEngine/components/result/hooks/useDebugChat.ts
@@ -1,0 +1,99 @@
+/*
+ * Debug chat logic (streaming AI reply: start / message / end)
+ */
+import { useState, useRef, type MutableRefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ChatItem } from '@/components/Chat/types'
+import { type ChatToolbarRef } from '@/components/Chat/ChatToolbar'
+
+/**
+ * Debug chat hook
+ * @param id config id
+ * @param abortRef abort reference shared with the extraction stream (kept as a placeholder, not used by the current send logic)
+ */
+export const useDebugChat = (
+  id: string | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  abortRef: MutableRefObject<(() => void) | null>,
+) => {
+  const { t } = useTranslation()
+  const [msg, setMsg] = useState('')
+  const [chatList, setChatList] = useState<ChatItem[]>([])
+  const [chatLoading, setChatLoading] = useState(false)
+  const [fileList, setFileList] = useState<any[]>([])
+  const [conversationId] = useState<string | null>(null)
+  const toolbarRef = useRef<ChatToolbarRef>(null)
+  const streamLoadingRef = useRef(false)
+
+  /** Append a user message */
+  const appendUserMessage = (content: string, files: any[]) => {
+    const userMessage: ChatItem = {
+      role: 'user',
+      content,
+      created_at: Date.now(),
+      meta_data: { files },
+    }
+    setChatList(prev => [...prev, userMessage])
+  }
+
+  /** Append an empty assistant message placeholder */
+  const appendAssistantPlaceholder = () => {
+    setChatList(prev => [...prev, { role: 'assistant', content: '', created_at: Date.now() }])
+  }
+
+  /** Append streaming content to the last assistant message */
+  const updateAssistantContent = (content?: string, patch?: Partial<ChatItem>) => {
+    if (!content && !patch) return
+    setChatList(prev => {
+      const next = [...prev]
+      const lastIndex = next.length - 1
+      const lastMsg = next[lastIndex] as ChatItem
+      if (lastMsg?.role !== 'assistant') return prev
+      next[lastIndex] = {
+        ...lastMsg,
+        content: (lastMsg.content || '') + (content || ''),
+        ...patch,
+      }
+      return next
+    })
+  }
+
+  /** Send a debug chat message: no API call, just append a fixed reply */
+  const handleChatSend = (msg?: string) => {
+    if (!id || chatLoading) return
+    const content = (msg || '').trim()
+    if (!content) return
+    const files = (toolbarRef.current?.getFiles() || []).filter(item => !['uploading', 'error'].includes(item.status))
+
+    appendUserMessage(content, files)
+    appendAssistantPlaceholder()
+    toolbarRef.current?.setFiles([])
+    setFileList([])
+    setMsg('')
+
+    streamLoadingRef.current = false
+    updateAssistantContent(t('memoryExtractionEngine.debugReply'))
+  }
+
+  /** Clear the debug chat content */
+  const clearChat = () => {
+    setChatList([])
+    setMsg('')
+    setFileList([])
+    toolbarRef.current?.setFiles([])
+  }
+
+  return {
+    msg,
+    setMsg,
+    chatList,
+    chatLoading,
+    fileList,
+    setFileList,
+    conversationId,
+    toolbarRef,
+    streamLoadingRef,
+    handleChatSend,
+    clearChat,
+  }
+}

--- a/web/src/views/MemoryExtractionEngine/components/result/hooks/usePilotRun.ts
+++ b/web/src/views/MemoryExtractionEngine/components/result/hooks/usePilotRun.ts
@@ -1,0 +1,255 @@
+/*
+ * Pilot run logic (multi-stage streaming: text preprocessing / knowledge extraction / edge building / dedup & disambiguation / result)
+ */
+import { useState, type MutableRefObject } from 'react'
+import type { AnyObject } from 'antd/es/_util/type'
+import { pilotRunMemoryExtractionConfig } from '@/api/memory'
+import { type SSEMessage } from '@/utils/stream'
+import { useI18n } from '@/store/locale'
+import type { TestResult, OntologyCoverage } from '../../../types'
+import { initObj, initialExpanded } from '../constants'
+import { getDebugChatMock } from '../debugChatMock'
+import type { ModuleItem } from '../types'
+import type { ChatItem } from '@/components/Chat/types'
+
+/**
+ * Pilot run hook
+ * @param id config id
+ * @param abortRef streaming abort reference
+ * @param chatList chat list
+ */
+export const usePilotRun = (
+  id: string | undefined,
+  abortRef: MutableRefObject<(() => void) | null>,
+  chatList: ChatItem[],
+) => {
+  const [runLoading, setRunLoading] = useState(false)
+  const { language } = useI18n()
+  const [activeTab, setActiveTab] = useState('processData')
+  const [testResult, setTestResult] = useState<TestResult>({} as TestResult)
+  const [coreEntitiesTab, setCoreEntitiesTab] = useState<string | null>(null)
+  const [textPreprocessing, setTextPreprocessing] = useState<ModuleItem>(initObj as ModuleItem)
+  const [chunking, setChunking] = useState<ModuleItem>(initObj as ModuleItem)
+  const [knowledgeExtraction, setKnowledgeExtraction] = useState<ModuleItem>(initObj as ModuleItem)
+  const [creatingNodesEdges, setCreatingNodesEdges] = useState<ModuleItem>(initObj as ModuleItem)
+  const [deduplication, setDeduplication] = useState<ModuleItem>(initObj as ModuleItem)
+  const [perceptual, setPerceptual] = useState<ModuleItem>(initObj as ModuleItem)
+  const [ontologyCoverage, setOntologyCoverage] = useState<OntologyCoverage>({} as OntologyCoverage)
+  const [expandedCards, setExpandedCards] = useState<Record<string, boolean>>(initialExpanded)
+
+  const toggleCard = (key: string) => {
+    setExpandedCards(prev => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  /** Run pilot test */
+  const handleRun = () => {
+    if (!id) return
+    setActiveTab('processData')
+    setCoreEntitiesTab(null)
+    setTextPreprocessing({ ...initObj } as ModuleItem)
+    setChunking({ ...initObj } as ModuleItem)
+    setKnowledgeExtraction({ ...initObj } as ModuleItem)
+    setCreatingNodesEdges({ ...initObj } as ModuleItem)
+    setDeduplication({ ...initObj } as ModuleItem)
+    setPerceptual({ ...initObj } as ModuleItem)
+    setTestResult({} as TestResult)
+    setExpandedCards(initialExpanded)
+    const handleStreamMessage = (list: SSEMessage[]) => {
+      list.forEach((data: AnyObject) => {
+        switch (data.event) {
+          case 'perceptual_extract': // start extracting perceptual memory
+            setPerceptual(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('perceptual')
+            break
+          case 'perceptual_result': // perceptual memory result
+            setPerceptual(prev => ({
+              ...prev,
+              data: data.data?.data?.perceptual_nodes || []
+            }))
+            setExpandedCards(prev => ({ ...prev, perceptual: true }))
+            break
+          case 'perceptual_complete': // perceptual memory extraction complete
+            setPerceptual(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'pruning_extract': // start semantic pruning
+            setTextPreprocessing(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('text_preprocessing')
+            break
+          case 'pruning_result': // semantic pruning result
+            setTextPreprocessing(prev => ({
+              ...prev,
+              data: [...prev.data, ...(data.data?.data?.user_message_changes || [])],
+            }))
+            break
+          case 'pruning_complete': // semantic pruning complete
+            setTextPreprocessing(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'chunking_extract': // start chunking
+            setChunking(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('chunking')
+            break
+          case 'chunking_result': // chunking in progress
+            setChunking(prev => ({
+              ...prev,
+              data: [...prev.data, data.data?.data]
+            }))
+            break
+          case 'chunking_complete': // chunking complete
+            setChunking(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'extract_statement': // start extracting statements
+            setKnowledgeExtraction(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('knowledge_extraction')
+            break
+          case 'extract_statement_result': // statement extraction in progress
+            setKnowledgeExtraction(prev => ({
+              ...prev,
+              data: [...prev.data, data.data?.data]
+            }))
+            break
+          case 'extract_statement_complete': // statement extraction complete
+            setKnowledgeExtraction(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'extract_triplet': // start extracting triplets
+            setCreatingNodesEdges(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('creating_nodes_edges')
+            break
+          case 'extract_triplet_result': // triplet extraction in progress (each carries entities/relationships)
+            setCreatingNodesEdges(prev => ({
+              ...prev,
+              data: [...prev.data, data.data?.data]
+            }))
+            break
+          case 'extract_triplet_complete': // triplet extraction complete
+            setCreatingNodesEdges(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'deduplication': // start dedup & merge
+            setDeduplication(prev => ({
+              ...prev,
+              status: 'processing',
+              start_at: data.data.time
+            }))
+            toggleCard('deduplication')
+            break
+          case 'dedup_result': // dedup & merge in progress
+            setDeduplication(prev => ({
+              ...prev,
+              data: [...prev.data, data.data.data]
+            }))
+            break
+          case 'dedup_complete': // dedup complete
+            setDeduplication(prev => ({
+              ...prev,
+              result: data.data?.data,
+              status: 'completed',
+              end_at: data.data.time
+            }))
+            break
+          case 'generating_results': // generating results
+            break
+          case 'result': // result
+            setTestResult(data.data?.extracted_result)
+            setOntologyCoverage(data.data?.ontology_coverage)
+            setExpandedCards(prev => ({
+              ...prev,
+              dataStatistics: true,
+              entityDeduplicationImpact: true,
+              disambiguation: true,
+              coreEntities: true,
+              triplet_samples: true,
+              ontologyCoverage: true,
+            }))
+            break
+        }
+      })
+    }
+    setRunLoading(true)
+    abortRef.current?.()
+    abortRef.current = null
+    const list = chatList?.length > 0 ? chatList : getDebugChatMock(language)
+    pilotRunMemoryExtractionConfig({
+      config_id: id,
+      messages: list.map(item => ({
+        role: item.role,
+        content: item.content,
+        files: item.meta_data?.files?.map(file => {
+          if (file.transfer_method === 'remote_url') {
+            return file
+          }
+          return {
+            type: file.type,
+            transfer_method: "local_file",
+            upload_file_id: file.response?.data?.file_id
+          }
+        }) || undefined,
+      })),
+    }, handleStreamMessage, (abort) => { abortRef.current = abort })
+      .finally(() => {
+        setRunLoading(false)
+      })
+  }
+
+  return {
+    runLoading,
+    activeTab,
+    setActiveTab,
+    testResult,
+    coreEntitiesTab,
+    setCoreEntitiesTab,
+    textPreprocessing,
+    chunking,
+    knowledgeExtraction,
+    creatingNodesEdges,
+    deduplication,
+    perceptual,
+    ontologyCoverage,
+    expandedCards,
+    toggleCard,
+    handleRun,
+  }
+}

--- a/web/src/views/MemoryExtractionEngine/components/result/types.ts
+++ b/web/src/views/MemoryExtractionEngine/components/result/types.ts
@@ -1,0 +1,26 @@
+/*
+ * Result module type definitions
+ */
+
+/**
+ * Result component props
+ */
+export interface ResultProps {
+  loading: boolean;
+  handleSave: () => void;
+  /** Disable the save action when using the system default config */
+  disabled?: boolean;
+  /** Whether semantic pruning is enabled; hides the pruning module when false */
+  pruningEnabled?: boolean;
+}
+
+/**
+ * Module processing item
+ */
+export interface ModuleItem {
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  data: any[];
+  result: any;
+  start_at?: number;
+  end_at?: number;
+}

--- a/web/src/views/MemoryExtractionEngine/constant.ts
+++ b/web/src/views/MemoryExtractionEngine/constant.ts
@@ -130,7 +130,7 @@ export const configList: ConfigVo[] = [
       {
         title: 'intelligentSemanticPruning',
         list: [
-          // Intelligent semantic pruning功能
+          // Intelligent semantic pruning toggle
           {
             label: 'intelligentSemanticPruningFunction',
             variableName: 'pruning_enabled',
@@ -138,7 +138,7 @@ export const configList: ConfigVo[] = [
             type: 'tinyint',
             meaning: 'intelligentSemanticPruningFunctionDesc',
           },
-          // Intelligent semantic pruning场景
+          // Intelligent semantic pruning scene
           {
             label: 'intelligentSemanticPruningScene',
             variableName: 'pruning_scene',
@@ -146,7 +146,7 @@ export const configList: ConfigVo[] = [
             type: 'enum',
             meaning: 'intelligentSemanticPruningSceneDesc',
           },
-          // Intelligent semantic pruning阈值
+          // Intelligent semantic pruning threshold
           {
             label: 'intelligentSemanticPruningThreshold',
             control: 'slider',

--- a/web/src/views/MemoryExtractionEngine/index.tsx
+++ b/web/src/views/MemoryExtractionEngine/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-03 17:30:02 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-02 16:12:48
+ * @Last Modified time: 2026-07-16 17:40:40
  */
 /**
  * Memory Extraction Engine Configuration Page
@@ -10,7 +10,7 @@
  * Supports real-time testing with example data
  */
 
-import { type FC, useState, useEffect } from 'react'
+import { type FC, useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { Row, Col, Space, Select, InputNumber, App, Form, Input, Flex, Tooltip, Divider } from 'antd'
@@ -19,15 +19,18 @@ import clsx from 'clsx'
 import Card from './components/Card'
 import type { ConfigForm, Variable } from './types'
 import { getMemoryExtractionConfig, updateMemoryExtractionConfig } from '@/api/memory'
-import Markdown from '@/components/Markdown'
+import ChatContent from '@/components/Chat/ChatContent'
+import type { ChatItem } from '@/components/Chat/types'
 import { configList, modelConfigList } from './constant'
 import Result from './components/Result'
+import { getDebugChatMock } from './components/result/debugChatMock'
 import SwitchFormItem from '@/components/FormItem/SwitchFormItem'
 import ModelSelect from '@/components/ModelSelect'
 import RbSlider from '@/components/RbSlider';
 import DescWrapper from '@/components/FormItem/DescWrapper'
 import LabelWrapper from '@/components/FormItem/LabelWrapper'
 import { useI18n } from '@/store/locale'
+import { formatDateTime } from '@/utils/format'
 
 /** Available configuration section keys */
 const keys = [
@@ -62,6 +65,10 @@ const MemoryExtractionEngine: FC = () => {
   const [loading, setLoading] = useState(false)
   const [iterationPeriodDisabled, setIterationPeriodDisabled] = useState(false)
   const [isDefault, setIsDefault] = useState(true)
+
+  /** Example conversation taken directly from the sample mock, split by language */
+  const exampleMessages = useMemo<ChatItem[]>(() => getDebugChatMock(language),
+  [language])
 
   useEffect(() => {
     document.title = [document.title.split(' - ')[0], t('memoryBear')].join(' - ')
@@ -150,8 +157,14 @@ const MemoryExtractionEngine: FC = () => {
                 </Flex>
 
                 {expandedKeys.includes('example') &&
-                  <div className="rb:text-[14px] rb:text-[#5B6167] rb:font-regular rb:leading-5 rb:mt-2.5 rb:mb-1.5">
-                    <Markdown content={t('memoryExtractionEngine.exampleText')} />
+                  <div className="rb:mt-2.5 rb:mb-1.5">
+                    <ChatContent
+                      data={exampleMessages}
+                      streamLoading={false}
+                      contentClassNames="rb:max-w-full!"
+                      labelFormat={(item) => formatDateTime(item.created_at)}
+                      labelPosition="bottom"
+                    />
                   </div>
                 }
               </div>
@@ -310,6 +323,7 @@ const MemoryExtractionEngine: FC = () => {
             loading={loading}
             handleSave={handleSave}
             disabled={isDefault}
+            pruningEnabled={values?.pruning_enabled}
           />
         </Col>
       </Row>

--- a/web/src/views/MemoryExtractionEngine/types.ts
+++ b/web/src/views/MemoryExtractionEngine/types.ts
@@ -93,6 +93,9 @@ export interface TestResult {
   memory: {
     chunks: number;
   };
+  perceptual: {
+    count: number;
+  };
   triplets: {
     count: number;
   };


### PR DESCRIPTION
## Summary by Sourcery

重构 Memory Extraction Engine 的结果视图，以支持对话式调试工作流、多阶段抽取可视化，以及由基于聊天的试运行驱动的感知记忆指标。

新功能：
- 引入调试聊天面板，支持发送消息和附件来驱动记忆抽取的试运行。
- 增加感知记忆抽取展示，包括在过程视图和最终结果视图中的多模态节点预览和摘要元数据。
- 使用本地化的模拟聊天记录替代静态 markdown 区块，展示引擎的示例对话数据。

增强改进：
- 将结果视图重构为模块化的 hooks 和子组件，用于试运行逻辑、调试聊天处理、过程数据可视化以及最终结果呈现。
- 扩展试运行 API 和客户端，使其基于聊天消息列表运行，而不是固定的示例文本输入。
- 更新进度计算和卡片展开逻辑，以适配新的抽取阶段，如分块（chunking）、陈述抽取、三元组抽取、剪枝以及感知记忆。
- 加强聊天组件，支持受控输入值，并通过共享的工具栏配置处理文件附件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Memory Extraction Engine result view to support a conversational debug workflow, multi-stage extraction visualization, and perceptual memory metrics driven by chat-based pilot runs.

New Features:
- Introduce a debug chat panel that allows sending messages and attachments to drive memory extraction pilot runs.
- Add perceptual memory extraction display, including multimodal node previews and summary metadata in both process and final result views.
- Display example conversation data for the engine using localized mock chat transcripts instead of a static markdown block.

Enhancements:
- Refactor the result view into modular hooks and subcomponents for pilot run logic, debug chat handling, process data visualization, and final result presentation.
- Extend the pilot run API and client to operate on a list of chat messages rather than a fixed example text input.
- Update progress computation and card expansion logic to accommodate new extraction stages such as chunking, statement extraction, triplet extraction, pruning, and perceptual memory.
- Enhance the chat component to support controlled input values and file attachment handling via a shared toolbar configuration.

</details>