### PR TITLE
fix(web): Notification only support Saas

### DIFF
--- a/web/src/components/Layout/Banner.tsx
+++ b/web/src/components/Layout/Banner.tsx
@@ -6,10 +6,13 @@ import { useTranslation } from 'react-i18next';
 import {
   useNotification,
 } from '@/store/notification';
+import { isPrivateAvailable } from '@/utils/private'
 
 const Banners: FC<{ className?: string }> = ({
   className
 }) => {
+  if (!isPrivateAvailable) return;
+
   const { t } = useTranslation();
   const { modal } = App.useApp()
   const {

--- a/web/src/components/NotificationCenter/index.tsx
+++ b/web/src/components/NotificationCenter/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/store/notification';
 import styles from './index.module.css';
 import { formatDateTime } from '@/utils/format';
+import { isPrivateAvailable } from '@/utils/private';
 import Empty from '@/components/Empty';
 
 const BellIcon = () => (
@@ -261,6 +262,8 @@ const NotificationPanel = ({ open }: NotificationPanelProps) => {
 };
 
 const NotificationBell = () => {
+  if (!isPrivateAvailable) return;
+
   const { t } = useTranslation();
   const { notificationStats } = useNotification();
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当私有通知不可用时，阻止渲染横幅和通知铃铛，从而避免在非 SaaS 环境中出现错误显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the banner and notification bell from rendering when private notifications are not available, avoiding incorrect display in non-SaaS environments.

</details>