### PR TITLE
Feature/user merge

### DIFF
--- a/api/app/controllers/app_controller.py
+++ b/api/app/controllers/app_controller.py
@@ -169,14 +169,13 @@ async def _get_or_create_draft_end_user_id(
         other_id: str,
 ) -> str:
     from app.models import EndUser, EndUserInfo
+    from app.repositories.end_user_repository import EndUserRepository
 
     async with get_async_db_context() as db:
-        existing_end_user = await db.scalar(
-            select(EndUser).where(
-                EndUser.workspace_id == workspace_id,
-                EndUser.other_id == other_id,
-                EndUser.is_active.is_(True),
-            ).order_by(EndUser.created_at.asc()).limit(1)
+        user_repo = EndUserRepository(db)
+
+        existing_end_user = await user_repo.get_end_user_by_other_id_async(
+            workspace_id, other_id
         )
         if existing_end_user and existing_end_user.app_id == app_id:
             return str(existing_end_user.id)
@@ -185,12 +184,8 @@ async def _get_or_create_draft_end_user_id(
             text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
             {"key": f"{workspace_id}|{other_id}"},
         )
-        end_user = await db.scalar(
-            select(EndUser).where(
-                EndUser.workspace_id == workspace_id,
-                EndUser.other_id == other_id,
-                EndUser.is_active.is_(True),
-            ).order_by(EndUser.created_at.asc()).limit(1)
+        end_user = await user_repo.get_end_user_by_other_id_async(
+            workspace_id, other_id
         )
         if end_user:
             end_user.app_id = app_id

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.logging_config import get_api_logger
 from app.core.memory.analytics.user_card_tags import normalize_stored_user_card_tags
+from app.core.quota_manager import get_end_user_memory_limit
 from app.core.response_utils import success
 from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.db import get_db, get_async_db_context
@@ -201,11 +202,8 @@ async def get_workspace_end_users(
     except Exception as e:
         api_logger.warning(f"批量获取活跃节点数失败，降级为 0: {str(e)}")
         active_counts = {}
-    try:
-        memory_limits = memory_dashboard_service.batch_get_memory_limits(db, end_user_ids)
-    except Exception as e:
-        api_logger.warning(f"批量获取配额上限失败，降级为默认值: {str(e)}")
-        memory_limits = {}
+
+    memory_limits = get_end_user_memory_limit(db, current_user.tenant_id)
 
     # 构建响应数据（先返回给用户，Redis/Celery 操作放后台）
     items = []
@@ -233,7 +231,7 @@ async def get_workspace_end_users(
             "memory_num": {
                 "total": memory_total,
                 "active_count": active_counts.get(user_id, 0),
-                "memory_limit": memory_limits.get(user_id, 300),
+                "memory_limit": memory_limits,
             },
             "memory_config": workspace_config,
         })

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -6,27 +6,28 @@
 最终路径: /v1/memory/...
 认证方式: API Key (@require_api_key)
 """
-
 import asyncio
 
 from fastapi import APIRouter, Body, Header, Request, Depends
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from starlette.responses import Response
 
-# 包装内部 controller
 from app.controllers import memory_controller
-from app.core.api_key_auth import require_api_key, require_api_key_self_db
-from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async, \
-    validate_end_user_in_workspace_async
+from app.core.api_key_auth import require_api_key, require_api_key_self_db, get_current_api_key_auth
+from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async, validate_end_user_in_workspace_async
+from app.core.error_codes import BizCode
 from app.core.logging_config import get_business_logger
 from app.core.memory.enums import Neo4jNodeType, SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.quota_stub import check_end_user_quota
-from app.core.response_utils import success
-from app.db import get_async_db_context, get_db
+from app.core.response_utils import success, fail
+from app.db import get_db, get_async_db_context, get_async_db
+from app.repositories.end_user_repository import EndUserRepository
 from app.schemas.api_key_schema import ApiKeyAuth
-from app.schemas.memory_agent_schema import Write_UserInput, InternalReadInput, ReadSyncInput
+from app.schemas.memory_agent_schema import Write_UserInput, InternalReadInput, ReadSyncInput, MergeEndUserInput
+from app.services.end_user_service import EndUserService
 from app.services.memory_config_service import MemoryConfigService
 
 router = APIRouter(prefix="/memory", tags=["V1 - Memory API"])
@@ -198,3 +199,28 @@ async def write_memory_async(
         current_user=current_user,
     )
     return _encode_result(result)
+
+
+@router.post("/merge")
+@require_api_key_self_db(scopes=["memory"])
+async def merge_memory(
+        payload: MergeEndUserInput,
+        db: AsyncSession = Depends(get_async_db)
+):
+    auth = get_current_api_key_auth()
+    if not payload.end_user_ids:
+        return fail(code=BizCode.USER_NOT_FOUND, msg="No users found.")
+    if payload.target in payload.end_user_ids:
+        payload.end_user_ids.remove(payload.target)
+    all_users = payload.end_user_ids & {payload.target}
+    activate_end_users = await EndUserRepository(db).filter_existing_ids_async(
+        all_users,
+        workspace_id=auth.workspace_id
+    )
+    not_found = all_users - activate_end_users
+    if not_found:
+        return fail(code=BizCode.USER_NOT_FOUND, msg=f"Not found users - {not_found}.")
+
+    await EndUserService(db).merge_end_users(payload.end_user_ids, payload.target)
+
+    return success(data={"end_user_id": payload.target.hex})

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -212,7 +212,7 @@ async def merge_memory(
         return fail(code=BizCode.USER_NOT_FOUND, msg="No users found.")
     if payload.target in payload.end_user_ids:
         payload.end_user_ids.remove(payload.target)
-    all_users = payload.end_user_ids & {payload.target}
+    all_users = payload.end_user_ids | {payload.target}
     activate_end_users = await EndUserRepository(db).filter_existing_ids_async(
         all_users,
         workspace_id=auth.workspace_id

--- a/api/app/controllers/service/message_feedback_api_controller.py
+++ b/api/app/controllers/service/message_feedback_api_controller.py
@@ -12,7 +12,6 @@ from app.core.logging_config import get_business_logger
 from app.core.response_utils import success
 from app.db import get_async_db
 from app.models import Conversation, Message, MessageFeedback
-from app.models.end_user_model import EndUser
 from app.schemas import app_schema, conversation_schema
 from app.schemas.api_key_schema import ApiKeyAuth
 
@@ -25,19 +24,18 @@ async def _resolve_v1_internal_user_id(
     workspace_id: uuid.UUID,
     external_user_id: str,
 ) -> str | None:
-    """将外部 user_id 解析为内部终端用户 ID，不存在时返回 None。"""
-    result = await db.execute(
-        select(EndUser.id)
-        .where(
-            EndUser.workspace_id == workspace_id,
-            EndUser.other_id == external_user_id,
-            EndUser.is_active.is_(True),
-        )
-        .order_by(EndUser.created_at.asc())
-        .limit(1)
+    """将外部 user_id 解析为内部终端用户 ID，不存在时返回 None。
+
+    通过 EndUserRepository 查询，自动处理合并路由：
+    若用户已被合并（is_active=False），会通过 EndUserMerge 表路由到目标用户。
+    """
+    from app.repositories.end_user_repository import EndUserRepository
+
+    user_repo = EndUserRepository(db)
+    end_user = await user_repo.get_end_user_by_other_id_async(
+        workspace_id, external_user_id
     )
-    end_user_id = result.scalar_one_or_none()
-    return str(end_user_id) if end_user_id else None
+    return str(end_user.id) if end_user else None
 
 
 @router.post("/messages/{message_id}/feedback", summary="提交消息反馈（点赞/点踩）")

--- a/api/app/core/api_key_auth.py
+++ b/api/app/core/api_key_auth.py
@@ -1,6 +1,8 @@
 import asyncio
+import inspect
 import time
 import uuid
+from contextvars import ContextVar
 from functools import wraps
 from typing import Optional, List
 
@@ -23,6 +25,29 @@ from app.schemas.api_key_schema import ApiKeyAuth
 from app.services.api_key_service import ApiKeyAuthService, RateLimiterService
 
 logger = get_api_logger()
+
+# ── ContextVar: side-channel for api_key_auth ────────────────────────
+# Allows endpoints to access ApiKeyAuth without declaring it in the function
+# signature, preventing FastAPI from misinterpreting the Pydantic model as a
+# body field (which causes 422 "Field required" errors).
+
+_current_api_key_auth: ContextVar["ApiKeyAuth | None"] = ContextVar("api_key_auth", default=None)
+
+
+def get_current_api_key_auth() -> "ApiKeyAuth":
+    """Return the ApiKeyAuth injected by ``@require_api_key_self_db``.
+
+    Use this in endpoints that do **not** declare ``api_key_auth`` in their
+    function signature — for example when the endpoint has its own Pydantic
+    body parameter that would conflict.
+
+    Raises :class:`BusinessException` if called without the decorator.
+    """
+    auth = _current_api_key_auth.get()
+    if auth is None:
+        raise BusinessException("API Key 认证信息缺失", BizCode.API_KEY_NOT_FOUND)
+    return auth
+
 
 # ── Async log-writer: batched single-consumer queue ──────────────────
 # Replaces per-request ``asyncio.create_task(log_api_key_usage(...))``
@@ -296,9 +321,7 @@ def require_api_key_self_db(
 
     def decorator(func):
         @wraps(func)
-        async def wrapper(*args, **kwargs):
-            request: Request = kwargs.get("request")
-
+        async def wrapper(request: Request, **kwargs):
             api_key = extract_api_key_from_request(request)
             if not api_key:
                 logger.warning("API Key 缺失", extra={
@@ -383,10 +406,19 @@ def require_api_key_self_db(
                     resource_id=api_key_obj.resource_id,
                 )
 
-            kwargs["api_key_auth"] = _api_key_auth
+            # Set ContextVar for endpoints that use get_current_api_key_auth()
+            _current_api_key_auth.set(_api_key_auth)
+            # Backward-compat: only inject into kwargs if the function expects it
+            _func_sig = inspect.signature(func)
+            if 'api_key_auth' in _func_sig.parameters:
+                kwargs["api_key_auth"] = _api_key_auth
 
             start_time = time.perf_counter()
-            response = await func(*args, **kwargs)
+            # Conditionally pass request: old endpoints need it, new ones don't
+            if 'request' in _func_sig.parameters:
+                response = await func(request, **kwargs)
+            else:
+                response = await func(**kwargs)
             end_time = time.perf_counter()
             response_time = (end_time - start_time) * 1000
 
@@ -405,6 +437,16 @@ def require_api_key_self_db(
                 "created_at": utcnow_naive(),
             })
             return response
+
+        # Inject ``request: Request`` into the wrapper's visible signature so
+        # FastAPI always passes the Request object — even when the underlying
+        # endpoint function doesn't declare it.
+        _func_sig = inspect.signature(func)
+        _req_param = inspect.Parameter(
+            'request', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request
+        )
+        _other_params = [p for name, p in _func_sig.parameters.items() if name != 'request']
+        wrapper.__signature__ = _func_sig.replace(parameters=[_req_param] + _other_params)
 
         return wrapper
 

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -87,7 +87,7 @@ class EntityBuilder(BaseBuilder):
             "aliases_name": self.record.get("aliases", []),
             "description": self.record.get("description"),
             "description_summary": self.record.get("description_summary"),
-            "description_timeline": self.record.get("description_timeline"),
+            "event_timeline": self.record.get("event_timeline"),
             "kw_score": self.record.get("kw_score", 0.0),
             "emb_score": self.record.get("embedding_score", 0.0)
         }
@@ -101,9 +101,9 @@ class EntityBuilder(BaseBuilder):
             (
                 "description",
                 (self.record.get("description", "") or "") +
-                (self.record.get("description_summary", "") or "") +
-                (self.record.get("description_timeline", "") or "")
+                (self.record.get("description_summary", "") or "")
             ),
+            ("event_timeline", self.record.get("event_timeline") or "")
         ]
         for tag, value in fields:
             if value:
@@ -230,7 +230,7 @@ class MetadataBuilder(BaseBuilder):
             "anchors": self.record.get("anchors", []) or [],
             "beliefs_or_stances": self.record.get("beliefs_or_stances", []) or [],
             "core_facts": self.record.get("core_facts", []) or [],
-            "events": self.record.get("events", []) or [],
+            "event_timeline": self.record.get("event_timeline", []) or [],
             "goals": self.record.get("goals", []) or [],
             "interests": self.record.get("interests", []) or [],
             "relations": self.record.get("relations", []) or [],
@@ -246,7 +246,7 @@ class MetadataBuilder(BaseBuilder):
             ("anchors", self.record.get("anchors", [])),
             ("beliefs-or-stances", self.record.get("beliefs_or_stances", [])),
             ("core-facts", self.record.get("core_facts", [])),
-            ("events", self.record.get("events", [])),
+            ("event_timeline", self.record.get("event_timeline", [])),
             ("goals", self.record.get("goals", [])),
             ("interests", self.record.get("interests", [])),
             ("relations", self.record.get("relations", [])),

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -16,7 +16,7 @@ from .app_model import App
 from .agent_app_config_model import AgentConfig
 from .app_release_model import AppRelease
 from .memory_increment_model import MemoryIncrement
-from .end_user_model import EndUser
+from .end_user_model import EndUser, EndUserMerge
 from .end_user_info_model import EndUserInfo
 from .appshare_model import AppShare
 from .release_share_model import ReleaseShare
@@ -73,6 +73,7 @@ __all__ = [
     "AppRelease",
     "MemoryIncrement",
     "EndUser",
+    "EndUserMerge",
     "EndUserInfo",
     "AppShare",
     "ReleaseShare",

--- a/api/app/models/end_user_model.py
+++ b/api/app/models/end_user_model.py
@@ -112,3 +112,13 @@ class EndUser(Base):
     
     # 与 EndUserInfo 的反向关系
     info = relationship("EndUserInfo", back_populates="end_user", cascade="all, delete-orphan")
+
+
+class EndUserMerge(Base):
+    __tablename__ = "end_user_merge"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False, index=True)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False, index=True)
+    origin_id = Column(UUID(as_uuid=True), nullable=True, index=True, comment="原始end_user_id")
+    origin_other_id = Column(String, nullable=False, index=True, comment="原始end_user other_id")
+    target_id = Column(UUID(as_uuid=True), nullable=False, index=True)

--- a/api/app/repositories/api_key_repository.py
+++ b/api/app/repositories/api_key_repository.py
@@ -1,11 +1,10 @@
 """API Key Repository"""
 import uuid
-import datetime
 from typing import Optional, List, Tuple
 
-from sqlalchemy.orm import Session, joinedload
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session, joinedload
 
 from app.core.utils.datetime_utils import utcnow_naive
 from app.models.api_key_model import ApiKey, ApiKeyLog

--- a/api/app/repositories/end_user_info_repository.py
+++ b/api/app/repositories/end_user_info_repository.py
@@ -3,6 +3,8 @@
 """
 import uuid
 from typing import Dict, List, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models.end_user_info_model import EndUserInfo
@@ -14,7 +16,7 @@ logger = get_logger(__name__)
 class EndUserInfoRepository:
     """终端用户信息仓储类"""
     
-    def __init__(self, db: Session):
+    def __init__(self, db: Session | AsyncSession):
         self.db = db
     
     def create(self, end_user_id: uuid.UUID, other_name: str, aliases: List[str] = None, meta_data: dict = None) -> EndUserInfo:

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -12,9 +12,8 @@ from app.core.logging_config import get_db_logger
 from app.core.utils.datetime_utils import utcnow_naive
 from app.models import User
 from app.models.end_user_info_model import EndUserInfo
-from app.models.end_user_model import EndUser
+from app.models.end_user_model import EndUser, EndUserMerge
 from app.models.workspace_model import Workspace
-from app.utils.redis_cache import redis_cache
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
@@ -142,7 +141,7 @@ class EndUserRepository:
             raise
 
     def get_end_user_by_id(self, end_user_id: uuid.UUID) -> Optional[EndUser]:
-        """根据 end_user_id 查询宿主"""
+        """根据 end_user_id 查询宿主。若已被合并则自动路由到目标。"""
         try:
             end_user = (
                 self.db.query(EndUser)
@@ -151,13 +150,47 @@ class EndUserRepository:
             )
             if end_user:
                 db_logger.info(f"成功查询到宿主 {end_user_id}")
-            else:
-                db_logger.info(f"未找到宿主 {end_user_id}")
-            return end_user
+                return end_user
+
+            resolved = self.resolve_merge_by_origin_id(end_user_id)
+            if resolved:
+                db_logger.info(f"宿主 {end_user_id} 已合并，路由到 {resolved.id}")
+                return resolved
+
+            db_logger.info(f"未找到宿主 {end_user_id}")
+            return None
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"查询宿主 {end_user_id} 时出错: {str(e)}")
             raise
+
+    def resolve_merge_by_origin_id(
+        self, origin_id: uuid.UUID
+    ) -> Optional["EndUser"]:
+        """同步版：检查合并映射并返回目标 EndUser。"""
+
+        merge_record = (
+            self.db.query(EndUserMerge)
+            .filter(EndUserMerge.origin_id == origin_id)
+            .order_by(EndUserMerge.id.desc())
+            .first()
+        )
+        if not merge_record:
+            return None
+
+        target_user = (
+            self.db.query(EndUser)
+            .filter(
+                EndUser.id == merge_record.target_id,
+                EndUser.is_active == True,
+            )
+            .first()
+        )
+        if target_user:
+            db_logger.info(
+                f"合并路由(sync): origin_id={origin_id} → target={merge_record.target_id}"
+            )
+        return target_user
 
     def get_active_end_user_in_workspace(
         self,
@@ -191,17 +224,24 @@ class EndUserRepository:
             end_user = result.scalars().first()
             if end_user:
                 db_logger.info(f"成功查询到宿主 {end_user_id}")
-            else:
-                db_logger.info(f"未找到宿主 {end_user_id}")
-            return end_user
+                return end_user
+
+            resolved = await self.resolve_merge_by_origin_id_async(end_user_id)
+            if resolved:
+                db_logger.info(f"宿主 {end_user_id} 已合并，路由到 {resolved.id}")
+                return resolved
+
+            db_logger.info(f"未找到宿主 {end_user_id}")
+            return None
         except Exception as e:
             await self.db.rollback()
             db_logger.error(f"查询宿主 {end_user_id} 时出错: {str(e)}")
             raise
 
     def get_end_user_by_other_id(self, workspace_id: uuid.UUID, other_id: str) -> Optional["EndUser"]:
-        """按 workspace_id + other_id 查找终端用户，不存在返回 None"""
-        return (
+        """按 workspace_id + other_id 查找终端用户，不存在返回 None。
+        若用户已被合并（is_active=False），自动路由到合并目标。"""
+        end_user = (
             self.db.query(EndUser)
             .filter(
                 EndUser.workspace_id == workspace_id,
@@ -210,6 +250,151 @@ class EndUserRepository:
             ).order_by(EndUser.created_at.asc())
             .first()
         )
+        if end_user:
+            return end_user
+
+        # 未找到活跃用户 → 检查是否已被合并
+        return self.resolve_merge_by_other_id(workspace_id, other_id)
+
+    def resolve_merge_by_other_id(
+        self, workspace_id: uuid.UUID, other_id: str
+    ) -> Optional["EndUser"]:
+        """同步版：检查合并映射并返回目标 EndUser。"""
+
+        merge_record = (
+            self.db.query(EndUserMerge)
+            .filter(
+                EndUserMerge.workspace_id == workspace_id,
+                EndUserMerge.origin_other_id == other_id,
+            )
+            .order_by(EndUserMerge.id.desc())
+            .first()
+        )
+        if not merge_record:
+            return None
+
+        target_user = (
+            self.db.query(EndUser)
+            .filter(
+                EndUser.id == merge_record.target_id,
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active == True,
+            )
+            .first()
+        )
+        if target_user:
+            db_logger.info(
+                f"合并路由(sync): other_id={other_id} → target={merge_record.target_id}"
+            )
+        return target_user
+
+    # ── EndUserMerge 写入操作 ──────────────────────────────────────
+
+    async def flatten_merge_chain_async(
+        self, source_ids: set[uuid.UUID], target_id: uuid.UUID, workspace_id: uuid.UUID,
+    ) -> None:
+        """将历史上指向 source 的合并记录摊平到 target。
+
+        当用户 B 之前被合并到 A，现在 A 又要合并到 C 时，
+        需要把 B→A 的记录更新为 B→C。
+        """
+        for src_id in source_ids:
+            await self.db.execute(
+                update(EndUserMerge)
+                .where(
+                    EndUserMerge.target_id == src_id,
+                    EndUserMerge.workspace_id == workspace_id,
+                )
+                .values(target_id=target_id)
+            )
+
+    def create_merge_record(
+        self,
+        origin_id: uuid.UUID,
+        origin_other_id: str,
+        target_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> EndUserMerge:
+        """创建一条 EndUserMerge 记录。"""
+        record = EndUserMerge(
+            workspace_id=workspace_id,
+            origin_id=origin_id,
+            origin_other_id=origin_other_id,
+            target_id=target_id,
+        )
+        self.db.add(record)
+        return record
+
+    async def migrate_reference_end_user_id_async(
+        self, src_id: uuid.UUID, target_id: uuid.UUID,
+    ) -> dict:
+        """将 PG 引用表中 source 的 end_user_id 迁移到 target。
+
+        小批量（1000 行/批）UPDATE，避免大事务锁表阻塞。
+
+        覆盖 conversations、memory_messages、memory_short_term、
+        memory_long_term、memory_forget_log、memory_perceptual、
+        memory_reflection_log、forgetting_cycle_history、
+        memory_display_record、memory_engine_display_event。
+
+        跳过 implicit_emotions_storage（UNIQUE 约束，需特殊处理）和
+        memory_config（end_user_id 为配置自身标识，非用户引用）。
+
+        Returns:
+            {table_name: rows_updated}
+        """
+        BATCH = 200
+        src_str = str(src_id)
+        tgt_str = str(target_id)
+        stats: dict[str, int] = {}
+
+        # ── 所有表定义：(model, col_name, src_value, tgt_value) ──
+        from app.models.conversation_model import Conversation
+        from app.models.memory_message_model import MemoryMessage
+        from app.models.memory_short_model import ShortTermMemory, LongTermMemory
+        from app.models.forgetting_cycle_history_model import ForgettingCycleHistory
+        from app.models.memory_display_record_model import MemoryDisplayRecord
+        from app.models.memory_engine_display_event_model import MemoryEngineDisplayEvent
+        from app.models.memory_forget_model import ForgetAuditModel
+        from app.models.memory_perceptual_model import MemoryPerceptualModel
+        from app.models.reflection_log_model import MemoryReflectionLog
+
+        all_tables: list[tuple[type, str, object, object]] = [
+            # String 类型
+            (Conversation, "user_id", src_str, tgt_str),
+            (MemoryMessage, "end_user_id", src_str, tgt_str),
+            (ShortTermMemory, "end_user_id", src_str, tgt_str),
+            (LongTermMemory, "end_user_id", src_str, tgt_str),
+            (ForgettingCycleHistory, "end_user_id", src_str, tgt_str),
+            (MemoryDisplayRecord, "end_user_id", src_str, tgt_str),
+            (MemoryEngineDisplayEvent, "end_user_id", src_str, tgt_str),
+            # UUID 类型（FK 到 end_users.id）
+            (ForgetAuditModel, "end_user_id", src_id, target_id),
+            (MemoryPerceptualModel, "end_user_id", src_id, target_id),
+            (MemoryReflectionLog, "end_user_id", src_id, target_id),
+        ]
+
+        for model, col_name, src_val, tgt_val in all_tables:
+            col = getattr(model, col_name)
+            total = 0
+            while True:
+                # 先 SELECT 一批主键，再 UPDATE，避免大范围锁表
+                pk_result = await self.db.execute(
+                    select(model.id).where(col == src_val).limit(BATCH)
+                )
+                ids = list(pk_result.scalars().all())
+                if not ids:
+                    break
+                upd_result = await self.db.execute(
+                    update(model)
+                    .where(model.id.in_(ids))
+                    .values(**{col_name: tgt_val})
+                )
+                total += upd_result.rowcount or 0
+            if total:
+                stats[model.__tablename__] = total
+
+        return stats
 
     def get_or_create_end_user(
             self,
@@ -248,6 +433,17 @@ class EndUserRepository:
                     self.db.commit()
                     self.db.refresh(end_user)
                     return end_user
+
+                # 未找到活跃用户 → 检查是否已被合并
+                merged_target = self.resolve_merge_by_other_id(workspace_id, other_id)
+                if merged_target:
+                    db_logger.info(
+                        f"other_id={other_id} 已合并，路由到 target={merged_target.id}"
+                    )
+                    merged_target.app_id = app_id
+                    self.db.commit()
+                    self.db.refresh(merged_target)
+                    return merged_target
 
                 # 创建新用户
                 end_user = EndUser(
@@ -289,7 +485,80 @@ class EndUserRepository:
             )
             .order_by(EndUser.created_at.asc())
         )
-        return result.scalars().first()
+        end_user = result.scalars().first()
+        if end_user:
+            return end_user
+
+        # 未找到活跃用户 → 检查是否已被合并到其它用户
+        return await self.resolve_merge_by_other_id_async(workspace_id, other_id)
+
+    async def resolve_merge_by_other_id_async(
+        self, workspace_id: uuid.UUID, other_id: str
+    ) -> Optional["EndUser"]:
+        """如果 other_id 对应的用户已被合并，返回合并目标用户。
+
+        查询 end_user_merge 表，若存在 origin_other_id 记录，
+        则返回对应的 target EndUser（活跃且属于同一 workspace）。
+        """
+
+        merge_result = await self.db.execute(
+            select(EndUserMerge.target_id)
+            .filter(
+                EndUserMerge.workspace_id == workspace_id,
+                EndUserMerge.origin_other_id == other_id,
+            )
+            .order_by(EndUserMerge.id.desc())
+            .limit(1)
+        )
+        target_id = merge_result.scalars().first()
+        if not target_id:
+            return None
+
+        target_result = await self.db.execute(
+            select(EndUser)
+            .filter(
+                EndUser.id == target_id,
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active == True,
+            )
+            .limit(1)
+        )
+        target_user = target_result.scalars().first()
+        if target_user:
+            db_logger.info(
+                f"合并路由: other_id={other_id} → target={target_id}"
+            )
+        return target_user
+
+    async def resolve_merge_by_origin_id_async(
+        self, origin_id: uuid.UUID
+    ) -> Optional["EndUser"]:
+        """如果 origin_id 对应的用户已被合并（is_active=False），返回合并目标用户。"""
+
+        merge_result = await self.db.execute(
+            select(EndUserMerge.target_id)
+            .filter(EndUserMerge.origin_id == origin_id)
+            .order_by(EndUserMerge.id.desc())
+            .limit(1)
+        )
+        target_id = merge_result.scalars().first()
+        if not target_id:
+            return None
+
+        target_result = await self.db.execute(
+            select(EndUser)
+            .filter(
+                EndUser.id == target_id,
+                EndUser.is_active == True,
+            )
+            .limit(1)
+        )
+        target_user = target_result.scalars().first()
+        if target_user:
+            db_logger.info(
+                f"合并路由: origin_id={origin_id} → target={target_id}"
+            )
+        return target_user
 
     async def get_or_create_end_user_async(
             self,
@@ -368,6 +637,38 @@ class EndUserRepository:
                 if existing:
                     return existing.id, existing.other_id
 
+                # 未找到活跃用户 → 检查是否已被合并（MCP 场景）
+                from app.models.end_user_model import EndUserMerge
+                merge_record = (
+                    self.db.query(EndUserMerge)
+                    .filter(
+                        EndUserMerge.workspace_id == workspace_id,
+                        or_(
+                            EndUserMerge.origin_id == user_id,
+                            EndUserMerge.origin_other_id == user_id,
+                        )
+                        if is_uuid(user_id)
+                        else EndUserMerge.origin_other_id == user_id,
+                    )
+                    .order_by(EndUserMerge.id.desc())
+                    .first()
+                )
+                if merge_record:
+                    target_user = (
+                        self.db.query(EndUser)
+                        .filter(
+                            EndUser.id == merge_record.target_id,
+                            EndUser.workspace_id == workspace_id,
+                            EndUser.is_active == True,
+                        )
+                        .first()
+                    )
+                    if target_user:
+                        db_logger.info(
+                            f"MCP 合并路由: user_id={user_id} → target={target_user.id}"
+                        )
+                        return target_user.id, target_user.other_id
+
                 end_user = EndUser(
                     workspace_id=workspace_id,
                     other_id=user_id
@@ -438,6 +739,20 @@ class EndUserRepository:
                 self.db.refresh(end_user)
                 return end_user
 
+            # 未找到活跃用户 → 检查是否已被合并到其它用户
+            merged_target = self.resolve_merge_by_other_id(workspace_id, other_id)
+            if merged_target:
+                db_logger.info(
+                    f"other_id={other_id} 已合并，路由到 target={merged_target.id}"
+                )
+                if app_id is not None:
+                    merged_target.app_id = app_id
+                if memory_config_id and not merged_target.memory_config_id:
+                    merged_target.memory_config_id = memory_config_id
+                self.db.commit()
+                self.db.refresh(merged_target)
+                return merged_target
+
             # 创建新用户（is_active 默认为 True）
             end_user = EndUser(
                 app_id=app_id,
@@ -505,6 +820,22 @@ class EndUserRepository:
                 await self.db.refresh(end_user)
                 return end_user
 
+            # 未找到活跃用户 → 检查是否已被合并到其它用户
+            merged_target = await self.resolve_merge_by_other_id_async(
+                workspace_id, other_id
+            )
+            if merged_target:
+                db_logger.info(
+                    f"other_id={other_id} 已合并，路由到 target={merged_target.id}"
+                )
+                if app_id is not None:
+                    merged_target.app_id = app_id
+                if memory_config_id and not merged_target.memory_config_id:
+                    merged_target.memory_config_id = memory_config_id
+                await self.db.commit()
+                await self.db.refresh(merged_target)
+                return merged_target
+
             # 创建新用户
             end_user = EndUser(
                 app_id=app_id,
@@ -538,11 +869,11 @@ class EndUserRepository:
             raise
 
     def get_by_id(self, end_user_id: uuid.UUID) -> Optional[EndUser]:
-        """根据ID获取终端用户（用于缓存操作）
-        
+        """根据ID获取终端用户（用于缓存操作）。若已合并则自动路由到目标。
+
         Args:
             end_user_id: 终端用户ID
-            
+
         Returns:
             Optional[EndUser]: 终端用户对象，如果不存在则返回None
         """
@@ -554,16 +885,22 @@ class EndUserRepository:
             )
             if end_user:
                 db_logger.debug(f"成功查询到终端用户 {end_user_id}")
-            else:
-                db_logger.debug(f"未找到终端用户 {end_user_id}")
-            return end_user
+                return end_user
+
+            resolved = self.resolve_merge_by_origin_id(end_user_id)
+            if resolved:
+                db_logger.debug(f"终端用户 {end_user_id} 已合并，路由到 {resolved.id}")
+                return resolved
+
+            db_logger.debug(f"未找到终端用户 {end_user_id}")
+            return None
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"查询终端用户 {end_user_id} 时出错: {str(e)}")
             raise
 
     async def get_by_id_async(self, end_user_id: uuid.UUID) -> Optional[EndUser]:
-        """根据ID获取终端用户（异步版本，供 AsyncSession 调用方使用）。"""
+        """根据ID获取终端用户（异步版本，供 AsyncSession 调用方使用）。若已合并则自动路由。"""
         try:
             result = await self.db.execute(
                 select(EndUser).where(
@@ -574,9 +911,15 @@ class EndUserRepository:
             end_user = result.scalars().first()
             if end_user:
                 db_logger.debug(f"成功查询到终端用户 {end_user_id}(异步)")
-            else:
-                db_logger.debug(f"未找到终端用户 {end_user_id}(异步)")
-            return end_user
+                return end_user
+
+            resolved = await self.resolve_merge_by_origin_id_async(end_user_id)
+            if resolved:
+                db_logger.debug(f"终端用户 {end_user_id} 已合并，路由到 {resolved.id}(异步)")
+                return resolved
+
+            db_logger.debug(f"未找到终端用户 {end_user_id}(异步)")
+            return None
         except Exception as e:
             await self.db.rollback()
             db_logger.error(f"查询终端用户 {end_user_id} 时出错(异步): {str(e)}")
@@ -603,6 +946,28 @@ class EndUserRepository:
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"批量校验终端用户ID时出错: {str(e)}")
+            raise
+
+    async def filter_existing_ids_async(
+            self,
+            end_user_ids: set[uuid.UUID],
+            workspace_id: uuid.UUID | None = None
+    ) -> Set[str]:
+        if not end_user_ids:
+            return set()
+
+        try:
+            stmt = select(EndUser.id).where(
+                EndUser.id.in_(end_user_ids), EndUser.is_active == True,
+            )
+            if workspace_id:
+                stmt = stmt.where(EndUser.workspace_id == workspace_id)
+            result = await self.db.execute(stmt)
+            end_user_ids = result.scalars().all()
+            return set(end_user_ids)
+        except Exception as e:
+            await self.db.rollback()
+            db_logger.error("批量校验终端用户异常%s", str(e))
             raise
 
     async def get_memory_insight_by_end_user_id_async(

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -952,7 +952,7 @@ class EndUserRepository:
             self,
             end_user_ids: set[uuid.UUID],
             workspace_id: uuid.UUID | None = None
-    ) -> Set[str]:
+    ) -> Set[uuid.UUID]:
         if not end_user_ids:
             return set()
 

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -38,6 +38,9 @@ RANGE_DEFS: List[Tuple[str, str]] = [
     ("user_assistant_original", "AssistantOriginal"),
     ("user_assistant_pruned", "AssistantPruned"),
     ("user_conversation", "Conversation"),
+    ("user_statement", "Statement"),
+    ("user_chunk", "Chunk"),
+    ("user_extracted_entity", "ExtractedEntity"),
 ]
 
 COMPOSITE_DEFS: List[Tuple[str, str, str]] = [
@@ -55,15 +58,6 @@ DELETE_AT_DEFS: List[Tuple[str, str, str]] = [
     ("user_entity_delete_at", "ExtractedEntity", "delete_at"),
     ("user_chunk_delete_at", "Chunk", "delete_at"),
 ]
-
-# 旧的单列 end_user_id 索引名称（已被复合索引替代，创建复合索引前需先删除）
-_LEGACY_RANGE_NAMES: set[str] = {
-    "user_chunk",
-    "user_statement",
-    "user_extracted_entity",
-    "user_memory_summary",
-    "user_perceptual",
-}
 
 # Uniqueness 约束: (name, label, property)
 CONSTRAINT_DEFS: List[Tuple[str, str, str]] = [
@@ -345,7 +339,8 @@ async def create_end_user_id_indexes():
                 SHOW INDEXES
                 YIELD name, labelsOrTypes, properties, type
                 WHERE type = 'RANGE'
-                  AND any(prop IN properties WHERE prop = 'end_user_id')
+                  AND size(properties) = 1
+                  AND properties[0] = 'end_user_id'
                 RETURN name,
                        labelsOrTypes[0] AS label,
                        properties[0] AS property,
@@ -363,28 +358,11 @@ async def create_composite_indexes():
     加速 search_by_embedding 游标批查询：
         WHERE end_user_id = $x AND id > $last ORDER BY id
 
-    复合索引的前缀列覆盖 end_user_id 单列查询，创建前会先删除旧的
-    单列 end_user_id 索引以避 Neo4j 的等价索引冲突。
+    注意：Neo4j 复合索引仅在查询同时过滤全部属性时才可用，并不覆盖
+    end_user_id 单列查询；单列查询由 create_end_user_id_indexes 负责。
     """
     connector = Neo4jConnector()
     try:
-        # 1. 删除旧的单列 end_user_id 索引（已被复合索引替代）
-        existing_rows = await connector.execute_query(
-            "SHOW INDEXES YIELD name, labelsOrTypes, properties, type "
-            "WHERE type = 'RANGE' "
-            "  AND size(properties) = 1 "
-            "  AND properties[0] = 'end_user_id' "
-            "RETURN name, labelsOrTypes[0] AS label"
-        )
-        for row in (existing_rows or []):
-            name = row.get("name", "")
-            if name in _LEGACY_RANGE_NAMES:
-                try:
-                    await connector.execute_query(f"DROP INDEX {name}")
-                    logger.info(f"[Index] 删除旧单列索引: {name}")
-                except Exception as e:
-                    logger.warning(f"[Index] 删除旧单列索引失败 {name}: {e}")
-
         desired: List[Dict[str, Any]] = []
         for name, label, id_prop in COMPOSITE_DEFS + DELETE_AT_DEFS:
             desired.append({

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1955,7 +1955,7 @@ RETURN e.id AS id,
        e.entity_type AS entity_type,
        e.description AS description,
        e.description_summary AS description_summary,
-       e.description_timeline AS description_timeline,
+       e.event_timeline AS event_timeline,
        COALESCE(e.activation_value, e.importance_score, 0.5) AS activation_value,
        COALESCE(e.importance_score, 0.5) AS importance_score,
        e.last_access_time AS last_access_time,
@@ -2043,7 +2043,7 @@ RETURN e.id AS id,
        e.entity_type AS entity_type,
        e.description AS description,
        e.description_summary AS description_summary,
-       e.description_timeline AS description_timeline,
+       e.event_timeline AS event_timeline,
        COALESCE(e.activation_value, e.importance_score, 0.5) AS activation_value,
        score
 ORDER BY score DESC
@@ -2143,7 +2143,7 @@ RETURN n.description AS description,
        n.anchors AS anchors,
        n.beliefs_or_stances AS beliefs_or_stances,
        n.core_facts AS core_facts,
-       n.events AS events,
+       n.event_timeline AS event_timeline,
        n.goals AS goals,
        n.interests AS interests,
        n.relations AS relations,
@@ -2964,4 +2964,94 @@ CALL () {
 RETURN *
 ORDER BY CASE WHEN sort_time IS NULL THEN 0 ELSE 1 END, sort_time ASC, extraction_count ASC
 LIMIT $batch_size
+"""
+
+# 将所有节点的 end_user_id 从 old 改为 new
+END_USER_MERGE_REASSIGN_NODES = """
+MATCH (n)
+WHERE n.end_user_id = $old_id
+SET n.end_user_id = $new_id
+RETURN count(n) AS updated_nodes
+"""
+
+# 将所有关系的 end_user_id 从 old 改为 new
+END_USER_MERGE_REASSIGN_EDGES = """
+MATCH ()-[r]->()
+WHERE r.end_user_id = $old_id
+SET r.end_user_id = $new_id
+RETURN count(r) AS updated_edges
+"""
+
+# 查找指定 end_user 的 User 实体节点
+END_USER_MERGE_FIND_USER_ENTITIES = """
+MATCH (n:ExtractedEntity {end_user_id: $end_user_id})
+WHERE n.name = '用户'
+RETURN n, elementId(n) AS elem_id
+"""
+
+# 合并更新 User 实体的所有属性
+END_USER_MERGE_UPDATE_USER = """
+MATCH (n:ExtractedEntity)
+WHERE elementId(n) = $elem_id
+SET n.description = $description,
+    n.description_summary = $description_summary,
+    n.aliases = $aliases,
+    n.anchors = $anchors,
+    n.beliefs_or_stances = $beliefs_or_stances,
+    n.core_facts = $core_facts,
+    n.description_timeline = $description_timeline,
+    n.event_timeline = $event_timeline,
+    n.events = $events,
+    n.goals = $goals,
+    n.interests = $interests,
+    n.relations = $relations,
+    n.traits = $traits
+"""
+
+# 重定向 source User 实体的入边到 target User 实体（保留原始关系类型）
+END_USER_MERGE_REDIRECT_INCOMING = """
+MATCH (src:ExtractedEntity {end_user_id: $old_id})
+WHERE src.name = '用户'
+MATCH (tgt:ExtractedEntity)
+WHERE (tgt.name = '用户')
+  AND tgt.end_user_id = $new_id
+WITH src, tgt
+MATCH (src)<-[r_in]-(other)
+WHERE NOT (other:ExtractedEntity)
+WITH other, tgt, r_in
+CALL apoc.create.relationship(other, type(r_in), properties(r_in), tgt)
+YIELD rel AS r_new
+SET r_new.end_user_id = $new_id
+DELETE r_in
+"""
+
+# 重定向 source User 实体的出边到 target User 实体（保留原始关系类型）
+END_USER_MERGE_REDIRECT_OUTGOING = """
+MATCH (src:ExtractedEntity {end_user_id: $old_id})
+WHERE src.name = '用户'
+MATCH (tgt:ExtractedEntity)
+WHERE (tgt.name = '用户')
+  AND tgt.end_user_id = $new_id
+WITH src, tgt
+MATCH (src)-[r_out]->(other)
+WHERE NOT (other:ExtractedEntity)
+WITH other, tgt, r_out
+CALL apoc.create.relationship(tgt, type(r_out), properties(r_out), other)
+YIELD rel AS r_new
+SET r_new.end_user_id = $new_id
+DELETE r_out
+"""
+
+# 删除 source 的 User 实体节点
+END_USER_MERGE_DELETE_USER_ENTITY = """
+MATCH (n:ExtractedEntity {end_user_id: $old_id})
+WHERE n.name = '用户'
+DETACH DELETE n
+"""
+
+# 将 source User 实体的 end_user_id 改为 target（仅 source 有 User 时）
+END_USER_MERGE_REASSIGN_USER_ENTITY = """
+MATCH (n:ExtractedEntity {end_user_id: $old_id})
+WHERE n.name = '用户'
+SET n.end_user_id = $new_id
 """

--- a/api/app/repositories/neo4j/end_user_merge_repository.py
+++ b/api/app/repositories/neo4j/end_user_merge_repository.py
@@ -1,0 +1,230 @@
+"""Neo4j 终端用户合并仓储。
+
+将 merge_end_users 中的 Neo4j 操作从 service 层抽离到 repositories/neo4j 下，
+Cypher 查询统一存放在 cypher_queries.py。
+"""
+
+import json
+import logging
+from typing import Any, List
+
+from app.repositories.neo4j.cypher_queries import (
+    END_USER_MERGE_DELETE_USER_ENTITY,
+    END_USER_MERGE_FIND_USER_ENTITIES,
+    END_USER_MERGE_REASSIGN_EDGES,
+    END_USER_MERGE_REASSIGN_NODES,
+    END_USER_MERGE_REASSIGN_USER_ENTITY,
+    END_USER_MERGE_REDIRECT_INCOMING,
+    END_USER_MERGE_REDIRECT_OUTGOING,
+    END_USER_MERGE_UPDATE_USER,
+)
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = logging.getLogger(__name__)
+
+
+class EndUserMergeNeo4jRepository:
+    """终端用户合并 — Neo4j 侧操作。"""
+
+    def __init__(self, connector: Neo4jConnector):
+        self.connector = connector
+
+    async def reassign_all_to_target(
+            self,
+            source_ids: List[str],
+            target_id: str,
+    ) -> dict:
+        """将 source 用户在 Neo4j 中的所有数据归入 target。
+
+        Returns:
+            {"nodes": int, "edges": int}
+        """
+        total_nodes = 0
+        total_edges = 0
+
+        for src_id in source_ids:
+            await self._merge_user_entity_nodes(src_id, target_id)
+
+            node_result = await self.connector.execute_query(
+                END_USER_MERGE_REASSIGN_NODES,
+                old_id=src_id,
+                new_id=target_id,
+            )
+            total_nodes += node_result[0]["updated_nodes"] if node_result else 0
+
+            edge_result = await self.connector.execute_query(
+                END_USER_MERGE_REASSIGN_EDGES,
+                old_id=src_id,
+                new_id=target_id,
+            )
+            total_edges += edge_result[0]["updated_edges"] if edge_result else 0
+
+            logger.info(
+                f"[Neo4jMerge] src={src_id} → target={target_id}, "
+                f"nodes={total_nodes}, edges={total_edges}"
+            )
+
+        return {"nodes": total_nodes, "edges": total_edges}
+
+    async def _merge_user_entity_nodes(
+            self, src_id_str: str, target_id_str: str
+    ) -> None:
+        src_records = await self.connector.execute_query(
+            END_USER_MERGE_FIND_USER_ENTITIES,
+            end_user_id=src_id_str,
+        )
+        if not src_records:
+            return
+
+        tgt_records = await self.connector.execute_query(
+            END_USER_MERGE_FIND_USER_ENTITIES,
+            end_user_id=target_id_str,
+        )
+
+        if tgt_records:
+            await self._merge_into_target_user(
+                src_id_str, target_id_str, src_records, tgt_records
+            )
+        else:
+            await self.connector.execute_query(
+                END_USER_MERGE_REASSIGN_USER_ENTITY,
+                old_id=src_id_str,
+                new_id=target_id_str,
+            )
+            logger.info(
+                f"[Neo4jMerge] User 实体 end_user_id 变更: "
+                f"{src_id_str} → {target_id_str}"
+            )
+
+    async def _merge_into_target_user(
+            self,
+            src_id_str: str,
+            target_id_str: str,
+            src_records: list,
+            tgt_records: list,
+    ) -> None:
+        """双方都有 User 节点：合并描述 → 边重定向 → 删除 source。"""
+        src_node = src_records[0].get("n", {})
+        tgt_node = tgt_records[0].get("n", {})
+        tgt_elem_id = tgt_records[0].get("elem_id", "")
+
+        def _dedup_list(items: List[Any]) -> List[Any]:
+            """列表去重，对 dict 使用 JSON 序列化作为去重键。"""
+            seen: set = set()
+            deduped: list = []
+            for item in items:
+                key = (
+                    json.dumps(item, sort_keys=True, ensure_ascii=False)
+                    if isinstance(item, dict)
+                    else item
+                )
+                if key not in seen:
+                    seen.add(key)
+                    deduped.append(item)
+            return deduped
+
+        def _merge_separated_string(tgt_str: str, src_str: str, sep: str = "；") -> str:
+            """合并两个以分隔符拼接的字符串，去重已存在的条目。
+
+            description_timeline / event_timeline / description 在 Neo4j
+            中存储为以 ``；``（U+FF1B）分隔的单个字符串，合并时需按条目级去重。
+            """
+            tgt_parts = [p.strip() for p in tgt_str.split(sep) if p.strip()] if tgt_str else []
+            src_parts = [p.strip() for p in src_str.split(sep) if p.strip()] if src_str else []
+            # 保留 tgt 顺序，仅追加 src 中未出现的条目
+            existing = set(tgt_parts)
+            new_parts = [p for p in src_parts if p not in existing]
+            return sep.join(tgt_parts + new_parts)
+
+        # --- 合并列表字段（去重） ---
+        merged_aliases = _dedup_list(
+            (tgt_node.get("aliases") or []) + (src_node.get("aliases") or [])
+        )
+        merged_anchors = _dedup_list(
+            (tgt_node.get("anchors") or []) + (src_node.get("anchors") or [])
+        )
+        merged_beliefs_or_stances = _dedup_list(
+            (tgt_node.get("beliefs_or_stances") or [])
+            + (src_node.get("beliefs_or_stances") or [])
+        )
+        merged_core_facts = _dedup_list(
+            (tgt_node.get("core_facts") or []) + (src_node.get("core_facts") or [])
+        )
+        merged_events = _dedup_list(
+            (tgt_node.get("events") or []) + (src_node.get("events") or [])
+        )
+        merged_goals = _dedup_list(
+            (tgt_node.get("goals") or []) + (src_node.get("goals") or [])
+        )
+        merged_interests = _dedup_list(
+            (tgt_node.get("interests") or []) + (src_node.get("interests") or [])
+        )
+        merged_relations = _dedup_list(
+            (tgt_node.get("relations") or []) + (src_node.get("relations") or [])
+        )
+        merged_traits = _dedup_list(
+            (tgt_node.get("traits") or []) + (src_node.get("traits") or [])
+        )
+
+        # --- 合并以；分隔的字符串字段（条目级去重） ---
+        merged_description_timeline = _merge_separated_string(
+            tgt_node.get("description_timeline") or "",
+            src_node.get("description_timeline") or "",
+        )
+        merged_event_timeline = _merge_separated_string(
+            tgt_node.get("event_timeline") or "",
+            src_node.get("event_timeline") or "",
+        )
+
+        # --- 合并普通字符串字段 ---
+        src_desc = (src_node.get("description") or "").strip()
+        tgt_desc = (tgt_node.get("description") or "").strip()
+        merged_desc = tgt_desc
+        if src_desc and tgt_desc:
+            merged_desc = f"{tgt_desc}；{src_desc}"
+        elif src_desc:
+            merged_desc = src_desc
+
+        src_summary = (src_node.get("description_summary") or "").strip()
+        tgt_summary = (tgt_node.get("description_summary") or "").strip()
+        merged_description_summary = tgt_summary
+        if src_summary and tgt_summary:
+            merged_description_summary = f"{tgt_summary}\n{src_summary}"
+        elif src_summary:
+            merged_description_summary = src_summary
+
+        # --- 更新目标节点 ---
+        await self.connector.execute_query(
+            END_USER_MERGE_UPDATE_USER,
+            elem_id=tgt_elem_id,
+            description=merged_desc,
+            description_summary=merged_description_summary,
+            aliases=merged_aliases,
+            anchors=merged_anchors,
+            beliefs_or_stances=merged_beliefs_or_stances,
+            core_facts=merged_core_facts,
+            description_timeline=merged_description_timeline,
+            event_timeline=merged_event_timeline,
+            events=merged_events,
+            goals=merged_goals,
+            interests=merged_interests,
+            relations=merged_relations,
+            traits=merged_traits,
+        )
+        logger.info(f"[Neo4jMerge] User 实体属性合并完成: src={src_id_str}")
+
+        await self.connector.execute_query(
+            END_USER_MERGE_REDIRECT_INCOMING,
+            old_id=src_id_str,
+            new_id=target_id_str,
+        )
+        await self.connector.execute_query(
+            END_USER_MERGE_REDIRECT_OUTGOING,
+            old_id=src_id_str,
+            new_id=target_id_str,
+        )
+        await self.connector.execute_query(
+            END_USER_MERGE_DELETE_USER_ENTITY,
+            old_id=src_id_str,
+        )
+        logger.info(f"[Neo4jMerge] 已删除 source User 实体: src={src_id_str}")

--- a/api/app/schemas/memory_agent_schema.py
+++ b/api/app/schemas/memory_agent_schema.py
@@ -104,6 +104,11 @@ class Write_UserInput(BaseModel):
     )
 
 
+class MergeEndUserInput(BaseModel):
+    end_user_ids: set[uuid.UUID] = Field()
+    target: uuid.UUID = Field(...)
+
+
 class AgentMemoryDataset(ABC):
     PRONOUN = ['我', '本人', '在下', '自己', '咱', '鄙人', '吴', '余']
     NAME = '用户'

--- a/api/app/services/end_user_service.py
+++ b/api/app/services/end_user_service.py
@@ -168,16 +168,9 @@ class EndUserService:
             f"[merge_end_users] 全部完成: source={source}, target={target}"
         )
 
-        # ── 5.5 刷新 target write_time ──
-        # 合并本身不是「消息写入」，但改变了 target 的图谱数据。
-        # 刷新 write_time 确保 scan_layer2_reflection 的活跃门（_is_active_recently）
-        # 能感知到这次变更——否则 lock_timeout 时直接派发失败，scan 又因 write_time 过期
-        # 判为「不活跃」而跳过，合并后的反思就彻底丢了。
         try:
             from app.services.memory_reflection_service import WorkspaceAppService
-            from app.db import get_db_context
-            with get_db_context() as sync_db:
-                WorkspaceAppService(sync_db).update_end_user_write_time(str(target))
+            await WorkspaceAppService(self.db).update_end_user_write_time_async(str(target))
         except Exception as e:
             logger.warning(
                 f"[merge_end_users] 刷新 target write_time 失败（不影响合并结果）: {e}",

--- a/api/app/services/end_user_service.py
+++ b/api/app/services/end_user_service.py
@@ -1,0 +1,227 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import BusinessException
+from app.core.logging_config import get_memory_logger
+from app.models import EndUserInfo
+from app.models.end_user_model import EndUser
+from app.repositories.end_user_info_repository import EndUserInfoRepository
+from app.repositories.end_user_repository import EndUserRepository
+from app.repositories.neo4j.end_user_merge_repository import EndUserMergeNeo4jRepository
+from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = get_memory_logger()
+
+
+class EndUserService:
+    def __init__(self, db: AsyncSession):
+        self.user_repo = EndUserRepository(db)
+        self.info_repo = EndUserInfoRepository(db)
+        self.db = db
+
+    async def merge_end_users(self, source: set[uuid.UUID], target: uuid.UUID):
+        """将 source 中的用户合并到 target 用户。
+
+        合并操作涵盖：
+        1. PG EndUserInfo：aliases / meta_data 合并到 target
+        2. Neo4j：所有节点的 end_user_id 改为 target；User 实体节点合并全部属性
+        3. Neo4j：关系属性 end_user_id 改为 target（保留原始关系类型）
+        4. PG 引用表：conversations / memory_messages / memory_short_term /
+           memory_long_term / memory_forget_log / memory_perceptual /
+           memory_reflection_log / forgetting_cycle_history /
+           memory_display_record / memory_engine_display_event
+           的 end_user_id 从 source 迁移到 target
+        5. PG EndUser：source 用户 is_active = False（软删除）
+        6. PG end_user_merge：记录每条合并映射（并摊平历史合并链）
+        7. 同步 target 的 memory_count
+        8. 触发 target 的 Layer2 反思（实体去重 + 描述合并，from_retry=True 跳过频率检查）
+        9. 后续通过 EndUserMerge 表 + is_active 过滤，API 请求自动路由到 target
+        """
+        # ── 0. 提前收集 source EndUser 行（软删除前需要 other_id） ──
+        source_users: dict[uuid.UUID, EndUser] = {}
+        for end_user_id in source:
+            eu = await self._get_end_user_any_async(end_user_id)
+            if eu:
+                source_users[end_user_id] = eu
+
+        # ── 1. 收集 source 和 target 的 EndUserInfo ──
+        end_user_infos: list[EndUserInfo] = []
+        for end_user_id in source:
+            end_user_info = await self.info_repo.get_end_user_info_async(end_user_id)
+            if end_user_info:
+                end_user_infos.append(end_user_info)
+
+        target_user_info = await self.info_repo.get_end_user_info_async(target)
+        if not target_user_info:
+            raise BusinessException(message=f"Target user not found.")
+
+        # ── 2. 合并 aliases 与 meta_data 到 target EndUserInfo ──
+        final_aliases: list[str] = list(target_user_info.aliases or [])
+        seen_alias_lower = {a.lower() for a in final_aliases}
+
+        merged_meta: dict = dict(target_user_info.meta_data or {})
+
+        for info in end_user_infos:
+            for alias in (info.aliases or []):
+                alias = alias.strip()
+                if alias and alias.lower() not in seen_alias_lower:
+                    final_aliases.append(alias)
+                    seen_alias_lower.add(alias.lower())
+
+            if info.meta_data:
+                for key, values in info.meta_data.items():
+                    if not isinstance(values, list):
+                        continue
+                    existing = list(merged_meta.get(key) or [])
+                    existing_set = {str(v).lower() for v in existing}
+                    for v in values:
+                        if str(v).lower() not in existing_set:
+                            existing.append(v)
+                            existing_set.add(str(v).lower())
+                    merged_meta[key] = existing
+
+        target_user_info.aliases = final_aliases
+        target_user_info.meta_data = merged_meta
+        await self.db.commit()
+        await self.db.refresh(target_user_info)
+        logger.info(
+            f"[merge_end_users] PG EndUserInfo 合并完成: "
+            f"target={target}, aliases_count={len(final_aliases)}, "
+            f"meta_keys={list(merged_meta.keys())}"
+        )
+
+        # ── 3. Neo4j 操作（委托给 EndUserMergeNeo4jRepository） ──
+        connector = Neo4jConnector(shared_driver=True)
+        try:
+            neo4j_repo = EndUserMergeNeo4jRepository(connector)
+            source_strs = [str(sid) for sid in source]
+            stats = await neo4j_repo.reassign_all_to_target(
+                source_strs, str(target)
+            )
+            logger.info(
+                f"[merge_end_users] Neo4j 合并完成: "
+                f"nodes={stats['nodes']}, edges={stats['edges']}"
+            )
+
+            # 同步 target 用户的 memory_count（合并后节点数已变化）
+            from app.core.memory.utils.memory_count_utils import (
+                sync_end_user_memory_count_from_neo4j,
+            )
+            new_count = await sync_end_user_memory_count_from_neo4j(
+                str(target), connector
+            )
+            logger.info(
+                f"[merge_end_users] target memory_count 同步完成: "
+                f"target={target}, count={new_count}"
+            )
+        finally:
+            await connector.close()
+
+        # ── 3.5 PG 引用表迁移：将 source 的 end_user_id 改为 target ──
+        pg_stats: dict[str, int] = {}
+        for src_id in source:
+            stats = await self.user_repo.migrate_reference_end_user_id_async(
+                src_id, target
+            )
+            for table, count in stats.items():
+                pg_stats[table] = pg_stats.get(table, 0) + count
+        if pg_stats:
+            logger.info(
+                f"[merge_end_users] PG 引用表迁移完成: {pg_stats}"
+            )
+
+        # ── 4. 软删除 source 用户 (PG is_active = False) ──
+        for src_id in source:
+            await self.user_repo.soft_delete_by_end_user_id_async(src_id)
+        logger.info(
+            f"[merge_end_users] 软删除完成: source_ids={source}"
+        )
+
+        # ── 5. 收集 workspace_id + 摊平历史合并链 + 写入新 EndUserMerge 记录 ──
+        # 所有 source 用户必须在同一 workspace（取第一个 source 的 workspace_id）
+        first_src_user = next((u for u in source_users.values() if u), None)
+        if not first_src_user:
+            raise BusinessException(message="No valid source user found.")
+        workspace_id = first_src_user.workspace_id
+
+        await self.user_repo.flatten_merge_chain_async(source, target, workspace_id)
+        if source:
+            logger.info(
+                f"[merge_end_users] 历史合并链已摊平: "
+                f"source={source} → target={target}"
+            )
+
+        for src_id in source:
+            src_user = source_users.get(src_id)
+            origin_other_id = src_user.other_id if src_user else str(src_id)
+            self.user_repo.create_merge_record(
+                origin_id=src_id,
+                origin_other_id=origin_other_id,
+                target_id=target,
+                workspace_id=workspace_id,
+            )
+
+        await self.db.commit()
+        logger.info(
+            f"[merge_end_users] 全部完成: source={source}, target={target}"
+        )
+
+        # ── 5.5 刷新 target write_time ──
+        # 合并本身不是「消息写入」，但改变了 target 的图谱数据。
+        # 刷新 write_time 确保 scan_layer2_reflection 的活跃门（_is_active_recently）
+        # 能感知到这次变更——否则 lock_timeout 时直接派发失败，scan 又因 write_time 过期
+        # 判为「不活跃」而跳过，合并后的反思就彻底丢了。
+        try:
+            from app.services.memory_reflection_service import WorkspaceAppService
+            from app.db import get_db_context
+            with get_db_context() as sync_db:
+                WorkspaceAppService(sync_db).update_end_user_write_time(str(target))
+        except Exception as e:
+            logger.warning(
+                f"[merge_end_users] 刷新 target write_time 失败（不影响合并结果）: {e}",
+                exc_info=True,
+            )
+
+        # ── 6. 触发 target 反思（合并后数据已变化，立刻做一轮去重 + 摘要） ──
+        try:
+            from app.services.memory_config_service import MemoryConfigService
+            config_svc = MemoryConfigService(self.db)
+            reflection_config_id = await config_svc.get_config_id_by_end_user_async(target)
+            if reflection_config_id:
+                from app.tasks import do_layer2_reflection
+                do_layer2_reflection.apply_async(
+                    kwargs={
+                        "end_user_id": str(target),
+                        "config_id": str(reflection_config_id),
+                        "workspace_id": str(workspace_id),
+                        "from_retry": True,  # 跳过频率/活跃检查，合并后必定反思
+                    },
+                    queue="reflection_tasks",
+                )
+                logger.info(
+                    f"[merge_end_users] 已派发 target 反思任务: target={target}, "
+                    f"config_id={reflection_config_id}"
+                )
+            else:
+                logger.warning(
+                    f"[merge_end_users] target 无可用的 memory_config，"
+                    f"跳过反思触发: target={target}"
+                )
+        except Exception as e:
+            logger.warning(
+                f"[merge_end_users] 派发反思任务失败（不影响合并结果）: {e}",
+                exc_info=True,
+            )
+
+    # ── helpers ────────────────────────────────────────────────
+
+    async def _get_end_user_any_async(
+        self, end_user_id: uuid.UUID
+    ) -> EndUser | None:
+        """获取 EndUser（不过滤 is_active），用于软删除前收集信息。"""
+        result = await self.db.execute(
+            select(EndUser).where(EndUser.id == end_user_id)
+        )
+        return result.scalars().first()

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, Any, Optional, Set
 
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
@@ -26,7 +27,7 @@ api_logger = get_api_logger()
 class WorkspaceAppService:
     """Workplace Application Service Class """
     
-    def __init__(self, db: Session):
+    def __init__(self, db: Session | AsyncSession):
         self.db = db
     
     def get_workspace_apps_detailed(self, workspace_id: str) -> Dict[str, Any]:
@@ -391,6 +392,22 @@ class WorkspaceAppService:
         except Exception as e:
             api_logger.error(f"更新用户写入时间失败，end_user_id: {end_user_id}, 错误: {str(e)}")
             self.db.rollback()
+            return False
+
+    async def update_end_user_write_time_async(self, end_user_id: str) -> bool:
+        try:
+            end_user = await EndUserRepository(self.db).get_end_user_by_id_async(uuid.UUID(end_user_id))
+            if end_user:
+                end_user.write_time = utcnow_naive()
+                await self.db.commit()
+                api_logger.info(f"成功更新用户写入时间，end_user_id: {end_user_id}")
+                return True
+            else:
+                api_logger.warning(f"未找到用户，end_user_id: {end_user_id}")
+                return False
+        except Exception as e:
+            api_logger.error(f"更新用户写入时间失败，end_user_id: {end_user_id}, 错误: {str(e)}")
+            await self.db.rollback()
             return False
 
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -2534,7 +2534,7 @@ def write_message_task(
     Returns:
         Dict containing status, result, elapsed_time, task_id
     """
-
+    loop = set_asyncio_event_loop()
     # MCP 入口兼容：收到 messages 但无 target_message 时，转换为新格式
     if target_message is None and messages:
         msg = messages[0] if messages else {"role": "user", "content": ""}
@@ -2543,32 +2543,48 @@ def write_message_task(
         context_after = []
         skip_cursor_advance = True
 
-        # RAG 存储类型走独立路径
-        if storage_type and storage_type.lower() == "rag":
-            loop = None
-            try:
-                loop = set_asyncio_event_loop()
+    # 解析 end_user_id：若排队期间用户已被合并，自动路由到目标用户
+    resolved_end_user_id = end_user_id
+    try:
+        with get_db_context() as db:
+            from app.repositories.end_user_repository import EndUserRepository
+            repo = EndUserRepository(db)
+            resolved = repo.resolve_merge_by_origin_id(uuid.UUID(end_user_id))
+            if resolved:
+                logger.info(
+                    f"[CELERY WRITE] end_user_id merged, redirecting: "
+                    f"{end_user_id} → {resolved.id}"
+                )
+                resolved_end_user_id = str(resolved.id)
+    except Exception as e:
+        logger.warning(
+            f"[CELERY WRITE] merge resolution failed for {end_user_id}: {e}, "
+            f"falling back to original ID"
+        )
 
-                async def _rag_write():
-                    from app.core.memory.memory_service import MemoryService
-                    await MemoryService.write_messages_to_rag(
-                        messages=messages,
-                        end_user_id=end_user_id,
-                        user_rag_memory_id=user_rag_memory_id,
-                    )
+    # RAG 存储类型走独立路径
+    if storage_type and storage_type.lower() == "rag":
+        try:
+            async def _rag_write():
+                from app.core.memory.memory_service import MemoryService
+                await MemoryService.write_messages_to_rag(
+                    messages=messages,
+                    end_user_id=resolved_end_user_id,
+                    user_rag_memory_id=user_rag_memory_id,
+                )
 
-                loop.run_until_complete(_rag_write())
-                return {"status": "SUCCESS", "result": "rag_write_complete", "task_id": self.request.id}
-            except Exception as e:
-                logger.error(f"[CELERY WRITE] RAG write failed: {e}", exc_info=True)
-                return {"status": "FAILURE", "error": str(e), "task_id": self.request.id}
-            finally:
-                if loop:
-                    _shutdown_loop_gracefully(loop)
+            loop.run_until_complete(_rag_write())
+            return {"status": "SUCCESS", "result": "rag_write_complete", "task_id": self.request.id}
+        except Exception as e:
+            logger.error(f"[CELERY WRITE] RAG write failed: {e}", exc_info=True)
+            return {"status": "FAILURE", "error": str(e), "task_id": self.request.id}
+        finally:
+            if loop:
+                _shutdown_loop_gracefully(loop)
 
     # 新格式：直接调用 MemoryService.write()
     logger.info(
-        f"[CELERY WRITE] Starting - end_user_id={end_user_id}, "
+        f"[CELERY WRITE] Starting - end_user_id={resolved_end_user_id}, "
         f"config_id={config_id}, conv={conversation_id or '-'}, "
         f"seq={message_seq}, language={language}"
     )
@@ -2579,7 +2595,7 @@ def write_message_task(
 
         service = MemoryService(
             config_id=uuid.UUID(config_id),
-            end_user_id=end_user_id,
+            end_user_id=resolved_end_user_id,
             workspace_id=workspace_id,
             language=language,
         )
@@ -2597,10 +2613,8 @@ def write_message_task(
         )
         return {"status": result.status, "extraction": result.extraction}
 
-    loop = None
     try:
         task_start_time = int(time.time())
-        loop = set_asyncio_event_loop()
 
         result = loop.run_until_complete(_run())
         elapsed_time = time.time() - start_time
@@ -2613,7 +2627,7 @@ def write_message_task(
             if redis_client is not None:
                 from datetime import timezone as _tz
                 _now_utc = to_iso_z(datetime.now(_tz.utc))
-                redis_client.set(f"write_message:last_done:{end_user_id}", _now_utc, ex=86400 * 30)
+                redis_client.set(f"write_message:last_done:{resolved_end_user_id}", _now_utc, ex=86400 * 30)
         except Exception as _e:
             logger.warning(f"[CELERY WRITE] 写入 last_done 时间戳失败: {_e}")
 
@@ -2625,7 +2639,7 @@ def write_message_task(
             async def _sync_count():
                 connector = Neo4jConnector()
                 try:
-                    return await sync_end_user_memory_count_from_neo4j(end_user_id, connector)
+                    return await sync_end_user_memory_count_from_neo4j(resolved_end_user_id, connector)
                 finally:
                     await connector.close()
 
@@ -2637,7 +2651,7 @@ def write_message_task(
         try:
             from app.services.memory_reflection_service import WorkspaceAppService
             with get_db_context() as db:
-                WorkspaceAppService(db).update_end_user_write_time(end_user_id)
+                WorkspaceAppService(db).update_end_user_write_time(resolved_end_user_id)
         except Exception as _wt_e:
             logger.warning(f"[CELERY WRITE] 更新 write_time 失败: {_wt_e}")
 
@@ -2730,8 +2744,27 @@ def fast_write_message_task(
     Returns:
         Dict containing status, result, task_id
     """
+    # 解析 end_user_id：若排队期间用户已被合并，自动路由到目标用户
+    resolved_end_user_id = end_user_id
+    try:
+        with get_db_context() as db:
+            from app.repositories.end_user_repository import EndUserRepository
+            repo = EndUserRepository(db)
+            resolved = repo.resolve_merge_by_origin_id(uuid.UUID(end_user_id))
+            if resolved:
+                logger.info(
+                    f"[CELERY FAST WRITE] end_user_id merged, redirecting: "
+                    f"{end_user_id} → {resolved.id}"
+                )
+                resolved_end_user_id = str(resolved.id)
+    except Exception as e:
+        logger.warning(
+            f"[CELERY FAST WRITE] merge resolution failed for {end_user_id}: {e}, "
+            f"falling back to original ID"
+        )
+
     logger.info(
-        f"[CELERY FAST WRITE] Starting - end_user_id={end_user_id}, "
+        f"[CELERY FAST WRITE] Starting - end_user_id={resolved_end_user_id}, "
         f"config_id={config_id}, conv={conversation_id or '-'}, "
         f"seq={message_seq}, language={language}, source={source or '-'}"
     )
@@ -2742,7 +2775,7 @@ def fast_write_message_task(
 
         service = MemoryService(
             config_id=uuid.UUID(config_id),
-            end_user_id=end_user_id,
+            end_user_id=resolved_end_user_id,
             workspace_id=workspace_id,
             language=language,
         )
@@ -4220,7 +4253,27 @@ def do_forget_for_user(self, end_user_id: str) -> Dict[str, Any]:
             end_user_id=end_user_id,
             workspace_id=workspace_id,
         )
-        result = await service.forget()
+
+        # 抢该用户的写锁：与反思 / 去重任务互斥，保证同一用户的图谱不被并发修改。
+        # Celery 任务线程独占 event loop，阻塞不影响其他任务，直接用同步上下文管理器。
+        sync_redis = get_sync_redis_client()
+        if sync_redis is not None:
+            write_lock = RedisFairLock(
+                key=f"memory_write:{end_user_id}",
+                redis_client=sync_redis,
+                expire=1200, timeout=60, auto_renewal=True,
+            )
+            try:
+                with write_lock:
+                    result = await service.forget()
+            except RuntimeError:
+                logger.warning(f"[ForgetDo] 获取写锁超时，跳过 user={end_user_id}")
+                if redis_client:
+                    # 移回候选集，等下一轮 scan 重新派发（与 scan_forget_candidates 派发失败的处理一致）
+                    await redis_client.smove(_FORGET_INFLIGHT_KEY, _FORGET_CANDIDATES_KEY, end_user_id)
+                return {"status": "lock_timeout"}
+        else:
+            result = await service.forget()
 
         if redis_client:
             await redis_client.srem(_FORGET_INFLIGHT_KEY, end_user_id)


### PR DESCRIPTION
## Summary by Sourcery

在持久化层和 API 中引入终端用户合并支持，确保查询和后台任务能够透明地路由到已合并的目标用户，同时整合其记忆数据。

新功能：
- 添加用于将多个终端用户合并为单一目标用户的 API 端点和服务层，包括校验和结果报告。
- 引入 `EndUserMerge` 模型和仓储逻辑，用于记录合并映射，并在查询和任务中支持从源用户到目标用户的自动路由。
- 添加 Neo4j 端的合并工具和 Cypher 查询，在用户合并时整合图节点、关系以及 User 实体属性。

缺陷修复：
- 确保受 API Key 保护的记忆端点可以通过侧通道访问认证上下文，而不会触发 FastAPI 的请求体校验错误。
- 修复记忆仪表盘配额，使其使用租户级终端用户记忆限制而不是按用户查找，从而避免易出错的批量获取。

增强改进：
- 更新终端用户仓储方法及其异步变体，在多个调用点的查询和创建流程中自动解析已合并用户。
- 调整 Celery 记忆写入和快速写入任务，在执行时解析合并后的终端用户 ID，并将解析出的 ID 传播到下游操作。
- 在忘记（forget）任务周围添加写锁，以按用户串行化图修改，防止并发反射/去重冲突。
- 统一 Neo4j 查询和搜索引擎结果构建器，使用统一的 `event_timeline` 字段替代传统的 `description_timeline`/`events` 属性。
- 扩展终端用户信息仓储以支持异步会话，并改进合并时的别名和元数据整合。
- 优化消息反馈和草稿终端用户解析逻辑，复用理解合并映射的仓储辅助方法。
- 简化 Neo4j 索引管理，将单列 `end_user_id` 索引与复合索引创建分离，并明确它们各自的查询覆盖范围。

杂项：
- 对仓储和导入进行小幅清理，标准化异步会话的使用，并为新的合并功能整理模型导出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce end-user merge support across persistence layers and APIs, ensuring queries and background tasks transparently route to merged target users while consolidating their memory data.

New Features:
- Add an API endpoint and service layer for merging multiple end users into a single target, including validation and result reporting.
- Introduce an EndUserMerge model and repository logic to record merge mappings and support automatic routing from source to target users in queries and tasks.
- Add Neo4j-side merge utilities and Cypher queries to consolidate graph nodes, relationships, and User entity attributes when users are merged.

Bug Fixes:
- Ensure API-key protected memory endpoints can access authentication context via a side-channel without triggering FastAPI body validation errors.
- Fix memory dashboard quotas to use tenant-level end-user memory limits instead of per-user lookups, avoiding error-prone batch fetching.

Enhancements:
- Update end-user repository methods and async variants to resolve merged users automatically for lookups and creation flows across multiple call sites.
- Adjust Celery memory write and fast-write tasks to resolve merged end-user IDs at execution time and propagate the resolved ID through downstream operations.
- Add write-locking around forget tasks to serialize graph modifications per user and prevent concurrent reflection/deduplication conflicts.
- Align Neo4j queries and search-engine result builders to use the unified event_timeline field instead of legacy description_timeline/events properties.
- Extend end-user info repository to support async sessions and improve merge-time alias and metadata consolidation.
- Refine message feedback and draft end-user resolution logic to reuse repository helpers that understand merge mappings.
- Simplify Neo4j index management by separating single-column end_user_id indexes from composite index creation and clarifying their respective query coverage.

Chores:
- Minor repository and import cleanups to standardize async session usage and model exports for the new merge functionality.

</details>