### PR TITLE
fix(web): add currentTotalQuota

### DIFF
--- a/web/src/api/user.ts
+++ b/web/src/api/user.ts
@@ -62,3 +62,7 @@ export const changeEmail = (data: ChangeEmailModalForm) => {
 export const getTenantSubscription = () => {
   return request.get('/tenant/subscription')
 }
+// Resource usage overview
+export const getQuotaUsage = () => {
+  return request.get('/tenants/quota/usage')
+}

--- a/web/src/views/Package/ResourcePackage.tsx
+++ b/web/src/views/Package/ResourcePackage.tsx
@@ -15,10 +15,11 @@ import clsx from 'clsx';
 import { CheckCircleFilled } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 
-import type { ResourcePack, ResourcePackTier } from './types';
+import type { ResourcePack, ResourcePackTier, ResourceUsageItem } from './types';
 import { billingUnits, getUnit } from './constant';
 import { getResourcePacks } from '@/api/package';
 import PackageIcon from './PackageIcon'
+import { getQuotaUsage } from '@/api/user'
 
 /** Generate unique key for cart item */
 const itemKey = (categoryKey: string, tierId: string) => `${categoryKey}_${tierId}`;
@@ -45,8 +46,15 @@ const ResourcePackage: FC = () => {
         setSelectedResourcePack(resourcePackList[0]);
       })
   }
+  const [quotaUsage, setQuotaUsage] = useState<Record<string, ResourceUsageItem>>({});
+  const getQuotaUsages = () => {
+    getQuotaUsage().then(res => {
+      setQuotaUsage(res as Record<string, ResourceUsageItem>);
+    })
+  }
   useEffect(() => {
     getResourcePackList();
+    getQuotaUsages();
   }, []);
 
   useEffect(() => {
@@ -244,13 +252,13 @@ const ResourcePackage: FC = () => {
                     <div className="rb:text-[12px] rb:text-[#5B6167]">{isZh ? selectedResourcePack.description_zh : selectedResourcePack.description_en}</div>
                   </div>
                 </Flex>
-                {/* <div className="rb:rounded-[10px] rb:bg-[#F7F8FA] rb:px-4 rb:py-2">
+                <div className="rb:rounded-[10px] rb:bg-[#F7F8FA] rb:px-4 rb:py-2">
                   <div className="rb:text-[12px] rb:text-[#5B6167] rb:mb-0.5">{t('package.currentTotalQuota')}</div>
                   <div className="rb:text-[16px]">
-                    <span className="rb:font-bold rb:font-[MiSans-Bold]">{currentQuota ?? '--'}</span>
-                    <span className="rb:font-medium">{t(`package.${activeCategory?.unit}`)}</span>
+                    <span className="rb:font-bold rb:font-[MiSans-Bold]">{quotaUsage[selectedResourcePack?.billing_units[0]]?.limit ?? '--'}</span>
+                    <span className="rb:font-medium">{t(`package.${getUnit(selectedResourcePack?.billing_units[0])}`)}</span>
                   </div>
-                </div> */}
+                </div>
               </Flex>
 
               {/* Select expansion tier */}

--- a/web/src/views/Package/index.tsx
+++ b/web/src/views/Package/index.tsx
@@ -33,6 +33,7 @@ import { useI18n } from '@/store/locale'
 import { useUser } from '@/store/user'
 import { useSubscription } from '@/store/subscription'
 import PackageIcon from './PackageIcon'
+import { isPrivateAvailable } from '@/utils/private'
 
 import arrowSvg from '@/assets/images/package/arrow.svg?react'
 
@@ -40,7 +41,6 @@ const btnClassNames = {
   permanent_free: 'rb:h-10! rb:rounded-[8px]!',
   default: 'rb:h-10! rb:rounded-[8px]! rb:bg-[#212332]! rb:text-white! rb:border-0! rb:hover:border-0! rb:hover:opacity-[0.8]',
 }
-const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 
 export const UnitWrapper = ({ titleKey, value, icon, unit, theme_color = '#171719' }: { titleKey: string; value?: number | string | null; icon: string; unit?: string; theme_color?: string; }) => {
   const { t } = useTranslation();
@@ -129,6 +129,7 @@ const Package: FC = () => {
   const { subscription: curPkg, fetchSubscription } = useSubscription()
 
   const checkResourcePacks = () => {
+    if (!isPrivateAvailable) return
     getResourcePacks({ page: 1, pagesize: 1 }).then(res => {
       const hasItems = (res as { items: unknown[] })?.items?.length > 0
       setHasResourcePacks(hasItems)
@@ -196,7 +197,7 @@ const Package: FC = () => {
     navigate('/orders');
   }
 
-  const isHasTop = isSaas || showTabs
+  const isHasTop = isPrivateAvailable || showTabs
   return (
     <>
       {isHasTop &&
@@ -210,7 +211,7 @@ const Package: FC = () => {
               onChange={handleChangeTab}
             />
           }
-          {isSaas &&
+          {isPrivateAvailable &&
             <Flex gap={12}>
               <Button className="rb:group" onClick={goToHistory}>
                 <div

--- a/web/src/views/Package/types.ts
+++ b/web/src/views/Package/types.ts
@@ -104,3 +104,16 @@ export interface ResourcePack {
   created_by: string;
   updated_by: string;
 }
+export interface ResourceUsageItem {
+  used: number;
+  limit: number;
+  percentage: number;
+  unit: string;
+  per_workspace: {
+    workspace_id: string;
+    workspace_name: string;
+    used: number;
+    limit: number;
+    percentage: number;
+  }[];
+}


### PR DESCRIPTION
## Summary by Sourcery

添加配额使用情况的获取与展示功能，用于资源包，并将面向 SaaS 的特定套餐 UI 通过私有可用性标志进行控制。

New Features:
- 使用后端配额使用数据，展示所选资源包当前的总配额。
- 暴露新的 API 客户端，用于获取租户配额使用数据。

Enhancements:
- 不再通过环境检查，而是通过集中化的私有可用性标志，来控制资源包的获取和 SaaS 特定的 UI 控件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add quota usage retrieval and display for resource packages and gate SaaS-specific package UI behind a private availability flag.

New Features:
- Display current total quota for the selected resource pack using backend quota usage data.
- Expose a new API client for fetching tenant quota usage data.

Enhancements:
- Gate resource package fetching and SaaS-specific UI controls behind a centralized private availability flag instead of environment checks.

</details>