### PR TITLE
refactor(chat-service)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -241,70 +241,6 @@ class AppChatService:
 
 
 
-    async def _persist_final_agent_execution(
-            self,
-            *,
-            app_id: uuid.UUID,
-            conversation_id: uuid.UUID,
-            agent_config_id: uuid.UUID | None,
-            started_at_ts: float,
-            status: str,
-            steps: list,
-            meta_data: dict,
-            elapsed_time: Optional[float] = None,
-            token_usage: Optional[dict] = None,
-            error_message: Optional[str] = None,
-            message_id: Optional[uuid.UUID] = None,
-    ) -> uuid.UUID:
-        if self._uses_async_session():
-            async with get_async_db_context() as db:
-                app_obj = await db.get(App, app_id)
-                execution = AgentExecution(
-                    app_id=app_id,
-                    conversation_id=conversation_id,
-                    message_id=message_id,
-                    agent_config_id=agent_config_id,
-                    release_id=app_obj.current_release_id if app_obj else None,
-                    triggered_by=None,
-                    steps=steps,
-                    status=status,
-                    started_at=parse_timestamp_to_utc_naive(started_at_ts),
-                    completed_at=utcnow_naive(),
-                    elapsed_time=elapsed_time,
-                    token_usage=token_usage,
-                    error_message=error_message,
-                    meta_data=meta_data,
-                )
-                db.add(execution)
-                await db.commit()
-                await db.refresh(execution)
-                return execution.id
-
-        app_obj = await self._db_get(App, app_id)
-        execution = AgentExecution(
-            app_id=app_id,
-            conversation_id=conversation_id,
-            message_id=message_id,
-            agent_config_id=agent_config_id,
-            release_id=app_obj.current_release_id if app_obj else None,
-            triggered_by=None,
-            steps=steps,
-            status=status,
-            started_at=parse_timestamp_to_utc_naive(started_at_ts),
-            completed_at=utcnow_naive(),
-            elapsed_time=elapsed_time,
-            token_usage=token_usage,
-            error_message=error_message,
-            meta_data=meta_data,
-        )
-        self.db.add(execution)
-        self.db.commit()
-        return execution.id
-
-
-
-
-
     async def _check_annotation_match_async(
             self,
             app_id: uuid.UUID,
@@ -1594,18 +1530,22 @@ class AppChatService:
                     if conv:
                         conv.message_count += 1
                     await db.commit()
-                await self._persist_final_agent_execution(
-                    app_id=config.app_id,
-                    conversation_id=conversation_id,
-                    agent_config_id=config.id,
-                    started_at_ts=start_time,
-                    status="completed",
-                    steps=all_node_executions,
-                    meta_data={"model": _api_key_model_name, "provider": _api_key_provider},
-                    elapsed_time=elapsed_time,
-                    token_usage={"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
-                    message_id=message_id,
-                )
+                await BatchPersistQueue.enqueue(PersistTask(
+                    task_type="save_agent_execution",
+                    args={
+                        "app_id": str(config.app_id),
+                        "conversation_id": str(conversation_id),
+                        "message_id": str(message_id),
+                        "agent_config_id": str(config.id) if config.id else None,
+                        "release_id": str(_release_id) if _release_id else None,
+                        "steps": all_node_executions,
+                        "status": "completed",
+                        "started_at_ts": start_time,
+                        "elapsed_time": elapsed_time,
+                        "token_usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens},
+                        "meta_data": {"model": _api_key_model_name, "provider": _api_key_provider},
+                    },
+                ))
 
             yield f"event: end\ndata: {json.dumps(end_data, ensure_ascii=False)}\n\n"
 
@@ -1643,21 +1583,26 @@ class AppChatService:
                 pass
             # 失败场景也改成尾部一次写，避免依赖首包前 execution。
             try:
-                elapsed_time = time.time() - start_time
-                await self._persist_final_agent_execution(
-                    app_id=config.app_id,
-                    conversation_id=conversation_id,
-                    agent_config_id=config.id,
-                    started_at_ts=start_time,
-                    status="failed",
-                    steps=node_executions if 'node_executions' in dir() else [],
-                    meta_data={
-                        "model": _api_key_model_name if '_api_key_model_name' in locals() else None,
-                        "provider": _api_key_provider if '_api_key_provider' in locals() else None,
+                from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
+                await BatchPersistQueue.enqueue(PersistTask(
+                    task_type="save_agent_execution",
+                    args={
+                        "app_id": str(config.app_id),
+                        "conversation_id": str(conversation_id),
+                        "message_id": None,
+                        "agent_config_id": str(config.id) if config.id else None,
+                        "release_id": None,
+                        "steps": node_executions if 'node_executions' in locals() else [],
+                        "status": "failed",
+                        "started_at_ts": start_time,
+                        "elapsed_time": time.time() - start_time,
+                        "error_message": str(e)[:2000],
+                        "meta_data": {
+                            "model": _api_key_model_name if '_api_key_model_name' in locals() else None,
+                            "provider": _api_key_provider if '_api_key_provider' in locals() else None,
+                        },
                     },
-                    elapsed_time=elapsed_time,
-                    error_message=str(e)[:2000],
-                )
+                ))
             except Exception:
                 pass  # 保存失败不影响错误事件发送
             # 发送错误事件

--- a/api/app/services/batch_persist_queue.py
+++ b/api/app/services/batch_persist_queue.py
@@ -543,6 +543,13 @@ async def _mark_memory_pending(conv_id: str) -> None:
         )
 
 
+def _to_uuid(value: Any) -> uuid_module.UUID | None:
+    """Coerce a str or UUID to UUID, returning None if falsy."""
+    if not value:
+        return None
+    return uuid_module.UUID(value) if isinstance(value, str) else value
+
+
 async def _handle_save_agent_execution(
     db: Any,
     **kwargs: Any,
@@ -551,18 +558,12 @@ async def _handle_save_agent_execution(
     from app.models.agent_execution_model import AgentExecution
     from app.core.utils.datetime_utils import parse_timestamp_to_utc_naive, utcnow_naive
 
-    app_id = uuid_module.UUID(kwargs["app_id"]) if isinstance(kwargs.get("app_id"), str) else kwargs.get("app_id")
-    conversation_id = uuid_module.UUID(kwargs["conversation_id"]) if isinstance(kwargs.get("conversation_id"), str) else kwargs.get("conversation_id")
-    message_id = uuid_module.UUID(kwargs["message_id"]) if isinstance(kwargs.get("message_id"), str) else kwargs.get("message_id")
-    agent_config_id = uuid_module.UUID(kwargs["agent_config_id"]) if kwargs.get("agent_config_id") else None
-    release_id = uuid_module.UUID(kwargs["release_id"]) if kwargs.get("release_id") else None
-
     execution = AgentExecution(
-        app_id=app_id,
-        conversation_id=conversation_id,
-        message_id=message_id,
-        agent_config_id=agent_config_id,
-        release_id=release_id,
+        app_id=_to_uuid(kwargs["app_id"]),
+        conversation_id=_to_uuid(kwargs["conversation_id"]),
+        message_id=_to_uuid(kwargs.get("message_id")),
+        agent_config_id=_to_uuid(kwargs.get("agent_config_id")),
+        release_id=_to_uuid(kwargs.get("release_id")),
         triggered_by=None,
         steps=kwargs.get("steps", []),
         status=kwargs.get("status", "completed"),


### PR DESCRIPTION
migrate agent execution persistence to batch queue

## Summary by Sourcery

通过批量持久化队列来进行路由的代理执行持久化，而不是直接从聊天服务写入。

增强内容：
- 将聊天服务中成功和失败的代理执行写入操作，改为在批量持久化队列上排队 `save_agent_execution` 任务。
- 在 `batch_persist_queue` 中通过共享助手函数简化 UUID 转换，并在代理执行处理逻辑中复用该助手函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route agent execution persistence through the batch persist queue instead of writing directly from the chat service.

Enhancements:
- Move successful and failed agent execution writes in the chat service to enqueue save_agent_execution tasks on the batch persistence queue.
- Simplify UUID coercion in batch_persist_queue via a shared helper and reuse it in agent execution handling logic.

</details>