### PR TITLE
fix(memory): deduplicate increment records by day in dashboard query

### DIFF
--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -195,17 +195,16 @@ async def get_workspace_memory_increment_async(
     """获取工作空间的记忆增量（异步版本）"""
     business_logger.info(f"获取记忆增量(异步): workspace_id={workspace_id}, limit={limit}, 操作者: {current_user.username}")
     from sqlalchemy import select as sa_select, func
-    from app.models.memory_increment_model import MemoryIncrement as MemoryIncrementORM
 
     # 每天只保留一条（取当天最新），再取最新的 limit 天：
     # DISTINCT ON (date(created_at)) + ORDER BY date DESC, created_at DESC 保证
     # 同一天内返回的是 created_at 最新的一条。
-    day_expr = func.date(MemoryIncrementORM.created_at)
+    day_expr = func.date(MemoryIncrement.created_at)
     stmt = (
-        sa_select(MemoryIncrementORM)
-        .where(MemoryIncrementORM.workspace_id == workspace_id)
+        sa_select(MemoryIncrement)
+        .where(MemoryIncrement.workspace_id == workspace_id)
         .distinct(day_expr)
-        .order_by(day_expr.desc(), MemoryIncrementORM.created_at.desc())
+        .order_by(day_expr.desc(), MemoryIncrement.created_at.desc())
         .limit(limit)
     )
     result = await db.execute(stmt)

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -194,14 +194,14 @@ async def get_workspace_memory_increment_async(
 ) -> List[MemoryIncrementSchema]:
     """获取工作空间的记忆增量（异步版本）"""
     business_logger.info(f"获取记忆增量(异步): workspace_id={workspace_id}, limit={limit}, 操作者: {current_user.username}")
-    from sqlalchemy import select as sa_select, func
+    from sqlalchemy import select, func
 
     # 每天只保留一条（取当天最新），再取最新的 limit 天：
     # DISTINCT ON (date(created_at)) + ORDER BY date DESC, created_at DESC 保证
     # 同一天内返回的是 created_at 最新的一条。
     day_expr = func.date(MemoryIncrement.created_at)
     stmt = (
-        sa_select(MemoryIncrement)
+        select(MemoryIncrement)
         .where(MemoryIncrement.workspace_id == workspace_id)
         .distinct(day_expr)
         .order_by(day_expr.desc(), MemoryIncrement.created_at.desc())

--- a/api/app/services/memory_dashboard_service.py
+++ b/api/app/services/memory_dashboard_service.py
@@ -194,17 +194,25 @@ async def get_workspace_memory_increment_async(
 ) -> List[MemoryIncrementSchema]:
     """获取工作空间的记忆增量（异步版本）"""
     business_logger.info(f"获取记忆增量(异步): workspace_id={workspace_id}, limit={limit}, 操作者: {current_user.username}")
-    from sqlalchemy import select as sa_select
+    from sqlalchemy import select as sa_select, func
     from app.models.memory_increment_model import MemoryIncrement as MemoryIncrementORM
 
+    # 每天只保留一条（取当天最新），再取最新的 limit 天：
+    # DISTINCT ON (date(created_at)) + ORDER BY date DESC, created_at DESC 保证
+    # 同一天内返回的是 created_at 最新的一条。
+    day_expr = func.date(MemoryIncrementORM.created_at)
     stmt = (
         sa_select(MemoryIncrementORM)
         .where(MemoryIncrementORM.workspace_id == workspace_id)
-        .order_by(MemoryIncrementORM.created_at.desc())
+        .distinct(day_expr)
+        .order_by(day_expr.desc(), MemoryIncrementORM.created_at.desc())
         .limit(limit)
     )
     result = await db.execute(stmt)
     records = result.scalars().all()
+
+    # 再按时间升序输出（最旧在前）
+    records.sort(key=lambda r: r.created_at)
 
     increments = [MemoryIncrementSchema.model_validate(r) for r in records]
     business_logger.info(f"成功获取 {len(increments)} 条记忆增量记录")

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -463,7 +463,7 @@ class MemoryReflectionService:
         from app.utils.config_utils import resolve_config_id_async
         from app.repositories.memory_config_repository import MemoryConfigRepository
         from app.models.workspace_model import Workspace
-        from sqlalchemy import select
+        from sqlalchemy import select as sa_select
 
         try:
             resolved_id = await resolve_config_id_async(str(config_data_id), db)
@@ -475,7 +475,7 @@ class MemoryReflectionService:
             tenant_id = None
             if memory_config_result.workspace_id:
                 ws_result = await db.execute(
-                    select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
+                    sa_select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
                 )
                 workspace = ws_result.scalars().first()
                 tenant_id = str(workspace.tenant_id) if workspace and workspace.tenant_id else None

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -198,9 +198,9 @@ class WorkspaceAppService:
 
     async def get_workspace_apps_detailed_async(self, workspace_id) -> Dict[str, Any]:
         """异步版：获取 workspace 下所有应用的详情。"""
-        from sqlalchemy import select as sa_select
+        from sqlalchemy import select
 
-        stmt = sa_select(App).where(
+        stmt = select(App).where(
             App.workspace_id == workspace_id,
             App.is_active.is_(True),
         )
@@ -225,9 +225,9 @@ class WorkspaceAppService:
 
     async def _process_app_releases_async(self, app: App, app_info: Dict[str, Any]) -> None:
         """异步版：处理应用的发布版本和配置信息。"""
-        from sqlalchemy import select as sa_select
+        from sqlalchemy import select
 
-        stmt = sa_select(AppRelease).where(AppRelease.app_id == app.id)
+        stmt = select(AppRelease).where(AppRelease.app_id == app.id)
         result = await self.db.execute(stmt)
         app_releases = list(result.scalars().all())
 
@@ -257,7 +257,7 @@ class WorkspaceAppService:
 
     async def _get_memory_config_async(self, memory_content: str) -> Optional[Dict[str, Any]]:
         """异步版：根据 memory_content 获取 memory_config 信息。"""
-        from sqlalchemy import select as sa_select
+        from sqlalchemy import select
         from app.utils.config_utils import resolve_config_id_async
 
         try:
@@ -271,7 +271,7 @@ class WorkspaceAppService:
             tenant_id = None
             if memory_config_result.workspace_id:
                 ws_result = await self.db.execute(
-                    sa_select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
+                    select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
                 )
                 workspace = ws_result.scalars().first()
                 tenant_id = str(workspace.tenant_id) if workspace and workspace.tenant_id else None
@@ -295,10 +295,10 @@ class WorkspaceAppService:
 
     async def _process_end_users_async(self, app: App, app_info: Dict[str, Any]) -> None:
         """异步版：查询应用关联的终端用户。"""
-        from sqlalchemy import select as sa_select
+        from sqlalchemy import select
         from app.models.end_user_model import EndUser
 
-        stmt = sa_select(EndUser).where(
+        stmt = select(EndUser).where(
             EndUser.app_id == app.id,
             EndUser.is_active.is_(True),
         )
@@ -463,7 +463,7 @@ class MemoryReflectionService:
         from app.utils.config_utils import resolve_config_id_async
         from app.repositories.memory_config_repository import MemoryConfigRepository
         from app.models.workspace_model import Workspace
-        from sqlalchemy import select as sa_select
+        from sqlalchemy import select
 
         try:
             resolved_id = await resolve_config_id_async(str(config_data_id), db)
@@ -475,7 +475,7 @@ class MemoryReflectionService:
             tenant_id = None
             if memory_config_result.workspace_id:
                 ws_result = await db.execute(
-                    sa_select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
+                    select(Workspace).where(Workspace.id == memory_config_result.workspace_id)
                 )
                 workspace = ws_result.scalars().first()
                 tenant_id = str(workspace.tenant_id) if workspace and workspace.tenant_id else None


### PR DESCRIPTION
## Summary by Sourcery

在仪表盘查询中按天去重工作区内存增量记录，仅返回每天最新的一条记录，并按时间顺序（从早到晚）输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deduplicate workspace memory increment records by day in the dashboard query, returning only the latest record per day and outputting them in ascending chronological order.

</details>