### PR TITLE
fix(rag): support full-doc block parents

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -95,7 +95,7 @@ router = APIRouter(
 )
 
 
-# @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
+@router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
 async def get_preview_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -95,7 +95,7 @@ router = APIRouter(
 )
 
 
-@router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
+# @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
 async def get_preview_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -300,7 +300,7 @@ async def get_preview_chunks(
     return success(data=jsonable_encoder(result), msg="Querying the document block preview list succeeded")
 
 
-@router.post("/{kb_id}/{document_id}/preview", response_model=ApiResponse)
+# @router.post("/{kb_id}/{document_id}/preview", response_model=ApiResponse)
 async def get_preview_chunks_hierarchy(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
-from app.core.rag.chunk.hierarchy import validate_parent_child_result
+from app.core.rag.chunk.hierarchy import GroupedChildChunks, validate_parent_child_result
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
 from app.core.rag.llm.cv_model import QWenCV
@@ -188,12 +188,13 @@ async def get_preview_chunks(
             source_file_id=str(db_document.file_id),
             source_file_name=db_file.file_name,
         )
-        validate_parent_child_result(
-            child_res,
-            parent_res,
-            parent_id_map,
-            str((db_document.parser_config or {}).get("parent_chunk_mode") or "paragraph"),
-        )
+        if isinstance(child_res, GroupedChildChunks):
+            validate_parent_child_result(
+                child_res,
+                parent_res,
+                parent_id_map,
+                str((db_document.parser_config or {}).get("parent_chunk_mode") or "paragraph"),
+            )
         # Combine parent and child chunks for preview
         parent_id_to_doc_id = {}
         all_preview = []
@@ -408,6 +409,7 @@ async def get_preview_chunks_hierarchy(
                 chunk_mode="parent_child",
                 parent_chunks=parent_res,
                 parent_id_map=parent_id_map,
+                parent_chunk_mode=str(parser_config.get("parent_chunk_mode") or "paragraph"),
             )
         elif chunk_mode == "qa":
             res = await asyncio.to_thread(

--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.logging_config import get_api_logger
+from app.core.rag.chunk.hierarchy import validate_parent_child_result
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.knowledge_graph.dispatch import dispatch_document_graph_sync
 from app.core.rag.llm.cv_model import QWenCV
@@ -186,6 +187,12 @@ async def get_preview_chunks(
             document_id=str(db_document.id),
             source_file_id=str(db_document.file_id),
             source_file_name=db_file.file_name,
+        )
+        validate_parent_child_result(
+            child_res,
+            parent_res,
+            parent_id_map,
+            str((db_document.parser_config or {}).get("parent_chunk_mode") or "paragraph"),
         )
         # Combine parent and child chunks for preview
         parent_id_to_doc_id = {}

--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -69,6 +69,12 @@ class LogicalChunk:
 
 
 @dataclass
+class ParentChildGroup:
+    parent: LogicalChunk
+    children: list[LogicalChunk] = field(default_factory=list)
+
+
+@dataclass
 class ChunkContext:
     filename: str
     binary: bytes | None
@@ -105,6 +111,7 @@ class MergeResult:
     chunks: list = field(default_factory=list)
     images: list | None = None
     logical_chunks: list[LogicalChunk] | None = None
+    parent_child_groups: list[ParentChildGroup] | None = None
     parent_chunks: list[LogicalChunk] | None = None
     child_chunks: list[LogicalChunk] | None = None
     parent_id_map: dict[int, int] | None = None

--- a/api/app/core/rag/chunk/hierarchy.py
+++ b/api/app/core/rag/chunk/hierarchy.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+
+def validate_parent_child_result(
+    child_chunks: list[Any],
+    parent_chunks: list[Any],
+    parent_id_map: dict[int, int],
+    mode: str = "parent_child",
+) -> None:
+    if not child_chunks and not parent_chunks and not parent_id_map:
+        return
+
+    expected_child_indices = set(range(len(child_chunks)))
+    mapped_child_indices = set(parent_id_map)
+    if mapped_child_indices != expected_child_indices:
+        missing = sorted(expected_child_indices - mapped_child_indices)
+        unexpected = sorted(mapped_child_indices - expected_child_indices, key=str)
+        raise ValueError(
+            f"Invalid {mode} hierarchy: child mapping is incomplete "
+            f"(missing={missing}, unexpected={unexpected})."
+        )
+
+    referenced_parent_indices: set[int] = set()
+    for child_index in range(len(child_chunks)):
+        parent_index = parent_id_map[child_index]
+        if not isinstance(parent_index, int) or not 0 <= parent_index < len(parent_chunks):
+            raise ValueError(
+                f"Invalid {mode} hierarchy: child index {child_index} maps to "
+                f"invalid parent index {parent_index!r}."
+            )
+        referenced_parent_indices.add(parent_index)
+
+    for parent_index in range(len(parent_chunks)):
+        if parent_index not in referenced_parent_indices:
+            raise ValueError(f"Invalid {mode} hierarchy: parent index {parent_index} has no children.")

--- a/api/app/core/rag/chunk/hierarchy.py
+++ b/api/app/core/rag/chunk/hierarchy.py
@@ -1,6 +1,10 @@
 from typing import Any
 
 
+class GroupedChildChunks(list[dict]):
+    pass
+
+
 def validate_parent_child_result(
     child_chunks: list[Any],
     parent_chunks: list[Any],

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -58,6 +58,10 @@ LIST_ITEM_START_PATTERNS = (
 )
 
 FULL_DOC_MAX_CHARS = 10000
+PARENT_CHILD_ATOMIC_TYPES = {
+    ParsedBlockType.TABLE,
+    ParsedBlockType.IMAGE,
+}
 
 
 class BlockMerger(ChunkMerger):
@@ -72,17 +76,24 @@ class BlockMerger(ChunkMerger):
 
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
             if ctx.parser_config.get("parent_chunk_mode") == "full-doc":
-                full_doc_parts = (self._full_doc_block_content(block) for block in blocks)
-                full_text = "\n\n".join(part for part in full_doc_parts if part.strip())
-                parent_chunks = []
+                full_doc_blocks = self._full_doc_blocks(blocks)
+                full_text = "\n\n".join(
+                    str(block.content)
+                    for block in full_doc_blocks
+                    if str(block.content or "").strip()
+                )
+                groups = []
                 if full_text:
-                    parent_chunks.append(
-                        LogicalChunk(
-                            type=LogicalChunkType.TEXT,
-                            content=full_text[:FULL_DOC_MAX_CHARS],
-                        )
+                    parent = LogicalChunk(type=LogicalChunkType.TEXT, content=full_text)
+                    children = self._blocks_to_logical_chunks(
+                        full_doc_blocks,
+                        token_num,
+                        delimiter,
+                        0,
+                        merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
+                        preserve_atomic_blocks=True,
                     )
-                groups = self._build_parent_child_groups(parent_chunks, token_num, delimiter, 0)
+                    groups.append(ParentChildGroup(parent=parent, children=children))
                 return self._parent_child_merge_result(groups, parse_result.pdf_parser)
 
             parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
@@ -93,6 +104,7 @@ class BlockMerger(ChunkMerger):
                 parent_chunk_delimiter,
                 0,
                 merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
+                preserve_atomic_blocks=True,
             )
             groups = self._build_parent_child_groups(
                 parent_chunks,
@@ -115,17 +127,34 @@ class BlockMerger(ChunkMerger):
             pdf_parser=parse_result.pdf_parser,
         )
 
-    def _full_doc_block_content(self, block: ParsedBlock) -> str:
-        content = str(block.content or "")
-        if block.type is not ParsedBlockType.IMAGE:
-            return content
+    def _full_doc_blocks(self, blocks: list[ParsedBlock]) -> list[ParsedBlock]:
+        selected: list[ParsedBlock] = []
+        content_length = 0
 
-        vision_text = block.metadata.get("vision_text")
-        if not isinstance(vision_text, str) or not vision_text.strip():
-            return content
-        if not content.strip():
-            return vision_text.strip()
-        return f"{content}\n\n{vision_text.strip()}"
+        for block in blocks:
+            content = str(block.content or "")
+            if not content.strip():
+                continue
+
+            separator_length = 2 if selected else 0
+            remaining = FULL_DOC_MAX_CHARS - content_length - separator_length
+            if remaining <= 0:
+                break
+
+            if len(content) <= remaining:
+                selected.append(block)
+                content_length += separator_length + len(content)
+                continue
+
+            if block.type in PARENT_CHILD_ATOMIC_TYPES:
+                break
+
+            truncated = deepcopy(block)
+            truncated.content = content[:remaining]
+            selected.append(truncated)
+            break
+
+        return selected
 
     def _blocks_to_logical_chunks(
         self,
@@ -135,6 +164,7 @@ class BlockMerger(ChunkMerger):
         overlap: int,
         *,
         merge_lists_with_text: bool = False,
+        preserve_atomic_blocks: bool = False,
     ) -> list[LogicalChunk]:
         logical_chunks: list[LogicalChunk] = []
         text_group: list[ParsedBlock] = []
@@ -178,7 +208,18 @@ class BlockMerger(ChunkMerger):
                 continue
 
             if block.type is ParsedBlockType.TABLE:
-                logical_chunks.extend(self._table_logical_chunks(block, token_num))
+                if preserve_atomic_blocks:
+                    logical_chunks.append(
+                        LogicalChunk(
+                            type=LogicalChunkType.TABLE,
+                            content=block.content,
+                            image=block.image,
+                            positions=deepcopy(block.positions),
+                            metadata=self._metadata_for_block(block),
+                        )
+                    )
+                else:
+                    logical_chunks.extend(self._table_logical_chunks(block, token_num))
                 continue
 
             if block.type is ParsedBlockType.IMAGE:
@@ -243,10 +284,7 @@ class BlockMerger(ChunkMerger):
         delimiter: str | None,
         overlap: int,
     ) -> list[LogicalChunk]:
-        if parent.type is LogicalChunkType.TABLE:
-            return self._split_logical_table_chunk(parent, token_num)
-
-        if parent.type is LogicalChunkType.IMAGE:
+        if parent.type in {LogicalChunkType.TABLE, LogicalChunkType.IMAGE}:
             return [deepcopy(parent)]
 
         block_type = parent.metadata.get("block_type")

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -25,6 +25,7 @@ from app.core.rag.chunk.context import (
     LogicalChunk,
     LogicalChunkType,
     MergeResult,
+    ParentChildGroup,
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
@@ -76,27 +77,16 @@ class BlockMerger(ChunkMerger):
                     for block in blocks
                     if str(block.content or "").strip()
                 )
-                parent_chunks = [
-                    LogicalChunk(
-                        type=LogicalChunkType.TEXT,
-                        content=full_text[:FULL_DOC_MAX_CHARS],
+                parent_chunks = []
+                if full_text:
+                    parent_chunks.append(
+                        LogicalChunk(
+                            type=LogicalChunkType.TEXT,
+                            content=full_text[:FULL_DOC_MAX_CHARS],
+                        )
                     )
-                ]
-                child_chunks = self._blocks_to_logical_chunks(
-                    blocks,
-                    token_num,
-                    delimiter,
-                    0,
-                )
-                parent_id_map = {index: 0 for index in range(len(child_chunks))}
-                return MergeResult(
-                    chunks=self._serialize_chunk_contents(child_chunks),
-                    logical_chunks=child_chunks,
-                    parent_chunks=parent_chunks,
-                    child_chunks=child_chunks,
-                    parent_id_map=parent_id_map,
-                    pdf_parser=parse_result.pdf_parser,
-                )
+                groups = self._build_parent_child_groups(parent_chunks, token_num, delimiter, 0)
+                return self._parent_child_merge_result(groups, parse_result.pdf_parser)
 
             parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
             parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter")
@@ -107,20 +97,13 @@ class BlockMerger(ChunkMerger):
                 0,
                 merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
             )
-            child_chunks, parent_id_map = self._build_children_from_parents(
+            groups = self._build_parent_child_groups(
                 parent_chunks,
                 token_num,
                 delimiter,
                 0,
             )
-            return MergeResult(
-                chunks=self._serialize_chunk_contents(child_chunks),
-                logical_chunks=child_chunks,
-                parent_chunks=parent_chunks,
-                child_chunks=child_chunks,
-                parent_id_map=parent_id_map,
-                pdf_parser=parse_result.pdf_parser,
-            )
+            return self._parent_child_merge_result(groups, parse_result.pdf_parser)
 
         logical_chunks = self._blocks_to_logical_chunks(
             blocks,
@@ -203,23 +186,46 @@ class BlockMerger(ChunkMerger):
         flush_text_group()
         return logical_chunks
 
-    def _build_children_from_parents(
+    def _build_parent_child_groups(
         self,
         parent_chunks: list[LogicalChunk],
         child_token_num: int,
         delimiter: str | None,
         overlap: int,
-    ) -> tuple[list[LogicalChunk], dict[int, int]]:
+    ) -> list[ParentChildGroup]:
+        return [
+            ParentChildGroup(
+                parent=parent,
+                children=self._split_parent_chunk(parent, child_token_num, delimiter, overlap),
+            )
+            for parent in parent_chunks
+        ]
+
+    def _parent_child_merge_result(
+        self,
+        groups: list[ParentChildGroup],
+        pdf_parser,
+    ) -> MergeResult:
+        parent_chunks: list[LogicalChunk] = []
         child_chunks: list[LogicalChunk] = []
         parent_id_map: dict[int, int] = {}
 
-        for parent_index, parent in enumerate(parent_chunks):
-            children = self._split_parent_chunk(parent, child_token_num, delimiter, overlap)
-            for child in children:
+        for group in groups:
+            parent_index = len(parent_chunks)
+            parent_chunks.append(group.parent)
+            for child in group.children:
                 parent_id_map[len(child_chunks)] = parent_index
                 child_chunks.append(child)
 
-        return child_chunks, parent_id_map
+        return MergeResult(
+            chunks=self._serialize_chunk_contents(child_chunks),
+            logical_chunks=child_chunks,
+            parent_child_groups=groups,
+            parent_chunks=parent_chunks,
+            child_chunks=child_chunks,
+            parent_id_map=parent_id_map,
+            pdf_parser=pdf_parser,
+        )
 
     def _split_parent_chunk(
         self,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -72,11 +72,8 @@ class BlockMerger(ChunkMerger):
 
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
             if ctx.parser_config.get("parent_chunk_mode") == "full-doc":
-                full_text = "\n\n".join(
-                    str(block.content)
-                    for block in blocks
-                    if str(block.content or "").strip()
-                )
+                full_doc_parts = (self._full_doc_block_content(block) for block in blocks)
+                full_text = "\n\n".join(part for part in full_doc_parts if part.strip())
                 parent_chunks = []
                 if full_text:
                     parent_chunks.append(
@@ -117,6 +114,18 @@ class BlockMerger(ChunkMerger):
             logical_chunks=logical_chunks,
             pdf_parser=parse_result.pdf_parser,
         )
+
+    def _full_doc_block_content(self, block: ParsedBlock) -> str:
+        content = str(block.content or "")
+        if block.type is not ParsedBlockType.IMAGE:
+            return content
+
+        vision_text = block.metadata.get("vision_text")
+        if not isinstance(vision_text, str) or not vision_text.strip():
+            return content
+        if not content.strip():
+            return vision_text.strip()
+        return f"{content}\n\n{vision_text.strip()}"
 
     def _blocks_to_logical_chunks(
         self,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -56,6 +56,8 @@ LIST_ITEM_START_PATTERNS = (
     PREFIXED_LIST_PATTERN,
 )
 
+FULL_DOC_MAX_CHARS = 10000
+
 
 class BlockMerger(ChunkMerger):
     def __init__(self):
@@ -68,6 +70,34 @@ class BlockMerger(ChunkMerger):
         chunk_overlap = _safe_int(ctx.parser_config.get("chunk_overlap", 0))
 
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
+            if ctx.parser_config.get("parent_chunk_mode") == "full-doc":
+                child_chunks = self._blocks_to_logical_chunks(
+                    blocks,
+                    token_num,
+                    delimiter,
+                    0,
+                )
+                full_text = "\n\n".join(
+                    str(chunk.content)
+                    for chunk in child_chunks
+                    if str(chunk.content or "").strip()
+                )
+                parent_chunks = [
+                    LogicalChunk(
+                        type=LogicalChunkType.TEXT,
+                        content=full_text[:FULL_DOC_MAX_CHARS],
+                    )
+                ]
+                parent_id_map = {index: 0 for index in range(len(child_chunks))}
+                return MergeResult(
+                    chunks=self._serialize_chunk_contents(child_chunks),
+                    logical_chunks=child_chunks,
+                    parent_chunks=parent_chunks,
+                    child_chunks=child_chunks,
+                    parent_id_map=parent_id_map,
+                    pdf_parser=parse_result.pdf_parser,
+                )
+
             parent_token_num = int(ctx.parser_config.get("parent_chunk_token_num", 1024))
             parent_chunk_delimiter = ctx.parser_config.get("parent_chunk_delimiter")
             parent_chunks = self._blocks_to_logical_chunks(

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -71,16 +71,10 @@ class BlockMerger(ChunkMerger):
 
         if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
             if ctx.parser_config.get("parent_chunk_mode") == "full-doc":
-                child_chunks = self._blocks_to_logical_chunks(
-                    blocks,
-                    token_num,
-                    delimiter,
-                    0,
-                )
                 full_text = "\n\n".join(
-                    str(chunk.content)
-                    for chunk in child_chunks
-                    if str(chunk.content or "").strip()
+                    str(block.content)
+                    for block in blocks
+                    if str(block.content or "").strip()
                 )
                 parent_chunks = [
                     LogicalChunk(
@@ -88,6 +82,12 @@ class BlockMerger(ChunkMerger):
                         content=full_text[:FULL_DOC_MAX_CHARS],
                     )
                 ]
+                child_chunks = self._blocks_to_logical_chunks(
+                    blocks,
+                    token_num,
+                    delimiter,
+                    0,
+                )
                 parent_id_map = {index: 0 for index in range(len(child_chunks))}
                 return MergeResult(
                     chunks=self._serialize_chunk_contents(child_chunks),

--- a/api/app/core/rag/chunk/merger/naive.py
+++ b/api/app/core/rag/chunk/merger/naive.py
@@ -28,7 +28,7 @@ def build_parent_child_logical_chunks(
         child_chunks: list[LogicalChunk] = []
         parent_id_map: dict[int, int] = {}
         child_token_num = int(parser_config.get("chunk_token_num", 128))
-        for child_text in split_text(full_text, child_token_num):
+        for child_text in split_text(truncated, child_token_num):
             if not child_text.strip():
                 continue
             parent_id_map[len(child_chunks)] = 0

--- a/api/app/core/rag/chunk/postprocessor.py
+++ b/api/app/core/rag/chunk/postprocessor.py
@@ -3,6 +3,7 @@ import copy
 from app.core.rag.nlp import add_positions, tokenize
 
 from .context import ChunkContext, LogicalChunk, LogicalChunkType, MergeResult, ParseResult
+from .hierarchy import validate_parent_child_result
 
 
 ZERO_WIDTH_TRANSLATION = str.maketrans("", "", "\u200b\u200c\u200d\ufeff")
@@ -32,6 +33,9 @@ class ChunkPostProcessor:
         parse_result: ParseResult,
         merge_result: MergeResult,
     ) -> list[dict] | tuple[list[dict], list[dict], dict[int, int]]:
+        if merge_result.parent_child_groups is not None:
+            return self._serialize_parent_child_groups(ctx, merge_result)
+
         if merge_result.parent_chunks is not None and merge_result.child_chunks is not None:
             child_chunks = self._serialize_chunks(ctx, merge_result.child_chunks, merge_result)
             parent_chunks = self._serialize_chunks(ctx, merge_result.parent_chunks, merge_result)
@@ -45,6 +49,48 @@ class ChunkPostProcessor:
             ]
         return self._serialize_chunks(ctx, logical_chunks, merge_result)
 
+    def _serialize_parent_child_groups(
+        self,
+        ctx: ChunkContext,
+        merge_result: MergeResult,
+    ) -> tuple[list[dict], list[dict], dict[int, int]]:
+        child_chunks: list[dict] = []
+        parent_chunks: list[dict] = []
+        parent_id_map: dict[int, int] = {}
+        mode = str(ctx.parser_config.get("parent_chunk_mode") or "paragraph")
+
+        for group_index, group in enumerate(merge_result.parent_child_groups or []):
+            parent_chunk = self._serialize_chunk(ctx, group.parent, merge_result, len(parent_chunks))
+            if parent_chunk is None:
+                raise ValueError(
+                    f"Invalid {mode} hierarchy: parent group {group_index} was removed during serialization."
+                )
+
+            serialized_children: list[dict] = []
+            for child in group.children:
+                serialized_child = self._serialize_chunk(
+                    ctx,
+                    child,
+                    merge_result,
+                    len(child_chunks) + len(serialized_children),
+                )
+                if serialized_child is not None:
+                    serialized_children.append(serialized_child)
+
+            if not serialized_children:
+                raise ValueError(
+                    f"Invalid {mode} hierarchy: parent group {group_index} has no serializable children."
+                )
+
+            parent_index = len(parent_chunks)
+            parent_chunks.append(parent_chunk)
+            for child in serialized_children:
+                parent_id_map[len(child_chunks)] = parent_index
+                child_chunks.append(child)
+
+        validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, mode)
+        return child_chunks, parent_chunks, parent_id_map
+
     def _serialize_chunks(
         self,
         ctx: ChunkContext,
@@ -53,21 +99,24 @@ class ChunkPostProcessor:
     ) -> list[dict]:
         result: list[dict] = []
         for index, chunk in enumerate(chunks):
-            if chunk.type is LogicalChunkType.TABLE:
-                table_chunk = self._serialize_table_chunk(ctx, chunk)
-                if table_chunk:
-                    result.append(table_chunk)
-                continue
-            if chunk.type is LogicalChunkType.IMAGE:
-                image_chunk = self._serialize_text_chunk(ctx, chunk, merge_result, index)
-                if image_chunk:
-                    image_chunk["doc_type_kwd"] = "image"
-                    result.append(image_chunk)
-                continue
-            text_chunk = self._serialize_text_chunk(ctx, chunk, merge_result, index)
-            if text_chunk:
-                result.append(text_chunk)
+            serialized_chunk = self._serialize_chunk(ctx, chunk, merge_result, index)
+            if serialized_chunk:
+                result.append(serialized_chunk)
         return result
+
+    def _serialize_chunk(
+        self,
+        ctx: ChunkContext,
+        chunk: LogicalChunk,
+        merge_result: MergeResult,
+        index: int,
+    ) -> dict | None:
+        if chunk.type is LogicalChunkType.TABLE:
+            return self._serialize_table_chunk(ctx, chunk)
+        serialized_chunk = self._serialize_text_chunk(ctx, chunk, merge_result, index)
+        if serialized_chunk and chunk.type is LogicalChunkType.IMAGE:
+            serialized_chunk["doc_type_kwd"] = "image"
+        return serialized_chunk
 
     def _serialize_text_chunk(
         self,

--- a/api/app/core/rag/chunk/postprocessor.py
+++ b/api/app/core/rag/chunk/postprocessor.py
@@ -3,7 +3,7 @@ import copy
 from app.core.rag.nlp import add_positions, tokenize
 
 from .context import ChunkContext, LogicalChunk, LogicalChunkType, MergeResult, ParseResult
-from .hierarchy import validate_parent_child_result
+from .hierarchy import GroupedChildChunks, validate_parent_child_result
 
 
 ZERO_WIDTH_TRANSLATION = str.maketrans("", "", "\u200b\u200c\u200d\ufeff")
@@ -54,7 +54,7 @@ class ChunkPostProcessor:
         ctx: ChunkContext,
         merge_result: MergeResult,
     ) -> tuple[list[dict], list[dict], dict[int, int]]:
-        child_chunks: list[dict] = []
+        child_chunks = GroupedChildChunks()
         parent_chunks: list[dict] = []
         parent_id_map: dict[int, int] = {}
         mode = str(ctx.parser_config.get("parent_chunk_mode") or "paragraph")

--- a/api/app/core/rag/chunk/postprocessor.py
+++ b/api/app/core/rag/chunk/postprocessor.py
@@ -2,7 +2,14 @@ import copy
 
 from app.core.rag.nlp import add_positions, tokenize
 
-from .context import ChunkContext, LogicalChunk, LogicalChunkType, MergeResult, ParseResult
+from .context import (
+    ChunkContext,
+    LogicalChunk,
+    LogicalChunkType,
+    MergeResult,
+    ParentChildGroup,
+    ParseResult,
+)
 from .hierarchy import GroupedChildChunks, validate_parent_child_result
 
 
@@ -37,9 +44,8 @@ class ChunkPostProcessor:
             return self._serialize_parent_child_groups(ctx, merge_result)
 
         if merge_result.parent_chunks is not None and merge_result.child_chunks is not None:
-            child_chunks = self._serialize_chunks(ctx, merge_result.child_chunks, merge_result)
-            parent_chunks = self._serialize_chunks(ctx, merge_result.parent_chunks, merge_result)
-            return child_chunks, parent_chunks, merge_result.parent_id_map or {}
+            groups = self._build_mapped_parent_child_groups(ctx, merge_result)
+            return self._serialize_parent_child_groups(ctx, merge_result, groups)
 
         logical_chunks = merge_result.logical_chunks
         if logical_chunks is None:
@@ -53,13 +59,15 @@ class ChunkPostProcessor:
         self,
         ctx: ChunkContext,
         merge_result: MergeResult,
+        groups: list[ParentChildGroup] | None = None,
     ) -> tuple[list[dict], list[dict], dict[int, int]]:
         child_chunks = GroupedChildChunks()
         parent_chunks: list[dict] = []
         parent_id_map: dict[int, int] = {}
         mode = str(ctx.parser_config.get("parent_chunk_mode") or "paragraph")
+        source_groups = groups if groups is not None else merge_result.parent_child_groups or []
 
-        for group_index, group in enumerate(merge_result.parent_child_groups or []):
+        for group_index, group in enumerate(source_groups):
             parent_chunk = self._serialize_chunk(ctx, group.parent, merge_result, len(parent_chunks))
             if parent_chunk is None:
                 raise ValueError(
@@ -90,6 +98,22 @@ class ChunkPostProcessor:
 
         validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, mode)
         return child_chunks, parent_chunks, parent_id_map
+
+    def _build_mapped_parent_child_groups(
+        self,
+        ctx: ChunkContext,
+        merge_result: MergeResult,
+    ) -> list[ParentChildGroup]:
+        parent_chunks = merge_result.parent_chunks or []
+        child_chunks = merge_result.child_chunks or []
+        parent_id_map = merge_result.parent_id_map or {}
+        mode = str(ctx.parser_config.get("parent_chunk_mode") or "paragraph")
+        validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, mode)
+
+        groups = [ParentChildGroup(parent=parent) for parent in parent_chunks]
+        for child_index, child in enumerate(child_chunks):
+            groups[parent_id_map[child_index]].children.append(child)
+        return groups
 
     def _serialize_chunks(
         self,

--- a/api/app/core/rag/utils/preview_utils.py
+++ b/api/app/core/rag/utils/preview_utils.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from copy import deepcopy
 
+from app.core.rag.chunk.hierarchy import validate_parent_child_result
 from app.core.rag.models.chunk import DocumentChunk, ChildDocumentChunk
 
 
@@ -66,6 +67,8 @@ def _build_parent_child_hierarchy(
     value 是父块在 parent_chunks 中的索引。
     子块按 child_idx 排序，确保 children 列表顺序与父块拼接文本一致。
     """
+    validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, "preview parent_child")
+
     # 将子块按父块索引分组
     parent_to_children: dict[int, list[tuple[int, dict]]] = defaultdict(list)
     for child_idx, parent_idx in parent_id_map.items():

--- a/api/app/core/rag/utils/preview_utils.py
+++ b/api/app/core/rag/utils/preview_utils.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from copy import deepcopy
 
-from app.core.rag.chunk.hierarchy import validate_parent_child_result
+from app.core.rag.chunk.hierarchy import GroupedChildChunks, validate_parent_child_result
 from app.core.rag.models.chunk import DocumentChunk, ChildDocumentChunk
 
 
@@ -19,6 +19,7 @@ def _build_preview_hierarchy(
     chunk_mode: str = "normal",
     parent_chunks: list[dict] | None = None,
     parent_id_map: dict[int, int] | None = None,
+    parent_chunk_mode: str | None = None,
 ) -> list[DocumentChunk]:
     """
     将原始分块结果转换为嵌套结构 DocumentChunk。
@@ -28,6 +29,7 @@ def _build_preview_hierarchy(
         chunk_mode: 分块模式，取值 "normal" | "parent_child" | "qa"
         parent_chunks: 父子模式下传入父块列表
         parent_id_map: 父子模式下子块索引 → 父块索引的映射
+        parent_chunk_mode: 父子模式下的父块模式
 
     Returns:
         嵌套结构的 DocumentChunk 列表
@@ -35,7 +37,12 @@ def _build_preview_hierarchy(
     if chunk_mode == "parent_child":
         if parent_chunks is None or parent_id_map is None:
             raise ValueError("parent_child mode requires parent_chunks and parent_id_map")
-        return _build_parent_child_hierarchy(parent_chunks, chunks, parent_id_map)
+        return _build_parent_child_hierarchy(
+            parent_chunks,
+            chunks,
+            parent_id_map,
+            parent_chunk_mode,
+        )
 
     if chunk_mode == "qa":
         return _build_qa_hierarchy(chunks)
@@ -59,6 +66,7 @@ def _build_parent_child_hierarchy(
     parent_chunks: list[dict],
     child_chunks: list[dict],
     parent_id_map: dict[int, int],
+    parent_chunk_mode: str | None = None,
 ) -> list[DocumentChunk]:
     """
     父子分块模式：将父块和子块组织为嵌套结构。
@@ -67,7 +75,9 @@ def _build_parent_child_hierarchy(
     value 是父块在 parent_chunks 中的索引。
     子块按 child_idx 排序，确保 children 列表顺序与父块拼接文本一致。
     """
-    validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, "preview parent_child")
+    if isinstance(child_chunks, GroupedChildChunks):
+        mode = str(parent_chunk_mode or "paragraph")
+        validate_parent_child_result(child_chunks, parent_chunks, parent_id_map, f"preview {mode}")
 
     # 将子块按父块索引分组
     parent_to_children: dict[int, list[tuple[int, dict]]] = defaultdict(list)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -26,7 +26,7 @@ from app.core.config import settings
 from app.core.logging_config import get_logger
 from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.memory.storage_services.reflection_engine import retry_registry as rr
-from app.core.rag.chunk.hierarchy import validate_parent_child_result
+from app.core.rag.chunk.hierarchy import GroupedChildChunks, validate_parent_child_result
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
@@ -1210,12 +1210,13 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                 source_file_id=document_info["file_id"],
                 source_file_name=document_info["file_name"],
             )
-            validate_parent_child_result(
-                child_res,
-                parent_res,
-                parent_id_map,
-                str(parser_config.get("parent_chunk_mode") or "paragraph"),
-            )
+            if isinstance(child_res, GroupedChildChunks):
+                validate_parent_child_result(
+                    child_res,
+                    parent_res,
+                    parent_id_map,
+                    str(parser_config.get("parent_chunk_mode") or "paragraph"),
+                )
         else:
             res = chunk(
                 filename=file_name,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -26,6 +26,7 @@ from app.core.config import settings
 from app.core.logging_config import get_logger
 from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.memory.storage_services.reflection_engine import retry_registry as rr
+from app.core.rag.chunk.hierarchy import validate_parent_child_result
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
@@ -1208,6 +1209,12 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
                 document_id=document_info["id"],
                 source_file_id=document_info["file_id"],
                 source_file_name=document_info["file_name"],
+            )
+            validate_parent_child_result(
+                child_res,
+                parent_res,
+                parent_id_map,
+                str(parser_config.get("parent_chunk_mode") or "paragraph"),
             )
         else:
             res = chunk(


### PR DESCRIPTION
## Business Background

BlockMerger ignored `parent_chunk_mode=full-doc`, so Markdown/TXT parent-child chunking still produced paragraph parents.

## Summary

- Honor full-doc mode in BlockMerger.
- Create one capped full-document parent and map all child chunks to it.

## Changes

- `api/app/core/rag/chunk/merger/block.py`

## Risk

- Affects only newly parsed parent-child documents routed through BlockMerger.
- API contracts, database schema, Elasticsearch metadata, paragraph mode, and API-key routes are unchanged.
- Existing indexed documents require re-parsing to use the corrected behavior.

## Test Plan

- [x] `PYTHONPATH=. .venv/bin/pytest tests/core/rag/chunk/test_block_merger.py -q` — 3 passed.
- [x] `.venv/bin/python -m compileall app/core/rag/chunk/merger/block.py` — passed.

## Summary by Sourcery

在启用父子输出模式时，为 BlockMerger 提供整篇文档级的父块（parent chunk）支持。

Bug 修复：
- 在 BlockMerger 中正确遵守 `parent_chunk_mode=full-doc` 配置，使父块可以跨越整篇文档，而不仅限于单个段落。

增强功能：
- 在 full-doc 模式下引入带上限的整篇文档父块，用于聚合所有子块（child chunks），并将它们映射到单个父块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support full-document parent chunking in BlockMerger when parent-child output mode is enabled.

Bug Fixes:
- Honor the `parent_chunk_mode=full-doc` configuration in BlockMerger so parent chunks can span the entire document instead of individual paragraphs.

Enhancements:
- Introduce a capped full-document parent chunk that aggregates all child chunks and maps them to a single parent for full-doc mode.

</details>