### PR TITLE
fix(memory-insight): use sync sessions in celery refresh

### DIFF
--- a/api/app/core/memory/analytics/memory_insight.py
+++ b/api/app/core/memory/analytics/memory_insight.py
@@ -436,6 +436,8 @@ def _memory_insight_result(
     }
 
 
+# 默认 False 保留 API 的异步 PostgreSQL 路径；
+# Celery 必须通过 refresh_memory_insight_for_worker() 显式传入 True，使用同步短 Session。
 async def refresh_memory_insight(
     end_user_id: str,
     workspace_id: uuid.UUID | str,

--- a/api/app/core/memory/analytics/memory_insight.py
+++ b/api/app/core/memory/analytics/memory_insight.py
@@ -16,7 +16,7 @@ from app.core.logging_config import get_logger
 from app.core.memory.pipelines.base_pipeline import ModelClientMixin
 from app.core.memory.utils.prompt.template_render import prompt_env
 from app.core.utils.datetime_utils import as_utc_aware, utcnow_naive
-from app.db import get_async_db_context
+from app.db import get_async_db_context, get_db_context
 from app.repositories.end_user_repository import (
     EndUserRepository,
     MemoryInsightSourceRow,
@@ -329,6 +329,8 @@ def classify_memory_cache_refresh(
 
 async def validate_neo4j_memory_insight_workspace(
     workspace_id: uuid.UUID | str,
+    *,
+    use_sync_db: bool = False,
 ) -> MemoryInsightWorkspaceValidation:
     try:
         workspace_uuid = (
@@ -339,12 +341,24 @@ async def validate_neo4j_memory_insight_workspace(
     except (TypeError, ValueError, AttributeError):
         return MemoryInsightWorkspaceValidation(False, "invalid_workspace_id")
 
-    async with get_async_db_context() as db:
-        workspace = await WorkspaceRepository(db).get_workspace_by_id_async(workspace_uuid)
-        if workspace is None:
-            return MemoryInsightWorkspaceValidation(False, "workspace_not_found")
-        is_active = cast(bool, cast(object, workspace.is_active))
-        raw_storage_type = cast(str | None, cast(object, workspace.storage_type))
+    if use_sync_db:
+        # Celery 旧实现保留如下：
+        # async with get_async_db_context() as db:
+        #     workspace = await WorkspaceRepository(db).get_workspace_by_id_async(workspace_uuid)
+        # 模块级 asyncpg pool 可能把其他 event loop 使用过的连接交给当前 Task。
+        with get_db_context() as db:
+            workspace = WorkspaceRepository(db).get_workspace_by_id(workspace_uuid)
+            if workspace is None:
+                return MemoryInsightWorkspaceValidation(False, "workspace_not_found")
+            is_active = cast(bool, cast(object, workspace.is_active))
+            raw_storage_type = cast(str | None, cast(object, workspace.storage_type))
+    else:
+        async with get_async_db_context() as db:
+            workspace = await WorkspaceRepository(db).get_workspace_by_id_async(workspace_uuid)
+            if workspace is None:
+                return MemoryInsightWorkspaceValidation(False, "workspace_not_found")
+            is_active = cast(bool, cast(object, workspace.is_active))
+            raw_storage_type = cast(str | None, cast(object, workspace.storage_type))
 
     if not is_active:
         return MemoryInsightWorkspaceValidation(
@@ -365,16 +379,34 @@ async def validate_neo4j_memory_insight_workspace(
 
 async def _create_memory_insight_llm_client(
     end_user_id: uuid.UUID,
+    *,
+    use_sync_db: bool = False,
 ) -> StructuredLLMClient:
-    async with get_async_db_context() as db:
-        config_service = MemoryConfigService(db)
-        config_id = await config_service.get_config_id_by_end_user_async(end_user_id)
-        memory_config = await config_service.load_memory_config_async(config_id)
-        llm_client = await ModelClientMixin.get_llm_client_async(
-            db,
-            memory_config.llm_model_id,
-            memory_config.tenant_id,
-        )
+    if use_sync_db:
+        # Celery 旧实现保留如下：
+        # config_id = await config_service.get_config_id_by_end_user_async(end_user_id)
+        # memory_config = await config_service.load_memory_config_async(config_id)
+        # llm_client = await ModelClientMixin.get_llm_client_async(...)
+        # 这些查询复用全局 asyncpg pool 时存在 Future attached to a different loop 风险。
+        with get_db_context() as db:
+            config_service = MemoryConfigService(db)
+            config_id = config_service.get_config_id_by_end_user(end_user_id)
+            memory_config = config_service.load_memory_config(config_id)
+            llm_client = ModelClientMixin.get_llm_client(
+                db,
+                memory_config.llm_model_id,
+                memory_config.tenant_id,
+            )
+    else:
+        async with get_async_db_context() as db:
+            config_service = MemoryConfigService(db)
+            config_id = await config_service.get_config_id_by_end_user_async(end_user_id)
+            memory_config = await config_service.load_memory_config_async(config_id)
+            llm_client = await ModelClientMixin.get_llm_client_async(
+                db,
+                memory_config.llm_model_id,
+                memory_config.tenant_id,
+            )
     return cast(
         StructuredLLMClient,
         cast(
@@ -408,6 +440,8 @@ async def refresh_memory_insight(
     end_user_id: str,
     workspace_id: uuid.UUID | str,
     language: str = "zh",
+    *,
+    use_sync_db: bool = False,
 ) -> dict[str, object]:
     """使用短 PG 会话生成并条件写回单个用户的 Memory Insight。"""
     started_at = time.monotonic()
@@ -425,7 +459,15 @@ async def refresh_memory_insight(
             error="无效的用户或工作空间ID格式",
         )
 
-    workspace_validation = await validate_neo4j_memory_insight_workspace(workspace_uuid)
+    if use_sync_db:
+        workspace_validation = await validate_neo4j_memory_insight_workspace(
+            workspace_uuid,
+            use_sync_db=True,
+        )
+    else:
+        workspace_validation = await validate_neo4j_memory_insight_workspace(
+            workspace_uuid
+        )
     if not workspace_validation.valid:
         return _memory_insight_result(
             success=False,
@@ -433,13 +475,25 @@ async def refresh_memory_insight(
             error=f"工作空间不可用于 Neo4j Memory Insight: {workspace_validation.reason}",
         )
 
-    async with get_async_db_context() as db:
-        source: MemoryInsightSourceRow | None = await EndUserRepository(
-            db
-        ).get_scoped_memory_insight_source_async(
-            workspace_id=workspace_uuid,
-            end_user_id=end_user_uuid,
-        )
+    source: MemoryInsightSourceRow | None
+    if use_sync_db:
+        # Celery 旧实现保留如下：
+        # async with get_async_db_context() as db:
+        #     source = await EndUserRepository(db).get_scoped_memory_insight_source_async(...)
+        # asyncpg 连接可能绑定其他 event loop，因此 worker 改用同步短 Session。
+        with get_db_context() as db:
+            source = EndUserRepository(db).get_scoped_memory_insight_source(
+                workspace_id=workspace_uuid,
+                end_user_id=end_user_uuid,
+            )
+    else:
+        async with get_async_db_context() as db:
+            source = await EndUserRepository(
+                db
+            ).get_scoped_memory_insight_source_async(
+                workspace_id=workspace_uuid,
+                end_user_id=end_user_uuid,
+            )
     if source is None:
         return _memory_insight_result(
             success=False,
@@ -474,7 +528,13 @@ async def refresh_memory_insight(
             key_findings=[],
         )
     else:
-        llm_client = await _create_memory_insight_llm_client(end_user_uuid)
+        if use_sync_db:
+            llm_client = await _create_memory_insight_llm_client(
+                end_user_uuid,
+                use_sync_db=True,
+            )
+        else:
+            llm_client = await _create_memory_insight_llm_client(end_user_uuid)
         output = await generate_memory_insight_output(
             llm_client,
             metadata_input,
@@ -484,19 +544,29 @@ async def refresh_memory_insight(
 
     actionable = [item.model_dump() for item in output.key_findings]
     refreshed_at = utcnow_naive()
-    async with get_async_db_context() as db:
-        updated = await EndUserRepository(
-            db
-        ).update_grounded_memory_insight_if_source_unchanged_async(
-            workspace_id=workspace_uuid,
-            end_user_id=end_user_uuid,
-            expected_write_time=source["write_time"],
-            expected_metadata_row_exists=source["metadata_row_exists"],
-            expected_metadata_updated_at=source["metadata_updated_at"],
-            memory_insight=output.overview,
-            key_findings=json.dumps(actionable, ensure_ascii=False),
-            refreshed_at=refreshed_at,
-        )
+    update_kwargs = {
+        "workspace_id": workspace_uuid,
+        "end_user_id": end_user_uuid,
+        "expected_write_time": source["write_time"],
+        "expected_metadata_row_exists": source["metadata_row_exists"],
+        "expected_metadata_updated_at": source["metadata_updated_at"],
+        "memory_insight": output.overview,
+        "key_findings": json.dumps(actionable, ensure_ascii=False),
+        "refreshed_at": refreshed_at,
+    }
+    if use_sync_db:
+        # Celery 旧实现保留如下：
+        # updated = await EndUserRepository(db).update_grounded_memory_insight_if_source_unchanged_async(...)
+        # 异步写回同样可能从全局 asyncpg pool 取得绑定其他 loop 的连接。
+        with get_db_context() as db:
+            updated = EndUserRepository(
+                db
+            ).update_grounded_memory_insight_if_source_unchanged(**update_kwargs)
+    else:
+        async with get_async_db_context() as db:
+            updated = await EndUserRepository(
+                db
+            ).update_grounded_memory_insight_if_source_unchanged_async(**update_kwargs)
 
     status = "refreshed" if updated else "superseded"
     logger.info(
@@ -515,3 +585,17 @@ async def refresh_memory_insight(
             error="源数据已更新，本轮洞察未写入",
         )
     return _memory_insight_result(success=True, output=output, status=status)
+
+
+async def refresh_memory_insight_for_worker(
+    end_user_id: str,
+    workspace_id: uuid.UUID | str,
+    language: str = "zh",
+) -> dict[str, object]:
+    """使用同步 PG 短 Session 刷新 Celery worker 中的 Memory Insight。"""
+    return await refresh_memory_insight(
+        end_user_id=end_user_id,
+        workspace_id=workspace_id,
+        language=language,
+        use_sync_db=True,
+    )

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -787,6 +787,43 @@ class EndUserRepository:
             "memory_insight_updated_at": row["memory_insight_updated_at"],
         }
 
+    def get_scoped_memory_insight_source(
+            self,
+            workspace_id: uuid.UUID,
+            end_user_id: uuid.UUID,
+    ) -> MemoryInsightSourceRow | None:
+        """同步读取 Neo4j Workspace 下的洞察源数据和并发版本。"""
+        result = self.db.execute(
+            select(
+                EndUserInfo.id.label("metadata_id"),
+                EndUserInfo.meta_data.label("meta_data"),
+                EndUserInfo.updated_at.label("metadata_updated_at"),
+                EndUser.write_time.label("write_time"),
+                EndUser.memory_insight_updated_at.label("memory_insight_updated_at"),
+            )
+            .select_from(EndUser)
+            .join(Workspace, Workspace.id == EndUser.workspace_id)
+            .outerjoin(EndUserInfo, EndUserInfo.end_user_id == EndUser.id)
+            .where(
+                EndUser.id == end_user_id,
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active.is_(True),
+                Workspace.is_active.is_(True),
+                Workspace.storage_type == "neo4j",
+            )
+            .limit(1)
+        )
+        row = result.mappings().one_or_none()
+        if row is None:
+            return None
+        return {
+            "meta_data": row["meta_data"],
+            "metadata_row_exists": row["metadata_id"] is not None,
+            "metadata_updated_at": row["metadata_updated_at"],
+            "write_time": row["write_time"],
+            "memory_insight_updated_at": row["memory_insight_updated_at"],
+        }
+
     def update_grounded_memory_insight_if_source_unchanged(
             self,
             workspace_id: uuid.UUID,

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -984,7 +984,6 @@ class UserMemoryService:
         language: str = "zh",
     ) -> Dict[str, Any]:
         """Celery 专用入口：同步 PG 读写，异步 Neo4j/LLM。"""
-        del workspace_id  # 保留与现有生成入口一致的调用形状。
         try:
             logger.info(f"开始为 end_user_id {end_user_id} 生成用户摘要, language={language}")
             user_uuid = uuid.UUID(end_user_id)

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -19,6 +19,7 @@ from app.core.memory.analytics.memory_insight import (
     MemoryInsightWorkspaceValidation,
     parse_stored_memory_insight_findings,
     refresh_memory_insight,
+    refresh_memory_insight_for_worker,
     validate_neo4j_memory_insight_workspace,
 )
 from app.core.memory.analytics.user_card_tags import normalize_stored_user_card_tags
@@ -815,6 +816,38 @@ class UserMemoryService:
                 "growth_trajectory": None,
                 "error": f"Neo4j或LLM服务不可用: {e}",
             }
+
+    async def generate_and_cache_insight_for_worker(
+        self,
+        end_user_id: str,
+        workspace_id: uuid.UUID,
+        language: str = "zh",
+    ) -> Dict[str, Any]:
+        """Celery 专用入口：PostgreSQL 仅使用同步短 Session。"""
+        try:
+            return await refresh_memory_insight_for_worker(
+                end_user_id=end_user_id,
+                workspace_id=workspace_id,
+                language=language,
+            )
+        except Exception as e:
+            logger.error(
+                "Celery 生成并缓存记忆洞察失败: end_user_id=%s workspace_id=%s error=%s",
+                end_user_id,
+                workspace_id,
+                e,
+                exc_info=True,
+            )
+            return {
+                "success": False,
+                "status": "generation_failed",
+                "memory_insight": None,
+                "behavior_pattern": None,
+                "key_findings": None,
+                "actionable_findings": [],
+                "growth_trajectory": None,
+                "error": f"Neo4j或LLM服务不可用: {e}",
+            }
     
     async def generate_and_cache_summary(
         self, 
@@ -942,6 +975,106 @@ class UserMemoryService:
                 "core_values": None,
                 "one_sentence": None,
                 "error": str(e)
+            }
+
+    async def generate_and_cache_summary_for_worker(
+        self,
+        end_user_id: str,
+        workspace_id: Optional[uuid.UUID] = None,
+        language: str = "zh",
+    ) -> Dict[str, Any]:
+        """Celery 专用入口：同步 PG 读写，异步 Neo4j/LLM。"""
+        del workspace_id  # 保留与现有生成入口一致的调用形状。
+        try:
+            logger.info(f"开始为 end_user_id {end_user_id} 生成用户摘要, language={language}")
+            user_uuid = uuid.UUID(end_user_id)
+
+            # Celery 旧异步查询保留如下：
+            # repo = EndUserRepository(db)
+            # end_user = await repo.get_by_id_async(user_uuid)
+            # 全局 asyncpg pool 可能复用其他 event loop 的连接，因此改用同步短 Session。
+            with get_db_context() as db:
+                end_user_exists = EndUserRepository(db).get_by_id(user_uuid) is not None
+
+            if not end_user_exists:
+                logger.error(f"end_user_id {end_user_id} 不存在")
+                return {
+                    "success": False,
+                    "user_summary": None,
+                    "personality": None,
+                    "core_values": None,
+                    "one_sentence": None,
+                    "error": "用户不存在",
+                }
+
+            logger.info(f"使用 end_user_id={end_user_id} 生成用户摘要")
+            result = await analytics_user_summary(end_user_id, language=language)
+            user_summary = result.get("user_summary", "")
+            personality = result.get("personality", "")
+            core_values = result.get("core_values", "")
+            one_sentence = result.get("one_sentence", "")
+
+            if not any([user_summary, personality, core_values, one_sentence]):
+                logger.warning(f"end_user_id {end_user_id} 的用户摘要生成结果为空")
+                return {
+                    "success": False,
+                    "user_summary": None,
+                    "personality": None,
+                    "core_values": None,
+                    "one_sentence": None,
+                    "error": "生成的用户摘要为空,可能Neo4j中没有该用户的数据",
+                }
+
+            # Celery 旧异步写回保留如下：
+            # success = await repo.update_user_summary_async(...)
+            # 异步写回也可能取到绑定其他 loop 的 asyncpg 连接。
+            with get_db_context() as db:
+                success = EndUserRepository(db).update_user_summary(
+                    user_uuid,
+                    user_summary,
+                    personality,
+                    core_values,
+                    one_sentence,
+                )
+
+            if success:
+                logger.info(f"成功为 end_user_id {end_user_id} 生成并缓存用户摘要")
+                return {
+                    "success": True,
+                    "user_summary": user_summary,
+                    "personality": personality,
+                    "core_values": core_values,
+                    "one_sentence": one_sentence,
+                    "error": None,
+                }
+            logger.error(f"更新 end_user_id {end_user_id} 的用户摘要缓存失败")
+            return {
+                "success": False,
+                "user_summary": user_summary,
+                "personality": personality,
+                "core_values": core_values,
+                "one_sentence": one_sentence,
+                "error": "数据库更新失败",
+            }
+        except ValueError:
+            logger.error(f"无效的 end_user_id 格式: {end_user_id}")
+            return {
+                "success": False,
+                "user_summary": None,
+                "personality": None,
+                "core_values": None,
+                "one_sentence": None,
+                "error": "无效的用户ID格式",
+            }
+        except Exception as e:
+            logger.error(f"Celery 生成并缓存用户摘要时出错: {str(e)}", exc_info=True)
+            return {
+                "success": False,
+                "user_summary": None,
+                "personality": None,
+                "core_values": None,
+                "one_sentence": None,
+                "error": str(e),
             }
 
 # for workspace    

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3786,29 +3786,39 @@ def do_refresh_insight_summary_cache(
 ) -> Dict[str, Any]:
     """按 scan 的独立判定刷新单个用户的记忆洞察或用户摘要缓存。
 
-    由 scan_refresh_insight_summary_cache 派发，每个用户一个独立任务、独立 db session，
-    跑完即释放内存。刷新标记默认开启，兼容发布前已入队的旧消息。
+    由 scan_refresh_insight_summary_cache 派发，每个用户一个独立任务；PostgreSQL
+    读写使用独立同步短 Session，Neo4j/LLM 保持异步。刷新标记默认开启，
+    兼容发布前已入队的旧消息。
     """
     start_time = time.time()
     inflight_key = CACHE_INFLIGHT_KEY_FMT.format(end_user_id=end_user_id)
 
     async def _run() -> Dict[str, Any]:
-        from app.db import get_async_db_context
         from app.services.user_memory_service import UserMemoryService
 
         service = UserMemoryService()
         ws_uuid = uuid.UUID(workspace_id)
         insight = None
         summary = None
-        async with get_async_db_context() as db:
-            if refresh_insight:
-                insight = await service.generate_and_cache_insight(
-                    db, end_user_id, ws_uuid, language=language,
-                )
-            if refresh_summary:
-                summary = await service.generate_and_cache_summary(
-                    db, end_user_id, ws_uuid, language=language,
-                )
+
+        # 旧 Celery 异步 PG 编排保留如下：
+        # async with get_async_db_context() as db:
+        #     insight = await service.generate_and_cache_insight(db, ...)
+        #     summary = await service.generate_and_cache_summary(db, ...)
+        # 模块级 asyncpg pool 会跨 Task/event loop 复用连接，存在
+        # "Future attached to a different loop" 和连接协议状态损坏风险。
+        if refresh_insight:
+            insight = await service.generate_and_cache_insight_for_worker(
+                end_user_id,
+                ws_uuid,
+                language=language,
+            )
+        if refresh_summary:
+            summary = await service.generate_and_cache_summary_for_worker(
+                end_user_id,
+                ws_uuid,
+                language=language,
+            )
 
         insight_success = bool(insight and insight.get("success"))
         summary_success = bool(summary and summary.get("success"))


### PR DESCRIPTION
## Summary

- Use short-lived synchronous PostgreSQL sessions for Celery Memory Insight and User Summary refresh tasks.
- Keep Neo4j and LLM operations asynchronous.
- Avoid asyncpg connection reuse across different event loops.
- Preserve the existing asynchronous API paths.

## Summary by Sourcery

在保持现有异步 API 不变的前提下，为基于 Celery 的记忆洞察和用户概要刷新任务使用短生命周期的同步 PostgreSQL 会话。

Bug Fixes（错误修复）:
- 避免在 Celery worker 中跨不同事件循环重用 asyncpg 连接，以防止跨循环的 Future 和连接状态错误。

Enhancements（增强）:
- 引入仅供 worker 使用的入口，用于生成和缓存记忆洞察和用户概要，这些入口依赖同步的数据库访问，但仍使用异步的 Neo4j 和 LLM 操作。
- 在记忆洞察逻辑中添加同步仓储方法以及可选的同步/异步切换，以支持更安全的 Celery 执行，而不影响常规的异步路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use short-lived synchronous PostgreSQL sessions for Celery-based memory insight and user summary refresh tasks while keeping existing asynchronous APIs intact.

Bug Fixes:
- Avoid asyncpg connection reuse across different event loops in Celery workers to prevent cross-loop Future and connection state errors.

Enhancements:
- Introduce worker-only entrypoints for generating and caching memory insights and user summaries that rely on synchronous DB access but still use asynchronous Neo4j and LLM operations.
- Add synchronous repository methods and optional sync/async switching in memory insight logic to support safer Celery execution without impacting regular async paths.

</details>