### PR TITLE
refactor(memory-config): refactor memory config to use workspace models and remove reflection model

### DIFF
--- a/api/app/controllers/emotion_config_controller.py
+++ b/api/app/controllers/emotion_config_controller.py
@@ -30,7 +30,6 @@ class EmotionConfigUpdate(BaseModel):
     """情绪配置更新请求模型"""
     config_id: Union[uuid.UUID, int, str]= Field(..., description="配置ID")
     emotion_enabled: bool = Field(..., description="是否启用情绪提取")
-    emotion_model_id: Optional[str] = Field(None, description="情绪分析专用模型ID")
     emotion_extract_keywords: bool = Field(..., description="是否提取情绪关键词")
     emotion_min_intensity: float = Field(..., ge=0.0, le=1.0, description="最小情绪强度阈值（0.0-1.0）")
     emotion_enable_subject: bool = Field(..., description="是否启用主体分类")

--- a/api/app/controllers/memory_config_controller.py
+++ b/api/app/controllers/memory_config_controller.py
@@ -225,18 +225,21 @@ async def start_reflection_configs(
         config_id = await resolve_config_id_async(config_id, db)
         try:
             api_logger.info(f"用户 {current_user.username} 查询反思配置，config_id: {config_id}")
-            result = await MemoryConfigRepository(db).query_reflection_config_by_id_async(config_id)
+            result = await MemoryConfigRepository(db).get_config_with_workspace_async(config_id)
+            if not result:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"未找到config_id为 {config_id} 的配置")
+            db_config, workspace = result
 
             reflection_config = {
                 "config_id": config_id,
-                "reflection_enabled": result.enable_self_reflexion,
-                "reflection_period_in_hours": result.iteration_period,
-                "reflexion_range": result.reflexion_range,
-                "baseline": result.baseline,
-                "reflection_model_id": result.reflection_model_id,
-                "memory_verify": result.memory_verify,
-                "quality_assessment": result.quality_assessment,
-                "is_default": bool(result.is_default)
+                "reflection_enabled": db_config.enable_self_reflexion,
+                "reflection_period_in_hours": db_config.iteration_period,
+                "reflexion_range": db_config.reflexion_range,
+                "baseline": db_config.baseline,
+                "reflection_model_id": workspace.llm,
+                "memory_verify": db_config.memory_verify,
+                "quality_assessment": db_config.quality_assessment,
+                "is_default": bool(db_config.is_default)
             }
             api_logger.info(f"成功查询反思配置，config_id: {config_id}")
             return success(data=reflection_config, msg="反思配置查询成功")
@@ -459,7 +462,6 @@ async def save_reflection_config(
                 iteration_period=request.reflection_period_in_hours,
                 reflexion_range=request.reflexion_range,
                 baseline=request.baseline,
-                reflection_model_id=request.reflection_model_id,
                 memory_verify=request.memory_verify,
                 quality_assessment=request.quality_assessment
             )
@@ -473,7 +475,6 @@ async def save_reflection_config(
                 "iteration_period": memory_config.iteration_period,
                 "reflexion_range": memory_config.reflexion_range,
                 "baseline": memory_config.baseline,
-                "reflection_model_id": memory_config.reflection_model_id,
                 "memory_verify": memory_config.memory_verify,
                 "quality_assessment": memory_config.quality_assessment}
 

--- a/api/app/controllers/memory_reflection_controller.py
+++ b/api/app/controllers/memory_reflection_controller.py
@@ -409,17 +409,17 @@ async def reflection_run(
         config_id = resolve_config_id(config_id, db)
 
         # Query reflection configuration using MemoryConfigRepository
-        result = await MemoryConfigRepository(db).query_reflection_config_by_id_async(config_id)
-        if not result:
+        config_with_workspace = await MemoryConfigRepository(db).get_config_with_workspace_async(config_id)
+        if not config_with_workspace:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"未找到config_id为 {config_id} 的配置"
             )
+        result, workspace = config_with_workspace
 
         api_logger.info(f"成功查询反思配置，config_id: {config_id}")
 
-        # Validate model ID existence
-        model_id = result.reflection_model_id
+        model_id = workspace.llm
         if model_id:
             try:
                 await ModelConfigService.get_model_by_id_async(db=db, model_id=uuid.UUID(model_id), tenant_id=current_user.tenant_id)

--- a/api/app/controllers/service/memory_config_api_controller.py
+++ b/api/app/controllers/service/memory_config_api_controller.py
@@ -393,7 +393,7 @@ async def update_config_emotion(
     """
     Update emotion engine config (full update).
 
-    All fields except emotion_model_id are required.
+    All configuration fields are required.
     Only configs belonging to the authorized workspace can be updated.
     """
     body = await request.json()

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -14,6 +14,7 @@ from app.models import User
 from app.models.end_user_info_model import EndUserInfo
 from app.models.end_user_model import EndUser, EndUserMerge
 from app.models.workspace_model import Workspace
+from app.utils.redis_cache import redis_cache
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
@@ -2450,7 +2451,7 @@ async def get_end_user_by_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> 
     return end_user
 
 
-# @redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
+@redis_cache(ttl=600, prefix='tenant', skip_args=["db"], return_type=uuid.UUID)
 def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
     stmt = (
         select(Workspace.tenant_id)
@@ -2461,7 +2462,7 @@ def get_tenant_id_by_end_user_id(db: Session, end_user_id: uuid.UUID) -> Optiona
     return result.scalar()
 
 
-# @redis_cache(ttl=600, prefix='tenant', skip_args=["db"])
+@redis_cache(ttl=600, prefix='tenant', skip_args=["db"], return_type=uuid.UUID)
 async def get_tenant_id_by_end_user_id_async(db: AsyncSession, end_user_id: uuid.UUID) -> Optional[uuid.UUID]:
     stmt = (
         select(Workspace.tenant_id)

--- a/api/app/repositories/memory_config_repository.py
+++ b/api/app/repositories/memory_config_repository.py
@@ -131,7 +131,6 @@ class MemoryConfigRepository:
             iteration_period: str,
             reflexion_range: str,
             baseline: str,
-            reflection_model_id: str,
             memory_verify: bool,
             quality_assessment: bool
     ) -> MemoryConfig:
@@ -146,7 +145,6 @@ class MemoryConfigRepository:
         memory_config_obj.iteration_period = iteration_period
         memory_config_obj.reflexion_range = reflexion_range
         memory_config_obj.baseline = baseline
-        memory_config_obj.reflection_model_id = reflection_model_id
         memory_config_obj.memory_verify = memory_verify
         memory_config_obj.quality_assessment = quality_assessment
         return memory_config_obj
@@ -517,16 +515,15 @@ class MemoryConfigRepository:
         config_id = resolve_config_id(config_id, self.db)
         db_logger.debug(f"查询萃取配置(异步): config_id={config_id}")
         try:
-            stmt = select(MemoryConfig).where(MemoryConfig.config_id == config_id)
-            result = await self.db.execute(stmt)
-            db_config = result.scalar_one_or_none()
-            if not db_config:
+            result = await self.get_config_with_workspace_async(config_id)
+            if not result:
                 db_logger.debug(f"萃取配置不存在: config_id={config_id}")
                 return None
+            db_config, workspace = result
             result_dict = {
-                "llm_id": db_config.llm_id, "embedding_id": db_config.embedding_id,
-                "rerank_id": db_config.rerank_id, "vision_id": db_config.vision_id,
-                "audio_id": db_config.audio_id, "video_id": db_config.video_id,
+                "llm_id": workspace.llm, "embedding_id": workspace.embedding,
+                "rerank_id": workspace.rerank, "vision_id": workspace.vision,
+                "audio_id": workspace.audio, "video_id": workspace.video,
                 "enable_llm_dedup_blockwise": db_config.enable_llm_dedup_blockwise,
                 "enable_llm_disambiguation": db_config.enable_llm_disambiguation,
                 "deep_retrieval": db_config.deep_retrieval,

--- a/api/app/schemas/memory_api_schema.py
+++ b/api/app/schemas/memory_api_schema.py
@@ -137,12 +137,6 @@ class ConfigUpdateExtractedRequest(BaseModel):
 
     Attributes:
         config_id: Configuration UUID to update (required)
-        llm_id: Optional LLM model configuration ID
-        audio_id: Optional audio model configuration ID
-        vision_id: Optional vision model configuration ID
-        video_id: Optional video model configuration ID
-        embedding_id: Optional embedding model configuration ID
-        rerank_id: Optional reranking model configuration ID
         enable_llm_dedup_blockwise: Optional toggle for LLM decision deduplication
         enable_llm_disambiguation: Optional toggle for LLM decision disambiguation
         deep_retrieval: Optional toggle for deep retrieval
@@ -165,12 +159,6 @@ class ConfigUpdateExtractedRequest(BaseModel):
     
     """
     config_id: str = Field(..., description="Configuration ID (UUID)")
-    llm_id: Optional[str] = Field(None, description="LLM model configuration ID")
-    audio_id: Optional[str] = Field(None, description="Audio model ID")
-    vision_id: Optional[str] = Field(None, description="Vision model ID")
-    video_id: Optional[str] = Field(None, description="Video model ID")
-    embedding_id: Optional[str] = Field(None, description="Embedding model configuration ID")
-    rerank_id: Optional[str] = Field(None, description="Reranking model configuration ID")
     enable_llm_dedup_blockwise: Optional[bool] = Field(None, description="Enable LLM decision deduplication")
     enable_llm_disambiguation: Optional[bool] = Field(None, description="Enable LLM decision disambiguation")
     deep_retrieval: Optional[bool] = Field(None, description="Deep retrieval toggle")
@@ -243,14 +231,12 @@ class EmotionConfigUpdateRequest(BaseModel):
     Attributes:
         config_id: Configuration UUID to update (required)
         emotion_enabled: Whether to enable emotion extraction
-        emotion_model_id: Emotion analysis model ID
         emotion_extract_keywords: Whether to extract emotion keywords
         emotion_min_intensity: Minimum emotion intensity threshold (0.0-1.0)
         emotion_enable_subject: Whether to enable subject classification for emotions
     """
     config_id: str = Field(..., description="Configuration ID (UUID)")
     emotion_enabled: bool = Field(..., description="Whether to enable emotion extraction")
-    emotion_model_id: Optional[str] = Field(None, description="Emotion analysis model ID")
     emotion_extract_keywords: bool = Field(..., description="Whether to extract emotion keywords")
     emotion_min_intensity: float = Field(..., ge=0.0, le=1.0, description="Minimum emotion intensity threshold")
     emotion_enable_subject: bool = Field(..., description="Whether to enable subject classification for emotions")
@@ -271,7 +257,6 @@ class ReflectionConfigUpdateRequest(BaseModel):
         reflection_period_in_hours: Reflection iteration period in hours
         reflexion_range: Reflection range (partial or all)
         baseline: Baseline for reflection (TIME/FACT/TIME-FACT)
-        reflection_model_id: Reflection model ID
         memory_verify: Whether to enable memory verification
         quality_assessment: Whether to enable quality assessment
     """
@@ -280,7 +265,6 @@ class ReflectionConfigUpdateRequest(BaseModel):
     reflection_period_in_hours: str = Field(..., description="Reflection iteration period in hours")
     reflexion_range: Literal["partial", "all"] = Field(..., description="Reflection range: partial/all")
     baseline: Literal["TIME", "FACT", "TIME-FACT"] = Field(..., description="Baseline: TIME/FACT/TIME-FACT")
-    reflection_model_id: str = Field(..., description="Reflection model ID")
     memory_verify: bool = Field(..., description="Whether to enable memory verification")
     quality_assessment: bool = Field(..., description="Whether to enable quality assessment")
 

--- a/api/app/schemas/memory_reflection_schemas.py
+++ b/api/app/schemas/memory_reflection_schemas.py
@@ -84,7 +84,6 @@ class Memory_Reflection(BaseModel):
     reflection_period_in_hours: str
     reflexion_range: Optional[str] = "partial"
     baseline: Optional[str] = "TIME"
-    reflection_model_id: str
     memory_verify: bool
     quality_assessment: bool
     

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -268,12 +268,6 @@ class ConfigUpdate(BaseModel):  # 更新记忆萃取引擎配置参数时使用�
 
 class ConfigUpdateExtracted(BaseModel):  # 更新记忆萃取引擎配置参数时使用的模型
     config_id: Union[uuid.UUID, int, str] = None
-    llm_id: Optional[str] = Field(None, description="LLM模型配置ID")
-    audio_id: Optional[str] = Field(None, description="语音模型ID")
-    vision_id: Optional[str] = Field(None, description="视觉模型ID")
-    video_id: Optional[str] = Field(None, description="视频模型ID")
-    embedding_id: Optional[str] = Field(None, description="嵌入模型配置ID")
-    rerank_id: Optional[str] = Field(None, description="重排序模型配置ID")
     enable_llm_dedup_blockwise: Optional[bool] = None
     enable_llm_disambiguation: Optional[bool] = None
     deep_retrieval: Optional[bool] = Field(None, validation_alias="deep_retrieval")

--- a/api/app/services/emotion_config_service.py
+++ b/api/app/services/emotion_config_service.py
@@ -11,9 +11,11 @@ from typing import Dict, Any
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from app.models.memory_config_model import MemoryConfig
+from app.models.workspace_model import Workspace
 from app.core.logging_config import get_business_logger
 
 logger = get_business_logger()
@@ -31,7 +33,7 @@ class EmotionConfigService:
         db: 数据库会话
     """
     
-    def __init__(self, db: Session):
+    def __init__(self, db: AsyncSession):
         """初始化情绪配置服务
         
         Args:
@@ -46,7 +48,6 @@ class EmotionConfigService:
         验证配置参数的有效性，包括：
         - emotion_min_intensity 在 [0.0, 1.0] 范围内
         - 布尔字段类型正确
-        - emotion_model_id 格式有效（如果提供）
         
         Args:
             config_data: 配置数据字典
@@ -76,14 +77,6 @@ class EmotionConfigService:
                     if not isinstance(value, bool):
                         raise ValueError(f"{field} 必须是布尔类型")
             
-            # 验证 emotion_model_id（如果提供）
-            if "emotion_model_id" in config_data:
-                model_id = config_data["emotion_model_id"]
-                if model_id is not None and not isinstance(model_id, str):
-                    raise ValueError("emotion_model_id 必须是字符串类型或 null")
-                if model_id is not None and len(model_id.strip()) == 0:
-                    raise ValueError("emotion_model_id 不能为空字符串")
-            
             logger.debug("情绪配置参数验证通过")
             return True
             
@@ -111,18 +104,20 @@ class EmotionConfigService:
         try:
             logger.info(f"获取情绪配置（异步）: config_id={config_id}")
 
-            stmt = select(MemoryConfig).where(MemoryConfig.config_id == config_id)
+            stmt = select(MemoryConfig, Workspace).join(
+                Workspace, MemoryConfig.workspace_id == Workspace.id
+            ).where(MemoryConfig.config_id == config_id)
             result = await self.db.execute(stmt)
-            config = result.scalars().first()
-
-            if not config:
+            row = result.first()
+            if not row:
                 logger.error(f"配置不存在: config_id={config_id}")
                 raise ValueError(f"配置不存在: config_id={config_id}")
+            config, workspace = row
 
             emotion_config = {
                 "config_id": config.config_id,
                 "emotion_enabled": config.emotion_enabled,
-                "emotion_model_id": config.emotion_model_id,
+                "emotion_model_id": workspace.llm,
                 "emotion_extract_keywords": config.emotion_extract_keywords,
                 "emotion_min_intensity": config.emotion_min_intensity,
                 "emotion_enable_subject": config.emotion_enable_subject,
@@ -175,8 +170,6 @@ class EmotionConfigService:
             # 更新字段
             if "emotion_enabled" in config_data:
                 config.emotion_enabled = config_data["emotion_enabled"]
-            if "emotion_model_id" in config_data:
-                config.emotion_model_id = config_data["emotion_model_id"]
             if "emotion_extract_keywords" in config_data:
                 config.emotion_extract_keywords = config_data["emotion_extract_keywords"]
             if "emotion_min_intensity" in config_data:

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -264,100 +264,6 @@ class MemoryConfigService:
         """
         self.db = db
 
-    def _validate_model_with_fallback(
-        self,
-        model_id: str,
-        model_type: str,
-        workspace_default: str,
-        workspace_tenant_id,
-        config_id,
-        workspace_id,
-        required: bool = False,
-    ) -> tuple:
-        """Validate a model with workspace default fallback — sync variant."""
-        if model_id:
-            try:
-                return validate_and_resolve_model_id(
-                    model_id, model_type, self.db, workspace_tenant_id,
-                    required=False, config_id=config_id, workspace_id=workspace_id,
-                )
-            except Exception as e:
-                logger.warning(
-                    f"{model_type} model validation failed, trying workspace default: {e}"
-                )
-
-        if workspace_default:
-            try:
-                result = validate_and_resolve_model_id(
-                    workspace_default, model_type, self.db, workspace_tenant_id,
-                    required=required, config_id=config_id, workspace_id=workspace_id,
-                )
-                if result[0]:
-                    logger.info(f"Using workspace default {model_type} model: {workspace_default}")
-                return result
-            except Exception as e:
-                logger.error(f"Workspace default {model_type} model also invalid: {e}")
-                if required:
-                    raise
-
-        if required:
-            raise InvalidConfigError(
-                f"{model_type.title()} model is required but not configured",
-                field_name=f"{model_type}_model_id",
-                invalid_value=model_id,
-                config_id=config_id,
-                workspace_id=workspace_id,
-            )
-
-        return None, None
-
-    async def _validate_model_with_fallback_async(
-        self,
-        model_id: str,
-        model_type: str,
-        workspace_default: str,
-        workspace_tenant_id,
-        config_id,
-        workspace_id,
-        required: bool = False,
-    ) -> tuple:
-        """Validate a model with workspace default fallback — async variant."""
-        if model_id:
-            try:
-                return await validate_and_resolve_model_id_async(
-                    model_id, model_type, self.db, workspace_tenant_id,
-                    required=False, config_id=config_id, workspace_id=workspace_id,
-                )
-            except Exception as e:
-                logger.warning(
-                    f"{model_type} model validation failed, trying workspace default: {e}"
-                )
-
-        if workspace_default:
-            try:
-                result = await validate_and_resolve_model_id_async(
-                    workspace_default, model_type, self.db, workspace_tenant_id,
-                    required=required, config_id=config_id, workspace_id=workspace_id,
-                )
-                if result[0]:
-                    logger.info(f"Using workspace default {model_type} model: {workspace_default}")
-                return result
-            except Exception as e:
-                logger.error(f"Workspace default {model_type} model also invalid: {e}")
-                if required:
-                    raise
-
-        if required:
-            raise InvalidConfigError(
-                f"{model_type.title()} model is required but not configured",
-                field_name=f"{model_type}_model_id",
-                invalid_value=model_id,
-                config_id=config_id,
-                workspace_id=workspace_id,
-            )
-
-        return None, None
-
     async def _validate_model_connectivity(
             self,
             model_id: str,
@@ -532,7 +438,7 @@ class MemoryConfigService:
 
         return result
 
-    @redis_cache(ttl=300, prefix="memory", skip_args=["self"], return_type=MemoryConfig)
+    @redis_cache(ttl=300, prefix="memory_config", skip_args=["self"], id_arg="config_id", return_type=MemoryConfig)
     def load_memory_config(
             self,
             config_id: UUID
@@ -587,65 +493,44 @@ class MemoryConfigService:
 
             memory_config, workspace = result
 
-            # Step 2: Validate embedding model with workspace fallback
+            # Step 2: Validate workspace models
             embed_start = time.time()
-            embedding_uuid, embedding_name = self._validate_model_with_fallback(
-                memory_config.embedding_id, "embedding", workspace.embedding,
-                workspace.tenant_id, validated_config_id, workspace.id,
-                required=True,
+            embedding_uuid, embedding_name = validate_and_resolve_model_id(
+                workspace.embedding, "embedding", self.db, workspace.tenant_id,
+                required=True, config_id=validated_config_id, workspace_id=workspace.id,
             )
             embed_time = time.time() - embed_start
             logger.info(f"[PERF] Embedding validation: {embed_time:.4f}s")
 
-            # Step 3: Resolve LLM model with workspace fallback
+            # Step 3: Resolve workspace models
             llm_start = time.time()
-            llm_uuid, llm_name = self._validate_model_with_fallback(
-                memory_config.llm_id, "llm", workspace.llm,
-                workspace.tenant_id, validated_config_id, workspace.id,
-                required=True,
+            llm_uuid, llm_name = validate_and_resolve_model_id(
+                workspace.llm, "llm", self.db, workspace.tenant_id,
+                required=True, config_id=validated_config_id, workspace_id=workspace.id,
             )
             llm_time = time.time() - llm_start
             logger.info(f"[PERF] LLM validation: {llm_time:.4f}s")
 
-            # Step 4: Resolve optional rerank model with workspace fallback
             rerank_start = time.time()
-            rerank_uuid, rerank_name = self._validate_model_with_fallback(
-                memory_config.rerank_id, "rerank", workspace.rerank,
-                workspace.tenant_id, validated_config_id, workspace.id,
-                required=False,
+            rerank_uuid, rerank_name = validate_and_resolve_model_id(
+                workspace.rerank, "rerank", self.db, workspace.tenant_id,
+                required=False, config_id=validated_config_id, workspace_id=workspace.id,
             )
             rerank_time = time.time() - rerank_start
-            if memory_config.rerank_id or workspace.rerank:
+            if workspace.rerank:
                 logger.info(f"[PERF] Rerank validation: {rerank_time:.4f}s")
 
             vision_uuid, vision_name = validate_and_resolve_model_id(
-                memory_config.vision_id,
-                "llm",
-                self.db,
-                workspace.tenant_id,
-                required=False,
-                config_id=validated_config_id,
-                workspace_id=workspace.id,
+                workspace.vision, "llm", self.db, workspace.tenant_id,
+                required=False, config_id=validated_config_id, workspace_id=workspace.id,
             )
-
             audio_uuid, audio_name = validate_and_resolve_model_id(
-                memory_config.audio_id,
-                "llm",
-                self.db,
-                workspace.tenant_id,
-                required=False,
-                config_id=validated_config_id,
-                workspace_id=workspace.id,
+                workspace.audio, "llm", self.db, workspace.tenant_id,
+                required=False, config_id=validated_config_id, workspace_id=workspace.id,
             )
-
             video_uuid, video_name = validate_and_resolve_model_id(
-                memory_config.video_id,
-                "llm",
-                self.db,
-                workspace.tenant_id,
-                required=False,
-                config_id=validated_config_id,
-                workspace_id=workspace.id,
+                workspace.video, "llm", self.db, workspace.tenant_id,
+                required=False, config_id=validated_config_id, workspace_id=workspace.id,
             )
             # Create immutable MemoryConfig object
             config = _build_memory_config(
@@ -699,7 +584,7 @@ class MemoryConfigService:
             else:
                 raise ConfigurationError(f"Failed to load configuration {config_id}: {e}")
 
-    @redis_cache(ttl=300, prefix="memory", skip_args=["self"], return_type=MemoryConfig)
+    @redis_cache(ttl=300, prefix="memory_config", skip_args=["self"], id_arg="config_id", return_type=MemoryConfig)
     async def load_memory_config_async(self, config_id: UUID) -> MemoryConfig:
         """Async version of load_memory_config — uses true async DB calls via AsyncSession.
 
@@ -739,31 +624,28 @@ class MemoryConfigService:
                 (video_uuid, video_name),
                 ontology_class_infos,
             ) = await asyncio.gather(
-                self._validate_model_with_fallback_async(
-                    memory_config_row.embedding_id, "embedding", workspace.embedding,
-                    workspace.tenant_id, memory_config_row.config_id, workspace.id,
-                    required=True,
-                ),
-                self._validate_model_with_fallback_async(
-                    memory_config_row.llm_id, "llm", workspace.llm,
-                    workspace.tenant_id, memory_config_row.config_id, workspace.id,
-                    required=True,
-                ),
-                self._validate_model_with_fallback_async(
-                    memory_config_row.rerank_id, "rerank", workspace.rerank,
-                    workspace.tenant_id, memory_config_row.config_id, workspace.id,
-                    required=False,
+                validate_and_resolve_model_id_async(
+                    workspace.embedding, "embedding", self.db, workspace.tenant_id,
+                    required=True, config_id=memory_config_row.config_id, workspace_id=workspace.id,
                 ),
                 validate_and_resolve_model_id_async(
-                    memory_config_row.vision_id, "llm", self.db, workspace.tenant_id,
+                    workspace.llm, "llm", self.db, workspace.tenant_id,
+                    required=True, config_id=memory_config_row.config_id, workspace_id=workspace.id,
+                ),
+                validate_and_resolve_model_id_async(
+                    workspace.rerank, "rerank", self.db, workspace.tenant_id,
                     required=False, config_id=memory_config_row.config_id, workspace_id=workspace.id,
                 ),
                 validate_and_resolve_model_id_async(
-                    memory_config_row.audio_id, "llm", self.db, workspace.tenant_id,
+                    workspace.vision, "llm", self.db, workspace.tenant_id,
                     required=False, config_id=memory_config_row.config_id, workspace_id=workspace.id,
                 ),
                 validate_and_resolve_model_id_async(
-                    memory_config_row.video_id, "llm", self.db, workspace.tenant_id,
+                    workspace.audio, "llm", self.db, workspace.tenant_id,
+                    required=False, config_id=memory_config_row.config_id, workspace_id=workspace.id,
+                ),
+                validate_and_resolve_model_id_async(
+                    workspace.video, "llm", self.db, workspace.tenant_id,
                     required=False, config_id=memory_config_row.config_id, workspace_id=workspace.id,
                 ),
                 _load_ontology_class_infos_async(self.db, memory_config_row.scene_id),

--- a/api/app/services/memory_reflection_service.py
+++ b/api/app/services/memory_reflection_service.py
@@ -547,22 +547,17 @@ class MemoryReflectionService:
             except (ValueError, TypeError):
                 iteration_period = 24
 
-        reflection_model_id = config_data.get("reflection_model_id", "")
-        if reflection_model_id:
-            reflection_model_id = str(reflection_model_id)
-
-        # 如果模型 ID 为空，且传了同步 db，尝试查工作空间默认
-        if not reflection_model_id and db is not None:
-            workspace_id = config_data.get("workspace_id")
-            if workspace_id:
-                try:
-                    from app.db import get_db_context
-                    with get_db_context() as sync_db:
-                        workspace_models = get_workspace_models_configs(sync_db, workspace_id)
-                        if workspace_models and workspace_models.get("llm"):
-                            reflection_model_id = workspace_models["llm"]
-                except Exception:
-                    pass
+        reflection_model_id = ""
+        workspace_id = config_data.get("workspace_id")
+        if db is not None and workspace_id:
+            try:
+                from app.db import get_db_context
+                with get_db_context() as sync_db:
+                    workspace_models = get_workspace_models_configs(sync_db, workspace_id)
+                    if workspace_models:
+                        reflection_model_id = workspace_models.get("llm") or ""
+            except Exception:
+                pass
 
         return ReflectionConfig(
             enabled=config_data.get("enable_self_reflexion", False),
@@ -710,17 +705,12 @@ class MemoryReflectionService:
             except (ValueError, TypeError):
                 iteration_period = 24
 
-        reflection_model_id = config_data.get("reflection_model_id", "")
-        if reflection_model_id:
-            reflection_model_id = str(reflection_model_id)
-
-        if not reflection_model_id:
-            workspace_id = config_data.get("workspace_id")
-            if workspace_id:
-                workspace_models = get_workspace_models_configs(db, workspace_id)
-                if workspace_models and workspace_models.get("llm"):
-                    reflection_model_id = workspace_models["llm"]
-                    api_logger.info(f"reflection_model_id 为空，使用工作空间默认 LLM: {reflection_model_id}")
+        workspace_id = config_data.get("workspace_id")
+        reflection_model_id = ""
+        if workspace_id:
+            workspace_models = get_workspace_models_configs(db, workspace_id)
+            if workspace_models:
+                reflection_model_id = workspace_models.get("llm") or ""
 
         return ReflectionConfig(
             enabled=config_data.get("enable_self_reflexion", False),

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -44,6 +44,8 @@ from app.utils.redis_cache import (
     get_workspace_model_public_version,
     set_json,
     workspace_model_options_key,
+    invalidate_cache,
+    invalidate_cache_sync,
 )
 
 # 获取业务逻辑专用日志器
@@ -750,12 +752,15 @@ def update_workspace(
         db.commit()
         db.refresh(db_workspace)
 
-        # storage_type 变更时，使 _prepare_v1_chat_memory_context_async 缓存失效
         if "storage_type" in update_data:
-            import asyncio
-            from app.utils.redis_cache import invalidate_cache
             try:
-                asyncio.run(invalidate_cache(prefix=f"storage_type:{workspace_id}"))
+                invalidate_cache_sync(prefix=f"storage_type:{workspace_id}")
+            except Exception:
+                pass
+
+        if any(field in update_data for field in ("llm", "embedding", "rerank")) and db_workspace.memory_config:
+            try:
+                invalidate_cache_sync(prefix=f"memory_config:{db_workspace.memory_config}")
             except Exception:
                 pass
 
@@ -1574,8 +1579,11 @@ async def update_workspace_models_configs(
             db.add(default_memory_config)
         db.commit()
         db.refresh(db_workspace)
-        if default_memory_config:
-            db.refresh(default_memory_config)
+        if db_workspace.memory_config:
+            try:
+                await invalidate_cache(prefix=f"memory_config:{db_workspace.memory_config}")
+            except Exception:
+                pass
 
         business_logger.info(
             f"工作空间模型配置更新成功: workspace_id={workspace_id}, "

--- a/api/app/utils/redis_cache.py
+++ b/api/app/utils/redis_cache.py
@@ -169,9 +169,8 @@ def redis_cache(
                 可通过 ``invalidate_cache(prefix=f"{prefix}:{value}")`` 精确清除。
         key_builder: 自定义 key 构建函数。
         cache_none: 是否缓存 ``None`` 返回值。
-        return_type: 返回值 Pydantic model 类型。
-                     序列化时自动调 ``model_dump(mode='json')``，
-                     反序列化时自动调 ``model_validate(data)`` 重建对象。
+        return_type: 返回值类型。支持 Pydantic model（反序列化时自动调
+                     ``model_validate(data)`` 重建对象）和 ``uuid.UUID``（从字符串重建）。
                      不支持 dataclass（会抛 TypeError）。
                      未指定时返回 JSON dict/list。
     """
@@ -192,6 +191,9 @@ def redis_cache(
             if hasattr(return_type, "model_validate"):
                 def _deserializer(data):
                     return return_type.model_validate(data)
+            elif isinstance(return_type, type) and issubclass(return_type, uuid.UUID):
+                def _deserializer(data):
+                    return uuid.UUID(str(data))
             elif dataclasses.is_dataclass(return_type):
                 raise TypeError(
                     f"return_type={return_type.__name__} is a dataclass, not supported. "
@@ -357,6 +359,59 @@ def redis_cache(
     return deco
 
 
+def _resolve_invalidation(
+        key: str | None,
+        prefix: str | None,
+        pattern: str | None,
+        batch_size: int,
+) -> str | None:
+    """共享的参数校验与匹配模式解析。
+
+    ``key`` 精确删除时返回 ``None``；否则返回可用的 glob 匹配模式。
+
+    Raises:
+        ValueError: ``batch_size <= 0``，或未提供任何匹配条件。
+    """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+    if key is not None:
+        return None
+    search = pattern or (f"cache:{prefix}:*" if prefix else None)
+    if search is None:
+        raise ValueError("Provide key=, prefix=, or pattern=")
+    return search
+
+
+async def _scan_unlink_async(redis: Any, search: str, batch_size: int) -> int:
+    """异步 SCAN + UNLINK 批量删除，返回已删除的 key 数量。"""
+    scan_hint = max(1, min(batch_size, 500))
+    deleted = 0
+    cursor = 0
+    while True:
+        cursor, keys = await redis.scan(cursor, match=search, count=scan_hint)
+        if keys:
+            for i in range(0, len(keys), batch_size):
+                deleted += await redis.unlink(*keys[i:i + batch_size])
+        if cursor == 0:
+            break
+    return deleted
+
+
+def _scan_unlink_sync(redis: Any, search: str, batch_size: int) -> int:
+    """同步 SCAN + UNLINK 批量删除，返回已删除的 key 数量。"""
+    scan_hint = max(1, min(batch_size, 500))
+    deleted = 0
+    cursor = 0
+    while True:
+        cursor, keys = redis.scan(cursor, match=search, count=scan_hint)
+        if keys:
+            for i in range(0, len(keys), batch_size):
+                deleted += redis.unlink(*keys[i:i + batch_size])
+        if cursor == 0:
+            break
+    return deleted
+
+
 async def invalidate_cache(
         key: str | None = None,
         *,
@@ -384,30 +439,33 @@ async def invalidate_cache(
     Raises:
         ValueError: 未提供任何匹配条件，或 batch_size <= 0。
     """
-    if batch_size < 1:
-        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
-
+    search = _resolve_invalidation(key, prefix, pattern, batch_size)
     redis = get_thread_safe_redis()
 
     if key is not None:
         return await redis.delete(key)
 
-    search = pattern or (f"cache:{prefix}:*" if prefix else None)
-    if search is None:
-        raise ValueError("Provide key=, prefix=, or pattern=")
+    deleted = await _scan_unlink_async(redis, search, batch_size)
+    if deleted:
+        logger.info("Invalidated %d cache keys matching '%s'", deleted, search)
+    return deleted
 
-    scan_hint = max(1, min(batch_size, 500))
-    deleted = 0
-    cursor = 0
-    while True:
-        cursor, keys = await redis.scan(cursor, match=search, count=scan_hint)
-        if keys:
-            for i in range(0, len(keys), batch_size):
-                chunk = keys[i:i + batch_size]
-                deleted += await redis.unlink(*chunk)
-        if cursor == 0:
-            break
 
+def invalidate_cache_sync(
+        key: str | None = None,
+        *,
+        prefix: str | None = None,
+        pattern: str | None = None,
+        batch_size: int = 1000,
+) -> int:
+    """同步主动删除缓存，参数和 ``invalidate_cache`` 保持一致。"""
+    search = _resolve_invalidation(key, prefix, pattern, batch_size)
+    redis = get_thread_safe_sync_redis()
+
+    if key is not None:
+        return redis.delete(key)
+
+    deleted = _scan_unlink_sync(redis, search, batch_size)
     if deleted:
         logger.info("Invalidated %d cache keys matching '%s'", deleted, search)
     return deleted


### PR DESCRIPTION
## Summary by Sourcery

对内存相关配置与工作区级模型设置进行对齐，简化反射/情绪/抽取配置，并改进 Redis 缓存及缓存失效工具。

New Features:
- 暴露用于 Redis 支持的缓存的同步缓存失效辅助方法，以补充现有的异步 API。

Bug Fixes:
- 确保反射、情绪和抽取端点在配置缺失或使用过期配置 ID 时，能够一致地回退到工作区 LLM 及相关模型。

Enhancements:
- 使用工作区模型字段加载内存、反射、情绪和抽取配置，而非基于每个配置的模型 ID。
- 标准化内存配置的 Redis 缓存键，并在缓存反序列化中支持 UUID 类型。
- 重构缓存失效逻辑，在异步和同步路径之间共享 SCAN+UNLINK 行为，并改进参数校验。
- 更新工作区模型配置更新流程，以主动使相关内存及存储类型缓存失效。

Documentation:
- 调整 API 和模式文档，移除每个配置的模型 ID 字段，并明确情绪配置中的必填字段。

Chores:
- 从模式、控制器和仓库中移除未使用的反射和情绪模型 ID 处理，以减少配置表面面积。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align memory-related configuration with workspace-level model settings, simplify reflection/emotion/extraction configs, and improve Redis caching and cache invalidation utilities.

New Features:
- Expose synchronous cache invalidation helper for Redis-backed caches to complement the existing async API.

Bug Fixes:
- Ensure reflection, emotion, and extraction endpoints fall back consistently to workspace LLM and related models instead of relying on stale or missing per-config IDs.

Enhancements:
- Load memory, reflection, emotion, and extraction configurations using workspace model fields instead of per-config model IDs.
- Standardize Redis cache keys for memory configs and support UUID types in cache deserialization.
- Refactor cache invalidation logic to share SCAN+UNLINK behavior between async and sync paths and to improve parameter validation.
- Update workspace model configuration updates to proactively invalidate related memory and storage-type caches.

Documentation:
- Adjust API and schema documentation to remove per-config model ID fields and clarify required emotion configuration fields.

Chores:
- Remove unused reflection and emotion model ID handling from schemas, controllers, and repositories to reduce configuration surface area.

</details>