### PR TITLE
fix(draft_run_service): prevent detached ORM instance access in message history

### DIFF
--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -2344,7 +2344,11 @@ class AgentRunService:
                 .order_by(Message.created_at.asc())  # 正序排列
                 .limit(max_history)
             )
-            history_msgs = result.scalars().all()
+            # Snapshot values before leaving the session: the context manager rolls
+            # back read-only transactions, which expires ORM instances on exit.
+            history_msgs = [
+                _snapshot_message(message) for message in result.scalars().all()
+            ]
 
         # 转换为 history 格式
         filtered_history = []


### PR DESCRIPTION
- Snapshot message values before leaving database session context manager
- Wrap ORM instances with _snapshot_message to preserve data after session rollback
- Prevent expired ORM instance errors when accessing message history in read-only transactions
- Addresses issue where context manager rollback would expire ORM instances on exit

## Summary by Sourcery

Bug Fixes:
- 防止在加载草稿运行消息历史记录时，由于访问已过期或已分离的 ORM 消息实例而导致的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent errors caused by accessing expired or detached ORM message instances when loading draft run message history.

</details>