### PR TITLE
fix(dashboard): add other_id field to end user response

### DIFF
--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -221,6 +221,7 @@ async def get_workspace_end_users(
             "end_user_id": user_id,
             "end_user": {
                 "id": user_id,
+                "other_id": end_user.other_id,
                 "other_name": end_user.other_name,
                 "label": "long" if end_user.other_name else "short",
             },


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 在工作区终端用户响应负载中包含终端用户的 `other_id` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include the end user's other_id field in the workspace end user response payload.

</details>