### PR TITLE
fix(memory):memory-permenant-db

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -745,6 +745,7 @@ class WritePipeline:
 
     async def _store(self, result: ExtractionResult) -> bool:
         """存储：永久容量分配 → 别名清洗 → Neo4j 写入（含死锁重试）。"""
+        from app.repositories.neo4j.cypher_queries import PERMANENT_MEMORY_COUNT
         from app.repositories.neo4j.graph_saver import (
             save_dialog_and_statements_to_neo4j,
         )
@@ -763,10 +764,15 @@ class WritePipeline:
         if permanent_candidates:
             candidate_count = len(permanent_candidates)
             try:
-                assigned = await assign_permanent_memory_slots(
-                    self._neo4j_connector,
+                count_rows = await self._neo4j_connector.execute_query(
+                    PERMANENT_MEMORY_COUNT,
+                    end_user_id=self.end_user_id,
+                )
+                used = int(count_rows[0]["used"]) if count_rows else 0
+                assigned = assign_permanent_memory_slots(
                     self.end_user_id,
                     result.statement_nodes,
+                    used=used,
                 )
                 logger.info(
                     "Permanent-memory slots assigned in serialized write: "

--- a/api/app/services/memory_value_ranking_service.py
+++ b/api/app/services/memory_value_ranking_service.py
@@ -9,14 +9,18 @@ from typing import Any, Callable, Sequence
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.quota_manager import get_end_user_memory_limit_async
+from app.core.quota_manager import (
+    get_end_user_memory_limit,
+    get_end_user_memory_limit_async,
+)
 from app.core.utils.datetime_utils import (
     convert_neo4j_datetime_to_python,
     to_timestamp_ms,
 )
-from app.db import get_async_db_context
+from app.db import get_async_db_context, get_db_context
 from app.repositories.end_user_repository import (
     EndUserRepository,
+    get_tenant_id_by_end_user_id,
     get_tenant_id_by_end_user_id_async,
 )
 from app.repositories.neo4j.cypher_queries import (
@@ -82,18 +86,14 @@ def disable_permanent_candidates(statement_nodes: Sequence[Any]) -> None:
             node.is_permanent = False
 
 
-async def get_total_memory_limit(end_user_id: str) -> int:
+def _parse_end_user_id(end_user_id: str) -> uuid.UUID:
     try:
-        parsed_id = uuid.UUID(end_user_id)
+        return uuid.UUID(end_user_id)
     except (ValueError, TypeError, AttributeError) as exc:
         raise PermanentMemoryNotFound("end user not found") from exc
 
-    async with get_async_db_context() as db:
-        tenant_id = await get_tenant_id_by_end_user_id_async(db, parsed_id)
-        if tenant_id is None:
-            raise PermanentMemoryNotFound("end user not found")
-        total_memory_limit = await get_end_user_memory_limit_async(db, tenant_id)
 
+def _normalize_total_memory_limit(total_memory_limit: Any) -> int:
     if (
         isinstance(total_memory_limit, bool)
         or not isinstance(total_memory_limit, Number)
@@ -106,19 +106,41 @@ async def get_total_memory_limit(end_user_id: str) -> int:
     return normalized
 
 
-async def assign_permanent_memory_slots(
-    connector: Neo4jConnector,
+async def get_total_memory_limit(end_user_id: str) -> int:
+    parsed_id = _parse_end_user_id(end_user_id)
+    async with get_async_db_context() as db:
+        tenant_id = await get_tenant_id_by_end_user_id_async(db, parsed_id)
+        if tenant_id is None:
+            raise PermanentMemoryNotFound("end user not found")
+        total_memory_limit = await get_end_user_memory_limit_async(db, tenant_id)
+
+    return _normalize_total_memory_limit(total_memory_limit)
+
+
+def get_total_memory_limit_sync(end_user_id: str) -> int:
+    """Load the memory quota through the sync SQLAlchemy engine for Celery."""
+    parsed_id = _parse_end_user_id(end_user_id)
+    with get_db_context() as db:
+        tenant_id = get_tenant_id_by_end_user_id(db, parsed_id)
+        if tenant_id is None:
+            raise PermanentMemoryNotFound("end user not found")
+        total_memory_limit = get_end_user_memory_limit(db, tenant_id)
+
+    return _normalize_total_memory_limit(total_memory_limit)
+
+
+def assign_permanent_memory_slots(
     end_user_id: str,
     statement_nodes: Sequence[Any],
+    *,
+    used: int,
 ) -> int:
-    """Read capacity state and assign final flags inside the serialized worker write."""
+    """Assign final flags using synchronous PostgreSQL access in a Celery worker."""
     candidates = [n for n in statement_nodes if bool(getattr(n, "is_permanent", False))]
     if not candidates:
         return 0
-    total_memory_limit = await get_total_memory_limit(end_user_id)
+    total_memory_limit = get_total_memory_limit_sync(end_user_id)
     limit = calculate_permanent_memory_limit(total_memory_limit)
-    count_rows = await connector.execute_query(PERMANENT_MEMORY_COUNT, end_user_id=end_user_id)
-    used = int(count_rows[0]["used"]) if count_rows else 0
     return allocate_permanent_slots(
         statement_nodes,
         used=used,


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在 Celery worker 中为永久内存槽分配使用同步数据库访问，同时在其他路径中保留异步配额获取。

错误修复：
- 通过切换到同步的 SQLAlchemy 引擎，并复用共享的验证/规范化逻辑，确保在 Celery worker 中正确加载永久内存配额。

改进：
- 将终端用户 ID 解析和内存限制规范化抽取为可复用的辅助函数，以供异步和同步代码路径共同使用。
- 将永久内存使用量统计从排名服务移动到写入流水线中，将已使用数量传递给槽位分配逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use synchronous database access for permanent memory slot assignment in Celery workers while keeping async quota retrieval for other paths.

Bug Fixes:
- Ensure permanent memory quota loading works correctly in Celery workers by switching to the synchronous SQLAlchemy engine and reusing shared validation/normalization logic.

Enhancements:
- Factor out end user ID parsing and memory limit normalization into reusable helpers for both async and sync code paths.
- Move permanent memory usage counting from the ranking service into the write pipeline, passing the used count into slot allocation.

</details>