### PR TITLE
feat(rag): process MinerU derived images for direct uploads

### DIFF
--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -14,6 +14,7 @@ from app.core.rag.chunk.context import (
     ParsedBlockType,
     ParseResult,
     is_direct_image_vision_enabled,
+    is_embedded_image_vision_enabled,
 )
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
@@ -43,22 +44,21 @@ class ImageChunkPipeline(ChunkPipeline):
         source_binary = self._read_binary(ctx)
         analysis_binary, analysis_filename, source_image = self._analysis_input(ctx.filename, source_binary)
 
-        mineru_markdown = ""
+        mineru_blocks = []
         if mode in {0, 1}:
-            mineru_markdown = self._parse_ocr_markdown(ctx, analysis_binary, analysis_filename)
+            mineru_blocks = self._parse_ocr_blocks(ctx, analysis_binary, analysis_filename)
 
         source_image_url = None
         markdown_parts = []
         if mode in {1, 2}:
             source_markdown, source_image_url = self._source_image_markdown(ctx, source_file_id)
             markdown_parts.append(source_markdown)
-        if mineru_markdown:
-            markdown_parts.append(mineru_markdown)
 
         blocks, source_image_block = self._parse_markdown_blocks(
             "\n\n".join(markdown_parts),
             source_image_url,
         )
+        blocks.extend(mineru_blocks)
         text_blocks = [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
 
         vision_text = ""
@@ -107,21 +107,23 @@ class ImageChunkPipeline(ChunkPipeline):
         analysis_filename = str(Path(filename).with_suffix(".png"))
         return image_binary.getvalue(), analysis_filename, first_frame
 
-    def _parse_ocr_markdown(
+    def _parse_ocr_blocks(
         self,
         ctx: ChunkContext,
         analysis_binary: bytes,
         analysis_filename: str,
-    ) -> str:
+    ) -> list[ParsedBlock]:
         ocr_ctx = replace(
             ctx,
             filename=analysis_filename,
             binary=analysis_binary,
         )
-        markdown = MinerUV3Parser().parse_markdown(ocr_ctx)
-        if not markdown or not markdown.strip():
+        blocks = MinerUV3Parser().parse(ocr_ctx).blocks or []
+        if not blocks:
             raise ValueError("MinerU returned empty Markdown for image OCR mode.")
-        return markdown
+        if is_embedded_image_vision_enabled(ctx.parser_config):
+            return blocks
+        return [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
 
     def _describe_source_image(self, ctx: ChunkContext, source_image: Image.Image) -> str:
         prompt = vision_llm_figure_describe_prompt(lang=getattr(ctx.vision_model, "lang", ctx.lang))


### PR DESCRIPTION
## Business Background
Direct image uploads can produce additional image blocks after MinerU parsing. The direct-image pipeline previously requested Markdown without image payloads and filtered all MinerU-derived image blocks, so those images could not reuse the knowledge-asset storage and vision-description pipeline.

## Summary
- Process MinerU-derived images for direct uploads in image vision modes 0 and 1.
- Follow the existing `embedded_image.vision_enabled` setting, which defaults to enabled.
- Reuse the MinerU payload attachment, knowledge-asset storage, `/files/{id}` URL rewrite, stale-asset cleanup, and vision-description pipeline merged by PR #1958.
- Drop derived image blocks when `embedded_image.vision_enabled` is explicitly disabled.
- Preserve original-image ordering, mode 2 behavior, and empty MinerU result validation.

## Changes
- `api/app/core/rag/chunk/pipeline/image.py`: switch direct-image OCR from Markdown-only parsing to processed MinerU blocks and apply the embedded-image retention setting.
- 1 backend file changed, with 11 insertions and 9 deletions.
- No frontend, API schema, database schema, migration, or Celery routing changes.

## Risk
- Default-enabled derived-image processing can increase image chunk count, asset storage, processing latency, and vision-model usage for direct image uploads in modes 0 and 1.
- `embedded_image.vision_enabled=false` retains the previous derived-image filtering behavior.
- Missing payloads, storage failures, and vision failures continue to use the existing per-image degradation behavior.

## Test Plan
- [x] `PYTHONPATH=. .venv/bin/python -m pytest tests/rag/chunk/test_direct_image_derived_blocks.py tests/rag/chunk/test_mineru_v3_parser.py tests/rag/chunk/test_image_vision.py tests/rag/chunk/test_image_vision_toggle.py -q` — 14 passed on the latest `develop` baseline.
- [x] `PYTHONPATH=. .venv/bin/python -m compileall -q app/core/rag/chunk/pipeline/image.py`
- [x] `git diff --check origin/develop..HEAD`

The regression tests are maintained locally under the repository test policy and are not included in the PR.

## External API Key Impact
No service controller, authentication, workspace scoping, or response contract changes. API Key flows that reuse the same direct-image pipeline will follow the same parser configuration.