### PR TITLE
fix(rag): harden evidence graph empty states

### DIFF
--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -58,7 +58,7 @@ from app.repositories import knowledge_repository, knowledgeshare_repository
 from app.services import knowledge_service, document_service
 from app.services import file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
-from app.services.model_service import ModelConfigService
+from app.services.model_service import ModelApiKeyService, ModelConfigService
 from app.services.qa_export_service import iter_qa_csv_chunks, make_qa_export_filename
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -271,11 +271,32 @@ async def get_knowledge_graph_entity_types(
         # 1. Check whether the model exists
         api_logger.debug(f"Check whether the model exists: {llm_id}")
         config = await ModelConfigService.get_model_by_id_async(db=db, model_id=llm_id)
+        if not config:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Model config does not exist",
+            )
+        api_key = await ModelApiKeyService.get_available_api_key_async(
+            db,
+            llm_id,
+            tenant_id=current_user.tenant_id,
+        )
+        if api_key is None or not api_key.api_key:
+            api_logger.warning(
+                "No available API key for graph entity type generation"
+                " llm_id=%s username=%s",
+                str(llm_id),
+                current_user.username,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="No available API key for the selected model",
+            )
         # 2. Prepare to configure chat_mdl information
         chat_model = Base(
-            key=config.api_keys[0].api_key,
-            model_name=config.api_keys[0].model_name,
-            base_url=config.api_keys[0].api_base
+            key=api_key.api_key,
+            model_name=api_key.model_name,
+            base_url=api_key.api_base
         )
         # response = graph_entity_types(chat_model, scenario)
         response = await asyncio.to_thread(graph_entity_types, chat_model, scenario)

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -586,7 +586,12 @@ class GraphElasticsearchStore:
                                 "unmapped_type": "long",
                             }
                         },
-                        {"entity_key_kwd": {"order": "asc"}},
+                        {
+                            "entity_key_kwd": {
+                                "order": "asc",
+                                "unmapped_type": "keyword",
+                            }
+                        },
                     ],
                 ),
                 self._client.search(
@@ -603,7 +608,12 @@ class GraphElasticsearchStore:
                                 "unmapped_type": "long",
                             }
                         },
-                        {"relation_key_kwd": {"order": "asc"}},
+                        {
+                            "relation_key_kwd": {
+                                "order": "asc",
+                                "unmapped_type": "keyword",
+                            }
+                        },
                     ],
                 ),
             )
@@ -759,7 +769,14 @@ class GraphElasticsearchStore:
                 ENTITY_PROJECTION,
                 [{"terms": {"entity_key_kwd": list(keys)}}],
             ),
-            sort=[{"entity_key_kwd": {"order": "asc"}}],
+            sort=[
+                {
+                    "entity_key_kwd": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                }
+            ],
         )
         raise_on_shard_failures(result, "load graph entity projections")
         projections: list[EntityProjectionHit] = []
@@ -813,7 +830,12 @@ class GraphElasticsearchStore:
                 ],
             ),
             sort=[
-                {"relation_key_kwd": {"order": "asc"}},
+                {
+                    "relation_key_kwd": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
         )
         raise_on_shard_failures(result, "load graph neighbor relations")

--- a/api/app/core/rag/knowledge_graph/prompts.py
+++ b/api/app/core/rag/knowledge_graph/prompts.py
@@ -8,9 +8,12 @@ ref within this response. Relation endpoints must reference
 entity refs emitted in the same response. Each relation should include concise
 high-level keywords explicitly supported by the source text. Omit uncertain facts. Do not answer
 the user, build communities, summarize a whole graph, or infer missing facts.
+Return a valid JSON object only. The JSON object must contain "entities" and
+"relations" arrays. Use empty arrays when no direct evidence is present. Do not
+return markdown, code fences, comments, or explanatory text.
 """.strip()
 
-EXTRACTION_PROMPT_VERSION = "2026-07-23-v2"
+EXTRACTION_PROMPT_VERSION = "2026-07-27-v1"
 
 QUERY_PLAN_PROMPT_VERSION = "2026-07-23-v2"
 


### PR DESCRIPTION
## Business Background
Evidence Graph can fail in several empty or partially configured states on the release branch: graph details may return 500 before dynamic projection fields are mapped, structured extraction can be rejected by OpenAI-compatible JSON response format validation, and graph entity type generation can crash when the selected model has no available API key.

## Summary
- Harden Evidence Graph projection reads when keyword sort fields are not mapped yet.
- Add an explicit JSON output contract to Evidence Graph extraction prompts and bump the extraction prompt version.
- Resolve graph entity type generation models through the shared available API key selector and return a clear 400 when no key is available.

## Changes
- api/app/controllers/knowledge_controller.py
- api/app/core/rag/knowledge_graph/elasticsearch_store.py
- api/app/core/rag/knowledge_graph/prompts.py

## Risk
Low. The Elasticsearch change only affects unmapped sort field handling; mapped projection sort behavior is unchanged. The prompt change is scoped to Evidence Graph extraction and updates the prompt cache version. Legacy GraphRAG does not use this projection read path or Evidence extraction prompt. The entity type endpoint hardening also affects the API Key route because it delegates to the same controller.

## External API Key Impact
The API Key knowledge graph entity types route reuses the internal controller, so missing or inactive model API keys now return a clear 400 instead of an unhandled 500.

## Test Plan
- [x] `PYTHONPATH=. uv run --frozen pytest tests/rag/knowledge_graph/test_elasticsearch_store.py -q` - 18 passed
- [x] `uv run --frozen python -m py_compile app/controllers/knowledge_controller.py app/core/rag/knowledge_graph/elasticsearch_store.py app/core/rag/knowledge_graph/prompts.py` - passed
- [x] Minimal Evidence Graph sort assertion for unmapped keyword fields - passed
- [x] Minimal Evidence extraction prompt JSON contract assertion - passed
- [x] Minimal graph entity type no-available-key assertion - passed
- [x] `git diff --check origin/release/v0.3.14..HEAD` - passed

## Summary by Sourcery

加强 Evidence Graph 在用于投影读取、抽取提示以及实体类型生成时，对于空配置或部分配置状态下的行为健壮性。

Bug Fixes:
- 防止当关键字排序字段尚未建立映射时，Elasticsearch Evidence Graph 投影和邻接关系查询发生失败。
- 确保在模型配置或 API key 缺失时，图实体类型生成和使用 API key 的路由能够返回清晰的客户端错误，而不是发生崩溃。

Enhancements:
- 对 Evidence Graph 抽取提示强制执行严格的 JSON 输出约定，并提升抽取提示版本以与新格式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden Evidence Graph behavior around empty or partially configured states for projection reads, extraction prompts, and entity type generation.

Bug Fixes:
- Prevent Elasticsearch Evidence Graph projections and neighbor relation queries from failing when keyword sort fields are not yet mapped.
- Ensure graph entity type generation and API key-backed routes return clear client errors when model config or API keys are missing instead of crashing.

Enhancements:
- Enforce a strict JSON output contract for Evidence Graph extraction prompts and bump the extraction prompt version to align with the new format.

</details>