### PR TITLE
fix(memory): correct interest weights and fallback

### DIFF
--- a/api/app/controllers/memory_analytics_controller.py
+++ b/api/app/controllers/memory_analytics_controller.py
@@ -358,21 +358,27 @@ async def get_interest_distribution_by_user_api(
         )
         if cached is not None:
             api_logger.info(f"Interest distribution cache hit: end_user_id={end_user_id}")
-            return success(data=cached, msg="获取兴趣分布标签成功")
+            return success(data=cached[:limit], msg="获取兴趣分布标签成功")
 
-        result = await memory_agent_service.get_interest_distribution_by_user(
+        result, cacheable = await memory_agent_service.generate_interest_distribution_by_user(
             end_user_id=end_user_id,
-            limit=limit,
+            limit=5,
             language=language
         )
 
-        await InterestMemoryCache.set_interest_distribution(
-            end_user_id=end_user_id,
-            language=language,
-            data=result,
-        )
+        if cacheable:
+            await InterestMemoryCache.set_interest_distribution(
+                end_user_id=end_user_id,
+                language=language,
+                data=result,
+            )
+        else:
+            api_logger.info(
+                "Interest distribution not cached after empty LLM result: "
+                f"end_user_id={end_user_id}"
+            )
 
-        return success(data=result, msg="获取兴趣分布标签成功")
+        return success(data=result[:limit], msg="获取兴趣分布标签成功")
     except Exception as e:
         api_logger.error(f"Interest distribution by user failed: {str(e)}")
         return fail(BizCode.INTERNAL_ERROR, "获取兴趣分布标签失败", str(e))

--- a/api/app/controllers/memory_analytics_controller.py
+++ b/api/app/controllers/memory_analytics_controller.py
@@ -374,7 +374,7 @@ async def get_interest_distribution_by_user_api(
             )
         else:
             api_logger.info(
-                "Interest distribution not cached after empty LLM result: "
+                "Interest distribution result is not cacheable; skipping cache: "
                 f"end_user_id={end_user_id}"
             )
 

--- a/api/app/core/memory/analytics/hot_memory_tags.py
+++ b/api/app/core/memory/analytics/hot_memory_tags.py
@@ -1,14 +1,46 @@
+import asyncio
 import logging
-from typing import List, Tuple
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, List, Tuple
 
 from pydantic import BaseModel, Field
 
 from app.core.memory.pipelines.base_pipeline import ModelClientMixin
 from app.db import get_db_context
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.repositories.neo4j.statement_repository import StatementRepository
 from app.services.memory_config_service import MemoryConfigService
 
 logger = logging.getLogger(__name__)
+
+INTEREST_DISTRIBUTION_LLM_TIMEOUT_SECONDS = 30
+INTEREST_DISTRIBUTION_TOTAL_TIMEOUT_SECONDS = 45
+INTEREST_DISTRIBUTION_MIN_FALLBACK_TIMEOUT_SECONDS = 5
+INTEREST_CANDIDATE_LIMIT = 40
+INTEREST_DISPLAY_LIMIT = 5
+INTEREST_EVIDENCE_ENTITY_LIMIT = 12
+INTEREST_EVIDENCE_PER_ENTITY_LIMIT = 2
+INTEREST_EVIDENCE_LIMIT = 20
+INTEREST_EVIDENCE_MAX_CHARS = 300
+INTEREST_EXCLUDED_NAMES = [
+    "用户",
+    "user",
+    "ai",
+    "ai助手",
+    "助手",
+    "assistant",
+    "ai回复",
+    "系统",
+    "system",
+    "时间戳",
+    "timestamp",
+]
+INTEREST_ISO_DATETIME_PATTERN = (
+    r"(?i)^\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?(?:z|[+-]\d{2}:?\d{2})?$"
+)
+INTEREST_UNIX_TIMESTAMP_PATTERN = r"^\d{10}(?:\d{3})?$"
 
 
 # 定义用于LLM结构化输出的Pydantic模型
@@ -17,9 +49,41 @@ class FilteredTags(BaseModel):
     meaningful_tags: List[str] = Field(..., description="从原始列表中筛选出的具有核心代表意义的名词列表。")
 
 
+class InterestEntityCandidate(BaseModel):
+    """带真实 Statement 频次的兴趣候选实体。"""
+
+    entity_id: str
+    name: str
+    entity_type: str = ""
+    frequency: int = Field(..., ge=1)
+
+
+class InterestStatementEvidence(BaseModel):
+    """候选实体关联的 Statement 语境证据。"""
+
+    statement_id: str
+    entity_ids: List[str]
+    statement_text: str
+
+
+class InterestGroup(BaseModel):
+    """LLM 归纳出的兴趣及其候选来源。"""
+
+    name: str
+    entity_ids: List[str]
+
+
 class InterestTags(BaseModel):
-    """用于接收LLM筛选后的兴趣活动标签列表的模型。"""
-    interest_tags: List[str] = Field(..., description="从原始列表中筛选出的代表用户兴趣活动的标签列表。")
+    """用于接收 LLM 归纳后的兴趣活动列表。"""
+
+    interests: List[InterestGroup] = Field(default_factory=list)
+
+
+class InterestDistributionGeneration(BaseModel):
+    """兴趣分布生成结果及其缓存决策。"""
+
+    items: List[Tuple[str, int]] = Field(default_factory=list)
+    cacheable: bool = True
 
 
 async def filter_tags_with_llm(tags: List[str], end_user_id: str) -> List[str]:
@@ -84,55 +148,193 @@ async def filter_tags_with_llm(tags: List[str], end_user_id: str) -> List[str]:
         return tags
 
 
-async def filter_interests_with_llm(tags: List[str], end_user_id: str, language: str = "zh") -> List[str]:
-    """
-    使用LLM从标签列表中筛选出代表用户兴趣活动的标签。
-    
-    与 filter_tags_with_llm 不同，此函数专注于识别"活动/行为"类兴趣，
-    过滤掉纯物品、工具、地点等不代表用户主动参与活动的名词。
-    
-    Args:
-        tags: 原始标签列表
-        end_user_id: 用户ID，用于获取LLM配置
-        
-    Returns:
-        筛选后的兴趣活动标签列表
-    """
+async def filter_interests_with_llm(
+    candidates: List[InterestEntityCandidate],
+    end_user_id: str,
+    language: str = "zh",
+    evidence: List[InterestStatementEvidence] | None = None,
+    existing_interests: List[str] | None = None,
+    timeout_seconds: float = INTEREST_DISTRIBUTION_LLM_TIMEOUT_SECONDS,
+) -> InterestTags:
+    """让 LLM 筛选并合并兴趣，可选使用 Statement 证据补充实体语境。"""
+    with get_db_context() as db:
+        config_service = MemoryConfigService(db)
+        config_id = config_service.get_config_id_by_end_user(end_user_id)
+        if not config_id:
+            raise ValueError(
+                f"No memory_config_id found for end_user_id: {end_user_id}."
+            )
+
+        memory_config = config_service.load_memory_config(config_id=config_id)
+        llm_client = ModelClientMixin.get_llm_client(
+            db,
+            memory_config.llm_model_id,
+            memory_config.tenant_id,
+        )
+
+    from app.core.memory.utils.prompt.prompt_utils import render_interest_filter_prompt
+
+    rendered_prompt = render_interest_filter_prompt(
+        [candidate.model_dump() for candidate in candidates],
+        language=language,
+        evidence=[item.model_dump() for item in evidence] if evidence else None,
+        existing_interests=existing_interests,
+    )
+    messages = [{"role": "user", "content": rendered_prompt}]
+    started_at = time.monotonic()
+    stage = "llm_fallback" if evidence else "llm_call"
+    if timeout_seconds <= 0:
+        raise TimeoutError(f"interest distribution {stage} has no remaining time budget")
     try:
-        with get_db_context() as db:
-            config_service = MemoryConfigService(db)
-            config_id = config_service.get_config_id_by_end_user(end_user_id)
-            if not config_id:
-                raise ValueError(
-                    f"No memory_config_id found for end_user_id: {end_user_id}."
-                )
+        raw_response = await asyncio.wait_for(
+            llm_client.call_structured(messages, InterestTags),
+            timeout=timeout_seconds,
+        )
+        response = (
+            raw_response
+            if isinstance(raw_response, InterestTags)
+            else InterestTags.model_validate(raw_response)
+        )
+    except Exception as exc:
+        logger.error(
+            "interest_distribution stage=%s_failed end_user_id=%s "
+            "candidate_count=%s evidence_count=%s timeout=%.3fs elapsed=%.3fs "
+            "error_type=%s error=%r",
+            stage,
+            end_user_id,
+            len(candidates),
+            len(evidence or []),
+            timeout_seconds,
+            time.monotonic() - started_at,
+            type(exc).__name__,
+            exc,
+            exc_info=True,
+        )
+        raise
 
-            memory_config = config_service.load_memory_config(
-                config_id=config_id,
+    logger.info(
+        "interest_distribution stage=%s end_user_id=%s candidate_count=%s "
+        "evidence_count=%s interest_count=%s timeout=%.3fs elapsed=%.3fs",
+        stage,
+        end_user_id,
+        len(candidates),
+        len(evidence or []),
+        len(response.interests),
+        timeout_seconds,
+        time.monotonic() - started_at,
+    )
+    return response
+
+
+def _remaining_interest_budget(started_at: float) -> float:
+    """根据统一起算时间计算本次兴趣分布生成的剩余总预算。"""
+    return max(
+        0.0,
+        INTEREST_DISTRIBUTION_TOTAL_TIMEOUT_SECONDS - (time.monotonic() - started_at),
+    )
+
+
+async def _await_with_interest_budget(
+    operation: Callable[[], Awaitable[Any]],
+    started_at: float,
+) -> Any:
+    """在共享总预算内执行一个异步阶段，避免单个查询或调用越过总截止时间。"""
+    remaining = _remaining_interest_budget(started_at)
+    if remaining <= 0:
+        raise TimeoutError("interest distribution total time budget exhausted")
+    return await asyncio.wait_for(operation(), timeout=remaining)
+
+
+def _log_interest_budget(
+    *,
+    end_user_id: str,
+    stage: str,
+    started_at: float,
+    second_call_executed: bool,
+    degradation_reason: str | None = None,
+) -> None:
+    """统一记录预算阶段、总耗时、剩余时间、第二次调用状态和降级原因。"""
+    elapsed = time.monotonic() - started_at
+    remaining = max(0.0, INTEREST_DISTRIBUTION_TOTAL_TIMEOUT_SECONDS - elapsed)
+    log_method = logger.warning if degradation_reason else logger.info
+    log_method(
+        "interest_distribution_budget end_user_id=%s stage=%s elapsed=%.3fs "
+        "remaining=%.3fs second_call_executed=%s degradation_reason=%s",
+        end_user_id,
+        stage,
+        elapsed,
+        remaining,
+        second_call_executed,
+        degradation_reason or "none",
+    )
+
+
+def normalize_interest_name(name: str) -> str:
+    """去除兴趣名首尾空白并折叠连续空白。"""
+    return " ".join(name.split())
+
+
+def validate_interest_groups(
+    candidates: List[InterestEntityCandidate],
+    groups: List[InterestGroup],
+) -> List[InterestGroup]:
+    """校验并规范化兴趣组，保留后端实际接受的来源实体。"""
+    valid_entity_ids = {candidate.entity_id for candidate in candidates}
+    claimed_entity_ids: set[str] = set()
+    validated_groups: dict[str, InterestGroup] = {}
+    has_named_interest = False
+
+    for group in groups:
+        name = normalize_interest_name(group.name)
+        if not name:
+            continue
+
+        has_named_interest = True
+        accepted_entity_ids: list[str] = []
+        for entity_id in group.entity_ids:
+            if entity_id not in valid_entity_ids or entity_id in claimed_entity_ids:
+                continue
+            claimed_entity_ids.add(entity_id)
+            accepted_entity_ids.append(entity_id)
+        if not accepted_entity_ids:
+            continue
+
+        normalized_name = name.casefold()
+        validated_group = validated_groups.get(normalized_name)
+        if validated_group is None:
+            validated_groups[normalized_name] = InterestGroup(
+                name=name,
+                entity_ids=accepted_entity_ids,
             )
+        else:
+            validated_group.entity_ids.extend(accepted_entity_ids)
+
+    if has_named_interest and not validated_groups:
+        raise ValueError("LLM returned interests without valid source entity IDs")
+
+    return list(validated_groups.values())
 
 
-            llm_client = ModelClientMixin.get_llm_client(
-                db, memory_config.llm_model_id, memory_config.tenant_id
-            )
+def aggregate_interest_groups(
+    candidates: List[InterestEntityCandidate],
+    groups: List[InterestGroup],
+    limit: int = INTEREST_DISPLAY_LIMIT,
+) -> List[Tuple[str, int]]:
+    """校验 LLM 来源并按候选实体真实频次汇总兴趣。"""
+    candidate_frequency = {
+        candidate.entity_id: candidate.frequency for candidate in candidates
+    }
+    validated_groups = validate_interest_groups(candidates, groups)
 
-        tag_list_str = ", ".join(tags)
-        from app.core.memory.utils.prompt.prompt_utils import render_interest_filter_prompt
-        rendered_prompt = render_interest_filter_prompt(tag_list_str, language=language)
-        messages = [
-            {
-                "role": "user",
-                "content": rendered_prompt
-            }
-        ]
-
-        structured_response = await llm_client.call_structured(messages, InterestTags)
-
-        return structured_response.interest_tags
-
-    except Exception as e:
-        logger.error(f"兴趣标签LLM筛选过程中发生错误: {e}", exc_info=True)
-        return tags
+    result = [
+        (
+            group.name,
+            sum(candidate_frequency[entity_id] for entity_id in group.entity_ids),
+        )
+        for group in validated_groups
+    ]
+    result.sort(key=lambda item: (-item[1], normalize_interest_name(item[0]).casefold()))
+    return result[:limit]
 
 
 async def get_raw_tags_from_db(
@@ -273,22 +475,16 @@ async def get_hot_memory_tags(end_user_id: str, limit: int = 10, by_user: bool =
         await connector.close()
 
 
-async def get_interest_distribution(end_user_id: str, limit: int = 10, by_user: bool = False, language: str = "zh") -> \
-List[Tuple[str, int]]:
-    """
-    获取用户的兴趣分布标签。
-    
-    与 get_hot_memory_tags 不同，此函数使用专门针对"活动/行为"的LLM prompt，
-    过滤掉纯物品、工具、地点等，只保留能代表用户兴趣爱好的活动类标签。
-
-    Args:
-        end_user_id: 必需参数。如果by_user=False，则为end_user_id；如果by_user=True，则为user_id
-        limit: 最终返回的标签数量限制（默认10）
-        by_user: 是否按user_id查询（默认False，按end_user_id查询）
-
-    Raises:
-        ValueError: 如果end_user_id未提供或为空
-    """
+async def generate_interest_distribution(
+    end_user_id: str,
+    limit: int = INTEREST_DISPLAY_LIMIT,
+    by_user: bool = False,
+    language: str = "zh",
+) -> InterestDistributionGeneration:
+    """生成兴趣分布；有效兴趣不超过两项时使用关联 Statement 补充判断。"""
+    # 总预算从生成入口统一起算，后续查询、LLM 调用和结果校验共享同一截止时间。
+    started_at = time.monotonic()
+    second_call_executed = False
     if not end_user_id or not end_user_id.strip():
         raise ValueError(
             "end_user_id is required. Please provide a valid end_user_id or user_id."
@@ -296,33 +492,286 @@ List[Tuple[str, int]]:
 
     connector = Neo4jConnector()
     try:
-        # 查询更多原始标签，给LLM提供充足上下文
-        query_limit = 40
-        raw_tags_with_freq = await get_raw_tags_from_db(connector, end_user_id, query_limit, by_user=by_user)
-        if not raw_tags_with_freq:
-            return []
+        repository = StatementRepository(connector)
+        # 候选查询也属于完整生成链路，不能只限制 LLM 调用时间。
+        try:
+            candidate_records = await _await_with_interest_budget(
+                lambda: repository.find_interest_entity_candidates(
+                    user_id=end_user_id,
+                    limit=INTEREST_CANDIDATE_LIMIT,
+                    excluded_names=INTEREST_EXCLUDED_NAMES,
+                    iso_datetime_pattern=INTEREST_ISO_DATETIME_PATTERN,
+                    unix_timestamp_pattern=INTEREST_UNIX_TIMESTAMP_PATTERN,
+                    by_user=by_user,
+                ),
+                started_at,
+            )
+        except Exception:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="candidate_query",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason=(
+                    "total_budget_exhausted"
+                    if _remaining_interest_budget(started_at) <= 0
+                    else "candidate_query_failed"
+                ),
+            )
+            raise
+        candidates = [
+            InterestEntityCandidate.model_validate(record)
+            for record in candidate_records
+        ]
+        # 首次有效结果尚未完成校验，此时预算耗尽不能返回任何部分结果。
+        if _remaining_interest_budget(started_at) <= 0:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="candidate_validation",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason="total_budget_exhausted",
+            )
+            raise TimeoutError(
+                "interest distribution total time budget exhausted before primary validation"
+            )
+        if not candidates:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="no_candidates",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+            )
+            return InterestDistributionGeneration(items=[], cacheable=True)
 
-        raw_tag_names = [tag for tag, freq in raw_tags_with_freq]
-        raw_freq_map = {tag: freq for tag, freq in raw_tags_with_freq}
+        # 每次业务级 LLM 调用最多 30 秒，同时不能超过当前剩余总预算。
+        primary_timeout = min(
+            INTEREST_DISTRIBUTION_LLM_TIMEOUT_SECONDS,
+            _remaining_interest_budget(started_at),
+        )
+        try:
+            interests = await _await_with_interest_budget(
+                lambda: filter_interests_with_llm(
+                    candidates,
+                    end_user_id,
+                    language=language,
+                    timeout_seconds=primary_timeout,
+                ),
+                started_at,
+            )
+        except Exception:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="primary_llm",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason=(
+                    "total_budget_exhausted"
+                    if _remaining_interest_budget(started_at) <= 0
+                    else "primary_llm_failed"
+                ),
+            )
+            raise
+        # LLM 虽已返回，但首次结果还未完成来源校验，预算耗尽仍按生成失败处理。
+        if _remaining_interest_budget(started_at) <= 0:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="primary_llm",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason="total_budget_exhausted",
+            )
+            raise TimeoutError(
+                "interest distribution total time budget exhausted before primary validation"
+            )
+        validated_primary_groups = validate_interest_groups(
+            candidates,
+            interests.interests,
+        )
+        combined_groups = list(validated_primary_groups)
+        primary_items = aggregate_interest_groups(
+            candidates,
+            validated_primary_groups,
+            limit=INTEREST_DISPLAY_LIMIT,
+        )
+        # 首次结果已完成校验，可以作为降级结果返回，但预算耗尽的结果不可缓存。
+        if _remaining_interest_budget(started_at) <= 0:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="primary_validation",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason="total_budget_exhausted",
+            )
+            return InterestDistributionGeneration(
+                items=primary_items[:limit],
+                cacheable=False,
+            )
 
-        # 使用兴趣活动专用prompt进行筛选（支持语义推断出新标签）
-        interest_tag_names = await filter_interests_with_llm(raw_tag_names, end_user_id, language=language)
+        if len(primary_items) <= 2:
+            claimed_entity_ids = {
+                entity_id
+                for group in validated_primary_groups
+                for entity_id in group.entity_ids
+            }
+            evidence_candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.entity_id not in claimed_entity_ids
+            ][:INTEREST_EVIDENCE_ENTITY_LIMIT]
 
-        # 构建最终标签列表：
-        # - 原始标签中存在的，保留原始频率
-        # - LLM推断出的新标签（不在原始列表中），赋予默认频率1
-        final_tags = []
-        seen = set()
-        for tag in interest_tag_names:
-            if tag in seen:
-                continue
-            seen.add(tag)
-            freq = raw_freq_map.get(tag, 1)
-            final_tags.append((tag, freq))
+            if evidence_candidates:
+                try:
+                    # Statement 证据查询继续消耗同一总预算，超时后只能降级到首次结果。
+                    evidence_records = await _await_with_interest_budget(
+                        lambda: repository.find_interest_statement_evidence(
+                            user_id=end_user_id,
+                            entity_ids=[candidate.entity_id for candidate in evidence_candidates],
+                            per_entity_limit=INTEREST_EVIDENCE_PER_ENTITY_LIMIT,
+                            limit=INTEREST_EVIDENCE_LIMIT,
+                            max_chars=INTEREST_EVIDENCE_MAX_CHARS,
+                            by_user=by_user,
+                        ),
+                        started_at,
+                    )
+                    evidence = [
+                        InterestStatementEvidence.model_validate(record)
+                        for record in evidence_records
+                    ]
+                    if _remaining_interest_budget(started_at) <= 0:
+                        _log_interest_budget(
+                            end_user_id=end_user_id,
+                            stage="statement_evidence",
+                            started_at=started_at,
+                            second_call_executed=second_call_executed,
+                            degradation_reason="total_budget_exhausted",
+                        )
+                        return InterestDistributionGeneration(
+                            items=primary_items[:limit],
+                            cacheable=False,
+                        )
+                    if evidence:
+                        evidenced_entity_ids = {
+                            entity_id
+                            for item in evidence
+                            for entity_id in item.entity_ids
+                        }
+                        fallback_candidates = [
+                            candidate
+                            for candidate in evidence_candidates
+                            if candidate.entity_id in evidenced_entity_ids
+                        ]
+                        if fallback_candidates:
+                            remaining = _remaining_interest_budget(started_at)
+                            # 恰好 5 秒仍允许调用；不足 5 秒时避免发起大概率无法完成的第二次调用。
+                            if remaining < INTEREST_DISTRIBUTION_MIN_FALLBACK_TIMEOUT_SECONDS:
+                                _log_interest_budget(
+                                    end_user_id=end_user_id,
+                                    stage="before_second_llm",
+                                    started_at=started_at,
+                                    second_call_executed=second_call_executed,
+                                    degradation_reason="total_budget_exhausted",
+                                )
+                                return InterestDistributionGeneration(
+                                    items=primary_items[:limit],
+                                    cacheable=False,
+                                )
+                            second_call_executed = True
+                            # 第二次调用沿用单次 30 秒上限，但通常只会获得剩余预算。
+                            fallback_timeout = min(
+                                INTEREST_DISTRIBUTION_LLM_TIMEOUT_SECONDS,
+                                remaining,
+                            )
+                            supplemental_interests = await _await_with_interest_budget(
+                                lambda: filter_interests_with_llm(
+                                    fallback_candidates,
+                                    end_user_id,
+                                    language=language,
+                                    evidence=evidence,
+                                    existing_interests=[name for name, _ in primary_items],
+                                    timeout_seconds=fallback_timeout,
+                                ),
+                                started_at,
+                            )
+                            # 第二次结果尚未进入最终聚合时耗尽预算，仍只返回已验证的首次结果。
+                            if _remaining_interest_budget(started_at) <= 0:
+                                _log_interest_budget(
+                                    end_user_id=end_user_id,
+                                    stage="second_llm",
+                                    started_at=started_at,
+                                    second_call_executed=second_call_executed,
+                                    degradation_reason="total_budget_exhausted",
+                                )
+                                return InterestDistributionGeneration(
+                                    items=primary_items[:limit],
+                                    cacheable=False,
+                                )
+                            combined_groups.extend(supplemental_interests.interests)
+                except Exception as exc:
+                    _log_interest_budget(
+                        end_user_id=end_user_id,
+                        stage="statement_fallback",
+                        started_at=started_at,
+                        second_call_executed=second_call_executed,
+                        degradation_reason=(
+                            "total_budget_exhausted"
+                            if _remaining_interest_budget(started_at) <= 0
+                            else "statement_fallback_failed"
+                        ),
+                    )
+                    logger.warning(
+                        "interest_distribution stage=statement_fallback_failed "
+                        "end_user_id=%s error_type=%s error=%r",
+                        end_user_id,
+                        type(exc).__name__,
+                        exc,
+                        exc_info=True,
+                    )
+                    return InterestDistributionGeneration(
+                        items=primary_items[:limit],
+                        cacheable=False,
+                    )
 
-        # 按频率降序排列
-        final_tags.sort(key=lambda x: x[1], reverse=True)
-
-        return final_tags[:limit]
+        # 聚合与排序也计入总预算；若处理期间越界，不返回未经预算内确认的补充结果。
+        items = aggregate_interest_groups(candidates, combined_groups, limit=limit)
+        if _remaining_interest_budget(started_at) <= 0:
+            _log_interest_budget(
+                end_user_id=end_user_id,
+                stage="final_validation",
+                started_at=started_at,
+                second_call_executed=second_call_executed,
+                degradation_reason="total_budget_exhausted",
+            )
+            return InterestDistributionGeneration(
+                items=primary_items[:limit],
+                cacheable=False,
+            )
+        _log_interest_budget(
+            end_user_id=end_user_id,
+            stage="completed",
+            started_at=started_at,
+            second_call_executed=second_call_executed,
+        )
+        return InterestDistributionGeneration(
+            items=items,
+            cacheable=bool(items),
+        )
     finally:
+        # Connector 清理不受业务预算限制，任何返回或异常路径都必须等待关闭完成。
         await connector.close()
+
+
+async def get_interest_distribution(
+    end_user_id: str,
+    limit: int = INTEREST_DISPLAY_LIMIT,
+    by_user: bool = False,
+    language: str = "zh",
+) -> List[Tuple[str, int]]:
+    """获取兴趣分布列表，保留既有调用合同。"""
+    generation = await generate_interest_distribution(
+        end_user_id=end_user_id,
+        limit=limit,
+        by_user=by_user,
+        language=language,
+    )
+    return generation.items

--- a/api/app/core/memory/utils/prompt/prompt_utils.py
+++ b/api/app/core/memory/utils/prompt/prompt_utils.py
@@ -526,21 +526,35 @@ async def render_ontology_extraction_prompt(
     return rendered_prompt
 
 
-def render_interest_filter_prompt(tag_list: str, language: str = "zh") -> str:
+def render_interest_filter_prompt(
+    candidates: list[dict[str, object]],
+    language: str = "zh",
+    evidence: list[dict[str, object]] | None = None,
+    existing_interests: list[str] | None = None,
+) -> str:
     """
     Renders the interest filter prompt using the interest_filter.jinja2 template.
 
     Args:
-        tag_list: Comma-separated string of raw tags to filter
+        candidates: Interest candidate entities with source IDs and frequencies
         language: Output language ("zh" for Chinese, "en" for English)
+        evidence: Optional Statement evidence associated with candidate entities
+        existing_interests: Accepted interests that the fallback must not duplicate
 
     Returns:
         Rendered prompt content as string
     """
     template = prompt_env.get_template("interest_filter.jinja2")
-    rendered_prompt = template.render(tag_list=tag_list, language=language)
-    log_prompt_rendering('interest filter', rendered_prompt)
-    return rendered_prompt
+    return template.render(
+        candidates_json=json.dumps(candidates, ensure_ascii=False),
+        evidence_json=json.dumps(evidence, ensure_ascii=False) if evidence else None,
+        existing_interests_json=(
+            json.dumps(existing_interests, ensure_ascii=False)
+            if existing_interests
+            else None
+        ),
+        language=language,
+    )
 
 
 async def render_neo4j_memory_summary_prompt(

--- a/api/app/core/memory/utils/prompt/prompts/interest_filter.jinja2
+++ b/api/app/core/memory/utils/prompt/prompts/interest_filter.jinja2
@@ -1,67 +1,59 @@
 {% if language == "zh" %}
-You are a user interest analysis expert. Your task is to infer and extract the user's core hobby/interest activities from a tag list. The tags may be specific project names, tool names, or compound nouns — your job is to identify the underlying interest they represent.
+你是用户兴趣分析器。输入是按用户记忆 Statement 频次排序的候选实体 JSON。{% if evidence_json %}本次还提供了与候选实体直接关联的用户记忆 Statement，仅用于补充实体语境。{% endif %}{% if existing_interests_json %}本次是补充判断，系统已经接受了一部分已有兴趣。{% endif %}
 
-**Step 1 - Infer the underlying interest from each tag**:
-Look at each tag and ask: "What hobby or interest does this tag suggest the user has?"
+请完成以下任务：
+1. 识别输入实体能够合理支撑的用户兴趣，包括运动与户外、旅行与地点体验、观赏体验、娱乐、阅读、学习、创作、收藏、美食及其他明确偏好，不限于主动参与的活动。
+2. frequency 只表示记忆中的提及次数，用于后端计算权重，不是筛选门槛。即使 frequency=1，只要实体能合理支撑某项兴趣，也应保留。
+3. 地点、物品或具体体验可以作为兴趣证据。例如“九溪十八涧”可支撑徒步或出游兴趣，“观日落”可支撑观赏日落兴趣；无法合理关联到兴趣的系统词、时间戳、天气或路况才忽略。
+4. 将同义、近义或表达同一兴趣的实体合并成一个简洁兴趣名称；在证据支持的范围内尽量识别不同兴趣，最多返回 5 项，但不强制补足。
+5. 每个兴趣必须返回支撑它的全部来源 entity_id；entity_id 只能从输入中选择。
+6. 可以根据实体含义做合理归纳，但不要根据输入之外的信息生成兴趣。无法由任何输入实体支撑时才返回空数组。
+{% if evidence_json %}7. Statement 是实体的语境证据。明确偏好、持续参与、主动学习或多次行为可以支撑兴趣；一次偶然事件、工作任务、他人偏好或普通事实不能单独认定为用户兴趣。仍然只返回候选 entity_id，不返回 statement_id。{% endif %}
+{% if existing_interests_json %}8. 只返回与已有兴趣不同的新增兴趣。不要重复、改名、细分或换一种说法返回已有兴趣；没有独立的新兴趣证据时返回空数组。{% endif %}
 
-Examples of inference:
-- '攀岩', '室内攀岩馆', '攀岩者数据仪表盘', '路线解锁地图', '指力', '路线等级', '当日攀岩流畅度' → '攀岩'
-- '风光摄影元数据增强器', 'EXIF数据', '.CR2文件', '.NEF文件', '日出拍摄点', '曝光补偿', '光圈', '太阳高度角', '云量预测图层' → '摄影'
-- '晨间冥想坚持天数', '身心协同峰值' → '冥想'
-- '川味可视化', '川菜' → '烹饪'
-- '开源项目命名建议', 'climbviz', '可视化', '力量增长雷达图' → '编程' 或 '数据可视化'
-- '吉他', '指弹', '琴谱' → '吉他'
-- '跑步', '5公里', '跑鞋' → '跑步'
-- '瑜伽垫', '瑜伽课' → '瑜伽'
+只返回符合结构化 Schema 的 JSON 对象，不要返回顶层数组、Markdown、频次、百分比、解释或额外字段。
+完整格式示例（示例 ID 仅用于说明格式，实际 entity_id 必须来自本次输入）：
+{"interests":[{"name":"徒步","entity_ids":["example_entity_id_1"]},{"name":"摄影","entity_ids":["example_entity_id_2"]}]}
+没有任何兴趣时返回：
+{"interests":[]}
 
-**Step 2 - Consolidate and deduplicate**:
-- Merge tags that point to the same interest into one representative label
-- Use concise, standard hobby names (e.g., '攀岩', '摄影', '编程', '烹饪', '冥想', '吉他', '跑步')
-- If multiple tags all point to '攀岩', output '攀岩' only once
-
-**Step 3 - Filter out non-interest tags**:
-Remove tags that do NOT suggest any hobby or interest:
-- Generic system/assistant terms (e.g., '助手', '用户', 'AI')
-- Pure abstract metrics with no clear hobby link (e.g., '完成时间', '日期', '自我评分')
-- Location names with no clear hobby link (e.g., '青城山后山' alone — but if combined with photography context, infer '摄影')
-
-**Output format**: Return a strict JSON object with a single key `interest_tags`, whose value is a list of concise interest activity names in Chinese. Do NOT return a bare list. Do NOT include any prose, markdown fences, or extra keys.
-
-**Example**:
-Input: ['攀岩', '攀岩者数据仪表盘', '路线解锁地图', '指力', '风光摄影元数据增强器', 'EXIF数据', '晨间冥想坚持天数', '川味可视化', '可视化', '助手', '完成时间']
-Output: {"interest_tags": ["攀岩", "摄影", "冥想", "烹饪", "编程"]}
-
-Now process the following tag list and return the inferred interest activities in Chinese as the specified JSON object: {{ tag_list }}
+候选实体：
+{{ candidates_json }}
+{% if existing_interests_json %}
+已有兴趣（不得重复）：
+{{ existing_interests_json }}
+{% endif %}
+{% if evidence_json %}
+关联 Statement 证据：
+{{ evidence_json }}
+{% endif %}
 {% else %}
-You are a user interest analysis expert. Your task is to infer and extract the user's core hobby/interest activities from a tag list. The tags may be specific project names, tool names, or compound nouns — your job is to identify the underlying interest they represent.
+You analyze user interests. The input is a JSON array of candidate entities ranked by the number of supporting user-memory Statements.{% if evidence_json %} This request also includes user-memory Statements directly linked to the candidate entities, solely to clarify entity context.{% endif %}{% if existing_interests_json %} This is a supplemental pass and some interests have already been accepted.{% endif %}
 
-**Step 1 - Infer the underlying interest from each tag**:
-Look at each tag and ask: "What hobby or interest does this tag suggest the user has?"
+Tasks:
+1. Identify interests reasonably supported by the input entities, including sports and outdoors, travel and place-based experiences, viewing experiences, entertainment, reading, learning, creation, collecting, food, and other clear preferences. Interests are not limited to activities the user actively performs.
+2. Frequency is only the number of mentions used by the backend for weighting; it is not a filtering threshold. Keep a clearly supported interest even when frequency=1.
+3. Places, objects, and specific experiences may provide interest evidence. For example, a hiking destination may support hiking or travel, and watching a sunset may support a sunset-viewing interest. Ignore only items that cannot reasonably support an interest, such as system terms, timestamps, weather, or traffic alone.
+4. Merge synonymous or closely related entities representing the same interest under one concise name. Identify distinct supported interests when possible, up to 5, but never pad the result.
+5. Return every supporting source entity_id for each interest. Use only entity IDs from the input.
+6. Reasonable semantic generalization from the entities is allowed, but do not invent interests unsupported by the input. Return an empty interests array only when no input entity supports an interest.
+{% if evidence_json %}7. Statements provide context for entities. Explicit preferences, sustained participation, active learning, or repeated behavior may support an interest. A one-off event, work task, another person's preference, or ordinary fact alone must not be treated as the user's interest. Return candidate entity IDs only, not statement IDs.{% endif %}
+{% if existing_interests_json %}8. Return only new interests distinct from the accepted interests. Do not repeat, rename, subdivide, or paraphrase an accepted interest. Return an empty array when there is no independently supported new interest.{% endif %}
 
-Examples of inference:
-- 'rock climbing', 'indoor climbing gym', 'climber dashboard', 'route map', 'finger strength' → 'rock climbing'
-- 'landscape photography metadata enhancer', 'EXIF data', 'sunrise shooting spot', 'exposure compensation' → 'photography'
-- 'morning meditation streak', 'mind-body peak' → 'meditation'
-- 'Sichuan cuisine visualization', 'Sichuan food' → 'cooking'
-- 'open source project', 'data visualization tool', 'Python' → 'programming'
-- 'guitar', 'fingerpicking', 'sheet music' → 'guitar'
-- 'running', '5km', 'running shoes' → 'running'
+Return only a JSON object matching the structured Schema. Do not return a top-level array, Markdown, frequencies, percentages, explanations, or extra fields.
+Complete format example (the example IDs only illustrate the format; actual entity IDs must come from the current input):
+{"interests":[{"name":"Hiking","entity_ids":["example_entity_id_1"]},{"name":"Photography","entity_ids":["example_entity_id_2"]}]}
+When no interest is supported, return:
+{"interests":[]}
 
-**Step 2 - Consolidate and deduplicate**:
-- Merge tags that point to the same interest into one representative label
-- Use concise, standard hobby names (e.g., 'rock climbing', 'photography', 'programming', 'cooking', 'meditation')
-- If multiple tags all point to 'rock climbing', output 'rock climbing' only once
-
-**Step 3 - Filter out non-interest tags**:
-Remove tags that do NOT suggest any hobby or interest:
-- Generic system/assistant terms (e.g., 'assistant', 'user', 'AI')
-- Pure abstract metrics with no clear hobby link (e.g., 'completion time', 'date', 'self-rating')
-
-**Output format**: Return a strict JSON object with a single key `interest_tags`, whose value is a list of concise interest activity names in English. Do NOT return a bare list. Do NOT include any prose, markdown fences, or extra keys.
-
-**Example**:
-Input: ['rock climbing', 'climber dashboard', 'route map', 'finger strength', 'landscape photography metadata enhancer', 'EXIF data', 'morning meditation streak', 'Sichuan cuisine visualization', 'visualization', 'assistant', 'completion time']
-Output: {"interest_tags": ["rock climbing", "photography", "meditation", "cooking", "programming"]}
-
-Now process the following tag list and return the inferred interest activities in English as the specified JSON object: {{ tag_list }}
+Candidate entities:
+{{ candidates_json }}
+{% if existing_interests_json %}
+Accepted interests (do not repeat):
+{{ existing_interests_json }}
+{% endif %}
+{% if evidence_json %}
+Linked Statement evidence:
+{{ evidence_json }}
+{% endif %}
 {% endif %}

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -112,6 +112,136 @@ SET s.emotion_type = item.emotion_type,
 RETURN s.id AS uuid
 """
 
+INTEREST_ENTITY_CANDIDATES_BY_END_USER = """
+MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e:ExtractedEntity)
+WHERE s.end_user_id = $id
+  AND e.end_user_id = $id
+  AND s.delete_at IS NULL
+  AND e.delete_at IS NULL
+  AND e.id IS NOT NULL
+  AND e.name IS NOT NULL
+  AND (
+    s.speaker IS NULL
+    OR toLower(trim(toString(s.speaker))) = 'user'
+  )
+WITH e.id AS entity_id,
+     trim(toString(e.name)) AS name,
+     coalesce(toString(e.entity_type), '') AS entity_type,
+     count(DISTINCT s.id) AS frequency
+WHERE name <> ''
+  AND NOT (toLower(name) IN $excluded_names)
+  AND NOT name =~ $iso_datetime_pattern
+  AND NOT name =~ $unix_timestamp_pattern
+RETURN entity_id, name, entity_type, frequency
+ORDER BY frequency DESC, toLower(name) ASC, entity_id ASC
+LIMIT $limit
+"""
+
+INTEREST_ENTITY_CANDIDATES_BY_USER = """
+MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e:ExtractedEntity)
+WHERE s.user_id = $id
+  AND e.user_id = $id
+  AND s.delete_at IS NULL
+  AND e.delete_at IS NULL
+  AND e.id IS NOT NULL
+  AND e.name IS NOT NULL
+  AND (
+    s.speaker IS NULL
+    OR toLower(trim(toString(s.speaker))) = 'user'
+  )
+WITH e.id AS entity_id,
+     trim(toString(e.name)) AS name,
+     coalesce(toString(e.entity_type), '') AS entity_type,
+     count(DISTINCT s.id) AS frequency
+WHERE name <> ''
+  AND NOT (toLower(name) IN $excluded_names)
+  AND NOT name =~ $iso_datetime_pattern
+  AND NOT name =~ $unix_timestamp_pattern
+RETURN entity_id, name, entity_type, frequency
+ORDER BY frequency DESC, toLower(name) ASC, entity_id ASC
+LIMIT $limit
+"""
+
+INTEREST_STATEMENT_EVIDENCE_BY_END_USER = """
+UNWIND range(0, size($entity_ids) - 1) AS entity_rank
+WITH entity_rank, $entity_ids[entity_rank] AS entity_id
+MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e:ExtractedEntity {id: entity_id})
+WHERE s.end_user_id = $id
+  AND e.end_user_id = $id
+  AND s.delete_at IS NULL
+  AND e.delete_at IS NULL
+  AND s.id IS NOT NULL
+  AND s.statement IS NOT NULL
+  AND trim(toString(s.statement)) <> ''
+  AND (
+    s.speaker IS NULL
+    OR toLower(trim(toString(s.speaker))) = 'user'
+  )
+WITH entity_rank, entity_id, s
+ORDER BY entity_rank ASC,
+         CASE WHEN toLower(trim(toString(s.speaker))) = 'user' THEN 0 ELSE 1 END ASC,
+         coalesce(s.dialog_at, s.created_at) DESC,
+         s.id ASC
+WITH entity_rank, entity_id, collect(s)[0..$per_entity_limit] AS statements
+UNWIND statements AS s
+WITH s, min(entity_rank) AS first_entity_rank
+MATCH (s)-[:REFERENCES_ENTITY]->(related_entity:ExtractedEntity)
+WHERE related_entity.id IN $entity_ids
+  AND related_entity.end_user_id = $id
+  AND related_entity.delete_at IS NULL
+WITH s,
+     first_entity_rank,
+     collect(DISTINCT toString(related_entity.id)) AS related_entity_ids
+RETURN toString(s.id) AS statement_id,
+       [entity_id IN $entity_ids WHERE entity_id IN related_entity_ids] AS entity_ids,
+       substring(trim(toString(s.statement)), 0, $max_chars) AS statement_text
+ORDER BY first_entity_rank ASC,
+         CASE WHEN toLower(trim(toString(s.speaker))) = 'user' THEN 0 ELSE 1 END ASC,
+         coalesce(s.dialog_at, s.created_at) DESC,
+         statement_id ASC
+LIMIT $limit
+"""
+
+INTEREST_STATEMENT_EVIDENCE_BY_USER = """
+UNWIND range(0, size($entity_ids) - 1) AS entity_rank
+WITH entity_rank, $entity_ids[entity_rank] AS entity_id
+MATCH (s:Statement)-[:REFERENCES_ENTITY]->(e:ExtractedEntity {id: entity_id})
+WHERE s.user_id = $id
+  AND e.user_id = $id
+  AND s.delete_at IS NULL
+  AND e.delete_at IS NULL
+  AND s.id IS NOT NULL
+  AND s.statement IS NOT NULL
+  AND trim(toString(s.statement)) <> ''
+  AND (
+    s.speaker IS NULL
+    OR toLower(trim(toString(s.speaker))) = 'user'
+  )
+WITH entity_rank, entity_id, s
+ORDER BY entity_rank ASC,
+         CASE WHEN toLower(trim(toString(s.speaker))) = 'user' THEN 0 ELSE 1 END ASC,
+         coalesce(s.dialog_at, s.created_at) DESC,
+         s.id ASC
+WITH entity_rank, entity_id, collect(s)[0..$per_entity_limit] AS statements
+UNWIND statements AS s
+WITH s, min(entity_rank) AS first_entity_rank
+MATCH (s)-[:REFERENCES_ENTITY]->(related_entity:ExtractedEntity)
+WHERE related_entity.id IN $entity_ids
+  AND related_entity.user_id = $id
+  AND related_entity.delete_at IS NULL
+WITH s,
+     first_entity_rank,
+     collect(DISTINCT toString(related_entity.id)) AS related_entity_ids
+RETURN toString(s.id) AS statement_id,
+       [entity_id IN $entity_ids WHERE entity_id IN related_entity_ids] AS entity_ids,
+       substring(trim(toString(s.statement)), 0, $max_chars) AS statement_text
+ORDER BY first_entity_rank ASC,
+         CASE WHEN toLower(trim(toString(s.speaker))) = 'user' THEN 0 ELSE 1 END ASC,
+         coalesce(s.dialog_at, s.created_at) DESC,
+         statement_id ASC
+LIMIT $limit
+"""
+
 CHUNK_NODE_SAVE = """
 UNWIND $chunks AS chunk
 MERGE (c:Chunk {id: chunk.id})

--- a/api/app/repositories/neo4j/statement_repository.py
+++ b/api/app/repositories/neo4j/statement_repository.py
@@ -7,13 +7,19 @@ Classes:
     StatementRepository: 陈述句仓储，管理StatementNode的CRUD操作
 """
 
-from typing import Dict, List, Sequence
+from typing import Any, Dict, List, Sequence
 from datetime import datetime
 
 from app.repositories.neo4j.base_neo4j_repository import BaseNeo4jRepository
 from app.core.memory.models.graph_models import StatementNode
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.core.memory.utils.data.ontology import TemporalInfo
+from app.repositories.neo4j.cypher_queries import (
+    INTEREST_ENTITY_CANDIDATES_BY_END_USER,
+    INTEREST_ENTITY_CANDIDATES_BY_USER,
+    INTEREST_STATEMENT_EVIDENCE_BY_END_USER,
+    INTEREST_STATEMENT_EVIDENCE_BY_USER,
+)
 
 
 class StatementRepository(BaseNeo4jRepository[StatementNode]):
@@ -122,3 +128,54 @@ class StatementRepository(BaseNeo4jRepository[StatementNode]):
             limit=limit,
         )
         return [record["statement"] for record in results]
+
+    async def find_interest_entity_candidates(
+        self,
+        user_id: str,
+        limit: int,
+        excluded_names: Sequence[str],
+        iso_datetime_pattern: str,
+        unix_timestamp_pattern: str,
+        by_user: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """按有效 Statement 数量查询兴趣候选实体。"""
+        query = (
+            INTEREST_ENTITY_CANDIDATES_BY_USER
+            if by_user
+            else INTEREST_ENTITY_CANDIDATES_BY_END_USER
+        )
+        return await self.connector.execute_query(
+            query,
+            id=user_id,
+            limit=limit,
+            excluded_names=list(excluded_names),
+            iso_datetime_pattern=iso_datetime_pattern,
+            unix_timestamp_pattern=unix_timestamp_pattern,
+        )
+
+    async def find_interest_statement_evidence(
+        self,
+        user_id: str,
+        entity_ids: Sequence[str],
+        per_entity_limit: int,
+        limit: int,
+        max_chars: int,
+        by_user: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """批量查询兴趣候选实体关联的有效 Statement 证据。"""
+        if not entity_ids:
+            return []
+
+        query = (
+            INTEREST_STATEMENT_EVIDENCE_BY_USER
+            if by_user
+            else INTEREST_STATEMENT_EVIDENCE_BY_END_USER
+        )
+        return await self.connector.execute_query(
+            query,
+            id=user_id,
+            entity_ids=list(entity_ids),
+            per_entity_limit=per_entity_limit,
+            limit=limit,
+            max_chars=max_chars,
+        )

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -26,7 +26,10 @@ from app.core.config import settings
 from app.core.logging_config import get_config_logger, get_logger
 from app.core.memory.agent.logger_file.log_streamer import LogStreamer
 from app.core.memory.agent.utils.type_classifier import status_typle
-from app.core.memory.analytics.hot_memory_tags import get_interest_distribution
+from app.core.memory.analytics.hot_memory_tags import (
+    generate_interest_distribution,
+    get_interest_distribution,
+)
 from app.db import get_db_context, get_db_read
 from app.models.knowledge_model import Knowledge, KnowledgeType
 from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
@@ -490,6 +493,36 @@ class MemoryAgentService:
         except Exception as e:
             logger.error(f"兴趣分布标签查询失败: {e}")
             raise Exception(f"兴趣分布标签查询失败: {e}")
+
+    async def generate_interest_distribution_by_user(
+            self,
+            end_user_id: Optional[str] = None,
+            limit: int = 5,
+            language: str = "zh",
+    ) -> tuple[List[Dict[str, Any]], bool]:
+        """生成兴趣分布，并返回是否应写入缓存。"""
+        try:
+            generation = await generate_interest_distribution(
+                end_user_id=end_user_id,
+                limit=limit,
+                by_user=False,
+                language=language,
+            )
+            items = [
+                {"name": name, "frequency": frequency}
+                for name, frequency in generation.items
+            ]
+            return items, generation.cacheable
+        except Exception as e:
+            error_type = type(e).__name__
+            logger.error(
+                "兴趣分布标签生成失败: error_type=%s error=%r",
+                error_type,
+                e,
+            )
+            raise Exception(
+                f"兴趣分布标签生成失败: {error_type}: {e!r}"
+            ) from e
 
     async def get_user_profile(
             self,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4995,7 +4995,7 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
                     logger.info(f"用户 {end_user_id} 兴趣分布缓存生成成功")
                 else:
                     not_cached += 1
-                    logger.info(f"用户 {end_user_id} LLM 未识别到兴趣，本次不写缓存")
+                    logger.info(f"用户 {end_user_id} 兴趣分布结果不可缓存，本次不写缓存")
             except Exception as e:
                 failed += 1
                 logger.error(f"用户 {end_user_id} 兴趣分布缓存生成失败: {e}")

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4940,6 +4940,7 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
         initialized = 0
         failed = 0
         skipped = 0
+        not_cached = 0
         language = "zh"
 
         service = MemoryAgentService()
@@ -4978,27 +4979,35 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
 
             logger.info(f"用户 {end_user_id} 无兴趣分布缓存，开始生成")
             try:
-                result = await service.get_interest_distribution_by_user(
+                result, cacheable = await service.generate_interest_distribution_by_user(
                     end_user_id=end_user_id,
                     limit=5,
                     language=language,
                 )
-                await InterestMemoryCache.set_interest_distribution(
-                    end_user_id=end_user_id,
-                    language=language,
-                    data=result,
-                    expire=INTEREST_CACHE_EXPIRE,
-                )
-                initialized += 1
-                logger.info(f"用户 {end_user_id} 兴趣分布缓存生成成功")
+                if cacheable:
+                    await InterestMemoryCache.set_interest_distribution(
+                        end_user_id=end_user_id,
+                        language=language,
+                        data=result,
+                        expire=INTEREST_CACHE_EXPIRE,
+                    )
+                    initialized += 1
+                    logger.info(f"用户 {end_user_id} 兴趣分布缓存生成成功")
+                else:
+                    not_cached += 1
+                    logger.info(f"用户 {end_user_id} LLM 未识别到兴趣，本次不写缓存")
             except Exception as e:
                 failed += 1
                 logger.error(f"用户 {end_user_id} 兴趣分布缓存生成失败: {e}")
 
-        logger.info(f"兴趣分布按需初始化完成: 初始化={initialized}, 跳过={skipped}, 失败={failed}")
+        logger.info(
+            f"兴趣分布按需初始化完成: 初始化={initialized}, "
+            f"未缓存={not_cached}, 跳过={skipped}, 失败={failed}"
+        )
         return {
             "status": "SUCCESS",
             "initialized": initialized,
+            "not_cached": not_cached,
             "skipped": skipped,
             "failed": failed,
         }
@@ -5006,8 +5015,13 @@ def init_interest_distribution_for_users(self, end_user_ids: List[str]) -> Dict[
     loop = set_asyncio_event_loop()
     try:
         result = loop.run_until_complete(_run())
-        # 全部失败（无初始化、无跳过）= 完全失败：raise → Celery FAILURE
-        if result["failed"] > 0 and result["initialized"] == 0 and result["skipped"] == 0:
+        # 全部失败（无初始化、无未缓存成功结果、无跳过）才标记 Celery FAILURE。
+        if (
+            result["failed"] > 0
+            and result["initialized"] == 0
+            and result["not_cached"] == 0
+            and result["skipped"] == 0
+        ):
             raise RuntimeError(
                 f"all {result['failed']} users failed to initialize interest distribution"
             )


### PR DESCRIPTION
Calculate interest weights from validated source entity frequencies.

Add Statement evidence fallback when the primary result has at most two interests.

Enforce a shared 45-second generation budget and preserve cache decisions across API and warmup paths.

## Summary by Sourcery

优化用户兴趣分布的生成逻辑：使用已验证的陈述实体频率，增加在检测到兴趣较少时基于陈述的回退路径，并在 API 与预热流程之间统一时间预算与缓存决策。

New Features:
- 引入「兴趣实体」与「陈述证据」模型，以及包含缓存决策记录的结构化生成结果。
- 添加 Cypher 查询与仓储方法，用于获取兴趣实体候选项及相关陈述证据，以支持兴趣推断。

Bug Fixes:
- 确保兴趣权重来源于已验证的陈述实体频率，而不仅仅是推断标签。
- 通过标记不可缓存的生成结果并在 API 与预热缓存流程中遵守该标记，避免缓存空的或退化的兴趣分布。

Enhancements:
- 重构兴趣过滤逻辑，使其接收结构化实体候选项，并按已验证的源实体汇总兴趣，同时加入健壮的验证与规范化逻辑。
- 在 Neo4j 查询与 LLM 调用之间实现共享的 45 秒时间预算，附带详细的预算感知日志与平滑降级路径。
- 更新兴趣过滤提示词，使其基于结构化候选项、可选的陈述证据与已有兴趣进行运作，并在初次兴趣较稀疏时支持第二次 LLM 处理。
- 调整兴趣分布 API 和后台缓存预热逻辑，使其使用新的生成流水线，同时保持现有对外响应结构不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine user interest distribution generation to use validated statement entity frequencies, add a statement-based fallback path when few interests are detected, and enforce a shared time budget with cacheability decisions across API and warmup flows.

New Features:
- Introduce interest entity and statement evidence models plus a structured generation result that records cacheability decisions.
- Add Cypher queries and repository methods to fetch interest entity candidates and related statement evidence for interest inference.

Bug Fixes:
- Ensure interest weights are derived from validated statement entity frequencies rather than inferred tags alone.
- Avoid caching empty or degraded interest distributions by marking non-cacheable generations and respecting this in API and warmup caching paths.

Enhancements:
- Rework interest filtering to accept structured entity candidates and aggregate interests by validated source entities, including robust validation and normalization logic.
- Implement a shared 45-second time budget across Neo4j queries and LLM calls with detailed budget-aware logging and graceful degradation paths.
- Update interest filter prompts to operate on structured candidates and optional statement evidence and existing interests, supporting a secondary LLM pass when primary interests are sparse.
- Adjust interest distribution API and background cache warmup to use the new generation pipeline while preserving the existing public response shape.

</details>