### PR TITLE
Feat/pilot qa perceptual

### DIFF
--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -13,7 +13,7 @@ from app.db import get_db, get_db_context
 from app.dependencies import get_current_user
 from app.models.user_model import User
 from app.schemas.memory_storage_schema import (
-    ConfigPilotRun,
+    PilotRunInput,
 )
 from app.schemas.response_schema import ApiResponse
 from app.services.memory_storage_service import (
@@ -78,17 +78,18 @@ async def get_storage_info(
 
 @router.post("/pilot_run", response_model=None)
 async def pilot_run(
-        payload: ConfigPilotRun,
+        payload: PilotRunInput,
         language_type: str = Header(default=None, alias="X-Language-Type"),
         current_user: User = Depends(get_current_user),
 ) -> StreamingResponse:
     # 使用集中化的语言校验
     language = get_language_from_header(language_type)
 
+    # v0.3.13: 入参改为 QA 格式 messages（与 /write 接口对齐），不再接收 dialogue_text / custom_text
+    total_files = sum(len(m.files) for m in payload.messages if m.files)
     api_logger.info(
         f"Pilot run requested: config_id={payload.config_id}, "
-        f"dialogue_text_length={len(payload.dialogue_text)}, "
-        f"custom_text_length={len(payload.custom_text) if payload.custom_text else 0}"
+        f"messages_count={len(payload.messages)}, files_count={total_files}"
     )
     # resolve_config_id 在 pilot_run_stream 内部的短 session 里执行
     # controller 层不再注入 db，避免 session 跨越整个流式响应生命周期

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -952,7 +952,7 @@ class WritePipeline:
         from app.db import get_db_context
         from app.repositories.memory_perceptual_repository import MemoryPerceptualRepository
         from app.schemas.app_schema import FileInput
-        from app.services.memory_perceptual_service import MemoryPerceptualService
+        from app.services.memory_perceptual_service import MemoryPerceptualService, _PerceptualSnapshot
 
         for msg in messages:
             files = msg.get("files") or []
@@ -979,19 +979,18 @@ class WritePipeline:
                                 key=lambda m: m.created_time if m.created_time else datetime.min,
                             )
                             # 在 Session 内提取所有需要的属性到一个简单对象中，
-                            # 彻底避免 DetachedInstanceError
-                            class _PerceptualSnapshot:
-                                pass
-                            snap = _PerceptualSnapshot()
-                            snap.id = memory.id
-                            snap.summary = memory.summary
-                            snap.meta_data = memory.meta_data
-                            snap.file_path = memory.file_path
-                            snap.file_name = memory.file_name
-                            snap.file_ext = memory.file_ext
-                            snap.perceptual_type = memory.perceptual_type
-                            snap.end_user_id = self.end_user_id  # 使用当前 pipeline 的 end_user_id，确保 Perceptual 节点归属当前用户
-                            snap.created_time = memory.created_time
+                            # 彻底避免 DetachedInstanceError（使用模块级 _PerceptualSnapshot）
+                            snap = _PerceptualSnapshot(
+                                id=memory.id,
+                                end_user_id=self.end_user_id,  # 使用当前 pipeline 的 end_user_id，确保 Perceptual 节点归属当前用户
+                                perceptual_type=memory.perceptual_type,
+                                file_path=memory.file_path,
+                                file_name=memory.file_name,
+                                file_ext=memory.file_ext,
+                                summary=memory.summary,
+                                meta_data=memory.meta_data,
+                                created_time=memory.created_time,
+                            )
                             file_object = snap
                         else:
                             # 不存在，创建 Perceptual 记录

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
@@ -121,6 +122,26 @@ def _convert_pruning_records(raw_records: list, end_user_id: str = "", source: s
         })
 
     return result
+
+
+@dataclass
+class _PerceptualSnapshot:
+    """MemoryPerceptualModel 的 Session 无关快照。
+
+    在 _preprocess_files 内部（DB Session 活跃期）从 ORM 实例拷贝生成，
+    切断与 SQLAlchemy Session 的绑定；供下游异步步骤（如 graph_build_step）
+    安全访问属性。
+    """
+
+    id: Any
+    end_user_id: str
+    perceptual_type: str
+    file_path: str
+    file_name: str
+    file_ext: str
+    summary: str
+    meta_data: Any
+    created_time: Any
 
 
 class ExtractionResult(BaseModel):
@@ -952,7 +973,7 @@ class WritePipeline:
         from app.db import get_db_context
         from app.repositories.memory_perceptual_repository import MemoryPerceptualRepository
         from app.schemas.app_schema import FileInput
-        from app.services.memory_perceptual_service import MemoryPerceptualService, _PerceptualSnapshot
+        from app.services.memory_perceptual_service import MemoryPerceptualService
 
         for msg in messages:
             files = msg.get("files") or []

--- a/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
+++ b/api/app/core/memory/storage_services/extraction_engine/extraction_pipeline_orchestrator.py
@@ -328,33 +328,6 @@ class NewExtractionOrchestrator:
             "embedding_output": None,
         }
 
-        if self.progress_callback:
-            statements_count = sum(
-                len(stmts)
-                for chunk_stmts in all_stmt_results.values()
-                for stmts in chunk_stmts.values()
-            )
-            entities_count = sum(
-                len(t_out.entities)
-                for stmt_triplets in all_triplet_results.values()
-                for t_out in stmt_triplets.values()
-            )
-            triplets_count = sum(
-                len(t_out.triplets)
-                for stmt_triplets in all_triplet_results.values()
-                for t_out in stmt_triplets.values()
-            )
-            await self.progress_callback(
-                "knowledge_extraction_complete",
-                "知识抽取完成",
-                {
-                    "entities_count": entities_count,
-                    "statements_count": statements_count,
-                    "temporal_ranges_count": 0,
-                    "triplets_count": triplets_count,
-                },
-            )
-
         logger.debug("Pilot extraction complete")
         return dialog_data_list
 
@@ -568,7 +541,25 @@ class NewExtractionOrchestrator:
                     (dialog.id, chunk.id, chunk_speaker, ctx, inp)
                 )
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # 开始陈述句提取（事件开始）
+        if self.progress_callback:
+            await self.progress_callback(
+                "extract_statement",
+                "开始提取陈述句",
+                {"chunk_count": len(tasks)},
+            )
+
+        # 使用 as_completed 替代 gather：每个 chunk 一完成就立刻 emit SSE，避免长时 LLM 调用期间 SSE 通道静默导致的代理/前端超时（原 gather 版本会等
+        async def _run_one_stmt(idx: int, coro: Any) -> Tuple[int, Any]:
+            try:
+                res = await coro
+            except BaseException as exc:  # noqa: BLE001 — 保留异常供下游 critical-step 语义处理
+                return idx, exc
+            return idx, res
+
+        wrapped_stmt_futs = [
+            asyncio.ensure_future(_run_one_stmt(i, t)) for i, t in enumerate(tasks)
+        ]
 
         # Organise into nested dict;同时记录每个 chunk 的输入上下文，供 snapshot 落盘核查。
         stmt_map: Dict[str, Dict[str, List[StatementStepOutput]]] = {}
@@ -577,7 +568,8 @@ class NewExtractionOrchestrator:
         # 流程并向上抛出。否则异常会在此被静默吞掉（设为 []），导致 WriteResult.status
         # 仍为 "success"，最终 Celery 任务被错误标记为 SUCCESS（Flower 显示成功）。
         first_error: BaseException | None = None
-        for i, result in enumerate(results):
+        for fut in asyncio.as_completed(wrapped_stmt_futs):
+            i, result = await fut
             dialog_id, chunk_id, speaker, _, inp = task_meta[i]
             if dialog_id not in stmt_map:
                 stmt_map[dialog_id] = {}
@@ -595,18 +587,27 @@ class NewExtractionOrchestrator:
                     s.speaker = speaker
                 stmt_map[dialog_id][chunk_id] = stmts
                 if self.progress_callback:
-                    # Frontend consumes knowledge_extraction_result with data.statement.
+                    # Frontend consumes extract_statement_result with data.statement.
                     # Emit one event per statement to keep payload contract simple.
                     for s in stmts:
                         await self.progress_callback(
-                            "knowledge_extraction_result",
-                            "知识抽取中",
+                            "extract_statement_result",
+                            "陈述句提取中",
                             {"statement": s.statement_text},
                         )
 
         # Stash the inputs map so the orchestrator can attach it to
         # ``_last_stage_outputs`` for snapshot/debugging.
         self._last_statement_inputs = stmt_inputs_map
+
+        # 陈述句提取完成（事件结束）
+        if self.progress_callback:
+            _stmt_count = sum(len(stmts) for dchunks in stmt_map.values() for stmts in dchunks.values())
+            await self.progress_callback(
+                "extract_statement_complete",
+                "陈述句提取完成",
+                {"statements_count": _stmt_count},
+            )
 
         # critical step 失败 → 中断 pipeline，让上层（WritePipeline → MemoryService.write
         # → write_message_task）感知失败并将 Celery 任务标记为 FAILURE / 触发重试。
@@ -641,10 +642,29 @@ class NewExtractionOrchestrator:
                     tasks.append(self.triplet_step.run(inp))
                     task_meta.append((dialog.id, stmt.statement_id))
 
-        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # 开始三元组提取（事件开始）
+        if self.progress_callback:
+            await self.progress_callback(
+                "extract_triplet",
+                "开始提取三元组",
+                {"statement_count": len(tasks)},
+            )
+
+        # 使用 as_completed 替代 gather：每个 statement 一完成就立刻 emit SSE，避免慢 statement 拖住整批进度反馈
+        async def _run_one_triplet(idx: int, coro: Any) -> Tuple[int, Any]:
+            try:
+                res = await coro
+            except BaseException as exc:  # noqa: BLE001 — 失败降级为默认输出，不上抛
+                return idx, exc
+            return idx, res
+
+        wrapped_triplet_futs = [
+            asyncio.ensure_future(_run_one_triplet(i, t)) for i, t in enumerate(tasks)
+        ]
 
         triplet_map: Dict[str, Dict[str, TripletStepOutput]] = {}
-        for i, result in enumerate(results):
+        for fut in asyncio.as_completed(wrapped_triplet_futs):
+            i, result = await fut
             dialog_id, stmt_id = task_meta[i]
             if dialog_id not in triplet_map:
                 triplet_map[dialog_id] = {}
@@ -659,23 +679,58 @@ class NewExtractionOrchestrator:
             else:
                 triplet_map[dialog_id][stmt_id] = result
                 if self.progress_callback:
+                    # 截断防护：单个 statement 可能抽出 >100 实体，全量 emit 会使 SSE
+                    _ENTITY_EMIT_LIMIT = 20
+                    _RELATION_EMIT_LIMIT = 10
                     await self.progress_callback(
                         "extract_triplet_result",
                         f"statement {stmt_id} 提取完成",
                         {
                             "statement_id": stmt_id,
-                            "triplet_count": len(result.triplets),
-                            "entity_count": len(result.entities),
-                            "triplets": [
+                            "entity_creation": [
                                 {
-                                    "subject_name": t.subject_name,
-                                    "predicate": t.predicate,
-                                    "object_name": t.object_name,
+                                    "entity_index": idx + 1,
+                                    "name": e.name,
+                                    "type": e.type,
+                                    "description": e.description,
                                 }
-                                for t in result.triplets[:5]
+                                for idx, e in enumerate(result.entities[:_ENTITY_EMIT_LIMIT])
                             ],
+                            "entity_total": len(result.entities),
+                            "relationship_creation": [
+                                {
+                                    "relationship_index": idx + 1,
+                                    "source_entity": t.subject_name,
+                                    "relation_type": t.predicate,
+                                    "target_entity": t.object_name,
+                                    "relationship_text": f"{t.subject_name} -[{t.predicate}]-> {t.object_name}",
+                                }
+                                for idx, t in enumerate(result.triplets[:_RELATION_EMIT_LIMIT])
+                            ],
+                            "relationship_total": len(result.triplets),
                         },
                     )
+
+        # 三元组提取完成（事件结束）
+        if self.progress_callback:
+            _entities_count = sum(
+                len(t_out.entities)
+                for stmt_triplets in triplet_map.values()
+                for t_out in stmt_triplets.values()
+            )
+            _triplets_count = sum(
+                len(t_out.triplets)
+                for stmt_triplets in triplet_map.values()
+                for t_out in stmt_triplets.values()
+            )
+            await self.progress_callback(
+                "extract_triplet_complete",
+                "三元组提取完成",
+                {
+                    "entities_count": _entities_count,
+                    "triplets_count": _triplets_count,
+                },
+            )
 
         return triplet_map
 

--- a/api/app/core/memory/storage_services/extraction_engine/steps/dedup_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/dedup_step.py
@@ -300,14 +300,13 @@ async def send_dedup_progress_callback(
                 "reduced_count": ent_edges_reduced,
             },
             "dedup_examples": dedup_details.get("dedup_examples", []),
-            "disamb_examples": dedup_details.get("disamb_examples", []),
             "summary": {
                 "total_merges": dedup_details.get("total_merges", 0),
-                "total_disambiguations": dedup_details.get("total_disambiguations", 0),
             },
         }
 
-        await progress_callback("dedup_disambiguation_complete", "去重消歧完成", dedup_stats)
+        # v0.3.13: 事件重命名 dedup_disambiguation_complete → dedup_complete，下线实体消歧推送
+        await progress_callback("dedup_complete", "去重完成", dedup_stats)
     except Exception as e:
         logger.error("发送去重消歧进度回调失败: %s", e, exc_info=True)
         try:
@@ -319,7 +318,7 @@ async def send_dedup_progress_callback(
                 },
                 "summary": f"实体去重合并{original_entities - final_entities}个",
             }
-            await progress_callback("dedup_disambiguation_complete", "去重消歧完成", basic_stats)
+            await progress_callback("dedup_complete", "去重完成", basic_stats)
         except Exception as e2:
             logger.error("发送基本去重统计失败: %s", e2, exc_info=True)
 
@@ -425,20 +424,11 @@ async def run_dedup(
                         f"{detail['main_entity_name']}合并{detail['merged_count']}个：相似实体已合并"
                     ),
                 }
-                await progress_callback("dedup_disambiguation_result", "实体去重中", dedup_result)
+                # v0.3.13: 事件重命名 dedup_disambiguation_result → dedup_result
+                await progress_callback("dedup_result", "实体去重中", dedup_result)
 
-            disamb_info = analyze_entity_disambiguation(disamb_records)
-            for i, detail in enumerate(disamb_info[:5]):
-                disamb_result = {
-                    "result_type": "entity_disambiguation",
-                    "disambiguated_entity_name": detail["entity_name"],
-                    "disambiguation_type": detail["disamb_type"],
-                    "confidence": detail.get("confidence", "unknown"),
-                    "reason": detail.get("reason", ""),
-                    "disamb_progress": f"{i + 1}/{min(len(disamb_info), 5)}",
-                    "message": f"{detail['entity_name']}消歧完成：{detail['disamb_type']}",
-                }
-                await progress_callback("dedup_disambiguation_result", "实体消歧中", disamb_result)
+            # v0.3.13: 下线实体消歧 API，移除 entity_disambiguation 子事件推送（
+            # analyze_entity_disambiguation 函数保留，仅不再以 SSE 向外推送）
 
             await send_dedup_progress_callback(
                 progress_callback,

--- a/api/app/core/memory/storage_services/extraction_engine/steps/dedup_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/dedup_step.py
@@ -196,12 +196,6 @@ def analyze_entity_merges(
     ]
 
 
-def analyze_entity_disambiguation(
-    disamb_records: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
-    """Return disambiguation records (pass-through)."""
-    return disamb_records if disamb_records else []
-
 
 def parse_dedup_report(
     merge_records: List[Dict[str, Any]],
@@ -304,8 +298,6 @@ async def send_dedup_progress_callback(
                 "total_merges": dedup_details.get("total_merges", 0),
             },
         }
-
-        # v0.3.13: 事件重命名 dedup_disambiguation_complete → dedup_complete，下线实体消歧推送
         await progress_callback("dedup_complete", "去重完成", dedup_stats)
     except Exception as e:
         logger.error("发送去重消歧进度回调失败: %s", e, exc_info=True)
@@ -360,7 +352,7 @@ async def run_dedup(
     logger.info("开始第一层实体去重")
 
     if progress_callback:
-        await progress_callback("deduplication", "正在去重消歧...")
+        await progress_callback("deduplication", "正在去重合并...")
 
     logger.info(
         "去重前: %d 个实体节点, %d 条陈述句-实体边, %d 条实体-实体边",
@@ -424,11 +416,7 @@ async def run_dedup(
                         f"{detail['main_entity_name']}合并{detail['merged_count']}个：相似实体已合并"
                     ),
                 }
-                # v0.3.13: 事件重命名 dedup_disambiguation_result → dedup_result
-                await progress_callback("dedup_result", "实体去重中", dedup_result)
-
-            # v0.3.13: 下线实体消歧 API，移除 entity_disambiguation 子事件推送（
-            # analyze_entity_disambiguation 函数保留，仅不再以 SSE 向外推送）
+                await progress_callback("dedup_result", "实体去重合并中", dedup_result)
 
             await send_dedup_progress_callback(
                 progress_callback,

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -125,11 +125,8 @@ async def build_graph_nodes_and_edges(
 
     entity_id_set: set = set()
     perceptual_id_set: set = set()
-    total_dialogs = len(dialog_data_list)
     processed_dialogs = 0
 
-    if progress_callback:
-        await progress_callback("creating_nodes_edges", "正在创建节点和边", {"total_dialogs": total_dialogs})
 
     for dialog_data in dialog_data_list:
         processed_dialogs += 1
@@ -300,22 +297,6 @@ async def build_graph_nodes_and_edges(
                         entity_nodes.append(entity_node)
                         entity_id_set.add(entity.id)
 
-                        # v0.3.13: 新增 entity_creation 子事件（与 relationship_creation 共享同一事件名 creating_nodes_edges_result）
-                        if progress_callback and len(entity_nodes) <= 20:
-                            entity_result = {
-                                "result_type": "entity_creation",
-                                "entity_index": len(entity_nodes),
-                                "name": entity_node.name,
-                                "type": entity_node.entity_type,
-                                "description": entity_node.description,
-                                "dialog_progress": f"{processed_dialogs}/{total_dialogs}",
-                            }
-                            await progress_callback(
-                                "creating_nodes_edges_result",
-                                f"实体创建中 ({processed_dialogs}/{total_dialogs})",
-                                entity_result,
-                            )
-
                     entity_connect_strength = getattr(entity, "connect_strength", "Strong")
                     stmt_entity_edges.append(
                         StatementEntityEdge(
@@ -356,22 +337,6 @@ async def build_graph_nodes_and_edges(
                                 invalid_at=_tv.invalid_at if _tv else None,
                             )
                         )
-
-                        if progress_callback and len(entity_entity_edges) <= 10:
-                            relationship_result = {
-                                "result_type": "relationship_creation",
-                                "relationship_index": len(entity_entity_edges),
-                                "source_entity": triplet.subject_name,
-                                "relation_type": triplet.predicate,
-                                "target_entity": triplet.object_name,
-                                "relationship_text": f"{triplet.subject_name} -[{triplet.predicate}]-> {triplet.object_name}",
-                                "dialog_progress": f"{processed_dialogs}/{total_dialogs}",
-                            }
-                            await progress_callback(
-                                "creating_nodes_edges_result",
-                                f"关系创建中 ({processed_dialogs}/{total_dialogs})",
-                                relationship_result,
-                            )
                     else:
                         missing_subject = "subject" if not subject_entity_id else ""
                         missing_object = "object" if not object_entity_id else ""
@@ -492,18 +457,6 @@ async def build_graph_nodes_and_edges(
             f"原始节点: {len(assistant_original_nodes)}, "
             f"剪枝节点: {len(assistant_pruned_nodes)}"
         )
-
-    if progress_callback:
-        nodes_edges_stats = {
-            "dialogue_nodes_count": len(dialogue_nodes),
-            "chunk_nodes_count": len(chunk_nodes),
-            "statement_nodes_count": len(statement_nodes),
-            "entity_nodes_count": len(entity_nodes),
-            "statement_chunk_edges_count": len(stmt_chunk_edges),
-            "statement_entity_edges_count": len(stmt_entity_edges),
-            "entity_entity_edges_count": len(entity_entity_edges),
-        }
-        await progress_callback("creating_nodes_edges_complete", "创建节点和边完成", nodes_edges_stats)
 
     return GraphBuildResult(
         dialogue_nodes=dialogue_nodes,

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -300,6 +300,22 @@ async def build_graph_nodes_and_edges(
                         entity_nodes.append(entity_node)
                         entity_id_set.add(entity.id)
 
+                        # v0.3.13: 新增 entity_creation 子事件（与 relationship_creation 共享同一事件名 creating_nodes_edges_result）
+                        if progress_callback and len(entity_nodes) <= 20:
+                            entity_result = {
+                                "result_type": "entity_creation",
+                                "entity_index": len(entity_nodes),
+                                "name": entity_node.name,
+                                "type": entity_node.entity_type,
+                                "description": entity_node.description,
+                                "dialog_progress": f"{processed_dialogs}/{total_dialogs}",
+                            }
+                            await progress_callback(
+                                "creating_nodes_edges_result",
+                                f"实体创建中 ({processed_dialogs}/{total_dialogs})",
+                                entity_result,
+                            )
+
                     entity_connect_strength = getattr(entity, "connect_strength", "Strong")
                     stmt_entity_edges.append(
                         StatementEntityEdge(

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -8,6 +8,7 @@ import uuid
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+from app.schemas.memory_agent_schema import WriteMessageItem
 
 
 # ============================================================================
@@ -342,10 +343,17 @@ class ConfigUpdateForget(BaseModel):  # 更新遗忘引擎配置参数时使用�
     offset: Optional[float] = Field(0.0, ge=0.0, le=1.0, description="偏移度，0-1 小数；默认 0.0")
 
 
-class ConfigPilotRun(BaseModel):  # 试运行触发请求模型
-    config_id: Union[uuid.UUID, int, str] = Field(..., description="配置ID（唯一，支持UUID、整数或字符串）")
-    dialogue_text: str = Field(..., description="前端传入的对话文本，格式如 '用户: ...\nAI: ...' 可多行，试运行必填")
-    custom_text: Optional[str] = Field(None, description="自定义输入文本，当配置关联本体场景时使用此字段进行试运行")
+class PilotRunInput(BaseModel):  # v0.3.13 试运行触发请求模型（QA 消息格式）
+    """试运行请求 — QA 格式输入。
+
+    与 /api/memory-storage/write 使用同一 messages 结构，避免两套输入解析逻辑。
+    """
+    config_id: Union[uuid.UUID, int, str] = Field(..., description="萃取引擎配置 ID（唯一，支持 UUID、整数或字符串）")
+    messages: List[WriteMessageItem] = Field(
+        ...,
+        min_length=1,
+        description="QA 格式消息列表，role 为 user/assistant，files 可选",
+    )
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -343,7 +343,7 @@ class ConfigUpdateForget(BaseModel):  # 更新遗忘引擎配置参数时使用�
     offset: Optional[float] = Field(0.0, ge=0.0, le=1.0, description="偏移度，0-1 小数；默认 0.0")
 
 
-class PilotRunInput(BaseModel):  # v0.3.13 试运行触发请求模型（QA 消息格式）
+class PilotRunInput(BaseModel):  # 试运行触发请求模型（QA 消息格式）
     """试运行请求 — QA 格式输入。
 
     与 /api/memory-storage/write 使用同一 messages 结构，避免两套输入解析逻辑。

--- a/api/app/services/memory_perceptual_service.py
+++ b/api/app/services/memory_perceptual_service.py
@@ -36,6 +36,24 @@ from app.services.prompt import prompt_manager
 business_logger = get_business_logger()
 
 
+class _PerceptualSnapshot:
+    """感知记忆内存快照（不持久化）。
+
+    字段与 MemoryPerceptualModel 对齐，用于试运行等无需写库的场景。
+    调用方按属性访问即可（.summary / .meta_data / .file_name 等）。
+    与写入主流程（WritePipeline._preprocess_files）共用。
+    """
+    __slots__ = (
+        "id", "end_user_id", "perceptual_type",
+        "file_path", "file_name", "file_ext",
+        "summary", "meta_data", "created_time",
+    )
+
+    def __init__(self, **kwargs):
+        for k in self.__slots__:
+            setattr(self, k, kwargs.get(k))
+
+
 class MemoryPerceptualService:
     def __init__(self, db: Session):
         self.db = db
@@ -254,12 +272,24 @@ class MemoryPerceptualService:
             memory_config: MemoryConfig,
             file: FileInput,
             content: str | None = None,
+            persist: bool = True,
     ):
-        with get_db_read() as db:
-            end_user = get_end_user_by_id(db, end_user_id)
-            workspace_id = end_user.workspace_id
-            workspace = get_workspace_by_id(db, workspace_id)
-            tenant_id = workspace.tenant_id
+        """生成感知记忆。
+
+        参数：
+            persist=True  — 默认，写入 memory_perceptual 表，返回 MemoryPerceptualModel。
+            persist=False — 试运行场景，不写库，返回 _PerceptualSnapshot 实例。
+                            同时绕开 end_user → workspace → tenant_id 的 DB 查询，
+                            直接从 memory_config.tenant_id 取。
+        """
+        if persist:
+            with get_db_read() as db:
+                end_user = get_end_user_by_id(db, end_user_id)
+                workspace_id = end_user.workspace_id
+                workspace = get_workspace_by_id(db, workspace_id)
+                tenant_id = workspace.tenant_id
+        else:
+            tenant_id = memory_config.tenant_id
         llm, model_config = self._get_mutlimodal_client(file.type, memory_config, tenant_id)
         if model_config is None or llm is None:
             return None
@@ -360,6 +390,22 @@ class MemoryPerceptualService:
             file_modalities = {
                 "speaker_count": content.get("speaker_count", 0)
             }
+        if not persist:
+            # 试运行：返回内存快照，不写库
+            return _PerceptualSnapshot(
+                id=None,
+                end_user_id=end_user_id,
+                perceptual_type=PerceptualType.trans_from_file_type(file.type),
+                file_path=file.url,
+                file_name=filename,
+                file_ext=file_ext,
+                summary=content.get("summary", ""),
+                meta_data={
+                    "content": file_content,
+                    "modalities": file_modalities,
+                },
+                created_time=None,
+            )
         memory = self.repository.create_perceptual_memory(
             end_user_id=uuid.UUID(end_user_id),
             perceptual_type=PerceptualType.trans_from_file_type(file.type),

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -33,7 +33,7 @@ from app.schemas.memory_storage_schema import (
     ConfigKey,
     ConfigParamsCreate,
     ConfigParamsDelete,
-    ConfigPilotRun,
+    PilotRunInput,
     ConfigUpdate,
     ConfigUpdateExtracted,
 )
@@ -283,7 +283,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
         return data_list
 
-    async def pilot_run_stream(self, payload: ConfigPilotRun, language: str = "zh") -> AsyncGenerator[str, None]:
+    async def pilot_run_stream(self, payload: PilotRunInput, language: str = "zh") -> AsyncGenerator[str, None]:
         """
         流式执行试运行，产生 SSE 格式的进度事件
 
@@ -293,7 +293,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         - 本方法不依赖 FastAPI Depends(get_db)，自行管理 session 生命周期
 
         Args:
-            payload: 试运行配置和对话文本（config_id 已由 controller 解析为 UUID）
+            payload: 试运行配置和 QA 格式消息列表（v0.3.13：config_id + messages）
             language: 语言类型 ("zh" 中文, "en" 英文)，默认中文
 
         Yields:
@@ -327,6 +327,11 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             if not cid:
                 raise ValueError("未提供 payload.config_id，禁止启动试运行")
 
+            # v0.3.13: 直接透传 messages，不再解析 dialogue_text / custom_text
+            messages = payload.messages
+            if not messages:
+                raise ValueError("试运行模式必须提供至少一条 message")
+
             with get_db_read() as db:
                 # 1a. 加载记忆配置
                 try:
@@ -338,26 +343,10 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 except ConfigurationError as e:
                     raise RuntimeError(f"Configuration loading failed: {e}")
 
-                # 1b. 确定使用的文本
-                if memory_config.scene_id:
-                    if hasattr(payload, 'custom_text') and payload.custom_text:
-                        dialogue_text = payload.custom_text.strip()
-                        logger.info(
-                            f"[PILOT_RUN_STREAM] Using custom_text for scene_id={memory_config.scene_id}, "
-                            f"length: {len(dialogue_text)}")
-                    else:
-                        dialogue_text = payload.dialogue_text.strip() if payload.dialogue_text else ""
-                        logger.info(
-                            f"[PILOT_RUN_STREAM] No custom_text provided, using dialogue_text "
-                            f"for scene_id={memory_config.scene_id}")
-                else:
-                    dialogue_text = payload.dialogue_text.strip() if payload.dialogue_text else ""
-                    logger.info(f"[PILOT_RUN_STREAM] No scene_id, using dialogue_text, length: {len(dialogue_text)}")
-
-                if not dialogue_text:
-                    raise ValueError("试运行模式必须提供有效的文本内容（dialogue_text 或 custom_text）")
-
-                logger.info(f"[PILOT_RUN_STREAM] Final text preview: {dialogue_text[:100]}")
+                logger.info(
+                    f"[PILOT_RUN_STREAM] messages count={len(messages)}, "
+                    f"scene_id={memory_config.scene_id}"
+                )
 
                 # 1c. 初始化 LLM 客户端（只需查一次模型配置，之后 llm_client 是独立对象）
                 try:
@@ -390,10 +379,11 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     from app.services.pilot_run_service import run_pilot_extraction
 
                     logger.info(
-                        f"[PILOT_RUN_STREAM] Calling run_pilot_extraction with dialogue_text length: {len(dialogue_text)}")
+                        f"[PILOT_RUN_STREAM] Calling run_pilot_extraction with messages count: {len(messages)}"
+                    )
                     await run_pilot_extraction(
                         memory_config=memory_config,
-                        dialogue_text=dialogue_text,
+                        messages=messages,
                         llm_client=llm_client,
                         progress_callback=progress_callback,
                         language=language,

--- a/api/app/services/pilot_run_service.py
+++ b/api/app/services/pilot_run_service.py
@@ -4,15 +4,23 @@ Pilot Run Service - 试运行服务
 用于执行记忆系统的试运行流程，不保存到 Neo4j。
 
 职责边界：
-- 文本解析、语义剪枝、语义分块（预处理）
+- QA 消息格式解析、文件 URL 解析、感知记忆生成（persist=False）
+- 语义剪枝、语义分块（预处理）
 - 调用 PilotWritePipeline 执行萃取链路
-- 输出结果文件
+- 输出结果文件（含试运行专属的 extracted_result.perceptual 字段注入）
+
+v0.3.13 变更：
+- 入参从 dialogue_text: str 改为 messages: List[WriteMessageItem]（与 /write 接口对齐）
+- 新增：文件 URL 解析 + 感知记忆内存快照（persist=False）
+- SSE `text_preprocessing_result` 的 pruning 子事件字段：deleted_messages → user_message_changes（仅 user 角色）
+- SSE 新增 `perceptual_result` 事件（感知记忆汇总，无 files 时也会发出，perceptual_nodes 为空数组）
+- `result.extracted_result` 新增 `perceptual` 字段 / 移除 `disambiguation` 字段
 """
 
+import json
 import os
-import re
 import time
-from typing import Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, List, Optional
 
 from app.core.utils.datetime_utils import utcnow_naive
 from app.core.config import settings
@@ -26,7 +34,10 @@ from app.core.memory.storage_services.extraction_engine.pipeline_help import (
     _write_extracted_result_summary,
     export_test_input_doc,
 )
+from app.schemas.app_schema import FileInput, TransferMethod
+from app.schemas.memory_agent_schema import WriteMessageItem
 from app.schemas.memory_config_schema import MemoryConfig
+from app.services.memory_perceptual_service import _PerceptualSnapshot
 
 
 logger = get_memory_logger(__name__)
@@ -68,23 +79,148 @@ def _save_triplets_from_dialogs(dialog_data_list: list[DialogData], output_path:
             f.write("\n")
 
 
+# ────────────────────────────────────────────────────────────────
+# 感知记忆 helper（试运行专用，来自 development.md §4.1.6）
+# ────────────────────────────────────────────────────────────────
+def _collect_perceptual_nodes_data(
+    snapshots: list[tuple[int, "_PerceptualSnapshot"]],
+) -> list[dict]:
+    """perceptual_result 事件 data.perceptual_nodes 构造。无快照时返回 []。"""
+    result: list[dict] = []
+    for _, snap in snapshots:
+        content = (snap.meta_data or {}).get("content", {}) or {}
+        result.append({
+            "file_type": snap.perceptual_type.value if snap.perceptual_type else None,
+            "file_name": snap.file_name,
+            "summary": snap.summary,
+            "topic": content.get("topic"),
+            "keywords": content.get("keywords", []),
+            "domain": content.get("domain"),
+        })
+    return result
+
+
+def _build_perceptual_summary(
+    snapshots: list[tuple[int, "_PerceptualSnapshot"]],
+) -> dict:
+    """result.extracted_result.perceptual 字段构造（无快照时返回零统计 + 空数组）。"""
+    from collections import Counter
+    file_types = [
+        snap.perceptual_type.value
+        for _, snap in snapshots
+        if snap.perceptual_type
+    ]
+    type_counter = Counter(file_types)
+    samples = _collect_perceptual_nodes_data(snapshots)
+    return {
+        "count": len(snapshots),
+        "file_type_distribution": [
+            {"file_type": t, "count": c} for t, c in type_counter.items()
+        ],
+        "samples": samples,   # 字段与 perceptual_result 事件一致
+    }
+
+
+async def _resolve_file_url(file: FileInput) -> Optional[str]:
+    """解析 FileInput 为可访问 URL（remote_url 直接返回，local_file 走 MultimodalService.get_file_url）。"""
+    if file.transfer_method == TransferMethod.REMOTE_URL:
+        return file.url
+    # local_file：需要短 session 查 file_metadata 并签名 URL
+    from app.db import get_db_read
+    from app.services.multimodal_service import MultimodalService
+    try:
+        with get_db_read() as db:
+            mm_service = MultimodalService(db, api_config=None)
+            return await mm_service.get_file_url(file)
+    except Exception as e:
+        logger.warning(f"[PILOT_RUN] 文件 URL 解析失败: file_id={file.upload_file_id}, err={e}")
+        return None
+
+
+async def _generate_perceptual_snapshots(
+    memory_config: MemoryConfig,
+    messages: List[WriteMessageItem],
+) -> list[tuple[int, _PerceptualSnapshot]]:
+    """遍历 messages 中的 files，生成感知记忆内存快照（persist=False）。
+
+    返回 (message_index, snapshot) 元组列表，用于后续把 summary 注入回对应 message。
+    单条 file 失败不阻断整体流程，仅记录 warning 日志。
+    """
+    from app.db import get_db_read
+    from app.services.memory_perceptual_service import MemoryPerceptualService
+
+    snapshots: list[tuple[int, _PerceptualSnapshot]] = []
+    for msg_idx, msg in enumerate(messages):
+        if not msg.files:
+            continue
+        for file in msg.files:
+            try:
+                resolved_url = await _resolve_file_url(file)
+                if not resolved_url:
+                    logger.warning(f"[PILOT_RUN] 文件 URL 解析为空，跳过: msg_idx={msg_idx}, file={file}")
+                    continue
+                file_for_perceptual = file.model_copy(update={"url": resolved_url})
+
+                with get_db_read() as db:
+                    perceptual_service = MemoryPerceptualService(db)
+                    snapshot = await perceptual_service.generate_perceptual_memory(
+                        end_user_id=str(memory_config.workspace_id),
+                        memory_config=memory_config,
+                        file=file_for_perceptual,
+                        content=msg.content,
+                        persist=False,
+                    )
+                if snapshot is None:
+                    logger.warning(
+                        f"[PILOT_RUN] 感知记忆生成返回 None，跳过: msg_idx={msg_idx}, file={file}"
+                    )
+                    continue
+                snapshots.append((msg_idx, snapshot))
+            except Exception as e:
+                logger.warning(
+                    f"[PILOT_RUN] 文件处理失败，跳过: msg_idx={msg_idx}, err={e}",
+                    exc_info=True,
+                )
+    return snapshots
+
+
+def _patch_extracted_result_json(perceptual_summary: dict) -> None:
+    """在 _write_extracted_result_summary 生成 extracted_result.json 之后，
+    注入 perceptual 字段并移除 disambiguation 字段（v0.3.13 契约）。
+    """
+    result_path = settings.get_memory_output_path("extracted_result.json")
+    if not os.path.isfile(result_path):
+        logger.warning(f"[PILOT_RUN] extracted_result.json 不存在，跳过 patch: {result_path}")
+        return
+    try:
+        with open(result_path, "r", encoding="utf-8") as rf:
+            data = json.load(rf)
+        data["perceptual"] = perceptual_summary
+        data.pop("disambiguation", None)   # v0.3.13: 消歧下线，安全移除
+        with open(result_path, "w", encoding="utf-8") as wf:
+            json.dump(data, wf, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logger.error(f"[PILOT_RUN] patch extracted_result.json 失败: {e}", exc_info=True)
+
+
 async def run_pilot_extraction(
     memory_config: MemoryConfig,
-    dialogue_text: str,
+    messages: List[WriteMessageItem],
     llm_client,
     progress_callback: Optional[Callable[[str, str, Optional[dict]], Awaitable[None]]] = None,
     language: str = "zh",
 ) -> None:
-    """执行试运行模式的知识提取流水线。
+    """执行试运行模式的知识提取流水线（v0.3.13 QA 消息格式）。
 
     职责：
-    1. 文本解析 → 语义剪枝 → 语义分块（预处理，需要 llm_client）
-    2. 调用 PilotWritePipeline 执行萃取链路（Pipeline 自行管理客户端）
-    3. 将萃取结果写入输出文件
+    1. 文件 URL 解析 + 感知记忆内存快照（persist=False）
+    2. 构建 DialogData → 语义剪枝 → 语义分块（预处理，需要 llm_client）
+    3. 调用 PilotWritePipeline 执行萃取链路（Pipeline 自行管理客户端）
+    4. 将萃取结果写入输出文件，并注入 perceptual 字段 / 移除 disambiguation
 
     Args:
         memory_config: 从数据库加载的内存配置对象
-        dialogue_text: 输入的对话文本
+        messages: QA 格式消息列表（role: user/assistant，files 可选）
         llm_client: 预先初始化的 LLM 客户端（调用方负责在 db session 关闭前完成初始化）
         progress_callback: 可选的进度回调 (stage, message, data)
         language: 语言类型 ("zh" | "en")
@@ -97,34 +233,76 @@ async def run_pilot_extraction(
 
     pipeline_start = time.time()
 
+    # ── 包装 progress_callback：在 creating_nodes_edges_complete 之后插入 perceptual_result ──
+    perceptual_snapshots: list[tuple[int, _PerceptualSnapshot]] = []
+    perceptual_emitted = {"done": False}
+
+    async def _wrapped_progress_callback(stage: str, message: str, data: Optional[dict] = None) -> None:
+        # 先透传原事件
+        if progress_callback:
+            await progress_callback(stage, message, data)
+        # 在 creating_nodes_edges_complete 之后、dedup 事件之前插入 perceptual_result（幂等）
+        if stage == "creating_nodes_edges_complete" and not perceptual_emitted["done"]:
+            perceptual_emitted["done"] = True
+            perceptual_nodes = _collect_perceptual_nodes_data(perceptual_snapshots)
+            if progress_callback:
+                await progress_callback(
+                    "perceptual_result", "感知记忆提取完成",
+                    {"perceptual_nodes": perceptual_nodes},
+                )
+
     try:
         # ── 步骤 1: llm_client 已由调用方在 db session 关闭前初始化传入 ──────
         step_start = time.time()
         log_time("Client Initialization", time.time() - step_start, log_file)
 
-        # ── 步骤 2: 文本解析 ────────────────────────────────────────────────
+        # ── 步骤 1.5: 文件 URL 解析 + 感知记忆生成（persist=False） ─────────
         step_start = time.time()
-        pattern = r"(用户|AI)[：:]\s*([^\n]+(?:\n(?!(?:用户|AI)[：:])[^\n]*)*?)"
-        matches = re.findall(pattern, dialogue_text, re.MULTILINE | re.DOTALL)
-        messages = [
-            ConversationMessage(role=r, msg=c.strip())
-            for r, c in matches
-            if c.strip()
-        ]
-        if not messages:
-            messages = [ConversationMessage(role="用户", msg=dialogue_text.strip())]
+        perceptual_snapshots.extend(
+            await _generate_perceptual_snapshots(memory_config, messages)
+        )
+        log_time("Perceptual Snapshot Generation", time.time() - step_start, log_file)
+
+        # 将 file_summary 注入回对应 message.content（对齐 WritePipeline._preprocess_files）
+        message_content_map: dict[int, str] = {}
+        for msg_idx, snap in perceptual_snapshots:
+            original = messages[msg_idx].content or ""
+            if snap.summary:
+                tag = f"<input-file-summary>{snap.summary}</input-file-summary>"
+                if tag not in original:
+                    message_content_map[msg_idx] = original + tag
+                    continue
+            message_content_map.setdefault(msg_idx, original)
+
+        # ── 步骤 2: 构建 DialogData ──────────────────────────────────────────
+        step_start = time.time()
+        role_map = {"user": "用户", "assistant": "AI"}
+        conv_msgs: list[ConversationMessage] = []
+        for idx, m in enumerate(messages):
+            content = message_content_map.get(idx, m.content or "")
+            content = content.strip()
+            if not content:
+                continue
+            conv_msgs.append(
+                ConversationMessage(role=role_map.get(m.role, m.role), msg=content)
+            )
+
+        if not conv_msgs:
+            raise ValueError("messages 为空或所有消息内容为空")
 
         dialog = DialogData(
-            context=ConversationContext(msgs=messages),
+            context=ConversationContext(msgs=conv_msgs),
             ref_id="pilot_dialog_1",
             end_user_id=str(memory_config.workspace_id),
             user_id=str(memory_config.tenant_id),
             apply_id=str(memory_config.config_id),
-            metadata={"source": "pilot_run", "input_type": "frontend_text"},
+            metadata={"source": "pilot_run", "input_type": "qa_messages"},
         )
 
         if progress_callback:
-            await progress_callback("text_preprocessing", "开始预处理文本（语义剪枝 + 语义分块）...")
+            await _wrapped_progress_callback(
+                "text_preprocessing", "开始预处理文本（语义剪枝 + 语义分块）...", None
+            )
 
         # ── 步骤 2.1: 语义剪枝 ─────────────────────────────────────────────
         pruned_dialogs = [dialog]
@@ -144,37 +322,46 @@ async def run_pilot_extraction(
                     scene_id=str(memory_config.scene_id) if memory_config.scene_id else None,
                     ontology_class_infos=memory_config.ontology_class_infos,
                 )
-                original_msgs = [{"role": m.role, "content": m.msg} for m in dialog.context.msgs]
+                # v0.3.13: 只关注 user 角色的剪枝变化（assistant 修改对前端无展示价值）
+                original_user_msgs: dict[int, str] = {
+                    i: m.msg for i, m in enumerate(dialog.context.msgs) if m.role in ("用户", "user")
+                }
                 pruned_dialogs = await SemanticPruner(config=config, llm_client=llm_client).prune_dataset([dialog])
 
                 if pruned_dialogs and pruned_dialogs[0].context:
-                    remaining = [{"role": m.role, "content": m.msg} for m in pruned_dialogs[0].context.msgs]
-                    # 找出被删除的消息（顺序匹配）
-                    kept_indices: list[int] = []
-                    ri = 0
-                    for oi, om in enumerate(original_msgs):
-                        if ri < len(remaining) and om == remaining[ri]:
-                            kept_indices.append(oi)
-                            ri += 1
-                    deleted_messages = [
-                        {"index": i, "role": m["role"], "content": m["content"]}
-                        for i, m in enumerate(original_msgs)
-                        if i not in kept_indices
+                    pruned_user_map: dict[int, str] = {}
+                    pruned_user_msgs = [
+                        m for m in pruned_dialogs[0].context.msgs
+                        if m.role in ("用户", "user")
                     ]
+                    # 按顺序匹配：剩余 user 消息按原次序对应原 user 消息（内容可能被修改）
+                    for (orig_idx, _orig_text), pmsg in zip(original_user_msgs.items(), pruned_user_msgs):
+                        pruned_user_map[orig_idx] = pmsg.msg
+
+                    user_message_changes = [
+                        {
+                            "index": idx,
+                            "original": original_user_msgs[idx],
+                            "pruned": pruned_user_map.get(idx, ""),   # 未保留 → ""
+                        }
+                        for idx in original_user_msgs
+                        if pruned_user_map.get(idx, "") != original_user_msgs[idx]   # 仅保留真变动
+                    ]
+
                     pruning_stats = {
                         "enabled": True,
                         "scene": config.pruning_scene,
                         "threshold": config.pruning_threshold,
-                        "deleted_count": len(deleted_messages),
+                        "changed_count": len(user_message_changes),
                     }
                     logger.info(
-                        f"[PILOT_RUN] 语义剪枝完成: {len(original_msgs)} → {len(remaining)} 条"
-                        f"（删除 {len(deleted_messages)} 条）"
+                        f"[PILOT_RUN] 语义剪枝完成: "
+                        f"原始 user 消息 {len(original_user_msgs)} 条，变化 {len(user_message_changes)} 条"
                     )
                     if progress_callback:
-                        await progress_callback(
+                        await _wrapped_progress_callback(
                             "text_preprocessing_result", "语义剪枝完成",
-                            {"type": "pruning", "deleted_messages": deleted_messages},
+                            {"type": "pruning", "user_message_changes": user_message_changes},
                         )
                 else:
                     logger.warning("[PILOT_RUN] 剪枝后对话为空，使用原始对话")
@@ -184,7 +371,7 @@ async def run_pilot_extraction(
                 logger.error(f"[PILOT_RUN] 语义剪枝失败，使用原始对话: {e}", exc_info=True)
                 pruned_dialogs = [dialog]
                 if progress_callback:
-                    await progress_callback(
+                    await _wrapped_progress_callback(
                         "text_preprocessing_result", "语义剪枝失败",
                         {"type": "pruning", "error": str(e), "fallback": "使用原始对话"},
                     )
@@ -201,7 +388,7 @@ async def run_pilot_extraction(
         if progress_callback:
             for dlg in chunked_dialogs:
                 for i, chunk in enumerate(dlg.chunks or []):
-                    await progress_callback(
+                    await _wrapped_progress_callback(
                         "text_preprocessing_result", f"分块 {i + 1} 处理完成",
                         {
                             "type": "chunking",
@@ -212,7 +399,7 @@ async def run_pilot_extraction(
                             "chunker_strategy": memory_config.chunker_strategy,
                         },
                     )
-            await progress_callback(
+            await _wrapped_progress_callback(
                 "text_preprocessing_complete", "预处理文本完成（剪枝 + 分块）",
                 {
                     "total_chunks": sum(len(dlg.chunks or []) for dlg in chunked_dialogs),
@@ -229,7 +416,7 @@ async def run_pilot_extraction(
         logger.info("Running pilot extraction pipeline...")
 
         if progress_callback:
-            await progress_callback("knowledge_extraction", "正在知识抽取...")
+            await _wrapped_progress_callback("knowledge_extraction", "正在知识抽取...", None)
 
         from app.core.memory.pipelines.pilot_write_pipeline import PilotWritePipeline
 
@@ -237,14 +424,14 @@ async def run_pilot_extraction(
             memory_config=memory_config,
             end_user_id=str(memory_config.workspace_id),
             language=language,
-            progress_callback=progress_callback,
+            progress_callback=_wrapped_progress_callback,
         ).run(chunked_dialogs)
 
         log_time("Extraction Pipeline", time.time() - step_start, log_file)
 
         # ── 步骤 4: 输出结果文件 ────────────────────────────────────────────
         if progress_callback:
-            await progress_callback("generating_results", "正在生成结果...")
+            await _wrapped_progress_callback("generating_results", "正在生成结果...", None)
 
         graph = pilot_result.graph
         settings.ensure_memory_output_dir()
@@ -261,6 +448,10 @@ async def run_pilot_extraction(
             chunk_nodes=graph.chunk_nodes,
             pipeline_output_dir=settings.get_memory_output_path(),
         )
+
+        # v0.3.13: 注入 perceptual 字段 / 移除 disambiguation 字段（试运行专属）
+        _patch_extracted_result_json(_build_perceptual_summary(perceptual_snapshots))
+
         logger.info("Pilot run completed: stop after layer-1 dedup (no Neo4j write)")
 
     except Exception as e:

--- a/api/app/services/pilot_run_service.py
+++ b/api/app/services/pilot_run_service.py
@@ -12,17 +12,19 @@ Pilot Run Service - 试运行服务
 v0.3.13 变更：
 - 入参从 dialogue_text: str 改为 messages: List[WriteMessageItem]（与 /write 接口对齐）
 - 新增：文件 URL 解析 + 感知记忆内存快照（persist=False）
-- SSE `text_preprocessing_result` 的 pruning 子事件字段：deleted_messages → user_message_changes（仅 user 角色）
-- SSE 新增 `perceptual_result` 事件（感知记忆汇总，无 files 时也会发出，perceptual_nodes 为空数组）
-- `result.extracted_result` 新增 `perceptual` 字段 / 移除 `disambiguation` 字段
+- SSE 剪枝与分块各自拥有完整三联事件：pruning_extract/pruning_result/pruning_complete
+  与 chunking_extract/chunking_result/chunking_complete
+- SSE 新增 perceptual / extract_statement / extract_triplet 三联事件
+- result.extracted_result 新增 perceptual 字段 / 移除 disambiguation 字段
 """
 
+import asyncio
 import json
 import os
 import time
-from typing import Any, Awaitable, Callable, List, Optional
+from collections import Counter
+from typing import Awaitable, Callable, List, Optional
 
-from app.core.utils.datetime_utils import utcnow_naive
 from app.core.config import settings
 from app.core.logging_config import get_memory_logger, log_time
 from app.core.memory.models.message_models import (
@@ -34,19 +36,38 @@ from app.core.memory.storage_services.extraction_engine.pipeline_help import (
     _write_extracted_result_summary,
     export_test_input_doc,
 )
+from app.core.utils.datetime_utils import ensure_dialog_at, utcnow_naive
 from app.schemas.app_schema import FileInput, TransferMethod
 from app.schemas.memory_agent_schema import WriteMessageItem
 from app.schemas.memory_config_schema import MemoryConfig
 from app.services.memory_perceptual_service import _PerceptualSnapshot
 
-
 logger = get_memory_logger(__name__)
 
+# 类型别名，提高可读性
+ProgressCallback = Callable[[str, str, Optional[dict]], Awaitable[None]]
+PerceptualEntry = tuple[int, _PerceptualSnapshot, str | None, str | None]
+
+# 中英 role 映射（downstream chunker/pipeline 要求 "用户"/"AI"）
+_ROLE_TO_CN = {"user": "用户", "assistant": "AI"}
+
+
+# ════════════════════════════════════════════════════════════════════
+# Helper: 进度回调空实现（避免调用方到处 if callback）
+# ════════════════════════════════════════════════════════════════════
+
+async def _noop_progress(stage: str, message: str, data: Optional[dict] = None) -> None:
+    """空回调，用于 progress_callback 为 None 时的兜底。"""
+
+
+# ════════════════════════════════════════════════════════════════════
+# Helper: 三元组 / 实体文本报告
+# ════════════════════════════════════════════════════════════════════
 
 def _save_triplets_from_dialogs(dialog_data_list: list[DialogData], output_path: str) -> None:
     """Write triplet/entity text report compatible with pipeline_help parsers."""
-    all_triplets = []
-    all_entities = []
+    all_triplets: list = []
+    all_entities: list = []
 
     for dialog in dialog_data_list:
         for chunk in getattr(dialog, "chunks", []) or []:
@@ -79,19 +100,19 @@ def _save_triplets_from_dialogs(dialog_data_list: list[DialogData], output_path:
             f.write("\n")
 
 
-# ────────────────────────────────────────────────────────────────
-# 感知记忆 helper（试运行专用，来自 development.md §4.1.6）
-# ────────────────────────────────────────────────────────────────
-def _collect_perceptual_nodes_data(
-    snapshots: list[tuple[int, "_PerceptualSnapshot"]],
-) -> list[dict]:
-    """perceptual_result 事件 data.perceptual_nodes 构造。无快照时返回 []。"""
+# ════════════════════════════════════════════════════════════════════
+# Helper: 感知记忆
+# ════════════════════════════════════════════════════════════════════
+
+def _collect_perceptual_nodes_data(snapshots: list[PerceptualEntry]) -> list[dict]:
+    """构造 perceptual_result 事件 data.perceptual_nodes。无快照时返回 []。"""
     result: list[dict] = []
-    for _, snap in snapshots:
+    for _, snap, file_type, url in snapshots:
         content = (snap.meta_data or {}).get("content", {}) or {}
         result.append({
-            "file_type": snap.perceptual_type.value if snap.perceptual_type else None,
+            "file_type": file_type,
             "file_name": snap.file_name,
+            "url": url,
             "summary": snap.summary,
             "topic": content.get("topic"),
             "keywords": content.get("keywords", []),
@@ -100,38 +121,42 @@ def _collect_perceptual_nodes_data(
     return result
 
 
-def _build_perceptual_summary(
-    snapshots: list[tuple[int, "_PerceptualSnapshot"]],
-) -> dict:
-    """result.extracted_result.perceptual 字段构造（无快照时返回零统计 + 空数组）。"""
-    from collections import Counter
-    file_types = [
-        snap.perceptual_type.value
-        for _, snap in snapshots
-        if snap.perceptual_type
-    ]
+def _build_perceptual_summary(snapshots: list[PerceptualEntry]) -> dict:
+    """构造 result.extracted_result.perceptual 字段（无快照时返回零统计 + 空数组）。"""
+    file_types = [ft for _, _, ft, _ in snapshots if ft]
     type_counter = Counter(file_types)
-    samples = _collect_perceptual_nodes_data(snapshots)
     return {
         "count": len(snapshots),
         "file_type_distribution": [
             {"file_type": t, "count": c} for t, c in type_counter.items()
         ],
-        "samples": samples,   # 字段与 perceptual_result 事件一致
+        "samples": _collect_perceptual_nodes_data(snapshots),
     }
 
 
-async def _resolve_file_url(file: FileInput) -> Optional[str]:
-    """解析 FileInput 为可访问 URL（remote_url 直接返回，local_file 走 MultimodalService.get_file_url）。"""
+async def _resolve_file_url(
+    file: FileInput,
+    mm_service: "Optional['MultimodalService']" = None,
+) -> Optional[str]:
+    """解析 FileInput 为可访问 URL。
+
+    - remote_url：直接返回 `file.url`，不需要 DB。
+    - local_file：需要走 `MultimodalService.get_file_url()`。调用方应传入共享的
+      `mm_service`（复用同一 read session）；未传时按旧路径临时开一次 session。
+    """
     if file.transfer_method == TransferMethod.REMOTE_URL:
         return file.url
-    # local_file：需要短 session 查 file_metadata 并签名 URL
-    from app.db import get_db_read
-    from app.services.multimodal_service import MultimodalService
+
     try:
-        with get_db_read() as db:
-            mm_service = MultimodalService(db, api_config=None)
+        if mm_service is not None:
             return await mm_service.get_file_url(file)
+
+        # 兼容：无共享 service 时临时开一次 session
+        from app.db import get_db_read
+        from app.services.multimodal_service import MultimodalService
+
+        with get_db_read() as db:
+            return await MultimodalService(db, api_config=None).get_file_url(file)
     except Exception as e:
         logger.warning(f"[PILOT_RUN] 文件 URL 解析失败: file_id={file.upload_file_id}, err={e}")
         return None
@@ -140,54 +165,95 @@ async def _resolve_file_url(file: FileInput) -> Optional[str]:
 async def _generate_perceptual_snapshots(
     memory_config: MemoryConfig,
     messages: List[WriteMessageItem],
-) -> list[tuple[int, _PerceptualSnapshot]]:
+) -> list[PerceptualEntry]:
     """遍历 messages 中的 files，生成感知记忆内存快照（persist=False）。
 
-    返回 (message_index, snapshot) 元组列表，用于后续把 summary 注入回对应 message。
-    单条 file 失败不阻断整体流程，仅记录 warning 日志。
+    优化点：
+    1. **共享 session 批解析 URL**：所有 `local_file` 的 URL 解析集中在一个
+       `get_db_read()` session 内完成；`remote_url` 无需 DB。
+    2. **LLM 调用并发化**：每个 file 的感知记忆生成通过 `asyncio.gather` 并行执行，
+       单文件失败不影响其他文件。
+
+    返回 (message_index, snapshot, file_type, resolved_url) 元组列表。
     """
     from app.db import get_db_read
     from app.services.memory_perceptual_service import MemoryPerceptualService
+    from app.services.multimodal_service import MultimodalService
 
-    snapshots: list[tuple[int, _PerceptualSnapshot]] = []
-    for msg_idx, msg in enumerate(messages):
-        if not msg.files:
-            continue
-        for file in msg.files:
-            try:
-                resolved_url = await _resolve_file_url(file)
-                if not resolved_url:
-                    logger.warning(f"[PILOT_RUN] 文件 URL 解析为空，跳过: msg_idx={msg_idx}, file={file}")
-                    continue
-                file_for_perceptual = file.model_copy(update={"url": resolved_url})
+    # ── Phase 1: 批量解析 URL（一次 session 内完成，remote_url 无需 DB）──
+    resolved_files: list[tuple[int, WriteMessageItem, FileInput, str]] = []
+    needs_db = any(
+        f.transfer_method != TransferMethod.REMOTE_URL
+        for msg in messages
+        for f in (msg.files or [])
+    )
 
-                with get_db_read() as db:
-                    perceptual_service = MemoryPerceptualService(db)
-                    snapshot = await perceptual_service.generate_perceptual_memory(
-                        end_user_id=str(memory_config.workspace_id),
-                        memory_config=memory_config,
-                        file=file_for_perceptual,
-                        content=msg.content,
-                        persist=False,
-                    )
-                if snapshot is None:
+    async def _collect_urls(mm_service: Optional[MultimodalService]) -> None:
+        for msg_idx, msg in enumerate(messages):
+            if not msg.files:
+                continue
+            for file in msg.files:
+                url = await _resolve_file_url(file, mm_service)
+                if not url:
                     logger.warning(
-                        f"[PILOT_RUN] 感知记忆生成返回 None，跳过: msg_idx={msg_idx}, file={file}"
+                        f"[PILOT_RUN] 文件 URL 解析为空，跳过: msg_idx={msg_idx}, file={file}"
                     )
                     continue
-                snapshots.append((msg_idx, snapshot))
-            except Exception as e:
-                logger.warning(
-                    f"[PILOT_RUN] 文件处理失败，跳过: msg_idx={msg_idx}, err={e}",
-                    exc_info=True,
-                )
-    return snapshots
+                resolved_files.append((msg_idx, msg, file, url))
 
+    if needs_db:
+        with get_db_read() as db:
+            await _collect_urls(MultimodalService(db, api_config=None))
+    else:
+        await _collect_urls(None)
+
+    if not resolved_files:
+        return []
+
+    # ── Phase 2: 并发生成感知记忆（每个协程独占一次 read session）──
+    async def _snapshot_one(
+        msg_idx: int,
+        msg: WriteMessageItem,
+        file: FileInput,
+        url: str,
+    ) -> Optional[PerceptualEntry]:
+        try:
+            file_for_perceptual = file.model_copy(update={"url": url})
+            with get_db_read() as db:
+                snapshot = await MemoryPerceptualService(db).generate_perceptual_memory(
+                    end_user_id=str(memory_config.workspace_id),
+                    memory_config=memory_config,
+                    file=file_for_perceptual,
+                    content=msg.content,
+                    persist=False,
+                )
+        except Exception as e:
+            logger.warning(
+                f"[PILOT_RUN] 文件处理失败，跳过: msg_idx={msg_idx}, err={e}",
+                exc_info=True,
+            )
+            return None
+        if snapshot is None:
+            logger.warning(
+                f"[PILOT_RUN] 感知记忆生成返回 None，跳过: msg_idx={msg_idx}, file={file}"
+            )
+            return None
+        return (msg_idx, snapshot, file.file_type, url)
+
+    results = await asyncio.gather(
+        *(_snapshot_one(*args) for args in resolved_files),
+        return_exceptions=False,  # 单任务已 try/except，不会外抛
+    )
+    # 按原 message 顺序（同 msg 下按 files 顺序）返回
+    return [r for r in results if r is not None]
+
+
+# ════════════════════════════════════════════════════════════════════
+# Helper: 结果文件 patch
+# ════════════════════════════════════════════════════════════════════
 
 def _patch_extracted_result_json(perceptual_summary: dict) -> None:
-    """在 _write_extracted_result_summary 生成 extracted_result.json 之后，
-    注入 perceptual 字段并移除 disambiguation 字段（v0.3.13 契约）。
-    """
+    """注入 perceptual 字段并移除 disambiguation 字段"""
     result_path = settings.get_memory_output_path("extracted_result.json")
     if not os.path.isfile(result_path):
         logger.warning(f"[PILOT_RUN] extracted_result.json 不存在，跳过 patch: {result_path}")
@@ -196,26 +262,179 @@ def _patch_extracted_result_json(perceptual_summary: dict) -> None:
         with open(result_path, "r", encoding="utf-8") as rf:
             data = json.load(rf)
         data["perceptual"] = perceptual_summary
-        data.pop("disambiguation", None)   # v0.3.13: 消歧下线，安全移除
+        data.pop("disambiguation", None)
         with open(result_path, "w", encoding="utf-8") as wf:
             json.dump(data, wf, ensure_ascii=False, indent=2)
     except Exception as e:
         logger.error(f"[PILOT_RUN] patch extracted_result.json 失败: {e}", exc_info=True)
 
 
+# ════════════════════════════════════════════════════════════════════
+# Helper: 语义剪枝子流程
+# ════════════════════════════════════════════════════════════════════
+
+async def _run_pruning(
+    dialog: DialogData,
+    memory_config: MemoryConfig,
+    llm_client,
+    emit: ProgressCallback,
+) -> tuple[list[DialogData], dict]:
+    """执行语义剪枝，返回 (pruned_dialogs, pruning_stats)。
+
+    stats.status 取值：
+    - `success`      剪枝成功，已产出 diff
+    - `empty_fallback` 剪枝后为空，使用原始对话
+    - `failed`       剪枝执行异常，使用原始对话
+    - `disabled`     未启用（当前函数不会产生此值，由上游控制）
+
+    enabled 始终反映配置开关（与 status 解耦），避免“启用但失败”被误读成“未启用”。
+    """
+    from app.core.memory.models.config_models import PruningConfig
+    from app.core.memory.storage_services.extraction_engine.data_preprocessing.data_pruning import (
+        SemanticPruner,
+    )
+
+    await emit("pruning_extract", "开始语义剪枝", None)
+
+    config = PruningConfig(
+        pruning_switch=memory_config.pruning_enabled,
+        pruning_scene=memory_config.pruning_scene,
+        pruning_threshold=memory_config.pruning_threshold,
+        scene_id=str(memory_config.scene_id) if memory_config.scene_id else None,
+        ontology_class_infos=memory_config.ontology_class_infos,
+    )
+
+    # 记录原始 user 消息用于 diff
+    original_user_msgs: dict[int, str] = {
+        i: m.msg for i, m in enumerate(dialog.context.msgs) if m.role == "user"
+    }
+
+    try:
+        pruned_dialogs = await SemanticPruner(config=config, llm_client=llm_client).prune_dataset([dialog])
+
+        if not (pruned_dialogs and pruned_dialogs[0].context):
+            logger.warning("[PILOT_RUN] 剪枝后对话为空，使用原始对话")
+            fallback_stats = {
+                "enabled": True,
+                "status": "empty_fallback",
+                "scene": config.pruning_scene,
+                "threshold": config.pruning_threshold,
+                "changed_count": 0,
+            }
+            await emit(
+                "pruning_result", "语义剪枝结果",
+                {"user_message_changes": [], "fallback": "剪枝后为空，使用原始对话"},
+            )
+            await emit("pruning_complete", "语义剪枝完成", fallback_stats)
+            return [dialog], fallback_stats
+
+        # 构建 user 消息 diff
+        pruned_user_msgs = [m for m in pruned_dialogs[0].context.msgs if m.role == "user"]
+        pruned_user_map: dict[int, str] = {}
+        for (orig_idx, _), pmsg in zip(original_user_msgs.items(), pruned_user_msgs):
+            pruned_user_map[orig_idx] = pmsg.msg
+
+        user_message_changes = [
+            {"index": idx, "original": original_user_msgs[idx], "pruned": pruned_user_map.get(idx, "")}
+            for idx in original_user_msgs
+            if pruned_user_map.get(idx, "") != original_user_msgs[idx]
+        ]
+
+        pruning_stats = {
+            "enabled": True,
+            "status": "success",
+            "scene": config.pruning_scene,
+            "threshold": config.pruning_threshold,
+            "changed_count": len(user_message_changes),
+        }
+        logger.info(
+            f"[PILOT_RUN] 语义剪枝完成: "
+            f"原始 user 消息 {len(original_user_msgs)} 条，变化 {len(user_message_changes)} 条"
+        )
+        await emit("pruning_result", "语义剪枝结果", {"user_message_changes": user_message_changes})
+        await emit("pruning_complete", "语义剪枝完成", pruning_stats)
+        return pruned_dialogs, pruning_stats
+
+    except Exception as e:
+        logger.error(f"[PILOT_RUN] 语义剪枝失败，使用原始对话: {e}", exc_info=True)
+        failed_stats = {
+            "enabled": True,
+            "status": "failed",
+            "scene": config.pruning_scene,
+            "threshold": config.pruning_threshold,
+            "changed_count": 0,
+            "error": str(e),
+        }
+        await emit("pruning_result", "语义剪枝失败", {"error": str(e), "fallback": "使用原始对话"})
+        await emit("pruning_complete", "语义剪枝完成", failed_stats)
+        return [dialog], failed_stats
+
+
+# ════════════════════════════════════════════════════════════════════
+# Helper: 语义分块子流程
+# ════════════════════════════════════════════════════════════════════
+
+async def _run_chunking(
+    pruned_dialogs: list[DialogData],
+    memory_config: MemoryConfig,
+    llm_client,
+    emit: ProgressCallback,
+) -> list[DialogData]:
+    """对剪枝后的对话列表执行语义分块，返回 chunked_dialogs。"""
+    from app.core.memory.storage_services.extraction_engine.knowledge_extraction.chunk_extraction import (
+        DialogueChunker,
+    )
+
+    await emit("chunking_extract", "开始分块", {"chunker_strategy": memory_config.chunker_strategy})
+
+    chunker = DialogueChunker(memory_config.chunker_strategy, llm_client=llm_client)
+    chunked_dialogs: list[DialogData] = []
+    for dlg in pruned_dialogs:
+        dlg.chunks = await chunker.process_dialogue(dlg)
+        chunked_dialogs.append(dlg)
+
+    # 逐块汇报进度
+    for dlg in chunked_dialogs:
+        for i, chunk in enumerate(dlg.chunks or []):
+            await emit(
+                "chunking_result", f"分块 {i + 1} 处理完成",
+                {
+                    "chunk_index": i + 1,
+                    "content": chunk.content[:200] + "..." if len(chunk.content) > 200 else chunk.content,
+                    "full_length": len(chunk.content),
+                    "dialog_id": dlg.id,
+                    "chunker_strategy": memory_config.chunker_strategy,
+                },
+            )
+
+    await emit(
+        "chunking_complete", "分块完成",
+        {
+            "total_chunks": sum(len(dlg.chunks or []) for dlg in chunked_dialogs),
+            "total_dialogs": len(chunked_dialogs),
+            "chunker_strategy": memory_config.chunker_strategy,
+        },
+    )
+    return chunked_dialogs
+
+
+# ════════════════════════════════════════════════════════════════════
+# 主入口
+# ════════════════════════════════════════════════════════════════════
+
 async def run_pilot_extraction(
     memory_config: MemoryConfig,
     messages: List[WriteMessageItem],
     llm_client,
-    progress_callback: Optional[Callable[[str, str, Optional[dict]], Awaitable[None]]] = None,
+    progress_callback: Optional[ProgressCallback] = None,
     language: str = "zh",
 ) -> None:
     """执行试运行模式的知识提取流水线（v0.3.13 QA 消息格式）。
 
-    职责：
+    流程：
     1. 文件 URL 解析 + 感知记忆内存快照（persist=False）
-    2. 构建 DialogData → 语义剪枝 → 语义分块（预处理，需要 llm_client）
-    3. 调用 PilotWritePipeline 执行萃取链路（Pipeline 自行管理客户端）
+    2. 构建 DialogData → 语义剪枝 → 语义分块
+    3. 调用 PilotWritePipeline 执行萃取链路
     4. 将萃取结果写入输出文件，并注入 perceptual 字段 / 移除 disambiguation
 
     Args:
@@ -227,64 +446,52 @@ async def run_pilot_extraction(
     """
     log_file = "logs/time.log"
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
+
     timestamp = utcnow_naive().strftime("%Y-%m-%d %H:%M:%S")
     with open(log_file, "a", encoding="utf-8") as f:
         f.write(f"\n=== Pilot Run Started: {timestamp} ===\n")
 
+    # 统一使用 emit，避免到处判断 callback 是否为 None
+    emit: ProgressCallback = progress_callback or _noop_progress
     pipeline_start = time.time()
 
-    # ── 包装 progress_callback：在 creating_nodes_edges_complete 之后插入 perceptual_result ──
-    perceptual_snapshots: list[tuple[int, _PerceptualSnapshot]] = []
-    perceptual_emitted = {"done": False}
-
-    async def _wrapped_progress_callback(stage: str, message: str, data: Optional[dict] = None) -> None:
-        # 先透传原事件
-        if progress_callback:
-            await progress_callback(stage, message, data)
-        # 在 creating_nodes_edges_complete 之后、dedup 事件之前插入 perceptual_result（幂等）
-        if stage == "creating_nodes_edges_complete" and not perceptual_emitted["done"]:
-            perceptual_emitted["done"] = True
-            perceptual_nodes = _collect_perceptual_nodes_data(perceptual_snapshots)
-            if progress_callback:
-                await progress_callback(
-                    "perceptual_result", "感知记忆提取完成",
-                    {"perceptual_nodes": perceptual_nodes},
-                )
-
     try:
-        # ── 步骤 1: llm_client 已由调用方在 db session 关闭前初始化传入 ──────
+        # ── 步骤 1: 文件 URL 解析 + 感知记忆生成（persist=False） ─────────
         step_start = time.time()
-        log_time("Client Initialization", time.time() - step_start, log_file)
+        await emit("perceptual_extract", "开始提取感知记忆", None)
 
-        # ── 步骤 1.5: 文件 URL 解析 + 感知记忆生成（persist=False） ─────────
-        step_start = time.time()
-        perceptual_snapshots.extend(
-            await _generate_perceptual_snapshots(memory_config, messages)
+        perceptual_snapshots = await _generate_perceptual_snapshots(memory_config, messages)
+
+        await emit(
+            "perceptual_result", "感知记忆结果",
+            {"perceptual_nodes": _collect_perceptual_nodes_data(perceptual_snapshots)},
         )
+        await emit("perceptual_complete", "感知记忆提取完成", {"count": len(perceptual_snapshots)})
         log_time("Perceptual Snapshot Generation", time.time() - step_start, log_file)
 
         # 将 file_summary 注入回对应 message.content（对齐 WritePipeline._preprocess_files）
         message_content_map: dict[int, str] = {}
-        for msg_idx, snap in perceptual_snapshots:
+        for msg_idx, snap, _ft, _url in perceptual_snapshots:
             original = messages[msg_idx].content or ""
-            if snap.summary:
-                tag = f"<input-file-summary>{snap.summary}</input-file-summary>"
-                if tag not in original:
-                    message_content_map[msg_idx] = original + tag
-                    continue
-            message_content_map.setdefault(msg_idx, original)
+            tag = f"<input-file-summary>{snap.summary}</input-file-summary>"
+            if snap.summary and tag not in original:
+                message_content_map[msg_idx] = original + tag
+            else:
+                message_content_map.setdefault(msg_idx, original)
 
-        # ── 步骤 2: 构建 DialogData ──────────────────────────────────────────
+        # ── 步骤 2: 构建 DialogData（保留英文 role 以兼容 SemanticPruner 配对逻辑）──
         step_start = time.time()
-        role_map = {"user": "用户", "assistant": "AI"}
         conv_msgs: list[ConversationMessage] = []
         for idx, m in enumerate(messages):
-            content = message_content_map.get(idx, m.content or "")
-            content = content.strip()
+            content = message_content_map.get(idx, m.content or "").strip()
             if not content:
                 continue
             conv_msgs.append(
-                ConversationMessage(role=role_map.get(m.role, m.role), msg=content)
+                ConversationMessage(
+                    role=m.role,
+                    msg=content,
+                    dialog_at=ensure_dialog_at(m.dialog_at),
+                )
             )
 
         if not conv_msgs:
@@ -299,124 +506,25 @@ async def run_pilot_extraction(
             metadata={"source": "pilot_run", "input_type": "qa_messages"},
         )
 
-        if progress_callback:
-            await _wrapped_progress_callback(
-                "text_preprocessing", "开始预处理文本（语义剪枝 + 语义分块）...", None
-            )
-
-        # ── 步骤 2.1: 语义剪枝 ─────────────────────────────────────────────
-        pruned_dialogs = [dialog]
-        pruning_stats: dict = {"enabled": False}
-
+        # ── 步骤 2.1: 语义剪枝 ────────────────────────────────────────────
         if memory_config.pruning_enabled:
-            try:
-                from app.core.memory.storage_services.extraction_engine.data_preprocessing.data_pruning import (
-                    SemanticPruner,
-                )
-                from app.core.memory.models.config_models import PruningConfig
+            pruned_dialogs, _ = await _run_pruning(dialog, memory_config, llm_client, emit)
+        else:
+            pruned_dialogs = [dialog]
 
-                config = PruningConfig(
-                    pruning_switch=memory_config.pruning_enabled,
-                    pruning_scene=memory_config.pruning_scene,
-                    pruning_threshold=memory_config.pruning_threshold,
-                    scene_id=str(memory_config.scene_id) if memory_config.scene_id else None,
-                    ontology_class_infos=memory_config.ontology_class_infos,
-                )
-                # v0.3.13: 只关注 user 角色的剪枝变化（assistant 修改对前端无展示价值）
-                original_user_msgs: dict[int, str] = {
-                    i: m.msg for i, m in enumerate(dialog.context.msgs) if m.role in ("用户", "user")
-                }
-                pruned_dialogs = await SemanticPruner(config=config, llm_client=llm_client).prune_dataset([dialog])
-
-                if pruned_dialogs and pruned_dialogs[0].context:
-                    pruned_user_map: dict[int, str] = {}
-                    pruned_user_msgs = [
-                        m for m in pruned_dialogs[0].context.msgs
-                        if m.role in ("用户", "user")
-                    ]
-                    # 按顺序匹配：剩余 user 消息按原次序对应原 user 消息（内容可能被修改）
-                    for (orig_idx, _orig_text), pmsg in zip(original_user_msgs.items(), pruned_user_msgs):
-                        pruned_user_map[orig_idx] = pmsg.msg
-
-                    user_message_changes = [
-                        {
-                            "index": idx,
-                            "original": original_user_msgs[idx],
-                            "pruned": pruned_user_map.get(idx, ""),   # 未保留 → ""
-                        }
-                        for idx in original_user_msgs
-                        if pruned_user_map.get(idx, "") != original_user_msgs[idx]   # 仅保留真变动
-                    ]
-
-                    pruning_stats = {
-                        "enabled": True,
-                        "scene": config.pruning_scene,
-                        "threshold": config.pruning_threshold,
-                        "changed_count": len(user_message_changes),
-                    }
-                    logger.info(
-                        f"[PILOT_RUN] 语义剪枝完成: "
-                        f"原始 user 消息 {len(original_user_msgs)} 条，变化 {len(user_message_changes)} 条"
-                    )
-                    if progress_callback:
-                        await _wrapped_progress_callback(
-                            "text_preprocessing_result", "语义剪枝完成",
-                            {"type": "pruning", "user_message_changes": user_message_changes},
-                        )
-                else:
-                    logger.warning("[PILOT_RUN] 剪枝后对话为空，使用原始对话")
-                    pruned_dialogs = [dialog]
-
-            except Exception as e:
-                logger.error(f"[PILOT_RUN] 语义剪枝失败，使用原始对话: {e}", exc_info=True)
-                pruned_dialogs = [dialog]
-                if progress_callback:
-                    await _wrapped_progress_callback(
-                        "text_preprocessing_result", "语义剪枝失败",
-                        {"type": "pruning", "error": str(e), "fallback": "使用原始对话"},
-                    )
-
-        # ── 步骤 2.2: 语义分块 ─────────────────────────────────────────────
-        from app.core.memory.storage_services.extraction_engine.knowledge_extraction.chunk_extraction import (
-            DialogueChunker,
-        )
-        chunked_dialogs = []
+        # 将 role 转为中文（downstream chunker/pipeline 要求）
         for dlg in pruned_dialogs:
-            dlg.chunks = await DialogueChunker(memory_config.chunker_strategy, llm_client=llm_client).process_dialogue(dlg)
-            chunked_dialogs.append(dlg)
+            if dlg.context and dlg.context.msgs:
+                for msg in dlg.context.msgs:
+                    msg.role = _ROLE_TO_CN.get(msg.role, msg.role)
 
-        if progress_callback:
-            for dlg in chunked_dialogs:
-                for i, chunk in enumerate(dlg.chunks or []):
-                    await _wrapped_progress_callback(
-                        "text_preprocessing_result", f"分块 {i + 1} 处理完成",
-                        {
-                            "type": "chunking",
-                            "chunk_index": i + 1,
-                            "content": chunk.content[:200] + "..." if len(chunk.content) > 200 else chunk.content,
-                            "full_length": len(chunk.content),
-                            "dialog_id": dlg.id,
-                            "chunker_strategy": memory_config.chunker_strategy,
-                        },
-                    )
-            await _wrapped_progress_callback(
-                "text_preprocessing_complete", "预处理文本完成（剪枝 + 分块）",
-                {
-                    "total_chunks": sum(len(dlg.chunks or []) for dlg in chunked_dialogs),
-                    "total_dialogs": len(chunked_dialogs),
-                    "chunker_strategy": memory_config.chunker_strategy,
-                    "pruning": pruning_stats,
-                },
-            )
-
+        # ── 步骤 2.2: 语义分块 ────────────────────────────────────────────
+        chunked_dialogs = await _run_chunking(pruned_dialogs, memory_config, llm_client, emit)
         log_time("Data Loading & Chunking", time.time() - step_start, log_file)
 
-        # ── 步骤 3: 萃取（PilotWritePipeline 自行管理客户端和本体加载）──────
+        # ── 步骤 3: 萃取 ──────────────────────────────────────────────────
         step_start = time.time()
         logger.info("Running pilot extraction pipeline...")
-
-        if progress_callback:
-            await _wrapped_progress_callback("knowledge_extraction", "正在知识抽取...", None)
 
         from app.core.memory.pipelines.pilot_write_pipeline import PilotWritePipeline
 
@@ -424,14 +532,13 @@ async def run_pilot_extraction(
             memory_config=memory_config,
             end_user_id=str(memory_config.workspace_id),
             language=language,
-            progress_callback=_wrapped_progress_callback,
+            progress_callback=emit,
         ).run(chunked_dialogs)
 
         log_time("Extraction Pipeline", time.time() - step_start, log_file)
 
-        # ── 步骤 4: 输出结果文件 ────────────────────────────────────────────
-        if progress_callback:
-            await _wrapped_progress_callback("generating_results", "正在生成结果...", None)
+        # ── 步骤 4: 输出结果文件 ──────────────────────────────────────────
+        await emit("generating_results", "正在生成结果...", None)
 
         graph = pilot_result.graph
         settings.ensure_memory_output_dir()
@@ -448,8 +555,6 @@ async def run_pilot_extraction(
             chunk_nodes=graph.chunk_nodes,
             pipeline_output_dir=settings.get_memory_output_path(),
         )
-
-        # v0.3.13: 注入 perceptual 字段 / 移除 disambiguation 字段（试运行专属）
         _patch_extracted_result_json(_build_perceptual_summary(perceptual_snapshots))
 
         logger.info("Pilot run completed: stop after layer-1 dedup (no Neo4j write)")


### PR DESCRIPTION
## Summary by Sourcery

更新试跑（pilot run）QA抽取流程，以使用结构化消息输入，为附加文件生成非持久化的感知记忆，并丰富流式进度事件，同时简化去重/消歧输出。

新功能：
- 支持将试跑输入作为与 `/write` API 对齐的问答（QA）风格消息，包括可选的文件附件。
- 为试跑添加感知记忆快照生成，但不写入持久化存储；包括将摘要和分布统计注入到 `extracted_result` 输出中。
- 引入新的 SSE 进度事件流，用于感知抽取、陈述（statement）抽取和三元组（triplet）抽取，并提供更细粒度的负载内容。

增强优化：
- 优化试跑服务中的语义剪枝和分块（chunking）子流程，增加明确的进度报告和角色处理。
- 在 write 和 pilot 流水线中使用不绑定会话（non-session-bound）的感知快照对象，以避免下游步骤中的 ORM 分离问题。
- 将陈述和三元组抽取切换为通过 `asyncio.as_completed` 逐步增量地输出结果，以在长任务执行期间保持 SSE 通道的响应性。
- 调整三元组抽取的 SSE 负载，使其专注于有界的实体和关系创建样本，而不是原始三元组列表。
- 通过移除遗留的关系和消歧特定进度事件，并整合去重完成报告，简化图构建和去重步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update pilot run QA extraction to use structured messages input, generate non-persistent perceptual memories for attached files, and enrich streaming progress events while simplifying dedup/disambiguation outputs.

New Features:
- Support pilot run input as QA-style messages aligned with the /write API, including optional file attachments.
- Add perceptual memory snapshot generation for pilot runs without persisting to storage, including summaries and distribution stats injected into extracted_result output.
- Introduce new SSE progress event streams for perceptual extraction, statement extraction, and triplet extraction with more granular payloads.

Enhancements:
- Refine semantic pruning and chunking sub-flows in the pilot run service with explicit progress reporting and role handling.
- Use non-session-bound perceptual snapshot objects in both write and pilot pipelines to avoid ORM detachment issues in downstream steps.
- Switch statement and triplet extraction to emit results incrementally via asyncio.as_completed to keep SSE channels responsive for long-running tasks.
- Adjust triplet extraction SSE payloads to focus on bounded samples of entity and relationship creation instead of raw triplet lists.
- Simplify graph build and dedup steps by removing legacy relationship and disambiguation-specific progress events and consolidating dedup completion reporting.

</details>