### PR TITLE
fix(sandbox)

### DIFF
--- a/e2b-infra/orchestrator/app/services/sandbox_manager.py
+++ b/e2b-infra/orchestrator/app/services/sandbox_manager.py
@@ -185,7 +185,11 @@ class SandboxManager:
         loop = asyncio.get_running_loop()
         data = snapshot_json.encode("utf-8")
 
-        await loop.run_in_executor(None, lambda: container.exec_run(["mkdir", "-p", "/input"]))
+        exit_code, output = await loop.run_in_executor(
+            None, lambda: container.exec_run(["mkdir", "-p", "/input"])
+        )
+        if exit_code != 0:
+            raise RuntimeError(f"Failed to create /input directory: {output}")
         tar_stream = _build_tar("snapshot.json", data)
         await loop.run_in_executor(None, lambda: container.put_archive("/input", tar_stream))
 


### PR DESCRIPTION
handle mkdir failure in sandbox manager

## Summary by Sourcery

Bug Fixes:
- 如果在沙箱容器中创建 `/input` 目录失败，则在写入快照归档之前抛出运行时错误

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Raise a runtime error if creating the /input directory in the sandbox container fails before writing the snapshot archive

</details>