### PR TITLE
Feat/memory read display

### DIFF
--- a/api/app/controllers/memory_display_controller.py
+++ b/api/app/controllers/memory_display_controller.py
@@ -1,6 +1,6 @@
 """记忆展示控制器
 
-提供写入展示记录和引擎动态卡片的分页查询接口。
+提供写入展示记录、读取展示卡片和引擎动态卡片的分页查询接口。
 """
 
 import uuid
@@ -19,6 +19,7 @@ from app.models.user_model import User
 from app.schemas.response_schema import ApiResponse, PageData, PageMeta
 from app.services.memory_display_record_service import MemoryDisplayRecordService
 from app.services.memory_engine_display_service import MemoryEngineDisplayService
+from app.services.memory_retrieval_display_service import MemoryRetrievalDisplayService
 
 api_logger = get_api_logger()
 
@@ -102,6 +103,85 @@ async def get_written_memories(
             exc_info=True,
         )
         return fail(BizCode.INTERNAL_ERROR, "写入展示记录查询失败", str(e))
+
+
+@router.get("/retrieved", response_model=ApiResponse)
+async def get_retrieved_memories(
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    language_type: str = Header(default=None, alias="X-Language-Type"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """获取读取展示卡片列表
+
+    一次用户可见的记忆检索对应一条记录，按 occurred_at 倒序分页。
+
+    X-Language-Type 只决定 search_mode 的展示文案；content 在检索发生时
+    已按当时的记忆语言聚合为快照，查询时不再翻译其中的“相关内容 / Related”文案。
+    """
+    workspace_id = current_user.current_workspace_id
+    if workspace_id is None:
+        return fail(
+            BizCode.INVALID_PARAMETER,
+            "请先切换到一个工作空间",
+            "current_workspace_id is None",
+        )
+
+    if not end_user_id or not end_user_id.strip():
+        return fail(
+            BizCode.MISSING_PARAMETER,
+            "end_user_id 不能为空",
+            "end_user_id is required",
+        )
+
+    normalized_end_user_id = end_user_id.strip()
+    try:
+        end_user_uuid = uuid.UUID(normalized_end_user_id)
+    except (ValueError, AttributeError):
+        return fail(
+            BizCode.INVALID_PARAMETER,
+            "无效的 end_user_id",
+            f"'{normalized_end_user_id}' is not a valid UUID",
+        )
+
+    try:
+        language = get_language_from_header(language_type)
+        query_result = MemoryRetrievalDisplayService.query_retrieved(
+            db=db,
+            end_user_id=end_user_uuid,
+            workspace_id=workspace_id,
+            language=language,
+            page=page,
+            pagesize=pagesize,
+        )
+        if query_result is None:
+            return fail(
+                BizCode.USER_NOT_FOUND,
+                "终端用户不存在",
+                "end_user not found in current workspace",
+            )
+        result_items, total = query_result
+
+        page_meta = PageMeta(
+            page=page,
+            pagesize=pagesize,
+            total=total,
+            hasnext=(page * pagesize < total),
+        )
+
+        return success(
+            data=PageData(page=page_meta, items=result_items),
+            msg="查询成功",
+        )
+
+    except Exception as e:
+        api_logger.error(
+            f"读取展示记录查询失败: end_user_id={end_user_id}, error={e}",
+            exc_info=True,
+        )
+        return fail(BizCode.INTERNAL_ERROR, "读取展示记录查询失败", str(e))
 
 
 @router.get("/engines", response_model=ApiResponse)

--- a/api/app/controllers/memory_display_controller.py
+++ b/api/app/controllers/memory_display_controller.py
@@ -1,6 +1,7 @@
 """记忆展示控制器
 
-提供写入展示记录、读取展示卡片和引擎动态卡片的分页查询接口。
+提供写入展示记录、读取展示卡片和引擎动态卡片的分页查询接口，
+以及把三者合并为一条时间线统一分页的聚合接口 /all。
 """
 
 import uuid
@@ -27,6 +28,181 @@ router = APIRouter(
     prefix="/memory-display",
     tags=["Memory Display"],
 )
+
+# /all 做整体分页，但跨三类数据统一排序必须先把它们取到内存里合并，
+# 因此对单类的取回条数设上限，防止响应构造无界增长。
+# 某类超过该上限时会打 warning，此时深页取不到被截断的部分。
+ALL_ITEM_LIMIT = 1000
+
+
+@router.get("/all", response_model=ApiResponse)
+async def get_all_memory_display(
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    timezone: str = Header(
+        ...,
+        alias="X-Timezone",
+        description="IANA 时区名称，前端必传 useI18n().timeZone，如 Asia/Shanghai",
+    ),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    include_engines: bool = Query(
+        True,
+        description="是否包含引擎动态卡片（engines）。false 时不查询该类数据，"
+                    "合并列表和 total 都不含它",
+    ),
+    language_type: str = Header(default=None, alias="X-Language-Type"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """一次获取写入记录、读取卡片和引擎动态卡片
+
+    与 /written、/retrieved、/engines 一样只有一份整体分页：三类数据合并成
+    一条按 occurred_at 倒序的列表统一分页，total 是各类条数之和。
+    每项新增 source 字段（written / retrieved / engines）标识来源，
+    其余字段与对应单接口逐字一致。
+
+    include_engines=false 时完全跳过引擎动态查询，返回的列表和 total 只含
+    written 和 retrieved；written 和 retrieved 无法排除，它们是本接口的基本内容。
+
+    其余参数语义与三个单接口完全一致：
+    - X-Timezone 只影响 engines 的自然日聚合边界，与 /engines 一样必传；
+      即使 include_engines=false 也要传，保持请求头契约稳定；
+    - X-Language-Type 只影响 engines 的 name/content；written 的 name/content
+      和 retrieved 的 query/content 都保持数据生成时的原始语言。
+    """
+    workspace_id = current_user.current_workspace_id
+    if workspace_id is None:
+        return fail(
+            BizCode.INVALID_PARAMETER,
+            "请先切换到一个工作空间",
+            "current_workspace_id is None",
+        )
+
+    if not end_user_id or not end_user_id.strip():
+        return fail(
+            BizCode.MISSING_PARAMETER,
+            "end_user_id 不能为空",
+            "end_user_id is required",
+        )
+
+    normalized_end_user_id = end_user_id.strip()
+    try:
+        end_user_uuid = uuid.UUID(normalized_end_user_id)
+    except (ValueError, AttributeError):
+        return fail(
+            BizCode.INVALID_PARAMETER,
+            "无效的 end_user_id",
+            f"'{normalized_end_user_id}' is not a valid UUID",
+        )
+
+    # 验证时区请求头（必传，非法值直接报错，避免按错误时区聚合）
+    if not timezone or not timezone.strip():
+        return fail(
+            BizCode.MISSING_PARAMETER,
+            "X-Timezone 不能为空",
+            "X-Timezone header is required",
+        )
+
+    try:
+        _, tz_name = resolve_iana_timezone(timezone)
+    except ValueError as e:
+        return fail(
+            BizCode.INVALID_PARAMETER,
+            f"无效的时区: {timezone.strip()}",
+            str(e),
+        )
+
+    try:
+        language = get_language_from_header(language_type)
+
+        written_result = MemoryDisplayRecordService.query_written(
+            db=db,
+            end_user_id=end_user_uuid,
+            workspace_id=workspace_id,
+            page=1,
+            pagesize=ALL_ITEM_LIMIT,
+        )
+        retrieved_result = MemoryRetrievalDisplayService.query_retrieved(
+            db=db,
+            end_user_id=end_user_uuid,
+            workspace_id=workspace_id,
+            page=1,
+            pagesize=ALL_ITEM_LIMIT,
+        )
+        engines_result = None
+        if include_engines:
+            engines_result = MemoryEngineDisplayService.query_cards(
+                db=db,
+                end_user_id=end_user_uuid,
+                workspace_id=workspace_id,
+                timezone=tz_name,
+                language=language,
+                page=1,
+                pagesize=ALL_ITEM_LIMIT,
+            )
+
+        # 三个 Service 都用同一个归属校验，任一为 None 说明用户不在当前工作空间
+        if (
+            written_result is None
+            or retrieved_result is None
+            or (include_engines and engines_result is None)
+        ):
+            return fail(
+                BizCode.USER_NOT_FOUND,
+                "终端用户不存在",
+                "end_user not found in current workspace",
+            )
+
+        blocks = {
+            "written": written_result,
+            "retrieved": retrieved_result,
+        }
+        if include_engines:
+            blocks["engines"] = engines_result
+
+        merged_items: list[dict] = []
+        total = 0
+        for source, (items, block_total) in blocks.items():
+            total += block_total
+            merged_items.extend({**item, "source": source} for item in items)
+            if block_total > len(items):
+                api_logger.warning(
+                    f"展示记录聚合查询被截断: end_user_id={end_user_id}, "
+                    f"source={source}, fetched={len(items)}, total={block_total}, "
+                    f"limit={ALL_ITEM_LIMIT}"
+                )
+
+        # occurred_at 倒序；同一时刻按 source、id 定序，保证翻页结果稳定
+        merged_items.sort(
+            key=lambda item: (
+                -(item.get("occurred_at") or 0),
+                item["source"],
+                str(item.get("id") or ""),
+            )
+        )
+
+        offset = (page - 1) * pagesize
+        page_meta = PageMeta(
+            page=page,
+            pagesize=pagesize,
+            total=total,
+            hasnext=(page * pagesize < total),
+        )
+
+        return success(
+            data=PageData(
+                page=page_meta,
+                items=merged_items[offset:offset + pagesize],
+            ),
+            msg="查询成功",
+        )
+
+    except Exception as e:
+        api_logger.error(
+            f"展示记录聚合查询失败: end_user_id={end_user_id}, error={e}",
+            exc_info=True,
+        )
+        return fail(BizCode.INTERNAL_ERROR, "展示记录查询失败", str(e))
 
 
 @router.get("/written", response_model=ApiResponse)

--- a/api/app/controllers/memory_display_controller.py
+++ b/api/app/controllers/memory_display_controller.py
@@ -110,7 +110,6 @@ async def get_retrieved_memories(
     end_user_id: str = Query(..., description="终端用户 ID"),
     page: int = Query(1, ge=1, description="页码，从 1 开始"),
     pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
-    language_type: str = Header(default=None, alias="X-Language-Type"),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> dict:
@@ -118,8 +117,8 @@ async def get_retrieved_memories(
 
     一次用户可见的记忆检索对应一条记录，按 occurred_at 倒序分页。
 
-    X-Language-Type 只决定 search_mode 的展示文案；content 在检索发生时
-    已按当时的记忆语言聚合为快照，查询时不再翻译其中的“相关内容 / Related”文案。
+    search_mode 始终返回稳定英文枚举，由前端负责展示文案映射；content
+    是检索发生时按当时记忆语言聚合的快照，查询时不再翻译。
     """
     workspace_id = current_user.current_workspace_id
     if workspace_id is None:
@@ -147,12 +146,10 @@ async def get_retrieved_memories(
         )
 
     try:
-        language = get_language_from_header(language_type)
         query_result = MemoryRetrievalDisplayService.query_retrieved(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,
-            language=language,
             page=page,
             pagesize=pagesize,
         )

--- a/api/app/controllers/service/mcp_memory.py
+++ b/api/app/controllers/service/mcp_memory.py
@@ -125,6 +125,7 @@ async def read_memory(
         result = await service.read(
             query=message,
             search_switch=strategy,
+            record_display=True,
         )
         logger.info(f"MCP read_memory succeeded for end_user={end_user_id}")
         return {

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -87,6 +87,7 @@ async def read_memory_sync(
             memory = await service.read(
                 payload.message, search_switch=SearchStrategy(payload.search_switch),
                 enable_rerank=payload.enable_rerank,
+                record_display=True,
             )
             return euid, {
                 "answer": memory.content,
@@ -116,7 +117,8 @@ async def read_memory_sync(
     )
     memory = await service.read(
         payload.message, search_switch=SearchStrategy(payload.search_switch),
-        enable_rerank=payload.enable_rerank)
+        enable_rerank=payload.enable_rerank,
+        record_display=True)
     return success(data={
         "answer": memory.content,
         "intermediate_outputs": [_.model_dump() for _ in memory.memories]

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -70,6 +70,17 @@ class Settings:
     BATCH_PERSIST_MAX_WAIT_MS: int = int(os.getenv("BATCH_PERSIST_MAX_WAIT_MS", "500"))
     BATCH_PERSIST_PUT_TIMEOUT_MS: int = int(os.getenv("BATCH_PERSIST_PUT_TIMEOUT_MS", "100"))
 
+    # Memory retrieval display queue (PG snapshot of user-visible memory reads)
+    MEMORY_RETRIEVAL_DISPLAY_QUEUE_SIZE: int = int(
+        os.getenv("MEMORY_RETRIEVAL_DISPLAY_QUEUE_SIZE", "5000")
+    )
+    MEMORY_RETRIEVAL_DISPLAY_MAX_BATCH: int = int(
+        os.getenv("MEMORY_RETRIEVAL_DISPLAY_MAX_BATCH", "50")
+    )
+    MEMORY_RETRIEVAL_DISPLAY_MAX_WAIT_MS: int = int(
+        os.getenv("MEMORY_RETRIEVAL_DISPLAY_MAX_WAIT_MS", "500")
+    )
+
     DB_AUTO_UPGRADE = os.getenv("DB_AUTO_UPGRADE", "false").lower() == "true"
 
     # Redis configuration

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -440,7 +440,16 @@ class MemoryService:
             includes: list | None = None,
             skip_summary: bool = False,
             enable_rerank: bool = False,
+            record_display: bool = False,
     ) -> MemorySearchResult:
+        """检索记忆。
+
+        Args:
+            record_display: 是否记录读取展示卡片。仅用户可见的记忆检索入口
+                （Agent 长期记忆工具、对话流记忆节点、服务端 /read/sync、MCP）
+                传 True；内部分析、调试和管理读取保持默认 False。
+                deep/normal/quick/express 之外的检索方式即使传 True 也不落库。
+        """
         if history is None:
             history = []
         if self.ctx.memory_config is None:
@@ -453,6 +462,7 @@ class MemoryService:
             includes=includes,
             skip_summary=skip_summary,
             enable_rerank=enable_rerank,
+            record_display=record_display,
         )
 
     async def forget(self) -> dict:
@@ -563,7 +573,11 @@ def create_long_term_memory_tool(
         logger.info(f" 长期记忆工具被调用！question={question}, user={end_user_id}")
         try:
             memory_service = await MemoryService.create(config_id, end_user_id, workspace_id=workspace_id)
-            search_result = await memory_service.read(question, SearchStrategy(search_mode))
+            search_result = await memory_service.read(
+                question,
+                SearchStrategy(search_mode),
+                record_display=True,
+            )
             return f"检索到以下历史记忆：\n\n{search_result.content}"
         except Exception as e:
             logger.error("长期记忆检索失败", extra={"error": str(e), "error_type": type(e).__name__})

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -445,10 +445,7 @@ class MemoryService:
         """检索记忆。
 
         Args:
-            record_display: 是否记录读取展示卡片。仅用户可见的记忆检索入口
-                （Agent 长期记忆工具、对话流记忆节点、服务端 /read/sync、MCP）
-                传 True；内部分析、调试和管理读取保持默认 False。
-                deep/normal/quick/express 之外的检索方式即使传 True 也不落库。
+            record_display: 是否记录读取展示卡片。
         """
         if history is None:
             history = []

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from app.core.memory.models.service_models import ForgetLog
@@ -12,6 +13,8 @@ from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
 from app.repositories.forget_log_repository import ForgetLogRepository
 from app.repositories.neo4j.cypher_queries import DELETE_NODE_BY_ELEMENT_ID
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+logger = logging.getLogger(__name__)
 
 
 class ForgettingPipeline(BasePipeline):
@@ -29,6 +32,21 @@ class ForgettingPipeline(BasePipeline):
 
         async with Neo4jConnector() as connector:
             await sync_end_user_memory_count_from_neo4j(self.ctx.end_user_id, connector)
+
+        # 引擎动态展示投影：只有本轮实际软删除数 > 0 才落一条 FORGETTING 卡片事件。
+        # 尽力写入，PG 失败不影响 Neo4j 软删除结果和定时任务返回值。
+        try:
+            from app.services.memory_engine_display_service import MemoryEngineDisplayService
+            await MemoryEngineDisplayService.save_forgetting_event(
+                end_user_id=self.ctx.end_user_id,
+                forget_summary=res,
+            )
+        except Exception as e:
+            logger.warning(
+                f"[EngineDisplay] 遗忘引擎展示写入异常（不影响主流程）: {e}",
+                exc_info=True,
+            )
+
         return res
 
     @staticmethod

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,6 +1,10 @@
 import asyncio
 import logging
+<<<<<<< HEAD
 import time
+=======
+import uuid
+>>>>>>> c2157701 (feat(memory):memory-retrieve-display)
 
 from app.core.memory.enums import Neo4jNodeType, SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
@@ -22,8 +26,18 @@ from app.core.memory.retrieval_trace.stage_projection import (
     project_result_items,
 )
 from app.core.models import RedBearLLM
+from app.core.utils.datetime_utils import utcnow
 from app.db import get_async_db_context
 from app.repositories.memory_short_repository import ShortTermMemoryRepository
+from app.schemas.memory_retrieval_display_schema import (
+    RETRIEVE_SEARCH_MODES,
+    RetrieveDisplayTask,
+)
+from app.services.memory_retrieval_display_queue import MemoryRetrievalDisplayQueue
+from app.services.memory_retrieval_display_service import (
+    build_retrieve_snapshot,
+    clean_query_for_display,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +77,14 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             includes=None,
             skip_summary=False,
             enable_rerank: bool = False,
+            record_display: bool = False,
     ) -> MemorySearchResult:
         started_at = time.perf_counter()
         self._run_started_at = started_at
         query = QueryPreprocessor.process(query)
+        # 展示用主问题必须在 deep/normal 的问题拆分之前固定下来
+        display_query = clean_query_for_display(query)
+
         match search_switch:
             case SearchStrategy.DEEP:
                 res = await self._deep_read(query, history, limit,
@@ -94,8 +112,12 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         if search_switch in [SearchStrategy.DEEP, SearchStrategy.NORMAL] and not self.ctx.draft:
             await self._save_short_term(query, search_switch, res)
 
+        if record_display:
+            self._dispatch_display_record(display_query, search_switch, res)
+
         return res
 
+<<<<<<< HEAD
     async def _emit_stage(self, stage: str, data: dict) -> None:
         await emit_memory_stage(stage, data)
 
@@ -130,6 +152,59 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
     def _ensure_run_started(self) -> None:
         if not self._run_started_at:
             self._run_started_at = time.perf_counter()
+=======
+    def _dispatch_display_record(
+            self,
+            display_query: str,
+            search_switch: SearchStrategy,
+            result: MemorySearchResult,
+    ) -> None:
+        """聚合读取展示快照并非阻塞投递，任何异常都不影响检索返回。"""
+        try:
+            search_mode = search_switch.name.lower()
+            if search_mode not in RETRIEVE_SEARCH_MODES:
+                logger.debug(
+                    f"[ReadPipeLine] 检索方式 {search_mode} 不在读取展示白名单内，跳过投递"
+                )
+                return
+
+            try:
+                end_user_uuid = uuid.UUID(str(self.ctx.end_user_id))
+            except (ValueError, AttributeError, TypeError):
+                logger.warning(
+                    f"[ReadPipeLine] end_user_id 不是合法 UUID，跳过读取展示投递: "
+                    f"{self.ctx.end_user_id}"
+                )
+                return
+
+            snapshot = build_retrieve_snapshot(
+                result=result,
+                query=display_query,
+                language=self.ctx.language,
+            )
+            if not snapshot:
+                logger.debug(
+                    "[ReadPipeLine] 本次检索没有可展示的 Summary/Entity，跳过投递"
+                )
+                return
+
+            MemoryRetrievalDisplayQueue.enqueue_nowait(
+                RetrieveDisplayTask(
+                    id=uuid.uuid4(),
+                    operation_id=uuid.uuid4(),
+                    end_user_id=end_user_uuid,
+                    search_mode=search_mode,
+                    query=snapshot["query"],
+                    content=snapshot["content"],
+                    occurred_at=utcnow(),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                f"[ReadPipeLine] 读取展示投递失败（不影响主流程）: {e}",
+                exc_info=True,
+            )
+>>>>>>> c2157701 (feat(memory):memory-retrieve-display)
 
     async def _get_search_service(
             self,

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
-<<<<<<< HEAD
 import time
-=======
 import uuid
->>>>>>> c2157701 (feat(memory):memory-retrieve-display)
 
 from app.core.memory.enums import Neo4jNodeType, SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
@@ -117,7 +116,6 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         return res
 
-<<<<<<< HEAD
     async def _emit_stage(self, stage: str, data: dict) -> None:
         await emit_memory_stage(stage, data)
 
@@ -152,7 +150,6 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
     def _ensure_run_started(self) -> None:
         if not self._run_started_at:
             self._run_started_at = time.perf_counter()
-=======
     def _dispatch_display_record(
             self,
             display_query: str,
@@ -204,7 +201,6 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                 f"[ReadPipeLine] 读取展示投递失败（不影响主流程）: {e}",
                 exc_info=True,
             )
->>>>>>> c2157701 (feat(memory):memory-retrieve-display)
 
     async def _get_search_service(
             self,

--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -126,13 +126,16 @@ class ReflectionPipeline:
         )
 
         try:
-            return await inspector.run(
+            result = await inspector.run(
                 end_user_id=self.end_user_id,
                 baseline=baseline,
                 language=self.language,
             )
         finally:
             await connector.close()
+
+        await self._save_reflection_display_event(result, "layer2_frequent")
+        return result
 
     async def run_dedup_full_scan(self, baseline: str = "HYBRID") -> Dict[str, Any]:
         """方案B：低频全量扫描去重 — 由每天一次的定时任务调用"""
@@ -153,9 +156,36 @@ class ReflectionPipeline:
         )
 
         try:
-            return await inspector.run_dedup_full_scan(self.end_user_id, baseline=baseline)
+            result = await inspector.run_dedup_full_scan(self.end_user_id, baseline=baseline)
         finally:
             await connector.close()
+
+        await self._save_reflection_display_event(result, "dedup_full_scan")
+        return result
+
+    async def _save_reflection_display_event(
+        self,
+        result: Dict[str, Any],
+        scan_type: str,
+    ) -> None:
+        """引擎动态展示投影：五类成果合计 > 0 时落一条 REFLECTION 卡片事件。
+
+        只用内存里的汇总结果，不需要 Neo4j 连接，因此放在 connector 关闭之后，
+        不延长连接持有时间。inspector 抛异常时调用方直接跳过写入。
+        尽力写入，PG 失败不影响归并结果和定时任务返回值。
+        """
+        try:
+            from app.services.memory_engine_display_service import MemoryEngineDisplayService
+            await MemoryEngineDisplayService.save_reflection_event(
+                end_user_id=self.end_user_id,
+                layer2_result=result,
+                scan_type=scan_type,
+            )
+        except Exception as e:
+            logger.warning(
+                f"[EngineDisplay] 反思引擎展示写入异常（不影响主流程）: {e}",
+                exc_info=True,
+            )
 
     async def run_layer3(self) -> Dict[str, Any]:
         """Layer 3 知识综合 — 由低频定时任务调用（如每天一次）

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from collections import defaultdict
 from typing import Any
 
 from app.core.memory.enums import Neo4jNodeType
@@ -28,11 +29,18 @@ class ForgetService:
         self.trigger_count = memory_limit
         self._connector: Neo4jConnector | None = None
         self._audit: list[ForgetLog] = []
+        # 展示投影所需的整轮累计量，run() 开头重置，避免实例复用时累计上一轮
+        self._scanned_count: int = 0
+        self._released_count: int = 0
+        self._node_type_counts: defaultdict[str, int] = defaultdict(int)
         self.target_ratio = (1 - self.ctx.memory_config.lambda_mem)
         self.target_count = max(int(memory_limit * self.target_ratio), 50)
 
     async def run(self) -> dict[str, Any]:
         self._audit = []
+        self._scanned_count = 0
+        self._released_count = 0
+        self._node_type_counts = defaultdict(int)
         async with Neo4jConnector() as connector:
             self._connector = connector
 
@@ -51,6 +59,9 @@ class ForgetService:
                     active_count, self.trigger_count,
                 )
                 summary["deleted"] = 0
+                summary["scanned_count"] = 0
+                summary["node_type_counts"] = {}
+                summary["net_active_change"] = 0
                 summary["final_count"] = active_count
                 return summary
 
@@ -65,15 +76,23 @@ class ForgetService:
             budget = await self._mixed_clean(budget)
 
             final_count = await forget_count_active_nodes(connector, self.ctx.end_user_id)
-            deleted = summary["initial_count"] - final_count
+            # 活跃节点净变化只用于运维观察：并发写入或实体归并都会干扰它，
+            # 因此不能作为"本轮软删除了多少"的依据。
+            net_active_change = summary["initial_count"] - final_count
 
-            summary["deleted"] = deleted
+            # deleted 是逐批 SET delete_at 的实际影响行数之和
+            summary["deleted"] = self._released_count
+            summary["scanned_count"] = self._scanned_count
+            summary["node_type_counts"] = dict(self._node_type_counts)
+            summary["net_active_change"] = net_active_change
             summary["budget"] = max(budget, 0)
             summary["final_count"] = final_count
 
             logger.info(
-                "ForgetService done — deleted=%d final=%d remaining_budget=%d",
-                deleted, final_count, summary["budget"],
+                "ForgetService done — scanned=%d deleted=%d net_active_change=%d "
+                "final=%d remaining_budget=%d",
+                self._scanned_count, self._released_count, net_active_change,
+                final_count, summary["budget"],
             )
             try:
                 uid = self.ctx.end_user_id
@@ -102,16 +121,19 @@ class ForgetService:
 
             element_ids = [row["element_id"] for row in candidates]
             now = utcnow()
+            self._scanned_count += len(candidates)
 
             deleted_in_batch = await forget_soft_delete_by_element_ids(
                 connector, self.ctx.end_user_id, element_ids, to_iso_z(now),
             )
 
             total_deleted += deleted_in_batch
+            self._released_count += deleted_in_batch
             budget -= deleted_in_batch
 
             for row in candidates:
                 node_type = row.get("node_type", "unknown")
+                self._node_type_counts[node_type] += 1
                 entry: ForgetLog = ForgetLog(
                     node_id=row.get("element_id"),
                     node_type=node_type,

--- a/api/app/core/workflow/nodes/memory/node.py
+++ b/api/app/core/workflow/nodes/memory/node.py
@@ -61,7 +61,8 @@ class MemoryReadNode(BaseNode):
         # TODO: Historical Messages -> Used to refer to coreference resolution
         search_result = await memory_service.read(
             query,
-            search_switch=SearchStrategy(self.typed_config.search_switch)
+            search_switch=SearchStrategy(self.typed_config.search_switch),
+            record_display=True,
         )
         self._process["memories_count"] = len(search_result.memories)
         return {

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -107,6 +107,10 @@ async def lifespan(app: FastAPI):
     from app.services.batch_persist_queue import BatchPersistQueue
     await BatchPersistQueue.start()
 
+    # Start memory retrieval display writer (bounded queue, never blocks reads)
+    from app.services.memory_retrieval_display_queue import MemoryRetrievalDisplayQueue
+    await MemoryRetrievalDisplayQueue.start()
+
     logger.info("应用程序启动完成")
 
     async with mcp_app.lifespan(app):
@@ -122,6 +126,10 @@ async def lifespan(app: FastAPI):
     from app.services.batch_persist_queue import BatchPersistQueue
     await BatchPersistQueue.flush()
     await BatchPersistQueue.stop()
+
+    from app.services.memory_retrieval_display_queue import MemoryRetrievalDisplayQueue
+    await MemoryRetrievalDisplayQueue.flush()
+    await MemoryRetrievalDisplayQueue.stop()
 
     from app.repositories.neo4j.neo4j_connector import Neo4jConnector
     await Neo4jConnector.shutdown()

--- a/api/app/models/memory_display_record_model.py
+++ b/api/app/models/memory_display_record_model.py
@@ -11,10 +11,12 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -27,6 +29,10 @@ class MemoryDisplayRecord(Base):
 
     记录每一次成功写入或检索操作的展示快照，
     前端写入区域和读取区域分别只查询对应 operation 的记录。
+
+    - ``WRITE``：一次写入可以对应多条 MemorySummary，保持按记忆一行；
+    - ``RETRIEVE``：一次检索只对应一行聚合读取卡片，
+      ``memory_id / memory_type / name`` 不使用，正文统一写入 ``content``。
     """
 
     __tablename__ = "memory_display_records"
@@ -39,13 +45,16 @@ class MemoryDisplayRecord(Base):
     )
     operation_id = Column(UUID(as_uuid=True), nullable=False)
     operation = Column(String(16), nullable=False)  # "WRITE" or "RETRIEVE"
-    memory_id = Column(String(64), nullable=False)
-    memory_type = Column(String(32), nullable=False)
-    name = Column(String(255), nullable=False)
+    # 以下三列仅 WRITE 使用，RETRIEVE 存 NULL
+    memory_id = Column(String(64), nullable=True)
+    memory_type = Column(String(32), nullable=True)
+    name = Column(String(255), nullable=True)
     content = Column(Text, nullable=False)
     score = Column(Float, nullable=True)
     rank = Column(Integer, nullable=True)
     search_mode = Column(String(16), nullable=True)
+    # 仅 RETRIEVE 使用：预处理后、问题拆分前的主检索问题
+    query = Column(Text, nullable=True)
     occurred_at = Column(
         DateTime, nullable=False, default=utcnow_naive
     )  # naive UTC
@@ -54,5 +63,21 @@ class MemoryDisplayRecord(Base):
         UniqueConstraint(
             "end_user_id", "operation_id", "operation", "memory_id",
             name="uq_memory_display_records_user_op_memory",
+        ),
+        # PostgreSQL 唯一约束允许多个 NULL，RETRIEVE 的 memory_id 为 NULL，
+        # 因此额外用部分唯一索引保证「一次检索一行」。
+        Index(
+            "uq_memory_display_retrieve_user_operation",
+            "end_user_id",
+            "operation_id",
+            unique=True,
+            postgresql_where=text("operation = 'RETRIEVE'"),
+        ),
+        Index(
+            "idx_memory_display_retrieve_user_occurred",
+            "end_user_id",
+            occurred_at.desc(),
+            id.desc(),
+            postgresql_where=text("operation = 'RETRIEVE'"),
         ),
     )

--- a/api/app/models/memory_engine_display_event_model.py
+++ b/api/app/models/memory_engine_display_event_model.py
@@ -18,7 +18,16 @@ class MemoryEngineDisplayEvent(Base):
     """引擎展示事件表
 
     记录每一次有效引擎触发的结构化事件。
-    同一轮写入操作最多产生三条事件（EXTRACTION/CROSS_MODAL/EMOTION）。
+
+    两类触发链路：
+    - 记忆写入（WritePipeline）：一轮最多三条事件
+      （EXTRACTION / CROSS_MODAL / EMOTION）；
+    - Celery 定时任务：一轮最多一条事件
+      （FORGETTING 来自配额驱动的定时遗忘整理，
+      REFLECTION 来自 Layer 2 高频巡检或每日全量去重）。
+
+    engine_type 的取值范围只由代码约定，PG 没有枚举类型也没有 CHECK 约束，
+    新增引擎类型不需要 migration。
     """
 
     __tablename__ = "memory_engine_display_records"
@@ -30,7 +39,8 @@ class MemoryEngineDisplayEvent(Base):
         nullable=False,
     )
     operation_id = Column(UUID(as_uuid=True), nullable=False)
-    engine_type = Column(String(32), nullable=False)  # EXTRACTION / CROSS_MODAL / EMOTION
+    # EXTRACTION / CROSS_MODAL / EMOTION / FORGETTING / REFLECTION
+    engine_type = Column(String(32), nullable=False)
     details = Column(JSONB, nullable=False, server_default="{}")
     occurred_at = Column(
         DateTime, nullable=False, default=utcnow_naive

--- a/api/app/repositories/memory_display_record_repository.py
+++ b/api/app/repositories/memory_display_record_repository.py
@@ -163,32 +163,20 @@ class MemoryDisplayRecordRepository:
     def query_retrieved_paginated(
         self,
         end_user_id: uuid.UUID,
-        workspace_id: uuid.UUID,
         page: int,
         pagesize: int,
     ) -> Tuple[List[MemoryDisplayRecord], int]:
         """按 occurred_at DESC, id DESC 分页查询读取展示记录。
 
         一次检索已经是一行，不再按 operation_id 分组或二次取明细。
-        查询附加 end_users 归属条件并限定 workspace_id，防止跨工作空间越权读取。
+        调用方负责校验终端用户的工作空间归属和可见性。
 
         Returns:
             (记录列表, 总条数)
         """
-        owned_by_workspace = (
-            select(EndUser.id)
-            .where(
-                EndUser.id == end_user_id,
-                EndUser.workspace_id == workspace_id,
-                EndUser.is_active.is_(True),
-            )
-            .exists()
-        )
-
         base_filter = (
             (MemoryDisplayRecord.end_user_id == end_user_id)
             & (MemoryDisplayRecord.operation == "RETRIEVE")
-            & owned_by_workspace
         )
 
         total = (

--- a/api/app/repositories/memory_display_record_repository.py
+++ b/api/app/repositories/memory_display_record_repository.py
@@ -9,6 +9,7 @@ from typing import List, Tuple
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models.end_user_model import EndUser
@@ -107,6 +108,86 @@ class MemoryDisplayRecordRepository:
         base_filter = (
             (MemoryDisplayRecord.end_user_id == end_user_id)
             & (MemoryDisplayRecord.operation == "WRITE")
+            & owned_by_workspace
+        )
+
+        total = (
+            self.db.query(func.count(MemoryDisplayRecord.id))
+            .filter(base_filter)
+            .scalar()
+        ) or 0
+
+        offset = (page - 1) * pagesize
+        items = (
+            self.db.query(MemoryDisplayRecord)
+            .filter(base_filter)
+            .order_by(
+                MemoryDisplayRecord.occurred_at.desc(),
+                MemoryDisplayRecord.id.desc(),
+            )
+            .offset(offset)
+            .limit(pagesize)
+            .all()
+        )
+
+        return items, total
+
+    @staticmethod
+    async def bulk_insert_retrieved_async(
+        db: AsyncSession,
+        rows: List[dict],
+    ) -> int:
+        """异步批量插入读取展示记录（operation = 'RETRIEVE'）。
+
+        不指定冲突目标：主键或部分唯一索引
+        ``uq_memory_display_retrieve_user_operation`` 任一冲突都视为已成功写入，
+        consumer 重试因此天然幂等。
+
+        Args:
+            db: AsyncSession
+            rows: 已聚合好的行（由 RetrieveDisplayTask.to_row() 生成）
+
+        Returns:
+            实际插入的行数
+        """
+        if not rows:
+            return 0
+
+        stmt = pg_insert(MemoryDisplayRecord).values(rows)
+        stmt = stmt.on_conflict_do_nothing()
+
+        result = await db.execute(stmt)
+        await db.commit()
+        return result.rowcount or 0
+
+    def query_retrieved_paginated(
+        self,
+        end_user_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        page: int,
+        pagesize: int,
+    ) -> Tuple[List[MemoryDisplayRecord], int]:
+        """按 occurred_at DESC, id DESC 分页查询读取展示记录。
+
+        一次检索已经是一行，不再按 operation_id 分组或二次取明细。
+        查询附加 end_users 归属条件并限定 workspace_id，防止跨工作空间越权读取。
+
+        Returns:
+            (记录列表, 总条数)
+        """
+        owned_by_workspace = (
+            select(EndUser.id)
+            .where(
+                EndUser.id == end_user_id,
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active.is_(True),
+            )
+            .exists()
+        )
+
+        base_filter = (
+            (MemoryDisplayRecord.end_user_id == end_user_id)
+            & (MemoryDisplayRecord.operation == "RETRIEVE")
             & owned_by_workspace
         )
 

--- a/api/app/schemas/memory_engine_display_schema.py
+++ b/api/app/schemas/memory_engine_display_schema.py
@@ -12,7 +12,13 @@ class EngineDisplayCardItem(BaseModel):
     """引擎展示卡片 - 前端列表项"""
 
     id: str = Field(..., description="确定性聚合卡片 ID（UUID v5）")
-    engine_type: Literal["EXTRACTION", "CROSS_MODAL", "EMOTION"] = Field(
+    engine_type: Literal[
+        "EXTRACTION",
+        "CROSS_MODAL",
+        "EMOTION",
+        "FORGETTING",
+        "REFLECTION",
+    ] = Field(
         ...,
         description="稳定英文引擎枚举，由前端负责文案映射",
     )

--- a/api/app/schemas/memory_retrieval_display_schema.py
+++ b/api/app/schemas/memory_retrieval_display_schema.py
@@ -1,0 +1,87 @@
+"""记忆读取展示 Schema
+
+包含：
+- 支持落库的检索方式白名单和展示文案翻译
+- 异步队列任务（不可变快照，不持有 ORM / Session / 请求上下文）
+- 读取卡片前端 DTO
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# 只有用户可见的四种检索方式会生成读取卡片；recent / meta 不在范围内。
+RETRIEVE_SEARCH_MODES: frozenset[str] = frozenset({"deep", "normal", "quick", "express"})
+
+SEARCH_MODE_LABELS: dict[str, dict[str, str]] = {
+    "zh": {
+        "deep": "深度检索",
+        "normal": "标准检索",
+        "quick": "快速检索",
+        "express": "极速检索",
+    },
+    "en": {
+        "deep": "Deep",
+        "normal": "Normal",
+        "quick": "Quick",
+        "express": "Express",
+    },
+}
+
+
+def translate_search_mode(mode: str | None, language: str = "zh") -> str:
+    """把 PG 中存储的检索方式枚举翻译为展示文案。
+
+    未知取值原样返回，保证新增检索方式时接口不报错。
+    """
+    labels = SEARCH_MODE_LABELS.get(language, SEARCH_MODE_LABELS["zh"])
+    return labels.get(mode, mode or "")
+
+
+@dataclass(frozen=True)
+class RetrieveDisplayTask:
+    """一次检索对应的读取展示快照。
+
+    投递前即生成固定的 ``id`` / ``operation_id`` / ``occurred_at``，
+    consumer 重试时复用同一份取值，配合 ``ON CONFLICT DO NOTHING`` 保证幂等。
+    """
+
+    id: uuid.UUID
+    operation_id: uuid.UUID
+    end_user_id: uuid.UUID
+    search_mode: str
+    query: str
+    content: str
+    occurred_at: datetime
+
+    def to_row(self) -> dict:
+        """转换为可直接用于批量 INSERT 的行。"""
+        return {
+            "id": self.id,
+            "end_user_id": self.end_user_id,
+            "operation_id": self.operation_id,
+            "operation": "RETRIEVE",
+            "memory_id": None,
+            "memory_type": None,
+            "name": None,
+            "content": self.content,
+            "score": None,
+            "rank": None,
+            "search_mode": self.search_mode,
+            "query": self.query,
+            "occurred_at": self.occurred_at,
+        }
+
+
+class MemoryRetrievalDisplayItem(BaseModel):
+    """读取展示卡片 - 前端列表项"""
+
+    id: str = Field(..., description="PG 记录主键，作为前端列表项唯一 key")
+    search_mode: str = Field(..., description="检索方式展示文案，由 X-Language-Type 决定语言")
+    query: str = Field(..., description="预处理后、问题拆分前的主检索问题")
+    content: str = Field(..., description="读取卡片正文，检索发生时已按当时语言聚合")
+    occurred_at: int = Field(..., description="检索完成并投递的时间，13 位 Unix 毫秒时间戳")

--- a/api/app/schemas/memory_retrieval_display_schema.py
+++ b/api/app/schemas/memory_retrieval_display_schema.py
@@ -1,7 +1,7 @@
 """记忆读取展示 Schema
 
 包含：
-- 支持落库的检索方式白名单和展示文案翻译
+- 支持落库的检索方式白名单
 - 异步队列任务（不可变快照，不持有 ORM / Session / 请求上下文）
 - 读取卡片前端 DTO
 """
@@ -11,35 +11,12 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 # 只有用户可见的四种检索方式会生成读取卡片；recent / meta 不在范围内。
 RETRIEVE_SEARCH_MODES: frozenset[str] = frozenset({"deep", "normal", "quick", "express"})
-
-SEARCH_MODE_LABELS: dict[str, dict[str, str]] = {
-    "zh": {
-        "deep": "深度检索",
-        "normal": "标准检索",
-        "quick": "快速检索",
-        "express": "极速检索",
-    },
-    "en": {
-        "deep": "Deep",
-        "normal": "Normal",
-        "quick": "Quick",
-        "express": "Express",
-    },
-}
-
-
-def translate_search_mode(mode: str | None, language: str = "zh") -> str:
-    """把 PG 中存储的检索方式枚举翻译为展示文案。
-
-    未知取值原样返回，保证新增检索方式时接口不报错。
-    """
-    labels = SEARCH_MODE_LABELS.get(language, SEARCH_MODE_LABELS["zh"])
-    return labels.get(mode, mode or "")
 
 
 @dataclass(frozen=True)
@@ -81,7 +58,10 @@ class MemoryRetrievalDisplayItem(BaseModel):
     """读取展示卡片 - 前端列表项"""
 
     id: str = Field(..., description="PG 记录主键，作为前端列表项唯一 key")
-    search_mode: str = Field(..., description="检索方式展示文案，由 X-Language-Type 决定语言")
+    search_mode: Literal["deep", "normal", "quick", "express"] = Field(
+        ...,
+        description="稳定英文检索方式枚举，由前端负责文案映射",
+    )
     query: str = Field(..., description="预处理后、问题拆分前的主检索问题")
     content: str = Field(..., description="读取卡片正文，检索发生时已按当时语言聚合")
     occurred_at: int = Field(..., description="检索完成并投递的时间，13 位 Unix 毫秒时间戳")

--- a/api/app/services/memory_engine_display_service.py
+++ b/api/app/services/memory_engine_display_service.py
@@ -1,7 +1,8 @@
 """记忆引擎展示 Service
 
 负责：
-- 从 ExtractionResult 组装 0~3 个有效引擎事件
+- 从 ExtractionResult 组装 0~3 个有效引擎事件（EXTRACTION / CROSS_MODAL / EMOTION）
+- 从遗忘、反思引擎的汇总结果组装 FORGETTING / REFLECTION 事件
 - 查询时按用户时区日期聚合事件并生成卡片文案
 - 异常隔离（PG 写入失败不影响主流程）
 """
@@ -89,7 +90,7 @@ class MemoryEngineDisplayService:
         return cards, total
 
     # ──────────────────────────────────────────────
-    # 写入侧：从 ExtractionResult 组装事件
+    # 写入侧：从各引擎的汇总结果组装事件
     # ──────────────────────────────────────────────
 
     @staticmethod
@@ -108,11 +109,7 @@ class MemoryEngineDisplayService:
             end_user_id: 终端用户 ID（字符串形式 UUID）
             extraction_result: WritePipeline 的 ExtractionResult
         """
-        from app.db import get_db_context
-        from app.models.memory_engine_display_event_model import MemoryEngineDisplayEvent
-
         try:
-            # 组装事件
             events_data = []
 
             extraction_event = _build_extraction_event(extraction_result)
@@ -129,48 +126,67 @@ class MemoryEngineDisplayService:
 
             if not events_data:
                 return
-
-            # 生成共享标识
-            operation_id = uuid.uuid4()
-            occurred_at = utcnow_naive()
-
-            # 转换为 ORM 实例
-            # end_user_id 需要转为 UUID 对象（PG 外键是 UUID 类型）
-            try:
-                user_uuid = uuid.UUID(end_user_id)
-            except (ValueError, AttributeError):
-                logger.warning(
-                    f"[EngineDisplay] 无法将 end_user_id 转为 UUID: {end_user_id}"
-                )
-                return
-
-            records = []
-            for data in events_data:
-                record = MemoryEngineDisplayEvent(
-                    id=uuid.uuid4(),
-                    end_user_id=user_uuid,
-                    operation_id=operation_id,
-                    engine_type=data["engine_type"],
-                    details=data["details"],
-                    occurred_at=occurred_at,
-                )
-                records.append(record)
-
-            # PG 写入（一次，不重试）
-            with get_db_context() as db:
-                repo = MemoryEngineDisplayEventRepository(db)
-                repo.bulk_insert_events(records)
-
-            logger.info(
-                f"[EngineDisplay] PG 写入成功: end_user_id={end_user_id}, "
-                f"operation_id={operation_id}, engines={[d['engine_type'] for d in events_data]}"
-            )
-
         except Exception as e:
             logger.error(
-                f"[EngineDisplay] PG 写入失败: end_user_id={end_user_id}, error={e}",
+                f"[EngineDisplay] 事件组装失败: end_user_id={end_user_id}, error={e}",
                 exc_info=True,
             )
+            return
+
+        await _persist_events(end_user_id, events_data)
+
+    @staticmethod
+    async def save_forgetting_event(
+        end_user_id: str,
+        forget_summary: dict,
+    ) -> None:
+        """配额驱动的定时遗忘整理完成后调用。
+
+        只有本轮实际软删除数 > 0 才写入一条 FORGETTING 事件；
+        手动删除单节点和清空全部记忆不走这里。
+
+        Args:
+            end_user_id: 终端用户 ID（字符串形式 UUID）
+            forget_summary: ForgetService.run() 的返回值
+        """
+        try:
+            event = _build_forgetting_event(forget_summary)
+        except Exception as e:
+            logger.error(
+                f"[EngineDisplay] 遗忘事件组装失败: end_user_id={end_user_id}, error={e}",
+                exc_info=True,
+            )
+            return
+        if event is None:
+            return
+        await _persist_events(end_user_id, [event])
+
+    @staticmethod
+    async def save_reflection_event(
+        end_user_id: str,
+        layer2_result: dict,
+        scan_type: str = "layer2_frequent",
+    ) -> None:
+        """Layer 2 高频巡检或每日全量去重完成后调用。
+
+        五类成果合计为 0（含未配置 LLM、全部子问题被跳过）时不写入。
+
+        Args:
+            end_user_id: 终端用户 ID（字符串形式 UUID）
+            layer2_result: Layer2Inspector.run() 或 run_dedup_full_scan() 的返回值
+            scan_type: "layer2_frequent"（高频巡检）或 "dedup_full_scan"（全量去重）
+        """
+        try:
+            event = _build_reflection_event(layer2_result, scan_type)
+        except Exception as e:
+            logger.error(
+                f"[EngineDisplay] 反思事件组装失败: end_user_id={end_user_id}, error={e}",
+                exc_info=True,
+            )
+            return
+        if event is None:
+            return
+        await _persist_events(end_user_id, [event])
 
     # ──────────────────────────────────────────────
     # 查询侧：聚合事件并生成卡片
@@ -218,6 +234,63 @@ class MemoryEngineDisplayService:
             })
 
         return cards
+
+
+# ──────────────────────────────────────────────
+# 内部函数：统一写入
+# ──────────────────────────────────────────────
+
+
+async def _persist_events(end_user_id: str, events_data: List[Dict[str, Any]]) -> None:
+    """生成共享标识、批量写入 PG、异常隔离。三个入口共用。
+
+    每次调用新生成 operation_id，因此不会撞唯一约束
+    uq_engine_display_user_type_op；本方案不要求跨调用幂等。
+    PG 写入只执行一次，不重试，失败只记日志。
+    """
+    from app.db import get_db_context
+    from app.models.memory_engine_display_event_model import MemoryEngineDisplayEvent
+
+    if not events_data:
+        return
+
+    # end_user_id 需要转为 UUID 对象（PG 外键是 UUID 类型）
+    try:
+        user_uuid = uuid.UUID(end_user_id)
+    except (ValueError, AttributeError, TypeError):
+        logger.warning(
+            f"[EngineDisplay] 无法将 end_user_id 转为 UUID: {end_user_id}"
+        )
+        return
+
+    operation_id = uuid.uuid4()
+    occurred_at = utcnow_naive()
+
+    records = [
+        MemoryEngineDisplayEvent(
+            id=uuid.uuid4(),
+            end_user_id=user_uuid,
+            operation_id=operation_id,
+            engine_type=data["engine_type"],
+            details=data["details"],
+            occurred_at=occurred_at,
+        )
+        for data in events_data
+    ]
+
+    try:
+        with get_db_context() as db:
+            MemoryEngineDisplayEventRepository(db).bulk_insert_events(records)
+        logger.info(
+            f"[EngineDisplay] PG 写入成功: end_user_id={end_user_id}, "
+            f"operation_id={operation_id}, "
+            f"engines={[d['engine_type'] for d in events_data]}"
+        )
+    except Exception as e:
+        logger.error(
+            f"[EngineDisplay] PG 写入失败: end_user_id={end_user_id}, error={e}",
+            exc_info=True,
+        )
 
 
 # ──────────────────────────────────────────────
@@ -302,9 +375,9 @@ def _build_cross_modal_event(result: Any) -> Optional[Dict[str, Any]]:
                 if name.lower() not in _ROLE_ENTITY_NAMES:
                     topic_counter[name] += 1
 
-        # 按出现次数排序，取前3
+        # 按出现次数降序、名称升序展示全部主题
         sorted_topics = sorted(topic_counter.items(), key=lambda x: (-x[1], x[0]))
-        topics = [t[0] for t in sorted_topics[:3]]
+        topics = [t[0] for t in sorted_topics]
 
     details: Dict[str, Any] = {
         "modality_counts": dict(modality_counts),
@@ -355,6 +428,100 @@ def _build_emotion_event(result: Any) -> Optional[Dict[str, Any]]:
             "emotion_stats": emotion_stats,
         },
     }
+
+
+# 反思引擎五类成果的 details key，写入侧和聚合侧共用
+_REFLECTION_COUNT_KEYS = (
+    "entity_merged_count",
+    "alias_merged_count",
+    "description_merged_count",
+    "metadata_extracted_count",
+    "unresolved_resolved_count",
+)
+
+
+def _build_forgetting_event(summary: Any) -> Optional[Dict[str, Any]]:
+    """组装遗忘引擎事件。
+
+    released_count 取 ForgetService 逐批累加的实际软删除数
+    （summary["deleted"]），不使用 initial_count - final_count。
+    被跳过或本轮没有实际软删除时不生成事件。
+    """
+    if not isinstance(summary, dict) or summary.get("skipped"):
+        return None
+
+    released = _as_count(summary.get("deleted"))
+    if released <= 0:
+        return None
+
+    scanned = _as_count(summary.get("scanned_count"))
+    node_type_counts = summary.get("node_type_counts")
+    if not isinstance(node_type_counts, dict):
+        node_type_counts = {}
+
+    return {
+        "engine_type": "FORGETTING",
+        "details": {
+            # 老版本 ForgetService 不返回 scanned_count 时退化为 released
+            "scanned_count": scanned or released,
+            "released_count": released,
+            "node_type_counts": {
+                str(k): _as_count(v) for k, v in node_type_counts.items()
+            },
+        },
+    }
+
+
+def _build_reflection_event(
+    result: Any,
+    scan_type: str,
+) -> Optional[Dict[str, Any]]:
+    """组装反思引擎事件。五类成果全为 0 时不生成。
+
+    高频巡检返回按子问题分组的嵌套结构，低频全量去重返回扁平结构，
+    因此 entity_merged_count 按 scan_type 分两种取法。两条链路对外的
+    merged_count 都已包含确定性直接归并，不再叠加 direct_merged_count。
+
+    子问题 status 为 skipped / timeout / error 时相关 key 缺失，
+    按 0 计入，不影响其他子问题成果展示。
+    """
+    if not isinstance(result, dict) or result.get("status") == "skipped":
+        return None
+
+    if scan_type == "dedup_full_scan":
+        entity_merged = _pick(result, "merged_count")
+    else:
+        entity_merged = _pick(result.get("entity_dedup"), "merged_count")
+
+    details: Dict[str, Any] = {
+        "scan_type": scan_type,
+        "entity_merged_count": entity_merged,
+        "alias_merged_count": _pick(result.get("alias_merge"), "merge_count"),
+        "description_merged_count": _pick(result.get("description_merge"), "merged_count"),
+        "metadata_extracted_count": _pick(result.get("metadata_extraction"), "extracted"),
+        "unresolved_resolved_count": _pick(
+            result.get("unresolved_entity"), "resolved", "forced"
+        ),
+    }
+
+    if all(details[key] == 0 for key in _REFLECTION_COUNT_KEYS):
+        return None
+    return {"engine_type": "REFLECTION", "details": details}
+
+
+def _as_count(value: Any) -> int:
+    """把任意来源的计数安全转为非负 int；无法转换按 0。"""
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _pick(sub: Any, *keys: str) -> int:
+    """从子问题结果里安全累加计数；非 dict 或 key 缺失都按 0。"""
+    if not isinstance(sub, dict):
+        return 0
+    return sum(_as_count(sub.get(k)) for k in keys)
 
 
 # ──────────────────────────────────────────────
@@ -422,12 +589,12 @@ def _merge_event_details(
                     if e.occurred_at and e.occurred_at > topic_info[normalized]["last_at"]:
                         topic_info[normalized]["last_at"] = e.occurred_at
 
-        # 主题排序：事件数降序 > 最后出现时间降序 > 名称升序
+        # 主题排序：事件数降序 > 最后出现时间降序 > 名称升序，完整展示
         sorted_topics = sorted(
             topic_info.items(),
             key=lambda x: (-x[1]["count"], -(x[1]["last_at"].timestamp() if x[1]["last_at"] else 0), x[0]),
         )
-        topics = [t[0] for t in sorted_topics[:3]]
+        topics = [t[0] for t in sorted_topics]
 
         return {
             "modality_counts": dict(merged_modality),
@@ -466,6 +633,31 @@ def _merge_event_details(
         return {
             "emotions": [{"type": t[0], "count": t[1]["count"]} for t in top_emotions],
         }
+
+    elif engine_type == "FORGETTING":
+        scanned = 0
+        released = 0
+        node_types: Dict[str, int] = defaultdict(int)
+        for e in events:
+            d = e.details or {}
+            scanned += _as_count(d.get("scanned_count"))
+            released += _as_count(d.get("released_count"))
+            for k, v in (d.get("node_type_counts") or {}).items():
+                node_types[str(k)] += _as_count(v)
+        return {
+            "scanned_count": scanned,
+            "released_count": released,
+            "node_type_counts": dict(node_types),
+        }
+
+    elif engine_type == "REFLECTION":
+        # 高频巡检和每日全量去重的成果在同一天相加，卡片不区分 scan_type
+        merged_counts = {key: 0 for key in _REFLECTION_COUNT_KEYS}
+        for e in events:
+            d = e.details or {}
+            for key in _REFLECTION_COUNT_KEYS:
+                merged_counts[key] += _as_count(d.get(key))
+        return merged_counts
 
     return {}
 
@@ -545,6 +737,38 @@ def _generate_card_text_zh(
 
         return name, content
 
+    elif engine_type == "FORGETTING":
+        name = "我整理了不再活跃的记忆"
+        scanned = merged.get("scanned_count", 0)
+        released = merged.get("released_count", 0)
+        if scanned > released:
+            head = f"评估了 {scanned} 条较早写入的记录，将其中 {released} 条移出了活跃记忆"
+        else:
+            head = f"将 {released} 条记录移出了活跃记忆"
+        content = f"{head}；情景摘要不参与整理，高频引用的实体受到保护。"
+        return name, content
+
+    elif engine_type == "REFLECTION":
+        name = "我梳理了记忆之间的重复和缺口"
+        labels = {
+            "entity_merged_count": "完成了 {n} 次重复实体合并",
+            "alias_merged_count": "归并了 {n} 组实体别名",
+            "description_merged_count": "整合了 {n} 个实体的零散描述",
+            "metadata_extracted_count": "补全了 {n} 个实体的结构化信息",
+            "unresolved_resolved_count": "解析了 {n} 条此前无法识别的陈述",
+        }
+        parts = [
+            labels[key].format(n=count)
+            for key, count in _rank_reflection_counts(merged)
+        ]
+        if not parts:
+            content = ""
+        elif len(parts) == 1:
+            content = parts[0] + "。"
+        else:
+            content = "，".join(parts[:-1]) + "，并" + parts[-1] + "。"
+        return name, content
+
     return ("", "")
 
 
@@ -622,12 +846,81 @@ def _generate_card_text_en(
             )
         return name, content
 
+    if engine_type == "FORGETTING":
+        name = "I tidied up memories that are no longer active"
+        scanned = merged.get("scanned_count", 0)
+        released = merged.get("released_count", 0)
+        if scanned > released:
+            head = (
+                f"I reviewed {scanned} older {_pluralize('record', scanned)} and moved "
+                f"{released} of them out of active memory"
+            )
+        else:
+            head = (
+                f"I moved {released} {_pluralize('record', released)} "
+                "out of active memory"
+            )
+        content = (
+            f"{head}. Episodic summaries are never touched, and frequently "
+            "referenced entities are protected."
+        )
+        return name, content
+
+    if engine_type == "REFLECTION":
+        name = "I reviewed duplicates and gaps across memories"
+        labels = {
+            "entity_merged_count": lambda n: (
+                f"merged {n} duplicate {_pluralize('entity', n, 'entities')}"
+            ),
+            "alias_merged_count": lambda n: (
+                f"consolidated {n} {_pluralize('group', n)} of entity aliases"
+            ),
+            "description_merged_count": lambda n: (
+                f"consolidated scattered descriptions for {n} "
+                f"{_pluralize('entity', n, 'entities')}"
+            ),
+            "metadata_extracted_count": lambda n: (
+                f"filled in structured information for {n} "
+                f"{_pluralize('entity', n, 'entities')}"
+            ),
+            "unresolved_resolved_count": lambda n: (
+                f"resolved {n} previously unrecognized "
+                f"{_pluralize('statement', n)}"
+            ),
+        }
+        parts = [
+            labels[key](count) for key, count in _rank_reflection_counts(merged)
+        ]
+        content = f"I {_join_english(parts)}." if parts else ""
+        return name, content
+
     return ("", "")
 
 
-def _pluralize(noun: str, count: int) -> str:
-    """Apply the regular English plural form used by card metrics."""
-    return noun if count == 1 else f"{noun}s"
+def _rank_reflection_counts(merged: Dict[str, Any]) -> List[tuple]:
+    """按（数量降序、字段名升序）返回全部非零成果。
+
+    过滤非 int 值，避免把 scan_type 这类字符串当成计数
+    （_merge_event_details 的 REFLECTION 分支只输出五个计数键，这里是防御）。
+    """
+    return sorted(
+        (
+            (key, value)
+            for key, value in merged.items()
+            if key in _REFLECTION_COUNT_KEYS
+            and isinstance(value, int)
+            and not isinstance(value, bool)
+            and value > 0
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+
+
+def _pluralize(noun: str, count: int, plural: str | None = None) -> str:
+    """Apply the English plural form used by card metrics."""
+    if count == 1:
+        return noun
+    return plural if plural is not None else f"{noun}s"
 
 
 def _join_english(parts: List[str]) -> str:

--- a/api/app/services/memory_retrieval_display_queue.py
+++ b/api/app/services/memory_retrieval_display_queue.py
@@ -1,0 +1,306 @@
+"""记忆读取展示专用异步写入队列
+
+检索主链路只做「内存聚合 → put_nowait → 立即返回」，
+绝不等待 PG 连接、事务或重试。展示记录不是检索事实源，
+队列满或进程异常退出时允许丢弃。
+
+当前产生读取展示记录的业务入口均运行在 FastAPI lifespan 进程中，正常通过
+进程内队列批量写入。未运行 FastAPI lifespan 时的 fire-and-forget 写入仅作为
+防御性降级，不属于正常业务链路，同样不阻塞检索返回。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, ClassVar
+
+from app.core.config import settings
+from app.db import get_async_db_context
+from app.repositories.memory_display_record_repository import (
+    MemoryDisplayRecordRepository,
+)
+from app.schemas.memory_retrieval_display_schema import RetrieveDisplayTask
+
+logger = logging.getLogger(__name__)
+
+# consumer 内的有限重试次数（重试复用相同 id / operation_id）
+_MAX_RETRIES = 2
+
+# 丢弃告警限频间隔（秒），避免队列长期打满时日志被刷爆
+_DROP_WARN_INTERVAL_SECONDS = 30.0
+
+# 关闭时 flush 的固定超时（秒），超时后允许丢弃剩余展示记录
+_SHUTDOWN_TIMEOUT_SECONDS = 10.0
+
+
+class MemoryRetrievalDisplayQueue:
+    """单例有界异步队列 + 后台批量写入。
+
+    用法::
+
+        # 启动（FastAPI lifespan）
+        await MemoryRetrievalDisplayQueue.start()
+
+        # 投递（检索主链路，非 async，绝不阻塞）
+        MemoryRetrievalDisplayQueue.enqueue_nowait(task)
+
+        # 关闭（FastAPI lifespan）
+        await MemoryRetrievalDisplayQueue.stop()
+    """
+
+    _instance: ClassVar["MemoryRetrievalDisplayQueue | None"] = None
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[RetrieveDisplayTask | None] = asyncio.Queue(
+            maxsize=settings.MEMORY_RETRIEVAL_DISPLAY_QUEUE_SIZE
+        )
+        self._consumer_task: asyncio.Task[Any] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._running = False
+        self._fallback_tasks: set[asyncio.Task[Any]] = set()
+        self._last_drop_warn_at = 0.0
+        self._metrics: dict[str, int] = {
+            "enqueued": 0,
+            "written": 0,
+            "dropped": 0,
+            "retried": 0,
+            "failed": 0,
+            "fallback": 0,
+        }
+
+    # ── 单例访问 ─────────────────────────────────────────
+
+    @classmethod
+    def _get(cls) -> "MemoryRetrievalDisplayQueue":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    # ── 公开 API ─────────────────────────────────────────
+
+    @classmethod
+    async def start(cls) -> None:
+        inst = cls._get()
+        if inst._running and inst._consumer_task and not inst._consumer_task.done():
+            return
+        inst._running = True
+        inst._loop = asyncio.get_running_loop()
+        inst._consumer_task = asyncio.create_task(inst._consumer())
+        logger.info("[RetrievalDisplay] 读取展示写入 consumer 已启动")
+
+    @classmethod
+    def enqueue_nowait(cls, task: RetrieveDisplayTask) -> bool:
+        """非阻塞投递。返回 False 表示本条展示记录被丢弃。"""
+        inst = cls._get()
+
+        if not inst._consumer_available():
+            return inst._schedule_fallback_write(task)
+
+        try:
+            inst._queue.put_nowait(task)
+        except asyncio.QueueFull:
+            inst._metrics["dropped"] += 1
+            inst._warn_dropped("队列已满")
+            return False
+
+        inst._metrics["enqueued"] += 1
+        return True
+
+    @classmethod
+    async def flush(cls) -> None:
+        """排空队列中剩余任务（关闭流程使用）。"""
+        inst = cls._get()
+        tasks = inst._drain()
+        if tasks:
+            logger.info("[RetrievalDisplay] flush 剩余 %d 条读取展示记录", len(tasks))
+            await inst._write_batch(tasks)
+
+    @classmethod
+    async def stop(cls) -> None:
+        """优雅关闭：投递哨兵、等待 consumer 收尾、等待兜底任务。"""
+        inst = cls._get()
+        if not inst._running:
+            return
+        inst._running = False
+
+        try:
+            inst._queue.put_nowait(None)
+        except asyncio.QueueFull:
+            pass
+
+        if inst._consumer_task is not None:
+            try:
+                await asyncio.wait_for(
+                    inst._consumer_task,
+                    timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[RetrievalDisplay] consumer 未在 %ss 内退出，丢弃剩余展示记录",
+                    _SHUTDOWN_TIMEOUT_SECONDS,
+                )
+                inst._consumer_task.cancel()
+            except Exception:
+                logger.warning("[RetrievalDisplay] consumer 退出异常", exc_info=True)
+
+        if inst._fallback_tasks:
+            pending = list(inst._fallback_tasks)
+            done, still_pending = await asyncio.wait(
+                pending,
+                timeout=_SHUTDOWN_TIMEOUT_SECONDS,
+            )
+            for stale in still_pending:
+                stale.cancel()
+
+        inst._consumer_task = None
+        inst._loop = None
+        logger.info(
+            "[RetrievalDisplay] consumer 已停止, metrics=%s, queue_size=%d",
+            inst._metrics,
+            inst._queue.qsize(),
+        )
+
+    @classmethod
+    def stats(cls) -> dict[str, int]:
+        """返回监控指标：投递数、写入成功数、丢弃数、重试数、失败数、队列长度。"""
+        inst = cls._get()
+        return {**inst._metrics, "queue_size": inst._queue.qsize()}
+
+    # ── 内部实现 ─────────────────────────────────────────
+
+    def _consumer_available(self) -> bool:
+        """consumer 是否运行在当前事件循环上且仍存活。"""
+        if not self._running or self._consumer_task is None:
+            return False
+        if self._consumer_task.done():
+            return False
+        try:
+            return asyncio.get_running_loop() is self._loop
+        except RuntimeError:
+            return False
+
+    def _schedule_fallback_write(self, task: RetrieveDisplayTask) -> bool:
+        """没有 consumer 时的兜底：当前事件循环上 fire-and-forget 写入。
+
+        仍然不阻塞检索返回，只是失去批量合并和统一 flush 的能力。
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._metrics["dropped"] += 1
+            self._warn_dropped("当前线程没有运行中的事件循环")
+            return False
+
+        fallback = loop.create_task(self._write_batch([task]))
+        self._fallback_tasks.add(fallback)
+        fallback.add_done_callback(self._fallback_tasks.discard)
+        self._metrics["fallback"] += 1
+        return True
+
+    def _warn_dropped(self, reason: str) -> None:
+        now = time.monotonic()
+        if now - self._last_drop_warn_at < _DROP_WARN_INTERVAL_SECONDS:
+            return
+        self._last_drop_warn_at = now
+        logger.warning(
+            "[RetrievalDisplay] 丢弃读取展示记录（%s）: dropped=%d, queue_size=%d",
+            reason,
+            self._metrics["dropped"],
+            self._queue.qsize(),
+        )
+
+    def _drain(self) -> list[RetrieveDisplayTask]:
+        tasks: list[RetrieveDisplayTask] = []
+        while not self._queue.empty():
+            try:
+                item = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if item is not None:
+                tasks.append(item)
+        return tasks
+
+    async def _consumer(self) -> None:
+        max_batch = settings.MEMORY_RETRIEVAL_DISPLAY_MAX_BATCH
+        max_wait = settings.MEMORY_RETRIEVAL_DISPLAY_MAX_WAIT_MS / 1000
+
+        while self._running:
+            try:
+                first = await asyncio.wait_for(self._queue.get(), timeout=max_wait)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+            if first is None:  # 哨兵
+                break
+
+            batch = [first]
+            deadline = time.monotonic() + max_wait
+            while len(batch) < max_batch:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    item = await asyncio.wait_for(
+                        self._queue.get(),
+                        timeout=min(remaining, 0.05),
+                    )
+                except asyncio.TimeoutError:
+                    break
+                except asyncio.CancelledError:
+                    self._running = False
+                    break
+                if item is None:
+                    self._running = False
+                    break
+                batch.append(item)
+
+            await self._write_batch(batch)
+
+        remaining_tasks = self._drain()
+        if remaining_tasks:
+            await self._write_batch(remaining_tasks)
+
+    async def _write_batch(self, batch: list[RetrieveDisplayTask]) -> None:
+        """有限重试批量写 PG；单批失败不影响后续批次。"""
+        if not batch:
+            return
+
+        rows = [task.to_row() for task in batch]
+        last_error: Exception | None = None
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                async with get_async_db_context() as db:
+                    inserted = await MemoryDisplayRecordRepository.bulk_insert_retrieved_async(
+                        db, rows
+                    )
+                self._metrics["written"] += inserted
+                logger.debug(
+                    "[RetrievalDisplay] PG 写入完成: attempted=%d, inserted=%d",
+                    len(rows),
+                    inserted,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 - 展示记录失败不反馈到检索
+                last_error = exc
+                if attempt + 1 < _MAX_RETRIES:
+                    self._metrics["retried"] += 1
+                logger.warning(
+                    "[RetrievalDisplay] PG 写入失败 (attempt %d/%d): %s",
+                    attempt + 1,
+                    _MAX_RETRIES,
+                    exc,
+                    exc_info=True,
+                )
+
+        self._metrics["failed"] += len(rows)
+        logger.error(
+            "[RetrievalDisplay] PG 写入在 %d 次尝试后仍失败: count=%d, error=%s",
+            _MAX_RETRIES,
+            len(rows),
+            last_error,
+        )

--- a/api/app/services/memory_retrieval_display_service.py
+++ b/api/app/services/memory_retrieval_display_service.py
@@ -23,7 +23,6 @@ from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.memory_display_record_repository import (
     MemoryDisplayRecordRepository,
 )
-from app.schemas.memory_retrieval_display_schema import translate_search_mode
 
 logger = logging.getLogger(__name__)
 
@@ -189,7 +188,6 @@ class MemoryRetrievalDisplayService:
         db: Session,
         end_user_id: uuid.UUID,
         workspace_id: uuid.UUID,
-        language: str,
         page: int,
         pagesize: int,
     ) -> tuple[List[dict], int] | None:
@@ -216,7 +214,7 @@ class MemoryRetrievalDisplayService:
         items = [
             {
                 "id": str(record.id),
-                "search_mode": translate_search_mode(record.search_mode, language),
+                "search_mode": record.search_mode,
                 "query": record.query or "",
                 "content": record.content,
                 "occurred_at": to_timestamp_ms(record.occurred_at),

--- a/api/app/services/memory_retrieval_display_service.py
+++ b/api/app/services/memory_retrieval_display_service.py
@@ -206,7 +206,6 @@ class MemoryRetrievalDisplayService:
         repo = MemoryDisplayRecordRepository(db)
         records, total = repo.query_retrieved_paginated(
             end_user_id=end_user_id,
-            workspace_id=workspace_id,
             page=page,
             pagesize=pagesize,
         )

--- a/api/app/services/memory_retrieval_display_service.py
+++ b/api/app/services/memory_retrieval_display_service.py
@@ -1,0 +1,226 @@
+"""记忆读取展示 Service
+
+负责：
+- 主检索问题的展示清洗（预处理后、问题拆分前）
+- 从最终 MemorySearchResult 中筛选展示节点并聚合为单条读取卡片
+- 读取卡片分页查询和前端 DTO 组装
+
+聚合全部在内存中完成，不触碰数据库；写库由
+``MemoryRetrievalDisplayQueue`` 的后台 consumer 执行。
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import Any, List
+
+from sqlalchemy.orm import Session
+
+from app.core.utils.datetime_utils import to_timestamp_ms
+from app.repositories.end_user_repository import EndUserRepository
+from app.repositories.memory_display_record_repository import (
+    MemoryDisplayRecordRepository,
+)
+from app.schemas.memory_retrieval_display_schema import translate_search_mode
+
+logger = logging.getLogger(__name__)
+
+# 展示文本上限（字符）
+QUERY_MAX_LENGTH = 200
+SUMMARY_MAX_LENGTH = 200
+ENTITY_MAX_LENGTH = 100
+
+# 单张卡片最多展示的节点数
+MAX_SUMMARY_COUNT = 3
+MAX_ENTITY_COUNT = 3
+
+_TRUNCATE_SUFFIX = "…"
+_FILE_SUMMARY_TAG_RE = re.compile(
+    r"<input-file-summary>.*?</input-file-summary>",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_display_text(text: Any, max_length: int) -> str:
+    """折叠连续空白 → strip → 按上限截断并补省略号。"""
+    if not text:
+        return ""
+    normalized = _WHITESPACE_RE.sub(" ", str(text)).strip()
+    if not normalized:
+        return ""
+    if len(normalized) > max_length:
+        return normalized[:max_length] + _TRUNCATE_SUFFIX
+    return normalized
+
+
+def clean_query_for_display(processed_query: str) -> str:
+    """把预处理后的主检索问题清洗为可展示的 query。
+
+    只做剥离文件摘要标签、空白规范化和截断，
+    不做任何语义改写，也不使用问题拆分后的子问题。
+    """
+    if not processed_query:
+        return ""
+    without_file_summary = _FILE_SUMMARY_TAG_RE.sub(" ", processed_query)
+    return normalize_display_text(without_file_summary, QUERY_MAX_LENGTH)
+
+
+def aggregate_display_content(
+    summaries: List[str],
+    entities: List[str],
+    language: str,
+) -> str:
+    """把入选的 Summary 正文和 Entity 名称聚合为卡片正文。
+
+    - 单条 Summary 直接输出，多条按数字序号逐行输出；
+    - Entity 以“相关内容 / Related”补充句附在正文之后；
+    - 两者都为空时返回空串，调用方据此跳过投递。
+    """
+    parts: List[str] = []
+
+    if len(summaries) == 1:
+        parts.append(summaries[0])
+    elif summaries:
+        parts.append(
+            "\n".join(f"{i}. {text}" for i, text in enumerate(summaries, start=1))
+        )
+
+    if entities:
+        if language == "en":
+            parts.append(f"Related: {', '.join(entities)}.")
+        else:
+            parts.append(f"相关内容：{'、'.join(entities)}。")
+
+    return "\n".join(parts)
+
+
+def build_retrieve_snapshot(
+    result: Any,
+    query: str,
+    language: str,
+) -> dict | None:
+    """从最终检索结果构造一条可直接入库的 RETRIEVE 快照。
+
+    Args:
+        result: 最终 MemorySearchResult（不会被修改）
+        query: 已清洗的主检索问题
+        language: 检索发生时的 MemoryContext.language
+
+    Returns:
+        ``{"query": ..., "content": ...}``；没有可展示节点时返回 None。
+    """
+    from app.core.memory.enums import Neo4jNodeType
+
+    memories = getattr(result, "memories", None) or []
+
+    # 按 (节点类型, memory_id) 保留最高分，避免不同标签偶然复用 id 时误去重
+    best: dict[tuple[str, str], tuple[float, Any]] = {}
+    for memory in memories:
+        source = getattr(memory, "source", None)
+        if source not in (Neo4jNodeType.MEMORYSUMMARY, Neo4jNodeType.EXTRACTEDENTITY):
+            continue
+
+        data = getattr(memory, "data", None) or {}
+        memory_id = str(data.get("id") or getattr(memory, "id", "") or "").strip()
+        if not memory_id:
+            logger.debug(
+                "[RetrievalDisplay] 跳过缺少合法 id 的展示节点: source=%s", source
+            )
+            continue
+
+        try:
+            score = float(getattr(memory, "score", 0) or 0)
+        except (TypeError, ValueError):
+            score = 0.0
+
+        key = (str(source), memory_id)
+        if key not in best or score > best[key][0]:
+            best[key] = (score, memory)
+
+    scored_summaries: list[tuple[float, str]] = []
+    scored_entities: list[tuple[float, str]] = []
+    for score, memory in best.values():
+        data = getattr(memory, "data", None) or {}
+        if memory.source == Neo4jNodeType.MEMORYSUMMARY:
+            text = normalize_display_text(data.get("content"), SUMMARY_MAX_LENGTH)
+            if text:
+                scored_summaries.append((score, text))
+        else:
+            text = normalize_display_text(data.get("name"), ENTITY_MAX_LENGTH)
+            if text:
+                scored_entities.append((score, text))
+
+    # 分数降序，同分按文本升序保证输出稳定
+    scored_summaries.sort(key=lambda item: (-item[0], item[1]))
+    scored_entities.sort(key=lambda item: (-item[0], item[1]))
+
+    summaries = [text for _, text in scored_summaries[:MAX_SUMMARY_COUNT]]
+
+    # Entity 按清洗后的名称去重后取前几条
+    seen_entity_keys: set[str] = set()
+    top_entities: list[str] = []
+    for _, text in scored_entities:
+        key = text.casefold()
+        if key in seen_entity_keys:
+            continue
+        seen_entity_keys.add(key)
+        top_entities.append(text)
+        if len(top_entities) >= MAX_ENTITY_COUNT:
+            break
+
+    # 已完整出现在入选 Summary 中的实体名不再重复进入补充句
+    summary_blob = "\n".join(summaries).casefold()
+    entities = [text for text in top_entities if text.casefold() not in summary_blob]
+
+    content = aggregate_display_content(summaries, entities, language)
+    if not content:
+        return None
+    return {"query": query, "content": content}
+
+
+class MemoryRetrievalDisplayService:
+    """读取展示业务逻辑层"""
+
+    @staticmethod
+    def query_retrieved(
+        db: Session,
+        end_user_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        language: str,
+        page: int,
+        pagesize: int,
+    ) -> tuple[List[dict], int] | None:
+        """查询读取展示卡片并组装前端 DTO。
+
+        一次检索已经是一行，直接按 occurred_at 分页，不再二次聚合。
+        返回 None 表示终端用户不属于当前工作空间。
+        """
+        end_user_repo = EndUserRepository(db)
+        if end_user_repo.get_active_end_user_in_workspace(
+            end_user_id,
+            workspace_id,
+        ) is None:
+            return None
+
+        repo = MemoryDisplayRecordRepository(db)
+        records, total = repo.query_retrieved_paginated(
+            end_user_id=end_user_id,
+            workspace_id=workspace_id,
+            page=page,
+            pagesize=pagesize,
+        )
+
+        items = [
+            {
+                "id": str(record.id),
+                "search_mode": translate_search_mode(record.search_mode, language),
+                "query": record.query or "",
+                "content": record.content,
+                "occurred_at": to_timestamp_ms(record.occurred_at),
+            }
+            for record in records
+        ]
+        return items, total


### PR DESCRIPTION
## Summary by Sourcery

添加检索端的展示记录与统一的记忆展示时间线，并扩展引擎展示以包含遗忘和反思结果。

New Features:
- 通过异步队列为用户可见的读取记录并持久化聚合记忆检索展示快照，并提供分页的检索卡片和统一的 `/all` 时间线 API。
- 将遗忘和反思引擎活动以新的 FORGETTING 和 REFLECTION 展示事件与卡片形式呈现，支持中文和英文。

Enhancements:
- 优化跨模态与主题聚合逻辑，展示全部主题而不再截断为前三名，并改进复数处理与排序工具。
- 改进遗忘引擎指标，用于跟踪扫描、删除、节点类型计数以及净活跃变更，以提升可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retrieval-side display recording and unified memory display timeline, and extend engine display to include forgetting and reflection results.

New Features:
- Record and persist aggregated memory retrieval display snapshots for user-visible reads via an async queue and expose paginated retrieval cards and a unified /all timeline API.
- Surface forgetting and reflection engine activity as new FORGETTING and REFLECTION display events and cards in both Chinese and English.

Enhancements:
- Refine cross-modal and topic aggregation to show all topics instead of truncating to top three and improve pluralization and ranking utilities.
- Improve forgetting engine metrics to track scanned, deleted, node type counts and net active changes for better observability.

</details>