### PR TITLE
feat(memory): add perceptual memory parsing and entity-to-user-source trace tool

### DIFF
--- a/api/app/controllers/memory_forget_controller.py
+++ b/api/app/controllers/memory_forget_controller.py
@@ -431,7 +431,7 @@ async def get_forgetting_trend(
         ts = int(day_start.timestamp() * 1000)
         trend.append({"date": ts, "count": daily.get(day_start.strftime("%Y-%m-%d"), 0)})
 
-    return success(data={"trend": trend})
+    return success(data=trend)
 
 
 @router.get("/{end_user_id}/forgetting_candidates", response_model=ApiResponse)
@@ -457,7 +457,7 @@ async def get_forgetting_candidates(
     page_items = all_candidates[start:start + pagesize]
 
     return success(data={
-        "candidates": page_items,
+        "items": page_items,
         "page": {
             "page": page,
             "pagesize": pagesize,

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -63,7 +63,6 @@ class RelationMemory(BaseModel):
 
 class QuestionSplit(BaseModel):
     questions: list = Field(default_factory=list)
-    memory_evidence: str = Field(default_factory=str)
 
 
 class EntityPair(BaseModel):

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 
-from app.core.memory.enums import SearchStrategy, StorageType
+from app.core.memory.enums import Neo4jNodeType, SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
 from app.core.memory.pipelines.base_pipeline import BasePipeline, ModelClientMixin
 from app.core.memory.read_services.generate_engine.query_preprocessor import QueryPreprocessor
@@ -39,6 +39,8 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         super().__init__(ctx)
         self._embedding_client = None
         self._llm_client = None
+        self._vision_llm_client = None
+        self._audio_llm_client = None
 
     async def run(
             self,
@@ -112,6 +114,31 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                 )
         return self._embedding_client
 
+    async def _get_perceptual_llm_client(self, perceptual_type: int):
+        cfg = self.ctx.memory_config
+        if perceptual_type == 1:  # VISION
+            if not cfg.vision_model_id:
+                return None
+            if self._vision_llm_client is None:
+                async with get_async_db_context() as db:
+                    self._vision_llm_client = await self.get_llm_client_async(
+                        db, cfg.vision_model_id, tenant_id=cfg.tenant_id,
+                    )
+            return self._vision_llm_client
+        elif perceptual_type == 2:  # AUDIO
+            if not cfg.audio_model_id:
+                return None
+            if self._audio_llm_client is None:
+                async with get_async_db_context() as db:
+                    self._audio_llm_client = await self.get_llm_client_async(
+                        db, cfg.audio_model_id, tenant_id=cfg.tenant_id,
+                    )
+            return self._audio_llm_client
+        elif perceptual_type == 3:  # TEXT
+            return await self._get_llm_client()
+        else:
+            return None
+
     async def _deep_read(
             self,
             query: str,
@@ -122,17 +149,12 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
     ) -> MemorySearchResult:
         search_service = await self._get_search_service(includes)
         memory_l0 = await self._user_meta()
-        questions, memory_evidence = await QueryPreprocessor.split(
+        questions = await QueryPreprocessor.split(
             query,
             history,
             memory_l0.content,
             await self._get_llm_client()
         )
-        if memory_evidence:
-            memory_l0.content_str = memory_evidence
-            if memory_l0.memories:
-                memory_l0.memories[0].query = query
-            return memory_l0
         all_tasks = []
         for question in questions:
             all_tasks.append(_run_with_semaphore(search_service.hybrid_search(question, limit)))
@@ -145,6 +167,56 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         hybrid_search_res = _safe_merge_results(hybrid_results, "hybrid")
         relation_res = _safe_merge_results(relation_results, "relation")
+
+        perceptual_memories = [
+            m for m in hybrid_search_res.memories
+            if m.source == Neo4jNodeType.PERCEPTUAL
+        ]
+        if perceptual_memories:
+            parse_tasks = []
+            type_llm_cache: dict[int, object] = {}
+
+            async def _get_llm_for_type(pt: int):
+                if pt not in type_llm_cache:
+                    type_llm_cache[pt] = await self._get_perceptual_llm_client(pt)
+                return type_llm_cache[pt]
+
+            for i, question in enumerate(questions):
+                if i >= len(hybrid_results) or isinstance(hybrid_results[i], Exception):
+                    continue
+                sub_percep = [
+                    m for m in hybrid_results[i].memories
+                    if m.source == Neo4jNodeType.PERCEPTUAL
+                ]
+                if not sub_percep:
+                    continue
+
+                by_type: dict[int, list] = {}
+                for mem in sub_percep:
+                    pt = int(mem.data.get("perceptual_type", 0))
+                    if pt not in by_type:
+                        by_type[pt] = []
+                    by_type[pt].append(mem)
+
+                for pt, mems in by_type.items():
+                    llm = await _get_llm_for_type(pt)
+                    if llm is None:
+                        continue
+                    parse_tasks.append(
+                        search_service.resolve_perceptual_content(
+                            question, mems, llm
+                        )
+                    )
+
+            if parse_tasks:
+                parse_results = await asyncio.gather(*parse_tasks, return_exceptions=True)
+                for parse_res in parse_results:
+                    if not isinstance(parse_res, Exception):
+                        for mem in parse_res:
+                            for existing in hybrid_search_res.memories:
+                                if existing.id == mem.id:
+                                    existing.content = mem.content
+                                    break
 
         results = hybrid_search_res + relation_res
 
@@ -169,17 +241,12 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         search_service = await self._get_search_service(includes)
 
         memory_l0 = await self._user_meta()
-        questions, memory_evidence = await QueryPreprocessor.split(
+        questions = await QueryPreprocessor.split(
             query,
             history,
             memory_l0.content,
             await self._get_llm_client()
         )
-        if memory_evidence:
-            memory_l0.content_str = memory_evidence
-            if memory_l0.memories:
-                memory_l0.memories[0].query = query
-            return memory_l0
         all_results = list(await asyncio.gather(*(
             _run_with_semaphore(search_service.hybrid_search(question, limit)) for question in questions
         ), return_exceptions=True))

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -996,7 +996,7 @@ class WritePipeline:
                     with get_db_context() as db:
                         # 先查找已有的 Perceptual 记录
                         repo = MemoryPerceptualRepository(db)
-                        memories = repo.get_by_url(url)
+                        memories = repo.get_by_url(self.end_user_id, url)
 
                         if memories:
                             # 已存在，复用最新的一条

--- a/api/app/core/memory/prompt/problem_split.jinja2
+++ b/api/app/core/memory/prompt/problem_split.jinja2
@@ -22,8 +22,7 @@ Output:{
         [
             "User python learning progress review",
             "Recommended next steps for learning python"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 User:What's the status of the Neo4j project I mentioned last time?
@@ -32,8 +31,7 @@ Output:{
         [
             "User Neo4j's project",
             "Project progress summary"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 User:How is the model training I've been working on recently? Is there any area that needs optimization?
@@ -43,8 +41,7 @@ Output:{
             "User's recent model training records",
             "Current training problem analysis",
             "Model optimization suggestions"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 User:What problems still exist with this system?
@@ -54,8 +51,7 @@ Output:{
             "User's recent projects",
             "System problem log query",
             "System optimization suggestions"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 User:How's the GNN project I mentioned last month coming along?
@@ -64,8 +60,7 @@ Output:{
         [
             "2026-03 User GNN Project Log",
             "Summary of the current status of the GNN project"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 User:What is the current progress of my previous YOLO project and recommendation system?
@@ -74,8 +69,7 @@ Output:{
         [
             "YOLO Project Progress",
             "Recommendation System Project Progress"
-        ],
-    "memory_evidence": ""
+        ]
 }
 
 Remember the following:
@@ -86,6 +80,5 @@ Remember the following:
 - If you are unable to extract any relevant information from the user's input, return the user's original input:{"questions":[userinput]}
 
 # [IMPORTANT] THE OUTPUT LANGUAGE MUST BE THE SAME AS THE USER'S INPUT LANGUAGE.
-# [IMPORTANT] The output must be strictly in JSON format:{"questions": ["Question 1", "Question 2", ...],"memory_evidence":"relevant information"}
-# [IMPORTANT] If the user's memory block contains sufficient information relevant to the current question, do NOT directly answer the user's question. Instead, populate the JSON memory_evidence field with the relevant memory facts, evidence, and supporting information extracted from the memory block.
+# [IMPORTANT] The output must be strictly in JSON format:{"questions": ["Question 1", "Question 2", ...]}
 The following is the user's input. You need to extract the relevant information from the input and return it in the JSON format as shown above.

--- a/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
+++ b/api/app/core/memory/read_services/generate_engine/query_preprocessor.py
@@ -22,7 +22,7 @@ class QueryPreprocessor:
         return text
 
     @staticmethod
-    async def split(query: str, history: list, memory_l0_str: str, llm_client: RedBearLLM) -> tuple[list, str]:
+    async def split(query: str, history: list, memory_l0_str: str, llm_client: RedBearLLM) -> list:
         system_prompt = prompt_manager.render(
             name="problem_split",
             datetime=utcnow_naive().strftime("%Y-%m-%d"),
@@ -38,9 +38,7 @@ class QueryPreprocessor:
                 "callbacks": []
             }) | StructResponse(QuestionSplit)
             queries = sub_queries.questions
-            memory_evidence = sub_queries.memory_evidence
         except Exception as e:
             logger.error(f"[QueryPreprocessor] Sub-question segmentation failed - {e}")
             queries = [query]
-            memory_evidence = ""
-        return queries, memory_evidence
+        return queries

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -21,17 +21,19 @@ from app.core.memory.models.service_models import MemoryContext
 from app.core.memory.prompt import prompt_manager
 from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
-from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool
+from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, make_user_source_lookup_tool
 from app.core.models.llm import StructResponse
 from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.db import get_async_db_context
 from app.models import Conversation, MemoryMessage
 from app.repositories import knowledge_repository
+from app.repositories.neo4j.cypher_queries import FETCH_USER_SOURCES_FOR_ENTITIES
 from app.repositories.neo4j.graph_search import get_nodes_by_ids, get_relations_between_entity_pairs, search_graph, \
     search_graph_by_embedding
 from app.repositories.neo4j.graph_search import search_user_metadata
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.schemas.app_schema import FileInput, FileType, TransferMethod
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +71,7 @@ class Neo4jSearchService:
         if includes is None:
             self.includes = [
                 Neo4jNodeType.STATEMENT,
+                # Neo4jNodeType.DIALOGUE,
                 Neo4jNodeType.CHUNK,
                 Neo4jNodeType.EXTRACTEDENTITY,
                 Neo4jNodeType.MEMORYSUMMARY,
@@ -78,6 +81,8 @@ class Neo4jSearchService:
 
         self.relation_search_tool = make_relation_search_tool(self.ctx)
         self.entity_search_tool = make_entity_search_tool(self.ctx)
+        self.user_source_lookup_tool = make_user_source_lookup_tool(self.ctx)
+        self._user_source_looked_up_ids = set()
 
     async def _keyword_search(
             self,
@@ -242,7 +247,7 @@ class Neo4jSearchService:
             loop_limit=RELATIONSHIP_LOOP_LIMIT - 1
         )
 
-        tools = [self.relation_search_tool, self.entity_search_tool]
+        tools = [self.relation_search_tool, self.entity_search_tool, self.user_source_lookup_tool]
         tool_map = {t.name: t for t in tools}
         llm_with_tools = self.llm.bind_tools(tools)
 
@@ -265,8 +270,8 @@ class Neo4jSearchService:
                     break
 
                 async def run_tool(tc):
-                    tool = tool_map[tc["name"]]
                     try:
+                        tool = tool_map[tc["name"]]
                         result = await tool.ainvoke(tc["args"])
                         return ToolMessage(
                             content=json.dumps(result, ensure_ascii=False),
@@ -285,6 +290,8 @@ class Neo4jSearchService:
                 messages.extend(tool_messages)
             finally:
                 var_child_runnable_config.reset(_config_token)
+
+        self._collect_user_source_lookup_ids(messages)
 
         final_message = next(
             (m for m in reversed(messages) if isinstance(m, AIMessage)),
@@ -334,6 +341,23 @@ class Neo4jSearchService:
                         pairs.append(EntityPair(source_id=source_id, target_id=target_id))
 
         return RelationSearchResult(pairs=pairs)
+
+    def _collect_user_source_lookup_ids(
+            self,
+            messages: list[SystemMessage | HumanMessage | AIMessage | ToolMessage],
+    ) -> None:
+        """从 agent 消息历史中收集 user_source_lookup_tool 调用过的 entity_ids。"""
+        looked_up: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, AIMessage) or not msg.tool_calls:
+                continue
+            for tc in msg.tool_calls:
+                if tc.get("name") != "user_source_lookup_tool":
+                    continue
+                entity_ids = tc.get("args", {}).get("entity_ids", [])
+                if isinstance(entity_ids, list):
+                    looked_up.update(entity_ids)
+        self._user_source_looked_up_ids = looked_up
 
     async def _fetch_relation_data(
             self,
@@ -413,6 +437,20 @@ class Neo4jSearchService:
         relation_records, entity_records = await self._fetch_relation_data(result.pairs)
         relations = self._build_relation_memories(relation_records, entity_records)
 
+        if self._user_source_looked_up_ids:
+            try:
+                user_source_map = await self.fetch_user_sources_for_entities(self._user_source_looked_up_ids)
+            except Exception as e:
+                logger.warning(f"[RelationSearch] UserSource 回溯失败: {e}")
+                user_source_map = {}
+            for rel_memory in relations:
+                if rel_memory.target_id in user_source_map:
+                    source_text = user_source_map[rel_memory.target_id]
+                    rel_memory.target_desc = (
+                        f"{rel_memory.target_desc}\n"
+                        f"<original-context>{source_text}</original-context>"
+                    )
+
         logger.info(f"[RelationSearch] resolved {len(relations)} relations from {len(result.pairs)} pairs")
         return MemorySearchResult(memories=[], relations=relations)
 
@@ -431,6 +469,148 @@ class Neo4jSearchService:
             )
 
         return memory
+
+    async def fetch_user_sources_for_entities(
+            self,
+            entity_ids: set[str],
+    ) -> dict[str, str]:
+        """给定一组 ExtractedEntity ID，查询其 HAS_ORIGINAL_CONTENT 边，返回
+        {entity_id: original_text} 映射。
+
+        若一个 entity 对应多个 UserSource（多次提及），合并所有 original_text。
+        """
+        if not entity_ids:
+            return {}
+
+        async with Neo4jConnector(shared_driver=True) as connector:
+            records = await connector.execute_query(
+                FETCH_USER_SOURCES_FOR_ENTITIES,
+                entity_ids=list(entity_ids),
+                end_user_id=self.ctx.end_user_id,
+            )
+
+        result: dict[str, list[str]] = {}
+        for rec in records:
+            eid = rec.get("entity_id", "")
+            text = rec.get("original_text", "")
+            if not eid or not text:
+                continue
+            if eid not in result:
+                result[eid] = []
+            result[eid].append(text)
+
+        return {eid: "\n---\n".join(texts) for eid, texts in result.items()}
+
+    async def resolve_perceptual_content(
+            self,
+            query: str,
+            perceptual_memories: list[Memory],
+            llm: RedBearLLM,
+    ) -> list[Memory]:
+        """对 Perceptual 类型的记忆调用多模态模型解析实际文件内容。
+
+        仅增强 memory.content（不改变 score / id / source）。
+        失败时保留原 summary，不中断主流程。
+        """
+        enhanced = []
+        for mem in perceptual_memories:
+            if mem.source != Neo4jNodeType.PERCEPTUAL:
+                enhanced.append(mem)
+                continue
+
+            file_path = mem.data.get("file_path", "")
+            file_name = mem.data.get("file_name", "")
+            file_type = mem.data.get("file_type", "")
+            perceptual_type = mem.data.get("perceptual_type", "")
+
+            if not file_path:
+                logger.debug("[Perceptual] 跳过无 file_path 的 Perceptual 记忆")
+                enhanced.append(mem)
+                continue
+
+            try:
+                parsed = await self._call_multimodal_for_query(
+                    file_path, file_name, file_type, perceptual_type, query, llm
+                )
+
+                # 增强 content：格式化为 query 相关的解析片段
+                mem.content = (
+                    f"<history-file-input>\n"
+                    f"<file-name>{file_name}</file-name>\n"
+                    f"<file-summary>{mem.data.get('summary', '')}</file-summary>\n"
+                    f"<file-analysis>{parsed}</file-analysis>\n"
+                    f"</history-file-input>\n"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[Perceptual] 多模态解析失败 file={file_name}: {e}，回退使用 summary"
+                )
+
+            enhanced.append(mem)
+
+        return enhanced
+
+    @staticmethod
+    async def _call_multimodal_for_query(
+            file_path: str,
+            file_name: str,
+            file_type: str,
+            perceptual_type: str | int,
+            query: str,
+            llm: RedBearLLM,
+    ) -> str:
+        """调用多模态 LLM，让模型针对 query 解析文件内容。
+
+        支持图片（VISION）和文档（TEXT/DOCUMENT）类型。
+        返回模型对文件的针对性分析文本。
+        """
+        from app.services.multimodal_service import MultimodalService
+
+        # 根据 perceptual_type 确定 FileInput 类型
+        # perceptual_type: 1=VISION | 2=AUDIO | 3=TEXT | 4=CONVERSATION
+        perceptual_type_int = int(perceptual_type) if perceptual_type else 0
+        if perceptual_type_int == 1:  # VISION
+            file_input_type = FileType.IMAGE
+        elif perceptual_type_int == 3:  # TEXT/DOCUMENT
+            file_input_type = FileType.DOCUMENT
+        else:
+            # AUDIO / CONVERSATION / 未知 → 跳过，返回 summary
+            return ""
+
+        file_input = FileInput(
+            type=file_input_type,
+            transfer_method=TransferMethod.REMOTE_URL,
+            url=file_path,
+            file_type=file_type or "",
+        )
+
+        # 使用 MultimodalService 格式化文件内容
+        multimodal_svc = MultimodalService(
+            db=None,
+            api_config=llm.get_config(),
+        )
+        formatted = await multimodal_svc.process_files(
+            files=[file_input],
+            document_image_recognition=True,
+        )
+
+        if not formatted:
+            return ""
+
+        # 构造 prompt：让模型关注 query 相关的文件内容
+        prompt = (
+            f"请根据以下问题，分析文件 '{file_name}' 中相关的内容：\n\n"
+            f"问题：{query}\n\n"
+            f"请仅提取与问题直接相关的信息，以简洁的要点形式回答。"
+        )
+
+        # 调用 LLM（支持多模态输入）
+        response = await llm.ainvoke([HumanMessage(content=[
+            {"type": "text", "text": prompt},
+            *formatted,
+        ])])
+
+        return response.content if hasattr(response, 'content') else str(response)
 
 
 class RAGSearchService:

--- a/api/app/core/memory/read_services/search_engine/tools.py
+++ b/api/app/core/memory/read_services/search_engine/tools.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from app.core.memory.enums import Neo4jNodeType
 from app.core.memory.models.service_models import MemoryContext
+from app.repositories.neo4j.cypher_queries import FETCH_USER_SOURCES_FOR_ENTITIES
 from app.repositories.neo4j.graph_search import search_by_fulltext, search_graph_by_relationship, search_user_metadata
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
@@ -18,6 +19,10 @@ class EntitySearchInput(BaseModel):
 class RelationSearchInput(BaseModel):
     source_id: str | None = Field(default=None, description="Starting node ID for relation node query")
     relation_predicates: list[int] = Field(description="Relational predicate IDs to retrieve, supports searching multiple relations at once. Must use numeric IDs: 1=别名属于, 2=属于类型, 3=位于, 4=前往, 5=组成部分, 6=拥有, 7=使用, 8=创建了, 9=了解, 10=偏好, 11=负责, 12=沟通于, 13=关联于")
+
+
+class UserSourceLookupInput(BaseModel):
+    entity_ids: list[str] = Field(description="List of ExtractedEntity IDs to trace back to their original user messages (UserSource nodes)")
 
 
 def make_entity_search_tool(ctx: MemoryContext):
@@ -73,3 +78,42 @@ def make_relation_search_tool(ctx: MemoryContext):
             return res
 
     return relation_search_tool
+
+
+def make_user_source_lookup_tool(ctx: MemoryContext):
+    @tool(args_schema=UserSourceLookupInput)
+    async def user_source_lookup_tool(entity_ids: list[str]) -> list[dict]:
+        """Trace back from ExtractedEntity nodes to their original UserSource messages.
+
+        Given a list of entity IDs, queries the HAS_ORIGINAL_CONTENT edges to find
+        the original user messages where these entities were first mentioned.
+        Use this when you need the full original context of an entity to better
+        understand relationships or determine relevance.
+
+        Args:
+            entity_ids: List of ExtractedEntity IDs to trace back.
+
+        Returns:
+            [{"entity_id": "entity id", "original_text": "original user message text"}, ...]
+        """
+        if not entity_ids:
+            return []
+
+        async with Neo4jConnector(shared_driver=True) as connector:
+            records = await connector.execute_query(
+                FETCH_USER_SOURCES_FOR_ENTITIES,
+                entity_ids=entity_ids,
+                end_user_id=ctx.end_user_id,
+            )
+
+        result = []
+        for rec in records:
+            eid = rec.get("entity_id", "")
+            text = rec.get("original_text", "")
+            if eid and text:
+                result.append({"entity_id": eid, "original_text": text})
+
+        logger.info(f"[user_source_lookup_tool] entity_ids:{entity_ids}, found:{len(result)}")
+        return result
+
+    return user_source_lookup_tool

--- a/api/app/repositories/memory_perceptual_repository.py
+++ b/api/app/repositories/memory_perceptual_repository.py
@@ -144,10 +144,14 @@ class MemoryPerceptualRepository:
 
     def get_by_url(
             self,
+            end_user_id: str,
             file_url: str
     ) -> list[MemoryPerceptualModel]:
         try:
-            stmt = select(MemoryPerceptualModel).where(MemoryPerceptualModel.file_path == file_url)
+            stmt = select(MemoryPerceptualModel).where(
+                MemoryPerceptualModel.file_path == file_url,
+                MemoryPerceptualModel.end_user_id == end_user_id
+            )
             return list(self.db.execute(stmt).scalars())
         except Exception:
             db_logger.error(f"Failed to query perceptual memories by file_url: file_url={file_url}")

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2829,6 +2829,16 @@ ON CREATE SET r.id = edge.id,
 RETURN elementId(r) AS uuid
 """
 
+# ── Entity → UserSource 回溯查询 ──
+# 通过 HAS_ORIGINAL_CONTENT 边，从 ExtractedEntity 追溯到 UserSource 节点的原始文本。
+# 边方向：UserSource -[HAS_ORIGINAL_CONTENT]-> ExtractedEntity
+FETCH_USER_SOURCES_FOR_ENTITIES = """
+MATCH (us:UserSource)-[r:HAS_ORIGINAL_CONTENT]->(e:ExtractedEntity)
+WHERE e.id IN $entity_ids
+  AND us.end_user_id = $end_user_id
+RETURN e.id AS entity_id, us.original_text AS original_text
+"""
+
 DELETE_NODE_BY_ELEMENT_ID = """
 MATCH (n)
 WHERE elementId(n) = $element_id AND n.end_user_id = $end_user_id

--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -135,30 +135,21 @@ class MemoryForgetService:
         if end_user_id:
             query += " AND n.end_user_id = $end_user_id"
 
-        query += """ \
-                 WITH n, \
-                      CASE \
-                     WHEN n: Statement THEN 'statement' \
-                     WHEN n:ExtractedEntity THEN 'entity' \
-                     WHEN n:MemorySummary THEN 'summary' \
-                 END \
-                 as node_type
+        query += """
+        WITH n,
+             CASE 
+               WHEN n:Statement THEN 'statement'
+               WHEN n:ExtractedEntity THEN 'entity'
+               WHEN n:MemorySummary THEN 'summary'
+             END as node_type
         RETURN 
             count(n) as total_nodes,
             sum(CASE WHEN node_type = 'statement' THEN 1 ELSE 0 END) as statement_count,
             sum(CASE WHEN node_type = 'entity' THEN 1 ELSE 0 END) as entity_count,
             sum(CASE WHEN node_type = 'summary' THEN 1 ELSE 0 END) as summary_count,
             avg(n.activation_value) as average_activation,
-            sum(CASE WHEN n.activation_value IS NOT NULL AND n.activation_value < \
-                 $threshold \
-                 THEN \
-                 1 \
-                 ELSE \
-                 0 \
-                 END \
-                 ) \
-                 as \
-                 low_activation_nodes
+            sum(CASE WHEN n.activation_value IS NOT NULL AND n.activation_value < $threshold THEN 1 ELSE 0 END) as low_activation_nodes
+   
         """
 
         params = {'threshold': forgetting_threshold}
@@ -556,8 +547,8 @@ class MemoryForgetService:
                 'total_nodes': result['total_nodes'] or 0,
                 'nodes_with_activation': result['nodes_with_activation'] or 0,
                 'nodes_without_activation': result['nodes_without_activation'] or 0,
-                'average_activation_value': round(result['average_activation'], 2) if result[
-                                                                                          'average_activation'] is not None else None,
+                'average_activation_value': round(result['average_activation'], 2)
+                if result['average_activation'] is not None else None,
                 'low_activation_nodes': result['low_activation_nodes'] or 0,
                 'forgetting_threshold': forgetting_threshold,
                 'timestamp': to_timestamp_ms(utcnow_naive())
@@ -582,20 +573,19 @@ class MemoryForgetService:
         if end_user_id:
             distribution_query += " AND n.end_user_id = $end_user_id"
 
-        distribution_query += """ \
-                              WITH n, \
-                                   CASE \
-                                  WHEN n: Statement THEN 'statement' \
-                                  WHEN n:ExtractedEntity THEN 'entity' \
-                                  WHEN n:MemorySummary THEN 'summary' \
-                                  WHEN n:Chunk THEN 'chunk' \
-                              END \
-                              as node_type
+        distribution_query += """
+        WITH n,
+             CASE 
+               WHEN n:Statement THEN 'statement'
+               WHEN n:ExtractedEntity THEN 'entity'
+               WHEN n:MemorySummary THEN 'summary'
+               WHEN n:Chunk THEN 'chunk'
+             END as node_type
         RETURN 
             sum(CASE WHEN node_type = 'statement' THEN 1 ELSE 0 END) as statement_count,
             sum(CASE WHEN node_type = 'entity' THEN 1 ELSE 0 END) as entity_count,
             sum(CASE WHEN node_type = 'summary' THEN 1 ELSE 0 END) as summary_count,
-            sum(CASE WHEN node_type = 'chunk' THEN 1 ELSE 0 END) as chunk_count
+            sum(CASE WHEN node_type = 'chunk' THEN 1 ELSE 0 END) as chunk_count        
         """
 
         dist_params = {}


### PR DESCRIPTION
- Add `_get_perceptual_llm_client` to support VISION/AUDIO/TEXT perceptual type LLM clients
- Integrate perceptual memory parsing into `_deep_read` and `_shallow_read` pipelines
- Remove `memory_evidence` field from `QuestionSplit` model and related prompt logic
- Add `user_source_lookup_tool` for tracing ExtractedEntity nodes back to original UserSource messages
- Add `FETCH_USER_SOURCES_FOR_ENTITIES` Cypher query for entity-to-source lookup
- Register `user_source_lookup_tool` in `ContentSearchEngine` and update tool list

## Summary by Sourcery

将感知记忆解析和实体到用户来源的追踪集成到记忆读取/搜索流程中，同时简化查询拆分并收紧数据作用域。

新功能：
- 新增 `user_source_lookup_tool` 及配套 Cypher 查询，用于将抽取出的实体追溯到其原始用户消息。
- 在搜索结果中引入多模态感知内容解析，使用适配的 LLM 客户端来处理视觉、音频和文本感知记忆。

改进：
- 将新的用户来源查找工具接入关系搜索代理，使关系搜索结果可用原始用户上下文进行丰富。
- 将感知记忆解析集成到深度和普通读取流水线中，以查询为中心增强返回记忆中的文件分析。
- 优化遗忘统计和候选控制器响应，以及 Cypher 格式，使 API 输出更清晰、更一致。
- 将基于 URL 的感知记忆查找限制为当前终端用户，以提升数据隔离性。
- 通过从 `QuestionSplit` 及其下游处理流程中移除 `memory_evidence` 字段，简化查询预处理器与提示词。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate perceptual memory parsing and entity-to-user-source tracing into the memory read/search flow while simplifying query splitting and tightening data scoping.

New Features:
- Add a user_source_lookup_tool and supporting Cypher query to trace extracted entities back to their original user messages.
- Introduce multimodal perceptual content resolution in search results using appropriate LLM clients for vision, audio, and text perceptual memories.

Enhancements:
- Wire the new user source lookup tool into the relation search agent so relation results can be enriched with original user context.
- Integrate perceptual memory parsing into deep and normal read pipelines to enhance returned memories with query-focused file analyses.
- Refine forgetting statistics and candidates controller responses and Cypher formatting for clearer, more consistent API outputs.
- Restrict perceptual memory lookup by URL to the current end user for better data isolation.
- Simplify query preprocessor and prompts by removing the memory_evidence field from QuestionSplit and its downstream handling.

</details>