### PR TITLE
fix(memory):memory-engines-display-datetime

### DIFF
--- a/api/app/controllers/internal/internal_sandbox_controller.py
+++ b/api/app/controllers/internal/internal_sandbox_controller.py
@@ -311,7 +311,12 @@ async def read_memory(
             end_user_id=end_user_id,
             workspace_id=workspace_id,
         )
-        result = await memory_service.read(query=body.query, search_switch=SearchStrategy.QUICK, limit=5)
+        result = await memory_service.read(
+            query=body.query,
+            search_switch=SearchStrategy.QUICK,
+            limit=5,
+            record_display=True,
+        )
 
         return {"memories": [{"content": result.content, "count": result.count}]}
 

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -25,7 +25,7 @@ from app.core.memory.retrieval_trace.stage_projection import (
     project_result_items,
 )
 from app.core.models import RedBearLLM
-from app.core.utils.datetime_utils import utcnow
+from app.core.utils.datetime_utils import utcnow_naive
 from app.db import get_async_db_context
 from app.repositories.memory_short_repository import ShortTermMemoryRepository
 from app.schemas.memory_retrieval_display_schema import (
@@ -193,7 +193,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                     search_mode=search_mode,
                     query=snapshot["query"],
                     content=snapshot["content"],
-                    occurred_at=utcnow(),
+                    occurred_at=utcnow_naive(),
                 )
             )
         except Exception as e:

--- a/api/app/schemas/memory_retrieval_display_schema.py
+++ b/api/app/schemas/memory_retrieval_display_schema.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -37,6 +37,10 @@ class RetrieveDisplayTask:
 
     def to_row(self) -> dict:
         """转换为可直接用于批量 INSERT 的行。"""
+        occurred_at = self.occurred_at
+        if occurred_at.tzinfo is not None:
+            occurred_at = occurred_at.astimezone(timezone.utc).replace(tzinfo=None)
+
         return {
             "id": self.id,
             "end_user_id": self.end_user_id,
@@ -50,7 +54,7 @@ class RetrieveDisplayTask:
             "rank": None,
             "search_mode": self.search_mode,
             "query": self.query,
-            "occurred_at": self.occurred_at,
+            "occurred_at": occurred_at,
         }
 
 


### PR DESCRIPTION
## Summary by Sourcery

规范内存显示时间戳为“朴素”UTC日期时间，并确保沙箱环境中的内存读取会被记录用于展示。

Bug Fixes:
- 在持久化内存显示记录之前，将带时区的 `occurred_at` 值转换为朴素的 UTC 时间，以避免日期时间处理不一致的问题。
- 在分发内存显示记录时使用 `utcnow_naive`，以与存储预期保持一致并防止与时区相关的问题。

Enhancements:
- 在通过内部沙箱控制器读取内存时，通过显式开启 `record_display` 来允许创建显示记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize memory display timestamps to use naive UTC datetimes and ensure sandbox memory reads are recorded for display.

Bug Fixes:
- Convert timezone-aware occurred_at values to naive UTC before persisting memory display records to avoid inconsistent datetime handling.
- Use utcnow_naive when dispatching memory display records to align with storage expectations and prevent timezone-related issues.

Enhancements:
- Enable display record creation when reading memory via the internal sandbox controller by explicitly turning on record_display.

</details>