### PR TITLE
Feature/memory activity zy

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -159,19 +159,19 @@ export const generateSuggestions = (end_user_id: string) => {
 export const analyticsRefresh = (end_user_id: string) => {
   return request.post('/memory/analytics/generate_cache', { end_user_id })
 }
-// 遗忘记忆配额表
+// Forgetting memory quota table
 export const getForgetMemoryQuota = (end_user_id: string | string) => {
   return request.get(`/memory/forget-memory/${end_user_id}/memory_quota`)
 }
-// 仅7日遗忘趋势
+// Seven-day forgetting trend
 export const getForgetMemoryTrend = (end_user_id: string) => {
   return request.get(`/memory/forget-memory/${end_user_id}/forgetting_trend`)
 }
-// 遗忘候选
+// Forgetting candidates
 export const getForgetMemoryCandidatesUrl = (end_user_id: string) => `/memory/forget-memory/${end_user_id}/forgetting_candidates`
-// 遗忘记录
+// Forgotten records
 export const getForgetMemoryLogsUrl = (end_user_id: string) => `/memory/forget-memory/${end_user_id}/forgotten_logs`
-// 刷新（清除遗忘缓存）
+// Refresh and clear the forgetting cache
 export const refreshForgetMemoryCache = (end_user_id: string) => {
   return request.post(`/memory/forget-memory/${end_user_id}/refresh_cache`)
 }
@@ -379,10 +379,23 @@ export const getMemoryReflectionLogs = (end_user_id: string) => {
 }
 
 /*************** end Memory Management APIs ******************************/
-
-
-/****************** API Parameters APIs *******************************/
-export const getMemoryApi = () => {
-  return request.get('/memory/docs/api')
+// Get written memory activity records
+export const getMemoryActivityWrittenUrl = '/memory-display/written';
+export const getMemoryActivityWritten = (data: { end_user_id: string; page?: number; pagesize?: number; }) => {
+  return request.get(getMemoryActivityWrittenUrl, data)
 }
-/*************** end API Parameters APIs ******************************/
+// Get read memory activity records
+export const getMemoryActivityReadUrl = '/memory-activity/read';
+export const getMemoryActivityRead = (data: { end_user_id: string; page?: number; pagesize?: number; }) => {
+  return request.get(getMemoryActivityReadUrl, data)
+}
+// Get engine memory activity records
+export const getMemoryActivityEngineUrl = '/memory-display/engines';
+export const getMemoryActivityEngine = (data: { end_user_id: string; page?: number; pagesize?: number; }) => {
+  return request.get(getMemoryActivityEngineUrl, data)
+}
+// Get all memory activity records
+export const getMemoryActivityUrl = '/memory-activity/all';
+export const getMemoryActivity = (data: { end_user_id: string; page?: number; pagesize?: number; }) => {
+  return request.get(getMemoryActivityUrl, data)
+}

--- a/web/src/components/PageScrollList/index.tsx
+++ b/web/src/components/PageScrollList/index.tsx
@@ -49,6 +49,8 @@ interface PageScrollListProps<T, Q = Record<string, unknown>> {
   url: string;
   /** Function to render each list item */
   renderItem: (item: T, index: number) => React.ReactNode;
+  /** Optional renderer that receives all currently loaded items */
+  renderItems?: (items: T[]) => React.ReactNode;
   /** Query parameters for API request */
   query?: Q;
   /** Number of columns in grid layout */
@@ -59,6 +61,7 @@ interface PageScrollListProps<T, Q = Record<string, unknown>> {
   heightClass?: string;
   gutter?: [number, number] | number;
   onTotalChange?: (total: number) => void;
+  empty?: React.ReactNode;
 }
 
 const defaultHeightClass = 'rb:h-[calc(100vh-118px)]!';
@@ -66,6 +69,7 @@ const defaultHeightClass = 'rb:h-[calc(100vh-118px)]!';
 /** Infinite scroll list component with pagination support */
 const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   renderItem,
+  renderItems,
   query,
   url,
   column = 4,
@@ -74,6 +78,7 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   heightClass,
   gutter = [12, 12],
   onTotalChange,
+  empty,
 }: PageScrollListProps<T, Q>, ref: React.Ref<PageScrollListRef>) => {
   /** Expose refresh method to parent component */
   useImperativeHandle(ref, () => ({
@@ -162,16 +167,18 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
         >
           {/* Render grid list or empty state */}
           {data.length > 0 ? (
-            <Row
-              gutter={gutter}
-            >
-              {data.map((item, index) => (
-                <Col key={(item as any).id || index} span={24/column}>
-                  {renderItem(item, index)}
-                </Col>
-              ))}
-            </Row>
-          ) : !loading ? <PageEmpty className={heightClass || defaultHeightClass} /> : null}
+            renderItems
+            ? renderItems(data)
+            : (
+              <Row gutter={gutter}>
+                {data.map((item, index) => (
+                  <Col key={(item as any).id || index} span={24/column}>
+                    {renderItem(item, index)}
+                  </Col>
+                ))}
+              </Row>
+            )
+          ) : !loading ? empty || <PageEmpty className={heightClass || defaultHeightClass} /> : null}
         </InfiniteScroll>
       </div>
     </>

--- a/web/src/components/PageTabs/index.tsx
+++ b/web/src/components/PageTabs/index.tsx
@@ -23,13 +23,17 @@ import { Segmented, type SegmentedProps } from 'antd';
 const PageTabs: FC<SegmentedProps> = ({
   value,
   options,
-  onChange
+  onChange,
+  size = "middle",
+  className = '',
+  ...props
 }) => {
   return <Segmented
     value={value}
     options={options}
     onChange={onChange}
-    className="pageTabs"
+    className={`pageTabs ${size} ${className}`}
+    {...props}
   />;
 };
 

--- a/web/src/components/SliderInput/index.tsx
+++ b/web/src/components/SliderInput/index.tsx
@@ -17,7 +17,7 @@
  * @component
  */
 
-import { useState, useEffect, type FC } from 'react';
+import { useState, useEffect, type FC, type ReactNode } from 'react';
 import { Slider, InputNumber, Row, Col } from 'antd';
 
 /** Props interface for SliderInput component */
@@ -37,7 +37,7 @@ interface SliderInputProps {
   /** Whether the component is disabled */
   disabled?: boolean;
   /** Optional label text */
-  label?: string;
+  label?: string | ReactNode;
   /** Additional CSS classes for container */
   className?: string;
   /** Additional CSS classes for slider */

--- a/web/src/components/Tag/index.tsx
+++ b/web/src/components/Tag/index.tsx
@@ -26,6 +26,7 @@ export interface TagProps {
   variant?: 'outline' | 'borderless'
   onClick?: () => void;
   circle?: boolean;
+  size?: 'small' | 'default';
 }
 
 /** Color theme mappings with text, border, and background colors */
@@ -40,10 +41,10 @@ const colors = {
 }
 
 /** Custom tag component with color themes */
-const Tag: FC<TagProps> = ({ color = 'processing', children, className, variant = 'outline', circle, onClick }) => {
+const Tag: FC<TagProps> = ({ color = 'processing', children, className, variant = 'outline', circle, onClick, size = 'default' }) => {
   return (
     <span onClick={onClick}
-      className={`rb:inline-block rb:px-1 rb:py-0.5 ${circle ? 'rb:rounded-full': 'rb:rounded-sm'} rb:text-[12px] rb:font-regular! rb:leading-4 rb:border ${colors[color]} ${className || ''} ${variant === 'borderless' ? 'rb:border-none!' : ''}`}>
+      className={`rb:inline-block rb:px-1 ${circle ? 'rb:rounded-full': 'rb:rounded-sm'} ${size === 'default' ? 'rb:text-[12px] rb:py-0.5' : 'rb:text-[10px]'} rb:font-regular! rb:leading-4 rb:border ${colors[color]} ${className || ''} ${variant === 'borderless' ? 'rb:border-none!' : ''}`}>
       {children}
     </span>
   )

--- a/web/src/i18n/en/applicationPart1.ts
+++ b/web/src/i18n/en/applicationPart1.ts
@@ -371,6 +371,8 @@ export const applicationPart1 = {
       text_to_speech: 'Text to Speech',
       text_to_speech_desc: 'Text can be converted to speech',
       suggested_questions_after_answer: 'Suggested Questions After Answer',
+      emotion_reply: 'Emotion-Aware Replies',
+      emotion_reply_desc: "Detect the emotion in the user's current message and adjust the reply's tone, structure, and information priority accordingly",
       opening_statement: 'Conversation Opening',
       opening_statement_desc: 'Set the conversation opening content',
       editOpeningStatement: 'Edit Opening Statement',

--- a/web/src/i18n/en/detail.ts
+++ b/web/src/i18n/en/detail.ts
@@ -61,7 +61,8 @@ export const detail = {
     episodicDetail: {
       title: 'Record every important scene you have truly experienced',
       total_all: 'Total Episodic Memories',
-      all: "All",
+      all: 'All Time',
+      allType: 'All Types',
       today: 'Today',
       this_week: 'This Week',
       this_month: 'This Month',

--- a/web/src/i18n/en/knowledgeBase.ts
+++ b/web/src/i18n/en/knowledgeBase.ts
@@ -228,6 +228,8 @@ export const knowledgeBase = {
       delimiter:'Text paragraph delimiter',
       customDelimiterPlaceholder: 'Please enter the delimiter',
       suggestedBlockSize:'Suggested text block size',
+      chunkOverlap: 'Chunk overlap size',
+      chunkOverlapRange: 'Chunk overlap size must be greater than 0 and less than the text block size',
       insertContent: 'Insert Content',
       editContent:'Edit Content',
       insertContentPlaceholder: 'Please enter the content',

--- a/web/src/i18n/en/userMemory.ts
+++ b/web/src/i18n/en/userMemory.ts
@@ -276,5 +276,18 @@ export const userMemory = {
       normal: 'Normal',
       userTag: 'User Tag',
       noTags: 'No tags',
+
+      memoryActivity: 'Memory Activity',
+      memoryActivitySubtitle: 'Memory read, write, and engine processing records',
+      activityDateToday: 'Today',
+      activityDateYesterday: 'Yesterday',
+      activityDateEarlier: 'Earlier',
+      activityFilterAll: 'All',
+      activityFilterEngine: 'Engine',
+      activityFilterRead: 'Read',
+      activityFilterWrite: 'Write',
+      EXTRACTION: 'Memory Extraction Engine',
+      CROSS_MODAL: 'Cross-modal Memory Association Engine',
+      EMOTION: 'Emotion Engine',
     },
 }

--- a/web/src/i18n/zh/applicationPart1.ts
+++ b/web/src/i18n/zh/applicationPart1.ts
@@ -369,6 +369,8 @@ export const applicationPart1 = {
       text_to_speech: '文字转语音',
       text_to_speech_desc: '文本可以转换成语音',
       suggested_questions_after_answer: '回答后建议问题',
+      emotion_reply: '情绪感知回复',
+      emotion_reply_desc: '识别用户当前消息的情绪，调整回复的语气、结构和信息优先级',
       opening_statement: '对话开场白',
       opening_statement_desc: '设置对话开场白内容',
       editOpeningStatement: '编辑开场白',

--- a/web/src/i18n/zh/detail.ts
+++ b/web/src/i18n/zh/detail.ts
@@ -61,7 +61,8 @@ export const detail = {
     episodicDetail: {
       title: '记录你真实经历过的每一个重要场景',
       total_all: '情景记忆总数',
-      all: "全部",
+      all: "全部时间",
+      allType: '全部类型',
       today: '今天',
       this_week: '本周',
       this_month: '本月',

--- a/web/src/i18n/zh/knowledgeBase.ts
+++ b/web/src/i18n/zh/knowledgeBase.ts
@@ -227,6 +227,8 @@ export const knowledgeBase = {
       delimiter: '文本段落分隔符',
       customDelimiterPlaceholder: '请输入分隔符',
       suggestedBlockSize: '建议文本块大小',
+      chunkOverlap: '分块重叠大小',
+      chunkOverlapRange: '分块重叠大小必须大于 0 且小于文本块大小',
       insertContent: '插入内容',
       editContent: '编辑内容',
       insertContentPlaceholder: '请输入内容',

--- a/web/src/i18n/zh/userMemory.ts
+++ b/web/src/i18n/zh/userMemory.ts
@@ -277,5 +277,18 @@ export const userMemory = {
       normal: '常规',
       userTag: '用户标签',
       noTags: '暂无标签',
+
+      memoryActivity: '记忆活动',
+      memoryActivitySubtitle: '记忆读写与引擎处理记录',
+      activityDateToday: '今天',
+      activityDateYesterday: '昨天',
+      activityDateEarlier: '更早',
+      activityFilterAll: '全部',
+      activityFilterEngine: '引擎',
+      activityFilterRead: '读取',
+      activityFilterWrite: '写入',
+      EXTRACTION: "记忆萃取引擎",
+      CROSS_MODAL: "跨模态记忆关联联想引擎",
+      EMOTION: "情感引擎",
     },
 }

--- a/web/src/styles/antd.css
+++ b/web/src/styles/antd.css
@@ -323,6 +323,22 @@
   box-shadow: 0px 2px 4px 0px rgba(33, 35, 50, 0.16);
 }
 
+.pageTabs.small.ant-segmented {
+  padding: 4px;
+  margin-left: 4px;
+}
+
+.pageTabs.small.ant-segmented .ant-segmented-item-label {
+  line-height: 24px;
+  min-height: 24px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
+.pageTabs.small.ant-segmented .ant-segmented-item-selected {
+  box-shadow: 0px 2px 4px 0px rgba(33, 35, 50, 0.16);
+}
+
 .ant-app {
   height: 100%;
 }

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -81,7 +81,9 @@ service.interceptors.request.use(
       }
     }
     const language = localStorage.getItem('language')
+    const timeZone = localStorage.getItem('timeZone')
     config.headers['X-Language-Type'] = language || 'en';
+    config.headers['X-Timezone'] = timeZone || 'Asia/Shanghai'
     config.headers.Cookie = undefined
     return config;
   },

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
@@ -171,11 +171,19 @@ const FeaturesConfigModal = forwardRef<FeaturesConfigModalRef, FeaturesConfigMod
                   desc={t('application.text_to_speech_desc')}
                 />
               </div>
-              {/* suggested_questions_after_answer */}
+
               <div className="rb:relative rb:border rb:border-[#DFE4ED] rb:p-3 rb:rounded-lg rb:bg-[#f5f7fc]">
                 <SwitchFormItem
                   title={t('application.suggested_questions_after_answer')}
                   name={['suggested_questions_after_answer', "enabled"]}
+                />
+              </div>
+
+              <div className="rb:relative rb:border rb:border-[#DFE4ED] rb:p-3 rb:rounded-lg rb:bg-[#f5f7fc]">
+                <SwitchFormItem
+                  title={t('application.emotion_reply')}
+                  desc={t('application.emotion_reply_desc')}
+                  name={['emotion_reply', "enabled"]}
                 />
               </div>
             </>}

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset.tsx
@@ -95,6 +95,7 @@ const CreateDataset = () => {
   const pollingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [delimiter, setDelimiter] = useState<string | undefined>(undefined);
   const [blockSize, setBlockSize] = useState<number>(512);
+  const [chunkOverlap, setChunkOverlap] = useState<number>(52);
   const [qaPrompt, setQaPrompt] = useState<string | undefined>()
   console.log('qaPrompt', qaPrompt)
   const [processingMethod, setProcessingMethod] = useState<ProcessingMethod>('directBlock');
@@ -158,14 +159,23 @@ const CreateDataset = () => {
     
     // 从参数设置进入确认上传时的处理
     if(current === 1 && nextStep === 2) {
+      if (
+        processingMethod === 'directBlock' &&
+        (!Number.isInteger(chunkOverlap) || chunkOverlap <= 0 || chunkOverlap >= blockSize)
+      ) {
+        messageApi.warning(t('knowledgeBase.chunkOverlapRange'));
+        return;
+      }
+
       // debugger
         // handlePreview(data[0],0) 
-        if(parameterSettings === 'customSettings' || processingMethod === 'qaExtract' || pdfEnhancementEnabled){
+        if(parameterSettings === 'customSettings' || processingMethod === 'qaExtract' || processingMethod === 'directBlock' || pdfEnhancementEnabled){
             rechunkFileIds.map((id) => {
               let parser_config = {
                 layout_recognize: pdfEnhancementMethod || 'DeepDOC',
                 delimiter: delimiter,
                 chunk_token_num: blockSize,
+                chunk_overlap: processingMethod === 'directBlock' ? chunkOverlap : undefined,
                 auto_questions: processingMethod === 'parentChildBlock' || processingMethod === 'directBlock' ? 0 : 1,
                 qa_prompt: qaPrompt,
               }
@@ -540,7 +550,15 @@ const CreateDataset = () => {
   const handleChange = (value: number | null) =>{
       if (value !== null) {
         setBlockSize(value);
+        if (processingMethod === 'directBlock' && chunkOverlap >= value) {
+          setChunkOverlap(Math.max(1, value - 1));
+        }
       }
+  }
+  const handleChunkOverlapChange = (value: number | null) => {
+    if (value !== null) {
+      setChunkOverlap(value);
+    }
   }
   // 删除已上传的文件
   const handleDeleteFile = async (fileId: string) => {
@@ -612,6 +630,7 @@ const CreateDataset = () => {
   const handleChangeProcessingMethod = (method: ProcessingMethod) => {
     if (method === 'directBlock') {
       setBlockSize(512)
+      setChunkOverlap(52)
     }
     setProcessingMethod(method)
   }
@@ -851,14 +870,34 @@ const CreateDataset = () => {
                   </Radio>
               </Radio.Group>
               {parameterSettings === 'customSettings' && processingMethod !== 'parentChildBlock' && (<>
-                <div className='rb:grid rb:grid-cols-2 rb:mt-5 rb-border rb:rounded-xl rb:px-6 rb:py-4 rb:gap-10'> 
+                <div className='rb:grid rb:grid-cols-3 rb:mt-5 rb-border rb:rounded-xl rb:px-6 rb:py-4 rb:gap-10'> 
                   <div>
                     <div className='rb:w-full rb:text-[#5B6167] rb:leading-5 rb:mb-2'>
                       {t('knowledgeBase.delimiter')}
                     </div>
                     <DelimiterSelector value={delimiter} onChange={setDelimiter} />
                   </div>
-                  <SliderInput label={t('knowledgeBase.suggestedBlockSize')} max={1024} min={1} step={1} value={blockSize} onChange={handleChange} />
+                  <SliderInput
+                    label={t('knowledgeBase.suggestedBlockSize')}
+                    max={1024}
+                    min={processingMethod === 'directBlock' ? 2 : 1}
+                    step={1}
+                    value={blockSize}
+                    onChange={handleChange}
+                  />
+                  {processingMethod === 'directBlock' && (
+                    <SliderInput
+                      label={<span>
+                        <span className="rb:text-[#ff5d34] rb:mr-1">*</span>
+                        {t('knowledgeBase.chunkOverlap')}
+                      </span>}
+                      max={blockSize - 1}
+                      min={1}
+                      step={1}
+                      value={chunkOverlap}
+                      onChange={handleChunkOverlapChange}
+                    />
+                  )}
                 </div>
                 {processingMethod === 'qaExtract' && (
                 <div>

--- a/web/src/views/UserMemoryDetail/Neo4j.tsx
+++ b/web/src/views/UserMemoryDetail/Neo4j.tsx
@@ -30,6 +30,7 @@ import { useI18n } from '@/store/locale'
 import PrivateWrap from '@/components/PrivateWrap'
 import { BrainView, ReflectMemory, type ReflectMemoryRef } from '@redbear/memory-brick'
 import { request } from '@/utils/request'
+import MemoryActivity from './components/MemoryActivity'
 
 const Neo4j: FC = () => {
   const { id } = useParams()
@@ -214,7 +215,7 @@ const Neo4j: FC = () => {
           </Flex>
         </Flex>
 
-        <Flex vertical className="rb:flex-1">
+        <Flex vertical className="rb:flex-1 rb:min-w-0">
           <NodeStatistics ref={nodeStatisticsRef} highlightKeys={brainMemories} />
           <RelationshipNetwork
             regionId={regionId}
@@ -228,6 +229,7 @@ const Neo4j: FC = () => {
             }}
           />
         </Flex>
+        <MemoryActivity className="rb:w-70 rb:shrink-0" />
       </Flex>
       <div onClick={(e) => e.stopPropagation()}>
         <EndUserProfile ref={ref} onDataLoaded={handleNameUpdate} className={selectedKey === 'userProfile' ? 'rb:block!' : 'rb:hidden!'} />

--- a/web/src/views/UserMemoryDetail/components/MemoryActivity/constants.ts
+++ b/web/src/views/UserMemoryDetail/components/MemoryActivity/constants.ts
@@ -1,0 +1,64 @@
+import {
+  BookOutlined,
+  BulbOutlined,
+  DatabaseOutlined,
+  EyeOutlined,
+  LaptopOutlined,
+  MessageOutlined,
+  StarOutlined,
+  ThunderboltOutlined,
+} from '@ant-design/icons'
+
+import {
+  getMemoryActivityEngineUrl,
+  getMemoryActivityReadUrl,
+  getMemoryActivityUrl,
+  getMemoryActivityWrittenUrl,
+} from '@/api/memory'
+import { isPrivateAvailable } from '@/utils/private'
+import type { ActivityDateGroup, ActivityFilter, ActivityType, MemoryType } from './types'
+
+export const activityDateGroups: ActivityDateGroup[] = ['today', 'yesterday', 'earlier']
+
+export const activityDateLabelKeys: Record<ActivityDateGroup, string> = {
+  today: 'activityDateToday',
+  yesterday: 'activityDateYesterday',
+  earlier: 'activityDateEarlier',
+}
+console.log('isPrivateAvailable', isPrivateAvailable)
+export const filterKeys: ActivityFilter[] = (
+  [
+    // 'all',
+    'engine',
+    // 'read',
+    'write',
+  ] satisfies ActivityFilter[]
+).filter((key) => (!isPrivateAvailable && key !== 'engine') || isPrivateAvailable)
+
+export const filterLabelKeys: Record<ActivityFilter, string> = {
+  all: 'activityFilterAll',
+  engine: 'activityFilterEngine',
+  read: 'activityFilterRead',
+  write: 'activityFilterWrite',
+}
+
+export const activityUrls: Record<ActivityFilter, string> = {
+  all: getMemoryActivityUrl,
+  engine: getMemoryActivityEngineUrl,
+  read: getMemoryActivityReadUrl,
+  write: getMemoryActivityWrittenUrl,
+}
+
+export const activityIcons: Record<ActivityType, typeof DatabaseOutlined> = {
+  write: DatabaseOutlined,
+  read: EyeOutlined,
+  engine: ThunderboltOutlined,
+}
+
+export const memoryTypeIcons: Record<MemoryType, typeof DatabaseOutlined> = {
+  conversation: MessageOutlined,
+  project_work: LaptopOutlined,
+  learning: BookOutlined,
+  decision: BulbOutlined,
+  important_event: StarOutlined,
+}

--- a/web/src/views/UserMemoryDetail/components/MemoryActivity/index.tsx
+++ b/web/src/views/UserMemoryDetail/components/MemoryActivity/index.tsx
@@ -1,0 +1,192 @@
+import { type FC, useState } from 'react'
+import { Flex, Tooltip, type SegmentedProps } from 'antd'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import clsx from 'clsx'
+
+import PageScrollList from '@/components/PageScrollList'
+import Empty from '@/components/Empty'
+import { useI18n } from '@/store/locale'
+import { formatDateTime } from '@/utils/format'
+import { TAG_COLORS } from '../../pages/EpisodicDetail'
+import Tag from '@/components/Tag'
+import PageTabs from '@/components/PageTabs'
+import {
+  activityDateGroups,
+  activityDateLabelKeys,
+  activityIcons,
+  activityUrls,
+  filterKeys,
+  filterLabelKeys,
+  memoryTypeIcons,
+} from './constants'
+import { getActivityDateGroup } from './utils'
+import type {
+  ActivityFilter,
+  ActivityQuery,
+  ActivityRecord,
+  ActivityType,
+  MemoryActivityProps,
+} from './types'
+
+const MemoryActivity: FC<MemoryActivityProps> = ({ className }) => {
+  const { id } = useParams()
+  const { t } = useTranslation()
+  const { language, changeLanguage, timeZone } = useI18n()
+  const [filter, setFilter] = useState<ActivityFilter>(filterKeys[0])
+  const [total, setTotal] = useState(0)
+
+  const handleFilterChange = (nextFilter: SegmentedProps['value']) => {
+    if (nextFilter === filter) return
+    setTotal(0)
+    setFilter(nextFilter as ActivityFilter)
+  }
+
+  const renderActivity = (record: ActivityRecord) => {
+    const activityType: ActivityType = record.engine_type
+      ? 'engine'
+      : 'write'
+    const ActivityIcon = record.memory_type
+      ? memoryTypeIcons[record.memory_type]
+      : activityIcons[activityType]
+
+    return (
+      <Flex gap={12} align="center" className="rb:rounded-xl rb:bg-white rb:p-3! rb:shadow-[0_1px_2px_rgba(0,0,0,0.05)] rb:transition-[background-color,box-shadow] rb:hover:bg-[#FAFAFC] rb:hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]">
+        <div
+          className={clsx('rb:flex rb:size-7.5 rb:items-center rb:justify-center rb:rounded-lg rb:text-[14px]', {
+            'rb:bg-gray-900 rb:text-white': activityType === 'engine',
+            // 'rb:bg-gray-50 rb:text-gray-400': activityType === 'read',
+            'rb:bg-gray-200 rb:text-gray-600': activityType === 'write',
+          })}
+          title={record.memory_type
+            ? t(`episodicDetail.${record.memory_type}`)
+            : t(`userMemory.${filterLabelKeys[activityType]}`)}
+        >
+          <ActivityIcon />
+        </div>
+
+        <Flex vertical gap={4} className="rb:min-w-0 rb:flex-1 rb:shrink-0">
+          <Tooltip title={record.name || '-'} placement="topLeft">
+            <Flex align="center" justify="space-between" gap={10} className="rb:min-w-0 rb:truncate rb:text-[12px] rb:leading-4.5 rb:font-medium">
+              {record.name || '-'}
+            </Flex>
+          </Tooltip>
+
+          <Tooltip title={record.content || '-'} placement="topLeft">
+            <div className="rb:line-clamp-2 rb:text-[10px] rb:leading-4.25 rb:text-gray-600">
+              {record.content || '-'}
+            </div>
+          </Tooltip>
+
+          <Flex align="center" justify="space-between" gap={10} className="rb:text-[10px] rb:leading-4 rb:text-gray-400">
+            <span className="rb:shrink-0">
+              {formatDateTime(record.occurred_at, 'HH:mm') || '-'}
+            </span>
+            {record.memory_type &&
+              <Tag size="small" color={TAG_COLORS[record.memory_type]} className="rb:shrink-0!">{t(`episodicDetail.${record.memory_type}`)}</Tag>
+            }
+            {record.engine_type &&
+              <Tag size="small" color="default" className="rb:shrink-0!">{t(`userMemory.${record.engine_type}`)}</Tag>
+            }
+          </Flex>
+        </Flex>
+      </Flex>
+    )
+  }
+
+  const renderGroupedActivities = (records: ActivityRecord[]) => {
+    const groups = activityDateGroups
+      .map(group => ({
+        group,
+        records: records.filter(record => getActivityDateGroup(record.occurred_at, timeZone) === group),
+      }))
+      .filter(({ records: groupRecords }) => groupRecords.length > 0)
+
+    return (
+      <Flex vertical gap={16}>
+        {groups.map(({ group, records: groupRecords }) => (
+          <section key={group}>
+            <Flex align="center" justify="space-between" className="rb:px-2! rb:pb-1.5!">
+              <span className="rb:text-[11px] rb:font-medium rb:text-gray-600">
+                {t(`userMemory.${activityDateLabelKeys[group]}`)}
+              </span>
+              <span className="rb:text-[10px] rb:tabular-nums rb:text-gray-400">
+                {groupRecords.length}
+              </span>
+            </Flex>
+            <Flex vertical gap={8}>
+              {groupRecords.map(record => (
+                <div key={record.id}>{renderActivity(record)}</div>
+              ))}
+            </Flex>
+          </section>
+        ))}
+      </Flex>
+    )
+  }
+
+  return (
+    <Flex vertical className={clsx('rb:h-full rb:min-h-0 rb:overflow-hidden rb:bg-[#F5F6F6] rb:rounded-xl rb:p-3!', className)}>
+      <header className="rb:pt-2 rb:pb-3">
+        <Flex align="center" justify="space-between" gap={16} className="rb:pl-1! rb:pr-2!">
+          <div className="rb:text-[16px] rb:leading-6 rb:font-bold rb:font-[MiSans-Bold] rb:tracking-normal">{t('userMemory.memoryActivity')}</div>
+
+          <Flex align="center" gap={8} className="rb:mt-0.5 rb:shrink-0">
+            <div className="rb:inline-flex rb:items-center rb:rounded-full rb:bg-gray-200 rb:p-0.5!">
+              {(['zh', 'en'] as const).map(lng => (
+                <button
+                  key={lng}
+                  type="button"
+                  className={clsx('rb:h-6 rb:cursor-pointer rb:rounded-full rb:border-0 rb:px-2.5! rb:text-[11px] rb:font-medium rb:transition-colors', language === lng
+                    ? 'rb:bg-white rb:shadow-[0_1px_2px_rgba(0,0,0,0.12)]'
+                    : 'rb:bg-transparent rb:text-gray-400 rb:hover:text-gray-900')}
+                  onClick={() => changeLanguage(lng)}
+                >
+                  {lng === 'zh' ? '中' : 'EN'}
+                </button>
+              ))}
+            </div>
+            <span className="rb:text-[12px] rb:font-bold rb:font-[MiSans-Bold] rb:tabular-nums rb:text-gray-600">{total}</span>
+          </Flex>
+        </Flex>
+        <div className="rb:pl-1 rb:mt-0.5 rb:text-[12px] rb:leading-4 rb:text-gray-600">{t('userMemory.memoryActivitySubtitle')}</div>
+
+        {filterKeys.length > 1 
+          ? <PageTabs
+            value={filter}
+            options={filterKeys
+              .map(value => ({
+                value,
+                label: t(`userMemory.${filterLabelKeys[value]}`)
+              }))}
+            onChange={handleFilterChange}
+            size="small"
+            block
+            className="rb:mt-2!"
+          />
+          : null
+        }
+      </header>
+
+      <div className="rb:min-h-0 rb:flex-1">
+        {id && (
+          <PageScrollList<ActivityRecord, ActivityQuery>
+            key={`${id}-${filter}`}
+            url={activityUrls[filter]}
+            query={{ end_user_id: id }}
+            column={1}
+            gutter={[0, 8]}
+            heightClass="rb:h-full!"
+            onTotalChange={setTotal}
+            renderItem={renderActivity}
+            renderItems={renderGroupedActivities}
+            empty={<Empty size={88} className="rb:h-[calc(100vh-166px)]!" />}
+            needLoading={false}
+          />
+        )}
+      </div>
+    </Flex>
+  )
+}
+
+export default MemoryActivity

--- a/web/src/views/UserMemoryDetail/components/MemoryActivity/types.ts
+++ b/web/src/views/UserMemoryDetail/components/MemoryActivity/types.ts
@@ -1,0 +1,27 @@
+export type ActivityType = 'write' | 'read' | 'engine';
+
+export type ActivityFilter = 'all' | ActivityType;
+
+export type ActivityDateGroup = 'today' | 'yesterday' | 'earlier';
+
+export type MemoryType = 'conversation' | 'project_work' | 'learning' | 'decision' | 'important_event';
+
+export type EngineType = 'EXTRACTION' | 'CROSS_MODAL' | 'EMOTION';
+export interface MemoryActivityProps {
+  className?: string
+}
+
+
+export interface ActivityRecord {
+  id: string
+  memory_id: string
+  memory_type?: MemoryType
+  engine_type?: EngineType;
+  name: string
+  content: string
+  occurred_at: number
+}
+
+export interface ActivityQuery {
+  end_user_id: string
+}

--- a/web/src/views/UserMemoryDetail/components/MemoryActivity/utils.ts
+++ b/web/src/views/UserMemoryDetail/components/MemoryActivity/utils.ts
@@ -1,0 +1,20 @@
+import dayjs from 'dayjs';
+import type { ActivityDateGroup } from './types'
+
+const DEFAULT_TIME_ZONE = 'Asia/Shanghai'
+
+export const getActivityDateGroup = (
+  occurredAt: number,
+  timeZone: string = DEFAULT_TIME_ZONE
+): ActivityDateGroup => {
+  const timestamp = occurredAt < 1_000_000_000_000 ? occurredAt * 1000 : occurredAt
+  const occurredDate = dayjs(timestamp)
+  if (!occurredDate.isValid()) return 'earlier'
+
+  const zonedOccurredDate = occurredDate.tz(timeZone)
+  const zonedToday = dayjs().tz(timeZone)
+
+  if (zonedOccurredDate.isSame(zonedToday, 'day')) return 'today'
+  if (zonedOccurredDate.isSame(zonedToday.subtract(1, 'day'), 'day')) return 'yesterday'
+  return 'earlier'
+}

--- a/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
+++ b/web/src/views/UserMemoryDetail/components/NodeStatistics.tsx
@@ -83,16 +83,14 @@ const NodeStatistics = forwardRef<NodeStatisticsRef, { highlightKeys?: string[] 
         justify="space-between"
         className={clsx(
           "rb:h-full rb:group rb:cursor-pointer rb:bg-[#FFFFFF]",{
-            'rb:rounded-xl rb:shaodow-[0px_2px_6px_0px_rgba(33,35,50,0.08)] rb:p-3!': !isChild,
+            'rb:rounded-xl rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.08)] rb:p-3!': !isChild,
             'rb:px-3! rb:pt-2! rb:pb-2.5! rb:w-full': isChild
           }
         )}
         onClick={() => handleViewDetail(key)}
       >
-        <div>
-          <div className={clsx("rb:leading-5 rb:font-regular", isHighlighted ? 'rb:text-[#155EEF]' : 'rb:text-[#5B6167]')}>
-            {t(`userMemory.${key}`)}
-          </div>
+        <div className={clsx("rb:leading-5 rb:font-regular", isHighlighted ? 'rb:text-[#155EEF]' : 'rb:text-[#5B6167]')}>
+          {t(`userMemory.${key}`)}
         </div>
         <Flex justify="space-between" align="center">
           <div className={clsx("rb:text-[24px] rb:leading-8 rb:font-extrabold rb:font-[MiSans-Heavy]", isHighlighted && 'rb:text-[#155EEF]')}>{item?.count ?? 0}</div>
@@ -106,7 +104,7 @@ const NodeStatistics = forwardRef<NodeStatisticsRef, { highlightKeys?: string[] 
   }))
 
   return (
-    <div className="rb:h-22">
+    <div>
       {loading
         ? <Skeleton active />
         : <div className="rb:w-full rb:grid rb:grid-cols-8 rb:gap-3 rb:h-full">
@@ -115,8 +113,8 @@ const NodeStatistics = forwardRef<NodeStatisticsRef, { highlightKeys?: string[] 
               return <div key={vo.key} className="rb:h-full">{renderCard(vo.key)}</div>
             }
             return (
-              <div key={vo.key} className={clsx("rb:col-span-3 rb:shaodow-[0px_2px_6px_0px_rgba(33,35,50,0.08)] rb:rounded-xl rb:bg-[#FFFFFF] rb:overflow-hidden")}>
-                <div className="rb:w-[136px] rb:h-5 rb:text-xs rb:text-[#171719] rb:py-[2px] rb:font-medium rb:text-center rb:rounded-tl-xl  rb:rounded-br-xl"
+              <div key={vo.key} className={clsx("rb:col-span-3 rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.08)] rb:rounded-xl rb:bg-[#FFFFFF] rb:overflow-hidden")}>
+                <div className="rb:w-34 rb:h-5 rb:text-xs rb:text-[#171719] rb:py-0.5 rb:font-medium rb:text-center rb:rounded-tl-xl  rb:rounded-br-xl"
                   style={{ background: 'linear-gradient( 90deg, #F0E3FE 0%, #D1E7FF 100%)' }}
                 >{t(`userMemory.${vo.key}`)}</div>
                 <div className="rb:grid rb:grid-cols-3">

--- a/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/EpisodicDetail.tsx
@@ -50,7 +50,7 @@ interface EpisodicMemoryDetail {
 }
 
 /** Maps episodic type keys to Ant Design Tag color presets. */
-const TAG_COLORS: Record<string, "processing" | "success" | "warning" | "error" | "default"> = {
+export const TAG_COLORS: Record<string, "processing" | "success" | "warning" | "error" | "default"> = {
   conversation: "processing",
   project_work: "success",
   learning: "warning",
@@ -181,7 +181,7 @@ const EpisodicDetail: FC = () => {
                   <Select
                     placeholder={t('common.pleaseSelect')}
                     options={[
-                      { value: 'all', label: t('episodicDetail.all') },
+                      { value: 'all', label: t('episodicDetail.allType') },
                       { value: 'conversation', label: t('episodicDetail.conversation') },
                       { value: 'project_work', label: t('episodicDetail.project_work') },
                       { value: 'learning', label: t('episodicDetail.learning') },


### PR DESCRIPTION
## Summary by Sourcery

在用户记忆详情视图中添加记忆活动面板，增强数据集分块控制，并扩展配置和 UI 组件，以支持新的活动、情绪和布局功能。

新功能：
- 在用户记忆详情页中引入记忆活动侧边栏，展示按类别分组的读取、写入和引擎处理记录，并支持筛选和本地化。
- 在创建知识库数据集时，为使用直接块处理模式添加文本块重叠配置支持。
- 暴露用于获取不同类别记忆活动记录的 API（写入、读取、引擎以及全部），并将其接入到 UI 中。
- 在应用功能设置中启用情绪感知回复配置。
- 允许 `PageScrollList` 渲染自定义分组布局，并让 `PageTabs`/`Tag` 组件支持尺寸变体，以实现更灵活的 UI 使用。

增强：
- 优化用户记忆统计卡片的布局和样式，以提高清晰度和呈现效果。
- 调整情节详情筛选项和标签，以区分时间范围选择与记忆类型选择。
- 在 API 请求中添加时区头信息传递，以支持对记忆活动进行基于时间的分组。
- 扩展 `SliderInput` 标签类型以接受丰富的 `ReactNode` 内容，并更新分段标签的小尺寸样式。

文档：
- 更新用户记忆、情节详情、知识库以及应用配置的 i18n 字符串，以涵盖记忆活动、块重叠、情绪回复和筛选标签等内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a memory activity panel to the user memory detail view, enhance dataset chunking controls, and extend configuration and UI components to support new activity, emotion, and layout features.

New Features:
- Introduce a Memory Activity sidebar in the user memory detail page showing grouped read, write, and engine processing records with filtering and localization.
- Add support for configuring text chunk overlap when using direct block processing in knowledge base dataset creation.
- Expose APIs for fetching different categories of memory activity records (written, read, engine, and all) and wire them into the UI.
- Enable emotion-aware reply configuration in the application features settings.
- Allow PageScrollList to render custom group layouts and PageTabs/Tag components to support size variants for more flexible UI usage.

Enhancements:
- Refine user memory statistics card layout and styling for clearer presentation.
- Adjust episodic detail filters and labels to distinguish between time range and memory type selections.
- Add timezone header propagation in API requests to support time-based grouping of memory activities.
- Extend SliderInput label typing to accept rich ReactNode content and update segmented tabs small-size styling.

Documentation:
- Update i18n strings for user memory, episodic detail, knowledge base, and application configuration to cover memory activity, chunk overlap, emotion reply, and filter labels.

</details>