### PR TITLE
fix(rag): respect embedding batch size

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -108,6 +108,7 @@ class Settings:
     # LLM Request Configuration
     LLM_TIMEOUT: float = float(os.getenv("LLM_TIMEOUT", "120.0"))
     LLM_MAX_RETRIES: int = int(os.getenv("LLM_MAX_RETRIES", "2"))
+    EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "10"))
 
     # Fast Write BERT 
     FAST_WRITE_EMOTION_URL: str = os.getenv("FAST_WRITE_EMOTION_URL", "")

--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Union
 
 from langchain_core.embeddings import Embeddings
 
+from app.core.config import settings
 from app.core.models.base import RedBearModelConfig, get_provider_embedding_class, RedBearModelFactory
 from app.models.models_model import ModelProvider
 
@@ -44,6 +45,7 @@ class RedBearEmbeddings(Embeddings):
                 "api_key": config.api_key,
                 "timeout": timeout,
                 "max_retries": config.max_retries,
+                "chunk_size": settings.EMBEDDING_BATCH_SIZE,
             }
             if provider == ModelProvider.SPEEDBEAR:
                 params["check_embedding_ctx_length"] = False

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -98,7 +98,7 @@ VIDEO_IMAGE_PATTERN = re.compile(
 )
 DEFAULT_PARSE_LANGUAGE = "Chinese"
 DEFAULT_PARSE_TO_PAGE = 100_000
-EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "20"))
+EMBEDDING_BATCH_SIZE = settings.EMBEDDING_BATCH_SIZE
 # Embedding 并发写入的最大线程数，需根据模型 API rate limit 调整
 EMBEDDING_MAX_WORKERS = int(os.getenv("EMBEDDING_MAX_WORKERS", "3"))
 # auto_questions LLM 并发调用的最大线程数


### PR DESCRIPTION
## Business Background
Evidence graph projection embedding could send more than 10 inputs in one request, causing OpenAI-compatible providers with a batch limit of 10 to reject graph rebuilds.

## Impact Scope
- Centralizes `EMBEDDING_BATCH_SIZE` in application settings with a default of 10.
- Applies the configured batch size to OpenAI-compatible embedding requests.
- Reuses the same setting in document chunk embedding tasks.
- Does not change graph extraction, storage, retrieval, or response contracts.

## Risk
Low. Smaller batches can increase the number of embedding requests, but prevent deterministic provider-side 400 errors. Existing deployments can continue overriding `EMBEDDING_BATCH_SIZE` through the environment.

## External API Key Impact
No external API route, controller, schema, authentication, workspace, or tenant behavior changes. API Key knowledge-base operations that reuse the same embedding runtime only inherit the safer request batching behavior; response contracts remain unchanged.

## Test Plan
- [x] `PYTHONPATH=. uv run --frozen --with asyncpg pytest tests/test_embedding_batch_size.py -q` (1 passed; local test file excluded from the commit per repository policy)
- [x] `PYTHONPATH=. uv run --frozen --with asyncpg python -m py_compile app/core/config.py app/core/models/embedding.py app/tasks.py tests/test_embedding_batch_size.py`
- [x] `git diff --check origin/release/v0.3.14..HEAD`

## Summary by Sourcery

集中并应用可配置的嵌入批处理大小，在嵌入配置和文档分块嵌入任务中统一使用，以确保请求批处理方式与提供商兼容。

Enhancements:
- 将 `EMBEDDING_BATCH_SIZE` 移动到应用设置中，并将默认值设为 10。
- 将基于设置的 `EMBEDDING_BATCH_SIZE` 接入到兼容 OpenAI 的嵌入客户端配置中。
- 在文档分块嵌入任务中复用集中化的 `EMBEDDING_BATCH_SIZE` 设置，而不是使用本地来源于环境变量的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and apply a configurable embedding batch size across embedding configuration and document chunk embedding tasks to ensure provider-compatible request batching.

Enhancements:
- Move EMBEDDING_BATCH_SIZE into application settings with a default of 10.
- Wire the settings-based EMBEDDING_BATCH_SIZE into OpenAI-compatible embedding client configuration.
- Reuse the centralized EMBEDDING_BATCH_SIZE setting in document chunk embedding tasks instead of a local environment-derived value.

</details>