### PR TITLE
feat(knowledge-retrieval): add graph retrieval switch for hybrid retrieval

### DIFF
--- a/api/app/core/workflow/nodes/knowledge/config.py
+++ b/api/app/core/workflow/nodes/knowledge/config.py
@@ -146,7 +146,8 @@ class KnowledgeRetrievalNodeConfig(BaseNodeConfig):
                         "similarity_threshold": 0.2,
                         "vector_similarity_weight": 0.3,
                         "top_k": 4,
-                        "retrieve_type": "hybrid"
+                        "retrieve_type": "hybrid",
+                        "enable_graph_retrieval": 1
                     }],
                     "metadata_filter_mode": "disabled",
                     "metadata_filters": None,

--- a/api/app/core/workflow/nodes/knowledge/node.py
+++ b/api/app/core/workflow/nodes/knowledge/node.py
@@ -372,6 +372,14 @@ class KnowledgeRetrievalNode(BaseNode):
         else:
             vector_similarity_weight = first_kb.vector_similarity_weight
         
+        # 混合检索下是否叠加图谱检索路由：请求级取第一个 KB 的配置作为兜底，
+        # 每个 KB 显式配置的 enable_graph_retrieval 仍会在检索层按 KB 覆盖生效
+        enable_graph_retrieval = (
+            1
+            if first_kb.retrieve_type == RetrieveType.HYBRID and first_kb.enable_graph_retrieval
+            else 0
+        )
+
         request = KnowledgeRetrievalRequest(
             query=query,
             caller=KnowledgeRetrievalCaller.WORKFLOW,
@@ -381,6 +389,7 @@ class KnowledgeRetrievalNode(BaseNode):
             vector_similarity_weight=vector_similarity_weight,
             top_k=self.typed_config.reranker_top_k or first_kb.top_k,
             retrieve_type=first_kb.retrieve_type,
+            enable_graph_retrieval=enable_graph_retrieval,
             rerank_id=self.typed_config.reranker_id,
             metadata_filter_mode=self.typed_config.metadata_filter_mode,
             metadata_filters=(

--- a/api/app/schemas/app_schema.py
+++ b/api/app/schemas/app_schema.py
@@ -108,6 +108,8 @@ class KnowledgeBaseConfig(BaseModel):
     # weight: float = Field(default=1.0, ge=0.0, le=1.0, description="知识库权重（用于多知识库融合）")
     vector_similarity_weight: float | None = Field(default=0.5, ge=0.0, le=1.0, description="向量相似度权重（语义/混合/图谱检索使用，分词检索不使用）")
     retrieve_type: str = Field(default="hybrid", description="检索方式participle｜ semantic｜hybrid")
+    # 混合检索下是否启用证据图谱通道（仅 hybrid 类型生效）；1=启用, 0=关闭, None=沿用请求级兜底
+    enable_graph_retrieval: Optional[int] = Field(default=None, ge=0, le=1, description="混合检索下是否启用证据图谱通道")
 
 
 class KnowledgeRetrievalConfig(BaseModel):

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -184,16 +184,32 @@ async def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -
         vector_similarity_weight = None
     else:
         vector_similarity_weight = _as_float(first_kb.get("vector_similarity_weight"), 0.5)
-    
+
+    # 混合检索下，按第一个 KB 的开关设置请求级图谱检索兜底
+    # （每个 KB 显式配置的 enable_graph_retrieval 仍会在检索层按 KB 覆盖生效）
+    enable_graph_retrieval = (
+        1
+        if (
+            retrieve_type == RetrieveType.HYBRID
+            and _as_int(first_kb.get("enable_graph_retrieval"), 0) == 1
+        )
+        else 0
+    )
+
+    # 仅透传带有 kb_id 的 KB 配置，避免缺字段导致请求校验失败
+    request_kbs = [kb for kb in knowledge_bases if kb.get("kb_id")]
+
     request = KnowledgeRetrievalRequest(
         query=query,
         caller=KnowledgeRetrievalCaller.AGENT,
         kb_ids=[uuid.UUID(kid) for kid in kb_ids],
+        knowledge_bases=request_kbs,
         top_k=_as_int(first_kb.get("top_k"), 3),
         similarity_threshold=_as_float(first_kb.get("similarity_threshold"), 0.7),
         vector_similarity_weight=vector_similarity_weight,
         retrieve_type=retrieve_type,
         rerank_id=rerank_id,
+        enable_graph_retrieval=enable_graph_retrieval,
     )
 
     result = await KnowledgeRetrievalService.retrieve_async(request=request, principal=None)

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -148,11 +148,13 @@ async def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -
     用第一个 KB 的参数作为全局默认；缺失值回落到 schema 默认值。
     """
     knowledge_bases = (kb_config or {}).get("knowledge_bases", []) or []
-    kb_ids = [kb.get("kb_id") for kb in knowledge_bases if kb.get("kb_id")]
+    # 单一过滤源:有 kb_id 的 KB 才会进入请求,request_kbs 与 kb_ids 强一致
+    valid_kbs = [kb for kb in knowledge_bases if kb.get("kb_id")]
+    kb_ids = [kb["kb_id"] for kb in valid_kbs]
     if not kb_ids:
         return []
 
-    first_kb = knowledge_bases[0] or {}
+    first_kb = valid_kbs[0] or {}
 
     def _as_float(value: Any, default: float) -> float:
         try:
@@ -196,14 +198,12 @@ async def _retrieve_chunks_via_standard(query: str, kb_config: Dict[str, Any]) -
         else 0
     )
 
-    # 仅透传带有 kb_id 的 KB 配置，避免缺字段导致请求校验失败
-    request_kbs = [kb for kb in knowledge_bases if kb.get("kb_id")]
-
+    # 透传与 kb_ids 同源的 KB 配置,避免重复过滤导致漂移
     request = KnowledgeRetrievalRequest(
         query=query,
         caller=KnowledgeRetrievalCaller.AGENT,
         kb_ids=[uuid.UUID(kid) for kid in kb_ids],
-        knowledge_bases=request_kbs,
+        knowledge_bases=valid_kbs,
         top_k=_as_int(first_kb.get("top_k"), 3),
         similarity_threshold=_as_float(first_kb.get("similarity_threshold"), 0.7),
         vector_similarity_weight=vector_similarity_weight,


### PR DESCRIPTION
1. add enable_graph_retrieval field to knowledge config and schema
2. add logic to handle graph retrieval switch in workflow node and draft run service
3. pass the switch value to retrieval request

## Summary by Sourcery

为混合知识检索新增一个可配置的图检索开关，并在工作流和草稿运行请求中进行传递。

新特性：
- 在知识库配置和模式中引入 `enable_graph_retrieval` 标志，用于在混合模式下控制图检索。
- 支持基于第一个知识库配置的请求级图检索回退，同时允许对每个知识库进行单独覆盖设置。
- 在来自工作流和草稿运行服务的知识检索请求中包含知识库配置和图检索开关。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable graph retrieval switch to hybrid knowledge retrieval and propagate it through workflow and draft run requests.

New Features:
- Introduce an enable_graph_retrieval flag in knowledge base configuration and schema to control graph retrieval in hybrid mode.
- Support request-level graph retrieval fallback based on the first knowledge base’s configuration while allowing per-KB overrides.
- Include knowledge base configurations and graph retrieval switch in knowledge retrieval requests from workflow and draft run services.

</details>