### PR TITLE
Hotfix/v0.3.14 patch

### DIFF
--- a/api/app/core/memory/utils/memory_count_utils.py
+++ b/api/app/core/memory/utils/memory_count_utils.py
@@ -3,9 +3,9 @@ import logging
 from uuid import UUID
 
 from app.aioRedis import get_thread_safe_redis
-from app.core.quota_manager import get_end_user_memory_limit_async
-from app.db import get_async_db_context
-from app.repositories.end_user_repository import EndUserRepository, get_tenant_id_by_end_user_id_async
+from app.core.quota_manager import get_end_user_memory_limit
+from app.db import get_db_context
+from app.repositories.end_user_repository import EndUserRepository, get_tenant_id_by_end_user_id
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.graph_search import forget_count_active_nodes
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -33,10 +33,10 @@ async def sync_end_user_memory_count_from_neo4j(
     node_count = int(result[0]["total"]) if result else 0
 
     memory_node_count = await forget_count_active_nodes(connector, end_user_id)
-    async with get_async_db_context() as db:
-        await EndUserRepository(db).update_memory_count_async(UUID(end_user_id), node_count)
-        tenant_id = await get_tenant_id_by_end_user_id_async(db, end_user_id)
-        memory_limit = await get_end_user_memory_limit_async(db, tenant_id)
+    with get_db_context() as db:
+        EndUserRepository(db).update_memory_count(UUID(end_user_id), node_count)
+        tenant_id = get_tenant_id_by_end_user_id(db, end_user_id)
+        memory_limit = get_end_user_memory_limit(db, tenant_id)
     redis_client = get_thread_safe_redis()
     if redis_client:
         if memory_node_count > memory_limit:

--- a/api/app/repositories/release_share_repository.py
+++ b/api/app/repositories/release_share_repository.py
@@ -2,7 +2,7 @@ import uuid
 from typing import Optional
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, update
 from app.core.utils.datetime_utils import utcnow_naive
 from app.models import ReleaseShare
 
@@ -58,21 +58,29 @@ class ReleaseShareRepository:
         return self.db.scalars(stmt).first() is not None
     
     def increment_view_count(self, share_id: uuid.UUID) -> None:
-        """增加访问次数（异步更新，不阻塞）"""
-        stmt = select(ReleaseShare).where(ReleaseShare.id == share_id)
-        share = self.db.scalars(stmt).first()
-        if share:
-            share.view_count += 1
-            share.last_accessed_at = utcnow_naive()
-            self.db.commit()
+        """原子增加访问次数，避免 SELECT+UPDATE 竞态导致行锁等待超时"""
+        stmt = (
+            update(ReleaseShare)
+            .where(ReleaseShare.id == share_id)
+            .values(
+                view_count=ReleaseShare.view_count + 1,
+                last_accessed_at=utcnow_naive(),
+                updated_at=utcnow_naive(),
+            )
+        )
+        self.db.execute(stmt)
+        self.db.commit()
 
     async def increment_view_count_async(self, share_id: uuid.UUID) -> None:
-        """异步增加访问次数"""
-        result = await self.db.execute(
-            select(ReleaseShare).where(ReleaseShare.id == share_id)
+        """异步原子增加访问次数，避免 SELECT+UPDATE 竞态导致行锁等待超时"""
+        stmt = (
+            update(ReleaseShare)
+            .where(ReleaseShare.id == share_id)
+            .values(
+                view_count=ReleaseShare.view_count + 1,
+                last_accessed_at=utcnow_naive(),
+                updated_at=utcnow_naive(),
+            )
         )
-        share = result.scalars().first()
-        if share:
-            share.view_count += 1
-            share.last_accessed_at = utcnow_naive()
-            await self.db.commit()
+        await self.db.execute(stmt)
+        await self.db.commit()

--- a/api/app/services/multimodal_service.py
+++ b/api/app/services/multimodal_service.py
@@ -303,6 +303,7 @@ PROVIDER_STRATEGIES = {
     "openai": OpenAIFormatStrategy,
     "volcano": OpenAIFormatStrategy,
     "speedbear": OpenAIFormatStrategy,
+    "gpustack": OpenAIFormatStrategy,
 }
 
 


### PR DESCRIPTION
## Summary by Sourcery

使浏览次数更新具备原子性，将终端用户内存计数切换为同步的数据库和配额访问，并为多模态格式化添加 GPUStack 支持。

Bug Fixes:
- 通过使用原子更新语句，在递增版本分享浏览次数时防止竞态条件和锁超时问题。
- 通过使用同步的数据库和配额访问路径，解决终端用户内存计数同步中的潜在异步/同步不匹配及相关运行时问题。

Enhancements:
- 通过现有的 OpenAI 格式化策略，在多模态服务格式化中支持 "gpustack" 提供方。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make view count updates atomic, switch end user memory counting to synchronous DB and quota access, and add GPUStack support to multimodal formatting.

Bug Fixes:
- Prevent race conditions and lock timeout issues when incrementing release share view counts by using atomic update statements.
- Resolve potential async/sync mismatch and related runtime issues in end user memory count synchronization by using synchronous DB and quota access paths.

Enhancements:
- Support the "gpustack" provider in multimodal service formatting via the existing OpenAI formatting strategy.

</details>