### PR TITLE
feat(api-key): add rate_limit_disabled field to bypass rate limiter for service keys

### DIFF
--- a/api/app/models/api_key_model.py
+++ b/api/app/models/api_key_model.py
@@ -43,6 +43,7 @@ class ApiKey(Base):
     # 限制和配额
     rate_limit = Column(Integer, default=10, comment="QPS限制（请求/秒）")
     daily_request_limit = Column(Integer, default=10000, comment="日请求限制")
+    rate_limit_disabled = Column(Boolean, default=False, nullable=False, comment="跳过全部限流检查（预置服务 Key 专用）")
 
     # 配额和使用统计
     quota_limit = Column(Integer, comment="配额限制（总请求数）")

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -399,7 +399,12 @@ class RateLimiterService:
         2. API Key 日调用量
 
         ``db`` 支持 ``Session`` 和 ``AsyncSession``，自动按类型选择同步/异步查询。
+
+        rate_limit_disabled=True 的 Key 跳过全部限流检查（如预置的 MemorySkills 空间 Key）。
         """
+        if api_key.rate_limit_disabled:
+            return True, "", {}
+
         # 1. 取套餐限额与 api_key 自身限额的最小值
         effective_limit = api_key.rate_limit
         tenant_limit = None


### PR DESCRIPTION
## Summary by Sourcery

为特定 API Key 添加禁用限流（rate limiting）的支持。

New Features:
- 在 API Key 上引入 `rate_limit_disabled` 标志，用于让指定的服务密钥绕过所有限流检查。

Enhancements:
- 当某个 API Key 启用了 `rate_limit_disabled` 时，短路（跳过）其限流检查逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for disabling rate limiting on specific API keys.

New Features:
- Introduce a rate_limit_disabled flag on API keys to bypass all rate limit checks for designated service keys.

Enhancements:
- Short-circuit the rate limit checking logic when rate_limit_disabled is enabled for an API key.

</details>