### PR TITLE
fix(cache): disable redis cache for tenant id retrieval

### DIFF
--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1771,7 +1771,7 @@ async def get_end_user_by_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> 
     return end_user
 
 
-@redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
+# @redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
 def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
     stmt = (
         select(Workspace.tenant_id)
@@ -1782,7 +1782,7 @@ def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optiona
     return result.scalar()
 
 
-@redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
+# @redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
 async def get_tenant_id_by_end_user_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
     stmt = (
         select(Workspace.tenant_id)


### PR DESCRIPTION
- Remove @redis_cache decorator from get_tenant_id_by_end_user_id
- Remove @redis_cache decorator from get_tenant_id_by_end_user_id_async

## Summary by Sourcery

Bug Fixes:
- 从同步和异步的终端用户租户 ID 获取逻辑中移除 Redis 缓存，以避免使用过期或错误的缓存数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove Redis caching from synchronous and asynchronous tenant ID retrieval by end user to avoid stale or incorrect cache usage.

</details>