### PR TITLE
feat(memory): expose memory tool retrieval details

### DIFF
--- a/api/app/controllers/public_share_controller.py
+++ b/api/app/controllers/public_share_controller.py
@@ -58,6 +58,10 @@ SHARE_FORWARD_EVENTS = frozenset({
     "start",
     "message",
     "message_replace",
+    "tool_start",
+    "memory_stage",
+    "tool_end",
+    "tool_error",
     "end",
     "error",
     "regenerate_end",
@@ -1460,8 +1464,8 @@ async def regenerate_message(
                             pre_create_execution=True,  # 让 start 事件携带真实 execution_id
                     ):
                         event_type = event.get("event", "message")
-                        # 体验分享端：只透出内容类事件与端点事件，过滤掉
-                        # node_*/workflow_*/cycle_item/intervention_* 等节点类事件
+                        # 体验分享端透出内容、端点和工具调用事件，过滤掉
+                        # node_*/workflow_*/cycle_item/intervention_* 等其他节点类事件。
                         if event_type not in SHARE_FORWARD_EVENTS:
                             continue
                         event_data = event.get("data", {})
@@ -1527,7 +1531,7 @@ async def regenerate_message(
                     user_rag_memory_id=user_rag_memory_id,
             ):
                 # AGENT 路径吐出来的是已序列化的 SSE 字符串（f"event: ...\ndata: ...\n\n"）。
-                # 解析 `event:` 行做白名单过滤，丢弃 reasoning/tool_*/agent_log/
+                # 解析 `event:` 行做白名单过滤，丢弃 reasoning/agent_log 等内部事件。
                 m = SSE_EVENT_LINE.search(event)
                 if m and m.group(1) not in SHARE_FORWARD_EVENTS:
                     continue

--- a/api/app/core/agent/langchain_agent.py
+++ b/api/app/core/agent/langchain_agent.py
@@ -22,6 +22,7 @@ from langchain_core.tools import BaseTool
 from langgraph.errors import GraphRecursionError
 
 from app.core.logging_config import get_business_logger
+from app.core.memory.retrieval_trace.stage_events import is_memory_stage_capture_enabled
 from app.core.models import RedBearLLM, RedBearModelConfig
 from app.core.utils.datetime_utils import to_iso_z, utcnow
 from app.models.models_model import ModelType
@@ -1046,6 +1047,8 @@ class LangChainAgent:
         # 收集节点执行记录
         node_executions: List[Dict[str, Any]] = []
         _tool_stack: List[Dict[str, Any]] = []
+        # LangChain 自定义事件只携带 run lineage；该映射用于把并行阶段事件归属到产品 step_id。
+        _tool_runs: Dict[str, str] = {}
 
         try:
             # 准备消息列表（支持多模态）
@@ -1196,6 +1199,9 @@ class LangChainAgent:
                         }
                         _tool_stack.append(node)
                         node_executions.append(node)
+                        run_id = event.get("run_id")
+                        if run_id:
+                            _tool_runs[str(run_id)] = step_id
                         trace.start_tool(
                             step_id=step_id,
                             tool_name=tool_name,
@@ -1206,18 +1212,61 @@ class LangChainAgent:
                         # 实时推送工具调用开始事件
                         yield {"type": "agent_log", "data": trace.to_dict()}
                         yield {"type": "tool_start", "step_id": step_id, "name": tool_name, "input": self._truncate_data(tool_input), "meta": tool_meta if tool_meta else None}
+                    elif kind == "on_custom_event" and event.get("name") == "memory_stage":
+                        if not is_memory_stage_capture_enabled():
+                            continue
+                        raw_stage = event.get("data") or {}
+                        event_run_id = event.get("run_id")
+                        parents = event.get("parent_ids") or []
+                        # Provider 对自定义事件的 run_id 层级不同，按自身到祖先顺序寻找最近的工具调用。
+                        candidate_run_ids = [event_run_id, *reversed(parents)]
+                        matched_step_id = None
+                        for candidate in candidate_run_ids:
+                            if candidate and str(candidate) in _tool_runs:
+                                matched_step_id = _tool_runs[str(candidate)]
+                                break
+                        if not matched_step_id:
+                            logger.warning("丢弃无法归属工具调用的 memory_stage: run_id=%s", event_run_id)
+                            continue
+                        matched_node = next(
+                            (node for node in reversed(node_executions) if node.get("step_id") == matched_step_id),
+                            None,
+                        )
+                        if not matched_node or matched_node.get("node_name") != "long_term_memory":
+                            logger.warning("丢弃归属非长期记忆工具的 memory_stage: run_id=%s", event_run_id)
+                            continue
+                        stage_payload = {
+                            "type": "memory_stage",
+                            "step_id": matched_step_id,
+                            "stage": raw_stage.get("stage"),
+                            "status": raw_stage.get("status", "completed"),
+                            "data": raw_stage.get("data") or {},
+                        }
+                        matched_node.setdefault("_memory_stages", []).append(stage_payload)
+                        yield stage_payload
                     elif kind == "on_tool_end":
                         tool_output = event.get("data", {}).get("output")
                         tool_name = event.get("name", "unknown")
+                        run_id = event.get("run_id")
+                        matched_step_id = _tool_runs.pop(str(run_id), None) if run_id else None
                         matched_node = None
-                        if _tool_stack:
+                        if matched_step_id:
+                            matched_node = next(
+                                (node for node in reversed(node_executions) if node.get("step_id") == matched_step_id),
+                                None,
+                            )
+                            _tool_stack[:] = [
+                                node for node in _tool_stack
+                                if node.get("step_id") != matched_step_id
+                            ]
+                        elif _tool_stack:
                             matched_node = _tool_stack.pop()
                         else:
                             for n in reversed(node_executions):
                                 if n["node_name"] == tool_name and n["status"] == "running":
                                     matched_node = n
                                     break
-                        matched_step_id = matched_node.get("step_id") if matched_node else None
+                        matched_step_id = matched_node.get("step_id") if matched_node else matched_step_id
                         if matched_node:
                             matched_node["status"] = "completed"
                             matched_node["output"] = self._truncate_data(tool_output)
@@ -1240,15 +1289,26 @@ class LangChainAgent:
                     elif kind == "on_tool_error":
                         error_msg = str(event.get("data", {}).get("error", ""))
                         tool_name = event.get("name", "unknown")
+                        run_id = event.get("run_id")
+                        matched_step_id = _tool_runs.pop(str(run_id), None) if run_id else None
                         matched_node = None
-                        if _tool_stack:
+                        if matched_step_id:
+                            matched_node = next(
+                                (node for node in reversed(node_executions) if node.get("step_id") == matched_step_id),
+                                None,
+                            )
+                            _tool_stack[:] = [
+                                node for node in _tool_stack
+                                if node.get("step_id") != matched_step_id
+                            ]
+                        elif _tool_stack:
                             matched_node = _tool_stack.pop()
                         else:
                             for n in reversed(node_executions):
                                 if n["node_name"] == tool_name and n["status"] == "running":
                                     matched_node = n
                                     break
-                        matched_step_id = matched_node.get("step_id") if matched_node else None
+                        matched_step_id = matched_node.get("step_id") if matched_node else matched_step_id
                         if matched_node:
                             matched_node["status"] = "failed"
                             matched_node["error"] = error_msg[:500]
@@ -1331,6 +1391,7 @@ class LangChainAgent:
             logger.error("=" * 80, exc_info=True)
             raise
         finally:
+            _tool_runs.clear()
             logger.info("=" * 80)
             logger.info("chat_stream 方法执行结束")
             logger.info("=" * 80)

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 
 from app.core.memory.enums import Neo4jNodeType, SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
@@ -11,6 +12,14 @@ from app.core.memory.read_services.search_engine.content_search import (
     RAGSearchService,
     HistorySearchService,
     MetaSearchService
+)
+from app.core.memory.retrieval_trace.stage_events import emit_memory_stage
+from app.core.memory.retrieval_trace.stage_projection import (
+    project_memory_items,
+    project_profile_data,
+    profile_has_content,
+    project_relation_items,
+    project_result_items,
 )
 from app.core.models import RedBearLLM
 from app.db import get_async_db_context
@@ -43,6 +52,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         self._vision_llm_client = None
         self._audio_llm_client = None
         self._rerank_client = None
+        self._run_started_at = 0.0
 
     async def run(
             self,
@@ -54,6 +64,8 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             skip_summary=False,
             enable_rerank: bool = False,
     ) -> MemorySearchResult:
+        started_at = time.perf_counter()
+        self._run_started_at = started_at
         query = QueryPreprocessor.process(query)
         match search_switch:
             case SearchStrategy.DEEP:
@@ -65,21 +77,59 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                                               includes=includes, skip_summary=skip_summary,
                                               enable_rerank=enable_rerank)
             case SearchStrategy.QUICK:
-                return await self._quick_read(query, limit, includes,
-                                              enable_rerank=enable_rerank)
+                res = await self._quick_read(query, limit, includes,
+                                             enable_rerank=enable_rerank)
             case SearchStrategy.EXPRESS:
-                return await self._express_read(query, limit, includes)
+                res = await self._express_read(query, limit, includes)
             case SearchStrategy.RECENT:
                 return await self._conv_history()
             case SearchStrategy.META:
-                return await self._user_meta()
+                res = await self._user_meta()
             case _:
                 raise RuntimeError("Unsupported search strategy")
+
+        if search_switch in [SearchStrategy.QUICK, SearchStrategy.EXPRESS, SearchStrategy.META]:
+            await self._emit_result_ready(res, started_at)
 
         if search_switch in [SearchStrategy.DEEP, SearchStrategy.NORMAL] and not self.ctx.draft:
             await self._save_short_term(query, search_switch, res)
 
         return res
+
+    async def _emit_stage(self, stage: str, data: dict) -> None:
+        await emit_memory_stage(stage, data)
+
+    @staticmethod
+    def _raw_memory_count(results: list) -> int:
+        return sum(len(result.memories) for result in results if isinstance(result, MemorySearchResult))
+
+    @staticmethod
+    def _raw_relation_count(results: list) -> int:
+        return sum(len(result.relations) for result in results if isinstance(result, MemorySearchResult))
+
+    async def _emit_result_ready(self, result: MemorySearchResult, started_at: float) -> None:
+        profile_result = MemorySearchResult(memories=[])
+        search_result = result
+        if result.memories:
+            first = result.memories[0]
+            # 非深度策略返回扁平列表，只有首项满足用户实体约定时才按画像投影。
+            if first.id == getattr(self.ctx, "end_user_id", None) and first.source == Neo4jNodeType.EXTRACTEDENTITY:
+                profile_result = MemorySearchResult(memories=[first])
+                search_result = MemorySearchResult(memories=result.memories[1:], relations=result.relations)
+        items = project_result_items(profile_result, search_result, limit=5)
+        await self._emit_stage("result_ready", {
+            "duration_ms": max(0, int(round((time.perf_counter() - started_at) * 1000))),
+            "total_count": len(result.memories),
+            "shown_count": len(items),
+            "items": items,
+        })
+
+    def _elapsed_ms(self) -> int:
+        return max(0, int(round((time.perf_counter() - self._run_started_at) * 1000)))
+
+    def _ensure_run_started(self) -> None:
+        if not self._run_started_at:
+            self._run_started_at = time.perf_counter()
 
     async def _get_search_service(
             self,
@@ -191,14 +241,24 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             skip_summary=False,
             enable_rerank: bool = False,
     ) -> MemorySearchResult:
+        self._ensure_run_started()
         search_service = await self._get_search_service(includes, enable_rerank=enable_rerank)
         memory_l0 = await self._user_meta()
+        profile = project_profile_data(memory_l0)
+        await self._emit_stage("profile_loaded", {
+            "has_profile": profile_has_content(profile),
+            "profile": profile,
+        })
         questions = await QueryPreprocessor.split(
             query,
             history,
             memory_l0.content,
             await self._get_llm_client()
         )
+        await self._emit_stage("query_split", {
+            "count": len(questions),
+            "questions": [str(question)[:100] for question in questions[:5]],
+        })
         all_tasks = []
         for question in questions:
             all_tasks.append(_run_with_semaphore(search_service.hybrid_search(question, limit)))
@@ -211,6 +271,20 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         hybrid_search_res = _safe_merge_results(hybrid_results, "hybrid")
         relation_res = _safe_merge_results(relation_results, "relation")
+        hybrid_search_res.memories.sort(key=lambda item: item.score, reverse=True)
+        relation_res.relations = list(relation_res.relations)
+        await self._emit_stage("hybrid_searched", {
+            "hit_count": self._raw_memory_count(hybrid_results),
+            "memory_count": len(hybrid_search_res.memories),
+            "shown_count": min(3, len(hybrid_search_res.memories)),
+            "items": project_memory_items(hybrid_search_res.memories, limit=3),
+        })
+        await self._emit_stage("relation_searched", {
+            "hit_count": self._raw_relation_count(relation_results),
+            "relation_count": len(relation_res.relations),
+            "shown_count": min(3, len(relation_res.relations)),
+            "items": project_relation_items(relation_res.relations, limit=3),
+        })
 
         perceptual_memories = [
             m for m in hybrid_search_res.memories
@@ -264,7 +338,16 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         results = hybrid_search_res + relation_res
 
+        await self._emit_stage("results_merged", {
+            "memory_count": len(results.memories),
+            "relation_count": len(results.relations),
+        })
+
         results.memories.sort(key=lambda x: x.score, reverse=True)
+        await self._emit_stage("results_ranked", {
+            "count": len(results.memories),
+            "order": "score_desc",
+        })
         if not skip_summary:
             results.content_str = await RetrievalSummaryProcessor.summary(
                 query,
@@ -273,7 +356,18 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                 await self._get_llm_client()
             )
 
-        return memory_l0 + results
+        await self._emit_stage("context_prepared", {"memory_count": len(results.memories)})
+
+        combined = memory_l0 + results
+        items = project_result_items(memory_l0, results, limit=5)
+        await self._emit_stage("result_ready", {
+            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 0,
+            "total_count": len(combined.memories),
+            "shown_count": len(items),
+            "items": items,
+        })
+
+        return combined
 
     async def _normal_read(
             self, query: str,
@@ -283,20 +377,45 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             skip_summary=False,
             enable_rerank: bool = False,
     ) -> MemorySearchResult:
+        self._ensure_run_started()
         search_service = await self._get_search_service(includes, enable_rerank=enable_rerank)
 
         memory_l0 = await self._user_meta()
+        profile = project_profile_data(memory_l0)
+        await self._emit_stage("profile_loaded", {
+            "has_profile": profile_has_content(profile),
+            "profile": profile,
+        })
         questions = await QueryPreprocessor.split(
             query,
             history,
             memory_l0.content,
             await self._get_llm_client()
         )
+        await self._emit_stage("query_split", {
+            "count": len(questions),
+            "questions": [str(question)[:100] for question in questions[:5]],
+        })
         all_results = list(await asyncio.gather(*(
             _run_with_semaphore(search_service.hybrid_search(question, limit)) for question in questions
         ), return_exceptions=True))
         results = _safe_merge_results(all_results, "normal")
         results.memories.sort(key=lambda x: x.score, reverse=True)
+        await self._emit_stage("hybrid_searched", {
+            "hit_count": self._raw_memory_count(all_results),
+            "memory_count": len(results.memories),
+            "shown_count": min(3, len(results.memories)),
+            "items": project_memory_items(results.memories, limit=3),
+        })
+        await self._emit_stage("results_merged", {
+            "memory_count": len(results.memories),
+            "relation_count": 0,
+        })
+        results.memories.sort(key=lambda x: x.score, reverse=True)
+        await self._emit_stage("results_ranked", {
+            "count": len(results.memories),
+            "order": "score_desc",
+        })
         if not skip_summary:
             results.content_str = await RetrievalSummaryProcessor.summary(
                 query,
@@ -304,7 +423,16 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                 memory_l0.content if memory_l0 else '',
                 await self._get_llm_client()
             )
-        return memory_l0 + results
+        await self._emit_stage("context_prepared", {"memory_count": len(results.memories)})
+        combined = memory_l0 + results
+        items = project_result_items(memory_l0, results, limit=5)
+        await self._emit_stage("result_ready", {
+            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 0,
+            "total_count": len(combined.memories),
+            "shown_count": len(items),
+            "items": items,
+        })
+        return combined
 
     async def _express_read(self, query: str, limit: int, includes=None) -> MemorySearchResult:
         """仅全文检索模式：不做 embedding、关系检索、query 拆分、摘要生成。"""

--- a/api/app/core/memory/retrieval_trace/__init__.py
+++ b/api/app/core/memory/retrieval_trace/__init__.py
@@ -1,0 +1,1 @@
+"""Memory retrieval trace events, projections, and message metadata."""

--- a/api/app/core/memory/retrieval_trace/message_trace.py
+++ b/api/app/core/memory/retrieval_trace/message_trace.py
@@ -1,0 +1,123 @@
+"""Request-local memory retrieval trace for assistant Message metadata."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from typing import Any
+
+from app.core.memory.retrieval_trace.stage_events import build_memory_stage_payload
+
+
+def normalize_tool_input(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def strip_memory_trace_transients(value: Any) -> Any:
+    """Remove request-only stage data before agent execution persistence."""
+    if isinstance(value, dict):
+        return {
+            key: strip_memory_trace_transients(item)
+            for key, item in value.items()
+            if key != "_memory_stages"
+        }
+    if isinstance(value, list):
+        return [strip_memory_trace_transients(item) for item in value]
+    return value
+
+
+class MessageTrace:
+    """Accumulate display-safe retrieval stages for one assistant message."""
+
+    def __init__(self) -> None:
+        self._calls: OrderedDict[str, dict[str, Any]] = OrderedDict()
+
+    def start_tool(self, *, step_id: str | None, name: str, input_value: Any) -> None:
+        # memory_retrieval 是长期记忆工具的产品协议，其他工具仍只保留 agent execution 轨迹。
+        if not step_id or name != "long_term_memory":
+            return
+        self._calls.setdefault(
+            str(step_id),
+            {"name": name, "input": normalize_tool_input(input_value), "status": "running", "stages": []},
+        )
+
+    def add_stage(
+        self,
+        *,
+        step_id: str | None,
+        stage: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        if not step_id or str(step_id) not in self._calls:
+            return None
+        try:
+            payload = build_memory_stage_payload(
+                stage=str(stage.get("stage") or ""),
+                data=stage.get("data") or {},
+            )
+        except (TypeError, ValueError):
+            return None
+        if payload is None:
+            return None
+        self._calls[str(step_id)]["stages"].append(payload)
+        return payload
+
+    def finish_tool(self, *, step_id: str | None, status: str, error: Any = None) -> None:
+        if not step_id or str(step_id) not in self._calls:
+            return
+        call = self._calls[str(step_id)]
+        call["status"] = "failed" if status in {"failed", "error"} else "completed"
+        if call["status"] == "failed" and error:
+            call["error"] = str(error)[:500]
+
+    def record_weak_tool(self, step: dict[str, Any]) -> list[dict[str, Any]]:
+        if step.get("node_name") != "long_term_memory":
+            return []
+        step_id = str(step.get("step_id") or "")
+        self.start_tool(step_id=step_id, name="long_term_memory", input_value=step.get("input"))
+        stages: list[dict[str, Any]] = []
+        for stage in step.get("_memory_stages") or []:
+            payload = self.add_stage(step_id=step_id, stage=stage)
+            if payload is not None:
+                stages.append(payload)
+        self.finish_tool(step_id=step_id, status=step.get("status", "completed"), error=step.get("error"))
+        return stages
+
+    def reconcile_tools(self, steps: list[dict[str, Any]]) -> None:
+        """Close traces when an Agent terminates without emitting tool_end/error."""
+        for step in steps:
+            step_id = str(step.get("step_id") or "")
+            status = step.get("status")
+            if step_id not in self._calls or status != "failed":
+                continue
+            self.finish_tool(
+                step_id=step_id,
+                status=status,
+                error=step.get("error"),
+            )
+
+    def build(self) -> dict[str, Any] | None:
+        """Build metadata only from terminal calls so incomplete traces are not exposed."""
+        tool_calls = [
+            call
+            for call in self._calls.values()
+            if call.get("status") in {"completed", "failed"}
+        ]
+        if not tool_calls:
+            return None
+        return {"schema_version": 1, "tool_calls": tool_calls}
+
+
+def merge_memory_trace(meta: dict[str, Any], trace: MessageTrace) -> dict[str, Any]:
+    merged = dict(meta or {})
+    memory_retrieval = trace.build()
+    if memory_retrieval is not None:
+        merged["memory_retrieval"] = memory_retrieval
+    return merged

--- a/api/app/core/memory/retrieval_trace/stage_events.py
+++ b/api/app/core/memory/retrieval_trace/stage_events.py
@@ -1,0 +1,249 @@
+"""Memory retrieval stage contract, custom-event dispatch, and per-tool collector."""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import AsyncIterable, AsyncIterator, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+logger = logging.getLogger(__name__)
+MemoryStagePayload = dict[str, Any]
+MemoryStageSink = list[MemoryStagePayload]
+# ContextVar keeps capture state isolated across concurrent streaming requests.
+_STAGE_CAPTURE_ENABLED: ContextVar[bool] = ContextVar("memory_stage_capture_enabled", default=False)
+_STAGE_SINK: ContextVar[MemoryStageSink | None] = ContextVar("memory_stage_sink", default=None)
+
+# Exact field sets form the public contract and prevent internal retrieval data from leaking.
+_STAGE_FIELDS = {
+    "profile_loaded": {"has_profile", "profile"},
+    "query_split": {"count", "questions"},
+    "hybrid_searched": {"hit_count", "memory_count", "shown_count", "items"},
+    "relation_searched": {"hit_count", "relation_count", "shown_count", "items"},
+    "results_merged": {"memory_count", "relation_count"},
+    "results_ranked": {"count", "order"},
+    "context_prepared": {"memory_count"},
+    "result_ready": {"duration_ms", "total_count", "shown_count", "items"},
+}
+_PROFILE_FIELDS = {
+    "aliases_name",
+    "description",
+    "core_facts",
+    "goals",
+    "interests",
+    "relations",
+    "beliefs_or_stances",
+    "anchors",
+    "events",
+    "traits",
+}
+_MEMORY_ITEM_FIELDS = {"rank", "memory_type", "source", "score", "content"}
+_FILE_FIELDS = {"file_name", "file_path", "file_type", "perceptual_type"}
+_RELATION_ITEM_FIELDS = {"source", "relation", "target", "target_desc"}
+
+
+class StageCollector(list[MemoryStagePayload]):
+    """List collector that remains callable for older local test helpers."""
+
+    def __call__(self, payload: MemoryStagePayload) -> None:
+        self.append(payload)
+
+
+def _is_non_negative_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
+def _has_exact_fields(value: Any, fields: set[str]) -> bool:
+    return isinstance(value, dict) and set(value) == fields
+
+
+def _valid_profile(profile: Any) -> bool:
+    if not _has_exact_fields(profile, _PROFILE_FIELDS):
+        return False
+    if not isinstance(profile["description"], str):
+        return False
+    return all(
+        isinstance(profile[field], list)
+        and len(profile[field]) <= 5
+        and all(isinstance(item, str) for item in profile[field])
+        and all(len(item) <= 200 for item in profile[field])
+        for field in _PROFILE_FIELDS - {"description"}
+    ) and len(profile["description"]) <= 200
+
+
+def _valid_file(file_data: Any) -> bool:
+    if not _has_exact_fields(file_data, _FILE_FIELDS):
+        return False
+    return (
+        all(isinstance(file_data[field], str) for field in ("file_name", "file_path", "file_type"))
+        and (
+            file_data["perceptual_type"] is None
+            or _is_non_negative_int(file_data["perceptual_type"])
+        )
+    )
+
+
+def _valid_memory_item(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    fields = set(item)
+    if fields not in (_MEMORY_ITEM_FIELDS, _MEMORY_ITEM_FIELDS | {"file"}):
+        return False
+    return (
+        _is_positive_int(item["rank"])
+        and isinstance(item["memory_type"], str)
+        and isinstance(item["source"], str)
+        and _is_number(item["score"])
+        and isinstance(item["content"], str)
+        and ("file" not in item or (item["memory_type"] == "file" and item["source"] == "Perceptual"))
+        and ("file" not in item or _valid_file(item["file"]))
+    )
+
+
+def _valid_relation_item(item: Any) -> bool:
+    return (
+        _has_exact_fields(item, _RELATION_ITEM_FIELDS)
+        and all(isinstance(item[field], str) for field in _RELATION_ITEM_FIELDS)
+    )
+
+
+def _valid_stage_data(stage: str, data: dict[str, Any]) -> bool:
+    if stage == "profile_loaded":
+        return isinstance(data["has_profile"], bool) and _valid_profile(data["profile"])
+    if stage == "query_split":
+        return (
+            _is_non_negative_int(data["count"])
+            and isinstance(data["questions"], list)
+            and len(data["questions"]) <= 5
+            and all(isinstance(question, str) for question in data["questions"])
+            and all(len(question) <= 100 for question in data["questions"])
+            and data["count"] >= len(data["questions"])
+        )
+    if stage in {"hybrid_searched", "relation_searched", "result_ready"}:
+        count_fields = {
+            "hybrid_searched": ("hit_count", "memory_count", "shown_count"),
+            "relation_searched": ("hit_count", "relation_count", "shown_count"),
+            "result_ready": ("duration_ms", "total_count", "shown_count"),
+        }[stage]
+        item_validator = _valid_relation_item if stage == "relation_searched" else _valid_memory_item
+        return (
+            all(_is_non_negative_int(data[field]) for field in count_fields)
+            and isinstance(data["items"], list)
+            and all(item_validator(item) for item in data["items"])
+            and data["shown_count"] == len(data["items"])
+        )
+    if stage == "results_merged":
+        return _is_non_negative_int(data["memory_count"]) and _is_non_negative_int(data["relation_count"])
+    if stage == "results_ranked":
+        return _is_non_negative_int(data["count"]) and data["order"] == "score_desc"
+    if stage == "context_prepared":
+        return _is_non_negative_int(data["memory_count"])
+    return False
+
+
+def build_memory_stage_payload(
+    *,
+    stage: str,
+    data: dict[str, Any] | None = None,
+) -> MemoryStagePayload | None:
+    """Validate a stage against the public schema, dropping unknown or malformed data."""
+    allowed = _STAGE_FIELDS.get(stage)
+    if allowed is None:
+        logger.warning("Dropping unknown memory stage: %s", stage)
+        return None
+    if not isinstance(data, dict):
+        logger.warning("Dropping memory stage %s with non-object data", stage)
+        return None
+    clean = data
+    if set(clean) != allowed or not _valid_stage_data(stage, clean):
+        logger.warning("Dropping memory stage %s with invalid payload", stage)
+        return None
+    return {
+        "stage": stage,
+        "status": "completed",
+        "data": clean,
+    }
+
+
+def get_memory_stage_sink() -> MemoryStageSink | None:
+    return _STAGE_SINK.get()
+
+
+def is_memory_stage_capture_enabled() -> bool:
+    return _STAGE_CAPTURE_ENABLED.get()
+
+
+@contextmanager
+def memory_stage_capture() -> Iterator[None]:
+    """Enable retrieval-stage production for one target request path."""
+    token = _STAGE_CAPTURE_ENABLED.set(True)
+    try:
+        yield
+    finally:
+        _STAGE_CAPTURE_ENABLED.reset(token)
+
+
+async def capture_memory_stage_stream(stream: AsyncIterable[Any]) -> AsyncIterator[Any]:
+    """Scope capture to upstream iteration so downstream consumers cannot inherit it."""
+    iterator = aiter(stream)
+    try:
+        while True:
+            try:
+                with memory_stage_capture():
+                    item = await anext(iterator)
+            except StopAsyncIteration:
+                return
+            yield item
+    finally:
+        close = getattr(iterator, "aclose", None)
+        if close is not None:
+            await close()
+
+
+@contextmanager
+def memory_stage_collector() -> Iterator[MemoryStageSink]:
+    """Buffer weak-model stages until its completed tool step can be replayed."""
+    stages: MemoryStageSink = StageCollector()
+    token = _STAGE_SINK.set(stages)
+    try:
+        yield stages
+    finally:
+        _STAGE_SINK.reset(token)
+
+
+async def emit_memory_stage(stage: str, data: dict[str, Any] | None = None) -> MemoryStagePayload | None:
+    """Collect for weak ReAct calls, otherwise dispatch a LangChain custom event."""
+    sink = get_memory_stage_sink()
+    if not _STAGE_CAPTURE_ENABLED.get() and sink is None:
+        return None
+    try:
+        payload = build_memory_stage_payload(stage=stage, data=data)
+    except Exception:
+        logger.warning("Unable to build memory stage %s", stage, exc_info=True)
+        return None
+    if payload is None:
+        return None
+    if sink is not None:
+        sink.append(payload)
+        return payload
+    try:
+        from langchain_core.callbacks.manager import adispatch_custom_event
+        await adispatch_custom_event("memory_stage", payload)
+    except Exception:
+        # Stage telemetry must never change retrieval semantics.
+        logger.debug("Memory stage dispatch unavailable for %s", stage, exc_info=True)
+    return payload

--- a/api/app/core/memory/retrieval_trace/stage_projection.py
+++ b/api/app/core/memory/retrieval_trace/stage_projection.py
@@ -1,0 +1,199 @@
+"""Project memory retrieval results into the public display contract.
+
+The projection deliberately depends only on memory-domain models.  It does not
+know about SSE, database persistence, or LangChain internals.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable
+from typing import Any
+
+from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.models.service_models import (
+    Memory,
+    MemorySearchResult,
+    RelationMemory,
+)
+
+_PROFILE_FIELDS = (
+    "aliases_name",
+    "description",
+    "core_facts",
+    "goals",
+    "interests",
+    "relations",
+    "beliefs_or_stances",
+    "anchors",
+    "events",
+    "traits",
+)
+_ARRAY_PROFILE_FIELDS = tuple(field for field in _PROFILE_FIELDS if field != "description")
+_TIME_PREFIX = re.compile(r"^\[\d{4}-\d{2}-\d{2}T[^]]+\]\s*")
+
+
+def display_text(value: Any, limit: int) -> str:
+    """Remove only the documented timestamp prefix and truncate text."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    text = _TIME_PREFIX.sub("", text, count=1)
+    return text[:limit]
+
+
+def _string_value(value: Any, limit: int) -> str:
+    if isinstance(value, dict):
+        for key in ("content", "name", "description", "target"):
+            candidate = display_text(value.get(key), limit)
+            if candidate:
+                return candidate
+        return ""
+    return display_text(value, limit)
+
+
+def _profile_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    values: list[str] = []
+    for item in list(value)[:5]:
+        text = _string_value(item, 200)
+        if text:
+            values.append(text)
+    return values
+
+
+def project_profile_data(result: MemorySearchResult | None) -> dict[str, Any]:
+    """Return the stable profile shape, including empty fields."""
+    source = result.memories[0].data if result and result.memories else {}
+    source = source if isinstance(source, dict) else {}
+    profile: dict[str, Any] = {
+        "aliases_name": _profile_list(source.get("aliases_name", source.get("aliases"))),
+        "description": _string_value(source.get("description"), 200),
+    }
+    for field in _ARRAY_PROFILE_FIELDS:
+        if field == "aliases_name":
+            continue
+        profile[field] = _profile_list(source.get(field))
+    return profile
+
+
+def profile_has_content(profile: dict[str, Any]) -> bool:
+    return any(bool(value) for value in profile.values())
+
+
+def memory_type(source: Neo4jNodeType | str) -> str:
+    value = source.value if isinstance(source, Neo4jNodeType) else str(source or "")
+    if value == "memory_l0":
+        return "profile"
+    return {
+        "Statement": "fact",
+        "Chunk": "fact",
+        "Dialogue": "fact",
+        "ExtractedEntity": "entity",
+        "MemorySummary": "summary",
+        "Perceptual": "file",
+        "Rag": "file",
+    }.get(value, "unknown")
+
+
+def _score(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return round(score, 4) if math.isfinite(score) else 0.0
+
+
+def sanitize_relevance(value: Any) -> float:
+    """Backward-compatible legacy helper; new payloads use ``score``."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(score):
+        return 0.0
+    return round(min(max(score, 0.0), 1.0), 4)
+
+
+def _memory_content(memory: Memory, kind: str) -> str:
+    data = memory.data if isinstance(memory.data, dict) else {}
+    if kind == "profile":
+        profile = project_profile_data(MemorySearchResult(memories=[memory]))
+        values = profile["core_facts"] or profile["aliases_name"] or ([profile["description"]] if profile["description"] else [])
+        return display_text("；".join(values), 300)
+    if memory_type(memory.source) == "entity":
+        candidates = (data.get("description"), data.get("description_summary"), data.get("name"), memory.content)
+    elif memory.source == Neo4jNodeType.PERCEPTUAL:
+        candidates = (memory.content, data.get("summary"))
+    elif memory.source == Neo4jNodeType.RAG:
+        candidates = (memory.content,)
+    else:
+        candidates = (data.get("content"), memory.content)
+    for candidate in candidates:
+        text = _string_value(candidate, 300)
+        if text:
+            return text
+    return ""
+
+
+def project_memory_item(memory: Memory, rank: int, *, kind: str | None = None) -> dict[str, Any]:
+    resolved_kind = kind or memory_type(memory.source)
+    item: dict[str, Any] = {
+        "rank": rank,
+        "memory_type": resolved_kind,
+        "source": memory.source.value if isinstance(memory.source, Neo4jNodeType) else str(memory.source),
+        "score": 1.0 if resolved_kind == "profile" else _score(memory.score),
+        "content": _memory_content(memory, resolved_kind),
+    }
+    # Rag 与 Perceptual 都展示为文件记忆，但只有 Perceptual 有稳定的文件元数据协议。
+    if resolved_kind == "file" and memory.source == Neo4jNodeType.PERCEPTUAL:
+        data = memory.data if isinstance(memory.data, dict) else {}
+        file_data = {
+            "file_name": display_text(data.get("file_name"), 1000),
+            "file_path": display_text(data.get("file_path"), 2000),
+            "file_type": display_text(data.get("file_type"), 200),
+            "perceptual_type": data.get("perceptual_type"),
+        }
+        if any(value not in (None, "") for value in file_data.values()):
+            item["file"] = file_data
+    return item
+
+
+def project_memory_items(memories: Iterable[Memory], limit: int = 3) -> list[dict[str, Any]]:
+    return [project_memory_item(memory, index) for index, memory in enumerate(list(memories)[:max(limit, 0)], start=1)]
+
+
+def project_relation_items(relations: Iterable[RelationMemory], limit: int = 3) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for relation in list(relations)[:max(limit, 0)]:
+        items.append({
+            "source": display_text(relation.source, 10_000),
+            "relation": display_text(relation.relation, 10_000),
+            "target": display_text(relation.target, 10_000),
+            "target_desc": display_text(relation.target_desc, 200),
+        })
+    return items
+
+
+def project_result_items(
+    profile_result: MemorySearchResult | None,
+    search_result: MemorySearchResult | None = None,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Build the final authoritative list, with a non-empty profile first."""
+    items: list[dict[str, Any]] = []
+    profile = project_profile_data(profile_result)
+    if profile_has_content(profile) and limit > 0:
+        profile_memory = profile_result.memories[0] if profile_result and profile_result.memories else None
+        if profile_memory:
+            items.append(project_memory_item(profile_memory, 1, kind="profile"))
+    if search_result:
+        for memory in search_result.memories:
+            if len(items) >= limit:
+                break
+            items.append(project_memory_item(memory, len(items) + 1))
+    for index, item in enumerate(items, start=1):
+        item["rank"] = index
+    return items

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import time
 import uuid
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Optional, Dict, Any, AsyncGenerator, Annotated, List, Literal
 from datetime import datetime, timezone
@@ -47,6 +48,12 @@ from app.core.memory.emotion.emotion_resolver import (
     apply_detection as apply_emotion_detection,
     start_detection as start_emotion_detection,
 )
+from app.core.memory.retrieval_trace.message_trace import (
+    MessageTrace,
+    merge_memory_trace,
+    strip_memory_trace_transients,
+)
+from app.core.memory.retrieval_trace.stage_events import capture_memory_stage_stream, memory_stage_capture
 
 logger = get_business_logger()
 
@@ -1062,6 +1069,7 @@ class AppChatService:
         save_messages_enqueued = False
 
         try:
+            memory_trace = MessageTrace()
             start_time = time.time()
             message_id = uuid.uuid4()
             user_message_id = uuid.uuid4()
@@ -1274,21 +1282,34 @@ class AppChatService:
             }
             use_agent_mode = ModelCapability.FUNCTION_CALL in capability
             if not use_agent_mode and tools:
-                system_prompt, orchestrator_node_executions = await ToolOrchestrator.create_and_run(
-                    tools=tools,
-                    system_prompt=system_prompt,
-                    message=message,
-                    history=history,
-                    api_key_config=_api_key_config,
-                    model_config=model_info,
-                    effective_params=model_parameters,
-                    processed_files=processed_files,
-                    context_evidence_loader=load_annotation_context,
-                )
+                stage_context = memory_stage_capture() if execution_mode == "in_process" else nullcontext()
+                with stage_context:
+                    system_prompt, orchestrator_node_executions = await ToolOrchestrator.create_and_run(
+                        tools=tools,
+                        system_prompt=system_prompt,
+                        message=message,
+                        history=history,
+                        api_key_config=_api_key_config,
+                        model_config=model_info,
+                        effective_params=model_parameters,
+                        processed_files=processed_files,
+                        context_evidence_loader=load_annotation_context,
+                    )
                 # 把已完成的工具调用步骤作为事件补发给前端
                 for step in orchestrator_node_executions:
                     event_type = "tool_error" if step.get("status") == "failed" else "tool_end"
+                    memory_stages = []
+                    if execution_mode == "in_process" and step.get("node_name") == "long_term_memory":
+                        memory_stages = memory_trace.record_weak_tool(step)
                     yield f"event: tool_start\ndata: {json.dumps({'step_id': step.get('step_id'), 'name': step.get('node_name'), 'input': step.get('input'), 'meta': step.get('meta')}, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
+                    for stage in memory_stages:
+                        stage_event = {
+                            "step_id": step.get("step_id"),
+                            "stage": stage.get("stage"),
+                            "status": stage.get("status", "completed"),
+                            "data": stage.get("data") or {},
+                        }
+                        yield f"event: memory_stage\ndata: {json.dumps(stage_event, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
                     yield f"event: {event_type}\ndata: {json.dumps({'step_id': step.get('step_id'), 'name': step.get('node_name'), 'output': step.get('output'), 'error': step.get('error'), 'meta': step.get('meta')}, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
                 tools = []
 
@@ -1391,6 +1412,9 @@ class AppChatService:
                 tenant_id=tenant_id, workspace_id=workspace_id
             )
 
+            capture_memory_stages = execution_mode == "in_process"
+            if capture_memory_stages:
+                _chunk_stream = capture_memory_stage_stream(_chunk_stream)
             async for chunk in _chunk_stream:
                 if isinstance(chunk, int):
                     total_tokens = chunk
@@ -1399,11 +1423,37 @@ class AppChatService:
                     yield f"event: reasoning\ndata: {json.dumps({'content': chunk['content']}, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "node_executions":
                     node_executions = chunk.get("data", [])
+                    if capture_memory_stages:
+                        memory_trace.reconcile_tools(node_executions)
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_start":
+                    if capture_memory_stages:
+                        memory_trace.start_tool(
+                            step_id=chunk.get("step_id"),
+                            name=chunk.get("name", ""),
+                            input_value=chunk.get("input"),
+                        )
                     yield f"event: tool_start\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'input': chunk.get('input'), 'meta': chunk.get('meta')}, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
+                elif (
+                    capture_memory_stages
+                    and isinstance(chunk, dict)
+                    and chunk.get("type") == "memory_stage"
+                ):
+                    payload = memory_trace.add_stage(step_id=chunk.get("step_id"), stage=chunk)
+                    if payload is None:
+                        continue
+                    stage_event = {"step_id": chunk.get("step_id"), **payload}
+                    yield f"event: memory_stage\ndata: {json.dumps(stage_event, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_end":
+                    if capture_memory_stages:
+                        memory_trace.finish_tool(step_id=chunk.get("step_id"), status="completed")
                     yield f"event: tool_end\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'output': chunk.get('output'), 'meta': chunk.get('meta')}, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "tool_error":
+                    if capture_memory_stages:
+                        memory_trace.finish_tool(
+                            step_id=chunk.get("step_id"),
+                            status="failed",
+                            error=chunk.get("error"),
+                        )
                     yield f"event: tool_error\ndata: {json.dumps({'step_id': chunk.get('step_id'), 'name': chunk['name'], 'error': chunk.get('error')}, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
                 elif isinstance(chunk, dict) and chunk.get("type") == "agent_log":
                     yield f"event: agent_log\ndata: {json.dumps(chunk, cls=CustomJsonEncoder, ensure_ascii=False)}\n\n"
@@ -1478,6 +1528,7 @@ class AppChatService:
                 "suggested_questions": suggested_questions,
                 "reasoning_content": full_reasoning or None
             }
+            assistant_meta = merge_memory_trace(assistant_meta, memory_trace)
 
             # 长期记忆写入由 conversation_service.add_message → MemoryWriteDispatcher 统一接管，
             # 这里不再触发老的 write_long_term 路径。
@@ -1507,7 +1558,10 @@ class AppChatService:
                     "is_omni": _api_key_is_omni
                 }
 
-            all_node_executions = orchestrator_node_executions + node_executions
+            all_node_executions = [
+                strip_memory_trace_transients(node)
+                for node in (orchestrator_node_executions + node_executions)
+            ]
             if not skip_save:
                 from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
 

--- a/api/app/services/tool_orchestrator.py
+++ b/api/app/services/tool_orchestrator.py
@@ -8,7 +8,13 @@ import asyncio
 import inspect
 import json
 import re
+from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.memory.retrieval_trace.stage_events import (
+    is_memory_stage_capture_enabled,
+    memory_stage_collector,
+)
 
 from app.core.logging_config import get_business_logger
 
@@ -366,7 +372,13 @@ class ToolOrchestrator:
             step_id = str(_uuid.uuid4())
 
             # 执行工具
-            tool_result = await self._call_tool(action, input_dict)
+            collector = (
+                memory_stage_collector()
+                if is_memory_stage_capture_enabled() and action == "long_term_memory"
+                else nullcontext([])
+            )
+            with collector as memory_stages:
+                tool_result = await self._call_tool(action, input_dict)
 
             success: bool = bool(tool_result.get("success", True))
             output: str = str(tool_result.get("output") or "")
@@ -429,6 +441,10 @@ class ToolOrchestrator:
                 "error": error,
                 "meta": tool_meta if tool_meta else None,
             }
+            if memory_stages:
+                # Request-local transport data.  AppChatService replays it and
+                # removes this key before agent-execution persistence.
+                node["_memory_stages"] = list(memory_stages)
             # 提取知识库来源
             if tool and hasattr(tool, "_last_sources") and tool._last_sources:
                 if not node["meta"]:


### PR DESCRIPTION
- Emit memory retrieval stage events for strong and weak model tool calls
- Persist normalized retrieval details in assistant message metadata
- Forward tool lifecycle and memory stage events during shared regeneration

## Summary by Sourcery

为结构化内存检索阶段增加遥测，并在助手消息的元数据中持久化按工具划分的检索追踪信息。

Enhancements:
- 在 deep、normal、quick、express 和 meta 等搜索策略中发出标准化的内存检索阶段事件。
- 将内存和关系搜索结果投影到受约束的、面向用户的 schema 中，用于内存阶段的负载数据。
- 以线程安全的方式捕获和收集强工具调用（agent）和弱工具调用（orchestrator）的内存阶段事件，包括在重新生成期间的回放支持。
- 通过共享/公共聊天流和经验分享端点转发内存阶段事件以及经过清洗的工具生命周期事件。
- 按请求记录标准化的长期内存工具调用追踪，并将其附加到助手消息的元数据中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add structured memory retrieval stage telemetry and persist per-tool retrieval traces in assistant message metadata.

Enhancements:
- Emit standardized memory retrieval stage events across deep, normal, quick, express, and meta search strategies.
- Project memory and relation search results into a constrained, user-facing schema for memory stage payloads.
- Thread-safe capture and collection of memory stage events for both strong (agent) and weak (orchestrator) tool calls, including replay support during regeneration.
- Forward memory stage events and sanitized tool lifecycle events through shared/public chat streams and experience sharing endpoints.
- Record normalized long-term memory tool call traces on a per-request basis and attach them to assistant message metadata.

</details>