### PR TITLE
fix(web): note node tools

### DIFF
--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteFormatPlugin.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteFormatPlugin.tsx
@@ -75,26 +75,40 @@ const NoteFormatPlugin = ({ nodeId, onFormatChange, fontSize = 12 }: { nodeId: s
           });
           editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
         });
+      } else if (format === 'link' && typeof value === 'string') {
+        editor.focus(() => {
+          editor.update(() => {
+            if (!$isRangeSelection(sel)) return;
+            $setSelection(sel);
+            const anchorNode = sel.anchor.getNode();
+            const linkNode = $getNearestNodeOfType(anchorNode, LinkNode);
+            if (linkNode) {
+              linkNode.setURL(value);
+            } else if (!sel.isCollapsed()) {
+              editor.dispatchCommand(TOGGLE_LINK_COMMAND, value);
+            }
+          });
+        });
       } else if (format === 'list') {
         editor.focus(() => {
-          if (sel) editor.update(() => $setSelection(sel));
-          editor.dispatchCommand(value ? INSERT_UNORDERED_LIST_COMMAND : REMOVE_LIST_COMMAND, undefined);
-          editor.update(() => $setSelection(null));
+          editor.update(() => {
+            if (!$isRangeSelection(sel)) return;
+            $setSelection(sel);
+            editor.dispatchCommand(value ? INSERT_UNORDERED_LIST_COMMAND : REMOVE_LIST_COMMAND, undefined);
+          });
         });
       } else if (hasSelection) {
         editor.focus(() => {
-          editor.update(() => $setSelection(sel));
-          if (format === 'bold' || format === 'italic' || format === 'strikethrough') {
-            editor.dispatchCommand(FORMAT_TEXT_COMMAND, format);
-          } else if (format === 'link') {
-            editor.dispatchCommand(TOGGLE_LINK_COMMAND, value as string | null);
-          } else if (format === 'fontSize') {
-            editor.update(() => {
-              $setSelection(sel);
+          editor.update(() => {
+            $setSelection(sel);
+            if (format === 'bold' || format === 'italic' || format === 'strikethrough') {
+              editor.dispatchCommand(FORMAT_TEXT_COMMAND, format);
+            } else if (format === 'link') {
+              editor.dispatchCommand(TOGGLE_LINK_COMMAND, value as string | null);
+            } else if (format === 'fontSize') {
               $patchStyleText(sel!, { 'font-size': `${value}px` });
-            });
-          }
-          editor.update(() => $setSelection(null));
+            }
+          });
         });
       }
     };

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteLinkPopovers.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteLinkPopovers.tsx
@@ -29,7 +29,9 @@ export const LinkPopover: FC<LinkPopoverProps> = ({ url, rect, onEdit, onRemove 
       onMouseDown={e => e.stopPropagation()}
     >
       <Flex align="center" gap={8}>
-        <a href={url} target="_blank" rel="noreferrer" style={{ color: '#2563eb', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', display: 'inline-block' }}>
+        <a href={url} target="_blank" rel="noreferrer"
+          className="rb:text-[#2563eb] rb:max-w-40 rb:overflow-hidden rb:inline-block rb:text-ellipsis"
+        >
           {url}
         </a>
         <Button size="small" type="text" icon={<EditOutlined />} onClick={onEdit}>{t('common.edit')}</Button>
@@ -44,12 +46,16 @@ interface EditLinkPopoverProps {
   rect: DOMRect;
   initialUrl: string;
   onConfirm: (url: string) => void;
+  onClose: () => void;
 }
 
-export const EditLinkPopover: FC<EditLinkPopoverProps> = ({ rect, initialUrl, onConfirm }) => {
+export const EditLinkPopover: FC<EditLinkPopoverProps> = ({ rect, initialUrl, onConfirm, onClose }) => {
   const { t } = useTranslation();
   const [url, setUrl] = useState(initialUrl);
-  const confirm = () => onConfirm(url);
+  const confirm = () => {
+    onClose();
+    onConfirm(url);
+  };
   return createPortal(
     <div
       style={{ ...POPOVER_STYLE, left: rect.left, top: rect.bottom + 4, padding: '8px' }}
@@ -62,8 +68,13 @@ export const EditLinkPopover: FC<EditLinkPopoverProps> = ({ rect, initialUrl, on
           placeholder={t('workflow.config.notes.enterLink')}
           value={url}
           onChange={e => setUrl(e.target.value)}
-          onKeyDown={e => e.stopPropagation()}
-          onPressEnter={confirm}
+          onKeyDown={e => {
+            e.stopPropagation();
+            if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              confirm();
+            }
+          }}
           autoFocus
         />
         <Button size="small" type="primary" onClick={confirm}>{t('common.confirm')}</Button>

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/index.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/index.tsx
@@ -28,6 +28,7 @@ const theme = {
 };
 
 const NOTE_NODES = [ListNode, ListItemNode, LinkNode];
+const NOTE_EDIT_LINK_OPEN_EVENT = 'note:edit-link-opened';
 
 const NOTE_STYLES = `
   .editor-text-bold { font-weight: bold; }
@@ -69,7 +70,26 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
   const { t } = useTranslation();
   const [linkState, setLinkState] = useState<{ url: string; rect: DOMRect } | null>(null);
   const [editLinkRect, setEditLinkRect] = useState<{ url: string; rect: DOMRect } | null>(null);
+  const editLinkOwner = useRef(Symbol('note-edit-link-popover'));
   const removingLink = useRef(false);
+
+  const openEditLink = useCallback((nextState: { url: string; rect: DOMRect }) => {
+    window.dispatchEvent(new CustomEvent(NOTE_EDIT_LINK_OPEN_EVENT, {
+      detail: { owner: editLinkOwner.current },
+    }));
+    setEditLinkRect(nextState);
+  }, []);
+
+  useEffect(() => {
+    const closeOtherEditLink = (event: Event) => {
+      const { owner } = (event as CustomEvent<{ owner: symbol }>).detail;
+      if (owner !== editLinkOwner.current) {
+        setEditLinkRect(null);
+      }
+    };
+    window.addEventListener(NOTE_EDIT_LINK_OPEN_EVENT, closeOtherEditLink);
+    return () => window.removeEventListener(NOTE_EDIT_LINK_OPEN_EVENT, closeOtherEditLink);
+  }, []);
 
   useEffect(() => {
     if (!linkState) return;
@@ -83,21 +103,21 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
       const { id, url, rect: passedRect } = (e as CustomEvent).detail;
       if (id !== nodeId) return;
       if (passedRect) {
-        setEditLinkRect({ url: url || '', rect: passedRect });
+        openEditLink({ url: url || '', rect: passedRect });
         return;
       }
       const sel = window.getSelection();
       if (sel && sel.rangeCount > 0) {
         const r = sel.getRangeAt(0).getBoundingClientRect();
-        if (r.width > 0 || r.height > 0) { setEditLinkRect({ url: url || '', rect: r }); return; }
+        if (r.width > 0 || r.height > 0) { openEditLink({ url: url || '', rect: r }); return; }
       }
       const linkEl = document.querySelector(`[data-note-id="${nodeId}"] a.note-link`) as HTMLElement;
       const rect = linkEl?.getBoundingClientRect() ?? new DOMRect(window.innerWidth / 2, 200, 0, 0);
-      setEditLinkRect({ url: url || '', rect });
+      openEditLink({ url: url || '', rect });
     };
     window.addEventListener('note:edit-link', handler);
     return () => window.removeEventListener('note:edit-link', handler);
-  }, [nodeId]);
+  }, [nodeId, openEditLink]);
 
   const handleFormatChange = useCallback((state: FormatState) => {
     onFormatChange?.(state);
@@ -154,8 +174,8 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
               onConfirm={(url) => {
                 removingLink.current = true;
                 window.dispatchEvent(new CustomEvent('note:format', { detail: { id: nodeId, format: 'link', value: url || null } }));
-                setEditLinkRect(null);
               }}
+              onClose={() => setEditLinkRect(null)}
             />
           )}
           {linkState && (
@@ -166,7 +186,7 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
                 removingLink.current = true;
                 const { rect, url } = linkState;
                 setLinkState(null);
-                setEditLinkRect({ url, rect });
+                openEditLink({ url, rect });
               }}
               onRemove={() => {
                 removingLink.current = true;

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteNodeToolbar.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteNodeToolbar.tsx
@@ -28,15 +28,23 @@ const NoteNodeToolbar: FC<NoteNodeToolbarProps> = ({ node, onFormat, toolConfig,
       <div
         className="rb:w-5 rb:h-5 rb:rounded-full rb:cursor-pointer rb:border rb:border-gray-200"
         style={{ background: theme.bg }}
-        onClick={() => onFormat('color', key)}
       />
     ),
   }));
 
   const fontSizeItems: MenuProps['items'] = FONT_SIZES.map(({ label, value }) => ({
     key: value,
-    label: <span onClick={() => onFormat('fontSize', value)}>{label}</span>,
+    label: <span>{label}</span>,
+    className: toolConfig.fontSize === value ? 'rb:bg-[#171719] rb:text-white!' : ''
   }));
+
+  const handleColorClick: MenuProps['onClick'] = ({ key }) => {
+    onFormat('color', key);
+  };
+
+  const handleFontSizeClick: MenuProps['onClick'] = ({ key }) => {
+    onFormat('fontSize', Number(key));
+  };
 
   const currentFontSize = FONT_SIZES.find(f => f.value === toolConfig.fontSize)?.label ?? '小';
 
@@ -71,20 +79,25 @@ const NoteNodeToolbar: FC<NoteNodeToolbarProps> = ({ node, onFormat, toolConfig,
       align="center"
       gap={8}
       className="rb:absolute rb:-top-11 rb:left-1/2 rb:-translate-x-1/2 rb:bg-white rb:z-10 rb:whitespace-nowrap rb:rounded-lg rb:py-1! rb:px-3!"
+      onPointerDown={e => e.stopPropagation()}
+      onMouseDown={e => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
       onClick={e => e.stopPropagation()}
     >
       {/* Color picker */}
-      <Dropdown menu={{ items: colorItems }} trigger={['click']}>
+      <Dropdown menu={{ items: colorItems, onClick: handleColorClick }} trigger={['click']}>
         <div
           className="rb:w-5 rb:h-5 rb:rounded-full rb:cursor-pointer rb:border rb:border-gray-200"
-          style={{ background: THEME_MAP[data.bgColor]?.bg || THEME_MAP.blue.bg }}
+          style={{ background: THEME_MAP[data.config?.theme?.defaultValue]?.bg || THEME_MAP.blue.bg }}
         />
       </Dropdown>
 
       <Divider type="vertical" />
 
       {/* Font size */}
-      <Dropdown menu={{ items: fontSizeItems }} trigger={['click']}>
+      <Dropdown menu={{ items: fontSizeItems, onClick: handleFontSizeClick }} trigger={['click']}>
         <Flex align="center" gap={4} className="rb:cursor-pointer rb:text-xs rb:text-gray-600 rb:select-none">
           <span className="rb:text-xs">Aa</span>
           <span className="rb:text-xs">{currentFontSize}</span>

--- a/web/src/views/Workflow/components/Nodes/NoteNode/index.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/index.tsx
@@ -19,6 +19,7 @@ const NoteNode: ReactShapeConfig['component'] = ({ node }) => {
     italic: false,
     strikethrough: false,
     list: false,
+    link: false,
   })
 
   const handleFormat = (type: string, value?: unknown) => {
@@ -107,18 +108,22 @@ const NoteNode: ReactShapeConfig['component'] = ({ node }) => {
         borderColor: data.isSelected ? theme.outer : theme.border,
       }}
     >
-      <div className="rb:h-4 rb:rounded-tl-2xl rb:rounded-tr-2xl"
+      <div key="note-header" className="rb:h-4 rb:rounded-tl-2xl rb:rounded-tr-2xl"
         style={{
           background: theme.title
         }}
       ></div>
-      {data.isSelected && <NoteNodeToolbar node={node!} nodeId={nodeId} toolConfig={toolConfig} onFormat={handleFormat} />}
+      {data.isSelected && <NoteNodeToolbar key="note-toolbar" node={node!} nodeId={nodeId} toolConfig={toolConfig} onFormat={handleFormat} />}
 
       <div
+        key="note-editor"
         className="rb:w-full rb:h-[calc(100%-36px)] rb:p-2.5 rb:overflow-auto"
         onMouseDown={e => {
           e.stopPropagation()
-          node?.setData({ ...node.getData(), isSelected: true })
+          const currentData = node?.getData()
+          if (node && !currentData?.isSelected) {
+            node.setData({ ...currentData, isSelected: true })
+          }
         }}
         onWheel={e => e.stopPropagation()}
       >
@@ -127,10 +132,14 @@ const NoteNode: ReactShapeConfig['component'] = ({ node }) => {
           value={data.config.text.defaultValue || ''}
           fontSize={toolConfig.fontSize}
           onChange={updateText}
-          onFormatChange={(state) => setToolConfig(prev => ({ ...prev, ...state }))}
+          onFormatChange={(state) => setToolConfig(prev => ({
+            ...prev,
+            ...state,
+            link: Boolean(state.linkUrl),
+          }))}
         />
       </div>
-      <Flex align="center" justify="space-between" className="rb:pl-2.5! rb:pr-1!">
+      <Flex key="note-footer" align="center" justify="space-between" className="rb:pl-2.5! rb:pr-1!">
         <div className="rb:text-[12px] rb:text-[#5B6167]">
           {data.config.show_author.defaultValue
             ? data.config.author.defaultValue


### PR DESCRIPTION
## Summary by Sourcery

改进工作流 Web 编辑器中 Note 节点的编辑体验和链接处理。

Bug 修复：
- 确保在 Note 编辑器中，列表和文本格式化操作能够正确保留并作用于当前选区。
- 修复链接格式化，使现有链接可以被更新，并且仅在存在非折叠选区时才应用新链接。
- 防止 Note 工具栏和链接编辑弹出层干扰节点选择和文本输入（包括输入法组合和 Enter 键处理）。
- 避免在编辑器区域交互时重复切换 Note 节点的选中状态。

功能增强：
- 引入协调的链接编辑弹出层，以确保在所有 Note 编辑器中同一时间仅显示一个编辑弹出层。
- 更新 Note 工具栏中的颜色和字体大小下拉菜单，改为使用菜单项的 onClick 处理程序，高亮显示当前字体大小，并从配置的主题中派生颜色。
- 优化链接弹出层中 URL 的样式，使用统一的工具类并改进截断行为。
- 在 Note 节点配置中根据链接 URL 的存在与否跟踪链接格式状态，以更好地反映编辑器状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Note node editing UX and link handling in the workflow web editor.

Bug Fixes:
- Ensure list and text formatting operations correctly preserve and operate on the current selection in the note editor.
- Fix link formatting so existing links can be updated and new links are applied only when a non-collapsed selection is present.
- Prevent the note toolbar and link edit popovers from interfering with node selection and text input (including IME composition and Enter handling).
- Avoid repeatedly toggling note node selection state when interacting with the editor area.

Enhancements:
- Introduce coordinated link edit popovers so only one edit popover is visible at a time across note editors.
- Update note toolbar color and font-size dropdowns to use menu onClick handlers, highlight the active font size, and derive color from the configured theme.
- Refine link popover styling for URLs to use consistent utility classes and improved truncation behavior.
- Track link format state in the note node config based on the presence of a link URL to better reflect editor state.

</details>