### PR TITLE
refactor(memory): optimize memory summary by combining llm calls and parallelizing preprocessing

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -41,7 +41,12 @@ from app.core.memory.models.graph_models import (
     StatementEntityEdge,
     StatementNode,
 )
+from app.core.memory.storage_services.extraction_engine.knowledge_extraction.memory_summary import (
+    memory_summary_generation,
+)
 from app.core.memory.utils.name_similarity_utils import cosine_similarity
+from app.repositories.neo4j.add_nodes import add_memory_summary_nodes
+from app.repositories.neo4j.add_edges import add_memory_summary_statement_edges
 
 logger = logging.getLogger(__name__)
 bear = BearLogger("memory.pipeline")
@@ -367,10 +372,13 @@ class WritePipeline:
                     target_idx = len(context_before)
                     all_messages = context_before + [target_message] + context_after
 
-                    # 文件预处理：先对 target 注入 file-summary（剪枝判断依赖此标签）
-                    await self._preprocess_files([all_messages[target_idx]])
-                    await self._preprocess_files(context_before)
-                    await self._preprocess_files(context_after)
+                    # 文件预处理：注入 file-summary（剪枝判断依赖此标签）
+                    # 三次预处理操作不同 msg dict 对象，各自独立开启 DB session，并行安全
+                    await asyncio.gather(
+                        self._preprocess_files([all_messages[target_idx]]),
+                        self._preprocess_files(context_before),
+                        self._preprocess_files(context_after),
+                    )
 
                     # 统一剪枝
                     from app.core.memory.storage_services.extraction_engine.data_preprocessing.pruning_service import prune_messages
@@ -382,6 +390,7 @@ class WritePipeline:
                         source=source,
                         language=self.language,
                         persist=not is_pilot_run,
+                        llm_client=self._llm_client,  # 复用 Pipeline 已创建的客户端
                     )
 
                     # 拆回三部分
@@ -491,48 +500,73 @@ class WritePipeline:
 
                     s.metadata(chunks=sum(len(d.chunks) for d in chunked_dialogs))
 
-                # Step 3: 萃取 - 知识提取
-                async with bear.step(3, 6, "萃取", "知识提取") as s:
-                    extraction_result = await self._extract(chunked_dialogs, is_pilot_run)
-                    stats = extraction_result.stats
-                    s.metadata(
-                        entities=stats["entity_count"],
-                        statements=stats["statement_count"],
-                        relations=stats["relation_count"],
-                    )
+                # Step 3: 萃取 + 摘要 LLM 生成并行启动
+                summary_gen_task = None
+                if not is_pilot_run:
+                    summary_gen_task = asyncio.create_task(memory_summary_generation(
+                        chunked_dialogs,
+                        llm_client=self._llm_client,
+                        embedder_client=self._embedder_client,
+                        language=self.language,
+                    ))
 
-                # 试运行模式到此结束
-                if is_pilot_run:
+                try:
+                    async with bear.step(3, 6, "萃取", "知识提取") as s:
+                        extraction_result = await self._extract(chunked_dialogs, is_pilot_run)
+                        stats = extraction_result.stats
+                        s.metadata(
+                            entities=stats["entity_count"],
+                            statements=stats["statement_count"],
+                            relations=stats["relation_count"],
+                        )
+
+                    # 试运行到此结束
+                    if is_pilot_run:
+                        return WriteResult(
+                            status="pilot_complete",
+                            extraction=extraction_result.stats,
+                            elapsed_seconds=0.0,
+                        )
+
+                    # Step 3.5: 构建 UserSource 子图
+                    if self._user_pruning_info:
+                        await self._build_user_source_subgraph(extraction_result)
+
+                    # Step 4: Store + Stats 并行（Neo4j + Redis 互不依赖）
+                    async with bear.step(4, 6, "存储", "写入 Neo4j + 统计缓存"):
+                        await asyncio.gather(
+                            self._store(extraction_result),
+                            self._update_stats_cache(extraction_result),
+                        )
+
+                    # Step 5: 摘要写入（依赖 Step 4 写入的 CONTAINS 边）
+                    async with bear.step(5, 6, "摘要", "写入情景记忆") as s:
+                        try:
+                            summaries = await summary_gen_task
+                            await add_memory_summary_nodes(summaries, self._neo4j_connector)
+                            await add_memory_summary_statement_edges(summaries, self._neo4j_connector)
+                            s.metadata(summary_count=len(summaries))
+                        except Exception as e:
+                            logger.error(f"Memory summary step failed: {e}", exc_info=True)
+
+                    # Step 6: 聚类（Celery 异步，不阻塞）
+                    async with bear.step(6, 6, "聚类", "增量更新社区") as s:
+                        await self._cluster(extraction_result)
+                        s.metadata(mode="async")
+
                     return WriteResult(
-                        status="pilot_complete",
+                        status="success",
                         extraction=extraction_result.stats,
                         elapsed_seconds=0.0,
                     )
 
-                # Step 3.5: 构建 UserSource 子图（剪枝原文 → 实体连边）
-                if self._user_pruning_info:
-                    await self._build_user_source_subgraph(extraction_result)
-
-                async with bear.step(4, 6, "存储", "写入 Neo4j"):
-                    await self._store(extraction_result)
-
-                # Step 6: 摘要 - 生成情景记忆摘要
-                async with bear.step(6, 6, "摘要", "生成情景记忆"):
-                    await self._summarize(chunked_dialogs)
-
-                # Step 5: 聚类 - 增量更新社区（Celery 异步任务，无需持锁）
-                async with bear.step(5, 6, "聚类", "增量更新社区") as s:
-                    await self._cluster(extraction_result)
-                    s.metadata(mode="async")
-
-                # 更新活动统计缓存
-                await self._update_stats_cache(extraction_result)
-
-                return WriteResult(
-                    status="success",
-                    extraction=extraction_result.stats,
-                    elapsed_seconds=0.0,
-                )
+                finally:
+                    if summary_gen_task is not None and not summary_gen_task.done():
+                        summary_gen_task.cancel()
+                        try:
+                            await summary_gen_task
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
         except Exception:
             raise
@@ -729,6 +763,9 @@ class WritePipeline:
                     await asyncio.sleep(1 * (attempt + 1))
                 else:
                     logger.error(f"Neo4j 写入在 {max_retries} 次尝试后仍部分失败")
+                    raise RuntimeError(
+                        f"Neo4j 写入在 {max_retries} 次重试后仍部分失败"
+                    )
             except Exception as e:
                 if self._is_deadlock(e) and attempt < max_retries - 1:
                     logger.warning(f"Neo4j 死锁，重试 ({attempt + 2}/{max_retries})")
@@ -924,36 +961,8 @@ class WritePipeline:
             )
 
     # ──────────────────────────────────────────────
-    # Step 5: 摘要
-    # （+ entity_description）+ meta_data部分在此提取
+    # (已内联到 run() 中：摘要 LLM 生成与萃取并行，Neo4j 写入在 _store 之后)
     # ──────────────────────────────────────────────
-    # TODO 乐力齐 需要做成异步celery任务
-    async def _summarize(self, chunked_dialogs: List[DialogData]) -> None:
-        """
-        摘要：生成情景记忆摘要 → 写入 Neo4j。
-
-        摘要生成失败不影响主流程（try/except 吞掉异常）。
-        直接复用 self._neo4j_connector，避免每次写入额外创建一个 driver。
-        """
-        from app.core.memory.storage_services.extraction_engine.knowledge_extraction.memory_summary import (
-            memory_summary_generation,
-        )
-        from app.repositories.neo4j.add_edges import (
-            add_memory_summary_statement_edges,
-        )
-        from app.repositories.neo4j.add_nodes import add_memory_summary_nodes
-
-        try:
-            summaries = await memory_summary_generation(
-                chunked_dialogs,
-                llm_client=self._llm_client,
-                embedder_client=self._embedder_client,
-                language=self.language,
-            )
-            await add_memory_summary_nodes(summaries, self._neo4j_connector)
-            await add_memory_summary_statement_edges(summaries, self._neo4j_connector)
-        except Exception as e:
-            logger.error(f"Memory summary step failed: {e}", exc_info=True)
 
     # ──────────────────────────────────────────────
     # 文件预处理（与旧路径 memory_agent_service._preprocess_files 一脉相承）

--- a/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
+++ b/api/app/core/memory/storage_services/extraction_engine/data_preprocessing/pruning_service.py
@@ -16,6 +16,9 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple
 
+from app.core.memory.storage_services.extraction_engine.data_preprocessing import SemanticPruner
+from app.core.memory.models.config_models import PruningConfig
+
 if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
 
@@ -40,6 +43,7 @@ async def prune_messages(
     source: str = "",
     language: str = "zh",
     persist: bool = True,
+    llm_client=None,
 ) -> Tuple[List[dict], list]:
     """对滑动窗口覆盖的所有消息执行剪枝/规整。
 
@@ -52,6 +56,7 @@ async def prune_messages(
         language: 语言
         persist: 是否将剪枝结果持久化到 DB。试运行(pilot)模式应传 False，
                  避免污染 PG 中的 pruned_content 字段。
+        llm_client: 外部传入的 LLM 客户端（由 Pipeline 复用），为 None 时自行创建。
 
     Returns:
         (pruned_messages, pruning_records) 元组：
@@ -75,8 +80,24 @@ async def prune_messages(
     prune_tasks: list = []
     db_updates: list = []
 
-    # 初始化 LLM 客户端（懒加载，整个调用共享）
-    llm_client = _get_llm_client(memory_config)
+    # 初始化 LLM 客户端：外部传入时复用，否则自行创建（兼容独立调用场景）
+    if llm_client is None:
+        llm_client = _get_llm_client(memory_config)
+
+    # 提前创建共享 PruningConfig + SemanticPruner（K 条消息复用同一实例）
+    # SemanticPruner.extract_assistant_hint() 内部仅读取 self 属性，无可变状态写入，协程并发安全
+    shared_pruning_config = PruningConfig(
+        pruning_switch=memory_config.pruning_enabled,
+        pruning_scene=memory_config.pruning_scene or "education",
+        pruning_threshold=memory_config.pruning_threshold,
+        scene_id=str(memory_config.scene_id) if memory_config.scene_id else None,
+        ontology_class_infos=memory_config.ontology_class_infos,
+    )
+    shared_pruner = SemanticPruner(
+        config=shared_pruning_config,
+        llm_client=llm_client,
+        language=language,
+    )
 
     for i, msg in enumerate(messages):
         role = msg.get("role", "")
@@ -102,19 +123,15 @@ async def prune_messages(
         if role == "user":
             pair = _next_assistant_content(messages, i)
             prune_tasks.append((i, "user", _call_llm_prune(
-                llm_client=llm_client,
-                memory_config=memory_config,
+                pruner=shared_pruner,
                 content=pair,
                 user_content=content,
-                language=language,
             )))
         elif role == "assistant":
             prune_tasks.append((i, "assistant", _call_llm_prune(
-                llm_client=llm_client,
-                memory_config=memory_config,
+                pruner=shared_pruner,
                 content=content,
                 user_content="",
-                language=language,
             )))
         else:
             result[i] = msg
@@ -248,41 +265,21 @@ def _get_llm_client(memory_config: "MemoryConfig"):
 
 
 async def _call_llm_prune(
-    llm_client,
-    memory_config: "MemoryConfig",
+    pruner,
     content: str,
     user_content: str,
-    language: str,
 ) -> PruneResult:
     """调用 SemanticPruner 执行单条消息剪枝。
 
     Args:
-        llm_client: LLM 客户端实例
-        memory_config: 记忆配置
+        pruner: 共享的 SemanticPruner 实例（协程安全，无可变状态）
         content: assistant 消息内容（user 角色调用时传入紧邻的 assistant 配对内容）
         user_content: user 消息内容（assistant 角色调用时传空字符串）
-        language: 语言
 
     Returns:
         PruneResult 命名元组
     """
-    from app.core.memory.storage_services.extraction_engine.data_preprocessing import SemanticPruner
-    from app.core.memory.models.config_models import PruningConfig
     from app.core.memory.models.message_models import ConversationMessage
-
-    pruning_config = PruningConfig(
-        pruning_switch=memory_config.pruning_enabled,
-        pruning_scene=memory_config.pruning_scene or "education",
-        pruning_threshold=memory_config.pruning_threshold,
-        scene_id=str(memory_config.scene_id) if memory_config.scene_id else None,
-        ontology_class_infos=memory_config.ontology_class_infos,
-    )
-
-    pruner = SemanticPruner(
-        config=pruning_config,
-        llm_client=llm_client,
-        language=language,
-    )
 
     user_msg = ConversationMessage(role="user", msg=user_content if user_content else "[context]")
     asst_msg = ConversationMessage(role="assistant", msg=content)

--- a/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/memory_summary.py
+++ b/api/app/core/memory/storage_services/extraction_engine/knowledge_extraction/memory_summary.py
@@ -10,7 +10,8 @@ from app.core.logging_config import get_memory_logger
 from app.core.memory.models.base_response import RobustLLMResponse
 from app.core.memory.models.graph_models import MemorySummaryNode
 from app.core.memory.models.message_models import DialogData
-from app.core.memory.utils.prompt.prompt_utils import render_memory_summary_prompt
+from app.core.memory.utils.prompt.prompt_utils import render_memory_summary_prompt # 相关内容也需要删除
+from app.core.memory.utils.prompt.prompt_utils import render_neo4j_memory_summary_prompt
 from app.core.language_utils import validate_language  # 使用集中化的语言校验
 from pydantic import Field
 
@@ -31,7 +32,31 @@ class MemorySummaryResponse(RobustLLMResponse):
     )
 
 
-async def generate_title_and_type_for_summary(
+class EpisodicCombinedResponse(RobustLLMResponse):
+    """Combined response: title + type + summary in one LLM call.
+
+    Used by neo4j_memory_summary.jinja2 prompt to reduce per-chunk LLM calls from 2 to 1.
+    """
+
+    title: str = Field(
+        ...,
+        description="Concise title capturing the core subject or event.",
+        min_length=1,
+        max_length=200,
+    )
+    type: str = Field(
+        ...,
+        description="Episodic memory type classification (conversation/project_work/learning/decision/important_event).",
+    )
+    summary: str = Field(
+        ...,
+        description="Faithful summary of the input chunk.",
+        min_length=1,
+        max_length=5000,
+    )
+
+
+async def generate_title_and_type_for_summary( # 只作用于遗忘，已经有新的任务替代遗忘的作用，确定后准备清理
     content: str,
     llm_client,
     language: str = "zh"
@@ -154,82 +179,21 @@ async def generate_title_and_type_for_summary(
         logger.error(f"生成标题和类型时出错 (language={language}): {str(e)}", exc_info=True)
         return (ERROR_TITLE, DEFAULT_TYPE)
 
-async def _process_chunk_summary(
-    dialog: DialogData,
-    chunk,
-    llm_client,
-    embedder: Any,
-    language: str = "zh",
-) -> Optional[MemorySummaryNode]:
-    """Process a single chunk to generate a memory summary node."""
-    # Skip empty chunks
-    if not chunk.content or not chunk.content.strip():
-        return None
 
-    try:
-        # 验证语言参数
-        language = validate_language(language)
-        
-        # Render prompt via Jinja2 for a single chunk
-        prompt_content = await render_memory_summary_prompt(
-            chunk_texts=chunk.content,
-            json_schema=MemorySummaryResponse.model_json_schema(),
-            max_words=200,
-            language=language,
-        )
+_SUMMARY_MAX_RETRIES = 2
 
-        messages = [
-            {"role": "system", "content": "You are an expert memory summarizer."},
-            {"role": "user", "content": prompt_content},
-        ]
+_VALID_EPISODIC_TYPES = {"conversation", "project_work", "learning", "decision", "important_event"}
 
-        # Generate structured summary with the existing LLM client
-        structured = await llm_client.call_structured(
-            messages,
-            MemorySummaryResponse,
-        )
-        summary_text = structured.summary.strip()
-        # Generate title and type for the summary
-        title = None
-        episodic_type = None
-        try:
-            title, episodic_type = await generate_title_and_type_for_summary(
-                content=summary_text,
-                llm_client=llm_client,
-                language=language
-            )
-            logger.debug(f"Generated title and type for MemorySummary (language={language}): title={title}, type={episodic_type}")
-        except Exception as e:
-            logger.warning(f"Failed to generate title and type for chunk {chunk.id}: {e}")
-            # Continue without title and type
-
-        # Embed the summary
-        embedding = (await embedder.aembed_documents([summary_text]))[0]
-
-        # Build node per chunk
-        # Note: title is stored in the 'name' field, type is stored in 'memory_type' field
-        node = MemorySummaryNode(
-            id=uuid4().hex,
-            name=title if title else f"MemorySummaryChunk_{chunk.id}",
-            end_user_id=dialog.end_user_id,
-            user_id=dialog.end_user_id,
-            apply_id=dialog.end_user_id,
-            run_id=dialog.run_id,  # 使用 dialog 的 run_id
-            created_at=utcnow_naive(),
-            dialog_id=dialog.id,
-            chunk_ids=[chunk.id],
-            content=summary_text,
-            memory_type=episodic_type,
-            summary_embedding=embedding,
-            metadata={"ref_id": dialog.ref_id},
-            config_id=dialog.config_id,  # 添加 config_id
-        )
-        return node
-
-    except Exception as e:
-        # Log the error but continue processing other chunks
-        logger.warning(f"Failed to generate summary for chunk {chunk.id} in dialog {dialog.id}: {e}", exc_info=True)
-        return None
+_EPISODIC_TYPE_MAPPING = {
+    "对话": "conversation",
+    "项目": "project_work",
+    "工作": "project_work",
+    "项目/工作": "project_work",
+    "学习": "learning",
+    "决策": "decision",
+    "重要事件": "important_event",
+    "事件": "important_event",
+}
 
 
 async def memory_summary_generation(
@@ -238,24 +202,89 @@ async def memory_summary_generation(
     embedder_client: Any,
     language: str = "zh",
 ) -> List[MemorySummaryNode]:
-    """Generate memory summaries per chunk, embed them, and return nodes.
-    
+    """Generate memory summaries per chunk with retry, embed them, and return nodes.
+
+    每个 chunk 通过单次 LLM 调用 (neo4j_memory_summary.jinja2) 同时产出
+    title、type、summary，失败时指数退避重试。
+
     Args:
         chunked_dialogs: 分块后的对话数据
-        llm_client: LLM客户端
+        llm_client: LLM 客户端
         embedder_client: 嵌入客户端
         language: 语言类型 ("zh" 中文, "en" 英文)，默认中文
     """
-    # Collect all tasks for parallel processing
-    tasks = []
-    for dialog in chunked_dialogs:
-        for chunk in dialog.chunks:
-            tasks.append(_process_chunk_summary(dialog, chunk, llm_client, embedder_client, language=language))
+    language = validate_language(language)
 
-    # Process all chunks in parallel
-    results = await asyncio.gather(*tasks, return_exceptions=False)
+    async def _process_chunk(dialog: DialogData, chunk) -> Optional[MemorySummaryNode]:
+        """处理单个 chunk：渲染 prompt → LLM → embed → 构建节点，带重试。"""
+        if not chunk.content or not chunk.content.strip():
+            return None
 
-    # Filter out None values (failed or empty chunks)
-    nodes = [node for node in results if node is not None]
+        for attempt in range(1, _SUMMARY_MAX_RETRIES + 1):
+            try:
+                # 渲染合并提示词
+                prompt_content = await render_neo4j_memory_summary_prompt(
+                    chunk_texts=chunk.content,
+                    max_words=200,
+                    language=language,
+                )
 
-    return nodes
+                # 单次 LLM 调用产出 title / type / summary
+                structured: EpisodicCombinedResponse = await llm_client.call_structured(
+                    [
+                        {"role": "system", "content": "You are an expert memory summarizer."},
+                        {"role": "user", "content": prompt_content},
+                    ],
+                    EpisodicCombinedResponse,
+                )
+
+                summary_text = structured.summary.strip()
+                if not summary_text:
+                    return None
+
+                # 归一化 type
+                episodic_type = structured.type.lower().strip()
+                if episodic_type not in _VALID_EPISODIC_TYPES:
+                    episodic_type = _EPISODIC_TYPE_MAPPING.get(episodic_type, "conversation")
+
+                # 生成 embedding
+                embedding = (await embedder_client.aembed_documents([summary_text]))[0]
+
+                return MemorySummaryNode(
+                    id=uuid4().hex,
+                    name=structured.title or f"MemorySummaryChunk_{chunk.id}",
+                    end_user_id=dialog.end_user_id,
+                    user_id=dialog.end_user_id,
+                    apply_id=dialog.end_user_id,
+                    run_id=dialog.run_id,
+                    created_at=utcnow_naive(),
+                    dialog_id=dialog.id,
+                    chunk_ids=[chunk.id],
+                    content=summary_text,
+                    memory_type=episodic_type,
+                    summary_embedding=embedding,
+                    metadata={"ref_id": dialog.ref_id},
+                    config_id=dialog.config_id,
+                )
+
+            except Exception as e:
+                if attempt == _SUMMARY_MAX_RETRIES:
+                    logger.warning(
+                        "Chunk %s in dialog %s summary failed after %d attempts: %s",
+                        chunk.id, dialog.id, _SUMMARY_MAX_RETRIES, e,
+                        exc_info=True,
+                    )
+                    return None
+                await asyncio.sleep(0.5 * attempt)
+
+    # 并发处理所有 chunk
+    results = await asyncio.gather(
+        *[
+            _process_chunk(dialog, chunk)
+            for dialog in chunked_dialogs
+            for chunk in dialog.chunks
+        ],
+        return_exceptions=False,
+    )
+
+    return [node for node in results if node is not None]

--- a/api/app/core/memory/utils/prompt/prompt_utils.py
+++ b/api/app/core/memory/utils/prompt/prompt_utils.py
@@ -233,7 +233,7 @@ async def render_triplet_extraction_prompt(
 
     return rendered_prompt
 
-async def render_memory_summary_prompt(
+async def render_memory_summary_prompt( # 只提供给RAG存储使用
     chunk_texts: str,
     json_schema: dict,
     max_words: int = 200,
@@ -540,4 +540,37 @@ def render_interest_filter_prompt(tag_list: str, language: str = "zh") -> str:
     template = prompt_env.get_template("interest_filter.jinja2")
     rendered_prompt = template.render(tag_list=tag_list, language=language)
     log_prompt_rendering('interest filter', rendered_prompt)
+    return rendered_prompt
+
+
+async def render_neo4j_memory_summary_prompt(
+    chunk_texts: str,
+    max_words: int = 200,
+    language: str = "zh",
+) -> str:
+    """Render the combined neo4j memory title + type + summary prompt.
+
+    Uses neo4j_memory_summary.jinja2 to generate title, type,
+    and summary in a single LLM call, reducing per-chunk calls from 2 to 1.
+
+    Args:
+        chunk_texts: The content of the chunk to summarize
+        max_words: Maximum words for the summary
+        language: Language for output ("zh" for Chinese, "en" for English)
+
+    Returns:
+        Rendered prompt content as string
+    """
+    template = prompt_env.get_template("neo4j_memory_summary.jinja2")
+    rendered_prompt = template.render(
+        chunk_texts=chunk_texts,
+        max_words=max_words,
+        language=language,
+    )
+    log_prompt_rendering('neo4j memory summary (title+type+summary)', rendered_prompt)
+    log_template_rendering('neo4j_memory_summary.jinja2', {
+        'chunk_texts_len': len(chunk_texts or ""),
+        'max_words': max_words,
+        'language': language,
+    })
     return rendered_prompt

--- a/api/app/core/memory/utils/prompt/prompts/neo4j_memory_summary.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/neo4j_memory_summary.jinja2
@@ -1,0 +1,57 @@
+=== Task ===
+Generate a concise title, classify the episodic memory, and produce a faithful summary from the input.
+
+=== Input ===
+{{ chunk_texts }}
+
+=== Requirements ===
+
+1. Title
+- Capture the core subject or event concisely.
+- The title must follow the primary language of `chunk_texts`.
+- For Chinese input, use 10-20 Chinese characters.
+- For English or other space-delimited languages, use 3-10 words.
+- Do not add information merely to satisfy the length requirement. Faithfulness takes priority.
+
+2. Type
+Classify the input into exactly one of the following types:
+
+- `conversation`: Daily communication, casual chat, discussion, social interaction, or content that cannot be clearly assigned to another type.
+- `project_work`: Work tasks, projects, meetings, clients, business activities, or professional collaboration.
+- `learning`: Learning, reading, research, training, knowledge acquisition, or skill development.
+- `decision`: A decision, choice, evaluation, trade-off, or plan in which selecting a course of action is the primary focus.
+- `important_event`: A major event, milestone, celebration, achievement, or memorable life experience.
+
+Classification rules:
+- Classify by the primary meaning of the input, not by isolated keywords.
+- Use `decision` only when making or recording a choice is the main point.
+- Use `important_event` only when the input clearly describes a milestone or significant event.
+- If multiple types apply, select the type that best represents the main intent or outcome.
+- If no other type clearly applies, use `conversation`.
+- The `type` value must always use the fixed English enum value.
+
+3. Summary
+- Summarize only information explicitly stated in `chunk_texts`.
+- Preserve factual statements, user preferences, relationships, and salient temporal context.
+- Do not infer, embellish, explain, or introduce new facts.
+- Avoid repetition and filler.
+- If the input is already concise, the summary may remain close to the original sentence.
+- The summary must follow the primary language of `chunk_texts`.
+- Keep the summary under {{ max_words or 200 }} words.
+
+=== Output Requirements ===
+- Return exactly one valid JSON object.
+- Include exactly three fields in this order: `title`, `type`, and `summary`.
+- All three field values must be strings.
+- Use only standard ASCII double quotes (`"`).
+- Escape quotation marks inside string values with backslashes (`\"`).
+- Do not include line breaks inside string values.
+- Do not output Markdown code fences, explanations, comments, or additional fields.
+
+Return only:
+
+{
+  "title": "Generated title",
+  "type": "conversation",
+  "summary": "Generated summary"
+}


### PR DESCRIPTION
## Summary by Sourcery

通过结合 LLM 的标题/类型/摘要生成、并行化预处理和存储步骤，以及集成 Neo4j 摘要持久化与改进后的裁剪客户端复用来优化情景记忆（episodic memory）的摘要过程。

New Features:
- 引入一个组合式情景记忆响应模型，在一次 LLM 调用中返回用于 Neo4j 记忆摘要的标题、类型和摘要。
- 添加专用的 Neo4j 记忆摘要提示模板和渲染器，用于统一生成标题/类型/摘要。

Enhancements:
- 重构记忆摘要生成逻辑，对每个 chunk 使用一次结构化的 LLM 调用，并加入重试机制、情景类型规范化以及并行 chunk 处理。
- 在写入流水线中并行化文件预处理和运行时步骤，使知识抽取、摘要生成、Neo4j 写入和统计缓存更新可以重叠进行。
- 在裁剪服务中复用外部提供的 LLM 客户端和共享的 `SemanticPruner` 实例，避免对每条消息进行客户端初始化并提升并发安全性。
- 收紧 Neo4j 写入错误处理逻辑，对于反复出现的部分失败不再仅记录日志，而是直接抛出异常。
- 将摘要步骤内联到主写入流水线流程中，移除单独的 `_summarize` 辅助函数，并统一步骤编号。

Documentation:
- 记录 Neo4j 记忆摘要提示的行为和输出契约，说明组合式标题/类型/摘要生成的规范。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize episodic memory summarization by combining LLM title/type/summary generation, parallelizing preprocessing and storage steps, and integrating Neo4j summary persistence with improved pruning client reuse.

New Features:
- Introduce a combined episodic memory response model that returns title, type, and summary in a single LLM call for Neo4j memory summaries.
- Add a dedicated neo4j memory summary prompt template and renderer for unified title/type/summary generation.

Enhancements:
- Refactor memory summary generation to use a single structured LLM call per chunk with retry logic, episodic type normalization, and parallel chunk processing.
- Parallelize file preprocessing and run-time steps in the write pipeline, overlapping knowledge extraction, summary generation, Neo4j writes, and stats cache updates.
- Reuse an externally provided LLM client and shared SemanticPruner instance in the pruning service to avoid per-message client initialization and improve concurrency safety.
- Tighten Neo4j write error handling to raise on repeated partial failures instead of silently logging.
- Inline the summarization step into the main write pipeline flow, removing the separate _summarize helper and aligning step numbering.

Documentation:
- Document the neo4j memory summary prompt behavior and output contract for combined title/type/summary generation.

</details>