### PR TITLE
Fix/kb zy

### DIFF
--- a/web/src/components/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeConfigModal.tsx
@@ -106,7 +106,9 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
         {(values?.retrieve_type === 'hybrid') &&
           <Form.Item
             name="enable_graph_retrieval"
-            valuePropName="checked"
+            getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
+            getValueFromEvent={(checked: boolean) => checked ? 1 : 0}
+            initialValue={0}
             label={t('knowledgeBase.hybridIsHasGraph')}
             layout="horizontal"
           >

--- a/web/src/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeListModal.tsx
@@ -178,7 +178,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
         retrieve_type: "hybrid",
         top_k: 3,
         weight: 1,
-        enable_graph_retrieval: false,
+        enable_graph_retrieval: 0,
       }
     })), 'knowledge')
     setVisible(false);

--- a/web/src/components/Knowledge/types.ts
+++ b/web/src/components/Knowledge/types.ts
@@ -34,6 +34,7 @@ export interface KnowledgeConfigForm {
   vector_similarity_weight?: number;
   top_k?: number;
   retrieve_type?: RetrieveType;
+  enable_graph_retrieval?: 0 | 1;
   weight?: number;
   config?: KnowledgeConfigForm;
 }

--- a/web/src/views/ApplicationConfig/hooks/agentHelpers.ts
+++ b/web/src/views/ApplicationConfig/hooks/agentHelpers.ts
@@ -77,6 +77,7 @@ export function buildAgentSaveParams(data: Config, values: Config): Config {
           top_k: kb_config.top_k,
           similarity_threshold: ['participle', 'semantic', 'graph'].includes(kb_config.retrieve_type || '') ? undefined : kb_config.similarity_threshold,
           vector_similarity_weight: kb_config.vector_similarity_weight,
+          enable_graph_retrieval: kb_config.enable_graph_retrieval,
           // ...(item.config || {})
         }
       })

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -179,7 +179,14 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
               )}  
 
               {(retrieveType === 'hybrid') &&
-                <Form.Item name="enable_graph_retrieval" valuePropName="checked" initialValue={true} label={t('knowledgeBase.hybridIsHasGraph')}>
+                <Form.Item
+                    name="enable_graph_retrieval"
+                    getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
+                    getValueFromEvent={(checked: boolean) => checked ? 1 : 0}
+                    initialValue={0}
+                    valuePropName="checked"
+                    label={t('knowledgeBase.hybridIsHasGraph')}
+                >
                     <Switch checkedChildren={t('knowledgeBase.yes')} unCheckedChildren={t('knowledgeBase.no')} />
                 </Form.Item>
               }

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -73,7 +73,7 @@ export interface RecallTestParams {
   hybrid?: boolean; // 是否混合检索
   hybrid_weight?: string;
   retrieve_type?: string; // 检索类型
-  enable_graph_retrieval?: boolean; // 是否启用图谱检索
+  enable_graph_retrieval?: number; // 是否启用图谱检索
 }
 // 文件夹 
 export interface FolderFormData {


### PR DESCRIPTION
## Summary by Sourcery

使知识库图检索配置对齐为使用数字标志，并在代理保存参数中持久化这些标志。

Bug Fixes:
- 修复混合检索图开关的绑定，使 UI 能够在勾选状态与数值型的 `enable_graph_retrieval` 之间正确映射。

Enhancements:
- 更新知识库与知识配置的类型及默认值，将 `enable_graph_retrieval` 从布尔值改为用 0/1 表示，以在各类表单和已保存配置中保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align knowledge base graph retrieval configuration to use numeric flags and persist them in agent save parameters.

Bug Fixes:
- Fix hybrid retrieval graph switch binding so UI correctly maps between checked state and numeric enable_graph_retrieval value.

Enhancements:
- Update knowledge base and knowledge config types and defaults to represent enable_graph_retrieval as 0/1 instead of boolean for consistency across forms and saved configs.

</details>