### PR TITLE
Feat/fast write pipeline

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -101,6 +101,9 @@ celery_app.conf.update(
         # Memory tasks → memory_tasks queue (threads worker)
         'app.core.memory.agent.write_message': {'queue': 'memory_tasks'},
 
+        # Fast Write tasks → memory_fast_tasks queue (threads worker，独立队列，避免与普通写入互相阻塞)
+        'app.core.memory.fast_write_message': {'queue': 'memory_fast_tasks'},
+
         # Document tasks → document_tasks queue (prefork worker)
         'app.core.rag.tasks.parse_document': {'queue': 'document_tasks'},
         'app.core.rag.tasks.sync_knowledge_for_kb': {'queue': 'document_tasks'},

--- a/api/app/celery_task_scheduler/scheduler.py
+++ b/api/app/celery_task_scheduler/scheduler.py
@@ -181,6 +181,12 @@ class RedisTaskScheduler:
             try:
                 meta = json.loads(all_pending[task_id])
                 lock_key = meta["lock_key"]
+                task_name = meta.get("task_name")
+                user_id = meta.get("user_id")
+                if not task_name or not user_id:
+                    # 兼容升级前写入的 pending 元数据。lock_key 格式固定为
+                    # ``{task_name}:{user_id}``，从右侧切分可避免影响任务名。
+                    task_name, _, user_id = lock_key.rpartition(":")
                 dispatched_at = meta.get("dispatched_at", 0)
                 age = now - dispatched_at
 
@@ -192,14 +198,16 @@ class RedisTaskScheduler:
                     if result_data.get("status") in ("SUCCESS", "FAILURE", "REVOKED"):
                         should_cleanup = True
                         logger.info(
-                            "Task finished: %s state=%s", task_id,
+                            "Task finished: task=%s user=%s task_id=%s msg_id=%s state=%s",
+                            task_name, user_id, task_id, meta.get("msg_id"),
                             result_data.get("status"),
                         )
                 elif age > TASK_TIMEOUT:
                     should_cleanup = True
                     logger.warning(
-                        "Task expired or lost: %s age=%.0fs, force cleanup",
-                        task_id, age,
+                        "Task expired or lost: task=%s user=%s task_id=%s msg_id=%s "
+                        "age=%.0fs, force cleanup",
+                        task_name, user_id, task_id, meta.get("msg_id"), age,
                     )
 
                 if should_cleanup:
@@ -279,13 +287,17 @@ class RedisTaskScheduler:
         user_id = unit_key.split(":", 1)[1] if ":" in unit_key else unit_key
         return stable_hash(user_id) % self._shard_count == self._shard_index
 
-    def _commit_post_dispatch(self, lock_key, task, msg_id, dispatch_lock):
+    def _commit_post_dispatch(
+        self, lock_key, task, msg_id, dispatch_lock, task_name, user_id,
+    ):
         pipe = self.redis.pipeline()
         pipe.set(lock_key, task.id, ex=3600)
         pipe.hset(PENDING_HASH, task.id, json.dumps({
             "lock_key": lock_key,
             "dispatched_at": time.time(),
             "msg_id": msg_id,
+            "task_name": task_name,
+            "user_id": user_id,
         }))
         pipe.delete(dispatch_lock)
         pipe.set(
@@ -329,7 +341,9 @@ class RedisTaskScheduler:
             return False
         for attempt in range(2):
             try:
-                self._commit_post_dispatch(lock_key, task, msg_id, dispatch_lock)
+                self._commit_post_dispatch(
+                    lock_key, task, msg_id, dispatch_lock, task_name, user_id,
+                )
                 break
             except Exception as e:
                 logger.error(
@@ -340,7 +354,10 @@ class RedisTaskScheduler:
                 self.errors += 1
 
         self.dispatched += 1
-        logger.info("Task dispatched: %s (msg=%s)", task.id, msg_id)
+        logger.info(
+            "Task dispatched: task=%s user=%s task_id=%s msg_id=%s",
+            task_name, user_id, task.id, msg_id,
+        )
         return True
 
     def _process_batch(self, unit_keys):

--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from app.core.memory.storage_services.extraction_engine.knowledge_extraction.chunk_extraction import DialogueChunker
 from app.core.memory.models.message_models import DialogData, ConversationContext, ConversationMessage
+from app.core.memory.utils.dialogue_id_utils import build_dialogue_id
 
 
 async def get_chunked_dialogs(
@@ -14,6 +15,9 @@ async def get_chunked_dialogs(
         snapshot=None,
         context_before: Optional[List[dict]] = None,
         context_after: Optional[List[dict]] = None,
+        conversation_id: str = "",
+        message_seq: int = 0,
+        source: str = "",
 ) -> List[DialogData]:
     """Generate chunks from structured messages using the specified chunker strategy.
 
@@ -69,12 +73,18 @@ async def get_chunked_dialogs(
         raise ValueError("Message list cannot be empty after filtering")
 
     conversation_context = ConversationContext(msgs=conversation_messages)
-    dialog_data = DialogData(
+    dialog_kwargs = dict(
         context=conversation_context,
         ref_id=ref_id,
         end_user_id=end_user_id,
         config_id=config_id,
     )
+    # 有分组信息（正写路径）时，出生即赋与快写统一的确定性 id（Dialog_{...}），使 DialogueNode.id
+    # 及所有引用 dialog_data.id 的子节点（Chunk/Assistant*/MemorySummary 的 dialog_id）天然一致，
+    # 由正写覆盖升级快写占位节点。缺少分组信息（如试运行）时省略 id，回退模型默认的随机 uuid。
+    if conversation_id or source:
+        dialog_kwargs["id"] = build_dialogue_id(conversation_id, message_seq, source, end_user_id)
+    dialog_data = DialogData(**dialog_kwargs)
 
 # step3： 分块
     chunker = DialogueChunker(chunker_strategy)

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -348,6 +348,49 @@ class MemoryService:
             source=source,
         )
 
+    async def fast_write(
+            self,
+            target_message: dict,
+            conversation_id: str = "",
+            message_seq: int = 0,
+            source: str = "",
+            dispatch_at: str = "",
+    ) -> dict:
+        """快速写入记忆：清洗 → Embedding → 写入 :Dialogue 节点
+
+        与 self.write() 并列，复用 __init__/create 已加载到 self.ctx 的 memory_config，
+        构造并驱动 FastWritePipeline（不重复加载配置）。
+
+        Args:
+            target_message: 目标消息 {"role": "user", "content": "...", "dialog_at": "..."}
+            conversation_id: 对话 ID（会话类入口非空，用于确定性 ID 生成）
+            message_seq: 目标消息的 message_seq
+            source: 写入来源（agent/service_api/mcp/workflow），用于节点 ID 生成
+            dispatch_at: 任务派发时刻的 UTC ISO 8601 时间戳，用于 created_at 时间降级
+
+        Returns:
+            dict: {"status": "success"|"dropped", "dialog_id": str | None}
+
+        Raises:
+            RuntimeError: 当前实例未加载 memory_config
+        """
+        from app.core.memory.pipelines.fast_write_pipeline import FastWritePipeline
+
+        if self.ctx.memory_config is None:
+            raise RuntimeError("MemoryService.fast_write() 需要 memory_config，但当前实例未加载配置")
+        pipeline = FastWritePipeline(
+            memory_config=self.ctx.memory_config,
+            end_user_id=self.ctx.end_user_id,
+            language=self.ctx.language,
+        )
+        return await pipeline.run(
+            target_message=target_message,
+            conversation_id=conversation_id,
+            message_seq=message_seq,
+            source=source,
+            dispatch_at=dispatch_at,
+        )
+
     async def pilot_write(
             self,
             chunked_dialogs: List["DialogData"],

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -223,12 +223,17 @@ class DialogueNode(Node):
         content: Full dialogue content as text
         dialog_embedding: Optional embedding vector for the entire dialogue
         config_id: Configuration ID used to process this dialogue
+        write_mode: Write pipeline marker ('fast' | 'normal')
+        emotion: Emotion field, persisted but unset this iteration (structure defined by later BERT emotion recognition)
     """
     ref_id: str = Field(..., description="Reference identifier of the dialog")
     content: str = Field(..., description="Dialogue content")
     dialog_embedding: Optional[List[float]] = Field(None, description="Dialog embedding vector")
     config_id: Optional[int | str] = Field(None,
                                            description="Configuration ID used to process this dialogue (integer or string)")
+    
+    write_mode: str = Field(default="normal",description="写入管线标识：'fast' | 'normal'")
+    emotion: Optional[str] = Field(default=None,description="情绪字段，本期落库但不填值；结构由后续 BERT 情绪识别方案定义")
 
 
 class StatementNode(Node):

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -233,7 +233,7 @@ class DialogueNode(Node):
                                            description="Configuration ID used to process this dialogue (integer or string)")
     
     write_mode: str = Field(default="normal",description="写入管线标识：'fast' | 'normal'")
-    emotion: Optional[str] = Field(default=None,description="情绪字段，本期落库但不填值；结构由后续 BERT 情绪识别方案定义")
+    emotion: Optional[str] = Field(default=None,description="情绪字段")
 
 
 class StatementNode(Node):

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -178,6 +178,57 @@ async def push_write_task(
     return msg_id
 
 
+async def push_fast_write_task(
+    end_user_id: str,
+    target_message: dict,
+    config_id: str,
+    workspace_id: str,
+    conversation_id: str = "",
+    message_seq: int = 0,
+    language: str = "zh",
+    source: str = "",
+) -> str:
+    """派发 Fast Write 任务，与正路径 push_write_task 并列。
+    Args:
+        end_user_id: 终端用户 ID（分片键）
+        target_message: 目标消息
+        config_id: 记忆配置 ID
+        workspace_id: 工作空间 ID
+        conversation_id: 对话 ID；API/MCP 场景传空字符串
+        message_seq: 消息序号
+        language: 语言
+        source: 写入来源（agent/service_api/mcp/workflow）
+
+    Returns:
+        任务 msg_id
+    """
+    from app.celery_task_scheduler import scheduler as celery_scheduler
+
+    # 记录任务派发时刻，作为 pipeline 内 dialog_at 的第二级兜底
+    dispatch_at = datetime.now(timezone.utc).isoformat()
+
+    msg_id = await celery_scheduler.push_task(
+        "app.core.memory.fast_write_message",
+        end_user_id,
+        {
+            "end_user_id": end_user_id,
+            "target_message": target_message,
+            "config_id": config_id,
+            "workspace_id": workspace_id,
+            "conversation_id": conversation_id or "",
+            "message_seq": message_seq,
+            "language": language,
+            "dispatch_at": dispatch_at,
+            "source": source,
+        },
+    )
+    logger.info(
+        f"[FastDispatcher] 快速写入任务已推送: end_user={end_user_id}, "
+        f"conv={conversation_id or '-'}, seq={message_seq}, msg_id={msg_id}"
+    )
+    return msg_id
+
+
 # ──────────────────────────────────────────────
 # 应用级记忆门禁检查
 # ──────────────────────────────────────────────
@@ -205,6 +256,74 @@ async def check_memory_enabled(app_id: str) -> bool:
     except Exception as e:
         logger.warning(f"[Dispatcher] 检查 memory.enabled 失败: app={app_id}, err={e}")
         return False
+
+
+async def check_fast_write_permission(
+    *,
+    role: str,
+    should_memorize: bool,
+    app_id: Optional[str] = None,
+    require_app_gate: bool = False,
+) -> bool:
+    """Fast Write 独立重做当前入口的 Normal 写入前置判定。
+    agent：appid（require_app_gate=true），should_memorize,role;
+    workflow:should_memorize,role;
+    api:role;
+    mcp:无;
+    """
+    if role != "user" or not should_memorize:
+        return False
+
+    if require_app_gate:
+        if not app_id:
+            return False
+        if not await check_memory_enabled(app_id):
+            return False
+
+    return True
+
+
+async def safe_push_fast_write(
+    *,
+    role: str,
+    should_memorize: bool,
+    app_id: Optional[str] = None,
+    require_app_gate: bool = False,
+    end_user_id: str,
+    target_message: dict,
+    config_id: str,
+    workspace_id: str,
+    conversation_id: str = "",
+    message_seq: int = 0,
+    language: str = "zh",
+    source: str = "",
+) -> None:
+    """Fast Write 派发的入口层隔离包装：权限判定 + 派发全程 best-effort。"""
+    try:
+        if not await check_fast_write_permission(
+            role=role,
+            should_memorize=should_memorize,
+            app_id=app_id,
+            require_app_gate=require_app_gate,
+        ):
+            return
+        await push_fast_write_task(
+            end_user_id=end_user_id,
+            target_message=target_message,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            message_seq=message_seq,
+            language=language,
+            source=source,
+        )
+    except Exception as e:
+        # 隔离：Fast 派发失败不影响 Normal 主流程；记录失败便于失败率监控采集
+        logger.warning(
+            "[FastDispatcher] fast write dispatch failed (isolated, normal flow unaffected): "
+            "end_user_id=%s, source=%s, conv=%s, seq=%s, err=%s",
+            end_user_id, source, conversation_id or "-", message_seq, e,
+        )
 
 
 # ──────────────────────────────────────────────
@@ -301,6 +420,24 @@ async def dispatch_api_service_async(
         )
         task_ids.append(msg_id)
 
+        # Fast Write 派发（隔离：失败不阻断上面的 Normal 派发循环）。
+        # role 直接取 written_mms[idx]（=msg）：write_batch 原样保留 role，且上面
+        # user_indices 已在用同一 role 值；API Normal 路径不过滤 should_memorize，
+        # 故 should_memorize=True；无 app_id 门禁。
+        await safe_push_fast_write(
+            role=str(msg.get("role", "user")),
+            should_memorize=True,
+            require_app_gate=False,
+            end_user_id=end_user_id,
+            target_message=msg,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            conversation_id="",
+            message_seq=msg["message_seq"],
+            language=language,
+            source=MemoryMessageSource.SERVICE_API.value,
+        )
+
     return task_ids
 
 
@@ -365,6 +502,25 @@ async def ingest_agent_message(
     await refresh_active_key(conversation_id)
     mark_conversation_pending(conversation_id)
 
+    # Fast Write 派发（隔离：失败不阻断下面的滑动窗口派发）。
+    # 权限取原始 message.role / should_memorize；Agent 有应用级门禁 require_app_gate=True。
+    _target_msg = written[0] if written else None
+    if _target_msg:
+        await safe_push_fast_write(
+            role=str(message.role),
+            should_memorize=should_memorize,
+            app_id=app_id,
+            require_app_gate=True,
+            end_user_id=end_user_id,
+            target_message=_target_msg,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            conversation_id=str(conversation_id),
+            message_seq=_target_msg["message_seq"],
+            language=language,
+            source=MemoryMessageSource.AGENT.value,
+        )
+
     await check_sliding_window_and_dispatch(
         conversation_id=str(conversation_id),
         config_id=config_id,
@@ -395,9 +551,15 @@ async def ingest_workflow_messages(
     的假设一致）。pure_workflow（策略工作流）没有记忆存储节点、无会话，不会走到这里。
     因此直接走 conversation 通道，无需空值守卫或哨兵兜底。
     """
+    # 按 write_batch 的空内容过滤规则构造原始消息列表，保证与返回值一一对齐
+    _persistable_inputs = [
+        msg for msg in messages
+        if str(msg.get("content", "") or "").strip()
+    ]
+
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        repo.write_batch(
+        written_mms = repo.write_batch(
             conversation_id=conversation_id,
             messages=messages,
             end_user_id=end_user_id,
@@ -407,6 +569,34 @@ async def ingest_workflow_messages(
 
     await refresh_active_key(conversation_id)
     mark_conversation_pending(conversation_id)
+
+    # Fast Write 派发（隔离：任一条失败不阻断整批循环，也不阻断下面的滑动窗口派发）。
+    # 权限取原始消息 role/should_memorize；Workflow 无 app_id 门禁 require_app_gate=False。
+    # 整段（含 zip strict 迭代）包 try：safe_push_fast_write 已吞单条异常，但 zip(strict=True)
+    # 长度不一致会抛 ValueError；此处兜底，确保 Fast 的任何问题都不会冒泡拖垮下面的 Normal 派发。
+    try:
+        for _raw_mm, _written_mm in zip(_persistable_inputs, written_mms, strict=True):
+            await safe_push_fast_write(
+                role=str(_raw_mm.get("role", "user")),
+                should_memorize=bool(_raw_mm.get("should_memorize", True)),
+                require_app_gate=False,
+                end_user_id=end_user_id,
+                target_message=_written_mm,
+                config_id=config_id,
+                workspace_id=workspace_id,
+                conversation_id=conversation_id,
+                message_seq=_written_mm["message_seq"],
+                language=language,
+                source=MemoryMessageSource.WORKFLOW.value,
+            )
+    except Exception as e:
+        logger.warning(
+            "[FastDispatcher] workflow fast write dispatch loop failed "
+            "(isolated, normal flow unaffected): conv=%s, end_user_id=%s, "
+            "persistable=%s, written=%s, err=%s",
+            conversation_id, end_user_id,
+            len(_persistable_inputs), len(written_mms), e,
+        )
 
     await check_sliding_window_and_dispatch(
         conversation_id=conversation_id,
@@ -750,4 +940,20 @@ async def dispatch_mcp_write(
         f"[Dispatcher] MCP 写入任务已推送: end_user={end_user_id}, "
         f"source=mcp, seq={target_seq}, msg_id={msg_id}"
     )
+
+    # Fast Write 派发（隔离：失败不影响已派发的 Normal，也不改变本函数向调用方的返回）。
+    # MCP 固定单条 user 消息语义，should_memorize 恒为 True，无 app_id 门禁。
+    await safe_push_fast_write(
+        role="user",
+        should_memorize=True,
+        require_app_gate=False,
+        end_user_id=end_user_id,
+        target_message=target_msg,
+        config_id=str(config_id),
+        workspace_id=workspace_id,
+        conversation_id="",
+        message_seq=target_seq,
+        source=MemoryMessageSource.MCP.value,
+    )
+
     return msg_id

--- a/api/app/core/memory/pipelines/fast_write_pipeline.py
+++ b/api/app/core/memory/pipelines/fast_write_pipeline.py
@@ -1,0 +1,340 @@
+"""
+FastWritePipeline — 快速写入流水线
+
+三步流水线：清洗 → Embedding → 写入 :Dialogue 节点。
+
+- 不继承、不复用 WritePipeline 编排代码，避免耦合。
+- 共用底层能力（embedder / neo4j connector）单独懒加载。
+- 产品语义约束：1 条 user message → 1 个 DialogueNode，不切块、不截断。
+- 关键失败向上抛出异常（不降级为业务 failed 结果），finally 中 _cleanup。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import uuid
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from app.schemas.memory_config_schema import MemoryConfig
+
+from app.core.memory.models.graph_models import DialogueNode
+from app.core.memory.utils.log.bear_logger import BearLogger
+from app.core.utils.datetime_utils import (
+    as_utc_aware,
+    ensure_dialog_at,
+    parse_iso_to_utc_naive,
+)
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = logging.getLogger(__name__)
+# 与 WritePipeline 共用同一个结构化步骤日志器（同名 logger，输出风格一致）
+bear = BearLogger("memory.pipeline")
+
+# 纯标点/空白匹配（中英文标点 + 空白）。fullmatch 命中即视为无有效内容。
+_PUNCT_PATTERN = re.compile(
+    r'''^[\s.,!?;:'"()\[\]{}。，！？；：''""（）【】《》…—-]+$'''
+)
+
+
+def _is_punct_only(text: str) -> bool:
+    """判断字符串是否仅由标点/空白构成。"""
+    return bool(_PUNCT_PATTERN.fullmatch(text))
+
+
+def _build_dialogue_id(conv_id: str, seq: int, source: str, user_id: str) -> str:
+    """确定性生成 DialogueNode ID（幂等 MERGE 的关键）。
+
+    - conv_id 非空（agent / workflow）→ f"Dialog_{conv_id}_{seq}"
+    - 否则（service_api / mcp）→ f"Dialog_{user_id}_{source}_{seq}"
+
+    前缀统一为中性 Dialog_（快慢共用），ID 确定性保证重复触发不产生重复节点。
+    """
+    if conv_id:
+        return f"Dialog_{conv_id}_{seq}"
+    return f"Dialog_{user_id}_{source}_{seq}"
+
+
+class FastWritePipeline:
+    """快速写入三步流水线编排器。"""
+
+    CONTENT_WARN_THRESHOLD = 8_000   # 超长告警阈值（不阻止写入）
+    NEO4J_MERGE_MAX_RETRY = 3
+    # Embedding 单步硬上限（秒）。底层 LangChain client 自带 max_retries * timeout，
+    # 慢/挂起的 endpoint 会突破 celery 任务的 soft_time_limit(30) / time_limit(60)，
+    # 导致 worker 被 SIGKILL 而非降级。此处用 asyncio.wait_for 兜底，超时即降级为 None。
+    EMBED_TIMEOUT_SEC = 15
+
+    def __init__(self, memory_config: "MemoryConfig", end_user_id: str, language: str = "zh"):
+        self.memory_config = memory_config
+        self.end_user_id = end_user_id
+        self.language = language
+
+        # 懒加载底层能力，首次使用时初始化
+        self._embedder = None
+        self._neo4j = None
+
+    async def run(
+        self,
+        target_message: dict,
+        conversation_id: str = "",
+        message_seq: int = 0,
+        source: str = "",
+        dispatch_at: str = "",
+    ) -> dict:
+        """驱动三步流水线。
+
+        用 BearLogger 输出与 WritePipeline 一致的结构化步骤日志：pipeline 起止用
+        ═══ 分隔线，每步完成输出 ``▶ [i/3] 分类：描述 ── ✔ 秒数`` 一行；步骤/流水线
+        失败由 BearLogger 记 ✘ 行并向上抛出（堆栈由 Celery 任务层 logger.exception 兜底）。
+
+        正常返回 {"status": "success"|"dropped", "dialog_id": str | None}。
+        关键失败不返回 failed 字典，而是向上抛出异常。finally 中执行 _cleanup。
+
+        dispatch_at 为任务派发时刻的 UTC ISO 8601 字符串，用于 DialogueNode.created_at
+        的时间来源降级（与 Normal Write 一致）：
+        target_message.dialog_at → dispatch_at → 服务端当前时间（ensure_dialog_at 兜底）。
+        """
+        async with bear.pipeline(
+            "FastWritePipeline",
+            mode="快速",
+            end_user_id=self.end_user_id,
+            conv=conversation_id or "-",
+            seq=message_seq,
+            source=source or "-",
+        ):
+            try:
+                # Step 1/3 — 轻量清洗
+                async with bear.step(1, 3, "清洗", "轻量清洗") as s:
+                    content = target_message.get("content", "") if target_message else ""
+                    cleaned, drop_reason = self._clean(content)
+                    s.metadata(
+                        text_len=len(cleaned),
+                        dropped=bool(drop_reason),
+                        reason=drop_reason or "-",
+                    )
+                if drop_reason:
+                    return {"status": "dropped", "reason": drop_reason, "dialog_id": None}
+
+                # Step 2/3 — Embedding（失败降级为 None，不重试）
+                async with bear.step(2, 3, "Embedding", "向量化") as s:
+                    embedding = await self._embed(cleaned)
+                    s.metadata(has_embedding=embedding is not None)
+
+                # 时间来源降级：dialog_at → dispatch_at → 当前时间（ensure_dialog_at 兜底）
+                created_at = as_utc_aware(
+                    parse_iso_to_utc_naive(
+                        ensure_dialog_at(target_message.get("dialog_at") or dispatch_at)
+                    )
+                )
+
+                # Step 3/3 — 构造并写入 DialogueNode
+                async with bear.step(3, 3, "存储", "写入 Dialogue") as s:
+                    node = self._build_dialogue_node(
+                        content=cleaned,
+                        embedding=embedding,
+                        conversation_id=conversation_id,
+                        message_seq=message_seq,
+                        source=source,
+                        created_at=created_at,
+                    )
+                    dialog_id = await self._persist(node)
+                    s.metadata(dialog_id=dialog_id)
+
+                return {"status": "success", "dialog_id": dialog_id}
+            finally:
+                await self._cleanup()
+
+    # ──────────────────────────────────────────────
+    # 以下为本任务范围外的方法占位，后续任务填充实现
+    # ──────────────────────────────────────────────
+
+    def _clean(self, content: str) -> Tuple[str, Optional[str]]:
+        """Step 1 — 轻量清洗（纯规则）。
+
+        返回 (cleaned_content, drop_reason)。drop_reason 非空表示应丢弃。
+
+        规则：
+        - content 为空 → ("", "empty")
+        - strip 后为空或纯标点 → ("", "punct_only")
+        - langid 语言检测，命中 "zh"/"en" 时更新 self.language，否则保留默认
+        - 超长（> CONTENT_WARN_THRESHOLD）→ 告警日志，但不截断、不丢弃
+        - 正常 → (cleaned, None)
+        """
+        if not content:
+            return "", "empty"
+
+        cleaned = content.strip()
+        if not cleaned or _is_punct_only(cleaned):
+            return "", "punct_only"
+
+        import langid
+
+        detected = langid.classify(cleaned)[0]
+        self.language = detected if detected in ("zh", "en") else self.language
+
+        if len(cleaned) > self.CONTENT_WARN_THRESHOLD:
+            logger.warning(
+                "[FastWrite] content exceeds warn threshold: text_len=%s, threshold=%s, "
+                "end_user_id=%s (not truncated)",
+                len(cleaned),
+                self.CONTENT_WARN_THRESHOLD,
+                self.end_user_id,
+            )
+
+        return cleaned, None
+
+    async def _embed(self, text: str) -> Optional[List[float]]:
+        """Step 2 — Embedding。
+
+        - text 为空 → 返回 None。
+        - 懒加载 embedder：与正路径 WritePipeline 一致，通过 ModelClientMixin.get_embedding_client
+          用 memory_config.embedding_model_id / tenant_id 构造，保证向量空间一致。
+        - 完整文本单次 aembed_query（不做前置截断）。
+        - 硬上限 EMBED_TIMEOUT_SEC：底层 client 的 max_retries * timeout 可能突破 celery
+          任务超时；用 asyncio.wait_for 兜底，超时即视为失败降级。
+        - 失败降级：任何异常（含超时）记录 warning 日志（含 text_len）并返回 None，不重试。
+        """
+        if not text:
+            return None
+
+        try:
+            if self._embedder is None:
+                from app.core.memory.pipelines.base_pipeline import ModelClientMixin
+                from app.db import get_db_context
+
+                with get_db_context() as db:
+                    self._embedder = ModelClientMixin.get_embedding_client(
+                        db,
+                        self.memory_config.embedding_model_id,
+                        self.memory_config.tenant_id,
+                    )
+
+            return await asyncio.wait_for(
+                self._embedder.aembed_query(text),
+                timeout=self.EMBED_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[FastWrite] embedding timed out, degrading to None: text_len=%s, "
+                "timeout=%ss, end_user_id=%s",
+                len(text),
+                self.EMBED_TIMEOUT_SEC,
+                self.end_user_id,
+            )
+            return None
+        except Exception as e:
+            logger.warning(
+                "[FastWrite] embedding failed, degrading to None: text_len=%s, "
+                "end_user_id=%s, error=%s",
+                len(text),
+                self.end_user_id,
+                e,
+            )
+            return None
+
+    def _build_dialogue_node(
+        self,
+        content: str,
+        embedding: Optional[List[float]],
+        conversation_id: str,
+        message_seq: int,
+        source: str,
+        created_at: "datetime",
+    ) -> DialogueNode:
+        """Step 3 — 构造 DialogueNode。
+
+        - 确定性 id：_build_dialogue_id（会话/无会话两种模板），保证幂等 MERGE。
+        - 随机 ref_id / run_id：uuid.uuid4().hex（与正路径一致）。
+        - content 为完整原文（不切块、不截断，即使超过告警阈值）。
+        - dialog_embedding 可为 None。
+        - config_id 取自 memory_config.config_id（UUID → str）。
+        - created_at 为消息真实发生时间（dialog_at → dispatch_at → 当前时间降级结果），
+          不再使用 worker 执行时刻，保证可回溯。
+        - 固定属性：write_mode="fast"、emotion=None。
+        """
+        dialog_id = _build_dialogue_id(
+            conversation_id, message_seq, source, self.end_user_id
+        )
+        return DialogueNode(
+            id=dialog_id,
+            name=f"Dialog_{dialog_id}",
+            ref_id=uuid.uuid4().hex,
+            end_user_id=self.end_user_id,
+            run_id=uuid.uuid4().hex,
+            created_at=created_at,
+            content=content,
+            dialog_embedding=embedding,
+            config_id=str(self.memory_config.config_id),
+            write_mode="fast",
+            emotion=None,
+        )
+
+    async def _persist(self, dialog_node: DialogueNode) -> str:
+        """Step 3 — 持久化 DialogueNode 到 Neo4j。
+
+        - 懒加载独立 connector（不共享 driver，由 _cleanup 负责关闭）。
+        - 用 add_dialogue_nodes([node], connector)，保证 Cypher / 摊平一致。
+        - 死锁重试：与 WritePipeline._is_deadlock 保持一致的宽松判定——异常消息中
+          包含 "deadlock"（大小写不敏感）即视为死锁，最多重试
+          NEO4J_MERGE_MAX_RETRY 次，退避 0.1*(attempt+1) 秒。
+        - 快速失败：非死锁异常、或返回节点数 != 1（RuntimeError），首次即抛出，不重试。
+        """
+        from app.repositories.neo4j.add_nodes import add_dialogue_nodes
+
+        if self._neo4j is None:
+            self._neo4j = Neo4jConnector()
+
+        for attempt in range(self.NEO4J_MERGE_MAX_RETRY):
+            try:
+                result = await add_dialogue_nodes([dialog_node], self._neo4j)
+                if len(result) != 1:
+                    raise RuntimeError(
+                        f"expected one dialogue UUID, got {len(result)}"
+                    )
+                logger.info(
+                    "[FastWrite] persisted: dialog_id=%s, end_user_id=%s, "
+                    "has_embedding=%s, attempt=%s",
+                    dialog_node.id,
+                    self.end_user_id,
+                    dialog_node.dialog_embedding is not None,
+                    attempt + 1,
+                )
+                return result[0]
+            except Exception as e:
+                # 与 WritePipeline._is_deadlock 一致的宽松判定：异常消息中包含
+                # "deadlock"（大小写不敏感）即视为死锁。
+                is_deadlock = "deadlock" in str(e).lower()
+                has_next_attempt = attempt < self.NEO4J_MERGE_MAX_RETRY - 1
+                if not is_deadlock or not has_next_attempt:
+                    raise
+                logger.warning(
+                    "[FastWrite] neo4j deadlock detected, retrying: attempt=%s/%s, "
+                    "end_user_id=%s, dialog_id=%s",
+                    attempt + 1,
+                    self.NEO4J_MERGE_MAX_RETRY,
+                    self.end_user_id,
+                    dialog_node.id,
+                )
+                await asyncio.sleep(0.1 * (attempt + 1))
+
+    async def _cleanup(self) -> None:
+        """释放懒加载的底层资源（关闭独立的 neo4j connector）。
+
+        关闭失败不影响主流程：记录 warning 后继续；最终清空引用便于 GC。
+        """
+        if self._neo4j is not None:
+            try:
+                await self._neo4j.close()
+            except Exception as e:
+                logger.warning(
+                    "[FastWrite] failed to close neo4j connector: end_user_id=%s, error=%s",
+                    self.end_user_id,
+                    e,
+                )
+            finally:
+                self._neo4j = None

--- a/api/app/core/memory/pipelines/fast_write_pipeline.py
+++ b/api/app/core/memory/pipelines/fast_write_pipeline.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
 
 from app.core.memory.models.graph_models import DialogueNode
+from app.core.memory.utils.dialogue_id_utils import build_dialogue_id
 from app.core.memory.utils.log.bear_logger import BearLogger
 from app.core.utils.datetime_utils import (
     as_utc_aware,
@@ -46,26 +47,12 @@ def _is_punct_only(text: str) -> bool:
     return bool(_PUNCT_PATTERN.fullmatch(text))
 
 
-def _build_dialogue_id(conv_id: str, seq: int, source: str, user_id: str) -> str:
-    """确定性生成 DialogueNode ID（幂等 MERGE 的关键）。
-
-    - conv_id 非空（agent / workflow）→ f"Dialog_{conv_id}_{seq}"
-    - 否则（service_api / mcp）→ f"Dialog_{user_id}_{source}_{seq}"
-
-    前缀统一为中性 Dialog_（快慢共用），ID 确定性保证重复触发不产生重复节点。
-    """
-    if conv_id:
-        return f"Dialog_{conv_id}_{seq}"
-    return f"Dialog_{user_id}_{source}_{seq}"
-
-
 class FastWritePipeline:
     """快速写入三步流水线编排器。"""
 
     CONTENT_WARN_THRESHOLD = 8_000   # 超长告警阈值（不阻止写入）
     NEO4J_MERGE_MAX_RETRY = 3
     # Embedding 单步硬上限（秒）。底层 LangChain client 自带 max_retries * timeout，
-    # 慢/挂起的 endpoint 会突破 celery 任务的 soft_time_limit(30) / time_limit(60)，
     # 导致 worker 被 SIGKILL 而非降级。此处用 asyncio.wait_for 兜底，超时即降级为 None。
     EMBED_TIMEOUT_SEC = 15
 
@@ -101,7 +88,7 @@ class FastWritePipeline:
         """
         async with bear.pipeline(
             "FastWritePipeline",
-            mode="快速",
+            mode="快速写入",
             end_user_id=self.end_user_id,
             conv=conversation_id or "-",
             seq=message_seq,
@@ -248,7 +235,7 @@ class FastWritePipeline:
     ) -> DialogueNode:
         """Step 3 — 构造 DialogueNode。
 
-        - 确定性 id：_build_dialogue_id（会话/无会话两种模板），保证幂等 MERGE。
+        - 确定性 id：build_dialogue_id（会话/无会话两种模板），保证幂等 MERGE。
         - 随机 ref_id / run_id：uuid.uuid4().hex（与正路径一致）。
         - content 为完整原文（不切块、不截断，即使超过告警阈值）。
         - dialog_embedding 可为 None。
@@ -257,12 +244,12 @@ class FastWritePipeline:
           不再使用 worker 执行时刻，保证可回溯。
         - 固定属性：write_mode="fast"、emotion=None。
         """
-        dialog_id = _build_dialogue_id(
+        dialog_id = build_dialogue_id(
             conversation_id, message_seq, source, self.end_user_id
         )
         return DialogueNode(
             id=dialog_id,
-            name=f"Dialog_{dialog_id}",
+            name=dialog_id,
             ref_id=uuid.uuid4().hex,
             end_user_id=self.end_user_id,
             run_id=uuid.uuid4().hex,

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -71,7 +71,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         return res
 
-    async def _get_search_service(self, includes=None, need_embedder=True, need_llm=True):
+    async def _get_search_serxvice(self, includes=None, need_embedder=True, need_llm=True):
         if self.ctx.storage_type == StorageType.NEO4J:
             if need_embedder and need_llm:
                 embedder, llm = await asyncio.gather(

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -71,7 +71,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         return res
 
-    async def _get_search_serxvice(self, includes=None, need_embedder=True, need_llm=True):
+    async def _get_search_service(self, includes=None, need_embedder=True, need_llm=True):
         if self.ctx.storage_type == StorageType.NEO4J:
             if need_embedder and need_llm:
                 embedder, llm = await asyncio.gather(

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -460,6 +460,11 @@ class WritePipeline:
                         snapshot=snapshot,
                         context_before=context_before_pruned,
                         context_after=context_after_pruned,
+                        # 传入分组信息，让 target dialog 出生即用与快写统一的确定性 id
+                        # （api/mcp 路径 conversation_id 为空、走 source 分支），实现覆盖升级。
+                        conversation_id=conversation_id,
+                        message_seq=message_seq,
+                        source=source,
                     )
                     # 注入剪枝记录到 dialog_data.metadata
                     if pruning_records:

--- a/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
+++ b/api/app/core/memory/storage_services/extraction_engine/steps/graph_build_step.py
@@ -121,9 +121,13 @@ def _resolve_perceptual_type(file_type: Optional[str]) -> tuple[str, int]:
 # ═══════════════════════════════════════════════════════════════════════════
 
 def _build_dialogue_node(dialog_data: DialogData) -> DialogueNode:
-    """从 DialogData 构建 DialogueNode。"""
+    """
+    从 DialogData 构建 DialogueNode。
+    write_mode 显式置 'normal'，用于覆盖升级快写占位节点。
+    """
     return DialogueNode(
-        name=f"Dialog_{dialog_data.id}",
+        # dialog_data.id 可能已是带 Dialog_ 前缀的确定性 id，name 直接复用，避免 Dialog_Dialog_ 双前缀
+        name=dialog_data.id,
         id=dialog_data.id,
         content=dialog_data.context.content if dialog_data.context else "",
         dialog_embedding=dialog_data.dialog_embedding,
@@ -134,6 +138,7 @@ def _build_dialogue_node(dialog_data: DialogData) -> DialogueNode:
         created_at=dialog_data.created_at,
         metadata=dialog_data.metadata,
         config_id=dialog_data.config_id,
+        write_mode="normal",
     )
 
 

--- a/api/app/core/memory/utils/dialogue_id_utils.py
+++ b/api/app/core/memory/utils/dialogue_id_utils.py
@@ -1,0 +1,15 @@
+"""
+dialogue_id_utils — Dialogue 节点确定性 ID 工具
+前缀统一为中性 ``Dialog_``（快慢共用，覆盖后同一节点也用该前缀，不产生语义误导）。
+"""
+
+from __future__ import annotations
+
+# Dialogue 节点 ID 前缀（快慢统一，勿随意修改，否则两路无法 MERGE 到同一节点）。
+DIALOGUE_ID_PREFIX = "Dialog_"
+
+
+def build_dialogue_id(conv_id: str, seq: int, source: str, user_id: str) -> str:
+    if conv_id:
+        return f"{DIALOGUE_ID_PREFIX}{conv_id}_{seq}"
+    return f"{DIALOGUE_ID_PREFIX}{user_id}_{source}_{seq}"

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -18,7 +18,7 @@ async def delete_all_nodes(end_user_id: str, connector: Neo4jConnector):
     return result
 
 
-async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConnector) -> Optional[List[str]]:
+async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConnector) -> List[str]:
     """Add dialogue nodes to Neo4j database.
 
     Args:
@@ -26,7 +26,14 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
         connector: Neo4j connector instance
 
     Returns:
-        List of created node UUIDs or None if failed
+        List of created node UUIDs (empty list when there is nothing to save).
+
+    Raises:
+        Exception: Re-raises the original underlying exception on persistence
+            failure after logging the full traceback. Callers must handle the
+            exception or let it propagate; the function never returns None on
+            failure so upstream can classify errors (e.g. Neo4j deadlock vs
+            permanent failures).
     """
     if not dialogues:
         logger.info("No dialogues to save")
@@ -44,7 +51,10 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
                 "name": dialogue.name,
                 "created_at": to_iso_z(dialogue.created_at),
                 "content": dialogue.content,
-                "dialog_embedding": dialogue.dialog_embedding
+                "dialog_embedding": dialogue.dialog_embedding,
+                "config_id": dialogue.config_id,
+                "write_mode": getattr(dialogue, "write_mode", "normal"),
+                "emotion": getattr(dialogue, "emotion", None),
             })
 
         result = await connector.execute_query(
@@ -56,9 +66,9 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
         logger.info(f"Successfully created {len(created_uuids)} dialogue nodes: {created_uuids}")
         return created_uuids
 
-    except Exception as e:
-        logger.error(f"Error creating dialogue nodes: {e}")
-        return None
+    except Exception:
+        logger.exception("Error creating dialogue nodes")
+        raise
 
 
 async def add_statement_nodes(statements: List[StatementNode], connector: Neo4jConnector) -> Optional[List[str]]:

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -14,7 +14,11 @@ DIALOGUE_NODE_SAVE = """
         n.ref_id = dialogue.ref_id,
         n.created_at = dialogue.created_at,
         n.content = dialogue.content,
-        n.dialog_embedding = dialogue.dialog_embedding
+        n.name = dialogue.name,
+        n.dialog_embedding = dialogue.dialog_embedding,
+        n.config_id = dialogue.config_id,
+        n.write_mode = coalesce(dialogue.write_mode, 'normal'),
+        n.emotion = dialogue.emotion
     RETURN n.id AS uuid
 """
 

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -8,17 +8,25 @@ from app.core.memory.enums import Neo4jNodeType
 DIALOGUE_NODE_SAVE = """
     UNWIND $dialogues AS dialogue
     MERGE (n:Dialogue {id: dialogue.id})
-    SET n.uuid = coalesce(n.uuid, dialogue.id),
-        n.end_user_id = dialogue.end_user_id,
-        n.run_id = dialogue.run_id,
-        n.ref_id = dialogue.ref_id,
-        n.created_at = dialogue.created_at,
-        n.content = dialogue.content,
-        n.name = dialogue.name,
-        n.dialog_embedding = dialogue.dialog_embedding,
-        n.config_id = dialogue.config_id,
-        n.write_mode = coalesce(dialogue.write_mode, 'normal'),
-        n.emotion = dialogue.emotion
+    SET n.uuid = coalesce(n.uuid, dialogue.id)
+    // 覆盖竞态守卫：只许 normal 覆盖 fast，不许 fast 反向降级 normal。
+    // 当已存在节点为 normal 且本次写入为 fast 时跳过内容写入（canWrite=[]），
+    // 保留正写的权威版本；其余情况（新建 / normal 覆盖 fast / 同模式重试）照常写入。
+    WITH n, dialogue,
+         CASE WHEN n.write_mode = 'normal' AND dialogue.write_mode = 'fast'
+              THEN [] ELSE [1] END AS canWrite
+    FOREACH (_ IN canWrite |
+        SET n.end_user_id = dialogue.end_user_id,
+            n.run_id = dialogue.run_id,
+            n.ref_id = dialogue.ref_id,
+            n.created_at = dialogue.created_at,
+            n.content = dialogue.content,
+            n.name = dialogue.name,
+            n.dialog_embedding = dialogue.dialog_embedding,
+            n.config_id = dialogue.config_id,
+            n.write_mode = coalesce(dialogue.write_mode, 'normal'),
+            n.emotion = dialogue.emotion
+    )
     RETURN n.id AS uuid
 """
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -1919,6 +1919,103 @@ def write_message_task(
             _shutdown_loop_gracefully(loop)
 
 
+@celery_app.task(
+    name="app.core.memory.fast_write_message",
+    bind=True,
+    acks_late=False,
+    max_retries=0
+)
+def fast_write_message_task(
+        self,
+        end_user_id: str,
+        target_message: Optional[dict] = None,
+        config_id: str = "",
+        workspace_id: str = "",
+        conversation_id: str = "",
+        message_seq: int = 0,
+        language: str = "zh",
+        dispatch_at: str = "",
+        source: str = "",
+) -> Dict[str, Any]:
+    """快速写入任务 — 构造 MemoryService 并驱动 fast_write。
+
+    职责：提供事件循环 + 计时 + backend 状态映射，不夹带业务加载逻辑。
+
+    backend 状态与业务结果分层：
+    - ``success`` / ``dropped`` 是 Pipeline 业务结果，放在返回值的 ``result`` 中；
+      任务正常返回时 backend 为 ``SUCCESS``。
+    - 持久化 / 配置 / 代码异常必须抛出任务函数，backend 才会标记 ``FAILURE``，
+      scheduler tracker 与失败率监控才能拿到真实状态。
+    - ``max_retries=0``：不做 Celery 层重试；Neo4j deadlock 的有界重试在 Pipeline 内完成。
+
+    Args:
+        end_user_id: 终端用户 ID（分片键）
+        target_message: 目标消息 {"role": "user", "content": "...", "dialog_at": "..."}
+        config_id: 记忆配置 ID
+        workspace_id: 工作空间 ID
+        conversation_id: 对话 ID（会话类入口非空，用于确定性 ID 生成）
+        message_seq: 消息序号
+        language: 语言
+        dispatch_at: 任务派发时刻的 UTC ISO 8601 时间戳
+        source: 写入来源（agent/service_api/mcp/workflow）
+
+    Returns:
+        Dict containing status, result, task_id
+    """
+    logger.info(
+        f"[CELERY FAST WRITE] Starting - end_user_id={end_user_id}, "
+        f"config_id={config_id}, conv={conversation_id or '-'}, "
+        f"seq={message_seq}, language={language}, source={source or '-'}"
+    )
+    start_time = time.time()
+
+    async def _run() -> dict:
+        from app.core.memory.memory_service import MemoryService
+
+        service = MemoryService(
+            config_id=uuid.UUID(config_id),
+            end_user_id=end_user_id,
+            workspace_id=workspace_id,
+            language=language,
+        )
+
+        return await service.fast_write(
+            target_message=target_message or {"role": "user", "content": ""},
+            conversation_id=conversation_id,
+            message_seq=message_seq,
+            source=source,
+            dispatch_at=dispatch_at,
+        )
+
+    loop = None
+    try:
+        loop = set_asyncio_event_loop()
+
+        result = loop.run_until_complete(_run())
+        elapsed_time = time.time() - start_time
+
+        logger.info(f"[CELERY FAST WRITE] Task completed - elapsed_time={elapsed_time:.2f}s")
+
+        try:
+            safe_result = jsonable_encoder(result)
+        except Exception:
+            safe_result = str(result)
+
+        return {
+            "status": "SUCCESS",
+            "result": safe_result,
+            "task_id": self.request.id,
+        }
+    except BaseException:
+        elapsed_time = time.time() - start_time
+        logger.exception(f"[CELERY FAST WRITE] Failed - elapsed_time={elapsed_time:.2f}s")
+        # 异常必须逃出任务函数，Celery backend 才会标记 FAILURE
+        raise
+    finally:
+        if loop:
+            _shutdown_loop_gracefully(loop)
+
+
 def _is_active_recently(db, end_user_id: str, inactive_hours: int | None = None) -> bool:
     """用户是否活跃：end_user.write_time 距今 < inactive_hours 小时（NULL 或读取失败视为不活跃）。
 

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - sandbox
     depends_on:
       - worker-memory
+      - worker-memory-fast
       - worker-document
       - worker-periodic
 
@@ -31,6 +32,20 @@ services:
       - ./files:/files
       - /etc/localtime:/etc/localtime:ro
     command: celery -A app.celery_worker.celery_app worker -E --loglevel=info --pool=threads --concurrency=100 --queues=memory_tasks -n memory_worker@%h
+    restart: unless-stopped
+    networks:
+      - celery
+
+  # Fast memory writer - consumes only memory_fast_tasks
+  worker-memory-fast:
+    image: redbear-mem-open:latest
+    container_name: worker-memory-fast
+    env_file:
+      - .env
+    volumes:
+      - ./files:/files
+      - /etc/localtime:/etc/localtime:ro
+    command: celery -A app.celery_worker.celery_app worker -E --loglevel=info --pool=threads --concurrency=32 --queues=memory_fast_tasks -n memory_fast_worker@%h
     restart: unless-stopped
     networks:
       - celery


### PR DESCRIPTION
## Summary by Sourcery

引入专用的快速内存写入流水线和任务流，在与现有的普通写入路径并行运行的同时，与核心请求处理逻辑保持隔离。

新功能：
- 添加用于轻量级单轮对话写入的 `FastWritePipeline`，包括清洗、嵌入和 Neo4j 持久化，并支持具备死锁感知的重试机制。
- 在 `MemoryService` 上暴露 `fast_write`，以及一个新的 Celery 任务，将快速写入作业在独立的 `memory_fast_tasks` 队列和工作进程上执行。
- 添加分发工具和入口点，从 API、agent、workflow 和 MCP 内存摄取流程中安全触发快速写入任务，并通过权限控制进行保护。

增强：
- 通过共享工具使对话节点 ID 具备确定性，以便快速和普通写入命中相同节点，并为对话节点打上 `write_mode` 和 `emotion` 字段标签。
- 更新 Neo4j 对话持久化逻辑，包含 `config_id`、`write_mode` 和 `emotion`，并防止快速写入覆盖已有的普通写入，同时允许普通写入升级快速写入生成的占位节点。
- 改进调度器的记账与日志记录，通过在待处理元数据中存储任务名称和用户 ID，并丰富分发/清理日志消息。
- 收紧 `add_dialogue_nodes` 的错误处理逻辑，在日志记录后对持久化失败始终抛出异常，确保上游调用方可以可靠地检测错误。
- 调整 agent/workflow 的对话分块逻辑，复用确定性的对话 ID，并将通过图构建的对话节点标记为普通写入。

构建：
- 扩展 `docker-compose` 和 Celery 路由，引入专用的快速内存工作进程，并绑定到 `memory_fast_tasks` 队列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated fast memory write pipeline and task flow that runs in parallel with the existing normal write path while keeping it isolated from core request handling.

New Features:
- Add a FastWritePipeline for lightweight single-dialogue writes including cleaning, embedding, and Neo4j persistence with deadlock-aware retries.
- Expose fast_write on MemoryService and a new Celery task to execute fast write jobs on a separate memory_fast_tasks queue and worker.
- Add dispatcher utilities and entrypoints to safely trigger fast write tasks from API, agent, workflow, and MCP memory ingestion flows with permission gating.

Enhancements:
- Make dialogue node IDs deterministic via a shared utility so fast and normal writes target the same nodes, and tag dialogue nodes with write_mode and emotion fields.
- Update Neo4j dialogue persistence to include config_id, write_mode, and emotion and to prevent fast writes from overwriting existing normal writes, while allowing normal writes to upgrade fast placeholders.
- Improve scheduler bookkeeping and logging by storing task name and user ID in pending metadata and enriching dispatch/cleanup log messages.
- Tighten add_dialogue_nodes error handling to always raise on persistence failures after logging, ensuring upstream callers can reliably detect errors.
- Adjust agent/workflow dialog chunking to reuse deterministic dialogue IDs and mark graph-built dialogue nodes as normal writes.

Build:
- Extend docker-compose and Celery routing to introduce a dedicated fast memory worker bound to the memory_fast_tasks queue.

</details>