### PR TITLE
feat(web): package add config

### DIFF
--- a/web/src/i18n/en/detail.ts
+++ b/web/src/i18n/en/detail.ts
@@ -252,6 +252,8 @@ export const detail = {
       active: 'Active',
       inactive: 'Inactive',
       api_ops_rate_limit: 'API OPS Rate Limit',
+      pre_user_memory_write_qps_limit: 'Pre-User Memory Write QPS Rate Limit',
+      end_user_memory_limit: 'End User Memory Limit',
       ops: 'req/s',
       pcs: 'pcs',
       GB: 'GB',

--- a/web/src/i18n/zh/detail.ts
+++ b/web/src/i18n/zh/detail.ts
@@ -252,6 +252,8 @@ export const detail = {
       active: '启用',
       inactive: '停用',
       api_ops_rate_limit: 'API OPS 频次',
+      pre_user_memory_write_qps_limit: '记忆写入 QPS 频次',
+      end_user_memory_limit: '用户记忆数量',
       ops: '次/秒',
       pcs: '个',
       GB: 'GB',

--- a/web/src/views/Package/constant.ts
+++ b/web/src/views/Package/constant.ts
@@ -50,4 +50,14 @@ export const billingUnits = [
     unit: 'ops', placeholder: 'numberPlaceholder',
     icon: 'api_ops',
   },
+  {
+    key: 'pre_user_memory_write_qps_limit',
+    unit: 'ops', placeholder: 'numberPlaceholder',
+    icon: 'api_ops',
+  },
+  {
+    key: 'end_user_memory_limit',
+    unit: 'pcs', placeholder: 'numberPlaceholder',
+    icon: 'api_ops',
+  },
 ]


### PR DESCRIPTION
## Summary by Sourcery

在 Web 套餐视图中添加与内存相关的速率限制的配置选项和标签。

新功能：
- 在套餐配置中新增计费单元条目，用于“单个预用户内存写入 QPS 限制”和“终端用户内存限制”。

增强：
- 在套餐详情视图中，为新的与内存相关的速率限制和限制字段添加英文和中文的 i18n 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration options and labels for memory-related rate limits in the web package view.

New Features:
- Introduce new billing unit entries for pre-user memory write QPS limit and end user memory limit in the package configuration.

Enhancements:
- Add English and Chinese i18n labels for the new memory-related rate limit and limit fields in the package details view.

</details>