### PR TITLE
feat(dashboard): add label filter for end user list

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -96,6 +96,7 @@ async def get_workspace_end_users(
     background_tasks: BackgroundTasks,
     workspace_id: Optional[uuid.UUID] = Query(None, description="工作空间ID（可选，默认当前用户工作空间）"),
     keyword: Optional[str] = Query(None, description="搜索关键词（同时模糊匹配 other_name 和 id）"),
+    label: Optional[str] = Query(None, description="标签过滤（long=有名称, short=无名称）"),
     page: int = Query(1, ge=1, description="页码，从1开始"),
     pagesize: int = Query(10, ge=1, description="每页数量"),
     db: Session = Depends(get_db),
@@ -144,6 +145,7 @@ async def get_workspace_end_users(
             page=page,
             pagesize=pagesize,
             keyword=keyword,
+            label=label,
         )
         raw_items = end_users_result.get("items", [])
         end_users = [item["end_user"] for item in raw_items]
@@ -155,6 +157,7 @@ async def get_workspace_end_users(
             page=page,
             pagesize=pagesize,
             keyword=keyword,
+            label=label,
         )
         raw_items = end_users_result.get("items", [])
         end_users = raw_items
@@ -219,6 +222,7 @@ async def get_workspace_end_users(
             "end_user": {
                 "id": user_id,
                 "other_name": end_user.other_name,
+                "label": "long" if end_user.other_name else "short",
             },
             "tags": normalize_stored_user_card_tags(getattr(end_user, "memory_tags", None)),
             "memory_num": {

--- a/api/app/controllers/service/memory_dashboard_api_controller.py
+++ b/api/app/controllers/service/memory_dashboard_api_controller.py
@@ -28,6 +28,7 @@ async def get_workspace_end_users(
     background_tasks: BackgroundTasks,
     api_key_auth: ApiKeyAuth = None,
     keyword: Optional[str] = Query(None, description="Search keyword (fuzzy match on other_name and id)"),
+    label: Optional[str] = Query(None, description="Label filter (long=has name, short=no name)"),
     page: int = Query(1, ge=1, description="Page number, starting from 1"),
     pagesize: int = Query(10, ge=1, description="Page size"),
 ):
@@ -60,6 +61,7 @@ async def get_workspace_end_users(
             background_tasks=background_tasks,
             workspace_id=api_key_auth.workspace_id,
             keyword=keyword,
+            label=label,
             page=page,
             pagesize=pagesize,
             db=db,

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1547,6 +1547,7 @@ class EndUserRepository:
             page: int,
             pagesize: int,
             keyword: Optional[str] = None,
+            label: Optional[str] = None,
     ) -> tuple[List[EndUser], int]:
         """Dashboard 专用：分页查询有记忆的宿主（memory_count > 0）
 
@@ -1558,6 +1559,7 @@ class EndUserRepository:
             page: 页码（从1开始）
             pagesize: 每页数量
             keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
+            label: 标签过滤（可选，"long" 表示有 other_name，"short" 表示无 other_name）
 
         Returns:
             tuple[List[EndUser], int]: (当前页宿主列表, 符合条件的总数)
@@ -1581,6 +1583,19 @@ class EndUserRepository:
             EndUser.memory_count > 0,
             EndUser.is_active == True,
         )
+
+        if label == "long":
+            query = query.filter(
+                EndUser.other_name.isnot(None),
+                EndUser.other_name != "",
+            )
+        elif label == "short":
+            query = query.filter(
+                or_(
+                    EndUser.other_name.is_(None),
+                    EndUser.other_name == "",
+                )
+            )
 
         if keyword:
             keyword = keyword.strip()
@@ -1611,6 +1626,7 @@ class EndUserRepository:
             page: int,
             pagesize: int,
             keyword: Optional[str] = None,
+            label: Optional[str] = None,
     ) -> tuple[list, int]:
         """Dashboard RAG 模式：分页查询有记忆的宿主
 
@@ -1624,6 +1640,7 @@ class EndUserRepository:
             page: 页码（从1开始）
             pagesize: 每页数量
             keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
+            label: 标签过滤（可选，"long" 表示有 other_name，"short" 表示无 other_name）
 
         Returns:
             tuple[list, int]: (items列表[{"end_user": ORM, "memory_count": int}], 总数)
@@ -1677,6 +1694,19 @@ class EndUserRepository:
                 EndUser.is_active == True,
             )
         )
+
+        if label == "long":
+            base_query = base_query.filter(
+                EndUser.other_name.isnot(None),
+                EndUser.other_name != "",
+            )
+        elif label == "short":
+            base_query = base_query.filter(
+                or_(
+                    EndUser.other_name.is_(None),
+                    EndUser.other_name == "",
+                )
+            )
 
         if keyword:
             keyword = keyword.strip()

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -78,7 +78,8 @@ def get_workspace_end_users_paginated(
     current_user: User,
     page: int,
     pagesize: int,
-    keyword: Optional[str] = None
+    keyword: Optional[str] = None,
+    label: Optional[str] = None,
 ) -> Dict[str, Any]:
     """获取工作空间的宿主列表（分页版本，支持模糊搜索）
 
@@ -108,6 +109,7 @@ def get_workspace_end_users_paginated(
             page=page,
             pagesize=pagesize,
             keyword=keyword,
+            label=label,
         )
 
         business_logger.info(f"成功获取 {len(end_users_orm)} 个宿主记录，总计 {total} 条")
@@ -126,6 +128,7 @@ def get_workspace_end_users_paginated_rag(
     page: int,
     pagesize: int,
     keyword: Optional[str] = None,
+    label: Optional[str] = None,
 ) -> Dict[str, Any]:
     """RAG 模式宿主列表分页。
 
@@ -148,6 +151,7 @@ def get_workspace_end_users_paginated_rag(
             page=page,
             pagesize=pagesize,
             keyword=keyword,
+            label=label,
         )
 
         business_logger.info(f"成功获取 RAG 宿主记录 {len(items)} 条，总计 {total} 条")


### PR DESCRIPTION
## Summary by Sourcery

为过滤仪表板终端用户列表添加支持，可根据指示是否存在备用名称的标签进行筛选。

新功能：
- 在仪表板终端用户列表 API 中引入可选的 label 参数，用于根据 `other_name` 是否存在或为空进行过滤。
- 在用于分页终端用户列表和 RAG 列表的内部控制器和对外 API 控制器中暴露该标签过滤器，并在每个终端用户的返回数据中提供一个 `label` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for filtering dashboard end user lists by a label indicating presence or absence of an alternate name.

New Features:
- Introduce an optional label parameter to dashboard end user list APIs to filter by whether other_name is present or empty.
- Expose the label filter in both internal and API-facing controllers for paginated end user and RAG lists, returning a label field in each end user payload.

</details>