### PR TITLE
feat(dashscope): enable omni mode for qwen long context models

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -204,9 +204,6 @@ class RedBearModelFactory:
         logger = get_business_logger()
         logger.debug(f"获取模型参数 - Provider: {provider}, Model: {config.model_name}, is_omni: {config.is_omni}, deep_thinking: {config.deep_thinking}")
 
-        # DashScope URL 自动路由在 get_provider_llm_class 内部处理（必须在 llm_class
-        # 选择前升级 is_omni，否则仍会被路由到原生 ChatTongyi）。
-
         filtered_extra_params, provider_specific = cls._extract_provider_specific_params(config.extra_params)
         default_headers = config.extra_params.get("default_headers")
         if default_headers:
@@ -483,23 +480,6 @@ class RedBearModelFactory:
 def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelType.LLM) -> type[BaseLLM]:
     """根据模型提供商获取对应的模型类"""
     provider = config.provider.lower()
-
-    # DashScope URL 自动路由：当前端传入 Maas compatible-mode URL（典型如
-    # https://{workspace}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1）时，
-    # 强制走 OpenAI 兼容模式，避免原生 ChatTongyi SDK 因 endpoint 表滞后导致
-    # "url error, please check url"。必须在 is_omni 判断之前升级。
-    if (
-        provider == ModelProvider.DASHSCOPE.value
-        and not config.is_omni
-        and config.base_url
-        and ("compatible-mode" in config.base_url or "maas.aliyuncs.com" in config.base_url)
-    ):
-        from app.core.logging_config import get_business_logger
-        get_business_logger().info(
-            f"[DashScope路由] 检测到 Maas compatible-mode base_url，自动升级 is_omni=True: "
-            f"model={config.model_name}, base_url={config.base_url}"
-        )
-        config.is_omni = True
 
     # dashscope的omni模型 和 volcano模型使用
     if provider == ModelProvider.DASHSCOPE and config.is_omni:

--- a/api/app/core/models/scripts/dashscope_models.yaml
+++ b/api/app/core/models/scripts/dashscope_models.yaml
@@ -1101,7 +1101,7 @@ models:
   capability:
   - thinking
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - agent-thought
@@ -1118,7 +1118,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1136,7 +1136,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1154,7 +1154,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1169,7 +1169,7 @@ models:
   capability:
   - thinking
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - agent-thought
@@ -1183,7 +1183,7 @@ models:
   capability:
   - thinking
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - agent-thought
@@ -1198,7 +1198,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - agent-thought
@@ -1215,7 +1215,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1233,7 +1233,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1251,7 +1251,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1269,7 +1269,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1287,7 +1287,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态
@@ -1305,7 +1305,7 @@ models:
   - thinking
   - json_output
   - function_call
-  is_omni: false
+  is_omni: true
   tags:
   - 大语言模型
   - 多模态


### PR DESCRIPTION
- Remove automatic URL-based omni mode detection logic from get_provider_llm_class
- Remove related comment explaining DashScope MaaS compatible-mode routing
- Update qwen-long and qwen-plus model configs to enable is_omni=true by default
- Simplifies model routing by making omni mode configuration explicit in model definitions rather than runtime detection

## Summary by Sourcery

启用 DashScope qwen long 和多模态模型默认使用 omni 模式，并简化 omni 路由逻辑。

新功能：
- 通过模型配置，为 DashScope qwen long 及相关多模态模型默认启用 omni 模式。

增强改进：
- 在 `get_provider_llm_class` 中移除基于 URL 的 DashScope 自动 omni 模式路由，改为依赖显式的模型配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DashScope qwen long and multimodal models to use omni mode by default and simplify omni routing logic.

New Features:
- Enable omni mode by default for DashScope qwen long and related multimodal models via model configuration.

Enhancements:
- Remove URL-based automatic omni mode routing for DashScope in get_provider_llm_class to rely on explicit model config.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

启用 DashScope qwen long 和多模态模型默认使用 omni 模式，并简化 omni 路由逻辑。

新功能：
- 通过模型配置，为 DashScope qwen long 及相关多模态模型默认启用 omni 模式。

增强改进：
- 在 `get_provider_llm_class` 中移除基于 URL 的 DashScope 自动 omni 模式路由，改为依赖显式的模型配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DashScope qwen long and multimodal models to use omni mode by default and simplify omni routing logic.

New Features:
- Enable omni mode by default for DashScope qwen long and related multimodal models via model configuration.

Enhancements:
- Remove URL-based automatic omni mode routing for DashScope in get_provider_llm_class to rely on explicit model config.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

启用 DashScope qwen long 和多模态模型默认使用 omni 模式，并简化 omni 路由逻辑。

新功能：
- 通过模型配置，为 DashScope qwen long 及相关多模态模型默认启用 omni 模式。

增强改进：
- 在 `get_provider_llm_class` 中移除基于 URL 的 DashScope 自动 omni 模式路由，改为依赖显式的模型配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DashScope qwen long and multimodal models to use omni mode by default and simplify omni routing logic.

New Features:
- Enable omni mode by default for DashScope qwen long and related multimodal models via model configuration.

Enhancements:
- Remove URL-based automatic omni mode routing for DashScope in get_provider_llm_class to rely on explicit model config.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

启用 DashScope qwen long 和多模态模型默认使用 omni 模式，并简化 omni 路由逻辑。

新功能：
- 通过模型配置，为 DashScope qwen long 及相关多模态模型默认启用 omni 模式。

增强改进：
- 在 `get_provider_llm_class` 中移除基于 URL 的 DashScope 自动 omni 模式路由，改为依赖显式的模型配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DashScope qwen long and multimodal models to use omni mode by default and simplify omni routing logic.

New Features:
- Enable omni mode by default for DashScope qwen long and related multimodal models via model configuration.

Enhancements:
- Remove URL-based automatic omni mode routing for DashScope in get_provider_llm_class to rely on explicit model config.

</details>

</details>

</details>