### PR TITLE
fix(rag): remove Elasticsearch result window limits

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -63,6 +63,69 @@ def _dispatch_document_graph_sync_best_effort(
         return None
 
 
+def _list_all_segments(vector_service: Any, **kwargs: Any) -> list[DocumentChunk]:
+    return list(vector_service.iter_by_segment(**kwargs))
+
+
+def _load_parent_fallback_page(
+    vector_service: Any,
+    *,
+    document_id: str,
+    keywords: str | None,
+    page: int,
+    pagesize: int,
+) -> tuple[
+    int,
+    list[DocumentChunk],
+    int,
+    list[DocumentChunk],
+    list[DocumentChunk],
+]:
+    offset = (page - 1) * pagesize
+    end = offset + pagesize
+    total_all = 0
+    total_parents = 0
+    flat_page: list[DocumentChunk] = []
+    parent_page: list[DocumentChunk] = []
+
+    for item in vector_service.iter_by_segment(
+        document_id=document_id,
+        query=keywords,
+        asc=True,
+    ):
+        if offset <= total_all < end:
+            flat_page.append(item)
+        if (item.metadata or {}).get("chunk_type") == "parent":
+            if offset <= total_parents < end:
+                parent_page.append(item)
+            total_parents += 1
+        total_all += 1
+
+    if total_parents == 0 or not parent_page:
+        return total_all, flat_page, total_parents, parent_page, []
+
+    parent_doc_ids = {
+        item.metadata.get("doc_id")
+        for item in parent_page
+        if item.metadata and item.metadata.get("doc_id")
+    }
+    selected_children: list[DocumentChunk] = []
+    if parent_doc_ids:
+        for item in vector_service.iter_by_segment(
+            document_id=document_id,
+            query=keywords,
+            asc=True,
+        ):
+            metadata = item.metadata or {}
+            if (
+                metadata.get("chunk_type") == "child"
+                and metadata.get("parent_id") in parent_doc_ids
+            ):
+                selected_children.append(item)
+
+    return total_all, flat_page, total_parents, parent_page, selected_children
+
+
 def _build_image2text_vision_model(db: Session, image2text_id: uuid.UUID, tenant_id: uuid.UUID):
     if not image2text_id:
         raise HTTPException(
@@ -534,8 +597,7 @@ async def get_chunks(
         api_logger.debug("Start executing document chunk query")
         vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
         if db_document.is_parent_child_mode:
-            # 方案 1：两次查询 + parent 级分页
-            # 4.1 查询 parent chunks（按 sort_id 排序，分页）
+            # Query parent chunks first and paginate at the parent level.
             total_parents, parent_items = await asyncio.to_thread(
                 vector_service.search_by_segment,
                 document_id=str(document_id),
@@ -546,25 +608,28 @@ async def get_chunks(
                 chunk_types="parent",
             )
 
-            # fallback：如果 parent 查询为空（旧数据或 chunk_type 缺失），查所有 chunks 在内存中区分
+            # Fall back to metadata chunk types for legacy indexes.
             if not parent_items and total_parents == 0:
                 api_logger.debug("Parent query returned empty, falling back to query all chunks")
-                total_all, all_items = await asyncio.to_thread(
-                    vector_service.search_by_segment,
+                (
+                    total_all,
+                    flat_page,
+                    total_parents,
+                    parent_items,
+                    child_items_fallback,
+                ) = await asyncio.to_thread(
+                    _load_parent_fallback_page,
+                    vector_service,
                     document_id=str(document_id),
-                    query=keywords,
-                    pagesize=10000,
-                    page=1,
-                    asc=True,
+                    keywords=keywords,
+                    page=page,
+                    pagesize=pagesize,
                 )
-                parent_items = [item for item in all_items if (item.metadata or {}).get("chunk_type") == "parent"]
-                child_items_fallback = [item for item in all_items if (item.metadata or {}).get("chunk_type") == "child"]
-                total_parents = len(parent_items)
 
-                if not parent_items:
-                    # 仍然没有 parent，按普通分块模式返回
+                if total_parents == 0:
+                    # Return a flat page when the document has no parent chunks.
                     result = {
-                        "items": all_items[(page - 1) * pagesize : page * pagesize],
+                        "items": flat_page,
                         "page": {
                             "page": page,
                             "pagesize": pagesize,
@@ -574,27 +639,27 @@ async def get_chunks(
                     }
                     return success(data=jsonable_encoder(result), msg="Query of document chunk list succeeded")
 
-                # 内存分页 + 组装
-                paginated_parents = parent_items[(page - 1) * pagesize : page * pagesize]
                 result = _build_nested_result(
-                    paginated_parents, child_items_fallback, page, pagesize, total_parents
+                    parent_items, child_items_fallback, page, pagesize, total_parents
                 )
                 return success(data=jsonable_encoder(result), msg="Query of document chunk list succeeded")
 
             parent_doc_ids = [p.metadata["doc_id"] for p in parent_items]
 
-            # 4.2 查询这些 parent 下的所有 child chunks（按 sort_id 排序，不分页）
-            _, child_items = await asyncio.to_thread(
-                vector_service.search_by_segment,
-                document_id=str(document_id),
-                pagesize=10000,
-                page=1,
-                asc=True,
-                chunk_types="child",
-                parent_ids=parent_doc_ids,
-            )
+            # Load every child for the selected parent page.
+            if parent_doc_ids:
+                child_items = await asyncio.to_thread(
+                    _list_all_segments,
+                    vector_service,
+                    document_id=str(document_id),
+                    asc=True,
+                    chunk_types="child",
+                    parent_ids=parent_doc_ids,
+                )
+            else:
+                child_items = []
 
-            # 4.3 组装嵌套结构
+            # Assemble the parent-child response without changing its schema.
             result = _build_nested_result(parent_items, child_items, page, pagesize, total_parents)
         else:
             # 普通分块模式：原有逻辑

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -113,7 +113,6 @@ def _load_parent_fallback_page(
     if parent_doc_ids:
         for item in vector_service.iter_by_segment(
             document_id=document_id,
-            query=keywords,
             asc=True,
         ):
             metadata = item.metadata or {}

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -67,64 +67,6 @@ def _list_all_segments(vector_service: Any, **kwargs: Any) -> list[DocumentChunk
     return list(vector_service.iter_by_segment(**kwargs))
 
 
-def _load_parent_fallback_page(
-    vector_service: Any,
-    *,
-    document_id: str,
-    keywords: str | None,
-    page: int,
-    pagesize: int,
-) -> tuple[
-    int,
-    list[DocumentChunk],
-    int,
-    list[DocumentChunk],
-    list[DocumentChunk],
-]:
-    offset = (page - 1) * pagesize
-    end = offset + pagesize
-    total_all = 0
-    total_parents = 0
-    flat_page: list[DocumentChunk] = []
-    parent_page: list[DocumentChunk] = []
-
-    for item in vector_service.iter_by_segment(
-        document_id=document_id,
-        query=keywords,
-        asc=True,
-    ):
-        if offset <= total_all < end:
-            flat_page.append(item)
-        if (item.metadata or {}).get("chunk_type") == "parent":
-            if offset <= total_parents < end:
-                parent_page.append(item)
-            total_parents += 1
-        total_all += 1
-
-    if total_parents == 0 or not parent_page:
-        return total_all, flat_page, total_parents, parent_page, []
-
-    parent_doc_ids = {
-        item.metadata.get("doc_id")
-        for item in parent_page
-        if item.metadata and item.metadata.get("doc_id")
-    }
-    selected_children: list[DocumentChunk] = []
-    if parent_doc_ids:
-        for item in vector_service.iter_by_segment(
-            document_id=document_id,
-            asc=True,
-        ):
-            metadata = item.metadata or {}
-            if (
-                metadata.get("chunk_type") == "child"
-                and metadata.get("parent_id") in parent_doc_ids
-            ):
-                selected_children.append(item)
-
-    return total_all, flat_page, total_parents, parent_page, selected_children
-
-
 def _build_image2text_vision_model(db: Session, image2text_id: uuid.UUID, tenant_id: uuid.UUID):
     if not image2text_id:
         raise HTTPException(
@@ -617,10 +559,9 @@ async def get_chunks(
                     parent_items,
                     child_items_fallback,
                 ) = await asyncio.to_thread(
-                    _load_parent_fallback_page,
-                    vector_service,
+                    vector_service.load_parent_child_fallback_page,
                     document_id=str(document_id),
-                    keywords=keywords,
+                    query=keywords,
                     page=page,
                     pagesize=pagesize,
                 )

--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from typing import Any, Optional
 import uuid
@@ -6,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile,
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import Response, StreamingResponse
 from sqlalchemy.orm import Session
+from starlette.background import BackgroundTask
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
@@ -23,7 +25,11 @@ from app.services.file_storage_service import (
     generate_kb_file_key,
     get_file_storage_service,
 )
-from app.services.file_service import _is_qa_doc, _build_qa_export
+from app.services.file_service import _is_qa_doc
+from app.services.qa_export_service import (
+    cleanup_qa_export_file,
+    iter_qa_export_file_chunks,
+)
 from app.core.quota_stub import check_knowledge_capacity_quota
 
 api_logger = get_api_logger()
@@ -222,15 +228,20 @@ async def get_file(
 
     # QA 文档：默认从 ES 导出修改后的内容
     if not original and _is_qa_doc(db, file_id):
-        result = _build_qa_export(db, file_id, db_file.kb_id)
-        if result:
-            content, filename, media_type = result
-            from urllib.parse import quote
-            return Response(
-                content=content,
-                media_type=media_type,
-                headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}"}
+        qa_export_spec = file_service.get_qa_export_spec(db, file_id, db_file.kb_id)
+        if qa_export_spec:
+            export_file = await asyncio.to_thread(
+                file_service.build_qa_export_file,
+                qa_export_spec,
             )
+            if export_file:
+                from urllib.parse import quote
+                return StreamingResponse(
+                    iter_qa_export_file_chunks(export_file.path),
+                    media_type=export_file.media_type,
+                    headers={"Content-Disposition": f"attachment; filename*=UTF-8''{quote(export_file.filename)}"},
+                    background=BackgroundTask(cleanup_qa_export_file, export_file.path),
+                )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="QA document has no exportable content")
 
     if not db_file.file_key:
@@ -281,21 +292,23 @@ async def batch_download_files(
             detail="所选文件均无有效存储Key",
         )
 
-    # 预取 QA 文档内容，非 QA 文档走原下载逻辑
-    pre_fetched: dict[str, bytes] = {}
+    qa_export_specs: dict[str, file_service.QAExportSpec] = {}
     for f in valid_files:
-        if _is_qa_doc(db, f.id):
-            result = _build_qa_export(db, f.id, f.kb_id)
-            if result:
-                content, _, _ = result
-                pre_fetched[f.file_key] = content
+        qa_export_spec = file_service.get_qa_export_spec(db, f.id, f.kb_id)
+        if qa_export_spec:
+            qa_export_specs[f.file_key] = qa_export_spec
 
     entries = file_service.build_zip_arcnames(valid_files)
     zip_name = file_service.make_zip_filename(valid_files, request_body.zip_filename)
 
     from urllib.parse import quote
     return StreamingResponse(
-        file_service.stream_zip_files(entries, storage_service, api_logger, pre_fetched),
+        file_service.stream_zip_files(
+            entries,
+            storage_service,
+            api_logger,
+            qa_export_specs=qa_export_specs,
+        ),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -9,6 +9,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTask
 
 from app.core.utils.datetime_utils import utcnow_naive
 from app.celery_app import celery_app
@@ -55,10 +56,12 @@ from app.services import file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.model_service import ModelApiKeyService, ModelConfigService
 from app.services.qa_export_service import (
-    iter_qa_csv_chunks,
+    cleanup_qa_csv_export_file,
+    iter_qa_csv_file_chunks,
     iter_qa_pairs_by_document,
     make_qa_export_filename,
     render_qa_pairs_export,
+    write_qa_csv_export_file,
 )
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -515,12 +518,15 @@ async def export_knowledge_qa_csv(
 
     from urllib.parse import quote
 
+    export_path = await asyncio.to_thread(write_qa_csv_export_file, kb_id)
+
     return StreamingResponse(
-        iter_qa_csv_chunks(kb_id),
+        iter_qa_csv_file_chunks(export_path),
         media_type="text/csv; charset=utf-8",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(filename)}",
         },
+        background=BackgroundTask(cleanup_qa_csv_export_file, export_path),
     )
 
 

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -1,7 +1,5 @@
-import csv as csv_module
 import asyncio
 import datetime
-import io
 import json
 from typing import Optional
 import uuid
@@ -60,6 +58,7 @@ from app.services.qa_export_service import (
     iter_qa_csv_chunks,
     iter_qa_pairs_by_document,
     make_qa_export_filename,
+    render_qa_pairs_export,
 )
 from app.core.quota_stub import check_knowledge_capacity_quota
 
@@ -89,31 +88,15 @@ def _build_qa_export_content(
     document_id: uuid.UUID | str,
     file_ext: str | None,
 ) -> bytes | None:
-    qa_pairs = list(iter_qa_pairs_by_document(kb_id, document_id))
-
-    if not qa_pairs:
+    rendered = render_qa_pairs_export(
+        list(iter_qa_pairs_by_document(kb_id, document_id)),
+        file_ext,
+    )
+    if rendered is None:
         return None
 
-    file_ext_lower = file_ext.lower() if file_ext else ".csv"
-    if file_ext_lower in (".xlsx", ".xls"):
-        import openpyxl
-
-        wb = openpyxl.Workbook()
-        ws = wb.active
-        ws.append(["question", "answer"])
-        for pair in qa_pairs:
-            ws.append([pair["question"], pair["answer"]])
-        output = io.BytesIO()
-        wb.save(output)
-        wb.close()
-        return output.getvalue()
-
-    text_output = io.StringIO()
-    writer = csv_module.writer(text_output)
-    writer.writerow(["question", "answer"])
-    for pair in qa_pairs:
-        writer.writerow([pair["question"], pair["answer"]])
-    return text_output.getvalue().encode("utf-8-sig")
+    content, _ = rendered
+    return content
 
 
 async def _dispatch_reparse_tasks_for_knowledge_async(

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -3,7 +3,7 @@ import asyncio
 import datetime
 import io
 import json
-from typing import Any, Optional
+from typing import Optional
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
@@ -40,10 +40,7 @@ from app.core.rag.retrieval.async_elasticsearch import (
     AsyncElasticsearchClientProvider,
 )
 from app.core.rag.utils.redis_conn import REDIS_CONN
-from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
-    ElasticSearchVectorFactory,
-    ElasticSearchVectorIndexOps,
-)
+from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorIndexOps
 from app.core.response_utils import success, fail
 from app.db import get_async_db, get_async_db_context
 from app.dependencies import get_current_user_async
@@ -59,7 +56,11 @@ from app.services import knowledge_service, document_service
 from app.services import file_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.model_service import ModelApiKeyService, ModelConfigService
-from app.services.qa_export_service import iter_qa_csv_chunks, make_qa_export_filename
+from app.services.qa_export_service import (
+    iter_qa_csv_chunks,
+    iter_qa_pairs_by_document,
+    make_qa_export_filename,
+)
 from app.core.quota_stub import check_knowledge_capacity_quota
 
 # Obtain a dedicated API logger
@@ -83,17 +84,12 @@ router = APIRouter(
 )
 
 
-def _build_qa_export_content(vector_service: Any, document_id: uuid.UUID | str, file_ext: str | None) -> bytes | None:
-    _, items = vector_service.search_by_segment(
-        document_id=str(document_id), pagesize=10000, page=1, asc=True
-    )
-    qa_pairs = []
-    for item in items:
-        if (item.metadata or {}).get("chunk_type") == "qa":
-            qa_pairs.append({
-                "question": (item.metadata or {}).get("question", ""),
-                "answer": (item.metadata or {}).get("answer", ""),
-            })
+def _build_qa_export_content(
+    kb_id: uuid.UUID | str,
+    document_id: uuid.UUID | str,
+    file_ext: str | None,
+) -> bytes | None:
+    qa_pairs = list(iter_qa_pairs_by_document(kb_id, document_id))
 
     if not qa_pairs:
         return None
@@ -575,15 +571,11 @@ async def kb_batch_download(
             raise BusinessException("该知识库下没有可下载的文件", BizCode.NOT_FOUND)
 
         qa_export_specs = []
-        qa_vector_service = None
         for f in files:
             doc_result = await db.execute(select(Document).where(Document.file_id == f.id))
             doc = doc_result.scalars().first()
             if doc and (doc.parser_config or {}).get("doc_type") == "qa":
-                if doc:
-                    if qa_vector_service is None:
-                        qa_vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
-                    qa_export_specs.append((f.file_key, f.file_ext, doc.id, qa_vector_service))
+                qa_export_specs.append((f.file_key, f.file_ext, doc.id, kb_id))
 
         entries = file_service.build_zip_arcnames(files)
         zip_name = file_service.make_zip_filename(files, request_body.zip_filename, base_name=db_knowledge.name)
@@ -591,8 +583,13 @@ async def kb_batch_download(
 
     # Prefetch QA document content before streaming so the generator does not hold a DB session.
     pre_fetched: dict[str, bytes] = {}
-    for file_key, file_ext, document_id, vector_service in qa_export_specs:
-        content = await asyncio.to_thread(_build_qa_export_content, vector_service, document_id, file_ext)
+    for file_key, file_ext, document_id, knowledge_id in qa_export_specs:
+        content = await asyncio.to_thread(
+            _build_qa_export_content,
+            knowledge_id,
+            document_id,
+            file_ext,
+        )
         if content:
             pre_fetched[file_key] = content
 

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -58,9 +58,7 @@ from app.services.model_service import ModelApiKeyService, ModelConfigService
 from app.services.qa_export_service import (
     cleanup_qa_csv_export_file,
     iter_qa_csv_file_chunks,
-    iter_qa_pairs_by_document,
     make_qa_export_filename,
-    render_qa_pairs_export,
     write_qa_csv_export_file,
 )
 from app.core.quota_stub import check_knowledge_capacity_quota
@@ -84,22 +82,6 @@ router = APIRouter(
     tags=["knowledges"],
     dependencies=[Depends(get_current_user_async)]  # Apply auth to all routes in this controller
 )
-
-
-def _build_qa_export_content(
-    kb_id: uuid.UUID | str,
-    document_id: uuid.UUID | str,
-    file_ext: str | None,
-) -> bytes | None:
-    rendered = render_qa_pairs_export(
-        list(iter_qa_pairs_by_document(kb_id, document_id)),
-        file_ext,
-    )
-    if rendered is None:
-        return None
-
-    content, _ = rendered
-    return content
 
 
 async def _dispatch_reparse_tasks_for_knowledge_async(
@@ -559,32 +541,30 @@ async def kb_batch_download(
         if not files:
             raise BusinessException("该知识库下没有可下载的文件", BizCode.NOT_FOUND)
 
-        qa_export_specs = []
+        qa_export_specs: dict[str, file_service.QAExportSpec] = {}
         for f in files:
             doc_result = await db.execute(select(Document).where(Document.file_id == f.id))
             doc = doc_result.scalars().first()
             if doc and (doc.parser_config or {}).get("doc_type") == "qa":
-                qa_export_specs.append((f.file_key, f.file_ext, doc.id, kb_id))
+                qa_export_specs[f.file_key] = file_service.QAExportSpec(
+                    kb_id=kb_id,
+                    document_id=doc.id,
+                    file_ext=f.file_ext,
+                    file_name=f.file_name,
+                )
 
         entries = file_service.build_zip_arcnames(files)
         zip_name = file_service.make_zip_filename(files, request_body.zip_filename, base_name=db_knowledge.name)
         total_files = len(files)
 
-    # Prefetch QA document content before streaming so the generator does not hold a DB session.
-    pre_fetched: dict[str, bytes] = {}
-    for file_key, file_ext, document_id, knowledge_id in qa_export_specs:
-        content = await asyncio.to_thread(
-            _build_qa_export_content,
-            knowledge_id,
-            document_id,
-            file_ext,
-        )
-        if content:
-            pre_fetched[file_key] = content
-
     from urllib.parse import quote
     return StreamingResponse(
-        file_service.stream_zip_files(entries, storage_service, api_logger, pre_fetched),
+        file_service.stream_zip_files(
+            entries,
+            storage_service,
+            api_logger,
+            qa_export_specs=qa_export_specs,
+        ),
         media_type="application/zip",
         headers={
             "Content-Disposition": f"attachment; filename*=UTF-8''{quote(zip_name)}",

--- a/api/app/core/rag/graphrag/general/index.py
+++ b/api/app/core/rag/graphrag/general/index.py
@@ -122,6 +122,32 @@ async def run_graphrag(
     return
 
 
+def _load_graphrag_document_chunks(
+    vector_service: ElasticSearchVector,
+    document_id: str,
+) -> list[str]:
+    from app.core.rag.common.token_utils import num_tokens_from_string
+
+    chunks: list[str] = []
+    current_chunk = ""
+    for document in vector_service.iter_by_segment(
+        document_id=str(document_id),
+        asc=True,
+    ):
+        if (document.metadata or {}).get("chunk_type") == "qa":
+            continue
+        content = document.page_content or ""
+        if num_tokens_from_string(current_chunk + content) < 1024:
+            current_chunk += content
+        else:
+            if current_chunk:
+                chunks.append(current_chunk)
+            current_chunk = content
+    if current_chunk:
+        chunks.append(current_chunk)
+    return chunks
+
+
 async def run_graphrag_for_kb(
     row: dict,
     document_ids: list[str],
@@ -145,34 +171,14 @@ async def run_graphrag_for_kb(
         callback(msg=f"[GraphRAG] kb:{kb_id} has no processable document_id.")
         return {"ok_documents": [], "failed_documents": [], "total_documents": 0, "total_chunks": 0, "seconds": 0.0}
 
-    def load_doc_chunks(document_id: str) -> list[str]:
-        from app.core.rag.common.token_utils import num_tokens_from_string
-
-        chunks = []
-        current_chunk = ""
-
-        total, items = vector_service.search_by_segment(document_id=str(document_id), query=None, pagesize=9999, page=1, asc=True)
-        for doc in items:
-            # 跳过 QA chunks，只用原文 chunks 构建图谱
-            if (doc.metadata or {}).get("chunk_type") == "qa":
-                continue
-            content = doc.page_content
-            if num_tokens_from_string(current_chunk + content) < 1024:
-                current_chunk += content
-            else:
-                if current_chunk:
-                    chunks.append(current_chunk)
-                current_chunk = content
-
-        if current_chunk:
-            chunks.append(current_chunk)
-
-        return chunks
-
     all_document_chunks: dict[str, list[str]] = {}
     total_chunks = 0
     for document_id in document_ids:
-        chunks = load_doc_chunks(document_id)
+        chunks = await trio.to_thread.run_sync(
+            _load_graphrag_document_chunks,
+            vector_service,
+            document_id,
+        )
         all_document_chunks[document_id] = chunks
         total_chunks += len(chunks)
 

--- a/api/app/core/rag/graphrag/utils.py
+++ b/api/app/core/rag/graphrag/utils.py
@@ -587,42 +587,62 @@ def flat_uniq_list(arr, key):
     return list(set(res))
 
 
-async def rebuild_graph(workspace_id, kb_id, exclude_rebuild=None):
+def _rebuild_graph_sync(workspace_id, kb_id, exclude_rebuild=None):
     graph = nx.Graph()
     flds = ["knowledge_graph_kwd", "page_content", "source_id"]
-    bs = 256
-    for i in range(0, 1024 * bs, bs):
-        es_res = await trio.to_thread.run_sync(
-            lambda: settings.docStoreConn.search(flds, [], {"kb_id": kb_id, "knowledge_graph_kwd": ["subgraph"]}, [], OrderByExpr(), i, bs, search.index_name(workspace_id), [kb_id])
-        )
-        # tot = settings.docStoreConn.getTotal(es_res)
-        es_res = settings.docStoreConn.getFields(es_res, flds)
-
-        if len(es_res) == 0:
-            break
-
-        for id, d in es_res.items():
-            assert d["knowledge_graph_kwd"] == "subgraph"
-            if isinstance(exclude_rebuild, list):
-                if sum([n in d["source_id"] for n in exclude_rebuild]):
-                    continue
-            elif exclude_rebuild in d["source_id"]:
+    query = {
+        "bool": {
+            "filter": [
+                {"term": {"kb_id": kb_id}},
+                {"term": {"knowledge_graph_kwd": "subgraph"}},
+            ],
+        },
+    }
+    for d in settings.docStoreConn.iter_search_after(
+        index_name=search.index_name(workspace_id),
+        query=query,
+        fields=flds,
+        batch_size=256,
+    ):
+        assert d["knowledge_graph_kwd"] == "subgraph"
+        if isinstance(exclude_rebuild, list):
+            if any(n in d["source_id"] for n in exclude_rebuild):
                 continue
+        elif exclude_rebuild is not None and exclude_rebuild in d["source_id"]:
+            continue
 
-            next_graph = json_graph.node_link_graph(json.loads(d["page_content"]), edges="edges")
-            merged_graph = nx.compose(graph, next_graph)
-            merged_source = {n: graph.nodes[n]["source_id"] + next_graph.nodes[n]["source_id"] for n in graph.nodes & next_graph.nodes}
-            nx.set_node_attributes(merged_graph, merged_source, "source_id")
-            if "source_id" in graph.graph:
-                merged_graph.graph["source_id"] = graph.graph["source_id"] + next_graph.graph["source_id"]
-            else:
-                merged_graph.graph["source_id"] = next_graph.graph["source_id"]
-            graph = merged_graph
+        next_graph = json_graph.node_link_graph(
+            json.loads(d["page_content"]),
+            edges="edges",
+        )
+        merged_graph = nx.compose(graph, next_graph)
+        merged_source = {
+            node: graph.nodes[node]["source_id"]
+            + next_graph.nodes[node]["source_id"]
+            for node in graph.nodes & next_graph.nodes
+        }
+        nx.set_node_attributes(merged_graph, merged_source, "source_id")
+        if "source_id" in graph.graph:
+            merged_graph.graph["source_id"] = (
+                graph.graph["source_id"] + next_graph.graph["source_id"]
+            )
+        else:
+            merged_graph.graph["source_id"] = next_graph.graph["source_id"]
+        graph = merged_graph
 
     if len(graph.nodes) == 0:
         return None
     graph.graph["source_id"] = sorted(graph.graph["source_id"])
     return graph
+
+
+async def rebuild_graph(workspace_id, kb_id, exclude_rebuild=None):
+    return await trio.to_thread.run_sync(
+        _rebuild_graph_sync,
+        workspace_id,
+        kb_id,
+        exclude_rebuild,
+    )
 
 
 def has_canceled(task_id):

--- a/api/app/core/rag/graphrag/utils.py
+++ b/api/app/core/rag/graphrag/utils.py
@@ -602,6 +602,7 @@ def _rebuild_graph_sync(workspace_id, kb_id, exclude_rebuild=None):
         index_name=search.index_name(workspace_id),
         query=query,
         fields=flds,
+        sort=[{"source_id": {"order": "asc", "missing": "_last"}}],
         batch_size=256,
     ):
         assert d["knowledge_graph_kwd"] == "subgraph"

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
-from collections.abc import Callable, Mapping, Sequence
+import logging
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,8 @@ from app.core.rag.vdb.field import Field
 from app.core.utils.datetime_utils import utcnow_naive
 
 
+logger = logging.getLogger(__name__)
+
 ENTITY_EVIDENCE = "entity_evidence"
 RELATION_EVIDENCE = "relation_evidence"
 ENTITY_PROJECTION = "entity_projection"
@@ -42,6 +45,65 @@ EVIDENCE_GRAPH_TYPES = (
     RELATION_PROJECTION,
     DOCUMENT_PROJECTION_MAP,
 )
+GRAPH_FULL_SCAN_BATCH_SIZE = 1000
+GRAPH_PIT_KEEP_ALIVE = "2m"
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _failure_summary(failures: Any) -> str:
+    if not isinstance(failures, list) or not failures:
+        return ""
+    summaries: list[str] = []
+    for failure in failures[:3]:
+        if isinstance(failure, Mapping):
+            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
+            if isinstance(reason, Mapping):
+                reason = reason.get("reason") or reason.get("type")
+            summaries.append(str(reason or "unknown"))
+        else:
+            summaries.append(str(failure))
+    return "; ".join(summaries)
+
+
+def _raise_on_search_response_failure(
+    response: Mapping[str, Any],
+    context: str,
+) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch search timed out during {context}")
+    failures = response.get("failures") or []
+    if failures:
+        details = _failure_summary(failures)
+        message = f"Elasticsearch search failed during {context}: failures={len(failures)}"
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
+    raise_on_shard_failures(response, context)
+
+
+def _raise_on_delete_by_query_failure(
+    response: Mapping[str, Any],
+    context: str,
+) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch delete_by_query timed out during {context}")
+    version_conflicts = _safe_int(response.get("version_conflicts"))
+    failures = response.get("failures") or []
+    if version_conflicts or failures:
+        details = _failure_summary(failures)
+        message = (
+            f"Elasticsearch delete_by_query failed during {context}: "
+            f"version_conflicts={version_conflicts} failures={len(failures)}"
+        )
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
 
 
 @lru_cache(maxsize=1)
@@ -129,6 +191,116 @@ class GraphElasticsearchStore:
             ignore_unavailable=True,
         )
 
+    @staticmethod
+    def _with_shard_doc_sort(
+        sort: Sequence[str | Mapping[str, Any]],
+    ) -> list[str | Mapping[str, Any]]:
+        result = list(sort)
+        has_shard_doc = any(
+            value == "_shard_doc"
+            or (isinstance(value, Mapping) and "_shard_doc" in value)
+            for value in result
+        )
+        if not has_shard_doc:
+            result.append({"_shard_doc": "asc"})
+        return result
+
+    async def _iter_search_after_hits(
+        self,
+        *,
+        index_name: str,
+        query: Mapping[str, Any],
+        sort: Sequence[str | Mapping[str, Any]],
+        context: str,
+        source_includes: Sequence[str] | None = None,
+        source: bool | Mapping[str, Any] | None = None,
+        batch_size: int = GRAPH_FULL_SCAN_BATCH_SIZE,
+    ) -> AsyncIterator[dict[str, Any]]:
+        if not 1 <= batch_size <= 10000:
+            raise ValueError("batch_size must be between 1 and 10000")
+
+        pit_id: str | None = None
+        cursor: list[Any] | None = None
+        try:
+            opened = await self._client.open_point_in_time(
+                index=index_name,
+                keep_alive=GRAPH_PIT_KEEP_ALIVE,
+                allow_partial_search_results=False,
+            )
+            pit_id = opened.get("id")
+            if not pit_id:
+                raise RuntimeError(f"Elasticsearch did not return a PIT id during {context}")
+
+            effective_sort = self._with_shard_doc_sort(sort)
+            while True:
+                search_kwargs: dict[str, Any] = {
+                    "pit": {"id": pit_id, "keep_alive": GRAPH_PIT_KEEP_ALIVE},
+                    "query": dict(query),
+                    "sort": effective_sort,
+                    "size": batch_size,
+                    "allow_partial_search_results": False,
+                }
+                if source is not None:
+                    search_kwargs["source"] = source
+                if source_includes is not None:
+                    search_kwargs["source_includes"] = list(source_includes)
+                if cursor is not None:
+                    search_kwargs["search_after"] = cursor
+
+                response = await self._client.search(**search_kwargs)
+                latest_pit_id = response.get("pit_id")
+                if latest_pit_id:
+                    pit_id = latest_pit_id
+                _raise_on_search_response_failure(response, context)
+
+                hits = list(response.get("hits", {}).get("hits", []))
+                if not hits:
+                    return
+
+                for hit in hits:
+                    yield hit
+
+                next_cursor = hits[-1].get("sort")
+                if not next_cursor or list(next_cursor) == cursor:
+                    raise RuntimeError(
+                        f"Elasticsearch search_after cursor did not advance during {context}"
+                    )
+                cursor = list(next_cursor)
+        finally:
+            if pit_id:
+                try:
+                    await self._client.close_point_in_time(id=pit_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to close Elasticsearch PIT during %s",
+                        context,
+                        exc_info=True,
+                    )
+
+    async def _collect_search_after_hits(
+        self,
+        *,
+        index_name: str,
+        query: Mapping[str, Any],
+        sort: Sequence[str | Mapping[str, Any]],
+        context: str,
+        source_includes: Sequence[str] | None = None,
+        source: bool | Mapping[str, Any] | None = None,
+        batch_size: int = GRAPH_FULL_SCAN_BATCH_SIZE,
+    ) -> list[dict[str, Any]]:
+        return [
+            hit
+            async for hit in self._iter_search_after_hits(
+                index_name=index_name,
+                query=query,
+                sort=sort,
+                context=context,
+                source_includes=source_includes,
+                source=source,
+                batch_size=batch_size,
+            )
+        ]
+
     async def load_document_chunks(
         self,
         chunk_index_name: str,
@@ -140,9 +312,8 @@ class GraphElasticsearchStore:
             {"term": {"metadata.document_id": document_id}},
             {"term": {"metadata.status": 1}},
         ]
-        result = await self._client.search(
-            index=chunk_index_name,
-            size=10000,
+        hits = await self._collect_search_after_hits(
+            index_name=chunk_index_name,
             query={"bool": {"filter": filters}},
             source_includes=[
                 "page_content",
@@ -158,11 +329,11 @@ class GraphElasticsearchStore:
                 {"metadata.sort_id": {"order": "asc", "unmapped_type": "long"}},
                 {"metadata.doc_id": {"order": "asc"}},
             ],
+            context="load graph source document",
         )
-        raise_on_shard_failures(result, "load graph source document")
 
         scoped_hits: list[dict[str, Any]] = []
-        for hit in self._hits(result):
+        for hit in hits:
             source = hit.get("_source") or {}
             metadata = source.get("metadata") or {}
             if not isinstance(metadata, Mapping):
@@ -204,24 +375,29 @@ class GraphElasticsearchStore:
         knowledge_id: str,
         document_id: str,
     ) -> AffectedProjectionKeys:
-        result = await self._client.search(
-            index=index_name,
-            size=10000,
+        hits = await self._collect_search_after_hits(
+            index_name=index_name,
             query=self._graph_query(
                 knowledge_id,
                 EVIDENCE_TYPES,
                 [{"term": {"document_id": document_id}}],
             ),
-            source=[
+            source_includes=[
                 "knowledge_graph_kwd",
                 "entity_key_kwd",
                 "relation_key_kwd",
             ],
+            sort=[
+                {"knowledge_graph_kwd": {"order": "asc"}},
+                {"entity_key_kwd": {"order": "asc", "missing": "_last"}},
+                {"relation_key_kwd": {"order": "asc", "missing": "_last"}},
+                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+            ],
+            context="load graph document evidence keys",
         )
-        raise_on_shard_failures(result, "load graph document evidence keys")
         entity_keys: set[str] = set()
         relation_keys: set[str] = set()
-        for hit in self._hits(result):
+        for hit in hits:
             source = hit.get("_source") or {}
             if source.get("knowledge_graph_kwd") == ENTITY_EVIDENCE:
                 if source.get("entity_key_kwd"):
@@ -276,15 +452,20 @@ class GraphElasticsearchStore:
             )
 
         self._ensure_valid(ensure_valid)
-        await self._client.delete_by_query(
+        result = await self._client.delete_by_query(
             index=index_name,
-            conflicts="proceed",
+            conflicts="abort",
             refresh=False,
+            wait_for_completion=True,
             query=self._graph_query(
                 knowledge_id,
                 EVIDENCE_TYPES,
                 [{"term": {"document_id": document_id}}],
             ),
+        )
+        _raise_on_delete_by_query_failure(
+            result,
+            "replace graph document evidence",
         )
 
         operations: list[dict[str, Any]] = []
@@ -324,18 +505,21 @@ class GraphElasticsearchStore:
     ) -> list[EntityEvidence]:
         if not entity_keys:
             return []
-        result = await self._client.search(
-            index=index_name,
-            size=10000,
+        hits = await self._collect_search_after_hits(
+            index_name=index_name,
             query=self._graph_query(
                 knowledge_id,
                 ENTITY_EVIDENCE,
                 [{"terms": {"entity_key_kwd": list(entity_keys)}}],
             ),
+            sort=[
+                {"entity_key_kwd": {"order": "asc"}},
+                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+            ],
+            context="load entity evidence",
         )
-        raise_on_shard_failures(result, "load entity evidence")
         evidence: list[EntityEvidence] = []
-        for hit in self._hits(result):
+        for hit in hits:
             source = hit.get("_source") or {}
             evidence.append(
                 EntityEvidence(
@@ -502,16 +686,15 @@ class GraphElasticsearchStore:
         index_name: str,
         knowledge_id: str,
     ) -> list[dict[str, Any]]:
-        result = await self._client.search(
-            index=index_name,
-            size=10000,
+        hits = await self._collect_search_after_hits(
+            index_name=index_name,
             query=self._graph_query(knowledge_id, DOCUMENT_PROJECTION_MAP),
             sort=[{"document_id": {"order": "asc"}}],
+            context="list graph document maps",
         )
-        raise_on_shard_failures(result, "list graph document maps")
         return [
             dict(source)
-            for hit in self._hits(result)
+            for hit in hits
             if isinstance((source := hit.get("_source")), Mapping)
         ]
 
@@ -523,12 +706,17 @@ class GraphElasticsearchStore:
         ensure_valid: Callable[[], None] | None = None,
     ) -> None:
         self._ensure_valid(ensure_valid)
-        await self._client.delete_by_query(
+        result = await self._client.delete_by_query(
             index=index_name,
-            conflicts="proceed",
+            conflicts="abort",
             ignore_unavailable=True,
             refresh=True,
+            wait_for_completion=True,
             query=self._graph_query(knowledge_id, EVIDENCE_GRAPH_TYPES),
+        )
+        _raise_on_delete_by_query_failure(
+            result,
+            "clear evidence graph",
         )
 
     async def clear_all_graph_documents(
@@ -539,11 +727,12 @@ class GraphElasticsearchStore:
         ensure_valid: Callable[[], None] | None = None,
     ) -> None:
         self._ensure_valid(ensure_valid)
-        await self._client.delete_by_query(
+        result = await self._client.delete_by_query(
             index=index_name,
-            conflicts="proceed",
+            conflicts="abort",
             ignore_unavailable=True,
             refresh=True,
+            wait_for_completion=True,
             query={
                 "bool": {
                     "filter": [
@@ -552,6 +741,10 @@ class GraphElasticsearchStore:
                     ]
                 }
             },
+        )
+        _raise_on_delete_by_query_failure(
+            result,
+            "clear all graph documents",
         )
 
     async def load_projection_graph(
@@ -1219,18 +1412,21 @@ class GraphElasticsearchStore:
         extra_filters: Sequence[Mapping[str, Any]],
         context: str,
     ) -> list[RelationEvidence]:
-        result = await self._client.search(
-            index=index_name,
-            size=10000,
+        hits = await self._collect_search_after_hits(
+            index_name=index_name,
             query=self._graph_query(
                 knowledge_id,
                 RELATION_EVIDENCE,
                 extra_filters,
             ),
+            sort=[
+                {"relation_key_kwd": {"order": "asc"}},
+                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+            ],
+            context=context,
         )
-        raise_on_shard_failures(result, context)
         evidence: list[RelationEvidence] = []
-        for hit in self._hits(result):
+        for hit in hits:
             source = hit.get("_source") or {}
             evidence.append(
                 RelationEvidence(

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -25,9 +25,9 @@ from app.core.rag.knowledge_graph.normalizer import (
 )
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.elasticsearch_queries import raise_on_shard_failures
+from app.core.rag.vdb.elasticsearch.pit_search import iter_async_pit_search_hits
 from app.core.rag.vdb.elasticsearch.response_validation import (
     raise_on_delete_by_query_failure,
-    raise_on_search_response_failure,
 )
 from app.core.rag.vdb.field import Field
 from app.core.utils.datetime_utils import utcnow_naive
@@ -138,92 +138,6 @@ class GraphElasticsearchStore:
             ignore_unavailable=True,
         )
 
-    @staticmethod
-    def _with_shard_doc_sort(
-        sort: Sequence[str | Mapping[str, Any]],
-    ) -> list[str | Mapping[str, Any]]:
-        result = list(sort)
-        has_shard_doc = any(
-            value == "_shard_doc"
-            or (isinstance(value, Mapping) and "_shard_doc" in value)
-            for value in result
-        )
-        if not has_shard_doc:
-            result.append({"_shard_doc": "asc"})
-        return result
-
-    async def _iter_search_after_hits(
-        self,
-        *,
-        index_name: str,
-        query: Mapping[str, Any],
-        sort: Sequence[str | Mapping[str, Any]],
-        context: str,
-        source_includes: Sequence[str] | None = None,
-        source: bool | Mapping[str, Any] | None = None,
-        batch_size: int = GRAPH_FULL_SCAN_BATCH_SIZE,
-    ) -> AsyncIterator[dict[str, Any]]:
-        if not 1 <= batch_size <= 10000:
-            raise ValueError("batch_size must be between 1 and 10000")
-
-        pit_id: str | None = None
-        cursor: list[Any] | None = None
-        try:
-            opened = await self._client.open_point_in_time(
-                index=index_name,
-                keep_alive=GRAPH_PIT_KEEP_ALIVE,
-                allow_partial_search_results=False,
-            )
-            pit_id = opened.get("id")
-            if not pit_id:
-                raise RuntimeError(f"Elasticsearch did not return a PIT id during {context}")
-
-            effective_sort = self._with_shard_doc_sort(sort)
-            while True:
-                search_kwargs: dict[str, Any] = {
-                    "pit": {"id": pit_id, "keep_alive": GRAPH_PIT_KEEP_ALIVE},
-                    "query": dict(query),
-                    "sort": effective_sort,
-                    "size": batch_size,
-                    "allow_partial_search_results": False,
-                }
-                if source is not None:
-                    search_kwargs["source"] = source
-                if source_includes is not None:
-                    search_kwargs["source_includes"] = list(source_includes)
-                if cursor is not None:
-                    search_kwargs["search_after"] = cursor
-
-                response = await self._client.search(**search_kwargs)
-                latest_pit_id = response.get("pit_id")
-                if latest_pit_id:
-                    pit_id = latest_pit_id
-                raise_on_search_response_failure(response, context)
-
-                hits = list(response.get("hits", {}).get("hits", []))
-                if not hits:
-                    return
-
-                for hit in hits:
-                    yield hit
-
-                next_cursor = hits[-1].get("sort")
-                if not next_cursor or list(next_cursor) == cursor:
-                    raise RuntimeError(
-                        f"Elasticsearch search_after cursor did not advance during {context}"
-                    )
-                cursor = list(next_cursor)
-        finally:
-            if pit_id:
-                try:
-                    await self._client.close_point_in_time(id=pit_id)
-                except Exception:
-                    logger.warning(
-                        "Failed to close Elasticsearch PIT during %s",
-                        context,
-                        exc_info=True,
-                    )
-
     async def _collect_search_after_hits(
         self,
         *,
@@ -237,14 +151,16 @@ class GraphElasticsearchStore:
     ) -> list[dict[str, Any]]:
         return [
             hit
-            async for hit in self._iter_search_after_hits(
-                index_name=index_name,
+            async for hit in iter_async_pit_search_hits(
+                self._client,
+                index=index_name,
                 query=query,
                 sort=sort,
                 context=context,
                 source_includes=source_includes,
                 source=source,
                 batch_size=batch_size,
+                keep_alive=GRAPH_PIT_KEEP_ALIVE,
             )
         ]
 

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import logging
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -25,15 +24,12 @@ from app.core.rag.knowledge_graph.normalizer import (
 )
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.elasticsearch_queries import raise_on_shard_failures
-from app.core.rag.vdb.elasticsearch.pit_search import iter_async_pit_search_hits
+from app.core.rag.vdb.elasticsearch.pit_search import iter_async_search_after_hits
 from app.core.rag.vdb.elasticsearch.response_validation import (
     raise_on_delete_by_query_failure,
 )
 from app.core.rag.vdb.field import Field
 from app.core.utils.datetime_utils import utcnow_naive
-
-
-logger = logging.getLogger(__name__)
 
 ENTITY_EVIDENCE = "entity_evidence"
 RELATION_EVIDENCE = "relation_evidence"
@@ -50,7 +46,6 @@ EVIDENCE_GRAPH_TYPES = (
     DOCUMENT_PROJECTION_MAP,
 )
 GRAPH_FULL_SCAN_BATCH_SIZE = 1000
-GRAPH_PIT_KEEP_ALIVE = "2m"
 
 
 @lru_cache(maxsize=1)
@@ -151,7 +146,7 @@ class GraphElasticsearchStore:
     ) -> list[dict[str, Any]]:
         return [
             hit
-            async for hit in iter_async_pit_search_hits(
+            async for hit in iter_async_search_after_hits(
                 self._client,
                 index=index_name,
                 query=query,
@@ -160,7 +155,6 @@ class GraphElasticsearchStore:
                 source_includes=source_includes,
                 source=source,
                 batch_size=batch_size,
-                keep_alive=GRAPH_PIT_KEEP_ALIVE,
             )
         ]
 
@@ -255,6 +249,7 @@ class GraphElasticsearchStore:
                 {"entity_key_kwd": {"order": "asc", "missing": "_last"}},
                 {"relation_key_kwd": {"order": "asc", "missing": "_last"}},
                 {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"document_id": {"order": "asc", "missing": "_last"}},
             ],
             context="load graph document evidence keys",
         )
@@ -378,6 +373,7 @@ class GraphElasticsearchStore:
             sort=[
                 {"entity_key_kwd": {"order": "asc"}},
                 {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"document_id": {"order": "asc", "missing": "_last"}},
             ],
             context="load entity evidence",
         )
@@ -1285,6 +1281,7 @@ class GraphElasticsearchStore:
             sort=[
                 {"relation_key_kwd": {"order": "asc"}},
                 {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"document_id": {"order": "asc", "missing": "_last"}},
             ],
             context=context,
         )

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -25,6 +25,10 @@ from app.core.rag.knowledge_graph.normalizer import (
 )
 from app.core.rag.models.chunk import DocumentChunk
 from app.core.rag.retrieval.elasticsearch_queries import raise_on_shard_failures
+from app.core.rag.vdb.elasticsearch.response_validation import (
+    raise_on_delete_by_query_failure,
+    raise_on_search_response_failure,
+)
 from app.core.rag.vdb.field import Field
 from app.core.utils.datetime_utils import utcnow_naive
 
@@ -47,63 +51,6 @@ EVIDENCE_GRAPH_TYPES = (
 )
 GRAPH_FULL_SCAN_BATCH_SIZE = 1000
 GRAPH_PIT_KEEP_ALIVE = "2m"
-
-
-def _safe_int(value: Any) -> int:
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _failure_summary(failures: Any) -> str:
-    if not isinstance(failures, list) or not failures:
-        return ""
-    summaries: list[str] = []
-    for failure in failures[:3]:
-        if isinstance(failure, Mapping):
-            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
-            if isinstance(reason, Mapping):
-                reason = reason.get("reason") or reason.get("type")
-            summaries.append(str(reason or "unknown"))
-        else:
-            summaries.append(str(failure))
-    return "; ".join(summaries)
-
-
-def _raise_on_search_response_failure(
-    response: Mapping[str, Any],
-    context: str,
-) -> None:
-    if response.get("timed_out"):
-        raise RuntimeError(f"Elasticsearch search timed out during {context}")
-    failures = response.get("failures") or []
-    if failures:
-        details = _failure_summary(failures)
-        message = f"Elasticsearch search failed during {context}: failures={len(failures)}"
-        if details:
-            message = f"{message}: {details}"
-        raise RuntimeError(message)
-    raise_on_shard_failures(response, context)
-
-
-def _raise_on_delete_by_query_failure(
-    response: Mapping[str, Any],
-    context: str,
-) -> None:
-    if response.get("timed_out"):
-        raise RuntimeError(f"Elasticsearch delete_by_query timed out during {context}")
-    version_conflicts = _safe_int(response.get("version_conflicts"))
-    failures = response.get("failures") or []
-    if version_conflicts or failures:
-        details = _failure_summary(failures)
-        message = (
-            f"Elasticsearch delete_by_query failed during {context}: "
-            f"version_conflicts={version_conflicts} failures={len(failures)}"
-        )
-        if details:
-            message = f"{message}: {details}"
-        raise RuntimeError(message)
 
 
 @lru_cache(maxsize=1)
@@ -251,7 +198,7 @@ class GraphElasticsearchStore:
                 latest_pit_id = response.get("pit_id")
                 if latest_pit_id:
                     pit_id = latest_pit_id
-                _raise_on_search_response_failure(response, context)
+                raise_on_search_response_failure(response, context)
 
                 hits = list(response.get("hits", {}).get("hits", []))
                 if not hits:
@@ -463,7 +410,7 @@ class GraphElasticsearchStore:
                 [{"term": {"document_id": document_id}}],
             ),
         )
-        _raise_on_delete_by_query_failure(
+        raise_on_delete_by_query_failure(
             result,
             "replace graph document evidence",
         )
@@ -714,7 +661,7 @@ class GraphElasticsearchStore:
             wait_for_completion=True,
             query=self._graph_query(knowledge_id, EVIDENCE_GRAPH_TYPES),
         )
-        _raise_on_delete_by_query_failure(
+        raise_on_delete_by_query_failure(
             result,
             "clear evidence graph",
         )
@@ -742,7 +689,7 @@ class GraphElasticsearchStore:
                 }
             },
         )
-        _raise_on_delete_by_query_failure(
+        raise_on_delete_by_query_failure(
             result,
             "clear all graph documents",
         )

--- a/api/app/core/rag/utils/es_conn.py
+++ b/api/app/core/rag/utils/es_conn.py
@@ -19,10 +19,7 @@ from app.core.rag.utils.doc_store_conn import DocStoreConnection, MatchExpr, Ord
 from app.core.rag.nlp import is_english, rag_tokenizer
 from app.core.rag.common.float_utils import get_float
 from app.core.rag.common.constants import PAGERANK_FLD, TAG_FLD
-from app.core.rag.vdb.elasticsearch.pit_search import (
-    DEFAULT_PIT_KEEP_ALIVE,
-    iter_pit_search_hits,
-)
+from app.core.rag.vdb.elasticsearch.pit_search import iter_search_after_hits
 from app.core.rag.vdb.elasticsearch.response_validation import (
     raise_on_delete_by_query_failure,
 )
@@ -288,23 +285,23 @@ class ESConnection(DocStoreConnection):
             index_name: str,
             query: Mapping[str, Any],
             fields: Sequence[str],
+            sort: Sequence[str | Mapping[str, Any]],
             batch_size: int = 1000,
-            keep_alive: str = DEFAULT_PIT_KEEP_ALIVE,
     ) -> Iterator[dict[str, Any]]:
         """
-        Iterate over search hits using an Elasticsearch point-in-time scan.
+        Iterate over search hits using Elasticsearch search_after.
 
         Returned dicts are copied from each hit's source. When the ES document
         id is available, it is exposed as ``_es_id`` to avoid colliding with
         source-defined ``_id`` fields.
         """
-        for hit in iter_pit_search_hits(
+        for hit in iter_search_after_hits(
             self.es,
             index=index_name,
             query=query,
+            sort=sort,
             source_includes=fields,
             batch_size=batch_size,
-            keep_alive=keep_alive,
         ):
             source = dict(hit.get("_source") or {})
             if hit.get("_id") is not None:

--- a/api/app/core/rag/utils/es_conn.py
+++ b/api/app/core/rag/utils/es_conn.py
@@ -20,6 +20,9 @@ from app.core.rag.nlp import is_english, rag_tokenizer
 from app.core.rag.common.float_utils import get_float
 from app.core.rag.common.constants import PAGERANK_FLD, TAG_FLD
 from app.core.rag.vdb.elasticsearch.pit_search import iter_pit_search_hits
+from app.core.rag.vdb.elasticsearch.response_validation import (
+    raise_on_delete_by_query_failure,
+)
 
 ATTEMPT_TIME = 2
 
@@ -479,7 +482,14 @@ class ESConnection(DocStoreConnection):
                 res = self.es.delete_by_query(
                     index=indexName,
                     body=Search().query(qry).to_dict(),
-                    refresh=True)
+                    refresh=True,
+                    conflicts="abort",
+                    wait_for_completion=True,
+                )
+                raise_on_delete_by_query_failure(
+                    res,
+                    "legacy graph document delete",
+                )
                 return res["deleted"]
             except ConnectionTimeout:
                 logger.exception("ES request timeout")
@@ -490,7 +500,8 @@ class ESConnection(DocStoreConnection):
                 logger.warning("ESConnection.delete got exception: " + str(e))
                 if re.search(r"(not_found)", str(e), re.IGNORECASE):
                     return 0
-        return 0
+                raise
+        raise RuntimeError("ESConnection.delete failed after Elasticsearch connection timeouts")
 
     """
     Helper functions for search result

--- a/api/app/core/rag/utils/es_conn.py
+++ b/api/app/core/rag/utils/es_conn.py
@@ -19,7 +19,10 @@ from app.core.rag.utils.doc_store_conn import DocStoreConnection, MatchExpr, Ord
 from app.core.rag.nlp import is_english, rag_tokenizer
 from app.core.rag.common.float_utils import get_float
 from app.core.rag.common.constants import PAGERANK_FLD, TAG_FLD
-from app.core.rag.vdb.elasticsearch.pit_search import iter_pit_search_hits
+from app.core.rag.vdb.elasticsearch.pit_search import (
+    DEFAULT_PIT_KEEP_ALIVE,
+    iter_pit_search_hits,
+)
 from app.core.rag.vdb.elasticsearch.response_validation import (
     raise_on_delete_by_query_failure,
 )
@@ -286,16 +289,26 @@ class ESConnection(DocStoreConnection):
             query: Mapping[str, Any],
             fields: Sequence[str],
             batch_size: int = 1000,
+            keep_alive: str = DEFAULT_PIT_KEEP_ALIVE,
     ) -> Iterator[dict[str, Any]]:
+        """
+        Iterate over search hits using an Elasticsearch point-in-time scan.
+
+        Returned dicts are copied from each hit's source. When the ES document
+        id is available, it is exposed as ``_es_id`` to avoid colliding with
+        source-defined ``_id`` fields.
+        """
         for hit in iter_pit_search_hits(
             self.es,
             index=index_name,
             query=query,
             source_includes=fields,
             batch_size=batch_size,
+            keep_alive=keep_alive,
         ):
             source = dict(hit.get("_source") or {})
-            source["_id"] = hit.get("_id")
+            if hit.get("_id") is not None:
+                source.setdefault("_es_id", hit.get("_id"))
             yield source
 
     def get(self, chunkId: str, indexName: str, knowledgebaseIds: list[str]) -> dict | None:

--- a/api/app/core/rag/utils/es_conn.py
+++ b/api/app/core/rag/utils/es_conn.py
@@ -3,6 +3,8 @@ import re
 import json
 import time
 import os
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Any
 from urllib.parse import urlparse
 
 import copy
@@ -17,6 +19,7 @@ from app.core.rag.utils.doc_store_conn import DocStoreConnection, MatchExpr, Ord
 from app.core.rag.nlp import is_english, rag_tokenizer
 from app.core.rag.common.float_utils import get_float
 from app.core.rag.common.constants import PAGERANK_FLD, TAG_FLD
+from app.core.rag.vdb.elasticsearch.pit_search import iter_pit_search_hits
 
 ATTEMPT_TIME = 2
 
@@ -272,6 +275,25 @@ class ESConnection(DocStoreConnection):
 
         logger.error(f"ESConnection.search timeout for {ATTEMPT_TIME} times!")
         raise Exception("ESConnection.search timeout.")
+
+    def iter_search_after(
+            self,
+            *,
+            index_name: str,
+            query: Mapping[str, Any],
+            fields: Sequence[str],
+            batch_size: int = 1000,
+    ) -> Iterator[dict[str, Any]]:
+        for hit in iter_pit_search_hits(
+            self.es,
+            index=index_name,
+            query=query,
+            source_includes=fields,
+            batch_size=batch_size,
+        ):
+            source = dict(hit.get("_source") or {})
+            source["_id"] = hit.get("_id")
+            yield source
 
     def get(self, chunkId: str, indexName: str, knowledgebaseIds: list[str]) -> dict | None:
         for i in range(ATTEMPT_TIME):

--- a/api/app/core/rag/utils/es_conn.py
+++ b/api/app/core/rag/utils/es_conn.py
@@ -454,10 +454,10 @@ class ESConnection(DocStoreConnection):
             chunk_ids = condition["id"]
             if not isinstance(chunk_ids, list):
                 chunk_ids = [chunk_ids]
-            if not chunk_ids:  # when chunk_ids is empty, delete all
-                qry = Q("match_all")
-            else:
-                qry = Q("ids", values=chunk_ids)
+            qry = Q("bool")
+            qry.filter.append(Q("term", kb_id=knowledgebaseId))
+            if chunk_ids:
+                qry.filter.append(Q("ids", values=chunk_ids))
         else:
             qry = Q("bool")
             for k, v in condition.items():

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -39,12 +40,18 @@ from app.core.rag.retrieval.elasticsearch_queries import (
     vector_hits_to_chunks,
 )
 from app.core.rag.vdb.field import Field
+from app.core.rag.vdb.elasticsearch.pit_search import (
+    iter_pit_search_hits,
+    pit_search_slice,
+)
 from app.core.rag.vdb.vector_base import BaseVector
 from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_INDEX_REFRESH_INTERVAL = "1s"
+ES_DEFAULT_MAX_RESULT_WINDOW = 10000
+ES_FULL_SCAN_BATCH_SIZE = 1000
 
 
 @dataclass(frozen=True)
@@ -194,69 +201,156 @@ class ElasticSearchVector(BaseVector):
             logger.warning(f"Index {self._collection_name} does not exist")
             return
 
-        # Obtaining All Actual ES _id,not metadata.doc_id
-        actual_ids = []
+        deleted = 0
+        for start in range(0, len(ids), ES_FULL_SCAN_BATCH_SIZE):
+            batch = ids[start:start + ES_FULL_SCAN_BATCH_SIZE]
+            result = self._client.delete_by_query(
+                index=self._collection_name,
+                query={"terms": {Field.DOC_ID.value: batch}},
+                refresh=False,
+                conflicts="abort",
+                wait_for_completion=True,
+            )
+            deleted += int(result.get("deleted", 0))
 
-        for doc_id in ids:
-            es_ids = self.get_ids_by_metadata_field('doc_id', doc_id)
-            if es_ids:
-                actual_ids.extend(es_ids)
-            else:
-                logger.warning(f"Document with metadata doc_id {doc_id} not found for deletion")
+        if refresh:
+            self._client.indices.refresh(index=self._collection_name)
+        logger.info(
+            "Deleted Elasticsearch documents by metadata IDs: index=%s requested=%s deleted=%s",
+            self._collection_name,
+            len(ids),
+            deleted,
+        )
 
-        if actual_ids:
-            actions = [{"_op_type": "delete", "_index": self._collection_name, "_id": es_id} for es_id in actual_ids]
-            try:
-                helpers.bulk(self._client, actions)
-                if refresh:
-                    self._client.indices.refresh(index=self._collection_name)
-            except BulkIndexError as e:
-                for error in e.errors:
-                    delete_error = error.get('delete', {})
-                    status = delete_error.get('status')
-                    doc_id = delete_error.get('_id')
-
-                    if status == 404:
-                        logger.warning(f"Document not found for deletion: {doc_id}")
-                    else:
-                        logger.error(f"Error deleting document: {error}")
-
-    def get_ids_by_metadata_field(self, key: str, value: str):
-        query = {"query": {"term": {f"{Field.METADATA_KEY.value}.{key}": value}}}
-        response = self._client.search(index=self._collection_name, body=query, size=10000)
-        if response['hits']['hits']:
-            return [hit['_id'] for hit in response['hits']['hits']]
-        else:
-            return None
+    def get_ids_by_metadata_field(self, key: str, value: str) -> list[str] | None:
+        ids = [
+            hit["_id"]
+            for hit in iter_pit_search_hits(
+                self._client,
+                index=self._collection_name,
+                query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
+                batch_size=ES_FULL_SCAN_BATCH_SIZE,
+                source=False,
+            )
+        ]
+        return ids or None
 
     def delete_by_metadata_field(self, key: str, value: str, *, refresh: bool = False):
         if not self._client.indices.exists(index=self._collection_name):
             return False
-        actual_ids = self.get_ids_by_metadata_field(key, value)
-
-        if actual_ids:
-            actions = [{"_op_type": "delete", "_index": self._collection_name, "_id": es_id} for es_id in actual_ids]
-            try:
-                helpers.bulk(self._client, actions)
-                if refresh:
-                    self._client.indices.refresh(index=self._collection_name)
-            except BulkIndexError as e:
-                for error in e.errors:
-                    delete_error = error.get('delete', {})
-                    status = delete_error.get('status')
-                    doc_id = delete_error.get('_id')
-
-                    if status == 404:
-                        logger.warning(f"Document not found for deletion: {doc_id}")
-                    else:
-                        logger.error(f"Error deleting document: {error}")
-                        raise
-
+        result = self._client.delete_by_query(
+            index=self._collection_name,
+            query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
+            refresh=refresh,
+            conflicts="abort",
+            wait_for_completion=True,
+        )
+        logger.info(
+            "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
+            self._collection_name,
+            key,
+            result.get("deleted", 0),
+        )
         return True
 
     def delete(self):
         if self._client.indices.exists(index=self._collection_name):
             self._client.indices.delete(index=self._collection_name, ignore=[400, 404])
+
+    def _build_segment_query(
+        self,
+        document_id: str | None,
+        query: str | None,
+        chunk_types: list[str] | str | None,
+        parent_ids: list[str] | str | None,
+    ) -> dict[str, Any]:
+        must: list[dict[str, Any]] = []
+        if document_id:
+            must.append({"term": {Field.DOCUMENT_ID.value: document_id}})
+        if query:
+            must.append({
+                "multi_match": {
+                    "query": query,
+                    "fields": [Field.CONTENT_KEY.value, Field.VISION_TEXT.value],
+                    "analyzer": "ik_max_word",
+                },
+            })
+        if chunk_types:
+            types = chunk_types if isinstance(chunk_types, list) else [chunk_types]
+            must.append({"terms": {Field.CHUNK_TYPE.value: types}})
+        if parent_ids:
+            values = parent_ids if isinstance(parent_ids, list) else [parent_ids]
+            must.append({
+                "terms": {f"{Field.METADATA_KEY.value}.{Field.PARENT_ID.value}": values}
+            })
+        return {"bool": {"must": must}}
+
+    @staticmethod
+    def _segment_sort(asc: bool) -> list[dict[str, Any]]:
+        order = "asc" if asc else "desc"
+        return [
+            {
+                Field.SORT_ID.value: {
+                    "order": order,
+                    "unmapped_type": "long",
+                    "missing": "_last",
+                }
+            },
+            {
+                Field.DOC_ID.value: {
+                    "order": order,
+                    "unmapped_type": "keyword",
+                    "missing": "_last",
+                }
+            },
+        ]
+
+    @staticmethod
+    def _segment_hit_to_chunk(hit: Mapping[str, Any]) -> DocumentChunk:
+        source = hit.get("_source") or {}
+        metadata = dict(source.get(Field.METADATA_KEY.value) or {})
+        chunk_type = source.get(Field.CHUNK_TYPE.value)
+        page_content = source.get(Field.CONTENT_KEY.value)
+        if chunk_type:
+            metadata["chunk_type"] = chunk_type
+        if chunk_type == "qa":
+            metadata["question"] = source.get(Field.QUESTION.value, "")
+            metadata["answer"] = source.get(Field.ANSWER.value, "")
+            page_content = (
+                f"question: {metadata['question']}\nanswer: {metadata['answer']}"
+            )
+        metadata["score"] = hit.get("_score")
+        return DocumentChunk(page_content=page_content, vector=None, metadata=metadata)
+
+    def iter_by_segment(
+        self,
+        document_id: str | None = None,
+        query: str | None = None,
+        *,
+        batch_size: int = ES_FULL_SCAN_BATCH_SIZE,
+        asc: bool = True,
+        chunk_types: list[str] | str | None = None,
+        parent_ids: list[str] | str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[DocumentChunk]:
+        indices = kwargs.get("indices", self._collection_name)
+        if not self._client.indices.exists(index=indices):
+            return
+
+        segment_query = self._build_segment_query(
+            document_id,
+            query,
+            chunk_types,
+            parent_ids,
+        )
+        for hit in iter_pit_search_hits(
+            self._client,
+            index=indices,
+            query=segment_query,
+            sort=self._segment_sort(asc),
+            batch_size=batch_size,
+        ):
+            yield self._segment_hit_to_chunk(hit)
 
     def search_by_segment(self, document_id: str | None = None, query: str | None = None, pagesize: int = 10, page: int = 1, asc: bool = True, chunk_types: list[str] | str | None = None, parent_ids: list[str] | str | None = None, **kwargs) -> tuple[int, list[DocumentChunk]]:  # 返回 (total, results):
         """
@@ -278,94 +372,43 @@ class ElasticSearchVector(BaseVector):
         if not self._client.indices.exists(index=indices):
             return 0, []
 
-        # Calculate the start position for the current page
-        from_ = pagesize * (page-1)
+        offset = pagesize * (page - 1)
+        segment_query = self._build_segment_query(
+            document_id,
+            query,
+            chunk_types,
+            parent_ids,
+        )
+        sort = self._segment_sort(asc)
 
-        # Construct the query with optional keyword matching
-        query_str = {
-            "query": {
-                "bool": {
-                    "must": []
-                }
-            },
-            "sort": [
-                {Field.SORT_ID.value: "asc" if asc else "desc"}  # Sort by the specified metadata field
-            ]
-        }
-
-        if document_id:
-            query_str["query"]["bool"]["must"].append({
-                "term": {
-                    Field.DOCUMENT_ID.value: document_id  # exact match document_id
-                }
-            })
-
-        if query:
-            query_str["query"]["bool"]["must"].append({
-                "multi_match": {
-                    "query": query,
-                    "fields": [Field.CONTENT_KEY.value, Field.VISION_TEXT.value],
-                    "analyzer": "ik_max_word",
-                },
-            })
-
-        if chunk_types:
-            types = chunk_types if isinstance(chunk_types, list) else [chunk_types]
-            query_str["query"]["bool"]["must"].append({
-                "terms": {
-                    Field.CHUNK_TYPE.value: types
-                }
-            })
-
-        if parent_ids:
-            pids = parent_ids if isinstance(parent_ids, list) else [parent_ids]
-            query_str["query"]["bool"]["must"].append({
-                "terms": {
-                    f"metadata.{Field.PARENT_ID.value}": pids
-                }
-            })
-
-        # For simplicity, we use from/size here which has a limit (usually up to 10,000).
-        try:
-            result = self._client.search(
+        if offset + pagesize <= ES_DEFAULT_MAX_RESULT_WINDOW:
+            try:
+                result = self._client.search(
+                    index=indices,
+                    from_=offset,
+                    size=pagesize,
+                    query=segment_query,
+                    sort=sort,
+                    track_total_hits=True,
+                )
+            except NotFoundError:
+                return 0, []
+            if "errors" in result:
+                raise ValueError(f"Error during query: {result['errors']}")
+            total = int(result["hits"]["total"]["value"])
+            hits = result["hits"]["hits"]
+        else:
+            total, hits = pit_search_slice(
+                self._client,
                 index=indices,
-                from_=from_,  # Only use from_ for the first page (simplified)
+                query=segment_query,
+                sort=sort,
+                offset=offset,
                 size=pagesize,
-                body=query_str,
+                batch_size=ES_FULL_SCAN_BATCH_SIZE,
             )
-        except NotFoundError:
-            return 0, []
 
-        if "errors" in result:
-            raise ValueError(f"Error during query: {result['errors']}")
-        total = result["hits"]["total"]["value"]  # Get total count
-
-        docs_and_scores = []
-        for res in result["hits"]["hits"]:
-            source = res["_source"]
-            page_content = source.get(Field.CONTENT_KEY.value)
-            vector = None
-            metadata = source.get(Field.METADATA_KEY.value, {})
-            chunk_type = source.get(Field.CHUNK_TYPE.value)
-            score = res["_score"]
-
-            # 将 QA 字段注入 metadata 供前端展示
-            if chunk_type:
-                metadata["chunk_type"] = chunk_type
-            if chunk_type == "qa":
-                metadata["question"] = source.get(Field.QUESTION.value, "")
-                metadata["answer"] = source.get(Field.ANSWER.value, "")
-                page_content = f"question: {metadata['question']}\nanswer: {metadata['answer']}"
-
-            docs_and_scores.append((DocumentChunk(page_content=page_content, vector=vector, metadata=metadata), score))
-
-        docs = []
-        for doc, score in docs_and_scores:
-            if doc.metadata is not None:
-                doc.metadata["score"] = score
-            docs.append(doc)
-
-        return total, docs
+        return total, [self._segment_hit_to_chunk(hit) for hit in hits]
 
     def get_by_segment(self, doc_id: str, **kwargs) -> tuple[int, list[DocumentChunk]]:  # 返回 (total, results):
         """
@@ -951,13 +994,6 @@ class ElasticSearchVectorIndexOps:
         if self._client.indices.exists(index=self._collection_name):
             self._client.indices.delete(index=self._collection_name, ignore=[400, 404])
 
-    def _get_ids_by_metadata_field(self, key: str, value: str) -> list[str] | None:
-        query = {"query": {"term": {f"{Field.METADATA_KEY.value}.{key}": value}}}
-        response = self._client.search(index=self._collection_name, body=query, size=10000)
-        if response["hits"]["hits"]:
-            return [hit["_id"] for hit in response["hits"]["hits"]]
-        return None
-
     def delete_by_metadata_field(
             self,
             key: str,
@@ -968,27 +1004,19 @@ class ElasticSearchVectorIndexOps:
         if not self._client.indices.exists(index=self._collection_name):
             return False
 
-        actual_ids = self._get_ids_by_metadata_field(key, value)
-        if not actual_ids:
-            return True
-
-        actions = [{"_op_type": "delete", "_index": self._collection_name, "_id": es_id} for es_id in actual_ids]
-        try:
-            helpers.bulk(self._client, actions)
-            if refresh:
-                self._client.indices.refresh(index=self._collection_name)
-        except BulkIndexError as e:
-            for error in e.errors:
-                delete_error = error.get("delete", {})
-                status = delete_error.get("status")
-                doc_id = delete_error.get("_id")
-
-                if status == 404:
-                    logger.warning(f"Document not found for deletion: {doc_id}")
-                else:
-                    logger.error(f"Error deleting document: {error}")
-                    raise
-
+        result = self._client.delete_by_query(
+            index=self._collection_name,
+            query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
+            refresh=refresh,
+            conflicts="abort",
+            wait_for_completion=True,
+        )
+        logger.info(
+            "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
+            self._collection_name,
+            key,
+            result.get("deleted", 0),
+        )
         return True
 
     def change_document_status(self, document_id: str, status: int) -> int:

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -41,7 +41,7 @@ from app.core.rag.retrieval.elasticsearch_queries import (
 )
 from app.core.rag.vdb.field import Field
 from app.core.rag.vdb.elasticsearch.pit_search import (
-    iter_pit_search_hits,
+    iter_search_after_hits,
     pit_search_slice,
 )
 from app.core.rag.vdb.elasticsearch.response_validation import (
@@ -261,10 +261,11 @@ class ElasticSearchVector(BaseVector):
     def get_ids_by_metadata_field(self, key: str, value: str) -> list[str] | None:
         ids = [
             hit["_id"]
-            for hit in iter_pit_search_hits(
+            for hit in iter_search_after_hits(
                 self._client,
                 index=self._collection_name,
                 query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
+                sort=self._segment_sort(True),
                 batch_size=ES_FULL_SCAN_BATCH_SIZE,
                 source=False,
             )
@@ -372,7 +373,7 @@ class ElasticSearchVector(BaseVector):
             chunk_types,
             parent_ids,
         )
-        for hit in iter_pit_search_hits(
+        for hit in iter_search_after_hits(
             self._client,
             index=indices,
             query=segment_query,

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -58,6 +58,34 @@ ES_DEFAULT_MAX_RESULT_WINDOW = 10000
 ES_FULL_SCAN_BATCH_SIZE = 1000
 
 
+def _delete_by_metadata_field(
+    client: Elasticsearch,
+    index_name: str,
+    key: str,
+    value: str,
+    *,
+    refresh: bool,
+) -> bool:
+    result = client.delete_by_query(
+        index=index_name,
+        query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
+        refresh=refresh,
+        conflicts="abort",
+        wait_for_completion=True,
+    )
+    raise_on_delete_by_query_failure(
+        result,
+        "delete by metadata field",
+    )
+    logger.info(
+        "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
+        index_name,
+        key,
+        result.get("deleted", 0),
+    )
+    return True
+
+
 @dataclass(frozen=True)
 class ModelApiKeyRuntimeConfig:
     model_name: str
@@ -246,24 +274,13 @@ class ElasticSearchVector(BaseVector):
     def delete_by_metadata_field(self, key: str, value: str, *, refresh: bool = False):
         if not self._client.indices.exists(index=self._collection_name):
             return False
-        result = self._client.delete_by_query(
-            index=self._collection_name,
-            query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
-            refresh=refresh,
-            conflicts="abort",
-            wait_for_completion=True,
-        )
-        raise_on_delete_by_query_failure(
-            result,
-            "delete by metadata field",
-        )
-        logger.info(
-            "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
+        return _delete_by_metadata_field(
+            self._client,
             self._collection_name,
             key,
-            result.get("deleted", 0),
+            value,
+            refresh=refresh,
         )
-        return True
 
     def delete(self):
         if self._client.indices.exists(index=self._collection_name):
@@ -1018,24 +1035,13 @@ class ElasticSearchVectorIndexOps:
         if not self._client.indices.exists(index=self._collection_name):
             return False
 
-        result = self._client.delete_by_query(
-            index=self._collection_name,
-            query={"term": {f"{Field.METADATA_KEY.value}.{key}": value}},
-            refresh=refresh,
-            conflicts="abort",
-            wait_for_completion=True,
-        )
-        raise_on_delete_by_query_failure(
-            result,
-            "delete by metadata field",
-        )
-        logger.info(
-            "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
+        return _delete_by_metadata_field(
+            self._client,
             self._collection_name,
             key,
-            result.get("deleted", 0),
+            value,
+            refresh=refresh,
         )
-        return True
 
     def change_document_status(self, document_id: str, status: int) -> int:
         body = {

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -381,6 +381,64 @@ class ElasticSearchVector(BaseVector):
         ):
             yield self._segment_hit_to_chunk(hit)
 
+    def load_parent_child_fallback_page(
+        self,
+        *,
+        document_id: str,
+        query: str | None,
+        page: int,
+        pagesize: int,
+    ) -> tuple[
+        int,
+        list[DocumentChunk],
+        int,
+        list[DocumentChunk],
+        list[DocumentChunk],
+    ]:
+        offset = (page - 1) * pagesize
+        end = offset + pagesize
+        total_all = 0
+        total_parents = 0
+        flat_page: list[DocumentChunk] = []
+        parent_page: list[DocumentChunk] = []
+
+        for item in self.iter_by_segment(
+            document_id=document_id,
+            query=query,
+            asc=True,
+        ):
+            metadata = item.metadata or {}
+            if offset <= total_all < end:
+                flat_page.append(item)
+            if metadata.get("chunk_type") == "parent":
+                if offset <= total_parents < end:
+                    parent_page.append(item)
+                total_parents += 1
+            total_all += 1
+
+        if total_parents == 0 or not parent_page:
+            return total_all, flat_page, total_parents, parent_page, []
+
+        parent_doc_ids = {
+            item.metadata.get("doc_id")
+            for item in parent_page
+            if item.metadata and item.metadata.get("doc_id")
+        }
+        selected_children: list[DocumentChunk] = []
+        if parent_doc_ids:
+            for item in self.iter_by_segment(
+                document_id=document_id,
+                asc=True,
+            ):
+                metadata = item.metadata or {}
+                if (
+                    metadata.get("chunk_type") == "child"
+                    and metadata.get("parent_id") in parent_doc_ids
+                ):
+                    selected_children.append(item)
+
+        return total_all, flat_page, total_parents, parent_page, selected_children
+
     def search_by_segment(self, document_id: str | None = None, query: str | None = None, pagesize: int = 10, page: int = 1, asc: bool = True, chunk_types: list[str] | str | None = None, parent_ids: list[str] | str | None = None, **kwargs) -> tuple[int, list[DocumentChunk]]:  # 返回 (total, results):
         """
         Search documents by segment (pagination) with optional keyword query.

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -46,6 +46,7 @@ from app.core.rag.vdb.elasticsearch.pit_search import (
 )
 from app.core.rag.vdb.elasticsearch.response_validation import (
     raise_on_delete_by_query_failure,
+    raise_on_search_response_failure,
 )
 from app.core.rag.vdb.vector_base import BaseVector
 from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
@@ -401,9 +402,11 @@ class ElasticSearchVector(BaseVector):
                     query=segment_query,
                     sort=sort,
                     track_total_hits=True,
+                    allow_partial_search_results=False,
                 )
             except NotFoundError:
                 return 0, []
+            raise_on_search_response_failure(result, "segment search")
             if "errors" in result:
                 raise ValueError(f"Error during query: {result['errors']}")
             total = int(result["hits"]["total"]["value"])

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -44,6 +44,9 @@ from app.core.rag.vdb.elasticsearch.pit_search import (
     iter_pit_search_hits,
     pit_search_slice,
 )
+from app.core.rag.vdb.elasticsearch.response_validation import (
+    raise_on_delete_by_query_failure,
+)
 from app.core.rag.vdb.vector_base import BaseVector
 from app.core.rag.models.chunk import DocumentChunk, chunk_retrieval_content
 
@@ -52,49 +55,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_INDEX_REFRESH_INTERVAL = "1s"
 ES_DEFAULT_MAX_RESULT_WINDOW = 10000
 ES_FULL_SCAN_BATCH_SIZE = 1000
-
-
-def _safe_int(value: Any) -> int:
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _delete_failure_summary(failures: Any) -> str:
-    if not isinstance(failures, list) or not failures:
-        return ""
-    summaries: list[str] = []
-    for failure in failures[:3]:
-        if isinstance(failure, Mapping):
-            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
-            if isinstance(reason, Mapping):
-                reason = reason.get("reason") or reason.get("type")
-            summaries.append(str(reason or "unknown"))
-        else:
-            summaries.append(str(failure))
-    return "; ".join(summaries)
-
-
-def _raise_on_delete_by_query_failure(
-    response: Mapping[str, Any],
-    *,
-    operation: str,
-) -> None:
-    if response.get("timed_out"):
-        raise RuntimeError(f"Elasticsearch {operation} timed out")
-
-    version_conflicts = _safe_int(response.get("version_conflicts"))
-    failures = response.get("failures") or []
-    if version_conflicts or failures:
-        details = _delete_failure_summary(failures)
-        message = (
-            f"Elasticsearch {operation} failed: "
-            f"version_conflicts={version_conflicts} failures={len(failures)}"
-        )
-        if details:
-            message = f"{message}: {details}"
-        raise RuntimeError(message)
 
 
 @dataclass(frozen=True)
@@ -254,9 +214,9 @@ class ElasticSearchVector(BaseVector):
                 conflicts="abort",
                 wait_for_completion=True,
             )
-            _raise_on_delete_by_query_failure(
+            raise_on_delete_by_query_failure(
                 result,
-                operation="delete by metadata IDs",
+                "delete by metadata IDs",
             )
             deleted += int(result.get("deleted", 0))
 
@@ -292,9 +252,9 @@ class ElasticSearchVector(BaseVector):
             conflicts="abort",
             wait_for_completion=True,
         )
-        _raise_on_delete_by_query_failure(
+        raise_on_delete_by_query_failure(
             result,
-            operation="delete by metadata field",
+            "delete by metadata field",
         )
         logger.info(
             "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
@@ -1062,9 +1022,9 @@ class ElasticSearchVectorIndexOps:
             conflicts="abort",
             wait_for_completion=True,
         )
-        _raise_on_delete_by_query_failure(
+        raise_on_delete_by_query_failure(
             result,
-            operation="delete by metadata field",
+            "delete by metadata field",
         )
         logger.info(
             "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -429,6 +429,7 @@ class ElasticSearchVector(BaseVector):
             for item in self.iter_by_segment(
                 document_id=document_id,
                 asc=True,
+                parent_ids=list(parent_doc_ids),
             ):
                 metadata = item.metadata or {}
                 if (

--- a/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
+++ b/api/app/core/rag/vdb/elasticsearch/elasticsearch_vector.py
@@ -54,6 +54,49 @@ ES_DEFAULT_MAX_RESULT_WINDOW = 10000
 ES_FULL_SCAN_BATCH_SIZE = 1000
 
 
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _delete_failure_summary(failures: Any) -> str:
+    if not isinstance(failures, list) or not failures:
+        return ""
+    summaries: list[str] = []
+    for failure in failures[:3]:
+        if isinstance(failure, Mapping):
+            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
+            if isinstance(reason, Mapping):
+                reason = reason.get("reason") or reason.get("type")
+            summaries.append(str(reason or "unknown"))
+        else:
+            summaries.append(str(failure))
+    return "; ".join(summaries)
+
+
+def _raise_on_delete_by_query_failure(
+    response: Mapping[str, Any],
+    *,
+    operation: str,
+) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch {operation} timed out")
+
+    version_conflicts = _safe_int(response.get("version_conflicts"))
+    failures = response.get("failures") or []
+    if version_conflicts or failures:
+        details = _delete_failure_summary(failures)
+        message = (
+            f"Elasticsearch {operation} failed: "
+            f"version_conflicts={version_conflicts} failures={len(failures)}"
+        )
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
+
+
 @dataclass(frozen=True)
 class ModelApiKeyRuntimeConfig:
     model_name: str
@@ -211,6 +254,10 @@ class ElasticSearchVector(BaseVector):
                 conflicts="abort",
                 wait_for_completion=True,
             )
+            _raise_on_delete_by_query_failure(
+                result,
+                operation="delete by metadata IDs",
+            )
             deleted += int(result.get("deleted", 0))
 
         if refresh:
@@ -244,6 +291,10 @@ class ElasticSearchVector(BaseVector):
             refresh=refresh,
             conflicts="abort",
             wait_for_completion=True,
+        )
+        _raise_on_delete_by_query_failure(
+            result,
+            operation="delete by metadata field",
         )
         logger.info(
             "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",
@@ -1010,6 +1061,10 @@ class ElasticSearchVectorIndexOps:
             refresh=refresh,
             conflicts="abort",
             wait_for_completion=True,
+        )
+        _raise_on_delete_by_query_failure(
+            result,
+            operation="delete by metadata field",
         )
         logger.info(
             "Deleted Elasticsearch documents by metadata field: index=%s field=%s deleted=%s",

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -367,30 +367,16 @@ async def iter_async_search_after_hits(
         cursor = _next_cursor(hits, cursor, context)
 
 
-def search_after_slice(
-    client: Elasticsearch,
+def _collect_page_slice(
+    pages: Iterator[PitSearchPage | SearchAfterPage],
     *,
-    index: str | Sequence[str],
-    query: Mapping[str, Any],
-    sort: Sequence[str | Mapping[str, Any]],
     offset: int,
     size: int,
-    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
 ) -> tuple[int, list[dict[str, Any]]]:
-    if offset < 0 or size < 0:
-        raise ValueError("offset and size must be non-negative")
-
     total = 0
     selected: list[dict[str, Any]] = []
     seen = 0
-    for page in iter_search_after_pages(
-        client,
-        index=index,
-        query=query,
-        sort=sort,
-        batch_size=batch_size,
-        track_total_hits=True,
-    ):
+    for page in pages:
         if page.total is not None:
             total = page.total
             if size == 0 or offset >= total:
@@ -409,6 +395,33 @@ def search_after_slice(
     return total, selected
 
 
+def search_after_slice(
+    client: Elasticsearch,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    offset: int,
+    size: int,
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+) -> tuple[int, list[dict[str, Any]]]:
+    if offset < 0 or size < 0:
+        raise ValueError("offset and size must be non-negative")
+
+    return _collect_page_slice(
+        iter_search_after_pages(
+            client,
+            index=index,
+            query=query,
+            sort=sort,
+            batch_size=batch_size,
+            track_total_hits=True,
+        ),
+        offset=offset,
+        size=size,
+    )
+
+
 def pit_search_slice(
     client: Elasticsearch,
     *,
@@ -422,9 +435,6 @@ def pit_search_slice(
     if offset < 0 or size < 0:
         raise ValueError("offset and size must be non-negative")
 
-    total = 0
-    selected: list[dict[str, Any]] = []
-    seen = 0
     pages = iter_pit_search_pages(
         client,
         index=index,
@@ -434,22 +444,7 @@ def pit_search_slice(
         track_total_hits=True,
     )
     try:
-        for page in pages:
-            if page.total is not None:
-                total = page.total
-                if size == 0 or offset >= total:
-                    break
-            if not page.hits or size == 0:
-                break
-
-            page_end = seen + len(page.hits)
-            take_start = max(offset - seen, 0)
-            take_end = min(offset + size - seen, len(page.hits))
-            if take_start < take_end:
-                selected.extend(page.hits[take_start:take_end])
-            seen = page_end
-            if len(selected) >= size or seen >= total:
-                break
+        total, selected = _collect_page_slice(pages, offset=offset, size=size)
     finally:
         pages.close()
     return total, selected

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -7,6 +7,10 @@ from typing import Any
 
 from elasticsearch import Elasticsearch
 
+from app.core.rag.vdb.elasticsearch.response_validation import (
+    raise_on_search_response_failure,
+)
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_PIT_KEEP_ALIVE = "2m"
@@ -25,48 +29,6 @@ def _total_value(response: Mapping[str, Any]) -> int:
     if isinstance(total, Mapping):
         return int(total.get("value", 0))
     return int(total or 0)
-
-
-def _int_value(value: Any) -> int:
-    try:
-        return int(value or 0)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _failure_summary(failures: Any) -> str:
-    if not isinstance(failures, list) or not failures:
-        return ""
-    summaries: list[str] = []
-    for failure in failures[:3]:
-        if isinstance(failure, Mapping):
-            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
-            if isinstance(reason, Mapping):
-                reason = reason.get("reason") or reason.get("type")
-            summaries.append(str(reason or "unknown"))
-        else:
-            summaries.append(str(failure))
-    return "; ".join(summaries)
-
-
-def _raise_on_search_failure(response: Mapping[str, Any]) -> None:
-    if response.get("timed_out"):
-        raise RuntimeError("Elasticsearch PIT search timed out")
-
-    shards = response.get("_shards") or {}
-    failed = _int_value(shards.get("failed") if isinstance(shards, Mapping) else 0)
-    failures = []
-    if isinstance(shards, Mapping):
-        failures = shards.get("failures") or []
-    if not failures:
-        failures = response.get("failures") or []
-
-    if failed or failures:
-        details = _failure_summary(failures)
-        message = f"Elasticsearch PIT search failed on {failed} shard(s)"
-        if details:
-            message = f"{message}: {details}"
-        raise RuntimeError(message)
 
 
 def _with_shard_tiebreaker(
@@ -128,7 +90,7 @@ def iter_pit_search_pages(
             latest_pit_id = response.get("pit_id")
             if latest_pit_id:
                 pit_id = latest_pit_id
-            _raise_on_search_failure(response)
+            raise_on_search_response_failure(response, "PIT search")
 
             hits = list(response.get("hits", {}).get("hits", []))
             total = _total_value(response) if first_page and track_total_hits else None

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -64,7 +64,11 @@ def iter_pit_search_pages(
     cursor: list[Any] | None = None
     first_page = True
     try:
-        opened = client.open_point_in_time(index=index, keep_alive=keep_alive)
+        opened = client.open_point_in_time(
+            index=index,
+            keep_alive=keep_alive,
+            allow_partial_search_results=False,
+        )
         pit_id = opened.get("id")
         if not pit_id:
             raise RuntimeError("Elasticsearch did not return a PIT id")
@@ -126,6 +130,80 @@ def iter_pit_search_hits(
             yield from page.hits
     finally:
         pages.close()
+
+
+async def iter_async_pit_search_hits(
+    client: Any,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]] = (),
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+    source: bool | Mapping[str, Any] | None = None,
+    source_includes: Sequence[str] | None = None,
+    keep_alive: str = DEFAULT_PIT_KEEP_ALIVE,
+    context: str = "async PIT search",
+) -> AsyncIterator[dict[str, Any]]:
+    if not 1 <= batch_size <= MAX_SEARCH_AFTER_BATCH_SIZE:
+        raise ValueError("batch_size must be between 1 and 10000")
+
+    pit_id: str | None = None
+    cursor: list[Any] | None = None
+    try:
+        opened = await client.open_point_in_time(
+            index=index,
+            keep_alive=keep_alive,
+            allow_partial_search_results=False,
+        )
+        pit_id = opened.get("id")
+        if not pit_id:
+            raise RuntimeError(f"Elasticsearch did not return a PIT id during {context}")
+
+        effective_sort = _with_shard_tiebreaker(sort)
+        while True:
+            search_kwargs: dict[str, Any] = {
+                "pit": {"id": pit_id, "keep_alive": keep_alive},
+                "query": dict(query),
+                "sort": effective_sort,
+                "size": batch_size,
+                "allow_partial_search_results": False,
+            }
+            if source is not None:
+                search_kwargs["source"] = source
+            if source_includes is not None:
+                search_kwargs["source_includes"] = list(source_includes)
+            if cursor is not None:
+                search_kwargs["search_after"] = cursor
+
+            response = await client.search(**search_kwargs)
+            latest_pit_id = response.get("pit_id")
+            if latest_pit_id:
+                pit_id = latest_pit_id
+            raise_on_search_response_failure(response, context)
+
+            hits = list(response.get("hits", {}).get("hits", []))
+            if not hits:
+                return
+
+            for hit in hits:
+                yield hit
+
+            next_cursor = hits[-1].get("sort")
+            if not next_cursor or list(next_cursor) == cursor:
+                raise RuntimeError(
+                    f"Elasticsearch search_after cursor did not advance during {context}"
+                )
+            cursor = list(next_cursor)
+    finally:
+        if pit_id:
+            try:
+                await client.close_point_in_time(id=pit_id)
+            except Exception:
+                logger.warning(
+                    "Failed to close Elasticsearch PIT during %s",
+                    context,
+                    exc_info=True,
+                )
 
 
 def pit_search_slice(

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from elasticsearch import Elasticsearch
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PIT_KEEP_ALIVE = "2m"
+DEFAULT_SEARCH_AFTER_BATCH_SIZE = 1000
+MAX_SEARCH_AFTER_BATCH_SIZE = 10000
+
+
+@dataclass(frozen=True)
+class PitSearchPage:
+    total: int | None
+    hits: list[dict[str, Any]]
+
+
+def _total_value(response: Mapping[str, Any]) -> int:
+    total = response.get("hits", {}).get("total", 0)
+    if isinstance(total, Mapping):
+        return int(total.get("value", 0))
+    return int(total or 0)
+
+
+def _with_shard_tiebreaker(
+    sort: Sequence[str | Mapping[str, Any]],
+) -> list[str | Mapping[str, Any]]:
+    result = list(sort)
+    has_shard_doc = any(
+        value == "_shard_doc"
+        or (isinstance(value, Mapping) and "_shard_doc" in value)
+        for value in result
+    )
+    if not has_shard_doc:
+        result.append({"_shard_doc": "asc"})
+    return result
+
+
+def iter_pit_search_pages(
+    client: Elasticsearch,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]] = (),
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+    source: bool | Mapping[str, Any] | None = None,
+    source_includes: Sequence[str] | None = None,
+    track_total_hits: bool = False,
+    keep_alive: str = DEFAULT_PIT_KEEP_ALIVE,
+) -> Iterator[PitSearchPage]:
+    if not 1 <= batch_size <= MAX_SEARCH_AFTER_BATCH_SIZE:
+        raise ValueError("batch_size must be between 1 and 10000")
+
+    pit_id: str | None = None
+    cursor: list[Any] | None = None
+    first_page = True
+    try:
+        opened = client.open_point_in_time(index=index, keep_alive=keep_alive)
+        pit_id = opened.get("id")
+        if not pit_id:
+            raise RuntimeError("Elasticsearch did not return a PIT id")
+
+        effective_sort = _with_shard_tiebreaker(sort)
+        while True:
+            search_kwargs: dict[str, Any] = {
+                "pit": {"id": pit_id, "keep_alive": keep_alive},
+                "query": dict(query),
+                "sort": effective_sort,
+                "size": batch_size,
+                "track_total_hits": track_total_hits if first_page else False,
+            }
+            if source is not None:
+                search_kwargs["source"] = source
+            if source_includes is not None:
+                search_kwargs["source_includes"] = list(source_includes)
+            if cursor is not None:
+                search_kwargs["search_after"] = cursor
+
+            response = client.search(**search_kwargs)
+            latest_pit_id = response.get("pit_id")
+            if latest_pit_id:
+                pit_id = latest_pit_id
+
+            hits = list(response.get("hits", {}).get("hits", []))
+            total = _total_value(response) if first_page and track_total_hits else None
+            if not hits:
+                if first_page and track_total_hits:
+                    yield PitSearchPage(total=total or 0, hits=[])
+                return
+
+            yield PitSearchPage(total=total, hits=hits)
+
+            next_cursor = hits[-1].get("sort")
+            if not next_cursor or list(next_cursor) == cursor:
+                raise RuntimeError(
+                    "Elasticsearch search_after sort cursor is missing or did not advance"
+                )
+            cursor = list(next_cursor)
+            first_page = False
+    finally:
+        if pit_id:
+            try:
+                client.close_point_in_time(id=pit_id)
+            except Exception:
+                logger.warning("Failed to close Elasticsearch PIT", exc_info=True)
+
+
+def iter_pit_search_hits(
+    client: Elasticsearch,
+    **kwargs: Any,
+) -> Iterator[dict[str, Any]]:
+    pages = iter_pit_search_pages(client, **kwargs)
+    try:
+        for page in pages:
+            yield from page.hits
+    finally:
+        pages.close()
+
+
+def pit_search_slice(
+    client: Elasticsearch,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    offset: int,
+    size: int,
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+) -> tuple[int, list[dict[str, Any]]]:
+    if offset < 0 or size < 0:
+        raise ValueError("offset and size must be non-negative")
+
+    total = 0
+    selected: list[dict[str, Any]] = []
+    seen = 0
+    pages = iter_pit_search_pages(
+        client,
+        index=index,
+        query=query,
+        sort=sort,
+        batch_size=batch_size,
+        track_total_hits=True,
+    )
+    try:
+        for page in pages:
+            if page.total is not None:
+                total = page.total
+            if not page.hits or size == 0:
+                break
+
+            page_end = seen + len(page.hits)
+            take_start = max(offset - seen, 0)
+            take_end = min(offset + size - seen, len(page.hits))
+            if take_start < take_end:
+                selected.extend(page.hits[take_start:take_end])
+            seen = page_end
+            if len(selected) >= size or seen >= total:
+                break
+    finally:
+        pages.close()
+    return total, selected

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -27,6 +27,48 @@ def _total_value(response: Mapping[str, Any]) -> int:
     return int(total or 0)
 
 
+def _int_value(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _failure_summary(failures: Any) -> str:
+    if not isinstance(failures, list) or not failures:
+        return ""
+    summaries: list[str] = []
+    for failure in failures[:3]:
+        if isinstance(failure, Mapping):
+            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
+            if isinstance(reason, Mapping):
+                reason = reason.get("reason") or reason.get("type")
+            summaries.append(str(reason or "unknown"))
+        else:
+            summaries.append(str(failure))
+    return "; ".join(summaries)
+
+
+def _raise_on_search_failure(response: Mapping[str, Any]) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError("Elasticsearch PIT search timed out")
+
+    shards = response.get("_shards") or {}
+    failed = _int_value(shards.get("failed") if isinstance(shards, Mapping) else 0)
+    failures = []
+    if isinstance(shards, Mapping):
+        failures = shards.get("failures") or []
+    if not failures:
+        failures = response.get("failures") or []
+
+    if failed or failures:
+        details = _failure_summary(failures)
+        message = f"Elasticsearch PIT search failed on {failed} shard(s)"
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
+
+
 def _with_shard_tiebreaker(
     sort: Sequence[str | Mapping[str, Any]],
 ) -> list[str | Mapping[str, Any]]:
@@ -73,6 +115,7 @@ def iter_pit_search_pages(
                 "sort": effective_sort,
                 "size": batch_size,
                 "track_total_hits": track_total_hits if first_page else False,
+                "allow_partial_search_results": False,
             }
             if source is not None:
                 search_kwargs["source"] = source
@@ -85,6 +128,7 @@ def iter_pit_search_pages(
             latest_pit_id = response.get("pit_id")
             if latest_pit_id:
                 pit_id = latest_pit_id
+            _raise_on_search_failure(response)
 
             hits = list(response.get("hits", {}).get("hits", []))
             total = _total_value(response) if first_page and track_total_hits else None

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -45,6 +45,56 @@ def _with_shard_tiebreaker(
     return result
 
 
+def _pit_search_kwargs(
+    *,
+    pit_id: str,
+    keep_alive: str,
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    batch_size: int,
+    source: bool | Mapping[str, Any] | None,
+    source_includes: Sequence[str] | None,
+    cursor: list[Any] | None,
+    track_total_hits: bool | None = None,
+) -> dict[str, Any]:
+    search_kwargs: dict[str, Any] = {
+        "pit": {"id": pit_id, "keep_alive": keep_alive},
+        "query": dict(query),
+        "sort": list(sort),
+        "size": batch_size,
+        "allow_partial_search_results": False,
+    }
+    if track_total_hits is not None:
+        search_kwargs["track_total_hits"] = track_total_hits
+    if source is not None:
+        search_kwargs["source"] = source
+    if source_includes is not None:
+        search_kwargs["source_includes"] = list(source_includes)
+    if cursor is not None:
+        search_kwargs["search_after"] = cursor
+    return search_kwargs
+
+
+def _latest_pit_id(response: Mapping[str, Any], current_pit_id: str) -> str:
+    latest = response.get("pit_id")
+    if latest:
+        return str(latest)
+    return current_pit_id
+
+
+def _next_cursor(
+    hits: list[dict[str, Any]],
+    cursor: list[Any] | None,
+    context: str,
+) -> list[Any]:
+    next_cursor = hits[-1].get("sort")
+    if not next_cursor or list(next_cursor) == cursor:
+        raise RuntimeError(
+            f"Elasticsearch search_after cursor did not advance during {context}"
+        )
+    return list(next_cursor)
+
+
 def iter_pit_search_pages(
     client: Elasticsearch,
     *,
@@ -75,26 +125,22 @@ def iter_pit_search_pages(
 
         effective_sort = _with_shard_tiebreaker(sort)
         while True:
-            search_kwargs: dict[str, Any] = {
-                "pit": {"id": pit_id, "keep_alive": keep_alive},
-                "query": dict(query),
-                "sort": effective_sort,
-                "size": batch_size,
-                "track_total_hits": track_total_hits if first_page else False,
-                "allow_partial_search_results": False,
-            }
-            if source is not None:
-                search_kwargs["source"] = source
-            if source_includes is not None:
-                search_kwargs["source_includes"] = list(source_includes)
-            if cursor is not None:
-                search_kwargs["search_after"] = cursor
-
-            response = client.search(**search_kwargs)
-            latest_pit_id = response.get("pit_id")
-            if latest_pit_id:
-                pit_id = latest_pit_id
-            raise_on_search_response_failure(response, "PIT search")
+            response = client.search(
+                **_pit_search_kwargs(
+                    pit_id=pit_id,
+                    keep_alive=keep_alive,
+                    query=query,
+                    sort=effective_sort,
+                    batch_size=batch_size,
+                    source=source,
+                    source_includes=source_includes,
+                    cursor=cursor,
+                    track_total_hits=track_total_hits if first_page else False,
+                )
+            )
+            pit_id = _latest_pit_id(response, pit_id)
+            context = "PIT search"
+            raise_on_search_response_failure(response, context)
 
             hits = list(response.get("hits", {}).get("hits", []))
             total = _total_value(response) if first_page and track_total_hits else None
@@ -105,12 +151,7 @@ def iter_pit_search_pages(
 
             yield PitSearchPage(total=total, hits=hits)
 
-            next_cursor = hits[-1].get("sort")
-            if not next_cursor or list(next_cursor) == cursor:
-                raise RuntimeError(
-                    "Elasticsearch search_after sort cursor is missing or did not advance"
-                )
-            cursor = list(next_cursor)
+            cursor = _next_cursor(hits, cursor, context)
             first_page = False
     finally:
         if pit_id:
@@ -161,24 +202,19 @@ async def iter_async_pit_search_hits(
 
         effective_sort = _with_shard_tiebreaker(sort)
         while True:
-            search_kwargs: dict[str, Any] = {
-                "pit": {"id": pit_id, "keep_alive": keep_alive},
-                "query": dict(query),
-                "sort": effective_sort,
-                "size": batch_size,
-                "allow_partial_search_results": False,
-            }
-            if source is not None:
-                search_kwargs["source"] = source
-            if source_includes is not None:
-                search_kwargs["source_includes"] = list(source_includes)
-            if cursor is not None:
-                search_kwargs["search_after"] = cursor
-
-            response = await client.search(**search_kwargs)
-            latest_pit_id = response.get("pit_id")
-            if latest_pit_id:
-                pit_id = latest_pit_id
+            response = await client.search(
+                **_pit_search_kwargs(
+                    pit_id=pit_id,
+                    keep_alive=keep_alive,
+                    query=query,
+                    sort=effective_sort,
+                    batch_size=batch_size,
+                    source=source,
+                    source_includes=source_includes,
+                    cursor=cursor,
+                )
+            )
+            pit_id = _latest_pit_id(response, pit_id)
             raise_on_search_response_failure(response, context)
 
             hits = list(response.get("hits", {}).get("hits", []))
@@ -188,12 +224,7 @@ async def iter_async_pit_search_hits(
             for hit in hits:
                 yield hit
 
-            next_cursor = hits[-1].get("sort")
-            if not next_cursor or list(next_cursor) == cursor:
-                raise RuntimeError(
-                    f"Elasticsearch search_after cursor did not advance during {context}"
-                )
-            cursor = list(next_cursor)
+            cursor = _next_cursor(hits, cursor, context)
     finally:
         if pit_id:
             try:

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -24,6 +24,12 @@ class PitSearchPage:
     hits: list[dict[str, Any]]
 
 
+@dataclass(frozen=True)
+class SearchAfterPage:
+    total: int | None
+    hits: list[dict[str, Any]]
+
+
 def _total_value(response: Mapping[str, Any]) -> int:
     total = response.get("hits", {}).get("total", 0)
     if isinstance(total, Mapping):
@@ -75,6 +81,35 @@ def _pit_search_kwargs(
     return search_kwargs
 
 
+def _search_after_kwargs(
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    batch_size: int,
+    source: bool | Mapping[str, Any] | None,
+    source_includes: Sequence[str] | None,
+    cursor: list[Any] | None,
+    track_total_hits: bool | None = None,
+) -> dict[str, Any]:
+    search_kwargs: dict[str, Any] = {
+        "index": index,
+        "query": dict(query),
+        "sort": list(sort),
+        "size": batch_size,
+        "allow_partial_search_results": False,
+    }
+    if track_total_hits is not None:
+        search_kwargs["track_total_hits"] = track_total_hits
+    if source is not None:
+        search_kwargs["source"] = source
+    if source_includes is not None:
+        search_kwargs["source_includes"] = list(source_includes)
+    if cursor is not None:
+        search_kwargs["search_after"] = cursor
+    return search_kwargs
+
+
 def _latest_pit_id(response: Mapping[str, Any], current_pit_id: str) -> str:
     latest = response.get("pit_id")
     if latest:
@@ -90,9 +125,65 @@ def _next_cursor(
     next_cursor = hits[-1].get("sort")
     if not next_cursor or list(next_cursor) == cursor:
         raise RuntimeError(
-            f"Elasticsearch search_after cursor did not advance during {context}"
+            f"Elasticsearch search_after sort cursor did not advance during {context}"
         )
     return list(next_cursor)
+
+
+def iter_search_after_pages(
+    client: Elasticsearch,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+    source: bool | Mapping[str, Any] | None = None,
+    source_includes: Sequence[str] | None = None,
+    track_total_hits: bool = False,
+    context: str = "search_after",
+) -> Iterator[SearchAfterPage]:
+    if not 1 <= batch_size <= MAX_SEARCH_AFTER_BATCH_SIZE:
+        raise ValueError("batch_size must be between 1 and 10000")
+    if not sort:
+        raise ValueError("sort is required for search_after")
+
+    cursor: list[Any] | None = None
+    first_page = True
+    while True:
+        response = client.search(
+            **_search_after_kwargs(
+                index=index,
+                query=query,
+                sort=sort,
+                batch_size=batch_size,
+                source=source,
+                source_includes=source_includes,
+                cursor=cursor,
+                track_total_hits=track_total_hits if first_page else False,
+            )
+        )
+        raise_on_search_response_failure(response, context)
+
+        hits = list(response.get("hits", {}).get("hits", []))
+        total = _total_value(response) if first_page and track_total_hits else None
+        if not hits:
+            if first_page and track_total_hits:
+                yield SearchAfterPage(total=total or 0, hits=[])
+            return
+
+        yield SearchAfterPage(total=total, hits=hits)
+
+        cursor = _next_cursor(hits, cursor, context)
+        first_page = False
+
+
+def iter_search_after_hits(
+    client: Elasticsearch,
+    **kwargs: Any,
+) -> Iterator[dict[str, Any]]:
+    pages = iter_search_after_pages(client, **kwargs)
+    for page in pages:
+        yield from page.hits
 
 
 def iter_pit_search_pages(
@@ -117,7 +208,6 @@ def iter_pit_search_pages(
         opened = client.open_point_in_time(
             index=index,
             keep_alive=keep_alive,
-            allow_partial_search_results=False,
         )
         pit_id = opened.get("id")
         if not pit_id:
@@ -194,7 +284,6 @@ async def iter_async_pit_search_hits(
         opened = await client.open_point_in_time(
             index=index,
             keep_alive=keep_alive,
-            allow_partial_search_results=False,
         )
         pit_id = opened.get("id")
         if not pit_id:
@@ -235,6 +324,89 @@ async def iter_async_pit_search_hits(
                     context,
                     exc_info=True,
                 )
+
+
+async def iter_async_search_after_hits(
+    client: Any,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+    source: bool | Mapping[str, Any] | None = None,
+    source_includes: Sequence[str] | None = None,
+    context: str = "async search_after",
+) -> AsyncIterator[dict[str, Any]]:
+    if not 1 <= batch_size <= MAX_SEARCH_AFTER_BATCH_SIZE:
+        raise ValueError("batch_size must be between 1 and 10000")
+    if not sort:
+        raise ValueError("sort is required for search_after")
+
+    cursor: list[Any] | None = None
+    while True:
+        response = await client.search(
+            **_search_after_kwargs(
+                index=index,
+                query=query,
+                sort=sort,
+                batch_size=batch_size,
+                source=source,
+                source_includes=source_includes,
+                cursor=cursor,
+            )
+        )
+        raise_on_search_response_failure(response, context)
+
+        hits = list(response.get("hits", {}).get("hits", []))
+        if not hits:
+            return
+
+        for hit in hits:
+            yield hit
+
+        cursor = _next_cursor(hits, cursor, context)
+
+
+def search_after_slice(
+    client: Elasticsearch,
+    *,
+    index: str | Sequence[str],
+    query: Mapping[str, Any],
+    sort: Sequence[str | Mapping[str, Any]],
+    offset: int,
+    size: int,
+    batch_size: int = DEFAULT_SEARCH_AFTER_BATCH_SIZE,
+) -> tuple[int, list[dict[str, Any]]]:
+    if offset < 0 or size < 0:
+        raise ValueError("offset and size must be non-negative")
+
+    total = 0
+    selected: list[dict[str, Any]] = []
+    seen = 0
+    for page in iter_search_after_pages(
+        client,
+        index=index,
+        query=query,
+        sort=sort,
+        batch_size=batch_size,
+        track_total_hits=True,
+    ):
+        if page.total is not None:
+            total = page.total
+            if size == 0 or offset >= total:
+                break
+        if not page.hits or size == 0:
+            break
+
+        page_end = seen + len(page.hits)
+        take_start = max(offset - seen, 0)
+        take_end = min(offset + size - seen, len(page.hits))
+        if take_start < take_end:
+            selected.extend(page.hits[take_start:take_end])
+        seen = page_end
+        if len(selected) >= size or seen >= total:
+            break
+    return total, selected
 
 
 def pit_search_slice(

--- a/api/app/core/rag/vdb/elasticsearch/pit_search.py
+++ b/api/app/core/rag/vdb/elasticsearch/pit_search.py
@@ -265,6 +265,8 @@ def pit_search_slice(
         for page in pages:
             if page.total is not None:
                 total = page.total
+                if size == 0 or offset >= total:
+                    break
             if not page.hits or size == 0:
                 break
 

--- a/api/app/core/rag/vdb/elasticsearch/response_validation.py
+++ b/api/app/core/rag/vdb/elasticsearch/response_validation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def int_value(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def failure_summary(failures: Any) -> str:
+    if not isinstance(failures, list) or not failures:
+        return ""
+    summaries: list[str] = []
+    for failure in failures[:3]:
+        if isinstance(failure, Mapping):
+            reason = failure.get("reason") or failure.get("type") or failure.get("cause")
+            if isinstance(reason, Mapping):
+                reason = reason.get("reason") or reason.get("type")
+            summaries.append(str(reason or "unknown"))
+        else:
+            summaries.append(str(failure))
+    return "; ".join(summaries)
+
+
+def raise_on_search_response_failure(
+    response: Mapping[str, Any],
+    context: str,
+) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch search timed out during {context}")
+
+    shards = response.get("_shards") or {}
+    failed = int_value(shards.get("failed") if isinstance(shards, Mapping) else 0)
+    failures: list[Any] = []
+    if isinstance(shards, Mapping):
+        shard_failures = shards.get("failures") or []
+        if isinstance(shard_failures, list):
+            failures.extend(shard_failures)
+
+    response_failures = response.get("failures") or []
+    if isinstance(response_failures, list):
+        failures.extend(response_failures)
+
+    if failed or failures:
+        details = failure_summary(failures)
+        message = (
+            f"Elasticsearch search failed during {context}: "
+            f"failed_shards={failed} failures={len(failures)}"
+        )
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
+
+
+def raise_on_delete_by_query_failure(
+    response: Mapping[str, Any],
+    context: str,
+) -> None:
+    if response.get("timed_out"):
+        raise RuntimeError(f"Elasticsearch delete_by_query timed out during {context}")
+
+    version_conflicts = int_value(response.get("version_conflicts"))
+    failures = response.get("failures") or []
+    if version_conflicts or failures:
+        details = failure_summary(failures)
+        message = (
+            f"Elasticsearch delete_by_query failed during {context}: "
+            f"version_conflicts={version_conflicts} failures={len(failures)}"
+        )
+        if details:
+            message = f"{message}: {details}"
+        raise RuntimeError(message)
+
+    if "deleted" not in response:
+        raise RuntimeError(
+            f"Elasticsearch delete_by_query returned no deleted count during {context}"
+        )

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -13,6 +13,7 @@ from app.models.file_model import File
 from app.schemas.file_schema import FileCreate, FileUpdate
 from app.repositories import file_repository
 from app.core.logging_config import get_business_logger
+from app.services.qa_export_service import iter_qa_pairs_by_document
 
 # Obtain a dedicated logger for business logic
 business_logger = get_business_logger()
@@ -110,7 +111,6 @@ def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple
     """
     from app.models.document_model import Document
     from app.models.knowledge_model import Knowledge
-    from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 
     db_file = db.query(File).filter(File.id == file_id).first()
     doc = db.query(Document).filter(Document.file_id == file_id).first()
@@ -121,18 +121,7 @@ def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple
     if not db_knowledge:
         return None
 
-    vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
-    _, items = vector_service.search_by_segment(
-        document_id=str(doc.id), pagesize=10000, page=1, asc=True
-    )
-
-    qa_pairs = []
-    for item in items:
-        if (item.metadata or {}).get("chunk_type") == "qa":
-            qa_pairs.append({
-                "question": (item.metadata or {}).get("question", ""),
-                "answer": (item.metadata or {}).get("answer", ""),
-            })
+    qa_pairs = list(iter_qa_pairs_by_document(kb_id, doc.id))
 
     if not qa_pairs:
         return None

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -1,6 +1,4 @@
 import asyncio
-import csv as csv_module
-import io
 import struct
 import uuid
 import zlib
@@ -13,7 +11,10 @@ from app.models.file_model import File
 from app.schemas.file_schema import FileCreate, FileUpdate
 from app.repositories import file_repository
 from app.core.logging_config import get_business_logger
-from app.services.qa_export_service import iter_qa_pairs_by_document
+from app.services.qa_export_service import (
+    iter_qa_pairs_by_document,
+    render_qa_pairs_export,
+)
 
 # Obtain a dedicated logger for business logic
 business_logger = get_business_logger()
@@ -122,34 +123,11 @@ def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple
         return None
 
     qa_pairs = list(iter_qa_pairs_by_document(kb_id, doc.id))
-
-    if not qa_pairs:
+    rendered = render_qa_pairs_export(qa_pairs, db_file.file_ext)
+    if rendered is None:
         return None
 
-    file_ext_lower = db_file.file_ext.lower() if db_file.file_ext else ".csv"
-    is_xlsx = file_ext_lower in (".xlsx", ".xls")
-
-    if is_xlsx:
-        import openpyxl
-        wb = openpyxl.Workbook()
-        ws = wb.active
-        ws.append(["question", "answer"])
-        for pair in qa_pairs:
-            ws.append([pair["question"], pair["answer"]])
-        output = io.BytesIO()
-        wb.save(output)
-        content = output.getvalue()
-        wb.close()
-        media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    else:
-        text_output = io.StringIO()
-        writer = csv_module.writer(text_output)
-        writer.writerow(["question", "answer"])
-        for pair in qa_pairs:
-            writer.writerow([pair["question"], pair["answer"]])
-        content = text_output.getvalue().encode("utf-8-sig")
-        media_type = "text/csv"
-
+    content, media_type = rendered
     return content, db_file.file_name, media_type
 
 

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -2,6 +2,8 @@ import asyncio
 import struct
 import uuid
 import zlib
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
 from typing import Any, AsyncGenerator
 from logging import Logger
 
@@ -12,12 +14,29 @@ from app.schemas.file_schema import FileCreate, FileUpdate
 from app.repositories import file_repository
 from app.core.logging_config import get_business_logger
 from app.services.qa_export_service import (
-    iter_qa_pairs_by_document,
-    render_qa_pairs_export,
+    cleanup_qa_export_file,
+    write_qa_document_export_file,
 )
 
 # Obtain a dedicated logger for business logic
 business_logger = get_business_logger()
+
+ZIP_STREAM_CHUNK_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class QAExportSpec:
+    kb_id: uuid.UUID | str
+    document_id: uuid.UUID | str
+    file_ext: str | None
+    file_name: str
+
+
+@dataclass(frozen=True)
+class QAExportFile:
+    path: str
+    filename: str
+    media_type: str
 
 
 def get_files_paginated(
@@ -106,10 +125,7 @@ def _is_qa_doc(db: Session, file_id: uuid.UUID) -> bool:
     return doc.parser_config.get("doc_type") == "qa"
 
 
-def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple[bytes, str, str] | None:
-    """从 ES 导出 QA 问答对，保留原始文件格式（CSV 或 XLSX）。
-    返回 (content_bytes, filename, media_type)，文档非 QA 类型或无数据时返回 None。
-    """
+def get_qa_export_spec(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> QAExportSpec | None:
     from app.models.document_model import Document
     from app.models.knowledge_model import Knowledge
 
@@ -122,13 +138,32 @@ def _build_qa_export(db: Session, file_id: uuid.UUID, kb_id: uuid.UUID) -> tuple
     if not db_knowledge:
         return None
 
-    qa_pairs = list(iter_qa_pairs_by_document(kb_id, doc.id))
-    rendered = render_qa_pairs_export(qa_pairs, db_file.file_ext)
-    if rendered is None:
+    if (doc.parser_config or {}).get("doc_type") != "qa":
         return None
 
-    content, media_type = rendered
-    return content, db_file.file_name, media_type
+    return QAExportSpec(
+        kb_id=kb_id,
+        document_id=doc.id,
+        file_ext=db_file.file_ext,
+        file_name=db_file.file_name,
+    )
+
+
+def build_qa_export_file(spec: QAExportSpec) -> QAExportFile | None:
+    result = write_qa_document_export_file(
+        kb_id=spec.kb_id,
+        document_id=spec.document_id,
+        file_ext=spec.file_ext,
+    )
+    if result is None:
+        return None
+
+    path, media_type = result
+    return QAExportFile(
+        path=path,
+        filename=spec.file_name,
+        media_type=media_type,
+    )
 
 
 def build_zip_arcnames(files: list[Any]) -> list[tuple[str, str, str]]:
@@ -174,6 +209,7 @@ async def stream_zip_files(
     storage_service: Any,
     logger: Logger,
     pre_fetched: dict[str, bytes] | None = None,
+    qa_export_specs: Mapping[str, QAExportSpec] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     """逐文件下载 → 实时 deflate 压缩 → yield ZIP 数据块，全程不落盘。
     单个文件下载失败时跳过并记录，最终 ZIP 内含 _skipped_files.txt 清单。
@@ -184,84 +220,127 @@ async def stream_zip_files(
     central_entries: list[tuple[bytes, int, int, int, int]] = []
     skipped_files: list[str] = []
     offset = 0
+    cleanup_paths: set[str] = set()
 
-    for file_name, file_key, arc_name in entries:
-        try:
-            if pre_fetched and file_key in pre_fetched:
-                content = pre_fetched[file_key]
-            else:
-                async with asyncio.timeout(120):
-                    content = await storage_service.download_file(file_key)
+    try:
+        for file_name, file_key, arc_name in entries:
+            try:
+                export_file: QAExportFile | None = None
+                if qa_export_specs and file_key in qa_export_specs:
+                    export_file = await asyncio.to_thread(
+                        build_qa_export_file,
+                        qa_export_specs[file_key],
+                    )
+                    if export_file is not None:
+                        cleanup_paths.add(export_file.path)
 
-            arc_name_bytes = arc_name.encode("utf-8")
+                if export_file is not None:
+                    chunk_source = _iter_qa_export_chunks(export_file.path)
+                elif pre_fetched and file_key in pre_fetched:
+                    chunk_source = _iter_bytes_content(pre_fetched[file_key])
+                else:
+                    async with asyncio.timeout(120):
+                        content = await storage_service.download_file(file_key)
+                    chunk_source = _iter_bytes_content(content)
+
+                arc_name_bytes = arc_name.encode("utf-8")
+                local_header = struct.pack(
+                    "<4sHHHHHIIIHH",
+                    b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(arc_name_bytes), 0,
+                ) + arc_name_bytes
+
+                yield local_header
+
+                crc = 0
+                uncompressed_size = 0
+                compressed_size = 0
+                compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+                async for chunk in chunk_source:
+                    crc = zlib.crc32(chunk, crc) & 0xFFFFFFFF
+                    uncompressed_size += len(chunk)
+                    compressed_chunk = compressor.compress(chunk)
+                    if compressed_chunk:
+                        compressed_size += len(compressed_chunk)
+                        yield compressed_chunk
+
+                compressed_tail = compressor.flush()
+                if compressed_tail:
+                    compressed_size += len(compressed_tail)
+                    yield compressed_tail
+
+                descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
+                yield descriptor
+
+                header_data_len = len(local_header) + compressed_size
+                central_entries.append((arc_name_bytes, crc, compressed_size, uncompressed_size, offset))
+                offset += header_data_len + 12
+                if export_file is not None:
+                    cleanup_qa_export_file(export_file.path)
+                    cleanup_paths.discard(export_file.path)
+            except Exception as e:
+                logger.warning(f"跳过文件 {file_name}: {e}")
+                skipped_files.append(file_name)
+                continue
+
+        # --- skipped_files manifest ---
+        if skipped_files:
+            lines = "\n".join(f"- {name}" for name in skipped_files)
+            content = f"以下文件下载失败，未包含在此ZIP包中：\n\n{lines}\n".encode("utf-8")
             crc = zlib.crc32(content) & 0xFFFFFFFF
             uncompressed_size = len(content)
             compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
             compressed_data = compressor.compress(content) + compressor.flush()
             compressed_size = len(compressed_data)
+            name_bytes = "_skipped_files.txt".encode("utf-8")
 
             local_header = struct.pack(
                 "<4sHHHHHIIIHH",
-                b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(arc_name_bytes), 0,
-            ) + arc_name_bytes
+                b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
+            ) + name_bytes
+            descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
 
             yield local_header
             yield compressed_data
-
-            descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
             yield descriptor
 
             header_data_len = len(local_header) + compressed_size
-            central_entries.append((arc_name_bytes, crc, compressed_size, uncompressed_size, offset))
+            central_entries.append((name_bytes, crc, compressed_size, uncompressed_size, offset))
             offset += header_data_len + 12
-        except Exception as e:
-            logger.warning(f"跳过文件 {file_name}: {e}")
-            skipped_files.append(file_name)
-            continue
 
-    # --- skipped_files manifest ---
-    if skipped_files:
-        lines = "\n".join(f"- {name}" for name in skipped_files)
-        content = f"以下文件下载失败，未包含在此ZIP包中：\n\n{lines}\n".encode("utf-8")
-        crc = zlib.crc32(content) & 0xFFFFFFFF
-        uncompressed_size = len(content)
-        compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
-        compressed_data = compressor.compress(content) + compressor.flush()
-        compressed_size = len(compressed_data)
-        name_bytes = "_skipped_files.txt".encode("utf-8")
+        # --- Central Directory ---
+        central_offset = offset
+        for arc_name_bytes, crc, compressed_size, uncompressed_size, local_offset in central_entries:
+            entry = struct.pack(
+                "<4sHHHHHHIIIHHHHHII",
+                b"PK\x01\x02", 20, 20, 0x0808, 8, 0, 0,
+                crc, compressed_size, uncompressed_size,
+                len(arc_name_bytes), 0, 0, 0, 0, 0, local_offset,
+            ) + arc_name_bytes
+            yield entry
+            offset += len(entry)
 
-        local_header = struct.pack(
-            "<4sHHHHHIIIHH",
-            b"PK\x03\x04", 20, 0x0808, 8, 0, 0, 0, 0, 0, len(name_bytes), 0,
-        ) + name_bytes
-        descriptor = struct.pack("<III", crc, compressed_size, uncompressed_size)
+        central_size = offset - central_offset
 
-        yield local_header
-        yield compressed_data
-        yield descriptor
+        eocd = struct.pack(
+            "<4sHHHHIIH",
+            b"PK\x05\x06", 0, 0,
+            len(central_entries), len(central_entries),
+            central_size, central_offset, 0,
+        )
+        yield eocd
+    finally:
+        for path in cleanup_paths:
+            cleanup_qa_export_file(path)
 
-        header_data_len = len(local_header) + compressed_size
-        central_entries.append((name_bytes, crc, compressed_size, uncompressed_size, offset))
-        offset += header_data_len + 12
 
-    # --- Central Directory ---
-    central_offset = offset
-    for arc_name_bytes, crc, compressed_size, uncompressed_size, local_offset in central_entries:
-        entry = struct.pack(
-            "<4sHHHHHHIIIHHHHHII",
-            b"PK\x01\x02", 20, 20, 0x0808, 8, 0, 0,
-            crc, compressed_size, uncompressed_size,
-            len(arc_name_bytes), 0, 0, 0, 0, 0, local_offset,
-        ) + arc_name_bytes
-        yield entry
-        offset += len(entry)
+async def _iter_bytes_content(content: bytes) -> AsyncIterator[bytes]:
+    yield content
 
-    central_size = offset - central_offset
 
-    eocd = struct.pack(
-        "<4sHHHHIIH",
-        b"PK\x05\x06", 0, 0,
-        len(central_entries), len(central_entries),
-        central_size, central_offset, 0,
-    )
-    yield eocd
+async def _iter_qa_export_chunks(path: str) -> AsyncIterator[bytes]:
+    with open(path, "rb") as file:
+        while True:
+            chunk = await asyncio.to_thread(file.read, ZIP_STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from typing import Any
 
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
@@ -45,10 +45,7 @@ def iter_qa_pairs_by_knowledge(
 
         for hit in hits:
             source = hit.get("_source") or {}
-            yield {
-                "question": _normalize_csv_value(source.get(Field.QUESTION.value)),
-                "answer": _normalize_csv_value(source.get(Field.ANSWER.value)),
-            }
+            yield _qa_pair_from_source(source)
 
         search_after = hits[-1].get("sort")
         if not search_after:
@@ -68,7 +65,7 @@ def iter_qa_pairs_by_document(
         return
 
     filters: list[dict[str, Any]] = [
-        {"term": {Field.CHUNK_TYPE.value: "qa"}},
+        _qa_chunk_type_filter(),
         {"term": {Field.KNOWLEDGE_ID.value: kb_id_str}},
         {"term": {Field.DOCUMENT_ID.value: str(document_id)}},
     ]
@@ -76,15 +73,12 @@ def iter_qa_pairs_by_document(
         client,
         index=index_name,
         query={"bool": {"filter": filters}},
-        source_includes=[Field.QUESTION.value, Field.ANSWER.value],
+        source_includes=_qa_source_includes(),
         sort=_qa_export_sort(),
         batch_size=max(1, min(batch_size, 10000)),
     ):
         source = hit.get("_source") or {}
-        yield {
-            "question": _normalize_csv_value(source.get(Field.QUESTION.value)),
-            "answer": _normalize_csv_value(source.get(Field.ANSWER.value)),
-        }
+        yield _qa_pair_from_source(source)
 
 
 def iter_qa_csv_chunks(
@@ -122,6 +116,43 @@ def _qa_export_sort() -> list[dict[str, Any]]:
     ]
 
 
+def _qa_chunk_type_filter() -> dict[str, Any]:
+    return {
+        "bool": {
+            "should": [
+                {"term": {Field.CHUNK_TYPE.value: "qa"}},
+                {"term": {f"{Field.METADATA_KEY.value}.{Field.CHUNK_TYPE.value}": "qa"}},
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
+def _qa_source_includes() -> list[str]:
+    return [
+        Field.QUESTION.value,
+        Field.ANSWER.value,
+        f"{Field.METADATA_KEY.value}.{Field.QUESTION.value}",
+        f"{Field.METADATA_KEY.value}.{Field.ANSWER.value}",
+    ]
+
+
+def _qa_pair_from_source(source: Mapping[str, Any]) -> dict[str, str]:
+    metadata = source.get(Field.METADATA_KEY.value) or {}
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    question = source.get(Field.QUESTION.value)
+    answer = source.get(Field.ANSWER.value)
+    if question is None:
+        question = metadata.get(Field.QUESTION.value)
+    if answer is None:
+        answer = metadata.get(Field.ANSWER.value)
+    return {
+        "question": _normalize_csv_value(question),
+        "answer": _normalize_csv_value(answer),
+    }
+
+
 def _build_qa_export_search_body(
     kb_id: str,
     batch_size: int,
@@ -131,13 +162,13 @@ def _build_qa_export_search_body(
         "query": {
             "bool": {
                 "filter": [
-                    {"term": {Field.CHUNK_TYPE.value: "qa"}},
+                    _qa_chunk_type_filter(),
                     {"term": {Field.KNOWLEDGE_ID.value: kb_id}},
                     {"term": {"metadata.status": 1}},
                 ]
             }
         },
-        "_source": [Field.QUESTION.value, Field.ANSWER.value],
+        "_source": _qa_source_includes(),
         "size": batch_size,
         "sort": _qa_export_sort(),
     }

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -1,5 +1,7 @@
 import csv
 import io
+import os
+import tempfile
 import uuid
 from collections.abc import Iterator, Mapping
 from typing import Any
@@ -14,6 +16,7 @@ from app.core.rag.vdb.field import Field
 
 QA_EXPORT_COLUMNS = ("question", "answer")
 QA_EXPORT_BATCH_SIZE = 1000
+QA_CSV_FILE_CHUNK_SIZE = 1024 * 1024
 QA_CSV_MEDIA_TYPE = "text/csv"
 QA_XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
@@ -77,13 +80,34 @@ def iter_qa_pairs_by_document(
         yield _qa_pair_from_source(source)
 
 
-def iter_qa_csv_chunks(
+def write_qa_csv_export_file(
     kb_id: uuid.UUID | str,
     batch_size: int = QA_EXPORT_BATCH_SIZE,
+) -> str:
+    fd, path = tempfile.mkstemp(prefix="memorybear-qa-export-", suffix=".csv")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8-sig", newline="") as output:
+            writer = csv.writer(output)
+            writer.writerow(QA_EXPORT_COLUMNS)
+            for pair in iter_qa_pairs_by_knowledge(kb_id=kb_id, batch_size=batch_size):
+                writer.writerow([pair["question"], pair["answer"]])
+    except Exception:
+        _remove_file_if_exists(path)
+        raise
+    return path
+
+
+def iter_qa_csv_file_chunks(
+    path: str,
+    chunk_size: int = QA_CSV_FILE_CHUNK_SIZE,
 ) -> Iterator[bytes]:
-    yield _write_csv_rows([QA_EXPORT_COLUMNS]).encode("utf-8-sig")
-    for pair in iter_qa_pairs_by_knowledge(kb_id=kb_id, batch_size=batch_size):
-        yield _write_csv_rows([(pair["question"], pair["answer"])]).encode("utf-8")
+    with open(path, "rb") as file:
+        while chunk := file.read(chunk_size):
+            yield chunk
+
+
+def cleanup_qa_csv_export_file(path: str) -> None:
+    _remove_file_if_exists(path)
 
 
 def render_qa_pairs_export(
@@ -211,6 +235,13 @@ def _write_xlsx_qa_pairs(qa_pairs: list[Mapping[str, Any]]) -> bytes:
         return output.getvalue()
     finally:
         wb.close()
+
+
+def _remove_file_if_exists(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
 
 
 def _normalize_csv_value(value: Any) -> str:

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -97,13 +97,68 @@ def write_qa_csv_export_file(
     return path
 
 
-def iter_qa_csv_file_chunks(
+def write_qa_document_export_file(
+    kb_id: uuid.UUID | str,
+    document_id: uuid.UUID | str,
+    file_ext: str | None,
+    batch_size: int = QA_EXPORT_BATCH_SIZE,
+) -> tuple[str, str] | None:
+    suffix = ".xlsx" if _is_xlsx_file(file_ext) else ".csv"
+    fd, path = tempfile.mkstemp(prefix="memorybear-qa-document-export-", suffix=suffix)
+    try:
+        if _is_xlsx_file(file_ext):
+            os.close(fd)
+            has_rows = _write_xlsx_qa_pairs_file(
+                iter_qa_pairs_by_document(
+                    kb_id=kb_id,
+                    document_id=document_id,
+                    batch_size=batch_size,
+                ),
+                path,
+            )
+            if not has_rows:
+                _remove_file_if_exists(path)
+                return None
+            return path, QA_XLSX_MEDIA_TYPE
+
+        has_rows = False
+        with os.fdopen(fd, "w", encoding="utf-8-sig", newline="") as output:
+            writer = csv.writer(output)
+            writer.writerow(QA_EXPORT_COLUMNS)
+            for pair in iter_qa_pairs_by_document(
+                kb_id=kb_id,
+                document_id=document_id,
+                batch_size=batch_size,
+            ):
+                has_rows = True
+                writer.writerow([pair["question"], pair["answer"]])
+        if not has_rows:
+            _remove_file_if_exists(path)
+            return None
+        return path, QA_CSV_MEDIA_TYPE
+    except Exception:
+        _remove_file_if_exists(path)
+        raise
+
+
+def iter_qa_export_file_chunks(
     path: str,
     chunk_size: int = QA_CSV_FILE_CHUNK_SIZE,
 ) -> Iterator[bytes]:
     with open(path, "rb") as file:
         while chunk := file.read(chunk_size):
             yield chunk
+
+
+def iter_qa_csv_file_chunks(
+    path: str,
+    chunk_size: int = QA_CSV_FILE_CHUNK_SIZE,
+) -> Iterator[bytes]:
+    yield from iter_qa_export_file_chunks(path, chunk_size)
+
+
+def cleanup_qa_export_file(path: str) -> None:
+    _remove_file_if_exists(path)
 
 
 def cleanup_qa_csv_export_file(path: str) -> None:
@@ -233,6 +288,32 @@ def _write_xlsx_qa_pairs(qa_pairs: list[Mapping[str, Any]]) -> bytes:
         output = io.BytesIO()
         wb.save(output)
         return output.getvalue()
+    finally:
+        wb.close()
+
+
+def _write_xlsx_qa_pairs_file(
+    qa_pairs: Iterator[dict[str, str]],
+    path: str,
+) -> bool:
+    import openpyxl
+
+    wb = openpyxl.Workbook(write_only=True)
+    try:
+        ws = wb.create_sheet()
+        ws.append(QA_EXPORT_COLUMNS)
+        has_rows = False
+        for pair in qa_pairs:
+            has_rows = True
+            ws.append(
+                [
+                    _normalize_csv_value(pair.get("question")),
+                    _normalize_csv_value(pair.get("answer")),
+                ]
+            )
+        if has_rows:
+            wb.save(path)
+        return has_rows
     finally:
         wb.close()
 

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -8,6 +8,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorClientProvider,
     ElasticSearchVectorIndexOps,
 )
+from app.core.rag.vdb.elasticsearch.pit_search import iter_pit_search_hits
 from app.core.rag.vdb.field import Field
 
 
@@ -54,6 +55,38 @@ def iter_qa_pairs_by_knowledge(
             return
 
 
+def iter_qa_pairs_by_document(
+    kb_id: uuid.UUID | str,
+    document_id: uuid.UUID | str,
+    batch_size: int = QA_EXPORT_BATCH_SIZE,
+) -> Iterator[dict[str, str]]:
+    kb_id_str = str(kb_id)
+    index_name = ElasticSearchVectorIndexOps.collection_name_for_knowledge(kb_id_str)
+    client = ElasticSearchVectorClientProvider.get_shared_client()
+
+    if not client.indices.exists(index=index_name):
+        return
+
+    filters: list[dict[str, Any]] = [
+        {"term": {Field.CHUNK_TYPE.value: "qa"}},
+        {"term": {Field.KNOWLEDGE_ID.value: kb_id_str}},
+        {"term": {Field.DOCUMENT_ID.value: str(document_id)}},
+    ]
+    for hit in iter_pit_search_hits(
+        client,
+        index=index_name,
+        query={"bool": {"filter": filters}},
+        source_includes=[Field.QUESTION.value, Field.ANSWER.value],
+        sort=_qa_export_sort(),
+        batch_size=max(1, min(batch_size, 10000)),
+    ):
+        source = hit.get("_source") or {}
+        yield {
+            "question": _normalize_csv_value(source.get(Field.QUESTION.value)),
+            "answer": _normalize_csv_value(source.get(Field.ANSWER.value)),
+        }
+
+
 def iter_qa_csv_chunks(
     kb_id: uuid.UUID | str,
     batch_size: int = QA_EXPORT_BATCH_SIZE,
@@ -61,6 +94,32 @@ def iter_qa_csv_chunks(
     yield _write_csv_rows([QA_EXPORT_COLUMNS]).encode("utf-8-sig")
     for pair in iter_qa_pairs_by_knowledge(kb_id=kb_id, batch_size=batch_size):
         yield _write_csv_rows([(pair["question"], pair["answer"])]).encode("utf-8")
+
+
+def _qa_export_sort() -> list[dict[str, Any]]:
+    return [
+        {
+            Field.DOCUMENT_ID.value: {
+                "order": "asc",
+                "unmapped_type": "keyword",
+                "missing": "_last",
+            }
+        },
+        {
+            Field.SORT_ID.value: {
+                "order": "asc",
+                "unmapped_type": "long",
+                "missing": "_last",
+            }
+        },
+        {
+            Field.DOC_ID.value: {
+                "order": "asc",
+                "unmapped_type": "keyword",
+                "missing": "_last",
+            }
+        },
+    ]
 
 
 def _build_qa_export_search_body(
@@ -80,29 +139,7 @@ def _build_qa_export_search_body(
         },
         "_source": [Field.QUESTION.value, Field.ANSWER.value],
         "size": batch_size,
-        "sort": [
-            {
-                Field.DOCUMENT_ID.value: {
-                    "order": "asc",
-                    "unmapped_type": "keyword",
-                    "missing": "_last",
-                }
-            },
-            {
-                Field.SORT_ID.value: {
-                    "order": "asc",
-                    "unmapped_type": "long",
-                    "missing": "_last",
-                }
-            },
-            {
-                Field.DOC_ID.value: {
-                    "order": "asc",
-                    "unmapped_type": "keyword",
-                    "missing": "_last",
-                }
-            },
-        ],
+        "sort": _qa_export_sort(),
     }
     if search_after:
         body["search_after"] = search_after

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -10,7 +10,7 @@ from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorClientProvider,
     ElasticSearchVectorIndexOps,
 )
-from app.core.rag.vdb.elasticsearch.pit_search import iter_pit_search_hits
+from app.core.rag.vdb.elasticsearch.pit_search import iter_search_after_hits
 from app.core.rag.vdb.field import Field
 
 
@@ -39,7 +39,7 @@ def iter_qa_pairs_by_knowledge(
     if not client.indices.exists(index=index_name):
         return
 
-    for hit in iter_pit_search_hits(
+    for hit in iter_search_after_hits(
         client,
         index=index_name,
         query=_qa_export_query(kb_id_str, active_only=True),
@@ -68,7 +68,7 @@ def iter_qa_pairs_by_document(
         {"term": {Field.KNOWLEDGE_ID.value: kb_id_str}},
         {"term": {Field.DOCUMENT_ID.value: str(document_id)}},
     ]
-    for hit in iter_pit_search_hits(
+    for hit in iter_search_after_hits(
         client,
         index=index_name,
         query={"bool": {"filter": filters}},

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -28,28 +28,22 @@ def iter_qa_pairs_by_knowledge(
     batch_size: int = QA_EXPORT_BATCH_SIZE,
 ) -> Iterator[dict[str, str]]:
     kb_id_str = str(kb_id)
-    batch_size = max(1, batch_size)
     index_name = ElasticSearchVectorIndexOps.collection_name_for_knowledge(kb_id_str)
     client = ElasticSearchVectorClientProvider.get_shared_client()
 
     if not client.indices.exists(index=index_name):
         return
 
-    search_after: list[Any] | None = None
-    while True:
-        body = _build_qa_export_search_body(kb_id_str, batch_size, search_after)
-        result = client.search(index=index_name, body=body)
-        hits = result.get("hits", {}).get("hits", [])
-        if not hits:
-            return
-
-        for hit in hits:
-            source = hit.get("_source") or {}
-            yield _qa_pair_from_source(source)
-
-        search_after = hits[-1].get("sort")
-        if not search_after:
-            return
+    for hit in iter_pit_search_hits(
+        client,
+        index=index_name,
+        query=_qa_export_query(kb_id_str, active_only=True),
+        source_includes=_qa_source_includes(),
+        sort=_qa_export_sort(),
+        batch_size=max(1, min(batch_size, 10000)),
+    ):
+        source = hit.get("_source") or {}
+        yield _qa_pair_from_source(source)
 
 
 def iter_qa_pairs_by_document(
@@ -137,6 +131,16 @@ def _qa_source_includes() -> list[str]:
     ]
 
 
+def _qa_export_query(kb_id: str, *, active_only: bool) -> dict[str, Any]:
+    filters: list[dict[str, Any]] = [
+        _qa_chunk_type_filter(),
+        {"term": {Field.KNOWLEDGE_ID.value: kb_id}},
+    ]
+    if active_only:
+        filters.append({"term": {"metadata.status": 1}})
+    return {"bool": {"filter": filters}}
+
+
 def _qa_pair_from_source(source: Mapping[str, Any]) -> dict[str, str]:
     metadata = source.get(Field.METADATA_KEY.value) or {}
     if not isinstance(metadata, Mapping):
@@ -159,15 +163,7 @@ def _build_qa_export_search_body(
     search_after: list[Any] | None,
 ) -> dict[str, Any]:
     body: dict[str, Any] = {
-        "query": {
-            "bool": {
-                "filter": [
-                    _qa_chunk_type_filter(),
-                    {"term": {Field.KNOWLEDGE_ID.value: kb_id}},
-                    {"term": {"metadata.status": 1}},
-                ]
-            }
-        },
+        "query": _qa_export_query(kb_id, active_only=True),
         "_source": _qa_source_includes(),
         "size": batch_size,
         "sort": _qa_export_sort(),

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -14,6 +14,8 @@ from app.core.rag.vdb.field import Field
 
 QA_EXPORT_COLUMNS = ("question", "answer")
 QA_EXPORT_BATCH_SIZE = 1000
+QA_CSV_MEDIA_TYPE = "text/csv"
+QA_XLSX_MEDIA_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 def make_qa_export_filename(knowledge_name: str | None) -> str:
@@ -82,6 +84,27 @@ def iter_qa_csv_chunks(
     yield _write_csv_rows([QA_EXPORT_COLUMNS]).encode("utf-8-sig")
     for pair in iter_qa_pairs_by_knowledge(kb_id=kb_id, batch_size=batch_size):
         yield _write_csv_rows([(pair["question"], pair["answer"])]).encode("utf-8")
+
+
+def render_qa_pairs_export(
+    qa_pairs: list[Mapping[str, Any]],
+    file_ext: str | None,
+) -> tuple[bytes, str] | None:
+    if not qa_pairs:
+        return None
+
+    if _is_xlsx_file(file_ext):
+        return _write_xlsx_qa_pairs(qa_pairs), QA_XLSX_MEDIA_TYPE
+
+    rows: list[tuple[str, ...]] = [QA_EXPORT_COLUMNS]
+    rows.extend(
+        (
+            _normalize_csv_value(pair.get("question")),
+            _normalize_csv_value(pair.get("answer")),
+        )
+        for pair in qa_pairs
+    )
+    return _write_csv_rows(rows).encode("utf-8-sig"), QA_CSV_MEDIA_TYPE
 
 
 def _qa_export_sort() -> list[dict[str, Any]]:
@@ -162,6 +185,32 @@ def _write_csv_rows(rows: list[tuple[str, ...]]) -> str:
     writer = csv.writer(output)
     writer.writerows(rows)
     return output.getvalue()
+
+
+def _is_xlsx_file(file_ext: str | None) -> bool:
+    file_ext_lower = file_ext.lower() if file_ext else ".csv"
+    return file_ext_lower in (".xlsx", ".xls")
+
+
+def _write_xlsx_qa_pairs(qa_pairs: list[Mapping[str, Any]]) -> bytes:
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    try:
+        ws = wb.active
+        ws.append(QA_EXPORT_COLUMNS)
+        for pair in qa_pairs:
+            ws.append(
+                [
+                    _normalize_csv_value(pair.get("question")),
+                    _normalize_csv_value(pair.get("answer")),
+                ]
+            )
+        output = io.BytesIO()
+        wb.save(output)
+        return output.getvalue()
+    finally:
+        wb.close()
 
 
 def _normalize_csv_value(value: Any) -> str:

--- a/api/app/services/qa_export_service.py
+++ b/api/app/services/qa_export_service.py
@@ -157,22 +157,6 @@ def _qa_pair_from_source(source: Mapping[str, Any]) -> dict[str, str]:
     }
 
 
-def _build_qa_export_search_body(
-    kb_id: str,
-    batch_size: int,
-    search_after: list[Any] | None,
-) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "query": _qa_export_query(kb_id, active_only=True),
-        "_source": _qa_source_includes(),
-        "size": batch_size,
-        "sort": _qa_export_sort(),
-    }
-    if search_after:
-        body["search_after"] = search_after
-    return body
-
-
 def _write_csv_rows(rows: list[tuple[str, ...]]) -> str:
     output = io.StringIO()
     writer = csv.writer(output)


### PR DESCRIPTION
## Business Background

MemoryBear knowledge-base operations had several Elasticsearch paths that either requested a fixed 10,000-result window or used `from/size` deep pagination. For documents, QA imports/exports, chunk browsing, Legacy GraphRAG, and the current Evidence Graph store layer, datasets larger than the default ES result window could be silently truncated or fail at deep pages.

## Summary

- Add shared sync and async `search_after` scanners with stable sorting, cursor validation, `allow_partial_search_results=false`, and shared ES response failure checks.
- Keep PIT support only where it is useful and bounded: deep `page/pagesize` chunk requests beyond the default result window use a short-lived PIT + `search_after` slice so one response has a stable total/page cut.
- Avoid PIT for long-running full scans: QA export, chunk full iteration, Legacy GraphRAG rebuild input, and Evidence Graph store full-read paths use ordinary `search_after` with stable business sort keys.
- Spool knowledge-level QA CSV exports into a temporary file before returning `StreamingResponse`, so slow-client backpressure does not hold ES scan resources or a PIT lease.
- Replace fixed-window delete flows with `delete_by_query`, `conflicts=abort`, `wait_for_completion=true`, and shared failure validation for timeout, shard failure, version conflict, and delete failures.
- Preserve QA CSV/XLSX/ZIP compatibility, including BOM, column order, workbook shape, file names, and media types; centralize single-document QA rendering in `qa_export_service`.
- Scope Legacy GraphRAG id-based deletes by `kb_id`, including the empty-id delete-all branch, and return ES document ids as `_es_id` to avoid source `_id` collisions.
- Include the current Evidence Graph store layer in the optimization for full reads and graph cleanup, while leaving retrieval candidate limits/topN and LLM input guards unchanged.

## Impact Scope

- Backend RAG only.
- No frontend changes.
- No database model or migration changes.
- No Elasticsearch `index.max_result_window` change.
- Existing `/api` and `/v1` request paths, parameters, response envelopes, status codes, and `page/pagesize/total/has_next` fields are unchanged.

## Risk

- Large full-scan tasks now process all matching ES documents, so delete, export, and graph rebuild jobs can take longer than before when the previous behavior was silently truncated.
- Deep page access remains page-based for compatibility; internally it scans forward to the requested offset, so latency grows with large offsets that are still within the exact total.
- Long full scans no longer use PIT by default. They rely on stable business sorting and failure checks rather than snapshot isolation, which matches the current consistency requirement and avoids unnecessary PIT resource usage.
- The fix prevents future truncation but does not automatically clean historical ghost chunks or rebuild graphs that were previously generated from incomplete input.

## External API Key Impact

- `app/controllers/service/rag_api_chunk_controller.py` is not modified.
- The `/v1/chunks/{kb_id}/{document_id}/chunks` route still delegates to the internal chunk controller and receives the deep-page fix without schema or auth changes.
- QA/file download routing remains unchanged; only internal ES reads become complete.

## Validation

- [x] `./.venv/bin/python -m pytest tests/rag/test_pit_search.py -q` → 3 passed.
- [x] `./.venv/bin/python -m py_compile app/controllers/chunk_controller.py app/controllers/knowledge_controller.py app/core/rag/graphrag/general/index.py app/core/rag/graphrag/utils.py app/core/rag/knowledge_graph/elasticsearch_store.py app/core/rag/utils/es_conn.py app/core/rag/vdb/elasticsearch/elasticsearch_vector.py app/core/rag/vdb/elasticsearch/pit_search.py app/core/rag/vdb/elasticsearch/response_validation.py app/services/file_service.py app/services/qa_export_service.py`
- [x] `git diff --check origin/develop..HEAD`
- [x] Scenario fake checks for delete_by_query validation, non-PIT QA CSV spooling, non-PIT chunk full iteration, short-lived PIT deep-page slicing, non-PIT Evidence Graph async scans, Legacy GraphRAG explicit `search_after` sort, and `_es_id` collision avoidance.
- [x] Static scan for remaining fixed `9999/10000` ES result-window reads and PIT usage. Remaining PIT business usage is limited to deep page slicing; remaining `10000` hits are retrieval candidate limits, aggregation bucket sizing, update paths, or non-ES parser/report limits outside this fix.

No live ES 8.x integration environment was exercised in this local validation.

## Summary by Sourcery

移除固定窗口的 Elasticsearch 分页，引入共享的 `search_after`/PIT 工具，使 RAG chunk、QA 导出和图操作能够安全处理大型结果集而不被截断。

**New Features:**
- 添加可复用的同步和异步 `search_after` 及 PIT 辅助方法，用于稳定的、基于游标的 Elasticsearch 扫描。
- 引入流式 QA 导出流程，将 CSV/XLSX 内容缓冲到临时文件，并将 QA 导出整合进单文件和 ZIP 下载 API 中。

**Bug Fixes:**
- 在 chunk 浏览、QA 导出、Legacy GraphRAG 和 Evidence Graph 读取中，移除深度分页和 10,000 结果窗口的假设，防止在大型知识库上出现静默截断。
- 将 Legacy GraphRAG 的 `delete_by_query` 操作按知识库 ID 进行范围限定，并将 Elasticsearch 文档 ID 暴露为 `_es_id`，以避免 source ID 冲突。

**Enhancements:**
- 重构基于 segment 的 chunk 搜索，使用稳定的业务排序、`search_after` 迭代以及基于 PIT 的切片来处理深度分页，同时保持现有分页语义。
- 更新 Evidence Graph 存储查询，改用异步 `search_after` 迭代，并在图刷新和清理时使用更健壮的 `delete_by_query` 校验。
- 优化 Legacy GraphRAG 图重建，使用 `search_after` 流式拉取子图 chunk，而非固定范围的搜索调用。
- 在 `qa_export_service` 中集中处理 QA 导出渲染，以保持知识级和文档级导出的 CSV/XLSX 格式一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove fixed-window Elasticsearch pagination and introduce shared search_after/PIT utilities so RAG chunk, QA export, and graph operations can safely handle large result sets without truncation.

New Features:
- Add reusable synchronous and asynchronous search_after and PIT helpers for stable, cursor-based Elasticsearch scans.
- Introduce streaming QA export flows that spool CSV/XLSX content to temporary files and integrate QA exports into single-file and ZIP download APIs.

Bug Fixes:
- Eliminate deep pagination and 10,000-result window assumptions in chunk browsing, QA exports, Legacy GraphRAG, and Evidence Graph reads to prevent silent truncation on large knowledge bases.
- Scope Legacy GraphRAG delete_by_query operations by knowledge base id and expose Elasticsearch document ids as _es_id to avoid source id collisions.

Enhancements:
- Refactor segment-based chunk search to use stable business sorts, search_after iteration, and PIT-backed slicing for deep pages while preserving existing paging semantics.
- Update Evidence Graph store queries to use async search_after iteration and robust delete_by_query validation for graph refresh and cleanup.
- Optimize Legacy GraphRAG graph rebuild to stream subgraph chunks via search_after instead of fixed-range search calls.
- Centralize QA export rendering in qa_export_service to keep CSV/XLSX formats consistent across knowledge and document-level exports.

</details>