### PR TITLE
fix(models): add server_default for rate_limit_disabled column

### DIFF
--- a/api/app/models/api_key_model.py
+++ b/api/app/models/api_key_model.py
@@ -2,7 +2,7 @@
 import datetime
 import uuid
 
-from sqlalchemy import Column, String, Boolean, DateTime, Integer, ForeignKey, Text
+from sqlalchemy import Column, String, Boolean, DateTime, Integer, ForeignKey, Text, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from enum import StrEnum
@@ -43,7 +43,7 @@ class ApiKey(Base):
     # 限制和配额
     rate_limit = Column(Integer, default=10, comment="QPS限制（请求/秒）")
     daily_request_limit = Column(Integer, default=10000, comment="日请求限制")
-    rate_limit_disabled = Column(Boolean, default=False, nullable=False, server_default="false", comment="跳过全部限流检查（预置服务 Key 专用）")
+    rate_limit_disabled = Column(Boolean, default=False, nullable=False, server_default=text("false"), comment="跳过全部限流检查（预置服务 Key 专用）")
 
     # 配额和使用统计
     quota_limit = Column(Integer, comment="配额限制（总请求数）")

--- a/api/app/models/api_key_model.py
+++ b/api/app/models/api_key_model.py
@@ -43,7 +43,7 @@ class ApiKey(Base):
     # 限制和配额
     rate_limit = Column(Integer, default=10, comment="QPS限制（请求/秒）")
     daily_request_limit = Column(Integer, default=10000, comment="日请求限制")
-    rate_limit_disabled = Column(Boolean, default=False, nullable=False, comment="跳过全部限流检查（预置服务 Key 专用）")
+    rate_limit_disabled = Column(Boolean, default=False, nullable=False, server_default="false", comment="跳过全部限流检查（预置服务 Key 专用）")
 
     # 配额和使用统计
     quota_limit = Column(Integer, comment="配额限制（总请求数）")


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 为 `rate_limit_disabled` 列在服务器端设置默认值为 `false`，以防止现有或新建记录中出现 `null` 或不一致的值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set a server-side default of false for the rate_limit_disabled column to prevent null or inconsistent values in existing or newly created records.

</details>