### PR TITLE
style(web): ui

### DIFF
--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -8,6 +8,7 @@ html, body, #root {
   font-family: -apple-system, PingFangSC, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-size: 16px;
 }
 
 /* 全局样式适配 */


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 在根 HTML 和 body 元素上定义 16px 的默认字体大小，以确保排版一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Define a 16px default font size on the root HTML and body elements for consistent typography.

</details>