### PR TITLE
feat(rag): store MinerU images as knowledge assets

### DIFF
--- a/api/app/controllers/document_controller.py
+++ b/api/app/controllers/document_controller.py
@@ -19,6 +19,7 @@ from app.core.rag.knowledge_graph.dispatch import (
     dispatch_document_graph_sync,
     enqueue_document_graph_sync,
 )
+from app.core.rag.chunk.parser.image_storage import cleanup_mineru_v3_images
 from app.core.rag.utils.redis_conn import REDIS_CONN
 from app.core.rag.vdb.elasticsearch.elasticsearch_vector import (
     ElasticSearchVectorFactory,
@@ -400,6 +401,14 @@ async def delete_document(
         )
 
         # 5. Delete file (storage errors are swallowed internally)
+        try:
+            await asyncio.to_thread(
+                cleanup_mineru_v3_images,
+                document_id,
+                storage_service=storage_service,
+            )
+        except Exception:
+            api_logger.warning("Failed to delete derived image assets: document_id=%s", document_id, exc_info=True)
         await _delete_file_record_async(db=db, file_id=file_id, storage_service=storage_service)
 
         # 6. Delete metadata bindings (app-level cleanup, FK no longer has CASCADE)

--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -14,7 +14,8 @@ from app.core.logging_config import get_api_logger
 from app.core.response_utils import success
 from app.db import get_db
 from app.dependencies import get_current_user
-from app.models import file_model
+from app.models import document_model, file_model
+from app.core.rag.chunk.parser.image_storage import cleanup_mineru_v3_images
 from app.models.user_model import User
 from app.schemas import file_schema, document_schema
 from app.schemas.response_schema import ApiResponse
@@ -58,7 +59,10 @@ async def get_files(
     if page < 1 or pagesize < 1:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The paging parameter must be greater than 0")
 
-    filters = [file_model.File.kb_id == kb_id]
+    filters = [
+        file_model.File.kb_id == kb_id,
+        file_model.File.file_role == file_model.FILE_ROLE_SOURCE,
+    ]
     if parent_id:
         filters.append(file_model.File.parent_id == parent_id)
     if keywords:
@@ -276,7 +280,8 @@ async def batch_download_files(
     """
 
     files = db.query(file_model.File).filter(
-        file_model.File.id.in_(request_body.file_ids)
+        file_model.File.id.in_(request_body.file_ids),
+        file_model.File.file_role == file_model.FILE_ROLE_SOURCE,
     ).all()
 
     if not files:
@@ -371,6 +376,11 @@ async def _delete_file(
     if db_file.file_ext == 'folder':
         # For folders, delete all child files from storage first
         child_files = db.query(file_model.File).filter(file_model.File.parent_id == db_file.id).all()
+        source_file_ids = [
+            child.id
+            for child in child_files
+            if child.file_role == file_model.FILE_ROLE_SOURCE
+        ]
         for child in child_files:
             if child.file_key:
                 try:
@@ -379,11 +389,33 @@ async def _delete_file(
                     api_logger.warning(f"Failed to delete child file from storage: {child.file_key} - {e}")
         db.query(file_model.File).filter(file_model.File.parent_id == db_file.id).delete()
     else:
+        source_file_ids = [db_file.id] if db_file.file_role == file_model.FILE_ROLE_SOURCE else []
         if db_file.file_key:
             try:
                 await storage_service.delete_file(db_file.file_key)
             except Exception as e:
                 api_logger.warning(f"Failed to delete file from storage: {db_file.file_key} - {e}")
+
+    if source_file_ids:
+        document_ids = [
+            document_id
+            for (document_id,) in db.query(document_model.Document.id).filter(
+                document_model.Document.file_id.in_(source_file_ids)
+            ).all()
+        ]
+        for document_id in document_ids:
+            try:
+                await asyncio.to_thread(
+                    cleanup_mineru_v3_images,
+                    document_id,
+                    storage_service=storage_service,
+                )
+            except Exception:
+                api_logger.warning(
+                    "Failed to delete derived image assets: document_id=%s",
+                    document_id,
+                    exc_info=True,
+                )
 
     db.delete(db_file)
     db.commit()

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -534,6 +534,7 @@ async def kb_batch_download(
         files_result = await db.execute(
             select(file_model.File).where(
                 file_model.File.kb_id == kb_id,
+                file_model.File.file_role == file_model.FILE_ROLE_SOURCE,
                 file_model.File.file_key.isnot(None),
                 file_model.File.file_key != "",
             )

--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -5,23 +5,30 @@ from typing import Any, Callable
 
 from app.core.rag.nlp import rag_tokenizer
 
-
 DEFAULT_PARSER_CONFIG = {
     "layout_recognize": "DeepDOC",
     "chunk_token_num": 512,
     "delimiter": "\n!?。；！？",
     "analyze_hyperlink": True,
-    "image_vision_enabled": True,
 }
 
 
-def is_image_vision_enabled(parser_config: dict | None) -> bool:
-    raw_value = (parser_config or {}).get("image_vision_enabled", True)
+def _scoped_vision_enabled(parser_config: dict | None, scope: str) -> bool:
+    scope_config = (parser_config or {}).get(scope)
+    raw_value = scope_config.get("vision_enabled", True) if isinstance(scope_config, dict) else True
     if isinstance(raw_value, bool):
         return raw_value
     if isinstance(raw_value, str):
         return raw_value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(raw_value)
+
+
+def is_embedded_image_vision_enabled(parser_config: dict | None) -> bool:
+    return _scoped_vision_enabled(parser_config, "embedded_image")
+
+
+def is_direct_image_vision_enabled(parser_config: dict | None) -> bool:
+    return _scoped_vision_enabled(parser_config, "image")
 
 
 class ChunkOutputMode(str, Enum):

--- a/api/app/core/rag/chunk/parser/image_storage.py
+++ b/api/app/core/rag/chunk/parser/image_storage.py
@@ -3,17 +3,30 @@ import logging
 import threading
 import uuid
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from app.core.config import settings
 from app.core.rag.chunk.parser.mineru_v3_client import MinerUV3Image
 from app.db import get_db_context
-from app.models.file_metadata_model import FileMetadata
-from app.services.file_storage_service import FileStorageService, generate_file_key
-
+from app.models.document_model import Document
+from app.models.file_model import FILE_ROLE_DERIVED_IMAGE, File
+from app.services.file_storage_service import FileStorageService, generate_kb_file_key
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StoredMinerUImageAsset:
+    file_id: uuid.UUID
+    download_url: str
+
+
+@dataclass(frozen=True)
+class _DocumentFileContext:
+    kb_id: uuid.UUID
+    created_by: uuid.UUID
 
 
 def store_mineru_v3_image(
@@ -26,7 +39,7 @@ def store_mineru_v3_image(
     source_file_name: str | None = None,
     source_src: str,
     storage_service: FileStorageService | None = None,
-) -> dict[str, str]:
+) -> StoredMinerUImageAsset | None:
     tenant_uuid = _parse_uuid(tenant_id)
     workspace_uuid = _parse_uuid(workspace_id)
     document_uuid = _parse_uuid(document_id)
@@ -38,7 +51,7 @@ def store_mineru_v3_image(
             document_id,
             source_src,
         )
-        return {}
+        return None
 
     file_id = _stable_image_file_id(
         tenant_id=tenant_uuid,
@@ -47,57 +60,40 @@ def store_mineru_v3_image(
         source_file_id=source_file_uuid,
         source_src=source_src,
     )
+    document_context = _load_document_file_context(document_uuid)
+    if document_context is None:
+        LOGGER.warning("[MinerUV3] image storage skipped: document not found document_id=%s", document_uuid)
+        return None
+
     file_ext = _normalize_file_ext(mineru_image.file_ext)
     file_name = _build_file_name(source_file_name, mineru_image.name or source_src, file_ext)
-    file_key = generate_file_key(tenant_uuid, workspace_uuid, file_id, file_ext)
+    file_key = generate_kb_file_key(document_context.kb_id, file_id, file_ext)
     storage_service = storage_service or FileStorageService()
 
-    _upsert_file_metadata(
+    _run_async(
+        lambda: storage_service.storage.upload(
+            file_key=file_key,
+            content=mineru_image.binary,
+            content_type=mineru_image.content_type,
+        )
+    )
+    _upsert_derived_image_file(
         file_id=file_id,
-        tenant_id=tenant_uuid,
-        workspace_id=workspace_uuid,
+        kb_id=document_context.kb_id,
+        created_by=document_context.created_by,
+        source_document_id=document_uuid,
         file_key=file_key,
         file_name=file_name,
         file_ext=file_ext,
         file_size=len(mineru_image.binary),
-        content_type=mineru_image.content_type,
-        status="pending",
+        file_role=FILE_ROLE_DERIVED_IMAGE,
     )
-    try:
-        uploaded_key = _run_async(
-            lambda: storage_service.upload_file(
-                tenant_id=tenant_uuid,
-                workspace_id=workspace_uuid,
-                file_id=file_id,
-                file_ext=file_ext,
-                content=mineru_image.binary,
-                content_type=mineru_image.content_type,
-            )
-        )
-    except Exception:
-        _mark_file_metadata_failed(file_id)
-        raise
-
-    _upsert_file_metadata(
-        file_id=file_id,
-        tenant_id=tenant_uuid,
-        workspace_id=workspace_uuid,
-        file_key=uploaded_key,
-        file_name=file_name,
-        file_ext=file_ext,
-        file_size=len(mineru_image.binary),
-        content_type=mineru_image.content_type,
-        status="completed",
-    )
-    return {
-        "image_file_id": str(file_id),
-        "image_download_url": _build_image_download_url(file_id),
-    }
+    return StoredMinerUImageAsset(file_id=file_id, download_url=_build_image_download_url(file_id))
 
 
 def _build_image_download_url(file_id: uuid.UUID) -> str:
     server_url = (settings.FILE_LOCAL_SERVER_URL or "").rstrip("/")
-    path = f"/storage/permanent/{file_id}"
+    path = f"/files/{file_id}"
     if not server_url:
         return path
     return f"{server_url}{path}"
@@ -151,54 +147,101 @@ def _build_file_name(source_file_name: str | None, image_name: str, file_ext: st
     return f"{stem[:max_stem_length]}{file_ext}"
 
 
-def _upsert_file_metadata(
+def _load_document_file_context(document_id: uuid.UUID) -> _DocumentFileContext | None:
+    with get_db_context() as db:
+        document = db.get(Document, document_id)
+        if document is None:
+            return None
+        return _DocumentFileContext(kb_id=document.kb_id, created_by=document.created_by)
+
+
+def _upsert_derived_image_file(
     *,
     file_id: uuid.UUID,
-    tenant_id: uuid.UUID,
-    workspace_id: uuid.UUID | None,
+    kb_id: uuid.UUID,
+    created_by: uuid.UUID,
+    source_document_id: uuid.UUID,
     file_key: str,
     file_name: str,
     file_ext: str,
     file_size: int,
-    content_type: str | None,
-    status: str,
+    file_role: str,
 ) -> None:
     with get_db_context() as db:
-        record = db.get(FileMetadata, file_id)
+        record = db.get(File, file_id)
         if record is None:
-            record = FileMetadata(
+            record = File(
                 id=file_id,
-                tenant_id=tenant_id,
-                workspace_id=workspace_id,
+                kb_id=kb_id,
+                created_by=created_by,
+                parent_id=None,
                 file_key=file_key,
                 file_name=file_name,
                 file_ext=file_ext,
                 file_size=file_size,
-                content_type=content_type,
-                status=status,
+                file_role=file_role,
+                source_document_id=source_document_id,
             )
             db.add(record)
         else:
-            record.tenant_id = tenant_id
-            record.workspace_id = workspace_id
+            record.kb_id = kb_id
+            record.created_by = created_by
+            record.parent_id = None
             record.file_key = file_key
             record.file_name = file_name
             record.file_ext = file_ext
             record.file_size = file_size
-            record.content_type = content_type
-            record.status = status
+            record.file_role = file_role
+            record.source_document_id = source_document_id
         db.commit()
 
 
-def _mark_file_metadata_failed(file_id: uuid.UUID) -> None:
-    try:
-        with get_db_context() as db:
-            record = db.get(FileMetadata, file_id)
-            if record is not None:
-                record.status = "failed"
-                db.commit()
-    except Exception:
-        LOGGER.warning("[MinerUV3] failed to mark image metadata as failed: file_id=%s", file_id, exc_info=True)
+def cleanup_mineru_v3_images(
+    document_id: uuid.UUID,
+    retained_file_ids: set[uuid.UUID] | None = None,
+    storage_service: FileStorageService | None = None,
+) -> int:
+    retained_file_ids = retained_file_ids or set()
+    with get_db_context() as db:
+        query = db.query(File).filter(
+            File.source_document_id == document_id,
+            File.file_role == FILE_ROLE_DERIVED_IMAGE,
+        )
+        candidates = [
+            (record.id, record.file_key)
+            for record in query.all()
+            if record.id not in retained_file_ids
+        ]
+
+    if not candidates:
+        return 0
+
+    storage_service = storage_service or FileStorageService()
+    deleted_ids: list[uuid.UUID] = []
+    for file_id, file_key in candidates:
+        try:
+            if file_key:
+                _run_async(lambda file_key=file_key: storage_service.delete_file(file_key))
+            deleted_ids.append(file_id)
+        except Exception:
+            LOGGER.warning(
+                "[MinerUV3] failed to delete derived image asset: document_id=%s file_id=%s",
+                document_id,
+                file_id,
+                exc_info=True,
+            )
+
+    if not deleted_ids:
+        return 0
+
+    with get_db_context() as db:
+        db.query(File).filter(
+            File.id.in_(deleted_ids),
+            File.source_document_id == document_id,
+            File.file_role == FILE_ROLE_DERIVED_IMAGE,
+        ).delete(synchronize_session=False)
+        db.commit()
+    return len(deleted_ids)
 
 
 def _run_async(coro_factory: Callable[[], Coroutine[Any, Any, Any]]) -> Any:

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -1,13 +1,16 @@
 import logging
 from pathlib import Path
 
-from app.core.rag.chunk.context import ParsedBlockType, ParseResult, is_image_vision_enabled
+from app.core.rag.chunk.context import (
+    ParsedBlockType,
+    ParseResult,
+    is_embedded_image_vision_enabled,
+)
 from app.core.rag.chunk.parser.base import DocumentParser
-from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.image_storage import store_mineru_v3_image
+from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.mineru_v3_client import MinerUV3Client
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,27 +22,27 @@ class MinerUV3Parser(DocumentParser):
     def parse(self, ctx) -> ParseResult:
         binary = self._read_binary(ctx)
 
-        image_vision_enabled = is_image_vision_enabled(ctx.parser_config)
+        embedded_image_vision_enabled = is_embedded_image_vision_enabled(ctx.parser_config)
         mineru_result = self.client.parse(
             file_name=ctx.filename,
             binary=binary,
             start_page_id=ctx.from_page,
             end_page_id=ctx.to_page,
             callback=ctx.callback,
-            return_images=image_vision_enabled,
+            return_images=embedded_image_vision_enabled,
         )
         blocks = StructMarkdownParser().parse_text(
             mineru_result.markdown,
             normalize_escaped_structure=True,
         )
-        if image_vision_enabled:
+        if embedded_image_vision_enabled:
             attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
             LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
             self._store_image_assets(attached_images, ctx)
         else:
             LOGGER.info("[MinerUV3] image block processing disabled by parser config")
 
-        if ctx.vision_model and image_vision_enabled:
+        if ctx.vision_model and embedded_image_vision_enabled:
             self._enhance_image_blocks(blocks, ctx)
         elif ctx.vision_model:
             LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from pathlib import Path
 
 from app.core.rag.chunk.context import (
@@ -7,7 +8,10 @@ from app.core.rag.chunk.context import (
     is_embedded_image_vision_enabled,
 )
 from app.core.rag.chunk.parser.base import DocumentParser
-from app.core.rag.chunk.parser.image_storage import store_mineru_v3_image
+from app.core.rag.chunk.parser.image_storage import (
+    cleanup_mineru_v3_images,
+    store_mineru_v3_image,
+)
 from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.mineru_v3_client import MinerUV3Client
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
@@ -36,11 +40,19 @@ class MinerUV3Parser(DocumentParser):
             normalize_escaped_structure=True,
         )
         if embedded_image_vision_enabled:
-            attached_count, attached_images = self._attach_images(blocks, mineru_result.images)
+            attached_count, attached_images, unresolved_count = self._attach_images(blocks, mineru_result.images)
             LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
-            self._store_image_assets(attached_images, ctx)
+            retained_file_ids, all_assets_stored = self._store_image_assets(attached_images, ctx)
+            all_assets_stored = all_assets_stored and unresolved_count == 0
         else:
             LOGGER.info("[MinerUV3] image block processing disabled by parser config")
+            retained_file_ids = set()
+            all_assets_stored = True
+
+        if all_assets_stored:
+            self._cleanup_stale_image_assets(ctx, retained_file_ids)
+        else:
+            LOGGER.warning("[MinerUV3] stale image cleanup skipped because one or more image assets were not stored")
 
         if ctx.vision_model and embedded_image_vision_enabled:
             self._enhance_image_blocks(blocks, ctx)
@@ -69,6 +81,7 @@ class MinerUV3Parser(DocumentParser):
     def _attach_images(self, blocks, images):
         attached_count = 0
         attached_images = []
+        unresolved_count = 0
         for block in blocks:
             if block.type is not ParsedBlockType.IMAGE:
                 continue
@@ -76,24 +89,26 @@ class MinerUV3Parser(DocumentParser):
             mineru_image = images.get(Path(src).name)
             if mineru_image is None:
                 LOGGER.warning("[MinerUV3] markdown image not found in payload: src=%s", src)
+                unresolved_count += 1
                 continue
             block.image = mineru_image.image
             attached_images.append((block, mineru_image, src))
             attached_count += 1
-        return attached_count, attached_images
+        return attached_count, attached_images, unresolved_count
 
-    def _store_image_assets(self, attached_images, ctx) -> None:
+    def _store_image_assets(self, attached_images, ctx) -> tuple[set[uuid.UUID], bool]:
         total = len(attached_images)
         if total == 0:
-            return
+            return set(), True
 
         LOGGER.info("[MinerUV3] image storage start: total=%s", total)
         self._callback(ctx, 0.74, f"MinerU V3 image storage start: total={total}.")
         stored_count = 0
         failed_count = 0
+        stored_file_ids: set[uuid.UUID] = set()
         for index, (block, mineru_image, src) in enumerate(attached_images, start=1):
             try:
-                asset_metadata = store_mineru_v3_image(
+                asset = store_mineru_v3_image(
                     mineru_image=mineru_image,
                     tenant_id=ctx.kwargs.get("tenant_id"),
                     workspace_id=ctx.kwargs.get("workspace_id"),
@@ -102,6 +117,10 @@ class MinerUV3Parser(DocumentParser):
                     source_file_name=ctx.kwargs.get("source_file_name") or ctx.filename,
                     source_src=src,
                 )
+                if asset is None:
+                    raise ValueError("image asset was not created")
+                self._replace_image_markdown_url(block, asset.download_url)
+                stored_file_ids.add(asset.file_id)
             except Exception as exc:
                 failed_count += 1
                 LOGGER.warning(
@@ -113,28 +132,46 @@ class MinerUV3Parser(DocumentParser):
                 )
                 self._callback(ctx, 0.74 + (0.03 * index / total), f"MinerU V3 image storage failed: {index}/{total}.")
                 continue
-            if asset_metadata:
-                block.metadata.update(asset_metadata)
-                self._replace_image_markdown_url(block, asset_metadata.get("image_download_url"))
-                stored_count += 1
-                LOGGER.info(
-                    "[MinerUV3] image stored: index=%s total=%s file_id=%s content_type=%s size=%s",
-                    index,
-                    total,
-                    asset_metadata.get("image_file_id"),
-                    mineru_image.content_type,
-                    len(mineru_image.binary),
-                )
+            stored_count += 1
+            LOGGER.info(
+                "[MinerUV3] image stored: index=%s total=%s file_id=%s content_type=%s size=%s",
+                index,
+                total,
+                asset.file_id,
+                mineru_image.content_type,
+                len(mineru_image.binary),
+            )
             self._callback(ctx, 0.74 + (0.03 * index / total), f"MinerU V3 image storage: {index}/{total}.")
 
         LOGGER.info("[MinerUV3] image storage summary: total=%s stored=%s failed=%s", total, stored_count, failed_count)
         self._callback(ctx, 0.77, f"MinerU V3 images stored: stored={stored_count}, failed={failed_count}.")
+        return stored_file_ids, failed_count == 0 and stored_count == total
 
     def _replace_image_markdown_url(self, block, image_url: str | None) -> None:
         if not image_url:
             return
         alt = str(block.metadata.get("alt") or "")
         block.content = f"![{alt}]({image_url})"
+        block.metadata["src"] = image_url
+
+    def _cleanup_stale_image_assets(self, ctx, retained_file_ids: set[uuid.UUID]) -> None:
+        document_id = ctx.kwargs.get("document_id")
+        try:
+            document_uuid = document_id if isinstance(document_id, uuid.UUID) else uuid.UUID(str(document_id))
+        except (TypeError, ValueError):
+            LOGGER.warning("[MinerUV3] stale image cleanup skipped: invalid document_id=%s", document_id)
+            return
+        try:
+            deleted_count = cleanup_mineru_v3_images(document_uuid, retained_file_ids)
+        except Exception:
+            LOGGER.warning(
+                "[MinerUV3] stale image cleanup failed: document_id=%s",
+                document_uuid,
+                exc_info=True,
+            )
+            return
+        if deleted_count:
+            LOGGER.info("[MinerUV3] stale image assets deleted: document_id=%s count=%s", document_uuid, deleted_count)
 
     def _enhance_image_blocks(self, blocks, ctx) -> None:
         enhance_image_blocks_with_vision(

--- a/api/app/core/rag/chunk/parser/pdf/deepdoc.py
+++ b/api/app/core/rag/chunk/parser/pdf/deepdoc.py
@@ -1,8 +1,8 @@
 import logging
 from timeit import default_timer as timer
 
+from app.core.rag.chunk.context import is_embedded_image_vision_enabled
 from app.core.rag.chunk.parser.base import DocumentParser
-from app.core.rag.chunk.context import is_image_vision_enabled
 from app.core.rag.deepdoc.parser import PdfParser
 from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_pdf_wrapper
 
@@ -18,7 +18,7 @@ class DeepDocPdfParser(PdfParser, DocumentParser):
         tables = vision_figure_parser_pdf_wrapper(
             tbls=tables,
             callback=ctx.callback,
-            vision_model=ctx.vision_model if is_image_vision_enabled(ctx.parser_config) else None,
+            vision_model=ctx.vision_model if is_embedded_image_vision_enabled(ctx.parser_config) else None,
             **ctx.kwargs,
         )
         return sections, tables, self

--- a/api/app/core/rag/chunk/parser/pdf/plain.py
+++ b/api/app/core/rag/chunk/parser/pdf/plain.py
@@ -1,5 +1,4 @@
 from app.core.rag.chunk.parser.base import DocumentParser
-from app.core.rag.chunk.context import is_image_vision_enabled
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
 
 
@@ -9,7 +8,7 @@ class PlainPdfParser(DocumentParser):
         if isinstance(layout_recognizer, bool):
             layout_recognizer = "DeepDOC" if layout_recognizer else "Plain Text"
 
-        if layout_recognizer == "Plain Text" or not is_image_vision_enabled(ctx.parser_config):
+        if layout_recognizer == "Plain Text":
             pdf_parser = PlainParser()
         else:
             pdf_parser = VisionParser(vision_model=ctx.vision_model, **ctx.kwargs)

--- a/api/app/core/rag/chunk/parser/pdf/selector.py
+++ b/api/app/core/rag/chunk/parser/pdf/selector.py
@@ -1,6 +1,6 @@
 import os
 
-from app.core.rag.chunk.context import is_image_vision_enabled
+from app.core.rag.chunk.context import is_embedded_image_vision_enabled
 from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_pdf_wrapper
 from app.core.rag.deepdoc.parser.mineru_parser import MinerUParser
 from app.core.rag.deepdoc.parser.pdf_parser import PlainParser, VisionParser
@@ -10,7 +10,7 @@ from .textln import TextLnParser
 
 
 def _image_vision_model(vision_model, parser_config):
-    if is_image_vision_enabled(parser_config):
+    if is_embedded_image_vision_enabled(parser_config):
         return vision_model
     return None
 
@@ -71,7 +71,7 @@ def by_textln(filename, binary=None, from_page=0, to_page=100000, lang="Chinese"
 
 
 def by_plaintext(filename, binary=None, from_page=0, to_page=100000, callback=None, vision_model=None, **kwargs):
-    if kwargs.get("layout_recognizer", "") == "Plain Text" or not is_image_vision_enabled(kwargs.get("parser_config")):
+    if kwargs.get("layout_recognizer", "") == "Plain Text":
         pdf_parser = PlainParser()
     else:
         pdf_parser = VisionParser(vision_model=vision_model, **kwargs)

--- a/api/app/core/rag/chunk/pipeline/docx.py
+++ b/api/app/core/rag/chunk/pipeline/docx.py
@@ -1,13 +1,16 @@
 import logging
 
-from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_docx_wrapper
+from app.core.rag.chunk.context import (
+    ChunkContext,
+    ParseResult,
+    is_embedded_image_vision_enabled,
+)
 from app.core.rag.chunk.parser.docx import DocxParser
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
+from app.core.rag.deepdoc.parser.figure_parser import vision_figure_parser_docx_wrapper
 from app.core.rag.utils.file_utils import extract_html, extract_links_from_docx
 
-from app.core.rag.chunk.context import ChunkContext, ParseResult, is_image_vision_enabled
 from .base import ChunkPipeline
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +43,7 @@ class DocxChunkPipeline(ChunkPipeline):
             sections=sections,
             tbls=tables,
             callback=ctx.callback,
-            vision_model=ctx.vision_model if is_image_vision_enabled(ctx.parser_config) else None,
+            vision_model=ctx.vision_model if is_embedded_image_vision_enabled(ctx.parser_config) else None,
             **ctx.kwargs,
         )
         ctx.callback(0.8, "Finish parsing.")

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -172,7 +172,7 @@ class ImageChunkPipeline(ChunkPipeline):
 
     def _source_file_url(self, source_file_id) -> str:
         server_url = (settings.FILE_LOCAL_SERVER_URL or "").rstrip("/")
-        path = f"/storage/permanent/{source_file_id}"
+        path = f"/files/{source_file_id}"
         return f"{server_url}{path}" if server_url else path
 
     def _has_content(self, blocks: list[ParsedBlock]) -> bool:

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -13,6 +13,7 @@ from app.core.rag.chunk.context import (
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
+    is_direct_image_vision_enabled,
 )
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
@@ -29,12 +30,19 @@ class ImageChunkPipeline(ChunkPipeline):
     """Parse directly uploaded images without changing embedded-image pipelines."""
 
     def parse(self, ctx: ChunkContext) -> ParseResult:
-        mode = self._image_vision_mode(ctx)
         source_file_id = self._source_file_id(ctx)
+        self._callback(ctx, 0.1, "Start to parse image.")
+
+        if not is_direct_image_vision_enabled(ctx.parser_config):
+            source_markdown, source_image_url = self._source_image_markdown(ctx, source_file_id)
+            blocks, _ = self._parse_markdown_blocks(source_markdown, source_image_url)
+            self._callback(ctx, 0.8, "Finish parsing image.")
+            return ParseResult(blocks=blocks, merge_strategy="blocks")
+
+        mode = self._image_vision_mode(ctx)
         source_binary = self._read_binary(ctx)
         analysis_binary, analysis_filename, source_image = self._analysis_input(ctx.filename, source_binary)
 
-        self._callback(ctx, 0.1, "Start to parse image.")
         mineru_markdown = ""
         if mode in {0, 1}:
             mineru_markdown = self._parse_ocr_markdown(ctx, analysis_binary, analysis_filename)
@@ -73,9 +81,10 @@ class ImageChunkPipeline(ChunkPipeline):
         return ParseResult(blocks=blocks, merge_strategy="blocks")
 
     def _image_vision_mode(self, ctx: ChunkContext) -> int:
-        raw_mode = ctx.parser_config.get("image_vision_mode", DEFAULT_IMAGE_VISION_MODE)
+        image_config = ctx.parser_config.get("image")
+        raw_mode = image_config.get("vision_mode", DEFAULT_IMAGE_VISION_MODE) if isinstance(image_config, dict) else DEFAULT_IMAGE_VISION_MODE
         if type(raw_mode) is not int or raw_mode not in IMAGE_VISION_MODES:
-            raise ValueError("parser_config.image_vision_mode must be an integer in {0, 1, 2}.")
+            raise ValueError("parser_config.image.vision_mode must be an integer in {0, 1, 2}.")
         return raw_mode
 
     def _read_binary(self, ctx: ChunkContext) -> bytes:
@@ -104,13 +113,10 @@ class ImageChunkPipeline(ChunkPipeline):
         analysis_binary: bytes,
         analysis_filename: str,
     ) -> str:
-        parser_config = dict(ctx.parser_config)
-        parser_config["image_vision_enabled"] = False
         ocr_ctx = replace(
             ctx,
             filename=analysis_filename,
             binary=analysis_binary,
-            parser_config=parser_config,
         )
         markdown = MinerUV3Parser().parse_markdown(ocr_ctx)
         if not markdown or not markdown.strip():

--- a/api/app/core/rag/chunk/pipeline/text.py
+++ b/api/app/core/rag/chunk/pipeline/text.py
@@ -7,7 +7,7 @@ from app.core.rag.chunk.context import (
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
-    is_image_vision_enabled,
+    is_embedded_image_vision_enabled,
 )
 from app.core.rag.chunk.parser.html import HtmlParser
 from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
@@ -46,7 +46,7 @@ class MarkdownChunkPipeline(ChunkPipeline):
         markdown_parser = StructMarkdownParser()
         blocks = markdown_parser.parse(ctx)
 
-        if ctx.vision_model and is_image_vision_enabled(ctx.parser_config):
+        if ctx.vision_model and is_embedded_image_vision_enabled(ctx.parser_config):
             for block in blocks:
                 if block.type is not ParsedBlockType.IMAGE:
                     continue

--- a/api/app/models/file_model.py
+++ b/api/app/models/file_model.py
@@ -1,9 +1,14 @@
-import datetime
 import uuid
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+
+from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
-from app.db import Base
+
 from app.core.utils.datetime_utils import utcnow_naive
+from app.db import Base
+
+FILE_ROLE_SOURCE = "source"
+FILE_ROLE_DERIVED_IMAGE = "derived_image"
+
 
 class File(Base):
     __tablename__ = "files"
@@ -17,4 +22,18 @@ class File(Base):
     file_size = Column(Integer, default=0, comment="file size(byte)")
     file_url = Column(String, index=True, nullable=True, comment="file comes from a website url")
     file_key = Column(String(512), nullable=True, index=True, comment="storage file key for FileStorageService")
+    file_role = Column(
+        String(32),
+        nullable=False,
+        default=FILE_ROLE_SOURCE,
+        server_default=FILE_ROLE_SOURCE,
+        index=True,
+        comment="source or derived_image",
+    )
+    source_document_id = Column(
+        UUID(as_uuid=True),
+        nullable=True,
+        index=True,
+        comment="documents.id for a derived image asset",
+    )
     created_at = Column(DateTime, default=utcnow_naive)

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -27,6 +27,7 @@ from app.core.logging_config import get_logger
 from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.memory.storage_services.reflection_engine import retry_registry as rr
 from app.core.rag.chunk.metadata import merge_parser_metadata
+from app.core.rag.chunk.parser.image_storage import cleanup_mineru_v3_images
 from app.core.rag.crawler.web_crawler import WebCrawler
 from app.core.rag.graphrag.general.index import init_graphrag, run_graphrag_for_kb
 from app.core.rag.graphrag.utils import get_llm_cache, set_llm_cache
@@ -86,6 +87,7 @@ from app.core.utils.datetime_utils import (
 )
 from app.db import get_db_context, get_db_read
 from app.models import App, AppRelease, Document, File, Knowledge, User, Workspace
+from app.models.file_model import FILE_ROLE_SOURCE
 from app.models.end_user_model import EndUser
 from app.models.models_model import ModelType
 from app.repositories.end_user_repository import get_end_users_by_workspace
@@ -2074,11 +2076,21 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
 
     def _get_existing_files(kb_uuid: uuid.UUID) -> list[dict]:
         with get_db_context() as db:
-            return [_snapshot_file(db_file) for db_file in db.query(File).filter(File.kb_id == kb_uuid).all()]
+            return [
+                _snapshot_file(db_file)
+                for db_file in db.query(File).filter(
+                    File.kb_id == kb_uuid,
+                    File.file_role == FILE_ROLE_SOURCE,
+                ).all()
+            ]
 
     def _get_file_by_url(kb_uuid: uuid.UUID, file_url: str) -> dict | None:
         with get_db_context() as db:
-            db_file = db.query(File).filter(File.kb_id == kb_uuid, File.file_url == file_url).first()
+            db_file = db.query(File).filter(
+                File.kb_id == kb_uuid,
+                File.file_role == FILE_ROLE_SOURCE,
+                File.file_url == file_url,
+            ).first()
             return _snapshot_file(db_file) if db_file else None
 
     def _create_file_record(
@@ -2194,7 +2206,11 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
     def _delete_stale_files(kb_uuid: uuid.UUID, file_urls: set, vector_service):
         with get_db_context() as db:
             stale_files = []
-            db_files = db.query(File).filter(File.kb_id == kb_uuid, File.file_url.notin_(file_urls)).all()
+            db_files = db.query(File).filter(
+                File.kb_id == kb_uuid,
+                File.file_role == FILE_ROLE_SOURCE,
+                File.file_url.notin_(file_urls),
+            ).all()
             for db_file in db_files:
                 db_document = db.query(Document).filter(Document.kb_id == kb_uuid,
                                                         Document.file_id == db_file.id).first()
@@ -2206,6 +2222,14 @@ def sync_knowledge_for_kb(kb_id: uuid.UUID):
             document_id = file_state.get("document_id")
             if document_id:
                 vector_service.delete_by_metadata_field(key="document_id", value=str(document_id))
+                try:
+                    cleanup_mineru_v3_images(document_id)
+                except Exception:
+                    logger.warning(
+                        "[SyncKB] failed to delete derived image assets: document_id=%s",
+                        document_id,
+                        exc_info=True,
+                    )
             if file_state.get("file_key"):
                 from app.services.file_storage_service import FileStorageService
 


### PR DESCRIPTION
## Business Background
MinerU-extracted images were stored through the generic FileMetadata path, while direct image chunks used a URL namespace that did not match knowledge-base files. This prevented unified knowledge-base ownership and lifecycle management.

## Summary
- Store MinerU-derived images as derived assets in the knowledge-base files table.
- Serve direct and derived image Markdown through the knowledge-base file endpoint.
- Keep derived assets out of file listings and ZIP exports, and clean them on successful reparse or source cleanup.
- Scope direct-image and embedded-document vision configuration independently.

## Changes
- 14 RAG backend files changed across parsing, asset storage, file lifecycle, and parser configuration.

## Risk
- Adds files.file_role and files.source_document_id; environment Alembic autogeneration is required before deployment.
- Existing FileMetadata assets are intentionally not migrated.
- No frontend, V1 route, audio, or video behavior is changed.

## Test Plan
- [x] NEO4J_PASSWORD=test-password PYTHONPATH=. .venv/bin/pytest tests/core/rag/chunk/test_knowledge_image_assets.py tests/core/rag/chunk/test_image_pipeline.py -q (38 passed)
- [x] PYTHONPATH=. .venv/bin/python -m compileall -q <changed modules>
- [x] git diff --check origin/develop..HEAD
- [ ] Full backend suite remains blocked by 227 pre-existing Workflow failures unrelated to this PR.

## Summary by Sourcery

将由 MinerU 生成的图像作为知识库文件记录进行存储，并在其生命周期管理上与源文档保持同步，同时为不同流水线限定图像识别（vision）行为范围。

New Features:
- 将 MinerU 抽取的图像作为派生图像文件资产，持久化存储在知识库文件表中，并通过文件下载接口对外提供。
- 更新解析流水线，将 MinerU 生成的图像 Markdown 重写为指向知识库文件的 URL，支持嵌入式和直接图像两种工作流。

Enhancements:
- 在文件上引入 `file_role` 和 `source_document_id` 字段，用于区分源文件与派生图像资产，并支持文件归属和清理语义。
- 将派生图像资产从文件列表、批量下载和知识库 ZIP 导出中排除，同时确保当源文档或文件被删除或变为过期状态时，这些派生图像也会被清理。
- 优化解析器配置，使其能够在文本、PDF、DOCX 和图像等不同流水线中，分别独立控制嵌入文档图像识别与直接图像识别的行为。
- 确保在文档删除、知识同步及文件移除操作期间，过期的 MinerU 派生图像会被正确清理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Store MinerU-derived images as knowledge-base file records and manage their lifecycle alongside source documents while scoping image vision behavior for different pipelines.

New Features:
- Persist MinerU-extracted images as derived image file assets within the knowledge-base files table and expose them via the file download endpoint.
- Update parsing pipelines to rewrite MinerU image Markdown to knowledge-base file URLs for both embedded and direct image workflows.

Enhancements:
- Introduce file_role and source_document_id on files to distinguish source files from derived image assets and to support ownership and cleanup semantics.
- Exclude derived image assets from file listings, batch downloads, and knowledge-base ZIP exports while ensuring they are removed when source documents or files are deleted or become stale.
- Refine parser configuration to independently control embedded-document image vision and direct-image vision behavior across text, PDF, DOCX, and image pipelines.
- Ensure stale MinerU-derived images are cleaned up during document deletion, knowledge sync, and file removal operations.

</details>