### PR TITLE
refactor(chat-service)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -1514,10 +1514,9 @@ class AppChatService:
                         },
                     ))
             else:
-                async with get_async_db_context() as _exec_db:
-                    _app_obj = await _exec_db.get(App, config.app_id)
-                    _release_id = _app_obj.current_release_id if _app_obj else None
                 async with get_async_db_context() as db:
+                    _app_obj = await db.get(App, config.app_id)
+                    _release_id = _app_obj.current_release_id if _app_obj else None
                     new_msg = Message(
                         id=message_id,
                         conversation_id=conversation_id,

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -537,8 +537,8 @@ class AppChatService:
         if hasattr(features_config, 'model_dump'):
             features_config = features_config.model_dump()
         web_search_feature = features_config.get("web_search", {})
-        if isinstance(web_search_feature, dict) and web_search_feature.get("enabled"):
-            web_search = True
+        if not (isinstance(web_search_feature, dict) and web_search_feature.get("enabled")):
+            web_search = False
 
         # 校验文件上传
         self.agent_service._validate_file_upload(features_config, files)
@@ -1070,8 +1070,8 @@ class AppChatService:
             if hasattr(features_config, 'model_dump'):
                 features_config = features_config.model_dump()
             web_search_feature = features_config.get("web_search", {})
-            if isinstance(web_search_feature, dict) and web_search_feature.get("enabled"):
-                web_search = True
+            if not (isinstance(web_search_feature, dict) and web_search_feature.get("enabled")):
+                web_search = False
 
             # 校验文件上传
             self.agent_service._validate_file_upload(features_config, files)
@@ -1514,6 +1514,9 @@ class AppChatService:
                         },
                     ))
             else:
+                async with get_async_db_context() as _exec_db:
+                    _app_obj = await _exec_db.get(App, config.app_id)
+                    _release_id = _app_obj.current_release_id if _app_obj else None
                 async with get_async_db_context() as db:
                     new_msg = Message(
                         id=message_id,
@@ -1530,6 +1533,7 @@ class AppChatService:
                     if conv:
                         conv.message_count += 1
                     await db.commit()
+                from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
                 await BatchPersistQueue.enqueue(PersistTask(
                     task_type="save_agent_execution",
                     args={

--- a/api/app/services/batch_persist_queue.py
+++ b/api/app/services/batch_persist_queue.py
@@ -43,7 +43,7 @@ class PersistTask:
     """Immutable description of a single persistence operation."""
 
     task_type: str
-    """One of: save_messages, save_execution, record_usage, after_turn, save_failed_message."""
+    """One of: save_messages, save_agent_execution, record_usage, after_turn, save_failed_message."""
 
     args: dict[str, Any]
     """Keyword arguments for the handler that executes this task."""
@@ -577,30 +577,6 @@ async def _handle_save_agent_execution(
     db.add(execution)
 
 
-async def _handle_save_execution(
-    db: Any,
-    result: Any,  # StreamResult
-    **kwargs: Any,
-) -> None:
-    """Persist agent execution record."""
-    from app.models.agent_execution_model import AgentExecution
-
-    execution = AgentExecution(
-        id=kwargs.get("execution_id"),
-        app_id=kwargs.get("app_id"),
-        conversation_id=kwargs.get("conversation_id"),
-        message_id=result.message_id,
-        user_id=kwargs.get("user_id"),
-        status=kwargs.get("status", "completed"),
-        node_executions=result.node_executions,
-        total_tokens=result.total_tokens,
-        elapsed_time=result.elapsed_time,
-        model_name=kwargs.get("api_key_model_name"),
-        provider=kwargs.get("api_key_provider"),
-    )
-    db.add(execution)
-
-
 async def _handle_record_usage(
     db: Any,
     **kwargs: Any,
@@ -659,7 +635,6 @@ async def _handle_save_node_executions(
 
 
 _TASK_HANDLERS: dict[str, Any] = {
-    "save_execution": _handle_save_execution,
     "save_agent_execution": _handle_save_agent_execution,
     "save_node_executions": _handle_save_node_executions,
     "record_usage": _handle_record_usage,


### PR DESCRIPTION
replace save_execution with save_agent_execution in batch persist queue

## Summary by Sourcery

重构聊天服务的持久化逻辑，以使用 `save_agent_execution` 任务，并调整代理聊天流程中的网页搜索功能处理方式。

新功能：
- 在通过批量持久化队列加载标注上下文时，持久化代理执行记录。

改进：
- 移除旧的 `save_execution` 任务类型和处理器，统一改用 `save_agent_execution`。
- 优化标准代理聊天流程和流式代理聊天流程中的网页搜索功能开关处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat service persistence to use the `save_agent_execution` task and adjust web search feature handling in agent chat flows.

New Features:
- Persist agent execution records when loading annotation context via the batch persist queue.

Enhancements:
- Remove the legacy `save_execution` task type and handler in favor of `save_agent_execution`.
- Refine web search feature flag handling in both standard and streaming agent chat flows.

</details>