### PR TITLE
fix(rag): respect embedding batch size

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -108,6 +108,7 @@ class Settings:
     # LLM Request Configuration
     LLM_TIMEOUT: float = float(os.getenv("LLM_TIMEOUT", "120.0"))
     LLM_MAX_RETRIES: int = int(os.getenv("LLM_MAX_RETRIES", "2"))
+    EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "10"))
 
     # Fast Write BERT 
     FAST_WRITE_EMOTION_URL: str = os.getenv("FAST_WRITE_EMOTION_URL", "")

--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Union
 
 from langchain_core.embeddings import Embeddings
 
+from app.core.config import settings
 from app.core.models.base import RedBearModelConfig, get_provider_embedding_class, RedBearModelFactory
 from app.models.models_model import ModelProvider
 
@@ -44,6 +45,7 @@ class RedBearEmbeddings(Embeddings):
                 "api_key": config.api_key,
                 "timeout": timeout,
                 "max_retries": config.max_retries,
+                "chunk_size": settings.EMBEDDING_BATCH_SIZE,
             }
             if provider == ModelProvider.SPEEDBEAR:
                 params["check_embedding_ctx_length"] = False

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -98,7 +98,7 @@ VIDEO_IMAGE_PATTERN = re.compile(
 )
 DEFAULT_PARSE_LANGUAGE = "Chinese"
 DEFAULT_PARSE_TO_PAGE = 100_000
-EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "20"))
+EMBEDDING_BATCH_SIZE = settings.EMBEDDING_BATCH_SIZE
 # Embedding 并发写入的最大线程数，需根据模型 API rate limit 调整
 EMBEDDING_MAX_WORKERS = int(os.getenv("EMBEDDING_MAX_WORKERS", "3"))
 # auto_questions LLM 并发调用的最大线程数

--- a/api/tests/test_embedding_batch_size.py
+++ b/api/tests/test_embedding_batch_size.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from app.core.config import settings
+from app.core.models import RedBearEmbeddings, RedBearModelConfig
+from app.models.models_model import ModelProvider
+
+
+class _LimitedAsyncEmbeddingClient:
+    async def create(self, *, input: list[Any], **_: Any) -> dict[str, Any]:
+        if len(input) > 10:
+            raise ValueError("batch size must not exceed 10")
+        return {
+            "data": [
+                {"embedding": [float(index)]}
+                for index, _item in enumerate(input)
+            ]
+        }
+
+
+async def test_openai_compatible_embedding_uses_configured_batch_size(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "EMBEDDING_BATCH_SIZE", 10)
+    embedding = RedBearEmbeddings(
+        RedBearModelConfig(
+            model_name="test-embedding",
+            provider=ModelProvider.SPEEDBEAR,
+            api_key="test-key",
+            base_url="https://example.com/v1",
+        )
+    )
+    embedding._model.async_client = _LimitedAsyncEmbeddingClient()
+
+    vectors = await embedding.aembed_documents(
+        [f"projection-{index}" for index in range(11)]
+    )
+
+    assert len(vectors) == 11


### PR DESCRIPTION
## Business Background
Evidence graph projection embedding could send more than 10 inputs in one request, causing OpenAI-compatible providers with a batch limit of 10 to reject graph rebuilds.

## Summary
- Reuse the existing `EMBEDDING_BATCH_SIZE` setting for chunk and graph embedding requests.
- Default the shared batch size to 10 and pass it to `OpenAIEmbeddings` as `chunk_size`.
- Add a regression test covering 11 inputs split across provider-safe requests.

## Changes
- `api/app/core/config.py`: define the shared embedding batch size.
- `api/app/core/models/embedding.py`: apply the configured size to OpenAI-compatible embeddings.
- `api/app/tasks.py`: reuse the shared setting for chunk embedding.
- `api/tests/test_embedding_batch_size.py`: cover the provider batch limit.

## Risk
Low. The change only reduces the default request batch size from 20 to 10 and keeps the environment variable override.

## Test Plan
- [x] `PYTHONPATH=. uv run --frozen --with asyncpg pytest tests/test_embedding_batch_size.py -q` (1 passed)
- [x] `PYTHONPATH=. uv run --frozen --with asyncpg python -m py_compile app/core/config.py app/core/models/embedding.py app/tasks.py tests/test_embedding_batch_size.py`

## Summary by Sourcery

遵循可配置的嵌入批处理大小设置，适配 OpenAI 兼容提供商，并在不同的嵌入代码路径之间复用共享配置。

Bug Fixes:
- 通过将配置的批处理大小注入到嵌入请求中，防止 OpenAI 兼容的嵌入提供商收到超过其支持上限的批次。

Enhancements:
- 将嵌入批处理大小配置集中到设置中，并在任务和嵌入模型构建中复用该配置。

Tests:
- 添加一个异步回归测试，确保 11 个输入会被拆分为遵守配置批处理大小、对提供商安全的嵌入请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Respect configurable embedding batch size for OpenAI-compatible providers and reuse a shared setting across embedding code paths.

Bug Fixes:
- Prevent OpenAI-compatible embedding providers from receiving batches larger than their supported limit by wiring the configured batch size into embedding requests.

Enhancements:
- Centralize embedding batch size configuration in settings and reuse it in tasks and embedding model construction.

Tests:
- Add an async regression test to ensure 11 inputs are split into provider-safe embedding requests honoring the configured batch size.

</details>