### PR TITLE
refactor(memory): remove deprecated temporal extraction config and prompt

### DIFF
--- a/api/app/core/memory/models/__init__.py
+++ b/api/app/core/memory/models/__init__.py
@@ -88,7 +88,6 @@ from app.core.memory.models.variate_config import (
     StatementExtractionConfig,
     ForgettingEngineConfig,
     TripletExtractionConfig,
-    TemporalExtractionConfig,
     DedupConfig,
     ExtractionPipelineConfig,
 )
@@ -146,7 +145,6 @@ __all__ = [
     "StatementExtractionConfig",
     "ForgettingEngineConfig",
     "TripletExtractionConfig",
-    "TemporalExtractionConfig",
     "DedupConfig",
     "ExtractionPipelineConfig",
 ]

--- a/api/app/core/memory/models/variate_config.py
+++ b/api/app/core/memory/models/variate_config.py
@@ -2,13 +2,12 @@
 
 This module contains Pydantic models for configuring various aspects
 of the extraction pipeline, including statement extraction, triplet extraction,
-temporal extraction, deduplication, and forgetting mechanisms.
+deduplication, and forgetting mechanisms.
 
 Classes:
     StatementExtractionConfig: Configuration for statement extraction
     ForgettingEngineConfig: Configuration for forgetting engine
     TripletExtractionConfig: Configuration for triplet extraction
-    TemporalExtractionConfig: Configuration for temporal extraction
     DedupConfig: Configuration for entity deduplication
     ExtractionPipelineConfig: Combined configuration for entire pipeline
 """
@@ -62,15 +61,6 @@ class TripletExtractionConfig(BaseModel):
     temperature: Optional[float] = Field(0.1, ge=0, le=2, description="LLM temperature for triplet extraction")
     enable_entity_normalization: bool = Field(True, description="Whether to normalize entity names")
     confidence_threshold: Optional[float] = Field(0.7, ge=0, le=1, description="Minimum confidence threshold for extracted triplets")
-
-
-class TemporalExtractionConfig(BaseModel):
-    """Configuration for temporal extraction behavior.
-
-    Attributes:
-        temperature: LLM temperature for temporal extraction (0-2, default: 0.1)
-    """
-    temperature: Optional[float] = Field(0.1, ge=0, le=2, description="LLM temperature for temporal extraction")
 
 
 class DedupConfig(BaseModel):
@@ -135,18 +125,16 @@ class ExtractionPipelineConfig(BaseModel):
 
     This model combines all configuration components for the complete
     extraction pipeline, including statement extraction, triplet extraction,
-    temporal extraction, deduplication, and forgetting mechanisms.
+    deduplication, and forgetting mechanisms.
 
     Attributes:
         statement_extraction: Configuration for statement extraction
         triplet_extraction: Configuration for triplet extraction
-        temporal_extraction: Configuration for temporal extraction
         deduplication: Configuration for entity deduplication
         forgetting_engine: Configuration for forgetting engine
     """
     statement_extraction: StatementExtractionConfig = Field(default_factory=StatementExtractionConfig)
     triplet_extraction: TripletExtractionConfig = Field(default_factory=TripletExtractionConfig)
-    temporal_extraction: TemporalExtractionConfig = Field(default_factory=TemporalExtractionConfig)
     deduplication: DedupConfig = Field(default_factory=DedupConfig)
     forgetting_engine: ForgettingEngineConfig = Field(default_factory=ForgettingEngineConfig)
     # 情绪引擎（旁路模块，SidecarStepFactory 通过此字段判断是否启用）

--- a/api/app/core/memory/utils/prompt/__init__.py
+++ b/api/app/core/memory/utils/prompt/__init__.py
@@ -8,7 +8,6 @@
 from .prompt_utils import (
     get_prompts,
     render_statement_extraction_prompt,
-    render_temporal_extraction_prompt,
     render_entity_dedup_prompt,
     render_triplet_extraction_prompt,
     render_memory_summary_prompt,
@@ -23,7 +22,6 @@ __all__ = [
     # prompt_utils
     "get_prompts",
     "render_statement_extraction_prompt",
-    "render_temporal_extraction_prompt",
     "render_entity_dedup_prompt",
     "render_triplet_extraction_prompt",
     "render_memory_summary_prompt",

--- a/api/app/core/memory/utils/prompt/prompt_utils.py
+++ b/api/app/core/memory/utils/prompt/prompt_utils.py
@@ -100,50 +100,6 @@ async def render_statement_extraction_prompt(
     })
 
     return rendered_prompt
-# TODO temporal与statement prompt合并在一起，以下代码不需要
-async def render_temporal_extraction_prompt(
-    ref_dates: dict,
-    statement: dict,
-    temporal_guide: dict,
-    statement_guide: dict,
-    json_schema: dict,
-    language: str = "zh",
-) -> str:
-    """
-    Renders the temporal extraction prompt using the extract_temporal.jinja2 template.
-
-    Args:
-        ref_dates: Reference dates for context.
-        statement: The statement to process.
-        temporal_guide: Guidance on temporal types.
-        statement_guide: Guidance on statement types.
-        json_schema: JSON schema for the expected output format.
-        language: Language for output ("zh" for Chinese, "en" for English)
-
-    Returns:
-        Rendered prompt content as a string.
-    """
-    template = prompt_env.get_template("extract_temporal.jinja2")
-    inputs = ref_dates | statement
-    rendered_prompt = template.render(
-        inputs=inputs,
-        temporal_guide=temporal_guide,
-        statement_guide=statement_guide,
-        json_schema=json_schema,
-        language=language,
-    )
-    # 记录渲染结果到提示日志（与示例日志结构一致）
-    log_prompt_rendering('temporal extraction', rendered_prompt)
-    # 可选：记录模板渲染信息
-    log_template_rendering('extract_temporal.jinja2', {
-        'inputs': 'ref_dates|statement',
-        'temporal_guide': 'dict',
-        'statement_guide': 'dict',
-        'json_schema': 'Temporal.schema'
-    })
-
-    return rendered_prompt
-
 def render_entity_dedup_prompt(
     entity_a: dict,
     entity_b: dict,


### PR DESCRIPTION
## Summary by Sourcery

从记忆提取管道中移除已弃用的时间提取配置和提示工具。

增强内容：
- 通过移除 `TemporalExtractionConfig` 模型及相关引用，简化提取管道配置。
- 通过移除未使用的时间提取提示渲染器及其公共导出，清理提示工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove deprecated temporal extraction configuration and prompt utilities from the memory extraction pipeline.

Enhancements:
- Simplify extraction pipeline configuration by dropping the TemporalExtractionConfig model and related references.
- Clean up prompt utilities by removing the unused temporal extraction prompt renderer and its public export.

</details>