### PR TITLE
feat(workflow): support cancelled status in workflow execution handling and logging

### DIFF
--- a/api/app/services/app_log_service.py
+++ b/api/app/services/app_log_service.py
@@ -292,7 +292,7 @@ class AppLogService:
             select(WorkflowExecution)
             .where(
                 WorkflowExecution.conversation_id == conversation_id,
-                WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout"])
+                WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout", "cancelled"])
             )
             .order_by(WorkflowExecution.started_at.asc())
         )
@@ -445,6 +445,12 @@ class AppLogService:
             elif execution.status == "timeout":
                 output_content = execution.error_message or ""
                 meta = {"timeout": True, "error_node_id": execution.error_node_id, "elapsed_time": execution.elapsed_time}
+            elif execution.status == "cancelled":
+                output_content = _extract_text(execution.output_data) if execution.output_data else ""
+                meta = {"cancelled": True, "elapsed_time": execution.elapsed_time}
+                logical_outputs = _extract_workflow_outputs(execution.output_data) if execution.output_data else None
+                if logical_outputs:
+                    meta["outputs"] = logical_outputs
             else:
                 # failed 状态：优先用 error_message，不要 dump output_data
                 output_content = execution.error_message or ""
@@ -490,7 +496,7 @@ class AppLogService:
         # 查询该会话关联的所有工作流执行记录（按时间正序）
         stmt = select(WorkflowExecution).where(
             WorkflowExecution.conversation_id == conversation_id,
-            WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout"])
+            WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout", "cancelled"])
         ).order_by(WorkflowExecution.started_at.asc())
 
         executions = self.db.scalars(stmt).all()

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -5786,7 +5786,7 @@ class WorkflowService:
         conv_id = chain[0].conversation_id
         fallback_executions = self.db.query(WorkflowExecution).filter(
             WorkflowExecution.conversation_id == conv_id,
-            WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout"]),
+            WorkflowExecution.status.in_(["completed", "failed", "waiting_human", "timeout", "cancelled"]),
         ).all() if conv_id else []
 
         def _find_execution_by_time(target_msg: MessageModel):
@@ -7147,6 +7147,25 @@ class WorkflowService:
                             "Lock wait timeout, using fallback vars: conversation_id=%s execution_id=%s",
                             conversation_id_uuid, execution.execution_id,
                         )
+                        # 尝试取消上一轮执行（A），从 Redis lock value 读取 A 的 execution_id
+                        try:
+                            holder_value = await aio_redis.get(_lock_key)
+                            if holder_value:
+                                holder_exec_id = (holder_value or "").split(":")[0]
+                                if holder_exec_id and holder_exec_id != execution.execution_id:
+                                    await self._patch_execution_async(
+                                        holder_exec_id, status="cancelled",
+                                    )
+                                    logger.info(
+                                        "Cancelled previous execution after lock timeout: "
+                                        "previous_execution=%s new_execution=%s",
+                                        holder_exec_id, execution.execution_id,
+                                    )
+                        except Exception as cancel_err:
+                            logger.warning(
+                                "Failed to cancel previous execution after lock timeout: %s",
+                                cancel_err,
+                            )
                         _lock_key = None
                     elif not _lock_degraded:
                         # 锁获取成功，重新读变量（上一轮可能刚释放）
@@ -8129,14 +8148,21 @@ class WorkflowService:
             # ── 中断/取消时持久化变量 + 释放锁 + 清理资源 ──
             if execution and execution.status == "running":
                 try:
+                    # 仅当快照包含完整变量时才持久化 output_data；
+                    # 不完整快照（如 LLM 流式 chunk）不保存，避免覆盖上一个已知完整终态。
+                    snapshot = (
+                        _last_event_data
+                        if self._is_snapshot_complete(_last_event_data)
+                        else None
+                    )
                     await self._patch_execution_async(
                         execution.execution_id,
                         status="cancelled",
-                        output_data=_last_event_data,
+                        output_data=snapshot,
                     )
-                    if not isinstance(_last_event_data, dict) or "variables" not in (_last_event_data or {}):
+                    if snapshot is None:
                         logger.warning(
-                            "cancelled without full variable snapshot: "
+                            "cancelled without complete variable snapshot: "
                             "execution_id=%s conversation_id=%s",
                             execution.execution_id, conversation_id_uuid,
                         )
@@ -8171,6 +8197,20 @@ class WorkflowService:
                     "Failed to cleanup intervention registry: execution_id=%s error=%s",
                     execution.execution_id, cleanup_err,
                 )
+
+    @staticmethod
+    def _is_snapshot_complete(data: dict | None) -> bool:
+        """SSE 事件 data 是否包含完整变量快照（含 variables.conv）。
+
+        只有 workflow_end 事件才会携带完整 variables 字段；
+        message/node_end 等中间事件不含，不应作为 cancelled 的变量恢复源。
+        """
+        if not isinstance(data, dict):
+            return False
+        if "variables" not in data:
+            return False
+        variables = data.get("variables") or {}
+        return isinstance(variables, dict) and "conv" in variables
 
     async def resume_intervention_stream(
             self,


### PR DESCRIPTION
- Added "cancelled" status to workflow execution status filters in both workflow_service.py and app_log_service.py
- Implemented automatic cancellation of previous workflow executions on lock timeout
- Enhanced cancelled execution handling to persist only complete variable snapshots
- Added dedicated logging and metadata for cancelled executions in app log service

## Summary by Sourcery

在执行处理和日志记录中支持已取消的工作流执行。

New Features:
- 在工作流和应用日志查询中，将已取消视为工作流执行的终止状态。
- 在应用日志中为已取消的执行捕获专门的助手消息内容和元数据。

Enhancements:
- 当锁等待超时表明有更新的执行已接管时，自动取消之前的工作流执行。
- 仅在存在完整变量快照时才持久化已取消执行的输出数据；在不满足条件时进行日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support cancelled workflow executions across execution handling and logging.

New Features:
- Treat cancelled as a terminal workflow execution status in workflow and app log queries.
- Capture dedicated assistant message content and metadata for cancelled executions in app logs.

Enhancements:
- Automatically cancel prior workflow executions when a lock wait timeout indicates a newer execution has taken over.
- Persist output data for cancelled executions only when a complete variable snapshot is available, logging when it is not.

</details>