### PR TITLE
fix(tool-display): enforce minimum retrieval duration

### DIFF
--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -138,14 +138,14 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                 search_result = MemorySearchResult(memories=result.memories[1:], relations=result.relations)
         items = project_result_items(profile_result, search_result, limit=5)
         await self._emit_stage("result_ready", {
-            "duration_ms": max(0, int(round((time.perf_counter() - started_at) * 1000))),
+            "duration_ms": max(1, int(round((time.perf_counter() - started_at) * 1000))),
             "total_count": len(result.memories),
             "shown_count": len(items),
             "items": items,
         })
 
     def _elapsed_ms(self) -> int:
-        return max(0, int(round((time.perf_counter() - self._run_started_at) * 1000)))
+        return max(1, int(round((time.perf_counter() - self._run_started_at) * 1000)))
 
     def _ensure_run_started(self) -> None:
         if not self._run_started_at:
@@ -432,7 +432,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         combined = memory_l0 + results
         items = project_result_items(memory_l0, results, limit=5)
         await self._emit_stage("result_ready", {
-            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 0,
+            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 1,
             "total_count": len(combined.memories),
             "shown_count": len(items),
             "items": items,
@@ -498,7 +498,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         combined = memory_l0 + results
         items = project_result_items(memory_l0, results, limit=5)
         await self._emit_stage("result_ready", {
-            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 0,
+            "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 1,
             "total_count": len(combined.memories),
             "shown_count": len(items),
             "items": items,

--- a/api/app/core/memory/retrieval_trace/stage_events.py
+++ b/api/app/core/memory/retrieval_trace/stage_events.py
@@ -137,11 +137,12 @@ def _valid_stage_data(stage: str, data: dict[str, Any]) -> bool:
         count_fields = {
             "hybrid_searched": ("hit_count", "memory_count", "shown_count"),
             "relation_searched": ("hit_count", "relation_count", "shown_count"),
-            "result_ready": ("duration_ms", "total_count", "shown_count"),
+            "result_ready": ("total_count", "shown_count"),
         }[stage]
         item_validator = _valid_relation_item if stage == "relation_searched" else _valid_memory_item
         return (
-            all(_is_non_negative_int(data[field]) for field in count_fields)
+            (stage != "result_ready" or _is_positive_int(data["duration_ms"]))
+            and all(_is_non_negative_int(data[field]) for field in count_fields)
             and isinstance(data["items"], list)
             and all(item_validator(item) for item in data["items"])
             and data["shown_count"] == len(data["items"])


### PR DESCRIPTION
Ensure retrieval stage duration_ms values never fall below 1 ms.
Reject zero duration_ms values in result_ready payload validation.

## Summary by Sourcery

在内存读取结果阶段强制执行一个非零的最小检索持续时间，并更新校验逻辑，要求 `result_ready` 事件的 `duration_ms` 为正值。

Bug Fixes:
- 通过将检索阶段持续时间下限限制为至少 1 ms，防止 `result_ready` 阶段的持续时间被报告为 0 ms。
- 确保检索追踪校验会拒绝 `duration_ms` 为非正值的 `result_ready` 事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce a minimum non-zero retrieval duration in memory read result stages and update validation to require positive duration_ms values for result_ready events.

Bug Fixes:
- Prevent result_ready retrieval stage durations from ever being reported as 0 ms by clamping to at least 1 ms.
- Ensure retrieval trace validation rejects result_ready events with non-positive duration_ms values.

</details>