### PR TITLE
feat(memory-display): add API endpoints for written memories and engine display cards

### DIFF
--- a/api/app/controllers/service/__init__.py
+++ b/api/app/controllers/service/__init__.py
@@ -13,6 +13,7 @@ from . import (
     memory_api_controller,
     memory_config_api_controller,
     memory_dashboard_api_controller,
+    memory_display_api_controller,
     ontology_api_controller,
     rag_api_chunk_controller,
     rag_api_document_controller,
@@ -37,6 +38,7 @@ service_router.include_router(end_user_api_controller.router)
 service_router.include_router(memory_config_api_controller.router)
 service_router.include_router(user_memory_api_controller.router)
 service_router.include_router(memory_dashboard_api_controller.router)
+service_router.include_router(memory_display_api_controller.router)
 service_router.include_router(ontology_api_controller.router)
 
 __all__ = ["service_router"]

--- a/api/app/controllers/service/memory_display_api_controller.py
+++ b/api/app/controllers/service/memory_display_api_controller.py
@@ -17,7 +17,7 @@ from app.controllers import memory_display_controller
 from app.core.api_key_auth import require_api_key_self_db
 from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async
 from app.core.logging_config import get_business_logger
-from app.db import get_async_db_context, get_db_context
+from app.db import get_async_db_context
 from app.schemas.api_key_schema import ApiKeyAuth
 
 router = APIRouter(prefix="/memory-display", tags=["V1 - Memory Display API"])
@@ -50,18 +50,18 @@ async def get_written_memories(
     memory_type 始终返回稳定英文枚举，由前端负责展示文案映射；name 和
     content 保持记忆生成时的原始语言，不受 X-Language-Type 影响。
     """
-    async with get_async_db_context() as auth_db:
-        current_user = await get_current_user_snapshot_from_api_key_async(auth_db, api_key_auth)
+    async with get_async_db_context() as db:
+        current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
 
     logger.info(f"V1 get written memories - workspace: {api_key_auth.workspace_id}")
 
-    with get_db_context() as sync_db:
+    async with get_async_db_context() as db:
         result = await memory_display_controller.get_written_memories(
             end_user_id=end_user_id,
             page=page,
             pagesize=pagesize,
             current_user=current_user,
-            db=sync_db,
+            db=db,
         )
     return _encode_result(result)
 
@@ -95,12 +95,12 @@ async def get_engine_display_cards(
     前端统一传全局时区设置（useI18n().timeZone），
     保证卡片的聚合日期与前端展示 occurred_at 时使用的时区一致。
     """
-    async with get_async_db_context() as auth_db:
-        current_user = await get_current_user_snapshot_from_api_key_async(auth_db, api_key_auth)
+    async with get_async_db_context() as db:
+        current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
 
     logger.info(f"V1 get engine display cards - workspace: {api_key_auth.workspace_id}")
 
-    with get_db_context() as sync_db:
+    async with get_async_db_context() as db:
         result = await memory_display_controller.get_engine_display_cards(
             end_user_id=end_user_id,
             timezone=timezone,
@@ -108,6 +108,6 @@ async def get_engine_display_cards(
             pagesize=pagesize,
             language_type=language_type,
             current_user=current_user,
-            db=sync_db,
+            db=db,
         )
     return _encode_result(result)

--- a/api/app/controllers/service/memory_display_api_controller.py
+++ b/api/app/controllers/service/memory_display_api_controller.py
@@ -1,0 +1,113 @@
+"""记忆展示 服务接口 基于 API Key 认证
+
+包装 memory_display_controller.py 中的内部接口，提供基于 API Key 认证的对外服务
+
+路由前缀: /memory/memory-display
+最终路径: /v1/memory/memory-display/...
+认证方式: API Key (@require_api_key)
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Header, Query, Request
+from fastapi.encoders import jsonable_encoder
+from starlette.responses import Response
+
+from app.controllers import memory_display_controller
+from app.core.api_key_auth import require_api_key_self_db
+from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async
+from app.core.logging_config import get_business_logger
+from app.db import get_async_db_context, get_db_context
+from app.schemas.api_key_schema import ApiKeyAuth
+
+router = APIRouter(prefix="/memory-display", tags=["V1 - Memory Display API"])
+logger = get_business_logger()
+
+
+def _encode_result(result):
+    """Encode result for JSON serialization, preserving Response objects as-is."""
+    if isinstance(result, Response):
+        return result
+    return jsonable_encoder(result)
+
+
+# ==================== 写入展示记录 ====================
+
+
+@router.get("/written")
+@require_api_key_self_db(scopes=["memory"])
+async def get_written_memories(
+    request: Request,
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    api_key_auth: ApiKeyAuth = None,
+):
+    """获取写入展示记录列表
+
+    返回指定用户的写入记忆展示记录，按 occurred_at 倒序分页。
+
+    memory_type 始终返回稳定英文枚举，由前端负责展示文案映射；name 和
+    content 保持记忆生成时的原始语言，不受 X-Language-Type 影响。
+    """
+    async with get_async_db_context() as auth_db:
+        current_user = await get_current_user_snapshot_from_api_key_async(auth_db, api_key_auth)
+
+    logger.info(f"V1 get written memories - workspace: {api_key_auth.workspace_id}")
+
+    with get_db_context() as sync_db:
+        result = await memory_display_controller.get_written_memories(
+            end_user_id=end_user_id,
+            page=page,
+            pagesize=pagesize,
+            current_user=current_user,
+            db=sync_db,
+        )
+    return _encode_result(result)
+
+
+# ==================== 引擎动态展示卡片 ====================
+
+
+@router.get("/engines")
+@require_api_key_self_db(scopes=["memory"])
+async def get_engine_display_cards(
+    request: Request,
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    timezone: str = Header(
+        ...,
+        alias="X-Timezone",
+        description="IANA 时区名称，前端必传 useI18n().timeZone，如 Asia/Shanghai",
+    ),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    language_type: Optional[str] = Header(None, alias="X-Language-Type"),
+    api_key_auth: ApiKeyAuth = None,
+):
+    """获取引擎动态展示卡片列表
+
+    按"指定时区下的自然日 + 引擎类型"聚合事件并返回卡片。
+
+    engine_type 始终返回 EXTRACTION、CROSS_MODAL 或 EMOTION，
+    由前端负责展示文案映射；X-Language-Type 仅控制 name/content 文案。
+
+    聚合边界必须在服务端确定，因此 X-Timezone 为必传请求头，
+    前端统一传全局时区设置（useI18n().timeZone），
+    保证卡片的聚合日期与前端展示 occurred_at 时使用的时区一致。
+    """
+    async with get_async_db_context() as auth_db:
+        current_user = await get_current_user_snapshot_from_api_key_async(auth_db, api_key_auth)
+
+    logger.info(f"V1 get engine display cards - workspace: {api_key_auth.workspace_id}")
+
+    with get_db_context() as sync_db:
+        result = await memory_display_controller.get_engine_display_cards(
+            end_user_id=end_user_id,
+            timezone=timezone,
+            page=page,
+            pagesize=pagesize,
+            language_type=language_type,
+            current_user=current_user,
+            db=sync_db,
+        )
+    return _encode_result(result)

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -25,7 +25,7 @@ from app.core.memory.retrieval_trace.stage_projection import (
     project_result_items,
 )
 from app.core.models import RedBearLLM
-from app.core.utils.datetime_utils import utcnow
+from app.core.utils.datetime_utils import utcnow, utcnow_naive
 from app.db import get_async_db_context
 from app.repositories.memory_short_repository import ShortTermMemoryRepository
 from app.schemas.memory_retrieval_display_schema import (
@@ -193,7 +193,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                     search_mode=search_mode,
                     query=snapshot["query"],
                     content=snapshot["content"],
-                    occurred_at=utcnow(),
+                    occurred_at=utcnow_naive(),
                 )
             )
         except Exception as e:


### PR DESCRIPTION
## Summary by Sourcery

添加已认证的 API 端点，用于获取 memory display 数据，并将 display occurrence 时间戳与 naive UTC 对齐。

New Features:
- 暴露 `/written` 端点，通过 API Key 认证，为指定终端用户获取分页的 written memory display 记录。
- 暴露 `/engines` 端点，通过 API Key 认证，以按时区感知（timezone-aware）的自然日与 engine 类型聚合的方式，获取分页的 engine display cards。

Enhancements:
- 更新 memory display 记录的派发逻辑，使 occurrence 时间使用 naive UTC 时间戳。
- 将新的 memory display API 路由注册到主服务路由中，使这些端点在 v1 memory API 命名空间下可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add authenticated API endpoints for memory display retrieval and align display occurrence timestamps with naive UTC.

New Features:
- Expose a `/written` endpoint to fetch paginated written memory display records for a given end user via API key authentication.
- Expose an `/engines` endpoint to fetch paginated engine display cards aggregated by timezone-aware natural days and engine type via API key authentication.

Enhancements:
- Update memory display record dispatch to use naive UTC timestamps for occurrence time.
- Register the new memory display API router with the main service router to make the endpoints available under the v1 memory API namespace.

</details>