### PR TITLE
fix(mcp-market): Rename pagination field from has_next to hasnext

### DIFF
--- a/api/app/controllers/mcp_market_config_controller.py
+++ b/api/app/controllers/mcp_market_config_controller.py
@@ -122,7 +122,7 @@ async def get_mcp_servers(
             "page": page,
             "pagesize": pagesize,
             "total": total,
-            "has_next": True if page * pagesize < total else False
+            "hasnext": True if page * pagesize < total else False
         }
     }
     # 5. Update mck_market.mcp_count


### PR DESCRIPTION
- Rename pagination response field from `has_next` to `hasnext` for consistency
- Update MCP servers endpoint to use standardized field naming
- Maintains backward compatibility in pagination logic

## Summary by Sourcery

Bug Fixes:
- 将分页字段名称与标准化的 `hasnext` 键对齐，以避免 MCP 市场响应中的不一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Align the pagination field name with the standardized `hasnext` key to avoid inconsistencies in MCP market responses.

</details>