### PR TITLE
refactor(memory):memory-display-db

### DIFF
--- a/api/app/controllers/memory_display_controller.py
+++ b/api/app/controllers/memory_display_controller.py
@@ -7,16 +7,15 @@
 import uuid
 
 from fastapi import APIRouter, Depends, Header, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.error_codes import BizCode
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import fail, success
 from app.core.utils.datetime_utils import resolve_iana_timezone
-from app.db import get_db
-from app.dependencies import get_current_user
-from app.models.user_model import User
+from app.db import get_async_db
+from app.dependencies import CurrentUserSnapshot, get_current_user_async
 from app.schemas.response_schema import ApiResponse, PageData, PageMeta
 from app.services.memory_display_record_service import MemoryDisplayRecordService
 from app.services.memory_engine_display_service import MemoryEngineDisplayService
@@ -51,8 +50,8 @@ async def get_all_memory_display(
                     "合并列表和 total 都不含它",
     ),
     language_type: str = Header(default=None, alias="X-Language-Type"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: CurrentUserSnapshot = Depends(get_current_user_async),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict:
     """一次获取写入记录、读取卡片和引擎动态卡片
 
@@ -115,14 +114,14 @@ async def get_all_memory_display(
     try:
         language = get_language_from_header(language_type)
 
-        written_result = MemoryDisplayRecordService.query_written(
+        written_result = await MemoryDisplayRecordService.query_written(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,
             page=1,
             pagesize=ALL_ITEM_LIMIT,
         )
-        retrieved_result = MemoryRetrievalDisplayService.query_retrieved(
+        retrieved_result = await MemoryRetrievalDisplayService.query_retrieved(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,
@@ -131,7 +130,7 @@ async def get_all_memory_display(
         )
         engines_result = None
         if include_engines:
-            engines_result = MemoryEngineDisplayService.query_cards(
+            engines_result = await MemoryEngineDisplayService.query_cards(
                 db=db,
                 end_user_id=end_user_uuid,
                 workspace_id=workspace_id,
@@ -210,8 +209,8 @@ async def get_written_memories(
     end_user_id: str = Query(..., description="终端用户 ID"),
     page: int = Query(1, ge=1, description="页码，从 1 开始"),
     pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: CurrentUserSnapshot = Depends(get_current_user_async),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict:
     """获取写入展示记录列表
 
@@ -246,7 +245,7 @@ async def get_written_memories(
         )
 
     try:
-        query_result = MemoryDisplayRecordService.query_written(
+        query_result = await MemoryDisplayRecordService.query_written(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,
@@ -286,8 +285,8 @@ async def get_retrieved_memories(
     end_user_id: str = Query(..., description="终端用户 ID"),
     page: int = Query(1, ge=1, description="页码，从 1 开始"),
     pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: CurrentUserSnapshot = Depends(get_current_user_async),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict:
     """获取读取展示卡片列表
 
@@ -322,7 +321,7 @@ async def get_retrieved_memories(
         )
 
     try:
-        query_result = MemoryRetrievalDisplayService.query_retrieved(
+        query_result = await MemoryRetrievalDisplayService.query_retrieved(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,
@@ -368,8 +367,8 @@ async def get_engine_display_cards(
     page: int = Query(1, ge=1, description="页码，从 1 开始"),
     pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
     language_type: str = Header(default=None, alias="X-Language-Type"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    current_user: CurrentUserSnapshot = Depends(get_current_user_async),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict:
     """获取引擎动态展示卡片列表
 
@@ -426,7 +425,7 @@ async def get_engine_display_cards(
 
     try:
         language = get_language_from_header(language_type)
-        query_result = MemoryEngineDisplayService.query_cards(
+        query_result = await MemoryEngineDisplayService.query_cards(
             db=db,
             end_user_id=end_user_uuid,
             workspace_id=workspace_id,

--- a/api/app/controllers/memory_value_ranking_controller.py
+++ b/api/app/controllers/memory_value_ranking_controller.py
@@ -5,11 +5,11 @@ import uuid
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.error_codes import BizCode
 from app.core.response_utils import fail, success
-from app.db import get_db
+from app.db import get_async_db
 from app.dependencies import CurrentUserSnapshot, get_current_user_async
 from app.schemas.memory_value_ranking_schema import (
     PermanentMemoryListApiResponse,
@@ -63,7 +63,7 @@ def _workspace_id(current_user: CurrentUserSnapshot) -> uuid.UUID | None:
 async def get_permanent_memory_quota(
     end_user_id: str = Query(...),
     current_user: CurrentUserSnapshot = Depends(get_current_user_async),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict | JSONResponse:
     workspace_id = _workspace_id(current_user)
     if workspace_id is None:
@@ -84,7 +84,7 @@ async def list_permanent_memories(
     page: int = Query(1, ge=1),
     pagesize: int = Query(20, ge=1, le=100),
     current_user: CurrentUserSnapshot = Depends(get_current_user_async),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict | JSONResponse:
     workspace_id = _workspace_id(current_user)
     if workspace_id is None:
@@ -116,7 +116,7 @@ async def unmark_permanent_memory(
     node_id: str,
     request: PermanentMemoryUnmarkRequest,
     current_user: CurrentUserSnapshot = Depends(get_current_user_async),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_async_db),
 ) -> dict | JSONResponse:
     workspace_id = _workspace_id(current_user)
     if workspace_id is None:

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -216,6 +216,31 @@ class EndUserRepository:
             )
             raise
 
+    async def get_active_end_user_in_workspace_async(
+        self,
+        end_user_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> Optional[EndUser]:
+        """异步查询当前工作空间内的有效终端用户。"""
+        try:
+            result = await self.db.execute(
+                select(EndUser)
+                .where(
+                    EndUser.id == end_user_id,
+                    EndUser.workspace_id == workspace_id,
+                    EndUser.is_active.is_(True),
+                )
+                .limit(1)
+            )
+            return result.scalars().first()
+        except Exception as e:
+            await self.db.rollback()
+            db_logger.error(
+                f"异步查询工作空间 {workspace_id} 下的终端用户 "
+                f"{end_user_id} 时出错: {str(e)}"
+            )
+            raise
+
     async def get_end_user_by_id_async(self, end_user_id: uuid.UUID) -> Optional[EndUser]:
         try:
             result = await self.db.execute(

--- a/api/app/repositories/memory_display_record_repository.py
+++ b/api/app/repositories/memory_display_record_repository.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class MemoryDisplayRecordRepository:
     """记忆展示记录数据访问层"""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: Session | AsyncSession):
         self.db = db
 
     def bulk_insert_written(
@@ -132,6 +132,47 @@ class MemoryDisplayRecordRepository:
 
         return items, total
 
+    async def query_written_paginated_async(
+        self,
+        end_user_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        page: int,
+        pagesize: int,
+    ) -> Tuple[List[MemoryDisplayRecord], int]:
+        """异步按 occurred_at DESC, id DESC 分页查询写入展示记录。"""
+        owned_by_workspace = (
+            select(EndUser.id)
+            .where(
+                EndUser.id == end_user_id,
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active.is_(True),
+            )
+            .exists()
+        )
+        base_filter = (
+            (MemoryDisplayRecord.end_user_id == end_user_id)
+            & (MemoryDisplayRecord.operation == "WRITE")
+            & owned_by_workspace
+        )
+
+        total_result = await self.db.execute(
+            select(func.count(MemoryDisplayRecord.id)).where(base_filter)
+        )
+        total = total_result.scalar() or 0
+
+        offset = (page - 1) * pagesize
+        items_result = await self.db.execute(
+            select(MemoryDisplayRecord)
+            .where(base_filter)
+            .order_by(
+                MemoryDisplayRecord.occurred_at.desc(),
+                MemoryDisplayRecord.id.desc(),
+            )
+            .offset(offset)
+            .limit(pagesize)
+        )
+        return list(items_result.scalars().all()), total
+
     @staticmethod
     async def bulk_insert_retrieved_async(
         db: AsyncSession,
@@ -199,3 +240,33 @@ class MemoryDisplayRecordRepository:
         )
 
         return items, total
+
+    async def query_retrieved_paginated_async(
+        self,
+        end_user_id: uuid.UUID,
+        page: int,
+        pagesize: int,
+    ) -> Tuple[List[MemoryDisplayRecord], int]:
+        """异步按 occurred_at DESC, id DESC 分页查询读取展示记录。"""
+        base_filter = (
+            (MemoryDisplayRecord.end_user_id == end_user_id)
+            & (MemoryDisplayRecord.operation == "RETRIEVE")
+        )
+
+        total_result = await self.db.execute(
+            select(func.count(MemoryDisplayRecord.id)).where(base_filter)
+        )
+        total = total_result.scalar() or 0
+
+        offset = (page - 1) * pagesize
+        items_result = await self.db.execute(
+            select(MemoryDisplayRecord)
+            .where(base_filter)
+            .order_by(
+                MemoryDisplayRecord.occurred_at.desc(),
+                MemoryDisplayRecord.id.desc(),
+            )
+            .offset(offset)
+            .limit(pagesize)
+        )
+        return list(items_result.scalars().all()), total

--- a/api/app/repositories/memory_engine_display_event_repository.py
+++ b/api/app/repositories/memory_engine_display_event_repository.py
@@ -7,8 +7,9 @@ import logging
 import uuid
 from typing import Any, Dict, List, Tuple
 
-from sqlalchemy import and_, or_, text
+from sqlalchemy import and_, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models.memory_engine_display_event_model import MemoryEngineDisplayEvent
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 class MemoryEngineDisplayEventRepository:
     """引擎展示事件数据访问层"""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: Session | AsyncSession):
         self.db = db
 
     def bulk_insert_events(
@@ -65,7 +66,7 @@ class MemoryEngineDisplayEventRepository:
         )
         return inserted
 
-    def query_aggregated_paginated(
+    async def query_aggregated_paginated(
         self,
         end_user_id: uuid.UUID,
         workspace_id: uuid.UUID,
@@ -113,10 +114,11 @@ class MemoryEngineDisplayEventRepository:
                 GROUP BY (r.occurred_at AT TIME ZONE 'UTC' AT TIME ZONE :tz)::date, r.engine_type
             ) sub
         """)
-        total = self.db.execute(
+        total_result = await self.db.execute(
             count_sql,
             {"user_id": end_user_id, "workspace_id": workspace_id, "tz": timezone},
-        ).scalar() or 0
+        )
+        total = total_result.scalar() or 0
 
         if total == 0:
             return [], 0
@@ -148,7 +150,7 @@ class MemoryEngineDisplayEventRepository:
             ORDER BY max_occurred_at DESC, engine_type ASC
             LIMIT :limit OFFSET :offset
         """)
-        keys_result = self.db.execute(
+        keys_query_result = await self.db.execute(
             keys_sql,
             {
                 "user_id": end_user_id,
@@ -157,7 +159,8 @@ class MemoryEngineDisplayEventRepository:
                 "limit": pagesize,
                 "offset": offset,
             },
-        ).fetchall()
+        )
+        keys_result = keys_query_result.fetchall()
 
         if not keys_result:
             return [], total
@@ -188,15 +191,15 @@ class MemoryEngineDisplayEventRepository:
                 )
             )
 
-        events = (
-            self.db.query(MemoryEngineDisplayEvent)
-            .filter(
+        events_result = await self.db.execute(
+            select(MemoryEngineDisplayEvent)
+            .where(
                 MemoryEngineDisplayEvent.end_user_id == end_user_id,
                 or_(*event_filters),
             )
             .order_by(MemoryEngineDisplayEvent.occurred_at.desc())
-            .all()
         )
+        events = list(events_result.scalars().all())
 
         specs_by_engine = {}
         for spec in group_specs:

--- a/api/app/services/memory_display_record_service.py
+++ b/api/app/services/memory_display_record_service.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from typing import List
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.repositories.end_user_repository import EndUserRepository
@@ -30,8 +30,8 @@ class MemoryDisplayRecordService:
     """记忆展示记录业务逻辑层"""
 
     @staticmethod
-    def query_written(
-        db: Session,
+    async def query_written(
+        db: AsyncSession,
         end_user_id: uuid.UUID,
         workspace_id: uuid.UUID,
         page: int,
@@ -42,14 +42,14 @@ class MemoryDisplayRecordService:
         返回 None 表示终端用户不属于当前工作空间。
         """
         end_user_repo = EndUserRepository(db)
-        if end_user_repo.get_active_end_user_in_workspace(
+        if await end_user_repo.get_active_end_user_in_workspace_async(
             end_user_id,
             workspace_id,
         ) is None:
             return None
 
         repo = MemoryDisplayRecordRepository(db)
-        records, total = repo.query_written_paginated(
+        records, total = await repo.query_written_paginated_async(
             end_user_id=end_user_id,
             workspace_id=workspace_id,
             page=page,

--- a/api/app/services/memory_engine_display_service.py
+++ b/api/app/services/memory_engine_display_service.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
 from app.repositories.end_user_repository import EndUserRepository
@@ -53,8 +53,8 @@ class MemoryEngineDisplayService:
     """引擎展示业务逻辑层"""
 
     @staticmethod
-    def query_cards(
-        db: Session,
+    async def query_cards(
+        db: AsyncSession,
         end_user_id: uuid.UUID,
         workspace_id: uuid.UUID,
         timezone: str,
@@ -67,14 +67,14 @@ class MemoryEngineDisplayService:
         返回 None 表示终端用户不属于当前工作空间。
         """
         end_user_repo = EndUserRepository(db)
-        if end_user_repo.get_active_end_user_in_workspace(
+        if await end_user_repo.get_active_end_user_in_workspace_async(
             end_user_id,
             workspace_id,
         ) is None:
             return None
 
         repo = MemoryEngineDisplayEventRepository(db)
-        groups, total = repo.query_aggregated_paginated(
+        groups, total = await repo.query_aggregated_paginated(
             end_user_id=end_user_id,
             workspace_id=workspace_id,
             timezone=timezone,

--- a/api/app/services/memory_retrieval_display_service.py
+++ b/api/app/services/memory_retrieval_display_service.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from typing import Any, List
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.datetime_utils import to_timestamp_ms
 from app.repositories.end_user_repository import EndUserRepository
@@ -184,8 +184,8 @@ class MemoryRetrievalDisplayService:
     """读取展示业务逻辑层"""
 
     @staticmethod
-    def query_retrieved(
-        db: Session,
+    async def query_retrieved(
+        db: AsyncSession,
         end_user_id: uuid.UUID,
         workspace_id: uuid.UUID,
         page: int,
@@ -197,14 +197,14 @@ class MemoryRetrievalDisplayService:
         返回 None 表示终端用户不属于当前工作空间。
         """
         end_user_repo = EndUserRepository(db)
-        if end_user_repo.get_active_end_user_in_workspace(
+        if await end_user_repo.get_active_end_user_in_workspace_async(
             end_user_id,
             workspace_id,
         ) is None:
             return None
 
         repo = MemoryDisplayRecordRepository(db)
-        records, total = repo.query_retrieved_paginated(
+        records, total = await repo.query_retrieved_paginated_async(
             end_user_id=end_user_id,
             page=page,
             pagesize=pagesize,

--- a/api/app/services/memory_value_ranking_service.py
+++ b/api/app/services/memory_value_ranking_service.py
@@ -7,7 +7,7 @@ import uuid
 from numbers import Number
 from typing import Any, Callable, Sequence
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.quota_manager import get_end_user_memory_limit_async
 from app.core.utils.datetime_utils import (
@@ -129,18 +129,23 @@ async def assign_permanent_memory_slots(
 class MemoryValueRankingService:
     def __init__(
         self,
-        db: Session,
+        db: AsyncSession,
         connector_factory: Callable[[], Neo4jConnector] | None = None,
     ) -> None:
         self.db = db
         self.connector_factory = connector_factory or Neo4jConnector
 
-    def _get_end_user(self, end_user_id: str | uuid.UUID, workspace_id: uuid.UUID):
+    async def _get_end_user(
+        self,
+        end_user_id: str | uuid.UUID,
+        workspace_id: uuid.UUID,
+    ):
         try:
             parsed_id = end_user_id if isinstance(end_user_id, uuid.UUID) else uuid.UUID(end_user_id)
         except (ValueError, TypeError, AttributeError) as exc:
             raise PermanentMemoryNotFound("end user not found") from exc
-        end_user = EndUserRepository(self.db).get_active_end_user_in_workspace(
+        end_user_repo = EndUserRepository(self.db)
+        end_user = await end_user_repo.get_active_end_user_in_workspace_async(
             parsed_id,
             workspace_id,
         )
@@ -168,7 +173,7 @@ class MemoryValueRankingService:
         end_user_id: str | uuid.UUID,
         workspace_id: uuid.UUID,
     ) -> PermanentMemoryQuota:
-        end_user = self._get_end_user(end_user_id, workspace_id)
+        end_user = await self._get_end_user(end_user_id, workspace_id)
         connector = self.connector_factory()
         try:
             total_memory_limit = await get_total_memory_limit(str(end_user.id))
@@ -188,7 +193,7 @@ class MemoryValueRankingService:
         page: int,
         page_size: int,
     ) -> PermanentMemoryList:
-        end_user = self._get_end_user(end_user_id, workspace_id)
+        end_user = await self._get_end_user(end_user_id, workspace_id)
         connector = self.connector_factory()
         try:
             total_memory_limit = await get_total_memory_limit(str(end_user.id))
@@ -236,7 +241,7 @@ class MemoryValueRankingService:
         end_user_id: str | uuid.UUID,
         workspace_id: uuid.UUID,
     ) -> PermanentMemoryUnmarkResult:
-        end_user = self._get_end_user(end_user_id, workspace_id)
+        end_user = await self._get_end_user(end_user_id, workspace_id)
         connector = self.connector_factory()
         try:
             total_memory_limit = await get_total_memory_limit(str(end_user.id))


### PR DESCRIPTION
## Summary by Sourcery

将内存展示和数值排序流程迁移为使用异步 SQLAlchemy 会话和查询，新增异步仓储与服务方法，并相应更新 FastAPI 控制器。

增强内容：
- 允许处理内存展示记录、终端用户以及引擎展示事件的仓储接受异步会话，并提供异步分页查询辅助方法。
- 将内存展示、检索和引擎展示服务转换为异步 API，这些 API 依赖异步的终端用户校验以及仓储访问。
- 重构内存数值排名服务和控制器，使其使用异步数据库访问以及异步终端用户查询，用于配额与永久内存操作。
- 更新与内存相关的 FastAPI 控制器，使其依赖异步数据库/会话提供器以及异步当前用户依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate memory display and value ranking flows to use async SQLAlchemy sessions and queries, adding async repository and service methods and updating FastAPI controllers accordingly.

Enhancements:
- Allow repositories handling memory display records, end users, and engine display events to accept async sessions and provide async paginated query helpers.
- Convert memory display, retrieval, and engine display services to async APIs that rely on async end-user validation and repository access.
- Refactor memory value ranking service and controller to use async DB access and asynchronous end-user lookup for quota and permanent memory operations.
- Update memory-related FastAPI controllers to depend on async database/session providers and async current-user dependencies.

</details>