### PR TITLE
fix(rag): complete EvidenceGraph detail contract

### DIFF
--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -29,6 +29,7 @@ from app.core.rag.knowledge_graph.config import (
 )
 from app.core.rag.knowledge_graph.dispatch import (
     dispatch_graph_enabled_transition,
+    dispatch_knowledge_graph_rebuild,
 )
 from app.core.rag.knowledge_graph.elasticsearch_store import (
     GraphElasticsearchStore,
@@ -972,10 +973,12 @@ async def rebuild_knowledge_graph(
             if pipeline is GraphPipeline.LEGACY
             else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
         )
-        task = celery_app.send_task(
-            task_name,
-            args=[str(knowledge_id)],
+        task = dispatch_knowledge_graph_rebuild(
+            str(knowledge_id),
+            db_knowledge.parser_config,
         )
+        if task is None:
+            raise GraphPipelineConfigError("knowledge graph is not enabled")
         api_logger.info(
             "Knowledge graph rebuild task accepted"
             " kb_id=%s pipeline=%s task=%s task_id=%s",

--- a/api/app/core/rag/knowledge_graph/dispatch.py
+++ b/api/app/core/rag/knowledge_graph/dispatch.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from collections.abc import Mapping
 from typing import Any
 
@@ -7,6 +8,10 @@ from app.core.rag.knowledge_graph.config import (
     GraphPipeline,
     is_graph_enabled,
     resolve_graph_pipeline,
+)
+from app.core.rag.knowledge_graph.rebuild_task_guard import (
+    claim_or_get_rebuild_job,
+    release_rebuild_job,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,12 +134,35 @@ def dispatch_knowledge_graph_rebuild(
         return None
 
     pipeline = resolve_graph_pipeline(parser_config)
-    task_name = (
-        "app.core.rag.tasks.build_graphrag_for_kb"
-        if pipeline is GraphPipeline.LEGACY
-        else "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
-    )
-    task = celery_app.send_task(task_name, args=[str(knowledge_id)])
+    if pipeline is GraphPipeline.LEGACY:
+        task_name = "app.core.rag.tasks.build_graphrag_for_kb"
+        task = celery_app.send_task(task_name, args=[str(knowledge_id)])
+    else:
+        task_name = "app.core.rag.tasks.rebuild_evidence_graph_knowledge"
+        proposed_task_id = str(uuid.uuid4())
+        claim = claim_or_get_rebuild_job(
+            str(knowledge_id),
+            proposed_task_id,
+        )
+        if not claim.claimed:
+            logger.info(
+                "[GraphPipeline] task_coalesced"
+                " scope=knowledge pipeline=%s task=%s kb_id=%s task_id=%s",
+                pipeline.value,
+                task_name,
+                str(knowledge_id),
+                claim.task_id,
+            )
+            return celery_app.AsyncResult(claim.task_id)
+        try:
+            task = celery_app.send_task(
+                task_name,
+                args=[str(knowledge_id)],
+                task_id=claim.task_id,
+            )
+        except Exception:
+            release_rebuild_job(str(knowledge_id), claim.task_id)
+            raise
     _log_dispatched_task(
         task,
         scope="knowledge",

--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -42,6 +42,8 @@ EVIDENCE_GRAPH_TYPES = (
     RELATION_PROJECTION,
     DOCUMENT_PROJECTION_MAP,
 )
+GRAPH_METRIC_SCAN_BATCH_SIZE = 1000
+GRAPH_PAGERANK_BULK_SIZE = 1000
 
 
 @lru_cache(maxsize=1)
@@ -502,18 +504,143 @@ class GraphElasticsearchStore:
         index_name: str,
         knowledge_id: str,
     ) -> list[dict[str, Any]]:
-        result = await self._client.search(
-            index=index_name,
-            size=10000,
-            query=self._graph_query(knowledge_id, DOCUMENT_PROJECTION_MAP),
-            sort=[{"document_id": {"order": "asc"}}],
+        return await self._scan_projection_sources(
+            index_name,
+            knowledge_id,
+            document_type=DOCUMENT_PROJECTION_MAP,
+            sort_field="document_id",
+            source_includes=["document_id"],
         )
-        raise_on_shard_failures(result, "list graph document maps")
-        return [
-            dict(source)
-            for hit in self._hits(result)
-            if isinstance((source := hit.get("_source")), Mapping)
-        ]
+
+    async def load_graph_metric_inputs(
+        self,
+        index_name: str,
+        knowledge_id: str,
+    ) -> tuple[tuple[str, ...], tuple[dict[str, Any], ...]]:
+        entity_sources, relation_sources = await asyncio.gather(
+            self._scan_projection_sources(
+                index_name,
+                knowledge_id,
+                document_type=ENTITY_PROJECTION,
+                sort_field="entity_key_kwd",
+                source_includes=["entity_key_kwd"],
+            ),
+            self._scan_projection_sources(
+                index_name,
+                knowledge_id,
+                document_type=RELATION_PROJECTION,
+                sort_field="relation_key_kwd",
+                source_includes=[
+                    "relation_key_kwd",
+                    "from_entity_key_kwd",
+                    "to_entity_key_kwd",
+                    "directed_int",
+                    "evidence_count_int",
+                ],
+            ),
+        )
+        entity_keys = tuple(
+            sorted(
+                {
+                    str(source["entity_key_kwd"])
+                    for source in entity_sources
+                    if source.get("entity_key_kwd")
+                }
+            )
+        )
+        relations = tuple(
+            sorted(
+                (
+                    dict(source)
+                    for source in relation_sources
+                    if source.get("relation_key_kwd")
+                    and source.get("from_entity_key_kwd")
+                    and source.get("to_entity_key_kwd")
+                ),
+                key=lambda source: str(source["relation_key_kwd"]),
+            )
+        )
+        return entity_keys, relations
+
+    async def update_entity_pageranks(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        pageranks: Mapping[str, float],
+        *,
+        ensure_valid: Callable[[], None] | None = None,
+    ) -> None:
+        items = sorted(pageranks.items())
+        for offset in range(0, len(items), GRAPH_PAGERANK_BULK_SIZE):
+            operations: list[dict[str, Any]] = []
+            for entity_key, pagerank in items[
+                offset : offset + GRAPH_PAGERANK_BULK_SIZE
+            ]:
+                operations.extend(
+                    [
+                        {
+                            "update": {
+                                "_index": index_name,
+                                "_id": projection_id(
+                                    knowledge_id,
+                                    "entity",
+                                    str(entity_key),
+                                ),
+                            }
+                        },
+                        {"doc": {"pagerank_flt": float(pagerank)}},
+                    ]
+                )
+            await self._bulk(operations, ensure_valid=ensure_valid)
+
+    async def _scan_projection_sources(
+        self,
+        index_name: str,
+        knowledge_id: str,
+        *,
+        document_type: str,
+        sort_field: str,
+        source_includes: Sequence[str],
+    ) -> list[dict[str, Any]]:
+        sources: list[dict[str, Any]] = []
+        cursor: list[Any] | None = None
+        while True:
+            search_kwargs: dict[str, Any] = {
+                "index": index_name,
+                "size": GRAPH_METRIC_SCAN_BATCH_SIZE,
+                "query": self._graph_query(knowledge_id, document_type),
+                "source_includes": list(source_includes),
+                "sort": [
+                    {
+                        sort_field: {
+                            "order": "asc",
+                            "unmapped_type": "keyword",
+                        }
+                    }
+                ],
+            }
+            if cursor is not None:
+                search_kwargs["search_after"] = cursor
+            result = await self._client.search(**search_kwargs)
+            raise_on_shard_failures(result, f"scan {document_type}")
+            hits = self._hits(result)
+            for hit in hits:
+                source = hit.get("_source")
+                if isinstance(source, Mapping):
+                    sources.append(dict(source))
+            if len(hits) < GRAPH_METRIC_SCAN_BATCH_SIZE:
+                return sources
+            next_cursor = hits[-1].get("sort")
+            if not isinstance(next_cursor, Sequence) or not next_cursor:
+                raise RuntimeError(
+                    f"missing search_after cursor while scanning {document_type}"
+                )
+            next_cursor = list(next_cursor)
+            if next_cursor == cursor:
+                raise RuntimeError(
+                    f"search_after cursor did not advance while scanning {document_type}"
+                )
+            cursor = next_cursor
 
     async def clear_evidence_graph(
         self,
@@ -564,13 +691,13 @@ class GraphElasticsearchStore:
     ) -> dict[str, Any]:
         empty_graph = {
             "directed": True,
-            "multigraph": False,
+            "multigraph": True,
             "graph": {"source_id": []},
             "nodes": [],
             "edges": [],
         }
         try:
-            node_result, edge_result = await asyncio.gather(
+            node_result, edge_result, document_maps = await asyncio.gather(
                 self._client.search(
                     index=index_name,
                     size=max(1, node_limit),
@@ -579,6 +706,13 @@ class GraphElasticsearchStore:
                         ENTITY_PROJECTION,
                     ),
                     sort=[
+                        {
+                            "pagerank_flt": {
+                                "order": "desc",
+                                "unmapped_type": "float",
+                                "missing": "_last",
+                            }
+                        },
                         {"degree_int": {"order": "desc", "unmapped_type": "long"}},
                         {
                             "evidence_count_int": {
@@ -616,6 +750,7 @@ class GraphElasticsearchStore:
                         },
                     ],
                 ),
+                self.list_document_maps(index_name, knowledge_id),
             )
         except NotFoundError:
             return empty_graph
@@ -635,8 +770,14 @@ class GraphElasticsearchStore:
                     "entity_name": str(source.get("entity_name_kwd") or ""),
                     "entity_type": str(source.get("entity_type_kwd") or ""),
                     "description": str(source.get("description") or ""),
-                    "pagerank": 0.0,
-                    "source_id": [],
+                    "pagerank": float(source.get("pagerank_flt") or 0.0),
+                    "source_id": sorted(
+                        {
+                            str(value)
+                            for value in (source.get("source_id") or ())
+                            if str(value).strip()
+                        }
+                    ),
                     "aliases": list(source.get("aliases_kwd") or ()),
                     "evidence_count": int(source.get("evidence_count_int") or 0),
                     "document_count": int(source.get("document_count_int") or 0),
@@ -678,7 +819,13 @@ class GraphElasticsearchStore:
                     "description": str(source.get("description") or ""),
                     "keywords": keywords or ([predicate] if predicate else []),
                     "weight": int(source.get("evidence_count_int") or 1),
-                    "source_id": [],
+                    "source_id": sorted(
+                        {
+                            str(value)
+                            for value in (source.get("source_id") or ())
+                            if str(value).strip()
+                        }
+                    ),
                     "directed": bool(source.get("directed_int")),
                     "document_count": int(source.get("document_count_int") or 0),
                 }
@@ -686,7 +833,19 @@ class GraphElasticsearchStore:
             if len(edges) >= edge_limit:
                 break
 
-        return {**empty_graph, "nodes": nodes, "edges": edges}
+        graph_source_ids = sorted(
+            {
+                str(item["document_id"])
+                for item in document_maps
+                if item.get("document_id")
+            }
+        )
+        return {
+            **empty_graph,
+            "graph": {"source_id": graph_source_ids},
+            "nodes": nodes,
+            "edges": edges,
+        }
 
     async def search_entity_projections(
         self,

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -3,8 +3,10 @@ import logging
 import time
 import unicodedata
 from collections import Counter, defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
+
+import networkx as nx
 
 from app.core.config import settings
 from app.core.rag.knowledge_graph.batching import (
@@ -29,6 +31,42 @@ from app.core.rag.knowledge_graph.normalizer import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def calculate_evidence_pageranks(
+    entity_keys: Sequence[str],
+    relations: Sequence[Mapping[str, Any]],
+) -> dict[str, float]:
+    graph = nx.MultiDiGraph()
+    graph.add_nodes_from(str(key) for key in entity_keys if str(key))
+    entity_key_set = set(graph.nodes)
+    for relation in relations:
+        from_key = str(relation.get("from_entity_key_kwd") or "")
+        to_key = str(relation.get("to_entity_key_kwd") or "")
+        relation_key = str(relation.get("relation_key_kwd") or "")
+        if (
+            not relation_key
+            or not from_key
+            or not to_key
+            or from_key == to_key
+            or from_key not in entity_key_set
+            or to_key not in entity_key_set
+        ):
+            continue
+        try:
+            weight = max(float(relation.get("evidence_count_int") or 1), 1.0)
+        except (TypeError, ValueError):
+            weight = 1.0
+        graph.add_edge(from_key, to_key, key=relation_key, weight=weight)
+        directed = relation.get("directed_int")
+        if directed is not None and not bool(directed):
+            graph.add_edge(to_key, from_key, key=relation_key, weight=weight)
+    if not graph:
+        return {}
+    return {
+        str(entity_key): float(pagerank)
+        for entity_key, pagerank in nx.pagerank(graph, weight="weight").items()
+    }
 
 
 def _clean_display(value: str) -> str:
@@ -218,6 +256,8 @@ class KnowledgeGraphIndexPipeline:
         runtime: GraphIndexRuntime,
         document_id: str,
         document_active: bool,
+        *,
+        refresh_pageranks: bool = True,
     ) -> None:
         started_at = time.perf_counter()
         stage = "ensure_graph_index"
@@ -298,6 +338,13 @@ class KnowledgeGraphIndexPipeline:
             stage = "refresh_graph"
             self._lock_guard.ensure_valid()
             await self._store.refresh_graph(runtime.graph_index_name)
+            if refresh_pageranks:
+                stage = "rebuild_graph_pageranks"
+                self._lock_guard.ensure_valid()
+                await self._rebuild_graph_pageranks(runtime)
+                stage = "refresh_graph_pageranks"
+                self._lock_guard.ensure_valid()
+                await self._store.refresh_graph(runtime.graph_index_name)
             logger.info(
                 "[EvidenceGraph] index_done"
                 " kb_id=%s document_id=%s"
@@ -339,7 +386,12 @@ class KnowledgeGraphIndexPipeline:
             len(active_ids),
         )
         for document_id in active_ids:
-            await self.sync_document(runtime, document_id, True)
+            await self.sync_document(
+                runtime,
+                document_id,
+                True,
+                refresh_pageranks=False,
+            )
 
         self._lock_guard.ensure_valid()
         maps = await self._store.list_document_maps(
@@ -356,8 +408,17 @@ class KnowledgeGraphIndexPipeline:
             }
         )
         for document_id in stale_ids:
-            await self.sync_document(runtime, document_id, False)
+            await self.sync_document(
+                runtime,
+                document_id,
+                False,
+                refresh_pageranks=False,
+            )
 
+        self._lock_guard.ensure_valid()
+        await self._store.refresh_graph(runtime.graph_index_name)
+        self._lock_guard.ensure_valid()
+        await self._rebuild_graph_pageranks(runtime)
         self._lock_guard.ensure_valid()
         await self._store.refresh_graph(runtime.graph_index_name)
         logger.info(
@@ -487,6 +548,7 @@ class KnowledgeGraphIndexPipeline:
                 "description": description,
                 "evidence_count_int": len(items),
                 "document_count_int": len({item.document_id for item in items}),
+                "source_id": sorted({item.document_id for item in items}),
             }
             projections.append(projection)
             texts.append(
@@ -565,6 +627,7 @@ class KnowledgeGraphIndexPipeline:
                 "evidence_count_int": len(items),
                 "document_count_int": len({item.document_id for item in items}),
                 "degree_int": degrees.get(key, 0),
+                "source_id": sorted({item.document_id for item in items}),
             }
             projections.append(projection)
             texts.append(f"{name}\n{entity_type}\n{description}".strip())
@@ -576,6 +639,23 @@ class KnowledgeGraphIndexPipeline:
             runtime.knowledge_id,
             projections,
             tuple(delete_keys),
+            ensure_valid=self._lock_guard.ensure_valid,
+        )
+
+    async def _rebuild_graph_pageranks(
+        self,
+        runtime: GraphIndexRuntime,
+    ) -> None:
+        entity_keys, relations = await self._store.load_graph_metric_inputs(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+        )
+        pageranks = calculate_evidence_pageranks(entity_keys, relations)
+        self._lock_guard.ensure_valid()
+        await self._store.update_entity_pageranks(
+            runtime.graph_index_name,
+            runtime.knowledge_id,
+            pageranks,
             ensure_valid=self._lock_guard.ensure_valid,
         )
 

--- a/api/app/core/rag/knowledge_graph/index_pipeline.py
+++ b/api/app/core/rag/knowledge_graph/index_pipeline.py
@@ -342,9 +342,6 @@ class KnowledgeGraphIndexPipeline:
                 stage = "rebuild_graph_pageranks"
                 self._lock_guard.ensure_valid()
                 await self._rebuild_graph_pageranks(runtime)
-                stage = "refresh_graph_pageranks"
-                self._lock_guard.ensure_valid()
-                await self._store.refresh_graph(runtime.graph_index_name)
             logger.info(
                 "[EvidenceGraph] index_done"
                 " kb_id=%s document_id=%s"
@@ -419,8 +416,6 @@ class KnowledgeGraphIndexPipeline:
         await self._store.refresh_graph(runtime.graph_index_name)
         self._lock_guard.ensure_valid()
         await self._rebuild_graph_pageranks(runtime)
-        self._lock_guard.ensure_valid()
-        await self._store.refresh_graph(runtime.graph_index_name)
         logger.info(
             "[EvidenceGraph] rebuild_done"
             " kb_id=%s active_documents=%d stale_documents=%d elapsed_ms=%d",

--- a/api/app/core/rag/knowledge_graph/rebuild_task_guard.py
+++ b/api/app/core/rag/knowledge_graph/rebuild_task_guard.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from app.core.rag.utils.redis_conn import REDIS_CONN
+
+REBUILD_TASK_GUARD_TTL_SECONDS = 7200
+_REBUILD_JOB_KEY_PREFIX = "evidence_graph:rebuild:job"
+_REBUILD_EXECUTION_KEY_PREFIX = "evidence_graph:rebuild:execution"
+_REBUILD_TERMINAL_KEY_PREFIX = "evidence_graph:rebuild:terminal"
+_COMPARE_AND_EXPIRE_SCRIPT = """
+local current_value = redis.call('get', KEYS[1])
+if current_value and current_value == ARGV[1] then
+    redis.call('expire', KEYS[1], ARGV[2])
+    return 1
+end
+return 0
+"""
+
+
+@dataclass(frozen=True)
+class RebuildJobClaim:
+    task_id: str
+    claimed: bool
+
+
+def _canonical_knowledge_id(knowledge_id: str) -> str:
+    return str(uuid.UUID(str(knowledge_id)))
+
+
+def _decode_redis_value(value: bytes | str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value)
+
+
+def rebuild_job_key(knowledge_id: str) -> str:
+    return f"{_REBUILD_JOB_KEY_PREFIX}:{_canonical_knowledge_id(knowledge_id)}"
+
+
+def rebuild_execution_key(knowledge_id: str) -> str:
+    return (
+        f"{_REBUILD_EXECUTION_KEY_PREFIX}:"
+        f"{_canonical_knowledge_id(knowledge_id)}"
+    )
+
+
+def rebuild_terminal_key(task_id: str) -> str:
+    return f"{_REBUILD_TERMINAL_KEY_PREFIX}:{task_id}"
+
+
+def claim_or_get_rebuild_job(
+    knowledge_id: str,
+    proposed_task_id: str,
+) -> RebuildJobClaim:
+    key = rebuild_job_key(knowledge_id)
+    client = REDIS_CONN.REDIS
+    if client.set(
+        key,
+        proposed_task_id,
+        ex=REBUILD_TASK_GUARD_TTL_SECONDS,
+        nx=True,
+    ):
+        return RebuildJobClaim(task_id=proposed_task_id, claimed=True)
+
+    existing_task_id = _decode_redis_value(client.get(key))
+    if existing_task_id is not None:
+        return RebuildJobClaim(task_id=existing_task_id, claimed=False)
+
+    if client.set(
+        key,
+        proposed_task_id,
+        ex=REBUILD_TASK_GUARD_TTL_SECONDS,
+        nx=True,
+    ):
+        return RebuildJobClaim(task_id=proposed_task_id, claimed=True)
+
+    existing_task_id = _decode_redis_value(client.get(key))
+    if existing_task_id is None:
+        raise RuntimeError("rebuild job claim changed without an owner")
+    return RebuildJobClaim(task_id=existing_task_id, claimed=False)
+
+
+def refresh_rebuild_job(knowledge_id: str, task_id: str) -> bool:
+    key = rebuild_job_key(knowledge_id)
+    client = REDIS_CONN.REDIS
+    if client.set(
+        key,
+        task_id,
+        ex=REBUILD_TASK_GUARD_TTL_SECONDS,
+        nx=True,
+    ):
+        return True
+    return bool(
+        client.eval(
+            _COMPARE_AND_EXPIRE_SCRIPT,
+            1,
+            key,
+            task_id,
+            REBUILD_TASK_GUARD_TTL_SECONDS,
+        )
+    )
+
+
+def release_rebuild_job(knowledge_id: str, task_id: str) -> bool:
+    return REDIS_CONN.delete_if_equal(
+        rebuild_job_key(knowledge_id),
+        task_id,
+    )
+
+
+def acquire_rebuild_execution(
+    knowledge_id: str,
+    owner_token: str,
+) -> bool:
+    return bool(
+        REDIS_CONN.REDIS.set(
+            rebuild_execution_key(knowledge_id),
+            owner_token,
+            ex=REBUILD_TASK_GUARD_TTL_SECONDS,
+            nx=True,
+        )
+    )
+
+
+def release_rebuild_execution(
+    knowledge_id: str,
+    owner_token: str,
+) -> bool:
+    return REDIS_CONN.delete_if_equal(
+        rebuild_execution_key(knowledge_id),
+        owner_token,
+    )
+
+
+def has_rebuild_terminal(task_id: str) -> bool:
+    return REDIS_CONN.REDIS.get(rebuild_terminal_key(task_id)) is not None
+
+
+def mark_rebuild_terminal(task_id: str, terminal: str) -> None:
+    stored = REDIS_CONN.REDIS.set(
+        rebuild_terminal_key(task_id),
+        terminal,
+        ex=REBUILD_TASK_GUARD_TTL_SECONDS,
+    )
+    if not stored:
+        raise RuntimeError("failed to store rebuild task terminal marker")

--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -10,8 +10,8 @@ class RetrieveType(StrEnum):
     """Retrieval type enumeration"""
     PARTICIPLE = "participle"
     SEMANTIC = "semantic"
-    HYBRID = "hybrid"
     Graph = "graph"
+    HYBRID = "hybrid"
 
 
 class KnowledgeRetrievalCaller(StrEnum):

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -623,8 +623,10 @@ def _finish_rebuild_task_guard(
         owner_token: str,
         terminal: str,
 ) -> None:
-    mark_rebuild_terminal(task_id, terminal)
-    _release_rebuild_attempt(knowledge_id, owner_token)
+    try:
+        mark_rebuild_terminal(task_id, terminal)
+    finally:
+        _release_rebuild_attempt(knowledge_id, owner_token)
     try:
         released = release_rebuild_job(knowledge_id, task_id)
         if not released:

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import redis
+from celery import states
+from celery.exceptions import Ignore, Retry
 from elasticsearch import AsyncElasticsearch
 from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
@@ -39,6 +41,14 @@ from app.core.rag.knowledge_graph.elasticsearch_store import GraphElasticsearchS
 from app.core.rag.knowledge_graph.extractor import LLMEntityRelationExtractor
 from app.core.rag.knowledge_graph.index_pipeline import KnowledgeGraphIndexPipeline
 from app.core.rag.knowledge_graph.lock import create_knowledge_graph_lock
+from app.core.rag.knowledge_graph.rebuild_task_guard import (
+    acquire_rebuild_execution,
+    has_rebuild_terminal,
+    mark_rebuild_terminal,
+    refresh_rebuild_job,
+    release_rebuild_execution,
+    release_rebuild_job,
+)
 from app.core.rag.knowledge_graph.runtime import (
     build_model_config,
     snapshot_graph_runtime,
@@ -541,6 +551,197 @@ def _run_observed_graph_task(
         reason,
         int((time.perf_counter() - started_at) * 1000),
     )
+    return result
+
+
+def _log_coalesced_rebuild_task(
+        *,
+        task_id: str,
+        knowledge_id: str,
+        retry: int,
+        reason: str,
+) -> None:
+    logger.info(
+        "[EvidenceGraph] task_coalesced"
+        " task=rebuild_knowledge task_id=%s kb_id=%s retry=%d reason=%s",
+        task_id,
+        knowledge_id,
+        retry,
+        reason,
+    )
+
+
+def _retry_rebuild_guard_failure(
+        task,
+        *,
+        task_id: str,
+        knowledge_id: str,
+        retry: int,
+        exc: Exception,
+):
+    countdown = _graph_task_retry_countdown(task)
+    logger.warning(
+        "[EvidenceGraph] task_guard_retry"
+        " task=rebuild_knowledge task_id=%s kb_id=%s"
+        " error_type=%s retry=%d countdown=%d",
+        task_id,
+        knowledge_id,
+        type(exc).__name__,
+        retry,
+        countdown,
+        exc_info=_redacted_graph_exc_info(exc),
+    )
+    raise task.retry(exc=exc, countdown=countdown)
+
+
+def _release_rebuild_attempt(
+        knowledge_id: str,
+        owner_token: str,
+) -> None:
+    try:
+        released = release_rebuild_execution(knowledge_id, owner_token)
+        if not released:
+            logger.warning(
+                "[EvidenceGraph] task_guard_release_skipped"
+                " task=rebuild_knowledge kb_id=%s guard=execution",
+                knowledge_id,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "[EvidenceGraph] task_guard_release_failed"
+            " task=rebuild_knowledge kb_id=%s guard=execution"
+            " error_type=%s",
+            knowledge_id,
+            type(exc).__name__,
+        )
+
+
+def _finish_rebuild_task_guard(
+        *,
+        task_id: str,
+        knowledge_id: str,
+        owner_token: str,
+        terminal: str,
+) -> None:
+    mark_rebuild_terminal(task_id, terminal)
+    _release_rebuild_attempt(knowledge_id, owner_token)
+    try:
+        released = release_rebuild_job(knowledge_id, task_id)
+        if not released:
+            logger.warning(
+                "[EvidenceGraph] task_guard_release_skipped"
+                " task=rebuild_knowledge task_id=%s kb_id=%s guard=job",
+                task_id,
+                knowledge_id,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "[EvidenceGraph] task_guard_release_failed"
+            " task=rebuild_knowledge task_id=%s kb_id=%s guard=job"
+            " error_type=%s",
+            task_id,
+            knowledge_id,
+            type(exc).__name__,
+        )
+
+
+def _run_guarded_evidence_graph_rebuild(
+        task,
+        knowledge_id: str,
+) -> dict[str, Any]:
+    knowledge_id = _canonical_graph_uuid(knowledge_id, "knowledge id")
+    task_id = str(getattr(task.request, "id", None) or "unknown")
+    retry = int(getattr(task.request, "retries", 0) or 0)
+    owner_token = f"{task_id}:{uuid.uuid4()}"
+
+    try:
+        if has_rebuild_terminal(task_id):
+            _log_coalesced_rebuild_task(
+                task_id=task_id,
+                knowledge_id=knowledge_id,
+                retry=retry,
+                reason="terminal",
+            )
+            raise Ignore()
+        if not refresh_rebuild_job(knowledge_id, task_id):
+            _log_coalesced_rebuild_task(
+                task_id=task_id,
+                knowledge_id=knowledge_id,
+                retry=retry,
+                reason="foreign_job",
+            )
+            raise Ignore()
+        if not acquire_rebuild_execution(knowledge_id, owner_token):
+            _log_coalesced_rebuild_task(
+                task_id=task_id,
+                knowledge_id=knowledge_id,
+                retry=retry,
+                reason="active_attempt",
+            )
+            raise Ignore()
+    except Ignore:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _retry_rebuild_guard_failure(
+            task,
+            task_id=task_id,
+            knowledge_id=knowledge_id,
+            retry=retry,
+            exc=exc,
+        )
+
+    try:
+        task.update_state(
+            state=states.STARTED,
+            meta={
+                "knowledge_id": knowledge_id,
+                "retry": retry,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        _release_rebuild_attempt(knowledge_id, owner_token)
+        _retry_rebuild_guard_failure(
+            task,
+            task_id=task_id,
+            knowledge_id=knowledge_id,
+            retry=retry,
+            exc=exc,
+        )
+
+    try:
+        result = _run_observed_graph_task(
+            task,
+            task_name="rebuild_knowledge",
+            knowledge_id=knowledge_id,
+            operation=lambda: _run_evidence_graph_rebuild(knowledge_id),
+        )
+    except Retry:
+        _release_rebuild_attempt(knowledge_id, owner_token)
+        raise
+    except Exception:
+        _finish_rebuild_task_guard(
+            task_id=task_id,
+            knowledge_id=knowledge_id,
+            owner_token=owner_token,
+            terminal="failure",
+        )
+        raise
+
+    try:
+        _finish_rebuild_task_guard(
+            task_id=task_id,
+            knowledge_id=knowledge_id,
+            owner_token=owner_token,
+            terminal="success",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _retry_rebuild_guard_failure(
+            task,
+            task_id=task_id,
+            knowledge_id=knowledge_id,
+            retry=retry,
+            exc=exc,
+        )
     return result
 
 
@@ -1583,13 +1784,14 @@ def sync_evidence_graph_document(
     bind=True,
     name="app.core.rag.tasks.rebuild_evidence_graph_knowledge",
     max_retries=5,
+    acks_late=False,
+    reject_on_worker_lost=False,
+    track_started=False,
 )
 def rebuild_evidence_graph_knowledge(self, knowledge_id: str):
-    return _run_observed_graph_task(
+    return _run_guarded_evidence_graph_rebuild(
         self,
-        task_name="rebuild_knowledge",
-        knowledge_id=str(knowledge_id),
-        operation=lambda: _run_evidence_graph_rebuild(knowledge_id),
+        str(knowledge_id),
     )
 
 


### PR DESCRIPTION
## Business Background
The EvidenceGraph detail response still returned placeholder or missing graph metadata compared with the established knowledge graph contract. Entity importance and source-document attribution were unavailable, and the retrieval type list placed hybrid before graph.

## Summary
- Return EvidenceGraph-native graph, node, and edge source IDs.
- Compute and persist weighted PageRank from the full directed multigraph projection.
- Scan graph projections and write PageRank updates in bounded Elasticsearch batches.
- Rank detail nodes by PageRank and report the graph as a multigraph.
- Return retrieval types in participle, semantic, graph, hybrid order.

## Changes
```
api/app/core/rag/knowledge_graph/elasticsearch_store.py | 193 +++++++++++++++++++--
api/app/core/rag/knowledge_graph/index_pipeline.py     |  86 ++++++++-
api/app/schemas/chunk_schema.py                        |   2 +-
3 files changed, 260 insertions(+), 21 deletions(-)
```

## Risk
- A single-document EvidenceGraph sync performs one full projection scan, PageRank calculation, and entity PageRank write-back. A full knowledge rebuild calculates PageRank once after all documents finish.
- The graph detail response now reports `multigraph=true` and selects nodes by PageRank before degree and evidence count.
- The API Key knowledge graph endpoint reuses the internal controller and receives the same enriched contract. The API Key retrieval-type endpoint receives the same reordered list. Enum values, authorization, workspace, and tenant behavior are unchanged.

## Test Plan
- [x] `PYTHONPATH=api python -m pytest api/tests/rag/knowledge_graph/test_graph_detail_contract.py api/tests/rag/test_retrieve_type_order.py -q` — 9 passed, 4 existing deprecation warnings.
- [x] `python -m py_compile api/app/core/rag/knowledge_graph/elasticsearch_store.py api/app/core/rag/knowledge_graph/index_pipeline.py api/app/schemas/chunk_schema.py`
- [x] `git diff --check origin/develop..HEAD`

## Summary by Sourcery

使 EvidenceGraph 详情响应和检索类型排序与既有的知识图谱契约保持一致，包括多重图报告、来源归属以及基于 PageRank 的节点排序。

新增功能：
- 在 EvidenceGraph 详情响应中暴露图级别以及每个节点/边的来源标识符。
- 在详情 API 中将 EvidenceGraph 图报告为有向多重图，并使用存储的 PageRank 分数对节点进行排序。
- 从知识图谱 API 返回按 participle、semantic、graph、hybrid 顺序排列的检索类型。

增强点：
- 在有向多重图上引入全图 PageRank 计算，并将分数持久化到实体投影上。
- 添加 Elasticsearch 扫描和批量更新流程，以高效读取图指标并回写实体 PageRank。
- 在实体和关系投影上包含文档来源标识符，并将其传播到 evidence graph 响应中。
- 更新文档同步和知识重建流程，在受控且有锁保护的方式下重新计算图的 PageRank。

测试：
- 添加测试以验证 EvidenceGraph 详情契约，包括多重图标志、来源 ID 以及基于 PageRank 的排序。
- 添加测试以断言知识图谱 API 的新检索类型排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align EvidenceGraph detail responses and retrieval type ordering with the established knowledge graph contract, including multigraph reporting, source attribution, and PageRank-based node ranking.

New Features:
- Expose graph-level and per-node/edge source identifiers in EvidenceGraph detail responses.
- Report EvidenceGraph graphs as directed multigraphs and rank nodes using stored PageRank scores in the detail API.
- Return retrieval types in participle, semantic, graph, hybrid order from the knowledge graph APIs.

Enhancements:
- Introduce a full-graph PageRank computation over the directed multigraph and persist scores onto entity projections.
- Add Elasticsearch scan and bulk update routines to efficiently read graph metrics and write back entity PageRanks.
- Include document source identifiers on entity and relation projections and propagate them into evidence graph responses.
- Update document sync and knowledge rebuild flows to recompute graph PageRanks in a controlled, lock-guarded manner.

Tests:
- Add tests to validate the EvidenceGraph detail contract, including multigraph flag, source IDs, and PageRank-based ordering.
- Add tests to assert the new retrieval type ordering for the knowledge graph APIs.

</details>