### PR TITLE
fix(app): invalidate workflow config cache after update

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -1708,9 +1708,9 @@ async def update_workflow_config(
         for var_def, resolved_def in zip(payload.variables, resolved):
             var_def.default = resolved_def.get("default", var_def.default)
     cfg = app_service.update_workflow_config(db, app_id=app_id, data=payload, workspace_id=workspace_id)
-    cache_key = workflow_config_key(app_id)
-    await delete_json_async(cache_key)
-    logger.info(f"[cache] invalidate workflow config: key={cache_key}")
+    # cache_key = workflow_config_key(app_id)
+    # await delete_json_async(cache_key)
+    # logger.info(f"[cache] invalidate workflow config: key={cache_key}")
     return success(data=WorkflowConfigSchema.model_validate(cfg))
 
 

--- a/api/app/services/app_service.py
+++ b/api/app/services/app_service.py
@@ -1793,6 +1793,7 @@ class AppService:
 
         self.db.commit()
         self.db.refresh(workflow_cfg)
+        delete_json(workflow_config_key(app_id))
 
         logger.info("Workflow 配置更新成功", extra={"app_id": str(app_id)})
         return workflow_cfg


### PR DESCRIPTION
The cache invalidation logic was moved from the controller to the service layer to ensure consistency and reliability. The async cache deletion is replaced with synchronous deletion in the service, and related logging is updated accordingly.

## Summary by Sourcery

Bug Fixes:
- 通过在服务层处理中删除操作，确保在更新后能够可靠地立即失效工作流配置缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure workflow configuration cache is reliably invalidated immediately after updates by handling deletion in the service layer.

</details>