### PR TITLE
fix:fastwrite localdatetime

### DIFF
--- a/api/app/core/memory/pipelines/fast_write_pipeline.py
+++ b/api/app/core/memory/pipelines/fast_write_pipeline.py
@@ -121,11 +121,11 @@ class FastWritePipeline:
                     )
 
                 # 时间来源降级：dialog_at → dispatch_at → 当前时间（ensure_dialog_at 兜底）
-                created_at = as_utc_aware(
-                    parse_iso_to_utc_naive(
-                        ensure_dialog_at(target_message.get("dialog_at") or dispatch_at)
-                    )
+                # LocalDateTime，而不是带时区的 DateTime。
+                created_at = parse_iso_to_utc_naive(
+                    ensure_dialog_at(target_message.get("dialog_at") or dispatch_at)
                 )
+
 
                 # Step 3/3 — 构造并写入 DialogueNode
                 async with bear.step(3, 3, "存储", "写入 Dialogue") as s:

--- a/api/app/repositories/neo4j/add_nodes.py
+++ b/api/app/repositories/neo4j/add_nodes.py
@@ -49,7 +49,7 @@ async def add_dialogue_nodes(dialogues: List[DialogueNode], connector: Neo4jConn
                 "run_id": dialogue.run_id,
                 "ref_id": dialogue.ref_id,
                 "name": dialogue.name,
-                "created_at": to_iso_z(dialogue.created_at),
+                "created_at": dialogue.created_at,
                 "content": dialogue.content,
                 "dialog_embedding": dialogue.dialog_embedding,
                 "config_id": dialogue.config_id,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 停止将对话的 `created_at` 时间戳转换为支持 UTC 的 ISO 字符串，改为将其以 `LocalDateTime` 值进行持久化，以匹配预期的存储格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop converting dialogue created_at timestamps to UTC-aware ISO strings and instead persist them as LocalDateTime values to match expected storage format.

</details>