### PR TITLE
feat(web): kb required

### DIFF
--- a/web/src/components/Knowledge/index.tsx
+++ b/web/src/components/Knowledge/index.tsx
@@ -32,12 +32,14 @@ interface KnowledgeProps {
   value?: KnowledgeConfig;
   onChange?: (config: KnowledgeConfig) => void;
   variant?: KnowledgeVariant;
+  required?: boolean;
 }
 
 const Knowledge: FC<KnowledgeProps> = ({
   value = { knowledge_bases: [] },
   onChange,
   variant = 'application',
+  required
 }) => {
   const { t } = useTranslation()
   const knowledgeModalRef = useRef<KnowledgeModalRef>(null)
@@ -210,7 +212,7 @@ const Knowledge: FC<KnowledgeProps> = ({
     <div>
       <Flex align="center" justify="space-between" className="rb:mb-2!">
         <div className="rb:text-[12px] rb:font-medium rb:leading-4.5">
-          <span className="rb:text-[#ff5d34] rb:text-[14px] rb:font-[SimSun,sans-serif] rb:mr-1">*</span>{t('application.knowledgeBaseAssociation')}
+          {required && <span className="rb:text-[#ff5d34] rb:text-[14px] rb:font-[SimSun,sans-serif] rb:mr-1">*</span>}{t('application.knowledgeBaseAssociation')}
         </div>
 
         <Button

--- a/web/src/views/Workflow/components/Properties/ConfigField.tsx
+++ b/web/src/views/Workflow/components/Properties/ConfigField.tsx
@@ -166,7 +166,7 @@ const ConfigField: FC<ConfigFieldProps> = ({ configKey: key }) => {
         key={key}
         name={key}
       >
-        <Knowledge variant="workflow" />
+        <Knowledge variant="workflow" required={config.required} />
       </Form.Item>
     )
   }


### PR DESCRIPTION
## Summary by Sourcery

使 Knowledge 组件的“必填”指示器可配置，并将其与工作流字段配置关联起来。

New Features:
- 为 Knowledge 组件新增一个可选的 `required` 标记，用于控制是否显示“必填”标记。

Enhancements:
- 将工作流配置中的 `config.required` 传递给 Knowledge 组件，使其必填状态能够在 UI 中得到体现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the Knowledge component’s required indicator configurable and wire it to workflow field configuration.

New Features:
- Add an optional required flag to the Knowledge component to control display of the required marker.

Enhancements:
- Propagate workflow config.required to the Knowledge component so the required state is reflected in the UI.

</details>