### PR TITLE
feat(memory): add enable_rerank option for memory search

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -85,7 +85,8 @@ async def read_memory_sync(
                 config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(euid)
             service = await MemoryService.create(config_id, end_user_id=euid)
             memory = await service.read(
-                payload.message, search_switch=SearchStrategy(payload.search_switch)
+                payload.message, search_switch=SearchStrategy(payload.search_switch),
+                enable_rerank=payload.enable_rerank,
             )
             return euid, {
                 "answer": memory.content,
@@ -106,7 +107,9 @@ async def read_memory_sync(
         config_id,
         end_user_id=payload.end_user_id,
     )
-    memory = await service.read(payload.message, search_switch=SearchStrategy(payload.search_switch))
+    memory = await service.read(
+        payload.message, search_switch=SearchStrategy(payload.search_switch),
+        enable_rerank=payload.enable_rerank)
     return success(data={
         "answer": memory.content,
         "intermediate_outputs": [_.model_dump() for _ in memory.memories]
@@ -132,7 +135,8 @@ async def read_memory_internal(
     async with get_async_db_context() as db:
         await validate_end_user_in_workspace_async(db, payload.end_user_id, api_key_auth.workspace_id)
         config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(payload.end_user_id)
-    logger.info(f"V1 memory read (internal) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
+    logger.info(
+        f"V1 memory read (internal) - end_user_id: {payload.end_user_id}, workspace: {api_key_auth.workspace_id}")
 
     # Resolve include strings to Neo4jNodeType enum values
     includes = None
@@ -148,7 +152,8 @@ async def read_memory_internal(
         search_switch=SearchStrategy(payload.search_switch),
         limit=payload.limit,
         includes=includes,
-        skip_summary=payload.skip_summary
+        skip_summary=payload.skip_summary,
+        enable_rerank=payload.enable_rerank,
     )
     return success(data={
         "answer": memory.content,

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -439,6 +439,7 @@ class MemoryService:
             limit: int = 10,
             includes: list | None = None,
             skip_summary: bool = False,
+            enable_rerank: bool = False,
     ) -> MemorySearchResult:
         if history is None:
             history = []
@@ -450,7 +451,8 @@ class MemoryService:
             history,
             limit,
             includes=includes,
-            skip_summary=skip_summary
+            skip_summary=skip_summary,
+            enable_rerank=enable_rerank,
         )
 
     async def forget(self) -> dict:

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -12,6 +12,7 @@ from app.core.memory.read_services.search_engine.content_search import (
     HistorySearchService,
     MetaSearchService
 )
+from app.core.models import RedBearLLM
 from app.db import get_async_db_context
 from app.repositories.memory_short_repository import ShortTermMemoryRepository
 
@@ -41,6 +42,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         self._llm_client = None
         self._vision_llm_client = None
         self._audio_llm_client = None
+        self._rerank_client = None
 
     async def run(
             self,
@@ -49,16 +51,22 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             history: list,
             limit: int = 10,
             includes=None,
-            skip_summary=False
+            skip_summary=False,
+            enable_rerank: bool = False,
     ) -> MemorySearchResult:
         query = QueryPreprocessor.process(query)
         match search_switch:
             case SearchStrategy.DEEP:
-                res = await self._deep_read(query, history, limit, includes=includes, skip_summary=skip_summary)
+                res = await self._deep_read(query, history, limit,
+                                            includes=includes, skip_summary=skip_summary,
+                                            enable_rerank=enable_rerank)
             case SearchStrategy.NORMAL:
-                res = await self._normal_read(query, history, limit, includes=includes, skip_summary=skip_summary)
+                res = await self._normal_read(query, history, limit,
+                                              includes=includes, skip_summary=skip_summary,
+                                              enable_rerank=enable_rerank)
             case SearchStrategy.QUICK:
-                return await self._quick_read(query, limit, includes)
+                return await self._quick_read(query, limit, includes,
+                                              enable_rerank=enable_rerank)
             case SearchStrategy.EXPRESS:
                 return await self._express_read(query, limit, includes)
             case SearchStrategy.RECENT:
@@ -73,7 +81,13 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         return res
 
-    async def _get_search_service(self, includes=None, need_embedder=True, need_llm=True):
+    async def _get_search_service(
+            self,
+            includes=None,
+            need_embedder=True,
+            need_llm=True,
+            enable_rerank: bool = False
+    ):
         if self.ctx.storage_type == StorageType.NEO4J:
             if need_embedder and need_llm:
                 embedder, llm = await asyncio.gather(
@@ -83,10 +97,21 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             else:
                 embedder = (await self._get_embedding_client()) if need_embedder else None
                 llm = (await self._get_llm_client()) if need_llm else None
+
+            reranker = None
+            if enable_rerank:
+                reranker = await self._get_rerank_client()
+                if reranker is None:
+                    logger.warning(
+                        "[ReadPipeLine] enable_rerank=True but rerank_model_id not configured, "
+                        "falling back to score fusion"
+                    )
+
             return Neo4jSearchService(
                 self.ctx,
                 embedder=embedder,
                 llm=llm,
+                reranker=reranker,
                 includes=includes,
             )
         else:
@@ -139,15 +164,34 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         else:
             return None
 
+    async def _get_rerank_client(self):
+        """懒加载 rerank client，仅在 rerank_model_id 已配置时可用。
+
+        Returns:
+            RedBearRerank | None: 如果 rerank_model_id 未配置则返回 None
+        """
+        cfg = self.ctx.memory_config
+        if cfg.rerank_model_id is None:
+            return None
+        if self._rerank_client is None:
+            async with get_async_db_context() as db:
+                self._rerank_client = await self.get_rerank_client_async(
+                    db,
+                    cfg.rerank_model_id,
+                    tenant_id=cfg.tenant_id
+                )
+        return self._rerank_client
+
     async def _deep_read(
             self,
             query: str,
             history: list,
             limit: int,
-            includes=None,
-            skip_summary=False
+            includes: list,
+            skip_summary=False,
+            enable_rerank: bool = False,
     ) -> MemorySearchResult:
-        search_service = await self._get_search_service(includes)
+        search_service = await self._get_search_service(includes, enable_rerank=enable_rerank)
         memory_l0 = await self._user_meta()
         questions = await QueryPreprocessor.split(
             query,
@@ -174,7 +218,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         ]
         if perceptual_memories:
             parse_tasks = []
-            type_llm_cache: dict[int, object] = {}
+            type_llm_cache: dict[int, RedBearLLM] = {}
 
             async def _get_llm_for_type(pt: int):
                 if pt not in type_llm_cache:
@@ -236,9 +280,10 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             history: list,
             limit: int,
             includes=None,
-            skip_summary=False
+            skip_summary=False,
+            enable_rerank: bool = False,
     ) -> MemorySearchResult:
-        search_service = await self._get_search_service(includes)
+        search_service = await self._get_search_service(includes, enable_rerank=enable_rerank)
 
         memory_l0 = await self._user_meta()
         questions = await QueryPreprocessor.split(
@@ -269,9 +314,19 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         memory_l0 = await meta_task
         return memory_l0 + express_res
 
-    async def _quick_read(self, query: str, limit: int, includes=None) -> MemorySearchResult:
+    async def _quick_read(
+            self,
+            query: str,
+            limit: int,
+            includes=None,
+            enable_rerank: bool = False
+    ) -> MemorySearchResult:
         meta_task = asyncio.ensure_future(self._user_meta())
-        search_service = await self._get_search_service(includes, need_llm=False)
+        search_service = await self._get_search_service(
+            includes,
+            need_llm=False,
+            enable_rerank=enable_rerank
+        )
         quick_res = await search_service.hybrid_search(query, limit)
         memory_l0 = await meta_task
         return memory_l0 + quick_res

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -214,10 +214,14 @@ class Neo4jSearchService:
                 )
                 for i, mem in enumerate(memories)
             ]
-
-            reranked = self.reranker.compress_documents(
-                documents, query, top_n=min(limit, len(documents))
-            )
+            reranked = []
+            if documents:
+                reranked = await asyncio.to_thread(
+                    self.reranker.compress_documents,
+                    documents,
+                    query,
+                    top_n=min(limit, len(documents))
+                )
             index_to_score = {
                 doc.metadata["index"]: doc.metadata.get("relevance_score", 0.0)
                 for doc in reranked

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -4,6 +4,7 @@ import logging
 import math
 import uuid
 
+from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables.config import RunnableConfig, var_child_runnable_config
 from sqlalchemy import select
@@ -21,9 +22,10 @@ from app.core.memory.models.service_models import MemoryContext
 from app.core.memory.prompt import prompt_manager
 from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
-from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, make_user_source_lookup_tool
+from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
+    make_user_source_lookup_tool
+from app.core.models import RedBearEmbeddings, RedBearLLM, RedBearRerank
 from app.core.models.llm import StructResponse
-from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.rag.nlp.search import knowledge_retrieval
 from app.db import get_async_db_context
 from app.models import Conversation, MemoryMessage
@@ -42,6 +44,8 @@ DEFAULT_FULLTEXT_SCORE_THRESHOLD = 1.5
 DEFAULT_COSINE_SCORE_THRESHOLD = 0.5
 DEFAULT_CONTENT_SCORE_THRESHOLD = 0.5
 
+MAX_RERANK_CHARS_PER_DOC = 2000
+
 RELATIONSHIP_LOOP_LIMIT = 6
 
 
@@ -51,6 +55,7 @@ class Neo4jSearchService:
             ctx: MemoryContext,
             embedder: RedBearEmbeddings | None = None,
             llm: RedBearLLM | None = None,
+            reranker: RedBearRerank | None = None,
             includes: list[Neo4jNodeType] | None = None,
             alpha: float = DEFAULT_ALPHA,
             fulltext_score_threshold: float = DEFAULT_FULLTEXT_SCORE_THRESHOLD,
@@ -65,6 +70,7 @@ class Neo4jSearchService:
 
         self.embedder: RedBearEmbeddings | None = embedder
         self.llm: RedBearLLM | None = llm
+        self.reranker: RedBearRerank | None = reranker
         self.connector: Neo4jConnector | None = None
 
         self.includes = includes
@@ -161,6 +167,81 @@ class Neo4jSearchService:
         )
         return results
 
+    async def _hybrid_search_with_model_rerank(
+            self,
+            kw_results: dict,
+            emb_results: dict,
+            query: str,
+            limit: int,
+    ) -> list[Memory]:
+        seen: dict[str, dict] = {}
+        for node_type in self.includes:
+            for record in kw_results.get(node_type, []):
+                rid = record.get("id", "")
+                if rid and rid not in seen:
+                    record["_node_type"] = node_type
+                    record["_source"] = "keyword"
+                    seen[rid] = record
+            for record in emb_results.get(node_type, []):
+                rid = record.get("id", "")
+                if rid and rid not in seen:
+                    record["_node_type"] = node_type
+                    record["_source"] = "embedding"
+                    seen[rid] = record
+
+        if not seen:
+            return []
+
+        memories: list[Memory] = []
+        for record in seen.values():
+            node_type = record.pop("_node_type")
+            memory = data_builder_factory(node_type, record)
+            memories.append(Memory(
+                score=memory.score,
+                content=memory.content,
+                data=memory.data,
+                source=node_type,
+                query=query,
+                id=memory.id,
+            ))
+
+        try:
+
+            documents = [
+                Document(
+                    page_content=mem.content[:MAX_RERANK_CHARS_PER_DOC],
+                    metadata={"index": i},
+                )
+                for i, mem in enumerate(memories)
+            ]
+
+            reranked = self.reranker.compress_documents(
+                documents, query, top_n=min(limit, len(documents))
+            )
+            index_to_score = {
+                doc.metadata["index"]: doc.metadata.get("relevance_score", 0.0)
+                for doc in reranked
+            }
+            for i, mem in enumerate(memories):
+                if i in index_to_score:
+                    mem.score = index_to_score[i]
+
+            memories.sort(key=lambda x: x.score, reverse=True)
+            memories = memories[:limit]
+
+            logger.info(
+                f"[Neo4jSearch] Model rerank applied: {len(documents)} → {len(memories)} memories"
+            )
+        except Exception as e:
+            logger.warning(
+                f"[Neo4jSearch] Model rerank failed, falling back to content_score: {e}",
+                exc_info=True,
+            )
+            memories.sort(key=lambda x: x.score, reverse=True)
+            memories = memories[:limit]
+
+        return memories
+
     def _normalize_kw_scores(self, items: list[dict]) -> list[dict]:
         if not items:
             return items
@@ -229,25 +310,32 @@ class Neo4jSearchService:
             logger.warning(f"[MemorySearch] embedding search error: {emb_results}")
             emb_results = {}
 
-        memories = []
-        for node_type in self.includes:
-            reranked = self._rerank(
-                kw_results.get(node_type, []),
-                emb_results.get(node_type, []),
-                limit
+        if self.reranker is not None:
+            memories = await self._hybrid_search_with_model_rerank(
+                kw_results, emb_results, query, limit
             )
-            for record in reranked:
-                memory = data_builder_factory(node_type, record)
-                memories.append(Memory(
-                    score=memory.score,
-                    content=memory.content,
-                    data=memory.data,
-                    source=node_type,
-                    query=query,
-                    id=memory.id
-                ))
-        memories.sort(key=lambda x: x.score, reverse=True)
-        return MemorySearchResult(memories=memories[:limit])
+        else:
+            memories = []
+            for node_type in self.includes:
+                reranked = self._rerank(
+                    kw_results.get(node_type, []),
+                    emb_results.get(node_type, []),
+                    limit
+                )
+                for record in reranked:
+                    memory = data_builder_factory(node_type, record)
+                    memories.append(Memory(
+                        score=memory.score,
+                        content=memory.content,
+                        data=memory.data,
+                        source=node_type,
+                        query=query,
+                        id=memory.id
+                    ))
+            memories.sort(key=lambda x: x.score, reverse=True)
+            memories = memories[:limit]
+
+        return MemorySearchResult(memories=memories)
 
     async def _run_relation_agent(self, query: str) -> RelationSearchResult:
         system_prompt = prompt_manager.render(

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -61,7 +61,8 @@ class StatementBuiler(BaseBuilder):
             "id": self.record.get("id"),
             "content": self.record.get("statement"),
             "kw_score": self.record.get("kw_score", 0.0),
-            "emb_score": self.record.get("embedding_score", 0.0)
+            "emb_score": self.record.get("embedding_score", 0.0),
+            "chunk_id": self.record.get("chunk_id", ""),
         }
 
     @property
@@ -118,7 +119,8 @@ class SummaryBuilder(BaseBuilder):
             "id": self.record.get("id"),
             "content": self.record.get("content"),
             "kw_score": self.record.get("kw_score", 0.0),
-            "emb_score": self.record.get("embedding_score", 0.0)
+            "emb_score": self.record.get("embedding_score", 0.0),
+            "chunk_ids": self.record.get("chunk_ids", []),
         }
 
     @property

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -55,6 +55,7 @@ class ReadSyncInput(BaseModel):
     end_user_ids: Optional[List[str]] = None
     session_id: uuid.UUID = Field(default_factory=uuid.uuid4)
     config_id: Optional[str] = None
+    enable_rerank: bool = Field(default=False)
 
     @model_validator(mode='after')
     def check_at_least_one_id(self):
@@ -78,6 +79,7 @@ class InternalReadInput(BaseModel):
     )
     limit: int = Field(default=10, description="返回的记忆数量上限", ge=1, le=100)
     skip_summary: bool = Field(default=False, description="跳过摘要")
+    enable_rerank: bool = Field(default=False)
 
 
 class WriteMessageItem(BaseModel):


### PR DESCRIPTION
- Add enable_rerank field to MemorySearchPayload and MemoryReadPayload schemas
- Pass enable_rerank through memory read pipeline to search services
- Implement lazy-loaded rerank client with configurable rerank_model_id
- Add model-based reranking in content search with hybrid fusion fallback

## Summary by Sourcery

为记忆搜索添加可选的基于模型的重排功能，并在记忆读取管线和 API 中贯穿一个新的 `enable_rerank` 标志。

New Features:
- 在记忆读取负载（payload）上引入 `enable_rerank` 标志，以在记忆搜索中切换基于模型的重排功能。
- 添加一个惰性加载的重排客户端，由配置的 `rerank_model_id` 驱动，并将其传入基于 Neo4j 的搜索服务。
- 实现对混合关键词/向量嵌入内容搜索结果的模型驱动重排，并在重排不可用时提供基于分数融合的回退机制。

Enhancements:
- 在搜索结果构建器中包含额外的块（chunk）标识符元数据，以在记忆搜索结果中携带块级信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional model-based reranking to memory search and wire a new enable_rerank flag through the memory read pipeline and APIs.

New Features:
- Introduce an enable_rerank flag on memory read payloads to toggle model-based reranking in memory search.
- Add a lazy-loaded rerank client driven by configured rerank_model_id and pass it into Neo4j-based search services.
- Implement model-driven reranking of hybrid keyword/embedding content search results with score-fusion fallback when reranking is unavailable.

Enhancements:
- Include additional chunk identifier metadata in search result builders to carry chunk-level information through memory search results.

</details>