### PR TITLE
Feature/logs zy

### DIFF
--- a/web/src/api/user.ts
+++ b/web/src/api/user.ts
@@ -62,3 +62,7 @@ export const changeEmail = (data: ChangeEmailModalForm) => {
 export const getTenantSubscription = () => {
   return request.get('/tenant/subscription')
 }
+// Resource usage overview
+export const getQuotaUsage = () => {
+  return request.get('/tenants/quota/usage')
+}

--- a/web/src/components/OverflowTags/index.tsx
+++ b/web/src/components/OverflowTags/index.tsx
@@ -73,6 +73,7 @@ const OverflowTags = ({ items = [], gap = 8, numTagColor = 'default', numTag, po
             {items.map((item, i) => <span key={i}>{item}</span>)}
           </div>
         }
+        placement="topLeft"
         {...(popoverProps || {})}
         open={popoverProps === false ? false : undefined}
       >

--- a/web/src/views/ApplicationConfig/Logs.tsx
+++ b/web/src/views/ApplicationConfig/Logs.tsx
@@ -48,6 +48,11 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
       className: 'rb:text-[#212332]'
     },
     {
+      title: 'User ID',
+      dataIndex: 'user_id',
+      key: 'user_id',
+    },
+    {
       title: t('application.created_at'),
       dataIndex: 'created_at',
       key: 'created_at',

--- a/web/src/views/KnowledgeBase/components/KnowledgeGraph.tsx
+++ b/web/src/views/KnowledgeBase/components/KnowledgeGraph.tsx
@@ -183,17 +183,22 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
       connectionCount[edge.tgt_id] = (connectionCount[edge.tgt_id] || 0) + 1
     })
 
-    // Process node data
-    rawNodes.forEach(node => {
+    // Process node data. Use a unique chart ID/name for every row so
+    // entities with the same entity_name are rendered independently.
+    const chartNodeIdMap = new Map<string, string>()
+    rawNodes.forEach((node, index) => {
       const connections = connectionCount[node.id] || 0
       const categoryIndex = categoryMap[node.entity_type] || 0
+      const chartNodeId = `knowledge-node-${index}`
+      chartNodeIdMap.set(node.id, chartNodeId)
       
       // Calculate node size based on pagerank and connection count
-      let symbolSize = Math.max(10, Math.min(50, node.pagerank * 200 + connections * 2))
+      const symbolSize = Math.max(10, Math.min(50, node.pagerank * 200 + connections * 2))
       
       processedNodes.push({
         ...node,
-        name: node.entity_name,
+        id: chartNodeId,
+        name: chartNodeId,
         category: categoryIndex,
         symbolSize,
         itemStyle: {
@@ -202,14 +207,12 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
       })
     })
 
-    // Process edge data
+    // Process edge data and point it to each node's unique chart ID.
     rawEdges.forEach(edge => {
-      // Note: Based on data structure, source and target fields may be opposite to src_id and tgt_id
-      // We use src_id and tgt_id as the correct connection relationship
       processedEdges.push({
-        ...edge, // Keep all original fields
-        source: edge.src_id, // Use src_id as source node
-        target: edge.tgt_id, // Use tgt_id as target node
+        ...edge,
+        source: chartNodeIdMap.get(edge.src_id) || edge.src_id,
+        target: chartNodeIdMap.get(edge.tgt_id) || edge.tgt_id,
         value: edge.weight || 1
       })
     })
@@ -266,8 +269,6 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
     }
   }, [nodes])
 
-  console.log('selectedNode', selectedNode)
-
   return (
     <Col span={24}>
       <RbCard 
@@ -287,14 +288,14 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
               <ReactEcharts
                 ref={chartRef}
                 option={{
-                  colors: Object.values(entityTypeColors),
+                  color: Object.values(entityTypeColors),
                   tooltip: {
                     show: true,
                     formatter: (params: any) => {
                       if (params.dataType === 'node') {
                         const node = params.data as KnowledgeNode
                         return `
-                          <div class="rb:max-w-[560px]">
+                          <div class="rb:max-w-140">
                             <div><strong>${node.entity_name}</strong></div>
                             <div>类型: ${node.entity_type}</div>
                             <div>重要度: ${(node.pagerank * 100).toFixed(2)}%</div>
@@ -303,10 +304,10 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
                       } else if (params.dataType === 'edge') {
                         const edge = params.data as KnowledgeEdge
                         return `
-                          <div class="rb:max-w-[560px]">
+                          <div class="rb:max-w-140">
                             <div><strong>关系</strong></div>
                             <div>权重: ${edge.weight}</div>
-                            <div class="rb:break-words rb:whitespace-pre-wrap">${edge.description}</div>
+                            <div class="rb:wrap-break-word rb:whitespace-pre-wrap">${edge.description}</div>
                           </div>
                         `
                       }
@@ -330,7 +331,7 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
                       label: {
                         show: true,
                         position: 'right',
-                        formatter: '{b}',
+                        formatter: (params: { data: KnowledgeNode }) => params.data.entity_name,
                         fontSize: 12
                       },
                       lineStyle: {
@@ -382,7 +383,7 @@ const KnowledgeGraph: FC<KnowledgeGraphProps> = ({ data, loading = false, title 
               {selectedNode && (
                 <div
                   ref={modalRef}
-                  className="rb:absolute rb:bg-white rb:border rb:border-[#EBEBEB] rb:rounded-[12px] rb:shadow-lg rb:p-4 rb:w-80 rb:z-10"
+                  className="rb:absolute rb:bg-white rb:border rb:border-[#EBEBEB] rb:rounded-xl rb:shadow-lg rb:p-4 rb:w-80 rb:z-10"
                   style={{
                     left: modalPosition.x,
                     top: modalPosition.y,

--- a/web/src/views/Package/ResourcePackage.tsx
+++ b/web/src/views/Package/ResourcePackage.tsx
@@ -21,8 +21,8 @@ import { getResourcePacks } from '@/api/package';
 import PackageIcon from './PackageIcon'
 import { getQuotaUsage } from '@/api/user'
 
-/** Generate unique key for cart item */
-const itemKey = (categoryKey: string, tierId: string) => `${categoryKey}_${tierId}`;
+/** Generate unique key for cart item by resource pack ID */
+const itemKey = (resourcePackId: string) => resourcePackId;
 
 
 const getPackage = (key: string) => {
@@ -64,7 +64,7 @@ const ResourcePackage: FC = () => {
   }, [selectedResourcePack]);
 
   const handleChangeTier = (tier: ResourcePackTier) => {
-    const key = itemKey(selectedResourcePack?.id || '', tier.tier_id || '');
+    const key = selectedResourcePack?.id || '';
     const current = cart[key];
     setActiveSpecTier(tier);
     setQuantity(current?.tiers?.[0]?.amount || 1);
@@ -77,7 +77,7 @@ const ResourcePackage: FC = () => {
   // Update cart
   const handleAddToCart = () => {
     if (!selectedResourcePack || !activeSpecTier) return;
-    const key = itemKey(selectedResourcePack.id, activeSpecTier?.tier_id);
+    const key = itemKey(selectedResourcePack.id);
     setCart(prev => {
       return {
         ...prev,
@@ -403,7 +403,7 @@ const ResourcePackage: FC = () => {
 
           <Flex vertical gap={12} className="rb:max-h-[280px] rb:overflow-y-auto">
             {cartItems.map((item, index) => {
-              const key = itemKey(item.id, item.tiers[0].tier_id);
+              const key = itemKey(item.id);
               const tier = item.tiers[0];
               return (
                 <Flex key={key} justify="space-between" align="center" gap={12}

--- a/web/src/views/Package/ResourcePackage.tsx
+++ b/web/src/views/Package/ResourcePackage.tsx
@@ -15,10 +15,11 @@ import clsx from 'clsx';
 import { CheckCircleFilled } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 
-import type { ResourcePack, ResourcePackTier } from './types';
+import type { ResourcePack, ResourcePackTier, ResourceUsageItem } from './types';
 import { billingUnits, getUnit } from './constant';
 import { getResourcePacks } from '@/api/package';
 import PackageIcon from './PackageIcon'
+import { getQuotaUsage } from '@/api/user'
 
 /** Generate unique key for cart item */
 const itemKey = (categoryKey: string, tierId: string) => `${categoryKey}_${tierId}`;
@@ -45,8 +46,15 @@ const ResourcePackage: FC = () => {
         setSelectedResourcePack(resourcePackList[0]);
       })
   }
+  const [quotaUsage, setQuotaUsage] = useState<Record<string, ResourceUsageItem>>({});
+  const getQuotaUsages = () => {
+    getQuotaUsage().then(res => {
+      setQuotaUsage(res as Record<string, ResourceUsageItem>);
+    })
+  }
   useEffect(() => {
     getResourcePackList();
+    getQuotaUsages();
   }, []);
 
   useEffect(() => {
@@ -244,13 +252,13 @@ const ResourcePackage: FC = () => {
                     <div className="rb:text-[12px] rb:text-[#5B6167]">{isZh ? selectedResourcePack.description_zh : selectedResourcePack.description_en}</div>
                   </div>
                 </Flex>
-                {/* <div className="rb:rounded-[10px] rb:bg-[#F7F8FA] rb:px-4 rb:py-2">
+                <div className="rb:rounded-[10px] rb:bg-[#F7F8FA] rb:px-4 rb:py-2">
                   <div className="rb:text-[12px] rb:text-[#5B6167] rb:mb-0.5">{t('package.currentTotalQuota')}</div>
                   <div className="rb:text-[16px]">
-                    <span className="rb:font-bold rb:font-[MiSans-Bold]">{currentQuota ?? '--'}</span>
-                    <span className="rb:font-medium">{t(`package.${activeCategory?.unit}`)}</span>
+                    <span className="rb:font-bold rb:font-[MiSans-Bold]">{quotaUsage[selectedResourcePack?.billing_units[0]]?.limit ?? '--'}</span>
+                    <span className="rb:font-medium">{t(`package.${getUnit(selectedResourcePack?.billing_units[0])}`)}</span>
                   </div>
-                </div> */}
+                </div>
               </Flex>
 
               {/* Select expansion tier */}

--- a/web/src/views/Package/index.tsx
+++ b/web/src/views/Package/index.tsx
@@ -33,6 +33,7 @@ import { useI18n } from '@/store/locale'
 import { useUser } from '@/store/user'
 import { useSubscription } from '@/store/subscription'
 import PackageIcon from './PackageIcon'
+import { isPrivateAvailable } from '@/utils/private'
 
 import arrowSvg from '@/assets/images/package/arrow.svg?react'
 
@@ -40,7 +41,6 @@ const btnClassNames = {
   permanent_free: 'rb:h-10! rb:rounded-[8px]!',
   default: 'rb:h-10! rb:rounded-[8px]! rb:bg-[#212332]! rb:text-white! rb:border-0! rb:hover:border-0! rb:hover:opacity-[0.8]',
 }
-const isSaas = import.meta.env.VITE_PROD_ENV === 'saas'
 
 export const UnitWrapper = ({ titleKey, value, icon, unit, theme_color = '#171719' }: { titleKey: string; value?: number | string | null; icon: string; unit?: string; theme_color?: string; }) => {
   const { t } = useTranslation();
@@ -129,6 +129,7 @@ const Package: FC = () => {
   const { subscription: curPkg, fetchSubscription } = useSubscription()
 
   const checkResourcePacks = () => {
+    if (!isPrivateAvailable) return
     getResourcePacks({ page: 1, pagesize: 1 }).then(res => {
       const hasItems = (res as { items: unknown[] })?.items?.length > 0
       setHasResourcePacks(hasItems)
@@ -196,7 +197,7 @@ const Package: FC = () => {
     navigate('/orders');
   }
 
-  const isHasTop = isSaas || showTabs
+  const isHasTop = isPrivateAvailable || showTabs
   return (
     <>
       {isHasTop &&
@@ -210,7 +211,7 @@ const Package: FC = () => {
               onChange={handleChangeTab}
             />
           }
-          {isSaas &&
+          {isPrivateAvailable &&
             <Flex gap={12}>
               <Button className="rb:group" onClick={goToHistory}>
                 <div

--- a/web/src/views/Package/types.ts
+++ b/web/src/views/Package/types.ts
@@ -104,3 +104,16 @@ export interface ResourcePack {
   created_by: string;
   updated_by: string;
 }
+export interface ResourceUsageItem {
+  used: number;
+  limit: number;
+  percentage: number;
+  unit: string;
+  per_workspace: {
+    workspace_id: string;
+    workspace_name: string;
+    used: number;
+    limit: number;
+    percentage: number;
+  }[];
+}


### PR DESCRIPTION
## Sourcery 总结

更新知识图谱渲染以使用唯一的图表节点标识符并改进工具提示和标签显示，为资源包视图增加资源使用情况感知，根据私有部署可用性对部分包的 UI 进行访问控制，扩展日志以包含用户标识信息，暴露新的配额使用情况 API 辅助方法，并优化溢出标签弹出层的行为。

新功能：
- 通过从后端获取并显示使用上限，为资源包展示单位配额使用情况。
- 在应用日志表中显示用户 ID，以便于追踪。
- 增加一个 API 辅助方法，用于从后端获取租户级别的配额使用数据。

增强改进：
- 确保知识图谱节点使用唯一的图表 ID，使得名称相同的实体可以独立渲染，同时标签仍显示原始实体名称。
- 调整知识图谱工具提示样式和边描述的换行方式，并优化选中节点的弹窗卡片样式。
- 简化资源包流程中的购物车键值设计，改为使用资源包 ID，而不是基于层级的组合键。
- 基于私有部署是否可用，有条件地启用资源包检查和购买历史相关操作。
- 将溢出标签的弹出层设置为从左上方出现，以获得更可预测的位置表现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update knowledge graph rendering to use unique chart node identifiers and improve tooltip and label display, add resource usage awareness to resource package views, gate certain package UI by private deployment availability, extend logs with user identification, expose a new quota usage API helper, and refine overflow tag popover behavior.

New Features:
- Display per-unit quota usage for resource packs by fetching and showing usage limits from the backend.
- Show user IDs in the application logs table to aid traceability.
- Add an API helper to retrieve tenant-wide quota usage data from the backend.

Enhancements:
- Ensure knowledge graph nodes use unique chart IDs so entities with identical names render independently while labels still show the original entity name.
- Tweak knowledge graph tooltip styling and edge description wrapping, and adjust modal card styling for selected nodes.
- Simplify cart keying in the resource package flow to use the resource pack ID instead of tier-based composite keys.
- Conditionally enable resource pack checks and purchase history actions based on private deployment availability.
- Set the overflow tags popover to appear from the top-left for more predictable positioning.

</details>