### PR TITLE
fix(memory): correct unresolved statement flag condition

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2623,7 +2623,7 @@ RETURN s.id AS statement_id
 
 UNRESOLVED_UPDATE_STATEMENT_FLAG = """
 MATCH (s:Statement {id: $statement_id})
-WHERE s.delete_at IS NULL
+WHERE s.delete_at IS NOT NULL
 SET s.has_unsolved_reference = false
 RETURN s.id AS statement_id
 """


### PR DESCRIPTION
- Fix WHERE clause to match statements where delete_at IS NOT NULL instead of IS NULL
- This ensures the has_unsolved_reference flag is only cleared for deleted statements

## Summary by Sourcery

Bug Fixes:
- 更正未解决语句标记的查询，仅更新 `delete_at` 已设置（即不为 null）的语句。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the unresolved statement flag query to only update statements where delete_at is set (i.e., not null).

</details>