### PR TITLE
fix(web): note node

### DIFF
--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteFormatPlugin.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteFormatPlugin.tsx
@@ -31,14 +31,16 @@ const NoteFormatPlugin = ({ nodeId, onFormatChange, fontSize = 12 }: { nodeId: s
         const style = 'getStyle' in anchorNode ? (anchorNode as { getStyle(): string }).getStyle() : '';
         const match = style.match(/font-size:\s*([\d.]+)px/);
         const nodeFontSize = match ? Number(match[1]) : fontSize;
-        const linkNode = $getNearestNodeOfType(anchorNode, LinkNode);
+        const anchorLink = $getNearestNodeOfType(anchorNode, LinkNode);
+        const focusLink = $getNearestNodeOfType(selection.focus.getNode(), LinkNode);
+        const linkUrl = anchorLink && anchorLink === focusLink ? anchorLink.getURL() : null;
         onFormatChange?.({
           bold: selection.hasFormat('bold'),
           italic: selection.hasFormat('italic'),
           strikethrough: selection.hasFormat('strikethrough'),
           list: !!$getNearestNodeOfType(anchorNode, ListNode),
           ...(nodeFontSize ? { fontSize: nodeFontSize } : {}),
-          linkUrl: linkNode ? linkNode.getURL() : null,
+          linkUrl,
         });
       });
     });

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteLinkPopovers.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/NoteLinkPopovers.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { type FC, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Flex, Button, Input } from 'antd';
@@ -52,6 +52,17 @@ interface EditLinkPopoverProps {
 export const EditLinkPopover: FC<EditLinkPopoverProps> = ({ rect, initialUrl, onConfirm, onClose }) => {
   const { t } = useTranslation();
   const [url, setUrl] = useState(initialUrl);
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [onClose]);
   const confirm = () => {
     onClose();
     onConfirm(url);

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/index.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteEditor/index.tsx
@@ -70,6 +70,7 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
   const { t } = useTranslation();
   const [linkState, setLinkState] = useState<{ url: string; rect: DOMRect } | null>(null);
   const [editLinkRect, setEditLinkRect] = useState<{ url: string; rect: DOMRect } | null>(null);
+  const editLinkRectRef = useRef<{ url: string; rect: DOMRect } | null>(null);
   const editLinkOwner = useRef(Symbol('note-edit-link-popover'));
   const removingLink = useRef(false);
 
@@ -77,19 +78,25 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
     window.dispatchEvent(new CustomEvent(NOTE_EDIT_LINK_OPEN_EVENT, {
       detail: { owner: editLinkOwner.current },
     }));
+    editLinkRectRef.current = nextState;
     setEditLinkRect(nextState);
+  }, []);
+
+  const closeEditLink = useCallback(() => {
+    editLinkRectRef.current = null;
+    setEditLinkRect(null);
   }, []);
 
   useEffect(() => {
     const closeOtherEditLink = (event: Event) => {
       const { owner } = (event as CustomEvent<{ owner: symbol }>).detail;
       if (owner !== editLinkOwner.current) {
-        setEditLinkRect(null);
+        closeEditLink();
       }
     };
     window.addEventListener(NOTE_EDIT_LINK_OPEN_EVENT, closeOtherEditLink);
     return () => window.removeEventListener(NOTE_EDIT_LINK_OPEN_EVENT, closeOtherEditLink);
-  }, []);
+  }, [closeEditLink]);
 
   useEffect(() => {
     if (!linkState) return;
@@ -100,24 +107,27 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
 
   useEffect(() => {
     const handler = (e: Event) => {
-      const { id, url, rect: passedRect } = (e as CustomEvent).detail;
+      const { id, hasSelection, hasLink, rect } = (e as CustomEvent).detail as {
+        id: string; hasSelection: boolean; hasLink: boolean; rect?: DOMRect;
+      };
       if (id !== nodeId) return;
-      if (passedRect) {
-        openEditLink({ url: url || '', rect: passedRect });
+      // Popover already open → close (toggle)
+      if (editLinkRectRef.current) { closeEditLink(); return; }
+      // No text selected → do nothing
+      if (!hasSelection || !rect) return;
+      // Text selected with link → remove link
+      if (hasLink) {
+        window.dispatchEvent(new CustomEvent('note:format', {
+          detail: { id: nodeId, format: 'link', value: null },
+        }));
         return;
       }
-      const sel = window.getSelection();
-      if (sel && sel.rangeCount > 0) {
-        const r = sel.getRangeAt(0).getBoundingClientRect();
-        if (r.width > 0 || r.height > 0) { openEditLink({ url: url || '', rect: r }); return; }
-      }
-      const linkEl = document.querySelector(`[data-note-id="${nodeId}"] a.note-link`) as HTMLElement;
-      const rect = linkEl?.getBoundingClientRect() ?? new DOMRect(window.innerWidth / 2, 200, 0, 0);
-      openEditLink({ url: url || '', rect });
+      // Text selected without link → open edit popover
+      openEditLink({ url: '', rect });
     };
-    window.addEventListener('note:edit-link', handler);
-    return () => window.removeEventListener('note:edit-link', handler);
-  }, [nodeId, openEditLink]);
+    window.addEventListener('note:link-click', handler);
+    return () => window.removeEventListener('note:link-click', handler);
+  }, [nodeId, openEditLink, closeEditLink]);
 
   const handleFormatChange = useCallback((state: FormatState) => {
     onFormatChange?.(state);
@@ -177,7 +187,7 @@ const NoteEditor: FC<NoteEditorProps> = ({ nodeId, value, fontSize = 12, onChang
                 removingLink.current = true;
                 window.dispatchEvent(new CustomEvent('note:format', { detail: { id: nodeId, format: 'link', value: url || null } }));
               }}
-              onClose={() => setEditLinkRect(null)}
+              onClose={closeEditLink}
             />
           )}
           {linkState && (

--- a/web/src/views/Workflow/components/Nodes/NoteNode/NoteNodeToolbar.tsx
+++ b/web/src/views/Workflow/components/Nodes/NoteNode/NoteNodeToolbar.tsx
@@ -1,6 +1,6 @@
 import { type FC } from 'react';
 import { Flex, Dropdown, type MenuProps, Switch, Button, Divider } from 'antd';
-import { UnorderedListOutlined, BoldOutlined, ItalicOutlined, StrikethroughOutlined, LinkOutlined, DashOutlined } from '@ant-design/icons';
+import { UnorderedListOutlined, BoldOutlined, ItalicOutlined, StrikethroughOutlined, LinkOutlined } from '@ant-design/icons';
 import { Node } from '@antv/x6';
 import { useTranslation } from 'react-i18next'
 
@@ -133,8 +133,12 @@ const NoteNodeToolbar: FC<NoteNodeToolbarProps> = ({ node, onFormat, toolConfig,
         icon={<LinkOutlined />}
         onClick={() => {
           const sel = window.getSelection();
-          const rect = sel && sel.rangeCount > 0 ? sel.getRangeAt(0).getBoundingClientRect() : undefined;
-          window.dispatchEvent(new CustomEvent('note:edit-link', { detail: { id: nodeId, url: '', rect } }));
+          const range = sel && sel.rangeCount > 0 ? sel.getRangeAt(0) : null;
+          const hasSelection = !!(range && !range.collapsed);
+          const rect = hasSelection && range ? range.getBoundingClientRect() : undefined;
+          window.dispatchEvent(new CustomEvent('note:link-click', {
+            detail: { id: nodeId, hasSelection, hasLink: toolConfig.link, rect },
+          }));
         }}
       />
 
@@ -167,7 +171,7 @@ const NoteNodeToolbar: FC<NoteNodeToolbarProps> = ({ node, onFormat, toolConfig,
           onClick: handleClick
         }}
       >
-        <DashOutlined />
+        <div className="rb:size-4.5 rb:cursor-pointer rb:bg-cover rb:bg-[url('@/assets/images/common/more.svg')]" />
       </Dropdown>
     </Flex>
   );


### PR DESCRIPTION
## Summary by Sourcery

改进笔记节点链接的编辑行为和工具栏控件

Bug 修复：
- 防止多个笔记链接弹出框相互冲突，并根据选区和现有链接状态正确切换
- 修复链接格式状态，仅当整个选区都在同一链接内时才显示 URL

增强功能：
- 新增对 Escape 键的处理，以关闭笔记链接编辑弹出框，并统一关闭逻辑
- 更新笔记节点工具栏的链接按钮，使用更丰富的选区元数据，并采用新的更多选项图标

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve note node link editing behavior and toolbar controls

Bug Fixes:
- Prevent multiple note link popovers from conflicting and ensure proper toggling based on selection and existing links
- Fix link formatting state to only show a URL when the whole selection is within a single link

Enhancements:
- Add Escape key handling to close the note link edit popover and centralize close logic
- Update the note node toolbar link button to use richer selection metadata and a new more-options icon

</details>