### PR TITLE
fix(web): markdown close singleTilde

### DIFF
--- a/web/src/components/Markdown/index.tsx
+++ b/web/src/components/Markdown/index.tsx
@@ -269,7 +269,7 @@ const RbMarkdown: FC<RbMarkdownProps> = ({
           //   }
           // },
         ]}
-        remarkPlugins={[RemarkGfm, RemarkMath, RemarkBreaks]}
+        remarkPlugins={[[RemarkGfm, { singleTilde: false }], RemarkMath, RemarkBreaks]}
         remarkRehypeOptions={{
           allowDangerousHtml: true,
         }}


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在 RemarkGfm 中禁用单波浪号（tilde）处理，以防止在解析包含波浪号字符的 Markdown 时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disable single-tilde handling in RemarkGfm to prevent incorrect Markdown parsing of tilde characters.

</details>