### PR TITLE
feat(web): agent node add config

### DIFF
--- a/web/src/components/ActiveMemoryConfig/index.tsx
+++ b/web/src/components/ActiveMemoryConfig/index.tsx
@@ -16,12 +16,14 @@ interface ActiveMemoryConfigProps {
   activeMemoryConfig: Memory | null | undefined;
   variant?: 'outline' | 'filled';
   size?: 'default' | 'small';
+  className?: string;
 }
 
 const ActiveMemoryConfig: FC<ActiveMemoryConfigProps> = ({
   activeMemoryConfig,
   variant = 'outline',
   size = 'default',
+  className,
 }) => {
   const { t } = useTranslation()
 
@@ -33,7 +35,7 @@ const ActiveMemoryConfig: FC<ActiveMemoryConfigProps> = ({
       'rb:py-2 rb:px-3 rb:rounded-lg': size === 'small',
       'rb-border rb:bg-white rb:p-3': variant === 'outline',
       'rb:bg-[#F5F5F5] rb:p-3!': variant === 'filled',
-    })}>
+    }, className)}>
       <Flex align="center" gap={12}
         className={clsx({
           'rb:text-[12px]': size === 'small'

--- a/web/src/i18n/en/workflowPart1.ts
+++ b/web/src/i18n/en/workflowPart1.ts
@@ -448,6 +448,7 @@ export const workflowPart1 = {
           context: 'Context',
           message: 'Query',
           max_iterations: 'Max Iterations',
+          long_term_memory: 'Memory Configuration',
         },
         name: 'Key',
         type: 'Type',

--- a/web/src/i18n/zh/workflowPart1.ts
+++ b/web/src/i18n/zh/workflowPart1.ts
@@ -448,6 +448,7 @@ export const workflowPart1 = {
           context: '上下文',
           message: '查询',
           max_iterations: '迭代次数',
+          long_term_memory: '记忆配置',
         },
         name: '键',
         type: '类型',

--- a/web/src/views/Workflow/components/Properties/BasicField.tsx
+++ b/web/src/views/Workflow/components/Properties/BasicField.tsx
@@ -58,9 +58,10 @@ const BasicField: FC<BasicFieldProps> = ({ configKey: key, config }) => {
   }
 
   return (
+    <>
     <Form.Item
       key={key}
-      name={key}
+      name={key === 'long_term_memory' ? [key, 'enable'] : key}
       label={key === 'vision_input'
         ? undefined : key === 'parallel_count'
           ? <span className="rb:text-[10px] rb:text-[#5B6167] rb:leading-3.5 rb:-mb-1!">{t(`workflow.config.${selectedNode?.data?.type}.${key}`)}</span>
@@ -181,13 +182,15 @@ const BasicField: FC<BasicFieldProps> = ({ configKey: key, config }) => {
           size="small"
         />
         : config.type === 'switch'
-        ? <Switch onChange={
-          key === 'group'
-            ? () => { form.setFieldValue('group_variables', []) }
-            : key === 'vision'
-              ? () => { form.setFieldValue('vision_input', undefined) }
-              : undefined
-        } />
+        ? <Switch
+          onChange={
+            key === 'group'
+              ? () => { form.setFieldValue('group_variables', []) }
+              : key === 'vision'
+                ? () => { form.setFieldValue('vision_input', undefined) }
+                : undefined
+          }
+        />
         : config.type === 'categoryList'
         ? <CategoryList
           parentName={key}
@@ -200,6 +203,14 @@ const BasicField: FC<BasicFieldProps> = ({ configKey: key, config }) => {
         : null
       }
     </Form.Item>
+    {key === 'long_term_memory' && (values?.long_term_memory as any)?.enable &&
+      <ActiveMemoryConfig
+        activeMemoryConfig={activeMemoryConfig}
+        size="small"
+        className="rb:mb-3! rb:-mt-2"
+      />
+    }
+    </>
   )
 }
 

--- a/web/src/views/Workflow/constant/nodeLibraryPart1.ts
+++ b/web/src/views/Workflow/constant/nodeLibraryPart1.ts
@@ -218,6 +218,15 @@ export const nodeLibraryPart1: NodeLibrary[] = [
               window_size: 20
             }
           },
+          knowledge_retrieval: {
+            type: 'knowledge',
+          },
+          long_term_memory: {
+            type: 'switch',
+            defaultValue: {
+              enable: false
+            }
+          },
           error_handle: {
             type: 'errorHandle',
             defaultValue: {


### PR DESCRIPTION
## Summary by Sourcery

为代理（agent）工作流节点添加可配置的长期记忆支持，并在 Web UI 中暴露相关设置。

New Features:
- 为代理节点引入长期记忆开关选项，默认处于禁用状态。
- 当在工作流属性中启用长期记忆时，显示 ActiveMemoryConfig 面板。
- 在代理节点配置中新增知识检索（knowledge retrieval）配置类型。

Enhancements:
- 允许 ActiveMemoryConfig 组件接受自定义 className，并在工作流表单中支持紧凑样式。
- 调整工作流 i18n 标签，以包含英文和中文的长期记忆配置标题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable long-term memory support to agent workflow nodes and expose its settings in the web UI.

New Features:
- Introduce a long-term memory switch option with default disabled state for agent nodes.
- Display an ActiveMemoryConfig panel when long-term memory is enabled in workflow properties.
- Add knowledge retrieval configuration type to agent node configuration.

Enhancements:
- Allow ActiveMemoryConfig component to accept custom className and support compact styling in workflow forms.
- Adjust workflow i18n labels to include long-term memory configuration titles in English and Chinese.

</details>