### PR TITLE
fix(memory):memory-display-timestamp

### DIFF
--- a/api/app/models/memory_display_record_model.py
+++ b/api/app/models/memory_display_record_model.py
@@ -17,7 +17,6 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
 
 from app.db import Base
 
@@ -46,11 +45,7 @@ class MemoryDisplayRecord(Base):
     score = Column(Float, nullable=True)
     rank = Column(Integer, nullable=True)
     search_mode = Column(String(16), nullable=True)
-    occurred_at = Column(
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-    )
+    occurred_at = Column(DateTime, nullable=False)  # naive UTC
 
     __table_args__ = (
         UniqueConstraint(

--- a/api/app/models/memory_display_record_model.py
+++ b/api/app/models/memory_display_record_model.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.db import Base
 
 
@@ -45,7 +46,9 @@ class MemoryDisplayRecord(Base):
     score = Column(Float, nullable=True)
     rank = Column(Integer, nullable=True)
     search_mode = Column(String(16), nullable=True)
-    occurred_at = Column(DateTime, nullable=False)  # naive UTC
+    occurred_at = Column(
+        DateTime, nullable=False, default=utcnow_naive
+    )  # naive UTC
 
     __table_args__ = (
         UniqueConstraint(

--- a/api/app/models/memory_engine_display_event_model.py
+++ b/api/app/models/memory_engine_display_event_model.py
@@ -10,6 +10,7 @@ import uuid
 from sqlalchemy import Column, DateTime, ForeignKey, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
+from app.core.utils.datetime_utils import utcnow_naive
 from app.db import Base
 
 
@@ -31,7 +32,9 @@ class MemoryEngineDisplayEvent(Base):
     operation_id = Column(UUID(as_uuid=True), nullable=False)
     engine_type = Column(String(32), nullable=False)  # EXTRACTION / CROSS_MODAL / EMOTION
     details = Column(JSONB, nullable=False, server_default="{}")
-    occurred_at = Column(DateTime, nullable=False)  # naive UTC
+    occurred_at = Column(
+        DateTime, nullable=False, default=utcnow_naive
+    )  # naive UTC
 
     __table_args__ = (
         UniqueConstraint(

--- a/api/app/services/memory_display_record_service.py
+++ b/api/app/services/memory_display_record_service.py
@@ -14,7 +14,7 @@ from typing import List
 
 from sqlalchemy.orm import Session
 
-from app.core.utils.datetime_utils import to_timestamp_ms, utcnow
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.memory_display_record_repository import (
     MemoryDisplayRecordRepository,
@@ -120,7 +120,7 @@ class MemoryDisplayRecordService:
 
         # 生成 operation_id（同批共用）
         operation_id = uuid.uuid4()
-        now = utcnow()
+        now = utcnow_naive()
 
         # 组装 PG 记录
         records = []


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将内存显示出现的时间戳存储为“天真”的 UTC（不带时区信息），而不是带时区的值，以避免不一致问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Store memory display occurrence timestamps as naive UTC instead of timezone-aware values to avoid inconsistencies.

</details>