### PR TITLE
fix(memory): add FK retry for agent message ingestion race condition

### DIFF
--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -16,10 +16,13 @@ MemoryWriteDispatcher — 记忆写入派发层
 各入口点保持原位置，通过本模块的函数进行统一派发。
 """
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, List, Optional
+
+from sqlalchemy.exc import IntegrityError
 
 from app.core.memory.enums import MemoryMessageSource
 from app.db import get_db_context, get_db_read
@@ -29,6 +32,11 @@ logger = logging.getLogger(__name__)
 
 # 滑动窗口大小
 WINDOW_SIZE = 3
+
+# ingest_agent_message 写 memory_messages 时，original_message_id 外键引用的 messages
+# 行可能因 BatchPersistQueue 攒批而尚未落库（FK 竞态），捕获后延迟重试直到最终一致。
+AGENT_MESSAGE_FK_RETRY = 4
+AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S = 0.3
 
 
 # ──────────────────────────────────────────────
@@ -479,25 +487,52 @@ async def ingest_agent_message(
         elif isinstance(_created, str):
             dialog_at = _created
 
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        written = repo.write_batch(
-            conversation_id=str(conversation_id),
-            messages=[{
-                "role": message.role,
-                "content": message.content,
-                "original_message_id": message.id,
-                "created_at": message.created_at,
-                "should_memorize": should_memorize,
-                "files": files,
-                "dialog_at": dialog_at,
-            }],
-            end_user_id=end_user_id,
-            source=MemoryMessageSource.AGENT,
-        )
-        if not written:
-            return False
-        db.commit()
+    # 写 memory_messages。original_message_id 外键指向 messages 表，而 messages 可能
+    # 经 BatchPersistQueue 攒批延迟落库——本表先 commit 时外键引用的行尚不存在，
+    # 会抛 IntegrityError（ForeignKeyViolation）。捕获后延迟重试，最终一致。
+    written: List[dict] = []
+    for attempt in range(AGENT_MESSAGE_FK_RETRY):
+        try:
+            with get_db_context() as db:
+                repo = MemoryMessageRepository(db)
+                written = repo.write_batch(
+                    conversation_id=str(conversation_id),
+                    messages=[{
+                        "role": message.role,
+                        "content": message.content,
+                        "original_message_id": message.id,
+                        "created_at": message.created_at,
+                        "should_memorize": should_memorize,
+                        "files": files,
+                        "dialog_at": dialog_at,
+                    }],
+                    end_user_id=end_user_id,
+                    source=MemoryMessageSource.AGENT,
+                )
+                if not written:
+                    return False
+                db.commit()
+            break
+        except IntegrityError as exc:
+            orig = getattr(exc, "orig", None)
+            is_fk = orig is not None and "ForeignKeyViolation" in type(orig).__name__
+            if not is_fk:
+                raise
+            if attempt >= AGENT_MESSAGE_FK_RETRY - 1:
+                # 重试耗尽：基本可断定 messages 行已永久缺失（落库失败/任务丢失），
+                # 该条记忆静默丢失，升级为 error 并带固定聚合标记，供日志平台配置告警。
+                logger.error(
+                    "MEMORY_MESSAGES_FK_EXHAUSTED retries=%d conv=%s end_user=%s "
+                    "original_message_id=%s app_id=%s err=%s",
+                    AGENT_MESSAGE_FK_RETRY, conversation_id, end_user_id,
+                    getattr(message, "id", ""), app_id, exc,
+                )
+                raise
+            logger.warning(
+                "ingest_agent_message FK 冲突（messages 尚未落库），重试 %d/%d: conv=%s, err=%s",
+                attempt + 1, AGENT_MESSAGE_FK_RETRY, conversation_id, exc,
+            )
+            await asyncio.sleep(AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S * (attempt + 1))
 
     await refresh_active_key(conversation_id)
     mark_conversation_pending(conversation_id)


### PR DESCRIPTION
## Summary by Sourcery

在将代理消息写入内存存储时，新增针对外键竞争条件的重试处理逻辑。

Bug Fixes（错误修复）:
- 在写入代理内存消息时，如果出现短暂的外键约束违反错误，通过带退避策略的重试机制进行处理，直到被引用的消息行成功持久化或重试次数耗尽为止。

Enhancements（增强功能）:
- 当发生外键重试或重试耗尽时，记录详细的警告和错误日志，以便于监控和告警。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retry handling for foreign key race conditions when ingesting agent messages into memory storage.

Bug Fixes:
- Handle transient foreign key violations when writing agent memory messages by retrying with backoff until the referenced message row is persisted or retries are exhausted.

Enhancements:
- Log detailed warnings and errors when foreign key retries occur or are exhausted to aid monitoring and alerting.

</details>