### PR TITLE
fix(memory): add missing await to get_workspace_end_users call

### DIFF
--- a/api/app/controllers/service/memory_dashboard_api_controller.py
+++ b/api/app/controllers/service/memory_dashboard_api_controller.py
@@ -65,7 +65,7 @@ async def get_workspace_end_users(
     # 2. Delegate to the manager-side logic; workspace_id is forced to the API Key's workspace.
     #    background_tasks is injected by FastAPI (not part of the API contract) and passed
     #    through to preserve the same post-response Celery dispatch behavior as the manager side.
-    return memory_dashboard_controller.get_workspace_end_users(
+    return await memory_dashboard_controller.get_workspace_end_users(
         background_tasks=background_tasks,
         workspace_id=api_key_auth.workspace_id,
         keyword=keyword,

--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -378,6 +378,7 @@ class Zygote:
         self._teardown_pipe_fd(fd, req_id)
 
     def _teardown_pipe_fd(self, fd: int, req_id: int) -> None:
+
         try:
             os.close(fd)
         except OSError:
@@ -391,6 +392,12 @@ class Zygote:
             return
 
         pid = req["pid"]
+        try:
+            os.kill(pid, 0)          # signal 0 = existence check
+        except ProcessLookupError:
+            pass
+        else:
+            self._send(P.MSG_STDERR, req_id, b"process terminated")
         self.reqs.pop(req_id, None)
         try:
             os.kill(pid, signal.SIGKILL)


### PR DESCRIPTION
- The async controller method was invoked without await, causing the coroutine to be returned instead of the actual response
- This ensures the endpoint correctly awaits the async function and returns the proper result

## Summary by Sourcery

Bug 修复：
- 通过在异步控制器方法上添加缺失的 `await`，修复了工作区终端用户 API 端点返回协程的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the workspace end users API endpoint returning a coroutine by adding the missing await on the async controller method.

</details>