### PR TITLE
feat(web): model logo

### DIFF
--- a/web/src/components/ModelSelect/index.tsx
+++ b/web/src/components/ModelSelect/index.tsx
@@ -4,7 +4,7 @@
  * @Last Modified by: ZhaoYing
  * @Last Modified time: 2026-05-18 12:10:55
  */
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useState, useMemo } from 'react';
 import { Select, Flex } from 'antd';
 import type { SelectProps } from 'antd/es/select';
 import { useTranslation } from 'react-i18next';
@@ -43,7 +43,7 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
 
   // Render the selected value inside the trigger with logo + truncated name
   const labelRender: SelectProps['labelRender'] = ({ value }) => {
-    const item = options.find((o) => o.id === value);
+    const item = allOptions.find((o) => o.id === value);
     if (!item) return undefined;
     const logo = getListLogoUrl(item.provider, item.logo as string);
     return (
@@ -55,14 +55,16 @@ const ModelSelect: FC<ModelSelectProps> = ({ params, placeholder, fontClassName,
     );
   };
 
+  const allOptions = useMemo(() => [...options, ...initialData], [JSON.stringify(options), JSON.stringify(initialData)]);
   useEffect(() => {
-    if (updateOptions) updateOptions([...options, ...initialData]);
-  }, [JSON.stringify(options), JSON.stringify(initialData)])
+    if (updateOptions) updateOptions(allOptions);
+  }, [JSON.stringify(allOptions), updateOptions])
+
 
   return (
     <Select
       placeholder={placeholder ?? t('common.pleaseSelect')}
-      options={[...options, ...initialData].map(item => ({ ...item, disabled: item.is_deprecated }))}
+      options={allOptions.map(item => ({ ...item, disabled: item.is_deprecated }))}
       fieldNames={{ label: 'name', value: 'id' }}
       allowClear
       // popupMatchSelectWidth={false}

--- a/web/src/views/KnowledgeBase/components/CreateModal.tsx
+++ b/web/src/views/KnowledgeBase/components/CreateModal.tsx
@@ -16,7 +16,10 @@ import {
 import RbModal from '@/components/RbModal'
 import SliderInput from '@/components/SliderInput'
 import { stringRegExp } from '@/utils/validator'
-import Tag from '@/components/Tag'
+import ModelSelect from '@/components/ModelSelect'
+import type { Model } from '@/views/ModelManagement/types'
+import { getCustomWorkspaceModels } from '@/api/workspaces'
+
 const { TextArea } = Input;
 
 // Global model data constant
@@ -29,7 +32,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
   const { modal, message: messageApi } = App.useApp()
   const [visible, setVisible] = useState(false);
   const [modelTypeList, setModelTypeList] = useState<string[]>([]);
-  const [modelOptionsByType, setModelOptionsByType] = useState<Record<string, { label: string; value: string }[]>>({});
+  const [modelOptionsByType, setModelOptionsByType] = useState<Record<string, Model[]>>({});
   const [datasets, setDatasets] = useState<KnowledgeBaseListItem | null>(null);
   const [currentType, setCurrentType] = useState<'General' | 'Web' | 'Third-party' | 'Folder'>('General');
   const [thirdPartyPlatform, setThirdPartyPlatform] = useState<'yuque' | 'feishu'>('yuque');
@@ -157,6 +160,23 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
         return `${type.toLowerCase()}_id`;
     }
   };
+  const typeToModelType = (type: string): string => {
+    switch ((type || '').toLowerCase()) {
+      case 'embedding':
+        return 'embedding';
+      case 'llm':
+        return 'llm';
+      case 'image2text':
+        return 'vision';
+      case 'rerank':
+      case 'reranker':
+        return 'rerank';
+      case 'chat':
+        return 'chat';
+      default: 
+        return type;
+    }
+  };
 
   const fetchModelLists = async (types: string[]) => {
     // If model data hasn't been fetched yet, fetch it once
@@ -171,17 +191,13 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
 
     // Filter out the required types from all model data
     const typesToFetch = types.includes('llm') ? [...types, 'chat'] : types;
-    const next: Record<string, { label: string; value: string }[]> = {};
+    const next: Record<string, Model[]> = {};
     
     typesToFetch.forEach((tp) => {
       const targetType = tp === 'image2text' ? 'chat' : tp;
       const filteredModels = (models?.items || []).filter((m: any) => m.type === targetType);
       next[tp] = filteredModels.map((m: any) => ({
-        label: <Flex gap={4} align="center">
-          <span className="rb:wrap-break-word rb:line-clamp-1">{m.name}</span>
-          {m.is_deprecated && <Tag color="default">{t('modelNew.deprecated')}</Tag>}
-        </Flex>,
-        value: m.id,
+        ...m,
         disabled: m.is_deprecated
       }));
     });
@@ -199,7 +215,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
         
         // If there are options and current field has no value, set first option as default
         if (options.length > 0 && !form.getFieldValue(fieldKey as any)) {
-          defaultValues[fieldKey] = options[0].value;
+          defaultValues[fieldKey] = options[0].id;
         }
       });
       
@@ -310,6 +326,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
     setBaseFields(record || null, actualType);
     getTypeList(record || null);
     setVisible(true);
+    handleGetCustomModels();
   };
 
   const getTypeList = async (record: KnowledgeBaseListItem | null) => {
@@ -333,6 +350,13 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
       setDynamicModelFields(datasets, modelTypeList);
     }
   }, [visible, modelTypeList]);
+
+  const [customModels, setCustomModels] = useState<Record<string, Model[]>>({})
+  const handleGetCustomModels = () => {
+    getCustomWorkspaceModels().then(res => {
+      setCustomModels((res || {}) as Record<string, Model[]>)
+    })
+  }
 
   // Encapsulate save method, add submit logic
   const handleSave = () => {
@@ -679,17 +703,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
       {currentType !== 'Folder' && dynamicTypeList.map((tp) => {
         const fieldKey = typeToFieldKey(tp);
         // When tp is 'llm', merge llm and chat options
-        let options = tp.toLowerCase() === 'llm' || tp.toLowerCase() === 'image2text'
-          ? [...(modelOptionsByType['llm'] || []), ...(modelOptionsByType['chat'] || [])]
-          : modelOptionsByType[tp] || [];
-        
-        // When tp is 'image2text', filter to only include models with 'vision' capability
-        if (tp.toLowerCase() === 'image2text') {
-          options = options.filter((opt: any) => {
-            const model = models?.items?.find((m: any) => m.id === opt.value);
-            return model?.capability?.includes('vision');
-          });
-        }
+        let options = customModels[typeToModelType(tp)] || [];
         return (
           <Form.Item
             key={tp}
@@ -697,12 +711,12 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({
             label={t(`knowledgeBase.createForm.${fieldKey}`) + ' ' + 'model'}
             rules={[{ required: true, message: t('knowledgeBase.createForm.modelRequired') }]}
           >
-            <Select
-              options={options}
+            <ModelSelect
+              fieldNames={{ label: 'name', value: 'id' }}
               placeholder={t(`knowledgeBase.createForm.${fieldKey}`)}
+              isAutoFetch={false}
+              initialData={options}
               allowClear={false}
-              showSearch
-              optionFilterProp="label"
               onChange={(value) => handleChange(value, tp)}
             />
           </Form.Item>

--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -10,14 +10,15 @@
  */
 
 import { type FC, useEffect, useState } from 'react';
-import { Form, App, Button, Skeleton, Select, Flex } from 'antd';
+import { Form, App, Button, Skeleton, Flex } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { SpaceConfigData } from './types'
 import { getWorkspaceModels, updateWorkspaceModels, getDefaultWorkspaceModel, getCustomWorkspaceModels } from '@/api/workspaces'
 import RadioGroupCard from '@/components/RadioGroupCard'
-import type { Capability, ModelListItem } from '@/views/ModelManagement/types'
+import type { Capability, Model } from '@/views/ModelManagement/types'
 import { isPrivateAvailable } from '@/utils/private'
+import ModelSelect from '@/components/ModelSelect'
 
 /** Required base model selectors */
 const baseModelFields: { name: string; label: string; required?: boolean }[] = [
@@ -42,20 +43,20 @@ const SpaceConfig: FC = () => {
 
   const values = Form.useWatch([], form);
 
-  const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
+  const [defaultModels, setDefaultModels] = useState<Record<string, Model>>({})
   const handleGetDefaultModels = () => {
     if (!isPrivateAvailable) {
       return
     }
     getDefaultWorkspaceModel().then(res => {
-      setDefaultModels((res || {}) as Record<string, ModelListItem>)
+      setDefaultModels((res || {}) as Record<string, Model>)
     })
   }
-  const [customModels, setCustomModels] = useState<Record<string, ModelListItem[]>>({})
+  const [customModels, setCustomModels] = useState<Record<string, Model[]>>({})
   const [lastConfig, setLastConfig] = useState<SpaceConfigData>({})
   const handleGetCustomModels = () => {
     getCustomWorkspaceModels().then(res => {
-      setCustomModels((res || {}) as Record<string, ModelListItem[]>)
+      setCustomModels((res || {}) as Record<string, Model[]>)
     })
   }
 
@@ -163,13 +164,11 @@ const SpaceConfig: FC = () => {
                   name={field.name}
                   rules={[{ required: true, message: t('common.pleaseSelect') }]}
                 >
-                  <Select
-                    allowClear
-                    showSearch
-                    optionFilterProp="label"
+                  <ModelSelect
                     fieldNames={{ label: 'name', value: 'id' }}
                     placeholder={t('common.pleaseSelect')}
-                    options={customModels[field.name]}
+                    isAutoFetch={false}
+                    initialData={customModels[field.name]}
                     className="rb:w-137.5!"
                   />
                 </Form.Item>
@@ -186,13 +185,11 @@ const SpaceConfig: FC = () => {
                   className="rb:font-medium rb:text-[#212332] rb:mb-6!"
                   name={field.name}
                 >
-                  <Select
-                    allowClear
-                    showSearch
-                    optionFilterProp="label"
+                  <ModelSelect
                     fieldNames={{ label: 'name', value: 'id' }}
                     placeholder={t('common.pleaseSelect')}
-                    options={customModels[field.name]}
+                    isAutoFetch={false}
+                    initialData={customModels[field.name]}
                     className="rb:w-137.5!"
                   />
                 </Form.Item>

--- a/web/src/views/SpaceManagement/components/SpaceModal.tsx
+++ b/web/src/views/SpaceManagement/components/SpaceModal.tsx
@@ -10,7 +10,7 @@
  */
 
 import { forwardRef, useImperativeHandle, useState } from 'react';
-import { Form, Input, App, Steps, Button, Select, Flex } from 'antd';
+import { Form, Input, App, Steps, Button, Flex } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { SpaceModalData, SpaceModalRef, Space, StorageType } from '../types'
@@ -22,8 +22,9 @@ import { getFileLink } from '@/api/fileStorage'
 import ragIcon from '@/assets/images/space/rag.png'
 import neo4jIcon from '@/assets/images/space/neo4j.png'
 import { stringRegExp } from '@/utils/validator';
-import type { ModelListItem } from '@/views/ModelManagement/types'
+import type { Model } from '@/views/ModelManagement/types'
 import { isPrivateAvailable } from '@/utils/private'
+import ModelSelect from '@/components/ModelSelect'
 
 const FormItem = Form.Item;
 
@@ -64,7 +65,7 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
   const [loading, setLoading] = useState(false)
   const [editVo, setEditVo] = useState<Space | null>(null)
   const [currentStep, setCurrentStep] = useState(0)
-  const [defaultModels, setDefaultModels] = useState<Record<string, ModelListItem>>({})
+  const [defaultModels, setDefaultModels] = useState<Record<string, Model>>({})
 
   const values = Form.useWatch([], form);
 
@@ -85,13 +86,13 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
       return
     }
     getDefaultWorkspaceModel().then(res => {
-      setDefaultModels((res || {}) as Record<string, ModelListItem>)
+      setDefaultModels((res || {}) as Record<string, Model>)
     })
   }
-  const [customModels, setCustomModels] = useState<Record<string, ModelListItem[]>>({})
+  const [customModels, setCustomModels] = useState<Record<string, Model[]>>({})
   const handleGetCustomModels = () => {
     getCustomWorkspaceModels().then(res => {
-      setCustomModels((res || {}) as Record<string, ModelListItem[]>)
+      setCustomModels((res || {}) as Record<string, Model[]>)
     })
   }
   /** Open modal with optional data */
@@ -276,13 +277,11 @@ const SpaceModal = forwardRef<SpaceModalRef, SpaceModalProps>(({
                 name={field.name}
                 rules={[{ required: field.required, message: t('common.selectPlaceholder', { title: t(`space.${field.label}`) }) }]}
               >
-                <Select
-                  allowClear
-                  showSearch
-                  optionFilterProp="label"
+                <ModelSelect
                   fieldNames={{ label: 'name', value: 'id' }}
                   placeholder={t('common.pleaseSelect')}
-                  options={customModels[field.name]}
+                  isAutoFetch={false}
+                  initialData={customModels[field.name]}
                 />
               </Form.Item>
             ))


### PR DESCRIPTION
## Summary by Sourcery

将共享的 ModelSelect 组件和工作区自定义模型数据集成到知识库创建、空间配置和空间管理流程中，以使用带有徽标和一致元数据的模型进行展示。

新功能：
- 在创建知识库时，新增对加载和使用工作区自定义模型的支持。
- 引入「类型到模型类型」的映射机制，用于为不同的知识库模型字段选择合适的自定义模型。

改进：
- 在知识库、空间配置和空间管理表单中，用 ModelSelect 组件替换原有的普通 Select 控件，以实现带徽标展示和弃用状态处理的更丰富模型显示。
- 在空间配置和空间管理的状态中，将类型从 ModelListItem 统一切换为 Model，以实现模型类型统一。
- 在 ModelSelect 中集中处理模型选项聚合逻辑，并通过记忆化的合并选项列表进行优化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate the shared ModelSelect component and workspace custom model data into knowledge base creation, space configuration, and space management flows to display models with logos and consistent metadata.

New Features:
- Add support for loading and using custom workspace models when creating knowledge bases.
- Introduce type-to-model-type mapping to select appropriate custom models for different knowledge base model fields.

Enhancements:
- Replace plain Select controls with the ModelSelect component across knowledge base, space configuration, and space management forms for richer model display with logos and deprecation handling.
- Unify model typing by switching from ModelListItem to Model in space configuration and space management state.
- Centralize model option aggregation logic in ModelSelect using a memoized combined options list.

</details>