### PR TITLE
fix(web): order info

### DIFF
--- a/web/src/views/OrderHistory/components/OrderDetail.tsx
+++ b/web/src/views/OrderHistory/components/OrderDetail.tsx
@@ -51,7 +51,7 @@ const OrderDetail = forwardRef<OrderDetailRef, OrderDetailProps>(({ getProductNa
       {
         key: 'order_no',
         label: t('pricing.order_no'),
-        children: (data as GroupOrder).order_group_id || (data as Order).order_no || '-'
+        children: (data as Order).order_no || '-'
       },
       {
         key: 'business_type',

--- a/web/src/views/OrderHistory/index.tsx
+++ b/web/src/views/OrderHistory/index.tsx
@@ -19,7 +19,7 @@ import { useLocation } from 'react-router-dom';
 import Table, { type TableRef } from '@/components/Table'
 import StatusTag from '@/components/StatusTag'
 import { formatDateTime } from '@/utils/format';
-import type { Order, GroupOrder, OrderDetailRef, Query } from './types'
+import type { Order, GroupOrder, OrderDetailRef, Query, OrderItem } from './types'
 import OrderDetail from './components/OrderDetail'
 import { orderListUrl } from '@/api/package'
 import { useI18n } from '@/store/locale'
@@ -107,13 +107,19 @@ const OrderHistory: React.FC = () => {
   }, [language])
   const getProductName = (data: Order | GroupOrder) => {
     if (!data) return '-'
-    if ((data as GroupOrder).order_group_id && (data as GroupOrder).orders?.length) {
+    if ((data as GroupOrder).orders?.length) {
       return (data as GroupOrder).orders.map((vo) => {
         const billing_units = [(vo.package_snapshot as ResourcePack).tier_snapshot].filter(Boolean)?.map((tier: ResourcePackTier) => {
           return Object.keys(tier.quota_grants).map(vo => `+${t(`package.${vo}`)}: ${tier.quota_grants[vo]}`)
         }).join(', ') || '-'
         return `${vo.package_snapshot[getGroupKeyWithLanguage('name') as keyof Order['package_snapshot']]} (${billing_units})×${vo.multiplier ?? 1}`
       }).join(', ')
+    }
+    if (((data as Order).package_snapshot as ResourcePack)?.billing_units?.length > 0) {
+        const billing_units = [((data as Order).package_snapshot as ResourcePack).tier_snapshot].filter(Boolean)?.map((tier: ResourcePackTier) => {
+          return Object.keys(tier.quota_grants).map(key => `+${t(`package.${key}`)}: ${tier.quota_grants[key]}`)
+        }).join(', ') || '-'
+        return `${((data as Order).package_snapshot as ResourcePack)[getGroupKeyWithLanguage('name') as keyof OrderItem['package_snapshot']]} (${billing_units})×${(data as Order).multiplier ?? 1}`
     }
     if ((data as Order).legacy_product_type) {
       return `${t(`pricing.${getProductType((data as Order).legacy_product_type as string)}.type`)}×${(data as Order).multiplier ?? 1}`
@@ -127,9 +133,6 @@ const OrderHistory: React.FC = () => {
       dataIndex: 'order_no',
       key: 'order_no',
       fixed: 'left',
-      render: (order_no, record) => {
-        return (record as GroupOrder).order_group_id || order_no
-      }
     },
     {
       title: t('pricing.package_snapshot'),
@@ -226,7 +229,7 @@ const OrderHistory: React.FC = () => {
         apiUrl={orderListUrl}
         apiParams={query}
         columns={columns}
-        rowKey={(record) => (record as GroupOrder).order_group_id || (record as Order).id || 'id'}
+        rowKey="order_no"
         isScroll={true}
       />
 

--- a/web/src/views/OrderHistory/types.ts
+++ b/web/src/views/OrderHistory/types.ts
@@ -60,13 +60,11 @@ export interface OrderDetailRef {
 
 export interface OrderItem extends Order {
   resource_pack_instance_id: string | null;
-  order_group_id: string;
   source_type: 'resource_pack' | 'package_plan';
   source_channel: 'direct';
   source_id: string | null;
 }
 export interface GroupOrder {
-  order_group_id: string;
   status: 'pending' | 'approved' | 'rejected';
   order_count: number;
   payable_amount: string;


### PR DESCRIPTION
## Summary by Sourcery

规范订单历史记录中的订单识别与展示方式。

Bug Fixes:
- 确保非组合订单在订单历史中显示正确的套餐名称和计费单元信息。

Enhancements:
- 通过移除组合订单 ID，并统一使用 `order_no` 作为行键，实现列表视图与详情视图中订单号使用的一致性。
- 通过移除未使用的组合订单标识字段，简化订单与组合订单类型的定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize order identification and display for order history records.

Bug Fixes:
- Ensure non-group orders display correct package name and billing unit details in order history.

Enhancements:
- Unify order number usage across list and detail views by removing group order IDs and consistently keying rows by order_no.
- Simplify order and group order type definitions by dropping unused group order identifier fields.

</details>