### PR TITLE
fix(web): agent tools

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat/helpers.ts
+++ b/web/src/views/ApplicationConfig/components/Chat/helpers.ts
@@ -198,7 +198,7 @@ export const addRunStartMessage = (prev: ChatData[], data: any): ChatData[] => {
         subContent: step_id ?[
           ...(lastMsg.subContent || []),
           {
-            node_id: `${name}`,
+            node_id: step_id,
             node_type: 'tool',
             node_name: name,
             status: 'pending',
@@ -213,11 +213,15 @@ export const addRunStartMessage = (prev: ChatData[], data: any): ChatData[] => {
 
 /** Finalises the tool-run detail on the targeted model's last assistant message. */
 export const addRunEndMessage = (prev: ChatData[], data: any): ChatData[] => {
-  const { model_config_id, conversation_id, meta, output, error } = data
+  const { model_config_id, conversation_id, meta, output, error, step_id } = data
   return mapModelLastVersion(prev, model_config_id, lastMsg => {
     if (lastMsg.role !== 'assistant') return lastMsg
     const lastSubContent = lastMsg.subContent || []
-    const lastSubContentItem = lastSubContent[lastSubContent.length - 1]
+    const targetIndex = step_id
+      ? lastSubContent.findIndex(vo => vo.node_id === step_id)
+      : lastSubContent.length - 1
+    if (targetIndex === -1) return lastMsg
+    const lastSubContentItem = lastSubContent[targetIndex]
     let sourceList: any[] = []
     if (meta?.sources?.length > 0 && (meta?.tool_type === 'knowledge_retrieval' || meta?.tool_type === 'skill')) {
       const groupedSources = meta?.sources.reduce((acc: any, source: any) => {
@@ -264,8 +268,9 @@ export const addRunEndMessage = (prev: ChatData[], data: any): ChatData[] => {
     return {
       ...lastMsg,
       subContent: [
-        ...lastSubContent.slice(0, -1),
+        ...lastSubContent.slice(0, targetIndex),
         ...sourceList,
+        ...lastSubContent.slice(targetIndex + 1),
       ],
     }
   }, conversation_id)


### PR DESCRIPTION
## Summary by Sourcery

通过使用步骤标识符而非工具名称，改进对聊天消息中工具运行子内容的跟踪和最终处理。

Bug Fixes:
- 确保工具运行开始消息将正确的步骤标识符存储为 `node_id`。
- 在运行结束时使用 `step_id` 正确定位并更新特定的工具运行子内容项，当未提供 `step_id` 时回退到最后一个子内容项。
- 在替换工具运行详情时保留周围的子内容项，而不是总是修改最后一条记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve tracking and finalisation of tool-run subcontent in chat messages by using step identifiers instead of tool names.

Bug Fixes:
- Ensure tool-run start messages store the correct step identifier as node_id.
- Correctly locate and update the specific tool-run subcontent item at run end using step_id, falling back to the last item when no step_id is provided.
- Preserve surrounding subcontent items when replacing tool-run details, rather than always modifying the last entry.

</details>