### PR TITLE
Feature/work memory zy

### DIFF
--- a/web/src/components/Markdown/index.tsx
+++ b/web/src/components/Markdown/index.tsx
@@ -269,7 +269,7 @@ const RbMarkdown: FC<RbMarkdownProps> = ({
           //   }
           // },
         ]}
-        remarkPlugins={[RemarkGfm, RemarkMath, RemarkBreaks]}
+        remarkPlugins={[[RemarkGfm, { singleTilde: false }], RemarkMath, RemarkBreaks]}
         remarkRehypeOptions={{
           allowDangerousHtml: true,
         }}

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -86,7 +86,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                 top_k: values.top_k || 100,
                 // hybrid: values.retrieve_type !== hybrid ? true : false,
                 retrieve_type: retrieveType,
-                enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval || false: undefined,
+                enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval: undefined,
             };
             console.log('RecallTest - params:', params);
             fetchData(params);

--- a/web/src/views/UserMemoryDetail/components/ApiMcpMessageList.tsx
+++ b/web/src/views/UserMemoryDetail/components/ApiMcpMessageList.tsx
@@ -1,0 +1,182 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import clsx from 'clsx'
+import { Divider, Flex, Skeleton } from 'antd'
+import { useTranslation } from 'react-i18next'
+import InfiniteScroll from 'react-infinite-scroll-component'
+
+import { getApiMcpMessages } from '@/api/memory'
+import Empty from '@/components/Empty'
+import Markdown from '@/components/Markdown'
+import { formatDateTime } from '@/utils/format'
+
+export type ApiMcpSource = 'mcp' | 'service_api'
+
+export interface ApiMcpMessageItem {
+  role: 'user' | 'assistant';
+  content: string;
+  dialog_at: number;
+  message_seq: number;
+  created_at: number;
+}
+
+interface ApiMcpMessagesResponse {
+  items: ApiMcpMessageItem[];
+  page: {
+    hasnext: boolean;
+  };
+}
+
+export interface ApiMcpMessageListRef {
+  refresh: () => void;
+}
+
+interface ApiMcpMessageListProps {
+  endUserId: string;
+  source: ApiMcpSource;
+  onMessagesChange?: (messages: ApiMcpMessageItem[]) => void;
+}
+
+const PAGE_SIZE = 20
+
+const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProps>(({
+  endUserId,
+  source,
+  onMessagesChange,
+}, ref) => {
+  const { t } = useTranslation()
+  const [messages, setMessages] = useState<ApiMcpMessageItem[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [hasMore, setHasMore] = useState<boolean>(true)
+  const messagesRef = useRef<ApiMcpMessageItem[]>([])
+  const pageRef = useRef<number>(1)
+  const loadingRef = useRef<boolean>(false)
+  const requestRef = useRef<number>(0)
+  const scrollableTarget = `api-mcp-message-list-${source}`
+
+  const refresh = useCallback(() => {
+    const requestId = ++requestRef.current
+    pageRef.current = 1
+    loadingRef.current = true
+    messagesRef.current = []
+    setMessages([])
+    setHasMore(true)
+    setLoading(true)
+    onMessagesChange?.([])
+
+    getApiMcpMessages(endUserId, {
+      source,
+      page: 1,
+      pagesize: PAGE_SIZE,
+    })
+      .then(res => {
+        if (requestId !== requestRef.current) return
+        const response = res as ApiMcpMessagesResponse
+        const nextMessages = response.items || []
+        messagesRef.current = nextMessages
+        setMessages(nextMessages)
+        setHasMore(Boolean(response.page?.hasnext))
+        onMessagesChange?.(nextMessages)
+      })
+      .catch(() => {
+        if (requestId === requestRef.current) {
+          setHasMore(false)
+        }
+      })
+      .finally(() => {
+        if (requestId !== requestRef.current) return
+        loadingRef.current = false
+        setLoading(false)
+      })
+  }, [endUserId, onMessagesChange, source])
+
+  const loadMore = useCallback(() => {
+    if (loadingRef.current || !hasMore) return
+
+    const requestId = requestRef.current
+    const nextPage = pageRef.current + 1
+    loadingRef.current = true
+
+    getApiMcpMessages(endUserId, {
+      source,
+      page: nextPage,
+      pagesize: PAGE_SIZE,
+    })
+      .then(res => {
+        if (requestId !== requestRef.current) return
+        const response = res as ApiMcpMessagesResponse
+        const nextMessages = [...messagesRef.current, ...(response.items || [])]
+        messagesRef.current = nextMessages
+        pageRef.current = nextPage
+        setMessages(nextMessages)
+        setHasMore(Boolean(response.page?.hasnext))
+        onMessagesChange?.(nextMessages)
+      })
+      .catch(() => {
+        if (requestId === requestRef.current) {
+          setHasMore(false)
+        }
+      })
+      .finally(() => {
+        if (requestId === requestRef.current) {
+          loadingRef.current = false
+        }
+      })
+  }, [endUserId, hasMore, onMessagesChange, source])
+
+  useImperativeHandle(ref, () => ({ refresh }), [refresh])
+
+  useEffect(() => {
+    refresh()
+    return () => {
+      requestRef.current += 1
+      loadingRef.current = false
+    }
+  }, [refresh])
+
+  if (loading) return <Skeleton active />
+  if (messages.length === 0) return <Empty />
+
+  return (
+    <div
+      id={scrollableTarget}
+      className="rb:mt-5! rb:h-[calc(100%-89px)]! rb:overflow-y-auto! rb:w-full! rb:overflow-x-hidden!"
+    >
+      <InfiniteScroll
+        dataLength={messages.length}
+        next={loadMore}
+        hasMore={hasMore}
+        loader={<Skeleton active paragraph={{ rows: 1 }} />}
+        scrollableTarget={scrollableTarget}
+      >
+        <Flex vertical gap={12}>
+          {messages.map((item, index) => (
+            <div key={`${item.message_seq}-${item.created_at}`}>
+              {index !== 0 && <Divider className="rb:mt-1! rb:mb-3! rb:ml-11! rb:w-[calc(100%-44px)]!" />}
+              <Flex align="start" gap={12}>
+                <div className={clsx('rb:size-8 rb:bg-cover', {
+                  'rb:bg-[url(@/assets/images/conversation/user.png)]': item.role === 'user',
+                  'rb:bg-[url(@/assets/images/conversation/ai.png)]': item.role === 'assistant',
+                })}></div>
+                <div className="rb:flex-1">
+                  <Flex gap={12} justify="space-between">
+                    <div className="rb:text-[12px] rb:text-[#5B6167] rb:leading-4.5 rb:mb-0.5">
+                      {item.role === 'assistant' ? t('userMemory.assistant') : t('userMemory.user')}
+                    </div>
+                    <div className="rb:text-[12px] rb:text-[#5B6167] rb:leading-4.5 rb:mb-0.5">
+                      {formatDateTime(item.dialog_at)}
+                    </div>
+                  </Flex>
+                  <Markdown content={item.content || ''} />
+                </div>
+              </Flex>
+            </div>
+          ))}
+        </Flex>
+      </InfiniteScroll>
+    </div>
+  )
+})
+
+ApiMcpMessageList.displayName = 'ApiMcpMessageList'
+
+export default ApiMcpMessageList

--- a/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
@@ -18,7 +18,6 @@ import {
   getConversationMessages,
   getConversationDetail,
   getApiMcpDataSources,
-  getApiMcpMessages,
   getMemoryInsightReport,
   getUserSummary,
 } from '@/api/memory'
@@ -30,7 +29,11 @@ import type { ChatItem } from '@/components/Chat/types'
 import PageLoading from '@/components/Empty/PageLoading'
 import type { Data as SummaryData } from '../components/AboutMe'
 import { type Data as InsightData, INSIGHT_KEYS } from '../components/MemoryInsight'
-import Markdown from '@/components/Markdown'
+import ApiMcpMessageList, {
+  type ApiMcpMessageItem,
+  type ApiMcpMessageListRef,
+  type ApiMcpSource,
+} from '../components/ApiMcpMessageList'
 
 /** A conversation session entry in the sidebar list. */
 export interface Conversation {
@@ -58,16 +61,9 @@ interface Detail {
 }
 
 interface ApiMcpListItem {
-  source: 'mcp' | 'service_api';
+  source: ApiMcpSource;
   message_count: number;
   latest_at: number;
-}
-interface ApiMcpMessageItem {
-  role: 'user' | 'assistant';
-  content: string;
-  dialog_at: number;
-  message_seq: number;
-  created_at: number;
 }
 
 /**
@@ -98,6 +94,7 @@ const WorkingDetail: FC = () => {
   const [summaryLoading, setSummaryLoading] = useState<boolean>(false)
   const [summary, setSummary] = useState<SummaryData>({} as SummaryData)
   const [selected, setSelected] = useState<Conversation | ApiMcpListItem | null>(null)
+  const apiMcpMessageListRef = useRef<ApiMcpMessageListRef>(null)
 
   /* Fetch conversation list + api/mcp data sources whenever the route user ID changes. */
   useEffect(() => {
@@ -130,18 +127,6 @@ const WorkingDetail: FC = () => {
         return response
       })
       .catch(() => [] as ApiMcpListItem[])
-  }
-  const getApiMcpDetail = (item: ApiMcpListItem) => {
-    if (!id || !item || !item.source) return
-    setDetailLoading(true)
-    getApiMcpMessages(id, { source: item.source, limit: 20 })
-      .then(res => {
-        setMessages((res as { items: ChatItem[] }).items)
-      })
-      .finally(() => {
-        setMessagesLoading(false)
-      })
-    getUserInsight()
   }
   /** Load the first page of conversations; resolves with the fetched items. */
   const getData = () => {
@@ -194,7 +179,6 @@ const WorkingDetail: FC = () => {
   }
 
   useEffect(() => {
-    console.log('conversationId', !id, selected, selected && !(selected as Conversation)?.id && !(selected as ApiMcpListItem)?.source)
     if (!id || !selected || (!(selected as Conversation)?.id && !(selected as ApiMcpListItem)?.source)) return
     getDetail(selected)
   }, [id, selected])
@@ -210,9 +194,9 @@ const WorkingDetail: FC = () => {
 
     setDetail(null)
     setMessages([])
-    setDetailLoading(true)
-    setMessagesLoading(true)
     if (conversationId) {
+      setDetailLoading(true)
+      setMessagesLoading(true)
       getConversationMessages(id, conversationId)
         .then(res => {
           setMessages(res as ChatItem[])
@@ -220,15 +204,26 @@ const WorkingDetail: FC = () => {
         .finally(() => {
           setMessagesLoading(false)
         })
-        getConversationDetail(id, conversationId)
-          .then(res => {
-            setDetail(res as Detail)
-          })
-          .finally(() => {
-            setDetailLoading(false)
-          })
+      getConversationDetail(id, conversationId)
+        .then(res => {
+          setDetail(res as Detail)
+        })
+        .finally(() => {
+          setDetailLoading(false)
+        })
     } else {
-      getApiMcpDetail(conversation as ApiMcpListItem)
+      setDetailLoading(false)
+      setMessagesLoading(false)
+      getUserInsight()
+    }
+  }
+
+  const handleRefresh = () => {
+    if ((selected as ApiMcpListItem)?.source) {
+      apiMcpMessageListRef.current?.refresh()
+      getUserInsight()
+    } else if (selected) {
+      getDetail(selected)
     }
   }
   /** Derive a human-readable date range (e.g. "2024.01 - 2024.03") from message timestamps. */
@@ -342,53 +337,30 @@ const WorkingDetail: FC = () => {
                   <div className="rb:text-[#5B6167] rb:leading-4.5 rb:text-[12px]">{timeRange}</div>
                   <Flex justify="space-between" align="center" className="rb:bg-[#F6F6F6] rb:rounded-lg rb:py-2.5! rb:pr-2.5! rb:pl-3.25! rb:mt-3!">
                     {t('workingDetail.conversationStream')}
-                    <Button className="rb:h-6!" onClick={() => getDetail(selected)}>{t('workingDetail.refresh')}</Button>
+                    <Button className="rb:h-6!" onClick={handleRefresh}>{t('workingDetail.refresh')}</Button>
                   </Flex>
-                  {messagesLoading
-                    ? <Skeleton active />
-                    : messages.length === 0
-                      ? <Empty />
-                      : (selected as ApiMcpListItem).source
-                      ? (
-                        <Flex vertical gap={12} className="rb:mt-5! rb:h-[calc(100%-89px)]! rb:overflow-y-auto! rb:w-full! rb:overflow-x-hidden!">
-                          {(messages as ApiMcpMessageItem[]).map((item, index) => (
-                            <div>
-                              {index !== 0 && <Divider className="rb:mt-1! rb:mb-3! rb:ml-11! rb:w-[calc(100%-44px)]!" />}
-                              <Flex
-                                align="start"
-                                gap={12}
-                              >
-                                <div className={clsx("rb:size-8 rb:bg-cover", {
-                                  'rb:bg-[url(@/assets/images/conversation/user.png)]': item.role === 'user',
-                                  'rb:bg-[url(@/assets/images/conversation/ai.png)]': item.role === 'assistant',
-                                })}></div>
-                                <div
-                                  className="rb:flex-1"
-                                >
-                                  <Flex gap={12} justify="space-between">
-                                    <div className="rb:text-[12px] rb:text-[#5B6167] rb:leading-4.5 rb:mb-0.5">
-                                      {item.role === 'assistant' ? t('userMemory.assistant') : t('userMemory.user')}
-                                    </div>
-                                    <div className="rb:text-[12px] rb:text-[#5B6167] rb:leading-4.5 rb:mb-0.5">
-                                      {formatDateTime(item.dialog_at)}
-                                    </div>
-                                  </Flex>
-                                  <Markdown content={item.content || ''} />
-                                </div>
-                              </Flex>
-                            </div>
-                          ))}
-                        </Flex>
-                      )
-                      : (
-                        <ChatContent
-                          classNames="rb:h-[calc(100%-77px)] rb:pt-5"
-                          contentClassNames="rb:max-w-110!"
-                          data={messages}
-                          streamLoading={false}
-                          labelFormat={(item) => formatDateTime(item.created_at)}
-                        />
-                      )
+                  {(selected as ApiMcpListItem).source && id
+                    ? (
+                      <ApiMcpMessageList
+                        ref={apiMcpMessageListRef}
+                        endUserId={id}
+                        source={(selected as ApiMcpListItem).source}
+                        onMessagesChange={setMessages}
+                      />
+                    )
+                    : messagesLoading
+                      ? <Skeleton active />
+                      : messages.length === 0
+                        ? <Empty />
+                        : (
+                          <ChatContent
+                            classNames="rb:h-[calc(100%-77px)] rb:pt-5"
+                            contentClassNames="rb:max-w-110!"
+                            data={messages}
+                            streamLoading={false}
+                            labelFormat={(item) => formatDateTime(item.created_at)}
+                          />
+                        )
                   }
                 </RbCard>
               </Col>


### PR DESCRIPTION
## Summary by Sourcery

引入一个专用的、带分页功能的 API/MCP 消息列表组件，并将其集成到工作记忆对话视图中，同时优化相关的加载与刷新行为。

新功能：
- 添加一个带无限滚动功能的 `ApiMcpMessageList` 组件，用于在用户记忆详情视图中展示 API/MCP 对话。

错误修复：
- 确保在回忆（recall）测试中，图检索标志仅在混合检索（hybrid retrieval）时发送，且不强制使用默认值。
- 配置 `RemarkGfm` 将单个波浪线（tilde）视为普通字符，以避免产生非预期的 Markdown 格式化。

改进：
- 重构 `WorkingDetail` 中的 API/MCP 消息处理逻辑，使用新的列表组件和集中定义的类型，简化消息加载和刷新流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated, paginated API/MCP message list component and integrate it into the working-memory conversation view, while refining related loading and refresh behaviour.

New Features:
- Add an ApiMcpMessageList component with infinite scroll to display API/MCP conversations in the user memory detail view.

Bug Fixes:
- Ensure graph retrieval flag in recall tests is only sent for hybrid retrieval without forcing a default value.
- Configure RemarkGfm to treat single tildes as literal characters to avoid unintended markdown formatting.

Enhancements:
- Refactor API/MCP message handling in WorkingDetail to use the new list component and centralised types, simplifying message loading and refresh flows.

</details>