### PR TITLE
fix(workflow&draft): resolve duplicate message persistence when workflow is used as a tool

### DIFF
--- a/api/app/core/tools/workflow/base.py
+++ b/api/app/core/tools/workflow/base.py
@@ -125,6 +125,8 @@ class WorkflowAsTool(BaseTool):
                 RunnableConfig(callbacks=[], tags=[], metadata={})
             )
             try:
+                # 工作流作为工具调用时是纯函数式执行：不创建会话、不落任何
+                # user/assistant 消息，只保留 execution 记录用于日志。
                 result = await self.workflow_service.run(
                     app_id=self.workflow_app_id,
                     payload=payload,
@@ -132,6 +134,7 @@ class WorkflowAsTool(BaseTool):
                     workspace_id=workspace_id,
                     release_id=self.release_id,
                     source="tool",
+                    skip_save=True,
                 )
             finally:
                 var_child_runnable_config.reset(config_token)

--- a/api/app/services/draft_run_service.py
+++ b/api/app/services/draft_run_service.py
@@ -4126,8 +4126,11 @@ class AgentRunService:
                 "error": r.get("error")
             })
 
-        # Phase 3: enqueue per-model message saves via batch persist queue
-        if not skip_save:
+        # Phase 3: enqueue per-model message saves via batch persist queue.
+        # 内层 run_stream 在 skip_save=False 时已自行落库 user+assistant，
+        # 这里仅在内层不落库（skip_save=True）时补落库；否则同一 user_message_id
+        # 会再插入一条 assistant 消息（此前因主键冲突整批回滚而被隐藏）。
+        if skip_save:
             from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
 
             # Build files_meta from FileInput list

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -6173,12 +6173,13 @@ class WorkflowService:
         has_existing_conversation = bool(payload.conversation_id)
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
+        # skip_save 语义：纯函数式执行（如工作流作为工具），不创建会话、不落消息
         conversation_id_uuid = await self._ensure_conversation_async(
             app_id=app_id,
             workspace_id=workspace_id,
             user_id=payload.user_id,
             conversation_id=conversation_id_uuid,
-            enable_conversation=supports_conversation,
+            enable_conversation=supports_conversation and not skip_save,
         )
         if conversation_id_uuid:
             payload.conversation_id = str(conversation_id_uuid)
@@ -6485,8 +6486,9 @@ class WorkflowService:
                     assistant_meta["citations"] = filtered_citations
                 # regenerate_mode 下由 regenerate() 统一保存版本化消息，
                 # 这里不能再入队 save_messages，否则会话里会多出一对幽灵消息
-                # （且流式重新生成会因同一 message_id 触发主键冲突）。
-                if conversation_id_uuid and not regenerate_mode:
+                # （且流式重新生成会因同一 message_id 触发主键冲突）；
+                # skip_save 下（工作流作为工具等纯函数式执行）同样不落消息。
+                if conversation_id_uuid and not regenerate_mode and not skip_save:
                     messages_finalized = True
                     _from_msg_id = await self._resolve_from_message_id_async(
                         payload.from_message_id,
@@ -6539,7 +6541,7 @@ class WorkflowService:
                 human_message, human_meta = self._extract_human_message_and_meta(
                     final_messages, payload.message or "", files
                 )
-                if not regenerate_mode:
+                if not regenerate_mode and not skip_save:
                     messages_finalized = True
                     await self._save_failed_conversation_async(
                         conversation_id_uuid, message_id, human_message, human_meta, result.get("error") or ""
@@ -6608,7 +6610,7 @@ class WorkflowService:
                 logger.warning(f"Failed to persist node executions on run error: {persist_err}")
             human_message, human_meta = self._extract_human_message_and_meta([], payload.message or "", files)
             # 若本轮消息已成功入队，不要再入队失败消息，避免重复写入
-            if not regenerate_mode and not messages_finalized:
+            if not skip_save and not regenerate_mode and not messages_finalized:
                 await self._save_failed_conversation_async(conversation_id_uuid, None, human_message, human_meta, str(e))
             raise BusinessException(
                 code=BizCode.INTERNAL_ERROR,
@@ -6751,12 +6753,13 @@ class WorkflowService:
         has_existing_conversation = bool(payload.conversation_id)
         # 转换 conversation_id 为 UUID
         conversation_id_uuid = uuid.UUID(payload.conversation_id) if payload.conversation_id else None
+        # skip_save 语义：纯函数式执行（如工作流作为工具），不创建会话、不落消息
         conversation_id_uuid = await self._ensure_conversation_async(
             app_id=app_id,
             workspace_id=workspace_id,
             user_id=payload.user_id,
             conversation_id=conversation_id_uuid,
-            enable_conversation=supports_conversation,
+            enable_conversation=supports_conversation and not skip_save,
         )
         if conversation_id_uuid:
             payload.conversation_id = str(conversation_id_uuid)


### PR DESCRIPTION
1. Adjust the batch message saving logic in draft_run_service so that messages are only saved as a fallback when skip_save is True
2. Add skip_save=True parameter to the workflow_as_tool invocation
3. Add semantic comments for skip_save in workflow_service and adjust the trigger conditions for conversation creation and message persistence, skipping message persistence for pure functional execution

## Summary by Sourcery

防止作为工具使用的工作流运行创建会话或持久化消息，并调整草稿运行批量持久化逻辑，以避免重复的助手消息。

错误修复：
- 确保作为工具调用的工作流执行以纯函数模式运行，不创建会话，也不持久化用户/助手消息。
- 修复由于批量持久化重新保存已由内部流式运行存储的消息而导致的重复助手消息插入问题。

增强功能：
- 明确并强制 `skip_save` 标志在各类工作流执行路径中的语义，包括会话创建和错误处理场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent workflow runs used as tools from creating conversations or persisting messages, and adjust draft run batch persistence to avoid duplicate assistant messages.

Bug Fixes:
- Ensure workflow executions invoked as tools run in a pure functional mode without creating conversations or persisting user/assistant messages.
- Fix duplicate assistant message insertion caused by batch persistence re-saving messages already stored by inner streaming runs.

Enhancements:
- Clarify and enforce the semantics of the skip_save flag across workflow execution paths, including conversation creation and error handling.

</details>