### PR TITLE
fix(tasks): reuse existing event loop to prevent Neo4j driver cross-loop reuse error

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3483,7 +3483,11 @@ def write_total_memory_task(workspace_id: str) -> Dict[str, Any]:
             }
 
     try:
-        result = asyncio.run(_run())
+        # 尝试获取现有事件循环，如果不存在则创建新的（与 write_all_workspaces_memory_task 一致，
+        # 避免 asyncio.run 每次新建并关闭 loop，导致进程内共享 Neo4j driver 跨 loop 复用报错）
+        loop = set_asyncio_event_loop()
+
+        result = loop.run_until_complete(_run())
         elapsed_time = time.time() - start_time
         result["elapsed_time"] = elapsed_time
         return result


### PR DESCRIPTION
…

## Summary by Sourcery

Bug Fixes:
- 通过在持久化的 asyncio 事件循环上执行异步任务，而不是反复创建和关闭事件循环，避免 Neo4j 驱动在跨事件循环复用时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Neo4j driver cross-event-loop reuse errors by executing the async task on a persistent asyncio event loop rather than repeatedly creating and closing loops.

</details>