### PR TITLE
feat(fast write):persist BERT emotion results to dialogue nodes

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -100,6 +100,11 @@ class Settings:
     LLM_TIMEOUT: float = float(os.getenv("LLM_TIMEOUT", "120.0"))
     LLM_MAX_RETRIES: int = int(os.getenv("LLM_MAX_RETRIES", "2"))
 
+    # Fast Write BERT 
+    FAST_WRITE_EMOTION_URL: str = os.getenv("FAST_WRITE_EMOTION_URL", "")
+    FAST_WRITE_EMOTION_MODEL: str = os.getenv("FAST_WRITE_EMOTION_MODEL", "")
+    FAST_WRITE_EMOTION_API_KEY: str = os.getenv("FAST_WRITE_EMOTION_API_KEY", "")
+
     # JWT Token Configuration
     SECRET_KEY: str = os.getenv("SECRET_KEY", "a_default_secret_key_that_is_long_and_random")
     ALGORITHM: str = "HS256"

--- a/api/app/core/memory/models/graph_models.py
+++ b/api/app/core/memory/models/graph_models.py
@@ -224,7 +224,8 @@ class DialogueNode(Node):
         dialog_embedding: Optional embedding vector for the entire dialogue
         config_id: Configuration ID used to process this dialogue
         write_mode: Write pipeline marker ('fast' | 'normal')
-        emotion: Emotion field, persisted but unset this iteration (structure defined by later BERT emotion recognition)
+        emotion: BERT top_emotion label written by Fast Write; None when the emotion service fails/times out or is unconfigured
+        emotion_score: BERT top_score (sigmoid probability, 0.0-1.0) paired with `emotion`; None under the same degraded conditions
     """
     ref_id: str = Field(..., description="Reference identifier of the dialog")
     content: str = Field(..., description="Dialogue content")
@@ -233,7 +234,13 @@ class DialogueNode(Node):
                                            description="Configuration ID used to process this dialogue (integer or string)")
     
     write_mode: str = Field(default="normal",description="写入管线标识：'fast' | 'normal'")
-    emotion: Optional[str] = Field(default=None,description="情绪字段")
+    emotion: Optional[str] = Field(default=None,description="BERT top_emotion；服务失败时为 None")
+    emotion_score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="BERT top_score（sigmoid 概率）；服务失败时为 None",
+    )
 
 
 class StatementNode(Node):

--- a/api/app/core/memory/pipelines/fast_write_pipeline.py
+++ b/api/app/core/memory/pipelines/fast_write_pipeline.py
@@ -55,6 +55,8 @@ class FastWritePipeline:
     # Embedding 单步硬上限（秒）。底层 LangChain client 自带 max_retries * timeout，
     # 导致 worker 被 SIGKILL 而非降级。此处用 asyncio.wait_for 兜底，超时即降级为 None。
     EMBED_TIMEOUT_SEC = 15
+    # BERT 情绪单步硬上限（秒），超时即降级为 None，不重试。
+    EMOTION_TIMEOUT_SEC = 2
 
     def __init__(self, memory_config: "MemoryConfig", end_user_id: str, language: str = "zh"):
         self.memory_config = memory_config
@@ -107,10 +109,16 @@ class FastWritePipeline:
                 if drop_reason:
                     return {"status": "dropped", "reason": drop_reason, "dialog_id": None}
 
-                # Step 2/3 — Embedding（失败降级为 None，不重试）
-                async with bear.step(2, 3, "Embedding", "向量化") as s:
-                    embedding = await self._embed(cleaned)
-                    s.metadata(has_embedding=embedding is not None)
+                # Step 2/3 — Embedding + BERT 情绪（并行，各自内部降级为 None，不重试）
+                async with bear.step(2, 3, "并行处理", "Embedding + 情绪") as s:
+                    embedding, emotion_result = await asyncio.gather(
+                        self._embed(cleaned),
+                        self._extract_emotion(cleaned),
+                    )
+                    s.metadata(
+                        has_embedding=embedding is not None,
+                        has_emotion=emotion_result is not None,
+                    )
 
                 # 时间来源降级：dialog_at → dispatch_at → 当前时间（ensure_dialog_at 兜底）
                 created_at = as_utc_aware(
@@ -128,6 +136,7 @@ class FastWritePipeline:
                         message_seq=message_seq,
                         source=source,
                         created_at=created_at,
+                        emotion_result=emotion_result,
                     )
                     dialog_id = await self._persist(node)
                     s.metadata(dialog_id=dialog_id)
@@ -224,6 +233,49 @@ class FastWritePipeline:
             )
             return None
 
+    async def _extract_emotion(self, text: str):
+        """Step 2 并行分支 — 调用已部署 BERT /v1/rerank 获取 top 情绪。
+
+        - text 为空、或未配置（URL/API_KEY/MODEL 任一缺失）→ 直接返回 None，不发请求、不空等超时。
+        - 已配置时才调用；硬超时 EMOTION_TIMEOUT_SEC，超时/异常一律降级为 None，不重试。
+        - 关键约束：服务故障绝不伪造 neutral；真实中性(emotion='neutral')
+          与服务失败(emotion=None)必须可区分。
+        """
+        if not text:
+            return None
+        # 未配置（URL / API_KEY / MODEL 任一缺失）直接跳过，不发请求、不空等超时
+        from app.core.config import settings
+        if (
+            not settings.FAST_WRITE_EMOTION_URL
+            or not settings.FAST_WRITE_EMOTION_API_KEY
+            or not settings.FAST_WRITE_EMOTION_MODEL
+        ):
+            return None
+        try:
+            from app.services.fast_write_emotion_client import predict as _predict_emotion
+            return await asyncio.wait_for(
+                _predict_emotion(text),
+                timeout=self.EMOTION_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[FastWrite] emotion timed out, degrading to None: text_len=%s, "
+                "timeout=%ss, end_user_id=%s",
+                len(text),
+                self.EMOTION_TIMEOUT_SEC,
+                self.end_user_id,
+            )
+            return None
+        except Exception as e:
+            logger.warning(
+                "[FastWrite] emotion failed, degrading to None: text_len=%s, "
+                "end_user_id=%s, error=%s",
+                len(text),
+                self.end_user_id,
+                e,
+            )
+            return None
+
     def _build_dialogue_node(
         self,
         content: str,
@@ -232,6 +284,7 @@ class FastWritePipeline:
         message_seq: int,
         source: str,
         created_at: "datetime",
+        emotion_result=None,
     ) -> DialogueNode:
         """Step 3 — 构造 DialogueNode。
 
@@ -242,7 +295,8 @@ class FastWritePipeline:
         - config_id 取自 memory_config.config_id（UUID → str）。
         - created_at 为消息真实发生时间（dialog_at → dispatch_at → 当前时间降级结果），
           不再使用 worker 执行时刻，保证可回溯。
-        - 固定属性：write_mode="fast"、emotion=None。
+        - 固定属性：write_mode="fast"。
+        - emotion/emotion_score 来自并行 BERT 分支（emotion_result）；失败/超时时为 None。
         """
         dialog_id = build_dialogue_id(
             conversation_id, message_seq, source, self.end_user_id
@@ -258,7 +312,8 @@ class FastWritePipeline:
             dialog_embedding=embedding,
             config_id=str(self.memory_config.config_id),
             write_mode="fast",
-            emotion=None,
+            emotion=emotion_result.emotion if emotion_result else None,
+            emotion_score=emotion_result.emotion_score if emotion_result else None,
         )
 
     async def _persist(self, dialog_node: DialogueNode) -> str:

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -55,6 +55,7 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
                 "config_id": dialogue.config_id,
                 "write_mode": getattr(dialogue, "write_mode", "normal"),
                 "emotion": getattr(dialogue, "emotion", None),
+                "emotion_score": getattr(dialogue, "emotion_score", None),
             })
 
         result = await connector.execute_query(

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -25,7 +25,9 @@ DIALOGUE_NODE_SAVE = """
             n.dialog_embedding = dialogue.dialog_embedding,
             n.config_id = dialogue.config_id,
             n.write_mode = coalesce(dialogue.write_mode, 'normal'),
-            n.emotion = dialogue.emotion
+            // emotion 粘性保留：本次写入未带值（None）则保留原值，避免正写（不算情绪）
+            n.emotion = coalesce(dialogue.emotion, n.emotion),
+            n.emotion_score = coalesce(dialogue.emotion_score, n.emotion_score)
     )
     RETURN n.id AS uuid
 """

--- a/api/app/services/fast_write_emotion_client.py
+++ b/api/app/services/fast_write_emotion_client.py
@@ -1,0 +1,85 @@
+"""Fast Write BERT 情绪 HTTP client。
+
+调用已部署的 BERT 情绪服务（`/v1/rerank`），返回 top 情绪及分数。
+
+并发模型说明：
+- 快写 Worker 为 ``--pool=threads --concurrency=32``，每个线程持有自己独立的
+  event loop（``set_asyncio_event_loop`` 复用、``_shutdown_loop_gracefully`` 不关）。
+- ``httpx.AsyncClient`` 的连接池绑定在创建它的那个 loop 上，因此**不能**用全进程单例
+  （单例只属于一个 loop，被其它线程的 loop 使用会跨 loop 出错）。
+- 这里用 ``threading.local()`` 做「每线程一个 client」的线程级单例：同线程后续所有
+  快写复用它（keep-alive 省握手），loop 万一被换掉则重建。
+
+失败语义：任何异常（网络/超时/HTTP 4xx-5xx/JSON 结构/枚举/值域）都向上抛出，由调用方
+``FastWritePipeline._extract_emotion`` 统一降级为 None——服务故障绝不伪造 neutral。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import httpx
+from pydantic import BaseModel
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# BERT 原生 10 类情绪枚举（与已部署服务对齐）
+_VALID_EMOTIONS = frozenset({
+    "neutral", "joy", "relief", "anxiety", "sadness",
+    "anger", "frustration", "loneliness", "confusion", "hope",
+})
+
+# 超时（秒），与 FastWritePipeline.EMOTION_TIMEOUT_SEC 对齐；硬编码，不走 env。
+_EMOTION_TIMEOUT_SEC = 2.0
+
+# 每线程一个 client：连接池绑定在创建它的 loop 上，threads pool 下每线程独立 loop，
+# 故用 thread-local 隔离，避免跨 loop 复用。
+_local = threading.local()
+
+
+class FastWriteEmotionResult(BaseModel):
+    """BERT 情绪结果（仅消费 top1）。"""
+
+    emotion: str
+    emotion_score: float
+
+
+def _get_client() -> httpx.AsyncClient:
+    """取当前线程/loop 的 AsyncClient；不存在或 loop 被换过则重建。"""
+    loop = asyncio.get_event_loop()
+    client = getattr(_local, "client", None)
+    if client is None or getattr(_local, "loop", None) is not loop:
+        _local.client = httpx.AsyncClient(
+            timeout=_EMOTION_TIMEOUT_SEC,
+            # 每线程串行、一次一请求：池子稳态只需 1 条，留 1 条余量给瞬时重连。
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=2),
+        )
+        _local.loop = loop
+    return _local.client
+
+
+async def predict(text: str) -> FastWriteEmotionResult:
+    """调用 BERT /v1/rerank，返回 top 情绪；任何异常向上抛出（由调用方降级）。"""
+    resp = await _get_client().post(
+        settings.FAST_WRITE_EMOTION_URL,
+        headers={"Authorization": f"Bearer {settings.FAST_WRITE_EMOTION_API_KEY}"},
+        json={"model": settings.FAST_WRITE_EMOTION_MODEL, "query": text},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    emotion = data.get("top_emotion")
+    raw_score = data.get("top_score")
+    if emotion not in _VALID_EMOTIONS or raw_score is None:
+        raise ValueError(
+            f"invalid emotion payload: top_emotion={emotion!r}, top_score={raw_score!r}"
+        )
+    score = float(raw_score)
+    if not (0.0 <= score <= 1.0):
+        raise ValueError(f"top_score out of range [0,1]: {score}")
+
+    return FastWriteEmotionResult(emotion=emotion, emotion_score=score)


### PR DESCRIPTION
## Summary by Sourcery

在快速写入对话节点中持久化基于 BERT 的情绪分析结果，同时保持流水线在故障和超时情况下的鲁棒性。

新特性：
- 在快速写入流水线中并行添加 BERT 情绪提取，与嵌入生成一同执行，对调用设置严格超时，并在服务失败或未配置时降级为 `None`。
- 为 Fast Write BERT 情绪服务引入按线程划分的异步 HTTP 客户端，并提供一个类型化的结果模型，用于携带最高情绪类别及其得分。
- 扩展对话节点以存储 BERT 情绪标签和概率得分，并通过 Neo4j 持久化和配置将这些字段串联起来。

增强：
- 更新快速写入流水线步骤的元数据和对话节点构造逻辑，以反映情绪提取结果，同时不破坏现有的写入行为。
- 使 Neo4j 对话节点的 upsert 操作在当前写入未提供新的情绪值时保留已有的情绪字段，从而在多次写入之间保持情绪数据的“黏性”。

构建：
- 为 Fast Write BERT 情绪服务添加端点、模型和 API 密钥的配置项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist BERT-based emotion analysis results in fast write dialogue nodes while keeping the pipeline resilient to failures and timeouts.

New Features:
- Add parallel BERT emotion extraction to the fast write pipeline alongside embeddings, with strict timeout and degradation to None when the service fails or is not configured.
- Introduce per-thread async HTTP client for the Fast Write BERT emotion service and a typed result model carrying top emotion and score.
- Extend dialogue nodes to store BERT emotion label and probability score, and wire these fields through Neo4j persistence and configuration.

Enhancements:
- Update fast write pipeline step metadata and dialogue node construction to reflect emotion extraction outcomes without disrupting existing write behavior.
- Make Neo4j dialogue upserts preserve existing emotion fields when a write does not provide new emotion values, maintaining emotion stickiness across writes.

Build:
- Add configuration settings for the Fast Write BERT emotion service endpoint, model, and API key.

</details>