### PR TITLE
feat(web): end user add type

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -25,6 +25,7 @@ import type { TestParams } from '@/views/MemoryConversation'
 import type { EndUser } from '@/views/UserMemoryDetail/types'
 import { handleSSE, type SSEMessage } from '@/utils/stream'
 import type { ChatItem } from '@/components/Chat/types'
+import type { Query } from '@/views/UserMemory/types';
 
 // Memory conversation
 export const readService = (query: TestParams) => {
@@ -64,7 +65,7 @@ export const getDashboardData = () => {
 
 /****************** User Memory APIs *******************************/
 export const userMemoryListUrl = '/dashboard/end_users'
-export const getUserMemoryList = (query?: { keyword?: string }) => {
+export const getUserMemoryList = (query?: Query) => {
   return request.get(userMemoryListUrl, query)
 }
 // User Memory - Delete end user

--- a/web/src/i18n/en/userMemory.ts
+++ b/web/src/i18n/en/userMemory.ts
@@ -61,6 +61,11 @@ export const userMemory = {
       EPISODIC_MEMORY: 'Episodic Memory',
       FORGET_MEMORY: 'Forget Memory',
 
+      memoryType: 'Memory Type',
+      allTermMemory: 'All Memory',
+      shortTermMemory: 'Short-Term Memory',
+      longTermMemory: 'Long-Term Memory',
+
       endUserProfile: 'Permanent Memory',
       editEndUserProfile: 'Edit',
       other_name: 'Name',

--- a/web/src/i18n/zh/userMemory.ts
+++ b/web/src/i18n/zh/userMemory.ts
@@ -61,7 +61,12 @@ export const userMemory = {
       EMOTIONAL_MEMORY: '情绪记忆',
       EPISODIC_MEMORY: '情景记忆',
       FORGET_MEMORY: '遗忘记忆',
-      
+
+      memoryType: '记忆类型',
+      allTermMemory: '全部',
+      shortTermMemory: '短时记忆',
+      longTermMemory: '长时记忆',
+
       endUserProfile: '永久记忆',
       editEndUserProfile: '编辑',
       other_name: '名称',

--- a/web/src/views/UserMemory/index.tsx
+++ b/web/src/views/UserMemory/index.tsx
@@ -9,13 +9,13 @@
  * Displays list of end users with their memory statistics and configuration
  */
 
-import { useRef } from 'react';
+import { useRef, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom'
-import { Row, Col, Form, Flex, Tooltip, App } from 'antd';
+import { Row, Col, Form, Flex, Tooltip, App, type SegmentedProps } from 'antd';
 import copy from 'copy-to-clipboard'
 
-import type { Data } from './types'
+import type { Data, Query, MemoryType } from './types'
 import { userMemoryListUrl } from '@/api/memory';
 import { useUser } from '@/store/user'
 import RbCard from '@/components/RbCard/Card'
@@ -27,6 +27,7 @@ import DeleteConfirmModal, { type DeleteConfirmModalRef } from './components/Del
 import Tag from '@/components/Tag'
 import { formatQuotaStatus, StatusProgress } from './components/StatusProgress'
 import OverflowTags from '@/components/OverflowTags'
+import PageTabs from '@/components/PageTabs';
 
 export default function UserMemory() {
   const { t } = useTranslation();
@@ -76,27 +77,46 @@ export default function UserMemory() {
       ? item?.end_user?.other_name 
       : item?.end_user?.id || ''
   }
+  const [activeTab, setActiveTab] = useState<'all' | MemoryType>('all');
+  const formatTabItems = useMemo(() => {
+    return ['all', 'long', 'short'].map(value => ({
+      value,
+      label: t(`userMemory.${value}TermMemory`),
+    }))
+  }, [t])
+  /** Handle tab change */
+  const handleChangeTab = (value: SegmentedProps['value']) => {
+    setActiveTab(value as ('all' | MemoryType));
+    form.resetFields()
+  }
 
   return (
     <div>
       <Form form={form}>
-        <Row gutter={16} className="rb:mb-4">
-          <Col span={8}>
+        <Flex align="center" justify="space-between" className="rb:mb-4!">
+          <PageTabs
+            value={activeTab}
+            options={formatTabItems}
+            onChange={handleChangeTab}
+          />
+          <Flex gap={12} className="rb:mb-4">
             <Form.Item name="keyword" noStyle>
               <SearchInput
                 placeholder={t('userMemory.searchPlaceholder')}
-                className="rb:w-full!"
               />
             </Form.Item>
-          </Col>
-        </Row>
+          </Flex>
+        </Flex>
       </Form>
 
     
-      <PageScrollList<Data, { keyword: string; }>
+      <PageScrollList<Data, Query>
         ref={scrollListRef}
         url={userMemoryListUrl}
-        query={{ keyword }}
+        query={{
+          keyword,
+          label: activeTab === 'all' ? undefined : activeTab
+        }}
         column={3}
         renderItem={(item) => {
           const { end_user, memory_num, memory_config, tags = [] } = item as Data;
@@ -149,7 +169,7 @@ export default function UserMemory() {
                   <RbStatistic title={t('userMemory.capacity')} value={memory_num?.total || 0} suffix={t('userMemory.memoryNum')} />
                 </Col>
                 <Col span={12}>
-                  <RbStatistic title={t('userMemory.type')} value={t(`userMemory.person`)} />
+                  <RbStatistic title={t('userMemory.memoryType')} value={end_user.label ? t(`userMemory.${end_user.label}TermMemory`) : '-'} />
                 </Col>
               </Row>
 

--- a/web/src/views/UserMemory/types.ts
+++ b/web/src/views/UserMemory/types.ts
@@ -4,14 +4,17 @@
  * @Last Modified by:   ZhaoYing 
  * @Last Modified time: 2026-02-03 17:53:36 
  */
+export type MemoryType = 'long' | 'short';
 /**
  * User memory data structure
  */
+
 export interface Data {
   end_user_id: string;
   end_user: {
     id: string;
     other_name: string;
+    label: MemoryType;
   },
   memory_num: {
     total: number;
@@ -23,4 +26,9 @@ export interface Data {
     memory_config_name: string;
   },
   tags: string[];
+}
+
+export interface Query {
+  keyword?: string;
+  label?: 'long' | 'short';
 }


### PR DESCRIPTION
## Summary by Sourcery

在终端用户记忆列表视图中添加对记忆类型的识别和过滤功能。

New Features:
- 在 UserMemory 视图中，通过标签页按记忆类型（全部、长期、短期）筛选终端用户。
- 在记忆统计部分显示每个终端用户的记忆类型标签。

Enhancements:
- 扩展 UserMemory 的数据和查询类型，以包含记忆类型元数据和标签筛选功能。
- 更新用户记忆列表的 API 辅助方法，使其接受带可选记忆类型标签的新类型化查询对象。

Documentation:
- 在 UserMemory 模块中添加用于记忆类型标签和标签页选项的英文和中文 i18n 字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add memory-type awareness and filtering to the end user memory list view.

New Features:
- Introduce tab-based filtering of end users by memory type (all, long-term, short-term) in the UserMemory view.
- Display each end user’s memory type label in the memory statistics section.

Enhancements:
- Extend UserMemory data and query types to include memory type metadata and label filters.
- Update the user memory list API helper to accept the new typed query object with optional memory type label.

Documentation:
- Add English and Chinese i18n strings for memory type labels and tab options in the UserMemory module.

</details>