### PR TITLE
fix(rag): scope knowledge resources to workspace

### DIFF
--- a/api/app/controllers/chunk_controller.py
+++ b/api/app/controllers/chunk_controller.py
@@ -23,7 +23,7 @@ from app.core.rag.retrieval.models import RetrievalPrincipal
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorFactory
 from app.core.response_utils import success
 from app.db import get_async_db
-from app.dependencies import get_current_user_async
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.models.document_model import Document
 from app.models.file_model import File as FileModel
 from app.models.user_model import User
@@ -95,7 +95,32 @@ router = APIRouter(
 )
 
 
+async def _require_document_in_knowledge(
+        db: AsyncSession,
+        kb_id: uuid.UUID,
+        document_id: uuid.UUID,
+        current_user: User,
+) -> Document:
+    db_document = await document_service.get_document_by_id_async(
+        db=db,
+        document_id=document_id,
+        current_user=current_user,
+        kb_id=kb_id,
+    )
+    if not db_document:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The document does not exist or you do not have permission to access it",
+        )
+    return db_document
+
+
+def _chunk_belongs_to_document(chunk: DocumentChunk, document_id: uuid.UUID) -> bool:
+    return str(chunk.metadata.get("document_id")) == str(document_id)
+
+
 @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_preview_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -127,16 +152,16 @@ async def get_preview_chunks(
             detail="The knowledge base does not exist or access is denied"
         )
     # 3. Check if the document exists
-    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
-    if not db_document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="The document does not exist or you do not have permission to access it"
-        )
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
 
     # 4. Check if the file exists
     db_file = await db.get(FileModel, db_document.file_id)
-    if not db_file:
+    if not db_file or db_file.kb_id != kb_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The file does not exist or you do not have permission to access it"
@@ -332,15 +357,15 @@ async def get_preview_chunks_hierarchy(
             detail="The knowledge base does not exist or access is denied"
         )
 
-    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
-    if not db_document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="The document does not exist or you do not have permission to access it"
-        )
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
 
     db_file = await db.get(FileModel, db_document.file_id)
-    if not db_file:
+    if not db_file or db_file.kb_id != kb_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="The file does not exist or you do not have permission to access it"
@@ -475,6 +500,7 @@ async def get_preview_chunks_hierarchy(
 
 
 @router.get("/{kb_id}/{document_id}/chunks", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -508,12 +534,12 @@ async def get_chunks(
         )
 
     # 3. 获取文档并判断分块模式
-    db_document = await document_service.get_document_by_id_async(db, document_id=document_id, current_user=current_user)
-    if not db_document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="The document does not exist or you do not have permission to access it"
-        )
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
 
     def _build_nested_result(
         parents: list[DocumentChunk],
@@ -642,6 +668,7 @@ async def get_chunks(
 
 
 @router.post("/{kb_id}/{document_id}/chunk", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def create_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -664,12 +691,12 @@ async def create_chunk(
             detail="The knowledge base does not exist or access is denied"
         )
     # 1. Obtain document information
-    db_document = await db.get(Document, document_id)
-    if not db_document:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="The document does not exist or you do not have permission to access it"
-        )
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
 
     # 校验 chunk_type 与文档分块模式的一致性
     if db_document.is_parent_child_mode:
@@ -731,6 +758,7 @@ async def create_chunk(
 
 
 @router.post("/{kb_id}/{document_id}/chunk/batch", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def create_chunks_batch(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -753,15 +781,12 @@ async def create_chunks_batch(
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The knowledge base does not exist or access is denied")
 
-    result = await db.execute(
-        select(Document).where(
-            Document.id == document_id,
-            Document.kb_id == kb_id,
-        )
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
     )
-    db_document = result.scalars().first()
-    if not db_document:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The document does not exist or you do not have permission to access it")
 
     # 批量校验 chunk_type
     if db_document.is_parent_child_mode:
@@ -825,6 +850,7 @@ async def create_chunks_batch(
 
 
 @router.post("/{kb_id}/import_qa", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def import_qa_new_doc(
         kb_id: uuid.UUID,
         file: UploadFile = File(..., description="CSV 或 Excel 文件（第一行标题跳过，第一列问题，第二列答案）"),
@@ -849,6 +875,17 @@ async def import_qa_new_doc(
     db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=kb_id, current_user=current_user)
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="知识库不存在或无权访问")
+
+    if parent_id is not None and parent_id != kb_id:
+        parent_result = await db.execute(
+            select(FileModel).where(
+                FileModel.id == parent_id,
+                FileModel.kb_id == kb_id,
+                FileModel.file_ext == "folder",
+            )
+        )
+        if parent_result.scalars().first() is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="父目录不存在或无权访问")
 
     # 3. 读取文件
     contents = await file.read()
@@ -912,6 +949,7 @@ async def import_qa_new_doc(
 
 
 @router.post("/{kb_id}/{document_id}/import_qa", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def import_qa_chunks(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -934,9 +972,12 @@ async def import_qa_chunks(
     if not db_knowledge:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="知识库不存在或无权访问")
 
-    db_document = await db.get(Document, document_id)
-    if not db_document:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="文档不存在或无权访问")
+    await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
 
     # 3. 读取文件内容，派发异步任务
     contents = await file.read()
@@ -952,6 +993,7 @@ async def import_qa_chunks(
 
 
 @router.get("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -972,9 +1014,16 @@ async def get_chunk(
             detail="The knowledge base does not exist or access is denied"
         )
 
+    await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
+
     vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
     total, items = await asyncio.to_thread(vector_service.get_by_segment, doc_id=doc_id)
-    if total:
+    if total and _chunk_belongs_to_document(items[0], document_id):
         return success(data=jsonable_encoder(items[0]), msg="Document chunk query successful")
     else:
         raise HTTPException(
@@ -984,6 +1033,7 @@ async def get_chunk(
 
 
 @router.put("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def update_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -1006,9 +1056,16 @@ async def update_chunk(
             detail="The knowledge base does not exist or access is denied"
         )
 
+    await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
+
     vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
     total, items = await asyncio.to_thread(vector_service.get_by_segment, doc_id=doc_id)
-    if total:
+    if total and _chunk_belongs_to_document(items[0], document_id):
         chunk = items[0]
         chunk.page_content = content
         # QA chunk: 更新 metadata 中的 question/answer
@@ -1029,6 +1086,7 @@ async def update_chunk(
 
 
 @router.delete("/{kb_id}/{document_id}/{doc_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_chunk(
         kb_id: uuid.UUID,
         document_id: uuid.UUID,
@@ -1049,11 +1107,18 @@ async def delete_chunk(
             detail="The knowledge base does not exist or access is denied"
         )
 
+    db_document = await _require_document_in_knowledge(
+        db=db,
+        kb_id=kb_id,
+        document_id=document_id,
+        current_user=current_user,
+    )
+
     vector_service = await asyncio.to_thread(ElasticSearchVectorFactory().init_vector, knowledge=db_knowledge)
-    if await asyncio.to_thread(vector_service.text_exists, doc_id):
+    total, items = await asyncio.to_thread(vector_service.get_by_segment, doc_id=doc_id)
+    if total and _chunk_belongs_to_document(items[0], document_id):
         await asyncio.to_thread(vector_service.delete_by_ids, [doc_id], refresh=force_refresh)
         # 更新 chunk_num
-        db_document = await db.get(Document, document_id)
         db_document.chunk_num -= 1
         await db.commit()
         _dispatch_document_graph_sync_best_effort(
@@ -1120,6 +1185,7 @@ async def retrieve_chunks_with_caller(
 
 
 @router.post("/retrieval", response_model=Any, status_code=status.HTTP_200_OK)
+@cur_workspace_access_guard_async()
 async def retrieve_chunks(
         retrieve_data: chunk_schema.ChunkRetrieve,
         current_user: User = Depends(get_current_user_async)

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -29,7 +29,7 @@ from app.core.exceptions import BusinessException
 from app.core.error_codes import BizCode
 from app.core.response_utils import success
 from app.db import get_async_db
-from app.dependencies import get_current_user_async
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.models import document_model
 from app.models import file_model
 from app.models.user_model import User
@@ -61,6 +61,7 @@ router = APIRouter(
 async def _delete_file_record_async(
         db: AsyncSession,
         file_id: uuid.UUID,
+        kb_id: uuid.UUID,
         storage_service: FileStorageService,
 ) -> None:
     db_file = await db.get(file_model.File, file_id)
@@ -71,9 +72,18 @@ async def _delete_file_record_async(
         )
         return
 
+    if db_file.kb_id != kb_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The file does not exist or access is denied",
+        )
+
     if db_file.file_ext == "folder":
         result = await db.execute(
-            select(file_model.File).where(file_model.File.parent_id == db_file.id)
+            select(file_model.File).where(
+                file_model.File.parent_id == db_file.id,
+                file_model.File.kb_id == kb_id,
+            )
         )
         child_files = list(result.scalars().all())
         for child in child_files:
@@ -95,6 +105,7 @@ async def _delete_file_record_async(
 
 
 @router.get("/{kb_id}/documents", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_documents(
         kb_id: uuid.UUID,
         parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id when type is Folder"),
@@ -120,6 +131,17 @@ async def get_documents(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The paging parameter must be greater than 0"
+        )
+
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(
+        db=db,
+        knowledge_id=kb_id,
+        current_user=current_user,
+    )
+    if not db_knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The knowledge base does not exist or access is denied",
         )
 
     # 2. Construct query conditions
@@ -178,6 +200,7 @@ async def get_documents(
 
 
 @router.post("/document", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def create_document(
         create_data: document_schema.DocumentCreate,
         db: AsyncSession = Depends(get_async_db),
@@ -189,6 +212,27 @@ async def create_document(
     api_logger.info(f"Create document request: file_name={create_data.file_name}, kb_id={create_data.kb_id}, username: {current_user.username}")
 
     try:
+        db_knowledge = await knowledge_service.get_knowledge_by_id_async(
+            db=db,
+            knowledge_id=create_data.kb_id,
+            current_user=current_user,
+        )
+        if not db_knowledge:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The knowledge base does not exist or access is denied",
+            )
+        file_result = await db.execute(
+            select(file_model.File).where(
+                file_model.File.id == create_data.file_id,
+                file_model.File.kb_id == create_data.kb_id,
+            )
+        )
+        if file_result.scalars().first() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The file does not exist or access is denied",
+            )
         api_logger.debug(f"Start creating a document: {create_data.file_name}")
         db_document = await document_service.create_document_async(db=db, document=create_data, current_user=current_user)
         api_logger.info(f"Document created successfully: {db_document.file_name} (ID: {db_document.id})")
@@ -199,6 +243,7 @@ async def create_document(
 
 
 @router.get("/{document_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_document(
         document_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -230,6 +275,7 @@ async def get_document(
 
 
 @router.put("/{document_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def update_document(
         document_id: uuid.UUID,
         update_data: document_schema.DocumentUpdate,
@@ -251,6 +297,24 @@ async def update_document(
         )
 
     db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=db_document.kb_id, current_user=current_user)
+    if db_knowledge is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The knowledge base does not exist or access is denied",
+        )
+
+    if update_data.file_id is not None:
+        file_result = await db.execute(
+            select(file_model.File).where(
+                file_model.File.id == update_data.file_id,
+                file_model.File.kb_id == db_document.kb_id,
+            )
+        )
+        if file_result.scalars().first() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The file does not exist or access is denied",
+            )
 
     # 2. 校验并处理 parser_config 更新
     update_dict = update_data.dict(exclude_unset=True)
@@ -334,6 +398,7 @@ async def update_document(
 
 
 @router.delete("/{document_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_document(
         document_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -409,7 +474,12 @@ async def delete_document(
             )
         except Exception:
             api_logger.warning("Failed to delete derived image assets: document_id=%s", document_id, exc_info=True)
-        await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
+        await _delete_file_record_async(
+            db=db,
+            file_id=file_id,
+            kb_id=kb_id,
+            storage_service=storage_service,
+        )
 
         # 6. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)
         api_logger.debug(f"Delete metadata bindings for document: {document_id}")
@@ -433,6 +503,7 @@ async def delete_document(
 
 
 @router.post("/{document_id}/chunks", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def parse_documents(
         document_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -459,7 +530,7 @@ async def parse_documents(
         api_logger.debug(f"Check whether the file exists: {db_document.file_id}")
         db_file = await db.get(file_model.File, db_document.file_id)
 
-        if not db_file:
+        if not db_file or db_file.kb_id != db_document.kb_id:
             api_logger.warning(f"The file does not exist or you do not have permission to access it: file_id={db_document.file_id}")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -515,6 +586,7 @@ async def parse_documents(
 
 
 @router.post("/metadata/batch", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def batch_update_document_metadata(
     data: metadata_schema.BatchUpdateMetadataRequest,
     db: AsyncSession = Depends(get_async_db),
@@ -561,6 +633,7 @@ async def batch_update_document_metadata(
 
 
 @router.put("/{document_id}/metadata", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def update_document_metadata(
     document_id: uuid.UUID,
     data: metadata_schema.DocumentMetadataUpdateRequest,
@@ -604,6 +677,7 @@ async def update_document_metadata(
 
 
 @router.get("/{document_id}/metadata", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_document_metadata(
     document_id: uuid.UUID,
     db: AsyncSession = Depends(get_async_db),
@@ -638,6 +712,7 @@ async def get_document_metadata(
 
 
 @router.post("/{document_id}/metadata", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_document_metadata(
     document_id: uuid.UUID,
     data: metadata_schema.DocumentMetadataDeleteRequest | None = Body(None),

--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -151,8 +151,24 @@ async def get_documents(
     ]
 
     if parent_id:
+        if parent_id != kb_id:
+            parent_result = await db.execute(
+                select(file_model.File).where(
+                    file_model.File.id == parent_id,
+                    file_model.File.kb_id == kb_id,
+                    file_model.File.file_ext == "folder",
+                )
+            )
+            if parent_result.scalars().first() is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="The parent folder does not exist or access is denied",
+                )
         file_result = await db.execute(
-            select(file_model.File).where(file_model.File.parent_id == parent_id)
+            select(file_model.File).where(
+                file_model.File.parent_id == parent_id,
+                file_model.File.kb_id == kb_id,
+            )
         )
         files = list(file_result.scalars().all())
         files_ids = [item.id for item in files]

--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -13,9 +13,10 @@ from app.core.config import settings
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import success
 from app.db import get_db
-from app.dependencies import get_current_user
+from app.dependencies import cur_workspace_access_guard, get_current_user
 from app.models import document_model, file_model
 from app.core.rag.chunk.parser.image_storage import cleanup_mineru_v3_images
+from app.models.knowledge_model import Knowledge
 from app.models.user_model import User
 from app.schemas import file_schema, document_schema
 from app.schemas.response_schema import ApiResponse
@@ -41,7 +42,43 @@ router = APIRouter(
 )
 
 
+def _require_workspace_knowledge(
+        db: Session,
+        kb_id: uuid.UUID,
+        current_user: User,
+):
+    db_knowledge = get_kb_by_id(db, knowledge_id=kb_id, current_user=current_user)
+    if not db_knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The knowledge base does not exist or access is denied",
+        )
+    return db_knowledge
+
+
+def _require_parent_folder(
+        db: Session,
+        kb_id: uuid.UUID,
+        parent_id: uuid.UUID | None,
+        current_user: User,
+) -> None:
+    if parent_id is None or parent_id == kb_id:
+        return
+    parent = file_service.get_file_by_id(
+        db=db,
+        file_id=parent_id,
+        current_user=current_user,
+        kb_id=kb_id,
+    )
+    if not parent or parent.file_ext != "folder":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The parent folder does not exist or access is denied",
+        )
+
+
 @router.get("/{kb_id}/{parent_id}/files", response_model=ApiResponse)
+@cur_workspace_access_guard()
 async def get_files(
         kb_id: uuid.UUID,
         parent_id: uuid.UUID,
@@ -58,6 +95,9 @@ async def get_files(
 
     if page < 1 or pagesize < 1:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The paging parameter must be greater than 0")
+
+    _require_workspace_knowledge(db, kb_id, current_user)
+    _require_parent_folder(db, kb_id, parent_id, current_user)
 
     filters = [
         file_model.File.kb_id == kb_id,
@@ -84,6 +124,7 @@ async def get_files(
 
 
 @router.post("/folder", response_model=ApiResponse)
+@cur_workspace_access_guard()
 async def create_folder(
         kb_id: uuid.UUID,
         parent_id: uuid.UUID,
@@ -94,6 +135,8 @@ async def create_folder(
     """Create a new folder"""
     api_logger.info(f"Create folder request: kb_id={kb_id}, parent_id={parent_id}, folder_name={folder_name}")
     try:
+        _require_workspace_knowledge(db, kb_id, current_user)
+        _require_parent_folder(db, kb_id, parent_id, current_user)
         create_folder_data = file_schema.FileCreate(
             kb_id=kb_id, created_by=current_user.id, parent_id=parent_id,
             file_name=folder_name, file_ext='folder', file_size=0,
@@ -106,6 +149,7 @@ async def create_folder(
 
 
 @router.post("/file", response_model=ApiResponse)
+@cur_workspace_access_guard()
 @check_knowledge_capacity_quota
 async def upload_file(
         kb_id: uuid.UUID,
@@ -117,6 +161,9 @@ async def upload_file(
 ):
     """Upload file to storage backend"""
     api_logger.info(f"upload file request: kb_id={kb_id}, parent_id={parent_id}, filename={file.filename}")
+
+    db_knowledge = _require_workspace_knowledge(db, kb_id, current_user)
+    _require_parent_folder(db, kb_id, parent_id, current_user)
 
     contents = await file.read()
     file_size = len(contents)
@@ -154,7 +201,6 @@ async def upload_file(
         "auto_keywords": 0, "auto_questions": 0, "html4excel": "false"
     }
     try:
-        db_knowledge = get_kb_by_id(db, knowledge_id=kb_id, current_user=current_user)
         if db_knowledge and db_knowledge.parser_config:
             default_parser_config.update(dict(db_knowledge.parser_config))
     except Exception:
@@ -172,6 +218,7 @@ async def upload_file(
 
 
 @router.post("/customtext", response_model=ApiResponse)
+@cur_workspace_access_guard()
 async def custom_text(
         kb_id: uuid.UUID,
         parent_id: uuid.UUID,
@@ -181,6 +228,8 @@ async def custom_text(
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ):
     """Custom text upload"""
+    _require_workspace_knowledge(db, kb_id, current_user)
+    _require_parent_folder(db, kb_id, parent_id, current_user)
     content_bytes = create_data.content.encode('utf-8')
     file_size = len(content_bytes)
     if file_size == 0:
@@ -219,14 +268,20 @@ async def custom_text(
 
 
 @router.get("/{file_id}", response_model=Any)
+@cur_workspace_access_guard()
 async def get_file(
         file_id: uuid.UUID,
         original: bool = Query(False, description="QA 文档是否下载原始文件（默认从 ES 导出修改后内容）"),
         db: Session = Depends(get_db),
+        current_user: User = Depends(get_current_user),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ) -> Any:
     """Download file by file_id — QA 文档默认从 ES 导出修改后内容，?original=true 下载原始文件"""
-    db_file = file_service.get_file_by_id(db, file_id=file_id)
+    db_file = file_service.get_file_by_id(
+        db,
+        file_id=file_id,
+        current_user=current_user,
+    )
     if not db_file:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
@@ -269,6 +324,7 @@ async def get_file(
 
 
 @router.post("/batch-download")
+@cur_workspace_access_guard()
 async def batch_download_files(
         request_body: file_schema.BatchDownloadRequest,
         current_user: User = Depends(get_current_user),
@@ -279,15 +335,22 @@ async def batch_download_files(
     QA 文档从 ES 导出修改后的内容，其余从存储下载。
     """
 
-    files = db.query(file_model.File).filter(
-        file_model.File.id.in_(request_body.file_ids),
-        file_model.File.file_role == file_model.FILE_ROLE_SOURCE,
-    ).all()
+    requested_file_ids = set(request_body.file_ids)
+    files = (
+        db.query(file_model.File)
+        .join(Knowledge, file_model.File.kb_id == Knowledge.id)
+        .filter(
+            file_model.File.id.in_(requested_file_ids),
+            Knowledge.workspace_id == current_user.current_workspace_id,
+            file_model.File.file_role == file_model.FILE_ROLE_SOURCE,
+        )
+        .all()
+    )
 
-    if not files:
+    if len(files) != len(requested_file_ids):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="未找到任何文件",
+            detail="文件不存在或无权访问",
         )
 
     valid_files = [f for f in files if f.file_key]
@@ -323,6 +386,7 @@ async def batch_download_files(
 
 
 @router.put("/{file_id}", response_model=ApiResponse)
+@cur_workspace_access_guard()
 async def update_file(
         file_id: uuid.UUID,
         update_data: file_schema.FileUpdate,
@@ -330,11 +394,24 @@ async def update_file(
         current_user: User = Depends(get_current_user)
 ):
     """Update file information (such as file name)"""
-    db_file = file_service.get_file_by_id(db, file_id=file_id)
+    db_file = file_service.get_file_by_id(
+        db,
+        file_id=file_id,
+        current_user=current_user,
+    )
     if not db_file:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
-    for field, value in update_data.dict(exclude_unset=True).items():
+    update_fields = update_data.dict(exclude_unset=True)
+    if "parent_id" in update_fields:
+        _require_parent_folder(
+            db=db,
+            kb_id=db_file.kb_id,
+            parent_id=update_fields["parent_id"],
+            current_user=current_user,
+        )
+
+    for field, value in update_fields.items():
         if hasattr(db_file, field):
             setattr(db_file, field, value)
 
@@ -349,6 +426,7 @@ async def update_file(
 
 
 @router.delete("/{file_id}", response_model=ApiResponse)
+@cur_workspace_access_guard()
 async def delete_file(
         file_id: uuid.UUID,
         db: Session = Depends(get_db),
@@ -368,14 +446,25 @@ async def _delete_file(
         storage_service: FileStorageService,
 ) -> None:
     """Delete a file or folder from storage and database"""
-    db_file = file_service.get_file_by_id(db, file_id=file_id)
+    db_file = file_service.get_file_by_id(
+        db,
+        file_id=file_id,
+        current_user=current_user,
+    )
     if not db_file:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
     # Delete from storage backend
     if db_file.file_ext == 'folder':
         # For folders, delete all child files from storage first
-        child_files = db.query(file_model.File).filter(file_model.File.parent_id == db_file.id).all()
+        child_files = (
+            db.query(file_model.File)
+            .filter(
+                file_model.File.parent_id == db_file.id,
+                file_model.File.kb_id == db_file.kb_id,
+            )
+            .all()
+        )
         source_file_ids = [
             child.id
             for child in child_files
@@ -387,7 +476,14 @@ async def _delete_file(
                     await storage_service.delete_file(child.file_key)
                 except Exception as e:
                     api_logger.warning(f"Failed to delete child file from storage: {child.file_key} - {e}")
-        db.query(file_model.File).filter(file_model.File.parent_id == db_file.id).delete()
+        (
+            db.query(file_model.File)
+            .filter(
+                file_model.File.parent_id == db_file.id,
+                file_model.File.kb_id == db_file.kb_id,
+            )
+            .delete()
+        )
     else:
         source_file_ids = [db_file.id] if db_file.file_role == file_model.FILE_ROLE_SOURCE else []
         if db_file.file_key:

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -43,7 +43,7 @@ from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import ElasticSearchVectorIndexOps
 from app.core.response_utils import success, fail
 from app.db import get_async_db, get_async_db_context
-from app.dependencies import get_current_user_async
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.models import knowledge_model
 from app.models import file_model
 from app.models.document_model import Document
@@ -275,6 +275,7 @@ async def get_knowledge_graph_entity_types(
 
 
 @router.get("/knowledges", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledges(
         parent_id: Optional[uuid.UUID] = Query(None, description="parent folder id"),
         page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
@@ -361,6 +362,7 @@ async def get_knowledges(
 
 
 @router.post("/knowledge", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 @check_knowledge_capacity_quota
 async def create_knowledge(
         create_data: knowledge_schema.KnowledgeCreate,
@@ -373,6 +375,18 @@ async def create_knowledge(
     api_logger.info(f"Request to create a knowledge base: name={create_data.name}, workspace_id={current_user.current_workspace_id}, username: {current_user.username}")
 
     try:
+        create_data.workspace_id = current_user.current_workspace_id
+        if create_data.parent_id and create_data.parent_id != current_user.current_workspace_id:
+            parent = await knowledge_service.get_knowledge_by_id_async(
+                db=db,
+                knowledge_id=create_data.parent_id,
+                current_user=current_user,
+            )
+            if not parent:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="The parent knowledge base does not exist or access is denied",
+                )
         api_logger.debug(f"Start creating the knowledge base: {create_data.name}")
         # 1. Check if the knowledge base name already exists
         db_knowledge_exist = await knowledge_service.get_knowledge_by_name_async(db, name=create_data.name, current_user=current_user)
@@ -404,6 +418,7 @@ async def create_knowledge(
 
 
 @router.get("/{knowledge_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledge(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -435,6 +450,7 @@ async def get_knowledge(
 
 
 @router.get("/{knowledge_id}/chunk-policy", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledge_chunk_policy(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -470,6 +486,7 @@ async def get_knowledge_chunk_policy(
 
 
 @router.put("/{knowledge_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def update_knowledge(
         knowledge_id: uuid.UUID,
         update_data: knowledge_schema.KnowledgeUpdate,
@@ -482,6 +499,7 @@ async def update_knowledge(
 
 
 @router.get("/{kb_id}/qa/export")
+@cur_workspace_access_guard_async()
 async def export_knowledge_qa_csv(
         kb_id: uuid.UUID,
         current_user: User = Depends(get_current_user_async),
@@ -515,6 +533,7 @@ async def export_knowledge_qa_csv(
 
 
 @router.post("/{kb_id}/batch-download")
+@cur_workspace_access_guard_async()
 async def kb_batch_download(
         kb_id: uuid.UUID,
         current_user: User = Depends(get_current_user_async),
@@ -599,6 +618,19 @@ async def _update_knowledge(
 
         # 2. If updating the embedding_id, delete the knowledge base vector index, reset all document parsing progress to 0, and set chunk_num to 0
         update_dict = update_data.model_dump(exclude_unset=True)
+        if "parent_id" in update_dict:
+            parent_id = update_dict["parent_id"]
+            if parent_id is not None and parent_id != current_user.current_workspace_id:
+                parent = await knowledge_service.get_knowledge_by_id_async(
+                    db=db,
+                    knowledge_id=parent_id,
+                    current_user=current_user,
+                )
+                if not parent:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="The parent knowledge base does not exist or access is denied",
+                    )
         graph_enabled_before: bool | None = None
         if "parser_config" in update_dict:
             try:
@@ -736,6 +768,7 @@ async def _update_knowledge(
 
 
 @router.delete("/{knowledge_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_knowledge(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -778,6 +811,7 @@ async def delete_knowledge(
 
 
 @router.get("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledge_graph(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -867,6 +901,7 @@ async def get_knowledge_graph(
 
 
 @router.delete("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_knowledge_graph(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -910,6 +945,7 @@ async def delete_knowledge_graph(
 
 
 @router.post("/{knowledge_id}/knowledge_graph", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def rebuild_knowledge_graph(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -1042,6 +1078,7 @@ async def check_feishu_auth(
 
 
 @router.post("/{knowledge_id}/sync", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def sync_knowledge(
         knowledge_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),

--- a/api/app/controllers/knowledge_metadata_controller.py
+++ b/api/app/controllers/knowledge_metadata_controller.py
@@ -5,7 +5,7 @@ from app.core.response_utils import success
 from app.core.logging_config import get_api_logger
 from app.core.exceptions import ResourceNotFoundException
 from app.db import get_async_db
-from app.dependencies import get_current_user_async
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.services.rag_access_service import require_current_workspace_knowledge_async
 from app.models.user_model import User
 from app.schemas import knowledge_metadata_schema as schemas
@@ -74,6 +74,7 @@ def _format_common_metadata_fields_result(result: dict) -> dict:
 
 
 @router.post("/metadata/fields", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def list_common_metadata_fields(
     data: schemas.KnowledgeMetadataFieldsRequest,
     db: AsyncSession = Depends(get_async_db),
@@ -102,6 +103,7 @@ async def list_common_metadata_fields(
 
 
 @router.get("/{kb_id}/metadata", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def list_metadata_fields(
     kb_id: uuid.UUID,
     db: AsyncSession = Depends(get_async_db),
@@ -125,6 +127,7 @@ async def list_metadata_fields(
 
 
 @router.post("/{kb_id}/metadata", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def create_metadata_field(
     kb_id: uuid.UUID,
     data: schemas.KnowledgeMetadataCreate,
@@ -158,6 +161,7 @@ async def create_metadata_field(
 
 
 @router.put("/{kb_id}/metadata/{metadata_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def update_metadata_field(
     kb_id: uuid.UUID,
     metadata_id: uuid.UUID,
@@ -191,6 +195,7 @@ async def update_metadata_field(
 
 
 @router.delete("/{kb_id}/metadata/{metadata_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_metadata_field(
     kb_id: uuid.UUID,
     metadata_id: uuid.UUID,
@@ -214,6 +219,7 @@ async def delete_metadata_field(
 
 
 @router.get("/{kb_id}/metadata/builtin", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_builtin_metadata_fields(
     kb_id: uuid.UUID,
     db: AsyncSession = Depends(get_async_db),
@@ -239,6 +245,7 @@ async def get_builtin_metadata_fields(
 
 
 @router.post("/{kb_id}/metadata/builtin/enable", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def toggle_builtin_metadata(
     kb_id: uuid.UUID,
     data: schemas.BuiltinMetadataEnableRequest,

--- a/api/app/controllers/knowledgeshare_controller.py
+++ b/api/app/controllers/knowledgeshare_controller.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db import get_async_db
-from app.dependencies import get_current_user_async
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.models.user_model import User
 from app.models import knowledgeshare_model, knowledge_model
 from app.schemas import knowledgeshare_schema, knowledge_schema
@@ -24,6 +24,7 @@ router = APIRouter(
 
 
 @router.get("/{kb_id}/knowledgeshares", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledgeshares(
         kb_id: uuid.UUID,
         page: int = Query(1, gt=0),  # Default: 1, which must be greater than 0
@@ -51,6 +52,17 @@ async def get_knowledgeshares(
         )
 
     # 2. Construct query conditions
+    db_knowledge = await knowledge_service.get_knowledge_by_id_async(
+        db=db,
+        knowledge_id=kb_id,
+        current_user=current_user,
+    )
+    if not db_knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The knowledge base does not exist or access is denied",
+        )
+
     filters = [
         knowledgeshare_model.KnowledgeShare.source_workspace_id == current_user.current_workspace_id,
         knowledgeshare_model.KnowledgeShare.source_kb_id == kb_id
@@ -90,6 +102,7 @@ async def get_knowledgeshares(
 
 
 @router.post("/knowledgeshare", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def create_knowledgeshare(
         create_data: knowledgeshare_schema.KnowledgeShareCreate,
         db: AsyncSession = Depends(get_async_db),
@@ -104,6 +117,11 @@ async def create_knowledgeshare(
     try:
         # 1.Create a knowledge base with permission_id=knowledge_model.PermissionType.Share
         db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=create_data.source_kb_id, current_user=current_user)
+        if not db_knowledge:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The source knowledge base does not exist or access is denied",
+            )
         knowledge = knowledge_schema.KnowledgeCreate(
             workspace_id=create_data.target_workspace_id,
             created_by=current_user.id,
@@ -140,6 +158,7 @@ async def create_knowledgeshare(
 
 
 @router.get("/{knowledgeshare_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def get_knowledgeshare(
         knowledgeshare_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),
@@ -171,6 +190,7 @@ async def get_knowledgeshare(
 
 
 @router.delete("/{knowledgeshare_id}", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
 async def delete_knowledgeshare(
         knowledgeshare_id: uuid.UUID,
         db: AsyncSession = Depends(get_async_db),

--- a/api/app/controllers/knowledgeshare_controller.py
+++ b/api/app/controllers/knowledgeshare_controller.py
@@ -7,6 +7,7 @@ from app.db import get_async_db
 from app.dependencies import cur_workspace_access_guard_async, get_current_user_async
 from app.models.user_model import User
 from app.models import knowledgeshare_model, knowledge_model
+from app.models.workspace_model import Workspace
 from app.schemas import knowledgeshare_schema, knowledge_schema
 from app.schemas.response_schema import ApiResponse
 from app.core.response_utils import success
@@ -115,6 +116,13 @@ async def create_knowledgeshare(
         f"Create a knowledge base sharing request: source_kb_id={create_data.source_kb_id}, source_workspace_id={current_user.current_workspace_id}, username: {current_user.username}")
 
     try:
+        target_workspace = await db.get(Workspace, create_data.target_workspace_id)
+        if not target_workspace:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The target workspace does not exist",
+            )
+
         # 1.Create a knowledge base with permission_id=knowledge_model.PermissionType.Share
         db_knowledge = await knowledge_service.get_knowledge_by_id_async(db, knowledge_id=create_data.source_kb_id, current_user=current_user)
         if not db_knowledge:

--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -19,6 +19,7 @@ from app.services import api_key_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied
 from app.services.rag_access_service import (
+    get_api_key_request_user,
     get_api_key_retrieval_principal_async,
     unwrap_current_workspace_guard,
 )
@@ -49,8 +50,7 @@ async def get_preview_chunks(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.get_preview_chunks(kb_id=kb_id,
                                                      document_id=document_id,
@@ -81,8 +81,7 @@ async def get_chunks(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.get_chunks(kb_id=kb_id,
                                              document_id=document_id,
@@ -110,8 +109,7 @@ async def create_chunk(
     create_data = chunk_schema.ChunkCreate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.create_chunk(kb_id=kb_id,
                                                document_id=document_id,
@@ -137,8 +135,7 @@ async def create_chunks_batch(
     batch_data = chunk_schema.ChunkBatchCreate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.create_chunks_batch(kb_id=kb_id,
                                                       document_id=document_id,
@@ -162,8 +159,7 @@ async def get_chunk(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.get_chunk(kb_id=kb_id,
                                             document_id=document_id,
@@ -190,8 +186,7 @@ async def update_chunk(
     update_data = chunk_schema.ChunkUpdate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.update_chunk(kb_id=kb_id,
                                                document_id=document_id,
@@ -217,8 +212,7 @@ async def delete_chunk(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.delete_chunk(kb_id=kb_id,
                                                document_id=document_id,
@@ -274,8 +268,7 @@ async def import_qa_new_doc(
     导入 QA 问答对并新建文档（CSV/Excel），异步处理（API Key 认证）
     """
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await chunk_controller.import_qa_new_doc(
         kb_id=kb_id,

--- a/api/app/controllers/service/rag_api_chunk_controller.py
+++ b/api/app/controllers/service/rag_api_chunk_controller.py
@@ -18,11 +18,15 @@ from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied
-from app.services.rag_access_service import get_api_key_retrieval_principal_async
+from app.services.rag_access_service import (
+    get_api_key_retrieval_principal_async,
+    unwrap_current_workspace_guard,
+)
 
 
 router = APIRouter(prefix="/chunks", tags=["V1 - RAG API"])
 api_logger = get_business_logger()
+chunk_controller = unwrap_current_workspace_guard(chunk_controller)
 
 
 @router.get("/{kb_id}/{document_id}/previewchunks", response_model=ApiResponse)

--- a/api/app/controllers/service/rag_api_document_controller.py
+++ b/api/app/controllers/service/rag_api_document_controller.py
@@ -14,10 +14,12 @@ from app.schemas import document_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
+from app.services.rag_access_service import unwrap_current_workspace_guard
 
 
 router = APIRouter(prefix="/documents", tags=["V1 - RAG API"])
 api_logger = get_business_logger()
+document_controller = unwrap_current_workspace_guard(document_controller)
 
 
 @router.get("/{kb_id}/documents", response_model=ApiResponse)
@@ -169,4 +171,3 @@ async def parse_documents(
     return await document_controller.parse_documents(document_id=document_id,
                                                      db=db,
                                                      current_user=current_user)
-

--- a/api/app/controllers/service/rag_api_document_controller.py
+++ b/api/app/controllers/service/rag_api_document_controller.py
@@ -14,7 +14,10 @@ from app.schemas import document_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
-from app.services.rag_access_service import unwrap_current_workspace_guard
+from app.services.rag_access_service import (
+    get_api_key_request_user,
+    unwrap_current_workspace_guard,
+)
 
 
 router = APIRouter(prefix="/documents", tags=["V1 - RAG API"])
@@ -46,8 +49,7 @@ async def get_documents(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.get_documents(kb_id=kb_id,
                                                    parent_id=parent_id,
@@ -77,8 +79,7 @@ async def create_document(
     create_data = document_schema.DocumentCreate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.create_document(create_data=create_data,
                                                      db=db,
@@ -98,8 +99,7 @@ async def get_document(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.get_document(document_id=document_id,
                                                   db=db,
@@ -122,8 +122,7 @@ async def update_document(
     update_data = document_schema.DocumentUpdate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.update_document(document_id=document_id,
                                                      update_data=update_data,
@@ -144,8 +143,7 @@ async def delete_document(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.delete_document(document_id=document_id,
                                                      db=db,
@@ -165,8 +163,7 @@ async def parse_documents(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await document_controller.parse_documents(document_id=document_id,
                                                      db=db,

--- a/api/app/controllers/service/rag_api_file_controller.py
+++ b/api/app/controllers/service/rag_api_file_controller.py
@@ -14,11 +14,13 @@ from app.schemas import file_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
+from app.services.rag_access_service import unwrap_current_workspace_guard
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 
 
 router = APIRouter(prefix="/files", tags=["V1 - RAG API"])
 api_logger = get_business_logger()
+file_controller = unwrap_current_workspace_guard(file_controller)
 
 
 @router.get("/{kb_id}/{parent_id}/files", response_model=ApiResponse)
@@ -141,8 +143,11 @@ async def custom_text(
 
 
 @router.get("/{file_id}", response_model=Any)
+@require_api_key(scopes=["rag"])
 async def get_file(
     file_id: uuid.UUID,
+    request: Request,
+    api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
     storage_service: FileStorageService = Depends(get_file_storage_service),
 ) -> Any:
@@ -152,9 +157,20 @@ async def get_file(
     - Construct the file path and check if it exists
     - Return a FileResponse to download the file
     """
-    return await file_controller.get_file(file_id=file_id,
-                                          db=db,
-                                          storage_service=storage_service)
+    api_key = api_key_service.ApiKeyService.get_api_key(
+        db,
+        api_key_auth.api_key_id,
+        api_key_auth.workspace_id,
+    )
+    current_user = api_key.creator
+    current_user.current_workspace_id = api_key_auth.workspace_id
+
+    return await file_controller.get_file(
+        file_id=file_id,
+        db=db,
+        current_user=current_user,
+        storage_service=storage_service,
+    )
 
 
 @router.put("/{file_id}", response_model=ApiResponse)
@@ -204,4 +220,3 @@ async def delete_file(
                                              db=db,
                                              current_user=current_user,
                                              storage_service=storage_service)
-

--- a/api/app/controllers/service/rag_api_file_controller.py
+++ b/api/app/controllers/service/rag_api_file_controller.py
@@ -142,11 +142,8 @@ async def custom_text(
 
 
 @router.get("/{file_id}", response_model=Any)
-@require_api_key(scopes=["rag"])
 async def get_file(
     file_id: uuid.UUID,
-    request: Request,
-    api_key_auth: ApiKeyAuth = None,
     db: Session = Depends(get_db),
     storage_service: FileStorageService = Depends(get_file_storage_service),
 ) -> Any:
@@ -156,17 +153,10 @@ async def get_file(
     - Construct the file path and check if it exists
     - Return a FileResponse to download the file
     """
-    api_key = api_key_service.ApiKeyService.get_api_key(
-        db,
-        api_key_auth.api_key_id,
-        api_key_auth.workspace_id,
-    )
-    current_user = get_api_key_request_user(api_key, api_key_auth)
-
     return await file_controller.get_file(
         file_id=file_id,
         db=db,
-        current_user=current_user,
+        current_user=None,
         storage_service=storage_service,
     )
 

--- a/api/app/controllers/service/rag_api_file_controller.py
+++ b/api/app/controllers/service/rag_api_file_controller.py
@@ -14,7 +14,10 @@ from app.schemas import file_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
-from app.services.rag_access_service import unwrap_current_workspace_guard
+from app.services.rag_access_service import (
+    get_api_key_request_user,
+    unwrap_current_workspace_guard,
+)
 from app.services.file_storage_service import FileStorageService, get_file_storage_service
 
 
@@ -46,8 +49,7 @@ async def get_files(
     """
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id=api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.get_files(kb_id=kb_id,
                                            parent_id=parent_id,
@@ -75,8 +77,7 @@ async def create_folder(
     """
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.create_folder(kb_id=kb_id,
                                                parent_id=parent_id,
@@ -101,8 +102,7 @@ async def upload_file(
     """
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.upload_file(kb_id=kb_id,
                                              parent_id=parent_id,
@@ -131,8 +131,7 @@ async def custom_text(
     create_data = file_schema.CustomTextFileCreate(**body)
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.custom_text(kb_id=kb_id,
                                              parent_id=parent_id,
@@ -162,8 +161,7 @@ async def get_file(
         api_key_auth.api_key_id,
         api_key_auth.workspace_id,
     )
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.get_file(
         file_id=file_id,
@@ -190,8 +188,7 @@ async def update_file(
     update_data = file_schema.FileUpdate(**body)
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.update_file(file_id=file_id,
                                              update_data=update_data,
@@ -213,8 +210,7 @@ async def delete_file(
     """
     # 0. Obtain the creator of the api key
     api_key = api_key_service.ApiKeyService.get_api_key(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await file_controller.delete_file(file_id=file_id,
                                              db=db,

--- a/api/app/controllers/service/rag_api_knowledge_controller.py
+++ b/api/app/controllers/service/rag_api_knowledge_controller.py
@@ -16,10 +16,12 @@ from app.schemas import knowledge_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
+from app.services.rag_access_service import unwrap_current_workspace_guard
 
 
 router = APIRouter(prefix="/knowledges", tags=["V1 - RAG API"])
 api_logger = get_business_logger()
+knowledge_controller = unwrap_current_workspace_guard(knowledge_controller)
 
 
 @router.get("/knowledgetype", response_model=ApiResponse)

--- a/api/app/controllers/service/rag_api_knowledge_controller.py
+++ b/api/app/controllers/service/rag_api_knowledge_controller.py
@@ -16,7 +16,10 @@ from app.schemas import knowledge_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.response_schema import ApiResponse
 from app.services import api_key_service
-from app.services.rag_access_service import unwrap_current_workspace_guard
+from app.services.rag_access_service import (
+    get_api_key_request_user,
+    unwrap_current_workspace_guard,
+)
 
 
 router = APIRouter(prefix="/knowledges", tags=["V1 - RAG API"])
@@ -53,8 +56,7 @@ async def get_knowledge_graph_entity_types(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.get_knowledge_graph_entity_types(llm_id=llm_id,
                                                                        scenario=scenario,
@@ -85,8 +87,7 @@ async def get_knowledges(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.get_knowledges(parent_id=parent_id,
                                                      page=page,
@@ -114,8 +115,7 @@ async def create_knowledge(
     create_data = knowledge_schema.KnowledgeCreate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.create_knowledge(create_data=create_data,
                                                        db=db,
@@ -135,8 +135,7 @@ async def get_knowledge(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.get_knowledge(knowledge_id=knowledge_id,
                                                     db=db,
@@ -156,8 +155,7 @@ async def update_knowledge(
     update_data = knowledge_schema.KnowledgeUpdate(**body)
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.update_knowledge(knowledge_id=knowledge_id,
                                                        update_data=update_data,
@@ -178,8 +176,7 @@ async def delete_knowledge(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.delete_knowledge(knowledge_id=knowledge_id,
                                                        db=db,
@@ -199,8 +196,7 @@ async def get_knowledge_graph(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.get_knowledge_graph(knowledge_id=knowledge_id,
                                                           db=db,
@@ -220,8 +216,7 @@ async def delete_knowledge_graph(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.delete_knowledge_graph(knowledge_id=knowledge_id,
                                                              db=db,
@@ -241,8 +236,7 @@ async def rebuild_knowledge_graph(
     """
     # 0. Obtain the creator of the api key
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.rebuild_knowledge_graph(knowledge_id=knowledge_id,
                                                               db=db,
@@ -262,8 +256,7 @@ async def check_yuque_auth(
     check yuque auth info
     """
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     api_logger.info(f"check yuque auth info, username: {current_user.username}")
 
@@ -287,8 +280,7 @@ async def check_feishu_auth(
     check feishu auth info
     """
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     api_logger.info(f"check feishu auth info, username: {current_user.username}")
 
@@ -311,8 +303,7 @@ async def sync_knowledge(
     sync knowledge base information based on knowledge_id
     """
     api_key = await api_key_service.ApiKeyService.get_api_key_async(db, api_key_auth.api_key_id, api_key_auth.workspace_id)
-    current_user = api_key.creator
-    current_user.current_workspace_id = api_key_auth.workspace_id
+    current_user = get_api_key_request_user(api_key, api_key_auth)
 
     return await knowledge_controller.sync_knowledge(knowledge_id=knowledge_id,
                                                      db=db,

--- a/api/app/repositories/document_repository.py
+++ b/api/app/repositories/document_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from app.core.utils.datetime_utils import to_iso_z, utcnow, utcnow_naive
 from app.models.document_model import Document
+from app.models.knowledge_model import Knowledge
 from app.schemas import document_schema
 from app.core.logging_config import get_db_logger
 
@@ -148,6 +149,35 @@ def get_document_by_id(db: Session, document_id: uuid.UUID) -> Document | None:
         raise
 
 
+def get_document_by_id_in_workspace(
+        db: Session,
+        document_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        kb_id: uuid.UUID | None = None,
+) -> Document | None:
+    """Return a document only when its knowledge base is in the given workspace."""
+    try:
+        query = (
+            db.query(Document)
+            .join(Knowledge, Document.kb_id == Knowledge.id)
+            .filter(
+                Document.id == document_id,
+                Knowledge.workspace_id == workspace_id,
+            )
+        )
+        if kb_id is not None:
+            query = query.filter(Document.kb_id == kb_id)
+        return query.first()
+    except Exception as e:
+        db_logger.error(
+            "Failed to query document in workspace: document_id=%s workspace_id=%s error=%s",
+            document_id,
+            workspace_id,
+            str(e),
+        )
+        raise
+
+
 async def get_document_by_id_async(db: AsyncSession, document_id: uuid.UUID) -> Document | None:
     """Async version of get_document_by_id."""
     try:
@@ -156,6 +186,36 @@ async def get_document_by_id_async(db: AsyncSession, document_id: uuid.UUID) -> 
         return result.scalars().first()
     except Exception as e:
         db_logger.error(f"Failed to query document by ID (async): document_id={document_id} - {str(e)}")
+        raise
+
+
+async def get_document_by_id_in_workspace_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        kb_id: uuid.UUID | None = None,
+) -> Document | None:
+    """Async workspace-scoped document lookup."""
+    try:
+        stmt = (
+            select(Document)
+            .join(Knowledge, Document.kb_id == Knowledge.id)
+            .where(
+                Document.id == document_id,
+                Knowledge.workspace_id == workspace_id,
+            )
+        )
+        if kb_id is not None:
+            stmt = stmt.where(Document.kb_id == kb_id)
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(
+            "Failed to query document in workspace (async): document_id=%s workspace_id=%s error=%s",
+            document_id,
+            workspace_id,
+            str(e),
+        )
         raise
 
 

--- a/api/app/repositories/file_repository.py
+++ b/api/app/repositories/file_repository.py
@@ -1,6 +1,7 @@
 import uuid
 from sqlalchemy.orm import Session
 from app.models.file_model import File
+from app.models.knowledge_model import Knowledge
 from app.schemas import file_schema
 from app.core.logging_config import get_db_logger
 
@@ -79,6 +80,35 @@ def get_file_by_id(db: Session, file_id: uuid.UUID) -> File | None:
         return file
     except Exception as e:
         db_logger.error(f"Failed to query the file based on the ID: file_id={file_id} - {str(e)}")
+        raise
+
+
+def get_file_by_id_in_workspace(
+        db: Session,
+        file_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        kb_id: uuid.UUID | None = None,
+) -> File | None:
+    """Return a knowledge file only when its knowledge base is in the given workspace."""
+    try:
+        query = (
+            db.query(File)
+            .join(Knowledge, File.kb_id == Knowledge.id)
+            .filter(
+                File.id == file_id,
+                Knowledge.workspace_id == workspace_id,
+            )
+        )
+        if kb_id is not None:
+            query = query.filter(File.kb_id == kb_id)
+        return query.first()
+    except Exception as e:
+        db_logger.error(
+            "Failed to query file in workspace: file_id=%s workspace_id=%s error=%s",
+            file_id,
+            workspace_id,
+            str(e),
+        )
         raise
 
 

--- a/api/app/repositories/knowledge_repository.py
+++ b/api/app/repositories/knowledge_repository.py
@@ -249,6 +249,31 @@ def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID) -> Knowledge | Non
         raise
 
 
+def get_knowledge_by_id_in_workspace(
+        db: Session,
+        knowledge_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+) -> Knowledge | None:
+    """Return a knowledge base only when it belongs to the given workspace."""
+    try:
+        return (
+            db.query(Knowledge)
+            .filter(
+                Knowledge.id == knowledge_id,
+                Knowledge.workspace_id == workspace_id,
+            )
+            .first()
+        )
+    except Exception as e:
+        db_logger.error(
+            "Failed to query knowledge base in workspace: knowledge_id=%s workspace_id=%s error=%s",
+            knowledge_id,
+            workspace_id,
+            str(e),
+        )
+        raise
+
+
 async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -> Knowledge | None:
     """Async version of get_knowledge_by_id."""
     db_logger.debug(f"Query knowledge base based on ID (async): knowledge_id={knowledge_id}")
@@ -264,6 +289,33 @@ async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID) -
         return knowledge
     except Exception as e:
         db_logger.error(f"Failed to query the knowledge base based on the ID (async): knowledge_id={knowledge_id} - {str(e)}")
+        raise
+
+
+async def get_knowledge_by_id_in_workspace_async(
+        db: AsyncSession,
+        knowledge_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+) -> Knowledge | None:
+    """Async workspace-scoped knowledge lookup with the normal detail loads."""
+    try:
+        stmt = (
+            select(Knowledge)
+            .options(*knowledge_schema_load_options())
+            .where(
+                Knowledge.id == knowledge_id,
+                Knowledge.workspace_id == workspace_id,
+            )
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(
+            "Failed to query knowledge base in workspace (async): knowledge_id=%s workspace_id=%s error=%s",
+            knowledge_id,
+            workspace_id,
+            str(e),
+        )
         raise
 
 

--- a/api/app/repositories/knowledgeshare_repository.py
+++ b/api/app/repositories/knowledgeshare_repository.py
@@ -196,6 +196,34 @@ def get_knowledgeshare_by_id(db: Session, knowledgeshare_id: uuid.UUID) -> Knowl
         raise
 
 
+def get_knowledgeshare_by_id_in_source_workspace(
+        db: Session,
+        knowledgeshare_id: uuid.UUID,
+        source_workspace_id: uuid.UUID,
+) -> KnowledgeShare | None:
+    """Return a share only to its source workspace."""
+    try:
+        return (
+            db.query(KnowledgeShare)
+            .filter(
+                or_(
+                    KnowledgeShare.id == knowledgeshare_id,
+                    KnowledgeShare.target_kb_id == knowledgeshare_id,
+                ),
+                KnowledgeShare.source_workspace_id == source_workspace_id,
+            )
+            .first()
+        )
+    except Exception as e:
+        db_logger.error(
+            "Failed to query knowledge share in source workspace: share_id=%s workspace_id=%s error=%s",
+            knowledgeshare_id,
+            source_workspace_id,
+            str(e),
+        )
+        raise
+
+
 async def get_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uuid.UUID) -> KnowledgeShare | None:
     """Async version of get_knowledgeshare_by_id."""
     try:
@@ -209,6 +237,32 @@ async def get_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id: uu
         return result.scalars().first()
     except Exception as e:
         db_logger.error(f"Failed to query knowledge share by ID (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
+        raise
+
+
+async def get_knowledgeshare_by_id_in_source_workspace_async(
+        db: AsyncSession,
+        knowledgeshare_id: uuid.UUID,
+        source_workspace_id: uuid.UUID,
+) -> KnowledgeShare | None:
+    """Async source-workspace-scoped knowledge share lookup."""
+    try:
+        stmt = select(KnowledgeShare).options(*_knowledgeshare_schema_load_options()).where(
+            or_(
+                KnowledgeShare.id == knowledgeshare_id,
+                KnowledgeShare.target_kb_id == knowledgeshare_id,
+            ),
+            KnowledgeShare.source_workspace_id == source_workspace_id,
+        )
+        result = await db.execute(stmt)
+        return result.scalars().first()
+    except Exception as e:
+        db_logger.error(
+            "Failed to query knowledge share in source workspace (async): share_id=%s workspace_id=%s error=%s",
+            knowledgeshare_id,
+            source_workspace_id,
+            str(e),
+        )
         raise
 
 
@@ -253,4 +307,33 @@ async def delete_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id:
     except Exception as e:
         db_logger.error(f"Failed to delete knowledge share record (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
         await db.rollback()
+        raise
+
+
+async def delete_knowledgeshare_by_id_in_source_workspace_async(
+        db: AsyncSession,
+        knowledgeshare_id: uuid.UUID,
+        source_workspace_id: uuid.UUID,
+) -> int:
+    """Delete a share only after its source workspace has been constrained."""
+    try:
+        result = await db.execute(
+            delete(KnowledgeShare).where(
+                or_(
+                    KnowledgeShare.id == knowledgeshare_id,
+                    KnowledgeShare.target_kb_id == knowledgeshare_id,
+                ),
+                KnowledgeShare.source_workspace_id == source_workspace_id,
+            )
+        )
+        await db.commit()
+        return result.rowcount or 0
+    except Exception as e:
+        await db.rollback()
+        db_logger.error(
+            "Failed to delete knowledge share in source workspace: share_id=%s workspace_id=%s error=%s",
+            knowledgeshare_id,
+            source_workspace_id,
+            str(e),
+        )
         raise

--- a/api/app/services/document_service.py
+++ b/api/app/services/document_service.py
@@ -108,11 +108,24 @@ async def create_document_async(
         raise
 
 
-def get_document_by_id(db: Session, document_id: uuid.UUID, current_user: User) -> Document | None:
+def get_document_by_id(
+        db: Session,
+        document_id: uuid.UUID,
+        current_user: User,
+        kb_id: uuid.UUID | None = None,
+) -> Document | None:
     business_logger.debug(f"Query document based on ID: document_id={document_id}, username: {current_user.username}")
 
     try:
-        document = document_repository.get_document_by_id(db=db, document_id=document_id)
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return None
+        document = document_repository.get_document_by_id_in_workspace(
+            db=db,
+            document_id=document_id,
+            workspace_id=workspace_id,
+            kb_id=kb_id,
+        )
         if document:
             business_logger.info(f"document query successful: {document.file_name} (ID: {document_id})")
         else:
@@ -123,11 +136,24 @@ def get_document_by_id(db: Session, document_id: uuid.UUID, current_user: User) 
         raise
 
 
-async def get_document_by_id_async(db: AsyncSession, document_id: uuid.UUID, current_user: User) -> Document | None:
+async def get_document_by_id_async(
+        db: AsyncSession,
+        document_id: uuid.UUID,
+        current_user: User,
+        kb_id: uuid.UUID | None = None,
+) -> Document | None:
     business_logger.debug(f"Query document based on ID (async): document_id={document_id}, username: {current_user.username}")
 
     try:
-        document = await document_repository.get_document_by_id_async(db=db, document_id=document_id)
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return None
+        document = await document_repository.get_document_by_id_in_workspace_async(
+            db=db,
+            document_id=document_id,
+            workspace_id=workspace_id,
+            kb_id=kb_id,
+        )
         if document:
             business_logger.info(f"document query successful (async): {document.file_name} (ID: {document_id})")
         else:

--- a/api/app/services/file_service.py
+++ b/api/app/services/file_service.py
@@ -85,11 +85,27 @@ def create_file(
         raise
 
 
-def get_file_by_id(db: Session, file_id: uuid.UUID) -> File | None:
+def get_file_by_id(
+        db: Session,
+        file_id: uuid.UUID,
+        current_user: User | None = None,
+        kb_id: uuid.UUID | None = None,
+) -> File | None:
     business_logger.debug(f"Query file based on ID: file_id={file_id}")
 
     try:
-        file = file_repository.get_file_by_id(db=db, file_id=file_id)
+        workspace_id = getattr(current_user, "current_workspace_id", None)
+        if current_user is not None:
+            if workspace_id is None:
+                return None
+            file = file_repository.get_file_by_id_in_workspace(
+                db=db,
+                file_id=file_id,
+                workspace_id=workspace_id,
+                kb_id=kb_id,
+            )
+        else:
+            file = file_repository.get_file_by_id(db=db, file_id=file_id)
         if file:
             business_logger.info(f"file query successful: {file.file_name} (ID: {file_id})")
         else:

--- a/api/app/services/knowledge_service.py
+++ b/api/app/services/knowledge_service.py
@@ -504,7 +504,14 @@ def get_knowledge_by_id(db: Session, knowledge_id: uuid.UUID, current_user: User
     business_logger.debug(f"Query knowledge base based on ID: knowledge_id={knowledge_id}, username: {current_user.username}")
     
     try:
-        knowledge = knowledge_repository.get_knowledge_by_id(db=db, knowledge_id=knowledge_id)
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return None
+        knowledge = knowledge_repository.get_knowledge_by_id_in_workspace(
+            db=db,
+            knowledge_id=knowledge_id,
+            workspace_id=workspace_id,
+        )
         if knowledge:
             business_logger.info(f"knowledge base query successful: {knowledge.name} (ID: {knowledge_id})")
         else:
@@ -519,7 +526,14 @@ async def get_knowledge_by_id_async(db: AsyncSession, knowledge_id: uuid.UUID, c
     business_logger.debug(f"Query knowledge base by ID (async): knowledge_id={knowledge_id}, username: {current_user.username}")
 
     try:
-        return await knowledge_repository.get_knowledge_by_id_async(db=db, knowledge_id=knowledge_id)
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return None
+        return await knowledge_repository.get_knowledge_by_id_in_workspace_async(
+            db=db,
+            knowledge_id=knowledge_id,
+            workspace_id=workspace_id,
+        )
     except Exception as e:
         business_logger.error(f"Failed to query knowledge by ID (async): knowledge_id={knowledge_id} - {str(e)}")
         raise

--- a/api/app/services/knowledgeshare_service.py
+++ b/api/app/services/knowledgeshare_service.py
@@ -159,9 +159,13 @@ async def get_knowledgeshare_by_id_async(
         current_user: User
 ) -> KnowledgeShare | None:
     try:
-        return await knowledgeshare_repository.get_knowledgeshare_by_id_async(
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return None
+        return await knowledgeshare_repository.get_knowledgeshare_by_id_in_source_workspace_async(
             db=db,
             knowledgeshare_id=knowledgeshare_id,
+            source_workspace_id=workspace_id,
         )
     except Exception as e:
         business_logger.error(f"Failed to query knowledge share (async): knowledgeshare_id={knowledgeshare_id} - {str(e)}")
@@ -190,9 +194,13 @@ async def delete_knowledgeshare_by_id_async(db: AsyncSession, knowledgeshare_id:
     business_logger.info(f"Delete knowledge base sharing (async): knowledgeshare_id={knowledgeshare_id}, operator: {current_user.username}")
 
     try:
-        await knowledgeshare_repository.delete_knowledgeshare_by_id_async(
+        workspace_id = current_user.current_workspace_id
+        if workspace_id is None:
+            return
+        await knowledgeshare_repository.delete_knowledgeshare_by_id_in_source_workspace_async(
             db=db,
             knowledgeshare_id=knowledgeshare_id,
+            source_workspace_id=workspace_id,
         )
         business_logger.info(
             f"knowledge base sharing deleted successfully (async): "

--- a/api/app/services/memory_konwledges_server.py
+++ b/api/app/services/memory_konwledges_server.py
@@ -19,6 +19,7 @@ from app.core.response_utils import success
 from app.db import get_db_context
 from app.models.document_model import Document
 from app.models.user_model import User
+from app.repositories import knowledge_repository
 from app.schemas import file_schema, document_schema
 from app.schemas.file_schema import CustomTextFileCreate
 from app.services import document_service, file_service, knowledge_service
@@ -32,10 +33,11 @@ class ChunkCreate(BaseModel):
 
 
 class SimpleUser:
-    def __init__(self, user_id: str):
+    def __init__(self, user_id: str, current_workspace_id: uuid.UUID):
         # 确保ID是UUID类型
         self.id = user_id
         self.username = user_id
+        self.current_workspace_id = current_workspace_id
 
 
 async def parse_document_by_id(document_id: uuid.UUID, db: Session, current_user: User):
@@ -477,8 +479,18 @@ async def write_rag(end_user_id, message, user_rag_memory_id) -> DocumentChunk:
         )
 
     with get_db_context() as db:
+        db_knowledge = knowledge_repository.get_knowledge_by_id(
+            db=db,
+            knowledge_id=kb_uuid,
+        )
+        if not db_knowledge:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="知识库不存在或访问被拒绝",
+            )
+
         create_data = CustomTextFileCreate(title=end_user_id, content=message)
-        current_user = SimpleUser(user_rag_memory_id)
+        current_user = SimpleUser(user_rag_memory_id, db_knowledge.workspace_id)
         # 检查文档是否已存在
         document = find_document_id_by_kb_and_filename(db=db, kb_id=user_rag_memory_id, file_name=f"{end_user_id}.txt")
         print('======', document)

--- a/api/app/services/rag_access_service.py
+++ b/api/app/services/rag_access_service.py
@@ -1,4 +1,6 @@
 import uuid
+from types import ModuleType
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +15,20 @@ from app.models.workspace_model import Workspace, WorkspaceMember
 from app.repositories import workspace_repository
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.services.knowledge_retrieval_service import KnowledgeRetrievalAccessDenied
+
+
+class _CurrentWorkspaceGuardBypass:
+    def __init__(self, controller: ModuleType):
+        self._controller = controller
+
+    def __getattr__(self, name: str) -> Any:
+        handler = getattr(self._controller, name)
+        return getattr(handler, "__wrapped__", handler)
+
+
+def unwrap_current_workspace_guard(controller: ModuleType) -> _CurrentWorkspaceGuardBypass:
+    """Expose controller handlers for API Key calls after API Key scope has been verified."""
+    return _CurrentWorkspaceGuardBypass(controller)
 
 
 async def get_api_key_retrieval_principal_async(

--- a/api/app/services/rag_access_service.py
+++ b/api/app/services/rag_access_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.core.rag.retrieval.models import RetrievalPrincipal
 from app.db import get_async_db_context
+from app.dependencies import CurrentUserSnapshot, make_snapshot
 from app.models.api_key_model import ApiKey
 from app.models import document_model, knowledge_model
 from app.models.user_model import User
@@ -29,6 +30,14 @@ class _CurrentWorkspaceGuardBypass:
 def unwrap_current_workspace_guard(controller: ModuleType) -> _CurrentWorkspaceGuardBypass:
     """Expose controller handlers for API Key calls after API Key scope has been verified."""
     return _CurrentWorkspaceGuardBypass(controller)
+
+
+def get_api_key_request_user(
+    api_key: ApiKey,
+    api_key_auth: ApiKeyAuth,
+) -> CurrentUserSnapshot:
+    """Build a request-local user snapshot scoped to the API Key workspace."""
+    return make_snapshot(api_key.creator, api_key_auth.workspace_id)
 
 
 async def get_api_key_retrieval_principal_async(


### PR DESCRIPTION
## Business Background
Knowledge-base resources were previously resolved by global IDs in several endpoints, allowing cross-workspace access attempts.

## Summary
- Scope internal RAG knowledge, document, file, chunk, metadata, and share resources to the active workspace.
- Scope external RAG API requests to the API Key workspace without changing V1 paths or response models.
- Preserve knowledge sharing behavior: require an existing target workspace but do not require target membership.
- Use a request-local API Key creator snapshot to avoid persisting a workspace change during V1 write requests.

## Changes
- 19 RAG backend files across controllers, services, and repositories.
- Four focused commits; no frontend, memory, or generic storage changes.

## Risk
- Cross-workspace resource IDs now return the existing not-found or access-denied paths.
- V1 route inventory and response models are unchanged; valid API Key calls remain bound to their key workspace.

## Test Plan
- [x] `cd api && PYTHONPATH=. uv run pytest tests/test_rag_workspace_scope.py tests/test_rag_workspace_guard_coverage.py -q` (14 passed)
- [x] Focused `compileall` and Ruff F821/F841 checks passed.
- [x] V1 route and response-model contract comparison found 0 additions, 0 removals, and 0 response-model changes.

## Summary by Sourcery

将 RAG 知识库资源和 V1 RAG API 访问范围限定到当前工作区以及 API Key 所属的工作区，同时保持现有的共享语义和 API 合约不变。

Bug Fixes:
- 防止在使用全局 ID 或批量操作时出现跨工作区访问知识库、文档、文件、切片（chunks）、元数据和共享记录的情况。
- 确保文档切片、QA 导入以及文件-文件夹关系都根据其所属的知识库和工作区进行校验，对于不匹配的情况返回 not-found/access-denied。
- 将知识共享的读取和删除限制在源工作区内，并对源/目标知识库和工作区进行校验。

Enhancements:
- 为知识、文档、文件和知识共享引入工作区作用域的仓库和服务查询，以集中控制访问权限。
- 在核心 RAG 控制器（knowledge、document、file、chunk、metadata、share）中应用工作区访问保护，以一致地强制执行工作区范围限制。
- 添加 API Key 请求用户快照和控制器解包装，使 V1 RAG API 路由在不改变路径或响应模型的前提下具备工作区作用域。

Tests:
- 添加并运行与 RAG 工作区范围和访问保护相关的测试，以验证工作区范围行为和保护逻辑的正确应用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Scope RAG knowledge-base resources and V1 RAG API access to the active workspace and the API key’s workspace while preserving sharing semantics and existing API contracts.

Bug Fixes:
- Prevent cross-workspace access to knowledge bases, documents, files, chunks, metadata, and shares when using global IDs or batch operations.
- Ensure document chunks, QA imports, and file-folder relationships are validated against the owning knowledge base and workspace, returning not-found/access-denied for mismatches.
- Restrict knowledge sharing retrieval and deletion to the source workspace and validate source/target knowledge bases and workspaces.

Enhancements:
- Introduce workspace-scoped repository and service queries for knowledge, documents, files, and knowledge shares to centralize access control.
- Apply workspace access guards across core RAG controllers (knowledge, document, file, chunk, metadata, share) to consistently enforce workspace scoping.
- Add API key request-user snapshots and controller unwrapping so V1 RAG API routes are workspace-scoped without changing paths or response models.

Tests:
- Add and run RAG workspace scope and guard coverage tests to verify workspace scoping behavior and guard application.

</details>