### PR TITLE
refactor(memory): replace async DB calls with sync versions in memory count utils

### DIFF
--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -3,9 +3,9 @@ import logging
 from uuid import UUID
 
 from app.aioRedis import get_thread_safe_redis
-from app.core.quota_manager import get_end_user_memory_limit_async
-from app.db import get_async_db_context
-from app.repositories.end_user_repository import EndUserRepository, get_tenant_id_by_end_user_id_async
+from app.core.quota_manager import get_end_user_memory_limit
+from app.db import get_db_context
+from app.repositories.end_user_repository import EndUserRepository, get_tenant_id_by_end_user_id
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.graph_search import forget_count_active_nodes
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -33,10 +33,10 @@ async def sync_end_user_memory_count_from_neo4j(
     node_count = int(result[0]["total"]) if result else 0
 
     memory_node_count = await forget_count_active_nodes(connector, end_user_id)
-    async with get_async_db_context() as db:
-        await EndUserRepository(db).update_memory_count_async(UUID(end_user_id), node_count)
-        tenant_id = await get_tenant_id_by_end_user_id_async(db, end_user_id)
-        memory_limit = await get_end_user_memory_limit_async(db, tenant_id)
+    with get_db_context() as db:
+        EndUserRepository(db).update_memory_count(UUID(end_user_id), node_count)
+        tenant_id = get_tenant_id_by_end_user_id(db, end_user_id)
+        memory_limit = get_end_user_memory_limit(db, tenant_id)
     redis_client = get_thread_safe_redis()
     if redis_client:
         if memory_node_count > memory_limit:


### PR DESCRIPTION
- Change async DB context and repository calls to synchronous equivalents
- Update imports to use sync functions for quota and tenant retrieval

## Summary by Sourcery

在内存计数工具中，将异步的数据库和配额检索调用替换为同步等价实现，同时保持周围的异步 Neo4j 交互不变。

增强内容：
- 使用同步的数据库上下文和终端用户仓库方法来更新内存计数。
- 将内存计数工具中的租户 ID 和终端用户内存限制查询切换为同步实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace asynchronous database and quota retrieval calls in memory count utilities with synchronous equivalents while keeping the surrounding async Neo4j interaction unchanged.

Enhancements:
- Use synchronous DB context and end user repository methods for updating memory counts.
- Switch tenant ID and end user memory limit lookups in memory count utilities to synchronous implementations.

</details>