### PR TITLE
fix(chat): add memory persistence and dispatch in chat completion flow

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from types import SimpleNamespace
 from typing import Optional, Dict, Any, AsyncGenerator, Annotated, List, Literal
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import Depends
 from sqlalchemy import select
@@ -111,9 +111,9 @@ class AppChatService:
 
     def __init__(self, db: Session | AsyncSession):
         self.db = db
-        self.conversation_service = ConversationService(db)
-        self.agent_service = AgentRunService(db)
-        self.workflow_service = WorkflowService(db)
+        self.conversation_service: ConversationService = ConversationService(db)
+        self.agent_service: AgentRunService = AgentRunService(db)
+        self.workflow_service: WorkflowService = WorkflowService(db)
 
     def _uses_async_session(self) -> bool:
         return isinstance(self.db, AsyncSession)
@@ -1547,6 +1547,27 @@ class AppChatService:
                     args=persist_args,
                 ))
                 save_messages_enqueued = True
+
+                # 记忆写入 + 派发：复用 conversation_service.dispatch_memory_sync
+                from app.models.conversation_model import Conversation
+
+                result_row = await self.db.execute(
+                    select(Conversation).where(Conversation.id == conversation_id)
+                )
+                conv = result_row.scalar_one_or_none()
+                if conv:
+                    now = datetime.now(timezone.utc)
+
+                    for m in [
+                        {"id": user_message_id, "role": "user", "content": message, "meta_data": human_meta, "should_memorize": memory},
+                        {"id": message_id, "role": "assistant", "content": full_content, "meta_data": assistant_meta, "should_memorize": True},
+                    ]:
+                        memorize = m.pop("should_memorize")
+                        self.conversation_service.dispatch_memory_sync(
+                            message=SimpleNamespace(conversation_id=conversation_id, created_at=now, **m),
+                            conversation=conv,
+                            should_memorize=memorize,
+                        )
 
                 # Enqueue agent execution after messages so the FK is satisfied
                 # within the same batch (messages commit first, then execution).

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -292,7 +292,7 @@ class ConversationService:
             self.db.refresh(message)
 
             if sync_memory:
-                self._dispatch_memory_sync(message, conversation, should_memorize)
+                self.dispatch_memory_sync(message, conversation, should_memorize)
 
             logger.info(
                 "Message added successfully",
@@ -371,7 +371,7 @@ class ConversationService:
                 self.db.refresh(message)
 
             if sync_memory:
-                self._dispatch_memory_sync(message, conversation, should_memorize)
+                self.dispatch_memory_sync(message, conversation, should_memorize)
 
             return message
         except Exception as e:
@@ -489,7 +489,7 @@ class ConversationService:
         )
         return msg
 
-    def _dispatch_memory_sync(
+    def dispatch_memory_sync(
         self,
         message: Message,
         conversation: Conversation,


### PR DESCRIPTION
## Summary by Sourcery

在聊天补全流程中，通过重用会话服务的同步内存分发机制，持久化并分发聊天消息的记忆，并将该分发器暴露出来以便复用。

Bug Fixes:
- 确保在聊天补全流程中的用户和助手消息能够被写入记忆，并以与其他会话消息一致的方式进行分发。

Enhancements:
- 将会话记忆分发方法对外暴露以便在各个服务间复用，而不是将其保持为私有。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist and dispatch chat message memory during the chat completion flow by reusing the conversation service’s synchronous memory dispatch, and expose that dispatcher for reuse.

Bug Fixes:
- Ensure user and assistant messages in the chat completion flow are written to memory and dispatched consistently with other conversation messages.

Enhancements:
- Expose the conversation memory dispatch method for reuse across services instead of keeping it private.

</details>