### PR TITLE
fix(web): modal notifications

### DIFF
--- a/web/src/components/Layout/Banner.tsx
+++ b/web/src/components/Layout/Banner.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type FC } from 'react';
-import { Alert } from 'antd';
+import { Alert, Flex } from 'antd';
+import { ExclamationCircleFilled } from '@ant-design/icons';
 import Marquee from 'react-fast-marquee';
 import { useTranslation } from 'react-i18next';
 
@@ -135,15 +136,25 @@ const Banners: FC<{ className?: string }> = ({
   const renderRbModal = () => {
     if (!activeModal) return null;
     const { mode, message } = activeModal;
-    console.log(activeModal);
     const confirmOkText = t('notificationCenter.actions.confirm');
     const remindLaterText = t('notificationCenter.actions.remindLater');
+    const title = (
+      <Flex gap={12}>
+        <span className="rb:text-[#faad14] rb:text-[18px]">
+        <ExclamationCircleFilled />
+        </span>
+        {message.title}
+      </Flex>
+    )
+    const content = (
+      <RbMarkdown content={message.content} />
+    )
 
     if (mode === 'confirm') {
       return (
         <RbModal
           open
-          title={message.title}
+          title={title}
           maskClosable={false}
           closable={false}
           keyboard={false}
@@ -153,7 +164,7 @@ const Banners: FC<{ className?: string }> = ({
           onOk={handleConfirmOk}
           onCancel={handleConfirmCancel}
         >
-          <RbMarkdown content={message.content} />
+          {content}
         </RbModal>
       );
     }
@@ -161,15 +172,15 @@ const Banners: FC<{ className?: string }> = ({
     return (
       <RbModal
         open
-        title={message.title}
-        closable
+        title={title}
+        closable={false}
         okText={confirmOkText}
         onOk={handleWarningOk}
         onCancel={handleWarningCancel}
         cancelButtonProps={{ style: { display: 'none' } }}
         className="rb-banner-warning-modal"
       >
-        <RbMarkdown content={message.content} />
+        {content}
       </RbModal>
     );
   };

--- a/web/src/components/Layout/Banner.tsx
+++ b/web/src/components/Layout/Banner.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, type FC } from 'react';
-import { Alert, App } from 'antd';
+import { useEffect, useRef, useState, type FC } from 'react';
+import { Alert } from 'antd';
 import Marquee from 'react-fast-marquee';
 import { useTranslation } from 'react-i18next';
 
@@ -8,6 +8,16 @@ import {
 } from '@/store/notification';
 import { isPrivateAvailable } from '@/utils/private'
 import RbMarkdown from '@/components/Markdown';
+import RbModal from '@/components/RbModal';
+import type { ModalMessage } from '@/store/notification/types';
+
+type ModalMode = 'confirm' | 'warning';
+
+interface ActiveModalState {
+  mode: ModalMode;
+  message: ModalMessage;
+  token: symbol;
+}
 
 const Banners: FC<{ className?: string }> = ({
   className
@@ -15,7 +25,6 @@ const Banners: FC<{ className?: string }> = ({
   if (!isPrivateAvailable) return;
 
   const { t } = useTranslation();
-  const { modal } = App.useApp()
   const {
     bannerMessages,
     modalMessages,
@@ -27,14 +36,27 @@ const Banners: FC<{ className?: string }> = ({
     teardownRealtime,
   } = useNotification();
 
-  // Single-instance lock + active modal identity/destroy handle for cleanup
+  // Single-instance lock + active modal identity for cleanup / stale-close guard.
   const openModalRef = useRef(false);
   const currentModalRef = useRef<{ id: string; token: symbol } | null>(null);
-  const destroyModalRef = useRef<(() => void) | null>(null);
+
+  /** Controlled <RbModal> state (replaces imperative modal.confirm / .warning). */
+  const [activeModal, setActiveModal] = useState<ActiveModalState | null>(null);
 
   useEffect(() => {
     setupRealtime();
   }, [setupRealtime]);
+
+  /**
+   * Close the currently displayed modal, but only if the caller still owns the
+   * token (i.e. a subsequent message hasn't already replaced it).
+   */
+  const closeActiveModal = (token: symbol) => {
+    if (currentModalRef.current?.token !== token) return;
+    openModalRef.current = false;
+    currentModalRef.current = null;
+    setActiveModal((current) => (current?.token === token ? null : current));
+  };
 
   useEffect(() => {
     if (openModalRef.current) {
@@ -44,12 +66,11 @@ const Banners: FC<{ className?: string }> = ({
         : false;
       if (currentMessageStillExists) return;
 
-      const destroyCurrentModal = destroyModalRef.current;
+      const token = currentModal?.token;
       openModalRef.current = false;
       currentModalRef.current = null;
-      destroyModalRef.current = null;
-      if (destroyCurrentModal) {
-        try { destroyCurrentModal(); } catch { /* noop */ }
+      if (token) {
+        setActiveModal((current) => (current?.token === token ? null : current));
       }
     }
 
@@ -61,97 +82,124 @@ const Banners: FC<{ className?: string }> = ({
     openModalRef.current = true;
     currentModalRef.current = { id: next.id, token: modalToken };
 
-    const releaseLock = () => {
-      if (currentModalRef.current?.token !== modalToken) return;
-      openModalRef.current = false;
-      currentModalRef.current = null;
-      destroyModalRef.current = null;
-    };
-    let destroy = null;
-
-    const okText = t('notificationCenter.actions.confirm');
-    const cancelText = t('notificationCenter.actions.remindLater');
-
-    if (isConfirmRequired) {
-      destroy = modal.confirm({
-        title: next.title,
-        content: <RbMarkdown content={next.content} />,
-        maskClosable: false,
-        closable: false,
-        keyboard: false,
-        centered: true,
-        okText,
-        cancelText,
-        onOk: async () => {
-          try {
-            await confirmMessage(next.id);
-          } finally {
-            releaseLock();
-          }
-        },
-        onCancel: () => {
-          // Handles both the 稍后 button AND the X-close of closable=true modals.
-          // requires_confirmation=false 时 closable=false + okCancel=false，因此 onCancel 不会被触发
-          snoozeModalMessage(next.id, 1);
-          releaseLock();
-        },
-      });
-    } else {
-      destroy = modal.warning({
-        title: next.title,
-        content: next.content,
-        icon: false,
-        closable: true,
-        okText,
-        onOk: async () => {
-          try {
-            await markAsRead(next.id);
-          } finally {
-            releaseLock();
-          }
-        },
-        onCancel: releaseLock,
-      });
-    }
-
-    destroyModalRef.current = (() => { destroy.destroy(); }) as () => void;
-  }, [modalMessages, modal, confirmMessage, snoozeModalMessage, markAsRead, t]);
+    setActiveModal({
+      mode: isConfirmRequired ? 'confirm' : 'warning',
+      message: next,
+      token: modalToken,
+    });
+  }, [modalMessages, confirmMessage, snoozeModalMessage, markAsRead]);
 
   // When the Banners host unmounts (e.g. route change), ensure the dangling
   // imperative modal is torn down and the global lock is reset.
   useEffect(() => {
     return () => {
-      if (destroyModalRef.current) {
-        try { destroyModalRef.current(); } catch { /* noop */ }
-      }
       openModalRef.current = false;
       currentModalRef.current = null;
-      destroyModalRef.current = null;
       teardownRealtime();
     };
   }, [teardownRealtime]);
 
+  /* ----------------------------- Render helpers ----------------------------- */
+
+  const handleConfirmOk = async () => {
+    if (!activeModal || activeModal.mode !== 'confirm') return;
+    try {
+      await confirmMessage(activeModal.message.id);
+    } finally {
+      closeActiveModal(activeModal.token);
+    }
+  };
+
+  const handleConfirmCancel = () => {
+    if (!activeModal || activeModal.mode !== 'confirm') return;
+    // Handles both the 稍后 button AND closable=true X-close; requires_confirmation
+    // uses okCancel=true so onCancel is only fired by those two interactions.
+    snoozeModalMessage(activeModal.message.id, 1);
+    closeActiveModal(activeModal.token);
+  };
+
+  const handleWarningOk = async () => {
+    if (!activeModal || activeModal.mode !== 'warning') return;
+    try {
+      await markAsRead(activeModal.message.id);
+    } finally {
+      closeActiveModal(activeModal.token);
+    }
+  };
+
+  const handleWarningCancel = () => {
+    if (!activeModal || activeModal.mode !== 'warning') return;
+    closeActiveModal(activeModal.token);
+  };
+
+  const renderRbModal = () => {
+    if (!activeModal) return null;
+    const { mode, message } = activeModal;
+    console.log(activeModal);
+    const confirmOkText = t('notificationCenter.actions.confirm');
+    const remindLaterText = t('notificationCenter.actions.remindLater');
+
+    if (mode === 'confirm') {
+      return (
+        <RbModal
+          open
+          title={message.title}
+          maskClosable={false}
+          closable={false}
+          keyboard={false}
+          centered
+          okText={confirmOkText}
+          cancelText={remindLaterText}
+          onOk={handleConfirmOk}
+          onCancel={handleConfirmCancel}
+        >
+          <RbMarkdown content={message.content} />
+        </RbModal>
+      );
+    }
+
+    return (
+      <RbModal
+        open
+        title={message.title}
+        closable
+        okText={confirmOkText}
+        onOk={handleWarningOk}
+        onCancel={handleWarningCancel}
+        cancelButtonProps={{ style: { display: 'none' } }}
+        className="rb-banner-warning-modal"
+      >
+        <RbMarkdown content={message.content} />
+      </RbModal>
+    );
+  };
+
+  /* ------------------------------- Top Alert -------------------------------- */
+
   const firstBanner = bannerMessages[0];
-  if (!firstBanner) {
-    return null;
-  }
 
   return (
-    <Alert
-      key={firstBanner.id}
-      type={firstBanner.theme === 'orange' ? 'warning' : 'error'}
-      banner
-      message={
-        <Marquee pauseOnHover gradient={false}>
-            {firstBanner.title} {firstBanner.summary}
-        </Marquee>
-      }
-      closable
-      onClose={() => {
-        void closeBanner(firstBanner.id);
-      }}
-      className={className || `rb:mb-3!`}
-    />
-  )
+    <>
+      {firstBanner && (
+        <Alert
+          key={firstBanner.id}
+          type={firstBanner.theme === 'orange' ? 'warning' : 'error'}
+          banner
+          message={
+            <Marquee pauseOnHover gradient={false}>
+                {firstBanner.title} {firstBanner.summary}
+            </Marquee>
+          }
+          closable
+          onClose={() => {
+            void closeBanner(firstBanner.id);
+          }}
+          className={className || `rb:mb-3!`}
+        />
+      )}
+      {renderRbModal()}
+    </>
+  );
 };
+
 export default Banners;


### PR DESCRIPTION
## Summary by Sourcery

在横幅通知布局中，用受控的基于 RbModal 的流程替换原先命令式使用的 Ant Design 模态框，从而正确管理模态框的生命周期和锁定行为；并在不存在横幅消息时有条件地渲染横幅警告。

Bug Fixes:
- 确保当通知对应的消息消失或布局卸载时，通知模态框能够正确关闭，防止出现过期或悬空的模态框。
- 通过条件渲染横幅警告，而不是假设横幅始终存在，避免在没有横幅消息时出现布局问题。

Enhancements:
- 使用受控的 RbModal 组件来显示通知确认和警告，使模态框行为与应用的设计系统保持一致，并允许在两种模态框中使用 Markdown 内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace imperative Ant Design modal usage in the banner notification layout with a controlled RbModal-based flow that correctly manages modal lifecycle and locking, and make the banner alert render conditionally when no banner messages exist.

Bug Fixes:
- Ensure notification modals close correctly when their backing messages disappear or the layout unmounts, preventing stale or dangling modals.
- Prevent layout issues when there are no banner messages by rendering the alert conditionally instead of assuming a banner is always present.

Enhancements:
- Use a controlled RbModal component for notification confirmations and warnings, aligning modal behavior with the app’s design system and allowing markdown content in both modal types.

</details>