### PR TITLE
fix(memory_agent_service): pass tenant_id to get_model_config to prevent detached ORM access

### DIFF
--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -29,6 +29,7 @@ from app.core.memory.agent.utils.type_classifier import status_typle
 from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
 from app.db import get_db_context, get_db_read
 from app.models.knowledge_model import Knowledge, KnowledgeType
+from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.schemas.memory_agent_schema import Write_UserInput
 from app.services.memory_config_service import MemoryConfigService
@@ -328,7 +329,8 @@ class MemoryAgentService:
                 memory_config = config_service.load_memory_config(
                     config_id=config_id
                 )
-                model_config = config_service.get_model_config(str(memory_config.llm_model_id))
+                tenant_id = get_tenant_id_by_end_user_id(db, end_user_id)
+                model_config = config_service.get_model_config(str(memory_config.llm_model_id), tenant_id)
             except Exception as e:
                 if "No memory configuration found" in str(e):
                     raise  # Re-raise our specific error


### PR DESCRIPTION
- Resolve tenant_id from end_user_id via repository call
- Pass tenant_id as second argument to get_model_config
- Fix potential detached ORM instance error when accessing model config

## Summary by Sourcery

Bug Fixes:
- 从 `end_user_id` 解析出 `tenant_id`，并将其传递给 `get_model_config`，以防止在加载模型配置时访问已分离的 ORM 实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve tenant_id from end_user_id and pass it to get_model_config to prevent detached ORM instance access when loading model configuration.

</details>