### PR TITLE
refactor(memory): migrate source messages from limit-based to page-based pagination

### DIFF
--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -180,26 +180,43 @@ async def get_sources(
 async def get_source_messages(
         end_user_id: uuid.UUID,
         source: str = Query(..., description="来源：service_api 或 mcp"),
-        limit: int = Query(default=20, ge=1, le=100, description="返回条数上限"),
+        page: int = Query(default=1, ge=1, description="页码，从 1 开始"),
+        pagesize: int = Query(default=20, ge=1, le=100, description="每页数量，最大 100"),
         current_user: CurrentUserSnapshot = Depends(get_current_user_async),
 ):
-    """按来源获取最近 N 条消息，从旧到新排列，形成连贯对话流。
+    """按来源分页获取工作记忆消息，按 message_seq 从旧到新排列，形成连贯对话流。
+
+    分页语义（service_api / mcp 两种来源完全一致）：
+    - page 从 1 开始；pagesize 默认 20、最大 100
+    - 返回 page 元数据 {page, pagesize, total, hasnext}
+    - 按 message_seq ASC 排序：message_seq 从小到大表示消息从旧到新，
+      该来源分组内单调递增，翻页无重复无遗漏
 
     Args:
         end_user_id: 终端用户 UUID
         source: service_api 或 mcp
-        limit: 返回条数上限（默认 20，最大 100）
+        page: 页码（默认 1，最小 1）
+        pagesize: 每页数量（默认 20，最小 1，最大 100）
     """
     allowed_sources = {MemoryMessageSource.SERVICE_API.value, MemoryMessageSource.MCP.value}
     if source not in allowed_sources:
-        return success(data={"items": [], "total": 0, "source": source}, msg="unsupported source")
+        return success(
+            data={
+                "items": [],
+                "total": 0,
+                "source": source,
+                "page": {"page": page, "pagesize": pagesize, "total": 0, "hasnext": False},
+            },
+            msg="unsupported source",
+        )
 
     async with get_async_db_context() as db:
         memory_message_repo = MemoryMessageRepository(db)
         rows, total = await memory_message_repo.list_recent_messages_by_source_async(
             end_user_id=str(end_user_id),
             source=source,
-            limit=limit,
+            page=page,
+            pagesize=pagesize,
         )
         items = [
             {
@@ -211,4 +228,17 @@ async def get_source_messages(
             }
             for m in rows
         ]
-    return success(data={"items": items, "total": total, "source": source}, msg="查询成功")
+    return success(
+        data={
+            "items": items,
+            "total": total,
+            "source": source,
+            "page": {
+                "page": page,
+                "pagesize": pagesize,
+                "total": total,
+                "hasnext": (page * pagesize) < total,
+            },
+        },
+        msg="查询成功",
+    )

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -320,15 +320,21 @@ class MemoryMessageRepository:
         ).scalar_one_or_none()
         return exists is not None
 
-    def list_recent_messages_by_source(
+    async def list_recent_messages_by_source_async(
         self,
         end_user_id: str,
         source: str,
-        limit: int = 20,
+        page: int = 1,
+        pagesize: int = 20,
     ) -> tuple[list[MemoryMessage], int]:
-        """按来源取最近 N 条消息（从旧到新排列）+ 该来源总条数。
+        """按来源分页获取消息 + 该来源总条数（异步版本）。
 
-        先按 created_at DESC 取最新 limit 条 ID，再按 created_at ASC 查询完整行返回。
+        分页语义（service_api / mcp 两种来源完全一致）：
+        - 使用 page / pagesize 分页，page 从 1 开始
+        - 按 message_seq ASC 排序：message_seq 从小到大表示消息从旧到新，
+          且在该来源分组内单调递增，保证翻页无重复、无遗漏
+        - total 通过窗口函数 count(*) OVER () 与数据同一条 SQL 返回，
+          避免独立的 COUNT 往返；页码越界时回退一次 COUNT 保证 total 准确
         """
         base_filter = [
             MemoryMessage.end_user_id == end_user_id,
@@ -336,71 +342,29 @@ class MemoryMessageRepository:
             MemoryMessage.source == source,
         ]
 
-        total = int(self.db.execute(
-            select(func.count(MemoryMessage.id)).where(*base_filter)
-        ).scalar_one())
-
-        if total == 0:
-            return [], 0
-
-        # 取最新 limit 条的 ID
-        recent_ids = list(self.db.execute(
-            select(MemoryMessage.id)
-            .where(*base_filter)
-            .order_by(MemoryMessage.created_at.desc())
-            .limit(limit)
-        ).scalars().all())
-
-        if not recent_ids:
-            return [], total
-
-        # 按 created_at ASC 排序返回完整行（从旧到新）
-        rows = list(self.db.execute(
-            select(MemoryMessage)
-            .where(MemoryMessage.id.in_(recent_ids))
-            .order_by(MemoryMessage.created_at.asc())
-        ).scalars().all())
-
-        return rows, total
-
-    async def list_recent_messages_by_source_async(
-        self,
-        end_user_id: str,
-        source: str,
-        limit: int = 20,
-    ) -> tuple[list[MemoryMessage], int]:
-        """按来源取最近 N 条消息（从旧到新排列）+ 该来源总条数（异步版本）。"""
-        base_filter = [
-            MemoryMessage.end_user_id == end_user_id,
-            MemoryMessage.conversation_id.is_(None),
-            MemoryMessage.source == source,
-        ]
-
-        total_result = await self.db.execute(
-            select(func.count(MemoryMessage.id)).where(*base_filter)
-        )
-        total = int(total_result.scalar_one())
-
-        if total == 0:
-            return [], 0
-
-        recent_ids_result = await self.db.execute(
-            select(MemoryMessage.id)
-            .where(*base_filter)
-            .order_by(MemoryMessage.created_at.desc())
-            .limit(limit)
-        )
-        recent_ids = list(recent_ids_result.scalars().all())
-
-        if not recent_ids:
-            return [], total
-
+        offset = (page - 1) * pagesize
         rows_result = await self.db.execute(
-            select(MemoryMessage)
-            .where(MemoryMessage.id.in_(recent_ids))
-            .order_by(MemoryMessage.created_at.asc())
+            select(
+                MemoryMessage,
+                func.count().over().label("total"),
+            )
+            .where(*base_filter)
+            .order_by(MemoryMessage.message_seq.asc())
+            .offset(offset)
+            .limit(pagesize)
         )
-        rows = list(rows_result.scalars().all())
+        rows_with_total = rows_result.all()
+
+        if not rows_with_total:
+            # 该页无数据：可能是该来源本身无消息，也可能是页码越界。
+            # 补一次 COUNT 返回真实 total，避免元数据失真。
+            total_result = await self.db.execute(
+                select(func.count(MemoryMessage.id)).where(*base_filter)
+            )
+            return [], int(total_result.scalar_one())
+
+        total = int(rows_with_total[0].total)
+        rows = [row[0] for row in rows_with_total]
 
         return rows, total
 


### PR DESCRIPTION
## Summary by Sourcery

将基于 source 的内存消息检索切换为使用基于页面的分页和消息序列排序。

Enhancements:
- 将基于 limit 的最近消息获取方式替换为基于 page/pagesize 的分页，并按 `message_seq` 排序，以在不同 source 之间保持一致性。
- 从 source messages API 返回结构化的分页元数据（`page`、`pagesize`、`total`、`hasnext`），并在控制器响应中向下传递。
- 通过回退到一次计数查询来处理超出范围的页面，在返回空结果的同时保持 `total` 的准确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch source-based memory message retrieval to use page-based pagination and message sequence ordering.

Enhancements:
- Replace limit-based recent message fetching with page/pagesize pagination ordered by message_seq for consistency across sources.
- Return structured pagination metadata (page, pagesize, total, hasnext) from the source messages API and propagate it through the controller response.
- Handle out-of-range pages by falling back to a count query to keep total accurate while returning empty results.

</details>