### PR TITLE
refactor(cache): simplify Redis cache operations and add async invalidation for workflow config

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -1697,6 +1697,7 @@ async def update_workflow_config(
         db: Annotated[Session, Depends(get_db)],
         current_user: Annotated[User, Depends(get_current_user)]
 ):
+    from app.utils.redis_cache import delete_json_async, workflow_config_key
     workspace_id = current_user.current_workspace_id
     if payload.variables:
         from app.services.workflow_service import WorkflowService
@@ -1707,6 +1708,9 @@ async def update_workflow_config(
         for var_def, resolved_def in zip(payload.variables, resolved):
             var_def.default = resolved_def.get("default", var_def.default)
     cfg = app_service.update_workflow_config(db, app_id=app_id, data=payload, workspace_id=workspace_id)
+    cache_key = workflow_config_key(app_id)
+    deleted = await delete_json_async(cache_key)
+    logger.info(f"[cache] invalidate workflow config: key={cache_key}, deleted={deleted}")
     return success(data=WorkflowConfigSchema.model_validate(cfg))
 
 

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -1709,8 +1709,8 @@ async def update_workflow_config(
             var_def.default = resolved_def.get("default", var_def.default)
     cfg = app_service.update_workflow_config(db, app_id=app_id, data=payload, workspace_id=workspace_id)
     cache_key = workflow_config_key(app_id)
-    deleted = await delete_json_async(cache_key)
-    logger.info(f"[cache] invalidate workflow config: key={cache_key}, deleted={deleted}")
+    await delete_json_async(cache_key)
+    logger.info(f"[cache] invalidate workflow config: key={cache_key}")
     return success(data=WorkflowConfigSchema.model_validate(cfg))
 
 

--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -37,6 +37,7 @@ from app.services.workflow_import_service import WorkflowImportService
 from app.services.workflow_service import WorkflowService, get_workflow_service
 from app.services.app_dsl_service import AppDslService
 from app.core.quota_stub import check_app_quota
+from app.utils.redis_cache import delete_json_async, workflow_config_key
 
 router = APIRouter(prefix="/apps", tags=["Apps"])
 logger = get_business_logger()
@@ -1697,7 +1698,6 @@ async def update_workflow_config(
         db: Annotated[Session, Depends(get_db)],
         current_user: Annotated[User, Depends(get_current_user)]
 ):
-    from app.utils.redis_cache import delete_json_async, workflow_config_key
     workspace_id = current_user.current_workspace_id
     if payload.variables:
         from app.services.workflow_service import WorkflowService

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1793,7 +1793,6 @@ class AppService:
 
         self.db.commit()
         self.db.refresh(workflow_cfg)
-        delete_json(workflow_config_key(app_id))
 
         logger.info("Workflow 配置更新成功", extra={"app_id": str(app_id)})
         return workflow_cfg

--- a/api/app/utils/redis_cache.py
+++ b/api/app/utils/redis_cache.py
@@ -450,11 +450,7 @@ def set_json(key: str, value: Any, ttl: int) -> None:
 
 def delete_json(key: str) -> None:
     try:
-        r = get_thread_safe_sync_redis()
-        result = r.delete(key)
-        cp = r.connection_pool.connection_kwargs
-        logger.info("[cache:delete_json] key=%s deleted=%s host=%s port=%s db=%s",
-                    key, result, cp.get("host"), cp.get("port"), cp.get("db"))
+        get_thread_safe_sync_redis().delete(key)
     except Exception:
         logger.warning("Redis cache invalidation failed: key=%s", key, exc_info=True)
 
@@ -472,23 +468,15 @@ async def get_json_async(key: str) -> Any:
 
 async def set_json_async(key: str, value: Any, ttl: int) -> None:
     try:
-        r = get_thread_safe_redis()
         payload = json.dumps(value, ensure_ascii=False, default=str, separators=(",", ":"))
-        await r.set(key, payload, ex=ttl_with_jitter(ttl))
-        cp = r.connection_pool.connection_kwargs
-        logger.info("[cache:set_json_async] key=%s host=%s port=%s db=%s",
-                    key, cp.get("host"), cp.get("port"), cp.get("db"))
+        await get_thread_safe_redis().set(key, payload, ex=ttl_with_jitter(ttl))
     except Exception:
         logger.warning("Redis async cache write failed: key=%s", key, exc_info=True)
 
 
 async def delete_json_async(key: str) -> None:
     try:
-        r = get_thread_safe_redis()
-        result = await r.delete(key)
-        cp = r.connection_pool.connection_kwargs
-        logger.info("[cache:delete_json_async] key=%s deleted=%s host=%s port=%s db=%s",
-                    key, result, cp.get("host"), cp.get("port"), cp.get("db"))
+        await get_thread_safe_redis().delete(key)
     except Exception:
         logger.warning("Redis async cache invalidation failed: key=%s", key, exc_info=True)
 


### PR DESCRIPTION
- Removed redundant Redis connection logging and variable assignments in redis_cache.py
- Replaced synchronous cache deletion with asynchronous deletion in app_controller.py for workflow config updates
- Removed redundant synchronous cache deletion in app_service.py

## Summary by Sourcery

简化 Redis 缓存辅助工具的使用，并将工作流配置缓存失效的逻辑在控制器中改为异步路径。

Enhancements:
- 精简 Redis JSON 缓存辅助方法，移除多余变量，以及在 set/delete 操作时的连接级日志记录。
- 将工作流配置缓存失效切换为在控制器中使用异步 Redis 删除，并移除之前在服务层中的同步失效逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify Redis cache helper usage and move workflow configuration cache invalidation to an asynchronous path in the controller.

Enhancements:
- Streamline Redis JSON cache helpers by removing redundant variables and connection-level logging for set/delete operations.
- Switch workflow configuration cache invalidation to use asynchronous Redis deletion in the controller and remove the previous synchronous invalidation from the service layer.

</details>