### PR TITLE
fix(web): agent run compare chat loading

### DIFF
--- a/web/src/views/ApplicationConfig/components/Chat/index.tsx
+++ b/web/src/views/ApplicationConfig/components/Chat/index.tsx
@@ -154,6 +154,7 @@ const Chat: FC<ChatProps> = ({
         toolbarRef.current?.setFiles([])
         setFileList([])
         updateChatList(prev => addAssistantMessage(prev))
+        updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: true })))
 
         const handleStreamMessage = createCompareStreamHandler({
           updateChatList,
@@ -183,6 +184,7 @@ const Chat: FC<ChatProps> = ({
               setLoading(false)
               compareLoadingRef.current = false
               updateChatList(prev => updateClusterErrorAssistantMessage(prev, 0))
+              updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
             })
             .finally(() => {
               setLoading(false)
@@ -193,6 +195,7 @@ const Chat: FC<ChatProps> = ({
       .catch(() => {
         setLoading(false)
         compareLoadingRef.current = false
+        updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
       })
   }
 
@@ -211,6 +214,7 @@ const Chat: FC<ChatProps> = ({
         toolbarRef.current?.setFiles([])
         setFileList([])
         updateChatList(prev => addAssistantMessage(prev))
+        updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: true })))
 
         const handleStreamMessage = createClusterStreamHandler({
           updateChatList,
@@ -235,6 +239,7 @@ const Chat: FC<ChatProps> = ({
               setLoading(false)
               compareLoadingRef.current = false
               updateChatList(prev => updateClusterErrorAssistantMessage(prev, 0))
+              updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
             })
             .finally(() => {
               setLoading(false)
@@ -245,6 +250,7 @@ const Chat: FC<ChatProps> = ({
       .catch(() => {
         setLoading(false)
         compareLoadingRef.current = false
+        updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
       })
   }
 
@@ -276,6 +282,10 @@ const Chat: FC<ChatProps> = ({
     })
     setLoading(true)
     compareLoadingRef.current = true
+    updateChatList(prev => prev.map(chat => ({
+      ...chat,
+      streamLoading: chat.model_config_id === column.model_config_id,
+    })))
 
     const handleStreamMessage = createRegenerateStreamHandler({
       modelConfigId: column.model_config_id,
@@ -296,6 +306,7 @@ const Chat: FC<ChatProps> = ({
         .finally(() => {
           setLoading(false)
           compareLoadingRef.current = false
+          updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
         })
     }, 0)
   }
@@ -416,13 +427,13 @@ const Chat: FC<ChatProps> = ({
                   />}
                   onSend={isCluster ? handleClusterSend : handleSend}
                   data={chat.list || []}
-                  streamLoading={compareLoadingRef.current}
+                  streamLoading={chat.streamLoading || compareLoadingRef.current}
                   labelPosition="top"
                   labelFormat={(item) => item.role === 'user' ? t('application.you') : chat.label || t(`application.ai`)}
                   renderRuntime={(item, index) => <Runtime source={source} item={item} index={index} />}
                   isSupportTools={!isCluster}
                   isAlwaysShowAssistantTools={!isCluster}
-                  isEnded={!loading}
+                  isEnded={!loading || !chat.streamLoading}
                   handleFeedback={isCluster ? undefined : handleFeedback}
                   handleFavorite={isCluster ? undefined : handleFavorite}
                   deleteMsg={isCluster ? undefined : deleteMsg}

--- a/web/src/views/ApplicationConfig/components/Chat/streamHandlers.ts
+++ b/web/src/views/ApplicationConfig/components/Chat/streamHandlers.ts
@@ -118,6 +118,7 @@ export const createCompareStreamHandler = (deps: CompareStreamDeps) => {
         }
         case 'compare_end':
           stopComparingSpinner()
+          updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
           setLoading(false)
           break
       }
@@ -177,6 +178,7 @@ export const createRegenerateStreamHandler = (deps: RegenerateStreamDeps) => {
           break
         case 'error':
           updateChatList(prev => updateErrorAssistantMessage(prev, message_length || 0, modelConfigId, error))
+          updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
           break
         case 'end': {
           stopComparingSpinner()
@@ -210,6 +212,7 @@ export const createRegenerateStreamHandler = (deps: RegenerateStreamDeps) => {
             updateChatList(prev => updateAssistantMessage(prev, content, modelConfigId, conversation_id, audio_url, citations, suggested_questions))
           }
           updateChatList(prev => updateErrorAssistantMessage(prev, message_length || 0, modelConfigId, error))
+          updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
           setLoading(false)
           break
         }
@@ -259,6 +262,7 @@ export const createClusterStreamHandler = (deps: ClusterStreamDeps) => {
           break
         case 'compare_end':
           stopComparingSpinner()
+          updateChatList(prev => prev.map(chat => ({ ...chat, streamLoading: false })))
           setLoading(false)
           break
       }

--- a/web/src/views/ApplicationConfig/types.ts
+++ b/web/src/views/ApplicationConfig/types.ts
@@ -236,6 +236,8 @@ export interface ChatData {
   list?: Array<ChatItem | ChatItem[]>;
   /** Conversation ID */
   conversation_id?: string | null;
+  /** Whether the model is currently streaming */
+  streamLoading?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

在应用配置界面的对比（compare）、聚类（cluster）和重新生成（regenerate）流程中改进聊天流式处理状态管理。

新功能：
- 通过在 `ChatData` 中新增 `streamLoading` 标志来跟踪每个聊天的流式处理状态，并将其传递到 `Chat` 组件。

错误修复：
- 确保聊天加载指示器在对比、聚类和重新生成操作中，能够正确反映流式处理活动以及结束状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve chat streaming state handling for compare, cluster, and regenerate flows in the application configuration UI.

New Features:
- Track per-chat streaming state via a new streamLoading flag in ChatData and propagate it to the Chat component.

Bug Fixes:
- Ensure chat loading indicators correctly reflect streaming activity and end states across compare, cluster, and regenerate operations.

</details>