### PR TITLE
feat(models): add Atlas Cloud provider

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -270,6 +270,7 @@ class RedBearModelFactory:
 
         if provider in [
             ModelProvider.OPENAI,
+            ModelProvider.ATLASCLOUD,
             ModelProvider.XINFERENCE,
             ModelProvider.GPUSTACK,
             ModelProvider.OLLAMA,
@@ -508,6 +509,7 @@ def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelTy
         return CompatibleChatOpenAI
     if provider in [
         ModelProvider.OPENAI,
+        ModelProvider.ATLASCLOUD,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
         ModelProvider.SPEEDBEAR,

--- a/api/app/core/models/scripts/atlascloud_models.yaml
+++ b/api/app/core/models/scripts/atlascloud_models.yaml
@@ -1,0 +1,38 @@
+provider: atlascloud
+models:
+- name: deepseek-ai/deepseek-v4-pro
+  type: chat
+  provider: atlascloud
+  description: DeepSeek V4 Pro served through the Atlas Cloud OpenAI-compatible API.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - json_output
+  - function_call
+  is_omni: false
+  tags:
+  - 大语言模型
+- name: deepseek-ai/deepseek-v4-flash
+  type: chat
+  provider: atlascloud
+  description: DeepSeek V4 Flash served through the Atlas Cloud OpenAI-compatible API.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - json_output
+  - function_call
+  is_omni: false
+  tags:
+  - 大语言模型
+- name: qwen/qwen3.5-27b
+  type: chat
+  provider: atlascloud
+  description: Qwen3.5 27B served through the Atlas Cloud OpenAI-compatible API.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - json_output
+  - function_call
+  is_omni: false
+  tags:
+  - 大语言模型

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -448,7 +448,8 @@ _PARAM_CAPABILITY_WARNINGS: dict[str, str] = {
 }
 
 _OPENAI_COMPATIBLE_PROVIDERS = frozenset({
-    ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK, ModelProvider.VOLCANO,
+    ModelProvider.OPENAI, ModelProvider.ATLASCLOUD, ModelProvider.XINFERENCE,
+    ModelProvider.GPUSTACK, ModelProvider.VOLCANO,
     ModelProvider.SPEEDBEAR,
 })
 
@@ -456,17 +457,20 @@ _PARAM_PROVIDER_SUPPORT: dict[str, frozenset[ModelProvider]] = {
     "top_k": frozenset({ModelProvider.OLLAMA, ModelProvider.DASHSCOPE, ModelProvider.BEDROCK}),
     "repetition_penalty": frozenset({ModelProvider.OLLAMA, ModelProvider.DASHSCOPE}),
     "seed": frozenset({
-        ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+        ModelProvider.OPENAI, ModelProvider.ATLASCLOUD, ModelProvider.XINFERENCE,
+        ModelProvider.GPUSTACK,
         ModelProvider.OLLAMA, ModelProvider.VOLCANO, ModelProvider.DASHSCOPE,
         ModelProvider.SPEEDBEAR,
         ModelProvider.BEDROCK,
     }),
     "frequency_penalty": frozenset({
-        ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+        ModelProvider.OPENAI, ModelProvider.ATLASCLOUD, ModelProvider.XINFERENCE,
+        ModelProvider.GPUSTACK,
         ModelProvider.VOLCANO, ModelProvider.DASHSCOPE, ModelProvider.SPEEDBEAR,
     }),
     "presence_penalty": frozenset({
-        ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+        ModelProvider.OPENAI, ModelProvider.ATLASCLOUD, ModelProvider.XINFERENCE,
+        ModelProvider.GPUSTACK,
         ModelProvider.VOLCANO, ModelProvider.DASHSCOPE, ModelProvider.SPEEDBEAR,
     }),
     "enable_search": frozenset({ModelProvider.DASHSCOPE}),
@@ -485,7 +489,8 @@ _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
 # format: [{"type": "text", "text": "..."}], [{"type": "image_url", ...}] etc.
 # DashScope non-Omni (ChatTongyi) uses its own format and rejects OpenAI-style lists.
 _MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
-    ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
+    ModelProvider.OPENAI, ModelProvider.ATLASCLOUD, ModelProvider.XINFERENCE,
+    ModelProvider.GPUSTACK,
     ModelProvider.VOLCANO, ModelProvider.SPEEDBEAR,
     ModelProvider.OLLAMA,
     ModelProvider.BEDROCK,

--- a/api/app/models/models_model.py
+++ b/api/app/models/models_model.py
@@ -47,6 +47,7 @@ class ModelCapability(StrEnum):
 class ModelProvider(StrEnum):
     """模型提供商枚举"""
     OPENAI = "openai"
+    ATLASCLOUD = "atlascloud"
     SPEEDBEAR = "speedbear"
     # ANTHROPIC = "anthropic"
     # GOOGLE = "google"

--- a/api/tests/core/models/test_atlascloud_provider.py
+++ b/api/tests/core/models/test_atlascloud_provider.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch
+
+from app.core.models.base import (
+    RedBearModelConfig,
+    RedBearModelFactory,
+    get_provider_llm_class,
+)
+from app.core.models.compatible_chat import CompatibleChatOpenAI
+from app.core.models.scripts.loader import get_models_by_provider
+from app.models.models_model import ModelProvider
+
+
+def test_atlascloud_models_are_registered():
+    models = get_models_by_provider(ModelProvider.ATLASCLOUD)
+
+    assert {model["name"] for model in models} == {
+        "deepseek-ai/deepseek-v4-pro",
+        "deepseek-ai/deepseek-v4-flash",
+        "qwen/qwen3.5-27b",
+    }
+    assert all(model["provider"] == "atlascloud" for model in models)
+    assert all("function_call" in model["capability"] for model in models)
+
+
+def test_atlascloud_uses_openai_compatible_chat_client():
+    config = RedBearModelConfig(
+        model_name="deepseek-ai/deepseek-v4-pro",
+        provider=ModelProvider.ATLASCLOUD,
+        api_key="test-key",
+        base_url="https://api.atlascloud.ai/v1",
+    )
+
+    assert get_provider_llm_class(config) is CompatibleChatOpenAI
+
+    sync_client = object()
+    async_client = object()
+    with patch(
+        "app.core.models.base._get_shared_openai_clients",
+        return_value=(sync_client, async_client),
+    ):
+        params = RedBearModelFactory.get_model_params(config)
+
+    assert params["model"] == "deepseek-ai/deepseek-v4-pro"
+    assert params["base_url"] == "https://api.atlascloud.ai/v1"
+    assert params["api_key"] == "test-key"
+    assert params["http_client"] is sync_client
+    assert params["http_async_client"] is async_client

--- a/web/src/views/ModelManagement/components/KeyConfigModal.tsx
+++ b/web/src/views/ModelManagement/components/KeyConfigModal.tsx
@@ -18,6 +18,10 @@ import type { KeyConfigModalForm, ProviderModelItem, KeyConfigModalRef, KeyConfi
 import RbModal from '@/components/RbModal'
 import { updateProviderApiKeys } from '@/api/models'
 
+const PROVIDER_API_BASES: Partial<Record<string, string>> = {
+  atlascloud: 'https://api.atlascloud.ai/v1',
+}
+
 /**
  * Key configuration modal component
  */
@@ -46,6 +50,10 @@ const KeyConfigModal = forwardRef<KeyConfigModalRef, KeyConfigModalProps>(({
   const handleOpen = (vo: ProviderModelItem) => {
     setVisible(true);
     setModel(vo);
+    const apiBase = PROVIDER_API_BASES[vo.provider]
+    if (apiBase) {
+      form.setFieldValue('api_base', apiBase)
+    }
   };
   /** Save API key configuration */
   const handleSave = () => {


### PR DESCRIPTION
## Summary

- register Atlas Cloud as a model provider with three chat model seeds
- route Atlas Cloud through the existing OpenAI-compatible client and workflow parameter handling
- prefill the Atlas Cloud API base URL in the provider key configuration modal
- add focused coverage for model registration and OpenAI-compatible client construction

## Validation

- `cd api && uv run --frozen python -m pytest -q tests/core/models/test_atlascloud_provider.py` (2 passed)
- isolated workflow provider compatibility checks passed
- Python 3.12 compile checks and YAML schema checks passed
- `uvx ruff check api/tests/core/models/test_atlascloud_provider.py` passed
- `npm run build` passed in `web`
- `git diff --check` passed
- targeted ESLint could not start because the existing repository config uses invalid severity `false` for `@typescript-eslint/no-explicit-any`
- Atlas public catalog endpoints returned HTTP 403 from this environment; model IDs were verified against the local official Atlas Cloud model reference

## Compliance

No README, docs, logo, sponsor, credits, or partner changes.

## 由 Sourcery 提供的摘要

将 Atlas Cloud 添加为兼容 OpenAI 的聊天模型提供商，并将其接入现有的模型配置、客户端选择和 UI 流程。

新增功能：
- 将 Atlas Cloud 注册为模型提供商，通过其兼容 OpenAI 的 API 提供三个聊天模型。
- 在打开提供商密钥配置弹窗时，预填 Atlas Cloud 的 API 基础 URL。

改进：
- 将 Atlas Cloud 视为在工作流参数和多模态支持方面兼容 OpenAI，复用共享的聊天客户端实现。

测试：
- 添加针对性的测试，用于验证 Atlas Cloud 模型的注册以及其对兼容 OpenAI 的聊天客户端的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Atlas Cloud 新增为兼容 OpenAI 的对话模型提供商，并将其集成到现有的模型配置、工作流以及客户端选择路径中。

新功能：
- 将 Atlas Cloud 注册为模型提供商，通过兼容 OpenAI 的 API 暴露三个对话模型。
- 在提供商密钥配置弹窗中预填 Atlas Cloud 的 API 基础 URL。

改进：
- 在工作流参数（例如 seed 和 penalties）以及多模态消息处理方面，将 Atlas Cloud 视为兼容 OpenAI 的提供商。
- 通过共享的兼容 OpenAI 的对话客户端和模型参数构建流水线来路由 Atlas Cloud 模型。

测试：
- 添加有针对性的测试，用于验证 Atlas Cloud 模型的注册以及对兼容 OpenAI 的对话客户端的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Atlas Cloud as an OpenAI-compatible chat model provider and integrate it into existing model configuration, workflow, and client selection paths.

New Features:
- Register Atlas Cloud as a model provider exposing three chat models via an OpenAI-compatible API.
- Prefill the Atlas Cloud API base URL in the provider key configuration modal.

Enhancements:
- Treat Atlas Cloud as OpenAI-compatible for workflow parameters such as seed and penalties, and for multimodal message handling.
- Route Atlas Cloud models through the shared OpenAI-compatible chat client and model parameter construction pipeline.

Tests:
- Add targeted tests to verify Atlas Cloud model registration and use of the OpenAI-compatible chat client.

</details>

新功能：
- 将 Atlas Cloud 注册为模型提供商，通过与 OpenAI 兼容的 API 提供三种聊天模型。
- 在打开提供商密钥配置弹窗时，预填 Atlas Cloud 的 API 基础 URL。

增强：
- 将 Atlas Cloud 视为在工作流参数和多模态支持方面与 OpenAI 兼容，并复用共享的聊天客户端实现。

测试：
- 添加针对性测试，以验证 Atlas Cloud 模型注册以及对与 OpenAI 兼容的聊天客户端的使用情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Atlas Cloud 新增为兼容 OpenAI 的对话模型提供商，并将其集成到现有的模型配置、工作流以及客户端选择路径中。

新功能：
- 将 Atlas Cloud 注册为模型提供商，通过兼容 OpenAI 的 API 暴露三个对话模型。
- 在提供商密钥配置弹窗中预填 Atlas Cloud 的 API 基础 URL。

改进：
- 在工作流参数（例如 seed 和 penalties）以及多模态消息处理方面，将 Atlas Cloud 视为兼容 OpenAI 的提供商。
- 通过共享的兼容 OpenAI 的对话客户端和模型参数构建流水线来路由 Atlas Cloud 模型。

测试：
- 添加有针对性的测试，用于验证 Atlas Cloud 模型的注册以及对兼容 OpenAI 的对话客户端的使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Atlas Cloud as an OpenAI-compatible chat model provider and integrate it into existing model configuration, workflow, and client selection paths.

New Features:
- Register Atlas Cloud as a model provider exposing three chat models via an OpenAI-compatible API.
- Prefill the Atlas Cloud API base URL in the provider key configuration modal.

Enhancements:
- Treat Atlas Cloud as OpenAI-compatible for workflow parameters such as seed and penalties, and for multimodal message handling.
- Route Atlas Cloud models through the shared OpenAI-compatible chat client and model parameter construction pipeline.

Tests:
- Add targeted tests to verify Atlas Cloud model registration and use of the OpenAI-compatible chat client.

</details>

</details>

</details>