### PR TITLE
Refactor/drop memory fk

### DIFF
--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -163,6 +163,35 @@ class MemoryService:
         )
 
     @staticmethod
+    async def ingest_agent_messages(
+        conversation_id: str,
+        messages: List[Any],
+        app_id: str,
+        config_id: str = "",
+        workspace_id: str = "",
+        end_user_id: str = "",
+        language: str = "zh",
+    ) -> bool:
+        """批量 Agent 消息摄入：一次事务写入 + 一次滑动窗口派发。
+
+        同一回合的 user + assistant 应通过此入口一次派发，避免两次
+        fire-and-forget 造成的 seq 分配竞态（顺序颠倒）。
+
+        每条 message 需带以下属性：
+            .id, .role, .content, .created_at, .meta_data, .should_memorize
+        """
+        from app.core.memory.pipelines.dispatcher import ingest_agent_messages
+        return await ingest_agent_messages(
+            conversation_id=conversation_id,
+            messages=messages,
+            app_id=app_id,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            end_user_id=end_user_id,
+            language=language,
+        )
+
+    @staticmethod
     async def ingest_workflow_messages(
         messages: List[dict],
         conversation_id: str,

--- a/api/app/core/memory/memory_service.py
+++ b/api/app/core/memory/memory_service.py
@@ -139,30 +139,6 @@ class MemoryService:
         return await refresh_user_card_tags(end_user_id, workspace_id)
 
     @staticmethod
-    async def ingest_agent_message(
-        conversation_id: str,
-        message: Any,
-        app_id: str,
-        config_id: str = "",
-        workspace_id: str = "",
-        end_user_id: str = "",
-        should_memorize: bool = True,
-        language: str = "zh",
-    ) -> bool:
-        """Agent 消息摄入：写入 memory_messages 表 + 触发滑动窗口派发。"""
-        from app.core.memory.pipelines.dispatcher import ingest_agent_message
-        return await ingest_agent_message(
-            conversation_id=conversation_id,
-            message=message,
-            app_id=app_id,
-            config_id=config_id,
-            workspace_id=workspace_id,
-            end_user_id=end_user_id,
-            should_memorize=should_memorize,
-            language=language,
-        )
-
-    @staticmethod
     async def ingest_agent_messages(
         conversation_id: str,
         messages: List[Any],

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -510,7 +510,7 @@ async def ingest_agent_messages(
             role_and_flag.append((str(m.role), should_memorize))
 
     # 写 memory_messages。original_message_id 与 messages 已解耦（无外键约束），
-    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_batch
+    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_pair
     # 捕获并降级为 warning，不影响主流程。
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -534,6 +534,149 @@ async def ingest_agent_message(
     return True
 
 
+async def ingest_agent_messages(
+    conversation_id: str,
+    messages: List["Any"],
+    app_id: str,
+    config_id: str = "",
+    workspace_id: str = "",
+    end_user_id: str = "",
+    language: str = "zh",
+) -> bool:
+    """批量 Agent 消息摄入：一次事务写入 memory_messages + 一次滑动窗口派发。
+
+    专用于同一回合的多条消息（典型场景：user + assistant 一起入队），确保：
+    1. 一次 pg_advisory_xact_lock，seq 按 messages 顺序连续递增（消除并发派发的
+       seq 分配竞态，避免 assistant.seq < user.seq 顺序颠倒）
+    2. 一次事务提交，一次滑动窗口派发，一次 refresh_active_key。
+
+    每条 message 需带以下属性：
+        .id, .role, .content, .created_at, .meta_data, .should_memorize
+
+    Returns:
+        True 表示成功写入至少一条，False 表示跳过(门禁未开或全部内容为空)
+    """
+    if not messages:
+        return False
+
+    if not await check_memory_enabled(app_id):
+        return False
+
+    # 构建 write_batch 输入 + 记录原始 role/should_memorize（用于后续 Fast Write）。
+    # write_batch 内部会过滤空 content，此处用相同规则同步 role_and_flag 列表，
+    # 保证之后与 written[] zip 对齐。
+    batch_inputs: list[dict] = []
+    role_and_flag: list[tuple[str, bool]] = []
+    for m in messages:
+        files = None
+        if hasattr(m, "meta_data") and m.meta_data:
+            files = m.meta_data.get("files")
+
+        dialog_at: Optional[str] = None
+        if hasattr(m, "created_at") and m.created_at:
+            _created = m.created_at
+            if isinstance(_created, datetime):
+                _created = _created.replace(tzinfo=timezone.utc) if _created.tzinfo is None else _created
+                dialog_at = _created.isoformat()
+            elif isinstance(_created, str):
+                dialog_at = _created
+
+        content_str = str(m.content or "")
+        should_memorize = bool(getattr(m, "should_memorize", True))
+
+        batch_inputs.append({
+            "role": m.role,
+            "content": m.content,
+            "original_message_id": m.id,
+            "created_at": m.created_at,
+            "should_memorize": should_memorize,
+            "files": files,
+            "dialog_at": dialog_at,
+        })
+
+        if content_str.strip():
+            role_and_flag.append((str(m.role), should_memorize))
+
+    # 写 memory_messages。original_message_id 外键指向 messages 表，而 messages 可能
+    # 经 BatchPersistQueue 攒批延迟落库——本表先 commit 时外键引用的行尚不存在，
+    # 会抛 IntegrityError（ForeignKeyViolation）。捕获后延迟重试，最终一致。
+    written: List[dict] = []
+    for attempt in range(AGENT_MESSAGE_FK_RETRY):
+        try:
+            with get_db_context() as db:
+                repo = MemoryMessageRepository(db)
+                written = repo.write_batch(
+                    conversation_id=str(conversation_id),
+                    messages=batch_inputs,
+                    end_user_id=end_user_id,
+                    source=MemoryMessageSource.AGENT,
+                )
+                if not written:
+                    return False
+                db.commit()
+            break
+        except IntegrityError as exc:
+            orig = getattr(exc, "orig", None)
+            is_fk = orig is not None and "ForeignKeyViolation" in type(orig).__name__
+            if not is_fk:
+                raise
+            if attempt >= AGENT_MESSAGE_FK_RETRY - 1:
+                # 重试耗尽：基本可断定 messages 行已永久缺失（落库失败/任务丢失），
+                # 该条记忆静默丢失，升级为 error 并带固定聚合标记，供日志平台配置告警。
+                logger.error(
+                    "MEMORY_MESSAGES_FK_EXHAUSTED retries=%d conv=%s end_user=%s "
+                    "batch_size=%d app_id=%s err=%s",
+                    AGENT_MESSAGE_FK_RETRY, conversation_id, end_user_id,
+                    len(batch_inputs), app_id, exc,
+                )
+                raise
+            logger.warning(
+                "ingest_agent_messages FK 冲突（messages 尚未落库），重试 %d/%d: conv=%s, err=%s",
+                attempt + 1, AGENT_MESSAGE_FK_RETRY, conversation_id, exc,
+            )
+            await asyncio.sleep(AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S * (attempt + 1))
+
+    await refresh_active_key(conversation_id)
+    mark_conversation_pending(conversation_id)
+
+    # Fast Write 派发（隔离：任一条失败不阻断整批，也不阻断下面的滑动窗口派发）。
+    # 权限取原始 role / should_memorize；Agent 路径有应用级门禁 require_app_gate=True。
+    # zip(strict=True)：len 不一致直接报错兜底（batch_inputs 与 write_batch 的空 content
+    # 过滤规则一致，理论上不会不齐；出现即上游数据异常，进 except 走隔离降级）。
+    try:
+        for (role, should_memorize), written_msg in zip(role_and_flag, written, strict=True):
+            await safe_push_fast_write(
+                role=role,
+                should_memorize=should_memorize,
+                app_id=app_id,
+                require_app_gate=True,
+                end_user_id=end_user_id,
+                target_message=written_msg,
+                config_id=config_id,
+                workspace_id=workspace_id,
+                conversation_id=str(conversation_id),
+                message_seq=written_msg["message_seq"],
+                language=language,
+                source=MemoryMessageSource.AGENT.value,
+            )
+    except Exception as e:
+        logger.warning(
+            "[FastDispatcher] agent fast write dispatch loop failed "
+            "(isolated, normal flow unaffected): conv=%s, end_user_id=%s, "
+            "batch=%s, written=%s, err=%s",
+            conversation_id, end_user_id, len(role_and_flag), len(written), e,
+        )
+
+    await check_sliding_window_and_dispatch(
+        conversation_id=str(conversation_id),
+        config_id=config_id,
+        end_user_id=end_user_id,
+        workspace_id=workspace_id,
+        language=language,
+    )
+    return True
+
+
 # ──────────────────────────────────────────────
 # 入口3: Workflow 消息摄入
 # ──────────────────────────────────────────────

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -597,44 +597,20 @@ async def ingest_agent_messages(
         if content_str.strip():
             role_and_flag.append((str(m.role), should_memorize))
 
-    # 写 memory_messages。original_message_id 外键指向 messages 表，而 messages 可能
-    # 经 BatchPersistQueue 攒批延迟落库——本表先 commit 时外键引用的行尚不存在，
-    # 会抛 IntegrityError（ForeignKeyViolation）。捕获后延迟重试，最终一致。
-    written: List[dict] = []
-    for attempt in range(AGENT_MESSAGE_FK_RETRY):
-        try:
-            with get_db_context() as db:
-                repo = MemoryMessageRepository(db)
-                written = repo.write_batch(
-                    conversation_id=str(conversation_id),
-                    messages=batch_inputs,
-                    end_user_id=end_user_id,
-                    source=MemoryMessageSource.AGENT,
-                )
-                if not written:
-                    return False
-                db.commit()
-            break
-        except IntegrityError as exc:
-            orig = getattr(exc, "orig", None)
-            is_fk = orig is not None and "ForeignKeyViolation" in type(orig).__name__
-            if not is_fk:
-                raise
-            if attempt >= AGENT_MESSAGE_FK_RETRY - 1:
-                # 重试耗尽：基本可断定 messages 行已永久缺失（落库失败/任务丢失），
-                # 该条记忆静默丢失，升级为 error 并带固定聚合标记，供日志平台配置告警。
-                logger.error(
-                    "MEMORY_MESSAGES_FK_EXHAUSTED retries=%d conv=%s end_user=%s "
-                    "batch_size=%d app_id=%s err=%s",
-                    AGENT_MESSAGE_FK_RETRY, conversation_id, end_user_id,
-                    len(batch_inputs), app_id, exc,
-                )
-                raise
-            logger.warning(
-                "ingest_agent_messages FK 冲突（messages 尚未落库），重试 %d/%d: conv=%s, err=%s",
-                attempt + 1, AGENT_MESSAGE_FK_RETRY, conversation_id, exc,
-            )
-            await asyncio.sleep(AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S * (attempt + 1))
+    # 写 memory_messages。original_message_id 与 messages 已解耦（无外键约束），
+    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_sync
+    # 捕获并降级为 warning，不影响主流程。
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        written = repo.write_batch(
+            conversation_id=str(conversation_id),
+            messages=batch_inputs,
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.AGENT,
+        )
+        if not written:
+            return False
+        db.commit()
 
     await refresh_active_key(conversation_id)
     mark_conversation_pending(conversation_id)

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -448,7 +448,7 @@ async def dispatch_api_service_async(
 
 async def ingest_agent_messages(
     conversation_id: str,
-    messages: List["Any"],
+    messages: List[Any],
     app_id: str,
     config_id: str = "",
     workspace_id: str = "",

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -446,94 +446,6 @@ async def dispatch_api_service_async(
 # ──────────────────────────────────────────────
 
 
-async def ingest_agent_message(
-    conversation_id: str,
-    message: "Any",
-    app_id: str,
-    config_id: str = "",
-    workspace_id: str = "",
-    end_user_id: str = "",
-    should_memorize: bool = True,
-    language: str = "zh",
-) -> bool:
-    """Agent 消息摄入：写入 memory_messages 表 + 触发滑动窗口派发。
-
-    Returns:
-        True 表示成功写入，False 表示跳过（门禁未开或写入失败）
-    """
-
-    if not await check_memory_enabled(app_id):
-        return False
-
-    files = None
-    if hasattr(message, "meta_data") and message.meta_data:
-        files = message.meta_data.get("files")
-
-    # Agent 路径：用 message.created_at 作为 dialog_at，语义上是对话真实发生的时间
-    dialog_at: Optional[str] = None
-    if hasattr(message, "created_at") and message.created_at:
-        _created = message.created_at
-        if isinstance(_created, datetime):
-            _created = _created.replace(tzinfo=timezone.utc) if _created.tzinfo is None else _created
-            dialog_at = _created.isoformat()
-        elif isinstance(_created, str):
-            dialog_at = _created
-
-    # 写 memory_messages。original_message_id 与 messages 已解耦（无外键约束），
-    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_sync
-    # 捕获并降级为 warning，不影响主流程。
-    with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        written = repo.write_batch(
-            conversation_id=str(conversation_id),
-            messages=[{
-                "role": message.role,
-                "content": message.content,
-                "original_message_id": message.id,
-                "created_at": message.created_at,
-                "should_memorize": should_memorize,
-                "files": files,
-                "dialog_at": dialog_at,
-            }],
-            end_user_id=end_user_id,
-            source=MemoryMessageSource.AGENT,
-        )
-        if not written:
-            return False
-        db.commit()
-
-    await refresh_active_key(conversation_id)
-    mark_conversation_pending(conversation_id)
-
-    # Fast Write 派发（隔离：失败不阻断下面的滑动窗口派发）。
-    # 权限取原始 message.role / should_memorize；Agent 有应用级门禁 require_app_gate=True。
-    _target_msg = written[0] if written else None
-    if _target_msg:
-        await safe_push_fast_write(
-            role=str(message.role),
-            should_memorize=should_memorize,
-            app_id=app_id,
-            require_app_gate=True,
-            end_user_id=end_user_id,
-            target_message=_target_msg,
-            config_id=config_id,
-            workspace_id=workspace_id,
-            conversation_id=str(conversation_id),
-            message_seq=_target_msg["message_seq"],
-            language=language,
-            source=MemoryMessageSource.AGENT.value,
-        )
-
-    await check_sliding_window_and_dispatch(
-        conversation_id=str(conversation_id),
-        config_id=config_id,
-        end_user_id=end_user_id,
-        workspace_id=workspace_id,
-        language=language,
-    )
-    return True
-
-
 async def ingest_agent_messages(
     conversation_id: str,
     messages: List["Any"],
@@ -598,7 +510,7 @@ async def ingest_agent_messages(
             role_and_flag.append((str(m.role), should_memorize))
 
     # 写 memory_messages。original_message_id 与 messages 已解耦（无外键约束），
-    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_sync
+    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_batch
     # 捕获并降级为 warning，不影响主流程。
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -16,13 +16,10 @@ MemoryWriteDispatcher — 记忆写入派发层
 各入口点保持原位置，通过本模块的函数进行统一派发。
 """
 
-import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, List, Optional
-
-from sqlalchemy.exc import IntegrityError
 
 from app.core.memory.enums import MemoryMessageSource
 from app.db import get_db_context, get_db_read
@@ -32,11 +29,6 @@ logger = logging.getLogger(__name__)
 
 # 滑动窗口大小
 WINDOW_SIZE = 3
-
-# ingest_agent_message 写 memory_messages 时，original_message_id 外键引用的 messages
-# 行可能因 BatchPersistQueue 攒批而尚未落库（FK 竞态），捕获后延迟重试直到最终一致。
-AGENT_MESSAGE_FK_RETRY = 4
-AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S = 0.3
 
 
 # ──────────────────────────────────────────────
@@ -487,52 +479,28 @@ async def ingest_agent_message(
         elif isinstance(_created, str):
             dialog_at = _created
 
-    # 写 memory_messages。original_message_id 外键指向 messages 表，而 messages 可能
-    # 经 BatchPersistQueue 攒批延迟落库——本表先 commit 时外键引用的行尚不存在，
-    # 会抛 IntegrityError（ForeignKeyViolation）。捕获后延迟重试，最终一致。
-    written: List[dict] = []
-    for attempt in range(AGENT_MESSAGE_FK_RETRY):
-        try:
-            with get_db_context() as db:
-                repo = MemoryMessageRepository(db)
-                written = repo.write_batch(
-                    conversation_id=str(conversation_id),
-                    messages=[{
-                        "role": message.role,
-                        "content": message.content,
-                        "original_message_id": message.id,
-                        "created_at": message.created_at,
-                        "should_memorize": should_memorize,
-                        "files": files,
-                        "dialog_at": dialog_at,
-                    }],
-                    end_user_id=end_user_id,
-                    source=MemoryMessageSource.AGENT,
-                )
-                if not written:
-                    return False
-                db.commit()
-            break
-        except IntegrityError as exc:
-            orig = getattr(exc, "orig", None)
-            is_fk = orig is not None and "ForeignKeyViolation" in type(orig).__name__
-            if not is_fk:
-                raise
-            if attempt >= AGENT_MESSAGE_FK_RETRY - 1:
-                # 重试耗尽：基本可断定 messages 行已永久缺失（落库失败/任务丢失），
-                # 该条记忆静默丢失，升级为 error 并带固定聚合标记，供日志平台配置告警。
-                logger.error(
-                    "MEMORY_MESSAGES_FK_EXHAUSTED retries=%d conv=%s end_user=%s "
-                    "original_message_id=%s app_id=%s err=%s",
-                    AGENT_MESSAGE_FK_RETRY, conversation_id, end_user_id,
-                    getattr(message, "id", ""), app_id, exc,
-                )
-                raise
-            logger.warning(
-                "ingest_agent_message FK 冲突（messages 尚未落库），重试 %d/%d: conv=%s, err=%s",
-                attempt + 1, AGENT_MESSAGE_FK_RETRY, conversation_id, exc,
-            )
-            await asyncio.sleep(AGENT_MESSAGE_FK_RETRY_BASE_DELAY_S * (attempt + 1))
+    # 写 memory_messages。original_message_id 与 messages 已解耦（无外键约束），
+    # 写入顺序不再受限，无需 FK 退避重试；异常冒泡由上层 dispatch_memory_sync
+    # 捕获并降级为 warning，不影响主流程。
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        written = repo.write_batch(
+            conversation_id=str(conversation_id),
+            messages=[{
+                "role": message.role,
+                "content": message.content,
+                "original_message_id": message.id,
+                "created_at": message.created_at,
+                "should_memorize": should_memorize,
+                "files": files,
+                "dialog_at": dialog_at,
+            }],
+            end_user_id=end_user_id,
+            source=MemoryMessageSource.AGENT,
+        )
+        if not written:
+            return False
+        db.commit()
 
     await refresh_active_key(conversation_id)
     mark_conversation_pending(conversation_id)

--- a/api/app/models/memory_message_model.py
+++ b/api/app/models/memory_message_model.py
@@ -47,9 +47,8 @@ class MemoryMessage(Base):
     )
     original_message_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("messages.id"),
         nullable=True,
-        comment="原始消息 ID（对 messages 表的引用；工作流/API/MCP 消息为 NULL）",
+        comment="原始消息 ID（对 messages 表的逻辑引用，非外键；工作流/API/MCP 消息为 NULL）",
     )
 
     # 归属与来源标识（用于替代哨兵 App 机制）

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -158,56 +158,6 @@ class AppChatService:
             return await self.db.get(model, identity)
         return self.db.get(model, identity)
 
-    async def _dispatch_memory_batch_pair(
-        self,
-        conversation_id: uuid.UUID,
-        user_message: dict,
-        assistant_message: dict,
-    ) -> None:
-        """批量派发一对 user/assistant 消息到记忆层（fire-and-forget）。
-
-        messages-memory-decoupling Phase 2: add_message[_async] 不再隐含派发记忆，
-        调用方显式通过本方法批量派发——一次 write_batch 分配连续 seq，批内严格
-        user < assistant。
-
-        Args:
-            conversation_id: 会话 ID。
-            user_message / assistant_message: 消息字段字典，支持键：
-                - id: uuid.UUID（消息 ID）
-                - content: str
-                - meta_data: dict | None
-                - should_memorize: bool（默认 True）
-        """
-        conv = await self._db_get(Conversation, conversation_id)
-        if not conv:
-            return
-        now = datetime.now(timezone.utc)
-        asyncio.create_task(
-            self.conversation_service.dispatch_memory_batch(
-                messages=[
-                    SimpleNamespace(
-                        id=user_message["id"],
-                        conversation_id=conversation_id,
-                        role="user",
-                        content=user_message["content"],
-                        meta_data=user_message.get("meta_data"),
-                        created_at=now,
-                        should_memorize=user_message.get("should_memorize", True),
-                    ),
-                    SimpleNamespace(
-                        id=assistant_message["id"],
-                        conversation_id=conversation_id,
-                        role="assistant",
-                        content=assistant_message["content"],
-                        meta_data=assistant_message.get("meta_data"),
-                        created_at=now,
-                        should_memorize=assistant_message.get("should_memorize", True),
-                    ),
-                ],
-                conversation=conv,
-            )
-        )
-
     async def _fetch_completed_file_metadata(self, local_ids: list[uuid.UUID]) -> dict[str, SimpleNamespace]:
         if not local_ids:
             return {}
@@ -579,7 +529,7 @@ class AppChatService:
                 meta_data={"usage": {}}
             )
             # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
-            await self._dispatch_memory_batch_pair(
+            await self.conversation_service.dispatch_memory_pair(
                 conversation_id,
                 user_message={"id": user_message_id, "content": message, "meta_data": {"files": []}},
                 assistant_message={"id": message_id, "content": annotation_match["answer"], "meta_data": {"usage": {}}},
@@ -1036,7 +986,7 @@ class AppChatService:
                 meta_data=assistant_meta,
             )
             # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
-            await self._dispatch_memory_batch_pair(
+            await self.conversation_service.dispatch_memory_pair(
                 conversation_id,
                 user_message={"id": user_message_id, "content": message, "meta_data": human_meta, "should_memorize": memory},
                 assistant_message={"id": message_id, "content": result["content"], "meta_data": assistant_meta, "should_memorize": memory},
@@ -1157,7 +1107,7 @@ class AppChatService:
                     meta_data={"usage": {}}
                 )
                 # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
-                await self._dispatch_memory_batch_pair(
+                await self.conversation_service.dispatch_memory_pair(
                     conversation_id,
                     user_message={"id": user_message_id, "content": message, "meta_data": {"files": []}},
                     assistant_message={"id": message_id, "content": annotation_match["answer"], "meta_data": {"usage": {}}},
@@ -1670,7 +1620,7 @@ class AppChatService:
 
                 # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper，
                 # 一次 write_batch 分配连续 seq，消除原先双 fire-and-forget 的 seq 颠倒。
-                await self._dispatch_memory_batch_pair(
+                await self.conversation_service.dispatch_memory_pair(
                     conversation_id,
                     user_message={"id": user_message_id, "content": message, "meta_data": human_meta, "should_memorize": memory},
                     assistant_message={"id": message_id, "content": full_content, "meta_data": assistant_meta, "should_memorize": True},
@@ -1875,25 +1825,6 @@ class AppChatService:
             }
         )
 
-        # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
-        await self._dispatch_memory_batch_pair(
-            conversation_id,
-            user_message={"id": user_message_id, "content": message, "should_memorize": memory},
-            assistant_message={
-                "id": ai_message.id,
-                "content": result.get("message", ""),
-                "meta_data": {
-                    "mode": result.get("mode"),
-                    "elapsed_time": result.get("elapsed_time"),
-                    "usage": result.get("usage", {
-                        "prompt_tokens": 0,
-                        "completion_tokens": 0,
-                        "total_tokens": 0
-                    })
-                },
-                "should_memorize": memory,
-            },
-        )
 
         return {
             "conversation_id": conversation_id,

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -158,6 +158,56 @@ class AppChatService:
             return await self.db.get(model, identity)
         return self.db.get(model, identity)
 
+    async def _dispatch_memory_batch_pair(
+        self,
+        conversation_id: uuid.UUID,
+        user_message: dict,
+        assistant_message: dict,
+    ) -> None:
+        """批量派发一对 user/assistant 消息到记忆层（fire-and-forget）。
+
+        messages-memory-decoupling Phase 2: add_message[_async] 不再隐含派发记忆，
+        调用方显式通过本方法批量派发——一次 write_batch 分配连续 seq，批内严格
+        user < assistant。
+
+        Args:
+            conversation_id: 会话 ID。
+            user_message / assistant_message: 消息字段字典，支持键：
+                - id: uuid.UUID（消息 ID）
+                - content: str
+                - meta_data: dict | None
+                - should_memorize: bool（默认 True）
+        """
+        conv = await self._db_get(Conversation, conversation_id)
+        if not conv:
+            return
+        now = datetime.now(timezone.utc)
+        asyncio.create_task(
+            self.conversation_service.dispatch_memory_batch(
+                messages=[
+                    SimpleNamespace(
+                        id=user_message["id"],
+                        conversation_id=conversation_id,
+                        role="user",
+                        content=user_message["content"],
+                        meta_data=user_message.get("meta_data"),
+                        created_at=now,
+                        should_memorize=user_message.get("should_memorize", True),
+                    ),
+                    SimpleNamespace(
+                        id=assistant_message["id"],
+                        conversation_id=conversation_id,
+                        role="assistant",
+                        content=assistant_message["content"],
+                        meta_data=assistant_message.get("meta_data"),
+                        created_at=now,
+                        should_memorize=assistant_message.get("should_memorize", True),
+                    ),
+                ],
+                conversation=conv,
+            )
+        )
+
     async def _fetch_completed_file_metadata(self, local_ids: list[uuid.UUID]) -> dict[str, SimpleNamespace]:
         if not local_ids:
             return {}
@@ -527,6 +577,12 @@ class AppChatService:
                 role="assistant",
                 content=annotation_match["answer"],
                 meta_data={"usage": {}}
+            )
+            # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
+            await self._dispatch_memory_batch_pair(
+                conversation_id,
+                user_message={"id": user_message_id, "content": message, "meta_data": {"files": []}},
+                assistant_message={"id": message_id, "content": annotation_match["answer"], "meta_data": {"usage": {}}},
             )
             elapsed_time = time.time() - start_time
             return {
@@ -971,7 +1027,6 @@ class AppChatService:
                 role="user",
                 content=message,
                 meta_data=human_meta,
-                should_memorize=memory,
             )
             await self.conversation_service.add_message_async(
                 message_id=message_id,
@@ -979,7 +1034,12 @@ class AppChatService:
                 role="assistant",
                 content=result["content"],
                 meta_data=assistant_meta,
-                should_memorize=memory,
+            )
+            # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
+            await self._dispatch_memory_batch_pair(
+                conversation_id,
+                user_message={"id": user_message_id, "content": message, "meta_data": human_meta, "should_memorize": memory},
+                assistant_message={"id": message_id, "content": result["content"], "meta_data": assistant_meta, "should_memorize": memory},
             )
             if used_context_engine:
                 _ctx_kwargs = dict(
@@ -1095,6 +1155,12 @@ class AppChatService:
                     role="assistant",
                     content=annotation_match["answer"],
                     meta_data={"usage": {}}
+                )
+                # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
+                await self._dispatch_memory_batch_pair(
+                    conversation_id,
+                    user_message={"id": user_message_id, "content": message, "meta_data": {"files": []}},
+                    assistant_message={"id": message_id, "content": annotation_match["answer"], "meta_data": {"usage": {}}},
                 )
                 yield f"event: start\ndata: {json.dumps({'conversation_id': str(conversation_id), 'message_id': str(message_id), 'user_message_id': str(user_message_id)}, ensure_ascii=False)}\n\n"
                 yield f"event: message\ndata: {json.dumps({'content': annotation_match['answer'], 'conversation_id': str(conversation_id)}, ensure_ascii=False)}\n\n"
@@ -1562,7 +1628,6 @@ class AppChatService:
                 strip_memory_trace_transients(node)
                 for node in (orchestrator_node_executions + node_executions)
             ]
-            from app.models.conversation_model import Conversation
             if not skip_save:
                 from app.services.batch_persist_queue import BatchPersistQueue, PersistTask
 
@@ -1603,39 +1668,13 @@ class AppChatService:
                 ))
                 save_messages_enqueued = True
 
-                # 记忆写入 + 派发：改为批量派发，一次 write_batch 分配连续 seq，
-                # 消除原先两次 fire-and-forget 并发引发的 seq 顺序颠倒问题。
-                result_row = await self.db.execute(
-                    select(Conversation).where(Conversation.id == conversation_id)
+                # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper，
+                # 一次 write_batch 分配连续 seq，消除原先双 fire-and-forget 的 seq 颠倒。
+                await self._dispatch_memory_batch_pair(
+                    conversation_id,
+                    user_message={"id": user_message_id, "content": message, "meta_data": human_meta, "should_memorize": memory},
+                    assistant_message={"id": message_id, "content": full_content, "meta_data": assistant_meta, "should_memorize": True},
                 )
-                conv = result_row.scalar_one_or_none()
-                if conv:
-                    now = datetime.now(timezone.utc)
-                    asyncio.create_task(
-                        self.conversation_service.dispatch_memory_batch(
-                            messages=[
-                                SimpleNamespace(
-                                    id=user_message_id,
-                                    conversation_id=conversation_id,
-                                    role="user",
-                                    content=message,
-                                    meta_data=human_meta,
-                                    created_at=now,
-                                    should_memorize=memory,
-                                ),
-                                SimpleNamespace(
-                                    id=message_id,
-                                    conversation_id=conversation_id,
-                                    role="assistant",
-                                    content=full_content,
-                                    meta_data=assistant_meta,
-                                    created_at=now,
-                                    should_memorize=True,
-                                ),
-                            ],
-                            conversation=conv,
-                        )
-                    )
 
                 # Enqueue agent execution after messages so the FK is satisfied
                 # within the same batch (messages commit first, then execution).
@@ -1834,6 +1873,26 @@ class AppChatService:
                     "total_tokens": 0
                 })
             }
+        )
+
+        # messages-memory-decoupling Phase 2: 记忆批量派发收敛到公共 helper。
+        await self._dispatch_memory_batch_pair(
+            conversation_id,
+            user_message={"id": user_message_id, "content": message, "should_memorize": memory},
+            assistant_message={
+                "id": ai_message.id,
+                "content": result.get("message", ""),
+                "meta_data": {
+                    "mode": result.get("mode"),
+                    "elapsed_time": result.get("elapsed_time"),
+                    "usage": result.get("usage", {
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0
+                    })
+                },
+                "should_memorize": memory,
+            },
         )
 
         return {

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -30,7 +30,7 @@ from app.schemas.app_schema import FileInput, FileType, TransferMethod
 from app.schemas.model_schema import ModelInfo
 from app.schemas.prompt_schema import render_prompt_message, PromptMessageRole
 from app.services.annotation_service import AnnotationService
-from app.services.conversation_service import ConversationService
+from app.services.conversation_service import ConversationService, fire_background_memory_task
 from app.services.context_engine_manager import ContextEngineManager
 from app.core.config import settings
 from app.services.draft_run_service import AgentRunService
@@ -1603,24 +1603,39 @@ class AppChatService:
                 ))
                 save_messages_enqueued = True
 
-                # 记忆写入 + 派发：复用 conversation_service.dispatch_memory_sync
+                # 记忆写入 + 派发：改为批量派发，一次 write_batch 分配连续 seq，
+                # 消除原先两次 fire-and-forget 并发引发的 seq 顺序颠倒问题。
                 result_row = await self.db.execute(
                     select(Conversation).where(Conversation.id == conversation_id)
                 )
                 conv = result_row.scalar_one_or_none()
                 if conv:
                     now = datetime.now(timezone.utc)
-
-                    for m in [
-                        {"id": user_message_id, "role": "user", "content": message, "meta_data": human_meta, "should_memorize": memory},
-                        {"id": message_id, "role": "assistant", "content": full_content, "meta_data": assistant_meta, "should_memorize": True},
-                    ]:
-                        memorize = m.pop("should_memorize")
-                        self.conversation_service.dispatch_memory_sync(
-                            message=SimpleNamespace(conversation_id=conversation_id, created_at=now, **m),
+                    fire_background_memory_task(
+                        self.conversation_service.dispatch_memory_batch(
+                            messages=[
+                                SimpleNamespace(
+                                    id=user_message_id,
+                                    conversation_id=conversation_id,
+                                    role="user",
+                                    content=message,
+                                    meta_data=human_meta,
+                                    created_at=now,
+                                    should_memorize=memory,
+                                ),
+                                SimpleNamespace(
+                                    id=message_id,
+                                    conversation_id=conversation_id,
+                                    role="assistant",
+                                    content=full_content,
+                                    meta_data=assistant_meta,
+                                    created_at=now,
+                                    should_memorize=True,
+                                ),
+                            ],
                             conversation=conv,
-                            should_memorize=memorize,
                         )
+                    )
 
                 # Enqueue agent execution after messages so the FK is satisfied
                 # within the same batch (messages commit first, then execution).

--- a/api/app/services/app_chat_service.py
+++ b/api/app/services/app_chat_service.py
@@ -30,7 +30,7 @@ from app.schemas.app_schema import FileInput, FileType, TransferMethod
 from app.schemas.model_schema import ModelInfo
 from app.schemas.prompt_schema import render_prompt_message, PromptMessageRole
 from app.services.annotation_service import AnnotationService
-from app.services.conversation_service import ConversationService, fire_background_memory_task
+from app.services.conversation_service import ConversationService
 from app.services.context_engine_manager import ContextEngineManager
 from app.core.config import settings
 from app.services.draft_run_service import AgentRunService
@@ -1611,7 +1611,7 @@ class AppChatService:
                 conv = result_row.scalar_one_or_none()
                 if conv:
                     now = datetime.now(timezone.utc)
-                    fire_background_memory_task(
+                    asyncio.create_task(
                         self.conversation_service.dispatch_memory_batch(
                             messages=[
                                 SimpleNamespace(

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -33,11 +33,6 @@ from app.services.prompt import prompt_manager
 logger = get_business_logger()
 
 
-# fire-and-forget 后台任务的强引用集合（供 dispatch_memory_sync 老链路使用；
-# Phase 3 迁移完成后可与老链路一并移除）。
-_BACKGROUND_MEMORY_TASKS: set[asyncio.Task] = set()
-
-
 class ConversationService:
     """
     Service layer for managing conversations and messages.

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,4 +1,5 @@
 """会话服务"""
+import asyncio
 import uuid
 from types import SimpleNamespace
 from datetime import timedelta
@@ -30,6 +31,39 @@ from app.services.model_service import ModelConfigService, ModelApiKeyService
 from app.services.prompt import prompt_manager
 
 logger = get_business_logger()
+
+
+# fire-and-forget 后台任务的强引用集合，避免 asyncio.ensure_future 返回的 Task
+# 因外部无引用被 GC 提前回收（官方文档明确警告）。任务完成时自动从集合中移除。
+_BACKGROUND_MEMORY_TASKS: set[asyncio.Task] = set()
+
+
+def fire_background_memory_task(coro) -> Optional[asyncio.Task]:
+    """把一个 coroutine 挂到当前事件循环，返回 Task 并保留强引用防 GC。
+
+    典型用法（调用方在 async 上下文里，希望 fire-and-forget 派发）::
+
+        fire_background_memory_task(
+            self.conversation_service.dispatch_memory_batch(messages=[...], conversation=conv)
+        )
+
+    Returns:
+        创建的 Task；若当前无正在运行的事件循环则返回 None 并发 warning。
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning(
+            "[ConversationService] fire_background_memory_task 跳过：无正在运行的事件循环"
+        )
+        # 关闭未使用的 coroutine，避免 "coroutine was never awaited" 警告
+        coro.close()
+        return None
+
+    task = loop.create_task(coro)
+    _BACKGROUND_MEMORY_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_MEMORY_TASKS.discard)
+    return task
 
 
 class ConversationService:
@@ -291,6 +325,9 @@ class ConversationService:
             self.db.commit()
             self.db.refresh(message)
 
+            # TODO(messages-memory-decoupling Phase 2): 迁移完所有成对调用点后，移除
+            # 此处 dispatch_memory_sync 调用，改由业务层显式调 dispatch_memory_batch。
+            # 参见 .kiro/specs/messages-memory-decoupling/design.md
             if sync_memory:
                 self.dispatch_memory_sync(message, conversation, should_memorize)
 
@@ -545,6 +582,53 @@ class ConversationService:
                 f"[ConversationService] dispatch_agent_message 调度失败（不影响主流程）: "
                 f"conv={message.conversation_id}, err={e}",
                 exc_info=True,
+            )
+
+    async def dispatch_memory_batch(
+        self,
+        messages: List[Any],
+        conversation: Conversation,
+    ) -> None:
+        """批量派发同一回合的多条消息到记忆系统（async 线性实现）。
+
+        与 dispatch_memory_sync 的区别：一次 write_batch（一次 pg_advisory_xact_lock
+        + 一次事务）分配连续 seq，一次滑动窗口派发。批内 seq 严格 user < assistant。
+
+        本方法**本身不 fire-and-forget**。调用方决定：
+            - fire-and-forget：`fire_background_memory_task(svc.dispatch_memory_batch(...))`
+            - 阻塞等待：`await svc.dispatch_memory_batch(...)`
+        主 chat 流程默认走 fire-and-forget，避免拖累流式响应。
+
+        Args:
+            messages: 消息列表，元素需带 .id / .conversation_id / .role /
+                .content / .created_at / .meta_data / .should_memorize 属性。
+                所有消息应属于同一对话，seq 分配顺序 = 列表顺序。
+            conversation: 所属 Conversation 实例（提供 workspace_id / app_id / user_id）。
+        """
+        # 数据形状规范化（None → {}, 缺失字段默认等）由下游 dispatcher.ingest_agent_messages
+        # 统一处理；空/异常输入由下游 if not messages / if not written 双重拦截；
+        # 本方法只做纯派发（薄派发层），不重复防御。
+        from app.db import get_async_db_context
+        from app.core.memory.memory_service import MemoryService
+
+        try:
+            async with get_async_db_context() as db:
+                config_id = await MemoryConfigService(db).get_workspace_active_config_id_async(
+                    conversation.workspace_id
+                )
+            await MemoryService.ingest_agent_messages(
+                conversation_id=str(messages[0].conversation_id) if messages else "",
+                messages=messages,
+                app_id=str(conversation.app_id),
+                config_id=str(config_id),
+                workspace_id=str(conversation.workspace_id),
+                end_user_id=str(conversation.user_id) if conversation.user_id else "",
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[ConversationService] dispatch_memory_batch 执行失败: "
+                f"conv={conversation.id}, batch={len(messages)}, err={exc}",
+                exc_info=exc,
             )
 
     def get_messages(

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -480,28 +480,23 @@ class ConversationService:
         messages: List[Any],
         conversation: Conversation,
     ) -> None:
-        """批量派发同一回合的多条消息到记忆系统（async 线性实现）。
+        """批量派发同一回合的多条消息到记忆系统。
 
         一次 write_batch（一次 pg_advisory_xact_lock + 一次事务）分配连续 seq，
-        一次滑动窗口派发。批内 seq 严格 user < assistant。
-
-        本方法**本身不 fire-and-forget**。调用方决定：
-            - fire-and-forget：`asyncio.create_task(svc.dispatch_memory_batch(...))`
-            - 阻塞等待：`await svc.dispatch_memory_batch(...)`
-        主 chat 流程默认走 fire-and-forget，避免拖累流式响应。
+        批内严格 user < assistant。本方法不 fire-and-forget，由调用方决定：
+        `asyncio.create_task(...)`（默认）或 `await ...`。
 
         Args:
             messages: 消息列表，元素需带 .id / .conversation_id / .role /
-                .content / .created_at / .meta_data / .should_memorize 属性。
-                所有消息应属于同一对话，seq 分配顺序 = 列表顺序。
+                .content / .created_at / .meta_data / .should_memorize 属性，
+                顺序即 seq 分配顺序。
             conversation: 所属 Conversation 实例（提供 workspace_id / app_id / user_id）。
         """
-        # 数据形状规范化（None → {}, 缺失字段默认等）由下游 dispatcher.ingest_agent_messages
-        # 统一处理；空/异常输入由下游 if not messages / if not written 双重拦截；
-        # 本方法只做纯派发（薄派发层），不重复防御。
+        # 纯派发层：数据规范化与空输入防御由下游 ingest_agent_messages 处理。
         from app.db import get_async_db_context
         from app.core.memory.memory_service import MemoryService
-
+        if not messages:
+            return
         try:
             async with get_async_db_context() as db:
                 config_id = await MemoryConfigService(db).get_workspace_active_config_id_async(

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,6 +1,8 @@
 """会话服务"""
+import asyncio
 import uuid
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Annotated
 from typing import Optional, List, Tuple, Dict, Any
 
@@ -14,7 +16,7 @@ from app.core.exceptions import BusinessException
 from app.core.exceptions import ResourceNotFoundException
 from app.core.logging_config import get_business_logger
 from app.core.models import RedBearLLM, RedBearModelConfig
-from app.core.utils.datetime_utils import to_timestamp_ms, utcnow_naive
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow, utcnow_naive
 from app.db import get_db
 from app.models import Conversation, Message, MessageFeedback, User, ModelType
 from app.models.conversation_model import ConversationDetail
@@ -283,7 +285,7 @@ class ConversationService:
             self.db.commit()
             self.db.refresh(message)
 
-            # 由业务层成对调用点显式调 dispatch_memory_batch
+            # 由业务层成对调用点显式调 dispatch_memory_pair
 
             logger.info(
                 "Message added successfully",
@@ -357,7 +359,7 @@ class ConversationService:
                 self.db.commit()
                 self.db.refresh(message)
 
-            # 由业务层成对调用点显式调 dispatch_memory_batch
+            # 由业务层成对调用点显式调 dispatch_memory_pair
 
             return message
         except Exception as e:
@@ -475,45 +477,64 @@ class ConversationService:
         )
         return msg
 
-    async def dispatch_memory_batch(
+    async def dispatch_memory_pair(
         self,
-        messages: List[Any],
-        conversation: Conversation,
+        conversation_id: uuid.UUID,
+        user_message: dict[str, Any],
+        assistant_message: dict[str, Any],
     ) -> None:
-        """批量派发同一回合的多条消息到记忆系统。
+        """查会话 + 解析记忆配置 + 组装成对消息 + fire-and-forget 批量派发。
 
         一次 write_batch（一次 pg_advisory_xact_lock + 一次事务）分配连续 seq，
-        批内严格 user < assistant。本方法不 fire-and-forget，由调用方决定：
-        `asyncio.create_task(...)`（默认）或 `await ...`。
+        批内严格 user < assistant。
 
         Args:
-            messages: 消息列表，元素需带 .id / .conversation_id / .role /
-                .content / .created_at / .meta_data / .should_memorize 属性，
-                顺序即 seq 分配顺序。
-            conversation: 所属 Conversation 实例（提供 workspace_id / app_id / user_id）。
+            conversation_id: 会话 ID。
+            user_message / assistant_message: 消息字段字典，支持键：
+                - id: uuid.UUID（消息 ID）
+                - content: str
+                - meta_data: dict | None
+                - should_memorize: bool（默认 True）
         """
-        # 纯派发层：数据规范化与空输入防御由下游 ingest_agent_messages 处理。
+        conversation = await self.conversation_repo.get_conversation_by_conversation_id_async(conversation_id)
+        if not conversation:
+            return
+
         from app.db import get_async_db_context
         from app.core.memory.memory_service import MemoryService
-        if not messages:
-            return
+
         try:
             async with get_async_db_context() as db:
                 config_id = await MemoryConfigService(db).get_workspace_active_config_id_async(
                     conversation.workspace_id
                 )
-            await MemoryService.ingest_agent_messages(
-                conversation_id=str(conversation.id),
-                messages=messages,
-                app_id=str(conversation.app_id),
-                config_id=str(config_id),
-                workspace_id=str(conversation.workspace_id),
-                end_user_id=str(conversation.user_id) if conversation.user_id else "",
+            now = utcnow()
+            messages = [
+                SimpleNamespace(
+                    id=m["id"],
+                    conversation_id=conversation_id,
+                    role=role,
+                    content=m["content"],
+                    meta_data=m.get("meta_data"),
+                    created_at=now,
+                    should_memorize=m.get("should_memorize", True),
+                )
+                for role, m in (("user", user_message), ("assistant", assistant_message))
+            ]
+            asyncio.create_task(
+                MemoryService.ingest_agent_messages(
+                    conversation_id=str(conversation.id),
+                    messages=messages,
+                    app_id=str(conversation.app_id),
+                    config_id=str(config_id),
+                    workspace_id=str(conversation.workspace_id),
+                    end_user_id=str(conversation.user_id) if conversation.user_id else "",
+                )
             )
         except Exception as exc:
             logger.warning(
-                f"[ConversationService] dispatch_memory_batch 执行失败: "
-                f"conv={conversation.id}, batch={len(messages)}, err={exc}",
+                f"[ConversationService] dispatch_memory_pair 执行失败: "
+                f"conv={conversation.id}, err={exc}",
                 exc_info=True,
             )
 

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -33,37 +33,9 @@ from app.services.prompt import prompt_manager
 logger = get_business_logger()
 
 
-# fire-and-forget 后台任务的强引用集合，避免 asyncio.ensure_future 返回的 Task
-# 因外部无引用被 GC 提前回收（官方文档明确警告）。任务完成时自动从集合中移除。
+# fire-and-forget 后台任务的强引用集合（供 dispatch_memory_sync 老链路使用；
+# Phase 3 迁移完成后可与老链路一并移除）。
 _BACKGROUND_MEMORY_TASKS: set[asyncio.Task] = set()
-
-
-def fire_background_memory_task(coro) -> Optional[asyncio.Task]:
-    """把一个 coroutine 挂到当前事件循环，返回 Task 并保留强引用防 GC。
-
-    典型用法（调用方在 async 上下文里，希望 fire-and-forget 派发）::
-
-        fire_background_memory_task(
-            self.conversation_service.dispatch_memory_batch(messages=[...], conversation=conv)
-        )
-
-    Returns:
-        创建的 Task；若当前无正在运行的事件循环则返回 None 并发 warning。
-    """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        logger.warning(
-            "[ConversationService] fire_background_memory_task 跳过：无正在运行的事件循环"
-        )
-        # 关闭未使用的 coroutine，避免 "coroutine was never awaited" 警告
-        coro.close()
-        return None
-
-    task = loop.create_task(coro)
-    _BACKGROUND_MEMORY_TASKS.add(task)
-    task.add_done_callback(_BACKGROUND_MEMORY_TASKS.discard)
-    return task
 
 
 class ConversationService:
@@ -569,7 +541,7 @@ class ConversationService:
                     logger.warning(
                         f"[ConversationService] dispatch_agent_message 异步执行失败: "
                         f"conv={_conversation_id}, err={exc}",
-                        exc_info=exc,
+                        exc_info=True,
                     )
 
             loop = asyncio.get_event_loop()
@@ -595,7 +567,7 @@ class ConversationService:
         + 一次事务）分配连续 seq，一次滑动窗口派发。批内 seq 严格 user < assistant。
 
         本方法**本身不 fire-and-forget**。调用方决定：
-            - fire-and-forget：`fire_background_memory_task(svc.dispatch_memory_batch(...))`
+            - fire-and-forget：`asyncio.create_task(svc.dispatch_memory_batch(...))`
             - 阻塞等待：`await svc.dispatch_memory_batch(...)`
         主 chat 流程默认走 fire-and-forget，避免拖累流式响应。
 
@@ -628,7 +600,7 @@ class ConversationService:
             logger.warning(
                 f"[ConversationService] dispatch_memory_batch 执行失败: "
                 f"conv={conversation.id}, batch={len(messages)}, err={exc}",
-                exc_info=exc,
+                exc_info=True,
             )
 
     def get_messages(

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,7 +1,5 @@
 """会话服务"""
-import asyncio
 import uuid
-from types import SimpleNamespace
 from datetime import timedelta
 from typing import Annotated
 from typing import Optional, List, Tuple, Dict, Any
@@ -238,8 +236,6 @@ class ConversationService:
             meta_data: Optional[dict] = None,
             message_id: Optional[uuid.UUID] = None,
             status: str = "completed",
-            sync_memory: bool = True,
-            should_memorize: bool = True,
             parent_message_id: Optional[uuid.UUID] = None,
     ) -> Message:
         """
@@ -252,11 +248,6 @@ class ConversationService:
             meta_data (Optional[dict]): Optional metadata.
             message_id (Optional[uuid.UUID]): Optional custom message UUID.
             status (str): Message status, default "completed".
-            should_memorize (bool): 会话级记忆开关——用户在会话中切换的"记忆"按钮状态。
-                True → memory_messages.should_memorize=true，会触发 Write_Pipeline；
-                False → memory_messages.should_memorize=false，cursor 只推进不萃取。
-                由调用方根据请求 payload.memory 透传。
-                注：仅当 sync_memory=True 时生效；sync_memory=False 时本参数被忽略。
 
         Returns:
             Message: Newly created Message instance.
@@ -292,11 +283,7 @@ class ConversationService:
             self.db.commit()
             self.db.refresh(message)
 
-            # TODO(messages-memory-decoupling Phase 2): 迁移完所有成对调用点后，移除
-            # 此处 dispatch_memory_sync 调用，改由业务层显式调 dispatch_memory_batch。
-            # 参见 .kiro/specs/messages-memory-decoupling/design.md
-            if sync_memory:
-                self.dispatch_memory_sync(message, conversation, should_memorize)
+            # 由业务层成对调用点显式调 dispatch_memory_batch
 
             logger.info(
                 "Message added successfully",
@@ -305,8 +292,6 @@ class ConversationService:
                     "message_id": str(message.id),
                     "role": role,
                     "content_length": len(content),
-                    "sync_memory": sync_memory,
-                    "should_memorize": should_memorize,
                 },
             )
 
@@ -334,8 +319,6 @@ class ConversationService:
             meta_data: Optional[dict] = None,
             message_id: Optional[uuid.UUID] = None,
             status: str = "completed",
-            sync_memory: bool = True,
-            should_memorize: bool = True,
             parent_message_id: Optional[uuid.UUID] = None,
     ) -> Message:
         """AsyncSession 版本的消息写入。"""
@@ -374,8 +357,7 @@ class ConversationService:
                 self.db.commit()
                 self.db.refresh(message)
 
-            if sync_memory:
-                self.dispatch_memory_sync(message, conversation, should_memorize)
+            # 由业务层成对调用点显式调 dispatch_memory_batch
 
             return message
         except Exception as e:
@@ -493,64 +475,6 @@ class ConversationService:
         )
         return msg
 
-    def dispatch_memory_sync(
-        self,
-        message: Message,
-        conversation: Conversation,
-        should_memorize: bool = True,
-    ) -> None:
-        try:
-            import asyncio
-            from app.db import get_async_db_context
-
-            workspace_id = str(conversation.workspace_id) if conversation.workspace_id else ""
-            end_user_id = str(conversation.user_id) if conversation.user_id else ""
-            _workspace_id = conversation.workspace_id
-            _app_id = str(conversation.app_id)
-            _conversation_id = str(message.conversation_id)
-            message_snapshot = SimpleNamespace(
-                id=message.id,
-                conversation_id=message.conversation_id,
-                role=message.role,
-                content=message.content,
-                meta_data=dict(message.meta_data or {}),
-                created_at=message.created_at,
-            )
-
-            from app.core.memory.memory_service import MemoryService
-
-            async def _run():
-                try:
-                    async with get_async_db_context() as db:
-                        config_id = await MemoryConfigService(db).get_workspace_active_config_id_async(_workspace_id)
-                    await MemoryService.ingest_agent_message(
-                        conversation_id=_conversation_id,
-                        message=message_snapshot,
-                        app_id=_app_id,
-                        config_id=str(config_id),
-                        workspace_id=workspace_id,
-                        end_user_id=end_user_id,
-                        should_memorize=should_memorize,
-                    )
-                except Exception as exc:
-                    logger.warning(
-                        f"[ConversationService] dispatch_agent_message 异步执行失败: "
-                        f"conv={_conversation_id}, err={exc}",
-                        exc_info=True,
-                    )
-
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                asyncio.ensure_future(_run())
-            else:
-                loop.run_until_complete(_run())
-        except Exception as e:
-            logger.warning(
-                f"[ConversationService] dispatch_agent_message 调度失败（不影响主流程）: "
-                f"conv={message.conversation_id}, err={e}",
-                exc_info=True,
-            )
-
     async def dispatch_memory_batch(
         self,
         messages: List[Any],
@@ -558,8 +482,8 @@ class ConversationService:
     ) -> None:
         """批量派发同一回合的多条消息到记忆系统（async 线性实现）。
 
-        与 dispatch_memory_sync 的区别：一次 write_batch（一次 pg_advisory_xact_lock
-        + 一次事务）分配连续 seq，一次滑动窗口派发。批内 seq 严格 user < assistant。
+        一次 write_batch（一次 pg_advisory_xact_lock + 一次事务）分配连续 seq，
+        一次滑动窗口派发。批内 seq 严格 user < assistant。
 
         本方法**本身不 fire-and-forget**。调用方决定：
             - fire-and-forget：`asyncio.create_task(svc.dispatch_memory_batch(...))`

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -503,7 +503,7 @@ class ConversationService:
                     conversation.workspace_id
                 )
             await MemoryService.ingest_agent_messages(
-                conversation_id=str(messages[0].conversation_id) if messages else "",
+                conversation_id=str(conversation.id),
                 messages=messages,
                 app_id=str(conversation.app_id),
                 config_id=str(config_id),

--- a/api/app/services/shared_chat_service.py
+++ b/api/app/services/shared_chat_service.py
@@ -615,7 +615,6 @@ class SharedChatService:
                 conversation_id=conversation.id,
                 role="user",
                 content=message,
-                should_memorize=memory,
             )
 
             self.conversation_service.add_message(
@@ -626,7 +625,6 @@ class SharedChatService:
                     "model": api_key_obj.model_name,
                     "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": total_tokens}
                 },
-                should_memorize=memory,
             )
 
             ModelApiKeyService.record_api_key_usage(self.db, api_key_obj.id)
@@ -768,7 +766,6 @@ class SharedChatService:
             conversation_id=conversation.id,
             role="user",
             content=message,
-            should_memorize=memory,
         )
 
         self.conversation_service.add_message(
@@ -780,7 +777,6 @@ class SharedChatService:
                 "elapsed_time": result.get("elapsed_time"),
                 "sub_results": result.get("sub_results")
             },
-            should_memorize=memory,
         )
 
         return {
@@ -907,7 +903,6 @@ class SharedChatService:
                 conversation_id=conversation.id,
                 role="user",
                 content=message,
-                should_memorize=memory,
             )
 
             self.conversation_service.add_message(
@@ -917,7 +912,6 @@ class SharedChatService:
                 meta_data={
                     "elapsed_time": elapsed_time
                 },
-                should_memorize=memory,
             )
 
             logger.info(

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -4799,7 +4799,6 @@ class WorkflowService:
             role="user",
             content=human_message,
             meta_data=human_meta,
-            sync_memory=False,
         )
         self.conversation_service.add_message(
             **({"message_id": message_id} if message_id else {}),
@@ -4807,7 +4806,6 @@ class WorkflowService:
             role="assistant",
             content="",
             meta_data={"error": error},
-            sync_memory=False,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary by Sourcery

将记忆消息与 `messages` 表解耦，并引入批量摄取/分发路径，以确保成对的用户/助手消息能够按顺序分配序号。

New Features:
- 在 memory dispatcher 和 memory service 中添加批量代理消息摄取 API，在单个事务中写入多条消息，并执行一次滑动窗口分发。
- 引入 `ConversationService.dispatch_memory_batch`，用于异步地将同一轮中的多条消息批量分发到记忆系统。

Bug Fixes:
- 通过避免在 `app_chat_service` 中并发、无需等待结果的分发操作，确保用户和助手的记忆消息序列按照正确顺序进行分配。

Enhancements:
- 移除 `MemoryMessage.original_message_id` 上的外键约束，并通过删除外键重试逻辑来简化代理消息摄取流程。
- 调整异步会话分发中的日志记录，使异常堆栈跟踪的日志输出保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple memory messages from the messages table and introduce a batch ingestion/dispatch path to ensure ordered sequence assignment for paired user/assistant messages.

New Features:
- Add a batch agent message ingestion API in the memory dispatcher and memory service that writes multiple messages in a single transaction and performs a single sliding-window dispatch.
- Introduce ConversationService.dispatch_memory_batch for asynchronously dispatching multiple messages from the same turn to the memory system.

Bug Fixes:
- Ensure user and assistant memory message sequences are assigned in correct order by avoiding concurrent fire-and-forget dispatches in app_chat_service.

Enhancements:
- Remove the foreign key constraint from MemoryMessage.original_message_id and simplify agent message ingestion by dropping FK retry logic.
- Adjust logging in asynchronous conversation dispatch to log exception stack traces consistently.

</details>