### PR TITLE
fix(web): enable_graph_retrieval

### DIFF
--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -86,7 +86,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                 top_k: values.top_k || 100,
                 // hybrid: values.retrieve_type !== hybrid ? true : false,
                 retrieve_type: retrieveType,
-                enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval || false: undefined,
+                enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval: undefined,
             };
             console.log('RecallTest - params:', params);
             fetchData(params);


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

错误修复：
- 确保只有在显式配置时才转发 `enable_graph_retrieval`，而不是在混合模式下默认为 `false`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure enable_graph_retrieval is only forwarded as explicitly configured instead of defaulting to false in hybrid mode.

</details>