### PR TITLE
fix(web): share chat

### DIFF
--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -1,7 +1,11 @@
 /**
  * useConversation
- * 会话页面的核心状态与逻辑：历史记录、配置加载、消息发送/重新生成、人工干预、反馈、收藏、删除等。
- * 所有接口均使用分享态 token（shareToken）调用。
+ * Core state and logic for the conversation page: history, config loading,
+ * message send/regenerate, human-in-the-loop interventions, feedback, favorite, delete, etc.
+ * All API calls use the share-mode token (shareToken).
+ *
+ * Action handlers are extracted to utils/conversationActions.ts;
+ * SSE stream handlers live in utils/streamHandlers.ts and utils/interventionHandlers.ts.
  */
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
@@ -9,24 +13,32 @@ import { useTranslation } from 'react-i18next'
 import { App } from 'antd'
 
 import {
-  getConversationHistory, sendConversation, getConversationDetail, getShareToken, getExperienceConfig,
-  feedbackMessage, deleteConversationMessage, regenerateMessage, switchMessageVersion, accessShareConversation,
-  interventionsSubmit, interventionsResumeSubmit, favoriteMessage,
+  getConversationHistory, getConversationDetail, getShareToken, getExperienceConfig,
+  accessShareConversation,
 } from '@/api/application'
 import { formatDateTime } from '@/utils/format'
 import { randomString, updateMetaIcon } from '@/utils/common'
 import type { ChatItem } from '@/components/Chat/types'
 import type { ChatToolbarRef } from '@/components/Chat/ChatToolbar'
 import type { Variable } from '@/views/Workflow/components/Properties/VariableList/types'
-import type { Variable as AppVariable } from '@/views/ApplicationConfig/components/VariableList/types'
 import type { FeaturesConfigForm } from '@/views/ApplicationConfig/types'
-import { replaceVariables, buildOpeningStatementMessage } from '@/components/Chat/openingStatement'
+import { buildOpeningStatementMessage } from '@/components/Chat/openingStatement'
 
 import type { HistoryItem, ShareModalRef, ReportModalRef } from '../types'
 import { useChatMessages } from './useChatMessages'
-import { createSendStreamHandler, createRegenerateStreamHandler } from '../utils/streamHandlers'
-import { applyInterventionSubmit, createResumeStreamHandler } from '../utils/interventionHandlers'
-import { applyMessagePatchById } from '../utils/messageMutations'
+import { createConversationActions } from '../utils/conversationActions'
+
+/** Group conversation history by date (pure function) */
+const groupHistoryByDate = (items: HistoryItem[]): Record<string, HistoryItem[]> => {
+  return items.reduce((groups: Record<string, HistoryItem[]>, item) => {
+    const date = formatDateTime(item.updated_at, 'YYYY-MM-DD')
+    if (!groups[date]) {
+      groups[date] = []
+    }
+    groups[date].push(item)
+    return groups
+  }, {})
+}
 
 export function useConversation() {
   const { t } = useTranslation()
@@ -42,7 +54,6 @@ export function useConversation() {
   const [message, setMessage] = useState<string>('')
   const [conversation_id, setConversationId] = useState<string | null>(null)
   const [historyList, setHistoryList] = useState<HistoryItem[]>([])
-  const [groupHistoryList, setGroupHistoryList] = useState<Record<string, HistoryItem[]>>({})
   const [pageLoading, setPageLoading] = useState(false)
   const [page, setPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
@@ -73,6 +84,9 @@ export function useConversation() {
   const chatIsEnded = useRef(true)
   const shareModalRef = useRef<ShareModalRef>(null)
   const reportModalRef = useRef<ReportModalRef>(null)
+  /** Set to true when a new conversation is created via streaming; skips getChatDetail in useEffect */
+  const skipChatDetailRef = useRef(false)
+  const [disabled, setDisabled] = useState(false)
 
   const {
     chatList,
@@ -176,20 +190,40 @@ export function useConversation() {
     }
   }, [toolbarReady, config])
 
-  /** 按日期对会话历史分组 */
-  const groupHistoryByDate = (items: HistoryItem[]): Record<string, HistoryItem[]> => {
-    return items.reduce((groups: Record<string, HistoryItem[]>, item) => {
-      const date = formatDateTime(item.created_at, 'YYYY-MM-DD')
-      if (!groups[date]) {
-        groups[date] = []
-      }
-      groups[date].push(item)
-      return groups
-    }, {})
-  }
+  /** Grouped by date (derived from historyList to avoid keeping two states in sync) */
+  const groupHistoryList = useMemo(() => groupHistoryByDate(historyList), [historyList])
 
-  /** 分页拉取会话历史 */
-  const [disabled, setDisabled] = useState(false)
+  /**
+   * After send / regenerate / resume succeeds, update the history list locally instead of
+   * re-fetching getConversationHistory: insert a new entry if the conversation ID doesn't
+   * exist (title taken from the first user message), or refresh updated_at if it already exists.
+   */
+  const upsertHistory = useCallback((conversationId: string, title?: string) => {
+    const now = Date.now()
+    setHistoryList(prev => {
+      const existingIndex = prev.findIndex(item => item.id === conversationId)
+      if (existingIndex === -1) {
+        const rawTitle = title?.trim() || t('memoryConversation.newConversation')
+        const newTitle = rawTitle.length > 50 ? `${rawTitle.slice(0, 50)}…` : rawTitle
+        const newItem: HistoryItem = {
+          id: conversationId,
+          app_id: '',
+          workspace_id: '',
+          user_id: null,
+          title: newTitle,
+          is_draft: false,
+          message_count: 1,
+          is_active: true,
+          created_at: now,
+          updated_at: now,
+        }
+        return [newItem, ...prev]
+      }
+      return prev.map(item => item.id === conversationId ? { ...item, updated_at: now } : item)
+    })
+  }, [t])
+
+  /** Paginated fetch of conversation history */
   const getHistory = (flag: boolean = false) => {
     if (!shareToken || shareToken === '' || (pageLoading || !hasMore) && !flag) return
     setPageLoading(true)
@@ -206,7 +240,6 @@ export function useConversation() {
           list = [...historyList, ...results]
         }
         setHistoryList(list)
-        setGroupHistoryList(groupHistoryByDate(list))
         if (page === 1 && !flag) {
           setConversationId(list[0]?.id || '')
         }
@@ -220,29 +253,6 @@ export function useConversation() {
       .finally(() => setPageLoading(false))
   }
 
-  /** 切换会话或开启新会话 */
-  const handleChangeHistory = (id: string | null) => {
-    if (disabled && id === null) return
-    if (id !== conversation_id) setConversationId(id)
-    if (abortRef.current) {
-      getHistory(true)
-    }
-    abortRef.current?.()
-    abortRef.current = null
-    if (!id) {
-      setMessage('')
-      // 新对话流式输出中 conversation_id 仍为 null，setConversationId 不会触发 useEffect，
-      // 需手动重置聊天列表与流式状态
-      const variables = toolbarRef.current?.getVariables() || []
-      const openingMsg = buildOpeningStatementMessage(features?.opening_statement, {
-        variables,
-        withTimestamp: true,
-        extra: { is_hidden_refresh: true },
-      })
-      setChatList(openingMsg ? [openingMsg] : [])
-    }
-  }
-
   const getChatDetail = () => {
     if (!conversation_id || !shareToken || shareToken === '') return
     getConversationDetail(shareToken, conversation_id)
@@ -253,8 +263,13 @@ export function useConversation() {
 
   useEffect(() => {
     if (conversation_id) {
-      getChatDetail()
+      if (skipChatDetailRef.current) {
+        skipChatDetailRef.current = false
+      } else {
+        getChatDetail()
+      }
     } else {
+      skipChatDetailRef.current = false
       const variables = toolbarRef.current?.getVariables() || []
       const openingMsg = buildOpeningStatementMessage(features?.opening_statement, {
         variables,
@@ -265,274 +280,14 @@ export function useConversation() {
     }
   }, [conversation_id, features?.opening_statement?.statement])
 
-  /** 校验工具栏变量，返回是否可发送及参数 */
-  const validateVariables = () => {
-    const variables = toolbarRef.current?.getVariables() || []
-    let isCanSend = true
-    const params: Record<string, any> = {}
-    if (variables.length > 0) {
-      const needRequired: string[] = []
-      variables.forEach(vo => {
-        params[vo.name] = vo.value ?? vo.defaultValue
-        if (vo.required && (params[vo.name] === null || params[vo.name] === undefined || params[vo.name] === '')) {
-          isCanSend = false
-          needRequired.push(vo.name)
-        }
-      })
-      if (needRequired.length) {
-        messageApi.error(`${needRequired.join(',')} ${t('workflow.variableRequired')}`)
-      }
-    }
-    return { isCanSend, params }
-  }
-
-  /** 发送消息并处理流式响应 */
-  const handleSend = (msg?: string) => {
-    if (!shareToken || shareToken === '') return
-    const files = (toolbarRef.current?.getFiles() || []).filter(item => !['uploading', 'error'].includes(item.status))
-    const { isCanSend, params } = validateVariables()
-    if (!isCanSend) return
-
-    setLoading(true)
-    chatIsEnded.current = false
-    streamLoadingRef.current = true
-    addUserMessage(conversation_id, msg || message, files)
-    addAssistantMessage()
-    toolbarRef.current?.setFiles([])
-    setFileList([])
-
-    const handleStreamMessage = createSendStreamHandler({
-      conversationId: conversation_id,
-      setChatList,
-      setConversationId,
-      setLoading,
-      updateAssistantMessage,
-      updateAssistantReasoningMessage,
-      startAudioPolling,
-      getHistory,
-      chatIsEnded,
-      streamLoadingRef,
-    })
-
-    sendConversation({
-      web_search: webSearch,
-      memory,
-      message: msg || message || '',
-      stream: true,
-      conversation_id: conversation_id || null,
-      files: files.map(file => {
-        if (file.url) {
-          return file
-        } else {
-          return {
-            type: file.type,
-            transfer_method: 'local_file',
-            upload_file_id: file.response.data.file_id,
-            file_type: file.response.data.file_type,
-            size: file.response.data.file_size,
-            name: file.response.data.file_name
-          }
-        }
-      }),
-      variables: params,
-      thinking,
-    }, handleStreamMessage, shareToken, (abort) => { abortRef.current = abort })
-      .catch(() => {
-        setLoading(false)
-        streamLoadingRef.current = false
-        chatIsEnded.current = true
-      })
-      .finally(() => {
-        setLoading(false)
-        streamLoadingRef.current = false
-        chatIsEnded.current = true
-      })
-  }
-
-  /** 人工干预动作点击：流式进行中直接提交，否则发起恢复执行 */
-  const handleInterventionActionClick = (actionId: string, fieldValues: Record<string, string>, execution_id?: string, node_id?: string) => {
-    if (!execution_id || !node_id || !shareToken) {
-      return
-    }
-    const data = {
-      node_id,
-      action_id: actionId,
-      form_data: fieldValues,
-    }
-    if (loading) {
-      interventionsSubmit(shareToken, execution_id, data)
-        .then(() => {
-          setChatList(prev => applyInterventionSubmit(prev, node_id, actionId, fieldValues))
-        })
-    } else {
-      const handleStreamMessage = createResumeStreamHandler({
-        actionId,
-        fieldValues,
-        node_id,
-        conversationId: conversation_id,
-        setChatList,
-        setConversationId,
-        setLoading,
-        updateAssistantMessage,
-        updateAssistantReasoningMessage,
-        startAudioPolling,
-        getHistory,
-        streamLoadingRef,
-      })
-      interventionsResumeSubmit(shareToken, execution_id, data, handleStreamMessage)
-    }
-  }
-
-  /** 重新生成指定助手消息 */
-  const regenerateMessages = (vo: ChatItem) => {
-    if (!shareToken || shareToken === '' || !vo.id) return
-    const { isCanSend, params } = validateVariables()
-    if (!isCanSend) return
-
-    setLoading(true)
-    chatIsEnded.current = false
-    streamLoadingRef.current = true
-    addAssistantMessage(vo.id)
-
-    const handleStreamMessage = createRegenerateStreamHandler({
-      messageId: vo.id,
-      conversationId: conversation_id,
-      setChatList,
-      setConversationId,
-      setLoading,
-      updateAssistantMessage,
-      updateAssistantReasoningMessage,
-      startAudioPolling,
-      getHistory,
-      chatIsEnded,
-      streamLoadingRef,
-    })
-
-    regenerateMessage(vo.id as string, {
-      web_search: webSearch,
-      memory,
-      stream: true,
-      variables: params,
-      thinking,
-    }, handleStreamMessage, shareToken, (abort) => { abortRef.current = abort })
-      .catch(() => {
-        setLoading(false)
-        streamLoadingRef.current = false
-        chatIsEnded.current = true
-      })
-      .finally(() => {
-        setLoading(false)
-        streamLoadingRef.current = false
-        chatIsEnded.current = true
-      })
-  }
-
-  const handleChangeMemory = () => {
-    if (config.app_type === 'workflow') return
-    const value = !memory
-    modal.confirm({
-      title: value ? t('memoryConversation.memoryTipTitle') : t('memoryConversation.memoryCancelTipTitle'),
-      okText: t('common.confirm'),
-      cancelText: t('common.cancel'),
-      onOk: () => {
-        setMemory(value)
-      },
-      onCancel: () => {
-        setMemory(!value)
-      }
-    })
-  }
-
-  const handleChangeDeepThinking = () => {
-    setThinking(prev => !prev)
-  }
-
-  const handleChangeVariables = (variables: Variable[]) => {
-    setChatList(prev => {
-      const firstMsg = prev[0] as ChatItem
-      if (firstMsg && firstMsg.role === 'assistant' && firstMsg.content && features?.opening_statement?.enabled && features?.opening_statement.statement && variables.length > 0) {
-        firstMsg.content = replaceVariables(features?.opening_statement.statement, variables as unknown as AppVariable[])
-        return [firstMsg, ...prev.slice(1)]
-      }
-      return prev
-    })
-  }
-
-  const deleteMessage = (vo: ChatItem) => {
-    if (!shareToken || shareToken === '' || !vo.id) return
-    modal.confirm({
-      title: t('common.confirmDelete'),
-      okText: t('common.delete'),
-      cancelText: t('common.cancel'),
-      okType: 'danger',
-      onOk: () => {
-        deleteConversationMessage(shareToken, vo.id as string)
-          .then(() => {
-            getChatDetail()
-            messageApi.success(t('common.deleteSuccess'))
-          })
-      }
-    })
-  }
-
-  const reportMsg = (vo: ChatItem) => {
-    reportModalRef.current?.handleOpen(vo)
-  }
-
-  /** 切换到指定版本的消息（本地乐观更新） */
-  const handleVersionChange = (page: number, item: ChatItem) => {
-    if (!shareToken || shareToken === '' || !item.id) return
-    switchMessageVersion(shareToken, item.id, page)
-      .then(() => {
-        setChatList(prev => {
-          const lastList = [...prev]
-          const filterIndex = lastList.findIndex(vo => Array.isArray(vo) && vo.filter(msg => msg.id === item.id).length > 0)
-
-          if (filterIndex < 0) return lastList
-
-          const currentItem: ChatItem[] = lastList[filterIndex] as ChatItem[]
-          lastList[filterIndex] = [...currentItem.map(msg => {
-            return {
-              ...msg,
-              is_current: msg.id === item.id,
-            }
-          })]
-
-          return [...lastList]
-        })
-        messageApi.success(t('common.operateSuccess'))
-      })
-  }
-
-  const handleShare = () => {
-    if (!conversation_id) return
-    shareModalRef.current?.handleOpen()
-  }
-
-  const handleFeedback = (feedbackType: 'like' | 'dislike', id?: string) => {
-    if (!shareToken || shareToken === '' || !conversation_id || !id) return
-    feedbackMessage(shareToken, id, { feedback_type: feedbackType })
-      .then((res) => {
-        const { feedback_type } = res as { feedback_type: 'like' | 'dislike' | null; }
-        messageApi.success(feedback_type === 'dislike'
-          ? t('memoryConversation.dislikeMsg')
-          : feedback_type === 'like'
-            ? t('memoryConversation.likeMsg')
-            : t('memoryConversation.cancelMsg')
-        )
-        setChatList(prev => applyMessagePatchById(prev, id, { feedback_type }))
-      })
-  }
-
-  const handleFavorite = (id?: string) => {
-    if (!shareToken || shareToken === '' || !conversation_id || !id) return
-    favoriteMessage(shareToken, id)
-      .then((res) => {
-        const { is_favorited } = res as { is_favorited: boolean; }
-        messageApi.success(t('common.operateSuccess'))
-        setChatList(prev => applyMessagePatchById(prev, id, { is_favorited }))
-      })
-  }
+  const actions = createConversationActions({
+    t, messageApi, modal, shareToken, conversation_id, message, webSearch, memory, thinking,
+    features, config, loading, disabled, setConversationId, setLoading, setMemory, setThinking,
+    setFileList, setMessage, setChatList, chatIsEnded, streamLoadingRef, toolbarRef, abortRef,
+    skipChatDetailRef, shareModalRef, reportModalRef, addUserMessage, addAssistantMessage,
+    updateAssistantMessage, updateAssistantReasoningMessage, startAudioPolling, upsertHistory,
+    getHistory, getChatDetail,
+  })
 
   const chatTitle = useMemo(() => {
     const conversation = historyList.find(item => item.id === conversation_id)
@@ -576,20 +331,8 @@ export function useConversation() {
     reportModalRef,
     setMessage,
     getHistory,
-    handleChangeHistory,
-    handleSend,
-    handleInterventionActionClick,
-    regenerateMessages,
-    handleChangeMemory,
-    handleChangeDeepThinking,
-    handleChangeVariables,
-    deleteMessage,
-    reportMsg,
-    handleVersionChange,
-    handleShare,
-    handleFeedback,
-    handleFavorite,
     disabled,
+    ...actions,
   }
 }
 

--- a/web/src/views/Conversation/utils/conversationActions.ts
+++ b/web/src/views/Conversation/utils/conversationActions.ts
@@ -1,0 +1,400 @@
+/**
+ * Conversation action factories.
+ * All user-action handlers (send, regenerate, intervention, feedback, favorite,
+ * delete, version switch, memory/thinking toggle, etc.) are extracted here as a
+ * single factory that receives the shared state from useConversation as deps.
+ * Pattern matches streamHandlers.ts / interventionHandlers.ts.
+ */
+import { App } from 'antd'
+
+import {
+  sendConversation, regenerateMessage, feedbackMessage, deleteConversationMessage,
+  switchMessageVersion, interventionsSubmit, interventionsResumeSubmit, favoriteMessage,
+} from '@/api/application'
+import { replaceVariables, buildOpeningStatementMessage } from '@/components/Chat/openingStatement'
+import type { ChatItem } from '@/components/Chat/types'
+import type { ChatToolbarRef } from '@/components/Chat/ChatToolbar'
+import type { Variable } from '@/views/Workflow/components/Properties/VariableList/types'
+import type { Variable as AppVariable } from '@/views/ApplicationConfig/components/VariableList/types'
+import type { FeaturesConfigForm } from '@/views/ApplicationConfig/types'
+import type { TFunction } from 'i18next'
+
+import type { ShareModalRef, ReportModalRef } from '../types'
+import { createSendStreamHandler, createRegenerateStreamHandler } from './streamHandlers'
+import { applyInterventionSubmit, createResumeStreamHandler } from './interventionHandlers'
+import { applyMessagePatchById } from './messageMutations'
+
+export interface ConversationActionDeps {
+  t: TFunction
+  messageApi: ReturnType<typeof App.useApp>['message']
+  modal: ReturnType<typeof App.useApp>['modal']
+  shareToken: string | null
+  conversation_id: string | null
+  message: string
+  webSearch: boolean
+  memory: boolean
+  thinking: boolean
+  features: FeaturesConfigForm
+  config: Record<string, any>
+  loading: boolean
+  disabled: boolean
+  setConversationId: (id: string | null) => void
+  setLoading: (value: boolean) => void
+  setMemory: (value: boolean) => void
+  setThinking: React.Dispatch<React.SetStateAction<boolean>>
+  setFileList: React.Dispatch<React.SetStateAction<any[]>>
+  setMessage: React.Dispatch<React.SetStateAction<string>>
+  setChatList: React.Dispatch<React.SetStateAction<Array<ChatItem | ChatItem[]>>>
+  chatIsEnded: React.MutableRefObject<boolean>
+  streamLoadingRef: React.MutableRefObject<boolean>
+  toolbarRef: React.MutableRefObject<ChatToolbarRef | null>
+  abortRef: React.MutableRefObject<(() => void) | null>
+  skipChatDetailRef: React.MutableRefObject<boolean>
+  shareModalRef: React.RefObject<ShareModalRef>
+  reportModalRef: React.RefObject<ReportModalRef>
+  addUserMessage: (conversation_id: string | null, message: string, files: any[]) => void
+  addAssistantMessage: (messageId?: string) => void
+  updateAssistantMessage: (
+    content?: string,
+    audio_url?: string,
+    audio_status?: string,
+    citations?: any[],
+    suggested_questions?: any[],
+    error?: string,
+    message_id?: string,
+    replace?: boolean,
+  ) => void
+  updateAssistantReasoningMessage: (content?: string, message_id?: string) => void
+  startAudioPolling: (audioUrl: string, idToPoll: string) => void
+  upsertHistory: (conversationId: string, title?: string) => void
+  getHistory: (flag?: boolean) => void
+  getChatDetail: () => void
+}
+
+export function createConversationActions(deps: ConversationActionDeps) {
+  const {
+    t, messageApi, modal, shareToken, conversation_id, message, webSearch, memory, thinking,
+    features, config, loading, disabled, setConversationId, setLoading, setMemory, setThinking,
+    setFileList, setMessage, setChatList, chatIsEnded, streamLoadingRef, toolbarRef, abortRef,
+    skipChatDetailRef, shareModalRef, reportModalRef, addUserMessage, addAssistantMessage,
+    updateAssistantMessage, updateAssistantReasoningMessage, startAudioPolling, upsertHistory,
+    getHistory, getChatDetail,
+  } = deps
+
+  /** Validate toolbar variables; returns whether sending is allowed and the params */
+  const validateVariables = () => {
+    const variables = toolbarRef.current?.getVariables() || []
+    let isCanSend = true
+    const params: Record<string, any> = {}
+    if (variables.length > 0) {
+      const needRequired: string[] = []
+      variables.forEach(vo => {
+        params[vo.name] = vo.value ?? vo.defaultValue
+        if (vo.required && (params[vo.name] === null || params[vo.name] === undefined || params[vo.name] === '')) {
+          isCanSend = false
+          needRequired.push(vo.name)
+        }
+      })
+      if (needRequired.length) {
+        messageApi.error(`${needRequired.join(',')} ${t('workflow.variableRequired')}`)
+      }
+    }
+    return { isCanSend, params }
+  }
+
+  /** Send a message and handle the streaming response */
+  const handleSend = (msg?: string) => {
+    if (!shareToken || shareToken === '') return
+    const files = (toolbarRef.current?.getFiles() || []).filter(item => !['uploading', 'error'].includes(item.status))
+    const { isCanSend, params } = validateVariables()
+    if (!isCanSend) return
+
+    // New conversation streaming: skip the duplicate getChatDetail call in useEffect
+    if (!conversation_id) {
+      skipChatDetailRef.current = true
+    }
+
+    setLoading(true)
+    chatIsEnded.current = false
+    streamLoadingRef.current = true
+    addUserMessage(conversation_id, msg || message, files)
+    addAssistantMessage()
+    toolbarRef.current?.setFiles([])
+    setFileList([])
+
+    const handleStreamMessage = createSendStreamHandler({
+      conversationId: conversation_id,
+      setChatList,
+      setConversationId,
+      setLoading,
+      updateAssistantMessage,
+      updateAssistantReasoningMessage,
+      startAudioPolling,
+      upsertHistory,
+      title: msg || message,
+      chatIsEnded,
+      streamLoadingRef,
+    })
+
+    sendConversation({
+      web_search: webSearch,
+      memory,
+      message: msg || message || '',
+      stream: true,
+      conversation_id: conversation_id || null,
+      files: files.map(file => {
+        if (file.url) {
+          return file
+        } else {
+          return {
+            type: file.type,
+            transfer_method: 'local_file',
+            upload_file_id: file.response.data.file_id,
+            file_type: file.response.data.file_type,
+            size: file.response.data.file_size,
+            name: file.response.data.file_name
+          }
+        }
+      }),
+      variables: params,
+      thinking,
+    }, handleStreamMessage, shareToken, (abort) => { abortRef.current = abort })
+      .catch(() => {
+        setLoading(false)
+        streamLoadingRef.current = false
+        chatIsEnded.current = true
+      })
+      .finally(() => {
+        setLoading(false)
+        streamLoadingRef.current = false
+        chatIsEnded.current = true
+      })
+  }
+
+  /** Human intervention action click: submit directly if streaming, otherwise resume execution */
+  const handleInterventionActionClick = (actionId: string, fieldValues: Record<string, string>, execution_id?: string, node_id?: string) => {
+    if (!execution_id || !node_id || !shareToken) {
+      return
+    }
+    const data = {
+      node_id,
+      action_id: actionId,
+      form_data: fieldValues,
+    }
+    if (loading) {
+      interventionsSubmit(shareToken, execution_id, data)
+        .then(() => {
+          setChatList(prev => applyInterventionSubmit(prev, node_id, actionId, fieldValues))
+        })
+    } else {
+      const handleStreamMessage = createResumeStreamHandler({
+        actionId,
+        fieldValues,
+        node_id,
+        conversationId: conversation_id,
+        setChatList,
+        setConversationId,
+        setLoading,
+        updateAssistantMessage,
+        updateAssistantReasoningMessage,
+        startAudioPolling,
+        upsertHistory,
+        streamLoadingRef,
+      })
+      interventionsResumeSubmit(shareToken, execution_id, data, handleStreamMessage)
+    }
+  }
+
+  /** Regenerate the specified assistant message */
+  const regenerateMessages = (vo: ChatItem) => {
+    if (!shareToken || shareToken === '' || !vo.id) return
+    const { isCanSend, params } = validateVariables()
+    if (!isCanSend) return
+
+    setLoading(true)
+    chatIsEnded.current = false
+    streamLoadingRef.current = true
+    addAssistantMessage(vo.id)
+
+    const handleStreamMessage = createRegenerateStreamHandler({
+      messageId: vo.id,
+      conversationId: conversation_id,
+      setChatList,
+      setConversationId,
+      setLoading,
+      updateAssistantMessage,
+      updateAssistantReasoningMessage,
+      startAudioPolling,
+      upsertHistory,
+      chatIsEnded,
+      streamLoadingRef,
+    })
+
+    regenerateMessage(vo.id as string, {
+      web_search: webSearch,
+      memory,
+      stream: true,
+      variables: params,
+      thinking,
+    }, handleStreamMessage, shareToken, (abort) => { abortRef.current = abort })
+      .catch(() => {
+        setLoading(false)
+        streamLoadingRef.current = false
+        chatIsEnded.current = true
+      })
+      .finally(() => {
+        setLoading(false)
+        streamLoadingRef.current = false
+        chatIsEnded.current = true
+      })
+  }
+
+  /** Switch to a conversation or start a new one */
+  const handleChangeHistory = (id: string | null) => {
+    if (disabled && id === null) return
+    // Manual conversation switch: ensure getChatDetail runs normally
+    skipChatDetailRef.current = false
+    if (id !== conversation_id) setConversationId(id)
+    if (abortRef.current) {
+      getHistory(true)
+    }
+    abortRef.current?.()
+    abortRef.current = null
+    if (!id) {
+      setMessage('')
+      // During new-conversation streaming, conversation_id is still null, so setConversationId
+      // won't trigger useEffect — manually reset the chat list and streaming state
+      const variables = toolbarRef.current?.getVariables() || []
+      const openingMsg = buildOpeningStatementMessage(features?.opening_statement, {
+        variables,
+        withTimestamp: true,
+        extra: { is_hidden_refresh: true },
+      })
+      setChatList(openingMsg ? [openingMsg] : [])
+    }
+  }
+
+  const handleChangeMemory = () => {
+    if (config.app_type === 'workflow') return
+    const value = !memory
+    modal.confirm({
+      title: value ? t('memoryConversation.memoryTipTitle') : t('memoryConversation.memoryCancelTipTitle'),
+      okText: t('common.confirm'),
+      cancelText: t('common.cancel'),
+      onOk: () => {
+        setMemory(value)
+      },
+      onCancel: () => {
+        setMemory(!value)
+      }
+    })
+  }
+
+  const handleChangeDeepThinking = () => {
+    setThinking(prev => !prev)
+  }
+
+  const handleChangeVariables = (variables: Variable[]) => {
+    setChatList(prev => {
+      const firstMsg = prev[0] as ChatItem
+      if (firstMsg && firstMsg.role === 'assistant' && firstMsg.content && features?.opening_statement?.enabled && features?.opening_statement.statement && variables.length > 0) {
+        firstMsg.content = replaceVariables(features?.opening_statement.statement, variables as unknown as AppVariable[])
+        return [firstMsg, ...prev.slice(1)]
+      }
+      return prev
+    })
+  }
+
+  const deleteMessage = (vo: ChatItem) => {
+    if (!shareToken || shareToken === '' || !vo.id) return
+    modal.confirm({
+      title: t('common.confirmDelete'),
+      okText: t('common.delete'),
+      cancelText: t('common.cancel'),
+      okType: 'danger',
+      onOk: () => {
+        deleteConversationMessage(shareToken, vo.id as string)
+          .then(() => {
+            getChatDetail()
+            messageApi.success(t('common.deleteSuccess'))
+          })
+      }
+    })
+  }
+
+  const reportMsg = (vo: ChatItem) => {
+    reportModalRef.current?.handleOpen(vo)
+  }
+
+  /** Switch to the specified message version (local optimistic update) */
+  const handleVersionChange = (page: number, item: ChatItem) => {
+    if (!shareToken || shareToken === '' || !item.id) return
+    switchMessageVersion(shareToken, item.id, page)
+      .then(() => {
+        setChatList(prev => {
+          const lastList = [...prev]
+          const filterIndex = lastList.findIndex(vo => Array.isArray(vo) && vo.filter(msg => msg.id === item.id).length > 0)
+
+          if (filterIndex < 0) return lastList
+
+          const currentItem: ChatItem[] = lastList[filterIndex] as ChatItem[]
+          lastList[filterIndex] = [...currentItem.map(msg => {
+            return {
+              ...msg,
+              is_current: msg.id === item.id,
+            }
+          })]
+
+          return [...lastList]
+        })
+        messageApi.success(t('common.operateSuccess'))
+      })
+  }
+
+  const handleShare = () => {
+    if (!conversation_id) return
+    shareModalRef.current?.handleOpen()
+  }
+
+  const handleFeedback = (feedbackType: 'like' | 'dislike', id?: string) => {
+    if (!shareToken || shareToken === '' || !conversation_id || !id) return
+    feedbackMessage(shareToken, id, { feedback_type: feedbackType })
+      .then((res) => {
+        const { feedback_type } = res as { feedback_type: 'like' | 'dislike' | null; }
+        messageApi.success(feedback_type === 'dislike'
+          ? t('memoryConversation.dislikeMsg')
+          : feedback_type === 'like'
+            ? t('memoryConversation.likeMsg')
+            : t('memoryConversation.cancelMsg')
+        )
+        setChatList(prev => applyMessagePatchById(prev, id, { feedback_type }))
+      })
+  }
+
+  const handleFavorite = (id?: string) => {
+    if (!shareToken || shareToken === '' || !conversation_id || !id) return
+    favoriteMessage(shareToken, id)
+      .then((res) => {
+        const { is_favorited } = res as { is_favorited: boolean; }
+        messageApi.success(t('common.operateSuccess'))
+        setChatList(prev => applyMessagePatchById(prev, id, { is_favorited }))
+      })
+  }
+
+  return {
+    validateVariables,
+    handleSend,
+    handleInterventionActionClick,
+    regenerateMessages,
+    handleChangeHistory,
+    handleChangeMemory,
+    handleChangeDeepThinking,
+    handleChangeVariables,
+    deleteMessage,
+    reportMsg,
+    handleVersionChange,
+    handleShare,
+    handleFeedback,
+    handleFavorite,
+  }
+}

--- a/web/src/views/Conversation/utils/interventionHandlers.ts
+++ b/web/src/views/Conversation/utils/interventionHandlers.ts
@@ -1,14 +1,15 @@
 /**
- * 人工干预（human-in-the-loop）相关处理。
- * 包含「干预提交后本地标记已解决」的纯函数，以及「恢复执行」的 SSE 流式处理工厂。
- * 逻辑与原 index.tsx 中的 handleInterventionActionClick 完全一致，仅抽离为模块。
+ * Human-in-the-loop intervention handlers.
+ * Includes a pure function that locally marks an intervention as resolved after submit,
+ * and a factory for SSE stream handling on "resume execution".
+ * Logic matches the original handleInterventionActionClick in index.tsx, extracted as a module.
  */
 import { type ButtonProps } from 'antd'
 
 import { type SSEMessage } from '@/utils/stream'
 import type { ChatItem } from '@/components/Chat/types'
 
-/** 干预提交成功后（流式进行中）本地把对应干预标记为已解决 */
+/** After intervention submit succeeds (while streaming), locally mark the matching intervention as resolved */
 export const applyInterventionSubmit = (
   prev: Array<ChatItem | ChatItem[]>,
   node_id: string,
@@ -62,13 +63,13 @@ export const applyInterventionSubmit = (
 }
 
 export interface ResumeHandlerDeps {
-  /** 触发恢复执行的动作 id */
+  /** Action id that triggers resume execution */
   actionId: string
-  /** 提交的表单数据 */
+  /** Submitted form data */
   fieldValues: Record<string, string>
-  /** 触发恢复执行的节点 id */
+  /** Node id that triggers resume execution */
   node_id: string
-  /** 当前会话 id */
+  /** Current conversation id */
   conversationId: string | null
   setChatList: React.Dispatch<React.SetStateAction<Array<ChatItem | ChatItem[]>>>
   setConversationId: (id: string | null) => void
@@ -85,17 +86,18 @@ export interface ResumeHandlerDeps {
   ) => void
   updateAssistantReasoningMessage: (content?: string, message_id?: string) => void
   startAudioPolling: (audioUrl: string, idToPoll: string) => void
-  getHistory: (flag?: boolean) => void
+  /** Locally update the history list after streaming ends (insert new / refresh updated_at for existing) */
+  upsertHistory: (conversationId: string, title?: string) => void
   streamLoadingRef: React.MutableRefObject<boolean>
 }
 
-/** 恢复执行（resume-submit）场景的流式处理器 */
+/** Stream handler for the resume-submit scenario */
 export const createResumeStreamHandler = (deps: ResumeHandlerDeps) => {
   const {
     actionId, fieldValues, node_id,
     conversationId, setChatList, setConversationId, setLoading,
     updateAssistantMessage, updateAssistantReasoningMessage, startAudioPolling,
-    getHistory, streamLoadingRef,
+    upsertHistory, streamLoadingRef,
   } = deps
 
   let currentConversationId: string | null = null
@@ -227,7 +229,7 @@ export const createResumeStreamHandler = (deps: ResumeHandlerDeps) => {
                 return prev
               }
 
-              // 找到最后一条 intervention 并更新其 form_fields 的 default_value
+              // Find the last intervention and update its form_fields default_value
               const updatedInterventions = [
                 ...lastMsg.interventions.slice(0, -1),
                 {
@@ -377,7 +379,7 @@ export const createResumeStreamHandler = (deps: ResumeHandlerDeps) => {
           })
           break
         case 'end':
-        case 'workflow_end':
+        case 'workflow_end': {
           if (audio_url) {
             updateAssistantMessage(content, audio_url, 'pending', citations, suggested_questions, error)
             const { file_id } = item.data as { file_id?: string }
@@ -386,21 +388,20 @@ export const createResumeStreamHandler = (deps: ResumeHandlerDeps) => {
             if (fileId && idToPoll) {
               startAudioPolling(audio_url, idToPoll)
             }
-          } else {
-            getHistory(true)
-            if (currentConversationId && currentConversationId !== conversationId) {
-              setConversationId(currentConversationId)
-            }
           }
           if ((citations && citations.length > 0) || (suggested_questions && suggested_questions.length > 0) || error) {
             updateAssistantMessage(content || '', audio_url, undefined, citations, suggested_questions, error)
           }
           setLoading(false)
-          getHistory(true)
+          const targetConvId = currentConversationId || conversationId
+          if (targetConvId) {
+            upsertHistory(targetConvId)
+          }
           if (currentConversationId && currentConversationId !== conversationId) {
             setConversationId(currentConversationId)
           }
           break
+        }
       }
     })
   }

--- a/web/src/views/Conversation/utils/streamHandlers.ts
+++ b/web/src/views/Conversation/utils/streamHandlers.ts
@@ -166,7 +166,10 @@ export interface StreamHandlerDeps {
   ) => void
   updateAssistantReasoningMessage: (content?: string, message_id?: string) => void
   startAudioPolling: (audioUrl: string, idToPoll: string) => void
-  getHistory: (flag?: boolean) => void
+  /** Locally update the history list after streaming ends (insert new / refresh updated_at for existing) */
+  upsertHistory: (conversationId: string, title?: string) => void
+  /** Title source for new conversations (first user message); only used in the send scenario */
+  title?: string
   chatIsEnded: React.MutableRefObject<boolean>
   streamLoadingRef: React.MutableRefObject<boolean>
 }
@@ -176,7 +179,7 @@ export const createSendStreamHandler = (deps: StreamHandlerDeps) => {
   const {
     conversationId, setChatList, setConversationId, setLoading,
     updateAssistantMessage, updateAssistantReasoningMessage, startAudioPolling,
-    getHistory, chatIsEnded, streamLoadingRef,
+    upsertHistory, title, chatIsEnded, streamLoadingRef,
   } = deps
 
   let currentConversationId: string | null = null
@@ -235,7 +238,7 @@ export const createSendStreamHandler = (deps: StreamHandlerDeps) => {
           break
         }
         case 'end':
-        case 'workflow_end':
+        case 'workflow_end': {
           if (audio_url) {
             updateAssistantMessage(content, audio_url, 'pending', citations, suggested_questions, error)
             const idToPoll = file_id || audio_url || ''
@@ -249,12 +252,16 @@ export const createSendStreamHandler = (deps: StreamHandlerDeps) => {
           }
           setChatList(prev => finalizeOutputs(prev))
           setLoading(false)
-          getHistory(true)
+          const targetConvId = currentConversationId || conversationId
+          if (targetConvId) {
+            upsertHistory(targetConvId, title)
+          }
           if (currentConversationId && currentConversationId !== conversationId) {
             setConversationId(currentConversationId)
           }
           chatIsEnded.current = true
           break
+        }
       }
     })
   }
@@ -265,7 +272,7 @@ export const createRegenerateStreamHandler = (deps: StreamHandlerDeps & { messag
   const {
     messageId, conversationId, setChatList, setConversationId, setLoading,
     updateAssistantMessage, updateAssistantReasoningMessage, startAudioPolling,
-    getHistory, chatIsEnded, streamLoadingRef,
+    upsertHistory, chatIsEnded, streamLoadingRef,
   } = deps
 
   let currentConversationId: string | null = null
@@ -328,7 +335,7 @@ export const createRegenerateStreamHandler = (deps: StreamHandlerDeps & { messag
           break
         }
         case 'end':
-        case 'workflow_end':
+        case 'workflow_end': {
           if (audio_url) {
             updateAssistantMessage(content, audio_url, 'pending', citations, suggested_questions, error, messageId)
             const idToPoll = file_id || audio_url || ''
@@ -336,23 +343,22 @@ export const createRegenerateStreamHandler = (deps: StreamHandlerDeps & { messag
             if (fileId && idToPoll) {
               startAudioPolling(audio_url, idToPoll)
             }
-          } else {
-            getHistory(true)
-            if (currentConversationId && currentConversationId !== conversationId) {
-              setConversationId(currentConversationId)
-            }
           }
           if ((citations && citations.length > 0) || (suggested_questions && suggested_questions.length > 0) || error) {
             updateAssistantMessage(content || '', audio_url, undefined, citations, suggested_questions, error, messageId)
           }
           setChatList(prev => finalizeOutputs(prev))
           setLoading(false)
-          getHistory(true)
+          const targetConvId = currentConversationId || conversationId
+          if (targetConvId) {
+            upsertHistory(targetConvId)
+          }
           if (currentConversationId && currentConversationId !== conversationId) {
             setConversationId(currentConversationId)
           }
           chatIsEnded.current = true
           break
+        }
       }
     })
   }


### PR DESCRIPTION
## Summary by Sourcery

重构会话操作处理逻辑，并改进共享聊天会话的历史记录更新。

新特性：
- 支持在流式发送、重新生成或恢复操作后，本地插入和刷新会话历史条目的时间戳，而无需从服务器重新获取。

错误修复：
- 确保在开始新的共享会话以及在共享模式下切换或恢复聊天时，会话详情加载和历史记录更新行为正确。

改进事项：
- 将会话操作处理从 `useConversation` 中抽取到专用的 `utils/conversationActions` 工厂中，以实现更清晰的关注点分离。
- 通过一个带有记忆（memoized）的辅助方法，从单一的历史列表状态派生分组的会话历史，以避免重复状态。
- 调整 SSE 流和干预（intervention）处理器，使其依赖新的本地历史 upsert 机制，并与会话详情加载进行更好协调。
- 引入 `skipChatDetail` 控制，在启动新的流式会话时避免重复的会话详情请求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor conversation action handling and improve history updates for shared chat conversations.

New Features:
- Support local insertion and timestamp refresh of conversation history entries after streaming send, regenerate, or resume actions without re-fetching from the server.

Bug Fixes:
- Ensure conversation detail loading and history updates behave correctly when starting new shared conversations and when switching or resuming chats in share mode.

Enhancements:
- Extract conversation action handlers from useConversation into a dedicated utils/conversationActions factory for clearer separation of concerns.
- Derive grouped conversation history from a single history list state via a memoized helper to avoid duplicated state.
- Adjust SSE stream and intervention handlers to rely on the new local history upsert mechanism and better coordinate with conversation detail loading.
- Introduce skipChatDetail control to prevent redundant conversation detail requests when starting a new streamed conversation.

</details>