### PR TITLE
feat(rag): merge structured Markdown blocks with context

### DIFF
--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -43,6 +43,11 @@ class LogicalChunkType(str, Enum):
     IMAGE = "image"
 
 
+class ImageVisionScope(str, Enum):
+    EMBEDDED = "embedded"
+    DIRECT = "direct"
+
+
 class ParsedBlockType(str, Enum):
     HEADING = "heading"
     TEXT = "text"
@@ -64,6 +69,7 @@ class ParsedBlock:
     image: Any = None
     positions: list | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    image_vision_scope: ImageVisionScope | None = None
 
 
 @dataclass
@@ -73,6 +79,9 @@ class LogicalChunk:
     image: Any = None
     positions: list | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    source_image_key: int | None = None
+    image_tag_complete: bool = False
+    image_vision_scope: ImageVisionScope | None = None
 
 
 @dataclass
@@ -111,6 +120,9 @@ class ParseResult:
     append_embed: bool = True
     blocks: list[ParsedBlock] | None = None
     markdown_preprocess_profile: str | None = None
+    structured_markdown_stream: bool = False
+    direct_image_vision_mode: int | None = None
+    direct_image_has_ocr_text: bool = False
 
 
 @dataclass

--- a/api/app/core/rag/chunk/context.py
+++ b/api/app/core/rag/chunk/context.py
@@ -1,7 +1,8 @@
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
 
 from app.core.rag.nlp import rag_tokenizer
 

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -32,6 +32,7 @@ from app.core.rag.chunk.context import (
     ParseResult,
 )
 from app.core.rag.chunk.merger.structured_stream import (
+    BlockSpan,
     SourceFragment,
     StructuredStream,
     block_separator,
@@ -88,6 +89,12 @@ class _ChunkDraft:
 class _ParentDraft:
     parent: LogicalChunk
     fragments: list[SourceFragment]
+
+
+@dataclass
+class _ChildDraft:
+    chunk: LogicalChunk
+    source_key: int | None = None
 
 
 class BlockMerger(ChunkMerger):
@@ -281,12 +288,30 @@ class BlockMerger(ChunkMerger):
         token_num: int,
         delimiter: str | None,
     ) -> list[ParentChildGroup]:
+        group_drafts: list[tuple[_ParentDraft, list[_ChildDraft]]] = []
+        all_child_drafts: list[_ChildDraft] = []
+        for draft in drafts:
+            child_drafts = [
+                child_draft
+                for child_draft in self._child_drafts_from_parent(
+                    draft,
+                    token_num,
+                    delimiter,
+                )
+                if self._is_serializable_child(child_draft.chunk)
+            ]
+            if not child_drafts:
+                continue
+            group_drafts.append((draft, child_drafts))
+            all_child_drafts.extend(child_drafts)
+
+        self._normalize_table_child_parts(all_child_drafts)
         return [
             ParentChildGroup(
                 parent=draft.parent,
-                children=self._children_from_parent(draft, token_num, delimiter),
+                children=[child_draft.chunk for child_draft in child_drafts],
             )
-            for draft in drafts
+            for draft, child_drafts in group_drafts
         ]
 
     def _children_from_parent(
@@ -295,17 +320,34 @@ class BlockMerger(ChunkMerger):
         token_num: int,
         delimiter: str | None,
     ) -> list[LogicalChunk]:
-        children: list[LogicalChunk] = []
+        child_drafts = [
+            child_draft
+            for child_draft in self._child_drafts_from_parent(
+                draft,
+                token_num,
+                delimiter,
+            )
+            if self._is_serializable_child(child_draft.chunk)
+        ]
+        self._normalize_table_child_parts(child_drafts)
+        return [child_draft.chunk for child_draft in child_drafts]
+
+    def _child_drafts_from_parent(
+        self,
+        draft: _ParentDraft,
+        token_num: int,
+        delimiter: str | None,
+    ) -> list[_ChildDraft]:
+        children: list[_ChildDraft] = []
         text_fragments: list[SourceFragment] = []
 
         def flush_text_fragments() -> None:
             if not text_fragments:
                 return
             children.extend(
-                self._text_children_from_fragments(
-                    text_fragments,
-                    token_num,
-                    delimiter,
+                _ChildDraft(chunk=child)
+                for child in self._text_children_from_fragments(
+                    text_fragments, token_num, delimiter
                 )
             )
             text_fragments.clear()
@@ -318,11 +360,41 @@ class BlockMerger(ChunkMerger):
 
             flush_text_fragments()
             children.extend(
-                self._specialized_children_from_fragment(fragment, token_num)
+                _ChildDraft(chunk=child, source_key=fragment.source_key)
+                for child in self._specialized_children_from_fragment(
+                    fragment,
+                    token_num,
+                )
             )
 
         flush_text_fragments()
         return children
+
+    @staticmethod
+    def _is_serializable_child(child: LogicalChunk) -> bool:
+        return bool(str(child.content or "").strip())
+
+    @staticmethod
+    def _normalize_table_child_parts(child_drafts: list[_ChildDraft]) -> None:
+        parts_by_source: dict[int, list[LogicalChunk]] = {}
+        for child_draft in child_drafts:
+            if (
+                child_draft.source_key is None
+                or child_draft.chunk.type is not LogicalChunkType.TABLE
+            ):
+                continue
+            parts_by_source.setdefault(child_draft.source_key, []).append(
+                child_draft.chunk
+            )
+
+        for parts in parts_by_source.values():
+            if len(parts) == 1:
+                parts[0].metadata.pop("table_part_index", None)
+                parts[0].metadata.pop("table_part_total", None)
+                continue
+            for index, part in enumerate(parts):
+                part.metadata["table_part_index"] = index
+                part.metadata["table_part_total"] = len(parts)
 
     def _text_children_from_fragments(
         self,
@@ -330,32 +402,39 @@ class BlockMerger(ChunkMerger):
         token_num: int,
         delimiter: str | None,
     ) -> list[LogicalChunk]:
-        content = self._join_text_fragments(fragments)
-        source_blocks = self._source_blocks(fragments)
-        metadata = self._metadata_for_range(source_blocks, "text")
-        metadata.pop("vision_text", None)
-        metadata.pop("image", None)
-        return [
-            LogicalChunk(
-                type=LogicalChunkType.TEXT,
-                content=chunk,
-                metadata=deepcopy(metadata),
-            )
-            for chunk in self.text_merger.merge(content, token_num, delimiter, 0)
-            if chunk.strip()
-        ]
+        stream = self._text_stream_from_fragments(fragments)
+        drafts: list[_ChunkDraft] = []
+        for segment in split_structured_stream(stream, delimiter):
+            units = self._stream_units(segment, token_num)
+            drafts.extend(self._pack_stream_units(units, token_num, 0))
+        return [self._draft_to_normal_chunk(draft) for draft in drafts]
 
     @staticmethod
-    def _join_text_fragments(fragments: list[SourceFragment]) -> str:
+    def _text_stream_from_fragments(
+        fragments: list[SourceFragment],
+    ) -> StructuredStream:
         parts: list[str] = []
+        spans: list[BlockSpan] = []
         previous: SourceFragment | None = None
+        offset = 0
         for fragment in fragments:
             separator = ""
             if previous is not None and previous.source_key != fragment.source_key:
                 separator = block_separator(previous.block, fragment.block)
             parts.extend([separator, fragment.content])
+            offset += len(separator)
+            start = offset
+            offset += len(fragment.content)
+            spans.append(
+                BlockSpan(
+                    source_key=fragment.source_key,
+                    block=fragment.block,
+                    start=start,
+                    end=offset,
+                )
+            )
             previous = fragment
-        return "".join(parts)
+        return StructuredStream(text="".join(parts), spans=spans)
 
     def _specialized_children_from_fragment(
         self,
@@ -382,6 +461,11 @@ class BlockMerger(ChunkMerger):
         language = str(block.metadata.get("language", ""))
         content = self._complete_code_fence(fragment.content, language)
         metadata = self._metadata_for_block(block)
+        pieces = self._split_code_content(content, token_num, language)
+        if any(num_tokens_from_string(piece) > token_num for piece in pieces):
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
         return [
             LogicalChunk(
                 type=LogicalChunkType.TEXT,
@@ -390,7 +474,7 @@ class BlockMerger(ChunkMerger):
                 positions=deepcopy(block.positions),
                 metadata=deepcopy(metadata),
             )
-            for piece in self._split_code_content(content, token_num, language)
+            for piece in pieces
             if piece.strip()
         ]
 
@@ -1088,17 +1172,6 @@ class BlockMerger(ChunkMerger):
         elif language:
             fence_start = f"```{language}"
             fence_end = "```"
-
-        if (
-            fence_start
-            and num_tokens_from_string(
-                self._wrap_code_lines([], fence_start, fence_end)
-            )
-            > token_num
-        ):
-            raise ValueError(
-                f"Structured wrapper cannot fit within token limit {token_num}."
-            )
 
         chunks: list[str] = []
         current_lines: list[str] = []

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -579,6 +579,7 @@ class BlockMerger(ChunkMerger):
         pending_table_overlap: _StreamUnit | None = None
 
         for index, unit in enumerate(units):
+            current_is_pending_overlap = False
             if self._is_incomplete_table_unit(unit):
                 if current:
                     drafts.append(self._units_to_draft(current))
@@ -605,12 +606,12 @@ class BlockMerger(ChunkMerger):
                     overlap,
                 )
                 pending_table_overlap = None
-                current.append(unit)
-                continue
+                current_is_pending_overlap = bool(current)
 
             candidate = [*current, unit]
             if self._heading_should_start_next_draft(current, unit, units, index, token_num):
-                drafts.append(self._units_to_draft(current))
+                if not current_is_pending_overlap:
+                    drafts.append(self._units_to_draft(current))
                 current = [unit]
                 continue
 
@@ -1213,6 +1214,23 @@ class BlockMerger(ChunkMerger):
     def _split_strict_table(self, table, token_num: int) -> list[str]:
         thead = table.find("thead")
         if not table.find_all("tr"):
+            table_text = table.get_text(" ", strip=True)
+            if table_text:
+                container = self._rowless_table_container(table)
+
+                def wrap_rowless(piece: str) -> str:
+                    payload = escape(piece)
+                    if container:
+                        payload = f"<{container}>{payload}</{container}>"
+                    return f"<table>{payload}</table>"
+
+                return self._hard_split_wrapped(
+                    table_text,
+                    token_num,
+                    wrap_rowless,
+                    strict=True,
+                )
+
             section = next(
                 (
                     name
@@ -1301,6 +1319,25 @@ class BlockMerger(ChunkMerger):
                 f"Structured wrapper cannot fit within token limit {token_num}."
             )
         return chunks
+
+    @staticmethod
+    def _rowless_table_container(table) -> str | None:
+        direct_text = "".join(
+            str(child).strip()
+            for child in table.children
+            if getattr(child, "name", None) is None
+        )
+        containers = [
+            child
+            for child in table.find_all(
+                ["caption", "thead", "tbody", "tfoot"],
+                recursive=False,
+            )
+            if child.get_text(" ", strip=True)
+        ]
+        if direct_text or len(containers) != 1:
+            return None
+        return str(containers[0].name)
 
     def _split_strict_table_row(
         self,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -184,6 +184,10 @@ class BlockMerger(ChunkMerger):
                 block=span.block,
                 content=stream.text[span.start : span.end],
                 complete=stream.text[span.start : span.end] == str(span.block.content or ""),
+                structure_valid=(
+                    span.block.type is not ParsedBlockType.TABLE
+                    or self._is_valid_table_content(stream.text[span.start : span.end])
+                ),
             )
             unit = _StreamUnit(
                 fragment=fragment,
@@ -226,7 +230,13 @@ class BlockMerger(ChunkMerger):
                 block=piece_block,
                 content=piece,
                 complete=False,
-                structure_valid=block_type is not ParsedBlockType.IMAGE,
+                structure_valid=(
+                    block_type is not ParsedBlockType.IMAGE
+                    and (
+                        block_type is not ParsedBlockType.TABLE
+                        or self._is_valid_table_content(piece)
+                    )
+                ),
             )
             separator = unit.separator_before if index == 0 else (
                 "\n" if block_type in {ParsedBlockType.CODE, ParsedBlockType.TABLE} else ""
@@ -244,6 +254,13 @@ class BlockMerger(ChunkMerger):
         current: list[_StreamUnit] = []
 
         for index, unit in enumerate(units):
+            if self._is_incomplete_table_unit(unit):
+                if current:
+                    drafts.append(self._units_to_draft(current))
+                    current = []
+                drafts.append(self._units_to_draft([unit]))
+                continue
+
             candidate = [*current, unit]
             if self._heading_should_start_next_draft(current, unit, units, index, token_num):
                 drafts.append(self._units_to_draft(current))
@@ -259,6 +276,13 @@ class BlockMerger(ChunkMerger):
         if current:
             drafts.append(self._units_to_draft(current))
         return drafts
+
+    @staticmethod
+    def _is_incomplete_table_unit(unit: _StreamUnit) -> bool:
+        return (
+            unit.fragment.block.type is ParsedBlockType.TABLE
+            and not unit.fragment.complete
+        )
 
     def _draft_to_normal_chunk(self, draft: _ChunkDraft) -> LogicalChunk:
         source_keys = {fragment.source_key for fragment in draft.fragments}
@@ -776,6 +800,13 @@ class BlockMerger(ChunkMerger):
 
         return chunks or [content]
 
+    @staticmethod
+    def _is_valid_table_content(content: str) -> bool:
+        stripped = content.strip()
+        if not stripped.startswith("<table") or not stripped.endswith("</table>"):
+            return False
+        return BeautifulSoup(stripped, "html.parser").find("table") is not None
+
     def _extract_table_parts(self, table) -> tuple[str, list[str]]:
         thead = table.find("thead")
         if thead is not None:
@@ -867,12 +898,18 @@ class BlockMerger(ChunkMerger):
     def _hard_split_wrapped(self, text: str, token_num: int, wrap) -> list[str]:
         tokens = encoder.encode(text)
         limit = max(int(token_num), 1)
+        if num_tokens_from_string(wrap("")) > limit:
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {limit}."
+            )
         chunks: list[str] = []
         index = 0
         while index < len(tokens):
             boundary = self._find_wrapped_token_boundary(tokens, index, limit, wrap)
             if boundary is None:
-                raise RuntimeError(f"Unable to find a valid UTF-8 boundary from token index {index}.")
+                raise ValueError(
+                    f"Structured content cannot fit within token limit {limit}."
+                )
 
             end, piece = boundary
             chunks.append(wrap(piece))
@@ -890,11 +927,6 @@ class BlockMerger(ChunkMerger):
         for end in range(search_end, start, -1):
             piece = self._decode_token_slice(tokens, start, end)
             if piece is not None and num_tokens_from_string(wrap(piece)) <= limit:
-                return end, piece
-
-        for end in range(start + 1, len(tokens) + 1):
-            piece = self._decode_token_slice(tokens, start, end)
-            if piece is not None:
                 return end, piece
         return None
 

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -602,36 +602,8 @@ class BlockMerger(ChunkMerger):
     ) -> list[_ChunkDraft]:
         drafts: list[_ChunkDraft] = []
         current: list[_StreamUnit] = []
-        pending_table_overlap: _StreamUnit | None = None
 
         for unit in units:
-            if self._is_incomplete_table_unit(unit):
-                if current:
-                    drafts.append(self._units_to_draft(current))
-                    current = []
-                drafts.append(self._units_to_draft([unit]))
-                pending_table_overlap = (
-                    self._table_overlap_unit(unit)
-                    if unit.fragment.structure_valid
-                    else None
-                )
-                continue
-
-            if (
-                pending_table_overlap is not None
-                and unit.fragment.block.type is ParsedBlockType.TABLE
-            ):
-                pending_table_overlap = None
-
-            if pending_table_overlap is not None and not current:
-                current = self._overlap_units(
-                    [pending_table_overlap],
-                    unit,
-                    token_num,
-                    overlap,
-                )
-                pending_table_overlap = None
-
             candidate = [*current, unit]
             if current and not self._stream_units_within_limit(candidate, token_num):
                 drafts.append(self._units_to_draft(current))
@@ -642,29 +614,6 @@ class BlockMerger(ChunkMerger):
         if current:
             drafts.append(self._units_to_draft(current))
         return drafts
-
-    @staticmethod
-    def _table_overlap_unit(unit: _StreamUnit) -> _StreamUnit:
-        block = deepcopy(unit.fragment.block)
-        block.metadata.pop("table_part_index", None)
-        block.metadata.pop("table_part_total", None)
-        return _StreamUnit(
-            fragment=SourceFragment(
-                source_key=unit.fragment.source_key,
-                block=block,
-                content=unit.fragment.content,
-                complete=unit.fragment.complete,
-                structure_valid=unit.fragment.structure_valid,
-            ),
-            separator_before=unit.separator_before,
-        )
-
-    @staticmethod
-    def _is_incomplete_table_unit(unit: _StreamUnit) -> bool:
-        return (
-            unit.fragment.block.type is ParsedBlockType.TABLE
-            and not unit.fragment.complete
-        )
 
     def _draft_to_normal_chunk(self, draft: _ChunkDraft) -> LogicalChunk:
         source_keys = {fragment.source_key for fragment in draft.fragments}

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -517,11 +517,40 @@ class BlockMerger(ChunkMerger):
 
     def _split_stream_unit(self, unit: _StreamUnit, token_num: int) -> list[_StreamUnit]:
         content = unit.fragment.content
+        block = unit.fragment.block
+        block_type = block.type
+        if block_type not in {
+            ParsedBlockType.IMAGE,
+            ParsedBlockType.CODE,
+            ParsedBlockType.TABLE,
+        }:
+            text_units = self.text_merger.split_recursive_units(
+                content,
+                token_num,
+                split_top_level=True,
+            )
+            if len(text_units) == 1 and text_units[0].text == content:
+                return [unit]
+
+            return [
+                _StreamUnit(
+                    fragment=SourceFragment(
+                        source_key=unit.fragment.source_key,
+                        block=block,
+                        content=text_unit.text,
+                        complete=False,
+                        structure_valid=True,
+                    ),
+                    separator_before=(
+                        unit.separator_before if index == 0 else text_unit.prefix
+                    ),
+                )
+                for index, text_unit in enumerate(text_units)
+            ]
+
         if num_tokens_from_string(content) <= token_num:
             return [unit]
 
-        block = unit.fragment.block
-        block_type = block.type
         if block_type is ParsedBlockType.IMAGE:
             pieces = self.text_merger.hard_split(content, token_num)
         elif block_type is ParsedBlockType.CODE:
@@ -533,8 +562,6 @@ class BlockMerger(ChunkMerger):
             )
         elif block_type is ParsedBlockType.TABLE:
             pieces = self._split_table_content(content, token_num, strict=True)
-        else:
-            pieces = self.text_merger.split_recursive(content, token_num)
 
         total = len(pieces)
         if any(num_tokens_from_string(piece) > token_num for piece in pieces):

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -461,7 +461,12 @@ class BlockMerger(ChunkMerger):
         language = str(block.metadata.get("language", ""))
         content = self._complete_code_fence(fragment.content, language)
         metadata = self._metadata_for_block(block)
-        pieces = self._split_code_content(content, token_num, language)
+        pieces = self._split_code_content(
+            content,
+            token_num,
+            language,
+            strict=True,
+        )
         if any(num_tokens_from_string(piece) > token_num for piece in pieces):
             raise ValueError(
                 f"Structured wrapper cannot fit within token limit {token_num}."
@@ -525,13 +530,18 @@ class BlockMerger(ChunkMerger):
                 content,
                 token_num,
                 str(block.metadata.get("language", "")),
+                strict=True,
             )
         elif block_type is ParsedBlockType.TABLE:
-            pieces = self._split_table_content(content, token_num)
+            pieces = self._split_table_content(content, token_num, strict=True)
         else:
             pieces = self.text_merger.split_recursive(content, token_num)
 
         total = len(pieces)
+        if any(num_tokens_from_string(piece) > token_num for piece in pieces):
+            raise ValueError(
+                f"Structured content cannot fit within token limit {token_num}."
+            )
         split_units: list[_StreamUnit] = []
         for index, piece in enumerate(pieces):
             piece_block = block
@@ -566,6 +576,7 @@ class BlockMerger(ChunkMerger):
     ) -> list[_ChunkDraft]:
         drafts: list[_ChunkDraft] = []
         current: list[_StreamUnit] = []
+        pending_table_overlap: _StreamUnit | None = None
 
         for index, unit in enumerate(units):
             if self._is_incomplete_table_unit(unit):
@@ -573,6 +584,28 @@ class BlockMerger(ChunkMerger):
                     drafts.append(self._units_to_draft(current))
                     current = []
                 drafts.append(self._units_to_draft([unit]))
+                pending_table_overlap = (
+                    self._table_overlap_unit(unit)
+                    if unit.fragment.structure_valid
+                    else None
+                )
+                continue
+
+            if (
+                pending_table_overlap is not None
+                and unit.fragment.block.type is ParsedBlockType.TABLE
+            ):
+                pending_table_overlap = None
+
+            if pending_table_overlap is not None and not current:
+                current = self._overlap_units(
+                    [pending_table_overlap],
+                    unit,
+                    token_num,
+                    overlap,
+                )
+                pending_table_overlap = None
+                current.append(unit)
                 continue
 
             candidate = [*current, unit]
@@ -592,6 +625,22 @@ class BlockMerger(ChunkMerger):
         return drafts
 
     @staticmethod
+    def _table_overlap_unit(unit: _StreamUnit) -> _StreamUnit:
+        block = deepcopy(unit.fragment.block)
+        block.metadata.pop("table_part_index", None)
+        block.metadata.pop("table_part_total", None)
+        return _StreamUnit(
+            fragment=SourceFragment(
+                source_key=unit.fragment.source_key,
+                block=block,
+                content=unit.fragment.content,
+                complete=unit.fragment.complete,
+                structure_valid=unit.fragment.structure_valid,
+            ),
+            separator_before=unit.separator_before,
+        )
+
+    @staticmethod
     def _is_incomplete_table_unit(unit: _StreamUnit) -> bool:
         return (
             unit.fragment.block.type is ParsedBlockType.TABLE
@@ -605,16 +654,20 @@ class BlockMerger(ChunkMerger):
         block = source_blocks[0]
 
         if single_source and block.type is ParsedBlockType.IMAGE:
+            image_tag_complete = (
+                len(draft.fragments) == 1 and draft.fragments[0].complete
+            )
+            metadata = self._metadata_for_block(block)
+            if not image_tag_complete:
+                metadata.pop("vision_text", None)
             return LogicalChunk(
                 type=LogicalChunkType.IMAGE,
                 content=draft.content,
                 image=block.image,
                 positions=deepcopy(block.positions),
-                metadata=self._metadata_for_block(block),
+                metadata=metadata,
                 source_image_key=draft.fragments[0].source_key,
-                image_tag_complete=(
-                    len(draft.fragments) == 1 and draft.fragments[0].complete
-                ),
+                image_tag_complete=image_tag_complete,
                 image_vision_scope=block.image_vision_scope,
             )
 
@@ -1077,17 +1130,53 @@ class BlockMerger(ChunkMerger):
             )
         return result
 
-    def _split_table_content(self, content: str, token_num: int) -> list[str]:
+    def _split_table_content(
+        self,
+        content: str,
+        token_num: int,
+        *,
+        strict: bool = False,
+    ) -> list[str]:
         if num_tokens_from_string(content) <= token_num:
             return [content]
 
         table = BeautifulSoup(content, "html.parser").find("table")
         if table is None:
-            return self._hard_split_wrapped(content, token_num, lambda piece: piece)
+            return self._hard_split_wrapped(
+                content,
+                token_num,
+                lambda piece: piece,
+                strict=strict,
+            )
+
+        if strict:
+            return self._split_strict_table(table, token_num)
 
         header_html, row_htmls = self._extract_table_parts(table)
         if not row_htmls:
-            return self._hard_split_wrapped(content, token_num, lambda piece: piece)
+            return self._hard_split_wrapped(
+                content,
+                token_num,
+                lambda piece: piece,
+                strict=strict,
+            )
+
+        chunks = self._split_table_rows(
+            header_html,
+            row_htmls,
+            token_num,
+            strict=False,
+        )
+        return chunks or [content]
+
+    def _split_table_rows(
+        self,
+        header_html: str,
+        row_htmls: list[str],
+        token_num: int,
+        *,
+        strict: bool,
+    ) -> list[str]:
 
         chunks: list[str] = []
         current_rows: list[str] = []
@@ -1098,7 +1187,14 @@ class BlockMerger(ChunkMerger):
                 if current_rows:
                     chunks.append(self._build_table_html(header_html, current_rows))
                     current_rows = []
-                chunks.extend(self._split_oversized_table_row(header_html, row_html, token_num))
+                chunks.extend(
+                    self._split_oversized_table_row(
+                        header_html,
+                        row_html,
+                        token_num,
+                        strict=strict,
+                    )
+                )
                 continue
 
             candidate_rows = [*current_rows, row_html]
@@ -1112,7 +1208,136 @@ class BlockMerger(ChunkMerger):
         if current_rows:
             chunks.append(self._build_table_html(header_html, current_rows))
 
-        return chunks or [content]
+        return chunks
+
+    def _split_strict_table(self, table, token_num: int) -> list[str]:
+        thead = table.find("thead")
+        if not table.find_all("tr"):
+            section = next(
+                (
+                    name
+                    for name in ("thead", "tbody", "tfoot")
+                    if table.find(name) is not None
+                ),
+                None,
+            )
+            empty_table = (
+                f"<table><{section}></{section}></table>"
+                if section
+                else "<table></table>"
+            )
+            if num_tokens_from_string(empty_table) <= token_num:
+                return [empty_table]
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
+
+        if thead is not None:
+            header_html = str(thead)
+            body_rows = [
+                row
+                for row in table.find_all("tr")
+                if row.find_parent("thead") is None
+            ]
+            if body_rows and num_tokens_from_string(
+                self._build_table_html(
+                    header_html,
+                    ["<tr><td></td></tr>"],
+                )
+            ) <= token_num:
+                return self._split_table_rows(
+                    header_html,
+                    [str(row) for row in body_rows],
+                    token_num,
+                    strict=True,
+                )
+            section_rows = [
+                ("thead", row) for row in thead.find_all("tr")
+            ]
+            section_rows.extend(("tbody", row) for row in body_rows)
+        else:
+            rows = table.find_all("tr")
+            if len(rows) > 1:
+                header_html = f"<thead>{rows[0]}</thead>"
+                if num_tokens_from_string(
+                    self._build_table_html(
+                        header_html,
+                        ["<tr><td></td></tr>"],
+                    )
+                ) <= token_num:
+                    return self._split_table_rows(
+                        header_html,
+                        [str(row) for row in rows[1:]],
+                        token_num,
+                        strict=True,
+                    )
+                section_rows = [
+                    ("thead", rows[0]),
+                    *(("tbody", row) for row in rows[1:]),
+                ]
+            else:
+                section_rows = [("tbody", row) for row in rows]
+
+        chunks: list[str] = []
+        for section, row in section_rows:
+            wrapped_row = self._build_section_table_html(section, str(row))
+            if num_tokens_from_string(wrapped_row) <= token_num:
+                chunks.append(wrapped_row)
+            else:
+                chunks.extend(
+                    self._split_strict_table_row(
+                        row,
+                        section,
+                        token_num,
+                    )
+                )
+
+        if not chunks or any(
+            not self._is_valid_table_content(chunk)
+            or num_tokens_from_string(chunk) > token_num
+            for chunk in chunks
+        ):
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
+        return chunks
+
+    def _split_strict_table_row(
+        self,
+        row,
+        section: str,
+        token_num: int,
+    ) -> list[str]:
+        cells = row.find_all(["th", "td"], recursive=False)
+        if not cells:
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
+
+        chunks: list[str] = []
+        for cell in cells:
+            cell_name = str(cell.name or "td").lower()
+            cell_text = cell.get_text(" ", strip=True)
+
+            def wrap_cell(piece: str, cell_name: str = cell_name) -> str:
+                row_fragment = (
+                    f"<tr><{cell_name}>{escape(piece)}</{cell_name}></tr>"
+                )
+                return self._build_section_table_html(section, row_fragment)
+
+            chunks.extend(
+                self._hard_split_wrapped(
+                    cell_text,
+                    token_num,
+                    wrap_cell,
+                    strict=True,
+                )
+            )
+        return chunks
+
+    @staticmethod
+    def _build_section_table_html(section: str, row_html: str) -> str:
+        return f"<table><{section}>{row_html}</{section}></table>"
 
     @staticmethod
     def _is_valid_table_content(content: str) -> bool:
@@ -1145,17 +1370,63 @@ class BlockMerger(ChunkMerger):
             return f"<table>{header_html}<tbody>{body}</tbody></table>"
         return f"<table><tbody>{body}</tbody></table>"
 
-    def _split_oversized_table_row(self, header_html: str, row_html: str, token_num: int) -> list[str]:
+    def _split_oversized_table_row(
+        self,
+        header_html: str,
+        row_html: str,
+        token_num: int,
+        *,
+        strict: bool = False,
+    ) -> list[str]:
         row = BeautifulSoup(row_html, "html.parser").find("tr")
+        if strict and row is not None:
+            cells = row.find_all(["th", "td"], recursive=False)
+            if cells:
+                chunks: list[str] = []
+                for cell in cells:
+                    cell_name = str(cell.name or "td").lower()
+                    cell_text = cell.get_text(" ", strip=True)
+
+                    def wrap_cell(
+                        piece: str,
+                        cell_name: str = cell_name,
+                    ) -> str:
+                        row_fragment = (
+                            f"<tr><{cell_name}>{escape(piece)}</{cell_name}></tr>"
+                        )
+                        return self._build_table_html(header_html, [row_fragment])
+
+                    chunks.extend(
+                        self._hard_split_wrapped(
+                            cell_text,
+                            token_num,
+                            wrap_cell,
+                            strict=True,
+                        )
+                    )
+                return chunks
+
         row_text = row.get_text(" | ", strip=True) if row is not None else row_html
 
         def wrap(piece: str) -> str:
             row_fragment = f"<tr><td>{escape(piece)}</td></tr>"
             return self._build_table_html(header_html, [row_fragment])
 
-        return self._hard_split_wrapped(row_text, token_num, wrap)
+        return self._hard_split_wrapped(
+            row_text,
+            token_num,
+            wrap,
+            strict=strict,
+        )
 
-    def _split_code_content(self, content: str, token_num: int, language: str = "") -> list[str]:
+    def _split_code_content(
+        self,
+        content: str,
+        token_num: int,
+        language: str = "",
+        *,
+        strict: bool = False,
+    ) -> list[str]:
         if num_tokens_from_string(content) <= token_num:
             return [content]
 
@@ -1181,7 +1452,15 @@ class BlockMerger(ChunkMerger):
                 if current_lines:
                     chunks.append(self._wrap_code_lines(current_lines, fence_start, fence_end))
                     current_lines = []
-                chunks.extend(self._split_oversized_code_line(line, token_num, fence_start, fence_end))
+                chunks.extend(
+                    self._split_oversized_code_line(
+                        line,
+                        token_num,
+                        fence_start,
+                        fence_end,
+                        strict=strict,
+                    )
+                )
                 continue
 
             candidate_lines = current_lines + [line]
@@ -1195,7 +1474,15 @@ class BlockMerger(ChunkMerger):
         if current_lines:
             chunks.append(self._wrap_code_lines(current_lines, fence_start, fence_end))
 
-        return chunks or [content]
+        result = chunks or [content]
+        if strict and any(
+            num_tokens_from_string(piece) > token_num
+            for piece in result
+        ):
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
+        return result
 
     def _split_oversized_code_line(
         self,
@@ -1203,27 +1490,49 @@ class BlockMerger(ChunkMerger):
         token_num: int,
         fence_start: str,
         fence_end: str,
+        *,
+        strict: bool = False,
     ) -> list[str]:
         return self._hard_split_wrapped(
             line,
             token_num,
             lambda piece: self._wrap_code_lines([piece], fence_start, fence_end),
+            strict=strict,
         )
 
-    def _hard_split_wrapped(self, text: str, token_num: int, wrap) -> list[str]:
+    def _hard_split_wrapped(
+        self,
+        text: str,
+        token_num: int,
+        wrap,
+        *,
+        strict: bool = False,
+    ) -> list[str]:
         tokens = encoder.encode(text)
         limit = max(int(token_num), 1)
-        if num_tokens_from_string(wrap("")) > limit:
+        if strict and num_tokens_from_string(wrap("")) > limit:
             raise ValueError(
                 f"Structured wrapper cannot fit within token limit {limit}."
             )
+        if strict and not tokens:
+            return [wrap("")]
         chunks: list[str] = []
         index = 0
         while index < len(tokens):
-            boundary = self._find_wrapped_token_boundary(tokens, index, limit, wrap)
+            boundary = self._find_wrapped_token_boundary(
+                tokens,
+                index,
+                limit,
+                wrap,
+                strict=strict,
+            )
             if boundary is None:
-                raise ValueError(
-                    f"Structured content cannot fit within token limit {limit}."
+                if strict:
+                    raise ValueError(
+                        f"Structured content cannot fit within token limit {limit}."
+                    )
+                raise RuntimeError(
+                    f"Unable to find a valid UTF-8 boundary from token index {index}."
                 )
 
             end, piece = boundary
@@ -1237,12 +1546,20 @@ class BlockMerger(ChunkMerger):
         start: int,
         limit: int,
         wrap,
+        *,
+        strict: bool = False,
     ) -> tuple[int, str] | None:
         search_end = min(len(tokens), start + limit)
         for end in range(search_end, start, -1):
             piece = self._decode_token_slice(tokens, start, end)
             if piece is not None and num_tokens_from_string(wrap(piece)) <= limit:
                 return end, piece
+
+        if not strict:
+            for end in range(start + 1, len(tokens) + 1):
+                piece = self._decode_token_slice(tokens, start, end)
+                if piece is not None:
+                    return end, piece
         return None
 
     @staticmethod

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -313,24 +313,6 @@ class BlockMerger(ChunkMerger):
             for draft, child_drafts in group_drafts
         ]
 
-    def _children_from_parent(
-        self,
-        draft: _ParentDraft,
-        token_num: int,
-        delimiter: str | None,
-    ) -> list[LogicalChunk]:
-        child_drafts = [
-            child_draft
-            for child_draft in self._child_drafts_from_parent(
-                draft,
-                token_num,
-                delimiter,
-            )
-            if self._is_serializable_child(child_draft.chunk)
-        ]
-        self._normalize_table_child_parts(child_drafts)
-        return [child_draft.chunk for child_draft in child_drafts]
-
     def _child_drafts_from_parent(
         self,
         draft: _ParentDraft,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -192,10 +192,12 @@ class BlockMerger(ChunkMerger):
             token_num,
         )
         stream = rebuild_structured_stream(parse_result.blocks or [])
-        drafts: list[_ChunkDraft] = []
-        for segment in split_structured_stream(stream, delimiter):
-            units = self._stream_units(segment, token_num)
-            drafts.extend(self._pack_stream_units(units, token_num, overlap))
+        drafts = self._segment_drafts(
+            stream,
+            token_num,
+            delimiter,
+            overlap,
+        )
 
         logical_chunks = [self._draft_to_normal_chunk(draft) for draft in drafts]
         return MergeResult(
@@ -211,11 +213,27 @@ class BlockMerger(ChunkMerger):
         delimiter: str | None,
     ) -> list[_ParentDraft]:
         stream = rebuild_structured_stream(blocks)
+        drafts = self._segment_drafts(stream, token_num, delimiter, 0)
+        return [self._chunk_draft_to_parent(draft) for draft in drafts]
+
+    def _segment_drafts(
+        self,
+        stream: StructuredStream,
+        token_num: int,
+        delimiter: str | None,
+        overlap: int,
+    ) -> list[_ChunkDraft]:
         drafts: list[_ChunkDraft] = []
         for segment in split_structured_stream(stream, delimiter):
+            source_units = self._source_stream_units(segment)
+            if not source_units:
+                continue
+            if self._stream_units_within_limit(source_units, token_num):
+                drafts.append(self._units_to_draft(source_units))
+                continue
             units = self._stream_units(segment, token_num)
-            drafts.extend(self._pack_stream_units(units, token_num, 0))
-        return [self._chunk_draft_to_parent(draft) for draft in drafts]
+            drafts.extend(self._pack_stream_units(units, token_num, overlap))
+        return drafts
 
     def _build_full_doc_parent_drafts(
         self,
@@ -384,10 +402,7 @@ class BlockMerger(ChunkMerger):
         delimiter: str | None,
     ) -> list[LogicalChunk]:
         stream = self._text_stream_from_fragments(fragments)
-        drafts: list[_ChunkDraft] = []
-        for segment in split_structured_stream(stream, delimiter):
-            units = self._stream_units(segment, token_num)
-            drafts.extend(self._pack_stream_units(units, token_num, 0))
+        drafts = self._segment_drafts(stream, token_num, delimiter, 0)
         return [self._draft_to_normal_chunk(draft) for draft in drafts]
 
     @staticmethod
@@ -477,6 +492,12 @@ class BlockMerger(ChunkMerger):
 
     def _stream_units(self, stream: StructuredStream, token_num: int) -> list[_StreamUnit]:
         units: list[_StreamUnit] = []
+        for source_unit in self._source_stream_units(stream):
+            units.extend(self._split_stream_unit(source_unit, token_num))
+        return units
+
+    def _source_stream_units(self, stream: StructuredStream) -> list[_StreamUnit]:
+        units: list[_StreamUnit] = []
         previous_end = 0
         for index, span in enumerate(stream.spans):
             fragment = SourceFragment(
@@ -493,7 +514,7 @@ class BlockMerger(ChunkMerger):
                 fragment=fragment,
                 separator_before="" if index == 0 else stream.text[previous_end : span.start],
             )
-            units.extend(self._split_stream_unit(unit, token_num))
+            units.append(unit)
             previous_end = span.end
         return units
 
@@ -675,8 +696,34 @@ class BlockMerger(ChunkMerger):
     def _units_to_draft(self, units: list[_StreamUnit]) -> _ChunkDraft:
         return _ChunkDraft(
             content=self._join_stream_units(units),
-            fragments=[unit.fragment for unit in units],
+            fragments=self._draft_fragments(units),
         )
+
+    @staticmethod
+    def _draft_fragments(units: list[_StreamUnit]) -> list[SourceFragment]:
+        fragments: list[SourceFragment] = []
+        for unit in units:
+            fragment = unit.fragment
+            if (
+                fragments
+                and fragments[-1].source_key == fragment.source_key
+                and fragment.block.type
+                in {*TEXT_LIKE_TYPES, ParsedBlockType.LIST}
+            ):
+                previous = fragments[-1]
+                content = f"{previous.content}{unit.separator_before}{fragment.content}"
+                fragments[-1] = SourceFragment(
+                    source_key=previous.source_key,
+                    block=previous.block,
+                    content=content,
+                    complete=content == str(previous.block.content or ""),
+                    structure_valid=(
+                        previous.structure_valid and fragment.structure_valid
+                    ),
+                )
+                continue
+            fragments.append(fragment)
+        return fragments
 
     @staticmethod
     def _join_stream_units(units: list[_StreamUnit]) -> str:

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -4,22 +4,6 @@ from html import escape
 
 from bs4 import BeautifulSoup
 
-from app.core.rag.common.token_utils import encoder, num_tokens_from_string
-from app.core.rag.chunk.parser.markdown_preprocessor import (
-    ALPHA_LIST_PATTERN,
-    CHINESE_LIST_PATTERN,
-    CIRCLED_LIST_PATTERN,
-    DEFINITION_LIST_PATTERN,
-    EMPTY_ORDERED_LIST_PATTERN,
-    KEYCAP_LIST_PATTERN,
-    ORDERED_LIST_PATTERN,
-    ORDINAL_LIST_PATTERN,
-    PAREN_ORDERED_LIST_PATTERN,
-    PREFIXED_LIST_PATTERN,
-    QA_LIST_PATTERN,
-    STEP_LIST_PATTERN,
-    UNORDERED_LIST_PATTERN,
-)
 from app.core.rag.chunk.context import (
     ChunkContext,
     ChunkOutputMode,
@@ -39,10 +23,25 @@ from app.core.rag.chunk.merger.structured_stream import (
     rebuild_structured_stream,
     split_structured_stream,
 )
+from app.core.rag.chunk.parser.markdown_preprocessor import (
+    ALPHA_LIST_PATTERN,
+    CHINESE_LIST_PATTERN,
+    CIRCLED_LIST_PATTERN,
+    DEFINITION_LIST_PATTERN,
+    EMPTY_ORDERED_LIST_PATTERN,
+    KEYCAP_LIST_PATTERN,
+    ORDERED_LIST_PATTERN,
+    ORDINAL_LIST_PATTERN,
+    PAREN_ORDERED_LIST_PATTERN,
+    PREFIXED_LIST_PATTERN,
+    QA_LIST_PATTERN,
+    STEP_LIST_PATTERN,
+    UNORDERED_LIST_PATTERN,
+)
+from app.core.rag.common.token_utils import encoder, num_tokens_from_string
 
 from .base import ChunkMerger
 from .text import TextMerger
-
 
 TEXT_LIKE_TYPES = {
     ParsedBlockType.HEADING,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from dataclasses import dataclass
 from html import escape
 
 from bs4 import BeautifulSoup
@@ -29,6 +30,12 @@ from app.core.rag.chunk.context import (
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
+)
+from app.core.rag.chunk.merger.structured_stream import (
+    SourceFragment,
+    StructuredStream,
+    rebuild_structured_stream,
+    split_structured_stream,
 )
 
 from .base import ChunkMerger
@@ -64,11 +71,32 @@ PARENT_CHILD_ATOMIC_TYPES = {
 }
 
 
+@dataclass(frozen=True)
+class _StreamUnit:
+    fragment: SourceFragment
+    separator_before: str = ""
+
+
+@dataclass
+class _ChunkDraft:
+    content: str
+    fragments: list[SourceFragment]
+
+
+@dataclass
+class _ParentDraft:
+    parent: LogicalChunk
+    fragments: list[SourceFragment]
+
+
 class BlockMerger(ChunkMerger):
     def __init__(self):
         self.text_merger = TextMerger()
 
     def merge(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
+        if parse_result.structured_markdown_stream:
+            return self._merge_structured_stream(ctx, parse_result)
+
         blocks = parse_result.blocks or []
         token_num = int(ctx.parser_config.get("chunk_token_num", 128))
         delimiter = ctx.parser_config.get("delimiter")
@@ -126,6 +154,227 @@ class BlockMerger(ChunkMerger):
             logical_chunks=logical_chunks,
             pdf_parser=parse_result.pdf_parser,
         )
+
+    def _merge_structured_stream(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
+        token_num = max(int(ctx.parser_config.get("chunk_token_num", 128)), 1)
+        delimiter = ctx.parser_config.get("delimiter")
+        overlap = TextMerger._normalize_overlap(
+            _safe_int(ctx.parser_config.get("chunk_overlap", 0)),
+            token_num,
+        )
+        stream = rebuild_structured_stream(parse_result.blocks or [])
+        drafts: list[_ChunkDraft] = []
+        for segment in split_structured_stream(stream, delimiter):
+            units = self._stream_units(segment, token_num)
+            drafts.extend(self._pack_stream_units(units, token_num, overlap))
+
+        logical_chunks = [self._draft_to_normal_chunk(draft) for draft in drafts]
+        return MergeResult(
+            chunks=self._serialize_chunk_contents(logical_chunks),
+            logical_chunks=logical_chunks,
+            pdf_parser=parse_result.pdf_parser,
+        )
+
+    def _stream_units(self, stream: StructuredStream, token_num: int) -> list[_StreamUnit]:
+        units: list[_StreamUnit] = []
+        previous_end = 0
+        for index, span in enumerate(stream.spans):
+            fragment = SourceFragment(
+                source_key=span.source_key,
+                block=span.block,
+                content=stream.text[span.start : span.end],
+                complete=stream.text[span.start : span.end] == str(span.block.content or ""),
+            )
+            unit = _StreamUnit(
+                fragment=fragment,
+                separator_before="" if index == 0 else stream.text[previous_end : span.start],
+            )
+            units.extend(self._split_stream_unit(unit, token_num))
+            previous_end = span.end
+        return units
+
+    def _split_stream_unit(self, unit: _StreamUnit, token_num: int) -> list[_StreamUnit]:
+        content = unit.fragment.content
+        if num_tokens_from_string(content) <= token_num:
+            return [unit]
+
+        block = unit.fragment.block
+        block_type = block.type
+        if block_type is ParsedBlockType.IMAGE:
+            pieces = self.text_merger.hard_split(content, token_num)
+        elif block_type is ParsedBlockType.CODE:
+            pieces = self._split_code_content(
+                content,
+                token_num,
+                str(block.metadata.get("language", "")),
+            )
+        elif block_type is ParsedBlockType.TABLE:
+            pieces = self._split_table_content(content, token_num)
+        else:
+            pieces = self.text_merger.split_recursive(content, token_num)
+
+        total = len(pieces)
+        split_units: list[_StreamUnit] = []
+        for index, piece in enumerate(pieces):
+            piece_block = block
+            if block_type is ParsedBlockType.TABLE and total > 1:
+                piece_block = deepcopy(block)
+                piece_block.metadata["table_part_index"] = index
+                piece_block.metadata["table_part_total"] = total
+            fragment = SourceFragment(
+                source_key=unit.fragment.source_key,
+                block=piece_block,
+                content=piece,
+                complete=False,
+                structure_valid=block_type is not ParsedBlockType.IMAGE,
+            )
+            separator = unit.separator_before if index == 0 else (
+                "\n" if block_type in {ParsedBlockType.CODE, ParsedBlockType.TABLE} else ""
+            )
+            split_units.append(_StreamUnit(fragment=fragment, separator_before=separator))
+        return split_units
+
+    def _pack_stream_units(
+        self,
+        units: list[_StreamUnit],
+        token_num: int,
+        overlap: int,
+    ) -> list[_ChunkDraft]:
+        drafts: list[_ChunkDraft] = []
+        current: list[_StreamUnit] = []
+
+        for index, unit in enumerate(units):
+            candidate = [*current, unit]
+            if self._heading_should_start_next_draft(current, unit, units, index, token_num):
+                drafts.append(self._units_to_draft(current))
+                current = [unit]
+                continue
+
+            if current and not self._stream_units_within_limit(candidate, token_num):
+                drafts.append(self._units_to_draft(current))
+                current = self._overlap_units(current, unit, token_num, overlap)
+
+            current.append(unit)
+
+        if current:
+            drafts.append(self._units_to_draft(current))
+        return drafts
+
+    def _draft_to_normal_chunk(self, draft: _ChunkDraft) -> LogicalChunk:
+        source_keys = {fragment.source_key for fragment in draft.fragments}
+        source_blocks = self._source_blocks(draft.fragments)
+        single_source = len(source_keys) == 1
+        block = source_blocks[0]
+
+        if single_source and block.type is ParsedBlockType.IMAGE:
+            return LogicalChunk(
+                type=LogicalChunkType.IMAGE,
+                content=draft.content,
+                image=block.image,
+                positions=deepcopy(block.positions),
+                metadata=self._metadata_for_block(block),
+                source_image_key=draft.fragments[0].source_key,
+                image_tag_complete=(
+                    len(draft.fragments) == 1 and draft.fragments[0].complete
+                ),
+                image_vision_scope=block.image_vision_scope,
+            )
+
+        if (
+            single_source
+            and block.type is ParsedBlockType.TABLE
+            and all(fragment.structure_valid for fragment in draft.fragments)
+        ):
+            return LogicalChunk(
+                type=LogicalChunkType.TABLE,
+                content=draft.content,
+                image=block.image,
+                positions=deepcopy(block.positions),
+                metadata=self._metadata_for_block(block),
+            )
+
+        if single_source and block.type is ParsedBlockType.CODE:
+            return LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=draft.content,
+                image=block.image,
+                positions=deepcopy(block.positions),
+                metadata=self._metadata_for_block(block),
+            )
+
+        metadata = self._metadata_for_range(source_blocks, "text")
+        metadata.pop("vision_text", None)
+        metadata.pop("image", None)
+        return LogicalChunk(
+            type=LogicalChunkType.TEXT,
+            content=draft.content,
+            metadata=metadata,
+        )
+
+    def _heading_should_start_next_draft(
+        self,
+        current: list[_StreamUnit],
+        unit: _StreamUnit,
+        units: list[_StreamUnit],
+        index: int,
+        token_num: int,
+    ) -> bool:
+        if not current or unit.fragment.block.type is not ParsedBlockType.HEADING:
+            return False
+        if index + 1 >= len(units):
+            return False
+        if not self._stream_units_within_limit([*current, unit], token_num):
+            return False
+        return not self._stream_units_within_limit([*current, unit, units[index + 1]], token_num)
+
+    def _overlap_units(
+        self,
+        completed: list[_StreamUnit],
+        next_unit: _StreamUnit,
+        token_num: int,
+        overlap: int,
+    ) -> list[_StreamUnit]:
+        if overlap <= 0:
+            return []
+
+        retained: list[_StreamUnit] = []
+        for unit in reversed(completed):
+            candidate = [unit, *retained]
+            if num_tokens_from_string(self._join_stream_units(candidate)) > overlap:
+                break
+            if not self._stream_units_within_limit([*candidate, next_unit], token_num):
+                break
+            retained = candidate
+        return retained
+
+    def _units_to_draft(self, units: list[_StreamUnit]) -> _ChunkDraft:
+        return _ChunkDraft(
+            content=self._join_stream_units(units),
+            fragments=[unit.fragment for unit in units],
+        )
+
+    @staticmethod
+    def _join_stream_units(units: list[_StreamUnit]) -> str:
+        return "".join(
+            unit.fragment.content
+            if index == 0
+            else f"{unit.separator_before}{unit.fragment.content}"
+            for index, unit in enumerate(units)
+        )
+
+    def _stream_units_within_limit(self, units: list[_StreamUnit], token_num: int) -> bool:
+        return num_tokens_from_string(self._join_stream_units(units)) <= token_num
+
+    @staticmethod
+    def _source_blocks(fragments: list[SourceFragment]) -> list[ParsedBlock]:
+        blocks: list[ParsedBlock] = []
+        seen: set[int] = set()
+        for fragment in fragments:
+            if fragment.source_key in seen:
+                continue
+            seen.add(fragment.source_key)
+            blocks.append(fragment.block)
+        return blocks
 
     def _full_doc_blocks(self, blocks: list[ParsedBlock]) -> list[ParsedBlock]:
         selected: list[ParsedBlock] = []

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -578,8 +578,7 @@ class BlockMerger(ChunkMerger):
         current: list[_StreamUnit] = []
         pending_table_overlap: _StreamUnit | None = None
 
-        for index, unit in enumerate(units):
-            current_is_pending_overlap = False
+        for unit in units:
             if self._is_incomplete_table_unit(unit):
                 if current:
                     drafts.append(self._units_to_draft(current))
@@ -606,15 +605,8 @@ class BlockMerger(ChunkMerger):
                     overlap,
                 )
                 pending_table_overlap = None
-                current_is_pending_overlap = bool(current)
 
             candidate = [*current, unit]
-            if self._heading_should_start_next_draft(current, unit, units, index, token_num):
-                if not current_is_pending_overlap:
-                    drafts.append(self._units_to_draft(current))
-                current = [unit]
-                continue
-
             if current and not self._stream_units_within_limit(candidate, token_num):
                 drafts.append(self._units_to_draft(current))
                 current = self._overlap_units(current, unit, token_num, overlap)
@@ -702,22 +694,6 @@ class BlockMerger(ChunkMerger):
             content=draft.content,
             metadata=metadata,
         )
-
-    def _heading_should_start_next_draft(
-        self,
-        current: list[_StreamUnit],
-        unit: _StreamUnit,
-        units: list[_StreamUnit],
-        index: int,
-        token_num: int,
-    ) -> bool:
-        if not current or unit.fragment.block.type is not ParsedBlockType.HEADING:
-            return False
-        if index + 1 >= len(units):
-            return False
-        if not self._stream_units_within_limit([*current, unit], token_num):
-            return False
-        return not self._stream_units_within_limit([*current, unit, units[index + 1]], token_num)
 
     def _overlap_units(
         self,

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -34,6 +34,7 @@ from app.core.rag.chunk.context import (
 from app.core.rag.chunk.merger.structured_stream import (
     SourceFragment,
     StructuredStream,
+    block_separator,
     rebuild_structured_stream,
     split_structured_stream,
 )
@@ -158,6 +159,28 @@ class BlockMerger(ChunkMerger):
     def _merge_structured_stream(self, ctx: ChunkContext, parse_result: ParseResult) -> MergeResult:
         token_num = max(int(ctx.parser_config.get("chunk_token_num", 128)), 1)
         delimiter = ctx.parser_config.get("delimiter")
+        if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
+            if ctx.parser_config.get("parent_chunk_mode") == "full-doc":
+                parent_drafts = self._build_full_doc_parent_drafts(
+                    parse_result.blocks or []
+                )
+            else:
+                parent_token_num = max(
+                    int(ctx.parser_config.get("parent_chunk_token_num", 1024)),
+                    1,
+                )
+                parent_drafts = self._build_parent_drafts(
+                    parse_result.blocks or [],
+                    parent_token_num,
+                    ctx.parser_config.get("parent_chunk_delimiter"),
+                )
+            groups = self._parent_child_groups_from_drafts(
+                parent_drafts,
+                token_num,
+                delimiter,
+            )
+            return self._parent_child_merge_result(groups, parse_result.pdf_parser)
+
         overlap = TextMerger._normalize_overlap(
             _safe_int(ctx.parser_config.get("chunk_overlap", 0)),
             token_num,
@@ -174,6 +197,213 @@ class BlockMerger(ChunkMerger):
             logical_chunks=logical_chunks,
             pdf_parser=parse_result.pdf_parser,
         )
+
+    def _build_parent_drafts(
+        self,
+        blocks: list[ParsedBlock],
+        token_num: int,
+        delimiter: str | None,
+    ) -> list[_ParentDraft]:
+        stream = rebuild_structured_stream(blocks)
+        drafts: list[_ChunkDraft] = []
+        for segment in split_structured_stream(stream, delimiter):
+            units = self._stream_units(segment, token_num)
+            drafts.extend(self._pack_stream_units(units, token_num, 0))
+        return [self._chunk_draft_to_parent(draft) for draft in drafts]
+
+    def _build_full_doc_parent_drafts(
+        self,
+        blocks: list[ParsedBlock],
+    ) -> list[_ParentDraft]:
+        fragments: list[SourceFragment] = []
+        content_parts: list[str] = []
+        previous: ParsedBlock | None = None
+        content_length = 0
+
+        for source_key, block in enumerate(blocks):
+            content = str(block.content or "")
+            if not content.strip():
+                continue
+
+            separator = block_separator(previous, block) if previous is not None else ""
+            remaining = FULL_DOC_MAX_CHARS - content_length - len(separator)
+            if remaining <= 0:
+                break
+
+            complete = len(content) <= remaining
+            if not complete and block.type in PARENT_CHILD_ATOMIC_TYPES:
+                break
+
+            selected_content = content if complete else content[:remaining]
+            content_parts.extend([separator, selected_content])
+            fragments.append(
+                SourceFragment(
+                    source_key=source_key,
+                    block=block,
+                    content=selected_content,
+                    complete=complete,
+                    structure_valid=(
+                        block.type is not ParsedBlockType.TABLE
+                        or self._is_valid_table_content(selected_content)
+                    ),
+                )
+            )
+            content_length += len(separator) + len(selected_content)
+            previous = block
+            if not complete:
+                break
+
+        if not fragments:
+            return []
+
+        source_blocks = self._source_blocks(fragments)
+        parent = LogicalChunk(
+            type=LogicalChunkType.TEXT,
+            content="".join(content_parts),
+            metadata=self._metadata_for_range(source_blocks, "text"),
+        )
+        return [_ParentDraft(parent=parent, fragments=fragments)]
+
+    def _chunk_draft_to_parent(self, draft: _ChunkDraft) -> _ParentDraft:
+        source_blocks = self._source_blocks(draft.fragments)
+        return _ParentDraft(
+            parent=LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=draft.content,
+                metadata=self._metadata_for_range(source_blocks, "text"),
+            ),
+            fragments=draft.fragments,
+        )
+
+    def _parent_child_groups_from_drafts(
+        self,
+        drafts: list[_ParentDraft],
+        token_num: int,
+        delimiter: str | None,
+    ) -> list[ParentChildGroup]:
+        return [
+            ParentChildGroup(
+                parent=draft.parent,
+                children=self._children_from_parent(draft, token_num, delimiter),
+            )
+            for draft in drafts
+        ]
+
+    def _children_from_parent(
+        self,
+        draft: _ParentDraft,
+        token_num: int,
+        delimiter: str | None,
+    ) -> list[LogicalChunk]:
+        children: list[LogicalChunk] = []
+        text_fragments: list[SourceFragment] = []
+
+        def flush_text_fragments() -> None:
+            if not text_fragments:
+                return
+            children.extend(
+                self._text_children_from_fragments(
+                    text_fragments,
+                    token_num,
+                    delimiter,
+                )
+            )
+            text_fragments.clear()
+
+        text_like_types = {*TEXT_LIKE_TYPES, ParsedBlockType.LIST}
+        for fragment in draft.fragments:
+            if fragment.block.type in text_like_types:
+                text_fragments.append(fragment)
+                continue
+
+            flush_text_fragments()
+            children.extend(
+                self._specialized_children_from_fragment(fragment, token_num)
+            )
+
+        flush_text_fragments()
+        return children
+
+    def _text_children_from_fragments(
+        self,
+        fragments: list[SourceFragment],
+        token_num: int,
+        delimiter: str | None,
+    ) -> list[LogicalChunk]:
+        content = self._join_text_fragments(fragments)
+        source_blocks = self._source_blocks(fragments)
+        metadata = self._metadata_for_range(source_blocks, "text")
+        metadata.pop("vision_text", None)
+        metadata.pop("image", None)
+        return [
+            LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=chunk,
+                metadata=deepcopy(metadata),
+            )
+            for chunk in self.text_merger.merge(content, token_num, delimiter, 0)
+            if chunk.strip()
+        ]
+
+    @staticmethod
+    def _join_text_fragments(fragments: list[SourceFragment]) -> str:
+        parts: list[str] = []
+        previous: SourceFragment | None = None
+        for fragment in fragments:
+            separator = ""
+            if previous is not None and previous.source_key != fragment.source_key:
+                separator = block_separator(previous.block, fragment.block)
+            parts.extend([separator, fragment.content])
+            previous = fragment
+        return "".join(parts)
+
+    def _specialized_children_from_fragment(
+        self,
+        fragment: SourceFragment,
+        token_num: int,
+    ) -> list[LogicalChunk]:
+        if fragment.block.type is ParsedBlockType.CODE:
+            return self._code_children_from_fragment(fragment, token_num)
+
+        units = self._split_stream_unit(
+            _StreamUnit(fragment=fragment),
+            token_num,
+        )
+        return [
+            self._draft_to_normal_chunk(self._units_to_draft([unit])) for unit in units
+        ]
+
+    def _code_children_from_fragment(
+        self,
+        fragment: SourceFragment,
+        token_num: int,
+    ) -> list[LogicalChunk]:
+        block = fragment.block
+        language = str(block.metadata.get("language", ""))
+        content = self._complete_code_fence(fragment.content, language)
+        metadata = self._metadata_for_block(block)
+        return [
+            LogicalChunk(
+                type=LogicalChunkType.TEXT,
+                content=piece,
+                image=block.image,
+                positions=deepcopy(block.positions),
+                metadata=deepcopy(metadata),
+            )
+            for piece in self._split_code_content(content, token_num, language)
+            if piece.strip()
+        ]
+
+    @staticmethod
+    def _complete_code_fence(content: str, language: str) -> str:
+        lines = content.split("\n")
+        if lines and lines[0].strip().startswith("```"):
+            if len(lines) == 1 or not lines[-1].strip().startswith("```"):
+                return f"{content}\n```"
+            return content
+        if language:
+            return f"```{language}\n{content}\n```"
+        return content
 
     def _stream_units(self, stream: StructuredStream, token_num: int) -> list[_StreamUnit]:
         units: list[_StreamUnit] = []
@@ -858,6 +1088,17 @@ class BlockMerger(ChunkMerger):
         elif language:
             fence_start = f"```{language}"
             fence_end = "```"
+
+        if (
+            fence_start
+            and num_tokens_from_string(
+                self._wrap_code_lines([], fence_start, fence_end)
+            )
+            > token_num
+        ):
+            raise ValueError(
+                f"Structured wrapper cannot fit within token limit {token_num}."
+            )
 
         chunks: list[str] = []
         current_lines: list[str] = []

--- a/api/app/core/rag/chunk/merger/block.py
+++ b/api/app/core/rag/chunk/merger/block.py
@@ -803,7 +803,8 @@ class BlockMerger(ChunkMerger):
     @staticmethod
     def _is_valid_table_content(content: str) -> bool:
         stripped = content.strip()
-        if not stripped.startswith("<table") or not stripped.endswith("</table>"):
+        normalized = stripped.lower()
+        if not normalized.startswith("<table") or not normalized.endswith("</table>"):
             return False
         return BeautifulSoup(stripped, "html.parser").find("table") is not None
 

--- a/api/app/core/rag/chunk/merger/structured_stream.py
+++ b/api/app/core/rag/chunk/merger/structured_stream.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 
 from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
 
-
 PROTECTED_DELIMITER_TYPES = {
     ParsedBlockType.IMAGE,
     ParsedBlockType.CODE,

--- a/api/app/core/rag/chunk/merger/structured_stream.py
+++ b/api/app/core/rag/chunk/merger/structured_stream.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass, field
+
+from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
+
+
+PROTECTED_DELIMITER_TYPES = {
+    ParsedBlockType.IMAGE,
+    ParsedBlockType.CODE,
+    ParsedBlockType.TABLE,
+}
+
+
+@dataclass(frozen=True)
+class BlockSpan:
+    source_key: int
+    block: ParsedBlock
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class SourceFragment:
+    source_key: int
+    block: ParsedBlock
+    content: str
+    complete: bool
+    structure_valid: bool = True
+
+
+@dataclass
+class StructuredStream:
+    text: str
+    spans: list[BlockSpan] = field(default_factory=list)
+
+
+def block_separator(previous: ParsedBlock, current: ParsedBlock) -> str:
+    return "\n\n" if current.type is ParsedBlockType.HEADING else "\n"
+
+
+def rebuild_structured_stream(blocks: list[ParsedBlock]) -> StructuredStream:
+    text_parts: list[str] = []
+    spans: list[BlockSpan] = []
+    previous: ParsedBlock | None = None
+    offset = 0
+
+    for source_key, block in enumerate(blocks):
+        content = str(block.content or "")
+        if not content:
+            continue
+
+        if previous is not None:
+            separator = block_separator(previous, block)
+            text_parts.append(separator)
+            offset += len(separator)
+
+        start = offset
+        text_parts.append(content)
+        offset += len(content)
+        spans.append(BlockSpan(source_key=source_key, block=block, start=start, end=offset))
+        previous = block
+
+    return StructuredStream(text="".join(text_parts), spans=spans)
+
+
+def split_structured_stream(stream: StructuredStream, delimiter: str | None) -> list[StructuredStream]:
+    if not delimiter:
+        return [stream]
+
+    ranges: list[tuple[int, int]] = []
+    segment_start = 0
+    search_start = 0
+    delimiter_length = len(delimiter)
+
+    while True:
+        delimiter_start = stream.text.find(delimiter, search_start)
+        if delimiter_start < 0:
+            break
+
+        delimiter_end = delimiter_start + delimiter_length
+        search_start = delimiter_end
+        if _intersects_protected_span(stream.spans, delimiter_start, delimiter_end):
+            continue
+
+        segment_end = delimiter_end if delimiter in {"。", "；"} else delimiter_start
+        if segment_start != segment_end:
+            ranges.append((segment_start, segment_end))
+        segment_start = delimiter_end
+
+    if segment_start != len(stream.text):
+        ranges.append((segment_start, len(stream.text)))
+
+    return [_stream_for_range(stream, start, end) for start, end in ranges]
+
+
+def fragments_for_stream(stream: StructuredStream) -> list[SourceFragment]:
+    return [
+        SourceFragment(
+            source_key=span.source_key,
+            block=span.block,
+            content=stream.text[span.start : span.end],
+            complete=stream.text[span.start : span.end] == str(span.block.content or ""),
+        )
+        for span in stream.spans
+    ]
+
+
+def _intersects_protected_span(spans: list[BlockSpan], start: int, end: int) -> bool:
+    return any(
+        span.block.type in PROTECTED_DELIMITER_TYPES and span.start < end and start < span.end
+        for span in spans
+    )
+
+
+def _stream_for_range(stream: StructuredStream, start: int, end: int) -> StructuredStream:
+    spans = [
+        BlockSpan(
+            source_key=span.source_key,
+            block=span.block,
+            start=max(span.start, start) - start,
+            end=min(span.end, end) - start,
+        )
+        for span in stream.spans
+        if span.start < end and start < span.end
+    ]
+    return StructuredStream(text=stream.text[start:end], spans=spans)

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -6,7 +6,7 @@ DEFAULT_TEXT_SEPARATORS = ["\n\n", "\n", "。", "；", " ", ""]
 
 
 @dataclass(frozen=True)
-class _SplitUnit:
+class TextSplitUnit:
     text: str
     prefix: str = ""
 
@@ -38,10 +38,44 @@ class TextMerger:
 
     def split_recursive(self, text: str, token_num: int) -> list[str]:
         limit = max(int(token_num), 1)
-        units = self._split_recursive(text, limit, 0, strict=True)
+        units = self.split_recursive_units(text, limit)
         chunks = self._merge_split_units(units, limit, 0)
         self._ensure_strict_limit(chunks, limit)
         return chunks
+
+    def split_recursive_units(
+        self,
+        text: str,
+        token_num: int,
+        *,
+        split_top_level: bool = False,
+    ) -> list[TextSplitUnit]:
+        """Return recursive split units without packing or overlap."""
+        limit = max(int(token_num), 1)
+        if not split_top_level or not self.separators:
+            return self._split_recursive(text, limit, 0, strict=True)
+
+        separator = self.separators[0]
+        if not separator:
+            return self._split_recursive(text, limit, 0, strict=True)
+
+        parts = self._split_with_separator(text, separator)
+        if len(parts) <= 1:
+            return self._split_recursive(text, limit, 0, strict=True)
+
+        units: list[TextSplitUnit] = []
+        for index, part in enumerate(parts):
+            prefix = "" if index == 0 else part.prefix
+            units.extend(
+                self._split_recursive(
+                    part.text,
+                    limit,
+                    1,
+                    prefix,
+                    strict=True,
+                )
+            )
+        return units
 
     def hard_split(self, text: str, token_num: int) -> list[str]:
         limit = max(int(token_num), 1)
@@ -75,17 +109,17 @@ class TextMerger:
         separator_index: int,
         prefix: str = "",
         strict: bool = False,
-    ) -> list[_SplitUnit]:
+    ) -> list[TextSplitUnit]:
         if not text or not text.strip():
             return []
         if self._within_limit(text, limit):
-            return [_SplitUnit(text=text, prefix=prefix)]
+            return [TextSplitUnit(text=text, prefix=prefix)]
 
         separator = self.separators[separator_index] if separator_index < len(self.separators) else ""
         if separator == "":
             hard_split = self._strict_hard_split if strict else self._hard_split
             return [
-                _SplitUnit(text=chunk, prefix=prefix if index == 0 else "")
+                TextSplitUnit(text=chunk, prefix=prefix if index == 0 else "")
                 for index, chunk in enumerate(hard_split(text, limit))
             ]
 
@@ -99,7 +133,7 @@ class TextMerger:
                 strict,
             )
 
-        result: list[_SplitUnit] = []
+        result: list[TextSplitUnit] = []
         for index, part in enumerate(parts):
             if not part or not part.text.strip():
                 continue
@@ -119,23 +153,28 @@ class TextMerger:
         self,
         text: str,
         separator: str,
-    ) -> list[_SplitUnit]:
+    ) -> list[TextSplitUnit]:
         raw_parts = text.split(separator)
         if separator in {"。", "；"}:
             return [
-                _SplitUnit(text=part + (separator if index < len(raw_parts) - 1 else ""))
+                TextSplitUnit(text=part + (separator if index < len(raw_parts) - 1 else ""))
                 for index, part in enumerate(raw_parts)
                 if part
             ]
         return [
-            _SplitUnit(text=part, prefix="" if index == 0 else separator)
+            TextSplitUnit(text=part, prefix="" if index == 0 else separator)
             for index, part in enumerate(raw_parts)
             if part
         ]
 
-    def _merge_split_units(self, split_units: list[_SplitUnit], limit: int, overlap: int) -> list[str]:
+    def _merge_split_units(
+        self,
+        split_units: list[TextSplitUnit],
+        limit: int,
+        overlap: int,
+    ) -> list[str]:
         docs: list[str] = []
-        current_doc: list[_SplitUnit] = []
+        current_doc: list[TextSplitUnit] = []
         total = 0
 
         for split_unit in split_units:
@@ -157,7 +196,7 @@ class TextMerger:
         return docs
 
     @staticmethod
-    def _join_units(split_units: list[_SplitUnit]) -> str:
+    def _join_units(split_units: list[TextSplitUnit]) -> str:
         if not split_units:
             return ""
         return "".join(

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 from app.core.rag.common.token_utils import encoder, num_tokens_from_string
 
-
 DEFAULT_TEXT_SEPARATORS = ["\n\n", "\n", "。", "；", " ", ""]
 
 

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -37,6 +37,14 @@ class TextMerger:
                 chunks.extend(self._merge_split_units(split_units, limit, overlap_tokens))
         return chunks
 
+    def split_recursive(self, text: str, token_num: int) -> list[str]:
+        limit = max(int(token_num), 1)
+        units = self._split_recursive(text, limit, 0)
+        return self._merge_split_units(units, limit, 0)
+
+    def hard_split(self, text: str, token_num: int) -> list[str]:
+        return self._hard_split(text, max(int(token_num), 1))
+
     def _extract_strings(self, value: str | list) -> list[str]:
         if isinstance(value, str):
             return [value]

--- a/api/app/core/rag/chunk/merger/text.py
+++ b/api/app/core/rag/chunk/merger/text.py
@@ -39,11 +39,16 @@ class TextMerger:
 
     def split_recursive(self, text: str, token_num: int) -> list[str]:
         limit = max(int(token_num), 1)
-        units = self._split_recursive(text, limit, 0)
-        return self._merge_split_units(units, limit, 0)
+        units = self._split_recursive(text, limit, 0, strict=True)
+        chunks = self._merge_split_units(units, limit, 0)
+        self._ensure_strict_limit(chunks, limit)
+        return chunks
 
     def hard_split(self, text: str, token_num: int) -> list[str]:
-        return self._hard_split(text, max(int(token_num), 1))
+        limit = max(int(token_num), 1)
+        chunks = self._strict_hard_split(text, limit)
+        self._ensure_strict_limit(chunks, limit)
+        return chunks
 
     def _extract_strings(self, value: str | list) -> list[str]:
         if isinstance(value, str):
@@ -64,7 +69,14 @@ class TextMerger:
             ]
         return [part for part in raw_parts if part]
 
-    def _split_recursive(self, text: str, limit: int, separator_index: int, prefix: str = "") -> list[_SplitUnit]:
+    def _split_recursive(
+        self,
+        text: str,
+        limit: int,
+        separator_index: int,
+        prefix: str = "",
+        strict: bool = False,
+    ) -> list[_SplitUnit]:
         if not text or not text.strip():
             return []
         if self._within_limit(text, limit):
@@ -72,21 +84,36 @@ class TextMerger:
 
         separator = self.separators[separator_index] if separator_index < len(self.separators) else ""
         if separator == "":
+            hard_split = self._strict_hard_split if strict else self._hard_split
             return [
                 _SplitUnit(text=chunk, prefix=prefix if index == 0 else "")
-                for index, chunk in enumerate(self._hard_split(text, limit))
+                for index, chunk in enumerate(hard_split(text, limit))
             ]
 
         parts = self._split_with_separator(text, separator)
         if len(parts) <= 1:
-            return self._split_recursive(text, limit, separator_index + 1, prefix)
+            return self._split_recursive(
+                text,
+                limit,
+                separator_index + 1,
+                prefix,
+                strict,
+            )
 
         result: list[_SplitUnit] = []
         for index, part in enumerate(parts):
             if not part or not part.text.strip():
                 continue
             unit_prefix = prefix if index == 0 else part.prefix
-            result.extend(self._split_recursive(part.text, limit, separator_index + 1, unit_prefix))
+            result.extend(
+                self._split_recursive(
+                    part.text,
+                    limit,
+                    separator_index + 1,
+                    unit_prefix,
+                    strict,
+                )
+            )
         return result
 
     def _split_with_separator(
@@ -175,6 +202,36 @@ class TextMerger:
             start = end
 
         return chunks
+
+    def _strict_hard_split(self, text: str, limit: int) -> list[str]:
+        tokens = encoder.encode(text)
+        chunks: list[str] = []
+        start = 0
+
+        while start < len(tokens):
+            end = min(start + limit, len(tokens))
+            chunk = None
+            while end > start:
+                try:
+                    chunk = encoder.decode(tokens[start:end], errors="strict")
+                    break
+                except UnicodeDecodeError:
+                    end -= 1
+            if chunk is None:
+                raise ValueError(
+                    f"Structured content cannot fit within token limit {limit}."
+                )
+            chunks.append(chunk)
+            start = end
+
+        return chunks
+
+    @staticmethod
+    def _ensure_strict_limit(chunks: list[str], limit: int) -> None:
+        if any(num_tokens_from_string(chunk) > limit for chunk in chunks):
+            raise ValueError(
+                f"Structured content cannot fit within token limit {limit}."
+            )
 
     @staticmethod
     def _within_limit(text: str, limit: int) -> bool:

--- a/api/app/core/rag/chunk/parser/image_vision.py
+++ b/api/app/core/rag/chunk/parser/image_vision.py
@@ -77,7 +77,7 @@ def enhance_image_blocks_with_vision(
         progress = progress_start + (progress_span * completed_count / total)
         try:
             vision_text = future.result()
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - isolate one image failure from the batch
             stats.failed_count += 1
             elapsed = time.monotonic() - image_started_at
             LOGGER.warning(

--- a/api/app/core/rag/chunk/parser/image_vision.py
+++ b/api/app/core/rag/chunk/parser/image_vision.py
@@ -198,14 +198,12 @@ def enhance_complete_image_chunks_with_vision(
     futures = {}
     completed_count = 0
     for index, (source_key, group, representative) in enumerate(pending_groups, start=1):
-        src = str(representative.metadata.get("src", ""))
         LOGGER.info(
-            "[%s] complete image vision enhancement submitted: index=%s total=%s source_key=%s src=%s",
+            "[%s] complete image vision enhancement submitted: index=%s total=%s source_key=%s",
             log_prefix,
             index,
             total,
             source_key,
-            src,
         )
         image_started_at = time.monotonic()
         try:
@@ -222,13 +220,12 @@ def enhance_complete_image_chunks_with_vision(
             progress = progress_start + (progress_span * completed_count / total)
             LOGGER.warning(
                 "[%s] complete image vision enhancement submission failed: "
-                "index=%s total=%s source_key=%s src=%s error=%s",
+                "index=%s total=%s source_key=%s error_type=%s",
                 log_prefix,
                 index,
                 total,
                 source_key,
-                src,
-                exc,
+                type(exc).__name__,
             )
             _callback(
                 callback,
@@ -236,10 +233,10 @@ def enhance_complete_image_chunks_with_vision(
                 f"{log_prefix} image vision enhancement failed: {completed_count}/{total}.",
             )
             continue
-        futures[future] = (index, source_key, group, src, image_started_at)
+        futures[future] = (index, source_key, group, image_started_at)
 
     for future in as_completed(futures):
-        index, source_key, group, src, image_started_at = futures[future]
+        index, source_key, group, image_started_at = futures[future]
         completed_count += 1
         progress = progress_start + (progress_span * completed_count / total)
         try:
@@ -249,14 +246,13 @@ def enhance_complete_image_chunks_with_vision(
             elapsed = time.monotonic() - image_started_at
             LOGGER.warning(
                 "[%s] complete image vision enhancement failed: "
-                "index=%s total=%s source_key=%s src=%s elapsed=%.2fs error=%s",
+                "index=%s total=%s source_key=%s elapsed=%.2fs error_type=%s",
                 log_prefix,
                 index,
                 total,
                 source_key,
-                src,
                 elapsed,
-                exc,
+                type(exc).__name__,
             )
             _callback(callback, progress, f"{log_prefix} image vision enhancement failed: {completed_count}/{total}.")
             continue
@@ -271,12 +267,11 @@ def enhance_complete_image_chunks_with_vision(
         elapsed = time.monotonic() - image_started_at
         LOGGER.info(
             "[%s] complete image vision enhancement finished: "
-            "index=%s total=%s source_key=%s src=%s elapsed=%.2fs text_chars=%s",
+            "index=%s total=%s source_key=%s elapsed=%.2fs text_chars=%s",
             log_prefix,
             index,
             total,
             source_key,
-            src,
             elapsed,
             len(vision_text),
         )

--- a/api/app/core/rag/chunk/parser/image_vision.py
+++ b/api/app/core/rag/chunk/parser/image_vision.py
@@ -1,14 +1,19 @@
 import logging
 import time
+from collections.abc import Callable, Sequence
 from concurrent.futures import as_completed
 from dataclasses import dataclass
-from typing import Callable, Sequence
 
 from app.core.rag.app.picture import vision_llm_chunk
-from app.core.rag.chunk.context import ParsedBlock, ParsedBlockType
+from app.core.rag.chunk.context import (
+    ImageVisionScope,
+    LogicalChunk,
+    LogicalChunkType,
+    ParsedBlock,
+    ParsedBlockType,
+)
 from app.core.rag.deepdoc.parser import figure_parser
 from app.core.rag.prompts.generator import vision_llm_figure_describe_prompt
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -108,6 +113,156 @@ def enhance_image_blocks_with_vision(
     stats.elapsed_seconds = time.monotonic() - started_at
     LOGGER.info(
         "[%s] image vision enhancement summary: total=%s success=%s empty=%s failed=%s elapsed=%.2fs",
+        log_prefix,
+        total,
+        stats.success_count,
+        stats.empty_count,
+        stats.failed_count,
+        stats.elapsed_seconds,
+    )
+    _callback(
+        callback,
+        progress_start + progress_span,
+        f"{log_prefix} image vision enhancement finished: "
+        f"success={stats.success_count}, empty={stats.empty_count}, failed={stats.failed_count}.",
+    )
+    return stats
+
+
+def enhance_complete_image_chunks_with_vision(
+    chunks: Sequence[LogicalChunk],
+    vision_model,
+    enabled_scopes: set[ImageVisionScope],
+    callback: Callable | None = None,
+    log_prefix: str = "Chunk",
+    lang: str = "Chinese",
+    progress_start: float = 0.80,
+    progress_span: float = 0.03,
+) -> ImageVisionEnhancementStats:
+    eligible_chunks = [
+        chunk
+        for chunk in chunks
+        if chunk.type is LogicalChunkType.IMAGE
+        and chunk.image_tag_complete
+        and chunk.source_image_key is not None
+        and chunk.image_vision_scope in enabled_scopes
+    ]
+    groups: dict[int, list[LogicalChunk]] = {}
+    for chunk in eligible_chunks:
+        groups.setdefault(chunk.source_image_key, []).append(chunk)
+
+    pending_groups: list[tuple[int, list[LogicalChunk], LogicalChunk]] = []
+    ready_count = 0
+    for source_key, group in groups.items():
+        existing_text = next(
+            (
+                str(chunk.metadata.get("vision_text") or "").strip()
+                for chunk in group
+                if str(chunk.metadata.get("vision_text") or "").strip()
+            ),
+            "",
+        )
+        if existing_text:
+            for chunk in group:
+                chunk.metadata["vision_text"] = existing_text
+            ready_count += 1
+            continue
+
+        representative = next((chunk for chunk in group if chunk.image is not None), None)
+        if representative is not None:
+            ready_count += 1
+            pending_groups.append((source_key, group, representative))
+
+    stats = ImageVisionEnhancementStats(
+        image_count=len(eligible_chunks),
+        ready_count=ready_count,
+    )
+    if not vision_model:
+        if eligible_chunks:
+            LOGGER.warning(
+                "[%s] no visual model detected; skipping complete image vision enhancement",
+                log_prefix,
+            )
+        return stats
+
+    if not pending_groups:
+        LOGGER.info("[%s] no complete images available for vision enhancement", log_prefix)
+        return stats
+
+    started_at = time.monotonic()
+    prompt = vision_llm_figure_describe_prompt(lang=getattr(vision_model, "lang", lang))
+    total = len(pending_groups)
+    LOGGER.info("[%s] complete image vision enhancement start: total=%s", log_prefix, total)
+    _callback(callback, progress_start, f"{log_prefix} image vision enhancement start: total={total}.")
+
+    futures = {}
+    for index, (source_key, group, representative) in enumerate(pending_groups, start=1):
+        src = str(representative.metadata.get("src", ""))
+        LOGGER.info(
+            "[%s] complete image vision enhancement submitted: index=%s total=%s source_key=%s src=%s",
+            log_prefix,
+            index,
+            total,
+            source_key,
+            src,
+        )
+        future = figure_parser.shared_executor.submit(
+            vision_llm_chunk,
+            representative.image,
+            vision_model,
+            prompt,
+            callback,
+        )
+        futures[future] = (index, source_key, group, src, time.monotonic())
+
+    completed_count = 0
+    for future in as_completed(futures):
+        index, source_key, group, src, image_started_at = futures[future]
+        completed_count += 1
+        progress = progress_start + (progress_span * completed_count / total)
+        try:
+            vision_text = str(future.result() or "").strip()
+        except Exception as exc:  # noqa: BLE001
+            stats.failed_count += 1
+            elapsed = time.monotonic() - image_started_at
+            LOGGER.warning(
+                "[%s] complete image vision enhancement failed: "
+                "index=%s total=%s source_key=%s src=%s elapsed=%.2fs error=%s",
+                log_prefix,
+                index,
+                total,
+                source_key,
+                src,
+                elapsed,
+                exc,
+            )
+            _callback(callback, progress, f"{log_prefix} image vision enhancement failed: {completed_count}/{total}.")
+            continue
+
+        if vision_text:
+            for chunk in group:
+                chunk.metadata["vision_text"] = vision_text
+            stats.success_count += 1
+        else:
+            stats.empty_count += 1
+
+        elapsed = time.monotonic() - image_started_at
+        LOGGER.info(
+            "[%s] complete image vision enhancement finished: "
+            "index=%s total=%s source_key=%s src=%s elapsed=%.2fs text_chars=%s",
+            log_prefix,
+            index,
+            total,
+            source_key,
+            src,
+            elapsed,
+            len(vision_text),
+        )
+        _callback(callback, progress, f"{log_prefix} image vision enhancement finished: {completed_count}/{total}.")
+
+    stats.elapsed_seconds = time.monotonic() - started_at
+    LOGGER.info(
+        "[%s] complete image vision enhancement summary: total=%s success=%s empty=%s failed=%s elapsed=%.2fs",
         log_prefix,
         total,
         stats.success_count,

--- a/api/app/core/rag/chunk/parser/image_vision.py
+++ b/api/app/core/rag/chunk/parser/image_vision.py
@@ -196,6 +196,7 @@ def enhance_complete_image_chunks_with_vision(
     _callback(callback, progress_start, f"{log_prefix} image vision enhancement start: total={total}.")
 
     futures = {}
+    completed_count = 0
     for index, (source_key, group, representative) in enumerate(pending_groups, start=1):
         src = str(representative.metadata.get("src", ""))
         LOGGER.info(
@@ -206,16 +207,37 @@ def enhance_complete_image_chunks_with_vision(
             source_key,
             src,
         )
-        future = figure_parser.shared_executor.submit(
-            vision_llm_chunk,
-            representative.image,
-            vision_model,
-            prompt,
-            callback,
-        )
-        futures[future] = (index, source_key, group, src, time.monotonic())
+        image_started_at = time.monotonic()
+        try:
+            future = figure_parser.shared_executor.submit(
+                vision_llm_chunk,
+                representative.image,
+                vision_model,
+                prompt,
+                callback,
+            )
+        except Exception as exc:  # noqa: BLE001
+            stats.failed_count += 1
+            completed_count += 1
+            progress = progress_start + (progress_span * completed_count / total)
+            LOGGER.warning(
+                "[%s] complete image vision enhancement submission failed: "
+                "index=%s total=%s source_key=%s src=%s error=%s",
+                log_prefix,
+                index,
+                total,
+                source_key,
+                src,
+                exc,
+            )
+            _callback(
+                callback,
+                progress,
+                f"{log_prefix} image vision enhancement failed: {completed_count}/{total}.",
+            )
+            continue
+        futures[future] = (index, source_key, group, src, image_started_at)
 
-    completed_count = 0
     for future in as_completed(futures):
         index, source_key, group, src, image_started_at = futures[future]
         completed_count += 1

--- a/api/app/core/rag/chunk/parser/markdown_preprocessor.py
+++ b/api/app/core/rag/chunk/parser/markdown_preprocessor.py
@@ -13,6 +13,9 @@ ESCAPED_HEADING_PATTERN = re.compile(r"^(\s*)\\(#{1,6})(\s+)")
 ESCAPED_UNORDERED_LIST_PATTERN = re.compile(r"^(\s*)\\([-+*])(\s+)")
 ESCAPED_THEMATIC_BREAK_PATTERN = re.compile(r"^(\s*)\\((?:-{3,}|\*{3,}|_{3,}))(\s*)$")
 ESCAPED_EMPHASIS_PATTERN = re.compile(r"\\([*_])")
+ESCAPED_CODE_FENCE_PATTERN = re.compile(
+    r"^(?P<indent>\s*)(?P<fence>(?:\\`){3})(?!\\`)(?P<info>[^\r\n]*)$"
+)
 STRUCTURAL_LINE_PATTERN = re.compile(
     r"^\s{0,3}(?:#{1,6}\s+|[-+*]\s+|\d+[.)）、|｜]\s*|(?:-{3,}|\*{3,}|_{3,})\s*$)"
 )
@@ -97,21 +100,31 @@ class MarkdownPreprocessor:
         *,
         normalize_escaped_structure: bool = False,
     ) -> MarkdownPreprocessResult:
+        raw_lines = text.split("\n")
+        escaped_code_fence_indexes = (
+            self._paired_escaped_code_fence_indexes(raw_lines)
+            if normalize_escaped_structure
+            else set()
+        )
         line_infos: list[MarkdownLineInfo] = []
         in_code = False
         in_list_context = False
         in_qa_list_context = False
         qa_blank_lines = 0
         qa_continuation_paragraphs = 0
-        for line_number, raw_line in enumerate(text.split("\n"), start=1):
-            stripped = raw_line.strip()
+        for line_index, raw_line in enumerate(raw_lines):
+            line_number = line_index + 1
+            line = raw_line
+            if line_index in escaped_code_fence_indexes:
+                line = self._normalize_escaped_code_fence(line)
+            stripped = line.strip()
             is_code_fence = stripped.startswith("```")
 
             if in_code:
                 line_infos.append(
                     MarkdownLineInfo(
                         raw=raw_line,
-                        text=raw_line,
+                        text=line,
                         line_number=line_number,
                         in_code=True,
                         is_code_fence=is_code_fence,
@@ -121,8 +134,7 @@ class MarkdownPreprocessor:
                     in_code = False
                 continue
 
-            line = raw_line
-            if normalize_escaped_structure:
+            if normalize_escaped_structure and not is_code_fence:
                 line = self._normalize_escaped_structural_line(line)
                 line = EMPTY_HTML_ANCHOR_PATTERN.sub("", line)
             stripped = line.strip()
@@ -208,6 +220,38 @@ class MarkdownPreprocessor:
         if heading_count or list_count or rule_count or STRUCTURAL_LINE_PATTERN.match(normalized):
             normalized = ESCAPED_EMPHASIS_PATTERN.sub(r"\1", normalized)
         return normalized
+
+    @staticmethod
+    def _normalize_escaped_code_fence(line: str) -> str:
+        match = ESCAPED_CODE_FENCE_PATTERN.match(line)
+        if match is None:
+            return line
+        fence = match.group("fence").replace("\\`", "`")
+        return f'{match.group("indent")}{fence}{match.group("info")}'
+
+    @staticmethod
+    def _paired_escaped_code_fence_indexes(lines: list[str]) -> set[int]:
+        paired_indexes: set[int] = set()
+        opening_index: int | None = None
+        in_literal_code = False
+
+        for index, line in enumerate(lines):
+            if opening_index is not None:
+                match = ESCAPED_CODE_FENCE_PATTERN.match(line)
+                if match is not None and not match.group("info").strip():
+                    paired_indexes.update((opening_index, index))
+                    opening_index = None
+                continue
+
+            if line.strip().startswith("```"):
+                in_literal_code = not in_literal_code
+                continue
+            if in_literal_code:
+                continue
+            if ESCAPED_CODE_FENCE_PATTERN.match(line) is not None:
+                opening_index = index
+
+        return paired_indexes
 
     def _list_metadata(self, line: str, *, enhanced: bool = False) -> dict[str, Any] | None:
         patterns = (

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -127,7 +127,7 @@ class MinerUV3Parser(DocumentParser):
                     raise ValueError("image asset was not created")
                 self._replace_image_markdown_url(block, asset.download_url)
                 stored_file_ids.add(asset.file_id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - isolate one asset failure from the batch
                 failed_count += 1
                 LOGGER.warning(
                     "[MinerUV3] image storage failed: index=%s total=%s src=%s error=%s",

--- a/api/app/core/rag/chunk/parser/mineru_v3.py
+++ b/api/app/core/rag/chunk/parser/mineru_v3.py
@@ -3,6 +3,7 @@ import uuid
 from pathlib import Path
 
 from app.core.rag.chunk.context import (
+    ImageVisionScope,
     ParsedBlockType,
     ParseResult,
     is_embedded_image_vision_enabled,
@@ -12,7 +13,6 @@ from app.core.rag.chunk.parser.image_storage import (
     cleanup_mineru_v3_images,
     store_mineru_v3_image,
 )
-from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.mineru_v3_client import MinerUV3Client
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
 
@@ -40,6 +40,9 @@ class MinerUV3Parser(DocumentParser):
             normalize_escaped_structure=True,
         )
         if embedded_image_vision_enabled:
+            for block in blocks:
+                if block.type is ParsedBlockType.IMAGE:
+                    block.image_vision_scope = ImageVisionScope.EMBEDDED
             attached_count, attached_images, unresolved_count = self._attach_images(blocks, mineru_result.images)
             LOGGER.info("[MinerUV3] markdown images attached: count=%s", attached_count)
             retained_file_ids, all_assets_stored = self._store_image_assets(attached_images, ctx)
@@ -54,11 +57,14 @@ class MinerUV3Parser(DocumentParser):
         else:
             LOGGER.warning("[MinerUV3] stale image cleanup skipped because one or more image assets were not stored")
 
-        if ctx.vision_model and embedded_image_vision_enabled:
-            self._enhance_image_blocks(blocks, ctx)
-        elif ctx.vision_model:
+        if ctx.vision_model and not embedded_image_vision_enabled:
             LOGGER.info("[MinerUV3] image vision enhancement disabled by parser config")
-        return ParseResult(blocks=blocks, merge_strategy="blocks", markdown_preprocess_profile="mineru")
+        return ParseResult(
+            blocks=blocks,
+            merge_strategy="blocks",
+            markdown_preprocess_profile="mineru",
+            structured_markdown_stream=True,
+        )
 
     def parse_markdown(self, ctx) -> str:
         binary = self._read_binary(ctx)
@@ -172,17 +178,6 @@ class MinerUV3Parser(DocumentParser):
             return
         if deleted_count:
             LOGGER.info("[MinerUV3] stale image assets deleted: document_id=%s count=%s", document_uuid, deleted_count)
-
-    def _enhance_image_blocks(self, blocks, ctx) -> None:
-        enhance_image_blocks_with_vision(
-            blocks,
-            vision_model=ctx.vision_model,
-            callback=ctx.callback,
-            log_prefix="MinerUV3",
-            lang=ctx.lang,
-            progress_start=0.77,
-            progress_span=0.02,
-        )
 
     def _callback(self, ctx, progress, message: str) -> None:
         if ctx.callback:

--- a/api/app/core/rag/chunk/pipeline/base.py
+++ b/api/app/core/rag/chunk/pipeline/base.py
@@ -3,7 +3,17 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from timeit import default_timer as timer
 
-from app.core.rag.chunk.context import ChunkContext, ChunkOutputMode, MergeResult, ParseResult
+from app.core.rag.chunk.context import (
+    ChunkContext,
+    ChunkOutputMode,
+    ImageVisionScope,
+    LogicalChunk,
+    LogicalChunkType,
+    MergeResult,
+    ParseResult,
+    is_direct_image_vision_enabled,
+    is_embedded_image_vision_enabled,
+)
 
 
 def _append_external_parent_child_chunks(
@@ -65,6 +75,8 @@ class ChunkPipeline(ABC):
 
         start = timer()
         merge_result = self.merge(ctx, parse_result)
+        self.enhance_merged_images(ctx, parse_result, merge_result)
+        self.validate_direct_image_result(parse_result, merge_result)
         if ctx.kwargs.get("section_only", False):
             return self.finalize_result(merge_result.chunks, embed_res, parse_result.url_res or [])
 
@@ -102,6 +114,73 @@ class ChunkPipeline(ABC):
             return ImageMerger().merge(ctx, parse_result)
 
         return NaiveMerger().merge(ctx, parse_result)
+
+    def enhance_merged_images(
+        self,
+        ctx: ChunkContext,
+        parse_result: ParseResult,
+        merge_result: MergeResult,
+    ) -> None:
+        from app.core.rag.chunk.parser.image_vision import (
+            enhance_complete_image_chunks_with_vision,
+        )
+
+        enabled_scopes = set()
+        if is_embedded_image_vision_enabled(ctx.parser_config):
+            enabled_scopes.add(ImageVisionScope.EMBEDDED)
+        if is_direct_image_vision_enabled(ctx.parser_config):
+            enabled_scopes.add(ImageVisionScope.DIRECT)
+
+        enhance_complete_image_chunks_with_vision(
+            self._vision_candidate_chunks(ctx, merge_result),
+            vision_model=ctx.vision_model,
+            enabled_scopes=enabled_scopes,
+            callback=ctx.callback,
+            lang=ctx.lang,
+        )
+
+    def validate_direct_image_result(
+        self,
+        parse_result: ParseResult,
+        merge_result: MergeResult,
+    ) -> None:
+        mode = parse_result.direct_image_vision_mode
+        if mode not in {1, 2}:
+            return
+
+        has_direct_vision_text = any(
+            chunk.type is LogicalChunkType.IMAGE
+            and chunk.image_tag_complete
+            and chunk.image_vision_scope is ImageVisionScope.DIRECT
+            and bool(str(chunk.metadata.get("vision_text") or "").strip())
+            for chunk in self._all_vision_result_chunks(merge_result)
+        )
+        if mode == 1 and not parse_result.direct_image_has_ocr_text and not has_direct_vision_text:
+            raise ValueError("Image mixed mode produced neither OCR text nor visual description.")
+        if mode == 2 and not has_direct_vision_text:
+            raise ValueError("Image pure vision mode produced no visual description.")
+
+    def _vision_candidate_chunks(
+        self,
+        ctx: ChunkContext,
+        merge_result: MergeResult,
+    ) -> list[LogicalChunk]:
+        if ctx.chunk_output_mode is ChunkOutputMode.PARENT_CHILD:
+            return [
+                child
+                for group in merge_result.parent_child_groups or []
+                for child in group.children
+            ]
+        return list(merge_result.logical_chunks or [])
+
+    def _all_vision_result_chunks(self, merge_result: MergeResult) -> list[LogicalChunk]:
+        if merge_result.parent_child_groups is not None:
+            return [
+                child
+                for group in merge_result.parent_child_groups
+                for child in group.children
+            ]
+        return list(merge_result.logical_chunks or [])
 
     def run_child(
         self,

--- a/api/app/core/rag/chunk/pipeline/base.py
+++ b/api/app/core/rag/chunk/pipeline/base.py
@@ -15,6 +15,8 @@ from app.core.rag.chunk.context import (
     is_embedded_image_vision_enabled,
 )
 
+LOGGER = logging.getLogger(__name__)
+
 
 def _append_external_parent_child_chunks(
     child_res: list[dict],
@@ -83,7 +85,7 @@ class ChunkPipeline(ABC):
         url_res = parse_result.url_res or []
         url_res.extend(self.hyperlink_preprocessor.collect_url_chunks(ctx, parse_result.urls or set(), self.run_child))
         main_result = self.postprocessor.process(ctx, parse_result, merge_result)
-        logging.info("naive_merge({}): {}".format(ctx.filename, timer() - start))
+        LOGGER.info("naive_merge(%s): %s", ctx.filename, timer() - start)
         if isinstance(main_result, tuple):
             child_res, parent_res, parent_id_map = main_result
             return _append_external_parent_child_chunks(child_res, parent_res, parent_id_map, embed_res + url_res)

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -1,5 +1,4 @@
 import io
-import logging
 import uuid
 from dataclasses import replace
 from pathlib import Path
@@ -7,9 +6,9 @@ from pathlib import Path
 from PIL import Image
 
 from app.core.config import settings
-from app.core.rag.app.picture import vision_llm_chunk
 from app.core.rag.chunk.context import (
     ChunkContext,
+    ImageVisionScope,
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
@@ -18,11 +17,9 @@ from app.core.rag.chunk.context import (
 )
 from app.core.rag.chunk.parser.mineru_v3 import MinerUV3Parser
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
-from app.core.rag.prompts.generator import vision_llm_figure_describe_prompt
 
 from .base import ChunkPipeline
 
-LOGGER = logging.getLogger(__name__)
 DEFAULT_IMAGE_VISION_MODE = 1
 IMAGE_VISION_MODES = {0, 1, 2}
 
@@ -38,7 +35,12 @@ class ImageChunkPipeline(ChunkPipeline):
             source_markdown, source_image_url = self._source_image_markdown(ctx, source_file_id)
             blocks, _ = self._parse_markdown_blocks(source_markdown, source_image_url)
             self._callback(ctx, 0.8, "Finish parsing image.")
-            return ParseResult(blocks=blocks, merge_strategy="blocks")
+            return ParseResult(
+                blocks=blocks,
+                merge_strategy="blocks",
+                structured_markdown_stream=True,
+                direct_image_vision_mode=None,
+            )
 
         mode = self._image_vision_mode(ctx)
         source_binary = self._read_binary(ctx)
@@ -59,26 +61,24 @@ class ImageChunkPipeline(ChunkPipeline):
             source_image_url,
         )
         blocks.extend(mineru_blocks)
-        text_blocks = [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
-
-        vision_text = ""
+        has_ocr_text = self._has_content(
+            [block for block in mineru_blocks if block.type is not ParsedBlockType.IMAGE]
+        )
         if mode in {1, 2}:
-            vision_text = self._describe_source_image(ctx, source_image)
-            if vision_text:
-                source_image_block.metadata["vision_text"] = vision_text
+            source_image_block.image = source_image
+            source_image_block.image_vision_scope = ImageVisionScope.DIRECT
 
-        if mode == 0:
-            if not self._has_content(text_blocks):
-                raise ValueError("MinerU returned no text content for image OCR mode.")
-        elif mode == 1:
-            if not self._has_content(text_blocks) and not vision_text:
-                raise ValueError("Image mixed mode produced neither OCR text nor visual description.")
-        else:
-            if not vision_text:
-                raise ValueError("Image pure vision mode produced no visual description.")
+        if mode == 0 and not has_ocr_text:
+            raise ValueError("MinerU returned no text content for image OCR mode.")
 
         self._callback(ctx, 0.8, "Finish parsing image.")
-        return ParseResult(blocks=blocks, merge_strategy="blocks")
+        return ParseResult(
+            blocks=blocks,
+            merge_strategy="blocks",
+            structured_markdown_stream=True,
+            direct_image_vision_mode=mode,
+            direct_image_has_ocr_text=has_ocr_text,
+        )
 
     def _image_vision_mode(self, ctx: ChunkContext) -> int:
         image_config = ctx.parser_config.get("image")
@@ -124,19 +124,6 @@ class ImageChunkPipeline(ChunkPipeline):
         if is_embedded_image_vision_enabled(ctx.parser_config):
             return blocks
         return [block for block in blocks if block.type is not ParsedBlockType.IMAGE]
-
-    def _describe_source_image(self, ctx: ChunkContext, source_image: Image.Image) -> str:
-        prompt = vision_llm_figure_describe_prompt(lang=getattr(ctx.vision_model, "lang", ctx.lang))
-        try:
-            vision_text = vision_llm_chunk(source_image, ctx.vision_model, prompt=prompt)
-        except Exception as exc:  # noqa: BLE001
-            LOGGER.warning("[ImagePipeline] source image vision failed: file_name=%s error=%s", ctx.filename, exc)
-            return ""
-
-        vision_text = str(vision_text or "").strip()
-        if not vision_text:
-            LOGGER.warning("[ImagePipeline] source image vision returned empty: file_name=%s", ctx.filename)
-        return vision_text
 
     def _source_file_id(self, ctx: ChunkContext) -> str:
         raw_file_id = ctx.kwargs.get("source_file_id")

--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -47,8 +47,15 @@ class ImageChunkPipeline(ChunkPipeline):
         analysis_binary, analysis_filename, source_image = self._analysis_input(ctx.filename, source_binary)
 
         mineru_blocks = []
-        if mode in {0, 1}:
+        if mode == 0:
             mineru_blocks = self._parse_ocr_blocks(ctx, analysis_binary, analysis_filename)
+        elif mode == 1:
+            mineru_blocks = self._parse_ocr_blocks(
+                ctx,
+                analysis_binary,
+                analysis_filename,
+                allow_empty=True,
+            )
 
         source_image_url = None
         markdown_parts = []
@@ -112,6 +119,8 @@ class ImageChunkPipeline(ChunkPipeline):
         ctx: ChunkContext,
         analysis_binary: bytes,
         analysis_filename: str,
+        *,
+        allow_empty: bool = False,
     ) -> list[ParsedBlock]:
         ocr_ctx = replace(
             ctx,
@@ -120,6 +129,8 @@ class ImageChunkPipeline(ChunkPipeline):
         )
         blocks = MinerUV3Parser().parse(ocr_ctx).blocks or []
         if not blocks:
+            if allow_empty:
+                return []
             raise ValueError("MinerU returned empty Markdown for image OCR mode.")
         if is_embedded_image_vision_enabled(ctx.parser_config):
             return blocks

--- a/api/app/core/rag/chunk/pipeline/text.py
+++ b/api/app/core/rag/chunk/pipeline/text.py
@@ -17,6 +17,8 @@ from app.core.rag.chunk.parser.txt import TxtParser
 
 from .base import ChunkPipeline
 
+LOGGER = logging.getLogger(__name__)
+
 
 class TextChunkPipeline(ChunkPipeline):
     def parse(self, ctx: ChunkContext) -> ParseResult:
@@ -57,9 +59,9 @@ class MarkdownChunkPipeline(ChunkPipeline):
                     if image:
                         block.image = image
         elif ctx.vision_model:
-            logging.info("Image vision enhancement disabled by parser config.")
+            LOGGER.info("Image vision enhancement disabled by parser config.")
         else:
-            logging.warning("No visual model detected. Skipping figure parsing enhancement.")
+            LOGGER.warning("No visual model detected. Skipping figure parsing enhancement.")
 
         if ctx.parser_config.get("hyperlink_urls", False) and ctx.is_root:
             for block in blocks:
@@ -75,7 +77,7 @@ class MarkdownChunkPipeline(ChunkPipeline):
                 urls.update(hyperlink_urls)
 
         ctx.callback(0.8, "Finish parsing.")
-        logging.debug(f"[Markdown Parsing Blocks]: {blocks}")
+        LOGGER.debug("[Markdown Parsing Blocks]: %s", blocks)
         return ParseResult(
             blocks=blocks,
             urls=urls,
@@ -111,26 +113,30 @@ class LegacyDocChunkPipeline(ChunkPipeline):
             os.environ.setdefault("TIKA_SERVER_PORT", "9998")
             tika.initVM()
             from tika import parser as tika_parser
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - Tika initialization can fail through optional dependencies
             ctx.callback(0.8, f"tika not available: {exc}. Unsupported .doc parsing.")
-            logging.warning(f"tika not available: {exc}. Unsupported .doc parsing for {ctx.filename}.")
+            LOGGER.warning(
+                "tika not available: %s. Unsupported .doc parsing for %s.",
+                exc,
+                ctx.filename,
+            )
             return ParseResult(direct_result=[], append_embed=False)
 
-        tmp_file = None
+        tmp_path = None
         try:
             suffix = os.path.splitext(ctx.filename)[1] or ".doc"
-            tmp_file = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-            if ctx.binary:
-                tmp_file.write(ctx.binary)
-            else:
-                with open(ctx.filename, "rb") as file:
-                    tmp_file.write(file.read())
-            tmp_file.close()
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+                if ctx.binary:
+                    tmp_file.write(ctx.binary)
+                else:
+                    with open(ctx.filename, "rb") as file:
+                        tmp_file.write(file.read())
 
-            doc_parsed = tika_parser.from_file(tmp_file.name)
+            doc_parsed = tika_parser.from_file(tmp_path)
         finally:
-            if tmp_file and os.path.exists(tmp_file.name):
-                os.unlink(tmp_file.name)
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
 
         if doc_parsed.get("content", None) is not None:
             sections = doc_parsed["content"].split("\n")
@@ -139,5 +145,5 @@ class LegacyDocChunkPipeline(ChunkPipeline):
             return ParseResult(sections=sections)
 
         ctx.callback(0.8, f"tika.parser got empty content from {ctx.filename}.")
-        logging.warning(f"tika.parser got empty content from {ctx.filename}.")
+        LOGGER.warning("tika.parser got empty content from %s.", ctx.filename)
         return ParseResult(direct_result=[], append_embed=False)

--- a/api/app/core/rag/chunk/pipeline/text.py
+++ b/api/app/core/rag/chunk/pipeline/text.py
@@ -4,13 +4,13 @@ import tempfile
 
 from app.core.rag.chunk.context import (
     ChunkContext,
+    ImageVisionScope,
     ParsedBlock,
     ParsedBlockType,
     ParseResult,
     is_embedded_image_vision_enabled,
 )
 from app.core.rag.chunk.parser.html import HtmlParser
-from app.core.rag.chunk.parser.image_vision import enhance_image_blocks_with_vision
 from app.core.rag.chunk.parser.json import JsonParser
 from app.core.rag.chunk.parser.structured_markdown import StructMarkdownParser
 from app.core.rag.chunk.parser.txt import TxtParser
@@ -46,22 +46,16 @@ class MarkdownChunkPipeline(ChunkPipeline):
         markdown_parser = StructMarkdownParser()
         blocks = markdown_parser.parse(ctx)
 
-        if ctx.vision_model and is_embedded_image_vision_enabled(ctx.parser_config):
+        embedded_image_vision_enabled = is_embedded_image_vision_enabled(ctx.parser_config)
+        if embedded_image_vision_enabled:
             for block in blocks:
                 if block.type is not ParsedBlockType.IMAGE:
                     continue
-                image = markdown_parser.load_image(str(block.metadata.get("src", "")))
-                if image:
-                    block.image = image
-            enhance_image_blocks_with_vision(
-                blocks,
-                vision_model=ctx.vision_model,
-                callback=ctx.callback,
-                log_prefix="Markdown",
-                lang=ctx.lang,
-                progress_start=0.2,
-                progress_span=0.55,
-            )
+                block.image_vision_scope = ImageVisionScope.EMBEDDED
+                if ctx.vision_model:
+                    image = markdown_parser.load_image(str(block.metadata.get("src", "")))
+                    if image:
+                        block.image = image
         elif ctx.vision_model:
             logging.info("Image vision enhancement disabled by parser config.")
         else:
@@ -82,7 +76,12 @@ class MarkdownChunkPipeline(ChunkPipeline):
 
         ctx.callback(0.8, "Finish parsing.")
         logging.debug(f"[Markdown Parsing Blocks]: {blocks}")
-        return ParseResult(blocks=blocks, urls=urls, merge_strategy="blocks")
+        return ParseResult(
+            blocks=blocks,
+            urls=urls,
+            merge_strategy="blocks",
+            structured_markdown_stream=True,
+        )
 
 
 class HtmlChunkPipeline(ChunkPipeline):


### PR DESCRIPTION
## Business Background
Structured Markdown parsing produced typed blocks, but normal and parent-child chunking did not consistently preserve surrounding context, overlap semantics, token ceilings, structured children, image provenance, or fenced code emitted by MinerU.

## Summary
- Rebuild ordered structured blocks into a unified stream for normal chunk packing.
- Apply custom delimiters only outside protected image, table, and fenced-code spans.
- Restore one-pass recursive split-unit overlap semantics, treating headings as regular text units.
- Allow valid oversized table parts to pack naturally with neighboring context.
- Preserve independent IMAGE, TABLE, and CODE children in parent-child mode.
- Defer embedded-image vision enhancement until final complete image chunks are known.
- Recover paired MinerU escaped code fences without changing ordinary Markdown escaping.

## Changes
- 10 RAG backend production files changed.
- 1,578 insertions and 142 deletions.
- No database schema, controller, frontend, docs, or committed test-file changes.

## Risk
- Chunk boundaries and metadata change for structured Markdown and MinerU content by design. Existing indexed documents require reparsing to receive the new behavior.
- Token ceilings remain enforced for all final chunks. Protected structured units are only split through their dedicated image, table, or code paths.
- Direct-image modes retain their existing validation behavior; embedded-image vision failures remain non-fatal.
- No direct changes to external API Key routes. API Key consumers that trigger or read knowledge-base parsing inherit the same chunking behavior through the shared RAG pipeline.

## Test Plan
- [x] PYTHONPATH=. uv run pytest --import-mode=importlib tests/rag/chunk/test_block_merger.py -q — 78 passed
- [x] PYTHONPATH=. uv run pytest --import-mode=importlib tests/rag/chunk/test_image_vision.py tests/rag/chunk/test_direct_image_derived_blocks.py -q — 21 passed
- [x] PYTHONPATH=. uv run pytest --import-mode=importlib tests/rag/chunk/test_mineru_v3_pdf_docx_pipeline.py -q — 5 passed
- [x] PYTHONPATH=. uv run pytest --import-mode=importlib tests/rag/chunk/test_structured_markdown_parser.py -k "code or escaped" -q — 7 passed
- [x] PYTHONPATH=. uv run python -m compileall -q app/core/rag/chunk
- [x] PYTHONPATH=. uv run ruff check --select F on the 10 changed production files
- [x] git diff --check origin/develop..HEAD

## Summary by Sourcery

将结构化 Markdown 和基于 MinerU 的块统一到单一分块（chunking）流水线中，在构建最终块之前，既保留受保护的图片/表格/代码结构，又延后图片视觉增强处理。

New Features:
- 为基于 `ParsedBlock` 的 Markdown 增加结构化流的重建与分段能力，用于同时驱动普通分块和父子分块。
- 引入按图片划分的视觉作用域，并在块合并后对完整图片块进行视觉增强，兼容嵌入式与直连图片模式。
- 支持直连图片解析模式，在共享的 RAG 流水线中，将 MinerU OCR 与延迟的视觉描述进行组合或替换。

Enhancements:
- 优化递归文本拆分工具，暴露可复用的拆分单元，支持严格硬拆分，以及在 token 限制下的重叠感知打包。
- 改进表格和代码的分块逻辑，在遵守 token 上限的同时，保留合法的 HTML 表格包装和 fenced-code 语义，包括 MinerU 转义的代码块边界。
- 调整 Markdown 和 MinerU 流水线，以标记结构化流、跟踪预处理配置，并简化嵌入图片的处理与日志记录。
- 扩展块上下文和解析结果字段，用于描述图片视觉作用域、结构化流可用性以及直连图片视觉模式的元数据。

Tests:
- 在新的结构化流和图片视觉行为下，保持现有的 RAG 分块、图片视觉、MinerU，以及结构化 Markdown 测试全部通过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify structured Markdown and MinerU-derived blocks into a single chunking pipeline that preserves protected image/table/code structure and defers image vision enhancement until final chunks are built.

New Features:
- Add structured stream rebuilding and segmenting for ParsedBlock-based Markdown to drive both normal and parent-child chunking.
- Introduce per-image vision scopes and post-merge image vision enhancement over complete image chunks for both embedded and direct image modes.
- Support direct-image parsing modes that combine or replace MinerU OCR with deferred visual description in the shared RAG pipeline.

Enhancements:
- Refine recursive text splitting utilities to expose reusable split units, strict hard-splitting, and overlap-aware packing under token limits.
- Improve table and code chunking to respect token ceilings while preserving valid HTML table wrappers and fenced-code semantics, including MinerU-escaped fences.
- Adjust Markdown and MinerU pipelines to mark structured streams, track preprocess profiles, and simplify embedded image handling and logging.
- Extend chunk context and parse results with fields describing image vision scope, structured-stream availability, and direct-image vision mode metadata.

Tests:
- Keep existing RAG chunking, image vision, MinerU, and structured Markdown tests passing against the new structured-stream and image-vision behavior.

</details>