### PR TITLE
fix(web): test/prod use latest version

### DIFF
--- a/web/install-private.js
+++ b/web/install-private.js
@@ -4,20 +4,19 @@ const PRIVATE_PACKAGE_NAME = '@redbear/memory-brick';
 const PRIVATE_REGISTRY = 'http://10.206.16.48:4873';
 
 // 版本通道降级链：稳定度递增，前一个不存在时依次降级到后一个
-// alpha（开发）→ beta（测试）→ latest（正式）
-const FALLBACK_CHAIN = ['alpha', 'beta', 'latest'];
+//  beta（开发）→ latest（正式）
+const FALLBACK_CHAIN = ['beta', 'latest'];
 
 // 各环境的首选通道，实际安装时会从此通道起沿 FALLBACK_CHAIN 依次降级
 const ENV_START_TAG = {
-  dev: 'alpha',   // 开发环境：优先 alpha
-  test: 'beta',   // 测试环境：优先 beta
-  prod: 'latest', // 生产环境：latest
+  dev: 'beta',   // 开发环境：优先 beta
+  // 测试与生产共用同一镜像，构建时安装同一版本，统一使用正式通道 latest
+  prod: 'latest',
 };
 
 // 环境别名归一化，兼容 development / production 等常见写法
 const ENV_ALIAS = {
   dev: 'dev', develop: 'dev', development: 'dev',
-  test: 'test', testing: 'test',
   prod: 'prod', prd: 'prod', production: 'prod',
 };
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview",
     "install:private": "node install-private.js",
     "install:private:dev": "node install-private.js dev",
-    "install:private:test": "node install-private.js test",
     "install:private:prod": "node install-private.js prod"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

对私有包的安装行为进行统一：开发环境构建从 beta 渠道开始，测试/生产环境共享同一个最新版本。

Bug Fixes:
- 确保测试和生产环境始终安装相同的最新私有包版本，而不是使用各自独立的渠道。

Enhancements:
- 简化环境标签处理逻辑，在私有包安装脚本中移除测试环境及其 alpha 渠道回退机制。

Build:
- 更新 npm 脚本，移除测试环境专用的私有包安装命令，仅保留开发（dev）和生产（prod）环境相关命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align private package install behavior so dev builds start from the beta channel and test/prod builds share the same latest version.

Bug Fixes:
- Ensure test and production environments consistently install the same latest private package version instead of using separate channels.

Enhancements:
- Simplify environment tag handling by removing the test environment and its alpha channel fallback in the private package installer script.

Build:
- Update npm scripts to remove the test-specific private package install command in favor of dev and prod only.

</details>