### PR TITLE
Fix/sandbox block

### DIFF
--- a/sandbox/lib/sandbox_seccomp/src/lib.rs
+++ b/sandbox/lib/sandbox_seccomp/src/lib.rs
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn apply_landlock_one(lib_path: *const c_char) -> c_int {
 
 /// Install seccomp filter. Default action: SCMP_ACT_KILL_PROCESS.
 ///
-/// `openat` is only allowed when the `O_CREAT` flag is **not** set, preventing
+/// `openat`/`open` is only allowed when the `O_CREAT` flag is **not** set, preventing
 /// the sandboxed process from creating new files.  If `O_CREAT` is present the
 /// call falls through to the default `KILL_PROCESS`.
 fn install_seccomp(enable_network: bool) -> Result<(), c_int> {
@@ -192,6 +192,20 @@ fn install_seccomp(enable_network: bool) -> Result<(), c_int> {
                 // Allow openat only when O_CREAT is NOT set in flags (arg idx 2).
                 let cmp = scmp_arg_cmp {
                     arg: 2,
+                    op: scmp_compare::SCMP_CMP_MASKED_EQ,
+                    datum_a: 0,                         // O_CREAT bit must be 0
+                    datum_b: libc::O_CREAT as u64,      // mask
+                };
+                if seccomp_rule_add_array(ctx, SCMP_ACT_ALLOW, sc, 1, &cmp) != 0 {
+                    seccomp_release(ctx);
+                    return Err(-7);
+                }
+            } else if sc == libc::SYS_open as i32 {
+                // Allow open only when O_CREAT is NOT set in flags (arg idx 1).
+                // open() has one fewer argument than openat(), so the flags
+                // parameter is at argument index 1 instead of 2.
+                let cmp = scmp_arg_cmp {
+                    arg: 1,
                     op: scmp_compare::SCMP_CMP_MASKED_EQ,
                     datum_a: 0,                         // O_CREAT bit must be 0
                     datum_b: libc::O_CREAT as u64,      // mask
@@ -266,8 +280,6 @@ fn install_seccomp(enable_network: bool) -> Result<(), c_int> {
 ///   RLIMIT_AS → (Landlock applied separately by caller) → no_new_privs
 ///   → seccomp
 ///
-/// In both modes, `openat` is only allowed when `O_CREAT` is not set.
-/// Must be called once per process before executing untrusted code.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn init_seccomp(
     uid: uid_t,

--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -355,6 +355,8 @@ class Zygote:
             os._exit(1)
 
     def _handle_kill(self, req_id: int) -> None:
+        """Kill the sandbox child.  The kernel will close the child's fds,
+        triggering pipe EOF -> _teardown_pipe_fd -> kill+waitpid chain."""
         req = self.reqs.get(req_id)
         if not req:
             return
@@ -376,7 +378,6 @@ class Zygote:
         self._teardown_pipe_fd(fd, req_id)
 
     def _teardown_pipe_fd(self, fd: int, req_id: int) -> None:
-        """Close one child-output fd and finish the request if both are done."""
         try:
             os.close(fd)
         except OSError:
@@ -388,12 +389,13 @@ class Zygote:
         req["open"].discard(fd)
         if req["open"]:
             return
-        # Both streams closed -> child exited; reap and report.
-        # Pop the request BEFORE waitpid so that any concurrent MSG_KILL
-        # (same req_id) sees the entry is already gone and bails out,
-        # closing the PID-reuse window.
+
         pid = req["pid"]
         self.reqs.pop(req_id, None)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
         try:
             _, status = os.waitpid(pid, 0)
             exit_code = os.waitstatus_to_exitcode(status)


### PR DESCRIPTION
## Summary by Sourcery

收紧沙箱中文件创建的限制，并确保当输出管道关闭时，zygote 工作线程能够可靠地杀死并回收子进程。

Bug Fixes:
- 阻止使用带有 `O_CREAT` 标志的 `open` 系统调用，以防止处于沙箱中的进程创建新文件。
- 确保在所有被跟踪的输出文件描述符关闭后，沙箱子进程会被显式发送 `SIGKILL` 并被回收，避免出现卡住或 PID 被重复使用的情况。

Enhancements:
- 明确 seccomp 文档，使其同时涵盖 `open` 和 `openat`，并扩展 zygote worker 的文档字符串，详细说明 kill 行为和管道拆除行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten sandbox file-creation restrictions and ensure zygote workers reliably kill and reap child processes when their output pipes close.

Bug Fixes:
- Block use of the open syscall with O_CREAT to prevent sandboxed processes from creating new files.
- Ensure sandbox child processes are explicitly SIGKILLed and reaped once all tracked output fds are closed, avoiding stuck or reused PIDs.

Enhancements:
- Clarify seccomp documentation to cover both open and openat and expand zygote worker docstrings around kill and pipe teardown behavior.

</details>