### PR TITLE
fix(ontology): replace lazy load with async count query for scene type_num

### DIFF
--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -391,8 +391,10 @@ async def update_scene(
             )
         
             # 构建响应
-            # 动态计算 type_num
-            type_num = len(scene.classes) if scene.classes else 0
+            # 动态计算 type_num（避免 AsyncSession 下懒加载触发 MissingGreenlet）
+            from app.repositories.ontology_class_repository import OntologyClassRepository
+            class_repo = OntologyClassRepository(db)
+            type_num = await class_repo.count_by_scene_async(scene_uuid)
         
             response = SceneResponse(
                 scene_id=scene.scene_id,

--- a/api/app/controllers/ontology_controller.py
+++ b/api/app/controllers/ontology_controller.py
@@ -58,6 +58,7 @@ from app.services.ontology_service import OntologyService
 from app.core.memory.utils.validation.owl_validator import OWLValidator
 from app.services.model_service import ModelConfigService
 from app.repositories.ontology_scene_repository import OntologySceneRepository
+from app.repositories.ontology_class_repository import OntologyClassRepository
 
 
 api_logger = get_api_logger()
@@ -392,7 +393,6 @@ async def update_scene(
         
             # 构建响应
             # 动态计算 type_num（避免 AsyncSession 下懒加载触发 MissingGreenlet）
-            from app.repositories.ontology_class_repository import OntologyClassRepository
             class_repo = OntologyClassRepository(db)
             type_num = await class_repo.count_by_scene_async(scene_uuid)
         

--- a/api/app/repositories/ontology_class_repository.py
+++ b/api/app/repositories/ontology_class_repository.py
@@ -305,3 +305,20 @@ class OntologyClassRepository:
         except Exception as e:
             logger.error(f"Failed to get scene ID by class (async): {str(e)}", exc_info=True)
             raise
+
+    async def count_by_scene_async(self, scene_id: UUID) -> int:
+        """获取场景下的类型数量
+
+        Args:
+            scene_id: 场景ID
+
+        Returns:
+            int: 类型数量
+        """
+        try:
+            stmt = select(func.count()).where(OntologyClass.scene_id == scene_id)
+            result = await self.db.execute(stmt)
+            return result.scalar() or 0
+        except Exception as e:
+            logger.error(f"Failed to count classes by scene (async): {str(e)}", exc_info=True)
+            raise

--- a/api/app/repositories/ontology_class_repository.py
+++ b/api/app/repositories/ontology_class_repository.py
@@ -316,7 +316,7 @@ class OntologyClassRepository:
             int: 类型数量
         """
         try:
-            stmt = select(func.count()).where(OntologyClass.scene_id == scene_id)
+            stmt = select(func.count(OntologyClass.class_id)).where(OntologyClass.scene_id == scene_id)
             result = await self.db.execute(stmt)
             return result.scalar() or 0
         except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

在使用 AsyncSession 时，用显式的异步计数查询替代对场景类的惰性加载访问，以安全地计算场景类型计数。

Bug 修复：
- 在为场景计算 `type_num` 时避免惰性加载场景类，从而防止 MissingGreenlet 错误。

增强功能：
- 添加一个按场景 ID 统计本体类数量的异步仓库方法，用于场景响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace lazy-loaded access to scene classes with an explicit async count query to safely compute scene type counts under AsyncSession.

Bug Fixes:
- Prevent MissingGreenlet errors by avoiding lazy loading of scene classes when computing type_num for a scene.

Enhancements:
- Add an async repository method to count ontology classes by scene ID for use in scene responses.

</details>