### PR TITLE
Feature/community network zy

### DIFF
--- a/web/src/components/D3Graph/CommunityGraph.tsx
+++ b/web/src/components/D3Graph/CommunityGraph.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo, useEffect, type FC } from 'react'
+import React, { useState, useRef, useMemo, useEffect, useLayoutEffect, type FC } from 'react'
 
 import { GRAPH_COLORS, initCommunityGraph } from './utils'
 import { useD3Graph } from './hooks'
@@ -20,6 +20,32 @@ const CommunityGraph: FC<CommunityGraphProps> = ({
 }) => {
   // Tooltip position and hovered node state
   const [tooltip, setTooltip] = useState<{ x: number; y: number; node: CommunityD3Node } | null>(null)
+
+  // Keep the tooltip open briefly while the pointer moves from a node into the tooltip.
+  const tooltipHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelTooltipHide = () => {
+    if (tooltipHideTimerRef.current) {
+      clearTimeout(tooltipHideTimerRef.current)
+      tooltipHideTimerRef.current = null
+    }
+  }
+
+  const updateTooltip = (next: { x: number; y: number; node: CommunityD3Node } | null) => {
+    cancelTooltipHide()
+
+    if (next) {
+      setTooltip(next)
+    } else {
+      tooltipHideTimerRef.current = setTimeout(() => {
+        setTooltip(null)
+        tooltipHideTimerRef.current = null
+      }, 150)
+    }
+  }
+
+  useEffect(() => () => {
+    if (tooltipHideTimerRef.current) clearTimeout(tooltipHideTimerRef.current)
+  }, [])
 
   // Keep callback refs stable to avoid re-initializing the graph on every render
   const onCommunityClickRef = useRef(onCommunityClick)
@@ -43,21 +69,54 @@ const CommunityGraph: FC<CommunityGraphProps> = ({
       graphState.communityMap,
       graphState.communityCaption,
       graphState.communityNodeMap,
-      { colors, showLegend, defaultZoom, setTooltip: renderTooltip ? setTooltip : () => {}, onCommunityClickRef, onNodeClickRef }
+      { colors, showLegend, defaultZoom, setTooltip: renderTooltip ? updateTooltip : () => {}, onCommunityClickRef, onNodeClickRef }
     )
   }, [graphState, showLegend, defaultZoom])
 
-  // Resolve tooltip content: use custom renderer if provided, otherwise fall back to DefaultTooltip
   const tooltipNode = tooltip && renderTooltipRef.current
     ? renderTooltipRef.current(tooltip.node)
     : null
+
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
+  const [tooltipPosition, setTooltipPosition] = useState({ left: 0, top: 0 })
+
+  useLayoutEffect(() => {
+    if (!tooltip || !tooltipRef.current) return
+
+    const container = tooltipRef.current.parentElement
+    if (!container) return
+
+    const { width, height } = container.getBoundingClientRect()
+    const { width: tooltipWidth, height: tooltipHeight } = tooltipRef.current.getBoundingClientRect()
+    const gap = 14
+    const padding = 8
+
+    const preferredLeft = tooltip.x + gap
+    const preferredTop = tooltip.y - 10
+    const left = preferredLeft + tooltipWidth > width
+      ? tooltip.x - tooltipWidth - gap
+      : preferredLeft
+    const top = preferredTop + tooltipHeight > height
+      ? tooltip.y - tooltipHeight - gap
+      : preferredTop
+
+    setTooltipPosition({
+      left: Math.min(Math.max(left, padding), Math.max(padding, width - tooltipWidth - padding)),
+      top: Math.min(Math.max(top, padding), Math.max(padding, height - tooltipHeight - padding)),
+    })
+  }, [tooltip])
 
   if (isEmpty) return <PageEmpty className="rb:h-full" />
   return (
     <div className="rb:w-full rb:h-full rb:relative">
       <div ref={containerRef} className="rb:w-full rb:h-full" />
       {tooltipNode ? (
-        <div style={{ position: 'absolute', left: tooltip!.x + 14, top: tooltip!.y - 10, pointerEvents: 'none', zIndex: 20 }}>
+        <div
+          ref={tooltipRef}
+          style={{ position: 'absolute', left: tooltipPosition.left, top: tooltipPosition.top, zIndex: 20 }}
+          onMouseEnter={cancelTooltipHide}
+          onMouseLeave={() => updateTooltip(null)}
+        >
           {tooltipNode}
         </div>
       ) : undefined}

--- a/web/src/views/ApplicationConfig/components/Skill/index.tsx
+++ b/web/src/views/ApplicationConfig/components/Skill/index.tsx
@@ -4,7 +4,7 @@
  * @Last Modified by: ZhaoYing
  * @Last Modified time: 2026-02-26 10:18:56
  */
-import { useEffect, type FC } from 'react'
+import { Fragment, useEffect, type FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Space, Switch, Form, Flex } from 'antd'
 import clsx from 'clsx'
@@ -84,14 +84,13 @@ const SkillList: FC<{value?: SkillConfigForm; onChange?: (config: SkillConfigFor
    * Clears all_skills flag and skill_ids array when enabled is set to false
    */
   useEffect(() => {
-    if (!skillConfig?.enabled) {
-      form.setFieldValue('skills', {
-        ...skillConfig,
-        all_skills: false,
-        skill_ids: []
-      })
+    if (skillConfig?.enabled === false) {
+      form.setFields([
+        { name: ['skills', 'all_skills'], value: false },
+        { name: ['skills', 'skill_ids'], value: [] }
+      ])
     }
-  }, [skillConfig?.enabled])
+  }, [skillConfig?.enabled, form])
 
 
   return (
@@ -125,16 +124,18 @@ const SkillList: FC<{value?: SkillConfigForm; onChange?: (config: SkillConfigFor
         <div className="rb:text-[#212332] rb:font-medium rb:leading-4.5 rb:px-1">{t('application.executeProcessPreview')}</div>
         <Flex align="center" justify="space-between" gap={14} className="rb:text-[12px] rb:bg-[#FFFFFF]! rb:rounded-lg rb-border rb:py-2.5! rb:pl-4! rb:pr-3.25! rb:mb-2!">
           {/* Render each step in the process flow with numbered badges */}
-          {processObj.map((key, index) => (<>
-            <Flex align="center" gap={8}>
-              {/* Step number badge */}
-              <Flex align="center" justify="center" className="rb:size-4 rb:rounded-full rb:bg-[#171719] rb:text-white rb:font-medium">{index + 1}</Flex>
-              {/* Step label */}
-              <span className="rb:inline-block rb:max-w-16">{t(`application.${key}`)}</span>
-            </Flex>
-            {/* Arrow separator between steps (except after last step) */}
-            {index !== processObj.length - 1 && <div className="rb:w-10 rb:h-4.5 rb:bg-cover rb:bg-[url('@/assets/images/application/arrow_right.svg')]"></div>}
-          </>))}
+          {processObj.map((key, index) => (
+            <Fragment key={index}>
+              <Flex align="center" gap={8}>
+                {/* Step number badge */}
+                <Flex align="center" justify="center" className="rb:size-4 rb:rounded-full rb:bg-[#171719] rb:text-white rb:font-medium">{index + 1}</Flex>
+                {/* Step label */}
+                <span className="rb:inline-block rb:max-w-16">{t(`application.${key}`)}</span>
+              </Flex>
+              {/* Arrow separator between steps (except after last step) */}
+              {index !== processObj.length - 1 && <div className="rb:w-10 rb:h-4.5 rb:bg-cover rb:bg-[url('@/assets/images/application/arrow_right.svg')]"></div>}
+            </Fragment>
+          ))}
         </Flex>
         {/* Dynamic skill binding configuration section */}
         <Form.Item noStyle>

--- a/web/src/views/ApplicationConfig/hooks/useAgent.tsx
+++ b/web/src/views/ApplicationConfig/hooks/useAgent.tsx
@@ -236,7 +236,7 @@ export function useAgent(
         model_parameters: {...(values?.model_parameters || {})} as unknown as ModelConfig,
         list: []
       }])
-      form.setFieldValue('capability', filterValue?.capability)
+      form.setFieldsValue({ capability: filterValue?.capability })
     }
   }, [modelList, values?.default_model_config_id])
 

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/index.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/index.tsx
@@ -39,7 +39,7 @@ const defaultValues: CreateDatasetFormValues = {
   ...parentChildBlockConfigValues,
   image: {
     vision_enabled: true,
-    vision_mode: '1',
+    vision_mode: 1,
   },
 };
 

--- a/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/CommunityNetwork.tsx
@@ -13,7 +13,7 @@ import { getMemoryCommunityGraph } from '@/api/memory'
 const NodeTooltip: FC<{ node: CommunityD3Node }> = ({ node }) => {
   const { t } = useTranslation()
   return (
-    <div className="rb:min-w-45 rb:max-w-65 rb:rounded-lg rb:border rb:border-[#DFE4ED] rb:bg-white rb:px-3.5 rb:py-2.5 rb:text-[13px] rb:shadow-[0_4px_16px_rgba(0,0,0,0.12)]">
+    <div className="rb:min-w-45 rb:max-w-65 rb:max-h-62.5 rb:overflow-y-auto rb:rounded-lg rb:border rb:border-[#DFE4ED] rb:bg-white rb:px-3.5 rb:py-2.5 rb:text-[13px] rb:shadow-[0_4px_16px_rgba(0,0,0,0.12)]">
       <div className="rb:mb-1.5 rb:text-sm rb:font-semibold rb:text-[#1a1a1a]">
         {node.properties?.name ?? node.name}
       </div>
@@ -23,11 +23,11 @@ const NodeTooltip: FC<{ node: CommunityD3Node }> = ({ node }) => {
         </div>
       )}
       <div className="rb:leading-5.5 rb:text-[#5B6167]">
-        {t('userMemory.type')}：
+        {t('userMemory.type')}: 
         <span className="rb:text-[#1a1a1a]">{node.properties?.entity_type}</span>
       </div>
       <div className="rb:leading-5.5 rb:text-[#5B6167]">
-        {t('userMemory.community')}：
+        {t('userMemory.community')}: 
         <span className="rb:font-medium" style={{ color: node.color }}>{node.properties?.community_name}</span>
       </div>
     </div>

--- a/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
+++ b/web/src/views/UserMemoryDetail/components/RelationshipNetwork.tsx
@@ -22,7 +22,6 @@ import {
   getMemorySearchEdges,
 } from '@/api/memory'
 import GraphNetworkChart from '@/components/Charts/GraphNetworkChart'
-import { Colors } from '@/components/Charts/GraphNetworkChart/utils/utils'
 import type { Node, Edge, EdgeClickData } from '@/components/Charts/GraphNetworkChart/types'
 import CommunityNetwork from './CommunityNetwork'
 import PageTabs from '@/components/PageTabs'
@@ -38,6 +37,29 @@ interface RelationshipNetworkProps {
   refresh: () => void;
   selectNodeId: string | null;
 }
+
+interface NodeTypeStyle {
+  category: number;
+  color: string;
+}
+
+const NODE_TYPE_STYLES = {
+  AssistantOriginal: { category: 0, color: '#155EEF' },
+  AssistantPruned: { category: 1, color: '#02AFD5' },
+  Chunk: { category: 2, color: '#FF5D34' },
+  Dialogue: { category: 3, color: '#6473E9' },
+  ExtractedEntity: { category: 4, color: '#369F21' },
+  Perceptual: { category: 5, color: '#4DA8FF' },
+  Statement: { category: 6, color: '#C86AFF' },
+  Conversation: { category: 7, color: '#F7BA1E' },
+  MemorySummary: { category: 8, color: '#5B6167' },
+} satisfies Record<GraphNode['label'], NodeTypeStyle>
+
+const UNKNOWN_NODE_TYPE_STYLE: NodeTypeStyle = { category: 0, color: '#A8ABB2' }
+
+const getNodeTypeStyle = (nodeType: string): NodeTypeStyle =>
+  NODE_TYPE_STYLES[nodeType as GraphNode['label']] || UNKNOWN_NODE_TYPE_STYLE
+
 const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedKey, setRegionId, setBrainMemories, setSelectedKey, refresh, selectNodeId }) => {
   const { t } = useTranslation()
   const { id } = useParams()
@@ -80,7 +102,6 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
     getMemorySearchEdges(id, { signal: edgeAbortRef.current.signal }).then((res) => {
       const { nodes, edges, statistics } = res as GraphData
       const curNodes: Node[] = []
-      const curNodeTypes = Object.keys(statistics.node_types)
 
       // Calculate connection count for each node
       const connectionCount: Record<string, number> = {}
@@ -92,7 +113,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
       // Process node data
       nodes.forEach(node => {
         const connections = connectionCount[node.id] || 0
-        const categoryIndex = curNodeTypes.indexOf(node.label)
+        const nodeTypeStyle = getNodeTypeStyle(node.label)
 
         // Get display name based on node type
         let displayName = ''
@@ -123,7 +144,8 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
         curNodes.push({
           ...node,
           name: displayName,
-          category: categoryIndex >= 0 ? categoryIndex : 0,
+          category: nodeTypeStyle.category,
+          itemStyle: { color: nodeTypeStyle.color },
           symbolSize: symbolSize, // Adjust node size based on connection count
         })
       })
@@ -253,7 +275,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
               })}
             >
               <Flex wrap gap={8}>
-                {categories.map((item, index) => (
+                {categories.map((item) => (
                   <Flex
                     key={item.name}
                     gap={4}
@@ -265,7 +287,7 @@ const RelationshipNetwork: FC<RelationshipNetworkProps> = ({ regionId, selectedK
                     onClick={() => handleClickCategory(item.name)}
                   >
                     <div className={clsx(`rb:size-1.25 rb:rounded-full rb:mr-2`)}
-                      style={{ backgroundColor: Colors[index] }}
+                      style={{ backgroundColor: getNodeTypeStyle(item.name).color }}
                     ></div>
                     {t(`userMemory.${item.name}`)}
                     <div className="rb:px-1 rb:rounded-full rb:bg-[#F6F6F6] rb:text-[10px] rb:h-3.5">{item.value}</div>

--- a/web/src/views/Workflow/components/CanvasToolbar.tsx
+++ b/web/src/views/Workflow/components/CanvasToolbar.tsx
@@ -60,7 +60,7 @@ const CanvasToolbar = forwardRef<CanvasToolbarRef, CanvasToolbarProps>(({
   return (
     <>
       <div
-        className={clsx("rb:cursor-pointer rb:z-9999  rb:absolute rb:bottom-5 rb:h-8.5 rb:bg-[#FFFFFF] rb:border rb:border-[#DFE4ED] rb:rounded-lg rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.15)] rb:px-3 rb:py-2 rb:text-[12px]", {
+        className={clsx("rb:cursor-pointer rb:z-1000  rb:absolute rb:bottom-5 rb:h-8.5 rb:bg-[#FFFFFF] rb:border rb:border-[#DFE4ED] rb:rounded-lg rb:shadow-[0px_2px_6px_0px_rgba(33,35,50,0.15)] rb:px-3 rb:py-2 rb:text-[12px]", {
           'rb:bottom-5': !isVariableInspectorVisible,
           'rb:bottom-88': isVariableInspectorVisible,
           'rb:left-73': !collapsed,

--- a/web/src/views/Workflow/hooks/useWorkflowGraph.ts
+++ b/web/src/views/Workflow/hooks/useWorkflowGraph.ts
@@ -1834,9 +1834,7 @@ export const useWorkflowGraph = ({
                 } else {
                   itemConfig[key].data = value.data
                 }
-              } else if (data.config[key] && 'defaultValue' in data.config[key] && (key !== 'knowledge_retrieval' || data.type === 'agent')) {
-                itemConfig[key] = data.config[key].defaultValue
-              } else if (key === 'knowledge_retrieval' && data.config[key] && 'defaultValue' in data.config[key]) {
+              } else if (data.type !== 'agent' && key === 'knowledge_retrieval' && data.config[key] && 'defaultValue' in data.config[key]) {
                 const { knowledge_bases } = data.config[key].defaultValue || {}
                 itemConfig = {
                   ...itemConfig,
@@ -1846,6 +1844,20 @@ export const useWorkflowGraph = ({
                     return { kb_id: vo.kb_id || vo.id, ...kb_config, }
                   })
                 }
+              } else if (key === 'knowledge_retrieval' && data.config[key] && 'defaultValue' in data.config[key]) {
+                const { knowledge_bases, ...rest } = data.config[key].defaultValue || {}
+                itemConfig = {
+                  ...itemConfig,
+                  knowledge_retrieval: {
+                    ...rest,
+                    knowledge_bases: knowledge_bases?.map((vo: any) => {
+                      const kb_config = vo.config || vo
+                      return { kb_id: vo.kb_id || vo.id, ...kb_config, }
+                    })
+                  }
+                }
+              } else if (data.config[key] && 'defaultValue' in data.config[key]) {
+                itemConfig[key] = data.config[key].defaultValue
               }
             })
           }


### PR DESCRIPTION
## Summary by Sourcery

改进社区、关系、工作流和应用视图中的图形工具提示、节点样式和配置处理。

Bug 修复：
- 在禁用技能时以更稳健的方式重置技能表单字段，并修复技能流程预览中的 React 列表 key 使用问题。
- 使用 `form.setFieldsValue` 设置代理（agent）能力的默认值，以避免由于部分表单更新而遗漏其他字段的情况。

增强功能：
- 为社区图形工具提示添加延迟隐藏和容器感知的定位，以提升可用性。
- 为关系网络中的节点和图例引入显式的节点类型样式映射，并为未知类型提供回退样式。
- 当内容超过最大高度时，允许社区网络工具提示支持滚动。
- 优化工作流图中 `knowledge_retrieval` 的默认配置处理，以区分代理节点和非代理节点。
- 调整画布工具栏的 z-index，以更好地与变量检查器共存。
- 更新 `create-dataset` 的默认图像 `vision_mode`，由字符串改为使用数值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve graph tooltips, node styling, and configuration handling across community, relationship, workflow, and application views.

Bug Fixes:
- Reset skills form fields more robustly when skills are disabled and fix React list key usage in the skill process preview.
- Use form.setFieldsValue for agent capability defaults to avoid partial form updates that could miss other values.

Enhancements:
- Add delayed hide and container-aware positioning for community graph tooltips to improve usability.
- Introduce explicit node-type style mapping for relationship network nodes and legends, including fallback styling for unknown types.
- Allow community network tooltips to scroll when content exceeds a maximum height.
- Refine workflow graph knowledge_retrieval default configuration handling for agent and non-agent nodes.
- Adjust canvas toolbar z-index to better coexist with the variable inspector.
- Update create-dataset default image vision_mode to use a numeric value instead of a string.

</details>