### PR TITLE
fix(rag): improve MinerU markdown chunking

### DIFF
--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -97,6 +97,7 @@ class ParseResult:
     url_res: list | None = None
     append_embed: bool = True
     blocks: list[ParsedBlock] | None = None
+    markdown_preprocess_profile: str | None = None
 
 
 @dataclass

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -561,9 +561,12 @@ class BlockMerger(ChunkMerger):
 
     def _metadata_for_block(self, block: ParsedBlock) -> dict:
         metadata = deepcopy(block.metadata)
+        block_type = block.type.value
+        if block.type is ParsedBlockType.LIST and block.metadata.get("contains_qa_marker"):
+            block_type = "qa"
         metadata.update(
             {
-                "block_type": block.type.value,
+                "block_type": block_type,
                 "block_seq_start": block.seq,
                 "block_seq_end": block.seq,
                 "start_line": block.start_line,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -117,15 +117,8 @@ class BlockMerger(ChunkMerger):
         logical_chunks: list[LogicalChunk] = []
         text_group: list[ParsedBlock] = []
         text_like_types = set(TEXT_LIKE_TYPES)
-
-        def is_text_like_block(block: ParsedBlock) -> bool:
-            if block.type in text_like_types:
-                return True
-            return (
-                merge_lists_with_text
-                and block.type is ParsedBlockType.LIST
-                and not block.metadata.get("contains_qa_marker")
-            )
+        if merge_lists_with_text:
+            text_like_types.add(ParsedBlockType.LIST)
 
         def flush_text_group():
             if not text_group:
@@ -148,7 +141,7 @@ class BlockMerger(ChunkMerger):
             text_group.clear()
 
         for block in blocks:
-            if is_text_like_block(block):
+            if block.type in text_like_types:
                 text_group.append(block)
                 continue
 

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -117,8 +117,15 @@ class BlockMerger(ChunkMerger):
         logical_chunks: list[LogicalChunk] = []
         text_group: list[ParsedBlock] = []
         text_like_types = set(TEXT_LIKE_TYPES)
-        if merge_lists_with_text:
-            text_like_types.add(ParsedBlockType.LIST)
+
+        def is_text_like_block(block: ParsedBlock) -> bool:
+            if block.type in text_like_types:
+                return True
+            return (
+                merge_lists_with_text
+                and block.type is ParsedBlockType.LIST
+                and not block.metadata.get("contains_qa_marker")
+            )
 
         def flush_text_group():
             if not text_group:
@@ -141,7 +148,7 @@ class BlockMerger(ChunkMerger):
             text_group.clear()
 
         for block in blocks:
-            if block.type in text_like_types:
+            if is_text_like_block(block):
                 text_group.append(block)
                 continue
 

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -37,6 +37,7 @@ from .text import TextMerger
 TEXT_LIKE_TYPES = {
     ParsedBlockType.HEADING,
     ParsedBlockType.TEXT,
+    ParsedBlockType.LIST,
     ParsedBlockType.BLOCKQUOTE,
 }
 
@@ -580,7 +581,8 @@ class BlockMerger(ChunkMerger):
         last = blocks[-1]
         metadata = {
             "block_type": block_type,
-            "block_types": [block.type.value for block in blocks],
+            "block_types": _unique_preserving_order(block.type.value for block in blocks),
+            "block_count": len(blocks),
             "block_seq_start": first.seq,
             "block_seq_end": last.seq,
             "start_line": first.start_line,
@@ -620,6 +622,16 @@ def _unique_paths(paths) -> list[list[str]]:
             continue
         seen.add(key)
         result.append(list(key))
+    return result
+
+
+def _unique_preserving_order(values) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        item = str(value)
+        if item in result:
+            continue
+        result.append(item)
     return result
 
 

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -37,7 +37,6 @@ from .text import TextMerger
 TEXT_LIKE_TYPES = {
     ParsedBlockType.HEADING,
     ParsedBlockType.TEXT,
-    ParsedBlockType.LIST,
     ParsedBlockType.BLOCKQUOTE,
 }
 
@@ -71,7 +70,13 @@ class BlockMerger(ChunkMerger):
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
             parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
             parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter")
-            parent_chunks = self._blocks_to_logical_chunks(blocks, parent_token_num, parent_chunk_delimiter, 0)
+            parent_chunks = self._blocks_to_logical_chunks(
+                blocks,
+                parent_token_num,
+                parent_chunk_delimiter,
+                0,
+                merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
+            )
             child_chunks, parent_id_map = self._build_children_from_parents(
                 parent_chunks,
                 token_num,
@@ -87,7 +92,13 @@ class BlockMerger(ChunkMerger):
                 pdf_parser=parse_result.pdf_parser,
             )
 
-        logical_chunks = self._blocks_to_logical_chunks(blocks, token_num, delimiter, chunk_overlap)
+        logical_chunks = self._blocks_to_logical_chunks(
+            blocks,
+            token_num,
+            delimiter,
+            chunk_overlap,
+            merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
+        )
         return MergeResult(
             chunks=self._serialize_chunk_contents(logical_chunks),
             logical_chunks=logical_chunks,
@@ -100,9 +111,14 @@ class BlockMerger(ChunkMerger):
         token_num: int,
         delimiter: str | None,
         overlap: int,
+        *,
+        merge_lists_with_text: bool = False,
     ) -> list[LogicalChunk]:
         logical_chunks: list[LogicalChunk] = []
         text_group: list[ParsedBlock] = []
+        text_like_types = set(TEXT_LIKE_TYPES)
+        if merge_lists_with_text:
+            text_like_types.add(ParsedBlockType.LIST)
 
         def flush_text_group():
             if not text_group:
@@ -125,7 +141,7 @@ class BlockMerger(ChunkMerger):
             text_group.clear()
 
         for block in blocks:
-            if block.type in TEXT_LIKE_TYPES:
+            if block.type in text_like_types:
                 text_group.append(block)
                 continue
 
@@ -562,12 +578,9 @@ class BlockMerger(ChunkMerger):
 
     def _metadata_for_block(self, block: ParsedBlock) -> dict:
         metadata = deepcopy(block.metadata)
-        block_type = block.type.value
-        if block.type is ParsedBlockType.LIST and block.metadata.get("contains_qa_marker"):
-            block_type = "qa"
         metadata.update(
             {
-                "block_type": block_type,
+                "block_type": block.type.value,
                 "block_seq_start": block.seq,
                 "block_seq_end": block.seq,
                 "start_line": block.start_line,
@@ -581,7 +594,6 @@ class BlockMerger(ChunkMerger):
         last = blocks[-1]
         metadata = {
             "block_type": block_type,
-            "block_types": _unique_preserving_order(block.type.value for block in blocks),
             "block_count": len(blocks),
             "block_seq_start": first.seq,
             "block_seq_end": last.seq,
@@ -622,16 +634,6 @@ def _unique_paths(paths) -> list[list[str]]:
             continue
         seen.add(key)
         result.append(list(key))
-    return result
-
-
-def _unique_preserving_order(values) -> list[str]:
-    result: list[str] = []
-    for value in values:
-        item = str(value)
-        if item in result:
-            continue
-        result.append(item)
     return result
 
 

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -39,7 +39,7 @@ CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*
 CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
 ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）|｜]|、(?!\s*[A-Za-z]))\s*(.+\S)\s*$")
 DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Z][A-Z0-9]{1,11})([：:])\s*(.+\S)\s*$")
-QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(.+\S)\s*$")
+QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(\S(?:.*\S)?)\s*$")
 ORDINAL_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)({LIST_BOUNDARY})\s*(.+\S)\s*$"
 )

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -38,8 +38,9 @@ KEYCAP_LIST_PATTERN = re.compile(r"^\s{0,3}([0-9]\ufe0f?\u20e3)\s*(.+\S)\s*$")
 CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*$")
 CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
 ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）|｜]|、(?!\s*[A-Za-z]))\s*(.+\S)\s*$")
+QA_QUESTION_MARKERS = {"问", "问题", "提问", "追问"}
+QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问题|答案|提问|回答|答复|回复|追问|问|答|拓展|补充)([?？:：|｜]|\s+)\s*(\S(?:.*\S)?)\s*$")
 DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}(?!问|答|拓展|补充)([^:：\n]{1,32})([：:])\s*(\S(?:.*\S)?)\s*$")
-QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(\S(?:.*\S)?)\s*$")
 ORDINAL_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)({LIST_BOUNDARY})\s*(.+\S)\s*$"
 )

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -38,7 +38,7 @@ KEYCAP_LIST_PATTERN = re.compile(r"^\s{0,3}([0-9]\ufe0f?\u20e3)\s*(.+\S)\s*$")
 CIRCLED_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CIRCLED_MARKERS}])\s*(.+\S)\s*$")
 CHINESE_LIST_PATTERN = re.compile(rf"^\s{{0,3}}([{CHINESE_NUMERAL_MARKERS}]+)({LIST_BOUNDARY})\s*(.+\S)\s*$")
 ALPHA_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Za-z])([.)）|｜]|、(?!\s*[A-Za-z]))\s*(.+\S)\s*$")
-DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}([A-Z][A-Z0-9]{1,11})([：:])\s*(.+\S)\s*$")
+DEFINITION_LIST_PATTERN = re.compile(r"^\s{0,3}(?!问|答|拓展|补充)([^:：\n]{1,32})([：:])\s*(\S(?:.*\S)?)\s*$")
 QA_LIST_PATTERN = re.compile(r"^\s{0,3}(问|答|拓展|补充)([?？:：|｜]|\s+)\s*(\S(?:.*\S)?)\s*$")
 ORDINAL_LIST_PATTERN = re.compile(
     rf"^\s{{0,3}}(首次|其次|再次|最后|第[{CHINESE_NUMERAL_MARKERS}0-9]+)({LIST_BOUNDARY})\s*(.+\S)\s*$"
@@ -220,7 +220,6 @@ class MarkdownPreprocessor:
             ("ordinal", ORDINAL_LIST_PATTERN),
             ("chinese", CHINESE_LIST_PATTERN),
             ("alpha", ALPHA_LIST_PATTERN),
-            ("definition", DEFINITION_LIST_PATTERN),
             ("qa", QA_LIST_PATTERN),
         )
         for marker_kind, pattern in patterns:
@@ -240,6 +239,14 @@ class MarkdownPreprocessor:
                 "list_marker": prefixed_match.group("marker").strip(),
                 "list_marker_kind": "prefixed",
                 "list_prefix": prefixed_match.group("prefix").strip(),
+                "list_level": _indent_level(line),
+                "contains_qa_marker": False,
+            }
+        definition_match = DEFINITION_LIST_PATTERN.match(line)
+        if definition_match:
+            return {
+                "list_marker": definition_match.group(1).strip(),
+                "list_marker_kind": "definition",
                 "list_level": _indent_level(line),
                 "contains_qa_marker": False,
             }

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -123,7 +123,7 @@ class MarkdownPreprocessor:
             line = raw_line
             if normalize_escaped_structure:
                 line = self._normalize_escaped_structural_line(line)
-            line = EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
+                line = EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
             stripped = line.strip()
 
             block_hint = None
@@ -147,7 +147,7 @@ class MarkdownPreprocessor:
                     in_qa_list_context = False
                     qa_continuation_paragraphs = 0
                 else:
-                    list_metadata = self._list_metadata(line)
+                    list_metadata = self._list_metadata(line, enhanced=normalize_escaped_structure)
                     if list_metadata:
                         block_hint = "list"
                         metadata = list_metadata
@@ -155,10 +155,10 @@ class MarkdownPreprocessor:
                         in_qa_list_context = in_qa_list_context or bool(list_metadata.get("contains_qa_marker"))
                         if list_metadata.get("contains_qa_marker"):
                             qa_continuation_paragraphs = 0
-                    elif in_list_context and self._is_list_continuation(
+                    elif normalize_escaped_structure and in_list_context and self._is_list_continuation(
                         line,
-                        in_qa_context=normalize_escaped_structure and in_qa_list_context,
-                        after_blank=normalize_escaped_structure and in_qa_list_context and after_qa_blank,
+                        in_qa_context=in_qa_list_context,
+                        after_blank=in_qa_list_context and after_qa_blank,
                         qa_continuation_paragraphs=qa_continuation_paragraphs,
                     ):
                         block_hint = "list_continuation"
@@ -208,20 +208,24 @@ class MarkdownPreprocessor:
             normalized = ESCAPED_EMPHASIS_PATTERN.sub(r"\1", normalized)
         return normalized
 
-    def _list_metadata(self, line: str) -> dict[str, Any] | None:
+    def _list_metadata(self, line: str, *, enhanced: bool = False) -> dict[str, Any] | None:
         patterns = (
             ("unordered", UNORDERED_LIST_PATTERN),
             ("ordered", ORDERED_LIST_PATTERN),
-            ("ordered", EMPTY_ORDERED_LIST_PATTERN),
-            ("ordered_parenthesis", PAREN_ORDERED_LIST_PATTERN),
-            ("keycap", KEYCAP_LIST_PATTERN),
-            ("circled", CIRCLED_LIST_PATTERN),
-            ("step", STEP_LIST_PATTERN),
-            ("ordinal", ORDINAL_LIST_PATTERN),
-            ("chinese", CHINESE_LIST_PATTERN),
-            ("alpha", ALPHA_LIST_PATTERN),
-            ("qa", QA_LIST_PATTERN),
         )
+        if enhanced:
+            patterns = (
+                *patterns,
+                ("ordered", EMPTY_ORDERED_LIST_PATTERN),
+                ("ordered_parenthesis", PAREN_ORDERED_LIST_PATTERN),
+                ("keycap", KEYCAP_LIST_PATTERN),
+                ("circled", CIRCLED_LIST_PATTERN),
+                ("step", STEP_LIST_PATTERN),
+                ("ordinal", ORDINAL_LIST_PATTERN),
+                ("chinese", CHINESE_LIST_PATTERN),
+                ("alpha", ALPHA_LIST_PATTERN),
+                ("qa", QA_LIST_PATTERN),
+            )
         for marker_kind, pattern in patterns:
             match = pattern.match(line)
             if not match:
@@ -233,6 +237,8 @@ class MarkdownPreprocessor:
                 "list_level": _indent_level(line),
                 "contains_qa_marker": marker_kind == "qa",
             }
+        if not enhanced:
+            return None
         prefixed_match = PREFIXED_LIST_PATTERN.match(line)
         if prefixed_match:
             return {

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -46,7 +46,7 @@ class MinerUV3Parser(DocumentParser):
             self._enhance_image_blocks(blocks, ctx)
         elif ctx.vision_model:
             LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")
-        return ParseResult(blocks=blocks, merge_strategy="blocks")
+        return ParseResult(blocks=blocks, merge_strategy="blocks", markdown_preprocess_profile="mineru")
 
     def _attach_images(self, blocks, images):
         attached_count = 0

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -9,7 +9,11 @@ from PIL import Image
 
 from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
 from app.core.rag.chunk.parser.base import DocumentParser
-from app.core.rag.chunk.parser.markdown_preprocessor import MarkdownLineInfo, MarkdownPreprocessor
+from app.core.rag.chunk.parser.markdown_preprocessor import (
+    MarkdownLineInfo,
+    MarkdownPreprocessor,
+    QA_QUESTION_MARKERS,
+)
 from app.core.rag.nlp import find_codec
 
 
@@ -154,7 +158,7 @@ class StructMarkdownParser(DocumentParser):
         )
 
     def _is_qa_question_line(self, index: int) -> bool:
-        return self._is_qa_list_line(index) and self._qa_marker(index) == "问"
+        return self._is_qa_list_line(index) and self._qa_marker(index) in QA_QUESTION_MARKERS
 
     def _qa_marker(self, index: int) -> str:
         return str(self._line_info(index).metadata.get("list_marker") or "")
@@ -331,8 +335,7 @@ class StructMarkdownParser(DocumentParser):
                 continue
 
             if self._is_qa_list_line(index):
-                marker = self._qa_marker(index)
-                if marker == "问":
+                if self._is_qa_question_line(index):
                     break
                 index += 1
                 continue

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -58,7 +58,10 @@ class StructMarkdownParser(DocumentParser):
                 index = self._append_image_line(index)
                 continue
             if self._is_list_line(index):
-                index = self._append_list(index)
+                if self._is_qa_list_line(index):
+                    index = self._append_qa_list(index)
+                else:
+                    index = self._append_list(index)
                 continue
             if stripped.startswith(">"):
                 index = self._append_blockquote(index)
@@ -143,6 +146,25 @@ class StructMarkdownParser(DocumentParser):
 
     def _is_list_line(self, index: int) -> bool:
         return self._line_info(index).block_hint == "list"
+
+    def _is_qa_list_line(self, index: int) -> bool:
+        return (
+            self._is_list_line(index)
+            and self._line_info(index).metadata.get("list_marker_kind") == "qa"
+        )
+
+    def _is_qa_question_line(self, index: int) -> bool:
+        return self._is_qa_list_line(index) and self._qa_marker(index) == "问"
+
+    def _qa_marker(self, index: int) -> str:
+        return str(self._line_info(index).metadata.get("list_marker") or "")
+
+    def _next_nonblank_index(self, index: int) -> int | None:
+        while index < len(self.lines):
+            if self.lines[index].strip():
+                return index
+            index += 1
+        return None
 
     def _is_list_body_line(self, index: int) -> bool:
         return self._line_info(index).block_hint in {"list", "list_continuation"}
@@ -286,6 +308,41 @@ class StructMarkdownParser(DocumentParser):
                 index += 1
                 continue
             break
+        content = self._block_content(start, index, compact_blank_lines=self._compact_block_spacing)
+        self._append_block(
+            ParsedBlockType.LIST,
+            content,
+            start_line=start + 1,
+            end_line=index,
+            metadata=self._list_metadata(start, index),
+        )
+        return index
+
+    def _append_qa_list(self, index: int) -> int:
+        start = index
+        index += 1
+        while index < len(self.lines):
+            line = self.lines[index]
+            if not line.strip():
+                next_index = self._next_nonblank_index(index + 1)
+                if next_index is not None and self._is_qa_question_line(next_index):
+                    break
+                index += 1
+                continue
+
+            if self._is_qa_list_line(index):
+                marker = self._qa_marker(index)
+                if marker == "问":
+                    break
+                index += 1
+                continue
+
+            if self._is_list_body_line(index) or line.startswith((" ", "\t")):
+                index += 1
+                continue
+
+            break
+
         content = self._block_content(start, index, compact_blank_lines=self._compact_block_spacing)
         self._append_block(
             ParsedBlockType.LIST,

--- a/api/app/core/rag/chunk/parser/structured_markdown.py
+++ b/api/app/core/rag/chunk/parser/structured_markdown.py
@@ -385,7 +385,7 @@ class StructMarkdownParser(DocumentParser):
             if self._is_block_start(index) or IMAGE_PATTERN.search(line):
                 break
             index += 1
-        content = self._block_content(start, index, compact_blank_lines=self._compact_block_spacing)
+        content = self._block_content(start, index)
         self._append_block(
             ParsedBlockType.TEXT,
             content,


### PR DESCRIPTION
## Background
MinerU markdown output can contain paragraph breaks that split related QA, list, and definition-like content into fragmented chunks. This PR narrows markdown preprocessing to the MinerU markdown parse path and improves downstream text merging behavior without changing the source markdown heading hierarchy.

## Scope
- Preserve source markdown text while only normalizing recognized extra blank-line boundaries before `StructMarkdownParser`.
- Keep MinerU-recognized list and QA-like blocks in the normal text merge flow.
- Remove unbounded `metadata.block_types` accumulation and keep compact range metadata.
- Keep recursive split overlap limited to normal text chunk splitting; parent-child mode does not apply overlap.
- Keep image vision enabled by default while honoring explicit `image_vision_enabled=false` for experiments.

## Risks
- The preprocessing rules intentionally only apply to MinerU markdown output. Non-MinerU markdown pipelines should keep their existing parser behavior.
- Pattern-based QA/list/definition recognition may still miss some rare document formats, but unmatched content should remain source-preserved rather than being rewritten broadly.

## Verification
- `uv run python -m compileall app/core/rag/chunk/context.py app/core/rag/chunk/merger/block.py app/core/rag/chunk/parser/markdown_preprocessor.py app/core/rag/chunk/parser/mineru_v3.py app/core/rag/chunk/parser/structured_markdown.py`
- MinerU chunk pipeline smoke test with `/Users/codingx/Documents/测试数据准备/docx/问题提纲.docx`: 3 text chunks, no `metadata.block_types`.
- MinerU chunk pipeline smoke test with `/Users/codingx/Documents/测试数据准备/pdf 文件准备/碳中和术语及解释.pdf`: 2 text chunks, no `metadata.block_types`.
- `rg -n '"block_types"|block_types' api/app -S`: no matches.

## External API Impact
No external API schema change. The change only affects internal RAG chunk parsing and merge behavior for documents parsed through MinerU.

## Summary by Sourcery

改进 MinerU 的 Markdown 预处理和结构化 Markdown 解析，以更好地保留问答/列表内容，生成更连贯的文本块，同时简化范围元数据。

Bug 修复：
- 将 QA 风格的列表行作为统一的列表块处理，避免相关的问答内容被拆分成独立的文本块。
- 将列表续行检测和 HTML 锚点去除，限制在增强型 Markdown 预处理阶段执行，避免修改未标准化的输入。
- 通过用紧凑的块计数摘要替代详细的块类型列表，防止每种块类型元数据无限累积。

增强功能：
- 优化 QA 和定义列表的正则表达式模式，以区分 QA 标记与通用定义，并接受更广泛的标签形式。
- 在结构化 Markdown 解析器中检测 QA 风格列表并将其视为列表块，同时在分块过程中将 MinerU 生成的列表与周围文本合并。
- 为 ParseResult 扩展一个 Markdown 预处理配置标志，并在合并管线中传递 MinerU 配置，以驱动 MinerU 专用的文本块合并行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MinerU markdown preprocessing and structured markdown parsing to better preserve QA/list content and produce more coherent text chunks while simplifying range metadata.

Bug Fixes:
- Handle QA-style list lines as unified list blocks so related question and answer content is not split into separate chunks.
- Limit list continuation detection and HTML anchor stripping to enhanced markdown preprocessing to avoid altering non-normalized input.
- Prevent unbounded accumulation of per-block type metadata by replacing detailed block type lists with a compact block count summary.

Enhancements:
- Refine QA and definition list regex patterns to distinguish QA markers from general definitions and accept a broader range of labels.
- Detect QA-style lists in the structured markdown parser and treat them as list blocks while merging MinerU-generated lists with surrounding text during chunking.
- Extend ParseResult with a markdown preprocess profile flag and propagate the MinerU profile through the merge pipeline to drive MinerU-specific chunk merge behavior.

</details>