### PR TITLE
fix(memory_config): 

### DIFF
--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -867,10 +867,8 @@ class AgentRunService:
         enabled = bool(memory_config and memory_config.get("enabled"))
         config_id = None
         if enabled and workspace_id:
-            if isinstance(self.db, AsyncSession):
-                config_id = await MemoryConfigService(self.db).get_workspace_active_config_id_async(workspace_id)
-            else:
-                config_id = MemoryConfigService(self.db).get_workspace_active_config_id(workspace_id)
+            async with get_async_db_context() as db:
+                config_id = await MemoryConfigService(db).get_workspace_active_config_id_async(workspace_id)
 
         tool = create_long_term_memory_tool(
             memory_config, user_id, workspace_id, storage_type, user_rag_memory_id,

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1542,7 +1542,7 @@ class WorkflowService:
         }
 
     @staticmethod
-    def _get_execution_source(execution: WorkflowExecution | None) -> str:
+    def _get_execution_source(execution: WorkflowExecution | WorkflowExecutionRef | None) -> str:
         if not execution:
             return "workflow_execution"
         meta_data = execution.meta_data or {}
@@ -1816,7 +1816,7 @@ class WorkflowService:
     def _build_public_execution_snapshot_record(
             self,
             *,
-            execution: WorkflowExecution,
+            execution: WorkflowExecution | WorkflowExecutionRef,
             node_executions: list[WorkflowNodeExecution],
             output_data: dict[str, Any],
             workflow_config: "WorkflowConfig | None" = None,
@@ -2171,7 +2171,7 @@ class WorkflowService:
             source=self._get_execution_source(execution),
         )
 
-    def _extract_execution_messages(self, execution: WorkflowExecution | None) -> list[dict[str, Any]]:
+    def _extract_execution_messages(self, execution: WorkflowExecution | WorkflowExecutionRef | None) -> list[dict[str, Any]]:
         if not execution or not isinstance(execution.output_data, dict):
             return []
         messages = self._serialize_execution_value(execution.output_data.get("messages") or [])

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -3757,7 +3757,7 @@ class WorkflowService:
             action_id: str,
             form_data: dict | None,
             kind: str | None,
-    ) -> WorkflowExecution | None:
+    ) -> WorkflowExecutionRef | None:
         execution = await self._get_execution_async(execution_id)
         if not execution or not node_id:
             return execution
@@ -4425,7 +4425,7 @@ class WorkflowService:
 
     def _set_human_intervention_state(
             self,
-            execution: WorkflowExecution,
+            execution: WorkflowExecution | WorkflowExecutionRef,
             visible_interventions: list[dict] | None = None,
             backlog_interventions: list[dict] | None = None,
     ) -> None:


### PR DESCRIPTION
migrate draft run service to use async DB context for memory config lookup

## Summary by Sourcery

在更广泛的范围内使用工作流执行引用，并更新草稿运行的内存配置加载逻辑，使其依赖异步数据库上下文。

Bug Fixes（缺陷修复）:
- 确保草稿运行中的内存配置查找始终使用异步数据库上下文，避免同步/异步上下文不匹配的问题。

Enhancements（功能增强）:
- 扩展工作流服务辅助方法，使其除了接受完整的 `WorkflowExecution` 对象外，也能接受 `WorkflowExecutionRef` 实例，以便在服务中支持更轻量的执行引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use workflow execution references more broadly and update draft run memory configuration loading to rely on an async database context.

Bug Fixes:
- Ensure memory configuration lookup in draft runs consistently uses the asynchronous database context to avoid sync/async mismatches.

Enhancements:
- Extend workflow service helpers to accept WorkflowExecutionRef instances alongside full WorkflowExecution objects to support lighter-weight execution references across the service.

</details>