### PR TITLE
fix(web): vision_mode default value

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/index.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/index.tsx
@@ -39,7 +39,7 @@ const defaultValues: CreateDatasetFormValues = {
   ...parentChildBlockConfigValues,
   image: {
     vision_enabled: true,
-    vision_mode: '1',
+    vision_mode: 1,
   },
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修正图像 `vision_mode` 的默认值，使其在“创建数据集”表单配置中与预期的数值类型一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the image vision_mode default value to match the expected numeric type in the Create Dataset form configuration.

</details>