### PR TITLE
fix/sandbox_security_patch

### DIFF
--- a/sandbox/Cargo.lock
+++ b/sandbox/Cargo.lock
@@ -448,6 +448,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +787,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1093,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sandbox-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-web",
  "async-channel",
@@ -1081,8 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "sandbox_seccomp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
+ "landlock",
  "libc",
  "libseccomp-sys",
 ]
@@ -1265,6 +1297,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sandbox/lib/sandbox_seccomp/Cargo.toml
+++ b/sandbox/lib/sandbox_seccomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandbox_seccomp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [lib]

--- a/sandbox/lib/sandbox_seccomp/src/lib.rs
+++ b/sandbox/lib/sandbox_seccomp/src/lib.rs
@@ -17,6 +17,12 @@ use crate::nodejs_syscalls::*;
 use libc::{c_char, c_int, chdir, chroot, gid_t, uid_t};
 use libseccomp_sys::*;
 use std::env;
+
+// ioctl request code (<sys/ioctl.h>, stable since Linux 1.0).
+// Not in the `libc` crate — defined here for seccomp argument filtering.
+// FIONBIO is what socket.setblocking()/settimeout() uses; it is the only
+// ioctl request we ALLOW. Every other request returns EPERM (see below).
+const FIONBIO:   u64 = 0x5421;  // set/clear non-blocking (→ settimeout)
 use std::ffi::{CStr, CString};
 use std::str::FromStr;
 
@@ -191,6 +197,38 @@ fn install_seccomp(enable_network: bool) -> Result<(), c_int> {
                     datum_b: libc::O_CREAT as u64,      // mask
                 };
                 if seccomp_rule_add_array(ctx, SCMP_ACT_ALLOW, sc, 1, &cmp) != 0 {
+                    seccomp_release(ctx);
+                    return Err(-7);
+                }
+            } else if sc == libc::SYS_ioctl as i32 {
+                // Allow ONLY FIONBIO (socket.setblocking/settimeout); every other
+                // ioctl request returns EPERM (graceful) instead of KILL_PROCESS.
+                //
+                // IMPORTANT: the EPERM rule uses `arg != FIONBIO` (SCMP_CMP_NE),
+                // NOT a no-argument catch-all. A no-arg ERRNO rule would also match
+                // FIONBIO, and since ERRNO outranks ALLOW in seccomp action
+                // precedence it would shadow the ALLOW and EPERM *everything*
+                // (breaking settimeout). The `!=` keeps the two rules disjoint.
+                // (This is why we can only ALLOW a single ioctl request value here:
+                // libseccomp rejects multiple comparisons on the same arg, so an
+                // "allow a set, EPERM the rest" filter is not expressible.)
+                let allow_cmp = scmp_arg_cmp {
+                    arg: 1,
+                    op: scmp_compare::SCMP_CMP_EQ,
+                    datum_a: FIONBIO,
+                    datum_b: 0,
+                };
+                if seccomp_rule_add_array(ctx, SCMP_ACT_ALLOW, sc, 1, &allow_cmp) != 0 {
+                    seccomp_release(ctx);
+                    return Err(-7);
+                }
+                let eperm_cmp = scmp_arg_cmp {
+                    arg: 1,
+                    op: scmp_compare::SCMP_CMP_NE,
+                    datum_a: FIONBIO,
+                    datum_b: 0,
+                };
+                if seccomp_rule_add_array(ctx, SCMP_ACT_ERRNO(libc::EPERM as u16), sc, 1, &eperm_cmp) != 0 {
                     seccomp_release(ctx);
                     return Err(-7);
                 }

--- a/sandbox/lib/sandbox_seccomp/src/lib.rs
+++ b/sandbox/lib/sandbox_seccomp/src/lib.rs
@@ -22,7 +22,7 @@ use std::str::FromStr;
 
 // ── Landlock (safe abstraction via landlock crate) ──
 
-use landlock::{ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, path_beneath_rules};
+use landlock::{ABI, Access, AccessFs, Ruleset, RulesetAttr, RulesetCreatedAttr, RulesetStatus, Scope, path_beneath_rules};
 
 /// Allowed syscalls from env `ALLOWED_SYSCALLS` or built-in defaults.
 pub fn get_allowed_syscalls(enable_network: bool) -> (Vec<i32>, Vec<i32>) {
@@ -72,6 +72,12 @@ fn set_no_new_privs() -> Result<(), c_int> {
     if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
         return Err(-3);
     }
+    // Prevent other processes (even same-UID) from reading /proc/<pid>/ files
+    // (maps, fd, environ, …).  The kernel already rejects non-owner access, but
+    // PR_SET_DUMPABLE=0 additionally hides the process from same-UID peers.
+    if unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) } != 0 {
+        return Err(-12);
+    }
     Ok(())
 }
 
@@ -101,6 +107,8 @@ fn set_memory_limit(max_as_bytes: u64) -> Result<(), c_int> {
         rlim_max: max_as_bytes as libc::rlim_t,
     };
     if unsafe { libc::setrlimit(libc::RLIMIT_AS, &lim) } != 0 {
+        let err = unsafe { *libc::__errno_location() };
+        eprintln!("set_memory_limit({max_as_bytes}) failed: errno={err}");
         return Err(-11);
     }
     Ok(())
@@ -134,9 +142,10 @@ pub unsafe extern "C" fn apply_landlock(paths: *const *const c_char) -> c_int {
         return -20;
     }
 
-    let abi = ABI::V5;
+    let abi = ABI::V6;
     let status = Ruleset::default()
         .handle_access(AccessFs::from_all(abi))
+        .and_then(|r| r.scope(Scope::Signal))
         .and_then(|r| r.create())
         .and_then(|r| r.add_rules(path_beneath_rules(&path_strs, AccessFs::from_read(abi))))
         .and_then(|r| r.restrict_self());

--- a/sandbox/lib/sandbox_seccomp/src/nodejs_syscalls.rs
+++ b/sandbox/lib/sandbox_seccomp/src/nodejs_syscalls.rs
@@ -7,7 +7,6 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_openat as i32,
     libc::SYS_newfstatat as i32,
     libc::SYS_statx as i32,
-    libc::SYS_ioctl as i32,
     libc::SYS_lseek as i32,
     libc::SYS_fstat as i32,
     libc::SYS_readlink as i32,
@@ -26,7 +25,6 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_rt_sigprocmask as i32,
     libc::SYS_sigaltstack as i32,
     libc::SYS_rt_sigreturn as i32,
-    libc::SYS_tgkill as i32,
     // Thread
     libc::SYS_futex as i32,
     libc::SYS_sched_yield as i32,
@@ -51,7 +49,12 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_eventfd2 as i32,
 ];
 
-pub static ALLOW_ERROR_SYSCALLS: &[i32] = &[libc::SYS_clone as i32, libc::SYS_clone3 as i32];
+pub static ALLOW_ERROR_SYSCALLS: &[i32] = &[
+    libc::SYS_clone as i32,
+    libc::SYS_clone3 as i32,
+    libc::SYS_tgkill as i32,
+    libc::SYS_ioctl as i32,
+];
 
 pub static ALLOW_NETWORK_SYSCALLS: &[i32] = &[
     libc::SYS_socket as i32,

--- a/sandbox/lib/sandbox_seccomp/src/nodejs_syscalls.rs
+++ b/sandbox/lib/sandbox_seccomp/src/nodejs_syscalls.rs
@@ -25,6 +25,7 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_rt_sigprocmask as i32,
     libc::SYS_sigaltstack as i32,
     libc::SYS_rt_sigreturn as i32,
+    libc::SYS_ioctl as i32,
     // Thread
     libc::SYS_futex as i32,
     libc::SYS_sched_yield as i32,
@@ -53,7 +54,6 @@ pub static ALLOW_ERROR_SYSCALLS: &[i32] = &[
     libc::SYS_clone as i32,
     libc::SYS_clone3 as i32,
     libc::SYS_tgkill as i32,
-    libc::SYS_ioctl as i32,
 ];
 
 pub static ALLOW_NETWORK_SYSCALLS: &[i32] = &[

--- a/sandbox/lib/sandbox_seccomp/src/python_syscalls.rs
+++ b/sandbox/lib/sandbox_seccomp/src/python_syscalls.rs
@@ -7,7 +7,6 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_newfstatat as i32,
     libc::SYS_statx as i32,
     libc::SYS_fstat as i32,
-    libc::SYS_ioctl as i32,
     libc::SYS_lseek as i32,
     libc::SYS_getdents64 as i32,
     libc::SYS_fcntl as i32,
@@ -19,7 +18,6 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_rt_sigaction as i32,
     libc::SYS_rt_sigprocmask as i32,
     libc::SYS_sigaltstack as i32,
-    libc::SYS_tgkill as i32,
     // Thread
     libc::SYS_futex as i32,
     libc::SYS_set_tid_address as i32,
@@ -43,7 +41,6 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_set_robust_list as i32,
     libc::SYS_get_robust_list as i32,
     libc::SYS_rseq as i32,
-    libc::SYS_prlimit64 as i32,
     // Time
     libc::SYS_clock_gettime as i32,
     libc::SYS_gettimeofday as i32,
@@ -67,6 +64,9 @@ pub static ALLOW_ERROR_SYSCALLS: &[i32] = &[
     libc::SYS_clone3 as i32,
     libc::SYS_mkdirat as i32,
     libc::SYS_mkdir as i32,
+    libc::SYS_tgkill as i32,
+    libc::SYS_ioctl as i32,
+    libc::SYS_prlimit64 as i32,
 ];
 
 pub static ALLOW_NETWORK_SYSCALLS: &[i32] = &[

--- a/sandbox/lib/sandbox_seccomp/src/python_syscalls.rs
+++ b/sandbox/lib/sandbox_seccomp/src/python_syscalls.rs
@@ -18,6 +18,7 @@ pub static ALLOW_SYSCALLS: &[i32] = &[
     libc::SYS_rt_sigaction as i32,
     libc::SYS_rt_sigprocmask as i32,
     libc::SYS_sigaltstack as i32,
+    libc::SYS_ioctl as i32,
     // Thread
     libc::SYS_futex as i32,
     libc::SYS_set_tid_address as i32,
@@ -65,7 +66,6 @@ pub static ALLOW_ERROR_SYSCALLS: &[i32] = &[
     libc::SYS_mkdirat as i32,
     libc::SYS_mkdir as i32,
     libc::SYS_tgkill as i32,
-    libc::SYS_ioctl as i32,
     libc::SYS_prlimit64 as i32,
 ];
 

--- a/sandbox/runtime/config.toml
+++ b/sandbox/runtime/config.toml
@@ -1,6 +1,6 @@
 # ── Sandbox runtime ──
 max_workers = 4
-worker_timeout = 30
+worker_timeout = 15
 
 enable_network = true
 enable_preload = false

--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -43,6 +43,10 @@ class _ReqInfo(TypedDict):
 # pipes (applying backpressure to the producing child instead of growing this
 # buffer without bound).
 _SEND_BUF_CAP = 4 * 1024 * 1024  # 4 MiB
+# Max single frame payload (16 MiB).  The server JSON payload is well under
+# 1 MiB; anything larger is either a corrupt stream or an attack.  Capping plen
+# here prevents an OOM from a malicious / broken frame header claiming 4 GiB.
+_MAX_FRAME_PAYLOAD = 16 * 1024 * 1024
 
 
 def _log(msg: str) -> None:
@@ -81,6 +85,10 @@ def _xor(data: bytes, key: bytes) -> bytes:
 
 class Zygote:
     def __init__(self, ctrl_fd: int, lib_so: str, lib_dir: str, warm_modules=()):
+        # Hide /proc/<pid>/ from same-UID peers (defense-in-depth).
+        # PR_SET_DUMPABLE = 4
+        ctypes.CDLL(None).prctl(4, 0, 0, 0, 0)
+
         self.lib_dir = lib_dir
         # Children start (and later chroot) here; also where the .so lives.
         os.chdir(lib_dir)
@@ -193,6 +201,9 @@ class Zygote:
         self._recv_buf.extend(chunk)
         while len(self._recv_buf) >= P.HEADER_SIZE:
             plen, mtype, req_id = P.HEADER.unpack_from(self._recv_buf, 0)
+            if plen > _MAX_FRAME_PAYLOAD:
+                _log(f"oversized frame: plen={plen} (max={_MAX_FRAME_PAYLOAD}); closing")
+                os._exit(1)
             if len(self._recv_buf) < P.HEADER_SIZE + plen:
                 break
             payload = bytes(self._recv_buf[P.HEADER_SIZE:P.HEADER_SIZE + plen])
@@ -344,14 +355,21 @@ class Zygote:
         req_id, mtype = self.fd_map[fd]
         try:
             data = os.read(fd, 65536)
-        except OSError:
+        except (OSError, MemoryError):
             data = b""
         if data:
             self._send(mtype, req_id, data)
             return
         # EOF on this stream.
-        os.close(fd)
-        del self.fd_map[fd]
+        self._teardown_pipe_fd(fd, req_id)
+
+    def _teardown_pipe_fd(self, fd: int, req_id: int) -> None:
+        """Close one child-output fd and finish the request if both are done."""
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        self.fd_map.pop(fd, None)
         req = self.reqs.get(req_id)
         if not req:
             return
@@ -359,13 +377,17 @@ class Zygote:
         if req["open"]:
             return
         # Both streams closed -> child exited; reap and report.
+        # Pop the request BEFORE waitpid so that any concurrent MSG_KILL
+        # (same req_id) sees the entry is already gone and bails out,
+        # closing the PID-reuse window.
+        pid = req["pid"]
+        self.reqs.pop(req_id, None)
         try:
-            _, status = os.waitpid(req["pid"], 0)
+            _, status = os.waitpid(pid, 0)
             exit_code = os.waitstatus_to_exitcode(status)
         except ChildProcessError:
             exit_code = -1
         self._send(P.MSG_DONE, req_id, P.DONE_STRUCT.pack(exit_code))
-        del self.reqs[req_id]
 
     # ------------------------------------------------------------------ loop
     def serve(self) -> None:
@@ -387,15 +409,30 @@ class Zygote:
             if writable:
                 self._flush()
             for fd in readable:
-                if fd == ctrl_fd:
-                    for mtype, req_id, payload in self._read_ctrl_frames():
-                        if mtype == P.MSG_RUN:
-                            self._handle_run(req_id, payload)
-                        elif mtype == P.MSG_KILL:
-                            self._handle_kill(req_id)
-                else:
-                    if fd in self.fd_map:
-                        self._on_pipe_readable(fd)
+                try:
+                    if fd == ctrl_fd:
+                        for mtype, req_id, payload in self._read_ctrl_frames():
+                            if mtype == P.MSG_RUN:
+                                self._handle_run(req_id, payload)
+                            elif mtype == P.MSG_KILL:
+                                self._handle_kill(req_id)
+                    else:
+                        if fd in self.fd_map:
+                            self._on_pipe_readable(fd)
+                except BaseException:
+                    # A single broken request / pipe must never crash the whole
+                    # zygote worker. Log, clean up the fd if we know it, and
+                    # keep serving other in-flight requests.
+                    try:
+                        _log(f"handler crash (fd={fd}):\n{traceback.format_exc()}")
+                    except Exception:
+                        pass
+                    if fd != ctrl_fd and fd in self.fd_map:
+                        try:
+                            req_id = self.fd_map[fd][0]
+                            self._teardown_pipe_fd(fd, req_id)
+                        except Exception:
+                            pass
 
 
 def main() -> None:

--- a/sandbox/runtime/prescript.js
+++ b/sandbox/runtime/prescript.js
@@ -22,6 +22,13 @@ if (!privilege) {
         throw `Landlock failed - ${ll_rc}`
     }
 }
+// Force initialization of stdout/stderr streams before seccomp blocks ioctl.
+// Node.js lazily creates these SyncWriteStream wrappers on first access; the
+// internal setup calls ioctl(fd, TCGETS) to check TTY status.  Doing it now
+// ensures user code can write to stdout/stderr after seccomp is applied.
+void process.stdout.isTTY
+void process.stderr.isTTY
+
 let seccomp_init = initSeccomp(uid, gid, options['enable_network'], options['max_as'], privilege)
 if (seccomp_init !== 0) {
     throw `code executor err - ${seccomp_init}`

--- a/sandbox/server/Cargo.toml
+++ b/sandbox/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandbox-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/sandbox/server/src/main.rs
+++ b/sandbox/server/src/main.rs
@@ -143,6 +143,9 @@ async fn main() -> std::io::Result<()> {
         std::env::var("CONFIG_PATH").unwrap_or_else(|_| "runtime/config.toml".into());
     let config = Config::load(&config_path).expect("Failed to load config");
 
+    // Hide /proc/<pid>/ from same-UID peers (defense-in-depth).
+    unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+
     let queue = QueueController::start(config.max_workers);
 
     let port = config.app.port;

--- a/sandbox/server/src/services/python.rs
+++ b/sandbox/server/src/services/python.rs
@@ -38,7 +38,17 @@ fn build_script(
         let mut paths = vec![LIB_PATH.to_string()];
         paths.extend(config.python_lib_paths.iter().cloned());
         paths.extend(config.nodejs_lib_paths.iter().cloned());
-        paths.extend(["/etc/ssl/certs".into(), "/etc".into()]);
+        paths.extend([
+            "/etc/ssl/certs".into(),
+            "/etc/hosts".into(),
+            "/etc/resolv.conf".into(),
+            "/etc/nsswitch.conf".into(),
+            "/etc/localtime".into(),
+            // /etc/localtime is typically a symlink into /usr/share/zoneinfo;
+            // Landlock resolves symlinks to the target, so the real path must
+            // also be reachable.
+            "/usr/share/zoneinfo".into(),
+        ]);
         serde_json::to_string(&paths).unwrap_or_else(|_| "[]".into())
     };
 
@@ -85,7 +95,13 @@ pub async fn run(
                     let mut paths = vec![LIB_PATH.to_string()];
                     paths.extend(config.python_lib_paths.iter().cloned());
                     paths.extend(config.nodejs_lib_paths.iter().cloned());
-                    paths.extend(["/etc/ssl/certs".into(), "/etc".into()]);
+                    paths.extend([
+                        "/etc/ssl/certs".into(),
+                        "/etc/hosts".into(),
+                        "/etc/resolv.conf".into(),
+                        "/etc/nsswitch.conf".into(),
+                        "/etc/localtime".into(),
+                    ]);
                     paths
                 };
                 let limits = crate::services::zygote::SandboxLimits {
@@ -144,9 +160,7 @@ pub async fn run(
         .stderr(Stdio::piped())
         .current_dir(LIB_PATH)
         .kill_on_drop(true);
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("spawn python: {e}"))?;
+    let mut child = cmd.spawn().map_err(|e| format!("spawn python: {e}"))?;
 
     // Write the script to stdin, then close it so Python starts execution.
     if let Some(mut stdin) = child.stdin.take() {
@@ -156,13 +170,10 @@ pub async fn run(
             .map_err(|e| format!("stdin write: {e}"))?;
     }
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(timeout_secs),
-        child.wait_with_output(),
-    )
-    .await
-    .map_err(|_| "Execution timeout".to_string())?
-    .map_err(|e| format!("process: {e}"))?;
+    let output = tokio::time::timeout(Duration::from_secs(timeout_secs), child.wait_with_output())
+        .await
+        .map_err(|_| "Execution timeout".to_string())?
+        .map_err(|e| format!("process: {e}"))?;
 
     Ok(ExecutionResult {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),


### PR DESCRIPTION
## Summary by Sourcery

在 worker、seccomp 和 server 组件中加强沙箱的安全性与健壮性，同时收紧默认资源限制。

New Features:
- 强制控制帧负载的最大大小，以防止超大或恶意消息。
- 为每个文件描述符增加拆卸逻辑，使子进程管道关闭可以干净地完成请求并避免 PID 重用竞争。
- 将 Landlock 规则扩展到 ABI v6，对信号进行范围限定，并为 Python worker 更新文件系统访问路径。
- 引入 ioctl 参数过滤，只允许 `FIONBIO`，对所有其他 ioctl 请求返回 `EPERM`。
- 在启用 seccomp 之前预初始化 Node.js 的 stdout/stderr，以便用户代码在沙箱化之后仍能安全地向这些流写入数据。

Bug Fixes:
- 防止单个损坏的请求、管道或处理器异常导致整个 zygote worker 循环崩溃。
- 确保内存限制失败时记录 errno，便于诊断。
- 将 `tgkill` 和 `prlimit64` 移入容错的系统调用列表，在仍然强制约束的同时避免被 seccomp 直接硬杀。

Enhancements:
- 在 zygote、seccomp 库和 server 中对同一 UID 的其他进程隐藏 `/proc/<pid>/`，以提高纵深防御能力。
- 将默认 worker 超时时间从 30 秒缩短到 15 秒，以限制长时间运行或卡住的执行。
- 重新组织 Node.js 和 Python 的允许系统调用列表，使之更好地与新的 ioctl 过滤和错误处理策略对齐。

Build:
- 将 `sandbox_seccomp` crate 版本提升到 `0.1.2`，以反映更新后的 seccomp 和 Landlock 行为。
- 将 `sandbox-server` crate 版本提升到 `0.2.0`，对应更严格的沙箱和配置更改。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen sandbox security and robustness across worker, seccomp, and server components while tightening default resource limits.

New Features:
- Enforce a maximum control-frame payload size to guard against oversized or malicious messages.
- Add per-fd teardown logic so child pipe closure cleanly completes requests and avoids PID-reuse races.
- Extend Landlock rules to ABI v6 with signal scoping and updated filesystem access paths for Python workers.
- Introduce ioctl argument filtering that only permits FIONBIO and returns EPERM for all other ioctl requests.
- Pre-initialize Node.js stdout/stderr before seccomp so user code can safely write to these streams after sandboxing.

Bug Fixes:
- Prevent a single broken request, pipe, or handler exception from crashing the entire zygote worker loop.
- Ensure memory limit failures are logged with errno for easier diagnosis.
- Move tgkill and prlimit64 into error-tolerant syscall lists to avoid hard seccomp kills while still enforcing constraints.

Enhancements:
- Hide /proc/<pid>/ from same-UID peers in the zygote, seccomp library, and server for defense-in-depth.
- Reduce the default worker timeout from 30s to 15s to limit long-running or stuck executions.
- Reorganize allowed syscall lists for Node.js and Python to better align with new ioctl filtering and error-handling policies.

Build:
- Bump sandbox_seccomp crate version to 0.1.2 to reflect updated seccomp and Landlock behavior.
- Bump sandbox-server crate version to 0.2.0 for the tightened sandbox and configuration changes.

</details>