### PR TITLE
fix(zygote_worker): fix zombie reaping and exit code handling in process termination

### DIFF
--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -390,37 +390,34 @@ class Zygote:
             return
 
         pid = req["pid"]
-        # WNOHANG returns (0,0) for a live child, (pid,status) for a zombie.
-        # os.kill(pid,0) also succeeds on zombies -> false positives on every
-        # timeout/SIGKILL.  Only flag it when the child is genuinely still alive.
-        # IMPORTANT: waitpid(WNOHANG) REAPS the zombie, so we must save the
-        # status here — a second waitpid() would fail with ChildProcessError.
-        status = None
+        self.reqs.pop(req_id, None)
+
+        # Wait with WNOHANG to distinguish zombie (already exited) from a live
+        # child that merely closed its stdio.  WNOHANG returns (0, 0) for a live
+        # child and (pid, status) for a zombie — and REAPS the zombie.
         try:
-            wpid, status = os.waitpid(pid, os.WNOHANG)
-            alive = wpid == 0
-            if alive:
-                status = None  # child still running, no status yet
+            wpid, zombie_status = os.waitpid(pid, os.WNOHANG)
         except ChildProcessError:
-            alive = False
-            status = None
-        if alive:
+            # Already reaped (shouldn't happen, but handle gracefully).
+            self._send(P.MSG_DONE, req_id, P.DONE_STRUCT.pack(-1))
+            return
+
+        if wpid != 0:
+            # ── Path 1: child already exited (zombie, now reaped) ──
+            exit_code = os.waitstatus_to_exitcode(zombie_status)
+        else:
+            # ── Path 2: child still running but closed stdio ──
             self._send(P.MSG_STDERR, req_id, b"process terminated")
-            self.reqs.pop(req_id, None)
             try:
                 os.kill(pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
             try:
-                _, status = os.waitpid(pid, 0)
+                _, kill_status = os.waitpid(pid, 0)
+                exit_code = os.waitstatus_to_exitcode(kill_status)
             except ChildProcessError:
-                pass
-        else:
-            self.reqs.pop(req_id, None)
-        if status is not None:
-            exit_code = os.waitstatus_to_exitcode(status)
-        else:
-            exit_code = -1
+                exit_code = -1
+
         self._send(P.MSG_DONE, req_id, P.DONE_STRUCT.pack(exit_code))
 
     # ------------------------------------------------------------------ loop

--- a/sandbox/runtime/pool/zygote_worker.py
+++ b/sandbox/runtime/pool/zygote_worker.py
@@ -393,21 +393,33 @@ class Zygote:
         # WNOHANG returns (0,0) for a live child, (pid,status) for a zombie.
         # os.kill(pid,0) also succeeds on zombies -> false positives on every
         # timeout/SIGKILL.  Only flag it when the child is genuinely still alive.
+        # IMPORTANT: waitpid(WNOHANG) REAPS the zombie, so we must save the
+        # status here — a second waitpid() would fail with ChildProcessError.
+        status = None
         try:
-            alive = os.waitpid(pid, os.WNOHANG)[0] == 0
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+            alive = wpid == 0
+            if alive:
+                status = None  # child still running, no status yet
         except ChildProcessError:
             alive = False
+            status = None
         if alive:
             self._send(P.MSG_STDERR, req_id, b"process terminated")
-        self.reqs.pop(req_id, None)
-        try:
-            os.kill(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        try:
-            _, status = os.waitpid(pid, 0)
+            self.reqs.pop(req_id, None)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            try:
+                _, status = os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
+        else:
+            self.reqs.pop(req_id, None)
+        if status is not None:
             exit_code = os.waitstatus_to_exitcode(status)
-        except ChildProcessError:
+        else:
             exit_code = -1
         self._send(P.MSG_DONE, req_id, P.DONE_STRUCT.pack(exit_code))
 


### PR DESCRIPTION
- Save waitpid status before reaping to avoid ChildProcessError on second wait
- Only send termination message and SIGKILL when process is still alive
- Ensure exit code is properly derived from saved status or defaults to -1

## Summary by Sourcery

改进子进程终止处理逻辑，以避免错误并确保返回正确的退出码。

Bug 修复：
- 防止在拆卸（teardown）过程中回收已终止的子进程时出现 `ChildProcessError`。
- 避免向已不再存活的进程发送终止消息和 `SIGKILL` 信号。
- 确保在可用时从已保存的 `waitpid` 状态中派生退出码，否则默认使用 `-1`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve child process termination handling to avoid errors and ensure correct exit codes.

Bug Fixes:
- Prevent ChildProcessError when reaping already-terminated child processes during teardown.
- Avoid sending termination messages and SIGKILL for processes that are no longer alive.
- Ensure exit codes are derived from the saved waitpid status when available and default to -1 otherwise.

</details>