### PR TITLE
fix(web): OverflowTags placement

### DIFF
--- a/web/src/components/OverflowTags/index.tsx
+++ b/web/src/components/OverflowTags/index.tsx
@@ -73,6 +73,7 @@ const OverflowTags = ({ items = [], gap = 8, numTagColor = 'default', numTag, po
             {items.map((item, i) => <span key={i}>{item}</span>)}
           </div>
         }
+        placement="topLeft"
         {...(popoverProps || {})}
         open={popoverProps === false ? false : undefined}
       >


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 为 OverflowTags 指定弹出框（popover）的位置，以防止溢出菜单出现不正确或不一致的定位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Specify the popover placement for OverflowTags to prevent incorrect or inconsistent positioning of the overflow menu.

</details>