### PR TITLE
Fix: 四维画像分析 LLM 返回 evidence 字段类型错误

### DIFF
--- a/api/app/core/memory/analytics/implicit_memory/prompts/dimension_analysis.jinja2
+++ b/api/app/core/memory/analytics/implicit_memory/prompts/dimension_analysis.jinja2
@@ -19,23 +19,27 @@ Summary {{ loop.index }}:
 ## Instructions
 1. Analyze the user's content for each dimension
 2. Calculate percentage scores (0-100%)
+3. Provide specific evidence as a LIST of strings for each dimension
+4. Provide reasoning explaining the score
+5. Assess confidence_level (0-100) based on data quality and quantity
+6. **IMPORTANT: evidence MUST be an array of strings, even if only one item**
 
 ## Output Format
 {
   "dimensions": {
-    "creativity": {"percentage": 0-100},
-    "aesthetic": {"percentage": 0-100},
-    "technology": {"percentage": 0-100},
-    "literature": {"percentage": 0-100}
+    "creativity": {"percentage": 0-100, "evidence": ["string", "string"], "reasoning": "string", "confidence_level": 0-100},
+    "aesthetic": {"percentage": 0-100, "evidence": ["string", "string"], "reasoning": "string", "confidence_level": 0-100},
+    "technology": {"percentage": 0-100, "evidence": ["string", "string"], "reasoning": "string", "confidence_level": 0-100},
+    "literature": {"percentage": 0-100, "evidence": ["string", "string"], "reasoning": "string", "confidence_level": 0-100}
   }
 }
 
 ## Example
 {
   "dimensions": {
-    "creativity": {"percentage": 75},
-    "aesthetic": {"percentage": 45},
-    "technology": {"percentage": 60},
-    "literature": {"percentage": 30}
+    "creativity": {"percentage": 75, "evidence": ["提出了多个创新性设计方案", "讨论了原创性思路"], "reasoning": "频繁展现创意思维", "confidence_level": 80},
+    "aesthetic": {"percentage": 45, "evidence": ["提到过界面设计偏好"], "reasoning": "偶尔涉及审美话题", "confidence_level": 50},
+    "technology": {"percentage": 60, "evidence": ["深入讨论了编程框架选择", "分享了技术文章"], "reasoning": "技术话题占比较高", "confidence_level": 85},
+    "literature": {"percentage": 30, "evidence": ["提到过阅读习惯"], "reasoning": "文学相关内容较少", "confidence_level": 40}
   }
 }


### PR DESCRIPTION
##问题
调用 POST /memory/implicit-memory/generate_profile 时抛出 LLM_ERROR: Dimension analysis failed: evidence Input should be a valid list。

##根因
dimension_analysis.jinja2 提示词只要求 LLM 输出 {"percentage": 0-100}，缺少 evidence、reasoning、confidence_level 字段声明。LLM 自主补充了 evidence 字段，但传入字符串而非数组，与 DimensionScoreResponse schema（evidence: List[str]）不匹配。

##修改内容
prompts/dimension_analysis.jinja2 — 补全四个字段（evidence、reasoning、confidence_level）的格式定义，明确 evidence 必须为字符串数组，并补充完整示例

##影响范围
仅影响隐性记忆四维画像分析的 LLM 提示词，不改动业务逻辑。

##验证方式
确保用户帐号下存在 ≥ 5 个带有 DERIVED_FROM_STATEMENT 关系的 MemorySummary 节点
调用 POST /memory/implicit-memory/generate_profile，确认不再报错并返回完整画像数据

## 由 Sourcery 提供的总结

阐明用于隐式记忆维度分析的 LLM 输出模式，以防止 evidence 字段的类型不匹配。

改进内容：
- 扩展维度分析提示词说明，要求对每个维度提供具有明确类型的 evidence、reasoning 和 confidence_level。
- 更新提示中的输出格式和示例，通过将 evidence 定义为字符串列表，使其与 DimensionScoreResponse 保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the LLM output schema for implicit memory dimension analysis to prevent evidence field type mismatches.

Enhancements:
- Extend the dimension analysis prompt instructions to require evidence, reasoning, and confidence_level for each dimension with explicit types.
- Update the output format and example in the prompt to align with DimensionScoreResponse by defining evidence as a list of strings.

</details>