### PR TITLE
fix(rag): split parent-child table children

### DIFF
--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -91,7 +91,7 @@ class BlockMerger(ChunkMerger):
                         delimiter,
                         0,
                         merge_lists_with_text=parse_result.markdown_preprocess_profile == "mineru",
-                        preserve_atomic_blocks=True,
+                        preserve_atomic_blocks=False,
                     )
                     groups.append(ParentChildGroup(parent=parent, children=children))
                 return self._parent_child_merge_result(groups, parse_result.pdf_parser)
@@ -284,7 +284,10 @@ class BlockMerger(ChunkMerger):
         delimiter: str | None,
         overlap: int,
     ) -> list[LogicalChunk]:
-        if parent.type in {LogicalChunkType.TABLE, LogicalChunkType.IMAGE}:
+        if parent.type is LogicalChunkType.TABLE:
+            return self._split_logical_table_chunk(parent, token_num)
+
+        if parent.type is LogicalChunkType.IMAGE:
             return [deepcopy(parent)]
 
         block_type = parent.metadata.get("block_type")


### PR DESCRIPTION
## Business Background
Parent-child chunking preserved table blocks as a single child in both paragraph and full-doc parent modes, bypassing the existing table-aware splitter and ignoring the configured child chunk token limit.

## Summary
- Split table children with the existing table-specific algorithm in paragraph parent mode.
- Enable table splitting while deriving full-doc children from the capped source blocks.
- Preserve image children and the direct chunking path unchanged.

## Changes
- api/app/core/rag/chunk/merger/block.py: route parent-child table children through the existing table splitter.

## Risk
Low and scoped to parent-child table child generation. Parent content, parent-child mapping, table metadata, image data, positions, and direct chunking behavior remain unchanged. Existing documents require reparsing to regenerate child chunks.

## External API Key Impact
No route, schema, authentication, or response contract changes. API Key users receive the corrected behavior only when documents using parent-child chunking are parsed or reparsed.

## Test Plan
- [x] PYTHONPATH=. .venv/bin/pytest tests/core/rag/chunk/test_block_merger.py -q — 11 passed
- [x] .venv/bin/python -m compileall -q app/core/rag/chunk/merger/block.py
- [x] git diff --check origin/develop..HEAD

## Summary by Sourcery

通过现有的“特定于表格”的分割器来路由父子关系的表格块，同时保留图像块和其他父子行为。

Bug Fixes:
- 确保父子关系中的表格子块使用“表格感知”的算法进行拆分，而不是被保留为单一的原子块。

Enhancements:
- 优化父块拆分逻辑，在父子模式下显式处理表格和图像两种块类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route parent-child table chunks through the existing table-specific splitter while preserving image chunks and other parent-child behavior.

Bug Fixes:
- Ensure parent-child table children are split using the table-aware algorithm instead of being preserved as single atomic blocks.

Enhancements:
- Refine parent chunk splitting to handle table and image chunk types explicitly in parent-child mode.

</details>