### PR TITLE
feat(rag): add Chinese evaluation reports

### DIFF
--- a/api/scripts/README_RAG_EVALUATION.md
+++ b/api/scripts/README_RAG_EVALUATION.md
@@ -1,0 +1,630 @@
+# MemoryBear 知识库评测脚本使用说明
+
+本文说明以下两个独立脚本的安装、配置和完整使用流程：
+
+- `rag_recall_eval.py`：语料快照、评测数据集生成、数据集校验和召回效果评测；
+- `rag_retrieval_load_test.py`：基于 Locust 的检索接口性能压测。
+
+两个脚本都只通过 HTTP 调用已经运行的 MemoryBear 服务，不导入 `app`、service、model 或数据库代码，也不读取项目 `.env`。可以将脚本复制到其他目录后单独运行。
+
+## 1. 评测范围
+
+本工具只评测知识库的召回能力：
+
+- 是否召回正确文档；
+- 是否召回正确 chunk/context；
+- 正确结果在返回列表中的位置；
+- 单文档、多文档和无命中场景；
+- 检索接口的成功率、延迟和实际吞吐量。
+
+本工具不生成或评测最终回答，不计算 Faithfulness、Answer Correctness、Answer Relevancy 等答案类指标。
+
+首版只支持内部 JWT 路由：
+
+```text
+POST /api/chunks/retrieval
+```
+
+暂不支持 `/v1/chunks/retrieval`、GraphRAG、Folder、Share target 和 `ex_ids`。
+
+## 2. 推荐运行方式
+
+### 2.1 使用 uv 自动安装隔离依赖
+
+两个脚本都包含 PEP 723 内联依赖声明。推荐始终使用 `uv run`：
+
+```bash
+uv run api/scripts/rag_recall_eval.py --help
+uv run api/scripts/rag_retrieval_load_test.py --help
+```
+
+`uv` 会为每个脚本创建独立缓存环境，不会把 Ragas 或 Locust 安装进 MemoryBear 的生产虚拟环境。
+
+召回脚本使用的关键依赖：
+
+```text
+ragas==0.4.3
+langchain-community==0.3.31
+```
+
+性能脚本使用的关键依赖：
+
+```text
+locust==2.45.0
+PyYAML==6.0.2
+```
+
+如果本机没有 `uv`，可以先安装：
+
+```bash
+pip install uv
+```
+
+### 2.2 为什么直接 python 会提示缺少 Locust
+
+下面的命令不会读取 PEP 723 依赖，因此当前 Python 环境没有安装 Locust 时会报 `ModuleNotFoundError`：
+
+```bash
+python api/scripts/rag_retrieval_load_test.py --help
+```
+
+请改为：
+
+```bash
+uv run api/scripts/rag_retrieval_load_test.py --help
+```
+
+如果必须使用普通 `python`，请为压测脚本单独创建环境：
+
+```bash
+python3 -m venv .venv-rag-load
+source .venv-rag-load/bin/activate
+pip install locust==2.45.0 PyYAML==6.0.2
+python api/scripts/rag_retrieval_load_test.py --help
+```
+
+不要为了运行压测而把 Locust 添加到 MemoryBear 的生产依赖。
+
+## 3. 准备认证和工作目录
+
+脚本使用当前用户的 JWT 调用内部接口。凭据只能通过环境变量传入：
+
+```bash
+export RAG_EVAL_BASE_URL="http://127.0.0.1:8000"
+export RAG_EVAL_JWT_TOKEN="<JWT>"
+```
+
+推荐把语料快照、数据集和结果放在已忽略的临时目录：
+
+```bash
+mkdir -p api/tmp/rag_evaluation/datasets
+mkdir -p api/tmp/rag_evaluation/runs
+```
+
+注意：
+
+- 不要把 JWT 写进 YAML、JSONL、命令行参数或 Git；
+- 快照包含完整 chunk 正文，属于敏感文件；
+- 生成的数据集通常包含 query 和 reference，也应按知识库数据管理；
+- 结果默认不保存完整召回正文，但仍可能包含文档和 chunk ID。
+
+## 4. 召回效果评测完整流程
+
+标准流程为：
+
+```text
+snapshot -> generate -> validate -> evaluate
+```
+
+### 4.1 第一步：生成知识库快照
+
+指定一个知识库：
+
+```bash
+uv run api/scripts/rag_recall_eval.py snapshot \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --kb-id "<knowledge_id>" \
+  --output api/tmp/rag_evaluation/datasets/corpus.snapshot.json
+```
+
+指定多个知识库时重复传入 `--kb-id`：
+
+```bash
+uv run api/scripts/rag_recall_eval.py snapshot \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --kb-id "<knowledge_id_1>" \
+  --kb-id "<knowledge_id_2>" \
+  --output api/tmp/rag_evaluation/datasets/corpus.snapshot.json
+```
+
+脚本通过以下只读接口获取数据：
+
+```text
+GET /api/knowledges/{knowledge_id}
+GET /api/documents/{knowledge_id}/documents
+GET /api/chunks/{knowledge_id}/{document_id}/chunks
+```
+
+默认只接受：
+
+- active 知识库；
+- 非 Folder 知识库；
+- `status == 1` 的文档；
+- `progress == 1` 且 `run == 0` 的已完成文档。
+
+如仅用于排查，可以使用 `--include-unready` 跳过文档就绪检查，但不建议用该快照生成正式评测数据集：
+
+```bash
+uv run api/scripts/rag_recall_eval.py snapshot \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --kb-id "<knowledge_id>" \
+  --include-unready \
+  --output api/tmp/rag_evaluation/datasets/corpus.snapshot.json
+```
+
+快照包含：
+
+- 知识库和文档信息；
+- chunk 正文与 metadata；
+- `physical_chunk_id`；
+- 父子块或 QA/source 规范化后的 `canonical_evidence_id`；
+- 每个 chunk 的内容 SHA256；
+- 整体 `physical_corpus_sha256`。
+
+首版快照通过分页接口读取，不是数据库事务或 Elasticsearch PIT 原子快照。生成快照期间应暂停目标知识库的上传、删除和重解析。
+
+### 4.2 第二步：配置数据集生成模型
+
+生成器调用 OpenAI-compatible `chat/completions` 接口，需要设置：
+
+```bash
+export RAG_EVAL_LLM_BASE_URL="https://example.com/v1"
+export RAG_EVAL_LLM_API_KEY="<LLM_API_KEY>"
+export RAG_EVAL_LLM_MODEL="<model_name>"
+```
+
+如果 `RAG_EVAL_LLM_BASE_URL` 不是以 `/chat/completions` 结尾，脚本会自动追加该路径。
+
+提供方需要支持：
+
+```json
+{"response_format": {"type": "json_object"}}
+```
+
+生成时会把选中的 source chunk 正文发送给配置的模型。敏感知识库应使用本地或私有部署模型，不要直接发送给未经批准的外部服务。
+
+### 4.3 第三步：生成评测数据集
+
+示例：生成 100 条数据，其中普通样本的 30% 为多文档问题，全部样本的 10% 为 no-hit 问题：
+
+```bash
+uv run api/scripts/rag_recall_eval.py generate \
+  --snapshot api/tmp/rag_evaluation/datasets/corpus.snapshot.json \
+  --output api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --count 100 \
+  --multi-ratio 0.30 \
+  --no-hit-ratio 0.10 \
+  --seed 20260715
+```
+
+主要参数：
+
+| 参数 | 默认值 | 说明 |
+| --- | ---: | --- |
+| `--count` | `50` | 生成样本总数 |
+| `--multi-ratio` | `0.3` | 非 no-hit 样本中的多文档比例 |
+| `--no-hit-ratio` | `0.1` | 全部样本中的无命中比例 |
+| `--seed` | `20260715` | source 选择和样本顺序的随机种子 |
+| `--max-source-chars` | `6000` | 每个 source 最多发送给 LLM 的字符数 |
+| `--temperature` | `0.3` | LLM temperature |
+| `--timeout` | `90` | 单次 LLM 请求超时秒数 |
+
+生成逻辑：
+
+1. 从快照中排除 QA chunk 和空 chunk；
+2. 父子模式优先使用 child 正文生成问题，但将 parent 作为规范化黄金 context；
+3. QA 模式使用 source 正文，QA 返回结果通过 `source_chunk_id` 映射到 source evidence；
+4. 单文档样本只使用物理单文档知识库或文件名唯一的文档；
+5. 多文档样本从两个不同文档选择证据，要求 LLM 生成需要组合两份证据的问题；
+6. query 和黄金 document/context ID 一起写入 JSONL，生成内容不会写回知识库。
+
+每条生成数据包含 `quality_status=generated_unreviewed`。首版的黄金 ID 是生成时选中的已知正确证据，尚未自动穷举语料中所有可能的等价 chunk；因此 Precision/nDCG 更适合相对比较，不应直接当成绝对业务正确率。
+
+no-hit 样本会标记 `low-confidence`。它表示生成器预期目标语料无法回答，不代表已经数学证明整个知识库不存在相关内容。
+
+### 4.4 第四步：校验数据集
+
+只校验 JSONL 结构：
+
+```bash
+uv run api/scripts/rag_recall_eval.py validate \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl
+```
+
+同时校验黄金 ID 和语料快照：
+
+```bash
+uv run api/scripts/rag_recall_eval.py validate \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --snapshot api/tmp/rag_evaluation/datasets/corpus.snapshot.json
+```
+
+校验内容包括：
+
+- JSONL 每行都是 object；
+- `case_id` 存在且唯一；
+- query 非空；
+- `target.kb_ids` 非空；
+- target 不包含服务端会静默忽略的未知字段；
+- 普通样本有黄金 context；
+- no-hit 样本没有黄金 context；
+- 数据集与快照的 `physical_corpus_sha256` 一致；
+- 黄金 context ID 存在于快照。
+
+### 4.5 第五步：执行召回评测
+
+```bash
+uv run api/scripts/rag_recall_eval.py evaluate \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --snapshot api/tmp/rag_evaluation/datasets/corpus.snapshot.json \
+  --output-dir api/tmp/rag_evaluation/runs/quality-hybrid-top10 \
+  --retrieve-type hybrid \
+  --top-k 10 \
+  --top-n 20 \
+  --similarity-threshold 0.2 \
+  --vector-similarity-weight 0.3
+```
+
+默认计算 `K=[1,3,5,10]`。如需自定义，重复传入 `--k`：
+
+```bash
+uv run api/scripts/rag_recall_eval.py evaluate \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --output-dir api/tmp/rag_evaluation/runs/quality-hybrid-custom-k \
+  --top-k 20 \
+  --top-n 30 \
+  --k 1 \
+  --k 5 \
+  --k 10 \
+  --k 20
+```
+
+必须满足：
+
+```text
+top_n >= top_k
+max(K) <= top_k
+```
+
+`--retrieve-type` 支持：
+
+```text
+participle
+semantic
+hybrid
+```
+
+如需设置重排阈值：
+
+```bash
+--rerank-score-threshold 0.3
+```
+
+#### 召回指标说明
+
+| 指标 | 含义 |
+| --- | --- |
+| `context_precision@K` | 前 K 个规范化 context 中黄金 context 的占比 |
+| `context_recall@K` | 黄金 context 被前 K 个结果覆盖的比例 |
+| `context_hit@K` | 前 K 个结果是否至少命中一个黄金 context |
+| `context_mrr@K` | 第一个黄金 context 排名的倒数，越靠前越高 |
+| `context_ndcg@K` | 多个黄金 context 按返回位置折损后的排序质量 |
+| `document_recall@K` | 正确文档被前 K 个唯一文档覆盖的比例 |
+| `document_hit@K` | 前 K 个唯一文档是否包含正确文档 |
+| `group_recall@K` | 多证据组在前 K 个结果中的最大覆盖程度 |
+| `complete_evidence_group@K` | 是否完整召回一个证据组 |
+| `ragas_id_context_precision@K` | Ragas IDBasedContextPrecision 结果 |
+| `ragas_id_context_recall@K` | Ragas IDBasedContextRecall 结果 |
+| `no_hit_accuracy` | no-hit 样本正确返回空列表的比例 |
+
+#### 召回评测输出
+
+指定的 `--output-dir` 中会生成：
+
+```text
+case_results.jsonl
+summary.json
+```
+
+`case_results.jsonl` 保存逐 case 的请求状态、耗时、返回 ID、指标和错误；`summary.json` 保存运行配置、数据集 hash、成功/失败数量和平均指标。
+
+如果 Ragas 导入或计算失败，逐 case 会出现 `ragas_error`，summary 的 `ragas_failure_count` 大于 0，进程以退出码 3 结束，避免只输出本地指标却被误认为 Ragas 已成功执行。
+
+## 5. Locust 性能压测
+
+性能脚本读取同一份评测 JSONL，但只使用：
+
+- `query`；
+- `target`；
+- `corpus_mode`；
+- `load_weight`；
+- 单文档场景的黄金 document ID，用于检查范围越界。
+
+它不在 Locust task 中计算 Ragas 指标，也不调用 LLM。
+
+### 5.1 创建性能配置
+
+创建一个本地 YAML，例如：
+
+```text
+api/tmp/rag_evaluation/load-smoke.yaml
+```
+
+内容：
+
+```yaml
+seed: 20260715
+endpoint: /api/chunks/retrieval
+
+retrieval:
+  retrieve_type: hybrid
+  top_k: 10
+  top_n: 20
+  similarity_threshold: 0.2
+  vector_similarity_weight: 0.3
+  rerank_score_threshold: 0.3
+
+load:
+  profile: smoke
+  users: 2
+  spawn_rate: 1
+  run_time: 30s
+  wait_seconds: 0
+  request_timeout_seconds: 60
+
+gates:
+  min_requests: 20
+  max_failure_ratio: 0.01
+  max_p95_ms: 2500
+  min_achieved_rps: 0.5
+```
+
+配置说明：
+
+| 字段 | 说明 |
+| --- | --- |
+| `seed` | query 加权抽样随机种子 |
+| `endpoint` | 首版必须为 `/api/chunks/retrieval` |
+| `retrieval` | 每个请求共同使用的召回参数 |
+| `load.profile` | `smoke`、`baseline`、`staircase` 或 `soak` |
+| `users` | 非 staircase 模式的并发用户数 |
+| `spawn_rate` | 每秒启动的用户数 |
+| `run_time` | Locust 时长，如 `30s`、`5m`、`1h` |
+| `wait_seconds` | 同一用户两次请求间等待时间，0 表示闭环持续请求 |
+| `request_timeout_seconds` | 单次 HTTP 超时 |
+| `min_requests` | 最少有效请求数量 |
+| `max_failure_ratio` | 最大失败率，0.01 表示 1% |
+| `max_p95_ms` | 最大 p95 延迟 |
+| `min_achieved_rps` | 可选，最小实际 RPS |
+
+示例阈值不是 MemoryBear 的正式 SLA，应根据测试环境和业务目标修改。
+
+### 5.2 运行 smoke、baseline 或 soak
+
+```bash
+uv run api/scripts/rag_retrieval_load_test.py \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --config api/tmp/rag_evaluation/load-smoke.yaml \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --output-dir api/tmp/rag_evaluation/runs/load-smoke-001
+```
+
+`--output-dir` 必须是尚不存在的目录，避免覆盖以前的压测结果。
+
+`baseline` 和 `soak` 使用相同结构，只需要修改 profile、并发和时长：
+
+```yaml
+load:
+  profile: baseline
+  users: 1
+  spawn_rate: 1
+  run_time: 2m
+  wait_seconds: 0
+  request_timeout_seconds: 60
+```
+
+```yaml
+load:
+  profile: soak
+  users: 10
+  spawn_rate: 2
+  run_time: 60m
+  wait_seconds: 0
+  request_timeout_seconds: 60
+```
+
+### 5.3 运行 staircase
+
+staircase 不使用顶层 `users`、`spawn_rate` 和 `run_time`，而是逐阶段配置：
+
+```yaml
+seed: 20260715
+endpoint: /api/chunks/retrieval
+
+retrieval:
+  retrieve_type: hybrid
+  top_k: 10
+  top_n: 20
+  similarity_threshold: 0.2
+  vector_similarity_weight: 0.3
+
+load:
+  profile: staircase
+  wait_seconds: 0
+  request_timeout_seconds: 60
+  stages:
+    - users: 1
+      spawn_rate: 1
+      duration_seconds: 60
+    - users: 5
+      spawn_rate: 2
+      duration_seconds: 120
+    - users: 10
+      spawn_rate: 2
+      duration_seconds: 180
+
+gates:
+  min_requests: 200
+  max_failure_ratio: 0.01
+  max_p95_ms: 2500
+```
+
+运行方式不变：
+
+```bash
+uv run api/scripts/rag_retrieval_load_test.py \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl \
+  --config api/tmp/rag_evaluation/load-staircase.yaml \
+  --base-url "$RAG_EVAL_BASE_URL" \
+  --output-dir api/tmp/rag_evaluation/runs/load-staircase-001
+```
+
+Locust 是闭环用户模型：一个用户会在上一次请求结束后再发下一次请求。报告中的 `achieved_rps` 是实际达到的吞吐，不代表开放到达模型下的系统硬 QPS 上限。
+
+### 5.4 Locust 成功和失败判定
+
+一次请求只有同时满足以下条件才计为成功：
+
+1. HTTP 状态码为 2xx；
+2. body 是 JSON object；
+3. `code == 0`；
+4. `data` 是 list；
+5. 单文档场景没有返回其他文档的 chunk。
+
+常见低基数错误类型：
+
+```text
+http_401
+http_429
+http_500
+invalid_json
+invalid_envelope
+business_code_nonzero
+invalid_data_schema
+single_scope_violation
+```
+
+普通有答案 case 返回空列表时，HTTP 请求仍可视为性能成功，因为“没有召回正确内容”属于质量问题，应由召回评测脚本判断。
+
+### 5.5 性能输出
+
+输出目录包含：
+
+```text
+manifest.json
+summary.json
+locust.json
+locust_stats.csv
+locust_stats_history.csv
+locust_failures.csv
+locust_exceptions.csv
+report.html
+```
+
+`summary.json` 包含：
+
+- request、success、failure 数量；
+- failure ratio；
+- achieved RPS；
+- p50、p90、p95、p99 和最大延迟；
+- 门禁失败原因；
+- 最终 passed 状态。
+
+## 6. 退出码
+
+| 退出码 | 含义 |
+| ---: | --- |
+| `0` | 输入有效，运行完成且门禁通过 |
+| `2` | 运行有效，但请求失败或性能门禁未通过 |
+| `3` | 配置、认证、数据集、快照、依赖或 Ragas 指标问题导致运行无效 |
+
+可在 shell 或 CI 中检查：
+
+```bash
+uv run api/scripts/rag_recall_eval.py validate \
+  --dataset api/tmp/rag_evaluation/datasets/retrieval.dataset.jsonl
+
+echo $?
+```
+
+## 7. 常见问题
+
+### 7.1 `No module named 'locust'`
+
+原因：使用了普通 `python`，当前解释器没有安装 Locust。
+
+解决：
+
+```bash
+uv run api/scripts/rag_retrieval_load_test.py --help
+```
+
+### 7.2 `Missing authentication token`
+
+设置 JWT：
+
+```bash
+export RAG_EVAL_JWT_TOKEN="<JWT>"
+```
+
+不要在 token 值前后额外添加 `Bearer`；脚本会自动构造 Authorization header。
+
+### 7.3 `Document ... is not ready`
+
+文档仍在解析、解析失败或任务状态没有结束。正式评测应等待：
+
+```text
+status == 1
+progress == 1
+run == 0
+```
+
+### 7.4 `Snapshot content does not match physical_corpus_sha256`
+
+快照文件被修改或损坏。重新执行 `snapshot`，不要手动修改快照正文或 metadata。
+
+### 7.5 `gold context ids missing from snapshot`
+
+数据集与快照不是同一语料版本，或者文档已经重解析并重新生成 `doc_id`。重新生成快照和数据集。
+
+### 7.6 `top_n must be greater than or equal to top_k`
+
+调整参数，例如：
+
+```bash
+--top-k 10 --top-n 20
+```
+
+### 7.7 Ragas 导入失败或 `ragas_failure_count > 0`
+
+必须通过 `uv run` 使用脚本锁定的依赖。如果手动安装，请使用 README 前述兼容版本；不要只安装最新版 `langchain-community`。
+
+### 7.8 LLM 不支持 `response_format`
+
+首版生成器要求 OpenAI-compatible JSON object 输出。如果提供方不支持该字段，需要更换兼容模型服务，或后续扩展脚本适配器。
+
+### 7.9 401 不一定表示 JWT 本身失效
+
+低并发先执行 smoke。如果高并发才出现 401，应同时检查服务端认证日志、数据库连接池和 session 生命周期，不要仅凭 Locust 的 401 直接判断 token 失效。
+
+## 8. 推荐实践
+
+1. 在测试或预发布环境执行正式压测，生产环境默认只运行低并发 smoke。
+2. 生成快照期间不要上传、删除或重解析目标文档。
+3. 数据集生成后先运行 `validate`，再运行 `evaluate`。
+4. 对比检索参数时复用同一份 dataset 和 corpus hash，每组参数单独创建 run 目录。
+5. 不要把不同 retrieve type 或不同 `top_k` 的性能结果混成一个总体 p95。
+6. 自动生成数据适合快速建立基线；关键版本可对少量样本抽查，但不要求人工逐条制作全部数据。
+7. 快照、数据集、LLM 输入和结果都可能含敏感知识，不要提交到 Git 或发送到未经批准的外部服务。

--- a/api/scripts/README_RAG_EVALUATION.md
+++ b/api/scripts/README_RAG_EVALUATION.md
@@ -6,6 +6,7 @@
 - `rag_retrieval_load_test.py`：基于 Locust 的检索接口性能压测。
 
 两个脚本都只通过 HTTP 调用已经运行的 MemoryBear 服务，不导入 `app`、service、model 或数据库代码，也不读取项目 `.env`。可以将脚本复制到其他目录后单独运行。
+两个脚本都会生成中文 `report.html`；JSON/JSONL 保留英文键名，供 CI、`jq` 和其他程序稳定读取。
 
 ## 1. 评测范围
 
@@ -336,9 +337,16 @@ hybrid
 ```text
 case_results.jsonl
 summary.json
+report.html
 ```
 
-`case_results.jsonl` 保存逐 case 的请求状态、耗时、返回 ID、指标和错误；`summary.json` 保存运行配置、数据集 hash、成功/失败数量和平均指标。
+`report.html` 是中文人可读报告，包含总体指标、单文档/多文档/no-hit 分组结果、逐 case 概要和指标解释。可以直接打开：
+
+```bash
+open api/tmp/rag_evaluation/runs/quality-hybrid-top10/report.html
+```
+
+`case_results.jsonl` 保存逐 case 的请求状态、耗时、返回 ID、指标和错误；`summary.json` 保存运行配置、数据集 hash、成功/失败数量和平均指标。这两个机器可读文件的字段名仍为英文，不影响中文报告。
 
 如果 Ragas 导入或计算失败，逐 case 会出现 `ragas_error`，summary 的 `ragas_failure_count` 大于 0，进程以退出码 3 结束，避免只输出本地指标却被误认为 Ragas 已成功执行。
 
@@ -531,6 +539,17 @@ locust_stats_history.csv
 locust_failures.csv
 locust_exceptions.csv
 report.html
+locust-report.html
+```
+
+`report.html` 是脚本生成的中文主报告，包含请求数、失败率、RPS、延迟分位数、门禁结果、失败类型，以及 staircase 的逐档并发统计。
+
+`locust-report.html` 是 Locust 生成的原始英文页，仅在需要查看 Locust 原生图表或诊断信息时使用。
+
+正常压测结束后直接打开中文报告：
+
+```bash
+open api/tmp/rag_evaluation/runs/load-smoke-001/report.html
 ```
 
 `summary.json` 包含：
@@ -541,6 +560,23 @@ report.html
 - p50、p90、p95、p99 和最大延迟；
 - 门禁失败原因；
 - 最终 passed 状态。
+
+### 5.6 为已有压测结果生成中文报告
+
+如果旧的运行目录中只有 Locust 英文 `report.html`，不用重新压测，执行：
+
+```bash
+uv run api/scripts/rag_retrieval_load_test.py \
+  --render-report-dir api/tmp/rag_evaluation/runs/load-smoke-001
+```
+
+脚本会：
+
+1. 读取目录中的 `manifest.json`、`summary.json` 和 Locust CSV；
+2. 把原有 Locust 英文页保留为 `locust-report.html`；
+3. 生成新的中文 `report.html`。
+
+如果运行被中断、没有 `summary.json`，但 `locust_stats.csv` 仍可读，中文页会标记“运行未完整结束”，只展示诊断数据，不判定门禁通过。
 
 ## 6. 退出码
 

--- a/api/scripts/rag_recall_eval.py
+++ b/api/scripts/rag_recall_eval.py
@@ -1,0 +1,957 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "ragas==0.4.3",
+#   "langchain-community==0.3.31",
+# ]
+# ///
+"""Standalone MemoryBear retrieval dataset generator and recall evaluator.
+
+The script intentionally imports no MemoryBear project modules. Run it with
+``uv run rag_recall_eval.py --help`` or install the inline dependency manually.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import os
+import random
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import warnings
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+DEFAULT_TOKEN_ENV = "RAG_EVAL_JWT_TOKEN"
+LLM_BASE_URL_ENV = "RAG_EVAL_LLM_BASE_URL"
+LLM_API_KEY_ENV = "RAG_EVAL_LLM_API_KEY"
+LLM_MODEL_ENV = "RAG_EVAL_LLM_MODEL"
+ALLOWED_TARGET_FIELDS = {"kb_ids", "file_names_filter"}
+
+
+class EvaluationError(RuntimeError):
+    """Raised when an input or remote response makes a run invalid."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise EvaluationError(f"Expected JSON object in {path}")
+    return value
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise EvaluationError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+            if not isinstance(row, dict):
+                raise EvaluationError(f"Expected JSON object at {path}:{line_number}")
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(canonical_json(row))
+            handle.write("\n")
+
+
+class ApiClient:
+    """Minimal HTTP client for the public JSON contract used by this tool."""
+
+    def __init__(self, base_url: str, token: str, timeout: float = 60.0):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout = timeout
+
+    def get(self, path: str, query: dict[str, Any] | None = None) -> Any:
+        if query:
+            path = f"{path}?{urllib.parse.urlencode(query, doseq=True)}"
+        return self._request("GET", path)
+
+    def post(self, path: str, payload: dict[str, Any]) -> Any:
+        return self._request("POST", path, payload)
+
+    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        url = f"{self.base_url}{path}"
+        body = canonical_json(payload).encode("utf-8") if payload is not None else None
+        request = urllib.request.Request(
+            url,
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.token}",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                raw = response.read().decode("utf-8")
+                status = response.status
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            raise EvaluationError(f"HTTP {exc.code} from {method} {path}: {raw[:500]}") from exc
+        except urllib.error.URLError as exc:
+            raise EvaluationError(f"Request failed for {method} {path}: {exc.reason}") from exc
+
+        if not 200 <= status < 300:
+            raise EvaluationError(f"HTTP {status} from {method} {path}")
+        try:
+            envelope = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise EvaluationError(f"Non-JSON response from {method} {path}") from exc
+        if not isinstance(envelope, dict):
+            raise EvaluationError(f"Non-object response from {method} {path}")
+        if envelope.get("code") != 0:
+            raise EvaluationError(
+                f"Business failure from {method} {path}: code={envelope.get('code')}, "
+                f"message={envelope.get('msg')!r}"
+            )
+        return envelope.get("data")
+
+
+def require_token(env_name: str) -> str:
+    token = os.getenv(env_name, "").strip()
+    if not token:
+        raise EvaluationError(f"Missing authentication token in environment variable {env_name}")
+    return token
+
+
+def paged_items(
+    client: ApiClient,
+    path: str,
+    extra_query: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    page = 1
+    rows: list[dict[str, Any]] = []
+    while True:
+        query = {"page": page, "pagesize": 100}
+        if extra_query:
+            query.update(extra_query)
+        data = client.get(path, query)
+        if not isinstance(data, dict) or not isinstance(data.get("items"), list):
+            raise EvaluationError(f"Invalid paged response from {path}")
+        rows.extend(item for item in data["items"] if isinstance(item, dict))
+        page_info = data.get("page") or {}
+        if not page_info.get("has_next"):
+            break
+        page += 1
+    return rows
+
+
+def flatten_chunk_items(
+    items: list[dict[str, Any]],
+    kb_id: str,
+    document_id: str,
+) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for item in items:
+        parent = dict(item)
+        children = parent.pop("children", None) or []
+        flattened.append(normalize_snapshot_chunk(parent, kb_id, document_id))
+        for child in children:
+            if isinstance(child, dict):
+                flattened.append(normalize_snapshot_chunk(child, kb_id, document_id))
+    return flattened
+
+
+def normalize_snapshot_chunk(item: dict[str, Any], kb_id: str, document_id: str) -> dict[str, Any]:
+    metadata = dict(item.get("metadata") or {})
+    metadata.setdefault("knowledge_id", kb_id)
+    metadata.setdefault("document_id", document_id)
+    content = item.get("page_content")
+    if not isinstance(content, str):
+        content = "" if content is None else str(content)
+    chunk_type = str(metadata.get("chunk_type") or "chunk")
+    physical_id = str(metadata.get("doc_id") or "")
+    if chunk_type == "child":
+        canonical_id = str(metadata.get("parent_id") or physical_id)
+    elif chunk_type == "qa":
+        canonical_id = str(metadata.get("source_chunk_id") or physical_id)
+    else:
+        canonical_id = physical_id
+    return {
+        "knowledge_id": str(metadata.get("knowledge_id") or kb_id),
+        "document_id": str(metadata.get("document_id") or document_id),
+        "physical_chunk_id": physical_id,
+        "canonical_evidence_id": canonical_id,
+        "chunk_type": chunk_type,
+        "parent_id": str(metadata.get("parent_id") or ""),
+        "source_chunk_id": str(metadata.get("source_chunk_id") or ""),
+        "sort_id": metadata.get("sort_id"),
+        "file_name": str(metadata.get("file_name") or ""),
+        "page_content": content,
+        "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        "metadata": metadata,
+    }
+
+
+def corpus_hash_payload(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    rows = []
+    for chunk in snapshot.get("chunks") or []:
+        rows.append(
+            {
+                "knowledge_id": chunk.get("knowledge_id"),
+                "document_id": chunk.get("document_id"),
+                "physical_chunk_id": chunk.get("physical_chunk_id"),
+                "canonical_evidence_id": chunk.get("canonical_evidence_id"),
+                "chunk_type": chunk.get("chunk_type"),
+                "parent_id": chunk.get("parent_id"),
+                "source_chunk_id": chunk.get("source_chunk_id"),
+                "sort_id": chunk.get("sort_id"),
+                "content_sha256": chunk.get("content_sha256"),
+            }
+        )
+    return sorted(rows, key=canonical_json)
+
+
+def snapshot_command(args: argparse.Namespace) -> int:
+    client = ApiClient(args.base_url, require_token(args.token_env), args.timeout)
+    knowledges: list[dict[str, Any]] = []
+    documents: list[dict[str, Any]] = []
+    chunks: list[dict[str, Any]] = []
+
+    for kb_id in args.kb_id:
+        knowledge = client.get(f"/api/knowledges/{urllib.parse.quote(kb_id)}")
+        if not isinstance(knowledge, dict):
+            raise EvaluationError(f"Invalid knowledge response for {kb_id}")
+        if knowledge.get("status") != 1:
+            raise EvaluationError(f"Knowledge base {kb_id} is not active")
+        if knowledge.get("type") == "Folder":
+            raise EvaluationError(f"Folder knowledge base {kb_id} is not supported")
+        knowledges.append(knowledge)
+
+        kb_documents = paged_items(
+            client,
+            f"/api/documents/{urllib.parse.quote(kb_id)}/documents",
+            {"orderby": "id", "desc": "false"},
+        )
+        for document in kb_documents:
+            document_id = str(document.get("id") or "")
+            if not document_id:
+                raise EvaluationError(f"Document without id in knowledge base {kb_id}")
+            if not args.include_unready:
+                if document.get("status") != 1 or document.get("progress") != 1 or document.get("run") != 0:
+                    raise EvaluationError(
+                        f"Document {document_id} is not ready: status={document.get('status')}, "
+                        f"progress={document.get('progress')}, run={document.get('run')}"
+                    )
+            documents.append({**document, "id": document_id, "kb_id": kb_id})
+            chunk_items = paged_items(
+                client,
+                f"/api/chunks/{urllib.parse.quote(kb_id)}/{urllib.parse.quote(document_id)}/chunks",
+            )
+            chunks.extend(flatten_chunk_items(chunk_items, kb_id, document_id))
+
+    snapshot = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "source": {"base_url": args.base_url.rstrip("/"), "auth_mode": "jwt"},
+        "knowledges": knowledges,
+        "documents": documents,
+        "chunks": chunks,
+    }
+    snapshot["physical_corpus_sha256"] = sha256_json(corpus_hash_payload(snapshot))
+    write_json(args.output, snapshot)
+    print(
+        canonical_json(
+            {
+                "output": str(args.output),
+                "knowledge_count": len(knowledges),
+                "document_count": len(documents),
+                "chunk_count": len(chunks),
+                "physical_corpus_sha256": snapshot["physical_corpus_sha256"],
+            }
+        )
+    )
+    return 0
+
+
+def parse_llm_json(raw: str) -> dict[str, Any]:
+    value = raw.strip()
+    if value.startswith("```"):
+        value = re.sub(r"^```(?:json)?\s*", "", value)
+        value = re.sub(r"\s*```$", "", value)
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", value, flags=re.DOTALL)
+        if not match:
+            raise EvaluationError("LLM did not return a JSON object")
+        parsed = json.loads(match.group(0))
+    if not isinstance(parsed, dict):
+        raise EvaluationError("LLM response is not a JSON object")
+    return parsed
+
+
+class OpenAICompatibleGenerator:
+    """Small OpenAI-compatible chat-completions client used only for generation."""
+
+    def __init__(self, timeout: float, temperature: float):
+        base_url = os.getenv(LLM_BASE_URL_ENV, "").strip().rstrip("/")
+        api_key = os.getenv(LLM_API_KEY_ENV, "").strip()
+        model = os.getenv(LLM_MODEL_ENV, "").strip()
+        missing = [
+            name
+            for name, value in (
+                (LLM_BASE_URL_ENV, base_url),
+                (LLM_API_KEY_ENV, api_key),
+                (LLM_MODEL_ENV, model),
+            )
+            if not value
+        ]
+        if missing:
+            raise EvaluationError(f"Missing LLM environment variables: {', '.join(missing)}")
+        self.url = base_url if base_url.endswith("/chat/completions") else f"{base_url}/chat/completions"
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        self.temperature = temperature
+
+    def generate(self, evidence: list[dict[str, str]], no_hit: bool = False) -> dict[str, str]:
+        if no_hit:
+            task = (
+                "Generate one natural user question that is unrelated to and cannot be answered by the provided "
+                "knowledge-base excerpts. Return JSON with query and an empty reference."
+            )
+        elif len(evidence) > 1:
+            task = (
+                "Generate one natural user question that requires combining every provided excerpt. Avoid copying "
+                "long phrases. Return JSON with query and a concise reference supported only by the excerpts."
+            )
+        else:
+            task = (
+                "Generate one natural user question answerable from the excerpt. Paraphrase the wording and avoid "
+                "mentioning documents or excerpts. Return JSON with query and a concise reference."
+            )
+        payload = {
+            "model": self.model,
+            "temperature": self.temperature,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You create retrieval benchmark queries. Output a JSON object only.",
+                },
+                {
+                    "role": "user",
+                    "content": f"{task}\n\nEvidence:\n{json.dumps(evidence, ensure_ascii=False)}",
+                },
+            ],
+        }
+        request = urllib.request.Request(
+            self.url,
+            data=canonical_json(payload).encode("utf-8"),
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                result = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.URLError, json.JSONDecodeError) as exc:
+            raise EvaluationError(f"LLM generation failed: {exc}") from exc
+        try:
+            content = result["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise EvaluationError("Unexpected LLM response contract") from exc
+        parsed = parse_llm_json(content)
+        query = str(parsed.get("query") or "").strip()
+        reference = str(parsed.get("reference") or "").strip()
+        if not query:
+            raise EvaluationError("LLM returned an empty query")
+        return {"query": query, "reference": reference}
+
+
+def context_id(chunk: dict[str, Any]) -> str:
+    return ":".join(
+        [
+            str(chunk.get("knowledge_id") or ""),
+            str(chunk.get("document_id") or ""),
+            str(chunk.get("canonical_evidence_id") or chunk.get("physical_chunk_id") or ""),
+        ]
+    )
+
+
+def document_context_id(chunk: dict[str, Any]) -> str:
+    return f"{chunk.get('knowledge_id')}:{chunk.get('document_id')}"
+
+
+def eligible_source_chunks(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    parent_ids = {
+        str(chunk.get("parent_id"))
+        for chunk in snapshot.get("chunks") or []
+        if chunk.get("chunk_type") == "child" and chunk.get("parent_id")
+    }
+    rows = []
+    for chunk in snapshot.get("chunks") or []:
+        chunk_type = chunk.get("chunk_type") or "chunk"
+        content = str(chunk.get("page_content") or "").strip()
+        if not content or chunk_type == "qa":
+            continue
+        if chunk_type == "parent" and str(chunk.get("physical_chunk_id")) in parent_ids:
+            continue
+        if not chunk.get("physical_chunk_id") or not chunk.get("canonical_evidence_id"):
+            continue
+        rows.append(chunk)
+    return rows
+
+
+def source_provenance(chunk: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "knowledge_id": chunk.get("knowledge_id"),
+        "document_id": chunk.get("document_id"),
+        "physical_chunk_id": chunk.get("physical_chunk_id"),
+        "canonical_evidence_id": chunk.get("canonical_evidence_id"),
+        "chunk_type": chunk.get("chunk_type"),
+        "content_sha256": chunk.get("content_sha256"),
+    }
+
+
+def build_generated_case(
+    index: int,
+    generated: dict[str, str],
+    sources: list[dict[str, Any]],
+    snapshot: dict[str, Any],
+    model: str,
+    seed: int,
+    no_hit: bool,
+    kb_document_counts: dict[str, int],
+    file_name_counts: dict[tuple[str, str], int],
+) -> dict[str, Any]:
+    if no_hit:
+        kb_ids = sorted(str(item.get("id")) for item in snapshot.get("knowledges") or [])
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "case_id": f"no-hit-{index:05d}",
+            "query": generated["query"],
+            "reference": "",
+            "corpus_mode": "no_hit",
+            "target": {"kb_ids": kb_ids},
+            "gold_document_ids": [],
+            "gold_context_ids": [],
+            "required_context_groups": [],
+            "alternative_context_groups": [],
+            "expected_no_hit": True,
+            "load_weight": 1,
+            "tags": ["generated", "no-hit", "low-confidence"],
+            "physical_corpus_sha256": snapshot["physical_corpus_sha256"],
+            "provenance": {"sources": [], "strategy": "out_of_scope_generation"},
+            "generation": {"model": model, "seed": seed, "generated_at": utc_now()},
+            "quality_status": "generated_unreviewed",
+        }
+
+    kb_ids = sorted({str(source.get("knowledge_id")) for source in sources})
+    gold_documents = sorted({document_context_id(source) for source in sources})
+    gold_contexts = list(dict.fromkeys(context_id(source) for source in sources))
+    target: dict[str, Any] = {"kb_ids": kb_ids}
+    if len(sources) > 1:
+        corpus_mode = "multi_document"
+    else:
+        source = sources[0]
+        kb_id = str(source.get("knowledge_id"))
+        file_name = str(source.get("file_name") or "")
+        if kb_document_counts[kb_id] == 1:
+            corpus_mode = "single_document_kb"
+        else:
+            corpus_mode = "single_document_filter"
+            target["file_names_filter"] = [file_name]
+            if file_name_counts[(kb_id, file_name)] != 1:
+                raise EvaluationError(f"File name {file_name!r} is not unique in knowledge base {kb_id}")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "case_id": f"{corpus_mode}-{index:05d}",
+        "query": generated["query"],
+        "reference": generated["reference"],
+        "corpus_mode": corpus_mode,
+        "target": target,
+        "gold_document_ids": gold_documents,
+        "gold_context_ids": gold_contexts,
+        "required_context_groups": [gold_contexts],
+        "alternative_context_groups": [],
+        "expected_no_hit": False,
+        "load_weight": 1,
+        "tags": ["generated", "multi-source" if len(sources) > 1 else "single-source"],
+        "physical_corpus_sha256": snapshot["physical_corpus_sha256"],
+        "provenance": {"sources": [source_provenance(source) for source in sources]},
+        "generation": {"model": model, "seed": seed, "generated_at": utc_now()},
+        "quality_status": "generated_unreviewed",
+    }
+
+
+def generate_command(args: argparse.Namespace) -> int:
+    snapshot = read_json(args.snapshot)
+    expected_hash = sha256_json(corpus_hash_payload(snapshot))
+    if snapshot.get("physical_corpus_sha256") != expected_hash:
+        raise EvaluationError("Snapshot content does not match physical_corpus_sha256")
+    sources = eligible_source_chunks(snapshot)
+    if not sources:
+        raise EvaluationError("Snapshot has no eligible non-QA source chunks")
+
+    documents = snapshot.get("documents") or []
+    kb_document_counts: dict[str, int] = defaultdict(int)
+    file_name_counts: dict[tuple[str, str], int] = defaultdict(int)
+    for document in documents:
+        kb_id = str(document.get("kb_id") or "")
+        file_name = str(document.get("file_name") or "")
+        kb_document_counts[kb_id] += 1
+        file_name_counts[(kb_id, file_name)] += 1
+
+    by_document: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    single_eligible: list[dict[str, Any]] = []
+    for source in sources:
+        kb_id = str(source.get("knowledge_id"))
+        document_id = str(source.get("document_id"))
+        by_document[(kb_id, document_id)].append(source)
+        file_name = str(source.get("file_name") or "")
+        if kb_document_counts[kb_id] == 1 or file_name_counts[(kb_id, file_name)] == 1:
+            single_eligible.append(source)
+    if not single_eligible:
+        raise EvaluationError("No source chunk can form an unambiguous single-document case")
+
+    rng = random.Random(args.seed)
+    generator = OpenAICompatibleGenerator(args.timeout, args.temperature)
+    no_hit_count = min(args.count, round(args.count * args.no_hit_ratio))
+    remaining = args.count - no_hit_count
+    multi_count = min(remaining, round(remaining * args.multi_ratio))
+    single_count = remaining - multi_count
+    if multi_count and len(by_document) < 2:
+        raise EvaluationError("At least two documents are required for multi-document generation")
+
+    plans: list[tuple[list[dict[str, Any]], bool]] = []
+    for _ in range(single_count):
+        plans.append(([rng.choice(single_eligible)], False))
+    document_keys = list(by_document)
+    for _ in range(multi_count):
+        selected_keys = rng.sample(document_keys, 2)
+        plans.append(([rng.choice(by_document[key]) for key in selected_keys], False))
+    for _ in range(no_hit_count):
+        context_sample = rng.sample(sources, min(5, len(sources)))
+        plans.append((context_sample, True))
+    rng.shuffle(plans)
+
+    cases: list[dict[str, Any]] = []
+    seen_queries: set[str] = set()
+    for index, (selected, no_hit) in enumerate(plans, start=1):
+        evidence = [
+            {
+                "source": f"source-{position + 1}",
+                "text": str(source.get("page_content") or "")[: args.max_source_chars],
+            }
+            for position, source in enumerate(selected)
+        ]
+        generated = generator.generate(evidence, no_hit=no_hit)
+        query_key = generated["query"].casefold()
+        if query_key in seen_queries:
+            raise EvaluationError(f"Duplicate generated query at case {index}")
+        seen_queries.add(query_key)
+        cases.append(
+            build_generated_case(
+                index=index,
+                generated=generated,
+                sources=[] if no_hit else selected,
+                snapshot=snapshot,
+                model=generator.model,
+                seed=args.seed,
+                no_hit=no_hit,
+                kb_document_counts=kb_document_counts,
+                file_name_counts=file_name_counts,
+            )
+        )
+        print(f"generated {index}/{len(plans)}", file=sys.stderr)
+
+    write_jsonl(args.output, cases)
+    print(
+        canonical_json(
+            {
+                "output": str(args.output),
+                "case_count": len(cases),
+                "single_count": single_count,
+                "multi_count": multi_count,
+                "no_hit_count": no_hit_count,
+                "physical_corpus_sha256": snapshot["physical_corpus_sha256"],
+            }
+        )
+    )
+    return 0
+
+
+def validate_cases(cases: list[dict[str, Any]], snapshot: dict[str, Any] | None = None) -> list[str]:
+    errors: list[str] = []
+    seen_ids: set[str] = set()
+    snapshot_hash = snapshot.get("physical_corpus_sha256") if snapshot else None
+    valid_context_ids = {context_id(chunk) for chunk in (snapshot or {}).get("chunks") or []}
+    for index, case in enumerate(cases, start=1):
+        prefix = f"case[{index}]"
+        case_id = str(case.get("case_id") or "")
+        if not case_id:
+            errors.append(f"{prefix}: missing case_id")
+        elif case_id in seen_ids:
+            errors.append(f"{prefix}: duplicate case_id {case_id}")
+        seen_ids.add(case_id)
+        if case.get("schema_version") != SCHEMA_VERSION:
+            errors.append(f"{prefix}: unsupported schema_version")
+        if not str(case.get("query") or "").strip():
+            errors.append(f"{prefix}: empty query")
+        target = case.get("target")
+        if not isinstance(target, dict) or not target.get("kb_ids"):
+            errors.append(f"{prefix}: target.kb_ids must be non-empty")
+        elif unknown := set(target) - ALLOWED_TARGET_FIELDS:
+            errors.append(f"{prefix}: unknown target fields {sorted(unknown)}")
+        gold = case.get("gold_context_ids") or []
+        if case.get("expected_no_hit"):
+            if gold:
+                errors.append(f"{prefix}: no-hit case must not contain gold_context_ids")
+        elif not gold:
+            errors.append(f"{prefix}: ordinary case needs gold_context_ids")
+        if snapshot_hash and case.get("physical_corpus_sha256") != snapshot_hash:
+            errors.append(f"{prefix}: snapshot hash mismatch")
+        if snapshot and not case.get("expected_no_hit"):
+            missing = sorted(set(gold) - valid_context_ids)
+            if missing:
+                errors.append(f"{prefix}: gold context ids missing from snapshot: {missing}")
+    return errors
+
+
+def validate_command(args: argparse.Namespace) -> int:
+    cases = read_jsonl(args.dataset)
+    snapshot = read_json(args.snapshot) if args.snapshot else None
+    errors = validate_cases(cases, snapshot)
+    result = {"valid": not errors, "case_count": len(cases), "errors": errors}
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if not errors else 3
+
+
+def ordered_unique(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def canonical_result_ids(item: dict[str, Any]) -> tuple[str, str]:
+    metadata = item.get("metadata") or {}
+    kb_id = str(metadata.get("knowledge_id") or "")
+    document_id = str(metadata.get("document_id") or "")
+    chunk_type = str(metadata.get("chunk_type") or "chunk")
+    physical_id = str(metadata.get("doc_id") or "")
+    if chunk_type == "child":
+        evidence_id = str(metadata.get("parent_id") or physical_id)
+    elif chunk_type == "qa":
+        evidence_id = str(metadata.get("source_chunk_id") or physical_id)
+    else:
+        evidence_id = physical_id
+    document_result_id = f"{kb_id}:{document_id}" if kb_id and document_id else ""
+    context_result_id = f"{kb_id}:{document_id}:{evidence_id}" if document_result_id and evidence_id else ""
+    return document_result_id, context_result_id
+
+
+def precision(retrieved: list[str], gold: set[str]) -> float | None:
+    return len(set(retrieved) & gold) / len(set(retrieved)) if retrieved else None
+
+
+def recall(retrieved: list[str], gold: set[str]) -> float:
+    return len(set(retrieved) & gold) / len(gold) if gold else 0.0
+
+
+def reciprocal_rank(retrieved: list[str], gold: set[str]) -> float:
+    for rank, item in enumerate(retrieved, start=1):
+        if item in gold:
+            return 1.0 / rank
+    return 0.0
+
+
+def ndcg(retrieved: list[str], gold: set[str]) -> float:
+    if not gold:
+        return 0.0
+    dcg = sum(1.0 / math.log2(rank + 1) for rank, item in enumerate(retrieved, start=1) if item in gold)
+    ideal_count = min(len(gold), len(retrieved))
+    ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_count + 1))
+    return dcg / ideal if ideal else 0.0
+
+
+def group_scores(retrieved: list[str], case: dict[str, Any]) -> tuple[float, bool]:
+    required_groups = case.get("required_context_groups") or []
+    alternatives = case.get("alternative_context_groups") or []
+    groups = [set(group) for group in required_groups]
+    groups.extend(set(group) for group in alternatives)
+    groups = [group for group in groups if group]
+    if not groups:
+        return 0.0, False
+    retrieved_set = set(retrieved)
+    scores = [len(retrieved_set & group) / len(group) for group in groups]
+    return max(scores), any(group <= retrieved_set for group in groups)
+
+
+async def ragas_id_scores(retrieved: list[str], gold: list[str]) -> tuple[float, float]:
+    from ragas import SingleTurnSample
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Importing IDBasedContext")
+        from ragas.metrics import IDBasedContextPrecision, IDBasedContextRecall
+
+    sample = SingleTurnSample(retrieved_context_ids=retrieved, reference_context_ids=gold)
+    ragas_precision = await IDBasedContextPrecision().single_turn_ascore(sample)
+    ragas_recall = await IDBasedContextRecall().single_turn_ascore(sample)
+    return float(ragas_precision), float(ragas_recall)
+
+
+def evaluate_command(args: argparse.Namespace) -> int:
+    cases = read_jsonl(args.dataset)
+    snapshot = read_json(args.snapshot) if args.snapshot else None
+    errors = validate_cases(cases, snapshot)
+    if errors:
+        raise EvaluationError("Dataset validation failed:\n" + "\n".join(errors))
+    client = ApiClient(args.base_url, require_token(args.token_env), args.timeout)
+    k_values = sorted(set(args.k or [1, 3, 5, 10]))
+    if not k_values or min(k_values) < 1:
+        raise EvaluationError("At least one positive K value is required")
+    if max(k_values) > args.top_k:
+        raise EvaluationError("max(K) must not exceed top_k")
+
+    details: list[dict[str, Any]] = []
+    failed_requests = 0
+    ragas_failures = 0
+    with asyncio.Runner() as runner:
+        for index, case in enumerate(cases, start=1):
+            payload = {
+                "query": case["query"],
+                **case["target"],
+                "retrieve_type": args.retrieve_type,
+                "top_k": args.top_k,
+                "top_n": args.top_n,
+                "similarity_threshold": args.similarity_threshold,
+                "vector_similarity_weight": args.vector_similarity_weight,
+                "rerank_score_threshold": args.rerank_score_threshold,
+            }
+            payload = {key: value for key, value in payload.items() if value is not None}
+            started = time.perf_counter()
+            try:
+                response_items = client.post("/api/chunks/retrieval", payload)
+                if not isinstance(response_items, list):
+                    raise EvaluationError("Retrieval data is not a list")
+                request_error = None
+            except EvaluationError as exc:
+                response_items = []
+                request_error = str(exc)
+                failed_requests += 1
+            elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+            document_ids: list[str] = []
+            context_ids: list[str] = []
+            invalid_provenance = 0
+            for item in response_items:
+                if not isinstance(item, dict):
+                    invalid_provenance += 1
+                    continue
+                document_id, context_result_id = canonical_result_ids(item)
+                if not document_id or not context_result_id:
+                    invalid_provenance += 1
+                    continue
+                document_ids.append(document_id)
+                context_ids.append(context_result_id)
+            document_ids = ordered_unique(document_ids)
+            context_ids = ordered_unique(context_ids)
+            result: dict[str, Any] = {
+                "case_id": case["case_id"],
+                "corpus_mode": case["corpus_mode"],
+                "request_success": request_error is None,
+                "request_error": request_error,
+                "elapsed_ms": elapsed_ms,
+                "result_count": len(response_items),
+                "invalid_provenance_count": invalid_provenance,
+                "retrieved_document_ids": document_ids,
+                "retrieved_context_ids": context_ids,
+                "metrics": {},
+            }
+            if case.get("expected_no_hit"):
+                result["metrics"]["no_hit_correct"] = not response_items
+            else:
+                gold_contexts = list(case.get("gold_context_ids") or [])
+                gold_context_set = set(gold_contexts)
+                gold_document_set = set(case.get("gold_document_ids") or [])
+                for k in k_values:
+                    retrieved_contexts = context_ids[:k]
+                    retrieved_documents = document_ids[:k]
+                    group_recall, complete_group = group_scores(retrieved_contexts, case)
+                    metric_row: dict[str, Any] = {
+                        "context_precision": precision(retrieved_contexts, gold_context_set),
+                        "context_recall": recall(retrieved_contexts, gold_context_set),
+                        "context_hit": bool(set(retrieved_contexts) & gold_context_set),
+                        "context_mrr": reciprocal_rank(retrieved_contexts, gold_context_set),
+                        "context_ndcg": ndcg(retrieved_contexts, gold_context_set),
+                        "document_recall": recall(retrieved_documents, gold_document_set),
+                        "document_hit": bool(set(retrieved_documents) & gold_document_set),
+                        "group_recall": group_recall,
+                        "complete_evidence_group": complete_group,
+                    }
+                    try:
+                        ragas_precision, ragas_recall = runner.run(
+                            ragas_id_scores(retrieved_contexts, gold_contexts)
+                        )
+                        metric_row["ragas_id_context_precision"] = ragas_precision
+                        metric_row["ragas_id_context_recall"] = ragas_recall
+                    except Exception as exc:  # noqa: BLE001 - metric failure belongs in the report
+                        metric_row["ragas_error"] = f"{type(exc).__name__}: {exc}"
+                        ragas_failures += 1
+                    result["metrics"][f"@{k}"] = metric_row
+            details.append(result)
+            print(f"evaluated {index}/{len(cases)}", file=sys.stderr)
+
+    summary_metrics: dict[str, Any] = {}
+    for k in k_values:
+        key = f"@{k}"
+        rows = [item["metrics"].get(key) for item in details if item["metrics"].get(key)]
+        if not rows:
+            continue
+        metric_names = sorted({name for row in rows for name, value in row.items() if isinstance(value, (int, float, bool))})
+        summary_metrics[key] = {
+            name: sum(float(row[name]) for row in rows if row.get(name) is not None)
+            / sum(1 for row in rows if row.get(name) is not None)
+            for name in metric_names
+            if any(row.get(name) is not None for row in rows)
+        }
+    no_hit_rows = [item for item in details if "no_hit_correct" in item["metrics"]]
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "dataset": str(args.dataset),
+        "dataset_sha256": hashlib.sha256(args.dataset.read_bytes()).hexdigest(),
+        "physical_corpus_sha256": cases[0].get("physical_corpus_sha256") if cases else None,
+        "case_count": len(cases),
+        "request_success_count": len(cases) - failed_requests,
+        "request_failure_count": failed_requests,
+        "ragas_failure_count": ragas_failures,
+        "no_hit_accuracy": (
+            sum(bool(item["metrics"]["no_hit_correct"]) for item in no_hit_rows) / len(no_hit_rows)
+            if no_hit_rows
+            else None
+        ),
+        "retrieval": {
+            "retrieve_type": args.retrieve_type,
+            "top_k": args.top_k,
+            "top_n": args.top_n,
+            "similarity_threshold": args.similarity_threshold,
+            "vector_similarity_weight": args.vector_similarity_weight,
+            "rerank_score_threshold": args.rerank_score_threshold,
+        },
+        "metrics": summary_metrics,
+    }
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    write_jsonl(args.output_dir / "case_results.jsonl", details)
+    write_json(args.output_dir / "summary.json", summary)
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if ragas_failures:
+        return 3
+    return 0 if failed_requests == 0 else 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot = subparsers.add_parser("snapshot", help="Export a private corpus snapshot over HTTP")
+    snapshot.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    snapshot.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
+    snapshot.add_argument("--kb-id", action="append", required=True)
+    snapshot.add_argument("--output", type=Path, required=True)
+    snapshot.add_argument("--timeout", type=float, default=60.0)
+    snapshot.add_argument("--include-unready", action="store_true")
+    snapshot.set_defaults(handler=snapshot_command)
+
+    generate = subparsers.add_parser("generate", help="Generate a JSONL evaluation dataset from a snapshot")
+    generate.add_argument("--snapshot", type=Path, required=True)
+    generate.add_argument("--output", type=Path, required=True)
+    generate.add_argument("--count", type=int, default=50)
+    generate.add_argument("--multi-ratio", type=float, default=0.3)
+    generate.add_argument("--no-hit-ratio", type=float, default=0.1)
+    generate.add_argument("--seed", type=int, default=20260715)
+    generate.add_argument("--max-source-chars", type=int, default=6000)
+    generate.add_argument("--temperature", type=float, default=0.3)
+    generate.add_argument("--timeout", type=float, default=90.0)
+    generate.set_defaults(handler=generate_command)
+
+    validate = subparsers.add_parser("validate", help="Validate a generated evaluation dataset")
+    validate.add_argument("--dataset", type=Path, required=True)
+    validate.add_argument("--snapshot", type=Path)
+    validate.set_defaults(handler=validate_command)
+
+    evaluate = subparsers.add_parser("evaluate", help="Run retrieval and calculate ID/ranking metrics")
+    evaluate.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    evaluate.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
+    evaluate.add_argument("--dataset", type=Path, required=True)
+    evaluate.add_argument("--snapshot", type=Path)
+    evaluate.add_argument("--output-dir", type=Path, required=True)
+    evaluate.add_argument("--retrieve-type", choices=["participle", "semantic", "hybrid"], default="hybrid")
+    evaluate.add_argument("--top-k", type=int, default=10)
+    evaluate.add_argument("--top-n", type=int, default=20)
+    evaluate.add_argument("--k", type=int, action="append")
+    evaluate.add_argument("--similarity-threshold", type=float, default=0.2)
+    evaluate.add_argument("--vector-similarity-weight", type=float, default=0.3)
+    evaluate.add_argument("--rerank-score-threshold", type=float)
+    evaluate.add_argument("--timeout", type=float, default=60.0)
+    evaluate.set_defaults(handler=evaluate_command)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        if getattr(args, "count", 1) < 1:
+            raise EvaluationError("count must be positive")
+        for name in ("multi_ratio", "no_hit_ratio"):
+            value = getattr(args, name, 0.0)
+            if not 0.0 <= value <= 1.0:
+                raise EvaluationError(f"{name} must be between 0 and 1")
+        if hasattr(args, "top_n") and args.top_n < args.top_k:
+            raise EvaluationError("top_n must be greater than or equal to top_k")
+        return int(args.handler(args))
+    except EvaluationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/api/scripts/rag_recall_eval.py
+++ b/api/scripts/rag_recall_eval.py
@@ -59,6 +59,11 @@ def sha256_json(value: Any) -> str:
     return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
 
 
+def chunk_content_sha256(chunk: dict[str, Any]) -> str:
+    content = str(chunk.get("page_content") or "")
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
 def read_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         value = json.load(handle)
@@ -241,9 +246,16 @@ def normalize_snapshot_chunk(
     }
 
 
-def corpus_hash_payload(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+def corpus_hash_payload(
+    snapshot: dict[str, Any], *, recompute_content_hashes: bool = False
+) -> list[dict[str, Any]]:
     rows = []
     for chunk in snapshot.get("chunks") or []:
+        content_sha256 = (
+            chunk_content_sha256(chunk)
+            if recompute_content_hashes
+            else chunk.get("content_sha256")
+        )
         rows.append(
             {
                 "knowledge_id": chunk.get("knowledge_id"),
@@ -254,10 +266,31 @@ def corpus_hash_payload(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
                 "parent_id": chunk.get("parent_id"),
                 "source_chunk_id": chunk.get("source_chunk_id"),
                 "sort_id": chunk.get("sort_id"),
-                "content_sha256": chunk.get("content_sha256"),
+                "content_sha256": content_sha256,
             }
         )
     return sorted(rows, key=canonical_json)
+
+
+def validate_snapshot_integrity(snapshot: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    chunks = snapshot.get("chunks") or []
+    if not isinstance(chunks, list):
+        return ["snapshot chunks must be a list"]
+    for index, chunk in enumerate(chunks, start=1):
+        if not isinstance(chunk, dict):
+            errors.append(f"snapshot chunk[{index}] must be an object")
+            continue
+        stored_hash = str(chunk.get("content_sha256") or "")
+        actual_hash = chunk_content_sha256(chunk)
+        if stored_hash != actual_hash:
+            errors.append(f"snapshot chunk[{index}] content_sha256 mismatch")
+    expected_hash = sha256_json(
+        corpus_hash_payload(snapshot, recompute_content_hashes=True)
+    )
+    if snapshot.get("physical_corpus_sha256") != expected_hash:
+        errors.append("snapshot physical_corpus_sha256 mismatch")
+    return errors
 
 
 def snapshot_command(args: argparse.Namespace) -> int:
@@ -559,9 +592,11 @@ def build_generated_case(
 
 def generate_command(args: argparse.Namespace) -> int:
     snapshot = read_json(args.snapshot)
-    expected_hash = sha256_json(corpus_hash_payload(snapshot))
-    if snapshot.get("physical_corpus_sha256") != expected_hash:
-        raise EvaluationError("Snapshot content does not match physical_corpus_sha256")
+    snapshot_errors = validate_snapshot_integrity(snapshot)
+    if snapshot_errors:
+        raise EvaluationError(
+            "Snapshot validation failed:\n" + "\n".join(snapshot_errors)
+        )
     sources = eligible_source_chunks(snapshot)
     if not sources:
         raise EvaluationError("Snapshot has no eligible non-QA source chunks")
@@ -662,6 +697,8 @@ def validate_cases(
     cases: list[dict[str, Any]], snapshot: dict[str, Any] | None = None
 ) -> list[str]:
     errors: list[str] = []
+    if snapshot is not None:
+        errors.extend(validate_snapshot_integrity(snapshot))
     if not cases:
         errors.append("dataset is empty")
         return errors

--- a/api/scripts/rag_recall_eval.py
+++ b/api/scripts/rag_recall_eval.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import html
 import json
 import math
 import os
@@ -82,7 +83,9 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
             try:
                 row = json.loads(line)
             except json.JSONDecodeError as exc:
-                raise EvaluationError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+                raise EvaluationError(
+                    f"Invalid JSONL at {path}:{line_number}: {exc}"
+                ) from exc
             if not isinstance(row, dict):
                 raise EvaluationError(f"Expected JSON object at {path}:{line_number}")
             rows.append(row)
@@ -113,7 +116,9 @@ class ApiClient:
     def post(self, path: str, payload: dict[str, Any]) -> Any:
         return self._request("POST", path, payload)
 
-    def _request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    def _request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> Any:
         url = f"{self.base_url}{path}"
         body = canonical_json(payload).encode("utf-8") if payload is not None else None
         request = urllib.request.Request(
@@ -132,9 +137,13 @@ class ApiClient:
                 status = response.status
         except urllib.error.HTTPError as exc:
             raw = exc.read().decode("utf-8", errors="replace")
-            raise EvaluationError(f"HTTP {exc.code} from {method} {path}: {raw[:500]}") from exc
+            raise EvaluationError(
+                f"HTTP {exc.code} from {method} {path}: {raw[:500]}"
+            ) from exc
         except urllib.error.URLError as exc:
-            raise EvaluationError(f"Request failed for {method} {path}: {exc.reason}") from exc
+            raise EvaluationError(
+                f"Request failed for {method} {path}: {exc.reason}"
+            ) from exc
 
         if not 200 <= status < 300:
             raise EvaluationError(f"HTTP {status} from {method} {path}")
@@ -155,7 +164,9 @@ class ApiClient:
 def require_token(env_name: str) -> str:
     token = os.getenv(env_name, "").strip()
     if not token:
-        raise EvaluationError(f"Missing authentication token in environment variable {env_name}")
+        raise EvaluationError(
+            f"Missing authentication token in environment variable {env_name}"
+        )
     return token
 
 
@@ -197,7 +208,9 @@ def flatten_chunk_items(
     return flattened
 
 
-def normalize_snapshot_chunk(item: dict[str, Any], kb_id: str, document_id: str) -> dict[str, Any]:
+def normalize_snapshot_chunk(
+    item: dict[str, Any], kb_id: str, document_id: str
+) -> dict[str, Any]:
     metadata = dict(item.get("metadata") or {})
     metadata.setdefault("knowledge_id", kb_id)
     metadata.setdefault("document_id", document_id)
@@ -273,7 +286,11 @@ def snapshot_command(args: argparse.Namespace) -> int:
             if not document_id:
                 raise EvaluationError(f"Document without id in knowledge base {kb_id}")
             if not args.include_unready:
-                if document.get("status") != 1 or document.get("progress") != 1 or document.get("run") != 0:
+                if (
+                    document.get("status") != 1
+                    or document.get("progress") != 1
+                    or document.get("run") != 0
+                ):
                     raise EvaluationError(
                         f"Document {document_id} is not ready: status={document.get('status')}, "
                         f"progress={document.get('progress')}, run={document.get('run')}"
@@ -343,14 +360,22 @@ class OpenAICompatibleGenerator:
             if not value
         ]
         if missing:
-            raise EvaluationError(f"Missing LLM environment variables: {', '.join(missing)}")
-        self.url = base_url if base_url.endswith("/chat/completions") else f"{base_url}/chat/completions"
+            raise EvaluationError(
+                f"Missing LLM environment variables: {', '.join(missing)}"
+            )
+        self.url = (
+            base_url
+            if base_url.endswith("/chat/completions")
+            else f"{base_url}/chat/completions"
+        )
         self.api_key = api_key
         self.model = model
         self.timeout = timeout
         self.temperature = temperature
 
-    def generate(self, evidence: list[dict[str, str]], no_hit: bool = False) -> dict[str, str]:
+    def generate(
+        self, evidence: list[dict[str, str]], no_hit: bool = False
+    ) -> dict[str, str]:
         if no_hit:
             task = (
                 "Generate one natural user question that is unrelated to and cannot be answered by the provided "
@@ -413,7 +438,11 @@ def context_id(chunk: dict[str, Any]) -> str:
         [
             str(chunk.get("knowledge_id") or ""),
             str(chunk.get("document_id") or ""),
-            str(chunk.get("canonical_evidence_id") or chunk.get("physical_chunk_id") or ""),
+            str(
+                chunk.get("canonical_evidence_id")
+                or chunk.get("physical_chunk_id")
+                or ""
+            ),
         ]
     )
 
@@ -465,7 +494,9 @@ def build_generated_case(
     file_name_counts: dict[tuple[str, str], int],
 ) -> dict[str, Any]:
     if no_hit:
-        kb_ids = sorted(str(item.get("id")) for item in snapshot.get("knowledges") or [])
+        kb_ids = sorted(
+            str(item.get("id")) for item in snapshot.get("knowledges") or []
+        )
         return {
             "schema_version": SCHEMA_VERSION,
             "case_id": f"no-hit-{index:05d}",
@@ -502,7 +533,9 @@ def build_generated_case(
             corpus_mode = "single_document_filter"
             target["file_names_filter"] = [file_name]
             if file_name_counts[(kb_id, file_name)] != 1:
-                raise EvaluationError(f"File name {file_name!r} is not unique in knowledge base {kb_id}")
+                raise EvaluationError(
+                    f"File name {file_name!r} is not unique in knowledge base {kb_id}"
+                )
     return {
         "schema_version": SCHEMA_VERSION,
         "case_id": f"{corpus_mode}-{index:05d}",
@@ -552,7 +585,9 @@ def generate_command(args: argparse.Namespace) -> int:
         if kb_document_counts[kb_id] == 1 or file_name_counts[(kb_id, file_name)] == 1:
             single_eligible.append(source)
     if not single_eligible:
-        raise EvaluationError("No source chunk can form an unambiguous single-document case")
+        raise EvaluationError(
+            "No source chunk can form an unambiguous single-document case"
+        )
 
     rng = random.Random(args.seed)
     generator = OpenAICompatibleGenerator(args.timeout, args.temperature)
@@ -561,7 +596,9 @@ def generate_command(args: argparse.Namespace) -> int:
     multi_count = min(remaining, round(remaining * args.multi_ratio))
     single_count = remaining - multi_count
     if multi_count and len(by_document) < 2:
-        raise EvaluationError("At least two documents are required for multi-document generation")
+        raise EvaluationError(
+            "At least two documents are required for multi-document generation"
+        )
 
     plans: list[tuple[list[dict[str, Any]], bool]] = []
     for _ in range(single_count):
@@ -621,11 +658,18 @@ def generate_command(args: argparse.Namespace) -> int:
     return 0
 
 
-def validate_cases(cases: list[dict[str, Any]], snapshot: dict[str, Any] | None = None) -> list[str]:
+def validate_cases(
+    cases: list[dict[str, Any]], snapshot: dict[str, Any] | None = None
+) -> list[str]:
     errors: list[str] = []
+    if not cases:
+        errors.append("dataset is empty")
+        return errors
     seen_ids: set[str] = set()
     snapshot_hash = snapshot.get("physical_corpus_sha256") if snapshot else None
-    valid_context_ids = {context_id(chunk) for chunk in (snapshot or {}).get("chunks") or []}
+    valid_context_ids = {
+        context_id(chunk) for chunk in (snapshot or {}).get("chunks") or []
+    }
     for index, case in enumerate(cases, start=1):
         prefix = f"case[{index}]"
         case_id = str(case.get("case_id") or "")
@@ -646,7 +690,9 @@ def validate_cases(cases: list[dict[str, Any]], snapshot: dict[str, Any] | None 
         gold = case.get("gold_context_ids") or []
         if case.get("expected_no_hit"):
             if gold:
-                errors.append(f"{prefix}: no-hit case must not contain gold_context_ids")
+                errors.append(
+                    f"{prefix}: no-hit case must not contain gold_context_ids"
+                )
         elif not gold:
             errors.append(f"{prefix}: ordinary case needs gold_context_ids")
         if snapshot_hash and case.get("physical_corpus_sha256") != snapshot_hash:
@@ -654,7 +700,9 @@ def validate_cases(cases: list[dict[str, Any]], snapshot: dict[str, Any] | None 
         if snapshot and not case.get("expected_no_hit"):
             missing = sorted(set(gold) - valid_context_ids)
             if missing:
-                errors.append(f"{prefix}: gold context ids missing from snapshot: {missing}")
+                errors.append(
+                    f"{prefix}: gold context ids missing from snapshot: {missing}"
+                )
     return errors
 
 
@@ -684,7 +732,11 @@ def canonical_result_ids(item: dict[str, Any]) -> tuple[str, str]:
     else:
         evidence_id = physical_id
     document_result_id = f"{kb_id}:{document_id}" if kb_id and document_id else ""
-    context_result_id = f"{kb_id}:{document_id}:{evidence_id}" if document_result_id and evidence_id else ""
+    context_result_id = (
+        f"{kb_id}:{document_id}:{evidence_id}"
+        if document_result_id and evidence_id
+        else ""
+    )
     return document_result_id, context_result_id
 
 
@@ -706,7 +758,11 @@ def reciprocal_rank(retrieved: list[str], gold: set[str]) -> float:
 def ndcg(retrieved: list[str], gold: set[str]) -> float:
     if not gold:
         return 0.0
-    dcg = sum(1.0 / math.log2(rank + 1) for rank, item in enumerate(retrieved, start=1) if item in gold)
+    dcg = sum(
+        1.0 / math.log2(rank + 1)
+        for rank, item in enumerate(retrieved, start=1)
+        if item in gold
+    )
     ideal_count = min(len(gold), len(retrieved))
     ideal = sum(1.0 / math.log2(rank + 1) for rank in range(1, ideal_count + 1))
     return dcg / ideal if ideal else 0.0
@@ -732,10 +788,280 @@ async def ragas_id_scores(retrieved: list[str], gold: list[str]) -> tuple[float,
         warnings.filterwarnings("ignore", message="Importing IDBasedContext")
         from ragas.metrics import IDBasedContextPrecision, IDBasedContextRecall
 
-    sample = SingleTurnSample(retrieved_context_ids=retrieved, reference_context_ids=gold)
+    sample = SingleTurnSample(
+        retrieved_context_ids=retrieved, reference_context_ids=gold
+    )
     ragas_precision = await IDBasedContextPrecision().single_turn_ascore(sample)
     ragas_recall = await IDBasedContextRecall().single_turn_ascore(sample)
     return float(ragas_precision), float(ragas_recall)
+
+
+METRIC_LABELS = {
+    "context_precision": "Chunk 精确率",
+    "context_recall": "Chunk 召回率",
+    "context_hit": "Chunk 命中率",
+    "context_mrr": "Chunk MRR",
+    "context_ndcg": "Chunk nDCG",
+    "document_recall": "文档召回率",
+    "document_hit": "文档命中率",
+    "group_recall": "证据组覆盖率",
+    "complete_evidence_group": "完整证据组命中率",
+    "ragas_id_context_precision": "Ragas ID 精确率",
+    "ragas_id_context_recall": "Ragas ID 召回率",
+}
+
+CORPUS_MODE_LABELS = {
+    "single_document_kb": "单文档知识库",
+    "single_document_filter": "单文档过滤",
+    "multi_document": "多文档",
+    "no_hit": "无答案",
+}
+
+
+def html_escape(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def format_percent(value: Any) -> str:
+    if value is None:
+        return "—"
+    return f"{float(value) * 100:.2f}%"
+
+
+def format_number(value: Any, digits: int = 2) -> str:
+    if value is None:
+        return "—"
+    return f"{float(value):.{digits}f}"
+
+
+def metric_keys_in_order(metrics: dict[str, Any]) -> list[str]:
+    return sorted(metrics, key=lambda value: int(value.lstrip("@")))
+
+
+def average_detail_metric(
+    rows: list[dict[str, Any]], key: str, metric: str
+) -> float | None:
+    values = [
+        item["metrics"][key][metric]
+        for item in rows
+        if isinstance(item.get("metrics", {}).get(key), dict)
+        and item["metrics"][key].get(metric) is not None
+    ]
+    if not values:
+        return None
+    return sum(float(value) for value in values) / len(values)
+
+
+def render_metric_table(
+    title: str,
+    metric_names: list[str],
+    summary_metrics: dict[str, Any],
+) -> str:
+    headers = "".join(
+        f"<th>{html_escape(METRIC_LABELS[name])}</th>" for name in metric_names
+    )
+    rows = []
+    for key in metric_keys_in_order(summary_metrics):
+        values = summary_metrics[key]
+        cells = "".join(
+            f"<td>{format_percent(values.get(name))}</td>" for name in metric_names
+        )
+        rows.append(f"<tr><th>K={html_escape(key.lstrip('@'))}</th>{cells}</tr>")
+    return (
+        f'<section><h2>{html_escape(title)}</h2><div class="table-wrap"><table>'
+        f"<thead><tr><th>截断位置</th>{headers}</tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table></div></section>"
+    )
+
+
+def render_recall_report(
+    summary: dict[str, Any], details: list[dict[str, Any]], output: Path
+) -> None:
+    summary_metrics = summary.get("metrics") or {}
+    metric_keys = metric_keys_in_order(summary_metrics)
+    display_key = metric_keys[-1] if metric_keys else None
+    display_label = f"K={display_key.lstrip('@')}" if display_key else "无 K 值"
+    request_failures = int(summary.get("request_failure_count") or 0)
+    ragas_failures = int(summary.get("ragas_failure_count") or 0)
+    status_ok = request_failures == 0 and ragas_failures == 0
+    status_text = "评测运行完成" if status_ok else "评测存在异常"
+    status_class = "good" if status_ok else "bad"
+    no_hit_count = sum(1 for item in details if item.get("corpus_mode") == "no_hit")
+
+    metric_sections = []
+    if summary_metrics:
+        metric_sections.extend(
+            [
+                render_metric_table(
+                    "Chunk 召回质量",
+                    [
+                        "context_precision",
+                        "context_recall",
+                        "context_hit",
+                        "context_mrr",
+                        "context_ndcg",
+                    ],
+                    summary_metrics,
+                ),
+                render_metric_table(
+                    "文档与多证据召回质量",
+                    [
+                        "document_recall",
+                        "document_hit",
+                        "group_recall",
+                        "complete_evidence_group",
+                    ],
+                    summary_metrics,
+                ),
+                render_metric_table(
+                    "Ragas ID 指标",
+                    ["ragas_id_context_precision", "ragas_id_context_recall"],
+                    summary_metrics,
+                ),
+            ]
+        )
+
+    group_rows = []
+    ordered_modes = [
+        "single_document_kb",
+        "single_document_filter",
+        "multi_document",
+        "no_hit",
+    ]
+    for mode in ordered_modes:
+        rows = [item for item in details if item.get("corpus_mode") == mode]
+        if not rows:
+            continue
+        successful = sum(bool(item.get("request_success")) for item in rows)
+        if mode == "no_hit":
+            no_hit_values = [
+                item.get("metrics", {}).get("no_hit_correct") for item in rows
+            ]
+            accuracy = sum(bool(value) for value in no_hit_values) / len(no_hit_values)
+            group_rows.append(
+                "<tr>"
+                f"<td>{html_escape(CORPUS_MODE_LABELS[mode])}</td><td>{len(rows)}</td><td>{successful}</td>"
+                f'<td colspan="4">无答案准确率 {format_percent(accuracy)}</td>'
+                "</tr>"
+            )
+            continue
+        key = display_key or ""
+        group_rows.append(
+            "<tr>"
+            f"<td>{html_escape(CORPUS_MODE_LABELS.get(mode, mode))}</td><td>{len(rows)}</td><td>{successful}</td>"
+            f"<td>{format_percent(average_detail_metric(rows, key, 'context_hit'))}</td>"
+            f"<td>{format_percent(average_detail_metric(rows, key, 'context_recall'))}</td>"
+            f"<td>{format_percent(average_detail_metric(rows, key, 'document_hit'))}</td>"
+            f"<td>{format_percent(average_detail_metric(rows, key, 'complete_evidence_group'))}</td>"
+            "</tr>"
+        )
+
+    case_rows = []
+    for item in details:
+        mode = str(item.get("corpus_mode") or "unknown")
+        metrics = item.get("metrics") or {}
+        if mode == "no_hit":
+            quality = "正确无结果" if metrics.get("no_hit_correct") else "误召回"
+            hit = "—"
+            mrr = "—"
+            complete = "—"
+        else:
+            row = metrics.get(display_key, {}) if display_key else {}
+            quality = "命中" if row.get("context_hit") else "未命中"
+            hit = format_percent(row.get("context_hit"))
+            mrr = format_number(row.get("context_mrr"), 3)
+            complete = format_percent(row.get("complete_evidence_group"))
+        request_status = "成功" if item.get("request_success") else "失败"
+        request_class = "good-text" if item.get("request_success") else "bad-text"
+        case_rows.append(
+            "<tr>"
+            f"<td><code>{html_escape(item.get('case_id'))}</code></td>"
+            f"<td>{html_escape(CORPUS_MODE_LABELS.get(mode, mode))}</td>"
+            f'<td class="{request_class}">{request_status}</td>'
+            f"<td>{format_number(item.get('elapsed_ms'), 1)} ms</td>"
+            f"<td>{int(item.get('result_count') or 0)}</td>"
+            f"<td>{html_escape(quality)}</td><td>{hit}</td><td>{mrr}</td><td>{complete}</td>"
+            "</tr>"
+        )
+
+    retrieval = summary.get("retrieval") or {}
+    rerank_threshold = retrieval.get("rerank_score_threshold")
+    rerank_label = "未设置" if rerank_threshold is None else rerank_threshold
+    report = f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>知识库召回效果评测报告</title>
+<style>
+:root {{ color-scheme: light; --ink:#172033; --muted:#637083; --line:#dce3ed; --panel:#f7f9fc; --good:#137a4b; --bad:#b42318; --accent:#3157d5; }}
+* {{ box-sizing:border-box; }}
+body {{ margin:0; background:#eef2f7; color:var(--ink); font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; }}
+main {{ width:min(1280px, calc(100% - 32px)); margin:32px auto; }}
+header, section {{ background:white; border:1px solid var(--line); border-radius:14px; padding:22px; margin-bottom:16px; box-shadow:0 6px 24px rgba(25,41,72,.05); }}
+h1 {{ margin:0 0 8px; font-size:28px; }} h2 {{ margin:0 0 14px; font-size:19px; }}
+p {{ margin:6px 0; }} .muted {{ color:var(--muted); }}
+.status {{ display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; }}
+.status.good {{ color:var(--good); background:#e8f7ef; }} .status.bad {{ color:var(--bad); background:#ffebe9; }}
+.cards {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:12px; margin-top:18px; }}
+.card {{ background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:14px; }}
+.card b {{ display:block; font-size:23px; margin-top:3px; }}
+.table-wrap {{ overflow:auto; }} table {{ width:100%; border-collapse:collapse; white-space:nowrap; }}
+th,td {{ border-bottom:1px solid var(--line); padding:10px 12px; text-align:right; }} th:first-child,td:first-child {{ text-align:left; }}
+thead th {{ background:var(--panel); color:#3c4960; position:sticky; top:0; }}
+code {{ font-family:"SFMono-Regular",Consolas,monospace; font-size:12px; }}
+.good-text {{ color:var(--good); font-weight:650; }} .bad-text {{ color:var(--bad); font-weight:650; }}
+.params {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:8px 18px; }}
+.params div {{ border-bottom:1px dashed var(--line); padding:6px 0; }}
+dl {{ display:grid; grid-template-columns:minmax(180px,260px) 1fr; gap:8px 18px; }} dt {{ font-weight:700; }} dd {{ margin:0; color:var(--muted); }}
+</style>
+</head>
+<body><main>
+<header>
+  <span class="status {status_class}">{status_text}</span>
+  <h1>知识库召回效果评测报告</h1>
+  <p class="muted">生成时间：{html_escape(summary.get("created_at"))}，本报告只评测检索与召回，不包含最终答案评测。</p>
+  <div class="cards">
+    <div class="card">评测 case<b>{int(summary.get("case_count") or 0)}</b></div>
+    <div class="card">请求成功<b>{int(summary.get("request_success_count") or 0)}</b></div>
+    <div class="card">请求失败<b>{request_failures}</b></div>
+    <div class="card">Ragas 计算失败<b>{ragas_failures}</b></div>
+    <div class="card">no-hit 样本<b>{no_hit_count}</b></div>
+    <div class="card">no-hit 准确率<b>{format_percent(summary.get("no_hit_accuracy"))}</b></div>
+  </div>
+</header>
+<section><h2>运行参数</h2><div class="params">
+  <div>数据集：<code>{html_escape(summary.get("dataset"))}</code></div>
+  <div>数据集 SHA256：<code>{html_escape(summary.get("dataset_sha256"))}</code></div>
+  <div>语料 SHA256：<code>{html_escape(summary.get("physical_corpus_sha256"))}</code></div>
+  <div>检索方式：{html_escape(retrieval.get("retrieve_type"))}</div>
+  <div>top_k / top_n：{html_escape(retrieval.get("top_k"))} / {html_escape(retrieval.get("top_n"))}</div>
+  <div>相似度阈值：{html_escape(retrieval.get("similarity_threshold"))}</div>
+  <div>向量权重：{html_escape(retrieval.get("vector_similarity_weight"))}</div>
+  <div>重排阈值：{html_escape(rerank_label)}</div>
+</div></section>
+{"".join(metric_sections)}
+<section><h2>分场景结果（{html_escape(display_label)}）</h2><div class="table-wrap"><table>
+<thead><tr><th>场景</th><th>case 数</th><th>请求成功</th><th>Chunk 命中率</th><th>Chunk 召回率</th><th>文档命中率</th><th>完整证据组</th></tr></thead>
+<tbody>{"".join(group_rows)}</tbody></table></div></section>
+<section><h2>逐 case 结果（{html_escape(display_label)}）</h2><div class="table-wrap"><table>
+<thead><tr><th>case ID</th><th>场景</th><th>请求</th><th>耗时</th><th>返回数</th><th>判定</th><th>Hit</th><th>MRR</th><th>完整证据组</th></tr></thead>
+<tbody>{"".join(case_rows)}</tbody></table></div></section>
+<section><h2>指标怎么看</h2><dl>
+  <dt>Chunk 精确率</dt><dd>前 K 个召回 chunk 中，黄金 chunk 所占比例。返回了很多无关 chunk 时会下降。</dd>
+  <dt>Chunk 召回率</dt><dd>黄金 chunk 中有多少被前 K 个结果覆盖。</dd>
+  <dt>Chunk 命中率</dt><dd>每个 case 前 K 个结果至少命中一个黄金 chunk 的比例。</dd>
+  <dt>MRR</dt><dd>第一个黄金 chunk 排名的倒数，越靠前越接近 100%。</dd>
+  <dt>nDCG</dt><dd>对多个黄金 chunk 的排名质量进行位置折损计算。</dd>
+  <dt>完整证据组</dt><dd>多文档问题所需的一整组证据是否都被召回。</dd>
+  <dt>Ragas ID 指标</dt><dd>Ragas 根据召回 context ID 与黄金 context ID 的集合关系计算的精确率和召回率。</dd>
+  <dt>no-hit 准确率</dt><dd>对预期知识库无法回答的问题，接口正确返回空列表的比例。</dd>
+</dl></section>
+<section><h2>数据局限</h2><p>黄金证据来自生成问题时选中的 source chunk，未自动穷举知识库中所有等价 chunk。`generated_unreviewed` 数据集适合建立基线和参数对比，不等同于经人工审核的绝对正确率。</p></section>
+</main></body></html>
+"""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(report, encoding="utf-8")
 
 
 def evaluate_command(args: argparse.Namespace) -> int:
@@ -766,7 +1092,9 @@ def evaluate_command(args: argparse.Namespace) -> int:
                 "vector_similarity_weight": args.vector_similarity_weight,
                 "rerank_score_threshold": args.rerank_score_threshold,
             }
-            payload = {key: value for key, value in payload.items() if value is not None}
+            payload = {
+                key: value for key, value in payload.items() if value is not None
+            }
             started = time.perf_counter()
             try:
                 response_items = client.post("/api/chunks/retrieval", payload)
@@ -806,7 +1134,9 @@ def evaluate_command(args: argparse.Namespace) -> int:
                 "metrics": {},
             }
             if case.get("expected_no_hit"):
-                result["metrics"]["no_hit_correct"] = not response_items
+                result["metrics"]["no_hit_correct"] = (
+                    request_error is None and not response_items
+                )
             else:
                 gold_contexts = list(case.get("gold_context_ids") or [])
                 gold_context_set = set(gold_contexts)
@@ -814,15 +1144,25 @@ def evaluate_command(args: argparse.Namespace) -> int:
                 for k in k_values:
                     retrieved_contexts = context_ids[:k]
                     retrieved_documents = document_ids[:k]
-                    group_recall, complete_group = group_scores(retrieved_contexts, case)
+                    group_recall, complete_group = group_scores(
+                        retrieved_contexts, case
+                    )
                     metric_row: dict[str, Any] = {
-                        "context_precision": precision(retrieved_contexts, gold_context_set),
+                        "context_precision": precision(
+                            retrieved_contexts, gold_context_set
+                        ),
                         "context_recall": recall(retrieved_contexts, gold_context_set),
                         "context_hit": bool(set(retrieved_contexts) & gold_context_set),
-                        "context_mrr": reciprocal_rank(retrieved_contexts, gold_context_set),
+                        "context_mrr": reciprocal_rank(
+                            retrieved_contexts, gold_context_set
+                        ),
                         "context_ndcg": ndcg(retrieved_contexts, gold_context_set),
-                        "document_recall": recall(retrieved_documents, gold_document_set),
-                        "document_hit": bool(set(retrieved_documents) & gold_document_set),
+                        "document_recall": recall(
+                            retrieved_documents, gold_document_set
+                        ),
+                        "document_hit": bool(
+                            set(retrieved_documents) & gold_document_set
+                        ),
                         "group_recall": group_recall,
                         "complete_evidence_group": complete_group,
                     }
@@ -842,10 +1182,19 @@ def evaluate_command(args: argparse.Namespace) -> int:
     summary_metrics: dict[str, Any] = {}
     for k in k_values:
         key = f"@{k}"
-        rows = [item["metrics"].get(key) for item in details if item["metrics"].get(key)]
+        rows = [
+            item["metrics"].get(key) for item in details if item["metrics"].get(key)
+        ]
         if not rows:
             continue
-        metric_names = sorted({name for row in rows for name, value in row.items() if isinstance(value, (int, float, bool))})
+        metric_names = sorted(
+            {
+                name
+                for row in rows
+                for name, value in row.items()
+                if isinstance(value, (int, float, bool))
+            }
+        )
         summary_metrics[key] = {
             name: sum(float(row[name]) for row in rows if row.get(name) is not None)
             / sum(1 for row in rows if row.get(name) is not None)
@@ -858,13 +1207,16 @@ def evaluate_command(args: argparse.Namespace) -> int:
         "created_at": utc_now(),
         "dataset": str(args.dataset),
         "dataset_sha256": hashlib.sha256(args.dataset.read_bytes()).hexdigest(),
-        "physical_corpus_sha256": cases[0].get("physical_corpus_sha256") if cases else None,
+        "physical_corpus_sha256": cases[0].get("physical_corpus_sha256")
+        if cases
+        else None,
         "case_count": len(cases),
         "request_success_count": len(cases) - failed_requests,
         "request_failure_count": failed_requests,
         "ragas_failure_count": ragas_failures,
         "no_hit_accuracy": (
-            sum(bool(item["metrics"]["no_hit_correct"]) for item in no_hit_rows) / len(no_hit_rows)
+            sum(bool(item["metrics"]["no_hit_correct"]) for item in no_hit_rows)
+            / len(no_hit_rows)
             if no_hit_rows
             else None
         ),
@@ -881,6 +1233,7 @@ def evaluate_command(args: argparse.Namespace) -> int:
     args.output_dir.mkdir(parents=True, exist_ok=True)
     write_jsonl(args.output_dir / "case_results.jsonl", details)
     write_json(args.output_dir / "summary.json", summary)
+    render_recall_report(summary, details, args.output_dir / "report.html")
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     if ragas_failures:
         return 3
@@ -891,8 +1244,14 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    snapshot = subparsers.add_parser("snapshot", help="Export a private corpus snapshot over HTTP")
-    snapshot.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    snapshot = subparsers.add_parser(
+        "snapshot", help="Export a private corpus snapshot over HTTP"
+    )
+    snapshot.add_argument(
+        "--base-url",
+        default=os.getenv("RAG_EVAL_BASE_URL"),
+        required=not os.getenv("RAG_EVAL_BASE_URL"),
+    )
     snapshot.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
     snapshot.add_argument("--kb-id", action="append", required=True)
     snapshot.add_argument("--output", type=Path, required=True)
@@ -900,7 +1259,9 @@ def build_parser() -> argparse.ArgumentParser:
     snapshot.add_argument("--include-unready", action="store_true")
     snapshot.set_defaults(handler=snapshot_command)
 
-    generate = subparsers.add_parser("generate", help="Generate a JSONL evaluation dataset from a snapshot")
+    generate = subparsers.add_parser(
+        "generate", help="Generate a JSONL evaluation dataset from a snapshot"
+    )
     generate.add_argument("--snapshot", type=Path, required=True)
     generate.add_argument("--output", type=Path, required=True)
     generate.add_argument("--count", type=int, default=50)
@@ -912,18 +1273,30 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--timeout", type=float, default=90.0)
     generate.set_defaults(handler=generate_command)
 
-    validate = subparsers.add_parser("validate", help="Validate a generated evaluation dataset")
+    validate = subparsers.add_parser(
+        "validate", help="Validate a generated evaluation dataset"
+    )
     validate.add_argument("--dataset", type=Path, required=True)
     validate.add_argument("--snapshot", type=Path)
     validate.set_defaults(handler=validate_command)
 
-    evaluate = subparsers.add_parser("evaluate", help="Run retrieval and calculate ID/ranking metrics")
-    evaluate.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    evaluate = subparsers.add_parser(
+        "evaluate", help="Run retrieval and calculate ID/ranking metrics"
+    )
+    evaluate.add_argument(
+        "--base-url",
+        default=os.getenv("RAG_EVAL_BASE_URL"),
+        required=not os.getenv("RAG_EVAL_BASE_URL"),
+    )
     evaluate.add_argument("--token-env", default=DEFAULT_TOKEN_ENV)
     evaluate.add_argument("--dataset", type=Path, required=True)
     evaluate.add_argument("--snapshot", type=Path)
     evaluate.add_argument("--output-dir", type=Path, required=True)
-    evaluate.add_argument("--retrieve-type", choices=["participle", "semantic", "hybrid"], default="hybrid")
+    evaluate.add_argument(
+        "--retrieve-type",
+        choices=["participle", "semantic", "hybrid"],
+        default="hybrid",
+    )
     evaluate.add_argument("--top-k", type=int, default=10)
     evaluate.add_argument("--top-n", type=int, default=20)
     evaluate.add_argument("--k", type=int, action="append")

--- a/api/scripts/rag_retrieval_load_test.py
+++ b/api/scripts/rag_retrieval_load_test.py
@@ -15,9 +15,13 @@ validates inputs and starts a headless Locust child using this same file.
 from __future__ import annotations
 
 import argparse
+import csv
+import html
 import json
 import os
 import random
+import re
+import statistics
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -73,7 +77,9 @@ def read_dataset(path: Path) -> list[dict[str, Any]]:
             try:
                 row = json.loads(line)
             except json.JSONDecodeError as exc:
-                raise LoadConfigError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+                raise LoadConfigError(
+                    f"Invalid JSONL at {path}:{line_number}: {exc}"
+                ) from exc
             if not isinstance(row, dict):
                 raise LoadConfigError(f"Expected object at {path}:{line_number}")
             rows.append(row)
@@ -86,11 +92,15 @@ def validate_runtime(config: dict[str, Any], samples: list[dict[str, Any]]) -> N
     retrieval = config.get("retrieval") or {}
     unknown_retrieval = set(retrieval) - RETRIEVAL_FIELDS
     if unknown_retrieval:
-        raise LoadConfigError(f"Unknown retrieval config fields: {sorted(unknown_retrieval)}")
+        raise LoadConfigError(
+            f"Unknown retrieval config fields: {sorted(unknown_retrieval)}"
+        )
     top_k = int(retrieval.get("top_k", 10))
     top_n = int(retrieval.get("top_n", 20))
     if not 1 <= top_k <= 100 or not 1 <= top_n <= 100 or top_n < top_k:
-        raise LoadConfigError("retrieval top_k/top_n must be within 1..100 and top_n >= top_k")
+        raise LoadConfigError(
+            "retrieval top_k/top_n must be within 1..100 and top_n >= top_k"
+        )
     load = config.get("load") or {}
     profile = str(load.get("profile") or "smoke")
     if profile not in {"smoke", "baseline", "staircase", "soak"}:
@@ -103,9 +113,13 @@ def validate_runtime(config: dict[str, Any], samples: list[dict[str, Any]]) -> N
             if not isinstance(stage, dict):
                 raise LoadConfigError(f"stage[{index}] must be an object")
             if int(stage.get("users", 0)) < 1 or float(stage.get("spawn_rate", 0)) <= 0:
-                raise LoadConfigError(f"stage[{index}] users/spawn_rate must be positive")
+                raise LoadConfigError(
+                    f"stage[{index}] users/spawn_rate must be positive"
+                )
             if float(stage.get("duration_seconds", 0)) <= 0:
-                raise LoadConfigError(f"stage[{index}] duration_seconds must be positive")
+                raise LoadConfigError(
+                    f"stage[{index}] duration_seconds must be positive"
+                )
     for index, sample in enumerate(samples, start=1):
         if not str(sample.get("query") or "").strip():
             raise LoadConfigError(f"sample[{index}] has an empty query")
@@ -114,10 +128,14 @@ def validate_runtime(config: dict[str, Any], samples: list[dict[str, Any]]) -> N
             raise LoadConfigError(f"sample[{index}] target.kb_ids must be non-empty")
         unknown_target = set(target) - TARGET_FIELDS
         if unknown_target:
-            raise LoadConfigError(f"sample[{index}] has unknown target fields: {sorted(unknown_target)}")
+            raise LoadConfigError(
+                f"sample[{index}] has unknown target fields: {sorted(unknown_target)}"
+            )
         weight = sample.get("load_weight", 1)
         if not isinstance(weight, int) or weight < 1:
-            raise LoadConfigError(f"sample[{index}] load_weight must be a positive integer")
+            raise LoadConfigError(
+                f"sample[{index}] load_weight must be a positive integer"
+            )
 
 
 def safe_write_json(path: Path, value: Any) -> None:
@@ -127,10 +145,351 @@ def safe_write_json(path: Path, value: Any) -> None:
         handle.write("\n")
 
 
+def read_json_object(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise LoadConfigError(f"Expected object in {path}")
+    return value
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def html_escape(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def parse_float(value: Any) -> float | None:
+    if value in (None, "", "N/A"):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_int(value: Any) -> int:
+    parsed = parse_float(value)
+    return int(parsed) if parsed is not None else 0
+
+
+def format_number(value: Any, digits: int = 2) -> str:
+    if value is None:
+        return "—"
+    return f"{float(value):.{digits}f}"
+
+
+def format_percent(value: Any) -> str:
+    if value is None:
+        return "—"
+    return f"{float(value) * 100:.2f}%"
+
+
+def summary_from_stats(output_dir: Path) -> dict[str, Any] | None:
+    rows = read_csv_rows(output_dir / "locust_stats.csv")
+    aggregate = next(
+        (row for row in reversed(rows) if row.get("Name") == "Aggregated"), None
+    )
+    if not aggregate:
+        return None
+    request_count = parse_int(aggregate.get("Request Count"))
+    failure_count = parse_int(aggregate.get("Failure Count"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "profile": None,
+        "request_count": request_count,
+        "success_count": request_count - failure_count,
+        "failure_count": failure_count,
+        "failure_ratio": failure_count / request_count if request_count else 1.0,
+        "achieved_rps": parse_float(aggregate.get("Requests/s")) or 0.0,
+        "latency_ms": {
+            "p50": parse_float(aggregate.get("50%")),
+            "p90": parse_float(aggregate.get("90%")),
+            "p95": parse_float(aggregate.get("95%")),
+            "p99": parse_float(aggregate.get("99%")),
+            "max": parse_float(aggregate.get("Max Response Time")),
+        },
+        "gate_failures": [],
+        "passed": None,
+    }
+
+
+def stage_statistics(
+    output_dir: Path, manifest: dict[str, Any]
+) -> list[dict[str, Any]]:
+    if manifest.get("profile") != "staircase":
+        return []
+    rows = [
+        row
+        for row in read_csv_rows(output_dir / "locust_stats_history.csv")
+        if row.get("Name") == "Aggregated" and parse_int(row.get("User Count")) > 0
+    ]
+    expected_users = [
+        int(stage.get("users", 0))
+        for stage in (manifest.get("load") or {}).get("stages") or []
+        if int(stage.get("users", 0)) > 0
+    ]
+    users = list(
+        dict.fromkeys(
+            expected_users or sorted({parse_int(row.get("User Count")) for row in rows})
+        )
+    )
+    results = []
+    for user_count in users:
+        group = [row for row in rows if parse_int(row.get("User Count")) == user_count]
+        if not group:
+            results.append(
+                {
+                    "users": user_count,
+                    "samples": 0,
+                    "rps": None,
+                    "p50": None,
+                    "p95": None,
+                }
+            )
+            continue
+
+        def median_field(field: str) -> float | None:
+            values = [
+                value
+                for row in group
+                if (value := parse_float(row.get(field))) is not None
+            ]
+            return float(statistics.median(values)) if values else None
+
+        results.append(
+            {
+                "users": user_count,
+                "samples": len(group),
+                "rps": median_field("Requests/s"),
+                "p50": median_field("50%"),
+                "p95": median_field("95%"),
+            }
+        )
+    return results
+
+
+def failure_statistics(output_dir: Path) -> list[dict[str, Any]]:
+    grouped: dict[str, int] = {}
+    for row in read_csv_rows(output_dir / "locust_failures.csv"):
+        raw_error = str(row.get("Error") or "unknown")
+        match = re.search(
+            r"(?:http_\d+|invalid_[a-z_]+|business_code_nonzero|single_scope_violation)",
+            raw_error,
+        )
+        error = match.group(0) if match else raw_error
+        grouped[error] = grouped.get(error, 0) + parse_int(row.get("Occurrences"))
+    return [
+        {"error": error, "count": count} for error, count in sorted(grouped.items())
+    ]
+
+
+GATE_LABELS = {
+    "min_requests": "最小请求数",
+    "max_failure_ratio": "最大失败率",
+    "max_p95_ms": "p95 最大耗时",
+    "min_achieved_rps": "最小实际 RPS",
+}
+
+PROFILE_LABELS = {
+    "smoke": "冒烟测试",
+    "baseline": "基线测试",
+    "staircase": "阶梯加压",
+    "soak": "稳定性压测",
+}
+
+
+def gate_actual_value(name: str, summary: dict[str, Any]) -> Any:
+    if name == "min_requests":
+        return summary.get("request_count")
+    if name == "max_failure_ratio":
+        return summary.get("failure_ratio")
+    if name == "max_p95_ms":
+        return (summary.get("latency_ms") or {}).get("p95")
+    if name == "min_achieved_rps":
+        return summary.get("achieved_rps")
+    return None
+
+
+def format_gate_value(name: str, value: Any) -> str:
+    if name == "max_failure_ratio":
+        return format_percent(value)
+    if name == "max_p95_ms":
+        return f"{format_number(value, 1)} ms"
+    if name == "min_achieved_rps":
+        return format_number(value, 2)
+    return html_escape(value)
+
+
+def preserve_locust_report(output_dir: Path) -> Path | None:
+    report = output_dir / "report.html"
+    locust_report = output_dir / "locust-report.html"
+    if locust_report.exists():
+        return locust_report
+    if report.exists():
+        prefix = report.read_text(encoding="utf-8", errors="replace")[:2000]
+        if "<title>Locust" in prefix:
+            report.replace(locust_report)
+            return locust_report
+    return None
+
+
+def render_performance_report(output_dir: Path) -> tuple[Path, bool]:
+    output_dir = output_dir.resolve()
+    manifest_path = output_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise LoadConfigError(f"Missing manifest.json in {output_dir}")
+    manifest = read_json_object(manifest_path)
+    summary_path = output_dir / "summary.json"
+    completed_run = summary_path.exists()
+    summary = (
+        read_json_object(summary_path)
+        if completed_run
+        else summary_from_stats(output_dir)
+    )
+    if summary is None:
+        raise LoadConfigError(
+            f"Missing summary.json and usable locust_stats.csv in {output_dir}"
+        )
+
+    locust_report = preserve_locust_report(output_dir)
+    failures = failure_statistics(output_dir)
+    stages = stage_statistics(output_dir, manifest)
+    passed = summary.get("passed") if completed_run else None
+    if not completed_run:
+        status_text, status_class = "运行未完整结束", "warn"
+    elif passed:
+        status_text, status_class = "性能门禁通过", "good"
+    else:
+        status_text, status_class = "性能门禁未通过", "bad"
+
+    gate_failures = set(summary.get("gate_failures") or [])
+    gate_rows = []
+    for name, expected in (manifest.get("gates") or {}).items():
+        actual = gate_actual_value(name, summary)
+        if not completed_run:
+            result = "未判定"
+            result_class = "warn-text"
+        elif name in gate_failures:
+            result = "未通过"
+            result_class = "bad-text"
+        else:
+            result = "通过"
+            result_class = "good-text"
+        gate_rows.append(
+            "<tr>"
+            f"<td>{html_escape(GATE_LABELS.get(name, name))}</td>"
+            f"<td>{format_gate_value(name, expected)}</td>"
+            f"<td>{format_gate_value(name, actual)}</td>"
+            f'<td class="{result_class}">{result}</td>'
+            "</tr>"
+        )
+    if not gate_rows:
+        gate_rows.append('<tr><td colspan="4">本次运行未配置性能门禁</td></tr>')
+
+    failure_rows = [
+        f"<tr><td><code>{html_escape(item['error'])}</code></td><td>{item['count']}</td></tr>"
+        for item in failures
+    ] or ['<tr><td colspan="2">未记录请求失败</td></tr>']
+    stage_rows = [
+        "<tr>"
+        f"<td>{item['users']}</td><td>{item['samples']}</td>"
+        f"<td>{format_number(item['rps'], 2)}</td>"
+        f"<td>{format_number(item['p50'], 1)} ms</td>"
+        f"<td>{format_number(item['p95'], 1)} ms</td>"
+        "</tr>"
+        for item in stages
+    ]
+
+    load = manifest.get("load") or {}
+    retrieval = manifest.get("retrieval") or {}
+    latency = summary.get("latency_ms") or {}
+    profile = str(manifest.get("profile") or summary.get("profile") or "unknown")
+    raw_report_link = (
+        '<a href="locust-report.html">Locust 原始英文报告</a>'
+        if locust_report
+        else "Locust 原始报告未生成"
+    )
+    incomplete_note = ""
+    if not completed_run:
+        incomplete_note = (
+            '<p class="notice">本次运行没有生成 <code>summary.json</code>，'
+            "页面中的请求与延迟数据来自 <code>locust_stats.csv</code>，不判定性能门禁。</p>"
+        )
+    stage_section = ""
+    if stages:
+        stage_section = f"""<section><h2>阶梯分档结果</h2>
+<p class="muted">RPS、p50 和 p95 取该并发档位秒级历史样本的中位数，避免把不同并发档聚合成一个值。</p>
+<div class="table-wrap"><table><thead><tr><th>并发用户</th><th>历史样本数</th><th>RPS</th><th>p50</th><th>p95</th></tr></thead>
+<tbody>{"".join(stage_rows)}</tbody></table></div></section>"""
+
+    report = f"""<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>知识库检索性能测试报告</title>
+<style>
+:root {{ color-scheme:light; --ink:#172033; --muted:#637083; --line:#dce3ed; --panel:#f7f9fc; --good:#137a4b; --bad:#b42318; --warn:#9a6700; }}
+* {{ box-sizing:border-box; }} body {{ margin:0; background:#eef2f7; color:var(--ink); font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI","PingFang SC","Microsoft YaHei",sans-serif; }}
+main {{ width:min(1200px,calc(100% - 32px)); margin:32px auto; }} header,section {{ background:#fff; border:1px solid var(--line); border-radius:14px; padding:22px; margin-bottom:16px; box-shadow:0 6px 24px rgba(25,41,72,.05); }}
+h1 {{ margin:0 0 8px; font-size:28px; }} h2 {{ margin:0 0 14px; font-size:19px; }} p {{ margin:6px 0; }} .muted {{ color:var(--muted); }}
+.status {{ display:inline-block; padding:4px 10px; border-radius:999px; font-weight:700; }} .status.good {{ color:var(--good); background:#e8f7ef; }} .status.bad {{ color:var(--bad); background:#ffebe9; }} .status.warn {{ color:var(--warn); background:#fff4ce; }}
+.cards {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:12px; margin-top:18px; }} .card {{ background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:14px; }} .card b {{ display:block; font-size:22px; margin-top:3px; }}
+.params {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:8px 18px; }} .params div {{ border-bottom:1px dashed var(--line); padding:6px 0; }}
+.table-wrap {{ overflow:auto; }} table {{ width:100%; border-collapse:collapse; white-space:nowrap; }} th,td {{ border-bottom:1px solid var(--line); padding:10px 12px; text-align:right; }} th:first-child,td:first-child {{ text-align:left; }} thead th {{ background:var(--panel); color:#3c4960; }}
+.good-text {{ color:var(--good); font-weight:650; }} .bad-text {{ color:var(--bad); font-weight:650; }} .warn-text {{ color:var(--warn); font-weight:650; }}
+.notice {{ border-left:4px solid var(--warn); padding:10px 14px; background:#fff9e8; }} code {{ font-family:"SFMono-Regular",Consolas,monospace; font-size:12px; }} a {{ color:#3157d5; }}
+</style>
+</head><body><main>
+<header><span class="status {status_class}">{status_text}</span><h1>知识库检索性能测试报告</h1>
+<p class="muted">测试类型：{html_escape(PROFILE_LABELS.get(profile, profile))}，开始记录时间：{html_escape(manifest.get("created_at"))}</p>
+{incomplete_note}
+<div class="cards">
+  <div class="card">请求数<b>{int(summary.get("request_count") or 0)}</b></div>
+  <div class="card">成功数<b>{int(summary.get("success_count") or 0)}</b></div>
+  <div class="card">失败数<b>{int(summary.get("failure_count") or 0)}</b></div>
+  <div class="card">失败率<b>{format_percent(summary.get("failure_ratio"))}</b></div>
+  <div class="card">实际 RPS<b>{format_number(summary.get("achieved_rps"), 2)}</b></div>
+</div></header>
+<section><h2>延迟指标</h2><div class="cards">
+  <div class="card">p50<b>{format_number(latency.get("p50"), 1)} ms</b></div>
+  <div class="card">p90<b>{format_number(latency.get("p90"), 1)} ms</b></div>
+  <div class="card">p95<b>{format_number(latency.get("p95"), 1)} ms</b></div>
+  <div class="card">p99<b>{format_number(latency.get("p99"), 1)} ms</b></div>
+  <div class="card">最大耗时<b>{format_number(latency.get("max"), 1)} ms</b></div>
+</div></section>
+<section><h2>运行参数</h2><div class="params">
+  <div>目标环境：{html_escape(manifest.get("base_url"))}</div><div>数据集 case：{html_escape(manifest.get("case_count"))}</div>
+  <div>负载 profile：{html_escape(profile)}</div><div>并发用户：{html_escape(load.get("users") or "阶梯分档")}</div>
+  <div>运行时间：{html_escape(load.get("run_time") or "见阶梯配置")}</div><div>请求超时：{html_escape(load.get("request_timeout_seconds") or 60)} s</div>
+  <div>检索方式：{html_escape(retrieval.get("retrieve_type") or "default")}</div><div>top_k / top_n：{html_escape(retrieval.get("top_k") or 10)} / {html_escape(retrieval.get("top_n") or 20)}</div>
+  <div>相似度阈值：{html_escape(retrieval.get("similarity_threshold"))}</div><div>向量权重：{html_escape(retrieval.get("vector_similarity_weight"))}</div>
+</div></section>
+<section><h2>性能门禁</h2><div class="table-wrap"><table><thead><tr><th>门禁</th><th>要求</th><th>实际</th><th>结果</th></tr></thead><tbody>{"".join(gate_rows)}</tbody></table></div></section>
+{stage_section}
+<section><h2>请求失败</h2><div class="table-wrap"><table><thead><tr><th>失败类型</th><th>次数</th></tr></thead><tbody>{"".join(failure_rows)}</tbody></table></div></section>
+<section><h2>原始产物</h2><p>{raw_report_link}</p><p class="muted">机器可读结果仍保存在 <code>summary.json</code>、<code>manifest.json</code> 和 <code>locust_*.csv</code>中。</p></section>
+<section><h2>口径说明</h2><p>RPS 表示每秒实际完成的请求数。p95 表示 95% 的已完成请求耗时不超过该值。性能成功只说明 HTTP 和返回结构正常，召回内容是否正确由召回效果评测脚本判定。</p></section>
+</main></body></html>
+"""
+    report_path = output_dir / "report.html"
+    report_path.write_text(report, encoding="utf-8")
+    return report_path, completed_run
+
+
 class Runtime:
     """Immutable runtime inputs loaded by the Locust child process."""
 
-    def __init__(self, dataset_path: Path, config_path: Path, output_dir: Path, base_url: str):
+    def __init__(
+        self, dataset_path: Path, config_path: Path, output_dir: Path, base_url: str
+    ):
         self.dataset_path = dataset_path
         self.config_path = config_path
         self.output_dir = output_dir
@@ -144,7 +503,9 @@ class Runtime:
         self.profile = str(self.load.get("profile") or "smoke")
         self.endpoint = str(self.config.get("endpoint") or "/api/chunks/retrieval")
         if self.endpoint != "/api/chunks/retrieval":
-            raise LoadConfigError("Only /api/chunks/retrieval is supported in the first release")
+            raise LoadConfigError(
+                "Only /api/chunks/retrieval is supported in the first release"
+            )
         seed = int(self.config.get("seed", 20260715))
         self.random = random.Random(seed)
         self.weights = [int(sample.get("load_weight", 1)) for sample in self.samples]
@@ -225,7 +586,10 @@ class RetrievalUser(HttpUser):
             if not isinstance(envelope.get("data"), list):
                 response.failure("invalid_data_schema")
                 return
-            if sample.get("corpus_mode") in {"single_document_kb", "single_document_filter"}:
+            if sample.get("corpus_mode") in {
+                "single_document_kb",
+                "single_document_filter",
+            }:
                 allowed = {
                     value.split(":", 1)[-1]
                     for value in sample.get("gold_document_ids") or []
@@ -285,9 +649,13 @@ def build_summary(environment: Any) -> tuple[dict[str, Any], list[str]]:
     if failure_ratio > float(gates.get("max_failure_ratio", 1.0)):
         failures.append("max_failure_ratio")
     p95 = summary["latency_ms"]["p95"]
-    if gates.get("max_p95_ms") is not None and (p95 is None or p95 > float(gates["max_p95_ms"])):
+    if gates.get("max_p95_ms") is not None and (
+        p95 is None or p95 > float(gates["max_p95_ms"])
+    ):
         failures.append("max_p95_ms")
-    if gates.get("min_achieved_rps") is not None and summary["achieved_rps"] < float(gates["min_achieved_rps"]):
+    if gates.get("min_achieved_rps") is not None and summary["achieved_rps"] < float(
+        gates["min_achieved_rps"]
+    ):
         failures.append("min_achieved_rps")
     summary["gate_failures"] = failures
     summary["passed"] = not failures
@@ -310,14 +678,26 @@ def default_output_dir() -> Path:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dataset", type=Path, required=True)
-    parser.add_argument("--config", type=Path, required=True)
-    parser.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    parser.add_argument("--dataset", type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"))
     parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--render-report-dir",
+        type=Path,
+        help="Render a Chinese report from an existing performance run without starting Locust",
+    )
     return parser
 
 
 def run_parent(args: argparse.Namespace) -> int:
+    missing = [
+        name for name in ("dataset", "config", "base_url") if not getattr(args, name)
+    ]
+    if missing:
+        raise LoadConfigError(
+            f"Missing required run arguments: {', '.join('--' + name.replace('_', '-') for name in missing)}"
+        )
     token = os.getenv(TOKEN_ENV, "").strip()
     if not token:
         raise LoadConfigError(f"Missing authentication token in {TOKEN_ENV}")
@@ -366,7 +746,7 @@ def run_parent(args: argparse.Namespace) -> int:
         str(stats_prefix),
         "--csv-full-history",
         "--html",
-        str(output_dir / "report.html"),
+        str(output_dir / "locust-report.html"),
         "--json-file",
         str(output_dir / "locust"),
     ]
@@ -382,12 +762,34 @@ def run_parent(args: argparse.Namespace) -> int:
             ]
         )
     completed = subprocess.run(command, env=env, check=False)
+    report_path, _ = render_performance_report(output_dir)
+    print(
+        json.dumps(
+            {"report": str(report_path), "locust_exit_code": completed.returncode},
+            ensure_ascii=False,
+        )
+    )
     return int(completed.returncode)
 
 
 def main() -> int:
     args = build_parser().parse_args()
     try:
+        if args.render_report_dir:
+            if any((args.dataset, args.config, args.output_dir)):
+                raise LoadConfigError(
+                    "--render-report-dir cannot be combined with --dataset, --config, or --output-dir"
+                )
+            report_path, completed_run = render_performance_report(
+                args.render_report_dir
+            )
+            print(
+                json.dumps(
+                    {"report": str(report_path), "completed_run": completed_run},
+                    ensure_ascii=False,
+                )
+            )
+            return 0
         return run_parent(args)
     except (LoadConfigError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/api/scripts/rag_retrieval_load_test.py
+++ b/api/scripts/rag_retrieval_load_test.py
@@ -47,6 +47,12 @@ RETRIEVAL_FIELDS = {
     "rerank_score_threshold",
 }
 TARGET_FIELDS = {"kb_ids", "file_names_filter"}
+GATE_FIELDS = {
+    "min_requests",
+    "max_failure_ratio",
+    "max_p95_ms",
+    "min_achieved_rps",
+}
 
 
 class LoadConfigError(RuntimeError):
@@ -120,6 +126,12 @@ def validate_runtime(config: dict[str, Any], samples: list[dict[str, Any]]) -> N
                 raise LoadConfigError(
                     f"stage[{index}] duration_seconds must be positive"
                 )
+    gates = config.get("gates") or {}
+    if not isinstance(gates, dict):
+        raise LoadConfigError("gates must be an object")
+    unknown_gates = set(gates) - GATE_FIELDS
+    if unknown_gates:
+        raise LoadConfigError(f"Unknown performance gates: {sorted(unknown_gates)}")
     for index, sample in enumerate(samples, start=1):
         if not str(sample.get("query") or "").strip():
             raise LoadConfigError(f"sample[{index}] has an empty query")

--- a/api/scripts/rag_retrieval_load_test.py
+++ b/api/scripts/rag_retrieval_load_test.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "locust==2.45.0",
+#   "PyYAML==6.0.2",
+# ]
+# ///
+"""Standalone Locust runner for the MemoryBear retrieval HTTP endpoint.
+
+Run with ``uv run rag_retrieval_load_test.py --help``. The parent process
+validates inputs and starts a headless Locust child using this same file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from locust import HttpUser, LoadTestShape, events, task
+
+
+SCHEMA_VERSION = 1
+TOKEN_ENV = "RAG_EVAL_JWT_TOKEN"
+CHILD_DATASET_ENV = "RAG_LOAD_DATASET"
+CHILD_CONFIG_ENV = "RAG_LOAD_CONFIG"
+CHILD_OUTPUT_ENV = "RAG_LOAD_OUTPUT_DIR"
+CHILD_BASE_URL_ENV = "RAG_LOAD_BASE_URL"
+RETRIEVAL_FIELDS = {
+    "retrieve_type",
+    "top_k",
+    "top_n",
+    "similarity_threshold",
+    "vector_similarity_weight",
+    "rerank_score_threshold",
+}
+TARGET_FIELDS = {"kb_ids", "file_names_filter"}
+
+
+class LoadConfigError(RuntimeError):
+    """Raised when the load test cannot start with valid inputs."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def read_config(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        if path.suffix.lower() == ".json":
+            value = json.load(handle)
+        else:
+            value = yaml.safe_load(handle)
+    if not isinstance(value, dict):
+        raise LoadConfigError(f"Expected object in config {path}")
+    return value
+
+
+def read_dataset(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise LoadConfigError(f"Invalid JSONL at {path}:{line_number}: {exc}") from exc
+            if not isinstance(row, dict):
+                raise LoadConfigError(f"Expected object at {path}:{line_number}")
+            rows.append(row)
+    if not rows:
+        raise LoadConfigError("Dataset is empty")
+    return rows
+
+
+def validate_runtime(config: dict[str, Any], samples: list[dict[str, Any]]) -> None:
+    retrieval = config.get("retrieval") or {}
+    unknown_retrieval = set(retrieval) - RETRIEVAL_FIELDS
+    if unknown_retrieval:
+        raise LoadConfigError(f"Unknown retrieval config fields: {sorted(unknown_retrieval)}")
+    top_k = int(retrieval.get("top_k", 10))
+    top_n = int(retrieval.get("top_n", 20))
+    if not 1 <= top_k <= 100 or not 1 <= top_n <= 100 or top_n < top_k:
+        raise LoadConfigError("retrieval top_k/top_n must be within 1..100 and top_n >= top_k")
+    load = config.get("load") or {}
+    profile = str(load.get("profile") or "smoke")
+    if profile not in {"smoke", "baseline", "staircase", "soak"}:
+        raise LoadConfigError(f"Unsupported load profile: {profile}")
+    if profile == "staircase":
+        stages = load.get("stages")
+        if not isinstance(stages, list) or not stages:
+            raise LoadConfigError("staircase profile requires at least one stage")
+        for index, stage in enumerate(stages, start=1):
+            if not isinstance(stage, dict):
+                raise LoadConfigError(f"stage[{index}] must be an object")
+            if int(stage.get("users", 0)) < 1 or float(stage.get("spawn_rate", 0)) <= 0:
+                raise LoadConfigError(f"stage[{index}] users/spawn_rate must be positive")
+            if float(stage.get("duration_seconds", 0)) <= 0:
+                raise LoadConfigError(f"stage[{index}] duration_seconds must be positive")
+    for index, sample in enumerate(samples, start=1):
+        if not str(sample.get("query") or "").strip():
+            raise LoadConfigError(f"sample[{index}] has an empty query")
+        target = sample.get("target")
+        if not isinstance(target, dict) or not target.get("kb_ids"):
+            raise LoadConfigError(f"sample[{index}] target.kb_ids must be non-empty")
+        unknown_target = set(target) - TARGET_FIELDS
+        if unknown_target:
+            raise LoadConfigError(f"sample[{index}] has unknown target fields: {sorted(unknown_target)}")
+        weight = sample.get("load_weight", 1)
+        if not isinstance(weight, int) or weight < 1:
+            raise LoadConfigError(f"sample[{index}] load_weight must be a positive integer")
+
+
+def safe_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(value, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+class Runtime:
+    """Immutable runtime inputs loaded by the Locust child process."""
+
+    def __init__(self, dataset_path: Path, config_path: Path, output_dir: Path, base_url: str):
+        self.dataset_path = dataset_path
+        self.config_path = config_path
+        self.output_dir = output_dir
+        self.base_url = base_url.rstrip("/")
+        self.samples = read_dataset(dataset_path)
+        self.config = read_config(config_path)
+        validate_runtime(self.config, self.samples)
+        self.retrieval = dict(self.config.get("retrieval") or {})
+        self.load = dict(self.config.get("load") or {})
+        self.gates = dict(self.config.get("gates") or {})
+        self.profile = str(self.load.get("profile") or "smoke")
+        self.endpoint = str(self.config.get("endpoint") or "/api/chunks/retrieval")
+        if self.endpoint != "/api/chunks/retrieval":
+            raise LoadConfigError("Only /api/chunks/retrieval is supported in the first release")
+        seed = int(self.config.get("seed", 20260715))
+        self.random = random.Random(seed)
+        self.weights = [int(sample.get("load_weight", 1)) for sample in self.samples]
+
+    def choose_sample(self) -> dict[str, Any]:
+        return self.random.choices(self.samples, weights=self.weights, k=1)[0]
+
+
+def load_child_runtime() -> Runtime | None:
+    dataset = os.getenv(CHILD_DATASET_ENV)
+    config = os.getenv(CHILD_CONFIG_ENV)
+    output = os.getenv(CHILD_OUTPUT_ENV)
+    base_url = os.getenv(CHILD_BASE_URL_ENV)
+    if not all((dataset, config, output, base_url)):
+        return None
+    return Runtime(Path(dataset), Path(config), Path(output), base_url)
+
+
+RUNTIME = load_child_runtime()
+
+
+class RetrievalUser(HttpUser):
+    """Locust user that calls only the deployed retrieval HTTP contract."""
+
+    abstract = RUNTIME is None
+    host = RUNTIME.base_url if RUNTIME else None
+
+    def on_start(self) -> None:
+        token = os.getenv(TOKEN_ENV, "").strip()
+        if not token:
+            raise LoadConfigError(f"Missing authentication token in {TOKEN_ENV}")
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def wait_time(self) -> float:
+        return float(RUNTIME.load.get("wait_seconds", 0.0)) if RUNTIME else 0.0
+
+    @task
+    def retrieve(self) -> None:
+        if RUNTIME is None:
+            return
+        sample = RUNTIME.choose_sample()
+        payload = {
+            "query": sample["query"],
+            **sample["target"],
+            **RUNTIME.retrieval,
+        }
+        request_name = "/api/chunks/retrieval|{}|{}".format(
+            sample.get("corpus_mode", "unknown"),
+            RUNTIME.retrieval.get("retrieve_type", "default"),
+        )
+        timeout = float(RUNTIME.load.get("request_timeout_seconds", 60.0))
+        with self.client.post(
+            RUNTIME.endpoint,
+            json=payload,
+            headers=self.headers,
+            name=request_name,
+            timeout=timeout,
+            catch_response=True,
+        ) as response:
+            if not 200 <= response.status_code < 300:
+                response.failure(f"http_{response.status_code}")
+                return
+            try:
+                envelope = response.json()
+            except ValueError:
+                response.failure("invalid_json")
+                return
+            if not isinstance(envelope, dict):
+                response.failure("invalid_envelope")
+                return
+            if envelope.get("code") != 0:
+                response.failure("business_code_nonzero")
+                return
+            if not isinstance(envelope.get("data"), list):
+                response.failure("invalid_data_schema")
+                return
+            if sample.get("corpus_mode") in {"single_document_kb", "single_document_filter"}:
+                allowed = {
+                    value.split(":", 1)[-1]
+                    for value in sample.get("gold_document_ids") or []
+                }
+                returned = {
+                    str((item.get("metadata") or {}).get("document_id") or "")
+                    for item in envelope["data"]
+                    if isinstance(item, dict)
+                }
+                returned.discard("")
+                if allowed and not returned <= allowed:
+                    response.failure("single_scope_violation")
+
+
+if RUNTIME is not None and RUNTIME.profile == "staircase":
+
+    class ConfiguredStaircaseShape(LoadTestShape):
+        """Load shape whose cumulative stages are supplied by the external config."""
+
+        def tick(self) -> tuple[int, float] | None:
+            elapsed = self.get_run_time()
+            cumulative = 0.0
+            stages = RUNTIME.load.get("stages") or []
+            for stage in stages:
+                cumulative += float(stage.get("duration_seconds", 0))
+                if elapsed < cumulative:
+                    return int(stage["users"]), float(stage.get("spawn_rate", 1))
+            return None
+
+
+def build_summary(environment: Any) -> tuple[dict[str, Any], list[str]]:
+    total = environment.stats.total
+    request_count = int(total.num_requests)
+    failure_count = int(total.num_failures)
+    failure_ratio = failure_count / request_count if request_count else 1.0
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "profile": RUNTIME.profile if RUNTIME else None,
+        "request_count": request_count,
+        "success_count": request_count - failure_count,
+        "failure_count": failure_count,
+        "failure_ratio": failure_ratio,
+        "achieved_rps": float(total.total_rps),
+        "latency_ms": {
+            "p50": total.get_response_time_percentile(0.50),
+            "p90": total.get_response_time_percentile(0.90),
+            "p95": total.get_response_time_percentile(0.95),
+            "p99": total.get_response_time_percentile(0.99),
+            "max": total.max_response_time,
+        },
+    }
+    failures: list[str] = []
+    gates = RUNTIME.gates if RUNTIME else {}
+    if request_count < int(gates.get("min_requests", 1)):
+        failures.append("min_requests")
+    if failure_ratio > float(gates.get("max_failure_ratio", 1.0)):
+        failures.append("max_failure_ratio")
+    p95 = summary["latency_ms"]["p95"]
+    if gates.get("max_p95_ms") is not None and (p95 is None or p95 > float(gates["max_p95_ms"])):
+        failures.append("max_p95_ms")
+    if gates.get("min_achieved_rps") is not None and summary["achieved_rps"] < float(gates["min_achieved_rps"]):
+        failures.append("min_achieved_rps")
+    summary["gate_failures"] = failures
+    summary["passed"] = not failures
+    return summary, failures
+
+
+@events.quitting.add_listener
+def on_quitting(environment: Any, **_: Any) -> None:
+    if RUNTIME is None:
+        return
+    summary, failures = build_summary(environment)
+    safe_write_json(RUNTIME.output_dir / "summary.json", summary)
+    environment.process_exit_code = 2 if failures else 0
+
+
+def default_output_dir() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path("rag_load_results") / stamp
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--base-url", default=os.getenv("RAG_EVAL_BASE_URL"), required=not os.getenv("RAG_EVAL_BASE_URL"))
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser
+
+
+def run_parent(args: argparse.Namespace) -> int:
+    token = os.getenv(TOKEN_ENV, "").strip()
+    if not token:
+        raise LoadConfigError(f"Missing authentication token in {TOKEN_ENV}")
+    dataset = args.dataset.resolve()
+    config_path = args.config.resolve()
+    samples = read_dataset(dataset)
+    config = read_config(config_path)
+    validate_runtime(config, samples)
+    output_dir = (args.output_dir or default_output_dir()).resolve()
+    output_dir.mkdir(parents=True, exist_ok=False)
+    runtime = Runtime(dataset, config_path, output_dir, args.base_url)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": utc_now(),
+        "dataset": str(dataset),
+        "config": str(config_path),
+        "base_url": args.base_url.rstrip("/"),
+        "case_count": len(samples),
+        "profile": runtime.profile,
+        "retrieval": runtime.retrieval,
+        "load": runtime.load,
+        "gates": runtime.gates,
+    }
+    safe_write_json(output_dir / "manifest.json", manifest)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            CHILD_DATASET_ENV: str(dataset),
+            CHILD_CONFIG_ENV: str(config_path),
+            CHILD_OUTPUT_ENV: str(output_dir),
+            CHILD_BASE_URL_ENV: args.base_url.rstrip("/"),
+        }
+    )
+    stats_prefix = output_dir / "locust"
+    command = [
+        sys.executable,
+        "-m",
+        "locust",
+        "-f",
+        str(Path(__file__).resolve()),
+        "--headless",
+        "-H",
+        args.base_url.rstrip("/"),
+        "--csv",
+        str(stats_prefix),
+        "--csv-full-history",
+        "--html",
+        str(output_dir / "report.html"),
+        "--json-file",
+        str(output_dir / "locust"),
+    ]
+    if runtime.profile != "staircase":
+        command.extend(
+            [
+                "--users",
+                str(int(runtime.load.get("users", 1))),
+                "--spawn-rate",
+                str(float(runtime.load.get("spawn_rate", 1))),
+                "--run-time",
+                str(runtime.load.get("run_time", "30s")),
+            ]
+        )
+    completed = subprocess.run(command, env=env, check=False)
+    return int(completed.returncode)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return run_parent(args)
+    except (LoadConfigError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Business Background
MemoryBear needs script-based RAG knowledge retrieval evaluation that can measure recall quality and retrieval performance without introducing UI work or production service dependencies.

## Summary
- Add a standalone recall evaluation script for corpus snapshotting, dataset generation, dataset validation, and retrieval metric evaluation.
- Add a standalone Locust-based retrieval load test runner.
- Add Chinese HTML report rendering for both recall and performance runs, plus usage documentation under `api/scripts`.

## Changes
```text
 api/scripts/README_RAG_EVALUATION.md   |  666 ++++++++++++++++
 api/scripts/rag_recall_eval.py         | 1330 ++++++++++++++++++++++++++++++++
 api/scripts/rag_retrieval_load_test.py |  800 +++++++++++++++++++
 3 files changed, 2796 insertions(+)
```

## Risk
- The scripts are standalone and intentionally avoid importing MemoryBear project modules.
- The recall tool currently targets the internal JWT retrieval flow and does not add or change external API Key routes.
- Generated snapshots and datasets may contain knowledge-base content and should be handled as sensitive local artifacts.
- The documentation is under `api/scripts`; no files under the repository `docs/` directory are included.

## External API Key Impact
No external API Key endpoint is changed. The PR does not modify `app/controllers/service/rag_api_*_controller.py`, service route contracts, permissions, workspace handling, tenant handling, or response schemas.

## Test Plan
- [x] `git diff --check origin/develop..HEAD`
- [x] `python3 -m py_compile api/scripts/rag_recall_eval.py api/scripts/rag_retrieval_load_test.py`
- [x] `uv run --no-project api/scripts/rag_recall_eval.py --help`
- [x] `uv run --no-project api/scripts/rag_retrieval_load_test.py --help`

## Summary by Sourcery

添加独立脚本和文档，用于在使用 JWT 认证的内部端点下，对 MemoryBear 进行 RAG 检索召回率评估和 HTTP 性能测试，并生成包含中文的 HTML 报告。

New Features:
- 引入一个脚本，用于对知识库语料进行快照、生成并验证检索评估数据集，并运行召回率指标计算，输出中文 HTML 报告。
- 引入一个基于 Locust 的负载测试运行器，用于对检索 HTTP 端点进行压测，支持可配置负载模型、性能门限，并生成中文性能报告。

Documentation:
- 在 `api/scripts` 下新增中文 README，说明 RAG 召回率评估和检索性能压测的安装、配置以及端到端工作流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add standalone scripts and documentation for evaluating RAG retrieval recall and HTTP performance against MemoryBear using JWT-authenticated internal endpoints, including Chinese HTML reporting.

New Features:
- Introduce a script to snapshot knowledge-base corpora, generate and validate retrieval evaluation datasets, and run recall metrics with Chinese HTML reports.
- Introduce a Locust-based load test runner for the retrieval HTTP endpoint with configurable load profiles, performance gates, and Chinese performance reports.

Documentation:
- Add Chinese README under api/scripts describing installation, configuration, and end-to-end workflows for RAG recall evaluation and retrieval performance load testing.

</details>