### PR TITLE
fix(api): Fix request injection for endpoints with request in signature

### DIFF
--- a/api/app/core/api_key_auth.py
+++ b/api/app/core/api_key_auth.py
@@ -414,11 +414,11 @@ def require_api_key_self_db(
                 kwargs["api_key_auth"] = _api_key_auth
 
             start_time = time.perf_counter()
-            # Conditionally pass request: old endpoints need it, new ones don't
+            # Bind arguments by name so Request can appear anywhere in the endpoint signature.
+            call_kwargs = dict(kwargs)
             if 'request' in _func_sig.parameters:
-                response = await func(request, **kwargs)
-            else:
-                response = await func(**kwargs)
+                call_kwargs['request'] = request
+            response = await func(**call_kwargs)
             end_time = time.perf_counter()
             response_time = (end_time - start_time) * 1000
 
@@ -438,15 +438,14 @@ def require_api_key_self_db(
             })
             return response
 
-        # Inject ``request: Request`` into the wrapper's visible signature so
-        # FastAPI always passes the Request object — even when the underlying
-        # endpoint function doesn't declare it.
+        # Inject ``request: Request`` only when the endpoint does not declare it.
         _func_sig = inspect.signature(func)
-        _req_param = inspect.Parameter(
-            'request', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request
-        )
-        _other_params = [p for name, p in _func_sig.parameters.items() if name != 'request']
-        wrapper.__signature__ = _func_sig.replace(parameters=[_req_param] + _other_params)
+        if 'request' not in _func_sig.parameters:
+            _req_param = inspect.Parameter(
+                'request', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request
+            )
+            _func_sig = _func_sig.replace(parameters=[_req_param, *_func_sig.parameters.values()])
+        wrapper.__signature__ = _func_sig
 
         return wrapper
 

--- a/api/app/core/api_key_auth.py
+++ b/api/app/core/api_key_auth.py
@@ -409,14 +409,14 @@ def require_api_key_self_db(
             # Set ContextVar for endpoints that use get_current_api_key_auth()
             _current_api_key_auth.set(_api_key_auth)
             # Backward-compat: only inject into kwargs if the function expects it
-            _func_sig = inspect.signature(func)
-            if 'api_key_auth' in _func_sig.parameters:
+            func_sig = inspect.signature(func)
+            if 'api_key_auth' in func_sig.parameters:
                 kwargs["api_key_auth"] = _api_key_auth
 
             start_time = time.perf_counter()
             # Bind arguments by name so Request can appear anywhere in the endpoint signature.
             call_kwargs = dict(kwargs)
-            if 'request' in _func_sig.parameters:
+            if 'request' in func_sig.parameters:
                 call_kwargs['request'] = request
             response = await func(**call_kwargs)
             end_time = time.perf_counter()
@@ -439,13 +439,13 @@ def require_api_key_self_db(
             return response
 
         # Inject ``request: Request`` only when the endpoint does not declare it.
-        _func_sig = inspect.signature(func)
-        if 'request' not in _func_sig.parameters:
+        wrapper_sig = inspect.signature(func)
+        if 'request' not in wrapper_sig.parameters:
             _req_param = inspect.Parameter(
                 'request', inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Request
             )
-            _func_sig = _func_sig.replace(parameters=[_req_param, *_func_sig.parameters.values()])
-        wrapper.__signature__ = _func_sig
+            wrapper_sig = wrapper_sig.replace(parameters=[_req_param, *wrapper_sig.parameters.values()])
+        wrapper.__signature__ = wrapper_sig
 
         return wrapper
 


### PR DESCRIPTION
## Summary by Sourcery

修复 API 密钥认证包装器中的请求注入逻辑，以正确支持在任意位置声明 `Request` 参数的端点。

Bug 修复：
- 确保在函数签名中包含 `Request` 参数的端点能够正确接收到 `Request` 对象，同时不会破坏未声明该参数的端点。

增强：
- 调整包装器的签名注入逻辑，仅在端点尚未声明 `Request` 参数时才添加该参数，从而更准确地匹配实际端点的函数签名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix request injection logic in API key auth wrapper to correctly support endpoints that declare a Request parameter in any position.

Bug Fixes:
- Ensure endpoints with a Request parameter in their signature receive the Request object without breaking endpoints that do not declare it.

Enhancements:
- Adjust wrapper signature injection to only add a Request parameter when the endpoint does not already declare one, matching actual endpoint signatures more accurately.

</details>