### PR TITLE
fix(rag): preserve public API file download

### DIFF
--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -268,19 +268,17 @@ async def custom_text(
 
 
 @router.get("/{file_id}", response_model=Any)
-@cur_workspace_access_guard()
 async def get_file(
         file_id: uuid.UUID,
         original: bool = Query(False, description="QA 文档是否下载原始文件（默认从 ES 导出修改后内容）"),
         db: Session = Depends(get_db),
-        current_user: User = Depends(get_current_user),
         storage_service: FileStorageService = Depends(get_file_storage_service),
 ) -> Any:
     """Download file by file_id — QA 文档默认从 ES 导出修改后内容，?original=true 下载原始文件"""
     db_file = file_service.get_file_by_id(
         db,
         file_id=file_id,
-        current_user=current_user,
+        current_user=None,
     )
     if not db_file:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")

--- a/api/app/controllers/file_controller.py
+++ b/api/app/controllers/file_controller.py
@@ -268,6 +268,7 @@ async def custom_text(
 
 
 @router.get("/{file_id}", response_model=Any)
+# Public compatibility exception for knowledge-base image block rendering.
 async def get_file(
         file_id: uuid.UUID,
         original: bool = Query(False, description="QA 文档是否下载原始文件（默认从 ES 导出修改后内容）"),

--- a/api/app/controllers/service/rag_api_file_controller.py
+++ b/api/app/controllers/service/rag_api_file_controller.py
@@ -156,7 +156,6 @@ async def get_file(
     return await file_controller.get_file(
         file_id=file_id,
         db=db,
-        current_user=None,
         storage_service=storage_service,
     )
 


### PR DESCRIPTION
## Background

Knowledge-base image blocks load `GET /api/files/{file_id}` without a JWT session. The endpoint must remain a deliberate public download exception, matching the existing V1 file-download behavior.

## Scope

- Remove the current-workspace guard and current-user dependency only from `GET /api/files/{file_id}`.
- Use the existing global file-ID lookup for that public endpoint.
- Keep the V1 proxy compatible with the updated internal handler signature.

## Risk

A caller that knows a valid file UUID can download a file served by this endpoint. This is an explicit, accepted compatibility exception for image-block rendering. All other `/api/files` operations remain current-workspace guarded.

## Verification

- `cd api && PYTHONPATH=. uv run pytest tests/test_memory_rag_workspace_context.py tests/test_rag_workspace_scope.py tests/test_rag_workspace_guard_coverage.py -q` (16 passed)
- `cd api && PYTHONPATH=. uv run python -m compileall -q app/controllers/file_controller.py app/controllers/service/rag_api_file_controller.py`
- `cd api && PYTHONPATH=. uv run ruff check --select F821 app/controllers/file_controller.py app/controllers/service/rag_api_file_controller.py`

## External API Key impact

`GET /v1/files/{file_id}` remains public and keeps its route and response behavior unchanged. Other V1 RAG endpoints are unchanged.

## Summary by Sourcery

允许通过 `GET /api/files/{file_id}` 端点进行公共文件下载，同时保持其他文件操作受工作区限制。

Bug Fixes:
- 恢复用于知识库图片渲染的 `GET /api/files/{file_id}` 的公共访问行为。

Enhancements:
- 使内部 RAG 文件代理处理程序与更新后的文件下载控制器签名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow public file downloads via the GET /api/files/{file_id} endpoint while keeping other file operations workspace-guarded.

Bug Fixes:
- Restore public access behavior for GET /api/files/{file_id} used by knowledge-base image rendering.

Enhancements:
- Align the internal RAG file proxy handler with the updated file download controller signature.

</details>