### PR TITLE
feat: add MiniMax provider catalog support

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -269,6 +269,7 @@ class RedBearModelFactory:
             ModelProvider.OPENAI,
             ModelProvider.XINFERENCE,
             ModelProvider.GPUSTACK,
+            ModelProvider.MINIMAX,
             ModelProvider.OLLAMA,
             ModelProvider.VOLCANO,
             ModelProvider.SPEEDBEAR,
@@ -490,6 +491,7 @@ def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelTy
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
+        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         return CompatibleChatOpenAI
@@ -516,6 +518,7 @@ def get_provider_embedding_class(provider: str) -> type[Embeddings]:
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
+        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         from langchain_openai import OpenAIEmbeddings

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -518,7 +518,6 @@ def get_provider_embedding_class(provider: str) -> type[Embeddings]:
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
-        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         from langchain_openai import OpenAIEmbeddings

--- a/api/app/core/models/scripts/minimax_models.yaml
+++ b/api/app/core/models/scripts/minimax_models.yaml
@@ -1,0 +1,31 @@
+provider: minimax
+models:
+- name: MiniMax-M3
+  type: llm
+  provider: minimax
+  description: MiniMax-M3 multimodal large language model with a 1,000,000 token context window, image input, video input, and adaptive thinking.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - vision
+  - video
+  - thinking
+  is_omni: false
+  tags:
+  - large-language-model
+  - multimodal
+  - vision
+  - video
+  - thinking
+- name: MiniMax-M2.7
+  type: llm
+  provider: minimax
+  description: MiniMax-M2.7 large language model with a 204,800 token context window and always-on thinking.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - thinking_only
+  is_omni: false
+  tags:
+  - large-language-model
+  - thinking

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -487,7 +487,6 @@ _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
 _MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
     ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
     ModelProvider.VOLCANO, ModelProvider.SPEEDBEAR,
-    ModelProvider.MINIMAX,
     ModelProvider.OLLAMA,
     ModelProvider.BEDROCK,
 })

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -487,6 +487,7 @@ _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
 _MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
     ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
     ModelProvider.VOLCANO, ModelProvider.SPEEDBEAR,
+    ModelProvider.MINIMAX,
     ModelProvider.OLLAMA,
     ModelProvider.BEDROCK,
 })

--- a/api/app/models/models_model.py
+++ b/api/app/models/models_model.py
@@ -48,6 +48,7 @@ class ModelProvider(StrEnum):
     """模型提供商枚举"""
     OPENAI = "openai"
     SPEEDBEAR = "speedbear"
+    MINIMAX = "minimax"
     # ANTHROPIC = "anthropic"
     # GOOGLE = "google"
     # BAIDU = "baidu"


### PR DESCRIPTION
Reason: Add MiniMax provider support to the model catalog and OpenAI-compatible runtime routing.

Changes:
- Added the MiniMax provider enum value.
- Routed MiniMax through the OpenAI-compatible LLM and embedding paths.
- Enabled MiniMax in the workflow multimodal provider allowlist.
- Added MiniMax-M3 and MiniMax-M2.7 catalog entries with the requested capabilities.

Checks:
- `python -m compileall` for the patched Python modules.
- `uv run python` source-level verification of the new provider enum, runtime routing, and catalog file.

## Summary by Sourcery

在模型目录和运行时路由中添加对 MiniMax 的支持。

新功能：
- 在模型提供方枚举和多模态提供方允许列表中引入 MiniMax 提供方。
- 通过兼容 OpenAI 的 LLM 和 embedding 实现，为 MiniMax 添加路由支持。
- 在目录中注册 MiniMax-M3 和 MiniMax-M2.7 模型，提供多模态和大上下文能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MiniMax as a supported provider across the model catalog and runtime routing.

New Features:
- Introduce the MiniMax provider to the model provider enumeration and multimodal provider allowlist.
- Add routing support for MiniMax through the OpenAI-compatible LLM and embedding implementations.
- Register MiniMax-M3 and MiniMax-M2.7 models in the catalog with multimodal and large-context capabilities.

</details>