### PR TITLE
fix(memory): exclude file metadata from model context

### DIFF
--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -640,7 +640,6 @@ class Neo4jSearchService:
                     # 完整结构继续供后续总结和最终回答使用，不直接投影给前端。
                     mem.content = (
                         f"<history-file-input>\n"
-                        f"<file-name>{file_name}</file-name>\n"
                         f"<file-summary>{mem.data.get('summary', '')}</file-summary>\n"
                         f"<file-analysis>{display_content}</file-analysis>\n"
                         f"</history-file-input>\n"

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -158,8 +158,6 @@ class PerceptualBuilder(BaseBuilder):
     def content(self) -> str:
         parts = ["<history-file-input>\n"]
         fields = [
-            ("file-name", self.record.get("file_name", "")),
-            ("file-path", self.record.get("file_path", "")),
             ("summary", self.record.get("summary", "")),
             ("topic", self.record.get("topic", "")),
             ("domain", self.record.get("domain", "")),


### PR DESCRIPTION
Prevent the answer model from exposing file paths or treating CDN-style file names as image URLs. Structured file metadata remains available in result_ready for frontend rendering.

## 由 Sourcery 提供的总结

改进：
- 停止在用于回答模型的生成历史文件输入内容中包含文件名和路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Stop including file name and path in the generated history file input content used by the answer model.

</details>