### PR TITLE
fix(memory-api): refactor memory read multi-user error handling and switch to self-db auth

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -11,6 +11,7 @@ import asyncio
 
 from fastapi import APIRouter, Body, Header, Request, Depends
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy.orm import Session
 from starlette.responses import Response
 
 # 包装内部 controller
@@ -172,7 +173,7 @@ async def write_memory_async(
         api_key_auth: ApiKeyAuth = None,
         body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
         language_type: str = Header(default=None, alias="X-Language-Type"),
-        db: str = Depends(get_db),
+        db: Session = Depends(get_db),
 ):
     """
     Write memory asynchronously (Celery task).

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -9,7 +9,7 @@
 
 import asyncio
 
-from fastapi import APIRouter, Body, Header, Request
+from fastapi import APIRouter, Body, Header, Request, Depends
 from fastapi.encoders import jsonable_encoder
 from starlette.responses import Response
 
@@ -23,7 +23,7 @@ from app.core.memory.enums import Neo4jNodeType, SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.quota_stub import check_end_user_quota
 from app.core.response_utils import success
-from app.db import get_db_context, get_async_db_context
+from app.db import get_db_context, get_async_db_context, get_db
 from app.dependencies import make_snapshot
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.memory_agent_schema import Write_UserInput, InternalReadInput, ReadSyncInput
@@ -38,7 +38,6 @@ def _encode_result(result):
     if isinstance(result, Response):
         return result
     return jsonable_encoder(result)
-
 
 
 @router.get("")
@@ -71,7 +70,7 @@ async def read_memory_sync(
 
     if payload.end_user_ids:
         # ── Multi-user mode: concurrent reads ──
-        end_user_ids = payload.end_user_ids
+        end_user_ids = set(payload.end_user_ids)
 
         async with get_async_db_context() as db:
             for euid in end_user_ids:
@@ -94,9 +93,16 @@ async def read_memory_sync(
             }
 
         results = await asyncio.gather(
-            *[_read_for_user(euid) for euid in end_user_ids]
+            *[_read_for_user(euid) for euid in end_user_ids],
+            return_exceptions=True
         )
-        return success(data={euid: data for euid, data in results})
+        res = {}
+        for data in results:
+            if isinstance(data, Exception):
+                pass
+            res[data[0]] = data[1]
+
+        return success(data={euid: data for data in results})
 
     # ── Single-user mode (backward-compatible) ──
     async with get_async_db_context() as db:
@@ -133,7 +139,8 @@ async def read_memory_internal(
     async with get_async_db_context() as db:
         await validate_end_user_in_workspace_async(db, payload.end_user_id, api_key_auth.workspace_id)
         config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(payload.end_user_id)
-    logger.info(f"V1 memory read (internal) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
+    logger.info(
+        f"V1 memory read (internal) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
 
     # Resolve include strings to Neo4jNodeType enum values
     includes = None
@@ -165,6 +172,7 @@ async def write_memory_async(
         api_key_auth: ApiKeyAuth = None,
         body_placeholder: str = Body(None, description="Placeholder - actual body parsed via request.json()"),
         language_type: str = Header(default=None, alias="X-Language-Type"),
+        db: str = Depends(get_db),
 ):
     """
     Write memory asynchronously (Celery task).

--- a/api/app/controllers/service/memory_config_api_controller.py
+++ b/api/app/controllers/service/memory_config_api_controller.py
@@ -120,9 +120,9 @@ async def read_all_config(
     with get_db_context() as auth_db:
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return await memory_config_controller.read_all_config(
-        current_user=current_user,
-    )
+        return await memory_config_controller.read_all_config(
+            current_user=current_user,
+        )
 
 
 @router.get("/scenes/simple")
@@ -142,9 +142,9 @@ async def get_ontology_scenes(
     with get_db_context() as auth_db:
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return await ontology_controller.get_scenes_simple(
-        current_user=current_user,
-    )
+        return await ontology_controller.get_scenes_simple(
+            current_user=current_user,
+        )
 
 
 @router.get("/read_config_extracted")
@@ -165,10 +165,10 @@ async def read_config_extracted(
         _verify_config_ownership(config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return await memory_config_controller.read_config_extracted(
-        config_id=config_id,
-        current_user=current_user,
-    )
+        return await memory_config_controller.read_config_extracted(
+            config_id=config_id,
+            current_user=current_user,
+        )
 
 
 @router.get("/read_config_forgetting")
@@ -189,11 +189,11 @@ async def read_config_forgetting(
         _verify_config_ownership(config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    result = await memory_config_controller.read_forgetting_config(
-        config_id=config_id,
-        current_user=current_user,
-    )
-    return jsonable_encoder(result)
+        result = await memory_config_controller.read_forgetting_config(
+            config_id=config_id,
+            current_user=current_user,
+        )
+        return jsonable_encoder(result)
 
 
 @router.get("/read_config_emotion")
@@ -214,10 +214,10 @@ async def read_config_emotion(
         _verify_config_ownership(config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return jsonable_encoder(await memory_config_controller.get_emotion_config(
-        config_id=config_id,
-        current_user=current_user,
-    ))
+        return jsonable_encoder(await memory_config_controller.get_emotion_config(
+            config_id=config_id,
+            current_user=current_user,
+        ))
 
 
 @router.get("/read_config_reflection")
@@ -238,10 +238,10 @@ async def read_config_reflection(
         _verify_config_ownership(config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return jsonable_encoder(await memory_config_controller.start_reflection_configs(
-        config_id=config_id,
-        current_user=current_user,
-    ))
+        return jsonable_encoder(await memory_config_controller.start_reflection_configs(
+            config_id=config_id,
+            current_user=current_user,
+        ))
 
 
 @router.post("/create_config")
@@ -266,27 +266,24 @@ async def create_memory_config(
     with get_db_context() as auth_db:
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    # 构造管理端 Schema，workspace_id 从 API Key 注入
-    mgmt_payload = ConfigParamsCreate(
-        config_name=payload.config_name,
-        config_desc=payload.config_desc or "",
-        scene_id=payload.scene_id,
-        llm_id=payload.llm_id,
-        embedding_id=payload.embedding_id,
-        rerank_id=payload.rerank_id,
-        reflection_model_id=payload.reflection_model_id,
-        emotion_model_id=payload.emotion_model_id,
-    )
-
-    # 需要 sync Session 给 quota check 装饰器；create_config 内部会自己开 async session
-    with get_db_context() as quota_db:
+        # 构造管理端 Schema，workspace_id 从 API Key 注入
+        mgmt_payload = ConfigParamsCreate(
+            config_name=payload.config_name,
+            config_desc=payload.config_desc or "",
+            scene_id=payload.scene_id,
+            llm_id=payload.llm_id,
+            embedding_id=payload.embedding_id,
+            rerank_id=payload.rerank_id,
+            reflection_model_id=payload.reflection_model_id,
+            emotion_model_id=payload.emotion_model_id,
+        )
         result = await memory_config_controller.create_config(
             payload=mgmt_payload,
             current_user=current_user,
-            db=quota_db,
+            db=auth_db,
             x_language_type=x_language_type,
         )
-    return jsonable_encoder(result)
+        return jsonable_encoder(result)
 
 
 @router.put("/update_config")
@@ -311,17 +308,17 @@ async def update_memory_config(
         _verify_config_ownership(payload.config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    mgmt_payload = ConfigUpdate(
-        config_id=payload.config_id,
-        config_name=payload.config_name,
-        config_desc=payload.config_desc,
-        scene_id=payload.scene_id,
-    )
+        mgmt_payload = ConfigUpdate(
+            config_id=payload.config_id,
+            config_name=payload.config_name,
+            config_desc=payload.config_desc,
+            scene_id=payload.scene_id,
+        )
 
-    return await memory_config_controller.update_config(
-        payload=mgmt_payload,
-        current_user=current_user,
-    )
+        return await memory_config_controller.update_config(
+            payload=mgmt_payload,
+            current_user=current_user,
+        )
 
 
 @router.put("/update_config_extracted")
@@ -347,13 +344,13 @@ async def update_memory_config_extracted(
         _verify_config_ownership(payload.config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    update_fields = payload.model_dump(exclude_unset=True)
-    mgmt_payload = ConfigUpdateExtracted(**update_fields)
+        update_fields = payload.model_dump(exclude_unset=True)
+        mgmt_payload = ConfigUpdateExtracted(**update_fields)
 
-    return await memory_config_controller.update_config_extracted(
-        payload=mgmt_payload,
-        current_user=current_user,
-    )
+        return await memory_config_controller.update_config_extracted(
+            payload=mgmt_payload,
+            current_user=current_user,
+        )
 
 
 @router.put("/update_config_forgetting")
@@ -379,15 +376,15 @@ async def update_memory_config_forgetting(
         _verify_config_ownership(payload.config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    update_fields = payload.model_dump(exclude_unset=True)
-    mgmt_payload = ForgettingConfigUpdateRequest(**update_fields)
+        update_fields = payload.model_dump(exclude_unset=True)
+        mgmt_payload = ForgettingConfigUpdateRequest(**update_fields)
 
-    # 将返回数据中UUID序列化处理
-    result = await memory_config_controller.update_forgetting_config(
-        payload=mgmt_payload,
-        current_user=current_user,
-    )
-    return jsonable_encoder(result)
+        # 将返回数据中UUID序列化处理
+        result = await memory_config_controller.update_forgetting_config(
+            payload=mgmt_payload,
+            current_user=current_user,
+        )
+        return jsonable_encoder(result)
 
 
 @router.put("/update_config_emotion")
@@ -412,12 +409,12 @@ async def update_config_emotion(
         _verify_config_ownership(payload.config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    update_fields = payload.model_dump(exclude_unset=True)
-    mgmt_payload = EmotionConfigUpdate(**update_fields)
-    return jsonable_encoder(await memory_config_controller.update_emotion_config(
-        config=mgmt_payload,
-        current_user=current_user,
-    ))
+        update_fields = payload.model_dump(exclude_unset=True)
+        mgmt_payload = EmotionConfigUpdate(**update_fields)
+        return jsonable_encoder(await memory_config_controller.update_emotion_config(
+            config=mgmt_payload,
+            current_user=current_user,
+        ))
 
 
 @router.put("/update_config_reflection")
@@ -442,13 +439,13 @@ async def update_config_reflection(
         _verify_config_ownership(payload.config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    update_fields = payload.model_dump(exclude_unset=True)
-    mgmt_payload = Memory_Reflection(**update_fields)
+        update_fields = payload.model_dump(exclude_unset=True)
+        mgmt_payload = Memory_Reflection(**update_fields)
 
-    return jsonable_encoder(await memory_config_controller.save_reflection_config(
-        request=mgmt_payload,
-        current_user=current_user,
-    ))
+        return jsonable_encoder(await memory_config_controller.save_reflection_config(
+            request=mgmt_payload,
+            current_user=current_user,
+        ))
 
 
 @router.delete("/delete_config")
@@ -472,7 +469,7 @@ async def delete_memory_config(
         _verify_config_ownership(config_id, api_key_auth.workspace_id, auth_db)
         current_user = _get_current_user(api_key_auth, auth_db)
 
-    return await memory_config_controller.delete_config(
-        config_id=config_id,
-        current_user=current_user,
-    )
+        return await memory_config_controller.delete_config(
+            config_id=config_id,
+            current_user=current_user,
+        )

--- a/api/app/controllers/service/memory_config_api_controller.py
+++ b/api/app/controllers/service/memory_config_api_controller.py
@@ -10,11 +10,11 @@ from sqlalchemy.orm import Session
 from app.controllers import memory_config_controller
 from app.controllers import ontology_controller
 from app.controllers.emotion_config_controller import EmotionConfigUpdate
-from app.core.api_key_auth import require_api_key
+from app.core.api_key_auth import require_api_key_self_db
 from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
-from app.db import get_db_context, get_async_db_context
+from app.db import get_db_context
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.memory_api_schema import (
@@ -104,7 +104,7 @@ def _verify_config_ownership(config_id: str, workspace_id: uuid.UUID, db: Sessio
 #     return success(data=ListConfigsResponse(**result).model_dump(), msg="Configs listed successfully")
 
 @router.get("/read_all_config")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def read_all_config(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -126,7 +126,7 @@ async def read_all_config(
 
 
 @router.get("/scenes/simple")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def get_ontology_scenes(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -148,7 +148,7 @@ async def get_ontology_scenes(
 
 
 @router.get("/read_config_extracted")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def read_config_extracted(
         request: Request,
         config_id: str = Query(..., description="config_id"),
@@ -172,7 +172,7 @@ async def read_config_extracted(
 
 
 @router.get("/read_config_forgetting")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def read_config_forgetting(
         request: Request,
         config_id: str = Query(..., description="config_id"),
@@ -197,7 +197,7 @@ async def read_config_forgetting(
 
 
 @router.get("/read_config_emotion")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def read_config_emotion(
         request: Request,
         config_id: str = Query(..., description="config_id"),
@@ -221,7 +221,7 @@ async def read_config_emotion(
 
 
 @router.get("/read_config_reflection")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def read_config_reflection(
         request: Request,
         config_id: str = Query(..., description="config_id"),
@@ -245,7 +245,7 @@ async def read_config_reflection(
 
 
 @router.post("/create_config")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def create_memory_config(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -290,7 +290,7 @@ async def create_memory_config(
 
 
 @router.put("/update_config")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def update_memory_config(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -325,7 +325,7 @@ async def update_memory_config(
 
 
 @router.put("/update_config_extracted")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def update_memory_config_extracted(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -357,7 +357,7 @@ async def update_memory_config_extracted(
 
 
 @router.put("/update_config_forgetting")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def update_memory_config_forgetting(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -391,7 +391,7 @@ async def update_memory_config_forgetting(
 
 
 @router.put("/update_config_emotion")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def update_config_emotion(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -421,7 +421,7 @@ async def update_config_emotion(
 
 
 @router.put("/update_config_reflection")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def update_config_reflection(
         request: Request,
         api_key_auth: ApiKeyAuth = None,
@@ -452,7 +452,7 @@ async def update_config_reflection(
 
 
 @router.delete("/delete_config")
-@require_api_key(scopes=["memory"])
+@require_api_key_self_db(scopes=["memory"])
 async def delete_memory_config(
         config_id: str,
         request: Request,


### PR DESCRIPTION
- Convert end_user_ids to set to avoid duplicate reads
- Add return_exceptions=True to asyncio.gather for fault isolation
- Fix result aggregation to handle per-user exceptions gracefully
- Replace require_api_key with require_api_key_self_db in config endpoints
- Add Depends(get_db) to write_memory endpoint for DB session injection

## Summary by Sourcery

改进内存 API 在多用户读取场景下的健壮性，并将内存配置端点迁移为基于自有数据库的 API Key 认证。

Bug 修复：
- 在多用户内存读取过程中对终端用户 ID 去重，以避免冗余查询。
- 在并发多用户内存读取时隔离故障，使单个用户的错误不会影响其他用户的结果。

功能增强：
- 将内存配置端点切换为使用自有数据库的 API Key 认证。
- 通过 FastAPI 的依赖注入机制，为异步写入内存端点注入数据库会话，以实现更一致的数据库访问。
- 整理内部内存读取处理器中的日志格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve memory API multi-user read robustness and migrate memory config endpoints to self-db based API key auth.

Bug Fixes:
- Deduplicate end user IDs during multi-user memory reads to avoid redundant queries.
- Isolate failures in concurrent multi-user memory reads so that per-user errors do not break other users' results.

Enhancements:
- Switch memory configuration endpoints to use self-db API key authentication.
- Inject a database session into the asynchronous write memory endpoint via FastAPI dependency injection for more consistent DB access.
- Tidy logging formatting in the internal memory read handler.

</details>