### PR TITLE
fix(rag): improve markdown preparse chunking

### DIFF
--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -11,7 +11,17 @@ DEFAULT_PARSER_CONFIG = {
     "chunk_token_num": 512,
     "delimiter": "\n!?。；！？",
     "analyze_hyperlink": True,
+    "image_vision_enabled": False,
 }
+
+
+def is_image_vision_enabled(parser_config: dict | None) -> bool:
+    raw_value = (parser_config or {}).get("image_vision_enabled", False)
+    if isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, str):
+        return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(raw_value)
 
 
 class ChunkOutputMode(str, Enum):

--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -11,12 +11,12 @@ DEFAULT_PARSER_CONFIG = {
     "chunk_token_num": 512,
     "delimiter": "\n!?。；！？",
     "analyze_hyperlink": True,
-    "image_vision_enabled": False,
+    "image_vision_enabled": True,
 }
 
 
 def is_image_vision_enabled(parser_config: dict | None) -> bool:
-    raw_value = (parser_config or {}).get("image_vision_enabled", False)
+    raw_value = (parser_config or {}).get("image_vision_enabled", True)
     if isinstance(raw_value, bool):
         return raw_value
     if isinstance(raw_value, str):

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -22,7 +22,6 @@ from .text import TextMerger
 TEXT_LIKE_TYPES = {
     ParsedBlockType.HEADING,
     ParsedBlockType.TEXT,
-    ParsedBlockType.LIST,
     ParsedBlockType.BLOCKQUOTE,
 }
 
@@ -71,7 +70,12 @@ class BlockMerger(ChunkMerger):
                 return
             metadata = self._metadata_for_range(text_group, "text")
             content = "\n\n".join(str(block.content) for block in text_group if str(block.content).strip())
-            for chunk in self.text_merger.merge(content, token_num, delimiter):
+            chunks = (
+                [content]
+                if delimiter is None and num_tokens_from_string(content) <= token_num
+                else self.text_merger.merge(content, token_num, delimiter)
+            )
+            for chunk in chunks:
                 logical_chunks.append(
                     LogicalChunk(
                         type=LogicalChunkType.TEXT,
@@ -87,6 +91,10 @@ class BlockMerger(ChunkMerger):
                 continue
 
             flush_text_group()
+
+            if block.type is ParsedBlockType.LIST:
+                logical_chunks.extend(self._list_logical_chunks(block, token_num, delimiter))
+                continue
 
             if block.type is ParsedBlockType.CODE:
                 logical_chunks.extend(self._code_logical_chunks(block, token_num))
@@ -135,6 +143,19 @@ class BlockMerger(ChunkMerger):
             return [deepcopy(parent)]
 
         block_type = parent.metadata.get("block_type")
+        if block_type == ParsedBlockType.LIST.value:
+            return [
+                LogicalChunk(
+                    type=LogicalChunkType.TEXT,
+                    content=chunk,
+                    image=parent.image,
+                    positions=deepcopy(parent.positions),
+                    metadata=deepcopy(parent.metadata),
+                )
+                for chunk in self._split_list_content(str(parent.content), token_num, delimiter)
+                if chunk.strip()
+            ]
+
         if block_type == ParsedBlockType.CODE.value:
             return [
                 LogicalChunk(
@@ -144,7 +165,11 @@ class BlockMerger(ChunkMerger):
                     positions=deepcopy(parent.positions),
                     metadata=deepcopy(parent.metadata),
                 )
-                for chunk in self._split_code_content(str(parent.content), token_num, parent.metadata.get("language", ""))
+                for chunk in self._split_code_content(
+                    str(parent.content),
+                    token_num,
+                    parent.metadata.get("language", ""),
+                )
                 if chunk.strip()
             ]
 
@@ -159,6 +184,63 @@ class BlockMerger(ChunkMerger):
             for chunk in self.text_merger.merge(str(parent.content), token_num, delimiter)
             if chunk.strip()
         ]
+
+    def _list_logical_chunks(self, block: ParsedBlock, token_num: int, delimiter: str | None) -> list[LogicalChunk]:
+        metadata = self._metadata_for_block(block)
+        return [
+            LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=content,
+                positions=deepcopy(block.positions),
+                metadata=deepcopy(metadata),
+            )
+            for content in self._split_list_content(str(block.content), token_num, delimiter)
+            if content.strip()
+        ]
+
+    def _split_list_content(self, content: str, token_num: int, delimiter: str | None = None) -> list[str]:
+        if num_tokens_from_string(content) <= token_num:
+            return [content]
+
+        items = self._split_list_items(content)
+        if len(items) <= 1:
+            return self.text_merger.merge(content, token_num, delimiter)
+
+        chunks: list[str] = []
+        current_items: list[str] = []
+        for item in items:
+            if num_tokens_from_string(item) > token_num:
+                if current_items:
+                    chunks.append("\n".join(current_items))
+                    current_items = []
+                chunks.extend(self.text_merger.merge(item, token_num, delimiter))
+                continue
+
+            candidate_items = [*current_items, item]
+            candidate = "\n".join(candidate_items)
+            if current_items and num_tokens_from_string(candidate) > token_num:
+                chunks.append("\n".join(current_items))
+                current_items = [item]
+            else:
+                current_items = candidate_items
+
+        if current_items:
+            chunks.append("\n".join(current_items))
+        return chunks or [content]
+
+    def _split_list_items(self, content: str) -> list[str]:
+        items: list[str] = []
+        current_lines: list[str] = []
+        for line in content.split("\n"):
+            starts_new_item = bool(line.strip()) and not line.startswith((" ", "\t"))
+            if starts_new_item and current_lines:
+                items.append("\n".join(current_lines).rstrip())
+                current_lines = [line]
+            else:
+                current_lines.append(line)
+        if current_lines:
+            items.append("\n".join(current_lines).rstrip())
+        return [item for item in items if item.strip()]
 
     def _code_logical_chunks(self, block: ParsedBlock, token_num: int) -> list[LogicalChunk]:
         metadata = self._metadata_for_block(block)
@@ -389,7 +471,7 @@ class BlockMerger(ChunkMerger):
     def _metadata_for_range(self, blocks: list[ParsedBlock], block_type: str) -> dict:
         first = blocks[0]
         last = blocks[-1]
-        return {
+        metadata = {
             "block_type": block_type,
             "block_types": [block.type.value for block in blocks],
             "block_seq_start": first.seq,
@@ -397,6 +479,38 @@ class BlockMerger(ChunkMerger):
             "start_line": first.start_line,
             "end_line": last.end_line,
         }
+        self._add_range_context_metadata(metadata, blocks)
+        return metadata
+
+    def _add_range_context_metadata(self, metadata: dict, blocks: list[ParsedBlock]) -> None:
+        heading_paths = _unique_paths(
+            block.metadata.get("heading_path", [])
+            for block in blocks
+            if isinstance(block.metadata, dict)
+        )
+        if len(heading_paths) == 1:
+            metadata["heading_path"] = heading_paths[0]
+        elif len(heading_paths) > 1:
+            metadata["heading_paths"] = heading_paths
+
+        if len(blocks) == 1 and blocks[0].type is ParsedBlockType.LIST:
+            for key in ("list_item_count", "list_markers", "list_marker_kinds", "contains_qa_marker"):
+                if key in blocks[0].metadata:
+                    metadata[key] = deepcopy(blocks[0].metadata[key])
 
     def _serialize_chunk_contents(self, chunks: list[LogicalChunk]) -> list[str]:
         return [str(chunk.content) for chunk in chunks if str(chunk.content or "").strip()]
+
+
+def _unique_paths(paths) -> list[list[str]]:
+    result: list[list[str]] = []
+    seen = set()
+    for path in paths:
+        if not isinstance(path, list):
+            continue
+        key = tuple(str(item) for item in path)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(list(key))
+    return result

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -452,28 +452,44 @@ class BlockMerger(ChunkMerger):
 
     def _hard_split_wrapped(self, text: str, token_num: int, wrap) -> list[str]:
         tokens = encoder.encode(text)
+        limit = max(int(token_num), 1)
         chunks: list[str] = []
         index = 0
         while index < len(tokens):
-            low = 1
-            high = len(tokens) - index
-            best = 0
-            while low <= high:
-                mid = (low + high) // 2
-                piece = encoder.decode(tokens[index:index + mid])
-                wrapped = wrap(piece)
-                if num_tokens_from_string(wrapped) <= token_num:
-                    best = mid
-                    low = mid + 1
-                else:
-                    high = mid - 1
+            boundary = self._find_wrapped_token_boundary(tokens, index, limit, wrap)
+            if boundary is None:
+                raise RuntimeError(f"Unable to find a valid UTF-8 boundary from token index {index}.")
 
-            if best <= 0:
-                best = 1
-            piece = encoder.decode(tokens[index:index + best])
+            end, piece = boundary
             chunks.append(wrap(piece))
-            index += best
+            index = end
         return chunks
+
+    def _find_wrapped_token_boundary(
+        self,
+        tokens: list[int],
+        start: int,
+        limit: int,
+        wrap,
+    ) -> tuple[int, str] | None:
+        search_end = min(len(tokens), start + limit)
+        for end in range(search_end, start, -1):
+            piece = self._decode_token_slice(tokens, start, end)
+            if piece is not None and num_tokens_from_string(wrap(piece)) <= limit:
+                return end, piece
+
+        for end in range(start + 1, len(tokens) + 1):
+            piece = self._decode_token_slice(tokens, start, end)
+            if piece is not None:
+                return end, piece
+        return None
+
+    @staticmethod
+    def _decode_token_slice(tokens: list[int], start: int, end: int) -> str | None:
+        try:
+            return encoder.decode(tokens[start:end], errors="strict")
+        except UnicodeDecodeError:
+            return None
 
     def _wrap_code_lines(self, lines: list[str], fence_start: str, fence_end: str) -> str:
         if not fence_start:

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -44,7 +44,7 @@ class BlockMerger(ChunkMerger):
                 parent_chunks,
                 token_num,
                 delimiter,
-                chunk_overlap,
+                0,
             )
             return MergeResult(
                 chunks=self._serialize_chunk_contents(child_chunks),

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -4,6 +4,21 @@ from html import escape
 from bs4 import BeautifulSoup
 
 from app.core.rag.common.token_utils import encoder, num_tokens_from_string
+from app.core.rag.chunk.parser.markdown_preprocessor import (
+    ALPHA_LIST_PATTERN,
+    CHINESE_LIST_PATTERN,
+    CIRCLED_LIST_PATTERN,
+    DEFINITION_LIST_PATTERN,
+    EMPTY_ORDERED_LIST_PATTERN,
+    KEYCAP_LIST_PATTERN,
+    ORDERED_LIST_PATTERN,
+    ORDINAL_LIST_PATTERN,
+    PAREN_ORDERED_LIST_PATTERN,
+    PREFIXED_LIST_PATTERN,
+    QA_LIST_PATTERN,
+    STEP_LIST_PATTERN,
+    UNORDERED_LIST_PATTERN,
+)
 from app.core.rag.chunk.context import (
     ChunkContext,
     ChunkOutputMode,
@@ -24,6 +39,22 @@ TEXT_LIKE_TYPES = {
     ParsedBlockType.TEXT,
     ParsedBlockType.BLOCKQUOTE,
 }
+
+LIST_ITEM_START_PATTERNS = (
+    UNORDERED_LIST_PATTERN,
+    ORDERED_LIST_PATTERN,
+    EMPTY_ORDERED_LIST_PATTERN,
+    PAREN_ORDERED_LIST_PATTERN,
+    KEYCAP_LIST_PATTERN,
+    CIRCLED_LIST_PATTERN,
+    STEP_LIST_PATTERN,
+    ORDINAL_LIST_PATTERN,
+    CHINESE_LIST_PATTERN,
+    ALPHA_LIST_PATTERN,
+    DEFINITION_LIST_PATTERN,
+    QA_LIST_PATTERN,
+    PREFIXED_LIST_PATTERN,
+)
 
 
 class BlockMerger(ChunkMerger):
@@ -225,40 +256,47 @@ class BlockMerger(ChunkMerger):
         delimiter: str | None = None,
         overlap: int = 0,
     ) -> list[str]:
-        if num_tokens_from_string(content) <= token_num:
+        limit = max(int(token_num), 1)
+        overlap_tokens = TextMerger._normalize_overlap(overlap, limit)
+        if num_tokens_from_string(content) <= limit:
             return [content]
 
         items = self._split_list_items(content)
         if len(items) <= 1:
-            return self.text_merger.merge(content, token_num, delimiter, overlap)
+            return self.text_merger.merge(content, limit, delimiter, overlap)
 
         chunks: list[str] = []
         current_items: list[str] = []
         for item in items:
-            if num_tokens_from_string(item) > token_num:
+            if num_tokens_from_string(item) > limit:
                 if current_items:
-                    chunks.append("\n".join(current_items))
+                    chunks.append(self._join_list_items(current_items))
                     current_items = []
-                chunks.extend(self.text_merger.merge(item, token_num, delimiter, overlap))
+                chunks.extend(self.text_merger.merge(item, limit, delimiter, overlap))
                 continue
 
             candidate_items = [*current_items, item]
-            candidate = "\n".join(candidate_items)
-            if current_items and num_tokens_from_string(candidate) > token_num:
-                chunks.append("\n".join(current_items))
-                current_items = [item]
-            else:
-                current_items = candidate_items
+            candidate = self._join_list_items(candidate_items)
+            if current_items and num_tokens_from_string(candidate) > limit:
+                chunks.append(self._join_list_items(current_items))
+                current_items = self._retain_list_overlap_items(
+                    current_items,
+                    item,
+                    limit,
+                    overlap_tokens,
+                )
+
+            current_items.append(item)
 
         if current_items:
-            chunks.append("\n".join(current_items))
+            chunks.append(self._join_list_items(current_items))
         return chunks or [content]
 
     def _split_list_items(self, content: str) -> list[str]:
         items: list[str] = []
         current_lines: list[str] = []
         for line in content.split("\n"):
-            starts_new_item = bool(line.strip()) and not line.startswith((" ", "\t"))
+            starts_new_item = self._is_list_item_start(line)
             if starts_new_item and current_lines:
                 items.append("\n".join(current_lines).rstrip())
                 current_lines = [line]
@@ -267,6 +305,30 @@ class BlockMerger(ChunkMerger):
         if current_lines:
             items.append("\n".join(current_lines).rstrip())
         return [item for item in items if item.strip()]
+
+    def _is_list_item_start(self, line: str) -> bool:
+        if not line.strip() or line.startswith((" ", "\t")):
+            return False
+        return any(pattern.match(line) for pattern in LIST_ITEM_START_PATTERNS)
+
+    def _retain_list_overlap_items(
+        self,
+        current_items: list[str],
+        next_item: str,
+        limit: int,
+        overlap: int,
+    ) -> list[str]:
+        retained = current_items[:]
+        while retained and (
+            num_tokens_from_string(self._join_list_items(retained)) > overlap
+            or num_tokens_from_string(self._join_list_items([*retained, next_item])) > limit
+        ):
+            retained = retained[1:]
+        return retained
+
+    @staticmethod
+    def _join_list_items(items: list[str]) -> str:
+        return "\n".join(items)
 
     def _code_logical_chunks(self, block: ParsedBlock, token_num: int) -> list[LogicalChunk]:
         metadata = self._metadata_for_block(block)

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -33,13 +33,19 @@ class BlockMerger(ChunkMerger):
     def merge(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
         blocks = parse_result.blocks or []
         token_num = int(ctx.parser_config.get("chunk_token_num", 128))
-        delimiter = ctx.parser_config.get("delimiter", "\n\n")
+        delimiter = ctx.parser_config.get("delimiter")
+        chunk_overlap = _safe_int(ctx.parser_config.get("chunk_overlap", 0))
 
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
             parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
-            parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter", "\n\n")
-            parent_chunks = self._blocks_to_logical_chunks(blocks, parent_token_num, parent_chunk_delimiter)
-            child_chunks, parent_id_map = self._build_children_from_parents(parent_chunks, token_num, delimiter)
+            parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter")
+            parent_chunks = self._blocks_to_logical_chunks(blocks, parent_token_num, parent_chunk_delimiter, 0)
+            child_chunks, parent_id_map = self._build_children_from_parents(
+                parent_chunks,
+                token_num,
+                delimiter,
+                chunk_overlap,
+            )
             return MergeResult(
                 chunks=self._serialize_chunk_contents(child_chunks),
                 logical_chunks=child_chunks,
@@ -49,7 +55,7 @@ class BlockMerger(ChunkMerger):
                 pdf_parser=parse_result.pdf_parser,
             )
 
-        logical_chunks = self._blocks_to_logical_chunks(blocks, token_num, delimiter)
+        logical_chunks = self._blocks_to_logical_chunks(blocks, token_num, delimiter, chunk_overlap)
         return MergeResult(
             chunks=self._serialize_chunk_contents(logical_chunks),
             logical_chunks=logical_chunks,
@@ -60,7 +66,8 @@ class BlockMerger(ChunkMerger):
         self,
         blocks: list[ParsedBlock],
         token_num: int,
-        delimiter: str,
+        delimiter: str | None,
+        overlap: int,
     ) -> list[LogicalChunk]:
         logical_chunks: list[LogicalChunk] = []
         text_group: list[ParsedBlock] = []
@@ -73,7 +80,7 @@ class BlockMerger(ChunkMerger):
             chunks = (
                 [content]
                 if delimiter is None and num_tokens_from_string(content) <= token_num
-                else self.text_merger.merge(content, token_num, delimiter)
+                else self.text_merger.merge(content, token_num, delimiter, overlap)
             )
             for chunk in chunks:
                 logical_chunks.append(
@@ -93,7 +100,7 @@ class BlockMerger(ChunkMerger):
             flush_text_group()
 
             if block.type is ParsedBlockType.LIST:
-                logical_chunks.extend(self._list_logical_chunks(block, token_num, delimiter))
+                logical_chunks.extend(self._list_logical_chunks(block, token_num, delimiter, overlap))
                 continue
 
             if block.type is ParsedBlockType.CODE:
@@ -122,20 +129,27 @@ class BlockMerger(ChunkMerger):
         self,
         parent_chunks: list[LogicalChunk],
         child_token_num: int,
-        delimiter: str,
+        delimiter: str | None,
+        overlap: int,
     ) -> tuple[list[LogicalChunk], dict[int, int]]:
         child_chunks: list[LogicalChunk] = []
         parent_id_map: dict[int, int] = {}
 
         for parent_index, parent in enumerate(parent_chunks):
-            children = self._split_parent_chunk(parent, child_token_num, delimiter)
+            children = self._split_parent_chunk(parent, child_token_num, delimiter, overlap)
             for child in children:
                 parent_id_map[len(child_chunks)] = parent_index
                 child_chunks.append(child)
 
         return child_chunks, parent_id_map
 
-    def _split_parent_chunk(self, parent: LogicalChunk, token_num: int, delimiter: str) -> list[LogicalChunk]:
+    def _split_parent_chunk(
+        self,
+        parent: LogicalChunk,
+        token_num: int,
+        delimiter: str | None,
+        overlap: int,
+    ) -> list[LogicalChunk]:
         if parent.type is LogicalChunkType.TABLE:
             return self._split_logical_table_chunk(parent, token_num)
 
@@ -152,7 +166,7 @@ class BlockMerger(ChunkMerger):
                     positions=deepcopy(parent.positions),
                     metadata=deepcopy(parent.metadata),
                 )
-                for chunk in self._split_list_content(str(parent.content), token_num, delimiter)
+                for chunk in self._split_list_content(str(parent.content), token_num, delimiter, overlap)
                 if chunk.strip()
             ]
 
@@ -181,11 +195,17 @@ class BlockMerger(ChunkMerger):
                 positions=deepcopy(parent.positions),
                 metadata=deepcopy(parent.metadata),
             )
-            for chunk in self.text_merger.merge(str(parent.content), token_num, delimiter)
+            for chunk in self.text_merger.merge(str(parent.content), token_num, delimiter, overlap)
             if chunk.strip()
         ]
 
-    def _list_logical_chunks(self, block: ParsedBlock, token_num: int, delimiter: str | None) -> list[LogicalChunk]:
+    def _list_logical_chunks(
+        self,
+        block: ParsedBlock,
+        token_num: int,
+        delimiter: str | None,
+        overlap: int,
+    ) -> list[LogicalChunk]:
         metadata = self._metadata_for_block(block)
         return [
             LogicalChunk(
@@ -194,17 +214,23 @@ class BlockMerger(ChunkMerger):
                 positions=deepcopy(block.positions),
                 metadata=deepcopy(metadata),
             )
-            for content in self._split_list_content(str(block.content), token_num, delimiter)
+            for content in self._split_list_content(str(block.content), token_num, delimiter, overlap)
             if content.strip()
         ]
 
-    def _split_list_content(self, content: str, token_num: int, delimiter: str | None = None) -> list[str]:
+    def _split_list_content(
+        self,
+        content: str,
+        token_num: int,
+        delimiter: str | None = None,
+        overlap: int = 0,
+    ) -> list[str]:
         if num_tokens_from_string(content) <= token_num:
             return [content]
 
         items = self._split_list_items(content)
         if len(items) <= 1:
-            return self.text_merger.merge(content, token_num, delimiter)
+            return self.text_merger.merge(content, token_num, delimiter, overlap)
 
         chunks: list[str] = []
         current_items: list[str] = []
@@ -213,7 +239,7 @@ class BlockMerger(ChunkMerger):
                 if current_items:
                     chunks.append("\n".join(current_items))
                     current_items = []
-                chunks.extend(self.text_merger.merge(item, token_num, delimiter))
+                chunks.extend(self.text_merger.merge(item, token_num, delimiter, overlap))
                 continue
 
             candidate_items = [*current_items, item]
@@ -514,3 +540,10 @@ def _unique_paths(paths) -> list[list[str]]:
         seen.add(key)
         result.append(list(key))
     return result
+
+
+def _safe_int(value, default: int = 0) -> int:
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return default

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -87,6 +87,12 @@ class TextMerger:
         separator: str,
     ) -> list[_SplitUnit]:
         raw_parts = text.split(separator)
+        if separator in {"。", "；"}:
+            return [
+                _SplitUnit(text=part + (separator if index < len(raw_parts) - 1 else ""))
+                for index, part in enumerate(raw_parts)
+                if part
+            ]
         return [
             _SplitUnit(text=part, prefix="" if index == 0 else separator)
             for index, part in enumerate(raw_parts)

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -1,25 +1,41 @@
+from dataclasses import dataclass
+
 from app.core.rag.common.token_utils import encoder, num_tokens_from_string
 
 
 DEFAULT_TEXT_SEPARATORS = ["\n\n", "\n", "。", "；", " ", ""]
 
 
+@dataclass(frozen=True)
+class _SplitUnit:
+    text: str
+    prefix: str = ""
+
+
 class TextMerger:
     def __init__(self, separators: list[str] | None = None):
         self.separators = separators or DEFAULT_TEXT_SEPARATORS
 
-    def merge(self, value: str | list, chunk_num: int, delimiter: str | None = None) -> list[str]:
+    def merge(
+        self,
+        value: str | list,
+        chunk_num: int,
+        delimiter: str | None = None,
+        overlap: int | None = 0,
+    ) -> list[str]:
         limit = max(int(chunk_num), 1)
-        separators = self._build_separators(delimiter)
+        overlap_tokens = self._normalize_overlap(overlap, limit)
         chunks: list[str] = []
         for text in self._extract_strings(value):
-            chunks.extend(self._split_recursive(text, limit, separators, 0))
+            for segment in self._split_by_custom_delimiter(text, delimiter):
+                if not segment or not segment.strip():
+                    continue
+                if self._within_limit(segment, limit):
+                    chunks.append(segment)
+                    continue
+                split_units = self._split_recursive(segment, limit, 0)
+                chunks.extend(self._merge_split_units(split_units, limit, overlap_tokens))
         return chunks
-
-    def _build_separators(self, delimiter: str | None) -> list[str]:
-        if delimiter is None:
-            return list(self.separators)
-        return [delimiter] + [separator for separator in self.separators if separator != delimiter]
 
     def _extract_strings(self, value: str | list) -> list[str]:
         if isinstance(value, str):
@@ -28,40 +44,96 @@ class TextMerger:
             return [item for item in value if isinstance(item, str)]
         return []
 
-    def _split_recursive(self, text: str, limit: int, separators: list[str], separator_index: int) -> list[str]:
-        if not text or not text.strip():
-            return []
-
-        separator = separators[separator_index] if separator_index < len(separators) else ""
-        if self._within_limit(text, limit) and (separator_index > 0 or not separator or separator not in text):
+    def _split_by_custom_delimiter(self, text: str, delimiter: str | None) -> list[str]:
+        if not delimiter:
             return [text]
-
-        if separator == "":
-            return self._hard_split(text, limit)
-
-        parts = self._split_with_separator(text, separator)
-        if len(parts) <= 1:
-            return self._split_recursive(text, limit, separators, separator_index + 1)
-
-        result: list[str] = []
-        for part in parts:
-            if not part or not part.strip():
-                continue
-            if self._within_limit(part, limit):
-                result.append(part)
-            else:
-                result.extend(self._split_recursive(part, limit, separators, separator_index + 1))
-        return result
-
-    def _split_with_separator(self, text: str, separator: str) -> list[str]:
-        raw_parts = text.split(separator)
-        if separator in {"。", "；"}:
+        raw_parts = text.split(delimiter)
+        if delimiter in {"。", "；"}:
             return [
-                part + (separator if index < len(raw_parts) - 1 else "")
+                part + (delimiter if index < len(raw_parts) - 1 else "")
                 for index, part in enumerate(raw_parts)
                 if part
             ]
         return [part for part in raw_parts if part]
+
+    def _split_recursive(self, text: str, limit: int, separator_index: int, prefix: str = "") -> list[_SplitUnit]:
+        if not text or not text.strip():
+            return []
+        if self._within_limit(text, limit):
+            return [_SplitUnit(text=text, prefix=prefix)]
+
+        separator = self.separators[separator_index] if separator_index < len(self.separators) else ""
+        if separator == "":
+            return [
+                _SplitUnit(text=chunk, prefix=prefix if index == 0 else "")
+                for index, chunk in enumerate(self._hard_split(text, limit))
+            ]
+
+        parts = self._split_with_separator(text, separator)
+        if len(parts) <= 1:
+            return self._split_recursive(text, limit, separator_index + 1, prefix)
+
+        result: list[_SplitUnit] = []
+        for index, part in enumerate(parts):
+            if not part or not part.text.strip():
+                continue
+            unit_prefix = prefix if index == 0 else part.prefix
+            result.extend(self._split_recursive(part.text, limit, separator_index + 1, unit_prefix))
+        return result
+
+    def _split_with_separator(
+        self,
+        text: str,
+        separator: str,
+    ) -> list[_SplitUnit]:
+        raw_parts = text.split(separator)
+        return [
+            _SplitUnit(text=part, prefix="" if index == 0 else separator)
+            for index, part in enumerate(raw_parts)
+            if part
+        ]
+
+    def _merge_split_units(self, split_units: list[_SplitUnit], limit: int, overlap: int) -> list[str]:
+        docs: list[str] = []
+        current_doc: list[_SplitUnit] = []
+        total = 0
+
+        for split_unit in split_units:
+            if current_doc and not self._within_limit(self._join_units([*current_doc, split_unit]), limit):
+                docs.append(self._join_units(current_doc))
+
+                while current_doc and (
+                    total > overlap
+                    or not self._within_limit(self._join_units([*current_doc, split_unit]), limit)
+                ):
+                    total -= num_tokens_from_string(current_doc[0].text)
+                    current_doc = current_doc[1:]
+
+            current_doc.append(split_unit)
+            total += num_tokens_from_string(split_unit.text)
+
+        if current_doc:
+            docs.append(self._join_units(current_doc))
+        return docs
+
+    @staticmethod
+    def _join_units(split_units: list[_SplitUnit]) -> str:
+        if not split_units:
+            return ""
+        return "".join(
+            split_unit.text if index == 0 else f"{split_unit.prefix}{split_unit.text}"
+            for index, split_unit in enumerate(split_units)
+        )
+
+    @staticmethod
+    def _normalize_overlap(overlap: int | None, limit: int) -> int:
+        try:
+            value = int(overlap or 0)
+        except (TypeError, ValueError):
+            value = 0
+        if value <= 0:
+            return 0
+        return min(value, max(limit - 1, 0))
 
     def _hard_split(self, text: str, limit: int) -> list[str]:
         tokens = encoder.encode(text)

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -29,7 +29,7 @@ CIRCLED_MARKERS = (
 CHINESE_NUMERAL_MARKERS = "零〇一二三四五六七八九十百千万壹贰貳貮叁參肆伍陆陸柒捌玖拾"
 
 UNORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}([-+*])\s+(.+\S)\s*$")
-ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d+)([.)）、|｜])\s*(.+\S)\s*$")
+ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d+)(?:[)）、|｜]|[.．](?!\d))\s*(.+\S)\s*$")
 EMPTY_ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d{1,3})([.)）、|｜])\s*$")
 PAREN_ORDERED_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}([（(]\s*(?:\d+|[{CHINESE_NUMERAL_MARKERS}]+)\s*[）)])\s*(.+\S)\s*$"
@@ -49,7 +49,7 @@ STEP_LIST_PATTERN = re.compile(
 PREFIXED_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(?P<prefix>[^:：|｜\n]{{1,24}}[：:|｜])\s*"
     rf"(?P<marker>"
-    rf"\d+[.)）、|｜]"
+    rf"\d+(?:[)）、|｜]|[.．](?!\d))"
     rf"|[（(]\s*(?:\d+|[{CHINESE_NUMERAL_MARKERS}]+)\s*[）)]"
     rf"|[0-9]\ufe0f?\u20e3"
     rf"|[{CIRCLED_MARKERS}]"
@@ -60,6 +60,13 @@ PREFIXED_LIST_PATTERN = re.compile(
     rf")\s*(?P<body>.*\S)?\s*$"
 )
 LIST_CONTINUATION_PATTERN = re.compile(r"^\s{0,3}.{1,24}(?:简介|介绍|说明|定义)[：:].+\S\s*$")
+QA_CONTINUATION_AFTER_BLANK_PATTERN = re.compile(
+    r"^(?:"
+    r"(?=.{12,})(?=.*[。！？；，,.;:：]).+"
+    r"|(?:当|若|如果|因此|所以|同时|另外|此外|其中|相关|产品|试验|测试|验证|优先|严酷|注意|GB/T|IEC).+"
+    r")"
+)
+MAX_QA_CONTINUATION_PARAGRAPHS = 3
 IMAGE_LINE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 HTML_TABLE_LINE_PATTERN = re.compile(r"^\s*<table\b", re.IGNORECASE)
 MARKDOWN_TABLE_LINE_PATTERN = re.compile(r"^\s*\|.+\|\s*$")
@@ -93,6 +100,8 @@ class MarkdownPreprocessor:
         in_code = False
         in_list_context = False
         in_qa_list_context = False
+        qa_blank_lines = 0
+        qa_continuation_paragraphs = 0
         for line_number, raw_line in enumerate(text.split("\n"), start=1):
             stripped = raw_line.strip()
             is_code_fence = stripped.startswith("```")
@@ -120,6 +129,13 @@ class MarkdownPreprocessor:
             block_hint = None
             metadata: dict[str, Any] = {}
             if not is_code_fence:
+                after_qa_blank = False
+                if not stripped:
+                    if in_qa_list_context:
+                        qa_blank_lines += 1
+                else:
+                    after_qa_blank = qa_blank_lines > 0
+                    qa_blank_lines = 0
                 heading_match = ATX_HEADING_PATTERN.match(line)
                 if heading_match:
                     block_hint = "heading"
@@ -129,6 +145,7 @@ class MarkdownPreprocessor:
                     }
                     in_list_context = False
                     in_qa_list_context = False
+                    qa_continuation_paragraphs = 0
                 else:
                     list_metadata = self._list_metadata(line)
                     if list_metadata:
@@ -136,9 +153,13 @@ class MarkdownPreprocessor:
                         metadata = list_metadata
                         in_list_context = True
                         in_qa_list_context = in_qa_list_context or bool(list_metadata.get("contains_qa_marker"))
+                        if list_metadata.get("contains_qa_marker"):
+                            qa_continuation_paragraphs = 0
                     elif in_list_context and self._is_list_continuation(
                         line,
                         in_qa_context=normalize_escaped_structure and in_qa_list_context,
+                        after_blank=normalize_escaped_structure and in_qa_list_context and after_qa_blank,
+                        qa_continuation_paragraphs=qa_continuation_paragraphs,
                     ):
                         block_hint = "list_continuation"
                         metadata = {
@@ -146,12 +167,16 @@ class MarkdownPreprocessor:
                             "qa_continuation": in_qa_list_context,
                             "list_level": _indent_level(line),
                         }
+                        if in_qa_list_context and after_qa_blank:
+                            qa_continuation_paragraphs += 1
                     elif stripped and not IMAGE_LINE_PATTERN.search(line):
                         in_list_context = False
                         in_qa_list_context = False
+                        qa_continuation_paragraphs = 0
                     elif IMAGE_LINE_PATTERN.search(line):
                         in_list_context = False
                         in_qa_list_context = False
+                        qa_continuation_paragraphs = 0
 
             line_infos.append(
                 MarkdownLineInfo(
@@ -167,6 +192,8 @@ class MarkdownPreprocessor:
                 in_code = True
                 in_list_context = False
                 in_qa_list_context = False
+                qa_blank_lines = 0
+                qa_continuation_paragraphs = 0
 
         return MarkdownPreprocessResult(
             lines=[line_info.text for line_info in line_infos],
@@ -218,7 +245,14 @@ class MarkdownPreprocessor:
             }
         return None
 
-    def _is_list_continuation(self, line: str, *, in_qa_context: bool = False) -> bool:
+    def _is_list_continuation(
+        self,
+        line: str,
+        *,
+        in_qa_context: bool = False,
+        after_blank: bool = False,
+        qa_continuation_paragraphs: int = 0,
+    ) -> bool:
         stripped = line.strip()
         if not stripped:
             return False
@@ -231,6 +265,11 @@ class MarkdownPreprocessor:
         ):
             return False
         if in_qa_context:
+            if after_blank:
+                return (
+                    qa_continuation_paragraphs < MAX_QA_CONTINUATION_PARAGRAPHS
+                    and bool(QA_CONTINUATION_AFTER_BLANK_PATTERN.match(stripped))
+                )
             return True
         return bool(LIST_CONTINUATION_PATTERN.match(line))
 

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -30,13 +30,14 @@ CHINESE_NUMERAL_MARKERS = "零〇一二三四五六七八九十百千万壹贰�
 
 UNORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}([-+*])\s+(.+\S)\s*$")
 ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d+)([.)）、|｜])\s*(.+\S)\s*$")
+EMPTY_ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d{1,3})([.)）、|｜])\s*$")
 PAREN_ORDERED_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}([（(]\s*(?:\d+|[{CHINESE_NUMERAL_MARKERS}]+)\s*[）)])\s*(.+\S)\s*$"
 )
 KEYCAP_LIST_PATTERN = re.compile(r"^\s{0,3}([0-9]\ufe0f?\u20e3)\s*(.+\S)\s*$")
 CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*$")
 CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
-ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）、|｜])\s*(.+\S)\s*$")
+ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）|｜]|、(?!\s*[A-Za-z]))\s*(.+\S)\s*$")
 DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Z][A-Z0-9]{1,11})([：:])\s*(.+\S)\s*$")
 QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(.+\S)\s*$")
 ORDINAL_LIST_PATTERN = re.compile(
@@ -45,7 +46,20 @@ ORDINAL_LIST_PATTERN = re.compile(
 STEP_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(.{{0,12}}?第[{CHINESE_NUMERAL_MARKERS}0-9]+步)({LIST_BOUNDARY})\s*(.+\S)\s*$"
 )
-LIST_CONTINUATION_PATTERN = re.compile(r"^\s{0,3}.{1,24}简介[：:].+\S\s*$")
+PREFIXED_LIST_PATTERN = re.compile(
+    rf"^\s{{0,3}}(?P<prefix>[^:：|｜\n]{{1,24}}[：:|｜])\s*"
+    rf"(?P<marker>"
+    rf"\d+[.)）、|｜]"
+    rf"|[（(]\s*(?:\d+|[{CHINESE_NUMERAL_MARKERS}]+)\s*[）)]"
+    rf"|[0-9]\ufe0f?\u20e3"
+    rf"|[{CIRCLED_MARKERS}]"
+    rf"|[{CHINESE_NUMERAL_MARKERS}]+(?:{LIST_BOUNDARY})"
+    rf"|[A-Za-z](?:[.)）|｜]|、(?!\s*[A-Za-z]))"
+    rf"|(?:首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)(?:{LIST_BOUNDARY})"
+    rf"|.{{0,12}}?第[{CHINESE_NUMERAL_MARKERS}0-9]+步(?:{LIST_BOUNDARY})"
+    rf")\s*(?P<body>.*\S)?\s*$"
+)
+LIST_CONTINUATION_PATTERN = re.compile(r"^\s{0,3}.{1,24}(?:简介|介绍|说明|定义)[：:].+\S\s*$")
 IMAGE_LINE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 HTML_TABLE_LINE_PATTERN = re.compile(r"^\s*<table\b", re.IGNORECASE)
 MARKDOWN_TABLE_LINE_PATTERN = re.compile(r"^\s*\|.+\|\s*$")
@@ -171,6 +185,7 @@ class MarkdownPreprocessor:
         patterns = (
             ("unordered", UNORDERED_LIST_PATTERN),
             ("ordered", ORDERED_LIST_PATTERN),
+            ("ordered", EMPTY_ORDERED_LIST_PATTERN),
             ("ordered_parenthesis", PAREN_ORDERED_LIST_PATTERN),
             ("keycap", KEYCAP_LIST_PATTERN),
             ("circled", CIRCLED_LIST_PATTERN),
@@ -191,6 +206,15 @@ class MarkdownPreprocessor:
                 "list_marker_kind": marker_kind,
                 "list_level": _indent_level(line),
                 "contains_qa_marker": marker_kind == "qa",
+            }
+        prefixed_match = PREFIXED_LIST_PATTERN.match(line)
+        if prefixed_match:
+            return {
+                "list_marker": prefixed_match.group("marker").strip(),
+                "list_marker_kind": "prefixed",
+                "list_prefix": prefixed_match.group("prefix").strip(),
+                "list_level": _indent_level(line),
+                "contains_qa_marker": False,
             }
         return None
 

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -47,6 +47,8 @@ STEP_LIST_PATTERN = re.compile(
 )
 LIST_CONTINUATION_PATTERN = re.compile(r"^\s{0,3}.{1,24}简介[：:].+\S\s*$")
 IMAGE_LINE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+HTML_TABLE_LINE_PATTERN = re.compile(r"^\s*<table\b", re.IGNORECASE)
+MARKDOWN_TABLE_LINE_PATTERN = re.compile(r"^\s*\|.+\|\s*$")
 
 
 @dataclass
@@ -76,6 +78,7 @@ class MarkdownPreprocessor:
         line_infos: list[MarkdownLineInfo] = []
         in_code = False
         in_list_context = False
+        in_qa_list_context = False
         for line_number, raw_line in enumerate(text.split("\n"), start=1):
             stripped = raw_line.strip()
             is_code_fence = stripped.startswith("```")
@@ -111,22 +114,30 @@ class MarkdownPreprocessor:
                         "heading_title": _strip_wrapping_emphasis(heading_match.group(2)),
                     }
                     in_list_context = False
+                    in_qa_list_context = False
                 else:
                     list_metadata = self._list_metadata(line)
                     if list_metadata:
                         block_hint = "list"
                         metadata = list_metadata
                         in_list_context = True
-                    elif in_list_context and self._is_list_continuation(line):
+                        in_qa_list_context = in_qa_list_context or bool(list_metadata.get("contains_qa_marker"))
+                    elif in_list_context and self._is_list_continuation(
+                        line,
+                        in_qa_context=normalize_escaped_structure and in_qa_list_context,
+                    ):
                         block_hint = "list_continuation"
                         metadata = {
                             "list_continuation": True,
+                            "qa_continuation": in_qa_list_context,
                             "list_level": _indent_level(line),
                         }
                     elif stripped and not IMAGE_LINE_PATTERN.search(line):
                         in_list_context = False
+                        in_qa_list_context = False
                     elif IMAGE_LINE_PATTERN.search(line):
                         in_list_context = False
+                        in_qa_list_context = False
 
             line_infos.append(
                 MarkdownLineInfo(
@@ -141,6 +152,7 @@ class MarkdownPreprocessor:
             if is_code_fence:
                 in_code = True
                 in_list_context = False
+                in_qa_list_context = False
 
         return MarkdownPreprocessResult(
             lines=[line_info.text for line_info in line_infos],
@@ -182,12 +194,20 @@ class MarkdownPreprocessor:
             }
         return None
 
-    def _is_list_continuation(self, line: str) -> bool:
+    def _is_list_continuation(self, line: str, *, in_qa_context: bool = False) -> bool:
         stripped = line.strip()
         if not stripped:
             return False
-        if IMAGE_LINE_PATTERN.search(line) or ATX_HEADING_PATTERN.match(line):
+        if (
+            stripped.startswith(("```", ">"))
+            or IMAGE_LINE_PATTERN.search(line)
+            or ATX_HEADING_PATTERN.match(line)
+            or HTML_TABLE_LINE_PATTERN.match(line)
+            or MARKDOWN_TABLE_LINE_PATTERN.match(line)
+        ):
             return False
+        if in_qa_context:
+            return True
         return bool(LIST_CONTINUATION_PATTERN.match(line))
 
 

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -9,6 +9,7 @@ EMPTY_HTML_ANCHOR_PATTERN = re.compile(
 )
 
 ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
+MINERU_FIELD_HEADING_BODY_PATTERN = re.compile(r"[：:；;。。，,]")
 ESCAPED_HEADING_PATTERN = re.compile(r"^(\s*)\\(#{1,6})(\s+)")
 ESCAPED_UNORDERED_LIST_PATTERN = re.compile(r"^(\s*)\\([-+*])(\s+)")
 ESCAPED_THEMATIC_BREAK_PATTERN = re.compile(r"^(\s*)\\((?:-{3,}|\*{3,}|_{3,}))(\s*)$")
@@ -93,9 +94,12 @@ class MarkdownPreprocessor:
         in_code = False
         in_list_context = False
         in_qa_list_context = False
+        pending_empty_html_anchor = False
         for line_number, raw_line in enumerate(text.split("\n"), start=1):
-            stripped = raw_line.strip()
-            is_code_fence = stripped.startswith("```")
+            raw_stripped = raw_line.strip()
+            is_code_fence = raw_stripped.startswith("```")
+            line_is_empty_html_anchor = bool(EMPTY_HTML_ANCHOR_PATTERN.fullmatch(raw_stripped))
+            preceded_by_empty_html_anchor = pending_empty_html_anchor
 
             if in_code:
                 line_infos.append(
@@ -109,6 +113,7 @@ class MarkdownPreprocessor:
                 )
                 if is_code_fence:
                     in_code = False
+                pending_empty_html_anchor = False
                 continue
 
             line = raw_line
@@ -121,6 +126,14 @@ class MarkdownPreprocessor:
             metadata: dict[str, Any] = {}
             if not is_code_fence:
                 heading_match = ATX_HEADING_PATTERN.match(line)
+                if heading_match and self._should_demote_mineru_field_heading(
+                    heading_match,
+                    normalize_escaped_structure=normalize_escaped_structure,
+                    preceded_by_empty_html_anchor=preceded_by_empty_html_anchor,
+                ):
+                    line = heading_match.group(2).strip()
+                    stripped = line.strip()
+                    heading_match = None
                 if heading_match:
                     block_hint = "heading"
                     metadata = {
@@ -167,6 +180,11 @@ class MarkdownPreprocessor:
                 in_code = True
                 in_list_context = False
                 in_qa_list_context = False
+                pending_empty_html_anchor = False
+            elif line_is_empty_html_anchor:
+                pending_empty_html_anchor = True
+            elif stripped:
+                pending_empty_html_anchor = False
 
         return MarkdownPreprocessResult(
             lines=[line_info.text for line_info in line_infos],
@@ -180,6 +198,20 @@ class MarkdownPreprocessor:
         if heading_count or list_count or rule_count or STRUCTURAL_LINE_PATTERN.match(normalized):
             normalized = ESCAPED_EMPHASIS_PATTERN.sub(r"\1", normalized)
         return normalized
+
+    def _should_demote_mineru_field_heading(
+        self,
+        heading_match: re.Match,
+        *,
+        normalize_escaped_structure: bool,
+        preceded_by_empty_html_anchor: bool,
+    ) -> bool:
+        if not normalize_escaped_structure or preceded_by_empty_html_anchor:
+            return False
+        body = heading_match.group(2).strip()
+        if _is_wrapped_emphasis(body):
+            return False
+        return bool(MINERU_FIELD_HEADING_BODY_PATTERN.search(body))
 
     def _list_metadata(self, line: str) -> dict[str, Any] | None:
         patterns = (
@@ -243,6 +275,15 @@ def _indent_level(line: str) -> int:
 def _strip_wrapping_emphasis(text: str) -> str:
     value = text.strip()
     for marker in ("**", "__"):
-        if value.startswith(marker) and value.endswith(marker) and len(value) > len(marker) * 2:
+        if _is_wrapped_emphasis(value, marker):
             return value[len(marker):-len(marker)].strip()
     return value
+
+
+def _is_wrapped_emphasis(text: str, marker: str | None = None) -> bool:
+    value = text.strip()
+    markers = (marker,) if marker else ("**", "__")
+    return any(
+        value.startswith(item) and value.endswith(item) and len(value) > len(item) * 2
+        for item in markers
+    )

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -9,7 +9,6 @@ EMPTY_HTML_ANCHOR_PATTERN = re.compile(
 )
 
 ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
-MINERU_FIELD_HEADING_BODY_PATTERN = re.compile(r"[：:；;。。，,]")
 ESCAPED_HEADING_PATTERN = re.compile(r"^(\s*)\\(#{1,6})(\s+)")
 ESCAPED_UNORDERED_LIST_PATTERN = re.compile(r"^(\s*)\\([-+*])(\s+)")
 ESCAPED_THEMATIC_BREAK_PATTERN = re.compile(r"^(\s*)\\((?:-{3,}|\*{3,}|_{3,}))(\s*)$")
@@ -94,12 +93,9 @@ class MarkdownPreprocessor:
         in_code = False
         in_list_context = False
         in_qa_list_context = False
-        pending_empty_html_anchor = False
         for line_number, raw_line in enumerate(text.split("\n"), start=1):
-            raw_stripped = raw_line.strip()
-            is_code_fence = raw_stripped.startswith("```")
-            line_is_empty_html_anchor = bool(EMPTY_HTML_ANCHOR_PATTERN.fullmatch(raw_stripped))
-            preceded_by_empty_html_anchor = pending_empty_html_anchor
+            stripped = raw_line.strip()
+            is_code_fence = stripped.startswith("```")
 
             if in_code:
                 line_infos.append(
@@ -113,7 +109,6 @@ class MarkdownPreprocessor:
                 )
                 if is_code_fence:
                     in_code = False
-                pending_empty_html_anchor = False
                 continue
 
             line = raw_line
@@ -126,14 +121,6 @@ class MarkdownPreprocessor:
             metadata: dict[str, Any] = {}
             if not is_code_fence:
                 heading_match = ATX_HEADING_PATTERN.match(line)
-                if heading_match and self._should_demote_mineru_field_heading(
-                    heading_match,
-                    normalize_escaped_structure=normalize_escaped_structure,
-                    preceded_by_empty_html_anchor=preceded_by_empty_html_anchor,
-                ):
-                    line = heading_match.group(2).strip()
-                    stripped = line.strip()
-                    heading_match = None
                 if heading_match:
                     block_hint = "heading"
                     metadata = {
@@ -180,11 +167,6 @@ class MarkdownPreprocessor:
                 in_code = True
                 in_list_context = False
                 in_qa_list_context = False
-                pending_empty_html_anchor = False
-            elif line_is_empty_html_anchor:
-                pending_empty_html_anchor = True
-            elif stripped:
-                pending_empty_html_anchor = False
 
         return MarkdownPreprocessResult(
             lines=[line_info.text for line_info in line_infos],
@@ -198,20 +180,6 @@ class MarkdownPreprocessor:
         if heading_count or list_count or rule_count or STRUCTURAL_LINE_PATTERN.match(normalized):
             normalized = ESCAPED_EMPHASIS_PATTERN.sub(r"\1", normalized)
         return normalized
-
-    def _should_demote_mineru_field_heading(
-        self,
-        heading_match: re.Match,
-        *,
-        normalize_escaped_structure: bool,
-        preceded_by_empty_html_anchor: bool,
-    ) -> bool:
-        if not normalize_escaped_structure or preceded_by_empty_html_anchor:
-            return False
-        body = heading_match.group(2).strip()
-        if _is_wrapped_emphasis(body):
-            return False
-        return bool(MINERU_FIELD_HEADING_BODY_PATTERN.search(body))
 
     def _list_metadata(self, line: str) -> dict[str, Any] | None:
         patterns = (
@@ -275,15 +243,6 @@ def _indent_level(line: str) -> int:
 def _strip_wrapping_emphasis(text: str) -> str:
     value = text.strip()
     for marker in ("**", "__"):
-        if _is_wrapped_emphasis(value, marker):
+        if value.startswith(marker) and value.endswith(marker) and len(value) > len(marker) * 2:
             return value[len(marker):-len(marker)].strip()
     return value
-
-
-def _is_wrapped_emphasis(text: str, marker: str | None = None) -> bool:
-    value = text.strip()
-    markers = (marker,) if marker else ("**", "__")
-    return any(
-        value.startswith(item) and value.endswith(item) and len(value) > len(item) * 2
-        for item in markers
-    )

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -30,10 +30,14 @@ CHINESE_NUMERAL_MARKERS = "零〇一二三四五六七八九十百千万壹贰�
 
 UNORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}([-+*])\s+(.+\S)\s*$")
 ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d+)([.)）、|｜])\s*(.+\S)\s*$")
+PAREN_ORDERED_LIST_PATTERN = re.compile(
+    rf"^\s{{0,3}}([（(]\s*(?:\d+|[{CHINESE_NUMERAL_MARKERS}]+)\s*[）)])\s*(.+\S)\s*$"
+)
 KEYCAP_LIST_PATTERN = re.compile(r"^\s{0,3}([0-9]\ufe0f?\u20e3)\s*(.+\S)\s*$")
 CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*$")
 CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
 ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）、|｜])\s*(.+\S)\s*$")
+DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Z][A-Z0-9]{1,11})([：:])\s*(.+\S)\s*$")
 QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(.+\S)\s*$")
 ORDINAL_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)({LIST_BOUNDARY})\s*(.+\S)\s*$"
@@ -41,6 +45,8 @@ ORDINAL_LIST_PATTERN = re.compile(
 STEP_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(.{{0,12}}?第[{CHINESE_NUMERAL_MARKERS}0-9]+步)({LIST_BOUNDARY})\s*(.+\S)\s*$"
 )
+LIST_CONTINUATION_PATTERN = re.compile(r"^\s{0,3}.{1,24}简介[：:].+\S\s*$")
+IMAGE_LINE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
 
 
 @dataclass
@@ -69,6 +75,7 @@ class MarkdownPreprocessor:
     ) -> MarkdownPreprocessResult:
         line_infos: list[MarkdownLineInfo] = []
         in_code = False
+        in_list_context = False
         for line_number, raw_line in enumerate(text.split("\n"), start=1):
             stripped = raw_line.strip()
             is_code_fence = stripped.startswith("```")
@@ -91,6 +98,7 @@ class MarkdownPreprocessor:
             if normalize_escaped_structure:
                 line = self._normalize_escaped_structural_line(line)
             line = EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
+            stripped = line.strip()
 
             block_hint = None
             metadata: dict[str, Any] = {}
@@ -102,11 +110,23 @@ class MarkdownPreprocessor:
                         "heading_level": len(heading_match.group(1)),
                         "heading_title": _strip_wrapping_emphasis(heading_match.group(2)),
                     }
+                    in_list_context = False
                 else:
                     list_metadata = self._list_metadata(line)
                     if list_metadata:
                         block_hint = "list"
                         metadata = list_metadata
+                        in_list_context = True
+                    elif in_list_context and self._is_list_continuation(line):
+                        block_hint = "list_continuation"
+                        metadata = {
+                            "list_continuation": True,
+                            "list_level": _indent_level(line),
+                        }
+                    elif stripped and not IMAGE_LINE_PATTERN.search(line):
+                        in_list_context = False
+                    elif IMAGE_LINE_PATTERN.search(line):
+                        in_list_context = False
 
             line_infos.append(
                 MarkdownLineInfo(
@@ -120,6 +140,7 @@ class MarkdownPreprocessor:
             )
             if is_code_fence:
                 in_code = True
+                in_list_context = False
 
         return MarkdownPreprocessResult(
             lines=[line_info.text for line_info in line_infos],
@@ -138,12 +159,14 @@ class MarkdownPreprocessor:
         patterns = (
             ("unordered", UNORDERED_LIST_PATTERN),
             ("ordered", ORDERED_LIST_PATTERN),
+            ("ordered_parenthesis", PAREN_ORDERED_LIST_PATTERN),
             ("keycap", KEYCAP_LIST_PATTERN),
             ("circled", CIRCLED_LIST_PATTERN),
             ("step", STEP_LIST_PATTERN),
             ("ordinal", ORDINAL_LIST_PATTERN),
             ("chinese", CHINESE_LIST_PATTERN),
             ("alpha", ALPHA_LIST_PATTERN),
+            ("definition", DEFINITION_LIST_PATTERN),
             ("qa", QA_LIST_PATTERN),
         )
         for marker_kind, pattern in patterns:
@@ -158,6 +181,14 @@ class MarkdownPreprocessor:
                 "contains_qa_marker": marker_kind == "qa",
             }
         return None
+
+    def _is_list_continuation(self, line: str) -> bool:
+        stripped = line.strip()
+        if not stripped:
+            return False
+        if IMAGE_LINE_PATTERN.search(line) or ATX_HEADING_PATTERN.match(line):
+            return False
+        return bool(LIST_CONTINUATION_PATTERN.match(line))
 
 
 def _indent_level(line: str) -> int:

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -1,0 +1,173 @@
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+EMPTY_HTML_ANCHOR_PATTERN = re.compile(
+    r"<a\b(?=[^>]*(?:\bid\s*=\s*['\"][^'\"]+['\"]|\bname\s*=\s*['\"][^'\"]+['\"]))(?![^>]*\bhref\s*=)[^>]*>\s*</a>",
+    re.IGNORECASE,
+)
+
+ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
+ESCAPED_HEADING_PATTERN = re.compile(r"^(\s*)\\(#{1,6})(\s+)")
+ESCAPED_UNORDERED_LIST_PATTERN = re.compile(r"^(\s*)\\([-+*])(\s+)")
+ESCAPED_THEMATIC_BREAK_PATTERN = re.compile(r"^(\s*)\\((?:-{3,}|\*{3,}|_{3,}))(\s*)$")
+ESCAPED_EMPHASIS_PATTERN = re.compile(r"\\([*_])")
+STRUCTURAL_LINE_PATTERN = re.compile(
+    r"^\s{0,3}(?:#{1,6}\s+|[-+*]\s+|\d+[.)）、|｜]\s*|(?:-{3,}|\*{3,}|_{3,})\s*$)"
+)
+
+LIST_BOUNDARY = r"[、.．)）：:|｜]|\s+"
+CIRCLED_MARKERS = (
+    "①②③④⑤⑥⑦⑧⑨⑩"
+    "⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳"
+    "㉑㉒㉓㉔㉕㉖㉗㉘㉙㉚"
+    "㉛㉜㉝㉞㉟㊱㊲㊳㊴㊵"
+    "㊶㊷㊸㊹㊺㊻㊼㊽㊾㊿"
+    "❶❷❸❹❺❻❼❽❾❿"
+)
+CHINESE_NUMERAL_MARKERS = "零〇一二三四五六七八九十百千万壹贰貳貮叁參肆伍陆陸柒捌玖拾"
+
+UNORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}([-+*])\s+(.+\S)\s*$")
+ORDERED_LIST_PATTERN = re.compile(r"^\s{0,3}(\d+)([.)）、|｜])\s*(.+\S)\s*$")
+KEYCAP_LIST_PATTERN = re.compile(r"^\s{0,3}([0-9]\ufe0f?\u20e3)\s*(.+\S)\s*$")
+CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*$")
+CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
+ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）、|｜])\s*(.+\S)\s*$")
+QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(.+\S)\s*$")
+ORDINAL_LIST_PATTERN = re.compile(
+    rf"^\s{{0,3}}(首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)({LIST_BOUNDARY})\s*(.+\S)\s*$"
+)
+STEP_LIST_PATTERN = re.compile(
+    rf"^\s{{0,3}}(.{{0,12}}?第[{CHINESE_NUMERAL_MARKERS}0-9]+步)({LIST_BOUNDARY})\s*(.+\S)\s*$"
+)
+
+
+@dataclass
+class MarkdownLineInfo:
+    raw: str
+    text: str
+    line_number: int
+    in_code: bool = False
+    is_code_fence: bool = False
+    block_hint: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MarkdownPreprocessResult:
+    lines: list[str]
+    line_infos: list[MarkdownLineInfo]
+
+
+class MarkdownPreprocessor:
+    def preprocess(
+        self,
+        text: str,
+        *,
+        normalize_escaped_structure: bool = False,
+    ) -> MarkdownPreprocessResult:
+        line_infos: list[MarkdownLineInfo] = []
+        in_code = False
+        for line_number, raw_line in enumerate(text.split("\n"), start=1):
+            stripped = raw_line.strip()
+            is_code_fence = stripped.startswith("```")
+
+            if in_code:
+                line_infos.append(
+                    MarkdownLineInfo(
+                        raw=raw_line,
+                        text=raw_line,
+                        line_number=line_number,
+                        in_code=True,
+                        is_code_fence=is_code_fence,
+                    )
+                )
+                if is_code_fence:
+                    in_code = False
+                continue
+
+            line = raw_line
+            if normalize_escaped_structure:
+                line = self._normalize_escaped_structural_line(line)
+            line = EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
+
+            block_hint = None
+            metadata: dict[str, Any] = {}
+            if not is_code_fence:
+                heading_match = ATX_HEADING_PATTERN.match(line)
+                if heading_match:
+                    block_hint = "heading"
+                    metadata = {
+                        "heading_level": len(heading_match.group(1)),
+                        "heading_title": _strip_wrapping_emphasis(heading_match.group(2)),
+                    }
+                else:
+                    list_metadata = self._list_metadata(line)
+                    if list_metadata:
+                        block_hint = "list"
+                        metadata = list_metadata
+
+            line_infos.append(
+                MarkdownLineInfo(
+                    raw=raw_line,
+                    text=line,
+                    line_number=line_number,
+                    is_code_fence=is_code_fence,
+                    block_hint=block_hint,
+                    metadata=metadata,
+                )
+            )
+            if is_code_fence:
+                in_code = True
+
+        return MarkdownPreprocessResult(
+            lines=[line_info.text for line_info in line_infos],
+            line_infos=line_infos,
+        )
+
+    def _normalize_escaped_structural_line(self, line: str) -> str:
+        normalized, heading_count = ESCAPED_HEADING_PATTERN.subn(r"\1\2\3", line, count=1)
+        normalized, list_count = ESCAPED_UNORDERED_LIST_PATTERN.subn(r"\1\2\3", normalized, count=1)
+        normalized, rule_count = ESCAPED_THEMATIC_BREAK_PATTERN.subn(r"\1\2\3", normalized, count=1)
+        if heading_count or list_count or rule_count or STRUCTURAL_LINE_PATTERN.match(normalized):
+            normalized = ESCAPED_EMPHASIS_PATTERN.sub(r"\1", normalized)
+        return normalized
+
+    def _list_metadata(self, line: str) -> dict[str, Any] | None:
+        patterns = (
+            ("unordered", UNORDERED_LIST_PATTERN),
+            ("ordered", ORDERED_LIST_PATTERN),
+            ("keycap", KEYCAP_LIST_PATTERN),
+            ("circled", CIRCLED_LIST_PATTERN),
+            ("step", STEP_LIST_PATTERN),
+            ("ordinal", ORDINAL_LIST_PATTERN),
+            ("chinese", CHINESE_LIST_PATTERN),
+            ("alpha", ALPHA_LIST_PATTERN),
+            ("qa", QA_LIST_PATTERN),
+        )
+        for marker_kind, pattern in patterns:
+            match = pattern.match(line)
+            if not match:
+                continue
+            marker = match.group(1)
+            return {
+                "list_marker": marker,
+                "list_marker_kind": marker_kind,
+                "list_level": _indent_level(line),
+                "contains_qa_marker": marker_kind == "qa",
+            }
+        return None
+
+
+def _indent_level(line: str) -> int:
+    leading = len(line) - len(line.lstrip(" "))
+    return leading // 2
+
+
+def _strip_wrapping_emphasis(text: str) -> str:
+    value = text.strip()
+    for marker in ("**", "__"):
+        if value.startswith(marker) and value.endswith(marker) and len(value) > len(marker) * 2:
+            return value[len(marker):-len(marker)].strip()
+    return value

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -29,7 +29,10 @@ class MinerUV3Parser(DocumentParser):
             end_page_id=ctx.to_page,
             callback=ctx.callback,
         )
-        blocks = StructMarkdownParser().parse_text(mineru_result.markdown)
+        blocks = StructMarkdownParser().parse_text(
+            mineru_result.markdown,
+            normalize_escaped_structure=True,
+        )
         attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
         LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
         self._store_image_assets(attached_images, ctx)

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -22,21 +22,27 @@ class MinerUV3Parser(DocumentParser):
             with open(ctx.filename, "rb") as file:
                 binary = file.read()
 
+        image_vision_enabled = is_image_vision_enabled(ctx.parser_config)
         mineru_result = self.client.parse(
             file_name=ctx.filename,
             binary=binary,
             start_page_id=ctx.from_page,
             end_page_id=ctx.to_page,
             callback=ctx.callback,
+            return_images=image_vision_enabled,
         )
         blocks = StructMarkdownParser().parse_text(
             mineru_result.markdown,
             normalize_escaped_structure=True,
         )
-        attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
-        LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
-        self._store_image_assets(attached_images, ctx)
-        if ctx.vision_model and is_image_vision_enabled(ctx.parser_config):
+        if image_vision_enabled:
+            attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
+            LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
+            self._store_image_assets(attached_images, ctx)
+        else:
+            LOGGER.info("[MinerUV3] image block processing disabled by parser config")
+
+        if ctx.vision_model and image_vision_enabled:
             self._enhance_image_blocks(blocks, ctx)
         elif ctx.vision_model:
             LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from app.core.rag.chunk.context import ParsedBlockType, ParseResult
+from app.core.rag.chunk.context import ParsedBlockType, ParseResult, is_image_vision_enabled
 from app.core.rag.chunk.parser.base import DocumentParser
 from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.image_storage import store_mineru_v3_image
@@ -36,8 +36,10 @@ class MinerUV3Parser(DocumentParser):
         attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
         LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
         self._store_image_assets(attached_images, ctx)
-        if ctx.vision_model:
+        if ctx.vision_model and is_image_vision_enabled(ctx.parser_config):
             self._enhance_image_blocks(blocks, ctx)
+        elif ctx.vision_model:
+            LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")
         return ParseResult(blocks=blocks, merge_strategy="blocks")
 
     def _attach_images(self, blocks, images):

--- a/api/app/core/rag/chunk/parser/mineru_v3_client.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3_client.py
@@ -92,6 +92,7 @@ class MinerUV3Client:
         start_page_id: int,
         end_page_id: int,
         callback: Callable | None = None,
+        return_images: bool = True,
     ) -> MinerUV3Result:
         if not self.api_server:
             raise RuntimeError("[MinerUV3] service unavailable: MINERU_V3_APISERVER is not configured")
@@ -99,12 +100,12 @@ class MinerUV3Client:
             raise RuntimeError("[MinerUV3] empty input binary")
 
         LOGGER.info("[MinerUV3] request start: file_name=%s, parse_method=auto", file_name)
-        task_id = self._submit_task(file_name, binary, start_page_id, end_page_id, callback)
+        task_id = self._submit_task(file_name, binary, start_page_id, end_page_id, callback, return_images)
         self._poll_task(task_id, callback)
         result_payload = self._fetch_result(task_id)
         file_result = self._extract_file_result(result_payload, file_name)
         markdown = self._extract_markdown(file_result, file_name)
-        images = self._extract_images(file_result)
+        images = self._extract_images(file_result) if return_images else {}
         LOGGER.info("[MinerUV3] markdown extracted: chars=%s", len(markdown))
         if callback:
             callback(0.70, "MinerU V3 markdown extracted.")
@@ -117,9 +118,10 @@ class MinerUV3Client:
         start_page_id: int,
         end_page_id: int,
         callback: Callable | None,
+        return_images: bool,
     ) -> str:
         url = f"{self.api_server}/tasks"
-        data = self._build_form_data(start_page_id, end_page_id)
+        data = self._build_form_data(start_page_id, end_page_id, return_images)
         files = {
             "files": (
                 Path(file_name).name,
@@ -184,7 +186,7 @@ class MinerUV3Client:
             raise RuntimeError(f"[MinerUV3] service unavailable: GET /tasks/{task_id}/result failed: {exc}") from exc
         return payload
 
-    def _build_form_data(self, start_page_id: int, end_page_id: int) -> dict[str, str]:
+    def _build_form_data(self, start_page_id: int, end_page_id: int, return_images: bool = True) -> dict[str, str]:
         return {
             "lang_list": "ch",
             "backend": "hybrid-engine",
@@ -198,7 +200,7 @@ class MinerUV3Client:
             "return_middle_json": "false",
             "return_model_output": "false",
             "return_content_list": "false",
-            "return_images": "true",
+            "return_images": "true" if return_images else "false",
             "response_format_zip": "false",
             "return_original_file": "false",
             "client_side_output_generation": "false",

--- a/api/app/core/rag/chunk/parser/pdf/deepdoc.py
+++ b/api/app/core/rag/chunk/parser/pdf/deepdoc.py
@@ -2,6 +2,7 @@ import logging
 from timeit import default_timer as timer
 
 from app.core.rag.chunk.parser.base import DocumentParser
+from app.core.rag.chunk.context import is_image_vision_enabled
 from app.core.rag.deepdoc.parser import PdfParser
 from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_pdf_wrapper
 
@@ -17,7 +18,7 @@ class DeepDocPdfParser(PdfParser, DocumentParser):
         tables = vision_figure_parser_pdf_wrapper(
             tbls=tables,
             callback=ctx.callback,
-            vision_model=ctx.vision_model,
+            vision_model=ctx.vision_model if is_image_vision_enabled(ctx.parser_config) else None,
             **ctx.kwargs,
         )
         return sections, tables, self

--- a/api/app/core/rag/chunk/parser/pdf/plain.py
+++ b/api/app/core/rag/chunk/parser/pdf/plain.py
@@ -1,4 +1,5 @@
 from app.core.rag.chunk.parser.base import DocumentParser
+from app.core.rag.chunk.context import is_image_vision_enabled
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
 
 
@@ -8,7 +9,7 @@ class PlainPdfParser(DocumentParser):
         if isinstance(layout_recognizer, bool):
             layout_recognizer = "DeepDOC" if layout_recognizer else "Plain Text"
 
-        if layout_recognizer == "Plain Text":
+        if layout_recognizer == "Plain Text" or not is_image_vision_enabled(ctx.parser_config):
             pdf_parser = PlainParser()
         else:
             pdf_parser = VisionParser(vision_model=ctx.vision_model, **ctx.kwargs)

--- a/api/app/core/rag/chunk/parser/pdf/selector.py
+++ b/api/app/core/rag/chunk/parser/pdf/selector.py
@@ -1,11 +1,18 @@
 import os
 
+from app.core.rag.chunk.context import is_image_vision_enabled
 from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_pdf_wrapper
 from app.core.rag.deepdoc.parser.mineru_parser import MinerUParser
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
 
 from .deepdoc import DeepDocPdfParser
 from .textln import TextLnParser
+
+
+def _image_vision_model(vision_model, parser_config):
+    if is_image_vision_enabled(parser_config):
+        return vision_model
+    return None
 
 
 def by_deepdoc(filename, binary=None, from_page=0, to_page=100000, lang="Chinese", callback=None, vision_model=None, pdf_cls=None, **kwargs):
@@ -20,7 +27,7 @@ def by_deepdoc(filename, binary=None, from_page=0, to_page=100000, lang="Chinese
     tables = vision_figure_parser_pdf_wrapper(
         tbls=tables,
         callback=callback,
-        vision_model=vision_model,
+        vision_model=_image_vision_model(vision_model, kwargs.get("parser_config")),
         **kwargs,
     )
     return sections, tables, pdf_parser
@@ -64,7 +71,7 @@ def by_textln(filename, binary=None, from_page=0, to_page=100000, lang="Chinese"
 
 
 def by_plaintext(filename, binary=None, from_page=0, to_page=100000, callback=None, vision_model=None, **kwargs):
-    if kwargs.get("layout_recognizer", "") == "Plain Text":
+    if kwargs.get("layout_recognizer", "") == "Plain Text" or not is_image_vision_enabled(kwargs.get("parser_config")):
         pdf_parser = PlainParser()
     else:
         pdf_parser = VisionParser(vision_model=vision_model, **kwargs)

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -26,6 +26,7 @@ class StructMarkdownParser(DocumentParser):
         self._seq = 0
         self.blocks: list[ParsedBlock] = []
         self._heading_stack: dict[int, str] = {}
+        self._compact_block_spacing = normalize_escaped_structure
         preprocess_result = MarkdownPreprocessor().preprocess(
             text,
             normalize_escaped_structure=normalize_escaped_structure,
@@ -142,6 +143,9 @@ class StructMarkdownParser(DocumentParser):
 
     def _is_list_line(self, index: int) -> bool:
         return self._line_info(index).block_hint == "list"
+
+    def _is_list_body_line(self, index: int) -> bool:
+        return self._line_info(index).block_hint in {"list", "list_continuation"}
 
     def _current_heading_path(self) -> list[str]:
         return [
@@ -278,11 +282,11 @@ class StructMarkdownParser(DocumentParser):
         index += 1
         while index < len(self.lines):
             line = self.lines[index]
-            if self._is_list_line(index) or line.startswith((" ", "\t")) or not line.strip():
+            if self._is_list_body_line(index) or line.startswith((" ", "\t")) or not line.strip():
                 index += 1
                 continue
             break
-        content = "\n".join(self.lines[start:index]).rstrip()
+        content = self._block_content(start, index, compact_blank_lines=self._compact_block_spacing)
         self._append_block(
             ParsedBlockType.LIST,
             content,
@@ -324,7 +328,7 @@ class StructMarkdownParser(DocumentParser):
             if self._is_block_start(index) or IMAGE_PATTERN.search(line):
                 break
             index += 1
-        content = "\n".join(self.lines[start:index])
+        content = self._block_content(start, index, compact_blank_lines=self._compact_block_spacing)
         self._append_block(
             ParsedBlockType.TEXT,
             content,
@@ -360,6 +364,12 @@ class StructMarkdownParser(DocumentParser):
         if len(cells) < 2:
             return False
         return all(re.match(r"^:?-{3,}:?$", cell.replace(" ", "")) for cell in cells if cell)
+
+    def _block_content(self, start: int, end: int, *, compact_blank_lines: bool = False) -> str:
+        lines = self.lines[start:end]
+        if compact_blank_lines:
+            lines = [line for line in lines if line.strip()]
+        return "\n".join(lines).rstrip()
 
     def _normalize_html_table(self, raw: str) -> str:
         tags = ["table", "td", "tr", "th", "tbody", "thead", "div"]

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -9,16 +9,12 @@ from PIL import Image
 
 from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
 from app.core.rag.chunk.parser.base import DocumentParser
+from app.core.rag.chunk.parser.markdown_preprocessor import MarkdownLineInfo, MarkdownPreprocessor
 from app.core.rag.nlp import find_codec
 
 
 IMAGE_PATTERN = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
-HEADING_PATTERN = re.compile(r"^(#{1,6})\s+.*$")
-LIST_PATTERN = re.compile(r"^\s*(?:[-*+]\s+|\d+\.\s+).*$")
-EMPTY_HTML_ANCHOR_PATTERN = re.compile(
-    r"<a\b(?=[^>]*(?:\bid\s*=\s*['\"][^'\"]+['\"]|\bname\s*=\s*['\"][^'\"]+['\"]))(?![^>]*\bhref\s*=)[^>]*>\s*</a>",
-    re.IGNORECASE,
-)
+HEADING_PATTERN = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$")
 
 
 class StructMarkdownParser(DocumentParser):
@@ -26,10 +22,16 @@ class StructMarkdownParser(DocumentParser):
         text = self._read_text(ctx.filename, ctx.binary)
         return self.parse_text(text)
 
-    def parse_text(self, text: str) -> list[ParsedBlock]:
+    def parse_text(self, text: str, *, normalize_escaped_structure: bool = False) -> list[ParsedBlock]:
         self._seq = 0
         self.blocks: list[ParsedBlock] = []
-        self.lines = self._strip_empty_html_anchors_outside_code(text.split("\n"))
+        self._heading_stack: dict[int, str] = {}
+        preprocess_result = MarkdownPreprocessor().preprocess(
+            text,
+            normalize_escaped_structure=normalize_escaped_structure,
+        )
+        self.lines = preprocess_result.lines
+        self.line_infos = preprocess_result.line_infos
 
         index = 0
         while index < len(self.lines):
@@ -39,7 +41,7 @@ class StructMarkdownParser(DocumentParser):
                 index += 1
                 continue
 
-            if self._is_heading(line):
+            if self._is_heading(index):
                 index = self._append_heading(index)
                 continue
             if stripped.startswith("```"):
@@ -54,7 +56,7 @@ class StructMarkdownParser(DocumentParser):
             if IMAGE_PATTERN.search(line):
                 index = self._append_image_line(index)
                 continue
-            if LIST_PATTERN.match(line):
+            if self._is_list_line(index):
                 index = self._append_list(index)
                 continue
             if stripped.startswith(">"):
@@ -64,24 +66,6 @@ class StructMarkdownParser(DocumentParser):
             index = self._append_text(index)
 
         return self.blocks
-
-    def _strip_empty_html_anchors_outside_code(self, lines: list[str]) -> list[str]:
-        cleaned_lines = []
-        in_code = False
-        for line in lines:
-            stripped = line.strip()
-            if stripped.startswith("```"):
-                cleaned_lines.append(line)
-                in_code = not in_code
-                continue
-            if in_code:
-                cleaned_lines.append(line)
-                continue
-            cleaned_lines.append(self._strip_empty_html_anchors(line))
-        return cleaned_lines
-
-    def _strip_empty_html_anchors(self, line: str) -> str:
-        return EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
 
     def md_to_html(self, text: str):
         if not text:
@@ -134,6 +118,8 @@ class StructMarkdownParser(DocumentParser):
     ) -> None:
         if isinstance(content, str) and not content.strip() and block_type is not ParsedBlockType.IMAGE:
             return
+        block_metadata = dict(metadata or {})
+        block_metadata.setdefault("heading_path", self._current_heading_path())
         self.blocks.append(
             ParsedBlock(
                 type=block_type,
@@ -143,24 +129,50 @@ class StructMarkdownParser(DocumentParser):
                 start_line=start_line,
                 end_line=end_line,
                 image=image,
-                metadata=metadata or {},
+                metadata=block_metadata,
             )
         )
         self._seq += 1
 
-    def _is_heading(self, line: str) -> bool:
-        return bool(HEADING_PATTERN.match(line))
+    def _line_info(self, index: int) -> MarkdownLineInfo:
+        return self.line_infos[index]
+
+    def _is_heading(self, index: int) -> bool:
+        return self._line_info(index).block_hint == "heading"
+
+    def _is_list_line(self, index: int) -> bool:
+        return self._line_info(index).block_hint == "list"
+
+    def _current_heading_path(self) -> list[str]:
+        return [
+            self._heading_stack[level]
+            for level in sorted(self._heading_stack)
+        ]
 
     def _append_heading(self, index: int) -> int:
         line = self.lines[index]
+        line_info = self._line_info(index)
         match = HEADING_PATTERN.match(line)
-        level = len(match.group(1)) if match else 1
+        level = int(line_info.metadata.get("heading_level") or (len(match.group(1)) if match else 1))
+        title = str(line_info.metadata.get("heading_title") or (match.group(2).strip() if match else line.strip()))
+        self._heading_stack = {
+            existing_level: existing_title
+            for existing_level, existing_title in self._heading_stack.items()
+            if existing_level < level
+        }
+        self._heading_stack[level] = title
         self._append_block(
             ParsedBlockType.HEADING,
             line,
             start_line=index + 1,
             end_line=index + 1,
-            metadata={"level": level},
+            metadata={
+                "level": level,
+                "heading_level": level,
+                "heading_title": title,
+                "heading_raw": line,
+                "heading_path": self._current_heading_path(),
+            },
         )
         return index + 1
 
@@ -266,16 +278,17 @@ class StructMarkdownParser(DocumentParser):
         index += 1
         while index < len(self.lines):
             line = self.lines[index]
-            if LIST_PATTERN.match(line) or line.startswith((" ", "\t")) or not line.strip():
+            if self._is_list_line(index) or line.startswith((" ", "\t")) or not line.strip():
                 index += 1
                 continue
             break
-        content = "\n".join(self.lines[start:index])
+        content = "\n".join(self.lines[start:index]).rstrip()
         self._append_block(
             ParsedBlockType.LIST,
             content,
             start_line=start + 1,
             end_line=index,
+            metadata=self._list_metadata(start, index),
         )
         return index
 
@@ -332,11 +345,11 @@ class StructMarkdownParser(DocumentParser):
         line = self.lines[index]
         stripped = line.strip()
         return (
-            self._is_heading(line)
+            self._is_heading(index)
             or stripped.startswith("```")
             or self._is_html_table_start(line)
             or self._is_markdown_table_start(index)
-            or LIST_PATTERN.match(line)
+            or self._is_list_line(index)
             or stripped.startswith(">")
         )
 
@@ -357,3 +370,34 @@ class StructMarkdownParser(DocumentParser):
             return f"<{tag_name}>"
 
         return re.sub(pattern, replace_tag, raw)
+
+    def _list_metadata(self, start: int, end: int) -> dict:
+        markers = []
+        marker_kinds = []
+        contains_qa_marker = False
+        for index in range(start, end):
+            line_info = self._line_info(index)
+            if line_info.block_hint != "list":
+                continue
+            marker = line_info.metadata.get("list_marker")
+            marker_kind = line_info.metadata.get("list_marker_kind")
+            if marker:
+                markers.append(marker)
+            if marker_kind:
+                marker_kinds.append(marker_kind)
+            contains_qa_marker = contains_qa_marker or bool(line_info.metadata.get("contains_qa_marker"))
+
+        return {
+            "list_item_count": len(markers),
+            "list_markers": markers,
+            "list_marker_kinds": _unique_preserving_order(marker_kinds),
+            "contains_qa_marker": contains_qa_marker,
+        }
+
+
+def _unique_preserving_order(values: list[str]) -> list[str]:
+    result = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return result

--- a/api/app/core/rag/chunk/pipeline/docx.py
+++ b/api/app/core/rag/chunk/pipeline/docx.py
@@ -5,7 +5,7 @@ from app.core.rag.chunk.parser.docx import DocxParser
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
 from app.core.rag.utils.file_utils import extract_html, extract_links_from_docx
 
-from app.core.rag.chunk.context import ChunkContext, ParseResult
+from app.core.rag.chunk.context import ChunkContext, ParseResult, is_image_vision_enabled
 from .base import ChunkPipeline
 
 
@@ -40,7 +40,7 @@ class DocxChunkPipeline(ChunkPipeline):
             sections=sections,
             tbls=tables,
             callback=ctx.callback,
-            vision_model=ctx.vision_model,
+            vision_model=ctx.vision_model if is_image_vision_enabled(ctx.parser_config) else None,
             **ctx.kwargs,
         )
         ctx.callback(0.8, "Finish parsing.")

--- a/api/app/core/rag/chunk/pipeline/text.py
+++ b/api/app/core/rag/chunk/pipeline/text.py
@@ -2,7 +2,13 @@ import logging
 import os
 import tempfile
 
-from app.core.rag.chunk.context import ChunkContext, ParsedBlock, ParsedBlockType, ParseResult
+from app.core.rag.chunk.context import (
+    ChunkContext,
+    ParsedBlock,
+    ParsedBlockType,
+    ParseResult,
+    is_image_vision_enabled,
+)
 from app.core.rag.chunk.parser.html import HtmlParser
 from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.json import JsonParser
@@ -40,7 +46,7 @@ class MarkdownChunkPipeline(ChunkPipeline):
         markdown_parser = StructMarkdownParser()
         blocks = markdown_parser.parse(ctx)
 
-        if ctx.vision_model:
+        if ctx.vision_model and is_image_vision_enabled(ctx.parser_config):
             for block in blocks:
                 if block.type is not ParsedBlockType.IMAGE:
                     continue
@@ -56,6 +62,8 @@ class MarkdownChunkPipeline(ChunkPipeline):
                 progress_start=0.2,
                 progress_span=0.55,
             )
+        elif ctx.vision_model:
+            logging.info("Image vision enhancement disabled by parser config.")
         else:
             logging.warning("No visual model detected. Skipping figure parsing enhancement.")
 

--- a/api/app/core/rag/chunk/postprocessor.py
+++ b/api/app/core/rag/chunk/postprocessor.py
@@ -96,8 +96,9 @@ class ChunkPostProcessor:
             add_positions(doc, [[index] * 5])
         if chunk.image is not None:
             doc["image"] = chunk.image
-        if chunk.metadata:
-            doc["metadata"] = copy.deepcopy(chunk.metadata)
+        metadata = self._chunk_metadata(chunk)
+        if metadata:
+            doc["metadata"] = metadata
         tokenize(doc, content, ctx.is_english)
         return doc
 
@@ -119,8 +120,9 @@ class ChunkPostProcessor:
             doc["doc_type_kwd"] = "image"
         if chunk.positions:
             add_positions(doc, chunk.positions)
-        if chunk.metadata:
-            doc["metadata"] = copy.deepcopy(chunk.metadata)
+        metadata = self._chunk_metadata(chunk)
+        if metadata:
+            doc["metadata"] = metadata
         tokenize(doc, content, ctx.is_english)
         doc["content_with_weight"] = content
         return doc
@@ -130,3 +132,8 @@ class ChunkPostProcessor:
         for entity in ZERO_WIDTH_HTML_ENTITIES:
             content = content.replace(entity, "")
         return content
+
+    def _chunk_metadata(self, chunk: LogicalChunk) -> dict:
+        metadata = copy.deepcopy(chunk.metadata) if chunk.metadata else {}
+        metadata.setdefault("heading_path", [])
+        return metadata


### PR DESCRIPTION
## Business Background
MinerU-generated Markdown can contain fragmented QA answers, list-like lines, and layout-driven spacing that degrade final RAG chunk quality. This change improves Markdown preparse structure hints and downstream text splitting so chunks preserve answer/list semantics more reliably.

## Summary
- Add Markdown preparse hints for headings, list-like markers, definitions, QA markers, and QA answer continuations.
- Keep MinerU QA answer continuations together and compact spacing only within confirmed content blocks.
- Update recursive text splitting to use two stages: optional custom delimiter splitting first, then recursive separator splitting for oversized segments.
- Apply `chunk_overlap` during recursive split-unit window merging in normal chunk mode only.
- Keep parent-child chunking overlap disabled for now.
- Disable image vision by default and skip MinerU image upload work when vision is disabled.

## Changes
```text
api/app/core/rag/chunk/context.py                  |  10 +
api/app/core/rag/chunk/merger/block.py             | 175 ++++++++++++++--
api/app/core/rag/chunk/merger/text.py              | 132 +++++++++---
api/app/core/rag/chunk/parser/markdown_preprocessor.py | 224 +++++++++++++++++++++
api/app/core/rag/chunk/parser/mineru_v3.py         |  23 ++-
api/app/core/rag/chunk/parser/mineru_v3_client.py  |  12 +-
api/app/core/rag/chunk/parser/pdf/deepdoc.py       |   3 +-
api/app/core/rag/chunk/parser/pdf/plain.py         |   3 +-
api/app/core/rag/chunk/parser/pdf/selector.py      |  11 +-
api/app/core/rag/chunk/parser/structured_markdown.py | 130 ++++++++----
api/app/core/rag/chunk/pipeline/docx.py            |   4 +-
api/app/core/rag/chunk/pipeline/text.py            |  12 +-
api/app/core/rag/chunk/postprocessor.py            |  15 +-
13 files changed, 649 insertions(+), 105 deletions(-)
```

## Risk
- Scope is limited to backend RAG parsing and chunk merging behavior.
- Existing parser output types and external chunk API schemas are unchanged.
- Parent-child chunking intentionally ignores `chunk_overlap` until that mode is designed separately.
- The new QA continuation behavior is constrained to MinerU-normalized Markdown paths to reduce accidental merges in ordinary Markdown.

## External API Key Interface Impact
No request/response schema change and no new external API route. API Key users may observe improved internal chunk content quality after document parsing, but the service contract remains unchanged.

## Test Plan
- [x] `cd api && uv run python -m py_compile app/core/rag/chunk/merger/text.py app/core/rag/chunk/merger/block.py`
- [x] `cd api && PYTHONPATH=. uv run pytest tests/core/rag/chunk/merger/test_text_merger.py tests/core/rag/chunk/merger/test_block_merger.py::test_overlap_reuses_complete_elements_within_one_heading_range tests/core/rag/chunk/merger/test_block_merger.py::test_parent_child_mode_ignores_overlap tests/core/rag/chunk/merger/test_block_merger.py::test_custom_delimiter_split_sequence_is_inserted_at_original_position -q` → 15 passed
- [x] `git diff --check origin/develop..HEAD`

## Summary by Sourcery

改进基于 Markdown 的 RAG 分块方式，以更好地保留标题、列表和问答语义，并使图像视觉处理变得可显式配置。

New Features:
- 引入一个 Markdown 预处理阶段，为每一行添加结构性提示注释，例如标题、列表标记、定义以及问答标记。
- 为列表块和由列表派生的父级分块增加专门处理，使列表项在进行基于 token 的拆分之前能够以更语义化的方式进行分块。

Bug Fixes:
- 确保分块重叠仅应用于普通分块模式，而不在父子分块模式中启用，直到该行为被明确设计。

Enhancements:
- 优化文本分块流程：先执行可选的自定义分隔符拆分，再进行递归的基于分隔符拆分，并在普通模式中控制分块重叠。
- 在块合并与序列化过程中传播标题路径和与列表相关的元数据，使下游消费方能够保留更丰富的文档结构上下文。
- 规范 MinerU 生成的 Markdown 结构，包括转义的标题和列表，以压缩空白并保持问答风格的列表续写紧密相连。

Deployment:
- 添加 `image_vision_enabled` 解析器配置标记，并将其贯穿 MinerU、文本、PDF 和 DOCX 流水线，用于控制何时执行图像解析和视觉增强。

Tests:
- 扩展和调整分块合并测试，以验证重叠行为、父子模式忽略重叠，以及自定义分隔符拆分顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve RAG markdown-based chunking to better preserve headings, lists, and QA semantics, and to make image vision processing explicitly configurable.

New Features:
- Introduce a markdown preprocessing stage that annotates lines with structural hints such as headings, list markers, definitions, and QA markers.
- Add specialized handling for list blocks and list-derived parent chunks so list items are chunked more semantically before token-based splitting.

Bug Fixes:
- Ensure chunk overlap is applied only in normal chunk mode and not in parent-child chunking until that behavior is explicitly designed.

Enhancements:
- Refine text chunking to perform optional custom-delimiter splitting followed by recursive separator-based splitting with controlled chunk overlap in normal mode.
- Propagate heading path and list-related metadata through block merging and serialization so downstream consumers retain richer document structure context.
- Normalize MinerU-generated markdown structure, including escaped headings and lists, to compact spacing and keep QA-style list continuations together.

Deployment:
- Add an `image_vision_enabled` parser configuration flag and thread it through MinerU, text, PDF, and DOCX pipelines to control when image parsing and vision enhancement are executed.

Tests:
- Extend and adjust chunk merger tests to validate overlap behavior, parent-child mode ignoring overlap, and custom delimiter split ordering.

</details>