### PR TITLE
fix(memory): fix memory search to require end_user_id and include MemorySummary

### DIFF
--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -507,6 +507,13 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
     async def _express_read(self, query: str, limit: int, includes=None) -> MemorySearchResult:
         """仅全文检索模式：不做 embedding、关系检索、query 拆分、摘要生成。"""
+        if includes is None:
+            includes = [
+                Neo4jNodeType.CHUNK,
+                Neo4jNodeType.STATEMENT,
+                Neo4jNodeType.EXTRACTEDENTITY,
+                Neo4jNodeType.DIALOGUE,
+            ]
         meta_task = asyncio.ensure_future(self._user_meta())
         search_service = await self._get_search_service(includes, need_embedder=False, need_llm=False)
         express_res = await search_service.keyword_search(query, limit)

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -77,7 +77,6 @@ class Neo4jSearchService:
         if includes is None:
             self.includes = [
                 Neo4jNodeType.STATEMENT,
-                # Neo4jNodeType.DIALOGUE,
                 Neo4jNodeType.CHUNK,
                 Neo4jNodeType.EXTRACTEDENTITY,
                 Neo4jNodeType.MEMORYSUMMARY,

--- a/api/app/repositories/neo4j/create_indexes.py
+++ b/api/app/repositories/neo4j/create_indexes.py
@@ -41,6 +41,7 @@ RANGE_DEFS: List[Tuple[str, str]] = [
     ("user_statement", "Statement"),
     ("user_chunk", "Chunk"),
     ("user_extracted_entity", "ExtractedEntity"),
+    ("user_memorysummary", "MemorySummary")
 ]
 
 COMPOSITE_DEFS: List[Tuple[str, str, str]] = [

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -2180,7 +2180,7 @@ LIMIT $limit
 
 SEARCH_STATEMENTS_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("statementsFulltext", $query) YIELD node AS s, score
-WHERE ($end_user_id IS NULL OR s.end_user_id = $end_user_id)
+WHERE s.end_user_id = $end_user_id
   AND s.delete_at IS NULL
 RETURN s.id AS id,
        s.statement AS statement,
@@ -2201,7 +2201,7 @@ LIMIT $limit
 
 SEARCH_ENTITIES_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("entitiesFulltext", $query) YIELD node AS e, score
-WHERE ($end_user_id IS NULL OR e.end_user_id = $end_user_id)
+WHERE e.end_user_id = $end_user_id
   AND e.delete_at IS NULL
 RETURN e.id AS id,
        e.name AS name,
@@ -2218,7 +2218,7 @@ LIMIT $limit
 
 SEARCH_CHUNKS_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("chunksFulltext", $query) YIELD node AS c, score
-WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+WHERE c.end_user_id = $end_user_id
   AND c.delete_at IS NULL
 RETURN c.id AS id,
        c.content AS content,
@@ -2231,7 +2231,7 @@ LIMIT $limit
 # MemorySummary keyword search using fulltext index
 SEARCH_MEMORY_SUMMARIES_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("summariesFulltext", $query) YIELD node AS m, score
-WHERE ($end_user_id IS NULL OR m.end_user_id = $end_user_id)
+WHERE m.end_user_id = $end_user_id
 RETURN m.id AS id,
        m.name AS name,
        m.end_user_id AS end_user_id,
@@ -2251,7 +2251,7 @@ LIMIT $limit
 # Community keyword search: matches name or summary via fulltext index
 SEARCH_COMMUNITIES_BY_FULLTEXT = """
 CALL db.index.fulltext.queryNodes("communitiesFulltext", $query) YIELD node AS c, score
-WHERE ($end_user_id IS NULL OR c.end_user_id = $end_user_id)
+WHERE c.end_user_id = $end_user_id
 RETURN c.community_id AS id,
        c.name AS name,
        c.summary AS content,


### PR DESCRIPTION
## Summary by Sourcery

收紧内存关键字搜索的范围，使其限定在每个终端用户之内，并确保 MemorySummary 数据被索引并纳入内容搜索流程。

Bug Fixes:
- 要求所有全文内存和社区搜索都提供 `end_user_id`，以避免出现跨用户的搜索结果。

Enhancements:
- 为快速（express）内存读取设置一个默认的包含集合，覆盖核心节点类型。
- 确保 `MemorySummary` 节点在内容关键字搜索中被包含，同时默认省略 `Dialogue`。
- 为用户的 `MemorySummary` 实体添加全文索引定义，以支持基于摘要的关键字搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten memory keyword search to be scoped per end user and ensure MemorySummary data is indexed and included in content search flows.

Bug Fixes:
- Require end_user_id for all fulltext memory and community searches to avoid cross-user results.

Enhancements:
- Set a default include set for express memory reads covering core node types.
- Ensure MemorySummary nodes are included in content keyword searches while omitting Dialogue by default.
- Add a fulltext index definition for user MemorySummary entities to support summary keyword search.

</details>