### PR TITLE
feat(memory): support perceptual details in retrieval stages

### DIFF
--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -361,13 +361,24 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             m for m in hybrid_search_res.memories
             if m.source == Neo4jNodeType.PERCEPTUAL
         ]
+        # 阶段事件展示的是命中的感知记忆总数，不能因解析失败或跳过解析而减少。
+        perceptual_memory_count = len(perceptual_memories)
         if perceptual_memories:
             parse_tasks = []
-            type_llm_cache: dict[int, RedBearLLM] = {}
+            # 同一感知类型复用模型客户端；初始化失败时记为 None，统一降级使用原 summary。
+            type_llm_cache: dict[int, RedBearLLM | None] = {}
 
             async def _get_llm_for_type(pt: int):
                 if pt not in type_llm_cache:
-                    type_llm_cache[pt] = await self._get_perceptual_llm_client(pt)
+                    try:
+                        type_llm_cache[pt] = await self._get_perceptual_llm_client(pt)
+                    except Exception:
+                        logger.warning(
+                            "[DeepRead] Unable to initialize perceptual model for type %s; using stored summary",
+                            pt,
+                            exc_info=True,
+                        )
+                        type_llm_cache[pt] = None
                 return type_llm_cache[pt]
 
             for i, question in enumerate(questions):
@@ -382,7 +393,31 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
                 by_type: dict[int, list] = {}
                 for mem in sub_percep:
-                    pt = int(mem.data.get("perceptual_type", 0))
+                    # 源数据可能是整数或数字字符串，其他格式不参与感知解析。
+                    raw_type = mem.data.get("perceptual_type", 0)
+                    if isinstance(raw_type, int) and not isinstance(raw_type, bool):
+                        pt = raw_type
+                    elif isinstance(raw_type, str) and raw_type.strip().isdigit():
+                        pt = int(raw_type.strip())
+                    else:
+                        logger.warning(
+                            "[DeepRead] Invalid perceptual_type %r for memory %s; using stored summary",
+                            raw_type,
+                            mem.id,
+                        )
+                        continue
+                    # 公开协议只允许感知类型 1、2、3，其他值保留原 summary 并对外投影为 null。
+                    if pt not in {1, 2, 3}:
+                        logger.warning(
+                            "[DeepRead] Unsupported perceptual_type %r for memory %s; using stored summary",
+                            raw_type,
+                            mem.id,
+                        )
+                        continue
+                    file_type = str(mem.data.get("file_type") or "").strip().lower()
+                    # VISION 同时包含图片和视频，本期仅图片和文档执行面向查询的内容解析。
+                    if (pt, file_type) not in {(1, "image"), (3, "document")}:
+                        continue
                     if pt not in by_type:
                         by_type[pt] = []
                     by_type[pt].append(mem)
@@ -405,16 +440,36 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
                             for existing in hybrid_search_res.memories:
                                 if existing.id == mem.id:
                                     existing.content = mem.content
+                                    # 公开纯文本独立保存，避免把内部 history-file-input 标签发给前端。
+                                    display_content = mem.data.get("_perceptual_display_content")
+                                    if display_content:
+                                        existing.data["_perceptual_display_content"] = display_content
                                     break
 
         results = hybrid_search_res + relation_res
+        merged_memory_count = len(results.memories)
+        merged_relation_count = len(results.relations)
+        results.memories.sort(key=lambda x: x.score, reverse=True)
+        # 两个完成阶段复用同一份最终前 5 投影，保证条目、排名和分数完全一致。
+        final_items = project_result_items(memory_l0, results, limit=5)
+        perceptual_items = [
+            item
+            for item in final_items
+            if item.get("memory_type") == "file" and item.get("source") == "Perceptual"
+        ]
+
+        if perceptual_memory_count > 0:
+            await self._emit_stage("perceptual_processed", {
+                "memory_count": perceptual_memory_count,
+                "shown_count": len(perceptual_items),
+                "items": perceptual_items,
+            })
 
         await self._emit_stage("results_merged", {
-            "memory_count": len(results.memories),
-            "relation_count": len(results.relations),
+            "memory_count": merged_memory_count,
+            "relation_count": merged_relation_count,
         })
 
-        results.memories.sort(key=lambda x: x.score, reverse=True)
         await self._emit_stage("results_ranked", {
             "count": len(results.memories),
             "order": "score_desc",
@@ -430,12 +485,11 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         await self._emit_stage("context_prepared", {"memory_count": len(results.memories)})
 
         combined = memory_l0 + results
-        items = project_result_items(memory_l0, results, limit=5)
         await self._emit_stage("result_ready", {
             "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 1,
             "total_count": len(combined.memories),
-            "shown_count": len(items),
-            "items": items,
+            "shown_count": len(final_items),
+            "items": final_items,
         })
 
         return combined

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -610,7 +610,7 @@ class Neo4jSearchService:
     ) -> list[Memory]:
         """对 Perceptual 类型的记忆调用多模态模型解析实际文件内容。
 
-        仅增强 memory.content（不改变 score / id / source）。
+        增强模型上下文，并单独保留公开展示文本（不改变 score / id / source）。
         失败时保留原 summary，不中断主流程。
         """
         enhanced = []
@@ -634,14 +634,17 @@ class Neo4jSearchService:
                     file_path, file_name, file_type, perceptual_type, query, llm
                 )
 
-                # 增强 content：格式化为 query 相关的解析片段
-                mem.content = (
-                    f"<history-file-input>\n"
-                    f"<file-name>{file_name}</file-name>\n"
-                    f"<file-summary>{mem.data.get('summary', '')}</file-summary>\n"
-                    f"<file-analysis>{parsed}</file-analysis>\n"
-                    f"</history-file-input>\n"
-                )
+                display_content = parsed.strip() if isinstance(parsed, str) else ""
+                if display_content:
+                    mem.data["_perceptual_display_content"] = display_content
+                    # 完整结构继续供后续总结和最终回答使用，不直接投影给前端。
+                    mem.content = (
+                        f"<history-file-input>\n"
+                        f"<file-name>{file_name}</file-name>\n"
+                        f"<file-summary>{mem.data.get('summary', '')}</file-summary>\n"
+                        f"<file-analysis>{display_content}</file-analysis>\n"
+                        f"</history-file-input>\n"
+                    )
             except Exception as e:
                 logger.warning(
                     f"[Perceptual] 多模态解析失败 file={file_name}: {e}，回退使用 summary"
@@ -665,18 +668,24 @@ class Neo4jSearchService:
         支持图片（VISION）和文档（TEXT/DOCUMENT）类型。
         返回模型对文件的针对性分析文本。
         """
-        from app.services.multimodal_service import MultimodalService
-
-        # 根据 perceptual_type 确定 FileInput 类型
-        # perceptual_type: 1=VISION | 2=AUDIO | 3=TEXT | 4=CONVERSATION
-        perceptual_type_int = int(perceptual_type) if perceptual_type else 0
-        if perceptual_type_int == 1:  # VISION
+        # 类型和文件类别必须同时匹配，避免将视频作为图片发送给模型。
+        if isinstance(perceptual_type, bool):
+            return ""
+        if isinstance(perceptual_type, int):
+            perceptual_type_int = perceptual_type
+        elif isinstance(perceptual_type, str) and perceptual_type.strip().isdigit():
+            perceptual_type_int = int(perceptual_type.strip())
+        else:
+            return ""
+        normalized_file_type = str(file_type or "").strip().lower()
+        if perceptual_type_int == 1 and normalized_file_type == FileType.IMAGE.value:
             file_input_type = FileType.IMAGE
-        elif perceptual_type_int == 3:  # TEXT/DOCUMENT
+        elif perceptual_type_int == 3 and normalized_file_type == FileType.DOCUMENT.value:
             file_input_type = FileType.DOCUMENT
         else:
-            # AUDIO / CONVERSATION / 未知 → 跳过，返回 summary
             return ""
+
+        from app.services.multimodal_service import MultimodalService
 
         file_input = FileInput(
             type=file_input_type,
@@ -693,6 +702,8 @@ class Neo4jSearchService:
         formatted = await multimodal_svc.process_files(
             files=[file_input],
             document_image_recognition=True,
+            # 公开感知结果不能包含文件处理异常；失败时返回空列表并回退已有 summary。
+            include_processing_errors=False,
         )
 
         if not formatted:

--- a/api/app/core/memory/retrieval_trace/stage_events.py
+++ b/api/app/core/memory/retrieval_trace/stage_events.py
@@ -22,6 +22,7 @@ _STAGE_FIELDS = {
     "query_split": {"count", "questions"},
     "hybrid_searched": {"hit_count", "memory_count", "shown_count", "items"},
     "relation_searched": {"hit_count", "relation_count", "shown_count", "items"},
+    "perceptual_processed": {"memory_count", "shown_count", "items"},
     "results_merged": {"memory_count", "relation_count"},
     "results_ranked": {"count", "order"},
     "context_prepared": {"memory_count"},
@@ -92,7 +93,10 @@ def _valid_file(file_data: Any) -> bool:
         all(isinstance(file_data[field], str) for field in ("file_name", "file_path", "file_type"))
         and (
             file_data["perceptual_type"] is None
-            or _is_non_negative_int(file_data["perceptual_type"])
+            or (
+                _is_non_negative_int(file_data["perceptual_type"])
+                and file_data["perceptual_type"] in {1, 2, 3}
+            )
         )
     )
 
@@ -146,6 +150,18 @@ def _valid_stage_data(stage: str, data: dict[str, Any]) -> bool:
             and isinstance(data["items"], list)
             and all(item_validator(item) for item in data["items"])
             and data["shown_count"] == len(data["items"])
+        )
+    if stage == "perceptual_processed":
+        return (
+            _is_non_negative_int(data["memory_count"])
+            and _is_non_negative_int(data["shown_count"])
+            and isinstance(data["items"], list)
+            and len(data["items"]) <= 5
+            and data["shown_count"] == len(data["items"])
+            and data["shown_count"] <= data["memory_count"]
+            and all(_valid_memory_item(item) for item in data["items"])
+            and all(item["memory_type"] == "file" for item in data["items"])
+            and all(item["source"] == "Perceptual" for item in data["items"])
         )
     if stage == "results_merged":
         return _is_non_negative_int(data["memory_count"]) and _is_non_negative_int(data["relation_count"])

--- a/api/app/core/memory/retrieval_trace/stage_projection.py
+++ b/api/app/core/memory/retrieval_trace/stage_projection.py
@@ -106,6 +106,22 @@ def _score(value: Any) -> float:
     return round(score, 4) if math.isfinite(score) else 0.0
 
 
+def _perceptual_type(value: Any) -> int | None:
+    """规范化公开感知类型，避免把异常源数据透传给前端。"""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        normalized = value
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped.isdigit():
+            return None
+        normalized = int(stripped)
+    else:
+        return None
+    return normalized if normalized in {1, 2, 3} else None
+
+
 def sanitize_relevance(value: Any) -> float:
     """Backward-compatible legacy helper; new payloads use ``score``."""
     try:
@@ -117,7 +133,7 @@ def sanitize_relevance(value: Any) -> float:
     return round(min(max(score, 0.0), 1.0), 4)
 
 
-def _memory_content(memory: Memory, kind: str) -> str:
+def _memory_content(memory: Memory, kind: str, *, prefer_perceptual_display: bool = False) -> str:
     data = memory.data if isinstance(memory.data, dict) else {}
     if kind == "profile":
         profile = project_profile_data(MemorySearchResult(memories=[memory]))
@@ -125,6 +141,9 @@ def _memory_content(memory: Memory, kind: str) -> str:
         return display_text("；".join(values), 300)
     if memory_type(memory.source) == "entity":
         candidates = (data.get("description"), data.get("description_summary"), data.get("name"), memory.content)
+    elif memory.source == Neo4jNodeType.PERCEPTUAL and prefer_perceptual_display:
+        # 最终结果只展示纯解析文本；解析为空或失败时回退到已存储的 summary。
+        candidates = (data.get("_perceptual_display_content"), data.get("summary"))
     elif memory.source == Neo4jNodeType.PERCEPTUAL:
         candidates = (memory.content, data.get("summary"))
     elif memory.source == Neo4jNodeType.RAG:
@@ -138,14 +157,24 @@ def _memory_content(memory: Memory, kind: str) -> str:
     return ""
 
 
-def project_memory_item(memory: Memory, rank: int, *, kind: str | None = None) -> dict[str, Any]:
+def project_memory_item(
+        memory: Memory,
+        rank: int,
+        *,
+        kind: str | None = None,
+        prefer_perceptual_display: bool = False,
+) -> dict[str, Any]:
     resolved_kind = kind or memory_type(memory.source)
     item: dict[str, Any] = {
         "rank": rank,
         "memory_type": resolved_kind,
         "source": memory.source.value if isinstance(memory.source, Neo4jNodeType) else str(memory.source),
         "score": 1.0 if resolved_kind == "profile" else _score(memory.score),
-        "content": _memory_content(memory, resolved_kind),
+        "content": _memory_content(
+            memory,
+            resolved_kind,
+            prefer_perceptual_display=prefer_perceptual_display,
+        ),
     }
     # Rag 与 Perceptual 都展示为文件记忆，但只有 Perceptual 有稳定的文件元数据协议。
     if resolved_kind == "file" and memory.source == Neo4jNodeType.PERCEPTUAL:
@@ -154,7 +183,8 @@ def project_memory_item(memory: Memory, rank: int, *, kind: str | None = None) -
             "file_name": display_text(data.get("file_name"), 1000),
             "file_path": display_text(data.get("file_path"), 2000),
             "file_type": display_text(data.get("file_type"), 200),
-            "perceptual_type": data.get("perceptual_type"),
+            # 对外仅暴露协议定义的 1、2、3，非法类型统一返回 null。
+            "perceptual_type": _perceptual_type(data.get("perceptual_type")),
         }
         if any(value not in (None, "") for value in file_data.values()):
             item["file"] = file_data
@@ -193,7 +223,12 @@ def project_result_items(
         for memory in search_result.memories:
             if len(items) >= limit:
                 break
-            items.append(project_memory_item(memory, len(items) + 1))
+            # 最终阶段启用公开感知文本，内部增强上下文仍保留在 memory.content 中。
+            items.append(project_memory_item(
+                memory,
+                len(items) + 1,
+                prefer_perceptual_display=True,
+            ))
     for index, item in enumerate(items, start=1):
         item["rank"] = index
     return items

--- a/api/app/services/multimodal_service.py
+++ b/api/app/services/multimodal_service.py
@@ -388,13 +388,15 @@ class MultimodalService:
             files: Optional[List[FileInput]],
             workspace_id: uuid.UUID = None,
             document_image_recognition: bool = False,
+            include_processing_errors: bool = True,
     ) -> List[Dict[str, Any]]:
         """
         处理文件列表，返回 LLM 可用的格式
-        
+
         Args:
             files: 文件输入列表
-            
+            include_processing_errors: 是否把失败文件的占位文本加入结果；为 False 时跳过失败文件并继续处理后续文件
+
         Returns:
             List[Dict]: LLM 可用的内容格式列表（根据 provider 返回不同格式）
         """
@@ -419,9 +421,13 @@ class MultimodalService:
             try:
                 if file.type == FileType.IMAGE and ModelCapability.VISION in self.capability:
                     is_support, content = await self._process_image(file, strategy)
-                    result.append(content)
+                    if is_support or include_processing_errors:
+                        result.append(content)
                 elif file.type == FileType.DOCUMENT:
                     is_support, content = await self._process_document(file, strategy)
+                    if not is_support and not include_processing_errors:
+                        # 只跳过当前失败文档，后续文件仍会继续处理；若最终无成功结果，上层回退已有 summary。
+                        continue
                     result.append(content)
                     # 仅当开关开启且模型支持视觉时，才提取文档内嵌图片
                     if document_image_recognition and ModelCapability.VISION in self.capability:
@@ -446,17 +452,20 @@ class MultimodalService:
                                     url=img_url,
                                     file_type="image/png",
                                 )
-                                _, img_content = await self._process_image(img_file, strategy_class(img_file))
-                                img_result.append(img_content)
+                                img_support, img_content = await self._process_image(img_file, strategy_class(img_file))
+                                if img_support or include_processing_errors:
+                                    img_result.append(img_content)
                             except Exception as img_err:
                                 logger.warning(f"文档图片处理失败: {img_err}")
                         result.extend(img_result)
                 elif file.type == FileType.AUDIO and "audio" in self.capability:
                     is_support, content = await self._process_audio(file, strategy)
-                    result.append(content)
+                    if is_support or include_processing_errors:
+                        result.append(content)
                 elif file.type == FileType.VIDEO and "video" in self.capability:
                     is_support, content = await self._process_video(file, strategy)
-                    result.append(content)
+                    if is_support or include_processing_errors:
+                        result.append(content)
                 else:
                     logger.warning(f"不支持的文件类型: {file.type}")
             except Exception as e:
@@ -469,11 +478,12 @@ class MultimodalService:
                     },
                     exc_info=True
                 )
-                # 继续处理其他文件，不中断整个流程
-                result.append({
-                    "type": "text",
-                    "text": f"[文件处理失败: {str(e)}]"
-                })
+                # 默认保留历史错误占位；关闭后只跳过当前失败文件，后续文件仍会继续处理。
+                if include_processing_errors:
+                    result.append({
+                        "type": "text",
+                        "text": f"[文件处理失败: {str(e)}]"
+                    })
 
         logger.info(f"成功处理 {len(result)}/{len(files)} 个文件，provider={self.provider}")
         return result


### PR DESCRIPTION
Add the perceptual_processed stage to Deep memory retrieval.
Expose display-safe Perceptual content and file metadata in retrieval results.
Reuse the final top-five projection across perceptual_processed and result_ready.
Validate perceptual types and restrict query-aware parsing to supported image and document files.
Fall back to stored summaries when file processing or perceptual analysis fails.
Preserve existing behavior for other multimodal file-processing callers.

## Summary by Sourcery

添加一个 `perceptual_processed` 检索阶段，在保持排序和前五投影在各阶段一致的同时，提供对展示安全的感知文件详情的访问。

新特性：
- 在深度记忆检索过程中发出一个 `perceptual_processed` 阶段，其中包含计数和前五个感知文件条目。
- 在检索投影和阶段事件中暴露已净化的感知文件元数据和只用于展示的内容。

增强点：
- 复用一个最终的前五投影用于 `results_merged` 和 `result_ready` 两个阶段，以确保完全相同的排序和分数。
- 改进感知类型和文件类型验证，使得只有受支持的图像和文档记忆会进行支持查询的感知处理。
- 当感知模型初始化、多模态解析或文件处理失败时，优先使用已存储的摘要，同时不干扰其他调用方。
- 扩展多模态文件处理，可选地在继续处理后续文件的同时抑制错误占位内容的输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a perceptual_processed retrieval stage that exposes display-safe perceptual file details while keeping ranking and top-5 projection consistent across stages.

New Features:
- Emit a perceptual_processed stage with counts and top-5 perceptual file items during deep memory retrieval.
- Expose sanitized perceptual file metadata and display-only content in retrieval projections and stage events.

Enhancements:
- Reuse a single final top-5 projection for both results_merged and result_ready stages to ensure identical ordering and scores.
- Improve perceptual type and file-type validation so only supported image and document memories are query-aware processed.
- Prefer stored summaries when perceptual model initialization, multimodal parsing, or file processing fails without disrupting other callers.
- Extend multimodal file processing to optionally suppress error placeholder content while continuing to process subsequent files.

</details>