### PR TITLE
feat(rag): add evidence graph pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ api/res/
 docs/
 examples/
 AGENTS.md
+CLAUDE.md
+api/tests/
+api/scripts/
 
 # Environment variables
 .env

--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -111,6 +111,10 @@ celery_app.conf.update(
         # GraphRAG tasks → graphrag_tasks queue (独立队列，避免阻塞文档解析)
         'app.core.rag.tasks.build_graphrag_for_kb': {'queue': 'graphrag_tasks'},
         'app.core.rag.tasks.build_graphrag_for_document': {'queue': 'graphrag_tasks'},
+        'app.core.rag.tasks.sync_evidence_graph_document': {'queue': 'graphrag_tasks'},
+        'app.core.rag.tasks.rebuild_evidence_graph_knowledge': {'queue': 'graphrag_tasks'},
+        'app.core.rag.tasks.migrate_evidence_graph_knowledge': {'queue': 'graphrag_tasks'},
+        'app.core.rag.tasks.clear_all_knowledge_graph_data': {'queue': 'graphrag_tasks'},
 
         # Beat/periodic tasks → periodic_tasks queue (dedicated periodic worker)
         'app.tasks.workspace_reflection_task': {'queue': 'periodic_tasks'},

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -40,6 +40,29 @@ from app.core.utils.datetime_utils import to_timestamp_ms
 api_logger = get_api_logger()
 
 
+def _dispatch_document_graph_sync_best_effort(
+    knowledge_id: str,
+    document_id: str,
+    parser_config: dict[str, Any] | None,
+) -> Any | None:
+    try:
+        return dispatch_document_graph_sync(
+            knowledge_id,
+            document_id,
+            parser_config,
+            dispatch_legacy=False,
+        )
+    except Exception as exc:
+        api_logger.error(
+            "Failed to dispatch graph sync after chunk mutation"
+            " knowledge_id=%s document_id=%s error_type=%s",
+            knowledge_id,
+            document_id,
+            type(exc).__name__,
+        )
+        return None
+
+
 def _build_image2text_vision_model(db: Session, image2text_id: uuid.UUID, tenant_id: uuid.UUID):
     if not image2text_id:
         raise HTTPException(
@@ -684,11 +707,10 @@ async def create_chunk(
     # 4.update chunk_num
     db_document.chunk_num += 1
     await db.commit()
-    dispatch_document_graph_sync(
+    _dispatch_document_graph_sync_best_effort(
         str(kb_id),
         str(document_id),
         db_knowledge.parser_config,
-        dispatch_legacy=False,
     )
 
     return success(data=jsonable_encoder(chunk), msg="Document chunk creation successful")
@@ -779,11 +801,10 @@ async def create_chunks_batch(
 
     db_document.chunk_num += len(chunks)
     await db.commit()
-    dispatch_document_graph_sync(
+    _dispatch_document_graph_sync_best_effort(
         str(kb_id),
         str(document_id),
         db_knowledge.parser_config,
-        dispatch_legacy=False,
     )
 
     return success(data=jsonable_encoder(chunks), msg=f"Batch created {len(chunks)} chunks successfully")
@@ -980,11 +1001,10 @@ async def update_chunk(
         if update_data.is_qa:
             chunk.metadata.update(update_data.qa_metadata)
         await asyncio.to_thread(vector_service.update_by_segment, chunk)
-        dispatch_document_graph_sync(
+        _dispatch_document_graph_sync_best_effort(
             str(kb_id),
             str(document_id),
             db_knowledge.parser_config,
-            dispatch_legacy=False,
         )
         return success(data=jsonable_encoder(chunk), msg="The document chunk has been successfully updated")
     else:
@@ -1022,11 +1042,10 @@ async def delete_chunk(
         db_document = await db.get(Document, document_id)
         db_document.chunk_num -= 1
         await db.commit()
-        dispatch_document_graph_sync(
+        _dispatch_document_graph_sync_best_effort(
             str(kb_id),
             str(document_id),
             db_knowledge.parser_config,
-            dispatch_legacy=False,
         )
         return success(msg="The document chunk has been successfully deleted")
     else:

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
 from app.core.rag.chunk.metadata import merge_parser_metadata
+from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
 from app.core.rag.llm.cv_model import QWenCV
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.models import RetrievalPrincipal
@@ -683,6 +684,12 @@ async def create_chunk(
     # 4.update chunk_num
     db_document.chunk_num += 1
     await db.commit()
+    dispatch_document_graph_sync(
+        str(kb_id),
+        str(document_id),
+        db_knowledge.parser_config,
+        dispatch_legacy=False,
+    )
 
     return success(data=jsonable_encoder(chunk), msg="Document chunk creation successful")
 
@@ -772,6 +779,12 @@ async def create_chunks_batch(
 
     db_document.chunk_num += len(chunks)
     await db.commit()
+    dispatch_document_graph_sync(
+        str(kb_id),
+        str(document_id),
+        db_knowledge.parser_config,
+        dispatch_legacy=False,
+    )
 
     return success(data=jsonable_encoder(chunks), msg=f"Batch created {len(chunks)} chunks successfully")
 
@@ -967,6 +980,12 @@ async def update_chunk(
         if update_data.is_qa:
             chunk.metadata.update(update_data.qa_metadata)
         await asyncio.to_thread(vector_service.update_by_segment, chunk)
+        dispatch_document_graph_sync(
+            str(kb_id),
+            str(document_id),
+            db_knowledge.parser_config,
+            dispatch_legacy=False,
+        )
         return success(data=jsonable_encoder(chunk), msg="The document chunk has been successfully updated")
     else:
         raise HTTPException(
@@ -1003,6 +1022,12 @@ async def delete_chunk(
         db_document = await db.get(Document, document_id)
         db_document.chunk_num -= 1
         await db.commit()
+        dispatch_document_graph_sync(
+            str(kb_id),
+            str(document_id),
+            db_knowledge.parser_config,
+            dispatch_legacy=False,
+        )
         return success(msg="The document chunk has been successfully deleted")
     else:
         raise HTTPException(

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -1078,7 +1078,12 @@ async def retrieve_chunks_with_caller(
             detail=str(exc),
         ) from exc
 
-    return success(data=jsonable_encoder(result.chunks), msg="retrieval successful")
+    response_data = (
+        result.model_dump()
+        if result.has_graph_data()
+        else result.chunks
+    )
+    return success(data=jsonable_encoder(response_data), msg="retrieval successful")
 
 
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import datetime
 import os
 from typing import Optional
@@ -14,6 +15,7 @@ from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
+from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
 from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
@@ -269,9 +271,11 @@ async def update_document(
         # kb_mode=1 且 new=False，或 kb_mode=2 且 new=True：通过，不改知识库
 
     # 3.1 If updating the status, synchronize the document status switch to whether it can be retrieved from the vector database
+    status_changed = False
     if "status" in update_dict:
         new_status = update_dict["status"]
         if new_status != db_document.status:
+            status_changed = True
             await asyncio.to_thread(
                 ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).change_document_status,
                 document_id=str(document_id),
@@ -293,6 +297,8 @@ async def update_document(
         api_logger.debug(f"updated fields: {', '.join(updated_fields)}")
 
     db_document.updated_at = utcnow_naive()
+    graph_parser_config = copy.deepcopy(db_knowledge.parser_config or {})
+    graph_knowledge_id = str(db_knowledge.id)
 
     # 4. Save to database
     try:
@@ -305,6 +311,14 @@ async def update_document(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Document update failed: {str(e)}"
+        )
+
+    if status_changed:
+        dispatch_document_graph_sync(
+            graph_knowledge_id,
+            str(document_id),
+            graph_parser_config,
+            dispatch_legacy=False,
         )
 
     # 5. Return the updated document
@@ -355,6 +369,9 @@ async def delete_document(
 
         # 3. Delete vector index (non-404 failures raise, caught by except below)
         db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
+        graph_parser_config = copy.deepcopy(db_knowledge.parser_config or {})
+        graph_knowledge_id = str(db_knowledge.id)
+        document_file_name = db_document.file_name
         await asyncio.to_thread(
             ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
             key="document_id",
@@ -372,8 +389,14 @@ async def delete_document(
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
         await db.delete(db_document)
         await db.commit()
+        dispatch_document_graph_sync(
+            graph_knowledge_id,
+            str(document_id),
+            graph_parser_config,
+            dispatch_legacy=False,
+        )
 
-        api_logger.info(f"The document has been successfully deleted: {db_document.file_name} (ID: {document_id})")
+        api_logger.info(f"The document has been successfully deleted: {document_file_name} (ID: {document_id})")
         return success(msg="The document has been successfully deleted")
     except Exception as e:
         api_logger.error(f"Failed to delete from the document: document_id={document_id} - {str(e)}")

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -64,7 +64,11 @@ async def _delete_file_record_async(
 ) -> None:
     db_file = await db.get(file_model.File, file_id)
     if not db_file:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+        api_logger.info(
+            "File record already absent during document cleanup: file_id=%s",
+            str(file_id),
+        )
+        return
 
     if db_file.file_ext == "folder":
         result = await db.execute(
@@ -353,7 +357,6 @@ async def delete_document(
             )
         file_id = db_document.file_id
         kb_id = db_document.kb_id
-        deletion_pending = db_document.status == 0
 
         db_knowledge = await knowledge_service.get_knowledge_by_id_async(
             db,
@@ -364,58 +367,46 @@ async def delete_document(
         graph_knowledge_id = str(db_knowledge.id)
         document_file_name = db_document.file_name
 
-        if not deletion_pending:
-            # 2. Cancel any running parse task via Redis
-            task_id = REDIS_CONN.get(_PARSE_TASK_KEY.format(doc_id=document_id))
-            if task_id:
-                api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
-                try:
-                    celery_app.control.revoke(task_id)
-                    api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
-                except NotImplementedError:
-                    # ThreadPool does not support force termination; rely on Redis cancel marker
-                    api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
-                except Exception as revoke_err:
-                    api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
-            # Set cancellation marker and clean up task key
-            REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
-            REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
+        # 2. Cancel any running parse task via Redis
+        task_id = REDIS_CONN.get(_PARSE_TASK_KEY.format(doc_id=document_id))
+        if task_id:
+            api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
+            try:
+                celery_app.control.revoke(task_id)
+                api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
+            except NotImplementedError:
+                # ThreadPool does not support terminate; rely on Redis cancel marker
+                api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
+            except Exception as revoke_err:
+                api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
+        # Set cancellation marker and clean up task key
+        REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
+        REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
 
-            # 3. Delete vector index (non-404 failures raise, caught by except below)
-            await asyncio.to_thread(
-                ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
-                key="document_id",
-                value=str(document_id),
-            )
+        # 3. Delete vector index (non-404 failures raise, caught by except below)
+        await asyncio.to_thread(
+            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
+            key="document_id",
+            value=str(document_id),
+        )
 
-            # 4. Delete file (storage errors are swallowed internally)
-            await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
+        # 4. Delete file (storage errors are swallowed internally)
+        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
 
-            # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
-            api_logger.debug(f"Delete metadata bindings for document: {document_id}")
-            await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
+        # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
+        api_logger.debug(f"Delete metadata bindings for document: {document_id}")
+        await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
 
-            # 6. Persist a retryable deletion state before graph cleanup is queued.
-            db_document.status = 0
-            db_document.updated_at = utcnow_naive()
-            await db.commit()
-        else:
-            api_logger.info(
-                "Retry pending document deletion"
-                " knowledge_id=%s document_id=%s",
-                graph_knowledge_id,
-                str(document_id),
-            )
-
-        # 7. Persist graph cleanup before hard-deleting the retry record.
+        # 6. Persist graph cleanup before hard-deleting the document record.
         await enqueue_document_graph_sync(
             graph_knowledge_id,
             str(document_id),
             graph_parser_config,
             dispatch_legacy=False,
+            document_deleted=True,
         )
 
-        # 8. Delete document from DB only after graph cleanup is recoverable.
+        # 7. Delete document from DB only after graph cleanup is recoverable.
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
         await db.delete(db_document)
         await db.commit()

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -15,7 +15,10 @@ from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
-from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
+from app.core.rag.knowledge_graph.dispatch import (
+    dispatch_document_graph_sync,
+    enqueue_document_graph_sync,
+)
 from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
@@ -350,56 +353,82 @@ async def delete_document(
             )
         file_id = db_document.file_id
         kb_id = db_document.kb_id
+        deletion_pending = db_document.status == 0
 
-        # 2. Cancel any running parse task via Redis
-        task_id = REDIS_CONN.get(_PARSE_TASK_KEY.format(doc_id=document_id))
-        if task_id:
-            api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
-            try:
-                celery_app.control.revoke(task_id)
-                api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
-            except NotImplementedError:
-                # ThreadPool does not support force termination; rely on Redis cancel marker
-                api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
-            except Exception as revoke_err:
-                api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
-        # Set cancellation marker and clean up task key
-        REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
-        REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
-
-        # 3. Delete vector index (non-404 failures raise, caught by except below)
-        db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(
+            db,
+            knowledge_id=kb_id,
+            current_user=current_user,
+        )
         graph_parser_config = copy.deepcopy(db_knowledge.parser_config or {})
         graph_knowledge_id = str(db_knowledge.id)
         document_file_name = db_document.file_name
-        await asyncio.to_thread(
-            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
-            key="document_id",
-            value=str(document_id),
-        )
 
-        # 4. Delete file (storage errors are swallowed internally)
-        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
+        if not deletion_pending:
+            # 2. Cancel any running parse task via Redis
+            task_id = REDIS_CONN.get(_PARSE_TASK_KEY.format(doc_id=document_id))
+            if task_id:
+                api_logger.warning(f"[DELETE] Revoking running parse task: task_id={task_id}, document_id={document_id}")
+                try:
+                    celery_app.control.revoke(task_id)
+                    api_logger.warning(f"[DELETE] Revoke signal sent for task_id={task_id}")
+                except NotImplementedError:
+                    # ThreadPool does not support force termination; rely on Redis cancel marker
+                    api_logger.info(f"[DELETE] ThreadPool does not support terminate, relying on Redis cancel marker for task_id={task_id}")
+                except Exception as revoke_err:
+                    api_logger.error(f"[DELETE] Failed to revoke task {task_id}: {revoke_err}")
+            # Set cancellation marker and clean up task key
+            REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
+            REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
 
-        # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
-        api_logger.debug(f"Delete metadata bindings for document: {document_id}")
-        await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
+            # 3. Delete vector index (non-404 failures raise, caught by except below)
+            await asyncio.to_thread(
+                ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
+                key="document_id",
+                value=str(document_id),
+            )
 
-        # 6. Delete document from DB (last — if DB fails, external resources are already cleaned)
-        api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
-        await db.delete(db_document)
-        await db.commit()
-        dispatch_document_graph_sync(
+            # 4. Delete file (storage errors are swallowed internally)
+            await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
+
+            # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
+            api_logger.debug(f"Delete metadata bindings for document: {document_id}")
+            await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
+
+            # 6. Persist a retryable deletion state before graph cleanup is queued.
+            db_document.status = 0
+            db_document.updated_at = utcnow_naive()
+            await db.commit()
+        else:
+            api_logger.info(
+                "Retry pending document deletion"
+                " knowledge_id=%s document_id=%s",
+                graph_knowledge_id,
+                str(document_id),
+            )
+
+        # 7. Persist graph cleanup before hard-deleting the retry record.
+        await enqueue_document_graph_sync(
             graph_knowledge_id,
             str(document_id),
             graph_parser_config,
             dispatch_legacy=False,
         )
 
+        # 8. Delete document from DB only after graph cleanup is recoverable.
+        api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")
+        await db.delete(db_document)
+        await db.commit()
+
         api_logger.info(f"The document has been successfully deleted: {document_file_name} (ID: {document_id})")
         return success(msg="The document has been successfully deleted")
     except Exception as e:
-        api_logger.error(f"Failed to delete from the document: document_id={document_id} - {str(e)}")
+        api_logger.error(
+            "Failed to delete document"
+            " document_id=%s error_type=%s",
+            str(document_id),
+            type(e).__name__,
+        )
         raise
 
 

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -383,21 +383,7 @@ async def delete_document(
         REDIS_CONN.set(_PARSE_CANCEL_KEY.format(doc_id=document_id), "1", exp=_PARSE_CANCEL_TTL)
         REDIS_CONN.delete(_PARSE_TASK_KEY.format(doc_id=document_id))
 
-        # 3. Delete vector index (non-404 failures raise, caught by except below)
-        await asyncio.to_thread(
-            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
-            key="document_id",
-            value=str(document_id),
-        )
-
-        # 4. Delete file (storage errors are swallowed internally)
-        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
-
-        # 5. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
-        api_logger.debug(f"Delete metadata bindings for document: {document_id}")
-        await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
-
-        # 6. Persist graph cleanup before hard-deleting the document record.
+        # 3. Persist graph cleanup before deleting any document resources.
         await enqueue_document_graph_sync(
             graph_knowledge_id,
             str(document_id),
@@ -405,6 +391,20 @@ async def delete_document(
             dispatch_legacy=False,
             document_deleted=True,
         )
+
+        # 4. Delete vector index (non-404 failures raise, caught by except below)
+        await asyncio.to_thread(
+            ElasticSearchVectorIndexOps.for_knowledge(db_knowledge.id).delete_by_metadata_field,
+            key="document_id",
+            value=str(document_id),
+        )
+
+        # 5. Delete file (storage errors are swallowed internally)
+        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
+
+        # 6. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
+        api_logger.debug(f"Delete metadata bindings for document: {document_id}")
+        await KnowledgeMetadataService.delete_document_metadata_async(db, document_id)
 
         # 7. Delete document from DB only after graph cleanup is recoverable.
         api_logger.debug(f"Perform document delete: {db_document.file_name} (ID: {document_id})")

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -21,6 +21,8 @@ from app.core.rag.common import settings
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
 from app.core.rag.integrations.yuque.client import YuqueAPIClient
 from app.core.rag.llm.chat_model import Base
+from app.core.rag.knowledge_graph.config import GraphPipelineConfigError
+from app.core.rag.parser_config import normalize_knowledge_parser_config_update
 from app.core.rag.nlp import rag_tokenizer, search
 from app.core.rag.prompts.generator import graph_entity_types
 from app.core.rag.utils.redis_conn import REDIS_CONN
@@ -381,6 +383,20 @@ async def create_knowledge(
         db_knowledge = await knowledge_service.create_knowledge_async(db=db, knowledge=create_data, current_user=current_user)
         api_logger.info(f"The knowledge base has been successfully created: {db_knowledge.name} (ID: {db_knowledge.id})")
         return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="The knowledge base has been successfully created")
+    except GraphPipelineConfigError as e:
+        api_logger.warning(
+            "Invalid graph pipeline configuration during knowledge creation",
+            extra={
+                "knowledge_name": create_data.name,
+                "error_type": type(e).__name__,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except HTTPException:
+        raise
     except Exception as e:
         api_logger.error(f"The creation of the knowledge base failed: {create_data.name} - {str(e)}")
         raise
@@ -578,7 +594,25 @@ async def _update_knowledge(
             )
 
         # 2. If updating the embedding_id, delete the knowledge base vector index, reset all document parsing progress to 0, and set chunk_num to 0
-        update_dict = update_data.dict(exclude_unset=True)
+        update_dict = update_data.model_dump(exclude_unset=True)
+        if "parser_config" in update_dict:
+            try:
+                update_dict["parser_config"] = normalize_knowledge_parser_config_update(
+                    db_knowledge.parser_config,
+                    update_dict["parser_config"],
+                )
+            except GraphPipelineConfigError as exc:
+                api_logger.warning(
+                    "Invalid graph pipeline configuration during knowledge update",
+                    extra={
+                        "knowledge_id": str(knowledge_id),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(exc),
+                ) from exc
         embedding_changed = False
         if "name" in update_dict:
             name = update_dict["name"]
@@ -602,13 +636,16 @@ async def _update_knowledge(
         # 2. Update fields (only update non-null fields)
         api_logger.debug(f"Start updating the knowledge base fields: {knowledge_id}")
         updated_fields = []
-        for field, value in update_data.dict(exclude_unset=True).items():
+        for field, value in update_dict.items():
             if hasattr(db_knowledge, field):
                 old_value = getattr(db_knowledge, field)
                 if old_value != value:
                     # update value
                     setattr(db_knowledge, field, value)
-                    updated_fields.append(f"{field}: {old_value} -> {value}")
+                    if field == "parser_config":
+                        updated_fields.append("parser_config: changed")
+                    else:
+                        updated_fields.append(f"{field}: {old_value} -> {value}")
 
         if embedding_changed and db_knowledge.chunk_num != 0:
             old_chunk_num = db_knowledge.chunk_num

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -889,6 +889,7 @@ async def delete_knowledge_graph(
         task = celery_app.send_task(
             "app.core.rag.tasks.clear_all_knowledge_graph_data",
             args=[str(knowledge_id)],
+            kwargs={"force": True},
         )
         api_logger.info(
             "Knowledge graph cleanup task accepted"

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -399,11 +399,10 @@ async def create_knowledge(
         return success(data=jsonable_encoder(knowledge_schema.Knowledge.model_validate(db_knowledge)), msg="The knowledge base has been successfully created")
     except GraphPipelineConfigError as e:
         api_logger.warning(
-            "Invalid graph pipeline configuration during knowledge creation",
-            extra={
-                "knowledge_name": create_data.name,
-                "error_type": type(e).__name__,
-            },
+            "Invalid graph pipeline configuration during knowledge creation"
+            " knowledge_name=%s error_type=%s",
+            create_data.name,
+            type(e).__name__,
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -621,11 +620,10 @@ async def _update_knowledge(
                 )
             except GraphPipelineConfigError as exc:
                 api_logger.warning(
-                    "Invalid graph pipeline configuration during knowledge update",
-                    extra={
-                        "knowledge_id": str(knowledge_id),
-                        "error_type": type(exc).__name__,
-                    },
+                    "Invalid graph pipeline configuration during knowledge update"
+                    " knowledge_id=%s error_type=%s",
+                    str(knowledge_id),
+                    type(exc).__name__,
                 )
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -682,18 +680,30 @@ async def _update_knowledge(
 
         if graph_enabled_before is not None:
             try:
-                dispatch_graph_enabled_transition(
+                graph_task = dispatch_graph_enabled_transition(
                     str(db_knowledge.id),
                     graph_enabled_before,
                     db_knowledge.parser_config,
                 )
+                if graph_task is not None:
+                    current_enabled = is_graph_enabled(db_knowledge.parser_config)
+                    pipeline = resolve_graph_pipeline(db_knowledge.parser_config)
+                    api_logger.info(
+                        "Knowledge graph enablement task accepted"
+                        " knowledge_id=%s previous_enabled=%s"
+                        " current_enabled=%s pipeline=%s task_id=%s",
+                        str(db_knowledge.id),
+                        str(graph_enabled_before).lower(),
+                        str(current_enabled).lower(),
+                        pipeline.value,
+                        str(getattr(graph_task, "id", None) or "unknown"),
+                    )
             except Exception as dispatch_error:
                 api_logger.error(
-                    "Failed to dispatch graph task after enablement change",
-                    extra={
-                        "knowledge_id": str(db_knowledge.id),
-                        "error_type": type(dispatch_error).__name__,
-                    },
+                    "Failed to dispatch graph task after enablement change"
+                    " knowledge_id=%s error_type=%s",
+                    str(db_knowledge.id),
+                    type(dispatch_error).__name__,
                 )
 
         if embedding_changed:
@@ -880,11 +890,10 @@ async def delete_knowledge_graph(
             args=[str(knowledge_id)],
         )
         api_logger.info(
-            "Knowledge graph cleanup task accepted",
-            extra={
-                "knowledge_id": str(knowledge_id),
-                "task_id": task.id,
-            },
+            "Knowledge graph cleanup task accepted"
+            " knowledge_id=%s task_id=%s",
+            str(knowledge_id),
+            str(task.id),
         )
         return success(
             data={"task_id": task.id},
@@ -943,6 +952,14 @@ async def rebuild_knowledge_graph(
         task = celery_app.send_task(
             task_name,
             args=[str(knowledge_id)],
+        )
+        api_logger.info(
+            "Knowledge graph rebuild task accepted"
+            " kb_id=%s pipeline=%s task=%s task_id=%s",
+            str(knowledge_id),
+            pipeline.value,
+            task_name,
+            str(task.id),
         )
         result = {
             "task_id": task.id

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -21,10 +21,24 @@ from app.core.rag.common import settings
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
 from app.core.rag.integrations.yuque.client import YuqueAPIClient
 from app.core.rag.llm.chat_model import Base
-from app.core.rag.knowledge_graph.config import GraphPipelineConfigError
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    GraphPipelineConfigError,
+    is_graph_enabled,
+    resolve_graph_pipeline,
+)
+from app.core.rag.knowledge_graph.dispatch import (
+    dispatch_graph_enabled_transition,
+)
+from app.core.rag.knowledge_graph.elasticsearch_store import (
+    GraphElasticsearchStore,
+)
 from app.core.rag.parser_config import normalize_knowledge_parser_config_update
 from app.core.rag.nlp import rag_tokenizer, search
 from app.core.rag.prompts.generator import graph_entity_types
+from app.core.rag.retrieval.async_elasticsearch import (
+    AsyncElasticsearchClientProvider,
+)
 from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
@@ -595,8 +609,12 @@ async def _update_knowledge(
 
         # 2. If updating the embedding_id, delete the knowledge base vector index, reset all document parsing progress to 0, and set chunk_num to 0
         update_dict = update_data.model_dump(exclude_unset=True)
+        graph_enabled_before: bool | None = None
         if "parser_config" in update_dict:
             try:
+                graph_enabled_before = is_graph_enabled(
+                    db_knowledge.parser_config
+                )
                 update_dict["parser_config"] = normalize_knowledge_parser_config_update(
                     db_knowledge.parser_config,
                     update_dict["parser_config"],
@@ -661,6 +679,22 @@ async def _update_knowledge(
         await db.commit()
         await db.refresh(db_knowledge)
         api_logger.info(f"The knowledge base has been successfully updated: {db_knowledge.name} (ID: {db_knowledge.id})")
+
+        if graph_enabled_before is not None:
+            try:
+                dispatch_graph_enabled_transition(
+                    str(db_knowledge.id),
+                    graph_enabled_before,
+                    db_knowledge.parser_config,
+                )
+            except Exception as dispatch_error:
+                api_logger.error(
+                    "Failed to dispatch graph task after enablement change",
+                    extra={
+                        "knowledge_id": str(db_knowledge.id),
+                        "error_type": type(dispatch_error).__name__,
+                    },
+                )
 
         if embedding_changed:
             try:
@@ -751,6 +785,23 @@ async def get_knowledge_graph(
                 detail="The knowledge base does not exist or access is denied"
             )
 
+        if resolve_graph_pipeline(
+            db_knowledge.parser_config
+        ) is GraphPipeline.EVIDENCE:
+            client = await AsyncElasticsearchClientProvider.get_shared_client()
+            graph = await GraphElasticsearchStore(
+                client
+            ).load_projection_graph(
+                search.index_name(str(db_knowledge.workspace_id)),
+                str(db_knowledge.id),
+                node_limit=256,
+                edge_limit=128,
+            )
+            return success(
+                data={"graph": graph, "mind_map": {}},
+                msg="Successfully obtained knowledge graph information",
+            )
+
         req = {
             "kb_id": [str(db_knowledge.id)],
             "knowledge_graph_kwd": ["graph"]
@@ -789,6 +840,11 @@ async def get_knowledge_graph(
                 filtered_edges = [o for o in obj["graph"]["edges"] if o["source"] != o["target"] and o["source"] in node_id_set and o["target"] in node_id_set]
                 obj["graph"]["edges"] = sorted(filtered_edges, key=lambda x: x.get("weight", 0), reverse=True)[:128]
         return success(data=obj, msg="Successfully obtained knowledge graph information")
+    except GraphPipelineConfigError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except HTTPException:
         raise
     except Exception as e:
@@ -819,15 +875,21 @@ async def delete_knowledge_graph(
                 detail="The knowledge base does not exist or you do not have permission to access it"
             )
 
-        # 2. delete knowledge graph
-        await asyncio.to_thread(
-            settings.docStoreConn.delete,
-            {"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]},
-            search.index_name(str(db_knowledge.workspace_id)),
-            str(db_knowledge.id),
+        task = celery_app.send_task(
+            "app.core.rag.tasks.clear_all_knowledge_graph_data",
+            args=[str(knowledge_id)],
         )
-        api_logger.info(f"The knowledge graph has been successfully deleted: {db_knowledge.name} (ID: {knowledge_id})")
-        return success(msg="The knowledge graph has been successfully deleted")
+        api_logger.info(
+            "Knowledge graph cleanup task accepted",
+            extra={
+                "knowledge_id": str(knowledge_id),
+                "task_id": task.id,
+            },
+        )
+        return success(
+            data={"task_id": task.id},
+            msg="Task accepted. Knowledge graph cleanup is being processed in the background.",
+        )
     except Exception as e:
         api_logger.error(f"Failed to delete from the knowledge base: knowledge_id={knowledge_id} - {str(e)}")
         raise
@@ -857,22 +919,40 @@ async def rebuild_knowledge_graph(
                 detail="The knowledge base does not exist or you do not have permission to access it"
             )
 
-        # 2. delete knowledge graph
-        await asyncio.to_thread(
-            settings.docStoreConn.delete,
-            {"knowledge_graph_kwd": ["graph", "subgraph", "entity", "relation"]},
-            search.index_name(str(db_knowledge.workspace_id)),
-            str(db_knowledge.id),
-        )
+        pipeline = resolve_graph_pipeline(db_knowledge.parser_config)
+        if pipeline is GraphPipeline.LEGACY:
+            await asyncio.to_thread(
+                settings.docStoreConn.delete,
+                {
+                    "knowledge_graph_kwd": [
+                        "graph",
+                        "subgraph",
+                        "entity",
+                        "relation",
+                    ]
+                },
+                search.index_name(str(db_knowledge.workspace_id)),
+                str(db_knowledge.id),
+            )
 
-        # 3. build knowledge graph
-        # from app.tasks import build_graphrag_for_kb
-        # build_graphrag_for_kb(kb_id)
-        task = celery_app.send_task("app.core.rag.tasks.build_graphrag_for_kb", args=[knowledge_id])
+        task_name = (
+            "app.core.rag.tasks.build_graphrag_for_kb"
+            if pipeline is GraphPipeline.LEGACY
+            else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
+        )
+        task = celery_app.send_task(
+            task_name,
+            args=[str(knowledge_id)],
+        )
         result = {
             "task_id": task.id
         }
         return success(data=result, msg="Task accepted. rebuild knowledge graph is being processed in the background.")
+    except GraphPipelineConfigError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except Exception as e:
         api_logger.error(f"Failed to rebuild knowledge graph: knowledge_id={knowledge_id} - {str(e)}")
         raise

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -277,7 +277,8 @@ async def get_knowledge_graph_entity_types(
             model_name=config.api_keys[0].model_name,
             base_url=config.api_keys[0].api_base
         )
-        response = graph_entity_types(chat_model, scenario)
+        # response = graph_entity_types(chat_model, scenario)
+        response = await asyncio.to_thread(graph_entity_types, chat_model, scenario)
         return success(data=response, msg="Successfully obtained knowledge graph entity types")
     except HTTPException:
         raise

--- a/api/app/controllers/knowledgeshare_controller.py
+++ b/api/app/controllers/knowledgeshare_controller.py
@@ -122,7 +122,12 @@ async def create_knowledgeshare(
             parser_id=db_knowledge.parser_id,
             parser_config=db_knowledge.parser_config
         )
-        db_knowledge = await knowledge_service.create_knowledge_async(db=db, knowledge=knowledge, current_user=current_user)
+        db_knowledge = await knowledge_service.create_knowledge_async(
+            db=db,
+            knowledge=knowledge,
+            current_user=current_user,
+            preserve_source_parser_config=True,
+        )
         # 2. Create a knowledge base for sharing
         api_logger.debug(f"Start creating the knowledge base sharing: {db_knowledge.name}")
         create_data.target_kb_id = db_knowledge.id

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -86,37 +86,88 @@ class Settings:
     KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY: int = int(
         os.getenv("KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY", "2")
     )
-    KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS: int = max(
-        128,
-        min(8000, int(os.getenv("KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS", "1200"))),
-    )
     KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY: int = max(
         1,
         min(16, int(os.getenv("KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY", "4"))),
     )
+    KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS: int = max(
+        1,
+        min(
+            2592000,
+            int(
+                os.getenv(
+                    "KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS",
+                    "604800",
+                )
+            ),
+        ),
+    )
     KNOWLEDGE_GRAPH_ENTITY_TOP_N: int = max(
         1,
-        min(100, int(os.getenv("KNOWLEDGE_GRAPH_ENTITY_TOP_N", "12"))),
+        min(100, int(os.getenv("KNOWLEDGE_GRAPH_ENTITY_TOP_N", "40"))),
     )
     KNOWLEDGE_GRAPH_RELATION_TOP_N: int = max(
         1,
-        min(100, int(os.getenv("KNOWLEDGE_GRAPH_RELATION_TOP_N", "12"))),
+        min(100, int(os.getenv("KNOWLEDGE_GRAPH_RELATION_TOP_N", "40"))),
+    )
+    KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD: float = max(
+        -1.0,
+        min(
+            1.0,
+            float(
+                os.getenv(
+                    "KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD",
+                    "0.20",
+                )
+            ),
+        ),
+    )
+    KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD: float = max(
+        -1.0,
+        min(
+            1.0,
+            float(
+                os.getenv(
+                    "KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD",
+                    "0.20",
+                )
+            ),
+        ),
     )
     KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N: int = max(
         1,
         min(100, int(os.getenv("KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N", "24"))),
     )
-    KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY: int = max(
+    KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER: int = max(
         1,
-        min(20, int(os.getenv("KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY", "3"))),
+        min(
+            20,
+            int(os.getenv("KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER", "5")),
+        ),
     )
-    KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT: int = max(
+    KNOWLEDGE_GRAPH_MAX_CANDIDATES: int = max(
         1,
-        min(20, int(os.getenv("KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT", "4"))),
+        min(500, int(os.getenv("KNOWLEDGE_GRAPH_MAX_CANDIDATES", "100"))),
+    )
+    KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK: int = max(
+        1,
+        min(20, int(os.getenv("KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK", "6"))),
+    )
+    KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS: int = max(
+        1,
+        min(
+            3600,
+            int(
+                os.getenv(
+                    "KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS",
+                    "300",
+                )
+            ),
+        ),
     )
     KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS: int = max(
         100,
-        min(30000, int(os.getenv("KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS", "3000"))),
+        min(30000, int(os.getenv("KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS", "15000"))),
     )
     KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS: int = max(
         1,

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -86,6 +86,42 @@ class Settings:
     KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY: int = int(
         os.getenv("KNOWLEDGE_RETRIEVAL_GRAPH_MAX_CONCURRENCY", "2")
     )
+    KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS: int = max(
+        128,
+        min(8000, int(os.getenv("KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS", "1200"))),
+    )
+    KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY: int = max(
+        1,
+        min(16, int(os.getenv("KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY", "4"))),
+    )
+    KNOWLEDGE_GRAPH_ENTITY_TOP_N: int = max(
+        1,
+        min(100, int(os.getenv("KNOWLEDGE_GRAPH_ENTITY_TOP_N", "12"))),
+    )
+    KNOWLEDGE_GRAPH_RELATION_TOP_N: int = max(
+        1,
+        min(100, int(os.getenv("KNOWLEDGE_GRAPH_RELATION_TOP_N", "12"))),
+    )
+    KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N: int = max(
+        1,
+        min(100, int(os.getenv("KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N", "24"))),
+    )
+    KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY: int = max(
+        1,
+        min(20, int(os.getenv("KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY", "3"))),
+    )
+    KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT: int = max(
+        1,
+        min(20, int(os.getenv("KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT", "4"))),
+    )
+    KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS: int = max(
+        100,
+        min(30000, int(os.getenv("KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS", "3000"))),
+    )
+    KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS: int = max(
+        1,
+        min(3600, int(os.getenv("KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS", "600"))),
+    )
 
     # Xinference configuration
     XINFERENCE_URL: str = os.getenv("XINFERENCE_URL", "http://127.0.0.1")

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -90,88 +90,9 @@ class Settings:
         1,
         min(16, int(os.getenv("KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY", "4"))),
     )
-    KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS: int = max(
-        1,
-        min(
-            2592000,
-            int(
-                os.getenv(
-                    "KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS",
-                    "604800",
-                )
-            ),
-        ),
-    )
-    KNOWLEDGE_GRAPH_ENTITY_TOP_N: int = max(
-        1,
-        min(100, int(os.getenv("KNOWLEDGE_GRAPH_ENTITY_TOP_N", "40"))),
-    )
-    KNOWLEDGE_GRAPH_RELATION_TOP_N: int = max(
-        1,
-        min(100, int(os.getenv("KNOWLEDGE_GRAPH_RELATION_TOP_N", "40"))),
-    )
-    KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD: float = max(
-        -1.0,
-        min(
-            1.0,
-            float(
-                os.getenv(
-                    "KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD",
-                    "0.20",
-                )
-            ),
-        ),
-    )
-    KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD: float = max(
-        -1.0,
-        min(
-            1.0,
-            float(
-                os.getenv(
-                    "KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD",
-                    "0.20",
-                )
-            ),
-        ),
-    )
-    KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N: int = max(
-        1,
-        min(100, int(os.getenv("KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N", "24"))),
-    )
-    KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER: int = max(
-        1,
-        min(
-            20,
-            int(os.getenv("KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER", "5")),
-        ),
-    )
-    KNOWLEDGE_GRAPH_MAX_CANDIDATES: int = max(
-        1,
-        min(500, int(os.getenv("KNOWLEDGE_GRAPH_MAX_CANDIDATES", "100"))),
-    )
-    KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK: int = max(
-        1,
-        min(20, int(os.getenv("KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK", "6"))),
-    )
-    KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS: int = max(
-        1,
-        min(
-            3600,
-            int(
-                os.getenv(
-                    "KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS",
-                    "300",
-                )
-            ),
-        ),
-    )
     KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS: int = max(
         100,
         min(30000, int(os.getenv("KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS", "15000"))),
-    )
-    KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS: int = max(
-        1,
-        min(3600, int(os.getenv("KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS", "600"))),
     )
 
     # Xinference configuration

--- a/api/app/core/rag/knowledge_graph/__init__.py
+++ b/api/app/core/rag/knowledge_graph/__init__.py
@@ -1,0 +1,13 @@
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    GraphPipelineConfigError,
+    is_graph_enabled,
+    resolve_graph_pipeline,
+)
+
+__all__ = [
+    "GraphPipeline",
+    "GraphPipelineConfigError",
+    "is_graph_enabled",
+    "resolve_graph_pipeline",
+]

--- a/api/app/core/rag/knowledge_graph/batching.py
+++ b/api/app/core/rag/knowledge_graph/batching.py
@@ -1,8 +1,6 @@
 from collections.abc import Mapping, Sequence
-from html import escape
 from typing import Any
 
-from app.core.rag.common.token_utils import num_tokens_from_string
 from app.core.rag.knowledge_graph.models import ExtractionBatch, SourceChunk
 
 
@@ -58,48 +56,16 @@ def select_source_chunks(raw_hits: Sequence[Mapping[str, Any]]) -> list[SourceCh
 
 
 def _render_chunk(chunk: SourceChunk) -> str:
-    source_chunk_id = escape(chunk.source_chunk_id, quote=True)
-    return (
-        f'<source_chunk id="{source_chunk_id}">\n'
-        f"{chunk.page_content}\n"
-        "</source_chunk>"
-    )
+    return chunk.page_content
 
 
 def build_extraction_batches(
     chunks: Sequence[SourceChunk],
-    max_tokens: int,
 ) -> list[ExtractionBatch]:
-    if max_tokens <= 0:
-        raise ValueError("max_tokens must be greater than zero")
-
-    batches: list[ExtractionBatch] = []
-    current_texts: list[str] = []
-    current_ids: list[str] = []
-
-    def flush() -> None:
-        if not current_texts:
-            return
-        batches.append(
-            ExtractionBatch(
-                text="\n\n".join(current_texts),
-                source_chunk_ids=tuple(current_ids),
-            )
+    return [
+        ExtractionBatch(
+            text=_render_chunk(chunk),
+            source_chunk_ids=(chunk.source_chunk_id,),
         )
-        current_texts.clear()
-        current_ids.clear()
-
-    for chunk in chunks:
-        rendered = _render_chunk(chunk)
-        candidate = "\n\n".join((*current_texts, rendered))
-        if current_texts and num_tokens_from_string(candidate) > max_tokens:
-            flush()
-
-        current_texts.append(rendered)
-        current_ids.append(chunk.source_chunk_id)
-
-        if num_tokens_from_string(rendered) > max_tokens:
-            flush()
-
-    flush()
-    return batches
+        for chunk in chunks
+    ]

--- a/api/app/core/rag/knowledge_graph/batching.py
+++ b/api/app/core/rag/knowledge_graph/batching.py
@@ -1,0 +1,105 @@
+from collections.abc import Mapping, Sequence
+from html import escape
+from typing import Any
+
+from app.core.rag.common.token_utils import num_tokens_from_string
+from app.core.rag.knowledge_graph.models import ExtractionBatch, SourceChunk
+
+
+_SOURCE_CHUNK_TYPES = frozenset({"chunk", "source", "child"})
+
+
+def _to_sort_id(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def select_source_chunks(raw_hits: Sequence[Mapping[str, Any]]) -> list[SourceChunk]:
+    chunks: list[SourceChunk] = []
+    for hit in raw_hits:
+        source = hit.get("_source")
+        if not isinstance(source, Mapping):
+            continue
+        metadata = source.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+
+        page_content = source.get("page_content")
+        if not isinstance(page_content, str) or not page_content.strip():
+            continue
+
+        source_chunk_id = metadata.get("doc_id")
+        document_id = metadata.get("document_id")
+        if source_chunk_id is None or document_id is None:
+            continue
+
+        chunk_type = str(metadata.get("chunk_type") or "chunk").strip().lower()
+        if chunk_type not in _SOURCE_CHUNK_TYPES:
+            continue
+
+        parent_id = metadata.get("parent_id")
+        chunks.append(
+            SourceChunk(
+                source_chunk_id=str(source_chunk_id),
+                document_id=str(document_id),
+                page_content=page_content,
+                sort_id=_to_sort_id(metadata.get("sort_id")),
+                chunk_type=chunk_type,
+                parent_id=str(parent_id) if parent_id is not None else None,
+            )
+        )
+
+    return sorted(
+        chunks,
+        key=lambda chunk: (chunk.sort_id, chunk.source_chunk_id),
+    )
+
+
+def _render_chunk(chunk: SourceChunk) -> str:
+    source_chunk_id = escape(chunk.source_chunk_id, quote=True)
+    return (
+        f'<source_chunk id="{source_chunk_id}">\n'
+        f"{chunk.page_content}\n"
+        "</source_chunk>"
+    )
+
+
+def build_extraction_batches(
+    chunks: Sequence[SourceChunk],
+    max_tokens: int,
+) -> list[ExtractionBatch]:
+    if max_tokens <= 0:
+        raise ValueError("max_tokens must be greater than zero")
+
+    batches: list[ExtractionBatch] = []
+    current_texts: list[str] = []
+    current_ids: list[str] = []
+
+    def flush() -> None:
+        if not current_texts:
+            return
+        batches.append(
+            ExtractionBatch(
+                text="\n\n".join(current_texts),
+                source_chunk_ids=tuple(current_ids),
+            )
+        )
+        current_texts.clear()
+        current_ids.clear()
+
+    for chunk in chunks:
+        rendered = _render_chunk(chunk)
+        candidate = "\n\n".join((*current_texts, rendered))
+        if current_texts and num_tokens_from_string(candidate) > max_tokens:
+            flush()
+
+        current_texts.append(rendered)
+        current_ids.append(chunk.source_chunk_id)
+
+        if num_tokens_from_string(rendered) > max_tokens:
+            flush()
+
+    flush()
+    return batches

--- a/api/app/core/rag/knowledge_graph/config.py
+++ b/api/app/core/rag/knowledge_graph/config.py
@@ -1,0 +1,46 @@
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Any
+
+
+class GraphPipelineConfigError(ValueError):
+    """Raised when a managed graph pipeline configuration is invalid."""
+
+
+class GraphPipeline(StrEnum):
+    LEGACY = "legacy"
+    EVIDENCE = "evidence"
+
+
+def require_graph_mapping(
+    parser_config: Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    if parser_config is None:
+        return {}
+    if not isinstance(parser_config, Mapping):
+        raise GraphPipelineConfigError("parser_config must be a mapping")
+    if "graphrag" not in parser_config:
+        return {}
+
+    graph_config = parser_config["graphrag"]
+    if not isinstance(graph_config, Mapping):
+        raise GraphPipelineConfigError("graphrag must be a mapping")
+    return graph_config
+
+
+def resolve_graph_pipeline(
+    parser_config: Mapping[str, Any] | None,
+) -> GraphPipeline:
+    graph_config = require_graph_mapping(parser_config)
+    raw_value = graph_config.get("pipeline", GraphPipeline.LEGACY.value)
+    try:
+        return GraphPipeline(str(raw_value).strip().lower())
+    except ValueError as exc:
+        raise GraphPipelineConfigError(
+            f"unsupported graph pipeline: {raw_value}"
+        ) from exc
+
+
+def is_graph_enabled(parser_config: Mapping[str, Any] | None) -> bool:
+    graph_config = require_graph_mapping(parser_config)
+    return graph_config.get("use_graphrag") is True

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -72,6 +72,52 @@ def dispatch_document_graph_sync(
     return task
 
 
+async def enqueue_document_graph_sync(
+    knowledge_id: str,
+    document_id: str,
+    parser_config: Mapping[str, Any] | None,
+    *,
+    dispatch_legacy: bool = True,
+) -> str | None:
+    if not is_graph_enabled(parser_config):
+        return None
+
+    pipeline = resolve_graph_pipeline(parser_config)
+    if pipeline is GraphPipeline.LEGACY:
+        if not dispatch_legacy:
+            return None
+        task_name = "app.core.rag.tasks.build_graphrag_for_document"
+        params = {
+            "document_id": str(document_id),
+            "knowledge_id": str(knowledge_id),
+        }
+    else:
+        task_name = "app.core.rag.tasks.sync_evidence_graph_document"
+        params = {
+            "knowledge_id": str(knowledge_id),
+            "document_id": str(document_id),
+        }
+
+    from app.celery_task_scheduler import scheduler as celery_scheduler
+
+    msg_id = await celery_scheduler.push_task(
+        task_name,
+        str(knowledge_id),
+        params,
+    )
+    logger.info(
+        "[GraphPipeline] task_persisted"
+        " scope=document pipeline=%s task=%s kb_id=%s"
+        " document_id=%s msg_id=%s",
+        pipeline.value,
+        task_name,
+        str(knowledge_id),
+        str(document_id),
+        str(msg_id),
+    )
+    return str(msg_id)
+
+
 def dispatch_knowledge_graph_rebuild(
     knowledge_id: str,
     parser_config: Mapping[str, Any] | None,

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -1,0 +1,49 @@
+from collections.abc import Mapping
+from typing import Any
+
+from app.celery_app import celery_app
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    is_graph_enabled,
+    resolve_graph_pipeline,
+)
+
+
+def dispatch_document_graph_sync(
+    knowledge_id: str,
+    document_id: str,
+    parser_config: Mapping[str, Any] | None,
+    *,
+    dispatch_legacy: bool = True,
+) -> Any | None:
+    if not is_graph_enabled(parser_config):
+        return None
+
+    pipeline = resolve_graph_pipeline(parser_config)
+    if pipeline is GraphPipeline.LEGACY:
+        if not dispatch_legacy:
+            return None
+        return celery_app.send_task(
+            "app.core.rag.tasks.build_graphrag_for_document",
+            args=[str(document_id), str(knowledge_id)],
+        )
+    return celery_app.send_task(
+        "app.core.rag.tasks.sync_evidence_graph_document",
+        args=[str(knowledge_id), str(document_id)],
+    )
+
+
+def dispatch_knowledge_graph_rebuild(
+    knowledge_id: str,
+    parser_config: Mapping[str, Any] | None,
+) -> Any | None:
+    if not is_graph_enabled(parser_config):
+        return None
+
+    pipeline = resolve_graph_pipeline(parser_config)
+    task_name = (
+        "app.core.rag.tasks.build_graphrag_for_kb"
+        if pipeline is GraphPipeline.LEGACY
+        else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
+    )
+    return celery_app.send_task(task_name, args=[str(knowledge_id)])

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from typing import Any
 
@@ -7,6 +8,32 @@ from app.core.rag.knowledge_graph.config import (
     is_graph_enabled,
     resolve_graph_pipeline,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _log_dispatched_task(
+    task: Any,
+    *,
+    scope: str,
+    pipeline: GraphPipeline,
+    task_name: str,
+    knowledge_id: str,
+    document_id: str | None = None,
+) -> None:
+    document_field = (
+        f" document_id={document_id}" if document_id is not None else ""
+    )
+    logger.info(
+        "[GraphPipeline] task_dispatched"
+        " scope=%s pipeline=%s task=%s kb_id=%s%s task_id=%s",
+        scope,
+        pipeline.value,
+        task_name,
+        str(knowledge_id),
+        document_field,
+        str(getattr(task, "id", None) or "unknown"),
+    )
 
 
 def dispatch_document_graph_sync(
@@ -23,14 +50,26 @@ def dispatch_document_graph_sync(
     if pipeline is GraphPipeline.LEGACY:
         if not dispatch_legacy:
             return None
-        return celery_app.send_task(
-            "app.core.rag.tasks.build_graphrag_for_document",
+        task_name = "app.core.rag.tasks.build_graphrag_for_document"
+        task = celery_app.send_task(
+            task_name,
             args=[str(document_id), str(knowledge_id)],
         )
-    return celery_app.send_task(
-        "app.core.rag.tasks.sync_evidence_graph_document",
-        args=[str(knowledge_id), str(document_id)],
+    else:
+        task_name = "app.core.rag.tasks.sync_evidence_graph_document"
+        task = celery_app.send_task(
+            task_name,
+            args=[str(knowledge_id), str(document_id)],
+        )
+    _log_dispatched_task(
+        task,
+        scope="document",
+        pipeline=pipeline,
+        task_name=task_name,
+        knowledge_id=str(knowledge_id),
+        document_id=str(document_id),
     )
+    return task
 
 
 def dispatch_knowledge_graph_rebuild(
@@ -46,7 +85,15 @@ def dispatch_knowledge_graph_rebuild(
         if pipeline is GraphPipeline.LEGACY
         else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
     )
-    return celery_app.send_task(task_name, args=[str(knowledge_id)])
+    task = celery_app.send_task(task_name, args=[str(knowledge_id)])
+    _log_dispatched_task(
+        task,
+        scope="knowledge",
+        pipeline=pipeline,
+        task_name=task_name,
+        knowledge_id=str(knowledge_id),
+    )
+    return task
 
 
 def dispatch_graph_enabled_transition(
@@ -62,7 +109,17 @@ def dispatch_graph_enabled_transition(
             str(knowledge_id),
             parser_config,
         )
-    return celery_app.send_task(
-        "app.core.rag.tasks.clear_all_knowledge_graph_data",
+    pipeline = resolve_graph_pipeline(parser_config)
+    task_name = "app.core.rag.tasks.clear_all_knowledge_graph_data"
+    task = celery_app.send_task(
+        task_name,
         args=[str(knowledge_id)],
     )
+    _log_dispatched_task(
+        task,
+        scope="knowledge",
+        pipeline=pipeline,
+        task_name=task_name,
+        knowledge_id=str(knowledge_id),
+    )
+    return task

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -78,6 +78,7 @@ async def enqueue_document_graph_sync(
     parser_config: Mapping[str, Any] | None,
     *,
     dispatch_legacy: bool = True,
+    document_deleted: bool = False,
 ) -> str | None:
     if not is_graph_enabled(parser_config):
         return None
@@ -97,6 +98,8 @@ async def enqueue_document_graph_sync(
             "knowledge_id": str(knowledge_id),
             "document_id": str(document_id),
         }
+        if document_deleted:
+            params["document_deleted"] = True
 
     from app.celery_task_scheduler import scheduler as celery_scheduler
 

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -47,3 +47,22 @@ def dispatch_knowledge_graph_rebuild(
         else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
     )
     return celery_app.send_task(task_name, args=[str(knowledge_id)])
+
+
+def dispatch_graph_enabled_transition(
+    knowledge_id: str,
+    previous_enabled: bool,
+    parser_config: Mapping[str, Any] | None,
+) -> Any | None:
+    current_enabled = is_graph_enabled(parser_config)
+    if current_enabled == previous_enabled:
+        return None
+    if current_enabled:
+        return dispatch_knowledge_graph_rebuild(
+            str(knowledge_id),
+            parser_config,
+        )
+    return celery_app.send_task(
+        "app.core.rag.tasks.clear_all_knowledge_graph_data",
+        args=[str(knowledge_id)],
+    )

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,0 +1,940 @@
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from elasticsearch import AsyncElasticsearch
+
+from app.core.rag.knowledge_graph.models import (
+    AffectedProjectionKeys,
+    EntityEvidence,
+    EntityProjectionHit,
+    GraphEvidenceHit,
+    GraphIndexRuntime,
+    RelationEvidence,
+    RelationProjectionHit,
+)
+from app.core.rag.knowledge_graph.normalizer import (
+    document_map_id,
+    projection_id,
+)
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.elasticsearch_queries import raise_on_shard_failures
+from app.core.utils.datetime_utils import utcnow_naive
+
+
+ENTITY_EVIDENCE = "entity_evidence"
+RELATION_EVIDENCE = "relation_evidence"
+ENTITY_PROJECTION = "entity_projection"
+RELATION_PROJECTION = "relation_projection"
+DOCUMENT_PROJECTION_MAP = "document_projection_map"
+
+EVIDENCE_TYPES = (ENTITY_EVIDENCE, RELATION_EVIDENCE)
+EVIDENCE_GRAPH_TYPES = (
+    ENTITY_EVIDENCE,
+    RELATION_EVIDENCE,
+    ENTITY_PROJECTION,
+    RELATION_PROJECTION,
+    DOCUMENT_PROJECTION_MAP,
+)
+
+
+class GraphElasticsearchStore:
+    def __init__(self, client: AsyncElasticsearch) -> None:
+        self._client = client
+
+    async def ensure_vector_mapping(
+        self,
+        index_name: str,
+        dimension: int,
+    ) -> str:
+        if dimension <= 0:
+            raise ValueError("vector dimension must be greater than zero")
+        field_name = f"q_{dimension}_vec"
+        mapping = await self._client.indices.get_mapping(index=index_name)
+        index_mapping = mapping.get(index_name)
+        if index_mapping is None and len(mapping) == 1:
+            index_mapping = next(iter(mapping.values()))
+        if not isinstance(index_mapping, Mapping):
+            raise ValueError(f"missing mapping for index: {index_name}")
+        mappings = index_mapping.get("mappings") or {}
+        properties = mappings.get("properties") or {}
+        current = properties.get(field_name)
+        if current is None:
+            await self._client.indices.put_mapping(
+                index=index_name,
+                properties={
+                    field_name: {
+                        "type": "dense_vector",
+                        "dims": dimension,
+                        "index": True,
+                        "similarity": "cosine",
+                    }
+                },
+            )
+        elif (
+            current.get("type") != "dense_vector"
+            or current.get("dims") != dimension
+        ):
+            raise ValueError(f"incompatible vector mapping for {field_name}")
+        return field_name
+
+    async def refresh_sources(
+        self,
+        chunk_index_name: str,
+        graph_index_name: str,
+    ) -> None:
+        await self._client.indices.refresh(
+            index=[chunk_index_name, graph_index_name],
+            ignore_unavailable=True,
+        )
+
+    async def refresh_graph(self, graph_index_name: str) -> None:
+        await self._client.indices.refresh(
+            index=graph_index_name,
+            ignore_unavailable=True,
+        )
+
+    async def load_document_chunks(
+        self,
+        chunk_index_name: str,
+        knowledge_id: str,
+        document_id: str,
+    ) -> list[dict[str, Any]]:
+        filters = [
+            {"term": {"metadata.knowledge_id": knowledge_id}},
+            {"term": {"metadata.document_id": document_id}},
+            {"term": {"metadata.status": 1}},
+        ]
+        result = await self._client.search(
+            index=chunk_index_name,
+            size=10000,
+            query={"bool": {"filter": filters}},
+            sort=[
+                {"metadata.sort_id": {"order": "asc", "unmapped_type": "long"}},
+                {"metadata.doc_id": {"order": "asc"}},
+            ],
+        )
+        raise_on_shard_failures(result, "load graph source document")
+
+        scoped_hits: list[dict[str, Any]] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            metadata = source.get("metadata") or {}
+            if not isinstance(metadata, Mapping):
+                continue
+            if str(metadata.get("knowledge_id")) != str(knowledge_id):
+                continue
+            if str(metadata.get("document_id")) != str(document_id):
+                continue
+            if metadata.get("status") != 1:
+                continue
+            scoped_hits.append(hit)
+        return scoped_hits
+
+    async def load_document_map(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        document_id: str,
+    ) -> dict[str, Any] | None:
+        result = await self._client.search(
+            index=index_name,
+            size=1,
+            query=self._graph_query(
+                knowledge_id,
+                DOCUMENT_PROJECTION_MAP,
+                [{"term": {"document_id": document_id}}],
+            ),
+        )
+        raise_on_shard_failures(result, "load graph document map")
+        hits = self._hits(result)
+        if not hits:
+            return None
+        source = hits[0].get("_source")
+        return dict(source) if isinstance(source, Mapping) else None
+
+    async def load_document_evidence_keys(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        document_id: str,
+    ) -> AffectedProjectionKeys:
+        result = await self._client.search(
+            index=index_name,
+            size=10000,
+            query=self._graph_query(
+                knowledge_id,
+                EVIDENCE_TYPES,
+                [{"term": {"document_id": document_id}}],
+            ),
+            source=[
+                "knowledge_graph_kwd",
+                "entity_key_kwd",
+                "relation_key_kwd",
+            ],
+        )
+        raise_on_shard_failures(result, "load graph document evidence keys")
+        entity_keys: set[str] = set()
+        relation_keys: set[str] = set()
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            if source.get("knowledge_graph_kwd") == ENTITY_EVIDENCE:
+                if source.get("entity_key_kwd"):
+                    entity_keys.add(str(source["entity_key_kwd"]))
+            elif source.get("knowledge_graph_kwd") == RELATION_EVIDENCE:
+                if source.get("relation_key_kwd"):
+                    relation_keys.add(str(source["relation_key_kwd"]))
+        return AffectedProjectionKeys(
+            entity_keys=tuple(sorted(entity_keys)),
+            relation_keys=tuple(sorted(relation_keys)),
+        )
+
+    async def replace_document_evidence(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        document_id: str,
+        entity_evidence: Sequence[EntityEvidence],
+        relation_evidence: Sequence[RelationEvidence],
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> AffectedProjectionKeys:
+        old_map = await self.load_document_map(
+            index_name,
+            knowledge_id,
+            document_id,
+        )
+        actual_old = await self.load_document_evidence_keys(
+            index_name,
+            knowledge_id,
+            document_id,
+        )
+        mapped_entity_keys = set((old_map or {}).get("entity_keys_kwd") or ())
+        mapped_relation_keys = set((old_map or {}).get("relation_keys_kwd") or ())
+        old_entity_keys = mapped_entity_keys | set(actual_old.entity_keys)
+        old_relation_keys = mapped_relation_keys | set(actual_old.relation_keys)
+
+        if (
+            old_entity_keys != mapped_entity_keys
+            or old_relation_keys != mapped_relation_keys
+        ):
+            await self._write_document_map(
+                index_name,
+                knowledge_id,
+                document_id,
+                entity_keys=old_entity_keys,
+                relation_keys=old_relation_keys,
+                source_chunk_ids=set(
+                    (old_map or {}).get("source_chunk_ids_kwd") or ()
+                ),
+                ensure_valid=ensure_valid,
+            )
+
+        self._ensure_valid(ensure_valid)
+        await self._client.delete_by_query(
+            index=index_name,
+            conflicts="proceed",
+            refresh=False,
+            query=self._graph_query(
+                knowledge_id,
+                EVIDENCE_TYPES,
+                [{"term": {"document_id": document_id}}],
+            ),
+        )
+
+        operations: list[dict[str, Any]] = []
+        for evidence in entity_evidence:
+            operations.extend(
+                self._index_operation(
+                    index_name,
+                    evidence.id,
+                    self._entity_evidence_source(evidence),
+                )
+            )
+        for evidence in relation_evidence:
+            operations.extend(
+                self._index_operation(
+                    index_name,
+                    evidence.id,
+                    self._relation_evidence_source(evidence),
+                )
+            )
+        await self._bulk(operations, ensure_valid=ensure_valid)
+
+        self._ensure_valid(ensure_valid)
+        await self.refresh_graph(index_name)
+
+        new_entity_keys = {item.entity_key for item in entity_evidence}
+        new_relation_keys = {item.relation_key for item in relation_evidence}
+        return AffectedProjectionKeys(
+            entity_keys=tuple(sorted(old_entity_keys | new_entity_keys)),
+            relation_keys=tuple(sorted(old_relation_keys | new_relation_keys)),
+        )
+
+    async def load_entity_evidence(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        entity_keys: Sequence[str],
+    ) -> list[EntityEvidence]:
+        if not entity_keys:
+            return []
+        result = await self._client.search(
+            index=index_name,
+            size=10000,
+            query=self._graph_query(
+                knowledge_id,
+                ENTITY_EVIDENCE,
+                [{"terms": {"entity_key_kwd": list(entity_keys)}}],
+            ),
+        )
+        raise_on_shard_failures(result, "load entity evidence")
+        evidence: list[EntityEvidence] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            evidence.append(
+                EntityEvidence(
+                    id=str(hit.get("_id") or source.get("id") or ""),
+                    kb_id=str(source["kb_id"]),
+                    document_id=str(source["document_id"]),
+                    source_chunk_id=str(source["source_chunk_id_kwd"]),
+                    entity_key=str(source["entity_key_kwd"]),
+                    entity_name=str(source["entity_name_kwd"]),
+                    entity_type=str(source["entity_type_kwd"]),
+                    description=str(source.get("description") or ""),
+                    aliases=tuple(source.get("aliases_kwd") or ()),
+                    confidence=float(source.get("confidence_flt") or 0.0),
+                )
+            )
+        return evidence
+
+    async def load_relation_evidence(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        relation_keys: Sequence[str],
+    ) -> list[RelationEvidence]:
+        if not relation_keys:
+            return []
+        return await self._load_relation_evidence_with_filters(
+            index_name,
+            knowledge_id,
+            [{"terms": {"relation_key_kwd": list(relation_keys)}}],
+            "load relation evidence",
+        )
+
+    async def load_relations_for_entity_keys(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        entity_keys: Sequence[str],
+    ) -> list[RelationEvidence]:
+        if not entity_keys:
+            return []
+        return await self._load_relation_evidence_with_filters(
+            index_name,
+            knowledge_id,
+            [
+                {
+                    "bool": {
+                        "should": [
+                            {"terms": {"from_entity_key_kwd": list(entity_keys)}},
+                            {"terms": {"to_entity_key_kwd": list(entity_keys)}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                }
+            ],
+            "load entity relation evidence",
+        )
+
+    async def write_entity_projections(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        projections: Sequence[Mapping[str, Any]],
+        delete_keys: Sequence[str] = (),
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        operations: list[dict[str, Any]] = []
+        for key in sorted(set(delete_keys)):
+            operations.append(
+                {
+                    "delete": {
+                        "_index": index_name,
+                        "_id": projection_id(knowledge_id, "entity", key),
+                    }
+                }
+            )
+        for projection in projections:
+            source = dict(projection)
+            source["knowledge_graph_kwd"] = ENTITY_PROJECTION
+            source["kb_id"] = knowledge_id
+            key = str(source["entity_key_kwd"])
+            operations.extend(
+                self._index_operation(
+                    index_name,
+                    projection_id(knowledge_id, "entity", key),
+                    source,
+                )
+            )
+        await self._bulk(operations, ensure_valid=ensure_valid)
+
+    async def write_relation_projections(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        projections: Sequence[Mapping[str, Any]],
+        delete_keys: Sequence[str] = (),
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        operations: list[dict[str, Any]] = []
+        for key in sorted(set(delete_keys)):
+            operations.append(
+                {
+                    "delete": {
+                        "_index": index_name,
+                        "_id": projection_id(knowledge_id, "relation", key),
+                    }
+                }
+            )
+        for projection in projections:
+            source = dict(projection)
+            source["knowledge_graph_kwd"] = RELATION_PROJECTION
+            source["kb_id"] = knowledge_id
+            key = str(source["relation_key_kwd"])
+            operations.extend(
+                self._index_operation(
+                    index_name,
+                    projection_id(knowledge_id, "relation", key),
+                    source,
+                )
+            )
+        await self._bulk(operations, ensure_valid=ensure_valid)
+
+    async def finish_document_map(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        document_id: str,
+        entity_evidence: Sequence[EntityEvidence],
+        relation_evidence: Sequence[RelationEvidence],
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        entity_keys = {item.entity_key for item in entity_evidence}
+        relation_keys = {item.relation_key for item in relation_evidence}
+        source_chunk_ids = {
+            item.source_chunk_id for item in (*entity_evidence, *relation_evidence)
+        }
+        if not entity_keys and not relation_keys:
+            await self._bulk(
+                [
+                    {
+                        "delete": {
+                            "_index": index_name,
+                            "_id": document_map_id(knowledge_id, document_id),
+                        }
+                    }
+                ],
+                ensure_valid=ensure_valid,
+            )
+            return
+        await self._write_document_map(
+            index_name,
+            knowledge_id,
+            document_id,
+            entity_keys=entity_keys,
+            relation_keys=relation_keys,
+            source_chunk_ids=source_chunk_ids,
+            ensure_valid=ensure_valid,
+        )
+
+    async def list_document_maps(
+        self,
+        index_name: str,
+        knowledge_id: str,
+    ) -> list[dict[str, Any]]:
+        result = await self._client.search(
+            index=index_name,
+            size=10000,
+            query=self._graph_query(knowledge_id, DOCUMENT_PROJECTION_MAP),
+            sort=[{"document_id": {"order": "asc"}}],
+        )
+        raise_on_shard_failures(result, "list graph document maps")
+        return [
+            dict(source)
+            for hit in self._hits(result)
+            if isinstance((source := hit.get("_source")), Mapping)
+        ]
+
+    async def clear_evidence_graph(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        self._ensure_valid(ensure_valid)
+        await self._client.delete_by_query(
+            index=index_name,
+            conflicts="proceed",
+            refresh=True,
+            query=self._graph_query(knowledge_id, EVIDENCE_GRAPH_TYPES),
+        )
+
+    async def clear_all_graph_documents(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        self._ensure_valid(ensure_valid)
+        await self._client.delete_by_query(
+            index=index_name,
+            conflicts="proceed",
+            refresh=True,
+            query={
+                "bool": {
+                    "filter": [
+                        {"term": {"kb_id": knowledge_id}},
+                        {"exists": {"field": "knowledge_graph_kwd"}},
+                    ]
+                }
+            },
+        )
+
+    async def search_entity_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        query_vector: Sequence[float],
+        top_n: int,
+    ) -> list[EntityProjectionHit]:
+        result = await self._projection_search(
+            runtime,
+            query_vector,
+            top_n,
+            ENTITY_PROJECTION,
+        )
+        return [
+            EntityProjectionHit(
+                entity_key=str(source["entity_key_kwd"]),
+                entity_name=str(source["entity_name_kwd"]),
+                score=float(hit.get("_score") or 0.0),
+            )
+            for hit in self._hits(result)
+            if isinstance((source := hit.get("_source")), Mapping)
+            and source.get("entity_key_kwd")
+            and source.get("entity_name_kwd")
+        ]
+
+    async def search_relation_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        query_vector: Sequence[float],
+        top_n: int,
+    ) -> list[RelationProjectionHit]:
+        result = await self._projection_search(
+            runtime,
+            query_vector,
+            top_n,
+            RELATION_PROJECTION,
+        )
+        return self._relation_projection_hits(result)
+
+    async def load_neighbor_relations(
+        self,
+        runtime: GraphIndexRuntime,
+        entity_keys: Sequence[str],
+        top_n: int,
+    ) -> list[RelationProjectionHit]:
+        if not entity_keys:
+            return []
+        result = await self._client.search(
+            index=runtime.graph_index_name,
+            size=top_n,
+            query=self._graph_query(
+                runtime.knowledge_id,
+                RELATION_PROJECTION,
+                [
+                    {
+                        "bool": {
+                            "should": [
+                                {"terms": {"from_entity_key_kwd": list(entity_keys)}},
+                                {"terms": {"to_entity_key_kwd": list(entity_keys)}},
+                            ],
+                            "minimum_should_match": 1,
+                        }
+                    }
+                ],
+            ),
+        )
+        raise_on_shard_failures(result, "load graph neighbor relations")
+        return self._relation_projection_hits(result)
+
+    async def load_evidence_for_projection_keys(
+        self,
+        runtime: GraphIndexRuntime,
+        entity_keys: Sequence[str],
+        relation_keys: Sequence[str],
+        evidence_per_key: int,
+        allowed_document_ids: Sequence[str] | None = None,
+    ) -> list[GraphEvidenceHit]:
+        should: list[dict[str, Any]] = []
+        if entity_keys:
+            should.append({"terms": {"entity_key_kwd": list(entity_keys)}})
+        if relation_keys:
+            should.append({"terms": {"relation_key_kwd": list(relation_keys)}})
+        if not should:
+            return []
+
+        extra_filters: list[dict[str, Any]] = [
+            {"bool": {"should": should, "minimum_should_match": 1}}
+        ]
+        if allowed_document_ids is not None:
+            if not allowed_document_ids:
+                return []
+            extra_filters.append(
+                {"terms": {"document_id": list(allowed_document_ids)}}
+            )
+        result = await self._client.search(
+            index=runtime.graph_index_name,
+            size=max(1, (len(entity_keys) + len(relation_keys)) * evidence_per_key * 4),
+            query=self._graph_query(
+                runtime.knowledge_id,
+                EVIDENCE_TYPES,
+                extra_filters,
+            ),
+        )
+        raise_on_shard_failures(result, "load graph projection evidence")
+
+        counts: defaultdict[tuple[str, str], int] = defaultdict(int)
+        evidence_hits: list[GraphEvidenceHit] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            document_type = source.get("knowledge_graph_kwd")
+            if document_type == ENTITY_EVIDENCE:
+                key = str(source.get("entity_key_kwd") or "")
+                group = (ENTITY_EVIDENCE, key)
+                entity_name = str(source.get("entity_name_kwd") or "") or None
+                relation_label = None
+            elif document_type == RELATION_EVIDENCE:
+                key = str(source.get("relation_key_kwd") or "")
+                group = (RELATION_EVIDENCE, key)
+                entity_name = None
+                relation_label = self._relation_label(source)
+            else:
+                continue
+            if not key or counts[group] >= evidence_per_key:
+                continue
+            counts[group] += 1
+            evidence_hits.append(
+                GraphEvidenceHit(
+                    source_chunk_id=str(source["source_chunk_id_kwd"]),
+                    document_id=str(source["document_id"]),
+                    score=float(hit.get("_score") or 0.0),
+                    entity_name=entity_name,
+                    relation_label=relation_label,
+                )
+            )
+        return evidence_hits
+
+    async def hydrate_source_chunks(
+        self,
+        *,
+        chunk_index_name: str,
+        knowledge_id: str,
+        source_chunk_ids: Sequence[str],
+        allowed_document_ids: Sequence[str] | None,
+        file_names: Sequence[str],
+    ) -> list[DocumentChunk]:
+        if not source_chunk_ids:
+            return []
+        filters: list[dict[str, Any]] = [
+            {"terms": {"metadata.doc_id": list(source_chunk_ids)}},
+            {"term": {"metadata.knowledge_id": knowledge_id}},
+            {"term": {"metadata.status": 1}},
+        ]
+        if allowed_document_ids is not None:
+            if not allowed_document_ids:
+                return []
+            filters.append(
+                {"terms": {"metadata.document_id": list(allowed_document_ids)}}
+            )
+        if file_names:
+            filters.append({"terms": {"metadata.file_name": list(file_names)}})
+
+        result = await self._client.search(
+            index=chunk_index_name,
+            size=len(set(source_chunk_ids)),
+            query={"bool": {"filter": filters}},
+        )
+        raise_on_shard_failures(result, "hydrate graph source chunks")
+
+        source_ids = {str(item) for item in source_chunk_ids}
+        allowed_documents = (
+            {str(item) for item in allowed_document_ids}
+            if allowed_document_ids is not None
+            else None
+        )
+        allowed_files = {str(item) for item in file_names}
+        chunks: list[DocumentChunk] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            metadata = source.get("metadata") or {}
+            if not isinstance(metadata, Mapping):
+                continue
+            if str(metadata.get("doc_id")) not in source_ids:
+                continue
+            if str(metadata.get("knowledge_id")) != str(knowledge_id):
+                continue
+            if metadata.get("status") != 1:
+                continue
+            if (
+                allowed_documents is not None
+                and str(metadata.get("document_id")) not in allowed_documents
+            ):
+                continue
+            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
+                continue
+            page_content = source.get("page_content")
+            if not isinstance(page_content, str):
+                continue
+            chunks.append(
+                DocumentChunk(
+                    page_content=page_content,
+                    vector=source.get("vector"),
+                    metadata=dict(metadata),
+                )
+            )
+        return chunks
+
+    async def _projection_search(
+        self,
+        runtime: GraphIndexRuntime,
+        query_vector: Sequence[float],
+        top_n: int,
+        projection_type: str,
+    ) -> Mapping[str, Any]:
+        vector_field = f"q_{len(query_vector)}_vec"
+        result = await self._client.search(
+            index=runtime.graph_index_name,
+            size=top_n,
+            query={
+                "script_score": {
+                    "query": self._graph_query(
+                        runtime.knowledge_id,
+                        projection_type,
+                    ),
+                    "script": {
+                        "source": (
+                            "cosineSimilarity(params.query_vector, "
+                            f"'{vector_field}') + 1.0"
+                        ),
+                        "params": {"query_vector": list(query_vector)},
+                    },
+                }
+            },
+        )
+        raise_on_shard_failures(result, f"search {projection_type}")
+        return result
+
+    async def _load_relation_evidence_with_filters(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        extra_filters: Sequence[Mapping[str, Any]],
+        context: str,
+    ) -> list[RelationEvidence]:
+        result = await self._client.search(
+            index=index_name,
+            size=10000,
+            query=self._graph_query(
+                knowledge_id,
+                RELATION_EVIDENCE,
+                extra_filters,
+            ),
+        )
+        raise_on_shard_failures(result, context)
+        evidence: list[RelationEvidence] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            evidence.append(
+                RelationEvidence(
+                    id=str(hit.get("_id") or source.get("id") or ""),
+                    kb_id=str(source["kb_id"]),
+                    document_id=str(source["document_id"]),
+                    source_chunk_id=str(source["source_chunk_id_kwd"]),
+                    relation_key=str(source["relation_key_kwd"]),
+                    from_entity_key=str(source["from_entity_key_kwd"]),
+                    from_entity_name=str(source["from_entity_name_kwd"]),
+                    to_entity_key=str(source["to_entity_key_kwd"]),
+                    to_entity_name=str(source["to_entity_name_kwd"]),
+                    predicate=str(source["predicate_kwd"]),
+                    description=str(source.get("description") or ""),
+                    directed=bool(source.get("directed_int")),
+                    confidence=float(source.get("confidence_flt") or 0.0),
+                )
+            )
+        return evidence
+
+    async def _write_document_map(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        document_id: str,
+        *,
+        entity_keys: set[str],
+        relation_keys: set[str],
+        source_chunk_ids: set[str],
+        ensure_valid: Callable[[], None] | None,
+    ) -> None:
+        source = {
+            "knowledge_graph_kwd": DOCUMENT_PROJECTION_MAP,
+            "kb_id": knowledge_id,
+            "document_id": document_id,
+            "entity_keys_kwd": sorted(entity_keys),
+            "relation_keys_kwd": sorted(relation_keys),
+            "source_chunk_ids_kwd": sorted(source_chunk_ids),
+            "updated_at": utcnow_naive().isoformat(),
+        }
+        await self._bulk(
+            self._index_operation(
+                index_name,
+                document_map_id(knowledge_id, document_id),
+                source,
+            ),
+            ensure_valid=ensure_valid,
+        )
+
+    async def _bulk(
+        self,
+        operations: Sequence[Mapping[str, Any]],
+        *,
+        ensure_valid: Callable[[], None] | None,
+    ) -> None:
+        if not operations:
+            return
+        self._ensure_valid(ensure_valid)
+        result = await self._client.bulk(operations=list(operations), refresh=False)
+        if result.get("errors"):
+            failures = []
+            for item in result.get("items") or []:
+                operation = next(iter(item.values()), {})
+                if operation.get("error"):
+                    failures.append(operation.get("error"))
+                if len(failures) == 3:
+                    break
+            raise RuntimeError(f"graph bulk write failed: {failures}")
+
+    @staticmethod
+    def _ensure_valid(ensure_valid: Callable[[], None] | None) -> None:
+        if ensure_valid is not None:
+            ensure_valid()
+
+    @staticmethod
+    def _index_operation(
+        index_name: str,
+        document_id: str,
+        source: Mapping[str, Any],
+    ) -> list[dict[str, Any]]:
+        return [
+            {"index": {"_index": index_name, "_id": document_id}},
+            dict(source),
+        ]
+
+    @staticmethod
+    def _entity_evidence_source(evidence: EntityEvidence) -> dict[str, Any]:
+        return {
+            "knowledge_graph_kwd": ENTITY_EVIDENCE,
+            "kb_id": evidence.kb_id,
+            "document_id": evidence.document_id,
+            "source_chunk_id_kwd": evidence.source_chunk_id,
+            "entity_key_kwd": evidence.entity_key,
+            "entity_name_kwd": evidence.entity_name,
+            "entity_type_kwd": evidence.entity_type,
+            "aliases_kwd": list(evidence.aliases),
+            "description": evidence.description,
+            "evidence_text": evidence.description[:300],
+            "confidence_flt": evidence.confidence,
+        }
+
+    @staticmethod
+    def _relation_evidence_source(evidence: RelationEvidence) -> dict[str, Any]:
+        return {
+            "knowledge_graph_kwd": RELATION_EVIDENCE,
+            "kb_id": evidence.kb_id,
+            "document_id": evidence.document_id,
+            "source_chunk_id_kwd": evidence.source_chunk_id,
+            "relation_key_kwd": evidence.relation_key,
+            "from_entity_key_kwd": evidence.from_entity_key,
+            "from_entity_name_kwd": evidence.from_entity_name,
+            "to_entity_key_kwd": evidence.to_entity_key,
+            "to_entity_name_kwd": evidence.to_entity_name,
+            "predicate_kwd": evidence.predicate,
+            "directed_int": int(evidence.directed),
+            "description": evidence.description,
+            "evidence_text": evidence.description[:300],
+            "confidence_flt": evidence.confidence,
+        }
+
+    @staticmethod
+    def _graph_query(
+        knowledge_id: str,
+        document_types: str | Sequence[str],
+        extra_filters: Sequence[Mapping[str, Any]] = (),
+    ) -> dict[str, Any]:
+        type_filter: dict[str, Any]
+        if isinstance(document_types, str):
+            type_filter = {"term": {"knowledge_graph_kwd": document_types}}
+        else:
+            type_filter = {
+                "terms": {"knowledge_graph_kwd": list(document_types)}
+            }
+        return {
+            "bool": {
+                "filter": [
+                    {"term": {"kb_id": knowledge_id}},
+                    type_filter,
+                    *[dict(item) for item in extra_filters],
+                ]
+            }
+        }
+
+    @staticmethod
+    def _hits(result: Mapping[str, Any]) -> list[dict[str, Any]]:
+        hits = (result.get("hits") or {}).get("hits") or []
+        return [dict(hit) for hit in hits if isinstance(hit, Mapping)]
+
+    @classmethod
+    def _relation_projection_hits(
+        cls,
+        result: Mapping[str, Any],
+    ) -> list[RelationProjectionHit]:
+        hits: list[RelationProjectionHit] = []
+        for hit in cls._hits(result):
+            source = hit.get("_source") or {}
+            if not isinstance(source, Mapping):
+                continue
+            if not source.get("relation_key_kwd"):
+                continue
+            hits.append(
+                RelationProjectionHit(
+                    relation_key=str(source["relation_key_kwd"]),
+                    from_entity_key=str(source["from_entity_key_kwd"]),
+                    to_entity_key=str(source["to_entity_key_kwd"]),
+                    label=cls._relation_label(source),
+                    score=float(hit.get("_score") or 0.0),
+                )
+            )
+        return hits
+
+    @staticmethod
+    def _relation_label(source: Mapping[str, Any]) -> str:
+        from_name = str(source.get("from_entity_name_kwd") or "")
+        predicate = str(source.get("predicate_kwd") or "")
+        to_name = str(source.get("to_entity_name_kwd") or "")
+        return " -> ".join(item for item in (from_name, predicate, to_name) if item)

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -142,6 +142,16 @@ class GraphElasticsearchStore:
             index=chunk_index_name,
             size=10000,
             query={"bool": {"filter": filters}},
+            source_includes=[
+                "page_content",
+                "metadata.knowledge_id",
+                "metadata.document_id",
+                "metadata.status",
+                "metadata.doc_id",
+                "metadata.sort_id",
+                "metadata.chunk_type",
+                "metadata.parent_id",
+            ],
             sort=[
                 {"metadata.sort_id": {"order": "asc", "unmapped_type": "long"}},
                 {"metadata.doc_id": {"order": "asc"}},

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,8 +1,9 @@
+import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-from elasticsearch import AsyncElasticsearch
+from elasticsearch import AsyncElasticsearch, NotFoundError
 
 from app.core.rag.knowledge_graph.models import (
     AffectedProjectionKeys,
@@ -506,6 +507,125 @@ class GraphElasticsearchStore:
                 }
             },
         )
+
+    async def load_projection_graph(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        *,
+        node_limit: int = 256,
+        edge_limit: int = 128,
+    ) -> dict[str, Any]:
+        empty_graph = {
+            "directed": True,
+            "multigraph": False,
+            "graph": {"source_id": []},
+            "nodes": [],
+            "edges": [],
+        }
+        try:
+            node_result, edge_result = await asyncio.gather(
+                self._client.search(
+                    index=index_name,
+                    size=max(1, node_limit),
+                    query=self._graph_query(
+                        knowledge_id,
+                        ENTITY_PROJECTION,
+                    ),
+                    sort=[
+                        {"degree_int": {"order": "desc", "unmapped_type": "long"}},
+                        {
+                            "evidence_count_int": {
+                                "order": "desc",
+                                "unmapped_type": "long",
+                            }
+                        },
+                        {"entity_key_kwd": {"order": "asc"}},
+                    ],
+                ),
+                self._client.search(
+                    index=index_name,
+                    size=max(1, edge_limit * 4),
+                    query=self._graph_query(
+                        knowledge_id,
+                        RELATION_PROJECTION,
+                    ),
+                    sort=[
+                        {
+                            "evidence_count_int": {
+                                "order": "desc",
+                                "unmapped_type": "long",
+                            }
+                        },
+                        {"relation_key_kwd": {"order": "asc"}},
+                    ],
+                ),
+            )
+        except NotFoundError:
+            return empty_graph
+
+        raise_on_shard_failures(node_result, "load graph entity projections")
+        raise_on_shard_failures(edge_result, "load graph relation projections")
+
+        nodes: list[dict[str, Any]] = []
+        for hit in self._hits(node_result):
+            source = hit.get("_source") or {}
+            entity_key = str(source.get("entity_key_kwd") or "")
+            if not entity_key:
+                continue
+            nodes.append(
+                {
+                    "id": entity_key,
+                    "entity_name": str(source.get("entity_name_kwd") or ""),
+                    "entity_type": str(source.get("entity_type_kwd") or ""),
+                    "description": str(source.get("description") or ""),
+                    "pagerank": 0.0,
+                    "source_id": [],
+                    "aliases": list(source.get("aliases_kwd") or ()),
+                    "evidence_count": int(source.get("evidence_count_int") or 0),
+                    "document_count": int(source.get("document_count_int") or 0),
+                    "degree": int(source.get("degree_int") or 0),
+                }
+            )
+            if len(nodes) >= node_limit:
+                break
+
+        node_ids = {node["id"] for node in nodes}
+        edges: list[dict[str, Any]] = []
+        for hit in self._hits(edge_result):
+            source = hit.get("_source") or {}
+            relation_key = str(source.get("relation_key_kwd") or "")
+            from_key = str(source.get("from_entity_key_kwd") or "")
+            to_key = str(source.get("to_entity_key_kwd") or "")
+            if (
+                not relation_key
+                or not from_key
+                or not to_key
+                or from_key == to_key
+                or from_key not in node_ids
+                or to_key not in node_ids
+            ):
+                continue
+            predicate = str(source.get("predicate_kwd") or "")
+            edges.append(
+                {
+                    "id": relation_key,
+                    "src_id": from_key,
+                    "tgt_id": to_key,
+                    "source": from_key,
+                    "target": to_key,
+                    "description": str(source.get("description") or ""),
+                    "keywords": [predicate] if predicate else [],
+                    "weight": int(source.get("evidence_count_int") or 1),
+                    "source_id": [],
+                    "directed": bool(source.get("directed_int")),
+                    "document_count": int(source.get("document_count_int") or 0),
+                }
+            )
+            if len(edges) >= edge_limit:
+                break
+
+        return {**empty_graph, "nodes": nodes, "edges": edges}
 
     async def search_entity_projections(
         self,

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -16,6 +16,7 @@ from app.core.rag.knowledge_graph.models import (
     ProjectionEvidenceGroup,
     RelationEvidence,
     RelationProjectionHit,
+    SourceChunkVectorHit,
 )
 from app.core.rag.knowledge_graph.normalizer import (
     document_map_id,
@@ -1011,7 +1012,7 @@ class GraphElasticsearchStore:
         *,
         allowed_document_ids: Sequence[str] | None,
         file_names: Sequence[str],
-    ) -> list[str]:
+    ) -> list[SourceChunkVectorHit]:
         source_ids = tuple(
             dict.fromkeys(
                 str(source_id)
@@ -1068,7 +1069,7 @@ class GraphElasticsearchStore:
         raise_on_shard_failures(result, "rank graph source chunks")
 
         allowed_sources = set(source_ids)
-        ranked: list[str] = []
+        ranked: list[SourceChunkVectorHit] = []
         seen: set[str] = set()
         for hit in self._hits(result):
             source = hit.get("_source") or {}
@@ -1083,7 +1084,14 @@ class GraphElasticsearchStore:
             ):
                 continue
             seen.add(source_id)
-            ranked.append(source_id)
+            ranked.append(
+                SourceChunkVectorHit(
+                    source_chunk_id=source_id,
+                    score=self._script_score_to_normalized_similarity(
+                        hit.get("_score")
+                    ),
+                )
+            )
         return ranked
 
     async def _projection_search(
@@ -1378,6 +1386,11 @@ class GraphElasticsearchStore:
         except (TypeError, ValueError):
             return -1.0
         return max(-1.0, min(1.0, score))
+
+    @classmethod
+    def _script_score_to_normalized_similarity(cls, raw_score: Any) -> float:
+        cosine_score = cls._script_score_to_cosine(raw_score)
+        return max(0.0, min(1.0, (cosine_score + 1.0) / 2.0))
 
     @staticmethod
     def _relation_label(source: Mapping[str, Any]) -> str:

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,9 +1,12 @@
 import asyncio
+import json
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
-from elasticsearch import AsyncElasticsearch, NotFoundError
+from elasticsearch import AsyncElasticsearch, BadRequestError, NotFoundError
 
 from app.core.rag.knowledge_graph.models import (
     AffectedProjectionKeys,
@@ -39,9 +42,38 @@ EVIDENCE_GRAPH_TYPES = (
 )
 
 
+@lru_cache(maxsize=1)
+def _graph_index_definition() -> dict[str, Any]:
+    mapping_path = (
+        Path(__file__).resolve().parents[1]
+        / "res"
+        / "mapping.json"
+    )
+    definition = json.loads(mapping_path.read_text(encoding="utf-8"))
+    if not isinstance(definition.get("settings"), Mapping) or not isinstance(
+        definition.get("mappings"), Mapping
+    ):
+        raise ValueError("invalid graph index mapping definition")
+    return definition
+
+
 class GraphElasticsearchStore:
     def __init__(self, client: AsyncElasticsearch) -> None:
         self._client = client
+
+    async def ensure_graph_index(self, index_name: str) -> None:
+        if await self._client.indices.exists(index=index_name):
+            return
+        definition = _graph_index_definition()
+        try:
+            await self._client.indices.create(
+                index=index_name,
+                settings=definition["settings"],
+                mappings=definition["mappings"],
+            )
+        except BadRequestError:
+            if not await self._client.indices.exists(index=index_name):
+                raise
 
     async def ensure_vector_mapping(
         self,
@@ -482,6 +514,7 @@ class GraphElasticsearchStore:
         await self._client.delete_by_query(
             index=index_name,
             conflicts="proceed",
+            ignore_unavailable=True,
             refresh=True,
             query=self._graph_query(knowledge_id, EVIDENCE_GRAPH_TYPES),
         )
@@ -497,6 +530,7 @@ class GraphElasticsearchStore:
         await self._client.delete_by_query(
             index=index_name,
             conflicts="proceed",
+            ignore_unavailable=True,
             refresh=True,
             query={
                 "bool": {
@@ -925,7 +959,7 @@ class GraphElasticsearchStore:
             "entity_keys_kwd": sorted(entity_keys),
             "relation_keys_kwd": sorted(relation_keys),
             "source_chunk_ids_kwd": sorted(source_chunk_ids),
-            "updated_at": utcnow_naive().isoformat(),
+            "updated_at": utcnow_naive().strftime("%Y-%m-%d %H:%M:%S"),
         }
         await self._bulk(
             self._index_operation(

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -14,6 +13,7 @@ from app.core.rag.knowledge_graph.models import (
     EntityProjectionHit,
     GraphEvidenceHit,
     GraphIndexRuntime,
+    ProjectionEvidenceGroup,
     RelationEvidence,
     RelationProjectionHit,
 )
@@ -23,6 +23,7 @@ from app.core.rag.knowledge_graph.normalizer import (
 )
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.elasticsearch_queries import raise_on_shard_failures
+from app.core.rag.vdb.field import Field
 from app.core.utils.datetime_utils import utcnow_naive
 
 
@@ -651,6 +652,11 @@ class GraphElasticsearchStore:
             ):
                 continue
             predicate = str(source.get("predicate_kwd") or "")
+            keywords = [
+                str(value)
+                for value in (source.get("keywords_kwd") or ())
+                if str(value).strip()
+            ]
             edges.append(
                 {
                     "id": relation_key,
@@ -659,7 +665,7 @@ class GraphElasticsearchStore:
                     "source": from_key,
                     "target": to_key,
                     "description": str(source.get("description") or ""),
-                    "keywords": [predicate] if predicate else [],
+                    "keywords": keywords or ([predicate] if predicate else []),
                     "weight": int(source.get("evidence_count_int") or 1),
                     "source_id": [],
                     "directed": bool(source.get("directed_int")),
@@ -676,38 +682,94 @@ class GraphElasticsearchStore:
         runtime: GraphIndexRuntime,
         query_vector: Sequence[float],
         top_n: int,
+        min_similarity: float = -1.0,
     ) -> list[EntityProjectionHit]:
         result = await self._projection_search(
             runtime,
             query_vector,
             top_n,
             ENTITY_PROJECTION,
+            min_similarity,
         )
-        return [
-            EntityProjectionHit(
-                entity_key=str(source["entity_key_kwd"]),
-                entity_name=str(source["entity_name_kwd"]),
-                score=float(hit.get("_score") or 0.0),
+        hits: list[EntityProjectionHit] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            if (
+                not isinstance(source, Mapping)
+                or not source.get("entity_key_kwd")
+                or not source.get("entity_name_kwd")
+            ):
+                continue
+            score = self._script_score_to_cosine(hit.get("_score"))
+            if score < min_similarity:
+                continue
+            hits.append(
+                EntityProjectionHit(
+                    entity_key=str(source["entity_key_kwd"]),
+                    entity_name=str(source["entity_name_kwd"]),
+                    score=score,
+                    degree=int(source.get("degree_int") or 0),
+                    evidence_count=int(source.get("evidence_count_int") or 0),
+                    document_count=int(source.get("document_count_int") or 0),
+                )
             )
-            for hit in self._hits(result)
-            if isinstance((source := hit.get("_source")), Mapping)
-            and source.get("entity_key_kwd")
-            and source.get("entity_name_kwd")
-        ]
+        return hits
 
     async def search_relation_projections(
         self,
         runtime: GraphIndexRuntime,
         query_vector: Sequence[float],
         top_n: int,
+        min_similarity: float = -1.0,
     ) -> list[RelationProjectionHit]:
         result = await self._projection_search(
             runtime,
             query_vector,
             top_n,
             RELATION_PROJECTION,
+            min_similarity,
         )
-        return self._relation_projection_hits(result)
+        return [
+            hit
+            for hit in self._relation_projection_hits(result, script_score=True)
+            if hit.score >= min_similarity
+        ]
+
+    async def load_entity_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        entity_keys: Sequence[str],
+    ) -> list[EntityProjectionHit]:
+        keys = tuple(dict.fromkeys(str(key) for key in entity_keys if str(key)))
+        if not keys:
+            return []
+        result = await self._client.search(
+            index=runtime.graph_index_name,
+            size=len(keys),
+            query=self._graph_query(
+                runtime.knowledge_id,
+                ENTITY_PROJECTION,
+                [{"terms": {"entity_key_kwd": list(keys)}}],
+            ),
+            sort=[{"entity_key_kwd": {"order": "asc"}}],
+        )
+        raise_on_shard_failures(result, "load graph entity projections")
+        projections: list[EntityProjectionHit] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            if not isinstance(source, Mapping) or not source.get("entity_key_kwd"):
+                continue
+            projections.append(
+                EntityProjectionHit(
+                    entity_key=str(source["entity_key_kwd"]),
+                    entity_name=str(source.get("entity_name_kwd") or ""),
+                    score=0.0,
+                    degree=int(source.get("degree_int") or 0),
+                    evidence_count=int(source.get("evidence_count_int") or 0),
+                    document_count=int(source.get("document_count_int") or 0),
+                )
+            )
+        return projections
 
     async def load_neighbor_relations(
         self,
@@ -719,7 +781,7 @@ class GraphElasticsearchStore:
             return []
         result = await self._client.search(
             index=runtime.graph_index_name,
-            size=top_n,
+            size=max(1, min(400, top_n * 4)),
             query=self._graph_query(
                 runtime.knowledge_id,
                 RELATION_PROJECTION,
@@ -735,82 +797,140 @@ class GraphElasticsearchStore:
                     }
                 ],
             ),
+            sort=[
+                {"relation_key_kwd": {"order": "asc"}},
+            ],
         )
         raise_on_shard_failures(result, "load graph neighbor relations")
-        return self._relation_projection_hits(result)
+        relations = self._relation_projection_hits(result)
+        endpoint_keys = tuple(
+            dict.fromkeys(
+                key
+                for relation in relations
+                for key in (relation.from_entity_key, relation.to_entity_key)
+                if key
+            )
+        )
+        endpoint_hits = await self.load_entity_projections(runtime, endpoint_keys)
+        degrees = {hit.entity_key: hit.degree for hit in endpoint_hits}
+        seed_positions = {
+            str(entity_key): index
+            for index, entity_key in enumerate(entity_keys)
+        }
+        missing_position = len(seed_positions)
+        decorated = [
+            relation.model_copy(
+                update={
+                    "endpoint_degree": (
+                        degrees.get(relation.from_entity_key, 0)
+                        + degrees.get(relation.to_entity_key, 0)
+                    )
+                }
+            )
+            for relation in relations
+        ]
+        decorated.sort(
+            key=lambda hit: (
+                -hit.endpoint_degree,
+                -hit.evidence_count,
+                min(
+                    seed_positions.get(
+                        hit.from_entity_key,
+                        missing_position,
+                    ),
+                    seed_positions.get(
+                        hit.to_entity_key,
+                        missing_position,
+                    ),
+                ),
+                hit.relation_key,
+            )
+        )
+        return decorated[:top_n]
 
-    async def load_evidence_for_projection_keys(
+    async def load_evidence_groups(
         self,
         runtime: GraphIndexRuntime,
         entity_keys: Sequence[str],
         relation_keys: Sequence[str],
-        evidence_per_key: int,
+        evidence_per_projection: int,
         allowed_document_ids: Sequence[str] | None = None,
-    ) -> list[GraphEvidenceHit]:
-        should: list[dict[str, Any]] = []
-        if entity_keys:
-            should.append({"terms": {"entity_key_kwd": list(entity_keys)}})
-        if relation_keys:
-            should.append({"terms": {"relation_key_kwd": list(relation_keys)}})
-        if not should:
+    ) -> list[ProjectionEvidenceGroup]:
+        if allowed_document_ids is not None and not allowed_document_ids:
+            return []
+        group_specs = [
+            ("entity", str(key), ENTITY_EVIDENCE, "entity_key_kwd")
+            for key in dict.fromkeys(entity_keys)
+            if str(key)
+        ] + [
+            ("relation", str(key), RELATION_EVIDENCE, "relation_key_kwd")
+            for key in dict.fromkeys(relation_keys)
+            if str(key)
+        ]
+        if not group_specs:
             return []
 
-        extra_filters: list[dict[str, Any]] = [
-            {"bool": {"should": should, "minimum_should_match": 1}}
-        ]
-        if allowed_document_ids is not None:
-            if not allowed_document_ids:
-                return []
-            extra_filters.append(
-                {"terms": {"document_id": list(allowed_document_ids)}}
+        searches: list[dict[str, Any]] = []
+        limit = max(1, int(evidence_per_projection))
+        for _, key, document_type, key_field in group_specs:
+            extra_filters: list[dict[str, Any]] = [{"term": {key_field: key}}]
+            if allowed_document_ids is not None:
+                extra_filters.append(
+                    {"terms": {"document_id": list(allowed_document_ids)}}
+                )
+            searches.extend(
+                [
+                    {"index": runtime.graph_index_name},
+                    {
+                        "size": limit,
+                        "query": self._graph_query(
+                            runtime.knowledge_id,
+                            document_type,
+                            extra_filters,
+                        ),
+                        "sort": [
+                            {
+                                "confidence_flt": {
+                                    "order": "desc",
+                                    "unmapped_type": "float",
+                                }
+                            },
+                            {"source_chunk_id_kwd": {"order": "asc"}},
+                        ],
+                    },
+                ]
             )
-        result = await self._client.search(
-            index=runtime.graph_index_name,
-            size=max(1, (len(entity_keys) + len(relation_keys)) * evidence_per_key * 4),
-            query=self._graph_query(
-                runtime.knowledge_id,
-                EVIDENCE_TYPES,
-                extra_filters,
-            ),
-        )
-        raise_on_shard_failures(result, "load graph projection evidence")
+        result = await self._client.msearch(searches=searches)
+        responses = result.get("responses") or []
+        if len(responses) != len(group_specs):
+            raise RuntimeError("graph evidence msearch response count mismatch")
 
-        counts: defaultdict[tuple[str, str], int] = defaultdict(int)
-        evidence_hits: list[GraphEvidenceHit] = []
-        for hit in self._hits(result):
-            source = hit.get("_source") or {}
-            document_type = source.get("knowledge_graph_kwd")
-            if document_type == ENTITY_EVIDENCE:
-                key = str(source.get("entity_key_kwd") or "")
-                group = (ENTITY_EVIDENCE, key)
-                entity_key = key
-                relation_key = None
-                entity_name = str(source.get("entity_name_kwd") or "") or None
-                relation_label = None
-            elif document_type == RELATION_EVIDENCE:
-                key = str(source.get("relation_key_kwd") or "")
-                group = (RELATION_EVIDENCE, key)
-                entity_key = None
-                relation_key = key
-                entity_name = None
-                relation_label = self._relation_label(source)
-            else:
-                continue
-            if not key or counts[group] >= evidence_per_key:
-                continue
-            counts[group] += 1
-            evidence_hits.append(
-                GraphEvidenceHit(
-                    source_chunk_id=str(source["source_chunk_id_kwd"]),
-                    document_id=str(source["document_id"]),
-                    score=float(source.get("confidence_flt") or 0.0),
-                    entity_key=entity_key,
-                    relation_key=relation_key,
-                    entity_name=entity_name,
-                    relation_label=relation_label,
+        groups: list[ProjectionEvidenceGroup] = []
+        for spec, response in zip(group_specs, responses, strict=True):
+            projection_type, projection_key, document_type, _ = spec
+            if response.get("error"):
+                raise RuntimeError("graph evidence msearch response failed")
+            raise_on_shard_failures(response, "load graph projection evidence group")
+            evidence = self._parse_group_evidence(
+                response,
+                document_type,
+                projection_key,
+            )
+            evidence.sort(
+                key=lambda hit: (
+                    -hit.score,
+                    hit.source_chunk_id,
+                    hit.evidence_id,
                 )
             )
-        return evidence_hits
+            groups.append(
+                ProjectionEvidenceGroup(
+                    projection_type=projection_type,
+                    projection_key=projection_key,
+                    evidence=tuple(evidence[:limit]),
+                )
+            )
+        return groups
 
     async def hydrate_source_chunks(
         self,
@@ -882,17 +1002,103 @@ class GraphElasticsearchStore:
             )
         return chunks
 
+    async def rank_source_chunks(
+        self,
+        runtime: GraphIndexRuntime,
+        source_chunk_ids: Sequence[str],
+        query_vector: Sequence[float],
+        limit: int,
+        *,
+        allowed_document_ids: Sequence[str] | None,
+        file_names: Sequence[str],
+    ) -> list[str]:
+        source_ids = tuple(
+            dict.fromkeys(
+                str(source_id)
+                for source_id in source_chunk_ids
+                if str(source_id)
+            )
+        )
+        maximum = min(max(0, int(limit)), len(source_ids))
+        if not source_ids or not query_vector or maximum <= 0:
+            return []
+        if allowed_document_ids is not None and not allowed_document_ids:
+            return []
+
+        vector_field = Field.VECTOR.value
+        filters: list[dict[str, Any]] = [
+            {"terms": {"metadata.doc_id": list(source_ids)}},
+            {"term": {"metadata.knowledge_id": runtime.knowledge_id}},
+            {"term": {"metadata.status": 1}},
+            {"exists": {"field": vector_field}},
+        ]
+        if allowed_document_ids is not None:
+            filters.append(
+                {
+                    "terms": {
+                        "metadata.document_id": list(allowed_document_ids)
+                    }
+                }
+            )
+        if file_names:
+            filters.append(
+                {"terms": {"metadata.file_name": list(file_names)}}
+            )
+
+        result = await self._client.search(
+            index=runtime.chunk_index_name,
+            size=maximum,
+            query={
+                "script_score": {
+                    "query": {"bool": {"filter": filters}},
+                    "script": {
+                        "source": (
+                            "cosineSimilarity(params.query_vector, "
+                            f"'{vector_field}') + 1.0"
+                        ),
+                        "params": {"query_vector": list(query_vector)},
+                    },
+                }
+            },
+            sort=[
+                {"_score": {"order": "desc"}},
+                {"metadata.doc_id": {"order": "asc"}},
+            ],
+        )
+        raise_on_shard_failures(result, "rank graph source chunks")
+
+        allowed_sources = set(source_ids)
+        ranked: list[str] = []
+        seen: set[str] = set()
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            metadata = source.get("metadata") or {}
+            if not isinstance(metadata, Mapping):
+                continue
+            source_id = str(metadata.get("doc_id") or "")
+            if (
+                not source_id
+                or source_id not in allowed_sources
+                or source_id in seen
+            ):
+                continue
+            seen.add(source_id)
+            ranked.append(source_id)
+        return ranked
+
     async def _projection_search(
         self,
         runtime: GraphIndexRuntime,
         query_vector: Sequence[float],
         top_n: int,
         projection_type: str,
+        min_similarity: float,
     ) -> Mapping[str, Any]:
         vector_field = f"q_{len(query_vector)}_vec"
         result = await self._client.search(
             index=runtime.graph_index_name,
             size=top_n,
+            min_score=float(min_similarity) + 1.0,
             query={
                 "script_score": {
                     "query": self._graph_query(
@@ -911,6 +1117,55 @@ class GraphElasticsearchStore:
         )
         raise_on_shard_failures(result, f"search {projection_type}")
         return result
+
+    def _parse_group_evidence(
+        self,
+        result: Mapping[str, Any],
+        document_type: str,
+        projection_key: str,
+    ) -> list[GraphEvidenceHit]:
+        evidence_hits: list[GraphEvidenceHit] = []
+        for hit in self._hits(result):
+            source = hit.get("_source") or {}
+            if not isinstance(source, Mapping):
+                continue
+            if source.get("knowledge_graph_kwd") != document_type:
+                continue
+            source_chunk_id = str(source.get("source_chunk_id_kwd") or "")
+            document_id = str(source.get("document_id") or "")
+            if not source_chunk_id or not document_id:
+                continue
+            if document_type == ENTITY_EVIDENCE:
+                entity_key = str(source.get("entity_key_kwd") or "")
+                if entity_key != projection_key:
+                    continue
+                evidence_hits.append(
+                    GraphEvidenceHit(
+                        evidence_id=str(hit.get("_id") or ""),
+                        source_chunk_id=source_chunk_id,
+                        document_id=document_id,
+                        score=float(source.get("confidence_flt") or 0.0),
+                        entity_key=entity_key,
+                        entity_name=(
+                            str(source.get("entity_name_kwd") or "") or None
+                        ),
+                    )
+                )
+            elif document_type == RELATION_EVIDENCE:
+                relation_key = str(source.get("relation_key_kwd") or "")
+                if relation_key != projection_key:
+                    continue
+                evidence_hits.append(
+                    GraphEvidenceHit(
+                        evidence_id=str(hit.get("_id") or ""),
+                        source_chunk_id=source_chunk_id,
+                        document_id=document_id,
+                        score=float(source.get("confidence_flt") or 0.0),
+                        relation_key=relation_key,
+                        relation_label=self._relation_label(source),
+                    )
+                )
+        return evidence_hits
 
     async def _load_relation_evidence_with_filters(
         self,
@@ -945,6 +1200,11 @@ class GraphElasticsearchStore:
                     to_entity_name=str(source["to_entity_name_kwd"]),
                     predicate=str(source["predicate_kwd"]),
                     description=str(source.get("description") or ""),
+                    keywords=tuple(
+                        str(value)
+                        for value in (source.get("keywords_kwd") or ())
+                        if str(value).strip()
+                    ),
                     directed=bool(source.get("directed_int")),
                     confidence=float(source.get("confidence_flt") or 0.0),
                 )
@@ -1045,6 +1305,7 @@ class GraphElasticsearchStore:
             "to_entity_key_kwd": evidence.to_entity_key,
             "to_entity_name_kwd": evidence.to_entity_name,
             "predicate_kwd": evidence.predicate,
+            "keywords_kwd": list(evidence.keywords),
             "directed_int": int(evidence.directed),
             "description": evidence.description,
             "evidence_text": evidence.description[:300],
@@ -1083,6 +1344,8 @@ class GraphElasticsearchStore:
     def _relation_projection_hits(
         cls,
         result: Mapping[str, Any],
+        *,
+        script_score: bool = False,
     ) -> list[RelationProjectionHit]:
         hits: list[RelationProjectionHit] = []
         for hit in cls._hits(result):
@@ -1097,10 +1360,24 @@ class GraphElasticsearchStore:
                     from_entity_key=str(source["from_entity_key_kwd"]),
                     to_entity_key=str(source["to_entity_key_kwd"]),
                     label=cls._relation_label(source),
-                    score=float(hit.get("_score") or 0.0),
+                    score=(
+                        cls._script_score_to_cosine(hit.get("_score"))
+                        if script_score
+                        else float(hit.get("_score") or 0.0)
+                    ),
+                    evidence_count=int(source.get("evidence_count_int") or 0),
+                    document_count=int(source.get("document_count_int") or 0),
                 )
             )
         return hits
+
+    @staticmethod
+    def _script_score_to_cosine(raw_score: Any) -> float:
+        try:
+            score = float(raw_score) - 1.0
+        except (TypeError, ValueError):
+            return -1.0
+        return max(-1.0, min(1.0, score))
 
     @staticmethod
     def _relation_label(source: Mapping[str, Any]) -> str:

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -708,6 +708,13 @@ class GraphElasticsearchStore:
                 EntityProjectionHit(
                     entity_key=str(source["entity_key_kwd"]),
                     entity_name=str(source["entity_name_kwd"]),
+                    entity_type=str(source.get("entity_type_kwd") or ""),
+                    description=str(source.get("description") or ""),
+                    aliases=tuple(
+                        str(value)
+                        for value in (source.get("aliases_kwd") or ())
+                        if str(value).strip()
+                    ),
                     score=score,
                     degree=int(source.get("degree_int") or 0),
                     evidence_count=int(source.get("evidence_count_int") or 0),
@@ -764,6 +771,13 @@ class GraphElasticsearchStore:
                 EntityProjectionHit(
                     entity_key=str(source["entity_key_kwd"]),
                     entity_name=str(source.get("entity_name_kwd") or ""),
+                    entity_type=str(source.get("entity_type_kwd") or ""),
+                    description=str(source.get("description") or ""),
+                    aliases=tuple(
+                        str(value)
+                        for value in (source.get("aliases_kwd") or ())
+                        if str(value).strip()
+                    ),
                     score=0.0,
                     degree=int(source.get("degree_int") or 0),
                     evidence_count=int(source.get("evidence_count_int") or 0),
@@ -1362,12 +1376,23 @@ class GraphElasticsearchStore:
                 continue
             if not source.get("relation_key_kwd"):
                 continue
+            directed = source.get("directed_int")
             hits.append(
                 RelationProjectionHit(
                     relation_key=str(source["relation_key_kwd"]),
                     from_entity_key=str(source["from_entity_key_kwd"]),
+                    from_entity_name=str(source.get("from_entity_name_kwd") or ""),
                     to_entity_key=str(source["to_entity_key_kwd"]),
+                    to_entity_name=str(source.get("to_entity_name_kwd") or ""),
+                    predicate=str(source.get("predicate_kwd") or ""),
                     label=cls._relation_label(source),
+                    description=str(source.get("description") or ""),
+                    keywords=tuple(
+                        str(value)
+                        for value in (source.get("keywords_kwd") or ())
+                        if str(value).strip()
+                    ),
+                    directed=True if directed is None else bool(directed),
                     score=(
                         cls._script_score_to_cosine(hit.get("_score"))
                         if script_score

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1126,6 +1126,7 @@ class GraphElasticsearchStore:
                     "query": self._graph_query(
                         runtime.knowledge_id,
                         projection_type,
+                        [{"exists": {"field": vector_field}}],
                     ),
                     "script": {
                         "source": (

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -619,11 +619,15 @@ class GraphElasticsearchStore:
             if document_type == ENTITY_EVIDENCE:
                 key = str(source.get("entity_key_kwd") or "")
                 group = (ENTITY_EVIDENCE, key)
+                entity_key = key
+                relation_key = None
                 entity_name = str(source.get("entity_name_kwd") or "") or None
                 relation_label = None
             elif document_type == RELATION_EVIDENCE:
                 key = str(source.get("relation_key_kwd") or "")
                 group = (RELATION_EVIDENCE, key)
+                entity_key = None
+                relation_key = key
                 entity_name = None
                 relation_label = self._relation_label(source)
             else:
@@ -635,7 +639,9 @@ class GraphElasticsearchStore:
                 GraphEvidenceHit(
                     source_chunk_id=str(source["source_chunk_id_kwd"]),
                     document_id=str(source["document_id"]),
-                    score=float(hit.get("_score") or 0.0),
+                    score=float(source.get("confidence_flt") or 0.0),
+                    entity_key=entity_key,
+                    relation_key=relation_key,
                     entity_name=entity_name,
                     relation_label=relation_label,
                 )

--- a/api/app/core/rag/knowledge_graph/extraction_cache.py
+++ b/api/app/core/rag/knowledge_graph/extraction_cache.py
@@ -1,0 +1,96 @@
+import hashlib
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from app.aioRedis import get_thread_safe_redis
+from app.core.rag.knowledge_graph.models import (
+    ExtractionBatch,
+    ExtractionResult,
+    GraphIndexRuntime,
+)
+from app.core.rag.knowledge_graph.prompts import EXTRACTION_PROMPT_VERSION
+
+
+logger = logging.getLogger(__name__)
+
+_CACHE_SCHEMA_VERSION = "1"
+
+
+class GraphExtractionCache:
+    def __init__(
+        self,
+        redis_factory: Callable[[], Any] = get_thread_safe_redis,
+        *,
+        ttl_seconds: int,
+    ) -> None:
+        self._redis_factory = redis_factory
+        self._ttl_seconds = max(1, int(ttl_seconds))
+
+    @staticmethod
+    def build_key(
+        runtime: GraphIndexRuntime,
+        batch: ExtractionBatch,
+    ) -> str:
+        normalized_text = str(batch.text)
+        payload = {
+            "workspace_id": runtime.workspace_id,
+            "provider": runtime.llm.provider,
+            "model_name": runtime.llm.model_name,
+            "api_base": runtime.llm.api_base or "",
+            "prompt_version": EXTRACTION_PROMPT_VERSION,
+            "schema_version": _CACHE_SCHEMA_VERSION,
+            "scene_name": " ".join(runtime.scene_name.split()),
+            "entity_types": list(runtime.entity_types),
+            "content_hash": hashlib.sha256(
+                normalized_text.encode("utf-8")
+            ).hexdigest(),
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        return f"evidence_graph:extraction:{_CACHE_SCHEMA_VERSION}:{digest}"
+
+    async def get(self, key: str) -> ExtractionResult | None:
+        try:
+            raw_value = await self._redis_factory().get(key)
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] extraction_cache status=error"
+                " operation=get error_type=%s",
+                type(exc).__name__,
+            )
+            return None
+        if raw_value is None:
+            return None
+        try:
+            return ExtractionResult.model_validate_json(raw_value)
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] extraction_cache status=error"
+                " operation=decode error_type=%s",
+                type(exc).__name__,
+            )
+            return None
+
+    async def set(self, key: str, result: ExtractionResult) -> bool:
+        try:
+            await self._redis_factory().set(
+                key,
+                result.model_dump_json(),
+                ex=self._ttl_seconds,
+            )
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] extraction_cache status=error"
+                " operation=set error_type=%s",
+                type(exc).__name__,
+            )
+            return False
+        return True

--- a/api/app/core/rag/knowledge_graph/extraction_cache.py
+++ b/api/app/core/rag/knowledge_graph/extraction_cache.py
@@ -16,6 +16,7 @@ from app.core.rag.knowledge_graph.prompts import EXTRACTION_PROMPT_VERSION
 logger = logging.getLogger(__name__)
 
 _CACHE_SCHEMA_VERSION = "1"
+_DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
 class GraphExtractionCache:
@@ -23,7 +24,7 @@ class GraphExtractionCache:
         self,
         redis_factory: Callable[[], Any] = get_thread_safe_redis,
         *,
-        ttl_seconds: int,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
     ) -> None:
         self._redis_factory = redis_factory
         self._ttl_seconds = max(1, int(ttl_seconds))

--- a/api/app/core/rag/knowledge_graph/extractor.py
+++ b/api/app/core/rag/knowledge_graph/extractor.py
@@ -1,10 +1,14 @@
 import asyncio
+import unicodedata
 from typing import Any, Protocol
 
 from app.core.rag.knowledge_graph.models import ExtractionBatch, ExtractionResult
 from app.core.rag.knowledge_graph.prompts import (
     EXTRACTION_SYSTEM_PROMPT,
     build_extraction_prompt,
+)
+from app.core.rag.knowledge_graph.structured_output import (
+    unwrap_structured_result,
 )
 
 
@@ -43,6 +47,11 @@ class LLMEntityRelationExtractor:
                         },
                     ],
                     ExtractionResult,
+                    include_raw=True,
+                )
+                raw_result = unwrap_structured_result(
+                    raw_result,
+                    ExtractionResult,
                 )
                 result = self._validate_result(raw_result, batch)
                 return result
@@ -63,25 +72,74 @@ class LLMEntityRelationExtractor:
         else:
             result = ExtractionResult.model_validate(raw_result)
 
-        allowed_sources = set(batch.source_chunk_ids)
+        if len(batch.source_chunk_ids) != 1:
+            raise ValueError("extraction batch must contain exactly one source chunk")
+        current_source_id = batch.source_chunk_ids[0]
         refs = [entity.ref for entity in result.entities]
         if len(refs) != len(set(refs)):
             raise ValueError("entity refs must be unique within a batch")
         known_refs = set(refs)
+        entities_by_ref = {
+            entity.ref: entity
+            for entity in result.entities
+        }
 
         for entity in result.entities:
-            entity_sources = set(entity.source_chunk_ids)
-            if not entity_sources or not entity_sources <= allowed_sources:
-                raise ValueError("unknown source chunk in entity")
+            entity.source_chunk_ids = [current_source_id]
 
+        valid_relations = []
         for relation in result.relations:
             if (
                 relation.from_ref not in known_refs
                 or relation.to_ref not in known_refs
             ):
-                raise ValueError("relation endpoint is not present in entities")
-            relation_sources = set(relation.source_chunk_ids)
-            if not relation_sources or not relation_sources <= allowed_sources:
-                raise ValueError("unknown source chunk in relation")
+                continue
+            relation.source_chunk_ids = [current_source_id]
+            from_entity = entities_by_ref[relation.from_ref]
+            to_entity = entities_by_ref[relation.to_ref]
+            relation.predicate = LLMEntityRelationExtractor._clean_text(
+                relation.predicate
+            )
+            relation.description = LLMEntityRelationExtractor._clean_text(
+                relation.description
+            )
+            if (
+                relation.from_ref == relation.to_ref
+                or LLMEntityRelationExtractor._identity_text(
+                    from_entity.name
+                )
+                == LLMEntityRelationExtractor._identity_text(to_entity.name)
+                or not relation.predicate
+                or not relation.description
+            ):
+                continue
+            relation.keywords = LLMEntityRelationExtractor._clean_keywords(
+                relation.keywords
+            )
+            valid_relations.append(relation)
+
+        result.relations = valid_relations
 
         return result
+
+    @staticmethod
+    def _clean_text(value: str) -> str:
+        return " ".join(
+            unicodedata.normalize("NFKC", str(value)).split()
+        ).strip()
+
+    @staticmethod
+    def _identity_text(value: str) -> str:
+        return "".join(
+            LLMEntityRelationExtractor._clean_text(value).casefold().split()
+        )
+
+    @staticmethod
+    def _clean_keywords(values: list[str]) -> list[str]:
+        return [
+            keyword
+            for value in values
+            if (
+                keyword := LLMEntityRelationExtractor._clean_text(value)
+            )
+        ]

--- a/api/app/core/rag/knowledge_graph/extractor.py
+++ b/api/app/core/rag/knowledge_graph/extractor.py
@@ -1,0 +1,87 @@
+import asyncio
+from typing import Any, Protocol
+
+from app.core.rag.knowledge_graph.models import ExtractionBatch, ExtractionResult
+from app.core.rag.knowledge_graph.prompts import (
+    EXTRACTION_SYSTEM_PROMPT,
+    build_extraction_prompt,
+)
+
+
+class EntityRelationExtractor(Protocol):
+    async def extract(self, batch: ExtractionBatch) -> ExtractionResult:
+        ...
+
+
+class LLMEntityRelationExtractor:
+    def __init__(
+        self,
+        llm: Any,
+        entity_types: tuple[str, ...],
+        scene_name: str,
+    ) -> None:
+        self._llm = llm
+        self._entity_types = entity_types
+        self._scene_name = scene_name
+
+    async def extract(self, batch: ExtractionBatch) -> ExtractionResult:
+        for attempt in range(2):
+            try:
+                raw_result = await self._llm.call_structured(
+                    [
+                        {
+                            "role": "system",
+                            "content": EXTRACTION_SYSTEM_PROMPT,
+                        },
+                        {
+                            "role": "user",
+                            "content": build_extraction_prompt(
+                                batch.text,
+                                self._entity_types,
+                                self._scene_name,
+                            ),
+                        },
+                    ],
+                    ExtractionResult,
+                )
+                result = self._validate_result(raw_result, batch)
+                return result
+            except Exception:
+                if attempt == 1:
+                    raise
+                await asyncio.sleep(0.25)
+
+        raise RuntimeError("unreachable extraction retry state")
+
+    @staticmethod
+    def _validate_result(
+        raw_result: Any,
+        batch: ExtractionBatch,
+    ) -> ExtractionResult:
+        if isinstance(raw_result, ExtractionResult):
+            result = ExtractionResult.model_validate(raw_result.model_dump())
+        else:
+            result = ExtractionResult.model_validate(raw_result)
+
+        allowed_sources = set(batch.source_chunk_ids)
+        refs = [entity.ref for entity in result.entities]
+        if len(refs) != len(set(refs)):
+            raise ValueError("entity refs must be unique within a batch")
+        known_refs = set(refs)
+
+        for entity in result.entities:
+            entity_sources = set(entity.source_chunk_ids)
+            if not entity_sources or not entity_sources <= allowed_sources:
+                raise ValueError("unknown source chunk in entity")
+
+        for relation in result.relations:
+            if (
+                relation.from_ref not in known_refs
+                or relation.to_ref not in known_refs
+            ):
+                raise ValueError("relation endpoint is not present in entities")
+            relation_sources = set(relation.source_chunk_ids)
+            if not relation_sources or not relation_sources <= allowed_sources:
+                raise ValueError("unknown source chunk in relation")
+
+        return result

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -211,9 +211,7 @@ class KnowledgeGraphIndexPipeline:
         self._extractor = extractor
         self._embedding = embedding
         self._lock_guard = lock_guard
-        self._extraction_cache = extraction_cache or GraphExtractionCache(
-            ttl_seconds=settings.KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS
-        )
+        self._extraction_cache = extraction_cache or GraphExtractionCache()
 
     async def sync_document(
         self,

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -1,0 +1,479 @@
+import asyncio
+import logging
+import unicodedata
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from typing import Any
+
+from app.core.config import settings
+from app.core.rag.knowledge_graph.batching import (
+    build_extraction_batches,
+    select_source_chunks,
+)
+from app.core.rag.knowledge_graph.models import (
+    EntityEvidence,
+    ExtractionBatch,
+    ExtractionResult,
+    GraphIndexRuntime,
+    RelationEvidence,
+)
+from app.core.rag.knowledge_graph.normalizer import (
+    entity_evidence_id,
+    entity_key,
+    normalize_name,
+    relation_evidence_id,
+    relation_key,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_display(value: str) -> str:
+    return " ".join(unicodedata.normalize("NFKC", str(value)).split()).strip()
+
+
+def _prefer_evidence(current: Any | None, candidate: Any) -> Any:
+    if current is None or candidate.confidence > current.confidence:
+        return candidate
+    return current
+
+
+def materialize_evidence(
+    knowledge_id: str,
+    document_id: str,
+    results: Sequence[ExtractionResult],
+) -> tuple[list[EntityEvidence], list[RelationEvidence]]:
+    entity_items: dict[str, EntityEvidence] = {}
+    relation_items: dict[str, RelationEvidence] = {}
+
+    for result in results:
+        entities_by_ref: dict[str, tuple[str, str, str]] = {}
+        for entity in result.entities:
+            display_name = _clean_display(entity.name)
+            display_type = _clean_display(entity.entity_type)
+            if not display_name or not display_type:
+                logger.warning(
+                    "Skipping graph entity with empty normalized fields",
+                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                )
+                continue
+            normalized_key = entity_key(
+                knowledge_id,
+                display_name,
+                display_type,
+            )
+            entities_by_ref[entity.ref] = (
+                normalized_key,
+                display_name,
+                display_type,
+            )
+            aliases = tuple(
+                dict.fromkeys(
+                    alias
+                    for raw_alias in entity.aliases
+                    if (alias := _clean_display(raw_alias))
+                )
+            )
+            description = _clean_display(entity.description)[:300]
+            for source_chunk_id in dict.fromkeys(entity.source_chunk_ids):
+                source_id = str(source_chunk_id).strip()
+                if not source_id:
+                    continue
+                evidence = EntityEvidence(
+                    id=entity_evidence_id(
+                        knowledge_id,
+                        document_id,
+                        source_id,
+                        normalized_key,
+                    ),
+                    kb_id=knowledge_id,
+                    document_id=document_id,
+                    source_chunk_id=source_id,
+                    entity_key=normalized_key,
+                    entity_name=display_name,
+                    entity_type=display_type,
+                    description=description,
+                    aliases=aliases,
+                    confidence=entity.confidence,
+                )
+                entity_items[evidence.id] = _prefer_evidence(
+                    entity_items.get(evidence.id),
+                    evidence,
+                )
+
+        for relation in result.relations:
+            from_entity = entities_by_ref.get(relation.from_ref)
+            to_entity = entities_by_ref.get(relation.to_ref)
+            if from_entity is None or to_entity is None:
+                logger.warning(
+                    "Skipping graph relation with unresolved endpoint",
+                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                )
+                continue
+            predicate = _clean_display(relation.predicate)
+            if not predicate:
+                logger.warning(
+                    "Skipping graph relation with empty predicate",
+                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                )
+                continue
+            normalized_relation_key = relation_key(
+                knowledge_id,
+                from_entity[0],
+                predicate,
+                to_entity[0],
+                relation.directed,
+            )
+            description = _clean_display(relation.description)[:300]
+            for source_chunk_id in dict.fromkeys(relation.source_chunk_ids):
+                source_id = str(source_chunk_id).strip()
+                if not source_id:
+                    continue
+                evidence = RelationEvidence(
+                    id=relation_evidence_id(
+                        knowledge_id,
+                        document_id,
+                        source_id,
+                        normalized_relation_key,
+                    ),
+                    kb_id=knowledge_id,
+                    document_id=document_id,
+                    source_chunk_id=source_id,
+                    relation_key=normalized_relation_key,
+                    from_entity_key=from_entity[0],
+                    from_entity_name=from_entity[1],
+                    to_entity_key=to_entity[0],
+                    to_entity_name=to_entity[1],
+                    predicate=predicate,
+                    description=description,
+                    directed=relation.directed,
+                    confidence=relation.confidence,
+                )
+                relation_items[evidence.id] = _prefer_evidence(
+                    relation_items.get(evidence.id),
+                    evidence,
+                )
+
+    return (
+        sorted(entity_items.values(), key=lambda item: item.id),
+        sorted(relation_items.values(), key=lambda item: item.id),
+    )
+
+
+class KnowledgeGraphIndexPipeline:
+    def __init__(
+        self,
+        store: Any,
+        extractor: Any,
+        embedding: Any,
+        lock_guard: Any,
+    ) -> None:
+        self._store = store
+        self._extractor = extractor
+        self._embedding = embedding
+        self._lock_guard = lock_guard
+
+    async def sync_document(
+        self,
+        runtime: GraphIndexRuntime,
+        document_id: str,
+        document_active: bool,
+    ) -> None:
+        self._lock_guard.ensure_valid()
+        await self._store.refresh_sources(
+            runtime.chunk_index_name,
+            runtime.graph_index_name,
+        )
+        hits = (
+            await self._store.load_document_chunks(
+                runtime.chunk_index_name,
+                runtime.knowledge_id,
+                document_id,
+            )
+            if document_active
+            else []
+        )
+        chunks = select_source_chunks(hits)
+        batches = build_extraction_batches(
+            chunks,
+            settings.KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS,
+        )
+        results = await self._extract_batches(batches)
+        entity_evidence, relation_evidence = materialize_evidence(
+            runtime.knowledge_id,
+            document_id,
+            results,
+        )
+
+        self._lock_guard.ensure_valid()
+        affected = await self._store.replace_document_evidence(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            document_id,
+            entity_evidence,
+            relation_evidence,
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+        self._lock_guard.ensure_valid()
+        await self._rebuild_relation_projections(
+            runtime,
+            affected.relation_keys,
+        )
+        self._lock_guard.ensure_valid()
+        await self._rebuild_entity_projections(
+            runtime,
+            affected.entity_keys,
+        )
+        self._lock_guard.ensure_valid()
+        await self._store.finish_document_map(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            document_id,
+            entity_evidence,
+            relation_evidence,
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+        self._lock_guard.ensure_valid()
+        await self._store.refresh_graph(runtime.graph_index_name)
+
+    async def rebuild_knowledge(
+        self,
+        runtime: GraphIndexRuntime,
+        active_document_ids: tuple[str, ...],
+    ) -> None:
+        active_ids = tuple(dict.fromkeys(active_document_ids))
+        for document_id in active_ids:
+            await self.sync_document(runtime, document_id, True)
+
+        self._lock_guard.ensure_valid()
+        maps = await self._store.list_document_maps(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+        )
+        active_set = set(active_ids)
+        stale_ids = sorted(
+            {
+                str(item.get("document_id"))
+                for item in maps
+                if item.get("document_id") is not None
+                and str(item.get("document_id")) not in active_set
+            }
+        )
+        for document_id in stale_ids:
+            await self.sync_document(runtime, document_id, False)
+
+        self._lock_guard.ensure_valid()
+        await self._store.refresh_graph(runtime.graph_index_name)
+
+    async def clear_knowledge(self, runtime: GraphIndexRuntime) -> None:
+        self._lock_guard.ensure_valid()
+        await self._store.clear_evidence_graph(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+
+    async def _extract_batches(
+        self,
+        batches: Sequence[ExtractionBatch],
+    ) -> list[ExtractionResult]:
+        if not batches:
+            return []
+        semaphore = asyncio.Semaphore(
+            settings.KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY
+        )
+
+        async def extract_one(batch: ExtractionBatch) -> ExtractionResult:
+            async with semaphore:
+                return await self._extractor.extract(batch)
+
+        tasks = [asyncio.create_task(extract_one(batch)) for batch in batches]
+        try:
+            return list(await asyncio.gather(*tasks))
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
+    async def _rebuild_relation_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        relation_keys: Sequence[str],
+    ) -> None:
+        affected_keys = tuple(sorted(set(relation_keys)))
+        if not affected_keys:
+            return
+        evidence = await self._store.load_relation_evidence(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            affected_keys,
+        )
+        grouped: defaultdict[str, list[RelationEvidence]] = defaultdict(list)
+        for item in evidence:
+            grouped[item.relation_key].append(item)
+
+        projections: list[dict[str, Any]] = []
+        texts: list[str] = []
+        delete_keys: list[str] = []
+        for key in affected_keys:
+            items = sorted(grouped.get(key, ()), key=lambda item: item.id)
+            if not items:
+                delete_keys.append(key)
+                continue
+            from_name = self._most_common(item.from_entity_name for item in items)
+            to_name = self._most_common(item.to_entity_name for item in items)
+            predicate = self._most_common(item.predicate for item in items)
+            description = self._aggregate_descriptions(items)
+            projection = {
+                "relation_key_kwd": key,
+                "from_entity_key_kwd": items[0].from_entity_key,
+                "from_entity_name_kwd": from_name,
+                "to_entity_key_kwd": items[0].to_entity_key,
+                "to_entity_name_kwd": to_name,
+                "predicate_kwd": predicate,
+                "directed_int": int(items[0].directed),
+                "description": description,
+                "evidence_count_int": len(items),
+                "document_count_int": len({item.document_id for item in items}),
+            }
+            projections.append(projection)
+            texts.append(
+                f"{from_name} -> {predicate} -> {to_name}\n{description}".strip()
+            )
+
+        await self._embed_projections(runtime, projections, texts)
+        self._lock_guard.ensure_valid()
+        await self._store.write_relation_projections(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            projections,
+            tuple(delete_keys),
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+
+    async def _rebuild_entity_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        entity_keys: Sequence[str],
+    ) -> None:
+        affected_keys = tuple(sorted(set(entity_keys)))
+        if not affected_keys:
+            return
+        entity_evidence, relation_evidence = await asyncio.gather(
+            self._store.load_entity_evidence(
+                runtime.graph_index_name,
+                runtime.knowledge_id,
+                affected_keys,
+            ),
+            self._store.load_relations_for_entity_keys(
+                runtime.graph_index_name,
+                runtime.knowledge_id,
+                affected_keys,
+            ),
+        )
+        grouped: defaultdict[str, list[EntityEvidence]] = defaultdict(list)
+        for item in entity_evidence:
+            grouped[item.entity_key].append(item)
+        degrees = self._entity_degrees(relation_evidence)
+
+        projections: list[dict[str, Any]] = []
+        texts: list[str] = []
+        delete_keys: list[str] = []
+        for key in affected_keys:
+            items = sorted(grouped.get(key, ()), key=lambda item: item.id)
+            if not items:
+                delete_keys.append(key)
+                continue
+            name = self._most_common(item.entity_name for item in items)
+            entity_type = self._most_common(item.entity_type for item in items)
+            aliases = sorted(
+                {
+                    alias
+                    for item in items
+                    for alias in item.aliases
+                    if normalize_name(alias) != normalize_name(name)
+                },
+                key=normalize_name,
+            )
+            description = self._aggregate_descriptions(items)
+            projection = {
+                "entity_key_kwd": key,
+                "entity_name_kwd": name,
+                "entity_type_kwd": entity_type,
+                "aliases_kwd": aliases,
+                "description": description,
+                "evidence_count_int": len(items),
+                "document_count_int": len({item.document_id for item in items}),
+                "degree_int": degrees.get(key, 0),
+            }
+            projections.append(projection)
+            texts.append(f"{name}\n{entity_type}\n{description}".strip())
+
+        await self._embed_projections(runtime, projections, texts)
+        self._lock_guard.ensure_valid()
+        await self._store.write_entity_projections(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            projections,
+            tuple(delete_keys),
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+
+    async def _embed_projections(
+        self,
+        runtime: GraphIndexRuntime,
+        projections: list[dict[str, Any]],
+        texts: list[str],
+    ) -> None:
+        if not projections:
+            return
+        vectors = await self._embedding.aembed_documents(texts)
+        if len(vectors) != len(projections):
+            raise ValueError("embedding count does not match graph projections")
+        dimensions = {len(vector) for vector in vectors}
+        if 0 in dimensions or len(dimensions) != 1:
+            raise ValueError("graph projection embeddings have invalid dimensions")
+        dimension = dimensions.pop()
+        self._lock_guard.ensure_valid()
+        vector_field = await self._store.ensure_vector_mapping(
+            runtime.graph_index_name,
+            dimension,
+        )
+        for projection, vector in zip(projections, vectors, strict=True):
+            projection[vector_field] = list(vector)
+
+    @staticmethod
+    def _aggregate_descriptions(items: Sequence[Any]) -> str:
+        descriptions: list[str] = []
+        for item in sorted(items, key=lambda value: (-value.confidence, value.id)):
+            description = _clean_display(item.description)
+            if description and description not in descriptions:
+                descriptions.append(description)
+            if len(descriptions) == 5:
+                break
+        return " | ".join(descriptions)
+
+    @staticmethod
+    def _most_common(values: Sequence[str] | Any) -> str:
+        ordered = [str(value) for value in values]
+        counts = Counter(ordered)
+        return max(
+            ordered,
+            key=lambda value: (counts[value], -ordered.index(value)),
+        )
+
+    @staticmethod
+    def _entity_degrees(
+        evidence: Sequence[RelationEvidence],
+    ) -> dict[str, int]:
+        unique_relations: dict[str, RelationEvidence] = {}
+        for item in sorted(evidence, key=lambda value: value.id):
+            unique_relations.setdefault(item.relation_key, item)
+        neighbors: defaultdict[str, set[str]] = defaultdict(set)
+        for item in unique_relations.values():
+            neighbors[item.from_entity_key].add(item.to_entity_key)
+            neighbors[item.to_entity_key].add(item.from_entity_key)
+        return {key: len(values) for key, values in neighbors.items()}

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -11,6 +11,7 @@ from app.core.rag.knowledge_graph.batching import (
     build_extraction_batches,
     select_source_chunks,
 )
+from app.core.rag.knowledge_graph.extraction_cache import GraphExtractionCache
 from app.core.rag.knowledge_graph.models import (
     EntityEvidence,
     ExtractionBatch,
@@ -38,6 +39,33 @@ def _prefer_evidence(current: Any | None, candidate: Any) -> Any:
     if current is None or candidate.confidence > current.confidence:
         return candidate
     return current
+
+
+def _clean_keywords(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                keyword
+                for value in values
+                if (keyword := _clean_display(value))
+            }
+        )
+    )
+
+
+def _bind_result_to_batch(
+    result: ExtractionResult,
+    batch: ExtractionBatch,
+) -> ExtractionResult:
+    if len(batch.source_chunk_ids) != 1:
+        raise ValueError("extraction batch must contain exactly one source chunk")
+    source_chunk_id = batch.source_chunk_ids[0]
+    bound = result.model_copy(deep=True)
+    for entity in bound.entities:
+        entity.source_chunk_ids = [source_chunk_id]
+    for relation in bound.relations:
+        relation.source_chunk_ids = [source_chunk_id]
+    return bound
 
 
 def materialize_evidence(
@@ -133,6 +161,7 @@ def materialize_evidence(
                 relation.directed,
             )
             description = _clean_display(relation.description)[:300]
+            keywords = _clean_keywords(relation.keywords)
             for source_chunk_id in dict.fromkeys(relation.source_chunk_ids):
                 source_id = str(source_chunk_id).strip()
                 if not source_id:
@@ -154,6 +183,7 @@ def materialize_evidence(
                     to_entity_name=to_entity[1],
                     predicate=predicate,
                     description=description,
+                    keywords=keywords,
                     directed=relation.directed,
                     confidence=relation.confidence,
                 )
@@ -175,11 +205,15 @@ class KnowledgeGraphIndexPipeline:
         extractor: Any,
         embedding: Any,
         lock_guard: Any,
+        extraction_cache: GraphExtractionCache | None = None,
     ) -> None:
         self._store = store
         self._extractor = extractor
         self._embedding = embedding
         self._lock_guard = lock_guard
+        self._extraction_cache = extraction_cache or GraphExtractionCache(
+            ttl_seconds=settings.KNOWLEDGE_GRAPH_EXTRACTION_CACHE_TTL_SECONDS
+        )
 
     async def sync_document(
         self,
@@ -209,10 +243,7 @@ class KnowledgeGraphIndexPipeline:
                 else []
             )
             chunks = select_source_chunks(hits)
-            batches = build_extraction_batches(
-                chunks,
-                settings.KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS,
-            )
+            batches = build_extraction_batches(chunks)
             logger.info(
                 "[EvidenceGraph] index_input"
                 " kb_id=%s document_id=%s active=%s"
@@ -226,7 +257,7 @@ class KnowledgeGraphIndexPipeline:
             )
 
             stage = "extract_batches"
-            results = await self._extract_batches(batches)
+            results = await self._extract_batches(batches, runtime)
             stage = "materialize_evidence"
             entity_evidence, relation_evidence = materialize_evidence(
                 runtime.knowledge_id,
@@ -357,20 +388,58 @@ class KnowledgeGraphIndexPipeline:
     async def _extract_batches(
         self,
         batches: Sequence[ExtractionBatch],
+        runtime: GraphIndexRuntime | None = None,
     ) -> list[ExtractionResult]:
         if not batches:
             return []
         semaphore = asyncio.Semaphore(
             settings.KNOWLEDGE_GRAPH_EXTRACT_MAX_CONCURRENCY
         )
+        cache_hits = 0
+        cache_misses = 0
+        llm_calls = 0
+        cache_stores = 0
 
         async def extract_one(batch: ExtractionBatch) -> ExtractionResult:
+            nonlocal cache_hits, cache_misses, llm_calls, cache_stores
             async with semaphore:
-                return await self._extractor.extract(batch)
+                cache_key = (
+                    self._extraction_cache.build_key(runtime, batch)
+                    if runtime is not None
+                    else None
+                )
+                if cache_key is not None:
+                    cached = await self._extraction_cache.get(cache_key)
+                    if cached is not None:
+                        cache_hits += 1
+                        return _bind_result_to_batch(cached, batch)
+                    cache_misses += 1
+                llm_calls += 1
+                result = _bind_result_to_batch(
+                    await self._extractor.extract(batch),
+                    batch,
+                )
+                if cache_key is not None:
+                    if await self._extraction_cache.set(cache_key, result):
+                        cache_stores += 1
+                return result
 
         tasks = [asyncio.create_task(extract_one(batch)) for batch in batches]
         try:
-            return list(await asyncio.gather(*tasks))
+            results = list(await asyncio.gather(*tasks))
+            if runtime is not None:
+                logger.info(
+                    "[EvidenceGraph] extraction_batches"
+                    " kb_id=%s batches=%d cache_hits=%d"
+                    " cache_misses=%d llm_calls=%d cache_stores=%d",
+                    runtime.knowledge_id,
+                    len(batches),
+                    cache_hits,
+                    cache_misses,
+                    llm_calls,
+                    cache_stores,
+                )
+            return results
         except BaseException:
             for task in tasks:
                 if not task.done():
@@ -407,6 +476,7 @@ class KnowledgeGraphIndexPipeline:
             to_name = self._most_common(item.to_entity_name for item in items)
             predicate = self._most_common(item.predicate for item in items)
             description = self._aggregate_descriptions(items)
+            keywords = self._aggregate_relation_keywords(items)
             projection = {
                 "relation_key_kwd": key,
                 "from_entity_key_kwd": items[0].from_entity_key,
@@ -414,6 +484,7 @@ class KnowledgeGraphIndexPipeline:
                 "to_entity_key_kwd": items[0].to_entity_key,
                 "to_entity_name_kwd": to_name,
                 "predicate_kwd": predicate,
+                "keywords_kwd": list(keywords),
                 "directed_int": int(items[0].directed),
                 "description": description,
                 "evidence_count_int": len(items),
@@ -421,7 +492,15 @@ class KnowledgeGraphIndexPipeline:
             }
             projections.append(projection)
             texts.append(
-                f"{from_name} -> {predicate} -> {to_name}\n{description}".strip()
+                "\n".join(
+                    part
+                    for part in (
+                        ", ".join(keywords),
+                        f"{from_name} -> {predicate} -> {to_name}",
+                        description,
+                    )
+                    if part
+                )
             )
 
         await self._embed_projections(runtime, projections, texts)
@@ -535,6 +614,21 @@ class KnowledgeGraphIndexPipeline:
             if len(descriptions) == 5:
                 break
         return " | ".join(descriptions)
+
+    @staticmethod
+    def _aggregate_relation_keywords(
+        items: Sequence[RelationEvidence],
+    ) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                {
+                    keyword
+                    for item in items
+                    for value in item.keywords
+                    if (keyword := _clean_display(value))
+                }
+            )
+        )
 
     @staticmethod
     def _elapsed_ms(started_at: float) -> int:

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -181,6 +181,8 @@ class KnowledgeGraphIndexPipeline:
         document_active: bool,
     ) -> None:
         self._lock_guard.ensure_valid()
+        await self._store.ensure_graph_index(runtime.graph_index_name)
+        self._lock_guard.ensure_valid()
         await self._store.refresh_sources(
             runtime.chunk_index_name,
             runtime.graph_index_name,

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 import unicodedata
 from collections import Counter, defaultdict
 from collections.abc import Sequence
@@ -54,8 +55,10 @@ def materialize_evidence(
             display_type = _clean_display(entity.entity_type)
             if not display_name or not display_type:
                 logger.warning(
-                    "Skipping graph entity with empty normalized fields",
-                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                    "[EvidenceGraph] evidence_skipped"
+                    " kb_id=%s document_id=%s reason=empty_entity_fields",
+                    knowledge_id,
+                    document_id,
                 )
                 continue
             normalized_key = entity_key(
@@ -107,15 +110,19 @@ def materialize_evidence(
             to_entity = entities_by_ref.get(relation.to_ref)
             if from_entity is None or to_entity is None:
                 logger.warning(
-                    "Skipping graph relation with unresolved endpoint",
-                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                    "[EvidenceGraph] evidence_skipped"
+                    " kb_id=%s document_id=%s reason=unresolved_relation_endpoint",
+                    knowledge_id,
+                    document_id,
                 )
                 continue
             predicate = _clean_display(relation.predicate)
             if not predicate:
                 logger.warning(
-                    "Skipping graph relation with empty predicate",
-                    extra={"knowledge_id": knowledge_id, "document_id": document_id},
+                    "[EvidenceGraph] evidence_skipped"
+                    " kb_id=%s document_id=%s reason=empty_relation_predicate",
+                    knowledge_id,
+                    document_id,
                 )
                 continue
             normalized_relation_key = relation_key(
@@ -180,71 +187,128 @@ class KnowledgeGraphIndexPipeline:
         document_id: str,
         document_active: bool,
     ) -> None:
-        self._lock_guard.ensure_valid()
-        await self._store.ensure_graph_index(runtime.graph_index_name)
-        self._lock_guard.ensure_valid()
-        await self._store.refresh_sources(
-            runtime.chunk_index_name,
-            runtime.graph_index_name,
-        )
-        hits = (
-            await self._store.load_document_chunks(
+        started_at = time.perf_counter()
+        stage = "ensure_graph_index"
+        try:
+            self._lock_guard.ensure_valid()
+            await self._store.ensure_graph_index(runtime.graph_index_name)
+            stage = "refresh_sources"
+            self._lock_guard.ensure_valid()
+            await self._store.refresh_sources(
                 runtime.chunk_index_name,
+                runtime.graph_index_name,
+            )
+            stage = "load_document_chunks"
+            hits = (
+                await self._store.load_document_chunks(
+                    runtime.chunk_index_name,
+                    runtime.knowledge_id,
+                    document_id,
+                )
+                if document_active
+                else []
+            )
+            chunks = select_source_chunks(hits)
+            batches = build_extraction_batches(
+                chunks,
+                settings.KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS,
+            )
+            logger.info(
+                "[EvidenceGraph] index_input"
+                " kb_id=%s document_id=%s active=%s"
+                " raw_hits=%d source_chunks=%d batches=%d",
                 runtime.knowledge_id,
                 document_id,
+                str(bool(document_active)).lower(),
+                len(hits),
+                len(chunks),
+                len(batches),
             )
-            if document_active
-            else []
-        )
-        chunks = select_source_chunks(hits)
-        batches = build_extraction_batches(
-            chunks,
-            settings.KNOWLEDGE_GRAPH_EXTRACT_BATCH_TOKENS,
-        )
-        results = await self._extract_batches(batches)
-        entity_evidence, relation_evidence = materialize_evidence(
-            runtime.knowledge_id,
-            document_id,
-            results,
-        )
 
-        self._lock_guard.ensure_valid()
-        affected = await self._store.replace_document_evidence(
-            runtime.graph_index_name,
-            runtime.knowledge_id,
-            document_id,
-            entity_evidence,
-            relation_evidence,
-            ensure_valid=self._lock_guard.ensure_valid,
-        )
-        self._lock_guard.ensure_valid()
-        await self._rebuild_relation_projections(
-            runtime,
-            affected.relation_keys,
-        )
-        self._lock_guard.ensure_valid()
-        await self._rebuild_entity_projections(
-            runtime,
-            affected.entity_keys,
-        )
-        self._lock_guard.ensure_valid()
-        await self._store.finish_document_map(
-            runtime.graph_index_name,
-            runtime.knowledge_id,
-            document_id,
-            entity_evidence,
-            relation_evidence,
-            ensure_valid=self._lock_guard.ensure_valid,
-        )
-        self._lock_guard.ensure_valid()
-        await self._store.refresh_graph(runtime.graph_index_name)
+            stage = "extract_batches"
+            results = await self._extract_batches(batches)
+            stage = "materialize_evidence"
+            entity_evidence, relation_evidence = materialize_evidence(
+                runtime.knowledge_id,
+                document_id,
+                results,
+            )
+
+            stage = "replace_document_evidence"
+            self._lock_guard.ensure_valid()
+            affected = await self._store.replace_document_evidence(
+                runtime.graph_index_name,
+                runtime.knowledge_id,
+                document_id,
+                entity_evidence,
+                relation_evidence,
+                ensure_valid=self._lock_guard.ensure_valid,
+            )
+            stage = "rebuild_relation_projections"
+            self._lock_guard.ensure_valid()
+            await self._rebuild_relation_projections(
+                runtime,
+                affected.relation_keys,
+            )
+            stage = "rebuild_entity_projections"
+            self._lock_guard.ensure_valid()
+            await self._rebuild_entity_projections(
+                runtime,
+                affected.entity_keys,
+            )
+            stage = "finish_document_map"
+            self._lock_guard.ensure_valid()
+            await self._store.finish_document_map(
+                runtime.graph_index_name,
+                runtime.knowledge_id,
+                document_id,
+                entity_evidence,
+                relation_evidence,
+                ensure_valid=self._lock_guard.ensure_valid,
+            )
+            stage = "refresh_graph"
+            self._lock_guard.ensure_valid()
+            await self._store.refresh_graph(runtime.graph_index_name)
+            logger.info(
+                "[EvidenceGraph] index_done"
+                " kb_id=%s document_id=%s"
+                " entity_evidence=%d relation_evidence=%d"
+                " affected_entities=%d affected_relations=%d elapsed_ms=%d",
+                runtime.knowledge_id,
+                document_id,
+                len(entity_evidence),
+                len(relation_evidence),
+                len(affected.entity_keys),
+                len(affected.relation_keys),
+                self._elapsed_ms(started_at),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "[EvidenceGraph] index_failed"
+                " kb_id=%s document_id=%s stage=%s"
+                " error_type=%s elapsed_ms=%d",
+                runtime.knowledge_id,
+                document_id,
+                stage,
+                type(exc).__name__,
+                self._elapsed_ms(started_at),
+            )
+            raise
 
     async def rebuild_knowledge(
         self,
         runtime: GraphIndexRuntime,
         active_document_ids: tuple[str, ...],
     ) -> None:
+        started_at = time.perf_counter()
         active_ids = tuple(dict.fromkeys(active_document_ids))
+        logger.info(
+            "[EvidenceGraph] rebuild_start kb_id=%s active_documents=%d",
+            runtime.knowledge_id,
+            len(active_ids),
+        )
         for document_id in active_ids:
             await self.sync_document(runtime, document_id, True)
 
@@ -267,13 +331,27 @@ class KnowledgeGraphIndexPipeline:
 
         self._lock_guard.ensure_valid()
         await self._store.refresh_graph(runtime.graph_index_name)
+        logger.info(
+            "[EvidenceGraph] rebuild_done"
+            " kb_id=%s active_documents=%d stale_documents=%d elapsed_ms=%d",
+            runtime.knowledge_id,
+            len(active_ids),
+            len(stale_ids),
+            self._elapsed_ms(started_at),
+        )
 
     async def clear_knowledge(self, runtime: GraphIndexRuntime) -> None:
+        started_at = time.perf_counter()
         self._lock_guard.ensure_valid()
         await self._store.clear_evidence_graph(
             runtime.graph_index_name,
             runtime.knowledge_id,
             ensure_valid=self._lock_guard.ensure_valid,
+        )
+        logger.info(
+            "[EvidenceGraph] clear_done kb_id=%s elapsed_ms=%d",
+            runtime.knowledge_id,
+            self._elapsed_ms(started_at),
         )
 
     async def _extract_batches(
@@ -457,6 +535,10 @@ class KnowledgeGraphIndexPipeline:
             if len(descriptions) == 5:
                 break
         return " | ".join(descriptions)
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return int((time.perf_counter() - started_at) * 1000)
 
     @staticmethod
     def _most_common(values: Sequence[str] | Any) -> str:

--- a/api/app/core/rag/knowledge_graph/lock.py
+++ b/api/app/core/rag/knowledge_graph/lock.py
@@ -1,0 +1,52 @@
+import threading
+
+import redis
+
+from app.core.config import settings
+from app.utils.redis_lock import RedisFairLock
+
+
+_CLIENT_INIT_LOCK = threading.Lock()
+_GRAPH_LOCK_POOL: redis.ConnectionPool | None = None
+_GRAPH_LOCK_CLIENT: redis.Redis | None = None
+
+
+def build_graph_lock_redis_config() -> dict[str, object]:
+    return {
+        "host": settings.REDIS_HOST,
+        "port": settings.REDIS_PORT,
+        "db": settings.REDIS_DB,
+        "password": settings.REDIS_PASSWORD,
+        "decode_responses": True,
+        "max_connections": 30,
+        "socket_connect_timeout": 5,
+        "socket_timeout": 10,
+        "retry_on_timeout": True,
+    }
+
+
+def get_graph_lock_redis_client() -> redis.Redis:
+    global _GRAPH_LOCK_POOL, _GRAPH_LOCK_CLIENT
+
+    if _GRAPH_LOCK_CLIENT is not None:
+        return _GRAPH_LOCK_CLIENT
+    with _CLIENT_INIT_LOCK:
+        if _GRAPH_LOCK_CLIENT is None:
+            _GRAPH_LOCK_POOL = redis.ConnectionPool(
+                **build_graph_lock_redis_config()
+            )
+            _GRAPH_LOCK_CLIENT = redis.Redis(
+                connection_pool=_GRAPH_LOCK_POOL
+            )
+    return _GRAPH_LOCK_CLIENT
+
+
+def create_knowledge_graph_lock(knowledge_id: str) -> RedisFairLock:
+    return RedisFairLock(
+        key=f"graphrag_task_{knowledge_id}",
+        redis_client=get_graph_lock_redis_client(),
+        expire=120,
+        retry_interval=1,
+        timeout=settings.KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS,
+        auto_renewal=True,
+    )

--- a/api/app/core/rag/knowledge_graph/lock.py
+++ b/api/app/core/rag/knowledge_graph/lock.py
@@ -1,4 +1,6 @@
+import logging
 import threading
+import time
 
 import redis
 
@@ -9,6 +11,57 @@ from app.utils.redis_lock import RedisFairLock
 _CLIENT_INIT_LOCK = threading.Lock()
 _GRAPH_LOCK_POOL: redis.ConnectionPool | None = None
 _GRAPH_LOCK_CLIENT: redis.Redis | None = None
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphLock(RedisFairLock):
+    def __init__(self, knowledge_id: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._knowledge_id = str(knowledge_id)
+
+    def acquire(self):
+        started_at = time.perf_counter()
+        try:
+            acquired = super().acquire()
+        except Exception as exc:
+            logger.warning(
+                "[EvidenceGraph] lock_failed"
+                " kb_id=%s error_type=%s wait_ms=%d",
+                self._knowledge_id,
+                type(exc).__name__,
+                self._elapsed_ms(started_at),
+            )
+            raise
+        wait_ms = self._elapsed_ms(started_at)
+        if acquired:
+            logger.info(
+                "[EvidenceGraph] lock_acquired kb_id=%s wait_ms=%d",
+                self._knowledge_id,
+                wait_ms,
+            )
+        else:
+            logger.warning(
+                "[EvidenceGraph] lock_timeout kb_id=%s wait_ms=%d",
+                self._knowledge_id,
+                wait_ms,
+            )
+        return acquired
+
+    def release(self):
+        if not self._locked:
+            return
+        valid_before_release = self.is_valid
+        super().release()
+        logger.info(
+            "[EvidenceGraph] lock_released"
+            " kb_id=%s valid_before_release=%s",
+            self._knowledge_id,
+            str(valid_before_release).lower(),
+        )
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return int((time.perf_counter() - started_at) * 1000)
 
 
 def build_graph_lock_redis_config() -> dict[str, object]:
@@ -41,8 +94,9 @@ def get_graph_lock_redis_client() -> redis.Redis:
     return _GRAPH_LOCK_CLIENT
 
 
-def create_knowledge_graph_lock(knowledge_id: str) -> RedisFairLock:
-    return RedisFairLock(
+def create_knowledge_graph_lock(knowledge_id: str) -> KnowledgeGraphLock:
+    return KnowledgeGraphLock(
+        knowledge_id=str(knowledge_id),
         key=f"graphrag_task_{knowledge_id}",
         redis_client=get_graph_lock_redis_client(),
         expire=120,

--- a/api/app/core/rag/knowledge_graph/lock.py
+++ b/api/app/core/rag/knowledge_graph/lock.py
@@ -11,6 +11,7 @@ from app.utils.redis_lock import RedisFairLock
 _CLIENT_INIT_LOCK = threading.Lock()
 _GRAPH_LOCK_POOL: redis.ConnectionPool | None = None
 _GRAPH_LOCK_CLIENT: redis.Redis | None = None
+_GRAPH_LOCK_WAIT_SECONDS = 10 * 60
 logger = logging.getLogger(__name__)
 
 
@@ -101,6 +102,6 @@ def create_knowledge_graph_lock(knowledge_id: str) -> KnowledgeGraphLock:
         redis_client=get_graph_lock_redis_client(),
         expire=120,
         retry_interval=1,
-        timeout=settings.KNOWLEDGE_GRAPH_LOCK_WAIT_SECONDS,
+        timeout=_GRAPH_LOCK_WAIT_SECONDS,
         auto_renewal=True,
     )

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -161,11 +161,11 @@ class GraphRetrievalRequest:
     runtime: GraphIndexRuntime
     allowed_document_ids: tuple[str, ...] | None
     file_names: tuple[str, ...]
-    entity_top_n: int
-    relation_top_n: int
-    neighbor_top_n: int
-    entity_similarity_threshold: float
-    relation_similarity_threshold: float
-    related_chunk_number: int
     max_candidates: int
-    max_paths_per_chunk: int
+    entity_top_n: int = 40
+    relation_top_n: int = 40
+    neighbor_top_n: int = 24
+    entity_similarity_threshold: float = 0.20
+    relation_similarity_threshold: float = 0.20
+    related_chunk_number: int = 5
+    max_paths_per_chunk: int = 6

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field
+
+from app.core.rag.retrieval.models import ModelRuntimeSnapshot
+
+
+class SourceChunk(BaseModel):
+    source_chunk_id: str
+    document_id: str
+    page_content: str
+    sort_id: int
+    chunk_type: str = "chunk"
+    parent_id: str | None = None
+
+
+class ExtractionBatch(BaseModel):
+    text: str
+    source_chunk_ids: tuple[str, ...]
+
+
+class ExtractedEntity(BaseModel):
+    ref: str
+    name: str
+    entity_type: str
+    description: str
+    aliases: list[str] = Field(default_factory=list)
+    source_chunk_ids: list[str]
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class ExtractedRelation(BaseModel):
+    from_ref: str
+    to_ref: str
+    predicate: str
+    description: str
+    directed: bool = True
+    source_chunk_ids: list[str]
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class ExtractionResult(BaseModel):
+    entities: list[ExtractedEntity] = Field(default_factory=list)
+    relations: list[ExtractedRelation] = Field(default_factory=list)
+
+
+class EntityEvidence(BaseModel):
+    id: str
+    kb_id: str
+    document_id: str
+    source_chunk_id: str
+    entity_key: str
+    entity_name: str
+    entity_type: str
+    description: str
+    aliases: tuple[str, ...] = ()
+    confidence: float
+
+
+class RelationEvidence(BaseModel):
+    id: str
+    kb_id: str
+    document_id: str
+    source_chunk_id: str
+    relation_key: str
+    from_entity_key: str
+    from_entity_name: str
+    to_entity_key: str
+    to_entity_name: str
+    predicate: str
+    description: str
+    directed: bool
+    confidence: float
+
+
+class AffectedProjectionKeys(BaseModel):
+    entity_keys: tuple[str, ...]
+    relation_keys: tuple[str, ...]
+
+
+class EntityProjectionHit(BaseModel):
+    entity_key: str
+    entity_name: str
+    score: float
+
+
+class RelationProjectionHit(BaseModel):
+    relation_key: str
+    from_entity_key: str
+    to_entity_key: str
+    label: str
+    score: float
+
+
+class GraphEvidenceHit(BaseModel):
+    source_chunk_id: str
+    document_id: str
+    score: float
+    entity_name: str | None = None
+    relation_label: str | None = None
+
+
+@dataclass(frozen=True)
+class GraphIndexRuntime:
+    knowledge_id: str
+    workspace_id: str
+    graph_index_name: str
+    chunk_index_name: str
+    entity_types: tuple[str, ...]
+    scene_name: str
+    llm: ModelRuntimeSnapshot
+    embedding: ModelRuntimeSnapshot
+
+
+@dataclass(frozen=True)
+class GraphRetrievalRequest:
+    query: str
+    runtime: GraphIndexRuntime
+    allowed_document_ids: tuple[str, ...] | None
+    file_names: tuple[str, ...]
+    entity_top_n: int
+    relation_top_n: int
+    neighbor_top_n: int
+    evidence_per_key: int
+    max_chunks_per_document: int

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -116,6 +116,11 @@ class GraphEvidenceHit(BaseModel):
     relation_label: str | None = None
 
 
+class SourceChunkVectorHit(BaseModel):
+    source_chunk_id: str
+    score: float
+
+
 class ProjectionEvidenceGroup(BaseModel):
     projection_type: str
     projection_key: str

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -25,7 +25,7 @@ class ExtractedEntity(BaseModel):
     entity_type: str
     description: str
     aliases: list[str] = Field(default_factory=list)
-    source_chunk_ids: list[str]
+    source_chunk_ids: list[str] = Field(default_factory=list)
     confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
@@ -34,8 +34,9 @@ class ExtractedRelation(BaseModel):
     to_ref: str
     predicate: str
     description: str
+    keywords: list[str] = Field(default_factory=list)
     directed: bool = True
-    source_chunk_ids: list[str]
+    source_chunk_ids: list[str] = Field(default_factory=list)
     confidence: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
@@ -44,9 +45,9 @@ class ExtractionResult(BaseModel):
     relations: list[ExtractedRelation] = Field(default_factory=list)
 
 
-class GraphQueryAnalysis(BaseModel):
-    entity_terms: list[str] = Field(default_factory=list)
-    relation_terms: list[str] = Field(default_factory=list)
+class GraphQueryPlan(BaseModel):
+    low_level_keywords: list[str] = Field(default_factory=list)
+    high_level_keywords: list[str] = Field(default_factory=list)
 
 
 class EntityEvidence(BaseModel):
@@ -74,6 +75,7 @@ class RelationEvidence(BaseModel):
     to_entity_name: str
     predicate: str
     description: str
+    keywords: tuple[str, ...] = ()
     directed: bool
     confidence: float
 
@@ -87,6 +89,9 @@ class EntityProjectionHit(BaseModel):
     entity_key: str
     entity_name: str
     score: float
+    degree: int = 0
+    evidence_count: int = 0
+    document_count: int = 0
 
 
 class RelationProjectionHit(BaseModel):
@@ -95,9 +100,13 @@ class RelationProjectionHit(BaseModel):
     to_entity_key: str
     label: str
     score: float
+    evidence_count: int = 0
+    document_count: int = 0
+    endpoint_degree: int = 0
 
 
 class GraphEvidenceHit(BaseModel):
+    evidence_id: str = ""
     source_chunk_id: str
     document_id: str
     score: float
@@ -105,6 +114,12 @@ class GraphEvidenceHit(BaseModel):
     relation_key: str | None = None
     entity_name: str | None = None
     relation_label: str | None = None
+
+
+class ProjectionEvidenceGroup(BaseModel):
+    projection_type: str
+    projection_key: str
+    evidence: tuple[GraphEvidenceHit, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -128,5 +143,8 @@ class GraphRetrievalRequest:
     entity_top_n: int
     relation_top_n: int
     neighbor_top_n: int
-    evidence_per_key: int
-    max_chunks_per_document: int
+    entity_similarity_threshold: float
+    relation_similarity_threshold: float
+    related_chunk_number: int
+    max_candidates: int
+    max_paths_per_chunk: int

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -44,6 +44,11 @@ class ExtractionResult(BaseModel):
     relations: list[ExtractedRelation] = Field(default_factory=list)
 
 
+class GraphQueryAnalysis(BaseModel):
+    entity_terms: list[str] = Field(default_factory=list)
+    relation_terms: list[str] = Field(default_factory=list)
+
+
 class EntityEvidence(BaseModel):
     id: str
     kb_id: str
@@ -96,6 +101,8 @@ class GraphEvidenceHit(BaseModel):
     source_chunk_id: str
     document_id: str
     score: float
+    entity_key: str | None = None
+    relation_key: str | None = None
     entity_name: str | None = None
     relation_label: str | None = None
 

--- a/api/app/core/rag/knowledge_graph/models.py
+++ b/api/app/core/rag/knowledge_graph/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -88,6 +89,9 @@ class AffectedProjectionKeys(BaseModel):
 class EntityProjectionHit(BaseModel):
     entity_key: str
     entity_name: str
+    entity_type: str = ""
+    description: str = ""
+    aliases: tuple[str, ...] = ()
     score: float
     degree: int = 0
     evidence_count: int = 0
@@ -97,8 +101,14 @@ class EntityProjectionHit(BaseModel):
 class RelationProjectionHit(BaseModel):
     relation_key: str
     from_entity_key: str
+    from_entity_name: str = ""
     to_entity_key: str
+    to_entity_name: str = ""
+    predicate: str = ""
     label: str
+    description: str = ""
+    keywords: tuple[str, ...] = ()
+    directed: bool = True
     score: float
     evidence_count: int = 0
     document_count: int = 0
@@ -119,6 +129,12 @@ class GraphEvidenceHit(BaseModel):
 class SourceChunkVectorHit(BaseModel):
     source_chunk_id: str
     score: float
+
+
+class GraphRetrievalResult(BaseModel):
+    chunks: list[Any] = Field(default_factory=list)
+    entities: list[dict[str, Any]] = Field(default_factory=list)
+    relationships: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class ProjectionEvidenceGroup(BaseModel):

--- a/api/app/core/rag/knowledge_graph/normalizer.py
+++ b/api/app/core/rag/knowledge_graph/normalizer.py
@@ -1,0 +1,89 @@
+import hashlib
+import json
+import re
+import unicodedata
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_name(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value))
+    return _WHITESPACE_RE.sub(" ", normalized).strip().casefold()
+
+
+def _digest(kind: str, *parts: str) -> str:
+    payload = json.dumps(
+        [kind, *(str(part) for part in parts)],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def entity_key(kb_id: str, name: str, entity_type: str) -> str:
+    return _digest(
+        "entity",
+        str(kb_id),
+        normalize_name(name),
+        normalize_name(entity_type),
+    )
+
+
+def relation_key(
+    kb_id: str,
+    from_entity_key: str,
+    predicate: str,
+    to_entity_key: str,
+    directed: bool,
+) -> str:
+    from_key = str(from_entity_key)
+    to_key = str(to_entity_key)
+    if not directed:
+        from_key, to_key = sorted((from_key, to_key))
+    return _digest(
+        "relation",
+        str(kb_id),
+        from_key,
+        normalize_name(predicate),
+        to_key,
+        "directed" if directed else "undirected",
+    )
+
+
+def entity_evidence_id(
+    kb_id: str,
+    document_id: str,
+    source_chunk_id: str,
+    normalized_entity_key: str,
+) -> str:
+    return _digest(
+        "entity_evidence",
+        str(kb_id),
+        str(document_id),
+        str(source_chunk_id),
+        str(normalized_entity_key),
+    )
+
+
+def relation_evidence_id(
+    kb_id: str,
+    document_id: str,
+    source_chunk_id: str,
+    normalized_relation_key: str,
+) -> str:
+    return _digest(
+        "relation_evidence",
+        str(kb_id),
+        str(document_id),
+        str(source_chunk_id),
+        str(normalized_relation_key),
+    )
+
+
+def projection_id(kb_id: str, projection_type: str, key: str) -> str:
+    return _digest("projection", str(kb_id), str(projection_type), str(key))
+
+
+def document_map_id(kb_id: str, document_id: str) -> str:
+    return _digest("document_map", str(kb_id), str(document_id))

--- a/api/app/core/rag/knowledge_graph/prompts.py
+++ b/api/app/core/rag/knowledge_graph/prompts.py
@@ -3,17 +3,29 @@ import json
 
 EXTRACTION_SYSTEM_PROMPT = """
 You extract traceable entities and direct relations from source chunks.
-Return only data explicitly supported by the input. Every entity and relation
-must cite one or more source_chunk_ids from the provided markers. Give every
-entity a unique ref within this response. Relation endpoints must reference
-entity refs emitted in the same response. Omit uncertain facts. Do not answer
+Return only data explicitly supported by the input. Give every entity a unique
+ref within this response. Relation endpoints must reference
+entity refs emitted in the same response. Each relation should include concise
+high-level keywords explicitly supported by the source text. Omit uncertain facts. Do not answer
 the user, build communities, summarize a whole graph, or infer missing facts.
 """.strip()
 
+EXTRACTION_PROMPT_VERSION = "2026-07-23-v2"
+
+QUERY_PLAN_PROMPT_VERSION = "2026-07-23-v2"
+
 
 QUERY_ANALYSIS_SYSTEM_PROMPT = """
-Split the query into entity-oriented terms and relation-oriented terms.
-Keep terms short and preserve proper names. Do not answer the query.
+Build a retrieval plan from the user's query. Return only two JSON arrays:
+low_level_keywords for concrete entities, proper names, attributes, and details;
+high_level_keywords for themes, concepts, and relation intent.
+
+Every keyword must be explicitly derived only from the query. Preserve meaningful phrases and
+never invent unsupported entities, products, organizations, dates, or technical
+terms. Prefer concise, meaningful phrases over isolated fragments. Keep both
+lists short and high-signal, without duplicates. For simple, vague, or
+nonsensical queries, return two empty arrays. Do not force both arrays to be
+non-empty and do not answer the query.
 """.strip()
 
 
@@ -35,11 +47,13 @@ def build_extraction_prompt(
     return (
         f"{scene_instruction}"
         f"Allowed entity types: {allowed_types}\n"
-        "Extract only direct evidence from the following marked chunks. "
-        "Copy marker ids exactly into source_chunk_ids.\n\n"
+        "Extract only direct evidence from the following source chunk.\n\n"
         f"{source_text}"
     )
 
 
 def build_query_analysis_prompt(query: str) -> str:
-    return f"Query:\n{query.strip()}"
+    return (
+        "Return a source-grounded low/high keyword plan for this query.\n"
+        f"Query:\n{query.strip()}"
+    )

--- a/api/app/core/rag/knowledge_graph/prompts.py
+++ b/api/app/core/rag/knowledge_graph/prompts.py
@@ -1,0 +1,45 @@
+import json
+
+
+EXTRACTION_SYSTEM_PROMPT = """
+You extract traceable entities and direct relations from source chunks.
+Return only data explicitly supported by the input. Every entity and relation
+must cite one or more source_chunk_ids from the provided markers. Give every
+entity a unique ref within this response. Relation endpoints must reference
+entity refs emitted in the same response. Omit uncertain facts. Do not answer
+the user, build communities, summarize a whole graph, or infer missing facts.
+""".strip()
+
+
+QUERY_ANALYSIS_SYSTEM_PROMPT = """
+Split the query into entity-oriented terms and relation-oriented terms.
+Keep terms short and preserve proper names. Do not answer the query.
+""".strip()
+
+
+def build_extraction_prompt(
+    source_text: str,
+    entity_types: tuple[str, ...],
+    scene_name: str,
+) -> str:
+    allowed_types = json.dumps(
+        list(entity_types),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    scene_instruction = (
+        f"Domain context: {scene_name.strip()}\n"
+        if scene_name.strip()
+        else ""
+    )
+    return (
+        f"{scene_instruction}"
+        f"Allowed entity types: {allowed_types}\n"
+        "Extract only direct evidence from the following marked chunks. "
+        "Copy marker ids exactly into source_chunk_ids.\n\n"
+        f"{source_text}"
+    )
+
+
+def build_query_analysis_prompt(query: str) -> str:
+    return f"Query:\n{query.strip()}"

--- a/api/app/core/rag/knowledge_graph/query_plan_cache.py
+++ b/api/app/core/rag/knowledge_graph/query_plan_cache.py
@@ -12,6 +12,7 @@ from app.core.rag.knowledge_graph.prompts import QUERY_PLAN_PROMPT_VERSION
 logger = logging.getLogger(__name__)
 
 _CACHE_SCHEMA_VERSION = "1"
+_DEFAULT_TTL_SECONDS = 5 * 60
 
 
 class GraphQueryPlanCache:
@@ -19,7 +20,7 @@ class GraphQueryPlanCache:
         self,
         redis_factory: Callable[[], Any] = get_thread_safe_redis,
         *,
-        ttl_seconds: int,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
     ) -> None:
         self._redis_factory = redis_factory
         self._ttl_seconds = max(1, int(ttl_seconds))

--- a/api/app/core/rag/knowledge_graph/query_plan_cache.py
+++ b/api/app/core/rag/knowledge_graph/query_plan_cache.py
@@ -1,0 +1,90 @@
+import hashlib
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from app.aioRedis import get_thread_safe_redis
+from app.core.rag.knowledge_graph.models import GraphIndexRuntime, GraphQueryPlan
+from app.core.rag.knowledge_graph.prompts import QUERY_PLAN_PROMPT_VERSION
+
+
+logger = logging.getLogger(__name__)
+
+_CACHE_SCHEMA_VERSION = "1"
+
+
+class GraphQueryPlanCache:
+    def __init__(
+        self,
+        redis_factory: Callable[[], Any] = get_thread_safe_redis,
+        *,
+        ttl_seconds: int,
+    ) -> None:
+        self._redis_factory = redis_factory
+        self._ttl_seconds = max(1, int(ttl_seconds))
+
+    @staticmethod
+    def build_key(runtime: GraphIndexRuntime, query: str) -> str:
+        normalized_query = str(query).strip()
+        query_hash = hashlib.sha256(normalized_query.encode("utf-8")).hexdigest()
+        payload = {
+            "workspace_id": runtime.workspace_id,
+            "provider": runtime.llm.provider,
+            "model_name": runtime.llm.model_name,
+            "api_base": runtime.llm.api_base or "",
+            "prompt_version": QUERY_PLAN_PROMPT_VERSION,
+            "schema_version": _CACHE_SCHEMA_VERSION,
+            "query_hash": query_hash,
+        }
+        digest = hashlib.sha256(
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        return f"evidence_graph:query_plan:{_CACHE_SCHEMA_VERSION}:{digest}"
+
+    async def get(self, key: str) -> GraphQueryPlan | None:
+        try:
+            raw_value = await self._redis_factory().get(key)
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] query_plan_cache status=error"
+                " operation=get error_type=%s",
+                type(exc).__name__,
+            )
+            return None
+        if raw_value is None:
+            logger.info("[EvidenceGraph] query_plan_cache status=miss")
+            return None
+        try:
+            plan = GraphQueryPlan.model_validate_json(raw_value)
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] query_plan_cache status=error"
+                " operation=decode error_type=%s",
+                type(exc).__name__,
+            )
+            return None
+        logger.info("[EvidenceGraph] query_plan_cache status=hit")
+        return plan
+
+    async def set(self, key: str, plan: GraphQueryPlan) -> bool:
+        try:
+            await self._redis_factory().set(
+                key,
+                plan.model_dump_json(),
+                ex=self._ttl_seconds,
+            )
+        except Exception as exc:
+            logger.info(
+                "[EvidenceGraph] query_plan_cache status=error"
+                " operation=set error_type=%s",
+                type(exc).__name__,
+            )
+            return False
+        logger.info("[EvidenceGraph] query_plan_cache status=stored")
+        return True

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import time
+from collections import deque
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -8,13 +10,19 @@ from app.core.config import settings
 from app.core.rag.knowledge_graph.models import (
     EntityProjectionHit,
     GraphEvidenceHit,
-    GraphQueryAnalysis,
+    GraphIndexRuntime,
+    GraphQueryPlan,
     GraphRetrievalRequest,
+    ProjectionEvidenceGroup,
     RelationProjectionHit,
 )
 from app.core.rag.knowledge_graph.prompts import (
     QUERY_ANALYSIS_SYSTEM_PROMPT,
     build_query_analysis_prompt,
+)
+from app.core.rag.knowledge_graph.query_plan_cache import GraphQueryPlanCache
+from app.core.rag.knowledge_graph.structured_output import (
+    unwrap_structured_result,
 )
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.elasticsearch_queries import normalize_vector
@@ -22,44 +30,158 @@ from app.core.rag.retrieval.elasticsearch_queries import normalize_vector
 
 logger = logging.getLogger(__name__)
 
-_RRF_BASE = 60
-_ENTITY_WEIGHT = 0.45
-_RELATION_WEIGHT = 0.40
-_NEIGHBOR_WEIGHT = 0.15
+
+@dataclass(frozen=True)
+class _DirectSeed:
+    branch: str
+    seed_type: str
+    key: str
+    label: str
+    score: float
+    rank: int
+    query_keywords: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _EvidencePath:
+    seed: _DirectSeed
+    evidence_type: str
+    evidence_key: str
+    evidence_confidence: float
+    source_chunk_id: str
+    document_id: str
+    expansion_type: str
+    expansion_rank: int = 0
+    via_relation: str | None = None
+    endpoint_entity: str | None = None
+
+    @property
+    def identity(self) -> tuple[str, ...]:
+        return (
+            self.seed.branch,
+            self.seed.seed_type,
+            self.seed.key,
+            self.evidence_type,
+            self.evidence_key,
+            self.source_chunk_id,
+            self.expansion_type,
+            str(self.expansion_rank),
+            self.via_relation or "",
+            self.endpoint_entity or "",
+        )
+
+    def as_metadata(self) -> dict[str, Any]:
+        return {
+            "branch": self.seed.branch,
+            "query_keywords": list(self.seed.query_keywords),
+            "seed_type": self.seed.seed_type,
+            "seed_key": self.seed.key,
+            "seed": self.seed.label,
+            "seed_score": self.seed.score,
+            "expansion_type": self.expansion_type,
+            "expansion_rank": self.expansion_rank,
+            "via_relation": self.via_relation,
+            "endpoint_entity": self.endpoint_entity,
+            "evidence_type": self.evidence_type,
+            "evidence_key": self.evidence_key,
+            "evidence_confidence": self.evidence_confidence,
+            "source_chunk_id": self.source_chunk_id,
+        }
 
 
 @dataclass
 class _ChunkMatch:
-    channel_scores: dict[tuple[str, str], float] = field(default_factory=dict)
-    entity_names: set[str] = field(default_factory=set)
-    relation_labels: set[str] = field(default_factory=set)
-    evidence_tokens: set[tuple[str, str, str]] = field(default_factory=set)
+    paths: list[_EvidencePath] = field(default_factory=list)
+    _path_tokens: set[tuple[str, ...]] = field(default_factory=set)
 
-    @property
-    def raw_score(self) -> float:
-        return sum(self.channel_scores.values())
-
-    @property
-    def match_count(self) -> int:
-        return len(self.entity_names) + len(self.relation_labels)
-
-    @property
-    def evidence_count(self) -> int:
-        return len(self.evidence_tokens)
-
-    def add_score(self, channel: str, key: str, score: float) -> None:
-        token = (channel, key)
-        self.channel_scores[token] = max(
-            self.channel_scores.get(token, 0.0),
-            max(0.0, float(score)),
-        )
+    def add(self, path: _EvidencePath) -> None:
+        if path.identity in self._path_tokens:
+            return
+        self._path_tokens.add(path.identity)
+        self.paths.append(path)
 
     def merge(self, other: "_ChunkMatch") -> None:
-        for (channel, key), score in other.channel_scores.items():
-            self.add_score(channel, key, score)
-        self.entity_names.update(other.entity_names)
-        self.relation_labels.update(other.relation_labels)
-        self.evidence_tokens.update(other.evidence_tokens)
+        for path in other.paths:
+            self.add(path)
+
+    @property
+    def graph_score(self) -> float:
+        return max((path.seed.score for path in self.paths), default=0.0)
+
+    @property
+    def support_count(self) -> int:
+        return len(
+            {
+                (path.seed.seed_type, path.seed.key)
+                for path in self.paths
+            }
+        )
+
+    @property
+    def evidence_confidence(self) -> float:
+        return max(
+            (path.evidence_confidence for path in self.paths),
+            default=0.0,
+        )
+
+    def matched_entities(self) -> list[str]:
+        return self._ordered_labels("entity")
+
+    def matched_relations(self) -> list[str]:
+        return self._ordered_labels("relation")
+
+    def expanded_relations(self) -> list[str]:
+        labels: dict[str, tuple[int, int]] = {}
+        for index, path in enumerate(self.paths):
+            if path.expansion_type != "relation" or not path.via_relation:
+                continue
+            current = labels.get(path.via_relation)
+            position = (path.seed.rank, index)
+            if current is None or position < current:
+                labels[path.via_relation] = position
+        return [label for label, _ in sorted(labels.items(), key=lambda item: item[1])]
+
+    def path_metadata(self, limit: int) -> list[dict[str, Any]]:
+        ordered = sorted(
+            self.paths,
+            key=lambda path: (
+                path.seed.rank,
+                0 if path.expansion_type == "direct" else 1,
+                path.expansion_rank,
+                -path.evidence_confidence,
+                path.evidence_type,
+                path.evidence_key,
+                path.source_chunk_id,
+            ),
+        )
+        return [path.as_metadata() for path in ordered[: max(1, limit)]]
+
+    def _ordered_labels(self, seed_type: str) -> list[str]:
+        labels: dict[str, tuple[int, int]] = {}
+        for index, path in enumerate(self.paths):
+            if path.seed.seed_type != seed_type or not path.seed.label:
+                continue
+            current = labels.get(path.seed.label)
+            position = (path.seed.rank, index)
+            if current is None or position < current:
+                labels[path.seed.label] = position
+        return [label for label, _ in sorted(labels.items(), key=lambda item: item[1])]
+
+
+@dataclass
+class _SeedCandidates:
+    seed: _DirectSeed
+    source_chunk_ids: list[str] = field(default_factory=list)
+
+    def add(self, source_chunk_id: str) -> None:
+        if source_chunk_id and source_chunk_id not in self.source_chunk_ids:
+            self.source_chunk_ids.append(source_chunk_id)
+
+
+@dataclass
+class _SourceGroup:
+    key: str
+    source_chunk_ids: list[str]
 
 
 class KnowledgeGraphRetrievalPipeline:
@@ -69,11 +191,15 @@ class KnowledgeGraphRetrievalPipeline:
         llm: Any,
         embedding: Any,
         parent_resolver: Any,
+        query_plan_cache: GraphQueryPlanCache | None = None,
     ) -> None:
         self._store = store
         self._llm = llm
         self._embedding = embedding
         self._parent_resolver = parent_resolver
+        self._query_plan_cache = query_plan_cache or GraphQueryPlanCache(
+            ttl_seconds=settings.KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS,
+        )
 
     async def retrieve(
         self,
@@ -102,12 +228,17 @@ class KnowledgeGraphRetrievalPipeline:
         started_at: float,
     ) -> list[DocumentChunk]:
         stage = "validate_filters"
+        timings: dict[str, int] = {}
         counts = {
-            "entity_hits": 0,
-            "relation_hits": 0,
-            "neighbor_hits": 0,
+            "raw_entity_seeds": 0,
+            "entity_seeds": 0,
+            "raw_relation_seeds": 0,
+            "relation_seeds": 0,
+            "neighbor_relations": 0,
+            "endpoint_entities": 0,
+            "evidence_groups": 0,
             "evidence_hits": 0,
-            "matched_chunks": 0,
+            "source_chunks": 0,
             "hydrated_chunks": 0,
             "scoped_chunks": 0,
             "result_count": 0,
@@ -122,164 +253,272 @@ class KnowledgeGraphRetrievalPipeline:
                     request,
                     started_at,
                     counts,
+                    timings,
                     reason="no_allowed_documents",
                 )
                 return []
 
-            stage = "query_analysis"
-            analysis = await self._analyze_query(
-                request.query,
-                request.runtime.knowledge_id,
-            )
-            entity_text = (
-                " ".join(self._clean_terms(analysis.entity_terms))
-                or request.query
-            )
-            relation_text = (
-                " ".join(self._clean_terms(analysis.relation_terms))
-                or request.query
-            )
-
-            stage = "query_embedding"
-            entity_vector, relation_vector = await asyncio.gather(
-                self._embedding.aembed_query(entity_text),
-                self._embedding.aembed_query(relation_text),
-            )
-            stage = "projection_search"
-            entity_hits, relation_hits = await asyncio.gather(
-                self._store.search_entity_projections(
-                    request.runtime,
-                    normalize_vector(entity_vector),
-                    request.entity_top_n,
-                ),
-                self._store.search_relation_projections(
-                    request.runtime,
-                    normalize_vector(relation_vector),
-                    request.relation_top_n,
-                ),
-            )
-
-            ranked_entities = self._deduplicate_entities(entity_hits)
-            ranked_relations = self._deduplicate_relations(relation_hits)
-            counts["entity_hits"] = len(ranked_entities)
-            counts["relation_hits"] = len(ranked_relations)
-            stage = "neighbor_search"
-            neighbor_hits = await self._store.load_neighbor_relations(
-                request.runtime,
-                tuple(hit.entity_key for hit in ranked_entities),
-                request.neighbor_top_n,
-            )
-            ranked_neighbors = self._deduplicate_relations(neighbor_hits)
-            counts["neighbor_hits"] = len(ranked_neighbors)
-
-            entity_ranks = {
-                hit.entity_key: rank
-                for rank, hit in enumerate(ranked_entities, start=1)
-            }
-            relation_ranks = {
-                hit.relation_key: rank
-                for rank, hit in enumerate(ranked_relations, start=1)
-            }
-            neighbor_ranks = {
-                hit.relation_key: rank
-                for rank, hit in enumerate(ranked_neighbors, start=1)
-            }
-            relation_keys = tuple(
-                dict.fromkeys(
-                    [hit.relation_key for hit in ranked_relations]
-                    + [hit.relation_key for hit in ranked_neighbors]
-                )
-            )
-            stage = "evidence_search"
-            evidence_hits = await self._store.load_evidence_for_projection_keys(
-                request.runtime,
-                tuple(entity_ranks),
-                relation_keys,
-                request.evidence_per_key,
-                allowed_document_ids=request.allowed_document_ids,
-            )
-            counts["evidence_hits"] = len(evidence_hits)
-            if not evidence_hits:
+            stage = "query_plan"
+            stage_started = time.perf_counter()
+            plan = await self._analyze_query(request.query, request.runtime)
+            timings["query_plan_ms"] = self._elapsed_ms(stage_started)
+            if not self._has_query_terms(plan):
                 self._log_outcome(
                     "retrieval_empty",
                     request,
                     started_at,
                     counts,
+                    timings,
+                    reason="no_query_keywords",
+                )
+                return []
+
+            stage = "query_embedding"
+            stage_started = time.perf_counter()
+            branch_vectors = await self._embed_query_plan(
+                request.query,
+                plan,
+            )
+            timings["embedding_ms"] = self._elapsed_ms(stage_started)
+
+            stage = "projection_search"
+            stage_started = time.perf_counter()
+            raw_entity_hits, raw_relation_hits = await self._search_direct_seeds(
+                request,
+                branch_vectors,
+            )
+            counts["raw_entity_seeds"] = len(raw_entity_hits)
+            counts["raw_relation_seeds"] = len(raw_relation_hits)
+            entity_hits = self._deduplicate_entities(
+                hit
+                for hit in raw_entity_hits
+                if hit.score >= request.entity_similarity_threshold
+            )
+            relation_hits = self._deduplicate_relations(
+                hit
+                for hit in raw_relation_hits
+                if hit.score >= request.relation_similarity_threshold
+            )
+            counts["entity_seeds"] = len(entity_hits)
+            counts["relation_seeds"] = len(relation_hits)
+            timings["projection_ms"] = self._elapsed_ms(stage_started)
+            self._log_seed_outcome(
+                request,
+                "local",
+                raw_entity_hits,
+                entity_hits,
+                request.entity_similarity_threshold,
+            )
+            self._log_seed_outcome(
+                request,
+                "global",
+                raw_relation_hits,
+                relation_hits,
+                request.relation_similarity_threshold,
+            )
+            if not entity_hits and not relation_hits:
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    timings,
+                    reason="no_valid_seeds",
+                )
+                return []
+
+            stage = "graph_expansion"
+            stage_started = time.perf_counter()
+            neighbor_relations, endpoint_entities = await self._expand_graph(
+                request,
+                entity_hits,
+                relation_hits,
+            )
+            counts["neighbor_relations"] = len(neighbor_relations)
+            counts["endpoint_entities"] = len(endpoint_entities)
+            timings["expansion_ms"] = self._elapsed_ms(stage_started)
+            final_entities = self._round_robin_entities(
+                entity_hits,
+                endpoint_entities,
+            )
+            final_relations = self._round_robin_relations(
+                neighbor_relations,
+                relation_hits,
+            )
+
+            stage = "evidence_search"
+            stage_started = time.perf_counter()
+            entity_keys = tuple(
+                hit.entity_key for hit in final_entities
+            )
+            relation_keys = tuple(
+                hit.relation_key for hit in final_relations
+            )
+            evidence_groups = await self._store.load_evidence_groups(
+                request.runtime,
+                entity_keys,
+                relation_keys,
+                max(request.max_candidates, request.related_chunk_number),
+                allowed_document_ids=request.allowed_document_ids,
+            )
+            counts["evidence_groups"] = len(evidence_groups)
+            counts["evidence_hits"] = sum(
+                len(group.evidence) for group in evidence_groups
+            )
+            timings["evidence_ms"] = self._elapsed_ms(stage_started)
+            if not evidence_groups:
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    timings,
                     reason="no_evidence",
                 )
                 return []
 
-            stage = "evidence_scoring"
-            matches = self._score_evidence(
-                evidence_hits,
-                ranked_entities,
-                ranked_relations,
-                ranked_neighbors,
-                entity_ranks,
-                relation_ranks,
-                neighbor_ranks,
+            stage = "candidate_ranking"
+            stage_started = time.perf_counter()
+            matches: dict[str, _ChunkMatch] = {}
+            group_map = {
+                (group.projection_type, group.projection_key): group
+                for group in evidence_groups
+            }
+            self._build_local_candidates(
+                plan,
+                entity_hits,
+                neighbor_relations,
+                group_map,
+                matches,
                 request.allowed_document_ids,
             )
-            counts["matched_chunks"] = len(matches)
-            if not matches:
+            self._build_global_candidates(
+                plan,
+                relation_hits,
+                endpoint_entities,
+                group_map,
+                matches,
+                request.allowed_document_ids,
+            )
+            entity_groups = self._build_source_groups(
+                tuple(hit.entity_key for hit in final_entities),
+                "entity",
+                group_map,
+                matches,
+            )
+            entity_sequence = await self._select_source_chunks(
+                request,
+                entity_groups,
+                branch_vectors.get("query"),
+                source_type="entity",
+            )
+            relation_groups = self._build_source_groups(
+                tuple(hit.relation_key for hit in final_relations),
+                "relation",
+                group_map,
+                matches,
+                excluded_source_ids=set(entity_sequence),
+            )
+            relation_sequence = await self._select_source_chunks(
+                request,
+                relation_groups,
+                branch_vectors.get("query"),
+                source_type="relation",
+            )
+            candidate_ids = self._merge_source_types(
+                entity_sequence,
+                relation_sequence,
+                request.max_candidates,
+            )
+            matches = {
+                source_id: matches[source_id]
+                for source_id in candidate_ids
+                if source_id in matches
+            }
+            counts["source_chunks"] = len(candidate_ids)
+            timings["ranking_ms"] = self._elapsed_ms(stage_started)
+            if not candidate_ids:
                 self._log_outcome(
                     "retrieval_empty",
                     request,
                     started_at,
                     counts,
-                    reason="no_scored_matches",
+                    timings,
+                    reason="no_source_chunks",
                 )
                 return []
 
             stage = "chunk_hydration"
+            stage_started = time.perf_counter()
             chunks = await self._store.hydrate_source_chunks(
                 chunk_index_name=request.runtime.chunk_index_name,
                 knowledge_id=request.runtime.knowledge_id,
-                source_chunk_ids=tuple(matches),
+                source_chunk_ids=tuple(candidate_ids),
                 allowed_document_ids=request.allowed_document_ids,
                 file_names=request.file_names,
             )
             counts["hydrated_chunks"] = len(chunks)
-            scoped_chunks = self._scope_hydrated_chunks(request, chunks, matches)
+            scoped_chunks = self._scope_hydrated_chunks(
+                request,
+                chunks,
+                matches,
+                candidate_ids,
+            )
             counts["scoped_chunks"] = len(scoped_chunks)
+            timings["hydration_ms"] = self._elapsed_ms(stage_started)
             if not scoped_chunks:
                 self._log_outcome(
                     "retrieval_empty",
                     request,
                     started_at,
                     counts,
+                    timings,
                     reason="no_scoped_chunks",
                 )
                 return []
 
-            parent_matches = self._build_parent_matches(scoped_chunks, matches)
+            stage = "parent_resolution"
+            stage_started = time.perf_counter()
+            candidate_order = {
+                source_id: index
+                for index, source_id in enumerate(candidate_ids)
+            }
+            parent_matches, parent_order = self._build_parent_matches(
+                scoped_chunks,
+                matches,
+                candidate_order,
+            )
             for chunk in scoped_chunks:
                 source_id = str((chunk.metadata or {}).get("doc_id") or "")
-                chunk.metadata["score"] = matches[source_id].raw_score
-
-            stage = "parent_resolution"
+                match = matches.get(source_id)
+                if match is not None:
+                    chunk.metadata["score"] = match.graph_score
             resolved = await self._parent_resolver(
                 scoped_chunks,
                 request.runtime.chunk_index_name,
             )
-            resolved_with_matches = self._attach_resolved_matches(
+            attached = self._attach_resolved_matches(
                 request,
                 resolved,
                 matches,
                 parent_matches,
+                candidate_order,
+                parent_order,
             )
-            stage = "rank_candidates"
-            result = self._rank_and_limit(
-                resolved_with_matches,
-                request.max_chunks_per_document,
+            result = self._finalize_candidates(
+                attached,
+                request.max_paths_per_chunk,
+                request.max_candidates,
             )
             counts["result_count"] = len(result)
+            timings["parent_ms"] = self._elapsed_ms(stage_started)
             self._log_outcome(
                 "retrieval_done" if result else "retrieval_empty",
                 request,
                 started_at,
                 counts,
-                reason=None if result else "no_ranked_chunks",
+                timings,
+                reason=None if result else "no_resolved_chunks",
             )
             return result
         except asyncio.CancelledError:
@@ -295,11 +534,654 @@ class KnowledgeGraphRetrievalPipeline:
             )
             raise
 
+    async def _embed_query_plan(
+        self,
+        query: str,
+        plan: GraphQueryPlan,
+    ) -> dict[str, list[float]]:
+        texts: list[str] = []
+        branches: list[str] = []
+        if self._has_query_terms(plan) and query.strip():
+            branches.append("query")
+            texts.append(query.strip())
+        if plan.low_level_keywords:
+            branches.append("local")
+            texts.append(" ".join(plan.low_level_keywords))
+        if plan.high_level_keywords:
+            branches.append("global")
+            texts.append(" ".join(plan.high_level_keywords))
+        if not texts:
+            return {}
+        query_embedder = getattr(self._embedding, "aembed_query", None)
+        if callable(query_embedder):
+            vectors = list(
+                await asyncio.gather(
+                    *(query_embedder(text) for text in texts)
+                )
+            )
+        else:
+            vectors = await self._embedding.aembed_documents(texts)
+        if len(vectors) != len(texts):
+            raise ValueError("query embedding count does not match graph branches")
+        return {
+            branch: normalize_vector(vector)
+            for branch, vector in zip(branches, vectors, strict=True)
+        }
+
+    async def _search_direct_seeds(
+        self,
+        request: GraphRetrievalRequest,
+        branch_vectors: dict[str, list[float]],
+    ) -> tuple[list[EntityProjectionHit], list[RelationProjectionHit]]:
+        entity_task = (
+            asyncio.create_task(
+                self._store.search_entity_projections(
+                    request.runtime,
+                    branch_vectors["local"],
+                    request.entity_top_n,
+                    request.entity_similarity_threshold,
+                )
+            )
+            if "local" in branch_vectors
+            else None
+        )
+        relation_task = (
+            asyncio.create_task(
+                self._store.search_relation_projections(
+                    request.runtime,
+                    branch_vectors["global"],
+                    request.relation_top_n,
+                    request.relation_similarity_threshold,
+                )
+            )
+            if "global" in branch_vectors
+            else None
+        )
+        try:
+            entity_hits = await entity_task if entity_task is not None else []
+            relation_hits = await relation_task if relation_task is not None else []
+        except BaseException:
+            for task in (entity_task, relation_task):
+                if task is not None and not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                *(task for task in (entity_task, relation_task) if task is not None),
+                return_exceptions=True,
+            )
+            raise
+        return list(entity_hits), list(relation_hits)
+
+    async def _expand_graph(
+        self,
+        request: GraphRetrievalRequest,
+        entity_hits: list[EntityProjectionHit],
+        relation_hits: list[RelationProjectionHit],
+    ) -> tuple[list[RelationProjectionHit], list[EntityProjectionHit]]:
+        neighbor_task = (
+            asyncio.create_task(
+                self._store.load_neighbor_relations(
+                    request.runtime,
+                    tuple(hit.entity_key for hit in entity_hits),
+                    request.neighbor_top_n,
+                )
+            )
+            if entity_hits
+            else None
+        )
+        endpoint_keys = tuple(
+            dict.fromkeys(
+                key
+                for relation in relation_hits
+                for key in (relation.from_entity_key, relation.to_entity_key)
+                if key
+            )
+        )
+        endpoint_task = (
+            asyncio.create_task(
+                self._store.load_entity_projections(
+                    request.runtime,
+                    endpoint_keys,
+                )
+            )
+            if endpoint_keys
+            else None
+        )
+        try:
+            neighbors = await neighbor_task if neighbor_task is not None else []
+            endpoints = await endpoint_task if endpoint_task is not None else []
+        except BaseException:
+            for task in (neighbor_task, endpoint_task):
+                if task is not None and not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                *(task for task in (neighbor_task, endpoint_task) if task is not None),
+                return_exceptions=True,
+            )
+            raise
+        return (
+            self._deduplicate_neighbor_relations(neighbors),
+            self._order_endpoint_entities(endpoints, endpoint_keys),
+        )
+
+    @classmethod
+    def _build_local_candidates(
+        cls,
+        plan: GraphQueryPlan,
+        entity_hits: Sequence[EntityProjectionHit],
+        neighbor_relations: Sequence[RelationProjectionHit],
+        group_map: dict[tuple[str, str], ProjectionEvidenceGroup],
+        matches: dict[str, _ChunkMatch],
+        allowed_document_ids: tuple[str, ...] | None,
+    ) -> list[_SeedCandidates]:
+        candidates: list[_SeedCandidates] = []
+        for rank, entity in enumerate(entity_hits, start=1):
+            seed = _DirectSeed(
+                branch="local",
+                seed_type="entity",
+                key=entity.entity_key,
+                label=entity.entity_name,
+                score=entity.score,
+                rank=rank,
+                query_keywords=tuple(plan.low_level_keywords),
+            )
+            seed_candidates = _SeedCandidates(seed=seed)
+            cls._add_group_paths(
+                seed_candidates,
+                group_map.get(("entity", entity.entity_key)),
+                seed,
+                matches,
+                allowed_document_ids,
+                expansion_type="direct",
+            )
+            for expansion_rank, relation in enumerate(
+                neighbor_relations,
+                start=1,
+            ):
+                if entity.entity_key not in {
+                    relation.from_entity_key,
+                    relation.to_entity_key,
+                }:
+                    continue
+                cls._add_group_paths(
+                    seed_candidates,
+                    group_map.get(("relation", relation.relation_key)),
+                    seed,
+                    matches,
+                    allowed_document_ids,
+                    expansion_type="relation",
+                    expansion_rank=expansion_rank,
+                    via_relation=relation.label,
+                )
+            if seed_candidates.source_chunk_ids:
+                candidates.append(seed_candidates)
+        return candidates
+
+    @classmethod
+    def _build_global_candidates(
+        cls,
+        plan: GraphQueryPlan,
+        relation_hits: Sequence[RelationProjectionHit],
+        endpoint_entities: Sequence[EntityProjectionHit],
+        group_map: dict[tuple[str, str], ProjectionEvidenceGroup],
+        matches: dict[str, _ChunkMatch],
+        allowed_document_ids: tuple[str, ...] | None,
+    ) -> list[_SeedCandidates]:
+        endpoint_map = {hit.entity_key: hit for hit in endpoint_entities}
+        candidates: list[_SeedCandidates] = []
+        for rank, relation in enumerate(relation_hits, start=1):
+            seed = _DirectSeed(
+                branch="global",
+                seed_type="relation",
+                key=relation.relation_key,
+                label=relation.label,
+                score=relation.score,
+                rank=rank,
+                query_keywords=tuple(plan.high_level_keywords),
+            )
+            seed_candidates = _SeedCandidates(seed=seed)
+            cls._add_group_paths(
+                seed_candidates,
+                group_map.get(("relation", relation.relation_key)),
+                seed,
+                matches,
+                allowed_document_ids,
+                expansion_type="direct",
+            )
+            for expansion_rank, endpoint_key in enumerate(
+                (
+                    relation.from_entity_key,
+                    relation.to_entity_key,
+                ),
+                start=1,
+            ):
+                endpoint = endpoint_map.get(endpoint_key)
+                if endpoint is None:
+                    continue
+                cls._add_group_paths(
+                    seed_candidates,
+                    group_map.get(("entity", endpoint.entity_key)),
+                    seed,
+                    matches,
+                    allowed_document_ids,
+                    expansion_type="endpoint_entity",
+                    expansion_rank=expansion_rank,
+                    via_relation=relation.label,
+                    endpoint_entity=endpoint.entity_name,
+                )
+            if seed_candidates.source_chunk_ids:
+                candidates.append(seed_candidates)
+        return candidates
+
+    @staticmethod
+    def _add_group_paths(
+        seed_candidates: _SeedCandidates,
+        group: ProjectionEvidenceGroup | None,
+        seed: _DirectSeed,
+        matches: dict[str, _ChunkMatch],
+        allowed_document_ids: tuple[str, ...] | None,
+        *,
+        expansion_type: str,
+        expansion_rank: int = 0,
+        via_relation: str | None = None,
+        endpoint_entity: str | None = None,
+    ) -> None:
+        if group is None:
+            return
+        allowed_documents = (
+            {str(value) for value in allowed_document_ids}
+            if allowed_document_ids is not None
+            else None
+        )
+        for evidence in group.evidence:
+            source_id = str(evidence.source_chunk_id).strip()
+            document_id = str(evidence.document_id).strip()
+            if not source_id or not document_id:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+            path = _EvidencePath(
+                seed=seed,
+                evidence_type=group.projection_type,
+                evidence_key=group.projection_key,
+                evidence_confidence=max(0.0, min(1.0, float(evidence.score))),
+                source_chunk_id=source_id,
+                document_id=document_id,
+                expansion_type=expansion_type,
+                expansion_rank=expansion_rank,
+                via_relation=via_relation,
+                endpoint_entity=endpoint_entity,
+            )
+            matches.setdefault(source_id, _ChunkMatch()).add(path)
+            seed_candidates.add(source_id)
+
+    @staticmethod
+    def _build_source_groups(
+        ordered_keys: Sequence[str],
+        projection_type: str,
+        group_map: dict[tuple[str, str], ProjectionEvidenceGroup],
+        matches: dict[str, _ChunkMatch],
+        excluded_source_ids: set[str] | None = None,
+    ) -> list[_SourceGroup]:
+        excluded = excluded_source_ids or set()
+        occurrence_count: dict[str, int] = {}
+        seen: set[str] = set()
+        groups: list[_SourceGroup] = []
+
+        for key in ordered_keys:
+            group = group_map.get((projection_type, key))
+            if group is None:
+                continue
+            source_ids: list[str] = []
+            for evidence in group.evidence:
+                source_id = str(evidence.source_chunk_id).strip()
+                if (
+                    not source_id
+                    or source_id in excluded
+                    or source_id not in matches
+                ):
+                    continue
+                occurrence_count[source_id] = (
+                    occurrence_count.get(source_id, 0) + 1
+                )
+                if source_id in seen:
+                    continue
+                seen.add(source_id)
+                source_ids.append(source_id)
+            if source_ids:
+                groups.append(
+                    _SourceGroup(
+                        key=key,
+                        source_chunk_ids=source_ids,
+                    )
+                )
+
+        for group in groups:
+            group.source_chunk_ids.sort(
+                key=lambda source_id: -occurrence_count.get(source_id, 0)
+            )
+        return groups
+
+    async def _select_source_chunks(
+        self,
+        request: GraphRetrievalRequest,
+        groups: Sequence[_SourceGroup],
+        query_vector: Sequence[float] | None,
+        *,
+        source_type: str,
+    ) -> list[str]:
+        if not groups:
+            return []
+        candidates = [
+            source_id
+            for group in groups
+            for source_id in group.source_chunk_ids
+        ]
+        vector_limit = int(
+            request.related_chunk_number * len(groups) / 2
+        )
+        ranker = getattr(self._store, "rank_source_chunks", None)
+        if query_vector and vector_limit > 0 and callable(ranker):
+            try:
+                ranked = await ranker(
+                    request.runtime,
+                    tuple(candidates),
+                    query_vector,
+                    vector_limit,
+                    allowed_document_ids=request.allowed_document_ids,
+                    file_names=request.file_names,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[EvidenceGraph] source_vector_fallback"
+                    " kb_id=%s source_type=%s error_type=%s",
+                    request.runtime.knowledge_id,
+                    source_type,
+                    type(exc).__name__,
+                )
+                ranked = []
+            allowed = set(candidates)
+            selected = [
+                source_id
+                for source_id in dict.fromkeys(ranked)
+                if source_id in allowed
+            ]
+            if selected:
+                self._log_source_selection(
+                    request,
+                    source_type,
+                    "vector",
+                    len(groups),
+                    len(candidates),
+                    len(selected),
+                )
+                return selected
+        selected = self._weighted_source_poll(
+            groups,
+            request.related_chunk_number,
+        )
+        self._log_source_selection(
+            request,
+            source_type,
+            "weight",
+            len(groups),
+            len(candidates),
+            len(selected),
+        )
+        return selected
+
+    @staticmethod
+    def _weighted_source_poll(
+        groups: Sequence[_SourceGroup],
+        max_related_chunks: int,
+    ) -> list[str]:
+        if not groups:
+            return []
+        maximum = max(1, int(max_related_chunks))
+        if len(groups) == 1:
+            return list(groups[0].source_chunk_ids[:maximum])
+
+        group_count = len(groups)
+        expected_counts = [
+            round(
+                maximum
+                - (index / (group_count - 1)) * (maximum - 1)
+            )
+            for index in range(group_count)
+        ]
+        selected: list[str] = []
+        used_counts: list[int] = []
+        unfilled_quota = 0
+        for group, expected in zip(
+            groups,
+            expected_counts,
+            strict=True,
+        ):
+            used = min(expected, len(group.source_chunk_ids))
+            selected.extend(group.source_chunk_ids[:used])
+            used_counts.append(used)
+            unfilled_quota += expected - used
+
+        for _ in range(unfilled_quota):
+            for index, group in enumerate(groups):
+                if used_counts[index] >= len(group.source_chunk_ids):
+                    continue
+                selected.append(
+                    group.source_chunk_ids[used_counts[index]]
+                )
+                used_counts[index] += 1
+                break
+            else:
+                break
+        return selected
+
+    @staticmethod
+    def _merge_source_types(
+        entity_sequence: Sequence[str],
+        relation_sequence: Sequence[str],
+        limit: int,
+    ) -> list[str]:
+        entities = deque(entity_sequence)
+        relations = deque(relation_sequence)
+        selected: list[str] = []
+        seen: set[str] = set()
+        maximum = max(1, int(limit))
+        while (entities or relations) and len(selected) < maximum:
+            for queue in (entities, relations):
+                while queue:
+                    source_id = queue.popleft()
+                    if source_id in seen:
+                        continue
+                    seen.add(source_id)
+                    selected.append(source_id)
+                    break
+                if len(selected) >= maximum:
+                    break
+        return selected
+
+    @staticmethod
+    def _log_source_selection(
+        request: GraphRetrievalRequest,
+        source_type: str,
+        method: str,
+        group_count: int,
+        candidate_count: int,
+        selected_count: int,
+    ) -> None:
+        logger.info(
+            "[EvidenceGraph] source_selection"
+            " kb_id=%s source_type=%s method=%s"
+            " groups=%d candidates=%d selected=%d",
+            request.runtime.knowledge_id,
+            source_type,
+            method,
+            group_count,
+            candidate_count,
+            selected_count,
+        )
+
+    @staticmethod
+    def _scope_hydrated_chunks(
+        request: GraphRetrievalRequest,
+        chunks: Sequence[DocumentChunk],
+        matches: dict[str, _ChunkMatch],
+        candidate_ids: Sequence[str],
+    ) -> list[DocumentChunk]:
+        allowed_documents = (
+            {str(item) for item in request.allowed_document_ids}
+            if request.allowed_document_ids is not None
+            else None
+        )
+        allowed_files = {str(item) for item in request.file_names}
+        by_source_id: dict[str, DocumentChunk] = {}
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            source_id = str(metadata.get("doc_id") or "")
+            document_id = str(metadata.get("document_id") or "")
+            if not source_id or source_id not in matches:
+                continue
+            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
+                continue
+            if metadata.get("status") != 1:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
+                continue
+            by_source_id.setdefault(source_id, chunk)
+        return [
+            by_source_id[source_id]
+            for source_id in candidate_ids
+            if source_id in by_source_id
+        ]
+
+    @staticmethod
+    def _build_parent_matches(
+        chunks: Sequence[DocumentChunk],
+        matches: dict[str, _ChunkMatch],
+        candidate_order: dict[str, int],
+    ) -> tuple[dict[str, _ChunkMatch], dict[str, int]]:
+        parent_matches: dict[str, _ChunkMatch] = {}
+        parent_order: dict[str, int] = {}
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            if metadata.get("chunk_type") != "child":
+                continue
+            parent_id = str(metadata.get("parent_id") or "")
+            source_id = str(metadata.get("doc_id") or "")
+            match = matches.get(source_id)
+            if not parent_id or match is None:
+                continue
+            parent_matches.setdefault(parent_id, _ChunkMatch()).merge(match)
+            parent_order[parent_id] = min(
+                parent_order.get(parent_id, 2**31 - 1),
+                candidate_order.get(source_id, 2**31 - 1),
+            )
+        return parent_matches, parent_order
+
+    @classmethod
+    def _attach_resolved_matches(
+        cls,
+        request: GraphRetrievalRequest,
+        chunks: Sequence[DocumentChunk],
+        source_matches: dict[str, _ChunkMatch],
+        parent_matches: dict[str, _ChunkMatch],
+        candidate_order: dict[str, int],
+        parent_order: dict[str, int],
+    ) -> list[tuple[DocumentChunk, _ChunkMatch, int]]:
+        allowed_documents = (
+            {str(item) for item in request.allowed_document_ids}
+            if request.allowed_document_ids is not None
+            else None
+        )
+        allowed_files = {str(item) for item in request.file_names}
+        attached: list[tuple[DocumentChunk, _ChunkMatch, int]] = []
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            source_id = str(metadata.get("doc_id") or "")
+            document_id = str(metadata.get("document_id") or "")
+            direct_match = source_matches.get(source_id)
+            parent_match = parent_matches.get(source_id)
+            if direct_match is None and parent_match is None:
+                continue
+            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
+                continue
+            if metadata.get("status") != 1:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
+                continue
+            match = _ChunkMatch()
+            if direct_match is not None:
+                match.merge(direct_match)
+            if parent_match is not None:
+                match.merge(parent_match)
+            order = min(
+                candidate_order.get(source_id, 2**31 - 1),
+                parent_order.get(source_id, 2**31 - 1),
+            )
+            attached.append((chunk, match, order))
+        attached.sort(
+            key=lambda item: (
+                item[2],
+                cls._chunk_sort_id(item[0]),
+                str((item[0].metadata or {}).get("doc_id") or ""),
+            )
+        )
+        return attached
+
+    @staticmethod
+    def _finalize_candidates(
+        attached: Sequence[tuple[DocumentChunk, _ChunkMatch, int]],
+        max_paths_per_chunk: int,
+        max_candidates: int,
+    ) -> list[DocumentChunk]:
+        selected: list[DocumentChunk] = []
+        seen_source_ids: set[str] = set()
+        for chunk, match, _ in attached:
+            source_id = str((chunk.metadata or {}).get("doc_id") or "")
+            if not source_id or source_id in seen_source_ids:
+                continue
+            seen_source_ids.add(source_id)
+            graph_rank = len(selected) + 1
+            chunk.metadata.update(
+                {
+                    "retrieval_source": "graph",
+                    "graph_rank": graph_rank,
+                    "graph_score": match.graph_score,
+                    "score": match.graph_score,
+                    "matched_entities": match.matched_entities(),
+                    "matched_relations": match.matched_relations(),
+                    "expanded_relations": match.expanded_relations(),
+                    "support_count": match.support_count,
+                    "evidence_confidence": match.evidence_confidence,
+                    "match_paths": match.path_metadata(max_paths_per_chunk),
+                }
+            )
+            selected.append(chunk)
+            if len(selected) >= max(1, int(max_candidates)):
+                break
+        return selected
+
     async def _analyze_query(
         self,
         query: str,
-        knowledge_id: str,
-    ) -> GraphQueryAnalysis:
+        runtime: GraphIndexRuntime,
+    ) -> GraphQueryPlan:
+        cache_key = self._query_plan_cache.build_key(runtime, query)
+        cached_plan = await self._query_plan_cache.get(cache_key)
+        normalized_cached = self._normalize_query_plan(query, cached_plan)
+        if (
+            normalized_cached is not None
+            and self._has_query_terms(normalized_cached)
+        ):
+            self._log_query_plan(
+                runtime.knowledge_id,
+                normalized_cached,
+                status="cache_hit",
+                fallback=False,
+            )
+            return normalized_cached
         try:
             raw_result = await self._llm.call_structured(
                 [
@@ -312,20 +1194,90 @@ class KnowledgeGraphRetrievalPipeline:
                         "content": build_query_analysis_prompt(query),
                     },
                 ],
-                GraphQueryAnalysis,
+                GraphQueryPlan,
+                include_raw=True,
             )
-            return GraphQueryAnalysis.model_validate(raw_result)
+            raw_result = unwrap_structured_result(
+                raw_result,
+                GraphQueryPlan,
+            )
+            raw_plan = GraphQueryPlan.model_validate(raw_result)
+            normalized_plan = self._normalize_query_plan(query, raw_plan)
+            if (
+                normalized_plan is None
+                or not self._has_query_terms(normalized_plan)
+            ):
+                fallback_plan = self._fallback_query_plan(query)
+                self._log_query_plan(
+                    runtime.knowledge_id,
+                    fallback_plan,
+                    status="empty",
+                    fallback=True,
+                )
+                return fallback_plan
+            await self._query_plan_cache.set(cache_key, normalized_plan)
+            self._log_query_plan(
+                runtime.knowledge_id,
+                normalized_plan,
+                status="generated",
+                fallback=False,
+            )
+            return normalized_plan
         except Exception as exc:
             logger.warning(
                 "[EvidenceGraph] query_analysis_fallback"
                 " kb_id=%s error_type=%s",
-                knowledge_id,
+                runtime.knowledge_id,
                 type(exc).__name__,
             )
-            return GraphQueryAnalysis(
-                entity_terms=[query],
-                relation_terms=[query],
+            fallback_plan = self._fallback_query_plan(query)
+            self._log_query_plan(
+                runtime.knowledge_id,
+                fallback_plan,
+                status="error",
+                fallback=True,
             )
+            return fallback_plan
+
+    @staticmethod
+    def _log_query_plan(
+        knowledge_id: str,
+        plan: GraphQueryPlan,
+        *,
+        status: str,
+        fallback: bool,
+    ) -> None:
+        logger.info(
+            "[EvidenceGraph] query_plan"
+            " kb_id=%s status=%s fallback=%s low_count=%d high_count=%d",
+            knowledge_id,
+            status,
+            str(fallback).lower(),
+            len(plan.low_level_keywords),
+            len(plan.high_level_keywords),
+        )
+
+    @staticmethod
+    def _log_seed_outcome(
+        request: GraphRetrievalRequest,
+        branch: str,
+        raw_hits: Sequence[Any],
+        passed_hits: Sequence[Any],
+        threshold: float,
+    ) -> None:
+        scores = [float(hit.score) for hit in raw_hits]
+        logger.info(
+            "[EvidenceGraph] retrieval_seeds"
+            " kb_id=%s branch=%s raw=%d passed=%d threshold=%.4f"
+            " score_min=%s score_max=%s",
+            request.runtime.knowledge_id,
+            branch,
+            len(raw_hits),
+            len(passed_hits),
+            threshold,
+            f"{min(scores):.4f}" if scores else "none",
+            f"{max(scores):.4f}" if scores else "none",
+        )
 
     @staticmethod
     def _log_outcome(
@@ -333,283 +1285,194 @@ class KnowledgeGraphRetrievalPipeline:
         request: GraphRetrievalRequest,
         started_at: float,
         counts: dict[str, int],
+        timings: dict[str, int],
         *,
         reason: str | None,
     ) -> None:
         reason_field = f" reason={reason}" if reason is not None else ""
+        timing_fields = " ".join(
+            f"{key}={value}" for key, value in sorted(timings.items())
+        )
         logger.info(
             "[EvidenceGraph] %s kb_id=%s%s"
-            " entity_hits=%d relation_hits=%d neighbor_hits=%d"
-            " evidence_hits=%d matched_chunks=%d hydrated_chunks=%d"
-            " scoped_chunks=%d result_count=%d elapsed_ms=%d",
+            " raw_entity_seeds=%d entity_seeds=%d"
+            " raw_relation_seeds=%d relation_seeds=%d"
+            " neighbor_relations=%d endpoint_entities=%d"
+            " evidence_groups=%d evidence_hits=%d source_chunks=%d"
+            " hydrated_chunks=%d scoped_chunks=%d result_count=%d"
+            " elapsed_ms=%d%s%s",
             event,
             request.runtime.knowledge_id,
             reason_field,
-            counts["entity_hits"],
-            counts["relation_hits"],
-            counts["neighbor_hits"],
+            counts["raw_entity_seeds"],
+            counts["entity_seeds"],
+            counts["raw_relation_seeds"],
+            counts["relation_seeds"],
+            counts["neighbor_relations"],
+            counts["endpoint_entities"],
+            counts["evidence_groups"],
             counts["evidence_hits"],
-            counts["matched_chunks"],
+            counts["source_chunks"],
             counts["hydrated_chunks"],
             counts["scoped_chunks"],
             counts["result_count"],
             KnowledgeGraphRetrievalPipeline._elapsed_ms(started_at),
+            " " if timing_fields else "",
+            timing_fields,
+        )
+
+    @classmethod
+    def _normalize_query_plan(
+        cls,
+        query: str,
+        raw_plan: GraphQueryPlan | None,
+    ) -> GraphQueryPlan | None:
+        if raw_plan is None:
+            return None
+        if not cls._normalize_query_text(query):
+            return None
+
+        return GraphQueryPlan(
+            low_level_keywords=cls._clean_query_terms(
+                raw_plan.low_level_keywords
+            ),
+            high_level_keywords=cls._clean_query_terms(
+                raw_plan.high_level_keywords
+            ),
+        )
+
+    @classmethod
+    def _clean_query_terms(
+        cls,
+        values: list[str],
+    ) -> list[str]:
+        terms: list[str] = []
+        for raw_value in values:
+            term = cls._normalize_query_text(raw_value)
+            if term:
+                terms.append(term)
+        return terms
+
+    @classmethod
+    def _fallback_query_plan(cls, query: str) -> GraphQueryPlan:
+        normalized_query = cls._normalize_query_text(query)
+        return GraphQueryPlan(
+            low_level_keywords=(
+                [normalized_query]
+                if normalized_query and len(normalized_query) < 50
+                else []
+            ),
+            high_level_keywords=[],
         )
 
     @staticmethod
-    def _elapsed_ms(started_at: float) -> int:
-        return int((time.perf_counter() - started_at) * 1000)
+    def _has_query_terms(plan: GraphQueryPlan) -> bool:
+        return bool(plan.low_level_keywords or plan.high_level_keywords)
 
     @staticmethod
-    def _clean_terms(terms: list[str]) -> tuple[str, ...]:
-        return tuple(
-            dict.fromkeys(
-                term
-                for value in terms
-                if (term := " ".join(str(value).split()).strip())
-            )
-        )
+    def _normalize_query_text(value: str) -> str:
+        return str(value).strip()
 
     @staticmethod
     def _deduplicate_entities(
-        hits: list[EntityProjectionHit],
+        hits: Sequence[EntityProjectionHit],
     ) -> list[EntityProjectionHit]:
         by_key: dict[str, EntityProjectionHit] = {}
         for hit in hits:
             current = by_key.get(hit.entity_key)
             if current is None or hit.score > current.score:
                 by_key[hit.entity_key] = hit
-        return sorted(
-            by_key.values(),
-            key=lambda hit: (-hit.score, hit.entity_key),
-        )
+        return list(by_key.values())
+
+    @staticmethod
+    def _order_endpoint_entities(
+        hits: Sequence[EntityProjectionHit],
+        ordered_keys: Sequence[str],
+    ) -> list[EntityProjectionHit]:
+        by_key: dict[str, EntityProjectionHit] = {}
+        for hit in hits:
+            current = by_key.get(hit.entity_key)
+            if current is None or hit.score > current.score:
+                by_key[hit.entity_key] = hit
+        return [
+            by_key[key]
+            for key in ordered_keys
+            if key in by_key
+        ]
+
+    @staticmethod
+    def _round_robin_entities(
+        local_hits: Sequence[EntityProjectionHit],
+        global_hits: Sequence[EntityProjectionHit],
+    ) -> list[EntityProjectionHit]:
+        merged: list[EntityProjectionHit] = []
+        seen: set[str] = set()
+        for index in range(max(len(local_hits), len(global_hits))):
+            for hits in (local_hits, global_hits):
+                if index >= len(hits):
+                    continue
+                hit = hits[index]
+                if hit.entity_key in seen:
+                    continue
+                seen.add(hit.entity_key)
+                merged.append(hit)
+        return merged
+
+    @staticmethod
+    def _round_robin_relations(
+        local_hits: Sequence[RelationProjectionHit],
+        global_hits: Sequence[RelationProjectionHit],
+    ) -> list[RelationProjectionHit]:
+        merged: list[RelationProjectionHit] = []
+        seen: set[str] = set()
+        for index in range(max(len(local_hits), len(global_hits))):
+            for hits in (local_hits, global_hits):
+                if index >= len(hits):
+                    continue
+                hit = hits[index]
+                if hit.relation_key in seen:
+                    continue
+                seen.add(hit.relation_key)
+                merged.append(hit)
+        return merged
 
     @staticmethod
     def _deduplicate_relations(
-        hits: list[RelationProjectionHit],
+        hits: Sequence[RelationProjectionHit],
     ) -> list[RelationProjectionHit]:
         by_key: dict[str, RelationProjectionHit] = {}
         for hit in hits:
             current = by_key.get(hit.relation_key)
             if current is None or hit.score > current.score:
                 by_key[hit.relation_key] = hit
+        return list(by_key.values())
+
+    @staticmethod
+    def _deduplicate_neighbor_relations(
+        hits: Sequence[RelationProjectionHit],
+    ) -> list[RelationProjectionHit]:
+        by_key: dict[str, int] = {}
+        ordered: list[RelationProjectionHit] = []
+        for hit in hits:
+            position = by_key.get(hit.relation_key)
+            if position is None:
+                by_key[hit.relation_key] = len(ordered)
+                ordered.append(hit)
+                continue
+            if hit.endpoint_degree > ordered[position].endpoint_degree:
+                ordered[position] = hit
         return sorted(
-            by_key.values(),
-            key=lambda hit: (-hit.score, hit.relation_key),
+            ordered,
+            key=lambda hit: -hit.endpoint_degree,
         )
-
-    @classmethod
-    def _score_evidence(
-        cls,
-        evidence_hits: list[GraphEvidenceHit],
-        entity_hits: list[EntityProjectionHit],
-        relation_hits: list[RelationProjectionHit],
-        neighbor_hits: list[RelationProjectionHit],
-        entity_ranks: dict[str, int],
-        relation_ranks: dict[str, int],
-        neighbor_ranks: dict[str, int],
-        allowed_document_ids: tuple[str, ...] | None,
-    ) -> dict[str, _ChunkMatch]:
-        allowed_documents = (
-            {str(item) for item in allowed_document_ids}
-            if allowed_document_ids is not None
-            else None
-        )
-        entity_names = {hit.entity_key: hit.entity_name for hit in entity_hits}
-        relation_labels = {
-            hit.relation_key: hit.label
-            for hit in (*relation_hits, *neighbor_hits)
-        }
-        matches: dict[str, _ChunkMatch] = {}
-
-        for evidence in evidence_hits:
-            source_id = str(evidence.source_chunk_id).strip()
-            document_id = str(evidence.document_id).strip()
-            if not source_id or not document_id:
-                continue
-            if allowed_documents is not None and document_id not in allowed_documents:
-                continue
-
-            match = matches.setdefault(source_id, _ChunkMatch())
-            if evidence.entity_key in entity_ranks:
-                key = str(evidence.entity_key)
-                rank = entity_ranks[key]
-                match.add_score(
-                    "entity",
-                    key,
-                    _ENTITY_WEIGHT / (_RRF_BASE + rank),
-                )
-                entity_name = evidence.entity_name or entity_names.get(key)
-                if entity_name:
-                    match.entity_names.add(entity_name)
-                match.evidence_tokens.add(("entity", key, document_id))
-
-            if evidence.relation_key:
-                key = str(evidence.relation_key)
-                if key in relation_ranks:
-                    match.add_score(
-                        "relation",
-                        key,
-                        _RELATION_WEIGHT / (_RRF_BASE + relation_ranks[key]),
-                    )
-                if key in neighbor_ranks:
-                    match.add_score(
-                        "neighbor",
-                        key,
-                        _NEIGHBOR_WEIGHT / (_RRF_BASE + neighbor_ranks[key]),
-                    )
-                if key in relation_ranks or key in neighbor_ranks:
-                    relation_label = evidence.relation_label or relation_labels.get(key)
-                    if relation_label:
-                        match.relation_labels.add(relation_label)
-                    match.evidence_tokens.add(("relation", key, document_id))
-
-        return {
-            source_id: match
-            for source_id, match in matches.items()
-            if match.channel_scores
-        }
 
     @staticmethod
-    def _scope_hydrated_chunks(
-        request: GraphRetrievalRequest,
-        chunks: list[DocumentChunk],
-        matches: dict[str, _ChunkMatch],
-    ) -> list[DocumentChunk]:
-        allowed_documents = (
-            {str(item) for item in request.allowed_document_ids}
-            if request.allowed_document_ids is not None
-            else None
-        )
-        allowed_files = {str(item) for item in request.file_names}
-        scoped: list[DocumentChunk] = []
-        seen_source_ids: set[str] = set()
-        for chunk in chunks:
-            metadata = chunk.metadata or {}
-            source_id = str(metadata.get("doc_id") or "")
-            document_id = str(metadata.get("document_id") or "")
-            if source_id not in matches or source_id in seen_source_ids:
-                continue
-            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
-                continue
-            if metadata.get("status") != 1:
-                continue
-            if allowed_documents is not None and document_id not in allowed_documents:
-                continue
-            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
-                continue
-            seen_source_ids.add(source_id)
-            scoped.append(chunk)
-        return scoped
-
-    @staticmethod
-    def _build_parent_matches(
-        chunks: list[DocumentChunk],
-        matches: dict[str, _ChunkMatch],
-    ) -> dict[str, _ChunkMatch]:
-        parent_matches: dict[str, _ChunkMatch] = {}
-        for chunk in chunks:
-            metadata = chunk.metadata or {}
-            if metadata.get("chunk_type") != "child":
-                continue
-            parent_id = str(metadata.get("parent_id") or "")
-            source_id = str(metadata.get("doc_id") or "")
-            if not parent_id or source_id not in matches:
-                continue
-            parent_matches.setdefault(parent_id, _ChunkMatch()).merge(matches[source_id])
-        return parent_matches
-
-    @classmethod
-    def _attach_resolved_matches(
-        cls,
-        request: GraphRetrievalRequest,
-        chunks: list[DocumentChunk],
-        source_matches: dict[str, _ChunkMatch],
-        parent_matches: dict[str, _ChunkMatch],
-    ) -> list[tuple[DocumentChunk, _ChunkMatch]]:
-        allowed_documents = (
-            {str(item) for item in request.allowed_document_ids}
-            if request.allowed_document_ids is not None
-            else None
-        )
-        allowed_files = {str(item) for item in request.file_names}
-        attached: list[tuple[DocumentChunk, _ChunkMatch]] = []
-        seen_ids: set[str] = set()
-        for chunk in chunks:
-            metadata = chunk.metadata or {}
-            source_id = str(metadata.get("doc_id") or "")
-            document_id = str(metadata.get("document_id") or "")
-            match = source_matches.get(source_id) or parent_matches.get(source_id)
-            if match is None or source_id in seen_ids:
-                continue
-            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
-                continue
-            if metadata.get("status") != 1:
-                continue
-            if allowed_documents is not None and document_id not in allowed_documents:
-                continue
-            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
-                continue
-            seen_ids.add(source_id)
-            attached.append((chunk, match))
-        return attached
-
-    @classmethod
-    def _rank_and_limit(
-        cls,
-        chunks_with_matches: list[tuple[DocumentChunk, _ChunkMatch]],
-        max_chunks_per_document: int,
-    ) -> list[DocumentChunk]:
-        if not chunks_with_matches:
-            return []
-        maximum_score = max(match.raw_score for _, match in chunks_with_matches)
-
-        decorated: list[tuple[DocumentChunk, _ChunkMatch]] = []
-        for chunk, match in chunks_with_matches:
-            graph_score = (
-                min(1.0, match.raw_score / maximum_score)
-                if maximum_score > 0
-                else 0.0
-            )
-            chunk.metadata.update(
-                {
-                    "retrieval_source": "graph",
-                    "graph_score": graph_score,
-                    "score": graph_score,
-                    "matched_entities": sorted(match.entity_names),
-                    "matched_relations": sorted(match.relation_labels),
-                }
-            )
-            decorated.append((chunk, match))
-
-        decorated.sort(key=cls._candidate_sort_key)
-        per_document: dict[str, int] = {}
-        selected: list[DocumentChunk] = []
-        limit = max(1, int(max_chunks_per_document))
-        for chunk, _ in decorated:
-            document_id = str((chunk.metadata or {}).get("document_id") or "")
-            count = per_document.get(document_id, 0)
-            if count >= limit:
-                continue
-            per_document[document_id] = count + 1
-            selected.append(chunk)
-        return selected
-
-    @staticmethod
-    def _candidate_sort_key(
-        item: tuple[DocumentChunk, _ChunkMatch],
-    ) -> tuple[float, int, int, int, str]:
-        chunk, match = item
-        raw_sort_id = (chunk.metadata or {}).get("sort_id")
+    def _chunk_sort_id(chunk: DocumentChunk) -> int:
         try:
-            sort_id = int(raw_sort_id)
+            return int((chunk.metadata or {}).get("sort_id"))
         except (TypeError, ValueError):
-            sort_id = 2**31 - 1
-        source_id = str((chunk.metadata or {}).get("doc_id") or "")
-        return (
-            -match.raw_score,
-            -match.match_count,
-            -match.evidence_count,
-            sort_id,
-            source_id,
-        )
+            return 2**31 - 1
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return int((time.perf_counter() - started_at) * 1000)

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -1,0 +1,472 @@
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.core.config import settings
+from app.core.rag.knowledge_graph.models import (
+    EntityProjectionHit,
+    GraphEvidenceHit,
+    GraphQueryAnalysis,
+    GraphRetrievalRequest,
+    RelationProjectionHit,
+)
+from app.core.rag.knowledge_graph.prompts import (
+    QUERY_ANALYSIS_SYSTEM_PROMPT,
+    build_query_analysis_prompt,
+)
+from app.core.rag.models.chunk import DocumentChunk
+from app.core.rag.retrieval.elasticsearch_queries import normalize_vector
+
+
+logger = logging.getLogger(__name__)
+
+_RRF_BASE = 60
+_ENTITY_WEIGHT = 0.45
+_RELATION_WEIGHT = 0.40
+_NEIGHBOR_WEIGHT = 0.15
+
+
+@dataclass
+class _ChunkMatch:
+    channel_scores: dict[tuple[str, str], float] = field(default_factory=dict)
+    entity_names: set[str] = field(default_factory=set)
+    relation_labels: set[str] = field(default_factory=set)
+    evidence_tokens: set[tuple[str, str, str]] = field(default_factory=set)
+
+    @property
+    def raw_score(self) -> float:
+        return sum(self.channel_scores.values())
+
+    @property
+    def match_count(self) -> int:
+        return len(self.entity_names) + len(self.relation_labels)
+
+    @property
+    def evidence_count(self) -> int:
+        return len(self.evidence_tokens)
+
+    def add_score(self, channel: str, key: str, score: float) -> None:
+        token = (channel, key)
+        self.channel_scores[token] = max(
+            self.channel_scores.get(token, 0.0),
+            max(0.0, float(score)),
+        )
+
+    def merge(self, other: "_ChunkMatch") -> None:
+        for (channel, key), score in other.channel_scores.items():
+            self.add_score(channel, key, score)
+        self.entity_names.update(other.entity_names)
+        self.relation_labels.update(other.relation_labels)
+        self.evidence_tokens.update(other.evidence_tokens)
+
+
+class KnowledgeGraphRetrievalPipeline:
+    def __init__(
+        self,
+        store: Any,
+        llm: Any,
+        embedding: Any,
+        parent_resolver: Any,
+    ) -> None:
+        self._store = store
+        self._llm = llm
+        self._embedding = embedding
+        self._parent_resolver = parent_resolver
+
+    async def retrieve(
+        self,
+        request: GraphRetrievalRequest,
+    ) -> list[DocumentChunk]:
+        timeout_seconds = settings.KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS / 1000
+        async with asyncio.timeout(timeout_seconds):
+            return await self._retrieve(request)
+
+    async def _retrieve(
+        self,
+        request: GraphRetrievalRequest,
+    ) -> list[DocumentChunk]:
+        if request.allowed_document_ids is not None and not request.allowed_document_ids:
+            return []
+
+        analysis = await self._analyze_query(request.query)
+        entity_text = " ".join(self._clean_terms(analysis.entity_terms)) or request.query
+        relation_text = " ".join(self._clean_terms(analysis.relation_terms)) or request.query
+
+        entity_vector, relation_vector = await asyncio.gather(
+            self._embedding.aembed_query(entity_text),
+            self._embedding.aembed_query(relation_text),
+        )
+        entity_hits, relation_hits = await asyncio.gather(
+            self._store.search_entity_projections(
+                request.runtime,
+                normalize_vector(entity_vector),
+                request.entity_top_n,
+            ),
+            self._store.search_relation_projections(
+                request.runtime,
+                normalize_vector(relation_vector),
+                request.relation_top_n,
+            ),
+        )
+
+        ranked_entities = self._deduplicate_entities(entity_hits)
+        ranked_relations = self._deduplicate_relations(relation_hits)
+        neighbor_hits = await self._store.load_neighbor_relations(
+            request.runtime,
+            tuple(hit.entity_key for hit in ranked_entities),
+            request.neighbor_top_n,
+        )
+        ranked_neighbors = self._deduplicate_relations(neighbor_hits)
+
+        entity_ranks = {
+            hit.entity_key: rank
+            for rank, hit in enumerate(ranked_entities, start=1)
+        }
+        relation_ranks = {
+            hit.relation_key: rank
+            for rank, hit in enumerate(ranked_relations, start=1)
+        }
+        neighbor_ranks = {
+            hit.relation_key: rank
+            for rank, hit in enumerate(ranked_neighbors, start=1)
+        }
+        relation_keys = tuple(
+            dict.fromkeys(
+                [hit.relation_key for hit in ranked_relations]
+                + [hit.relation_key for hit in ranked_neighbors]
+            )
+        )
+        evidence_hits = await self._store.load_evidence_for_projection_keys(
+            request.runtime,
+            tuple(entity_ranks),
+            relation_keys,
+            request.evidence_per_key,
+            allowed_document_ids=request.allowed_document_ids,
+        )
+        if not evidence_hits:
+            return []
+
+        matches = self._score_evidence(
+            evidence_hits,
+            ranked_entities,
+            ranked_relations,
+            ranked_neighbors,
+            entity_ranks,
+            relation_ranks,
+            neighbor_ranks,
+            request.allowed_document_ids,
+        )
+        if not matches:
+            return []
+
+        chunks = await self._store.hydrate_source_chunks(
+            chunk_index_name=request.runtime.chunk_index_name,
+            knowledge_id=request.runtime.knowledge_id,
+            source_chunk_ids=tuple(matches),
+            allowed_document_ids=request.allowed_document_ids,
+            file_names=request.file_names,
+        )
+        scoped_chunks = self._scope_hydrated_chunks(request, chunks, matches)
+        if not scoped_chunks:
+            return []
+
+        parent_matches = self._build_parent_matches(scoped_chunks, matches)
+        for chunk in scoped_chunks:
+            source_id = str((chunk.metadata or {}).get("doc_id") or "")
+            chunk.metadata["score"] = matches[source_id].raw_score
+
+        resolved = await self._parent_resolver(
+            scoped_chunks,
+            request.runtime.chunk_index_name,
+        )
+        resolved_with_matches = self._attach_resolved_matches(
+            request,
+            resolved,
+            matches,
+            parent_matches,
+        )
+        return self._rank_and_limit(
+            resolved_with_matches,
+            request.max_chunks_per_document,
+        )
+
+    async def _analyze_query(self, query: str) -> GraphQueryAnalysis:
+        try:
+            raw_result = await self._llm.call_structured(
+                [
+                    {
+                        "role": "system",
+                        "content": QUERY_ANALYSIS_SYSTEM_PROMPT,
+                    },
+                    {
+                        "role": "user",
+                        "content": build_query_analysis_prompt(query),
+                    },
+                ],
+                GraphQueryAnalysis,
+            )
+            return GraphQueryAnalysis.model_validate(raw_result)
+        except Exception as exc:
+            logger.warning(
+                "Graph query analysis failed; using the original query: %s",
+                exc,
+            )
+            return GraphQueryAnalysis(
+                entity_terms=[query],
+                relation_terms=[query],
+            )
+
+    @staticmethod
+    def _clean_terms(terms: list[str]) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                term
+                for value in terms
+                if (term := " ".join(str(value).split()).strip())
+            )
+        )
+
+    @staticmethod
+    def _deduplicate_entities(
+        hits: list[EntityProjectionHit],
+    ) -> list[EntityProjectionHit]:
+        by_key: dict[str, EntityProjectionHit] = {}
+        for hit in hits:
+            current = by_key.get(hit.entity_key)
+            if current is None or hit.score > current.score:
+                by_key[hit.entity_key] = hit
+        return sorted(
+            by_key.values(),
+            key=lambda hit: (-hit.score, hit.entity_key),
+        )
+
+    @staticmethod
+    def _deduplicate_relations(
+        hits: list[RelationProjectionHit],
+    ) -> list[RelationProjectionHit]:
+        by_key: dict[str, RelationProjectionHit] = {}
+        for hit in hits:
+            current = by_key.get(hit.relation_key)
+            if current is None or hit.score > current.score:
+                by_key[hit.relation_key] = hit
+        return sorted(
+            by_key.values(),
+            key=lambda hit: (-hit.score, hit.relation_key),
+        )
+
+    @classmethod
+    def _score_evidence(
+        cls,
+        evidence_hits: list[GraphEvidenceHit],
+        entity_hits: list[EntityProjectionHit],
+        relation_hits: list[RelationProjectionHit],
+        neighbor_hits: list[RelationProjectionHit],
+        entity_ranks: dict[str, int],
+        relation_ranks: dict[str, int],
+        neighbor_ranks: dict[str, int],
+        allowed_document_ids: tuple[str, ...] | None,
+    ) -> dict[str, _ChunkMatch]:
+        allowed_documents = (
+            {str(item) for item in allowed_document_ids}
+            if allowed_document_ids is not None
+            else None
+        )
+        entity_names = {hit.entity_key: hit.entity_name for hit in entity_hits}
+        relation_labels = {
+            hit.relation_key: hit.label
+            for hit in (*relation_hits, *neighbor_hits)
+        }
+        matches: dict[str, _ChunkMatch] = {}
+
+        for evidence in evidence_hits:
+            source_id = str(evidence.source_chunk_id).strip()
+            document_id = str(evidence.document_id).strip()
+            if not source_id or not document_id:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+
+            match = matches.setdefault(source_id, _ChunkMatch())
+            if evidence.entity_key in entity_ranks:
+                key = str(evidence.entity_key)
+                rank = entity_ranks[key]
+                match.add_score(
+                    "entity",
+                    key,
+                    _ENTITY_WEIGHT / (_RRF_BASE + rank),
+                )
+                entity_name = evidence.entity_name or entity_names.get(key)
+                if entity_name:
+                    match.entity_names.add(entity_name)
+                match.evidence_tokens.add(("entity", key, document_id))
+
+            if evidence.relation_key:
+                key = str(evidence.relation_key)
+                if key in relation_ranks:
+                    match.add_score(
+                        "relation",
+                        key,
+                        _RELATION_WEIGHT / (_RRF_BASE + relation_ranks[key]),
+                    )
+                if key in neighbor_ranks:
+                    match.add_score(
+                        "neighbor",
+                        key,
+                        _NEIGHBOR_WEIGHT / (_RRF_BASE + neighbor_ranks[key]),
+                    )
+                if key in relation_ranks or key in neighbor_ranks:
+                    relation_label = evidence.relation_label or relation_labels.get(key)
+                    if relation_label:
+                        match.relation_labels.add(relation_label)
+                    match.evidence_tokens.add(("relation", key, document_id))
+
+        return {
+            source_id: match
+            for source_id, match in matches.items()
+            if match.channel_scores
+        }
+
+    @staticmethod
+    def _scope_hydrated_chunks(
+        request: GraphRetrievalRequest,
+        chunks: list[DocumentChunk],
+        matches: dict[str, _ChunkMatch],
+    ) -> list[DocumentChunk]:
+        allowed_documents = (
+            {str(item) for item in request.allowed_document_ids}
+            if request.allowed_document_ids is not None
+            else None
+        )
+        allowed_files = {str(item) for item in request.file_names}
+        scoped: list[DocumentChunk] = []
+        seen_source_ids: set[str] = set()
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            source_id = str(metadata.get("doc_id") or "")
+            document_id = str(metadata.get("document_id") or "")
+            if source_id not in matches or source_id in seen_source_ids:
+                continue
+            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
+                continue
+            if metadata.get("status") != 1:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
+                continue
+            seen_source_ids.add(source_id)
+            scoped.append(chunk)
+        return scoped
+
+    @staticmethod
+    def _build_parent_matches(
+        chunks: list[DocumentChunk],
+        matches: dict[str, _ChunkMatch],
+    ) -> dict[str, _ChunkMatch]:
+        parent_matches: dict[str, _ChunkMatch] = {}
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            if metadata.get("chunk_type") != "child":
+                continue
+            parent_id = str(metadata.get("parent_id") or "")
+            source_id = str(metadata.get("doc_id") or "")
+            if not parent_id or source_id not in matches:
+                continue
+            parent_matches.setdefault(parent_id, _ChunkMatch()).merge(matches[source_id])
+        return parent_matches
+
+    @classmethod
+    def _attach_resolved_matches(
+        cls,
+        request: GraphRetrievalRequest,
+        chunks: list[DocumentChunk],
+        source_matches: dict[str, _ChunkMatch],
+        parent_matches: dict[str, _ChunkMatch],
+    ) -> list[tuple[DocumentChunk, _ChunkMatch]]:
+        allowed_documents = (
+            {str(item) for item in request.allowed_document_ids}
+            if request.allowed_document_ids is not None
+            else None
+        )
+        allowed_files = {str(item) for item in request.file_names}
+        attached: list[tuple[DocumentChunk, _ChunkMatch]] = []
+        seen_ids: set[str] = set()
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            source_id = str(metadata.get("doc_id") or "")
+            document_id = str(metadata.get("document_id") or "")
+            match = source_matches.get(source_id) or parent_matches.get(source_id)
+            if match is None or source_id in seen_ids:
+                continue
+            if str(metadata.get("knowledge_id")) != request.runtime.knowledge_id:
+                continue
+            if metadata.get("status") != 1:
+                continue
+            if allowed_documents is not None and document_id not in allowed_documents:
+                continue
+            if allowed_files and str(metadata.get("file_name")) not in allowed_files:
+                continue
+            seen_ids.add(source_id)
+            attached.append((chunk, match))
+        return attached
+
+    @classmethod
+    def _rank_and_limit(
+        cls,
+        chunks_with_matches: list[tuple[DocumentChunk, _ChunkMatch]],
+        max_chunks_per_document: int,
+    ) -> list[DocumentChunk]:
+        if not chunks_with_matches:
+            return []
+        maximum_score = max(match.raw_score for _, match in chunks_with_matches)
+
+        decorated: list[tuple[DocumentChunk, _ChunkMatch]] = []
+        for chunk, match in chunks_with_matches:
+            graph_score = (
+                min(1.0, match.raw_score / maximum_score)
+                if maximum_score > 0
+                else 0.0
+            )
+            chunk.metadata.update(
+                {
+                    "retrieval_source": "graph",
+                    "graph_score": graph_score,
+                    "score": graph_score,
+                    "matched_entities": sorted(match.entity_names),
+                    "matched_relations": sorted(match.relation_labels),
+                }
+            )
+            decorated.append((chunk, match))
+
+        decorated.sort(key=cls._candidate_sort_key)
+        per_document: dict[str, int] = {}
+        selected: list[DocumentChunk] = []
+        limit = max(1, int(max_chunks_per_document))
+        for chunk, _ in decorated:
+            document_id = str((chunk.metadata or {}).get("document_id") or "")
+            count = per_document.get(document_id, 0)
+            if count >= limit:
+                continue
+            per_document[document_id] = count + 1
+            selected.append(chunk)
+        return selected
+
+    @staticmethod
+    def _candidate_sort_key(
+        item: tuple[DocumentChunk, _ChunkMatch],
+    ) -> tuple[float, int, int, int, str]:
+        chunk, match = item
+        raw_sort_id = (chunk.metadata or {}).get("sort_id")
+        try:
+            sort_id = int(raw_sort_id)
+        except (TypeError, ValueError):
+            sort_id = 2**31 - 1
+        source_id = str((chunk.metadata or {}).get("doc_id") or "")
+        return (
+            -match.raw_score,
+            -match.match_count,
+            -match.evidence_count,
+            sort_id,
+            source_id,
+        )

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -12,6 +12,7 @@ from app.core.rag.knowledge_graph.models import (
     GraphEvidenceHit,
     GraphIndexRuntime,
     GraphQueryPlan,
+    GraphRetrievalResult,
     GraphRetrievalRequest,
     ProjectionEvidenceGroup,
     RelationProjectionHit,
@@ -212,6 +213,13 @@ class KnowledgeGraphRetrievalPipeline:
         self,
         request: GraphRetrievalRequest,
     ) -> list[DocumentChunk]:
+        result = await self.retrieve_with_graph_data(request)
+        return result.chunks
+
+    async def retrieve_with_graph_data(
+        self,
+        request: GraphRetrievalRequest,
+    ) -> GraphRetrievalResult:
         started_at = time.perf_counter()
         timeout_seconds = settings.KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS / 1000
         timeout_context = asyncio.timeout(timeout_seconds)
@@ -233,7 +241,7 @@ class KnowledgeGraphRetrievalPipeline:
         self,
         request: GraphRetrievalRequest,
         started_at: float,
-    ) -> list[DocumentChunk]:
+    ) -> GraphRetrievalResult:
         stage = "validate_filters"
         timings: dict[str, int] = {}
         counts = {
@@ -263,7 +271,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_allowed_documents",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "query_plan"
             stage_started = time.perf_counter()
@@ -278,7 +286,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_query_keywords",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "query_embedding"
             stage_started = time.perf_counter()
@@ -332,7 +340,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_valid_seeds",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "graph_expansion"
             stage_started = time.perf_counter()
@@ -382,7 +390,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_evidence",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "candidate_ranking"
             stage_started = time.perf_counter()
@@ -463,7 +471,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_source_chunks",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "chunk_hydration"
             stage_started = time.perf_counter()
@@ -492,7 +500,7 @@ class KnowledgeGraphRetrievalPipeline:
                     timings,
                     reason="no_scoped_chunks",
                 )
-                return []
+                return GraphRetrievalResult()
 
             stage = "parent_resolution"
             stage_started = time.perf_counter()
@@ -534,8 +542,12 @@ class KnowledgeGraphRetrievalPipeline:
                 source_vector_scores,
                 parent_vector_scores,
             )
-            result = self._finalize_candidates(
+            selected_attached = self._select_attached_candidates(
                 attached,
+                request.max_candidates,
+            )
+            result = self._finalize_candidates(
+                selected_attached,
                 request.max_paths_per_chunk,
                 request.max_candidates,
             )
@@ -549,7 +561,17 @@ class KnowledgeGraphRetrievalPipeline:
                 timings,
                 reason=None if result else "no_resolved_chunks",
             )
-            return result
+            return GraphRetrievalResult(
+                chunks=result,
+                entities=self._format_result_entities(
+                    selected_attached,
+                    final_entities,
+                ),
+                relationships=self._format_result_relationships(
+                    selected_attached,
+                    final_relations,
+                ),
+            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -1216,6 +1238,109 @@ class KnowledgeGraphRetrievalPipeline:
             )
         )
         return attached
+
+    @staticmethod
+    def _select_attached_candidates(
+        attached: Sequence[tuple[DocumentChunk, _ChunkMatch, int, float | None]],
+        max_candidates: int,
+    ) -> list[tuple[DocumentChunk, _ChunkMatch, int, float | None]]:
+        selected: list[tuple[DocumentChunk, _ChunkMatch, int, float | None]] = []
+        seen_source_ids: set[str] = set()
+        for item in attached:
+            chunk = item[0]
+            source_id = str((chunk.metadata or {}).get("doc_id") or "")
+            if not source_id or source_id in seen_source_ids:
+                continue
+            seen_source_ids.add(source_id)
+            selected.append(item)
+            if len(selected) >= max(1, int(max_candidates)):
+                break
+        return selected
+
+    @classmethod
+    def _format_result_entities(
+        cls,
+        selected: Sequence[tuple[DocumentChunk, _ChunkMatch, int, float | None]],
+        entities: Sequence[EntityProjectionHit],
+    ) -> list[dict[str, Any]]:
+        entity_map = {entity.entity_key: entity for entity in entities}
+        source_ids_by_key = cls._projection_source_ids(selected, "entity")
+        result: list[dict[str, Any]] = []
+        for entity_key, source_ids in source_ids_by_key.items():
+            entity = entity_map.get(entity_key)
+            if entity is None:
+                continue
+            result.append(
+                {
+                    "entity_key": entity.entity_key,
+                    "entity_name": entity.entity_name,
+                    "entity_type": entity.entity_type,
+                    "description": entity.description,
+                    "aliases": list(entity.aliases),
+                    "score": entity.score,
+                    "degree": entity.degree,
+                    "evidence_count": entity.evidence_count,
+                    "document_count": entity.document_count,
+                    "source_chunk_ids": source_ids,
+                }
+            )
+        return result
+
+    @classmethod
+    def _format_result_relationships(
+        cls,
+        selected: Sequence[tuple[DocumentChunk, _ChunkMatch, int, float | None]],
+        relationships: Sequence[RelationProjectionHit],
+    ) -> list[dict[str, Any]]:
+        relationship_map = {
+            relationship.relation_key: relationship
+            for relationship in relationships
+        }
+        source_ids_by_key = cls._projection_source_ids(selected, "relation")
+        result: list[dict[str, Any]] = []
+        for relation_key, source_ids in source_ids_by_key.items():
+            relationship = relationship_map.get(relation_key)
+            if relationship is None:
+                continue
+            result.append(
+                {
+                    "relation_key": relationship.relation_key,
+                    "src_id": relationship.from_entity_key,
+                    "tgt_id": relationship.to_entity_key,
+                    "from_entity_key": relationship.from_entity_key,
+                    "from_entity_name": relationship.from_entity_name,
+                    "to_entity_key": relationship.to_entity_key,
+                    "to_entity_name": relationship.to_entity_name,
+                    "predicate": relationship.predicate,
+                    "label": relationship.label,
+                    "description": relationship.description,
+                    "keywords": list(relationship.keywords),
+                    "directed": relationship.directed,
+                    "score": relationship.score,
+                    "weight": relationship.evidence_count,
+                    "evidence_count": relationship.evidence_count,
+                    "document_count": relationship.document_count,
+                    "endpoint_degree": relationship.endpoint_degree,
+                    "source_chunk_ids": source_ids,
+                }
+            )
+        return result
+
+    @staticmethod
+    def _projection_source_ids(
+        selected: Sequence[tuple[DocumentChunk, _ChunkMatch, int, float | None]],
+        projection_type: str,
+    ) -> dict[str, list[str]]:
+        source_ids_by_key: dict[str, list[str]] = {}
+        for _, match, _, _ in selected:
+            for path in match.paths:
+                if path.evidence_type != projection_type:
+                    continue
+                key = path.evidence_key
+                source_ids = source_ids_by_key.setdefault(key, [])
+                if path.source_chunk_id not in source_ids:
+                    source_ids.append(path.source_chunk_id)
+        return source_ids_by_key
 
     @staticmethod
     def _finalize_candidates(

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -78,120 +79,227 @@ class KnowledgeGraphRetrievalPipeline:
         self,
         request: GraphRetrievalRequest,
     ) -> list[DocumentChunk]:
+        started_at = time.perf_counter()
         timeout_seconds = settings.KNOWLEDGE_GRAPH_RETRIEVAL_TIMEOUT_MS / 1000
-        async with asyncio.timeout(timeout_seconds):
-            return await self._retrieve(request)
+        timeout_context = asyncio.timeout(timeout_seconds)
+        try:
+            async with timeout_context:
+                return await self._retrieve(request, started_at)
+        except TimeoutError as exc:
+            if timeout_context.expired():
+                logger.warning(
+                    "[EvidenceGraph] retrieval_failed"
+                    " kb_id=%s stage=timeout error_type=%s elapsed_ms=%d",
+                    request.runtime.knowledge_id,
+                    type(exc).__name__,
+                    self._elapsed_ms(started_at),
+                )
+            raise
 
     async def _retrieve(
         self,
         request: GraphRetrievalRequest,
+        started_at: float,
     ) -> list[DocumentChunk]:
-        if request.allowed_document_ids is not None and not request.allowed_document_ids:
-            return []
-
-        analysis = await self._analyze_query(request.query)
-        entity_text = " ".join(self._clean_terms(analysis.entity_terms)) or request.query
-        relation_text = " ".join(self._clean_terms(analysis.relation_terms)) or request.query
-
-        entity_vector, relation_vector = await asyncio.gather(
-            self._embedding.aembed_query(entity_text),
-            self._embedding.aembed_query(relation_text),
-        )
-        entity_hits, relation_hits = await asyncio.gather(
-            self._store.search_entity_projections(
-                request.runtime,
-                normalize_vector(entity_vector),
-                request.entity_top_n,
-            ),
-            self._store.search_relation_projections(
-                request.runtime,
-                normalize_vector(relation_vector),
-                request.relation_top_n,
-            ),
-        )
-
-        ranked_entities = self._deduplicate_entities(entity_hits)
-        ranked_relations = self._deduplicate_relations(relation_hits)
-        neighbor_hits = await self._store.load_neighbor_relations(
-            request.runtime,
-            tuple(hit.entity_key for hit in ranked_entities),
-            request.neighbor_top_n,
-        )
-        ranked_neighbors = self._deduplicate_relations(neighbor_hits)
-
-        entity_ranks = {
-            hit.entity_key: rank
-            for rank, hit in enumerate(ranked_entities, start=1)
+        stage = "validate_filters"
+        counts = {
+            "entity_hits": 0,
+            "relation_hits": 0,
+            "neighbor_hits": 0,
+            "evidence_hits": 0,
+            "matched_chunks": 0,
+            "hydrated_chunks": 0,
+            "scoped_chunks": 0,
+            "result_count": 0,
         }
-        relation_ranks = {
-            hit.relation_key: rank
-            for rank, hit in enumerate(ranked_relations, start=1)
-        }
-        neighbor_ranks = {
-            hit.relation_key: rank
-            for rank, hit in enumerate(ranked_neighbors, start=1)
-        }
-        relation_keys = tuple(
-            dict.fromkeys(
-                [hit.relation_key for hit in ranked_relations]
-                + [hit.relation_key for hit in ranked_neighbors]
+        try:
+            if (
+                request.allowed_document_ids is not None
+                and not request.allowed_document_ids
+            ):
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    reason="no_allowed_documents",
+                )
+                return []
+
+            stage = "query_analysis"
+            analysis = await self._analyze_query(
+                request.query,
+                request.runtime.knowledge_id,
             )
-        )
-        evidence_hits = await self._store.load_evidence_for_projection_keys(
-            request.runtime,
-            tuple(entity_ranks),
-            relation_keys,
-            request.evidence_per_key,
-            allowed_document_ids=request.allowed_document_ids,
-        )
-        if not evidence_hits:
-            return []
+            entity_text = (
+                " ".join(self._clean_terms(analysis.entity_terms))
+                or request.query
+            )
+            relation_text = (
+                " ".join(self._clean_terms(analysis.relation_terms))
+                or request.query
+            )
 
-        matches = self._score_evidence(
-            evidence_hits,
-            ranked_entities,
-            ranked_relations,
-            ranked_neighbors,
-            entity_ranks,
-            relation_ranks,
-            neighbor_ranks,
-            request.allowed_document_ids,
-        )
-        if not matches:
-            return []
+            stage = "query_embedding"
+            entity_vector, relation_vector = await asyncio.gather(
+                self._embedding.aembed_query(entity_text),
+                self._embedding.aembed_query(relation_text),
+            )
+            stage = "projection_search"
+            entity_hits, relation_hits = await asyncio.gather(
+                self._store.search_entity_projections(
+                    request.runtime,
+                    normalize_vector(entity_vector),
+                    request.entity_top_n,
+                ),
+                self._store.search_relation_projections(
+                    request.runtime,
+                    normalize_vector(relation_vector),
+                    request.relation_top_n,
+                ),
+            )
 
-        chunks = await self._store.hydrate_source_chunks(
-            chunk_index_name=request.runtime.chunk_index_name,
-            knowledge_id=request.runtime.knowledge_id,
-            source_chunk_ids=tuple(matches),
-            allowed_document_ids=request.allowed_document_ids,
-            file_names=request.file_names,
-        )
-        scoped_chunks = self._scope_hydrated_chunks(request, chunks, matches)
-        if not scoped_chunks:
-            return []
+            ranked_entities = self._deduplicate_entities(entity_hits)
+            ranked_relations = self._deduplicate_relations(relation_hits)
+            counts["entity_hits"] = len(ranked_entities)
+            counts["relation_hits"] = len(ranked_relations)
+            stage = "neighbor_search"
+            neighbor_hits = await self._store.load_neighbor_relations(
+                request.runtime,
+                tuple(hit.entity_key for hit in ranked_entities),
+                request.neighbor_top_n,
+            )
+            ranked_neighbors = self._deduplicate_relations(neighbor_hits)
+            counts["neighbor_hits"] = len(ranked_neighbors)
 
-        parent_matches = self._build_parent_matches(scoped_chunks, matches)
-        for chunk in scoped_chunks:
-            source_id = str((chunk.metadata or {}).get("doc_id") or "")
-            chunk.metadata["score"] = matches[source_id].raw_score
+            entity_ranks = {
+                hit.entity_key: rank
+                for rank, hit in enumerate(ranked_entities, start=1)
+            }
+            relation_ranks = {
+                hit.relation_key: rank
+                for rank, hit in enumerate(ranked_relations, start=1)
+            }
+            neighbor_ranks = {
+                hit.relation_key: rank
+                for rank, hit in enumerate(ranked_neighbors, start=1)
+            }
+            relation_keys = tuple(
+                dict.fromkeys(
+                    [hit.relation_key for hit in ranked_relations]
+                    + [hit.relation_key for hit in ranked_neighbors]
+                )
+            )
+            stage = "evidence_search"
+            evidence_hits = await self._store.load_evidence_for_projection_keys(
+                request.runtime,
+                tuple(entity_ranks),
+                relation_keys,
+                request.evidence_per_key,
+                allowed_document_ids=request.allowed_document_ids,
+            )
+            counts["evidence_hits"] = len(evidence_hits)
+            if not evidence_hits:
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    reason="no_evidence",
+                )
+                return []
 
-        resolved = await self._parent_resolver(
-            scoped_chunks,
-            request.runtime.chunk_index_name,
-        )
-        resolved_with_matches = self._attach_resolved_matches(
-            request,
-            resolved,
-            matches,
-            parent_matches,
-        )
-        return self._rank_and_limit(
-            resolved_with_matches,
-            request.max_chunks_per_document,
-        )
+            stage = "evidence_scoring"
+            matches = self._score_evidence(
+                evidence_hits,
+                ranked_entities,
+                ranked_relations,
+                ranked_neighbors,
+                entity_ranks,
+                relation_ranks,
+                neighbor_ranks,
+                request.allowed_document_ids,
+            )
+            counts["matched_chunks"] = len(matches)
+            if not matches:
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    reason="no_scored_matches",
+                )
+                return []
 
-    async def _analyze_query(self, query: str) -> GraphQueryAnalysis:
+            stage = "chunk_hydration"
+            chunks = await self._store.hydrate_source_chunks(
+                chunk_index_name=request.runtime.chunk_index_name,
+                knowledge_id=request.runtime.knowledge_id,
+                source_chunk_ids=tuple(matches),
+                allowed_document_ids=request.allowed_document_ids,
+                file_names=request.file_names,
+            )
+            counts["hydrated_chunks"] = len(chunks)
+            scoped_chunks = self._scope_hydrated_chunks(request, chunks, matches)
+            counts["scoped_chunks"] = len(scoped_chunks)
+            if not scoped_chunks:
+                self._log_outcome(
+                    "retrieval_empty",
+                    request,
+                    started_at,
+                    counts,
+                    reason="no_scoped_chunks",
+                )
+                return []
+
+            parent_matches = self._build_parent_matches(scoped_chunks, matches)
+            for chunk in scoped_chunks:
+                source_id = str((chunk.metadata or {}).get("doc_id") or "")
+                chunk.metadata["score"] = matches[source_id].raw_score
+
+            stage = "parent_resolution"
+            resolved = await self._parent_resolver(
+                scoped_chunks,
+                request.runtime.chunk_index_name,
+            )
+            resolved_with_matches = self._attach_resolved_matches(
+                request,
+                resolved,
+                matches,
+                parent_matches,
+            )
+            stage = "rank_candidates"
+            result = self._rank_and_limit(
+                resolved_with_matches,
+                request.max_chunks_per_document,
+            )
+            counts["result_count"] = len(result)
+            self._log_outcome(
+                "retrieval_done" if result else "retrieval_empty",
+                request,
+                started_at,
+                counts,
+                reason=None if result else "no_ranked_chunks",
+            )
+            return result
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[EvidenceGraph] retrieval_failed"
+                " kb_id=%s stage=%s error_type=%s elapsed_ms=%d",
+                request.runtime.knowledge_id,
+                stage,
+                type(exc).__name__,
+                self._elapsed_ms(started_at),
+            )
+            raise
+
+    async def _analyze_query(
+        self,
+        query: str,
+        knowledge_id: str,
+    ) -> GraphQueryAnalysis:
         try:
             raw_result = await self._llm.call_structured(
                 [
@@ -209,13 +317,48 @@ class KnowledgeGraphRetrievalPipeline:
             return GraphQueryAnalysis.model_validate(raw_result)
         except Exception as exc:
             logger.warning(
-                "Graph query analysis failed; using the original query: %s",
-                exc,
+                "[EvidenceGraph] query_analysis_fallback"
+                " kb_id=%s error_type=%s",
+                knowledge_id,
+                type(exc).__name__,
             )
             return GraphQueryAnalysis(
                 entity_terms=[query],
                 relation_terms=[query],
             )
+
+    @staticmethod
+    def _log_outcome(
+        event: str,
+        request: GraphRetrievalRequest,
+        started_at: float,
+        counts: dict[str, int],
+        *,
+        reason: str | None,
+    ) -> None:
+        reason_field = f" reason={reason}" if reason is not None else ""
+        logger.info(
+            "[EvidenceGraph] %s kb_id=%s%s"
+            " entity_hits=%d relation_hits=%d neighbor_hits=%d"
+            " evidence_hits=%d matched_chunks=%d hydrated_chunks=%d"
+            " scoped_chunks=%d result_count=%d elapsed_ms=%d",
+            event,
+            request.runtime.knowledge_id,
+            reason_field,
+            counts["entity_hits"],
+            counts["relation_hits"],
+            counts["neighbor_hits"],
+            counts["evidence_hits"],
+            counts["matched_chunks"],
+            counts["hydrated_chunks"],
+            counts["scoped_chunks"],
+            counts["result_count"],
+            KnowledgeGraphRetrievalPipeline._elapsed_ms(started_at),
+        )
+
+    @staticmethod
+    def _elapsed_ms(started_at: float) -> int:
+        return int((time.perf_counter() - started_at) * 1000)
 
     @staticmethod
     def _clean_terms(terms: list[str]) -> tuple[str, ...]:

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -205,9 +205,7 @@ class KnowledgeGraphRetrievalPipeline:
         self._llm = llm
         self._embedding = embedding
         self._parent_resolver = parent_resolver
-        self._query_plan_cache = query_plan_cache or GraphQueryPlanCache(
-            ttl_seconds=settings.KNOWLEDGE_GRAPH_QUERY_PLAN_CACHE_TTL_SECONDS,
-        )
+        self._query_plan_cache = query_plan_cache or GraphQueryPlanCache()
 
     async def retrieve(
         self,

--- a/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/retrieval_pipeline.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import time
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -15,6 +15,7 @@ from app.core.rag.knowledge_graph.models import (
     GraphRetrievalRequest,
     ProjectionEvidenceGroup,
     RelationProjectionHit,
+    SourceChunkVectorHit,
 )
 from app.core.rag.knowledge_graph.prompts import (
     QUERY_ANALYSIS_SYSTEM_PROMPT,
@@ -182,6 +183,12 @@ class _SeedCandidates:
 class _SourceGroup:
     key: str
     source_chunk_ids: list[str]
+
+
+@dataclass
+class _SourceSelection:
+    source_chunk_ids: list[str] = field(default_factory=list)
+    vector_scores: dict[str, float] = field(default_factory=dict)
 
 
 class KnowledgeGraphRetrievalPipeline:
@@ -406,7 +413,7 @@ class KnowledgeGraphRetrievalPipeline:
                 group_map,
                 matches,
             )
-            entity_sequence = await self._select_source_chunks(
+            entity_selection = await self._select_source_chunks(
                 request,
                 entity_groups,
                 branch_vectors.get("query"),
@@ -417,19 +424,29 @@ class KnowledgeGraphRetrievalPipeline:
                 "relation",
                 group_map,
                 matches,
-                excluded_source_ids=set(entity_sequence),
+                excluded_source_ids=set(entity_selection.source_chunk_ids),
             )
-            relation_sequence = await self._select_source_chunks(
+            relation_selection = await self._select_source_chunks(
                 request,
                 relation_groups,
                 branch_vectors.get("query"),
                 source_type="relation",
             )
+            source_vector_scores = {
+                **entity_selection.vector_scores,
+                **relation_selection.vector_scores,
+            }
             candidate_ids = self._merge_source_types(
-                entity_sequence,
-                relation_sequence,
+                entity_selection.source_chunk_ids,
+                relation_selection.source_chunk_ids,
                 request.max_candidates,
             )
+            candidate_id_set = set(candidate_ids)
+            source_vector_scores = {
+                source_id: score
+                for source_id, score in source_vector_scores.items()
+                if source_id in candidate_id_set
+            }
             matches = {
                 source_id: matches[source_id]
                 for source_id in candidate_ids
@@ -483,16 +500,26 @@ class KnowledgeGraphRetrievalPipeline:
                 source_id: index
                 for index, source_id in enumerate(candidate_ids)
             }
-            parent_matches, parent_order = self._build_parent_matches(
-                scoped_chunks,
-                matches,
-                candidate_order,
+            parent_matches, parent_order, parent_vector_scores = (
+                self._build_parent_matches(
+                    scoped_chunks,
+                    matches,
+                    candidate_order,
+                    source_vector_scores,
+                )
             )
             for chunk in scoped_chunks:
                 source_id = str((chunk.metadata or {}).get("doc_id") or "")
                 match = matches.get(source_id)
                 if match is not None:
-                    chunk.metadata["score"] = match.graph_score
+                    vector_score = source_vector_scores.get(source_id)
+                    chunk.metadata["graph_score"] = match.graph_score
+                    if vector_score is not None:
+                        chunk.metadata["chunk_vector_score"] = vector_score
+                    chunk.metadata["score"] = self._metadata_score(
+                        match,
+                        vector_score,
+                    )
             resolved = await self._parent_resolver(
                 scoped_chunks,
                 request.runtime.chunk_index_name,
@@ -504,6 +531,8 @@ class KnowledgeGraphRetrievalPipeline:
                 parent_matches,
                 candidate_order,
                 parent_order,
+                source_vector_scores,
+                parent_vector_scores,
             )
             result = self._finalize_candidates(
                 attached,
@@ -868,9 +897,9 @@ class KnowledgeGraphRetrievalPipeline:
         query_vector: Sequence[float] | None,
         *,
         source_type: str,
-    ) -> list[str]:
+    ) -> _SourceSelection:
         if not groups:
-            return []
+            return _SourceSelection()
         candidates = [
             source_id
             for group in groups
@@ -900,21 +929,17 @@ class KnowledgeGraphRetrievalPipeline:
                 )
                 ranked = []
             allowed = set(candidates)
-            selected = [
-                source_id
-                for source_id in dict.fromkeys(ranked)
-                if source_id in allowed
-            ]
-            if selected:
+            selection = self._ranked_source_selection(ranked, allowed)
+            if selection.source_chunk_ids:
                 self._log_source_selection(
                     request,
                     source_type,
                     "vector",
                     len(groups),
                     len(candidates),
-                    len(selected),
+                    len(selection.source_chunk_ids),
                 )
-                return selected
+                return selection
         selected = self._weighted_source_poll(
             groups,
             request.related_chunk_number,
@@ -927,7 +952,51 @@ class KnowledgeGraphRetrievalPipeline:
             len(candidates),
             len(selected),
         )
-        return selected
+        return _SourceSelection(source_chunk_ids=selected)
+
+    @classmethod
+    def _ranked_source_selection(
+        cls,
+        ranked_hits: Sequence[Any],
+        allowed: set[str],
+    ) -> _SourceSelection:
+        selected: list[str] = []
+        scores: dict[str, float] = {}
+        seen: set[str] = set()
+        for hit in ranked_hits:
+            source_id, score = cls._extract_source_vector_hit(hit)
+            if not source_id or source_id not in allowed or source_id in seen:
+                continue
+            seen.add(source_id)
+            selected.append(source_id)
+            if score is not None:
+                scores[source_id] = score
+        return _SourceSelection(
+            source_chunk_ids=selected,
+            vector_scores=scores,
+        )
+
+    @staticmethod
+    def _extract_source_vector_hit(hit: Any) -> tuple[str, float | None]:
+        if isinstance(hit, SourceChunkVectorHit):
+            return hit.source_chunk_id, float(hit.score)
+        if isinstance(hit, Mapping):
+            source_id = str(
+                hit.get("source_chunk_id")
+                or hit.get("source_id")
+                or hit.get("id")
+                or ""
+            )
+            score = hit.get("score")
+        elif isinstance(hit, tuple) and len(hit) >= 2:
+            source_id = str(hit[0] or "")
+            score = hit[1]
+        else:
+            return str(hit or ""), None
+        try:
+            return source_id, float(score)
+        except (TypeError, ValueError):
+            return source_id, None
 
     @staticmethod
     def _weighted_source_poll(
@@ -1059,9 +1128,11 @@ class KnowledgeGraphRetrievalPipeline:
         chunks: Sequence[DocumentChunk],
         matches: dict[str, _ChunkMatch],
         candidate_order: dict[str, int],
-    ) -> tuple[dict[str, _ChunkMatch], dict[str, int]]:
+        source_vector_scores: dict[str, float],
+    ) -> tuple[dict[str, _ChunkMatch], dict[str, int], dict[str, float]]:
         parent_matches: dict[str, _ChunkMatch] = {}
         parent_order: dict[str, int] = {}
+        parent_vector_scores: dict[str, float] = {}
         for chunk in chunks:
             metadata = chunk.metadata or {}
             if metadata.get("chunk_type") != "child":
@@ -1076,7 +1147,12 @@ class KnowledgeGraphRetrievalPipeline:
                 parent_order.get(parent_id, 2**31 - 1),
                 candidate_order.get(source_id, 2**31 - 1),
             )
-        return parent_matches, parent_order
+            vector_score = source_vector_scores.get(source_id)
+            if vector_score is not None:
+                existing_score = parent_vector_scores.get(parent_id)
+                if existing_score is None or vector_score > existing_score:
+                    parent_vector_scores[parent_id] = vector_score
+        return parent_matches, parent_order, parent_vector_scores
 
     @classmethod
     def _attach_resolved_matches(
@@ -1087,14 +1163,16 @@ class KnowledgeGraphRetrievalPipeline:
         parent_matches: dict[str, _ChunkMatch],
         candidate_order: dict[str, int],
         parent_order: dict[str, int],
-    ) -> list[tuple[DocumentChunk, _ChunkMatch, int]]:
+        source_vector_scores: dict[str, float],
+        parent_vector_scores: dict[str, float],
+    ) -> list[tuple[DocumentChunk, _ChunkMatch, int, float | None]]:
         allowed_documents = (
             {str(item) for item in request.allowed_document_ids}
             if request.allowed_document_ids is not None
             else None
         )
         allowed_files = {str(item) for item in request.file_names}
-        attached: list[tuple[DocumentChunk, _ChunkMatch, int]] = []
+        attached: list[tuple[DocumentChunk, _ChunkMatch, int, float | None]] = []
         for chunk in chunks:
             metadata = chunk.metadata or {}
             source_id = str(metadata.get("doc_id") or "")
@@ -1120,7 +1198,16 @@ class KnowledgeGraphRetrievalPipeline:
                 candidate_order.get(source_id, 2**31 - 1),
                 parent_order.get(source_id, 2**31 - 1),
             )
-            attached.append((chunk, match, order))
+            vector_scores = [
+                score
+                for score in (
+                    source_vector_scores.get(source_id),
+                    parent_vector_scores.get(source_id),
+                )
+                if score is not None
+            ]
+            vector_score = max(vector_scores) if vector_scores else None
+            attached.append((chunk, match, order, vector_score))
         attached.sort(
             key=lambda item: (
                 item[2],
@@ -1132,36 +1219,50 @@ class KnowledgeGraphRetrievalPipeline:
 
     @staticmethod
     def _finalize_candidates(
-        attached: Sequence[tuple[DocumentChunk, _ChunkMatch, int]],
+        attached: Sequence[tuple[DocumentChunk, _ChunkMatch, int, float | None]],
         max_paths_per_chunk: int,
         max_candidates: int,
     ) -> list[DocumentChunk]:
         selected: list[DocumentChunk] = []
         seen_source_ids: set[str] = set()
-        for chunk, match, _ in attached:
+        for chunk, match, _, vector_score in attached:
             source_id = str((chunk.metadata or {}).get("doc_id") or "")
             if not source_id or source_id in seen_source_ids:
                 continue
             seen_source_ids.add(source_id)
             graph_rank = len(selected) + 1
+            chunk_score = KnowledgeGraphRetrievalPipeline._metadata_score(
+                match,
+                vector_score,
+            )
+            metadata = {
+                "retrieval_source": "graph",
+                "graph_rank": graph_rank,
+                "graph_score": match.graph_score,
+                "score": chunk_score,
+                "matched_entities": match.matched_entities(),
+                "matched_relations": match.matched_relations(),
+                "expanded_relations": match.expanded_relations(),
+                "support_count": match.support_count,
+                "evidence_confidence": match.evidence_confidence,
+                "match_paths": match.path_metadata(max_paths_per_chunk),
+            }
+            if vector_score is not None:
+                metadata["chunk_vector_score"] = vector_score
             chunk.metadata.update(
-                {
-                    "retrieval_source": "graph",
-                    "graph_rank": graph_rank,
-                    "graph_score": match.graph_score,
-                    "score": match.graph_score,
-                    "matched_entities": match.matched_entities(),
-                    "matched_relations": match.matched_relations(),
-                    "expanded_relations": match.expanded_relations(),
-                    "support_count": match.support_count,
-                    "evidence_confidence": match.evidence_confidence,
-                    "match_paths": match.path_metadata(max_paths_per_chunk),
-                }
+                metadata
             )
             selected.append(chunk)
             if len(selected) >= max(1, int(max_candidates)):
                 break
         return selected
+
+    @staticmethod
+    def _metadata_score(
+        match: _ChunkMatch,
+        vector_score: float | None,
+    ) -> float:
+        return vector_score if vector_score is not None else match.graph_score
 
     async def _analyze_query(
         self,

--- a/api/app/core/rag/knowledge_graph/runtime.py
+++ b/api/app/core/rag/knowledge_graph/runtime.py
@@ -13,7 +13,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
 )
 from app.db import get_db_context
 from app.models.knowledge_model import Knowledge
-from app.models.models_model import ModelType
+from app.models.models_model import ModelConfig
 from app.models.workspace_model import Workspace
 from app.services.model_service import ModelApiKeyService
 
@@ -35,6 +35,17 @@ def _require_runtime_api_key(api_key: object | None, model_role: str) -> object:
             f"no available {model_role} API key for graph runtime"
         )
     return api_key
+
+
+def _require_model_config(db, model_id: uuid.UUID, model_role: str) -> ModelConfig:
+    model_config = db.query(ModelConfig).filter(
+        ModelConfig.id == model_id
+    ).first()
+    if model_config is None:
+        raise GraphPipelineConfigError(
+            f"{model_role} model config does not exist: {model_id}"
+        )
+    return model_config
 
 
 def snapshot_graph_runtime(knowledge_id: str) -> GraphIndexRuntime:
@@ -69,6 +80,17 @@ def snapshot_graph_runtime(knowledge_id: str) -> GraphIndexRuntime:
             raise GraphPipelineConfigError(
                 "graph runtime requires both LLM and embedding models"
             )
+
+        llm_config = _require_model_config(
+            db,
+            knowledge.llm_id,
+            "LLM",
+        )
+        embedding_config = _require_model_config(
+            db,
+            knowledge.embedding_id,
+            "embedding",
+        )
 
         llm_api_key = _require_runtime_api_key(
             ModelApiKeyService.get_available_api_key(
@@ -109,11 +131,11 @@ def snapshot_graph_runtime(knowledge_id: str) -> GraphIndexRuntime:
             scene_name=str(graph_config.get("scene_name") or ""),
             llm=ModelRuntimeSnapshot.from_api_key(
                 llm_api_key,
-                model_type=ModelType.LLM.value,
+                model_type=str(llm_config.type),
             ),
             embedding=ModelRuntimeSnapshot.from_api_key(
                 embedding_api_key,
-                model_type=ModelType.EMBEDDING.value,
+                model_type=str(embedding_config.type),
             ),
         )
 

--- a/api/app/core/rag/knowledge_graph/runtime.py
+++ b/api/app/core/rag/knowledge_graph/runtime.py
@@ -1,0 +1,120 @@
+import uuid
+
+from app.core.models import RedBearModelConfig
+from app.core.rag.knowledge_graph.config import (
+    GraphPipelineConfigError,
+    is_graph_enabled,
+    require_graph_mapping,
+)
+from app.core.rag.knowledge_graph.models import GraphIndexRuntime
+from app.core.rag.retrieval.models import ModelRuntimeSnapshot
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
+    ElasticSearchVectorIndexOps,
+)
+from app.db import get_db_context
+from app.models.knowledge_model import Knowledge
+from app.models.models_model import ModelType
+from app.models.workspace_model import Workspace
+from app.services.model_service import ModelApiKeyService
+
+
+def build_model_config(snapshot: ModelRuntimeSnapshot) -> RedBearModelConfig:
+    return RedBearModelConfig(
+        model_name=snapshot.model_name,
+        provider=snapshot.provider,
+        api_key=snapshot.api_key,
+        base_url=snapshot.api_base,
+        capability=list(snapshot.capability),
+        is_omni=snapshot.is_omni,
+    )
+
+
+def _require_runtime_api_key(api_key: object | None, model_role: str) -> object:
+    if api_key is None:
+        raise GraphPipelineConfigError(
+            f"no available {model_role} API key for graph runtime"
+        )
+    return api_key
+
+
+def snapshot_graph_runtime(knowledge_id: str) -> GraphIndexRuntime:
+    try:
+        knowledge_uuid = uuid.UUID(str(knowledge_id))
+    except ValueError as exc:
+        raise GraphPipelineConfigError(
+            f"invalid knowledge id: {knowledge_id}"
+        ) from exc
+
+    with get_db_context() as db:
+        knowledge = db.query(Knowledge).filter(
+            Knowledge.id == knowledge_uuid
+        ).first()
+        if knowledge is None:
+            raise GraphPipelineConfigError(
+                f"knowledge does not exist: {knowledge_id}"
+            )
+        if not is_graph_enabled(knowledge.parser_config):
+            raise GraphPipelineConfigError(
+                f"graph is disabled for knowledge: {knowledge_id}"
+            )
+
+        workspace = db.query(Workspace).filter(
+            Workspace.id == knowledge.workspace_id
+        ).first()
+        if workspace is None:
+            raise GraphPipelineConfigError(
+                f"workspace does not exist: {knowledge.workspace_id}"
+            )
+        if knowledge.llm_id is None or knowledge.embedding_id is None:
+            raise GraphPipelineConfigError(
+                "graph runtime requires both LLM and embedding models"
+            )
+
+        llm_api_key = _require_runtime_api_key(
+            ModelApiKeyService.get_available_api_key(
+                db,
+                knowledge.llm_id,
+                tenant_id=workspace.tenant_id,
+            ),
+            "LLM",
+        )
+        embedding_api_key = _require_runtime_api_key(
+            ModelApiKeyService.get_available_api_key(
+                db,
+                knowledge.embedding_id,
+                tenant_id=workspace.tenant_id,
+            ),
+            "embedding",
+        )
+
+        graph_config = require_graph_mapping(knowledge.parser_config)
+        raw_entity_types = graph_config.get("entity_types") or ()
+        if not isinstance(raw_entity_types, (list, tuple)):
+            raise GraphPipelineConfigError("graphrag.entity_types must be a list")
+
+        snapshot = GraphIndexRuntime(
+            knowledge_id=str(knowledge.id),
+            workspace_id=str(workspace.id),
+            graph_index_name=f"graphrag_{workspace.id}",
+            chunk_index_name=(
+                ElasticSearchVectorIndexOps.collection_name_for_knowledge(
+                    knowledge.id
+                )
+            ),
+            entity_types=tuple(
+                str(entity_type).strip()
+                for entity_type in raw_entity_types
+                if str(entity_type).strip()
+            ),
+            scene_name=str(graph_config.get("scene_name") or ""),
+            llm=ModelRuntimeSnapshot.from_api_key(
+                llm_api_key,
+                model_type=ModelType.LLM.value,
+            ),
+            embedding=ModelRuntimeSnapshot.from_api_key(
+                embedding_api_key,
+                model_type=ModelType.EMBEDDING.value,
+            ),
+        )
+
+    return snapshot

--- a/api/app/core/rag/knowledge_graph/structured_output.py
+++ b/api/app/core/rag/knowledge_graph/structured_output.py
@@ -1,0 +1,47 @@
+from collections.abc import Mapping
+from typing import Any
+
+from json_repair import json_repair
+
+
+def unwrap_structured_result(raw_result: Any, schema: type) -> Any:
+    if not isinstance(raw_result, Mapping) or "parsed" not in raw_result:
+        return raw_result
+
+    parsed = raw_result.get("parsed")
+    if parsed is not None:
+        return parsed
+
+    raw_message = raw_result.get("raw")
+    additional = getattr(raw_message, "additional_kwargs", None)
+    tool_calls = (
+        additional.get("tool_calls", [])
+        if isinstance(additional, Mapping)
+        else []
+    )
+    payloads: list[str] = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, Mapping):
+            continue
+        function = tool_call.get("function")
+        if not isinstance(function, Mapping):
+            continue
+        arguments = function.get("arguments")
+        if isinstance(arguments, str) and arguments.strip():
+            payloads.append(arguments)
+
+    content = getattr(raw_message, "content", None)
+    if isinstance(content, str) and content.strip():
+        payloads.append(content)
+
+    for payload in payloads:
+        repaired = json_repair.repair_json(
+            payload,
+            return_objects=True,
+        )
+        return schema.model_validate(repaired)
+
+    parsing_error = raw_result.get("parsing_error")
+    raise ValueError("structured output is not parseable") from (
+        parsing_error if isinstance(parsing_error, Exception) else None
+    )

--- a/api/app/core/rag/parser_config.py
+++ b/api/app/core/rag/parser_config.py
@@ -1,0 +1,158 @@
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    GraphPipelineConfigError,
+    require_graph_mapping,
+    resolve_graph_pipeline,
+)
+
+
+def _default_graph_config() -> dict[str, Any]:
+    return {
+        "use_graphrag": False,
+        "scene_name": "",
+        "entity_types": [
+            "organization",
+            "person",
+            "geo",
+            "event",
+            "category",
+        ],
+        "method": "general",
+        "resolution": True,
+        "community": True,
+        "pipeline": GraphPipeline.EVIDENCE.value,
+    }
+
+
+def build_default_knowledge_parser_config() -> dict[str, Any]:
+    return {
+        "entry_url": "https://ai.redbearai.com",
+        "max_pages": 20,
+        "delay_seconds": 1.0,
+        "timeout_seconds": 10,
+        "user_agent": "KnowledgeBaseCrawler/1.0",
+        "yuque_user_id": "User ID",
+        "yuque_token": "Token",
+        "feishu_app_id": "App ID",
+        "feishu_app_secret": "App Secret",
+        "feishu_folder_token": "Folder Token",
+        "sync_cron": "30 7 * * 1-5",
+        "layout_recognize": "DeepDOC",
+        "chunk_token_num": 128,
+        "delimiter": "\n",
+        "auto_keywords": 0,
+        "auto_questions": 0,
+        "html4excel": False,
+        "parent_child_mode": False,
+        "parent_chunk_token_num": 1024,
+        "parent_chunk_delimiter": "\n\n",
+        "graphrag": _default_graph_config(),
+    }
+
+
+def build_default_document_parser_config() -> dict[str, Any]:
+    return {
+        "layout_recognize": "DeepDOC",
+        "chunk_token_num": 130,
+        "delimiter": "\n",
+        "auto_keywords": 0,
+        "auto_questions": 0,
+        "html4excel": False,
+        "parent_child_mode": False,
+        "parent_chunk_token_num": 1024,
+        "parent_chunk_delimiter": "\n\n",
+        "graphrag": _default_graph_config(),
+    }
+
+
+def _copy_parser_config(
+    parser_config: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if parser_config is None:
+        return {}
+    if not isinstance(parser_config, Mapping):
+        raise GraphPipelineConfigError("parser_config must be a mapping")
+    return deepcopy(dict(parser_config))
+
+
+def normalize_new_knowledge_parser_config(
+    parser_config: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    requested = _copy_parser_config(parser_config)
+    requested_graph = require_graph_mapping(requested)
+    if "pipeline" in requested_graph:
+        requested_pipeline = resolve_graph_pipeline(
+            {"graphrag": requested_graph}
+        )
+        if requested_pipeline is not GraphPipeline.EVIDENCE:
+            raise GraphPipelineConfigError(
+                "new knowledge must use the evidence graph pipeline"
+            )
+
+    normalized = build_default_knowledge_parser_config()
+    normalized.update(
+        {key: value for key, value in requested.items() if key != "graphrag"}
+    )
+    graph_config = normalized["graphrag"]
+    graph_config.update(deepcopy(dict(requested_graph)))
+    graph_config["pipeline"] = GraphPipeline.EVIDENCE.value
+    return normalized
+
+
+def normalize_knowledge_parser_config_update(
+    current: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if incoming is None:
+        raise GraphPipelineConfigError("parser_config update must be a mapping")
+
+    incoming_copy = _copy_parser_config(incoming)
+    current_graph = require_graph_mapping(current)
+    incoming_graph = require_graph_mapping(incoming_copy)
+    current_pipeline = resolve_graph_pipeline(current)
+
+    if "pipeline" in incoming_graph:
+        requested_pipeline = resolve_graph_pipeline(
+            {"graphrag": incoming_graph}
+        )
+        if requested_pipeline is not current_pipeline:
+            raise GraphPipelineConfigError(
+                "graph pipeline changes require managed migration"
+            )
+
+    normalized = {
+        key: value
+        for key, value in incoming_copy.items()
+        if key != "graphrag"
+    }
+    merged_graph = deepcopy(dict(current_graph))
+    merged_graph.update(deepcopy(dict(incoming_graph)))
+    merged_graph["pipeline"] = current_pipeline.value
+    normalized["graphrag"] = merged_graph
+    return normalized
+
+
+def set_graph_pipeline_for_migration(
+    parser_config: Mapping[str, Any] | None,
+    pipeline: GraphPipeline | str,
+) -> dict[str, Any]:
+    try:
+        target_pipeline = (
+            pipeline
+            if isinstance(pipeline, GraphPipeline)
+            else GraphPipeline(str(pipeline).strip().lower())
+        )
+    except ValueError as exc:
+        raise GraphPipelineConfigError(
+            f"unsupported graph pipeline: {pipeline}"
+        ) from exc
+
+    normalized = _copy_parser_config(parser_config)
+    graph_config = deepcopy(dict(require_graph_mapping(normalized)))
+    graph_config["pipeline"] = target_pipeline.value
+    normalized["graphrag"] = graph_config
+    return normalized

--- a/api/app/core/rag/parser_config.py
+++ b/api/app/core/rag/parser_config.py
@@ -83,6 +83,14 @@ def normalize_new_knowledge_parser_config(
     parser_config: Mapping[str, Any] | None,
 ) -> dict[str, Any]:
     requested = _copy_parser_config(parser_config)
+    chunk_mode_requested = any(
+        key in requested
+        for key in (
+            "auto_questions",
+            "parent_child_mode",
+            "parent_chunk_mode",
+        )
+    )
     requested_graph = require_graph_mapping(requested)
     if "pipeline" in requested_graph:
         requested_pipeline = resolve_graph_pipeline(
@@ -100,6 +108,9 @@ def normalize_new_knowledge_parser_config(
     graph_config = normalized["graphrag"]
     graph_config.update(deepcopy(dict(requested_graph)))
     graph_config["pipeline"] = GraphPipeline.EVIDENCE.value
+    if not chunk_mode_requested:
+        normalized.pop("auto_questions", None)
+        normalized.pop("parent_child_mode", None)
     return normalized
 
 

--- a/api/app/core/rag/retrieval/graph_bridge.py
+++ b/api/app/core/rag/retrieval/graph_bridge.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
 
 from app.core.config import settings
+from app.core.rag.knowledge_graph.config import GraphPipeline
 from app.core.rag.llm.chat_model import Base
 from app.core.rag.llm.embedding_model import OpenAIEmbed
 from app.core.rag.models.chunk import DocumentChunk
@@ -44,6 +45,8 @@ class GraphRetrievalBridge:
     ) -> DocumentChunk | None:
         if not isinstance(snapshot, GraphRetrievalSnapshot):
             raise TypeError("GraphRetrievalBridge requires a GraphRetrievalSnapshot")
+        if snapshot.pipeline is not GraphPipeline.LEGACY:
+            raise ValueError("legacy graph bridge requires the legacy pipeline")
 
         wait_started_at = time.perf_counter()
         semaphore = cls._get_semaphore()

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, NoReturn, TypeAlias
 
+from app.core.rag.knowledge_graph.config import GraphPipeline
 from app.schemas.chunk_schema import RetrieveType
 
 
@@ -212,12 +213,43 @@ class RetrievalTimings:
 
 
 @dataclass(frozen=True)
-class GraphRetrievalSnapshot:
-    query: str
-    workspace_ids: tuple[str, ...]
-    knowledge_ids: tuple[str, ...]
+class GraphTargetSnapshot:
+    knowledge_id: uuid.UUID
+    workspace_id: uuid.UUID
+    chunk_index_name: str
+    graph_index_name: str
+    pipeline: GraphPipeline
     llm: ModelRuntimeSnapshot
     embedding: ModelRuntimeSnapshot
+
+
+@dataclass(frozen=True)
+class GraphRetrievalSnapshot:
+    query: str
+    pipeline: GraphPipeline
+    targets: tuple[GraphTargetSnapshot, ...]
+
+    def __post_init__(self) -> None:
+        if not self.targets:
+            raise ValueError("graph retrieval snapshot requires at least one target")
+        if any(target.pipeline is not self.pipeline for target in self.targets):
+            raise ValueError("graph retrieval targets must use the selected pipeline")
+
+    @property
+    def workspace_ids(self) -> tuple[str, ...]:
+        return tuple(str(target.workspace_id) for target in self.targets)
+
+    @property
+    def knowledge_ids(self) -> tuple[str, ...]:
+        return tuple(str(target.knowledge_id) for target in self.targets)
+
+    @property
+    def llm(self) -> ModelRuntimeSnapshot:
+        return self.targets[0].llm
+
+    @property
+    def embedding(self) -> ModelRuntimeSnapshot:
+        return self.targets[0].embedding
 
 
 @dataclass(frozen=True)

--- a/api/app/core/rag/retrieval/models.py
+++ b/api/app/core/rag/retrieval/models.py
@@ -158,6 +158,7 @@ class RetrievalParams:
     top_n: int
     retrieve_type: RetrieveType
     rerank_score_threshold: float = 0.1
+    enable_graph_retrieval: bool = False
 
 
 @dataclass(frozen=True)

--- a/api/app/models/document_model.py
+++ b/api/app/models/document_model.py
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
 from app.core.utils.datetime_utils import utcnow_naive
+from app.core.rag.parser_config import build_default_document_parser_config
 
 
 def _parse_bool_config(value: Any) -> bool:
@@ -33,31 +34,8 @@ class Document(Base):
                        comment="{field_name: value}")
     parser_id = Column(String, index=True, nullable=False, comment="default parser ID")
     parser_config = Column(JSON, nullable=False,
-                           default={
-                               "layout_recognize": "DeepDOC",
-                               "chunk_token_num": 130,
-                               "delimiter": "\n",
-                               "auto_keywords": 0,
-                               "auto_questions": 0,
-                               "html4excel": False,
-                               "parent_child_mode": False,
-                               "parent_chunk_token_num": 1024,
-                               "parent_chunk_delimiter": "\n\n",
-                               "graphrag": {
-                                   "use_graphrag": False,
-                                   "scene_name": "",
-                                   "entity_types": [
-                                       "organization",
-                                       "person",
-                                       "geo",
-                                       "event",
-                                       "category"
-                                   ],
-                                   "method": "general",
-                                   "resolution": True,
-                                   "community": True
-                               }
-                           }, comment="default parser config")
+                           default=build_default_document_parser_config,
+                           comment="default parser config")
     chunk_num = Column(Integer, default=0, comment="chunk num")
     progress = Column(Float, default=0)
     progress_msg = Column(String, default="", comment="process message")

--- a/api/app/models/knowledge_model.py
+++ b/api/app/models/knowledge_model.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from app.db import Base
 from app.core.utils.datetime_utils import utcnow_naive
+from app.core.rag.parser_config import build_default_knowledge_parser_config
 from sqlalchemy.orm import relationship
 
 
@@ -64,42 +65,7 @@ class Knowledge(Base):
     chunk_num = Column(Integer, default=0, comment="chunk num")
     parser_id = Column(String, index=True, default="naive", comment="default parser ID")
     parser_config = Column(JSON, nullable=False,
-                           default={
-                               "entry_url": "https://ai.redbearai.com",
-                               "max_pages": 20,
-                               "delay_seconds": 1.0,
-                               "timeout_seconds": 10,
-                               "user_agent": "KnowledgeBaseCrawler/1.0",
-                               "yuque_user_id": "User ID",
-                               "yuque_token": "Token",
-                               "feishu_app_id": "App ID",
-                               "feishu_app_secret": "App Secret",
-                               "feishu_folder_token": "Folder Token",
-                               "sync_cron": "30 7 * * 1-5",
-                               "layout_recognize": "DeepDOC",
-                               "chunk_token_num": 128,
-                               "delimiter": "\n",
-                               "auto_keywords": 0,
-                               "auto_questions": 0,
-                               "html4excel": False,
-                               "parent_child_mode": False,
-                               "parent_chunk_token_num": 1024,
-                               "parent_chunk_delimiter": "\n\n",
-                               "graphrag": {
-                                   "use_graphrag": False,
-                                   "scene_name": "",
-                                   "entity_types": [
-                                       "organization",
-                                       "person",
-                                       "geo",
-                                       "event",
-                                       "category"
-                                   ],
-                                   "method": "general",
-                                   "resolution": True,
-                                   "community": True
-                               }
-                           },
+                           default=build_default_knowledge_parser_config,
                            comment="default parser config")
     status = Column(Integer, index=True, default=1, comment="is it validate(0: disable, 1: enable, 2:Soft-delete)")
     builtin_metadata_enabled = Column(Integer, default=0, nullable=False, server_default='0',

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -7,18 +7,28 @@ from app.models.knowledge_model import Knowledge, PermissionType
 from app.models.models_model import ModelApiKey, ModelConfig
 from app.schemas import knowledge_schema
 from app.core.logging_config import get_db_logger
-from app.core.rag.parser_config import build_default_knowledge_parser_config
+from app.core.rag.parser_config import (
+    build_default_knowledge_parser_config,
+    normalize_new_knowledge_parser_config,
+)
 
 # Obtain a dedicated logger for the database
 db_logger = get_db_logger()
 
 
 def _knowledge_values(
-        knowledge: knowledge_schema.KnowledgeCreate
+        knowledge: knowledge_schema.KnowledgeCreate,
+        *,
+        preserve_source_parser_config: bool = False,
 ) -> dict:
     values = knowledge.model_dump()
-    if values.get("parser_config") is None:
-        values["parser_config"] = build_default_knowledge_parser_config()
+    if preserve_source_parser_config:
+        if values.get("parser_config") is None:
+            values["parser_config"] = build_default_knowledge_parser_config()
+    else:
+        values["parser_config"] = normalize_new_knowledge_parser_config(
+            values.get("parser_config")
+        )
     return values
 
 
@@ -171,11 +181,21 @@ async def get_chunked_knowledgeids_async(
         raise
 
 
-def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -> Knowledge:
+def create_knowledge(
+        db: Session,
+        knowledge: knowledge_schema.KnowledgeCreate,
+        *,
+        preserve_source_parser_config: bool = False,
+) -> Knowledge:
     db_logger.debug(f"Create a knowledge base record: name={knowledge.name}")
     
     try:
-        db_knowledge = Knowledge(**_knowledge_values(knowledge))
+        db_knowledge = Knowledge(
+            **_knowledge_values(
+                knowledge,
+                preserve_source_parser_config=preserve_source_parser_config,
+            )
+        )
         db.add(db_knowledge)
         db.commit()
         db_logger.info(f"knowledge base record created successfully: {knowledge.name} (ID: {db_knowledge.id})")
@@ -186,12 +206,22 @@ def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -
         raise
 
 
-async def create_knowledge_async(db: AsyncSession, knowledge: knowledge_schema.KnowledgeCreate) -> Knowledge:
+async def create_knowledge_async(
+        db: AsyncSession,
+        knowledge: knowledge_schema.KnowledgeCreate,
+        *,
+        preserve_source_parser_config: bool = False,
+) -> Knowledge:
     """Async version of create_knowledge."""
     db_logger.debug(f"Create a knowledge base record (async): name={knowledge.name}")
 
     try:
-        db_knowledge = Knowledge(**_knowledge_values(knowledge))
+        db_knowledge = Knowledge(
+            **_knowledge_values(
+                knowledge,
+                preserve_source_parser_config=preserve_source_parser_config,
+            )
+        )
         db.add(db_knowledge)
         await db.commit()
         await db.refresh(db_knowledge)

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -7,9 +7,19 @@ from app.models.knowledge_model import Knowledge, PermissionType
 from app.models.models_model import ModelApiKey, ModelConfig
 from app.schemas import knowledge_schema
 from app.core.logging_config import get_db_logger
+from app.core.rag.parser_config import build_default_knowledge_parser_config
 
 # Obtain a dedicated logger for the database
 db_logger = get_db_logger()
+
+
+def _knowledge_values(
+        knowledge: knowledge_schema.KnowledgeCreate
+) -> dict:
+    values = knowledge.model_dump()
+    if values.get("parser_config") is None:
+        values["parser_config"] = build_default_knowledge_parser_config()
+    return values
 
 
 def knowledge_schema_load_options():
@@ -165,7 +175,7 @@ def create_knowledge(db: Session, knowledge: knowledge_schema.KnowledgeCreate) -
     db_logger.debug(f"Create a knowledge base record: name={knowledge.name}")
     
     try:
-        db_knowledge = Knowledge(**knowledge.model_dump())
+        db_knowledge = Knowledge(**_knowledge_values(knowledge))
         db.add(db_knowledge)
         db.commit()
         db_logger.info(f"knowledge base record created successfully: {knowledge.name} (ID: {db_knowledge.id})")
@@ -181,7 +191,7 @@ async def create_knowledge_async(db: AsyncSession, knowledge: knowledge_schema.K
     db_logger.debug(f"Create a knowledge base record (async): name={knowledge.name}")
 
     try:
-        db_knowledge = Knowledge(**knowledge.model_dump())
+        db_knowledge = Knowledge(**_knowledge_values(knowledge))
         db.add(db_knowledge)
         await db.commit()
         await db.refresh(db_knowledge)

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -118,6 +118,12 @@ class ChunkRetrieve(BaseModel):
     top_k: int | None = Field(20, ge=1, le=100)
     top_n: int | None = Field(20, ge=1, le=100)
     retrieve_type: RetrieveType | None = Field(None)
+    enable_graph_retrieval: int = Field(
+        0,
+        ge=0,
+        le=1,
+        description="Whether to add the graph retrieval route to hybrid retrieval. 1 enables it.",
+    )
     rerank_score_threshold: float | None = Field(None, ge=0, le=1)
     metadata_filters: list[FilterGroup] | None = Field(None, description="filter condition groups")
     metadata_filter_mode: MetadataFilterMode = Field(MetadataFilterMode.MANUAL, description="filter mode")

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -29,6 +29,15 @@ class KnowledgeBaseConfig(BaseModel):
     rerank_score_threshold: float | None = Field(default=None, ge=0, le=1, description="Knowledge base rerank score threshold")
     top_k: int = Field(default=4, ge=1, le=100, description="Knowledge base top k")
     retrieve_type: RetrieveType = Field(default=RetrieveType.PARTICIPLE, description="Retrieve type")
+    enable_graph_retrieval: int | None = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description=(
+            "Whether this knowledge base adds the Evidence Graph channel "
+            "during hybrid retrieval. Falls back to the request value when omitted."
+        ),
+    )
 
 
 class ChunkType(StrEnum):

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -19,6 +19,12 @@ class KnowledgeRetrievalRequest(BaseModel):
     top_n: int | None = Field(default=None, ge=1, le=100)
     caller: KnowledgeRetrievalCaller = KnowledgeRetrievalCaller.GENERAL
     retrieve_type: RetrieveType = RetrieveType.HYBRID
+    enable_graph_retrieval: int = Field(
+        default=0,
+        ge=0,
+        le=1,
+        description="Whether to add the graph retrieval route to hybrid retrieval. 1 enables it.",
+    )
     rerank_id: UUID | None = None
     rerank_score_threshold: float | None = Field(default=None, ge=0, le=1)
     metadata_filters: list[FilterGroup] = Field(default_factory=list)
@@ -33,6 +39,11 @@ class KnowledgeRetrievalRequest(BaseModel):
     def metadata_filters_prepared(self) -> bool:
         """Whether AUTO filtering was already evaluated by an internal adapter."""
         return self._metadata_filters_prepared
+
+    @property
+    def graph_retrieval_mix_enabled(self) -> bool:
+        """Whether hybrid retrieval should add an evidence-graph route."""
+        return self.enable_graph_retrieval == 1
 
     @field_validator("query")
     @classmethod

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -45,6 +45,19 @@ class KnowledgeRetrievalRequest(BaseModel):
         """Whether hybrid retrieval should add an evidence-graph route."""
         return self.enable_graph_retrieval == 1
 
+    def graph_retrieval_mix_enabled_for(
+        self,
+        config: KnowledgeBaseConfig | None,
+    ) -> bool:
+        """Resolve the hybrid Evidence Graph flag for one knowledge base."""
+        if (
+            config is not None
+            and "enable_graph_retrieval" in config.model_fields_set
+            and config.enable_graph_retrieval is not None
+        ):
+            return config.enable_graph_retrieval == 1
+        return self.graph_retrieval_mix_enabled
+
     @field_validator("query")
     @classmethod
     def validate_query(cls, value: str) -> str:

--- a/api/app/schemas/knowledge_retrieval_schema.py
+++ b/api/app/schemas/knowledge_retrieval_schema.py
@@ -57,5 +57,10 @@ class KnowledgeRetrievalRequest(BaseModel):
 
 class KnowledgeRetrievalResult(BaseModel):
     chunks: list[Any] = Field(default_factory=list)
+    entities: list[Any] = Field(default_factory=list)
+    relationships: list[Any] = Field(default_factory=list)
+
+    def has_graph_data(self) -> bool:
+        return bool(self.entities or self.relationships)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -6,10 +6,17 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    GraphPipelineConfigError,
+    is_graph_enabled,
+    resolve_graph_pipeline,
+)
 from app.core.rag.metadata.filter_engine import FilterGroup as EngineFilterGroup, MetadataFilterEngine
 from app.core.rag.retrieval.exceptions import KnowledgeRetrievalConfigError
 from app.core.rag.retrieval.models import (
     GraphRetrievalSnapshot,
+    GraphTargetSnapshot,
     ModelRuntimeSnapshot,
     RetrievalParams,
     RetrievalPreparation,
@@ -524,17 +531,71 @@ class KnowledgeRetrievalPreparation:
         targets: list[RetrievalTarget],
         tenant_id: uuid.UUID | None,
     ) -> GraphRetrievalSnapshot | None:
-        if not any(target.params.retrieve_type == RetrieveType.Graph for target in targets):
+        graph_targets = [
+            target
+            for target in targets
+            if target.params.retrieve_type == RetrieveType.Graph
+        ]
+        if not graph_targets:
             return None
-        llm = await cls._snapshot_model_runtime(db, refs[0].knowledge.llm_id, tenant_id)
-        if not llm:
+
+        refs_by_knowledge_id = {
+            ref.knowledge.id: ref
+            for ref in refs
+        }
+        resolved_targets: list[
+            tuple[RetrievalTarget, Any, GraphPipeline]
+        ] = []
+        pipelines: set[GraphPipeline] = set()
+        for target in graph_targets:
+            ref = refs_by_knowledge_id.get(target.knowledge_id)
+            if ref is None:
+                raise KnowledgeRetrievalConfigError(
+                    f"knowledge snapshot is missing for graph target {target.knowledge_id}"
+                )
+            knowledge = ref.knowledge
+            if not is_graph_enabled(knowledge.parser_config):
+                raise KnowledgeRetrievalConfigError(
+                    f"knowledge graph is disabled: {knowledge.id}"
+                )
+            try:
+                pipeline = resolve_graph_pipeline(knowledge.parser_config)
+            except GraphPipelineConfigError as exc:
+                raise KnowledgeRetrievalConfigError(str(exc)) from exc
+            pipelines.add(pipeline)
+            resolved_targets.append((target, knowledge, pipeline))
+
+        if len(pipelines) != 1:
             raise KnowledgeRetrievalConfigError(
-                f"No LLM api key found for knowledge {refs[0].knowledge.id}",
+                "all graph targets must use the same graph pipeline"
             )
+
+        target_snapshots: list[GraphTargetSnapshot] = []
+        for target, knowledge, pipeline in resolved_targets:
+            llm = await cls._snapshot_model_runtime(
+                db,
+                knowledge.llm_id,
+                tenant_id,
+            )
+            if not llm:
+                raise KnowledgeRetrievalConfigError(
+                    f"No LLM api key found for knowledge {knowledge.id}",
+                )
+            target_snapshots.append(
+                GraphTargetSnapshot(
+                    knowledge_id=target.knowledge_id,
+                    workspace_id=target.workspace_id,
+                    chunk_index_name=target.index_name,
+                    graph_index_name=f"graphrag_{target.workspace_id}",
+                    pipeline=pipeline,
+                    llm=llm,
+                    embedding=target.embedding,
+                )
+            )
+
+        pipeline = target_snapshots[0].pipeline
         return GraphRetrievalSnapshot(
             query=request.query,
-            workspace_ids=tuple(str(target.workspace_id) for target in targets),
-            knowledge_ids=tuple(str(target.knowledge_id) for target in targets),
-            llm=llm,
-            embedding=targets[0].embedding,
+            pipeline=pipeline,
+            targets=tuple(target_snapshots),
         )

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -89,13 +89,16 @@ class KnowledgeRetrievalPreparation:
                 graph=None,
             )
 
-        metadata_defs_by_kb = {
-            target.knowledge_id: await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(
-                db,
-                target.knowledge_id,
+        metadata_defs_by_kb: dict[uuid.UUID, dict[str, dict]] = {}
+        for target in targets:
+            if target.knowledge_id in metadata_defs_by_kb:
+                continue
+            metadata_defs_by_kb[target.knowledge_id] = (
+                await KnowledgeMetadataService.get_metadata_defs_for_filtering_async(
+                    db,
+                    target.knowledge_id,
+                )
             )
-            for target in targets
-        }
         common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
         metadata_llm = await cls._build_metadata_llm_snapshot(
             db,
@@ -177,10 +180,32 @@ class KnowledgeRetrievalPreparation:
             principal,
             getattr(refs[0].knowledge, "workspace_id", None),
         )
-        targets = [
-            await cls._build_retrieval_target_async(db, request, ref, tenant_id)
-            for ref in refs
-        ]
+        targets: list[RetrievalTarget] = []
+        for ref in refs:
+            params = cls._build_retrieval_params(request, ref.config)
+            targets.append(
+                await cls._build_retrieval_target_async(
+                    db,
+                    request,
+                    ref,
+                    tenant_id,
+                    params=params,
+                )
+            )
+            if cls._should_add_graph_mix_target(request, ref.knowledge, params):
+                graph_params = cls._copy_retrieval_params(
+                    params,
+                    retrieve_type=RetrieveType.Graph,
+                )
+                targets.append(
+                    await cls._build_retrieval_target_async(
+                        db,
+                        request,
+                        ref,
+                        tenant_id,
+                        params=graph_params,
+                    )
+                )
         return targets, tenant_id
 
     @staticmethod
@@ -208,9 +233,11 @@ class KnowledgeRetrievalPreparation:
         request: KnowledgeRetrievalRequest,
         ref: _KnowledgeRetrievalRef,
         tenant_id: uuid.UUID | None,
+        *,
+        params: RetrievalParams | None = None,
     ) -> RetrievalTarget:
         knowledge = ref.knowledge
-        params = cls._build_retrieval_params(request, ref.config)
+        params = params or cls._build_retrieval_params(request, ref.config)
         evidence_graph = False
         if params.retrieve_type == RetrieveType.Graph:
             try:
@@ -288,6 +315,39 @@ class KnowledgeRetrievalPreparation:
             top_n=top_n,
             retrieve_type=retrieve_type,
             rerank_score_threshold=rerank_score_threshold,
+        )
+
+    @classmethod
+    def _should_add_graph_mix_target(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        knowledge: Any,
+        params: RetrievalParams,
+    ) -> bool:
+        if (
+            not request.graph_retrieval_mix_enabled
+            or params.retrieve_type != RetrieveType.HYBRID
+            or not is_graph_enabled(knowledge.parser_config)
+        ):
+            return False
+        try:
+            return resolve_graph_pipeline(knowledge.parser_config) is GraphPipeline.EVIDENCE
+        except GraphPipelineConfigError as exc:
+            raise KnowledgeRetrievalConfigError(str(exc)) from exc
+
+    @staticmethod
+    def _copy_retrieval_params(
+        params: RetrievalParams,
+        *,
+        retrieve_type: RetrieveType,
+    ) -> RetrievalParams:
+        return RetrievalParams(
+            similarity_threshold=params.similarity_threshold,
+            vector_similarity_weight=params.vector_similarity_weight,
+            top_k=params.top_k,
+            top_n=params.top_n,
+            retrieve_type=retrieve_type,
+            rerank_score_threshold=params.rerank_score_threshold,
         )
 
     @classmethod

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -192,20 +192,6 @@ class KnowledgeRetrievalPreparation:
                     params=params,
                 )
             )
-            if cls._should_add_graph_mix_target(ref.knowledge, params):
-                graph_params = cls._copy_retrieval_params(
-                    params,
-                    retrieve_type=RetrieveType.Graph,
-                )
-                targets.append(
-                    await cls._build_retrieval_target_async(
-                        db,
-                        request,
-                        ref,
-                        tenant_id,
-                        params=graph_params,
-                    )
-                )
         return targets, tenant_id
 
     @staticmethod
@@ -320,39 +306,6 @@ class KnowledgeRetrievalPreparation:
                 if retrieve_type == RetrieveType.HYBRID
                 else False
             ),
-        )
-
-    @classmethod
-    def _should_add_graph_mix_target(
-        cls,
-        knowledge: Any,
-        params: RetrievalParams,
-    ) -> bool:
-        if (
-            not params.enable_graph_retrieval
-            or params.retrieve_type != RetrieveType.HYBRID
-            or not is_graph_enabled(knowledge.parser_config)
-        ):
-            return False
-        try:
-            return resolve_graph_pipeline(knowledge.parser_config) is GraphPipeline.EVIDENCE
-        except GraphPipelineConfigError as exc:
-            raise KnowledgeRetrievalConfigError(str(exc)) from exc
-
-    @staticmethod
-    def _copy_retrieval_params(
-        params: RetrievalParams,
-        *,
-        retrieve_type: RetrieveType,
-    ) -> RetrievalParams:
-        return RetrievalParams(
-            similarity_threshold=params.similarity_threshold,
-            vector_similarity_weight=params.vector_similarity_weight,
-            top_k=params.top_k,
-            top_n=params.top_n,
-            retrieve_type=retrieve_type,
-            rerank_score_threshold=params.rerank_score_threshold,
-            enable_graph_retrieval=params.enable_graph_retrieval,
         )
 
     @classmethod
@@ -619,12 +572,18 @@ class KnowledgeRetrievalPreparation:
         targets: list[RetrievalTarget],
         tenant_id: uuid.UUID | None,
     ) -> GraphRetrievalSnapshot | None:
-        graph_targets = [
+        graph_candidates = [
             target
             for target in targets
-            if target.params.retrieve_type == RetrieveType.Graph
+            if (
+                target.params.retrieve_type == RetrieveType.Graph
+                or (
+                    target.params.retrieve_type == RetrieveType.HYBRID
+                    and target.params.enable_graph_retrieval
+                )
+            )
         ]
-        if not graph_targets:
+        if not graph_candidates:
             return None
 
         refs_by_knowledge_id = {
@@ -635,7 +594,7 @@ class KnowledgeRetrievalPreparation:
             tuple[RetrievalTarget, Any, GraphPipeline]
         ] = []
         pipelines: set[GraphPipeline] = set()
-        for target in graph_targets:
+        for target in graph_candidates:
             ref = refs_by_knowledge_id.get(target.knowledge_id)
             if ref is None:
                 raise KnowledgeRetrievalConfigError(
@@ -643,16 +602,25 @@ class KnowledgeRetrievalPreparation:
                 )
             knowledge = ref.knowledge
             if not is_graph_enabled(knowledge.parser_config):
-                raise KnowledgeRetrievalConfigError(
-                    f"knowledge graph is disabled: {knowledge.id}"
-                )
+                if target.params.retrieve_type == RetrieveType.Graph:
+                    raise KnowledgeRetrievalConfigError(
+                        f"knowledge graph is disabled: {knowledge.id}"
+                    )
+                continue
             try:
                 pipeline = resolve_graph_pipeline(knowledge.parser_config)
             except GraphPipelineConfigError as exc:
                 raise KnowledgeRetrievalConfigError(str(exc)) from exc
+            if (
+                target.params.retrieve_type == RetrieveType.HYBRID
+                and pipeline is not GraphPipeline.EVIDENCE
+            ):
+                continue
             pipelines.add(pipeline)
             resolved_targets.append((target, knowledge, pipeline))
 
+        if not resolved_targets:
+            return None
         if len(pipelines) != 1:
             raise KnowledgeRetrievalConfigError(
                 "all graph targets must use the same graph pipeline"

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -192,7 +192,7 @@ class KnowledgeRetrievalPreparation:
                     params=params,
                 )
             )
-            if cls._should_add_graph_mix_target(request, ref.knowledge, params):
+            if cls._should_add_graph_mix_target(ref.knowledge, params):
                 graph_params = cls._copy_retrieval_params(
                     params,
                     retrieve_type=RetrieveType.Graph,
@@ -315,17 +315,21 @@ class KnowledgeRetrievalPreparation:
             top_n=top_n,
             retrieve_type=retrieve_type,
             rerank_score_threshold=rerank_score_threshold,
+            enable_graph_retrieval=(
+                request.graph_retrieval_mix_enabled_for(config)
+                if retrieve_type == RetrieveType.HYBRID
+                else False
+            ),
         )
 
     @classmethod
     def _should_add_graph_mix_target(
         cls,
-        request: KnowledgeRetrievalRequest,
         knowledge: Any,
         params: RetrievalParams,
     ) -> bool:
         if (
-            not request.graph_retrieval_mix_enabled
+            not params.enable_graph_retrieval
             or params.retrieve_type != RetrieveType.HYBRID
             or not is_graph_enabled(knowledge.parser_config)
         ):
@@ -348,6 +352,7 @@ class KnowledgeRetrievalPreparation:
             top_n=params.top_n,
             retrieve_type=retrieve_type,
             rerank_score_threshold=params.rerank_score_threshold,
+            enable_graph_retrieval=params.enable_graph_retrieval,
         )
 
     @classmethod

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -114,16 +114,14 @@ class KnowledgeRetrievalPreparation:
             targets,
             tenant_id,
         )
-        evidence_graph_only = (
+        single_evidence_graph_target = (
             graph is not None
             and graph.pipeline is GraphPipeline.EVIDENCE
-            and all(
-                target.params.retrieve_type == RetrieveType.Graph
-                for target in targets
-            )
+            and len(targets) == 1
+            and targets[0].params.retrieve_type == RetrieveType.Graph
         )
         request_reranker = None
-        if not evidence_graph_only:
+        if not single_evidence_graph_target:
             request_reranker = await cls._snapshot_model_runtime(
                 db,
                 request.rerank_id,

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -224,13 +224,9 @@ class KnowledgeRetrievalPreparation:
     ) -> RetrievalTarget:
         knowledge = ref.knowledge
         params = params or cls._build_retrieval_params(request, ref.config)
-        evidence_graph = False
         if params.retrieve_type == RetrieveType.Graph:
             try:
-                evidence_graph = (
-                    resolve_graph_pipeline(knowledge.parser_config)
-                    is GraphPipeline.EVIDENCE
-                )
+                resolve_graph_pipeline(knowledge.parser_config)
             except GraphPipelineConfigError as exc:
                 raise KnowledgeRetrievalConfigError(str(exc)) from exc
         if not knowledge.embedding_id:
@@ -240,13 +236,11 @@ class KnowledgeRetrievalPreparation:
         if not embedding:
             raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
 
-        reranker = None
-        if not evidence_graph:
-            if not knowledge.reranker_id:
-                raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
-            reranker = await cls._snapshot_model_runtime(db, knowledge.reranker_id, tenant_id)
-            if not reranker:
-                raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+        if not knowledge.reranker_id:
+            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+        reranker = await cls._snapshot_model_runtime(db, knowledge.reranker_id, tenant_id)
+        if not reranker:
+            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
 
         return RetrievalTarget(
             knowledge_id=knowledge.id,

--- a/api/app/services/knowledge_retrieval_preparation.py
+++ b/api/app/services/knowledge_retrieval_preparation.py
@@ -97,11 +97,6 @@ class KnowledgeRetrievalPreparation:
             for target in targets
         }
         common_metadata_defs = cls._get_common_metadata_defs(metadata_defs_by_kb)
-        request_reranker = await cls._snapshot_model_runtime(
-            db,
-            request.rerank_id,
-            tenant_id,
-        )
         metadata_llm = await cls._build_metadata_llm_snapshot(
             db,
             request,
@@ -116,6 +111,21 @@ class KnowledgeRetrievalPreparation:
             targets,
             tenant_id,
         )
+        evidence_graph_only = (
+            graph is not None
+            and graph.pipeline is GraphPipeline.EVIDENCE
+            and all(
+                target.params.retrieve_type == RetrieveType.Graph
+                for target in targets
+            )
+        )
+        request_reranker = None
+        if not evidence_graph_only:
+            request_reranker = await cls._snapshot_model_runtime(
+                db,
+                request.rerank_id,
+                tenant_id,
+            )
         return RetrievalPreparation(
             targets=tuple(targets),
             tenant_id=tenant_id,
@@ -200,23 +210,36 @@ class KnowledgeRetrievalPreparation:
         tenant_id: uuid.UUID | None,
     ) -> RetrievalTarget:
         knowledge = ref.knowledge
+        params = cls._build_retrieval_params(request, ref.config)
+        evidence_graph = False
+        if params.retrieve_type == RetrieveType.Graph:
+            try:
+                evidence_graph = (
+                    resolve_graph_pipeline(knowledge.parser_config)
+                    is GraphPipeline.EVIDENCE
+                )
+            except GraphPipelineConfigError as exc:
+                raise KnowledgeRetrievalConfigError(str(exc)) from exc
         if not knowledge.embedding_id:
             raise KnowledgeRetrievalConfigError(f"embedding_id config error: {knowledge.id}")
-        if not knowledge.reranker_id:
-            raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
 
         embedding = await cls._snapshot_model_runtime(db, knowledge.embedding_id, tenant_id)
-        reranker = await cls._snapshot_model_runtime(db, knowledge.reranker_id, tenant_id)
         if not embedding:
             raise KnowledgeRetrievalConfigError(f"No embedding api key found for knowledge {knowledge.id}")
-        if not reranker:
-            raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
+
+        reranker = None
+        if not evidence_graph:
+            if not knowledge.reranker_id:
+                raise KnowledgeRetrievalConfigError(f"reranker_id config error: {knowledge.id}")
+            reranker = await cls._snapshot_model_runtime(db, knowledge.reranker_id, tenant_id)
+            if not reranker:
+                raise KnowledgeRetrievalConfigError(f"No reranker api key found for knowledge {knowledge.id}")
 
         return RetrievalTarget(
             knowledge_id=knowledge.id,
             workspace_id=knowledge.workspace_id,
             index_name=ElasticSearchVectorIndexOps.collection_name_for_knowledge(knowledge.id),
-            params=cls._build_retrieval_params(request, ref.config),
+            params=params,
             embedding=embedding,
             reranker=reranker,
         )

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1126,7 +1126,7 @@ class KnowledgeRetrievalService:
         source_chunk_ids = cls._graph_items_unique_list(entities, "source_chunk_ids")
         return DocumentChunk(
             page_content="\n".join(
-                ["Graph entities:"]
+                ["Entities:"]
                 + [
                     cls._format_graph_entity_line(entity, index)
                     for index, entity in enumerate(entities, start=1)
@@ -1140,7 +1140,6 @@ class KnowledgeRetrievalService:
                 "score": 1,
                 "graph_score": 1,
                 "graph_item_count": len(entities),
-                "entities": cls._graph_items_payload(entities),
                 "source_chunk_ids": source_chunk_ids,
             },
         )
@@ -1156,7 +1155,7 @@ class KnowledgeRetrievalService:
         )
         return DocumentChunk(
             page_content="\n".join(
-                ["Graph relationships:"]
+                ["Relationships:"]
                 + [
                     cls._format_graph_relationship_line(relationship, index)
                     for index, relationship in enumerate(relationships, start=1)
@@ -1170,7 +1169,6 @@ class KnowledgeRetrievalService:
                 "score": 1,
                 "graph_score": 1,
                 "graph_item_count": len(relationships),
-                "relationships": cls._graph_items_payload(relationships),
                 "source_chunk_ids": source_chunk_ids,
             },
         )
@@ -1183,17 +1181,11 @@ class KnowledgeRetrievalService:
     ) -> str:
         entity_key = cls._graph_item_text(entity, "entity_key")
         entity_name = cls._graph_item_text(entity, "entity_name") or entity_key
-        entity_type = cls._graph_item_text(entity, "entity_type")
         description = cls._graph_item_text(entity, "description")
-        aliases = cls._graph_item_list(entity, "aliases")
-        parts = [f"{index}. {entity_name or entity_key or 'unknown'}"]
-        if entity_type:
-            parts.append(f"type={entity_type}")
-        if aliases:
-            parts.append(f"aliases={', '.join(aliases)}")
+        parts = [entity_name or entity_key or "unknown"]
         if description:
             parts.append(description)
-        return " | ".join(parts)
+        return f"{index}. " + " - ".join(parts)
 
     @classmethod
     def _format_graph_relationship_line(
@@ -1215,8 +1207,6 @@ class KnowledgeRetrievalService:
         predicate = cls._graph_item_text(relationship, "predicate")
         label = cls._graph_item_text(relationship, "label")
         description = cls._graph_item_text(relationship, "description")
-        keywords = cls._graph_item_list(relationship, "keywords")
-        source_chunk_ids = cls._graph_item_list(relationship, "source_chunk_ids")
         connector = (
             "->"
             if cls._graph_item_value(relationship, "directed") is not False
@@ -1227,27 +1217,13 @@ class KnowledgeRetrievalService:
             if from_name and to_name
             else from_name or to_name
         )
-        parts = [f"Relationship: {endpoints or relation_key}"]
+        parts = [endpoints or relation_key or "unknown"]
         relation_label = predicate or label
         if relation_label:
-            parts.append(f"Label: {relation_label}")
-        if keywords:
-            parts.append(f"Keywords: {', '.join(keywords)}")
+            parts.append(relation_label)
         if description:
-            parts.append(f"Description: {description}")
-        return f"{index}. " + " | ".join(parts)
-
-    @staticmethod
-    def _graph_items_payload(items: Sequence[Any]) -> list[Any]:
-        result: list[Any] = []
-        for item in items:
-            if isinstance(item, dict):
-                result.append(dict(item))
-            elif hasattr(item, "model_dump"):
-                result.append(item.model_dump())
-            else:
-                result.append({"value": str(item)})
-        return result
+            parts.append(description)
+        return f"{index}. " + " - ".join(parts)
 
     @classmethod
     def _graph_items_unique_list(

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -220,6 +220,7 @@ class KnowledgeRetrievalService:
             "type": request.retrieve_type,
             "top_k": request.top_k,
             "top_n": request.top_n,
+            "enable_graph_retrieval": request.enable_graph_retrieval,
             "metadata_mode": request.metadata_filter_mode,
             "async_mode": "native",
         }
@@ -299,6 +300,12 @@ class KnowledgeRetrievalService:
                 chunks.insert(0, graph_document)
 
         chunks = cls._include_document_ids(chunks, document_ids_include)
+        graph_context_chunks = cls._build_graph_context_chunks(
+            retrieval_result.entities,
+            retrieval_result.relationships,
+        )
+        if graph_context_chunks:
+            chunks = graph_context_chunks + chunks
         logger.info(
             "[Retrieval] finish %s",
             cls._format_log_fields(
@@ -307,6 +314,7 @@ class KnowledgeRetrievalService:
                     "reason": "ok",
                     "target_count": len(preparation.targets),
                     "document_filter_count": len(document_ids_include or []),
+                    "graph_context_count": len(graph_context_chunks),
                     "final_count": len(chunks),
                     "elapsed_ms": cls._elapsed_ms(started_at),
                     "async_mode": "native",
@@ -1094,6 +1102,169 @@ class KnowledgeRetrievalService:
             seen_keys.add(key)
             result.append(item)
         return result
+
+    @classmethod
+    def _build_graph_context_chunks(
+        cls,
+        entities: Sequence[Any],
+        relationships: Sequence[Any],
+    ) -> list[DocumentChunk]:
+        chunks: list[DocumentChunk] = []
+        chunks.extend(
+            cls._graph_entity_to_chunk(entity, index)
+            for index, entity in enumerate(entities)
+        )
+        chunks.extend(
+            cls._graph_relationship_to_chunk(relationship, index)
+            for index, relationship in enumerate(relationships)
+        )
+        return chunks
+
+    @classmethod
+    def _graph_entity_to_chunk(
+        cls,
+        entity: Any,
+        index: int,
+    ) -> DocumentChunk:
+        entity_key = cls._graph_item_text(entity, "entity_key") or f"entity-{index}"
+        entity_name = cls._graph_item_text(entity, "entity_name") or entity_key
+        entity_type = cls._graph_item_text(entity, "entity_type")
+        description = cls._graph_item_text(entity, "description")
+        aliases = cls._graph_item_list(entity, "aliases")
+        source_chunk_ids = cls._graph_item_list(entity, "source_chunk_ids")
+        parts = [f"Entity: {entity_name}"]
+        if entity_type:
+            parts.append(f"Type: {entity_type}")
+        if aliases:
+            parts.append(f"Aliases: {', '.join(aliases)}")
+        if description:
+            parts.append(f"Description: {description}")
+        return DocumentChunk(
+            page_content="\n".join(parts),
+            metadata={
+                "doc_id": f"graph_entity:{entity_key}",
+                "chunk_type": "graph_entity",
+                "retrieval_source": "graph",
+                "graph_item_type": "entity",
+                "score": 1,
+                "graph_score": cls._graph_item_value(entity, "score"),
+                "entity_key": entity_key,
+                "entity_name": entity_name,
+                "entity_type": entity_type,
+                "aliases": aliases,
+                "source_chunk_ids": source_chunk_ids,
+                "degree": cls._graph_item_value(entity, "degree"),
+                "evidence_count": cls._graph_item_value(entity, "evidence_count"),
+                "document_count": cls._graph_item_value(entity, "document_count"),
+            },
+        )
+
+    @classmethod
+    def _graph_relationship_to_chunk(
+        cls,
+        relationship: Any,
+        index: int,
+    ) -> DocumentChunk:
+        relation_key = (
+            cls._graph_item_text(relationship, "relation_key")
+            or f"relationship-{index}"
+        )
+        from_name = (
+            cls._graph_item_text(relationship, "from_entity_name")
+            or cls._graph_item_text(relationship, "from_entity_key")
+            or cls._graph_item_text(relationship, "src_id")
+        )
+        to_name = (
+            cls._graph_item_text(relationship, "to_entity_name")
+            or cls._graph_item_text(relationship, "to_entity_key")
+            or cls._graph_item_text(relationship, "tgt_id")
+        )
+        predicate = cls._graph_item_text(relationship, "predicate")
+        label = cls._graph_item_text(relationship, "label")
+        description = cls._graph_item_text(relationship, "description")
+        keywords = cls._graph_item_list(relationship, "keywords")
+        source_chunk_ids = cls._graph_item_list(relationship, "source_chunk_ids")
+        connector = (
+            "->"
+            if cls._graph_item_value(relationship, "directed") is not False
+            else "--"
+        )
+        endpoints = (
+            f"{from_name} {connector} {to_name}"
+            if from_name and to_name
+            else from_name or to_name
+        )
+        parts = [f"Relationship: {endpoints or relation_key}"]
+        relation_label = predicate or label
+        if relation_label:
+            parts.append(f"Label: {relation_label}")
+        if keywords:
+            parts.append(f"Keywords: {', '.join(keywords)}")
+        if description:
+            parts.append(f"Description: {description}")
+        return DocumentChunk(
+            page_content="\n".join(parts),
+            metadata={
+                "doc_id": f"graph_relationship:{relation_key}",
+                "chunk_type": "graph_relationship",
+                "retrieval_source": "graph",
+                "graph_item_type": "relationship",
+                "score": 1,
+                "graph_score": cls._graph_item_value(relationship, "score"),
+                "relation_key": relation_key,
+                "src_id": cls._graph_item_value(relationship, "src_id"),
+                "tgt_id": cls._graph_item_value(relationship, "tgt_id"),
+                "from_entity_key": cls._graph_item_value(
+                    relationship,
+                    "from_entity_key",
+                ),
+                "from_entity_name": from_name,
+                "to_entity_key": cls._graph_item_value(
+                    relationship,
+                    "to_entity_key",
+                ),
+                "to_entity_name": to_name,
+                "predicate": predicate,
+                "label": label,
+                "keywords": keywords,
+                "directed": cls._graph_item_value(relationship, "directed"),
+                "source_chunk_ids": source_chunk_ids,
+                "weight": cls._graph_item_value(relationship, "weight"),
+                "evidence_count": cls._graph_item_value(
+                    relationship,
+                    "evidence_count",
+                ),
+                "document_count": cls._graph_item_value(
+                    relationship,
+                    "document_count",
+                ),
+                "endpoint_degree": cls._graph_item_value(
+                    relationship,
+                    "endpoint_degree",
+                ),
+            },
+        )
+
+    @staticmethod
+    def _graph_item_value(item: Any, key: str) -> Any:
+        if isinstance(item, dict):
+            return item.get(key)
+        return getattr(item, key, None)
+
+    @classmethod
+    def _graph_item_text(cls, item: Any, key: str) -> str:
+        value = cls._graph_item_value(item, key)
+        return str(value).strip() if value is not None else ""
+
+    @classmethod
+    def _graph_item_list(cls, item: Any, key: str) -> list[str]:
+        value = cls._graph_item_value(item, key)
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple, set)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
 
     @classmethod
     def _filter_graph_items_by_chunk_paths(

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -324,8 +324,10 @@ class KnowledgeRetrievalService:
         )
         return KnowledgeRetrievalResult(
             chunks=chunks,
-            entities=retrieval_result.entities,
-            relationships=retrieval_result.relationships,
+            # Top-level graph payload is intentionally suppressed while clients
+            # read the same graph data from the grouped graph chunks above.
+            # entities=retrieval_result.entities,
+            # relationships=retrieval_result.relationships,
         )
 
     @classmethod

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -281,7 +281,7 @@ class KnowledgeRetrievalService:
 
         client = await AsyncElasticsearchClientProvider.get_shared_client()
         store = AsyncElasticSearchRetrieval(client, timings)
-        chunks = await cls._retrieve_targets(
+        retrieval_result = await cls._retrieve_targets(
             request,
             preparation,
             document_ids_include,
@@ -289,6 +289,7 @@ class KnowledgeRetrievalService:
             log_id,
             timings,
         )
+        chunks = retrieval_result.chunks
         if (
             preparation.graph
             and preparation.graph.pipeline is GraphPipeline.LEGACY
@@ -313,7 +314,11 @@ class KnowledgeRetrievalService:
                 | timings.as_log_fields()
             ),
         )
-        return KnowledgeRetrievalResult(chunks=chunks)
+        return KnowledgeRetrievalResult(
+            chunks=chunks,
+            entities=retrieval_result.entities,
+            relationships=retrieval_result.relationships,
+        )
 
     @classmethod
     def retrieve(cls, *args: Any, **kwargs: Any) -> KnowledgeRetrievalResult:
@@ -364,10 +369,10 @@ class KnowledgeRetrievalService:
         store: AsyncElasticSearchRetrieval,
         log_id: str,
         timings: RetrievalTimings | None = None,
-    ) -> list[DocumentChunk]:
+    ) -> KnowledgeRetrievalResult:
         targets = preparation.targets
         if not targets:
-            return []
+            return KnowledgeRetrievalResult()
 
         max_workers = max(
             1,
@@ -399,9 +404,9 @@ class KnowledgeRetrievalService:
         async def retrieve_one(
             index: int,
             target: RetrievalTarget,
-        ) -> tuple[int, list[DocumentChunk]]:
+        ) -> tuple[int, KnowledgeRetrievalResult]:
             async with semaphore:
-                chunks = await cls._retrieve_single_target(
+                result = await cls._retrieve_single_target(
                     request,
                     target,
                     document_ids_include,
@@ -418,7 +423,7 @@ class KnowledgeRetrievalService:
                     ),
                     timings=timings,
                 )
-                return index, chunks
+                return index, result
 
         tasks = [
             asyncio.create_task(retrieve_one(index, target))
@@ -433,8 +438,12 @@ class KnowledgeRetrievalService:
             raise
 
         chunks_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
-        for index, target_chunks in retrieved:
-            chunks_by_index[index] = target_chunks
+        graph_entities: list[Any] = []
+        graph_relationships: list[Any] = []
+        for index, target_result in retrieved:
+            chunks_by_index[index] = target_result.chunks
+            graph_entities.extend(target_result.entities)
+            graph_relationships.extend(target_result.relationships)
         evidence_graph_only = (
             preparation.graph is not None
             and preparation.graph.pipeline is GraphPipeline.EVIDENCE
@@ -452,12 +461,37 @@ class KnowledgeRetrievalService:
                 for chunk in target_chunks
             ]
         )
-        return await cls._finalize_retrieval_chunks(
+        chunks = await cls._finalize_retrieval_chunks(
             request,
             preparation,
             candidates,
             log_id,
             timings,
+        )
+        graph_entities = cls._deduplicate_graph_items(
+            graph_entities,
+            "entity_key",
+        )
+        graph_relationships = cls._deduplicate_graph_items(
+            graph_relationships,
+            "relation_key",
+        )
+        graph_entities = cls._filter_graph_items_by_chunk_paths(
+            graph_entities,
+            chunks,
+            "entity_key",
+            "entity",
+        )
+        graph_relationships = cls._filter_graph_items_by_chunk_paths(
+            graph_relationships,
+            chunks,
+            "relation_key",
+            "relation",
+        )
+        return KnowledgeRetrievalResult(
+            chunks=chunks,
+            entities=graph_entities,
+            relationships=graph_relationships,
         )
 
     @staticmethod
@@ -491,7 +525,7 @@ class KnowledgeRetrievalService:
         log_id: str | None = None,
         graph_target: GraphTargetSnapshot | None = None,
         timings: RetrievalTimings | None = None,
-    ) -> list[DocumentChunk]:
+    ) -> KnowledgeRetrievalResult:
         started_at = time.perf_counter()
         target_type = target.params.retrieve_type
         if (
@@ -524,7 +558,7 @@ class KnowledgeRetrievalService:
         if target_type == RetrieveType.PARTICIPLE:
             chunks = await store.search_by_full_text(request.query, full_text_options)
             cls._log_target_done(target, 0, len(chunks), len(chunks), len(chunks), started_at, timings=timings)
-            return chunks
+            return KnowledgeRetrievalResult(chunks=chunks)
 
         vector_options = cls._search_options(
             target,
@@ -537,7 +571,7 @@ class KnowledgeRetrievalService:
         if target_type == RetrieveType.SEMANTIC:
             chunks = await store.search_by_vector(embedding, request.query, vector_options)
             cls._log_target_done(target, len(chunks), 0, len(chunks), len(chunks), started_at, timings=timings)
-            return chunks
+            return KnowledgeRetrievalResult(chunks=chunks)
 
         vector_task = asyncio.create_task(
             store.search_by_vector(embedding, request.query, vector_options)
@@ -591,7 +625,7 @@ class KnowledgeRetrievalService:
             local_rerank=True,
             timings=timings,
         )
-        return chunks
+        return KnowledgeRetrievalResult(chunks=chunks)
 
     @classmethod
     async def _retrieve_evidence_graph_target(
@@ -604,7 +638,7 @@ class KnowledgeRetrievalService:
         started_at: float,
         timings: RetrievalTimings | None,
         log_id: str | None,
-    ) -> list[DocumentChunk]:
+    ) -> KnowledgeRetrievalResult:
         if graph_target.knowledge_id != target.knowledge_id:
             raise ValueError("graph target does not match retrieval target")
 
@@ -633,7 +667,7 @@ class KnowledgeRetrievalService:
                 embedding,
                 store.resolve_parent_chunks,
             )
-            chunks = await pipeline.retrieve(
+            graph_result = await pipeline.retrieve_with_graph_data(
                 GraphRetrievalRequest(
                     query=request.query,
                     runtime=GraphIndexRuntime(
@@ -674,6 +708,7 @@ class KnowledgeRetrievalService:
                     ),
                 )
             )
+            chunks = graph_result.chunks
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -687,6 +722,7 @@ class KnowledgeRetrievalService:
                 type(exc).__name__,
                 cls._elapsed_ms(graph_started_at),
             )
+            graph_result = None
             chunks = []
         finally:
             cls._record_timing(timings, "graph_ms", graph_started_at)
@@ -700,7 +736,13 @@ class KnowledgeRetrievalService:
             started_at,
             timings=timings,
         )
-        return chunks
+        if graph_result is None:
+            return KnowledgeRetrievalResult(chunks=chunks)
+        return KnowledgeRetrievalResult(
+            chunks=chunks,
+            entities=graph_result.entities,
+            relationships=graph_result.relationships,
+        )
 
     @classmethod
     async def _finalize_retrieval_chunks(
@@ -1034,6 +1076,67 @@ class KnowledgeRetrievalService:
             seen_keys.add(dedupe_key)
             result.append(chunk)
         return result
+
+    @staticmethod
+    def _deduplicate_graph_items(
+        items: Sequence[Any],
+        key_field: str,
+    ) -> list[Any]:
+        seen_keys: set[str] = set()
+        result: list[Any] = []
+        for item in items:
+            if isinstance(item, dict):
+                key = str(item.get(key_field) or "")
+            else:
+                key = str(getattr(item, key_field, "") or "")
+            if not key or key in seen_keys:
+                continue
+            seen_keys.add(key)
+            result.append(item)
+        return result
+
+    @classmethod
+    def _filter_graph_items_by_chunk_paths(
+        cls,
+        items: Sequence[Any],
+        chunks: Sequence[DocumentChunk],
+        key_field: str,
+        projection_type: str,
+    ) -> list[Any]:
+        keys = cls._graph_projection_keys_from_chunks(chunks, projection_type)
+        if not keys:
+            return list(items)
+        return [
+            item
+            for item in items
+            if cls._graph_item_key(item, key_field) in keys
+        ]
+
+    @staticmethod
+    def _graph_projection_keys_from_chunks(
+        chunks: Sequence[DocumentChunk],
+        projection_type: str,
+    ) -> set[str]:
+        keys: set[str] = set()
+        for chunk in chunks:
+            match_paths = (chunk.metadata or {}).get("match_paths") or []
+            if not isinstance(match_paths, list):
+                continue
+            for path in match_paths:
+                if not isinstance(path, dict):
+                    continue
+                if path.get("evidence_type") != projection_type:
+                    continue
+                key = str(path.get("evidence_key") or "")
+                if key:
+                    keys.add(key)
+        return keys
+
+    @staticmethod
+    def _graph_item_key(item: Any, key_field: str) -> str:
+        if isinstance(item, dict):
+            return str(item.get(key_field) or "")
+        return str(getattr(item, key_field, "") or "")
 
     @staticmethod
     def _include_document_ids(

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -708,11 +708,7 @@ class KnowledgeRetrievalService:
                     related_chunk_number=(
                         settings.KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER
                     ),
-                    max_candidates=max(
-                        settings.KNOWLEDGE_GRAPH_MAX_CANDIDATES,
-                        request.top_k,
-                        target.params.top_k,
-                    ),
+                    max_candidates=target.params.top_k,
                     max_paths_per_chunk=(
                         settings.KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK
                     ),

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -412,6 +412,7 @@ class KnowledgeRetrievalService:
                         and target.params.retrieve_type == RetrieveType.HYBRID
                     ),
                     request_reranker=preparation.request_reranker,
+                    log_id=log_id,
                     graph_target=graph_targets_by_knowledge_id.get(
                         target.knowledge_id
                     ),
@@ -453,6 +454,7 @@ class KnowledgeRetrievalService:
         *,
         use_request_reranker: bool,
         request_reranker: Any,
+        log_id: str | None = None,
         graph_target: GraphTargetSnapshot | None = None,
         timings: RetrievalTimings | None = None,
     ) -> list[DocumentChunk]:
@@ -471,6 +473,7 @@ class KnowledgeRetrievalService:
                 store,
                 started_at,
                 timings,
+                log_id,
             )
 
         full_text_options = cls._search_options(
@@ -566,6 +569,7 @@ class KnowledgeRetrievalService:
         store: AsyncElasticSearchRetrieval,
         started_at: float,
         timings: RetrievalTimings | None,
+        log_id: str | None,
     ) -> list[DocumentChunk]:
         if graph_target.knowledge_id != target.knowledge_id:
             raise ValueError("graph target does not match retrieval target")
@@ -623,10 +627,15 @@ class KnowledgeRetrievalService:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            stage = "timeout" if isinstance(exc, TimeoutError) else "pipeline"
             logger.warning(
-                "[Retrieval] graph target failed kb=%s error_type=%s",
+                "[Retrieval] graph_target_failed"
+                " id=%s kb_id=%s stage=%s error_type=%s elapsed_ms=%d",
+                log_id or "unknown",
                 cls._compact_id(target.knowledge_id),
+                stage,
                 type(exc).__name__,
+                cls._elapsed_ms(graph_started_at),
             )
             chunks = []
         finally:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -672,14 +672,20 @@ class KnowledgeRetrievalService:
             and len(targets) == 1
             and targets[0].params.retrieve_type == RetrieveType.HYBRID
         )
-        needs_global_rerank = len(targets) > 1 or (
-            request.rerank_id is not None and not single_hybrid_uses_request_rerank
-        ) or (
-            len(targets) == 1
-            and targets[0].params.retrieve_type == RetrieveType.Graph
-            and preparation.graph is not None
+        evidence_graph_only = (
+            preparation.graph is not None
             and preparation.graph.pipeline is GraphPipeline.EVIDENCE
-            and targets[0].reranker is not None
+            and all(
+                target.params.retrieve_type == RetrieveType.Graph
+                for target in targets
+            )
+        )
+        needs_global_rerank = not evidence_graph_only and (
+            len(targets) > 1
+            or (
+                request.rerank_id is not None
+                and not single_hybrid_uses_request_rerank
+            )
         )
         if needs_global_rerank:
             global_rerank_started_at = time.perf_counter()

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -1110,65 +1110,96 @@ class KnowledgeRetrievalService:
         relationships: Sequence[Any],
     ) -> list[DocumentChunk]:
         chunks: list[DocumentChunk] = []
-        chunks.extend(
-            cls._graph_entity_to_chunk(entity, index)
-            for index, entity in enumerate(entities)
-        )
-        chunks.extend(
-            cls._graph_relationship_to_chunk(relationship, index)
-            for index, relationship in enumerate(relationships)
-        )
+        if entities:
+            chunks.append(cls._graph_entities_to_chunk(entities))
+        if relationships:
+            chunks.append(cls._graph_relationships_to_chunk(relationships))
         return chunks
 
     @classmethod
-    def _graph_entity_to_chunk(
+    def _graph_entities_to_chunk(
         cls,
-        entity: Any,
-        index: int,
+        entities: Sequence[Any],
     ) -> DocumentChunk:
-        entity_key = cls._graph_item_text(entity, "entity_key") or f"entity-{index}"
-        entity_name = cls._graph_item_text(entity, "entity_name") or entity_key
-        entity_type = cls._graph_item_text(entity, "entity_type")
-        description = cls._graph_item_text(entity, "description")
-        aliases = cls._graph_item_list(entity, "aliases")
-        source_chunk_ids = cls._graph_item_list(entity, "source_chunk_ids")
-        parts = [f"Entity: {entity_name}"]
-        if entity_type:
-            parts.append(f"Type: {entity_type}")
-        if aliases:
-            parts.append(f"Aliases: {', '.join(aliases)}")
-        if description:
-            parts.append(f"Description: {description}")
+        source_chunk_ids = cls._graph_items_unique_list(entities, "source_chunk_ids")
         return DocumentChunk(
-            page_content="\n".join(parts),
+            page_content="\n".join(
+                ["Graph entities:"]
+                + [
+                    cls._format_graph_entity_line(entity, index)
+                    for index, entity in enumerate(entities, start=1)
+                ]
+            ),
             metadata={
-                "doc_id": f"graph_entity:{entity_key}",
-                "chunk_type": "graph_entity",
+                "doc_id": "graph_entities",
+                "chunk_type": "graph_entities",
                 "retrieval_source": "graph",
-                "graph_item_type": "entity",
+                "graph_item_type": "entities",
                 "score": 1,
-                "graph_score": cls._graph_item_value(entity, "score"),
-                "entity_key": entity_key,
-                "entity_name": entity_name,
-                "entity_type": entity_type,
-                "aliases": aliases,
+                "graph_score": 1,
+                "graph_item_count": len(entities),
+                "entities": cls._graph_items_payload(entities),
                 "source_chunk_ids": source_chunk_ids,
-                "degree": cls._graph_item_value(entity, "degree"),
-                "evidence_count": cls._graph_item_value(entity, "evidence_count"),
-                "document_count": cls._graph_item_value(entity, "document_count"),
             },
         )
 
     @classmethod
-    def _graph_relationship_to_chunk(
+    def _graph_relationships_to_chunk(
+        cls,
+        relationships: Sequence[Any],
+    ) -> DocumentChunk:
+        source_chunk_ids = cls._graph_items_unique_list(
+            relationships,
+            "source_chunk_ids",
+        )
+        return DocumentChunk(
+            page_content="\n".join(
+                ["Graph relationships:"]
+                + [
+                    cls._format_graph_relationship_line(relationship, index)
+                    for index, relationship in enumerate(relationships, start=1)
+                ]
+            ),
+            metadata={
+                "doc_id": "graph_relationships",
+                "chunk_type": "graph_relationships",
+                "retrieval_source": "graph",
+                "graph_item_type": "relationships",
+                "score": 1,
+                "graph_score": 1,
+                "graph_item_count": len(relationships),
+                "relationships": cls._graph_items_payload(relationships),
+                "source_chunk_ids": source_chunk_ids,
+            },
+        )
+
+    @classmethod
+    def _format_graph_entity_line(
+        cls,
+        entity: Any,
+        index: int,
+    ) -> str:
+        entity_key = cls._graph_item_text(entity, "entity_key")
+        entity_name = cls._graph_item_text(entity, "entity_name") or entity_key
+        entity_type = cls._graph_item_text(entity, "entity_type")
+        description = cls._graph_item_text(entity, "description")
+        aliases = cls._graph_item_list(entity, "aliases")
+        parts = [f"{index}. {entity_name or entity_key or 'unknown'}"]
+        if entity_type:
+            parts.append(f"type={entity_type}")
+        if aliases:
+            parts.append(f"aliases={', '.join(aliases)}")
+        if description:
+            parts.append(description)
+        return " | ".join(parts)
+
+    @classmethod
+    def _format_graph_relationship_line(
         cls,
         relationship: Any,
         index: int,
-    ) -> DocumentChunk:
-        relation_key = (
-            cls._graph_item_text(relationship, "relation_key")
-            or f"relationship-{index}"
-        )
+    ) -> str:
+        relation_key = cls._graph_item_text(relationship, "relation_key")
         from_name = (
             cls._graph_item_text(relationship, "from_entity_name")
             or cls._graph_item_text(relationship, "from_entity_key")
@@ -1202,48 +1233,35 @@ class KnowledgeRetrievalService:
             parts.append(f"Keywords: {', '.join(keywords)}")
         if description:
             parts.append(f"Description: {description}")
-        return DocumentChunk(
-            page_content="\n".join(parts),
-            metadata={
-                "doc_id": f"graph_relationship:{relation_key}",
-                "chunk_type": "graph_relationship",
-                "retrieval_source": "graph",
-                "graph_item_type": "relationship",
-                "score": 1,
-                "graph_score": cls._graph_item_value(relationship, "score"),
-                "relation_key": relation_key,
-                "src_id": cls._graph_item_value(relationship, "src_id"),
-                "tgt_id": cls._graph_item_value(relationship, "tgt_id"),
-                "from_entity_key": cls._graph_item_value(
-                    relationship,
-                    "from_entity_key",
-                ),
-                "from_entity_name": from_name,
-                "to_entity_key": cls._graph_item_value(
-                    relationship,
-                    "to_entity_key",
-                ),
-                "to_entity_name": to_name,
-                "predicate": predicate,
-                "label": label,
-                "keywords": keywords,
-                "directed": cls._graph_item_value(relationship, "directed"),
-                "source_chunk_ids": source_chunk_ids,
-                "weight": cls._graph_item_value(relationship, "weight"),
-                "evidence_count": cls._graph_item_value(
-                    relationship,
-                    "evidence_count",
-                ),
-                "document_count": cls._graph_item_value(
-                    relationship,
-                    "document_count",
-                ),
-                "endpoint_degree": cls._graph_item_value(
-                    relationship,
-                    "endpoint_degree",
-                ),
-            },
-        )
+        return f"{index}. " + " | ".join(parts)
+
+    @staticmethod
+    def _graph_items_payload(items: Sequence[Any]) -> list[Any]:
+        result: list[Any] = []
+        for item in items:
+            if isinstance(item, dict):
+                result.append(dict(item))
+            elif hasattr(item, "model_dump"):
+                result.append(item.model_dump())
+            else:
+                result.append({"value": str(item)})
+        return result
+
+    @classmethod
+    def _graph_items_unique_list(
+        cls,
+        items: Sequence[Any],
+        key: str,
+    ) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for item in items:
+            for value in cls._graph_item_list(item, key):
+                if value in seen:
+                    continue
+                seen.add(value)
+                result.append(value)
+        return result
 
     @staticmethod
     def _graph_item_value(item: Any, key: str) -> Any:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -763,7 +763,11 @@ class KnowledgeRetrievalService:
             finally:
                 cls._record_timing(timings, "global_rerank_ms", global_rerank_started_at)
         elif evidence_graph_only:
-            ranked_chunks = unique_chunks
+            ranked_chunks = sorted(
+                unique_chunks,
+                key=lambda chunk: (chunk.metadata or {}).get("score", 0),
+                reverse=True,
+            )
             threshold = None
             filtered_chunks = ranked_chunks
         else:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -831,15 +831,13 @@ class KnowledgeRetrievalService:
             and len(targets) == 1
             and targets[0].params.retrieve_type == RetrieveType.HYBRID
         )
-        evidence_graph_only = (
+        single_evidence_graph_target = (
             preparation.graph is not None
             and preparation.graph.pipeline is GraphPipeline.EVIDENCE
-            and all(
-                target.params.retrieve_type == RetrieveType.Graph
-                for target in targets
-            )
+            and len(targets) == 1
+            and targets[0].params.retrieve_type == RetrieveType.Graph
         )
-        needs_global_rerank = not evidence_graph_only and (
+        needs_global_rerank = not single_evidence_graph_target and (
             len(targets) > 1
             or (
                 request.rerank_id is not None
@@ -871,7 +869,7 @@ class KnowledgeRetrievalService:
                 ]
             finally:
                 cls._record_timing(timings, "global_rerank_ms", global_rerank_started_at)
-        elif evidence_graph_only:
+        elif single_evidence_graph_target:
             ranked_chunks = sorted(
                 unique_chunks,
                 key=lambda chunk: (chunk.metadata or {}).get("score", 0),

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -498,10 +498,24 @@ class KnowledgeRetrievalService:
             "relation_key",
             "relation",
         )
+        if not cls._preserves_evidence_graph_context(preparation):
+            graph_entities = []
+            graph_relationships = []
         return KnowledgeRetrievalResult(
             chunks=chunks,
             entities=graph_entities,
             relationships=graph_relationships,
+        )
+
+    @staticmethod
+    def _preserves_evidence_graph_context(
+        preparation: RetrievalPreparation,
+    ) -> bool:
+        return (
+            len(preparation.targets) == 1
+            and preparation.targets[0].params.retrieve_type == RetrieveType.Graph
+            and preparation.graph is not None
+            and preparation.graph.pipeline is GraphPipeline.EVIDENCE
         )
 
     @staticmethod
@@ -1315,7 +1329,7 @@ class KnowledgeRetrievalService:
     ) -> list[Any]:
         keys = cls._graph_projection_keys_from_chunks(chunks, projection_type)
         if not keys:
-            return list(items)
+            return []
         return [
             item
             for item in items

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -696,22 +696,7 @@ class KnowledgeRetrievalService:
                         else None
                     ),
                     file_names=tuple(request.file_names_filter),
-                    entity_top_n=settings.KNOWLEDGE_GRAPH_ENTITY_TOP_N,
-                    relation_top_n=settings.KNOWLEDGE_GRAPH_RELATION_TOP_N,
-                    neighbor_top_n=settings.KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N,
-                    entity_similarity_threshold=(
-                        settings.KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD
-                    ),
-                    relation_similarity_threshold=(
-                        settings.KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD
-                    ),
-                    related_chunk_number=(
-                        settings.KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER
-                    ),
                     max_candidates=target.params.top_k,
-                    max_paths_per_chunk=(
-                        settings.KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK
-                    ),
                 )
             )
             chunks = graph_result.chunks

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -649,6 +649,38 @@ class KnowledgeRetrievalService:
         timings: RetrievalTimings | None,
         log_id: str | None,
     ) -> KnowledgeRetrievalResult:
+        result = await cls._retrieve_evidence_graph_channel(
+            request,
+            target,
+            graph_target,
+            document_ids_include,
+            store,
+            timings,
+            log_id,
+        )
+        chunks = result.chunks
+        cls._log_target_done(
+            target,
+            0,
+            0,
+            len(chunks),
+            len(chunks),
+            started_at,
+            timings=timings,
+        )
+        return result
+
+    @classmethod
+    async def _retrieve_evidence_graph_channel(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        target: RetrievalTarget,
+        graph_target: GraphTargetSnapshot,
+        document_ids_include: list[str] | None,
+        store: AsyncElasticSearchRetrieval,
+        timings: RetrievalTimings | None,
+        log_id: str | None,
+    ) -> KnowledgeRetrievalResult:
         if graph_target.knowledge_id != target.knowledge_id:
             raise ValueError("graph target does not match retrieval target")
 
@@ -713,22 +745,10 @@ class KnowledgeRetrievalService:
                 type(exc).__name__,
                 cls._elapsed_ms(graph_started_at),
             )
-            graph_result = None
-            chunks = []
+            return KnowledgeRetrievalResult()
         finally:
             cls._record_timing(timings, "graph_ms", graph_started_at)
 
-        cls._log_target_done(
-            target,
-            0,
-            0,
-            len(chunks),
-            len(chunks),
-            started_at,
-            timings=timings,
-        )
-        if graph_result is None:
-            return KnowledgeRetrievalResult(chunks=chunks)
         return KnowledgeRetrievalResult(
             chunks=chunks,
             entities=graph_result.entities,

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -16,6 +16,15 @@ from app.core.models import (
     RedBearModelConfig,
     RedBearRerank,
 )
+from app.core.rag.knowledge_graph.config import GraphPipeline
+from app.core.rag.knowledge_graph.elasticsearch_store import GraphElasticsearchStore
+from app.core.rag.knowledge_graph.models import (
+    GraphIndexRuntime,
+    GraphRetrievalRequest,
+)
+from app.core.rag.knowledge_graph.retrieval_pipeline import (
+    KnowledgeGraphRetrievalPipeline,
+)
 from app.core.rag.metadata.filter_engine import (
     FilterCondition as EngineFilterCondition,
     FilterGroup as EngineFilterGroup,
@@ -27,6 +36,7 @@ from app.core.rag.retrieval.async_elasticsearch import (
 )
 from app.core.rag.retrieval.graph_bridge import GraphRetrievalBridge
 from app.core.rag.retrieval.models import (
+    GraphTargetSnapshot,
     ModelRuntimeSnapshot,
     RetrievalParams,
     RetrievalPreparation,
@@ -279,7 +289,10 @@ class KnowledgeRetrievalService:
             log_id,
             timings,
         )
-        if preparation.graph:
+        if (
+            preparation.graph
+            and preparation.graph.pipeline is GraphPipeline.LEGACY
+        ):
             graph_document = await GraphRetrievalBridge.retrieve(preparation.graph, timings)
             if graph_document:
                 chunks.insert(0, graph_document)
@@ -374,6 +387,14 @@ class KnowledgeRetrievalService:
             ),
         )
         semaphore = asyncio.Semaphore(max_workers)
+        graph_targets_by_knowledge_id = (
+            {
+                graph_target.knowledge_id: graph_target
+                for graph_target in preparation.graph.targets
+            }
+            if preparation.graph is not None
+            else {}
+        )
 
         async def retrieve_one(
             index: int,
@@ -391,6 +412,9 @@ class KnowledgeRetrievalService:
                         and target.params.retrieve_type == RetrieveType.HYBRID
                     ),
                     request_reranker=preparation.request_reranker,
+                    graph_target=graph_targets_by_knowledge_id.get(
+                        target.knowledge_id
+                    ),
                     timings=timings,
                 )
                 return index, chunks
@@ -429,10 +453,26 @@ class KnowledgeRetrievalService:
         *,
         use_request_reranker: bool,
         request_reranker: Any,
+        graph_target: GraphTargetSnapshot | None = None,
         timings: RetrievalTimings | None = None,
     ) -> list[DocumentChunk]:
         started_at = time.perf_counter()
         target_type = target.params.retrieve_type
+        if (
+            target_type == RetrieveType.Graph
+            and graph_target is not None
+            and graph_target.pipeline is GraphPipeline.EVIDENCE
+        ):
+            return await cls._retrieve_evidence_graph_target(
+                request,
+                target,
+                graph_target,
+                document_ids_include,
+                store,
+                started_at,
+                timings,
+            )
+
         full_text_options = cls._search_options(
             target,
             request,
@@ -517,6 +557,93 @@ class KnowledgeRetrievalService:
         return chunks
 
     @classmethod
+    async def _retrieve_evidence_graph_target(
+        cls,
+        request: KnowledgeRetrievalRequest,
+        target: RetrievalTarget,
+        graph_target: GraphTargetSnapshot,
+        document_ids_include: list[str] | None,
+        store: AsyncElasticSearchRetrieval,
+        started_at: float,
+        timings: RetrievalTimings | None,
+    ) -> list[DocumentChunk]:
+        if graph_target.knowledge_id != target.knowledge_id:
+            raise ValueError("graph target does not match retrieval target")
+
+        graph_started_at = time.perf_counter()
+        try:
+            client = await AsyncElasticsearchClientProvider.get_shared_client()
+            graph_store = GraphElasticsearchStore(client)
+            llm_type = (
+                ModelType.CHAT
+                if graph_target.llm.model_type == ModelType.CHAT.value
+                else ModelType.LLM
+            )
+            llm = RedBearLLM(
+                cls._model_config(graph_target.llm),
+                type=llm_type,
+            )
+            embedding = RedBearEmbeddings(
+                cls._model_config(graph_target.embedding)
+            )
+            pipeline = KnowledgeGraphRetrievalPipeline(
+                graph_store,
+                llm,
+                embedding,
+                store.resolve_parent_chunks,
+            )
+            chunks = await pipeline.retrieve(
+                GraphRetrievalRequest(
+                    query=request.query,
+                    runtime=GraphIndexRuntime(
+                        knowledge_id=str(graph_target.knowledge_id),
+                        workspace_id=str(graph_target.workspace_id),
+                        graph_index_name=graph_target.graph_index_name,
+                        chunk_index_name=graph_target.chunk_index_name,
+                        entity_types=(),
+                        scene_name="",
+                        llm=graph_target.llm,
+                        embedding=graph_target.embedding,
+                    ),
+                    allowed_document_ids=(
+                        tuple(document_ids_include)
+                        if document_ids_include is not None
+                        else None
+                    ),
+                    file_names=tuple(request.file_names_filter),
+                    entity_top_n=settings.KNOWLEDGE_GRAPH_ENTITY_TOP_N,
+                    relation_top_n=settings.KNOWLEDGE_GRAPH_RELATION_TOP_N,
+                    neighbor_top_n=settings.KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N,
+                    evidence_per_key=settings.KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY,
+                    max_chunks_per_document=(
+                        settings.KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT
+                    ),
+                )
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[Retrieval] graph target failed kb=%s error_type=%s",
+                cls._compact_id(target.knowledge_id),
+                type(exc).__name__,
+            )
+            chunks = []
+        finally:
+            cls._record_timing(timings, "graph_ms", graph_started_at)
+
+        cls._log_target_done(
+            target,
+            0,
+            0,
+            len(chunks),
+            len(chunks),
+            started_at,
+            timings=timings,
+        )
+        return chunks
+
+    @classmethod
     async def _finalize_retrieval_chunks(
         cls,
         request: KnowledgeRetrievalRequest,
@@ -538,6 +665,12 @@ class KnowledgeRetrievalService:
         )
         needs_global_rerank = len(targets) > 1 or (
             request.rerank_id is not None and not single_hybrid_uses_request_rerank
+        ) or (
+            len(targets) == 1
+            and targets[0].params.retrieve_type == RetrieveType.Graph
+            and preparation.graph is not None
+            and preparation.graph.pipeline is GraphPipeline.EVIDENCE
+            and targets[0].reranker is not None
         )
         if needs_global_rerank:
             global_rerank_started_at = time.perf_counter()

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -589,21 +589,63 @@ class KnowledgeRetrievalService:
         full_text_task = asyncio.create_task(
             store.search_by_full_text(request.query, full_text_options)
         )
-        try:
-            vector_chunks, full_text_chunks = await asyncio.gather(
-                vector_task,
-                full_text_task,
+        graph_task = (
+            asyncio.create_task(
+                cls._retrieve_evidence_graph_channel(
+                    request,
+                    target,
+                    graph_target,
+                    document_ids_include,
+                    store,
+                    timings,
+                    log_id,
+                )
             )
-        except BaseException:
-            vector_task.cancel()
-            full_text_task.cancel()
-            await asyncio.gather(
-                vector_task,
-                full_text_task,
-                return_exceptions=True,
+            if (
+                target_type == RetrieveType.HYBRID
+                and target.params.enable_graph_retrieval
+                and graph_target is not None
+                and graph_target.pipeline is GraphPipeline.EVIDENCE
             )
-            raise
-        candidates = cls._deduplicate_chunks(vector_chunks + full_text_chunks)
+            else None
+        )
+        if graph_task is None:
+            try:
+                vector_chunks, full_text_chunks = await asyncio.gather(
+                    vector_task,
+                    full_text_task,
+                )
+            except BaseException:
+                vector_task.cancel()
+                full_text_task.cancel()
+                await asyncio.gather(
+                    vector_task,
+                    full_text_task,
+                    return_exceptions=True,
+                )
+                raise
+            graph_result = KnowledgeRetrievalResult()
+        else:
+            try:
+                vector_chunks, full_text_chunks, graph_result = await asyncio.gather(
+                    vector_task,
+                    full_text_task,
+                    graph_task,
+                )
+            except BaseException:
+                vector_task.cancel()
+                full_text_task.cancel()
+                graph_task.cancel()
+                await asyncio.gather(
+                    vector_task,
+                    full_text_task,
+                    graph_task,
+                    return_exceptions=True,
+                )
+                raise
+        candidates = cls._deduplicate_chunks(
+            vector_chunks + full_text_chunks + graph_result.chunks
+        )
         reranker = request_reranker if use_request_reranker else target.reranker
         local_rerank_started_at = time.perf_counter()
         try:

--- a/api/app/services/knowledge_retrieval_service.py
+++ b/api/app/services/knowledge_retrieval_service.py
@@ -435,7 +435,23 @@ class KnowledgeRetrievalService:
         chunks_by_index: list[list[DocumentChunk]] = [[] for _ in targets]
         for index, target_chunks in retrieved:
             chunks_by_index[index] = target_chunks
-        candidates = [chunk for target_chunks in chunks_by_index for chunk in target_chunks]
+        evidence_graph_only = (
+            preparation.graph is not None
+            and preparation.graph.pipeline is GraphPipeline.EVIDENCE
+            and all(
+                target.params.retrieve_type == RetrieveType.Graph
+                for target in targets
+            )
+        )
+        candidates = (
+            cls._round_robin_chunk_groups(chunks_by_index)
+            if evidence_graph_only
+            else [
+                chunk
+                for target_chunks in chunks_by_index
+                for chunk in target_chunks
+            ]
+        )
         return await cls._finalize_retrieval_chunks(
             request,
             preparation,
@@ -443,6 +459,24 @@ class KnowledgeRetrievalService:
             log_id,
             timings,
         )
+
+    @staticmethod
+    def _round_robin_chunk_groups(
+        groups: Sequence[Sequence[DocumentChunk]],
+    ) -> list[DocumentChunk]:
+        positions = [0 for _ in groups]
+        result: list[DocumentChunk] = []
+        while True:
+            progressed = False
+            for index, group in enumerate(groups):
+                if positions[index] >= len(group):
+                    continue
+                result.append(group[positions[index]])
+                positions[index] += 1
+                progressed = True
+            if not progressed:
+                break
+        return result
 
     @classmethod
     async def _retrieve_single_target(
@@ -584,7 +618,10 @@ class KnowledgeRetrievalService:
                 else ModelType.LLM
             )
             llm = RedBearLLM(
-                cls._model_config(graph_target.llm),
+                cls._model_config(
+                    graph_target.llm,
+                    extra_params={"temperature": 0},
+                ),
                 type=llm_type,
             )
             embedding = RedBearEmbeddings(
@@ -618,9 +655,22 @@ class KnowledgeRetrievalService:
                     entity_top_n=settings.KNOWLEDGE_GRAPH_ENTITY_TOP_N,
                     relation_top_n=settings.KNOWLEDGE_GRAPH_RELATION_TOP_N,
                     neighbor_top_n=settings.KNOWLEDGE_GRAPH_NEIGHBOR_TOP_N,
-                    evidence_per_key=settings.KNOWLEDGE_GRAPH_EVIDENCE_PER_KEY,
-                    max_chunks_per_document=(
-                        settings.KNOWLEDGE_GRAPH_MAX_CHUNKS_PER_DOCUMENT
+                    entity_similarity_threshold=(
+                        settings.KNOWLEDGE_GRAPH_ENTITY_SIMILARITY_THRESHOLD
+                    ),
+                    relation_similarity_threshold=(
+                        settings.KNOWLEDGE_GRAPH_RELATION_SIMILARITY_THRESHOLD
+                    ),
+                    related_chunk_number=(
+                        settings.KNOWLEDGE_GRAPH_RELATED_CHUNK_NUMBER
+                    ),
+                    max_candidates=max(
+                        settings.KNOWLEDGE_GRAPH_MAX_CANDIDATES,
+                        request.top_k,
+                        target.params.top_k,
+                    ),
+                    max_paths_per_chunk=(
+                        settings.KNOWLEDGE_GRAPH_MAX_PATHS_PER_CHUNK
                     ),
                 )
             )
@@ -712,6 +762,10 @@ class KnowledgeRetrievalService:
                 ]
             finally:
                 cls._record_timing(timings, "global_rerank_ms", global_rerank_started_at)
+        elif evidence_graph_only:
+            ranked_chunks = unique_chunks
+            threshold = None
+            filtered_chunks = ranked_chunks
         else:
             ranked_chunks = sorted(
                 unique_chunks,

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -399,7 +399,9 @@ def create_knowledge(
 
         business_logger.debug(f"Start creating the knowledge base: {knowledge.name}")
         db_knowledge = knowledge_repository.create_knowledge(
-            db=db, knowledge=knowledge
+            db=db,
+            knowledge=knowledge,
+            preserve_source_parser_config=preserve_source_parser_config,
         )
         business_logger.info(f"The knowledge base has been successfully created: {knowledge.name} (ID: {db_knowledge.id}), creator: {current_user.username}")
         return db_knowledge
@@ -484,7 +486,9 @@ async def create_knowledge_async(
             business_logger.debug(f"Auto-bind image2text model: {model.id}")
 
         db_knowledge = await knowledge_repository.create_knowledge_async(
-            db=db, knowledge=knowledge
+            db=db,
+            knowledge=knowledge,
+            preserve_source_parser_config=preserve_source_parser_config,
         )
         business_logger.info(
             f"The knowledge base has been successfully created (async): "

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -15,8 +15,21 @@ from app.core.logging_config import get_business_logger
 from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
 from app.models.models_model import ModelType
+from app.core.rag.parser_config import normalize_new_knowledge_parser_config
 
 business_logger = get_business_logger()
+
+
+def _normalize_parser_config_for_create(
+        knowledge: KnowledgeCreate,
+        *,
+        preserve_source_parser_config: bool,
+) -> None:
+    if preserve_source_parser_config:
+        return
+    knowledge.parser_config = normalize_new_knowledge_parser_config(
+        knowledge.parser_config
+    )
 
 
 def _build_knowledge_items_with_folder_trees(
@@ -317,11 +330,19 @@ async def get_chunked_knowledgeids_async(
 
 
 def create_knowledge(
-        db: Session, knowledge: KnowledgeCreate, current_user: User
+        db: Session,
+        knowledge: KnowledgeCreate,
+        current_user: User,
+        *,
+        preserve_source_parser_config: bool = False,
 ) -> Knowledge:
     business_logger.info(f"Create a knowledge base: {knowledge.name}, creator: {current_user.username}")
 
     try:
+        _normalize_parser_config_for_create(
+            knowledge,
+            preserve_source_parser_config=preserve_source_parser_config,
+        )
         knowledge.created_by = current_user.id
         if knowledge.workspace_id is None:
             knowledge.workspace_id = current_user.current_workspace_id
@@ -388,11 +409,19 @@ def create_knowledge(
 
 
 async def create_knowledge_async(
-        db: AsyncSession, knowledge: KnowledgeCreate, current_user: User
+        db: AsyncSession,
+        knowledge: KnowledgeCreate,
+        current_user: User,
+        *,
+        preserve_source_parser_config: bool = False,
 ) -> Knowledge:
     business_logger.info(f"Create a knowledge base (async): {knowledge.name}, creator: {current_user.username}")
 
     try:
+        _normalize_parser_config_for_create(
+            knowledge,
+            preserve_source_parser_config=preserve_source_parser_config,
+        )
         knowledge.created_by = current_user.id
         if knowledge.workspace_id is None:
             knowledge.workspace_id = current_user.current_workspace_id

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -281,13 +281,15 @@ def _execute_evidence_document(
         state: _GraphTaskState,
         document_id: str,
         lock_guard,
+        *,
+        document_active: bool,
 ) -> None:
     runtime = snapshot_graph_runtime(state.knowledge_id)
     asyncio.run(
         _run_evidence_document_async(
             runtime,
             str(document_id),
-            bool(state.document_active),
+            document_active,
             lock_guard,
         )
     )
@@ -351,6 +353,8 @@ def _commit_evidence_pipeline(
 def _run_evidence_graph_document(
         knowledge_id: str,
         document_id: str,
+        *,
+        document_deleted: bool = False,
 ) -> dict[str, Any]:
     knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
     document_id = _canonical_graph_uuid(document_id, "document id")
@@ -361,7 +365,14 @@ def _run_evidence_graph_document(
             return {"status": "skipped", "reason": "pipeline_changed"}
         if not state.graph_enabled:
             return {"status": "skipped", "reason": "graph_disabled"}
-        _execute_evidence_document(state, document_id, lock_guard)
+        _execute_evidence_document(
+            state,
+            document_id,
+            lock_guard,
+            document_active=(
+                False if document_deleted else bool(state.document_active)
+            ),
+        )
         lock_guard.ensure_valid()
         return {
             "status": "completed",
@@ -1525,15 +1536,24 @@ def sync_evidence_graph_document(
         self,
         knowledge_id: str,
         document_id: str,
+        document_deleted: bool = False,
 ):
     return _run_observed_graph_task(
         self,
         task_name="sync_document",
         knowledge_id=str(knowledge_id),
         document_id=str(document_id),
-        operation=lambda: _run_evidence_graph_document(
-            knowledge_id,
-            document_id,
+        operation=lambda: (
+            _run_evidence_graph_document(
+                knowledge_id,
+                document_id,
+                document_deleted=True,
+            )
+            if document_deleted
+            else _run_evidence_graph_document(
+                knowledge_id,
+                document_id,
+            )
         ),
     )
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -7,11 +7,13 @@ import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import redis
+from elasticsearch import AsyncElasticsearch
 from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
 from sqlalchemy import select, cast, String
@@ -20,11 +22,31 @@ from app.aioRedis import get_thread_safe_redis
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
+from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.memory.storage_services.reflection_engine import retry_registry as rr
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
 from app.core.rag.graphrag.utils import get_llm_cache, set_llm_cache
+from app.core.rag.knowledge_graph.config import (
+    GraphPipeline,
+    GraphPipelineConfigError,
+    is_graph_enabled,
+    resolve_graph_pipeline,
+)
+from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
+from app.core.rag.knowledge_graph.elasticsearch_store import GraphElasticsearchStore
+from app.core.rag.knowledge_graph.extractor import LLMEntityRelationExtractor
+from app.core.rag.knowledge_graph.index_pipeline import KnowledgeGraphIndexPipeline
+from app.core.rag.knowledge_graph.lock import create_knowledge_graph_lock
+from app.core.rag.knowledge_graph.runtime import (
+    build_model_config,
+    snapshot_graph_runtime,
+)
+from app.core.rag.parser_config import set_graph_pipeline_for_migration
+from app.core.rag.retrieval.async_elasticsearch import (
+    build_async_elasticsearch_client_config,
+)
 from app.core.rag.integrations.feishu.client import FeishuAPIClient
 from app.core.rag.integrations.feishu.models import FileInfo
 from app.core.rag.integrations.yuque.client import YuqueAPIClient
@@ -55,6 +77,7 @@ from app.core.utils.datetime_utils import (
 from app.db import get_db_context, get_db_read
 from app.models import App, AppRelease, Document, File, Knowledge, User, Workspace
 from app.models.end_user_model import EndUser
+from app.models.models_model import ModelType
 from app.repositories.end_user_repository import get_end_users_by_workspace
 from app.schemas import document_schema, file_schema
 from app.services.memory_config_service import MemoryConfigService
@@ -82,6 +105,321 @@ EMBEDDING_MAX_WORKERS = int(os.getenv("EMBEDDING_MAX_WORKERS", "3"))
 AUTO_QUESTIONS_MAX_WORKERS = int(os.getenv("AUTO_QUESTIONS_MAX_WORKERS", "5"))
 # 文档解析页数上限
 MAX_DOCUMENT_PAGES = int(os.getenv("MAX_DOCUMENT_PAGES", "200"))
+
+
+@dataclass(frozen=True)
+class _GraphTaskState:
+    knowledge_id: str
+    workspace_id: str
+    pipeline: GraphPipeline
+    graph_enabled: bool
+    document_active: bool | None
+    active_document_ids: tuple[str, ...]
+    fingerprint: str
+
+
+def _canonical_graph_uuid(value: object, field_name: str) -> str:
+    try:
+        return str(uuid.UUID(str(value)))
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise GraphPipelineConfigError(
+            f"invalid {field_name}: {value}"
+        ) from exc
+
+
+def _graph_task_fingerprint(knowledge: Knowledge) -> str:
+    import hashlib
+
+    graph_config = (knowledge.parser_config or {}).get("graphrag")
+    payload = {
+        "llm_id": str(knowledge.llm_id) if knowledge.llm_id else None,
+        "embedding_id": (
+            str(knowledge.embedding_id) if knowledge.embedding_id else None
+        ),
+        "graphrag": graph_config,
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_graph_task_state(
+        knowledge_id: str,
+        document_id: str | None = None,
+        *,
+        include_active_documents: bool = False,
+) -> _GraphTaskState:
+    knowledge_uuid = uuid.UUID(
+        _canonical_graph_uuid(knowledge_id, "knowledge id")
+    )
+    document_uuid = (
+        uuid.UUID(_canonical_graph_uuid(document_id, "document id"))
+        if document_id
+        else None
+    )
+
+    with get_db_context() as db:
+        knowledge = db.query(Knowledge).filter(
+            Knowledge.id == knowledge_uuid
+        ).first()
+        if knowledge is None:
+            raise GraphPipelineConfigError(
+                f"knowledge does not exist: {knowledge_id}"
+            )
+        workspace = db.query(Workspace).filter(
+            Workspace.id == knowledge.workspace_id
+        ).first()
+        if workspace is None:
+            raise GraphPipelineConfigError(
+                f"workspace does not exist: {knowledge.workspace_id}"
+            )
+
+        document_active: bool | None = None
+        if document_uuid is not None:
+            document = db.query(Document).filter(
+                Document.id == document_uuid,
+                Document.kb_id == knowledge_uuid,
+            ).first()
+            document_active = document is not None and document.status == 1
+
+        active_document_ids: tuple[str, ...] = ()
+        if include_active_documents:
+            documents = db.query(Document).filter(
+                Document.kb_id == knowledge_uuid,
+                Document.status == 1,
+                Document.chunk_num > 0,
+            ).order_by(Document.id).all()
+            active_document_ids = tuple(str(document.id) for document in documents)
+
+        return _GraphTaskState(
+            knowledge_id=str(knowledge.id),
+            workspace_id=str(workspace.id),
+            pipeline=resolve_graph_pipeline(knowledge.parser_config),
+            graph_enabled=is_graph_enabled(knowledge.parser_config),
+            document_active=document_active,
+            active_document_ids=active_document_ids,
+            fingerprint=_graph_task_fingerprint(knowledge),
+        )
+
+
+def _build_evidence_index_pipeline(runtime, client, lock_guard):
+    llm_type = (
+        ModelType.CHAT
+        if runtime.llm.model_type == ModelType.CHAT.value
+        else ModelType.LLM
+    )
+    llm = RedBearLLM(build_model_config(runtime.llm), type=llm_type)
+    embedding = RedBearEmbeddings(build_model_config(runtime.embedding))
+    extractor = LLMEntityRelationExtractor(
+        llm,
+        runtime.entity_types,
+        runtime.scene_name,
+    )
+    return KnowledgeGraphIndexPipeline(
+        store=GraphElasticsearchStore(client),
+        extractor=extractor,
+        embedding=embedding,
+        lock_guard=lock_guard,
+    )
+
+
+async def _run_evidence_document_async(
+        runtime,
+        document_id: str,
+        document_active: bool,
+        lock_guard,
+) -> None:
+    client = AsyncElasticsearch(**build_async_elasticsearch_client_config())
+    try:
+        pipeline = _build_evidence_index_pipeline(runtime, client, lock_guard)
+        await pipeline.sync_document(runtime, document_id, document_active)
+    finally:
+        await client.close()
+
+
+async def _run_evidence_rebuild_async(runtime, active_document_ids, lock_guard) -> None:
+    client = AsyncElasticsearch(**build_async_elasticsearch_client_config())
+    try:
+        pipeline = _build_evidence_index_pipeline(runtime, client, lock_guard)
+        await pipeline.rebuild_knowledge(runtime, active_document_ids)
+    finally:
+        await client.close()
+
+
+async def _run_evidence_clear_async(
+        graph_index_name: str,
+        knowledge_id: str,
+        lock_guard,
+        *,
+        clear_all: bool,
+) -> None:
+    client = AsyncElasticsearch(**build_async_elasticsearch_client_config())
+    try:
+        store = GraphElasticsearchStore(client)
+        if clear_all:
+            await store.clear_all_graph_documents(
+                graph_index_name,
+                knowledge_id,
+                ensure_valid=lock_guard.ensure_valid,
+            )
+        else:
+            await store.clear_evidence_graph(
+                graph_index_name,
+                knowledge_id,
+                ensure_valid=lock_guard.ensure_valid,
+            )
+    finally:
+        await client.close()
+
+
+def _execute_evidence_document(
+        state: _GraphTaskState,
+        document_id: str,
+        lock_guard,
+) -> None:
+    runtime = snapshot_graph_runtime(state.knowledge_id)
+    asyncio.run(
+        _run_evidence_document_async(
+            runtime,
+            str(document_id),
+            bool(state.document_active),
+            lock_guard,
+        )
+    )
+
+
+def _execute_evidence_rebuild(state: _GraphTaskState, lock_guard) -> None:
+    runtime = snapshot_graph_runtime(state.knowledge_id)
+    asyncio.run(
+        _run_evidence_rebuild_async(
+            runtime,
+            state.active_document_ids,
+            lock_guard,
+        )
+    )
+
+
+def _execute_evidence_clear(
+        state: _GraphTaskState,
+        lock_guard,
+        *,
+        clear_all: bool,
+) -> None:
+    asyncio.run(
+        _run_evidence_clear_async(
+            f"graphrag_{state.workspace_id}",
+            state.knowledge_id,
+            lock_guard,
+            clear_all=clear_all,
+        )
+    )
+
+
+def _commit_evidence_pipeline(
+        knowledge_id: str,
+        expected_fingerprint: str,
+) -> None:
+    knowledge_uuid = uuid.UUID(
+        _canonical_graph_uuid(knowledge_id, "knowledge id")
+    )
+    with get_db_context() as db:
+        knowledge = db.query(Knowledge).filter(
+            Knowledge.id == knowledge_uuid
+        ).with_for_update().first()
+        if knowledge is None:
+            raise GraphPipelineConfigError(
+                f"knowledge does not exist: {knowledge_id}"
+            )
+        if resolve_graph_pipeline(knowledge.parser_config) is GraphPipeline.EVIDENCE:
+            return
+        if _graph_task_fingerprint(knowledge) != expected_fingerprint:
+            raise RuntimeError(
+                "graph migration inputs changed while rebuilding"
+            )
+        knowledge.parser_config = set_graph_pipeline_for_migration(
+            knowledge.parser_config,
+            GraphPipeline.EVIDENCE,
+        )
+        db.commit()
+
+
+def _run_evidence_graph_document(
+        knowledge_id: str,
+        document_id: str,
+) -> dict[str, Any]:
+    knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
+    document_id = _canonical_graph_uuid(document_id, "document id")
+    with create_knowledge_graph_lock(knowledge_id) as lock_guard:
+        lock_guard.ensure_valid()
+        state = _load_graph_task_state(knowledge_id, document_id)
+        if state.pipeline is not GraphPipeline.EVIDENCE:
+            return {"status": "skipped", "reason": "pipeline_changed"}
+        if not state.graph_enabled:
+            return {"status": "skipped", "reason": "graph_disabled"}
+        _execute_evidence_document(state, document_id, lock_guard)
+        lock_guard.ensure_valid()
+        return {
+            "status": "completed",
+            "knowledge_id": knowledge_id,
+            "document_id": document_id,
+        }
+
+
+def _run_evidence_graph_rebuild(knowledge_id: str) -> dict[str, Any]:
+    knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
+    with create_knowledge_graph_lock(knowledge_id) as lock_guard:
+        lock_guard.ensure_valid()
+        state = _load_graph_task_state(
+            knowledge_id,
+            include_active_documents=True,
+        )
+        if state.pipeline is not GraphPipeline.EVIDENCE:
+            return {"status": "skipped", "reason": "pipeline_changed"}
+        if not state.graph_enabled:
+            return {"status": "skipped", "reason": "graph_disabled"}
+        _execute_evidence_rebuild(state, lock_guard)
+        lock_guard.ensure_valid()
+        return {"status": "completed", "knowledge_id": knowledge_id}
+
+
+def _run_evidence_graph_migration(knowledge_id: str) -> dict[str, Any]:
+    knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
+    with create_knowledge_graph_lock(knowledge_id) as lock_guard:
+        lock_guard.ensure_valid()
+        state = _load_graph_task_state(
+            knowledge_id,
+            include_active_documents=True,
+        )
+        if state.pipeline is GraphPipeline.EVIDENCE:
+            return {"status": "already_evidence", "knowledge_id": knowledge_id}
+
+        if state.graph_enabled and state.active_document_ids:
+            _execute_evidence_rebuild(state, lock_guard)
+        else:
+            _execute_evidence_clear(state, lock_guard, clear_all=False)
+        lock_guard.ensure_valid()
+        _commit_evidence_pipeline(knowledge_id, state.fingerprint)
+        lock_guard.ensure_valid()
+        return {"status": "migrated", "knowledge_id": knowledge_id}
+
+
+def _run_clear_all_knowledge_graph_data(knowledge_id: str) -> dict[str, Any]:
+    knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
+    with create_knowledge_graph_lock(knowledge_id) as lock_guard:
+        lock_guard.ensure_valid()
+        state = _load_graph_task_state(knowledge_id)
+        _execute_evidence_clear(state, lock_guard, clear_all=True)
+        lock_guard.ensure_valid()
+        return {"status": "cleared", "knowledge_id": knowledge_id}
+
+
+def _graph_task_retry_countdown(task) -> int:
+    return min(300, 2 ** int(task.request.retries or 0))
 
 
 def _resolve_model_api_key(db, model_config_id, tenant_id, role: str):
@@ -453,7 +791,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             document_label = file_name or str(document_id)
 
             parser_config = db_document.parser_config or {}
-            knowledge_parser_config = db_knowledge.parser_config or {}
             auto_questions_topn = parser_config.get("auto_questions", 0)
             document_info = {
                 "id": str(db_document.id),
@@ -470,9 +807,6 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             if auto_questions_topn:
                 llm_config = _build_llm_config(db, db_knowledge.llm_id, tenant_id)
             knowledge_id = str(db_knowledge.id)
-            use_graphrag = bool(
-                knowledge_parser_config.get("graphrag", {}).get("use_graphrag", False)
-            )
             vision_model = _build_vision_model(file_name, db, db_knowledge.image2text_id, tenant_id)
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
@@ -858,18 +1192,34 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
 
         _update_document(document_id, _mark_done)
 
-        if use_graphrag:
+        with get_db_context() as graph_db:
+            current_knowledge = graph_db.query(Knowledge).filter(
+                Knowledge.id == uuid.UUID(knowledge_id)
+            ).first()
+            current_graph_config = (
+                dict(current_knowledge.parser_config or {})
+                if current_knowledge is not None
+                else None
+            )
+
+        if current_graph_config is not None and is_graph_enabled(current_graph_config):
             if _should_abort(document_id):
                 _clear_redis_state(document_id)
                 logger.info(f"[ParseDoc] document={document_id} cancelled via Redis -- stopped")
                 return f"parse document '{document_label}' aborted (deleted or cancelled)."
-            progress_lines.append(f"{_progress_ts()} GraphRAG enabled, dispatching async task.")
+            progress_lines.append(
+                f"{_progress_ts()} Knowledge graph enabled, dispatching async task."
+            )
 
             def _mark_graphrag_dispatched(doc):
                 doc.progress_msg = _progress_msg()
 
             _update_document(document_id, _mark_graphrag_dispatched)
-            build_graphrag_for_document.delay(str(document_id), knowledge_id)
+            dispatch_document_graph_sync(
+                knowledge_id,
+                str(document_id),
+                current_graph_config,
+            )
 
         _clear_redis_state(document_id)
         result = f"parse document '{document_info['file_name']}' processed successfully."
@@ -926,6 +1276,8 @@ def build_graphrag_for_kb(kb_id: uuid.UUID):
             graphrag_conf = parser_config.get("graphrag", {})
             if not graphrag_conf.get("use_graphrag", False):
                 return f"build knowledge graph '{kb_name}' skipped: graphrag not enabled"
+            if resolve_graph_pipeline(parser_config) is not GraphPipeline.LEGACY:
+                return f"build knowledge graph '{kb_name}' skipped: pipeline changed"
 
             db_documents = db.query(Document).filter(Document.kb_id == kb_id).all()
             document_ids = [str(doc.id) for doc in db_documents]
@@ -1004,6 +1356,16 @@ def build_graphrag_for_document(document_id: str, knowledge_id: str):
             tenant_id = db_workspace.tenant_id
             parser_config = db_knowledge.parser_config or {}
             graphrag_conf = parser_config.get("graphrag", {})
+            if not graphrag_conf.get("use_graphrag", False):
+                return (
+                    f"build_graphrag_for_document '{document_id}' skipped: "
+                    "graphrag not enabled"
+                )
+            if resolve_graph_pipeline(parser_config) is not GraphPipeline.LEGACY:
+                return (
+                    f"build_graphrag_for_document '{document_id}' skipped: "
+                    "pipeline changed"
+                )
             with_resolution = graphrag_conf.get("resolution", False)
             with_community = graphrag_conf.get("community", False)
 
@@ -1062,6 +1424,97 @@ def build_graphrag_for_document(document_id: str, knowledge_id: str):
     except Exception as e:
         logger.error(f"[GraphRAG] doc={document_id} failed: {e}", exc_info=True)
         return f"build_graphrag_for_document '{document_id}' failed: {e}"
+
+
+@celery_app.task(
+    bind=True,
+    name="app.core.rag.tasks.sync_evidence_graph_document",
+    max_retries=5,
+)
+def sync_evidence_graph_document(
+        self,
+        knowledge_id: str,
+        document_id: str,
+):
+    try:
+        return _run_evidence_graph_document(knowledge_id, document_id)
+    except GraphPipelineConfigError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "[EvidenceGraph] document sync failed",
+            extra={
+                "knowledge_id": str(knowledge_id),
+                "document_id": str(document_id),
+            },
+        )
+        raise self.retry(
+            exc=exc,
+            countdown=_graph_task_retry_countdown(self),
+        )
+
+
+@celery_app.task(
+    bind=True,
+    name="app.core.rag.tasks.rebuild_evidence_graph_knowledge",
+    max_retries=5,
+)
+def rebuild_evidence_graph_knowledge(self, knowledge_id: str):
+    try:
+        return _run_evidence_graph_rebuild(knowledge_id)
+    except GraphPipelineConfigError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "[EvidenceGraph] knowledge rebuild failed",
+            extra={"knowledge_id": str(knowledge_id)},
+        )
+        raise self.retry(
+            exc=exc,
+            countdown=_graph_task_retry_countdown(self),
+        )
+
+
+@celery_app.task(
+    bind=True,
+    name="app.core.rag.tasks.migrate_evidence_graph_knowledge",
+    max_retries=5,
+)
+def migrate_evidence_graph_knowledge(self, knowledge_id: str):
+    try:
+        return _run_evidence_graph_migration(knowledge_id)
+    except GraphPipelineConfigError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "[EvidenceGraph] knowledge migration failed",
+            extra={"knowledge_id": str(knowledge_id)},
+        )
+        raise self.retry(
+            exc=exc,
+            countdown=_graph_task_retry_countdown(self),
+        )
+
+
+@celery_app.task(
+    bind=True,
+    name="app.core.rag.tasks.clear_all_knowledge_graph_data",
+    max_retries=5,
+)
+def clear_all_knowledge_graph_data(self, knowledge_id: str):
+    try:
+        return _run_clear_all_knowledge_graph_data(knowledge_id)
+    except GraphPipelineConfigError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "[EvidenceGraph] clear all graph data failed",
+            extra={"knowledge_id": str(knowledge_id)},
+        )
+        raise self.retry(
+            exc=exc,
+            countdown=_graph_task_retry_countdown(self),
+        )
 
 
 @celery_app.task(name="app.core.rag.tasks.import_qa_chunks", queue="qa_import")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -413,6 +413,8 @@ def _run_clear_all_knowledge_graph_data(knowledge_id: str) -> dict[str, Any]:
     with create_knowledge_graph_lock(knowledge_id) as lock_guard:
         lock_guard.ensure_valid()
         state = _load_graph_task_state(knowledge_id)
+        if state.graph_enabled:
+            return {"status": "skipped", "reason": "graph_reenabled"}
         _execute_evidence_clear(state, lock_guard, clear_all=True)
         lock_guard.ensure_valid()
         return {"status": "cleared", "knowledge_id": knowledge_id}

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -408,12 +408,16 @@ def _run_evidence_graph_migration(knowledge_id: str) -> dict[str, Any]:
         return {"status": "migrated", "knowledge_id": knowledge_id}
 
 
-def _run_clear_all_knowledge_graph_data(knowledge_id: str) -> dict[str, Any]:
+def _run_clear_all_knowledge_graph_data(
+        knowledge_id: str,
+        *,
+        force: bool = False,
+) -> dict[str, Any]:
     knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
     with create_knowledge_graph_lock(knowledge_id) as lock_guard:
         lock_guard.ensure_valid()
         state = _load_graph_task_state(knowledge_id)
-        if state.graph_enabled:
+        if state.graph_enabled and not force:
             return {"status": "skipped", "reason": "graph_reenabled"}
         _execute_evidence_clear(state, lock_guard, clear_all=True)
         lock_guard.ensure_valid()
@@ -1567,12 +1571,19 @@ def migrate_evidence_graph_knowledge(self, knowledge_id: str):
     name="app.core.rag.tasks.clear_all_knowledge_graph_data",
     max_retries=5,
 )
-def clear_all_knowledge_graph_data(self, knowledge_id: str):
+def clear_all_knowledge_graph_data(
+        self,
+        knowledge_id: str,
+        force: bool = False,
+):
     return _run_observed_graph_task(
         self,
         task_name="clear_knowledge",
         knowledge_id=str(knowledge_id),
-        operation=lambda: _run_clear_all_knowledge_graph_data(knowledge_id),
+        operation=lambda: _run_clear_all_knowledge_graph_data(
+            knowledge_id,
+            force=force,
+        ),
     )
 
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -118,6 +118,16 @@ class _GraphTaskState:
     fingerprint: str
 
 
+class _GraphDocumentDeletionPending(RuntimeError):
+    """The graph cleanup must wait until the document deletion is committed."""
+
+
+def _document_active_state(document: Document | None) -> bool | None:
+    if document is None:
+        return None
+    return document.status == 1
+
+
 def _canonical_graph_uuid(value: object, field_name: str) -> str:
     try:
         return str(uuid.UUID(str(value)))
@@ -185,7 +195,7 @@ def _load_graph_task_state(
                 Document.id == document_uuid,
                 Document.kb_id == knowledge_uuid,
             ).first()
-            document_active = document is not None and document.status == 1
+            document_active = _document_active_state(document)
 
         active_document_ids: tuple[str, ...] = ()
         if include_active_documents:
@@ -365,6 +375,10 @@ def _run_evidence_graph_document(
             return {"status": "skipped", "reason": "pipeline_changed"}
         if not state.graph_enabled:
             return {"status": "skipped", "reason": "graph_disabled"}
+        if document_deleted and state.document_active is not None:
+            raise _GraphDocumentDeletionPending(
+                "document deletion has not been committed"
+            )
         _execute_evidence_document(
             state,
             document_id,
@@ -485,6 +499,9 @@ def _run_observed_graph_task(
         raise
     except Exception as exc:
         countdown = _graph_task_retry_countdown(task)
+        retry_options = {}
+        if isinstance(exc, _GraphDocumentDeletionPending):
+            retry_options["max_retries"] = 8
         logger.warning(
             "[EvidenceGraph] task_retry"
             " task=%s task_id=%s kb_id=%s%s"
@@ -499,7 +516,11 @@ def _run_observed_graph_task(
             int((time.perf_counter() - started_at) * 1000),
             exc_info=_redacted_graph_exc_info(exc),
         )
-        raise task.retry(exc=exc, countdown=countdown)
+        raise task.retry(
+            exc=exc,
+            countdown=countdown,
+            **retry_options,
+        )
 
     status_value = str(result.get("status") or "completed")
     is_skip = status_value in {"skipped", "already_evidence"}

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import redis
 from elasticsearch import AsyncElasticsearch
@@ -420,6 +420,90 @@ def _run_clear_all_knowledge_graph_data(knowledge_id: str) -> dict[str, Any]:
 
 def _graph_task_retry_countdown(task) -> int:
     return min(300, 2 ** int(task.request.retries or 0))
+
+
+def _redacted_graph_exc_info(exc: Exception):
+    redacted = RuntimeError(f"{type(exc).__name__}: message redacted")
+    return type(redacted), redacted, exc.__traceback__
+
+
+def _run_observed_graph_task(
+        task,
+        *,
+        task_name: str,
+        knowledge_id: str,
+        operation: Callable[[], dict[str, Any]],
+        document_id: str | None = None,
+) -> dict[str, Any]:
+    started_at = time.perf_counter()
+    task_id = str(getattr(task.request, "id", None) or "unknown")
+    retry = int(getattr(task.request, "retries", 0) or 0)
+    document_field = (
+        f" document_id={document_id}" if document_id is not None else ""
+    )
+    logger.info(
+        "[EvidenceGraph] task_start"
+        " task=%s task_id=%s kb_id=%s%s retry=%d",
+        task_name,
+        task_id,
+        str(knowledge_id),
+        document_field,
+        retry,
+    )
+    try:
+        result = operation()
+    except GraphPipelineConfigError as exc:
+        logger.error(
+            "[EvidenceGraph] task_failed"
+            " task=%s task_id=%s kb_id=%s%s"
+            " status=failure error_type=%s retry=%d elapsed_ms=%d",
+            task_name,
+            task_id,
+            str(knowledge_id),
+            document_field,
+            type(exc).__name__,
+            retry,
+            int((time.perf_counter() - started_at) * 1000),
+        )
+        raise
+    except Exception as exc:
+        countdown = _graph_task_retry_countdown(task)
+        logger.warning(
+            "[EvidenceGraph] task_retry"
+            " task=%s task_id=%s kb_id=%s%s"
+            " error_type=%s retry=%d countdown=%d elapsed_ms=%d",
+            task_name,
+            task_id,
+            str(knowledge_id),
+            document_field,
+            type(exc).__name__,
+            retry,
+            countdown,
+            int((time.perf_counter() - started_at) * 1000),
+            exc_info=_redacted_graph_exc_info(exc),
+        )
+        raise task.retry(exc=exc, countdown=countdown)
+
+    status_value = str(result.get("status") or "completed")
+    is_skip = status_value in {"skipped", "already_evidence"}
+    reason = str(
+        result.get("reason")
+        or ("idempotent" if status_value == "already_evidence" else "none")
+    )
+    logger.info(
+        "[EvidenceGraph] %s"
+        " task=%s task_id=%s kb_id=%s%s"
+        " status=%s reason=%s elapsed_ms=%d",
+        "task_skip" if is_skip else "task_done",
+        task_name,
+        task_id,
+        str(knowledge_id),
+        document_field,
+        status_value,
+        reason,
+        int((time.perf_counter() - started_at) * 1000),
+    )
+    return result
 
 
 def _resolve_model_api_key(db, model_config_id, tenant_id, role: str):
@@ -1436,22 +1520,16 @@ def sync_evidence_graph_document(
         knowledge_id: str,
         document_id: str,
 ):
-    try:
-        return _run_evidence_graph_document(knowledge_id, document_id)
-    except GraphPipelineConfigError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "[EvidenceGraph] document sync failed",
-            extra={
-                "knowledge_id": str(knowledge_id),
-                "document_id": str(document_id),
-            },
-        )
-        raise self.retry(
-            exc=exc,
-            countdown=_graph_task_retry_countdown(self),
-        )
+    return _run_observed_graph_task(
+        self,
+        task_name="sync_document",
+        knowledge_id=str(knowledge_id),
+        document_id=str(document_id),
+        operation=lambda: _run_evidence_graph_document(
+            knowledge_id,
+            document_id,
+        ),
+    )
 
 
 @celery_app.task(
@@ -1460,19 +1538,12 @@ def sync_evidence_graph_document(
     max_retries=5,
 )
 def rebuild_evidence_graph_knowledge(self, knowledge_id: str):
-    try:
-        return _run_evidence_graph_rebuild(knowledge_id)
-    except GraphPipelineConfigError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "[EvidenceGraph] knowledge rebuild failed",
-            extra={"knowledge_id": str(knowledge_id)},
-        )
-        raise self.retry(
-            exc=exc,
-            countdown=_graph_task_retry_countdown(self),
-        )
+    return _run_observed_graph_task(
+        self,
+        task_name="rebuild_knowledge",
+        knowledge_id=str(knowledge_id),
+        operation=lambda: _run_evidence_graph_rebuild(knowledge_id),
+    )
 
 
 @celery_app.task(
@@ -1481,19 +1552,12 @@ def rebuild_evidence_graph_knowledge(self, knowledge_id: str):
     max_retries=5,
 )
 def migrate_evidence_graph_knowledge(self, knowledge_id: str):
-    try:
-        return _run_evidence_graph_migration(knowledge_id)
-    except GraphPipelineConfigError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "[EvidenceGraph] knowledge migration failed",
-            extra={"knowledge_id": str(knowledge_id)},
-        )
-        raise self.retry(
-            exc=exc,
-            countdown=_graph_task_retry_countdown(self),
-        )
+    return _run_observed_graph_task(
+        self,
+        task_name="migrate_knowledge",
+        knowledge_id=str(knowledge_id),
+        operation=lambda: _run_evidence_graph_migration(knowledge_id),
+    )
 
 
 @celery_app.task(
@@ -1502,19 +1566,12 @@ def migrate_evidence_graph_knowledge(self, knowledge_id: str):
     max_retries=5,
 )
 def clear_all_knowledge_graph_data(self, knowledge_id: str):
-    try:
-        return _run_clear_all_knowledge_graph_data(knowledge_id)
-    except GraphPipelineConfigError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "[EvidenceGraph] clear all graph data failed",
-            extra={"knowledge_id": str(knowledge_id)},
-        )
-        raise self.retry(
-            exc=exc,
-            countdown=_graph_task_retry_countdown(self),
-        )
+    return _run_observed_graph_task(
+        self,
+        task_name="clear_knowledge",
+        knowledge_id=str(knowledge_id),
+        operation=lambda: _run_clear_all_knowledge_graph_data(knowledge_id),
+    )
 
 
 @celery_app.task(name="app.core.rag.tasks.import_qa_chunks", queue="qa_import")

--- a/api/app/utils/redis_lock.py
+++ b/api/app/utils/redis_lock.py
@@ -101,6 +101,15 @@ class RedisFairLock:
         self.auto_renewal = auto_renewal
         self._renew_thread = None
         self._stop_renew = threading.Event()
+        self._renewal_lost = threading.Event()
+
+    @property
+    def is_valid(self) -> bool:
+        return self._locked and not self._renewal_lost.is_set()
+
+    def ensure_valid(self) -> None:
+        if not self.is_valid:
+            raise RuntimeError(f"Redis lock ownership lost: {self.key}")
 
     def _exec_with_retry(self, func, *args, raise_on_fail=True, **kwargs):
         """
@@ -143,6 +152,7 @@ class RedisFairLock:
 
             if ok == 1:
                 self._locked = True
+                self._renewal_lost.clear()
                 if self.auto_renewal:
                     self._start_renewal()
                 return True
@@ -162,16 +172,29 @@ class RedisFairLock:
             if self._stop_renew.is_set():
                 break
 
-            success = self._exec_with_retry(
-                self.redis.eval,
-                RENEW_SCRIPT,
-                1,
-                self.key,
-                self.value,
-                str(self.expire),
-                raise_on_fail=False,
-            )
+            try:
+                success = self._exec_with_retry(
+                    self.redis.eval,
+                    RENEW_SCRIPT,
+                    1,
+                    self.key,
+                    self.value,
+                    str(self.expire),
+                    raise_on_fail=False,
+                )
+            except RedisError:
+                self._renewal_lost.set()
+                self._logger.exception(
+                    "[RedisFairLock] Redis renewal failed for key=%s",
+                    self.key,
+                )
+                break
             if not success:
+                self._renewal_lost.set()
+                self._logger.error(
+                    "[RedisFairLock] Redis lock renewal lost ownership for key=%s",
+                    self.key,
+                )
                 break
 
     def _start_renewal(self):


### PR DESCRIPTION
## Business Background
Knowledge graph retrieval needs a traceable evidence-based pipeline that can return source chunks with graph provenance instead of only returning a legacy graph summary document.

## Summary
- Adds the evidence graph extraction, indexing, storage, lock, query-plan, and retrieval pipeline.
- Routes graph lifecycle and graph management behavior by parser-configured graph pipeline.
- Integrates evidence graph retrieval into the shared knowledge retrieval service.
- Exposes graph-derived source chunks with vector score metadata, grouped graph entity/relation context chunks, and an opt-in graph route for hybrid retrieval.
- Keeps top-level graph entity/relation payload suppressed while clients consume graph context through returned chunks.

## Changes
- 36 files changed, 6807 insertions(+), 159 deletions(-)
- Main areas: `api/app/core/rag/knowledge_graph/`, retrieval service/preparation schemas, graph lifecycle dispatch, knowledge/document controllers, parser config, tasks, and Redis lock support.

## Risk
- Evidence graph retrieval adds new Elasticsearch projection/evidence indexes and more retrieval stages than legacy GraphRAG.
- Real Elasticsearch integration and full end-to-end graph rebuild/retrieval validation still need environment-level verification.
- The shared retrieval path affects internal retrieval, workflow/agent callers, and API-key delegated retrieval surfaces.

## External API Key Impact
- API-key chunk retrieval reuses the internal chunk retrieval controller/service path, so it inherits the new retrieval behavior and the `enable_graph_retrieval` request parameter.
- No separate external-only route was added.

## Test Plan
- [x] `git diff --check origin/develop..HEAD` passed.
- [x] `git diff --name-only origin/develop..HEAD -- '*.py' | xargs python3 -m py_compile` passed.
- [x] `cd api && PYTHONPATH=. uv run --frozen python -m pytest tests/rag/knowledge_graph/test_config.py tests/rag/knowledge_graph/test_redis_lock_health.py tests/rag/knowledge_graph/test_retrieval_preparation.py tests/rag/knowledge_graph/test_retrieval_pipeline.py tests/rag/test_graph_retrieval_bridge.py -q` passed: 40 passed.
- [ ] `ruff` was not run because the current virtualenv cannot spawn `ruff` (`No such file or directory`).