### PR TITLE
feature/memory_search_user_source

### DIFF
--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -61,8 +61,8 @@ class ForgettingPipeline(BasePipeline):
         )
 
         content = (
-            row.get("content") or row.get("statement") or row.get("name")
-            or row.get("text") or ""
+            row.get("content") or row.get("statement") or row.get("text")
+            or row.get("name") or ""
         )
 
         log = ForgetLog(

--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -31,6 +31,7 @@ _SELF_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _SELF_DIR)
 import protocol as P  # noqa: E402
 
+
 class _ReqInfo(TypedDict):
     """Bookkeeping for one in-flight sandbox request."""
     pid: int
@@ -77,7 +78,7 @@ def _xor(data: bytes, key: bytes) -> bytes:
         seg_len = end - i
         keystream = key * (seg_len // kl) + key[: seg_len % kl]
         out[i:end] = (
-            int.from_bytes(mv[i:end], "big") ^ int.from_bytes(keystream, "big")
+                int.from_bytes(mv[i:end], "big") ^ int.from_bytes(keystream, "big")
         ).to_bytes(seg_len, "big")
         i = end
     return bytes(out)
@@ -95,7 +96,8 @@ class Zygote:
 
         # Warm load of the seccomp library. Inherited by every child via COW.
         self.lib = ctypes.CDLL(lib_so)
-        self.lib.init_seccomp.argtypes = [ctypes.c_uint32, ctypes.c_uint32, ctypes.c_bool, ctypes.c_uint64, ctypes.c_bool]
+        self.lib.init_seccomp.argtypes = [ctypes.c_uint32, ctypes.c_uint32, ctypes.c_bool, ctypes.c_uint64,
+                                          ctypes.c_bool]
         self.lib.init_seccomp.restype = ctypes.c_int
 
         self.lib.apply_landlock.argtypes = [ctypes.POINTER(ctypes.c_char_p)]
@@ -135,8 +137,8 @@ class Zygote:
         # "SyntaxError: UTF-8 decode error".
         try:
             import codecs
-            import encodings          # noqa: F401
-            import encodings.utf_8    # noqa: F401
+            import encodings  # noqa: F401
+            import encodings.utf_8  # noqa: F401
             import encodings.aliases  # noqa: F401
             for enc in ("utf-8", "ascii", "latin-1", "utf-16", "idna"):
                 try:
@@ -213,25 +215,35 @@ class Zygote:
     # -------------------------------------------------------------- request
     def _handle_run(self, req_id: int, payload: bytes) -> None:
         req = json.loads(payload)
-        out_r, out_w = os.pipe()
-        err_r, err_w = os.pipe()
+        out_r = out_w = err_r = err_w = -1
+        try:
+            out_r, out_w = os.pipe()
+            err_r, err_w = os.pipe()
 
-        # Flush our own buffers so children never inherit unflushed bytes.
-        sys.stdout.flush()
-        sys.stderr.flush()
+            # Flush our own buffers so children never inherit unflushed bytes.
+            sys.stdout.flush()
+            sys.stderr.flush()
 
-        pid = os.fork()
-        if pid == 0:
-            # ---- child ----
-            self._child_exec(req, out_w, err_w, out_r, err_r)
-            os._exit(127)  # unreachable
+            pid = os.fork()
+            if pid == 0:
+                # ---- child ----
+                self._child_exec(req, out_w, err_w, out_r, err_r)
+                os._exit(127)
 
-        # ---- parent (zygote) ----
-        os.close(out_w)
-        os.close(err_w)
-        self.reqs[req_id] = {"pid": pid, "out": out_r, "err": err_r, "open": {out_r, err_r}}
-        self.fd_map[out_r] = (req_id, P.MSG_STDOUT)
-        self.fd_map[err_r] = (req_id, P.MSG_STDERR)
+            # ---- parent (zygote) ----
+            os.close(out_w)
+            os.close(err_w)
+            self.reqs[req_id] = {"pid": pid, "out": out_r, "err": err_r, "open": {out_r, err_r}}
+            self.fd_map[out_r] = (req_id, P.MSG_STDOUT)
+            self.fd_map[err_r] = (req_id, P.MSG_STDERR)
+        except Exception:
+            for fd in (out_w, err_w, out_r, err_r):
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+            raise
 
     def _child_exec(self, req: dict, out_w: int, err_w: int, out_r: int, err_r: int) -> None:
         # Redirect stdout/stderr to the pipes; disconnect from everything else.

--- a/sandbox/server/src/services/zygote.rs
+++ b/sandbox/server/src/services/zygote.rs
@@ -222,7 +222,19 @@ impl Drop for ZygoteManager {
     fn drop(&mut self) {
         self.running.store(false, Ordering::SeqCst);
         self._read_task.abort();
-        // Child is killed when its handle drops.
+        // std::process::Child does NOT kill on drop (unlike tokio's Child with
+        // kill_on_drop).  Without explicit kill+wait the zygote worker becomes
+        // an orphan that turns into a zombie when it exits, permanently consuming
+        // a PID slot.  Repeated restarts can exhaust the PID namespace.
+        //
+        // kill() + wait() is safe here: the zygote worker is single-threaded,
+        // does not block signals, and exits promptly on SIGKILL.
+        if let Err(e) = self._child.kill() {
+            tracing::warn!(error = %e, "zygote: kill failed during drop");
+        }
+        if let Err(e) = self._child.wait() {
+            tracing::warn!(error = %e, "zygote: wait failed during drop");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary by Sourcery

确保 zygote 工作进程和内存管线内容处理更加健壮，并得到正确的优先级。

Bug Fixes:
- 在 Python zygote worker 中添加防御性的 pipe/fork 处理逻辑，在失败时重新抛出异常前关闭所有已打开的文件描述符。
- 在管理器销毁（drop）时显式杀死并等待 Rust zygote worker 子进程，以防止孤儿/僵尸进程以及 PID 枯竭。

Enhancements:
- 调整遗忘管线的内容字段选择逻辑，在构建遗忘日志时优先选择文本而不是名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure zygote worker processes and memory pipeline content handling are more robust and correctly prioritized.

Bug Fixes:
- Add defensive pipe/fork handling in the Python zygote worker to close any opened file descriptors on failure before re-raising.
- Explicitly kill and wait for the Rust zygote worker child process on manager drop to prevent orphaned/zombie processes and PID exhaustion.

Enhancements:
- Adjust the forgetting pipeline content field selection to prefer text before name when constructing forget logs.

</details>