### PR TITLE
fix(batch_persist): pass files parameter in memory persist queue

### DIFF
--- a/api/app/services/batch_persist_queue.py
+++ b/api/app/services/batch_persist_queue.py
@@ -458,6 +458,7 @@ async def _bulk_persist_messages(
                 "content": user_content,
                 "role": "user",
                 "should_memorize": should_memorize,
+                "files": user_meta.get("files"),
             })
             _memory_params.append({
                 "conv_id": conv_id,
@@ -562,6 +563,7 @@ async def _write_memory_messages_batch(
                 content=entry.get("content", ""),
                 message_seq=next_seq,
                 should_memorize=entry.get("should_memorize", True),
+                files=entry.get("files"),
                 created_at=now,
                 dialog_at=dialog_at,
             ))


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 在批量持久化队列中排队并写入记忆消息时，将用户消息元数据中的附件文件一并包含进去。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include attached files from user message metadata when enqueueing and writing memory messages in the batch persist queue.

</details>