### PR TITLE
feat(chat-service)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -1504,6 +1504,7 @@ class AppChatService:
                     "is_omni": _api_key_is_omni
                 }
 
+            all_node_executions = orchestrator_node_executions + node_executions
             if not skip_save:
                 from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
 
@@ -1543,6 +1544,28 @@ class AppChatService:
                     args=persist_args,
                 ))
 
+                # Enqueue agent execution after messages so the FK is satisfied
+                # within the same batch (messages commit first, then execution).
+                async with get_async_db_context() as _exec_db:
+                    _app_obj = await _exec_db.get(App, config.app_id)
+                    _release_id = _app_obj.current_release_id if _app_obj else None
+                await BatchPersistQueue.enqueue(PersistTask(
+                    task_type="save_agent_execution",
+                    args={
+                        "app_id": str(config.app_id),
+                        "conversation_id": str(conversation_id),
+                        "message_id": str(message_id),
+                        "agent_config_id": str(config.id) if config.id else None,
+                        "release_id": str(_release_id) if _release_id else None,
+                        "steps": all_node_executions,
+                        "status": "completed",
+                        "started_at_ts": start_time,
+                        "elapsed_time": elapsed_time,
+                        "token_usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
+                        "meta_data": {"model": _api_key_model_name, "provider": _api_key_provider},
+                    },
+                ))
+
                 if used_context_engine:
                     await BatchPersistQueue.enqueue(PersistTask(
                         task_type="after_turn",
@@ -1571,23 +1594,18 @@ class AppChatService:
                     if conv:
                         conv.message_count += 1
                     await db.commit()
-            # 首包后再一次性落 Agent execution，避免首包前 create + 尾部 update 双写。
-            all_node_executions = orchestrator_node_executions + node_executions
-            await self._persist_final_agent_execution(
-                app_id=config.app_id,
-                conversation_id=conversation_id,
-                agent_config_id=config.id,
-                started_at_ts=start_time,
-                status="completed",
-                steps=all_node_executions,
-                meta_data={
-                    "model": _api_key_model_name,
-                    "provider": _api_key_provider,
-                },
-                elapsed_time=elapsed_time,
-                token_usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
-                message_id=message_id,
-            )
+                await self._persist_final_agent_execution(
+                    app_id=config.app_id,
+                    conversation_id=conversation_id,
+                    agent_config_id=config.id,
+                    started_at_ts=start_time,
+                    status="completed",
+                    steps=all_node_executions,
+                    meta_data={"model": _api_key_model_name, "provider": _api_key_provider},
+                    elapsed_time=elapsed_time,
+                    token_usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
+                    message_id=message_id,
+                )
 
             yield f"event: end\ndata: {json.dumps(end_data, ensure_ascii=False)}\n\n"
 

--- a/api/app/services/batch_persist_queue.py
+++ b/api/app/services/batch_persist_queue.py
@@ -543,6 +543,39 @@ async def _mark_memory_pending(conv_id: str) -> None:
         )
 
 
+async def _handle_save_agent_execution(
+    db: Any,
+    **kwargs: Any,
+) -> None:
+    """Persist agent execution record after messages are committed."""
+    from app.models.agent_execution_model import AgentExecution
+    from app.core.utils.datetime_utils import parse_timestamp_to_utc_naive, utcnow_naive
+
+    app_id = uuid_module.UUID(kwargs["app_id"]) if isinstance(kwargs.get("app_id"), str) else kwargs.get("app_id")
+    conversation_id = uuid_module.UUID(kwargs["conversation_id"]) if isinstance(kwargs.get("conversation_id"), str) else kwargs.get("conversation_id")
+    message_id = uuid_module.UUID(kwargs["message_id"]) if isinstance(kwargs.get("message_id"), str) else kwargs.get("message_id")
+    agent_config_id = uuid_module.UUID(kwargs["agent_config_id"]) if kwargs.get("agent_config_id") else None
+    release_id = uuid_module.UUID(kwargs["release_id"]) if kwargs.get("release_id") else None
+
+    execution = AgentExecution(
+        app_id=app_id,
+        conversation_id=conversation_id,
+        message_id=message_id,
+        agent_config_id=agent_config_id,
+        release_id=release_id,
+        triggered_by=None,
+        steps=kwargs.get("steps", []),
+        status=kwargs.get("status", "completed"),
+        started_at=parse_timestamp_to_utc_naive(kwargs["started_at_ts"]),
+        completed_at=utcnow_naive(),
+        elapsed_time=kwargs.get("elapsed_time"),
+        token_usage=kwargs.get("token_usage"),
+        error_message=kwargs.get("error_message"),
+        meta_data=kwargs.get("meta_data", {}),
+    )
+    db.add(execution)
+
+
 async def _handle_save_execution(
     db: Any,
     result: Any,  # StreamResult
@@ -626,6 +659,7 @@ async def _handle_save_node_executions(
 
 _TASK_HANDLERS: dict[str, Any] = {
     "save_execution": _handle_save_execution,
+    "save_agent_execution": _handle_save_agent_execution,
     "save_node_executions": _handle_save_node_executions,
     "record_usage": _handle_record_usage,
     "after_turn": _handle_after_turn,


### PR DESCRIPTION
persist agent execution via batch queue after messages commit

## Summary by Sourcery

在消息提交后，通过批处理队列持久化代理执行记录，以确保外键完整性，并使执行记录的保存与现有的批处理持久化流程保持一致。

新功能：
- 为与会话和消息关联的代理执行记录添加通过批处理队列保存的支持。

改进：
- 优化聊天服务流程，在消息及相关任务通过批处理队列完成提交后，将最终的代理执行记录持久化操作加入队列。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist agent execution records via the batch queue after message commits to ensure foreign key integrity and align execution saving with existing batch persistence flow.

New Features:
- Add batch queue support for saving agent execution records tied to conversations and messages.

Enhancements:
- Refine chat service flow to enqueue final agent execution persistence after messages and related tasks are committed via the batch queue.

</details>