### PR TITLE
feat(rag): add direct image chunk pipeline

### DIFF
--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -17,10 +17,7 @@ class MinerUV3Parser(DocumentParser):
         self.client = client or MinerUV3Client()
 
     def parse(self, ctx) -> ParseResult:
-        binary = ctx.binary
-        if binary is None:
-            with open(ctx.filename, "rb") as file:
-                binary = file.read()
+        binary = self._read_binary(ctx)
 
         image_vision_enabled = is_image_vision_enabled(ctx.parser_config)
         mineru_result = self.client.parse(
@@ -47,6 +44,24 @@ class MinerUV3Parser(DocumentParser):
         elif ctx.vision_model:
             LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")
         return ParseResult(blocks=blocks, merge_strategy="blocks", markdown_preprocess_profile="mineru")
+
+    def parse_markdown(self, ctx) -> str:
+        binary = self._read_binary(ctx)
+        mineru_result = self.client.parse(
+            file_name=ctx.filename,
+            binary=binary,
+            start_page_id=ctx.from_page,
+            end_page_id=ctx.to_page,
+            callback=ctx.callback,
+            return_images=False,
+        )
+        return mineru_result.markdown
+
+    def _read_binary(self, ctx) -> bytes:
+        if ctx.binary is not None:
+            return ctx.binary
+        with open(ctx.filename, "rb") as file:
+            return file.read()
 
     def _attach_images(self, blocks, images):
         attached_count = 0

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -1,0 +1,145 @@
+import io
+import logging
+import uuid
+from dataclasses import replace
+from pathlib import Path
+
+from PIL import Image
+
+from app.core.config import settings
+from app.core.rag.app.picture import vision_llm_chunk
+from app.core.rag.chunk.context import (
+    ChunkContext,
+    ParsedBlock,
+    ParsedBlockType,
+    ParseResult,
+)
+from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
+from app.core.rag.prompts.generator import vision_llm_figure_describe_prompt
+
+from .base import ChunkPipeline
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_IMAGE_VISION_MODE = 1
+IMAGE_VISION_MODES = {0, 1, 2}
+
+
+class ImageChunkPipeline(ChunkPipeline):
+    """Parse directly uploaded images without changing embedded-image pipelines."""
+
+    def parse(self, ctx: ChunkContext) -> ParseResult:
+        mode = self._image_vision_mode(ctx)
+        source_file_id = self._source_file_id(ctx)
+        source_binary = self._read_binary(ctx)
+        analysis_binary, analysis_filename, source_image = self._analysis_input(ctx.filename, source_binary)
+
+        self._callback(ctx, 0.1, "Start to parse image.")
+        text_blocks: list[ParsedBlock] = []
+        if mode in {0, 1}:
+            text_blocks = self._parse_ocr_text(ctx, analysis_binary, analysis_filename)
+
+        vision_text = ""
+        if mode in {1, 2}:
+            vision_text = self._describe_source_image(ctx, source_image)
+
+        if mode == 0:
+            if not self._has_content(text_blocks):
+                raise ValueError("MinerU returned no text content for image OCR mode.")
+            blocks = text_blocks
+        elif mode == 1:
+            if not self._has_content(text_blocks) and not vision_text:
+                raise ValueError("Image mixed mode produced neither OCR text nor visual description.")
+            blocks = [self._source_image_block(ctx, source_file_id, vision_text), *text_blocks]
+        else:
+            if not vision_text:
+                raise ValueError("Image pure vision mode produced no visual description.")
+            blocks = [self._source_image_block(ctx, source_file_id, vision_text)]
+
+        self._callback(ctx, 0.8, "Finish parsing image.")
+        return ParseResult(blocks=blocks, merge_strategy="blocks")
+
+    def _image_vision_mode(self, ctx: ChunkContext) -> int:
+        raw_mode = ctx.parser_config.get("image_vision_mode", DEFAULT_IMAGE_VISION_MODE)
+        if type(raw_mode) is not int or raw_mode not in IMAGE_VISION_MODES:
+            raise ValueError("parser_config.image_vision_mode must be an integer in {0, 1, 2}.")
+        return raw_mode
+
+    def _read_binary(self, ctx: ChunkContext) -> bytes:
+        if ctx.binary is not None:
+            return ctx.binary
+        with open(ctx.filename, "rb") as file:
+            return file.read()
+
+    def _analysis_input(self, filename: str, source_binary: bytes) -> tuple[bytes, str, Image.Image]:
+        with Image.open(io.BytesIO(source_binary)) as image:
+            image.seek(0)
+            source_image = image.convert("RGB").copy()
+
+        if Path(filename).suffix.lower() != ".gif":
+            return source_binary, filename, source_image
+
+        first_frame = source_image.convert("RGB")
+        image_binary = io.BytesIO()
+        first_frame.save(image_binary, format="PNG")
+        analysis_filename = str(Path(filename).with_suffix(".png"))
+        return image_binary.getvalue(), analysis_filename, first_frame
+
+    def _parse_ocr_text(
+        self,
+        ctx: ChunkContext,
+        analysis_binary: bytes,
+        analysis_filename: str,
+    ) -> list[ParsedBlock]:
+        parser_config = dict(ctx.parser_config)
+        parser_config["image_vision_enabled"] = False
+        ocr_ctx = replace(
+            ctx,
+            filename=analysis_filename,
+            binary=analysis_binary,
+            parser_config=parser_config,
+        )
+        result = MinerUV3Parser().parse(ocr_ctx)
+        blocks = result.blocks or []
+        if not blocks:
+            raise ValueError("MinerU returned empty Markdown for image OCR mode.")
+        return [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
+
+    def _describe_source_image(self, ctx: ChunkContext, source_image: Image.Image) -> str:
+        prompt = vision_llm_figure_describe_prompt(lang=getattr(ctx.vision_model, "lang", ctx.lang))
+        try:
+            vision_text = vision_llm_chunk(source_image, ctx.vision_model, prompt=prompt)
+        except Exception as exc:  # noqa: BLE001
+            LOGGER.warning("[ImagePipeline] source image vision failed: file_name=%s error=%s", ctx.filename, exc)
+            return ""
+
+        vision_text = str(vision_text or "").strip()
+        if not vision_text:
+            LOGGER.warning("[ImagePipeline] source image vision returned empty: file_name=%s", ctx.filename)
+        return vision_text
+
+    def _source_file_id(self, ctx: ChunkContext) -> str:
+        raw_file_id = ctx.kwargs.get("source_file_id")
+        if not raw_file_id:
+            raise ValueError("source_file_id is required to create an image chunk.")
+        try:
+            return str(uuid.UUID(str(raw_file_id)))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("source_file_id must be a valid UUID for image chunking.") from exc
+
+    def _source_image_block(self, ctx: ChunkContext, source_file_id: str, vision_text: str) -> ParsedBlock:
+        filename = Path(ctx.kwargs.get("source_file_name") or ctx.filename).name
+        content = f"![{filename}]({self._source_file_url(source_file_id)})"
+        metadata = {"vision_text": vision_text} if vision_text else {}
+        return ParsedBlock(type=ParsedBlockType.IMAGE, content=content, metadata=metadata)
+
+    def _source_file_url(self, source_file_id) -> str:
+        server_url = (settings.FILE_LOCAL_SERVER_URL or "").rstrip("/")
+        path = f"/storage/permanent/{source_file_id}"
+        return f"{server_url}{path}" if server_url else path
+
+    def _has_content(self, blocks: list[ParsedBlock]) -> bool:
+        return any(str(block.content or "").strip() for block in blocks)
+
+    def _callback(self, ctx: ChunkContext, progress: float, message: str) -> None:
+        if ctx.callback:
+            ctx.callback(progress, message)

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -15,6 +15,7 @@ from app.core.rag.chunk.context import (
     ParseResult,
 )
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
+from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
 from app.core.rag.prompts.generator import vision_llm_figure_describe_prompt
 
 from .base import ChunkPipeline
@@ -34,26 +35,39 @@ class ImageChunkPipeline(ChunkPipeline):
         analysis_binary, analysis_filename, source_image = self._analysis_input(ctx.filename, source_binary)
 
         self._callback(ctx, 0.1, "Start to parse image.")
-        text_blocks: list[ParsedBlock] = []
+        mineru_markdown = ""
         if mode in {0, 1}:
-            text_blocks = self._parse_ocr_text(ctx, analysis_binary, analysis_filename)
+            mineru_markdown = self._parse_ocr_markdown(ctx, analysis_binary, analysis_filename)
+
+        source_image_url = None
+        markdown_parts = []
+        if mode in {1, 2}:
+            source_markdown, source_image_url = self._source_image_markdown(ctx, source_file_id)
+            markdown_parts.append(source_markdown)
+        if mineru_markdown:
+            markdown_parts.append(mineru_markdown)
+
+        blocks, source_image_block = self._parse_markdown_blocks(
+            "\n\n".join(markdown_parts),
+            source_image_url,
+        )
+        text_blocks = [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
 
         vision_text = ""
         if mode in {1, 2}:
             vision_text = self._describe_source_image(ctx, source_image)
+            if vision_text:
+                source_image_block.metadata["vision_text"] = vision_text
 
         if mode == 0:
             if not self._has_content(text_blocks):
                 raise ValueError("MinerU returned no text content for image OCR mode.")
-            blocks = text_blocks
         elif mode == 1:
             if not self._has_content(text_blocks) and not vision_text:
                 raise ValueError("Image mixed mode produced neither OCR text nor visual description.")
-            blocks = [self._source_image_block(ctx, source_file_id, vision_text), *text_blocks]
         else:
             if not vision_text:
                 raise ValueError("Image pure vision mode produced no visual description.")
-            blocks = [self._source_image_block(ctx, source_file_id, vision_text)]
 
         self._callback(ctx, 0.8, "Finish parsing image.")
         return ParseResult(blocks=blocks, merge_strategy="blocks")
@@ -84,12 +98,12 @@ class ImageChunkPipeline(ChunkPipeline):
         analysis_filename = str(Path(filename).with_suffix(".png"))
         return image_binary.getvalue(), analysis_filename, first_frame
 
-    def _parse_ocr_text(
+    def _parse_ocr_markdown(
         self,
         ctx: ChunkContext,
         analysis_binary: bytes,
         analysis_filename: str,
-    ) -> list[ParsedBlock]:
+    ) -> str:
         parser_config = dict(ctx.parser_config)
         parser_config["image_vision_enabled"] = False
         ocr_ctx = replace(
@@ -98,11 +112,10 @@ class ImageChunkPipeline(ChunkPipeline):
             binary=analysis_binary,
             parser_config=parser_config,
         )
-        result = MinerUV3Parser().parse(ocr_ctx)
-        blocks = result.blocks or []
-        if not blocks:
+        markdown = MinerUV3Parser().parse_markdown(ocr_ctx)
+        if not markdown or not markdown.strip():
             raise ValueError("MinerU returned empty Markdown for image OCR mode.")
-        return [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
+        return markdown
 
     def _describe_source_image(self, ctx: ChunkContext, source_image: Image.Image) -> str:
         prompt = vision_llm_figure_describe_prompt(lang=getattr(ctx.vision_model, "lang", ctx.lang))
@@ -126,11 +139,30 @@ class ImageChunkPipeline(ChunkPipeline):
         except (TypeError, ValueError) as exc:
             raise ValueError("source_file_id must be a valid UUID for image chunking.") from exc
 
-    def _source_image_block(self, ctx: ChunkContext, source_file_id: str, vision_text: str) -> ParsedBlock:
+    def _source_image_markdown(self, ctx: ChunkContext, source_file_id: str) -> tuple[str, str]:
         filename = Path(ctx.kwargs.get("source_file_name") or ctx.filename).name
-        content = f"![{filename}]({self._source_file_url(source_file_id)})"
-        metadata = {"vision_text": vision_text} if vision_text else {}
-        return ParsedBlock(type=ParsedBlockType.IMAGE, content=content, metadata=metadata)
+        source_image_url = self._source_file_url(source_file_id)
+        return f"![{filename}]({source_image_url})", source_image_url
+
+    def _parse_markdown_blocks(
+        self,
+        markdown: str,
+        source_image_url: str | None,
+    ) -> tuple[list[ParsedBlock], ParsedBlock | None]:
+        blocks = StructMarkdownParser().parse_text(markdown, normalize_escaped_structure=True)
+        source_image_block = None
+        filtered_blocks = []
+        for block in blocks:
+            if block.type is not ParsedBlockType.IMAGE:
+                filtered_blocks.append(block)
+                continue
+            if source_image_url and source_image_block is None and block.metadata.get("src") == source_image_url:
+                source_image_block = block
+                filtered_blocks.append(block)
+
+        if source_image_url and source_image_block is None:
+            raise ValueError("Failed to parse the source image Markdown tag.")
+        return filtered_blocks, source_image_block
 
     def _source_file_url(self, source_file_id) -> str:
         server_url = (settings.FILE_LOCAL_SERVER_URL or "").rstrip("/")

--- a/api/app/core/rag/chunk/router.py
+++ b/api/app/core/rag/chunk/router.py
@@ -2,6 +2,7 @@ import re
 
 from .pipeline.docx import DocxChunkPipeline
 from .pipeline.excel import ExcelChunkPipeline
+from .pipeline.image import ImageChunkPipeline
 from .pipeline.media import AudioChunkPipeline, PictureVideoChunkPipeline
 from .pipeline.pdf import PdfChunkPipeline, PresentationChunkPipeline
 from .pipeline.text import (
@@ -23,7 +24,9 @@ class FileTypeRouter:
             return PresentationChunkPipeline()
         if re.search(r"\.(da|wave|wav|mp3|aac|flac|ogg|aiff|au|midi|wma|realaudio|vqf|oggvorbis|ape?)$", filename, re.IGNORECASE):
             return AudioChunkPipeline()
-        if re.search(r"\.(png|jpeg|jpg|gif|bmp|svg|mp4|mov|avi|flv|mpeg|mpg|webm|wmv|3gp|3gpp|mkv?)$", filename, re.IGNORECASE):
+        if re.search(r"\.(png|jpeg|jpg|webp|gif)$", filename, re.IGNORECASE):
+            return ImageChunkPipeline()
+        if re.search(r"\.(mp4|mov|avi|flv|mpeg|mpg|webm|wmv|3gp|3gpp|mkv?)$", filename, re.IGNORECASE):
             return PictureVideoChunkPipeline()
         if re.search(r"\.(csv|xlsx?)$", filename, re.IGNORECASE):
             return ExcelChunkPipeline()

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -102,8 +102,8 @@ AUDIO_PATTERN = re.compile(
     r"\.(da|wave|wav|mp3|aac|flac|ogg|aiff|au|midi|wma|realaudio|vqf|oggvorbis|ape?)$",
     re.IGNORECASE,
 )
-VIDEO_IMAGE_PATTERN = re.compile(
-    r"\.(png|jpeg|jpg|gif|bmp|svg|mp4|mov|avi|flv|mpeg|mpg|webm|wmv|3gp|3gpp|mkv?)$",
+VIDEO_PATTERN = re.compile(
+    r"\.(mp4|mov|avi|flv|mpeg|mpg|webm|wmv|3gp|3gpp|mkv?)$",
     re.IGNORECASE,
 )
 DEFAULT_PARSE_LANGUAGE = "Chinese"
@@ -1017,8 +1017,19 @@ def process_item(item: dict):
     return result
 
 
-def _build_vision_model(file_path: str, db, image2text_id, tenant_id):
-    """根据文件类型选择合适的视觉/音频模型，避免冗余初始化。"""
+def _build_image_vision_model(db, image2text_id, tenant_id):
+    """Build the knowledge-base image-to-text model for document parsing."""
+    image2text_key = _resolve_model_api_key(db, image2text_id, tenant_id, "image2text")
+    return QWenCV(
+        key=image2text_key.api_key,
+        model_name=image2text_key.model_name,
+        lang=DEFAULT_PARSE_LANGUAGE,
+        base_url=image2text_key.api_base,
+    )
+
+
+def _build_media_model(file_path: str):
+    """Build the existing audio or video model when the file type requires one."""
     if AUDIO_PATTERN.search(file_path):
         omni_key = os.getenv("QWEN3_OMNI_API_KEY", "")
         omni_model = os.getenv("QWEN3_OMNI_MODEL_NAME", "qwen3-omni-flash")
@@ -1029,7 +1040,7 @@ def _build_vision_model(file_path: str, db, image2text_id, tenant_id):
             lang=DEFAULT_PARSE_LANGUAGE,
             base_url=omni_base,
         )
-    if VIDEO_IMAGE_PATTERN.search(file_path):
+    if VIDEO_PATTERN.search(file_path):
         omni_key = os.getenv("QWEN3_OMNI_API_KEY", "")
         omni_model = os.getenv("QWEN3_OMNI_MODEL_NAME", "qwen3-omni-flash")
         omni_base = os.getenv("QWEN3_OMNI_BASE_URL", "https://dashscope.aliyuncs.com/compatible-mode/v1")
@@ -1039,14 +1050,7 @@ def _build_vision_model(file_path: str, db, image2text_id, tenant_id):
             lang=DEFAULT_PARSE_LANGUAGE,
             base_url=omni_base,
         )
-    # 默认：使用知识库配置的 image2text 模型
-    image2text_key = _resolve_model_api_key(db, image2text_id, tenant_id, "image2text")
-    return QWenCV(
-        key=image2text_key.api_key,
-        model_name=image2text_key.model_name,
-        lang=DEFAULT_PARSE_LANGUAGE,
-        base_url=image2text_key.api_base,
-    )
+    return None
 
 
 @celery_app.task(name="app.core.rag.tasks.parse_document")
@@ -1132,7 +1136,8 @@ def parse_document(file_key: str, document_id: uuid.UUID, file_name: str = ""):
             if auto_questions_topn:
                 llm_config = _build_llm_config(db, db_knowledge.llm_id, tenant_id)
             knowledge_id = str(db_knowledge.id)
-            vision_model = _build_vision_model(file_name, db, db_knowledge.image2text_id, tenant_id)
+            image_vision_model = _build_image_vision_model(db, db_knowledge.image2text_id, tenant_id)
+            vision_model = _build_media_model(file_name) or image_vision_model
             vector_service = ElasticSearchVectorFactory().init_vector(knowledge=db_knowledge)
 
             progress_lines.append(f"{_progress_ts()} Start to parse.")


### PR DESCRIPTION
## Business Background
Knowledge-base uploads need direct indexing support for PNG, JPG, JPEG, WEBP, and GIF files with selectable OCR, mixed, and vision-only chunk semantics.

## Summary
- Route supported direct image formats to an isolated image chunk pipeline.
- Support exact integer `image_vision_mode` values 0, 1, and 2, defaulting to mixed mode.
- Normalize every mode through MarkdownPreprocessor, StructMarkdownParser, and BlockMerger; retain only the original-image tag where required.
- Separate knowledge-base image vision model construction from existing audio and video model selection.

## Changes
- `api/app/core/rag/chunk/parser/mineru_v3.py`
- `api/app/core/rag/chunk/pipeline/image.py`
- `api/app/core/rag/chunk/router.py`
- `api/app/tasks.py`

## Risk
- Scope is limited to the direct image chunk pipeline; existing non-image pipelines and V1/API-Key controllers are unchanged.
- Invalid image mode values fail during direct image parsing. GIF analysis uses only frame 0 while chunks continue to reference the original GIF file.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/pytest tests/core/rag/chunk/test_image_pipeline.py -q` (28 passed)
- [x] `.venv/bin/python -m compileall -q app/core/rag/chunk/pipeline/image.py app/core/rag/chunk/parser/mineru_v3.py app/core/rag/chunk/router.py app/tasks.py`
- [x] `ruff check api/app/core/rag/chunk/pipeline/image.py api/app/core/rag/chunk/router.py`
- [x] `git diff --check origin/develop..HEAD`

## Summary by Sourcery

为直接图像上传添加专用的图像分块（image chunk）管线，并将图像视觉模型的选择从现有的音频/视频媒体模型中分离出来。

New Features:
- 引入 `ImageChunkPipeline`，支持以可配置的图像视觉模式，将 PNG、JPG、JPEG、WEBP 和 GIF 直接上传到知识库。
- 将受支持的图像文件路由到新的图像管线，同时保持现有的音频和视频路由不变。

Enhancements:
- 优化 `MinerUV3` 解析，以支持二进制复用，并为图像 OCR 处理提供直接 Markdown 提取能力。
- 将视觉模型构建拆分为独立的图像构建器和媒体构建器，避免在媒体管线上堆积图像解析负载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated image chunk pipeline for direct image uploads and separate image vision model selection from existing audio/video media models.

New Features:
- Introduce an ImageChunkPipeline for direct PNG, JPG, JPEG, WEBP, and GIF knowledge-base uploads with configurable image vision modes.
- Route supported image files to the new image pipeline while keeping existing audio and video routing intact.

Enhancements:
- Refine MinerUV3 parsing to support binary reuse and direct Markdown extraction for image OCR processing.
- Split vision model construction into distinct image and media builders to avoid overloading the media pipeline with image parsing.

</details>