### PR TITLE
fix(forget_log_repository): add secondary sort by id to pagination query

### DIFF
--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -193,7 +193,7 @@ class ForgetLogRepository:
         page = max(page, 1)
         offset = (page - 1) * pagesize
         result = await db.execute(
-            base_query.order_by(ForgetAuditModel.delete_at.desc()).offset(offset).limit(pagesize)
+            base_query.order_by(ForgetAuditModel.delete_at.desc(), ForgetAuditModel.id.desc()).offset(offset).limit(pagesize)
         )
         items = list(result.scalars().all())
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过在分页查询中基于记录 ID 引入辅助排序，解决各页面中 forget 日志排序不一致的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve inconsistent ordering of forget logs across pages by introducing a secondary sort on record ID in the pagination query.

</details>