### PR TITLE
fix(web): @redbear/memory-brick version

### DIFF
--- a/web/install-private.js
+++ b/web/install-private.js
@@ -1,6 +1,6 @@
 const { execSync } = await import('child_process');
 // 企业私有配置（自行替换）
-const PRIVATE_PACKAGE = '@redbear/memory-brick@0.0.16-beta.0';
+const PRIVATE_PACKAGE = '@redbear/memory-brick';
 const PRIVATE_REGISTRY = 'http://10.206.16.48:4873';
 
 console.log('🔍 检测内网环境，校验私有模块权限...');


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

增强内容：
- 放宽私有 Web 安装脚本中 @redbear/memory-brick 的版本限制，以依赖默认由注册表解析的版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Relax the version constraint for @redbear/memory-brick in the private web installation script to rely on the default registry-resolved version.

</details>