### PR TITLE
feat(sandbox): add nodejs_max_old_space_mb config and harden Node.js sandbox flags

### DIFF
--- a/sandbox/runtime/config.toml
+++ b/sandbox/runtime/config.toml
@@ -23,10 +23,15 @@ sandbox_uid = 65537
 sandbox_gid = 65537
 
 # Per-request virtual address space cap (RLIMIT_AS), in bytes, passed to
-# init_seccomp. Bounds a single execution's memory. 0 disables. Node needs a
-# higher value than Python (V8 reserves ~700MB of virtual space just to start).
-python_max_as_bytes = 1073741824   # 1 GiB
-nodejs_max_as_bytes = 2147483648   # 2 GiB
+# init_seccomp. Bounds a single execution's memory. 0 disables.
+# Node uses --jitless so V8 virtual-space reservation is much lower.
+python_max_as_bytes = 268435456    # 256 MiB
+nodejs_max_as_bytes = 536870912    # 512 MiB (jitless)
+
+# V8 --max-old-space-size in MiB. Caps JS heap below RLIMIT_AS so heap-OOM
+# produces a clean JS error instead of SIGKILL / ENOMEM panic.
+# Default: 256 MiB.
+nodejs_max_old_space_mb = 256
 
 # ── Server ──
 [app]

--- a/sandbox/server/src/config.rs
+++ b/sandbox/server/src/config.rs
@@ -110,6 +110,10 @@ pub struct Config {
     #[serde(default = "default_nodejs_max_as_bytes")]
     pub nodejs_max_as_bytes: u64,
 
+    /// V8 --max-old-space-size in MB (JS heap cap). Default 768 MiB.
+    #[serde(default = "default_nodejs_max_old_space_mb")]
+    pub nodejs_max_old_space_mb: u32,
+
     #[serde(default)]
     pub proxy: ProxyConfig,
 }
@@ -134,8 +138,10 @@ fn default_sandbox_uid() -> u32 { 65537 }
 /// Non-root group. Never 0.
 fn default_sandbox_gid() -> u32 { 65537 }
 
-fn default_python_max_as_bytes() -> u64 { 1024 * 1024 * 1024 } // 1 GiB
-fn default_nodejs_max_as_bytes() -> u64 { 2 * 1024 * 1024 * 1024 } // 2 GiB
+fn default_python_max_as_bytes() -> u64 { 256 * 1024 * 1024 } // 256 MiB
+fn default_nodejs_max_as_bytes() -> u64 { 512 * 1024 * 1024 } // 512 MiB (jitless)
+
+fn default_nodejs_max_old_space_mb() -> u32 { 256 }
 
 fn default_python_lib_paths() -> Vec<String> {
     vec![
@@ -203,6 +209,13 @@ impl Config {
         }
         if let Ok(v) = std::env::var("NODEJS_MAX_AS_BYTES") {
             if let Ok(n) = v.parse() { self.nodejs_max_as_bytes = n; }
+        }
+        if let Ok(v) = std::env::var("NODEJS_MAX_OLD_SPACE_MB") {
+            if let Ok(n) = v.parse() { self.nodejs_max_old_space_mb = n; }
+        }
+        // Backward compat: old env var name
+        if let Ok(v) = std::env::var("NODE_MAX_OLD_SPACE_MB") {
+            if let Ok(n) = v.parse() { self.nodejs_max_old_space_mb = n; }
         }
         if let Ok(v) = std::env::var("SOCKS5_PROXY") {
             self.proxy.socks5 = v;

--- a/sandbox/server/src/main.rs
+++ b/sandbox/server/src/main.rs
@@ -167,6 +167,7 @@ async fn main() -> std::io::Result<()> {
         privilege = config.privilege,
         python_max_as_mb = config.python_max_as_bytes / 1048576,
         nodejs_max_as_mb = config.nodejs_max_as_bytes / 1048576,
+        nodejs_max_old_space_mb = config.nodejs_max_old_space_mb,
         "Sandbox flags"
     );
 

--- a/sandbox/server/src/services/nodejs.rs
+++ b/sandbox/server/src/services/nodejs.rs
@@ -79,13 +79,12 @@ pub async fn run(
     }
 
     // Cap V8's JS heap so JS-object bombs die with a clean heap-OOM below the
-    // RLIMIT_AS ceiling. Override with NODE_MAX_OLD_SPACE_MB.
-    let old_space_mb = std::env::var("NODE_MAX_OLD_SPACE_MB")
-        .ok()
-        .and_then(|v| v.trim().parse::<u32>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(768);
+    // RLIMIT_AS ceiling. Configurable via config or NODEJS_MAX_OLD_SPACE_MB env.
+    let old_space_mb = config.nodejs_max_old_space_mb;
     cmd.arg(format!("--max-old-space-size={old_space_mb}"))
+        .arg("--jitless")
+        .arg("--no-expose_wasm")
+        .arg("--disable-proto=throw")
         .arg("-")
         .arg(LIB_PATH)
         .arg(sandbox_uid.to_string())

--- a/sandbox/server/src/services/python.rs
+++ b/sandbox/server/src/services/python.rs
@@ -35,7 +35,7 @@ fn build_script(
         // Privileged mode — Landlock not used, paths never read.
         "[]".into()
     } else {
-        let mut paths = vec![LIB_PATH.to_string()];
+        let mut paths: Vec<String> = vec![];
         paths.extend(config.python_lib_paths.iter().cloned());
         paths.extend(config.nodejs_lib_paths.iter().cloned());
         paths.extend([
@@ -92,7 +92,7 @@ pub async fn run(
                 let allowed_paths: Vec<String> = if config.privilege {
                     vec![]
                 } else {
-                    let mut paths = vec![LIB_PATH.to_string()];
+                    let mut paths: Vec<String> = vec![];
                     paths.extend(config.python_lib_paths.iter().cloned());
                     paths.extend(config.nodejs_lib_paths.iter().cloned());
                     paths.extend([


### PR DESCRIPTION
- Add configurable V8 --max-old-space-size via nodejs_max_old_space_mb
- Enable --jitless, --no-expose_wasm, --disable-proto=throw for Node.js
- Lower default RLIMIT_AS for Python (256 MiB) and Node.js (512 MiB)
- Remove LIB_PATH from Landlock allowed paths for non-privileged Python
- Support both NODEJS_MAX_OLD_SPACE_MB and legacy NODE_MAX_OLD_SPACE_MB env vars

## Summary by Sourcery

在引入可配置的 V8 堆内存限制和更严格的 Node.js 沙盒机制的同时，收紧了 Python 和 Node.js 运行时的内存限制与文件系统访问权限。

New Features:
- 新增可配置的 `nodejs_max_old_space_mb` 选项及对应的环境变量，用于控制 Node.js 沙盒中的 V8 `--max-old-space-size` 参数。

Enhancements:
- 降低 Python 和 Node.js 的默认 `RLIMIT_AS` 上限，以减少单次执行的内存占用并实施更严格的内存限制。
- 通过默认启用 `--jitless`、`--no-expose_wasm` 和 `--disable-proto=throw` 标志来加固 Node.js 沙盒。
- 从非特权 Python 执行的 Landlock 允许路径中移除共享库路径，以进一步收紧文件系统访问范围。
- 在启动日志中暴露已配置的 Node.js old-space 和 address-space 限制，以提升可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable V8 heap limits and stricter Node.js sandboxing while tightening memory limits and filesystem access for Python and Node.js runtimes.

New Features:
- Add a configurable nodejs_max_old_space_mb option and corresponding environment variables to control V8 --max-old-space-size for Node.js sandboxes.

Enhancements:
- Lower default RLIMIT_AS caps for Python and Node.js to reduce per-execution memory usage and enforce tighter limits.
- Harden the Node.js sandbox by enabling --jitless, --no-expose_wasm, and --disable-proto=throw flags by default.
- Remove the shared library path from Landlock-allowed paths for non-privileged Python executions to narrow filesystem access.
- Expose the configured Node.js old-space and address-space limits in startup logging for better observability.

</details>