### PR TITLE
feat(web): memory model config

### DIFF
--- a/web/src/components/RbSlider/index.tsx
+++ b/web/src/components/RbSlider/index.tsx
@@ -86,9 +86,11 @@ const RbSlider: FC<RbSliderProps> = ({
         value={curValue}
         disabled={disabled}
         onChange={handleSliderChange}
-        classNames={size === 'small' ? {
-          rail: 'rb:w-[calc(100%-6px)]!'
-        } : undefined}
+        classNames={Object.assign(
+          {},
+          size === 'small' ? { rail: 'rb:w-[calc(100%-6px)]!', root: 'rb:my-0!' } : {},
+          rest.classNames ?? {}
+        )}
         className={size === 'small' ? `${size} rb:flex-1!` : 'rb:flex-1!'}
       />
       {/* Display current value or minimum value */}

--- a/web/src/views/EmotionEngine/index.tsx
+++ b/web/src/views/EmotionEngine/index.tsx
@@ -12,7 +12,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Row, Col, Form, Button, App, Space, Flex, Tooltip } from 'antd';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -66,6 +66,7 @@ const configList = [
 const EmotionEngine: React.FC = () => {
   const { t } = useTranslation();
   const { id } = useParams();
+  const navigate = useNavigate();
   const [configData, setConfigData] = useState<ConfigForm>({} as ConfigForm);
   const [form] = Form.useForm<ConfigForm>();
   const { message: messageApi } = App.useApp();
@@ -150,6 +151,15 @@ const EmotionEngine: React.FC = () => {
             }}
           >
             <Flex vertical gap={12}>
+              <Flex
+                align="center"
+                justify="space-between"
+                className="rb:cursor-pointer rb:bg-[#F6F6F6] rb:h-8 rb:rounded-lg rb:font-medium rb:leading-5 rb:pl-2! rb:pr-1! rb:hover:shadow-[0px_2px_8px_0px_rgba(23,23,25,0.16)]"
+                onClick={() => navigate('/space-config')}
+              >
+                {t('menu.spaceConfig')}
+                <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/memory/arrow_right.svg')]" />
+              </Flex>
               {configList.map(config => {
                 if (config.type === 'decimal') {
                   return (
@@ -176,6 +186,7 @@ const EmotionEngine: React.FC = () => {
                           isInput={true}
                           prefix={<span className="rb:text-[#5B6167]">{t('emotionEngine.currentValue')}:</span>}
                           inputClassName="rb:w-[155px]!"
+                          classNames={isDefault ? { track: 'rb:bg-[#171719]! rb:opacity-65' } : {}}
                         />
                       </Form.Item>
                     </div>
@@ -184,16 +195,29 @@ const EmotionEngine: React.FC = () => {
                 if (config.type === 'modelSelect') {
                   return (
                     <div key={config.key} className="rb:bg-[#F6F6F6] rb:rounded-xl rb:p-3">
-                      <LabelWrapper title={t(`emotionEngine.${config.key}`)} className="rb:mb-3">
-                        <DescWrapper desc={t(`emotionEngine.${config.key}_desc`)} className="rb:mt-1" />
-                      </LabelWrapper>
+                      <Flex gap={24} align="center" justify="space-between" className="rb:mb-3!">
+                        <LabelWrapper title={t(`emotionEngine.${config.key}`)}>
+                          <DescWrapper desc={t(`emotionEngine.${config.key}_desc`)} className="rb:mt-1" />
+                        </LabelWrapper>
+
+                        <Button
+                          type="link"
+                          disabled={false}
+                          size="small"
+                          className="rb:text-[12px]!"
+                          onClick={() => navigate('/space-config')}
+                        >
+                          {t('menu.spaceConfig')}
+                          <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/memory/arrow_right.svg')]" />
+                        </Button>
+                      </Flex>
                       <Form.Item
                         name={config.key}
                         className="rb:mb-0!"
                       >
                         <ModelSelect
                           params={config.params}
-                          disabled={isDefault || (!values?.emotion_enabled && config.key !== 'emotion_enabled')}
+                          disabled={true}
                         />
                       </Form.Item>
                     </div>
@@ -201,6 +225,7 @@ const EmotionEngine: React.FC = () => {
                 }
                 return (
                   <SwitchFormItem
+                    key={config.key}
                     title={t(`emotionEngine.${config.key}`)}
                     name={config.key}
                     desc={<>
@@ -262,7 +287,7 @@ const EmotionEngine: React.FC = () => {
               <div className="rb:font-medium rb:leading-5 rb:px-1 rb:mb-2.5">{t('emotionEngine.configSuggest')}</div>
               <Flex gap={10} vertical>
                 {['first', 'customer_service', 'data_analysis', 'risk_warning'].map(key => (
-                  <div className="rb:bg-[#F6F6F6] rb:px-3 rb:py-2.5 rb:rounded-xl">{t(`emotionEngine.${key}`)}: {t(`emotionEngine.${key}_desc`)}</div>
+                  <div key={key} className="rb:bg-[#F6F6F6] rb:px-3 rb:py-2.5 rb:rounded-xl">{t(`emotionEngine.${key}`)}: {t(`emotionEngine.${key}_desc`)}</div>
                 ))}
               </Flex>
             </div>
@@ -278,7 +303,7 @@ const EmotionEngine: React.FC = () => {
 
                 <Flex vertical gap={4}>
                   {['neutral_emotion', 'minor_dissatisfaction', 'expect_improvement'].map((key, index) => (
-                    <Flex gap={28} align="center" justify="space-between" className="rb:bg-white rb:px-3! rb:py-2! rb:rounded-lg">
+                    <Flex key={key} gap={28} align="center" justify="space-between" className="rb:bg-white rb:px-3! rb:py-2! rb:rounded-lg">
                       <Flex align="center" justify="space-between" className="rb:w-[55%]!">
                         <span className="rb:font-medium">{t(`emotionEngine.${key}`)}</span>
                         <span>{t('emotionEngine.confidence')}: {key === 'neutral_emotion' ? 0.85 : key === 'minor_dissatisfaction' ? 0.45 : 0.32}</span>

--- a/web/src/views/ForgettingEngine/index.tsx
+++ b/web/src/views/ForgettingEngine/index.tsx
@@ -225,6 +225,7 @@ const ForgettingEngine: React.FC = () => {
                           isInput={true}
                           prefix={<span className="rb:text-[#5B6167]">{t('emotionEngine.currentValue')}:</span>}
                           inputClassName="rb:w-[155px]!"
+                          classNames={isDefault ? { track: 'rb:bg-[#171719]! rb:opacity-65' } : {}}
                         />
                         : null
                       }

--- a/web/src/views/MemoryExtractionEngine/components/Card.tsx
+++ b/web/src/views/MemoryExtractionEngine/components/Card.tsx
@@ -11,7 +11,7 @@
 
 import { type FC, type ReactNode } from 'react'
 import clsx from 'clsx';
-import { Flex, Space, Tooltip } from 'antd';
+import { Flex, Tooltip } from 'antd';
 
 import RbCard from '@/components/RbCard/Card'
 
@@ -51,12 +51,12 @@ const Card: FC<CardProps> = ({
         className="rb:font-[MiSans-Bold] rb:font-bold rb:cursor-pointer"
         onClick={type && handleExpand ? () => handleExpand(type) : undefined}
       >
-        <Space size={4}>
+        <Flex gap={4} className="rb:flex-1!">
           {title}
           {subTitle && <Tooltip title={subTitle}>
             <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/question.svg')]"></div>
           </Tooltip>}
-        </Space>
+        </Flex>
         {handleExpand && <div
           className={clsx("rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/common/arrow_up.svg')]", {
             'rb:rotate-180': !expanded,
@@ -66,7 +66,7 @@ const Card: FC<CardProps> = ({
       headerType="borderless"
       className={className}
       headerClassName={`rb:h-[50px]! rb:pb-[12px]! rb:pt-[16px]! rb:leading-[22px]! rb:font-[MiSans-Bold] rb:font-bold rb:text-[16px] ${headerClassName}`}
-      bodyClassName={`rb:px-3! rb:py-0! ${expanded ? 'rb:pb-3!' : 'rb:pb-0!'} ${bodyClassName}`}
+      bodyClassName={`rb:px-3! rb:pt-0! ${expanded ? 'rb:pb-3!' : 'rb:pb-0!'} ${bodyClassName}`}
       extra={extra}
     >
       {(expanded || !(type && handleExpand)) && children}

--- a/web/src/views/MemoryExtractionEngine/index.tsx
+++ b/web/src/views/MemoryExtractionEngine/index.tsx
@@ -12,8 +12,8 @@
 
 import { type FC, useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
-import { Row, Col, Space, Select, InputNumber, App, Form, Input, Flex, Tooltip, Divider } from 'antd'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Row, Col, Space, Select, InputNumber, App, Form, Input, Flex, Tooltip, Divider, Button } from 'antd'
 import clsx from 'clsx'
 
 import Card from './components/Card'
@@ -58,6 +58,7 @@ const MemoryExtractionEngine: FC = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
   const { id } = useParams()
+  const navigate = useNavigate()
   const { language } = useI18n()
   const [expandedKeys, setExpandedKeys] = useState<string[]>(keys)
   const [form] = Form.useForm<ConfigForm>()
@@ -170,30 +171,34 @@ const MemoryExtractionEngine: FC = () => {
               </div>
 
               <Card
-                title={t('memoryExtractionEngine.modelConfig')}
+                title={
+                  <Flex align="center" justify="space-between" className="rb:w-full!">
+                    {t('memoryExtractionEngine.modelConfig')}
+                    <Button type="link" disabled={false} className="rb:text-[12px]!" size="small" onClick={() => navigate('/space-config')}>
+                      {t('menu.spaceConfig')}
+                    </Button>
+                  </Flex>
+                }
                 type="modelConfig"
                 expanded={expandedKeys.includes('modelConfig')}
                 handleExpand={handleExpand}
               >
-                {/* <Form form={modelForm}> */}
-                  <Flex vertical gap={12}>
-                    <Flex gap={12} vertical>
-                      {modelConfigList.map(config => (
-                        <div key={config.key} className="rb:bg-[#F6F6F6] rb:rounded-xl rb:p-3">
-                          <LabelWrapper title={t(`memoryExtractionEngine.${config.key}`)} className="rb:mb-3" />
-                          <Form.Item
-                            name={config.key}
-                            className="rb:mb-0!"
-                          >
-                            <ModelSelect
-                              params={config.params}
-                            />
-                          </Form.Item>
-                        </div>
-                      ))}
-                    </Flex>
-                  </Flex>
-                {/* </Form> */}
+                <Flex gap={12} vertical>
+                  {modelConfigList.map(config => (
+                    <div key={config.key} className="rb:bg-[#F6F6F6] rb:rounded-xl rb:p-3">
+                      <LabelWrapper title={t(`memoryExtractionEngine.${config.key}`)} className="rb:mb-3!" />
+                      <Form.Item
+                        name={config.key}
+                        className="rb:mb-0!"
+                      >
+                        <ModelSelect
+                          params={config.params}
+                          disabled={true}
+                        />
+                      </Form.Item>
+                    </div>
+                  ))}
+                </Flex>
               </Card>
 
               <Flex vertical gap={16}>
@@ -296,6 +301,7 @@ const MemoryExtractionEngine: FC = () => {
                                           isInput={true}
                                           prefix={<span className="rb:text-[#5B6167]">{t('emotionEngine.currentValue')}:</span>}
                                           inputClassName="rb:w-[155px]!"
+                                          classNames={isDefault ? { track: 'rb:bg-[#171719]! rb:opacity-65' } : {}}
                                         />
                                       </>
                                       : config.control === 'inputNumber'

--- a/web/src/views/SelfReflectionEngine/index.tsx
+++ b/web/src/views/SelfReflectionEngine/index.tsx
@@ -12,7 +12,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Row, Col, Form, App, Button, Space, Select, Flex, Divider } from 'antd';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -87,6 +87,7 @@ const configList = [
 const SelfReflectionEngine: React.FC = () => {
   const { t } = useTranslation();
   const { id } = useParams();
+  const navigate = useNavigate();
   const [configData, setConfigData] = useState<ConfigForm>({} as ConfigForm);
   const [form] = Form.useForm<ConfigForm>();
   const { message } = App.useApp();
@@ -208,9 +209,22 @@ const SelfReflectionEngine: React.FC = () => {
                 if (config.type === 'modelSelect') {
                   return (
                     <div key={config.key}>
-                      <LabelWrapper title={t(`reflectionEngine.${config.key}`)} className="rb:mb-3">
-                        <DescWrapper desc={t(`reflectionEngine.${config.key}_desc`)} className="rb:mt-1" />
-                      </LabelWrapper>
+                      <Flex gap={24} align="center" justify="space-between" className="rb:mb-3!">
+                        <LabelWrapper title={t(`reflectionEngine.${config.key}`)}>
+                          <DescWrapper desc={t(`reflectionEngine.${config.key}_desc`)} className="rb:mt-1" />
+                        </LabelWrapper>
+
+                        <Button
+                          type="link"
+                          disabled={false}
+                          size="small"
+                          className="rb:text-[12px]!"
+                          onClick={() => navigate('/space-config')}
+                        >
+                          {t('menu.spaceConfig')}
+                          <div className="rb:size-4 rb:bg-cover rb:bg-[url('@/assets/images/memory/arrow_right.svg')]" />
+                        </Button>
+                      </Flex>
                       <Form.Item
                         name={config.key}
                         className="rb:mb-0!"
@@ -218,7 +232,7 @@ const SelfReflectionEngine: React.FC = () => {
                         <ModelSelect
                           params={config.params}
                           placeholder={t('common.pleaseSelect')}
-                          disabled={isDefault || (!values?.reflection_enabled && config.key !== 'reflection_enabled')}
+                          disabled={true}
                         />
                       </Form.Item>
                     </div>


### PR DESCRIPTION
## Summary by Sourcery

在多个引擎配置视图中引入到空间配置页面的导航，并将模型选择设置改为只读，同时优化相关 UI 布局和滑块样式。

新特性：
- 在记忆、情感和自我反思引擎配置视图中添加空间配置的导航入口。

增强与优化：
- 在记忆、情感和自我反思引擎中禁用模型选择控件，将其呈现为不可编辑的配置。
- 调整引擎视图中的卡片标题、布局和间距，以提升对齐效果和可读性。
- 扩展 `RbSlider`，将外部 `classNames` 与不同尺寸的样式合并，以提供更灵活的展示。
- 当使用默认值时，优化滑块外观，在相关引擎视图中通过降低轨道亮度来实现更柔和的显示效果。
- 在情感引擎中为映射生成的列表补充缺失的 React key，以提升渲染稳定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce navigation from multiple engine configuration views to the space configuration page and make model selection settings read-only while refining related UI layout and slider styling.

New Features:
- Add space configuration navigation entry to memory, emotion, and self-reflection engine configuration views.

Enhancements:
- Disable model selection controls in memory, emotion, and self-reflection engines to present them as non-editable configuration.
- Adjust card headers, layout, and spacing in engine views for improved alignment and readability.
- Extend RbSlider to merge external classNames with size-specific styling for more flexible presentation.
- Refine slider appearance when using default values by dimming the track in relevant engine views.
- Add missing React keys to mapped lists in emotion engine for more stable rendering.

</details>