### PR TITLE
refactor(app_chat_service)

### DIFF
--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -1508,6 +1508,7 @@ class AppChatService:
                 }
 
             all_node_executions = orchestrator_node_executions + node_executions
+            from app.models.conversation_model import Conversation
             if not skip_save:
                 from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
 
@@ -1549,8 +1550,6 @@ class AppChatService:
                 save_messages_enqueued = True
 
                 # 记忆写入 + 派发：复用 conversation_service.dispatch_memory_sync
-                from app.models.conversation_model import Conversation
-
                 result_row = await self.db.execute(
                     select(Conversation).where(Conversation.id == conversation_id)
                 )


### PR DESCRIPTION
move Conversation import to top of execution block

## Summary by Sourcery

增强：
- 将 `Conversation` 模型的导入语句移动到注释上下文加载器执行代码块的顶部，以避免重复的内联导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Relocate the Conversation model import to the top of the execution block in the annotation context loader to avoid duplicate inline imports.

</details>