### PR TITLE
feat(reflection): add final failure notification after retry exhaustion

### DIFF
--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -16,7 +16,12 @@ ReflectionPipeline — 反思引擎流水线（离线部分）
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
+
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
 
 if TYPE_CHECKING:
     from app.schemas.memory_config_schema import MemoryConfig
@@ -112,7 +117,18 @@ class ReflectionPipeline:
         await self._lazy_init()
 
         if not self._llm_client:
-            return {"status": "skipped", "reason": "no llm_id configured"}
+            return {
+                "status": "error",
+                "reason_code": ReflectionFailureReason.REFLECTION_MODEL_UNAVAILABLE.value,
+                "model_type": ReflectionModelType.LLM.value,
+                "failed_operation": "reflection_model_init",
+                "business_failure_count": 1,
+                "reason_codes": [
+                    ReflectionFailureReason.REFLECTION_MODEL_UNAVAILABLE.value
+                ],
+                "model_types": [ReflectionModelType.LLM.value],
+                "failed_operations": ["reflection_model_init"],
+            }
 
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
         from app.core.memory.storage_services.reflection_engine.layer2_inspector import Layer2Inspector
@@ -142,7 +158,18 @@ class ReflectionPipeline:
         await self._lazy_init()
 
         if not self._llm_client:
-            return {"status": "skipped", "reason": "no llm_id configured"}
+            return {
+                "status": "error",
+                "reason_code": ReflectionFailureReason.REFLECTION_MODEL_UNAVAILABLE.value,
+                "model_type": ReflectionModelType.LLM.value,
+                "failed_operation": "reflection_model_init",
+                "business_failure_count": 1,
+                "reason_codes": [
+                    ReflectionFailureReason.REFLECTION_MODEL_UNAVAILABLE.value
+                ],
+                "model_types": [ReflectionModelType.LLM.value],
+                "failed_operations": ["reflection_model_init"],
+            }
 
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
         from app.core.memory.storage_services.reflection_engine.layer2_inspector import Layer2Inspector

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
@@ -15,6 +15,12 @@ import json
 import logging
 from typing import Any, Dict, List, Tuple
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -244,6 +250,10 @@ async def extract_metadata_for_user(
 
     extracted = 0
     failed = 0
+    model_failure_count = 0
+    reason_codes: List[str] = []
+    model_types: List[str] = []
+    failed_operations: List[str] = []
     details: List[Dict[str, Any]] = []  # 每个实体的详细变更记录
     trace_entities: List[dict] = []
     trace_llm: List[dict] = []
@@ -294,11 +304,34 @@ async def extract_metadata_for_user(
                             "field_changes": [], "status": "applied", "reason": None,
                             "extra": {"synced_fields": list((patched["post_state"] or {}).keys())},
                         })
+        except ReflectionBusinessError as exc:
+            failed += 1
+            model_failure_count += 1
+            reason = exc.reason_code.value
+            if reason not in reason_codes:
+                reason_codes.append(reason)
+                model_types.append(exc.model_type.value)
+            if exc.failed_operation not in failed_operations:
+                failed_operations.append(exc.failed_operation)
+            logger.error(
+                f"[Metadata] 实体 {entity_id} 元数据提取失败 "
+                f"reason_code={reason} failed_operation={exc.failed_operation}",
+                exc_info=True,
+            )
         except Exception as e:
             failed += 1
             logger.warning(f"[Metadata] 实体 {entity_id} 元数据提取失败: {e}")
 
-    out: Dict[str, Any] = {"extracted": extracted, "failed": failed, "details": details}
+    out: Dict[str, Any] = {
+        "status": "error" if model_failure_count else "success",
+        "extracted": extracted,
+        "failed": failed,
+        "details": details,
+        "business_failure_count": model_failure_count,
+        "reason_codes": reason_codes,
+        "model_types": model_types,
+        "failed_operations": failed_operations,
+    }
     if collect_trace:
         out["_trace"] = {
             "input": {"entities": trace_entities},
@@ -318,7 +351,8 @@ async def _run_metadata_llm(
     绕开 MetadataExtractionStep：其基类的 call_structured 依赖
     llm_client.response_structured（OpenAIClient 接口），反思注入的 RedBearLLM
     仅提供 call_structured 实例方法。此处复用抽取引擎的模板与 Pydantic schema，
-    仅由反思侧接管调用协议。sidecar 语义：LLM 失败返回空结果、不中断反思。
+    仅由反思侧接管调用协议。合法的空 operations 表示本轮无变更；模型调用或
+    结构化结果异常必须抛出受控领域异常，由实体循环聚合，不能伪装成空结果。
     """
     from app.core.memory.utils.prompt.prompt_utils import prompt_env
     from app.core.memory.models.metadata_models import MetadataExtractionResponse
@@ -344,15 +378,31 @@ async def _run_metadata_llm(
             [{"role": "user", "content": prompt}],
             MetadataExtractionResponse,
         )
-    except Exception as e:
-        logger.warning(f"[Metadata] LLM 提取失败，返回空 operations: {e}")
-        return MetadataStepOutput(operations=[])
+    except Exception as exc:
+        logger.error("[Metadata] LLM 提取失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "metadata_extraction_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
     if raw is None:
-        return MetadataStepOutput(operations=[])
-    operations = list(getattr(raw, "operations", []) or [])
-    dropped = getattr(raw, "_dropped_ops_count", 0) or 0
-    return MetadataStepOutput(operations=operations, dropped_ops_count=dropped)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "metadata_extraction_result_parse",
+            model_type=ReflectionModelType.LLM,
+        )
+    try:
+        operations = list(raw.operations or [])
+        dropped = getattr(raw, "_dropped_ops_count", 0) or 0
+        return MetadataStepOutput(operations=operations, dropped_ops_count=dropped)
+    except Exception as exc:
+        logger.error("[Metadata] LLM 结构化结果解析失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "metadata_extraction_result_parse",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
 
 async def _extract_single_entity(
@@ -429,7 +479,6 @@ async def _extract_single_entity(
             truncated_sink=truncated_recs if collect_trace else None,
         ),
     )
-
     counts = result.counts()
     logger.info(
         f"[Metadata] 实体 {entity_name}({entity_id}) patch 完成: "

--- a/api/app/core/memory/storage_services/reflection_engine/errors.py
+++ b/api/app/core/memory/storage_services/reflection_engine/errors.py
@@ -1,0 +1,49 @@
+"""Layer2 反思结构化失败契约。
+
+反思流水线只向重试和可选扩展层暴露受控错误码，禁止把供应商响应、Prompt
+或原始异常文本写入结构化失败状态。
+"""
+
+from enum import StrEnum
+
+
+class ReflectionFailureReason(StrEnum):
+    """需要结构化处理的反思模型错误。"""
+
+    REFLECTION_MODEL_UNAVAILABLE = "REFLECTION_MODEL_UNAVAILABLE"
+    MODEL_CALL_FAILED = "MODEL_CALL_FAILED"
+    RESULT_PARSE_FAILED = "RESULT_PARSE_FAILED"
+
+
+class ReflectionModelType(StrEnum):
+    """模型类型维度，与失败阶段（reason_code）正交。"""
+
+    LLM = "llm"
+    EMBEDDING = "embedding"
+    UNKNOWN = "unknown"
+
+
+class ReflectionBusinessError(RuntimeError):
+    """不携带供应商原始异常文本的受控业务异常。"""
+
+    def __init__(
+        self,
+        reason_code: ReflectionFailureReason,
+        failed_operation: str,
+        model_type: ReflectionModelType | str = ReflectionModelType.UNKNOWN,
+    ) -> None:
+        self.reason_code = ReflectionFailureReason(reason_code)
+        self.failed_operation = failed_operation
+        self.model_type = ReflectionModelType(model_type)
+        super().__init__(f"{self.reason_code.value}:{failed_operation}")
+
+
+class ReflectionRetriesExhausted(RuntimeError):
+    """受控模型失败达到重试阈值后抛出。"""
+
+    def __init__(
+        self,
+        reason_code: ReflectionFailureReason,
+    ) -> None:
+        self.reason_code = ReflectionFailureReason(reason_code)
+        super().__init__(self.reason_code.value)

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -9,6 +9,11 @@ from pydantic import BaseModel
 
 from datetime import datetime
 from app.core.config import settings
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
 from app.core.utils.datetime_utils import (
     utcnow_naive,
     as_utc_aware,
@@ -186,6 +191,8 @@ class Layer2Inspector:
         self.dedup_config = self.config.entity_dedup
         self._semaphore = asyncio.Semaphore(self.desc_config.merge_concurrency)
         self._recorder: Optional[ReflectionSnapshotRecorder] = None
+        # 实体合并后 name_embedding 重算失败记录（不中断合并，由步骤聚合进告警）
+        self._embedding_errors: List[str] = []
 
     def _snap(self, subproblem: str, stage: str, data) -> None:
         """安全落普通阶段文件；recorder 为 None / 关闭 / 异常时只告警，不影响主流程。"""
@@ -235,6 +242,23 @@ class Layer2Inspector:
         except asyncio.TimeoutError:
             logger.warning(f"[Layer2 高频] {name}超时跳过 end_user_id={end_user_id}")
             return {"status": "timeout"}
+        except ReflectionBusinessError as exc:
+            logger.error(
+                f"[Layer2 高频] {name}业务失败 end_user_id={end_user_id} "
+                f"reason_code={exc.reason_code.value} "
+                f"failed_operation={exc.failed_operation}",
+                exc_info=True,
+            )
+            return {
+                "status": "error",
+                "reason_code": exc.reason_code.value,
+                "model_type": exc.model_type.value,
+                "failed_operation": exc.failed_operation,
+                "business_failure_count": 1,
+                "reason_codes": [exc.reason_code.value],
+                "model_types": [exc.model_type.value],
+                "failed_operations": [exc.failed_operation],
+            }
 
     async def run(self, end_user_id: str, baseline: str = "HYBRID",
                   language: str = "zh") -> Dict[str, Any]:
@@ -311,7 +335,10 @@ class Layer2Inspector:
                 self._run_metadata_extraction(end_user_id, language), remaining(),
             )
             results["metadata_extraction"] = meta
-            meta_ok = meta.get("status") not in ("timeout", "skipped")
+            meta_ok = (
+                meta.get("status") not in ("timeout", "skipped", "error")
+                and int(meta.get("business_failure_count", 0) or 0) == 0
+            )
             if meta_ok:
                 logger.info(
                     f"[Layer2 高频] 元数据提取完成 end_user_id={end_user_id}, "
@@ -506,6 +533,8 @@ class Layer2Inspector:
             result["merge_count"] = len(merge_ids)
             result["drop_count"] = len(drop_ids)
             return result
+        except ReflectionBusinessError:
+            raise
         except Exception as e:
             logger.warning(f"[AliasMerge] 执行失败 end_user_id={end_user_id}: {e}")
             return {"status": "error", "error": str(e)}
@@ -559,6 +588,8 @@ class Layer2Inspector:
                 self._snap("metadata_extraction", "2_llm_raw", trace.get("llm_raw"))
                 self._snap_changes("metadata_extraction", trace.get("changes") or [])
             return {"status": "success", **result}
+        except ReflectionBusinessError:
+            raise
         except Exception as e:
             logger.warning(
                 f"[Metadata] 元数据提取失败 end_user_id={end_user_id}: {e}"
@@ -575,6 +606,7 @@ class Layer2Inspector:
         from .llm.entity_dedup_judge import judge_batch
         from .deterministic.cypher_merger import choose_keeper, execute_merge, build_merged_aliases
 
+        self._embedding_errors = []
         config = self.dedup_config
 
         # 1. 两路候选召回（并行）— 计时
@@ -784,14 +816,24 @@ class Layer2Inspector:
                 })
                 self._snap_changes("entity_dedup", snap_changes)
 
+        embedding_failed = bool(self._embedding_errors)
         return {
-            "status": "success",
+            "status": "error" if embedding_failed else "success",
             "candidate_count": total_candidates,
             "llm_pool": len(llm_pool),
             "discard_pool": len(discard_pool),
             "merged_count": merged_count,
             "direct_merged_count": direct_merged_count,
             "recorded_count": recorded_count,
+            "business_failure_count": len(self._embedding_errors),
+            "reason_codes": (
+                [ReflectionFailureReason.MODEL_CALL_FAILED.value]
+                if embedding_failed else []
+            ),
+            "model_types": (
+                [ReflectionModelType.EMBEDDING.value] if embedding_failed else []
+            ),
+            "failed_operations": list(dict.fromkeys(self._embedding_errors)),
         }
 
 
@@ -1001,6 +1043,11 @@ class Layer2Inspector:
         total_direct_merged = 0
         truncated = False
         had_type_error = False
+        business_failure_count = 0
+        reason_codes: list[str] = []
+        model_types: list[str] = []
+        failed_operations: list[str] = []
+        self._embedding_errors = []
         # 快照累积（跨类型聚合到 entity_dedup 一个子目录）
         snap_input: list = []
         snap_llm: list = []
@@ -1026,6 +1073,24 @@ class Layer2Inspector:
                     truncated = True
                     logger.warning(f"[Layer2 低频] 触发软超时 type={entity_type}")
                     break
+                except ReflectionBusinessError as exc:
+                    had_type_error = True
+                    business_failure_count += 1
+                    if exc.reason_code.value not in reason_codes:
+                        reason_codes.append(exc.reason_code.value)
+                        model_types.append(exc.model_type.value)
+                    elif model_types[reason_codes.index(exc.reason_code.value)] == \
+                            ReflectionModelType.UNKNOWN.value and exc.model_type.value != \
+                            ReflectionModelType.UNKNOWN.value:
+                        model_types[reason_codes.index(exc.reason_code.value)] = exc.model_type.value
+                    if exc.failed_operation not in failed_operations:
+                        failed_operations.append(exc.failed_operation)
+                    logger.error(
+                        f"[Layer2 低频] 类型业务失败 type={entity_type} "
+                        f"reason_code={exc.reason_code.value} "
+                        f"failed_operation={exc.failed_operation}",
+                    )
+                    continue
                 except Exception as e:                  # 单类型真异常：跳过、继续下一个
                     had_type_error = True
                     logger.warning(f"[Layer2 低频] 类型处理失败 type={entity_type}: {e}")
@@ -1042,6 +1107,20 @@ class Layer2Inspector:
                 self._snap("entity_dedup", "2_llm_raw", {"types": snap_llm})
                 self._snap_changes("entity_dedup", snap_changes)
 
+        # 合并 name_embedding 重算失败（Embedding 模型，不中断合并）
+        for op in self._embedding_errors:
+            if op not in failed_operations:
+                failed_operations.append(op)
+        if self._embedding_errors:
+            business_failure_count += len(self._embedding_errors)
+            if ReflectionFailureReason.MODEL_CALL_FAILED.value not in reason_codes:
+                reason_codes.append(ReflectionFailureReason.MODEL_CALL_FAILED.value)
+                model_types.append(ReflectionModelType.EMBEDDING.value)
+            else:
+                idx = reason_codes.index(ReflectionFailureReason.MODEL_CALL_FAILED.value)
+                if model_types[idx] == ReflectionModelType.UNKNOWN.value:
+                    model_types[idx] = ReflectionModelType.EMBEDDING.value
+
         return {
             "scanned_types": scanned_types,
             "merged_count": total_merged,
@@ -1049,6 +1128,11 @@ class Layer2Inspector:
             "total_types": len(entity_types),     # 新增
             "truncated": truncated,               # 新增：预算耗尽/类型超时未扫完
             "had_type_error": had_type_error,     # 新增：有类型抛异常被兜底跳过
+            "status": "error" if business_failure_count else "success",
+            "business_failure_count": business_failure_count,
+            "reason_codes": reason_codes,
+            "model_types": model_types,
+            "failed_operations": failed_operations,
         }
     @staticmethod
     def _merged_description(keeper_desc: str, loser_desc: str) -> str:
@@ -1319,7 +1403,11 @@ class Layer2Inspector:
         return True
 
     async def _reembed_if_name_changed(self, keeper: Dict, merged_name: str) -> None:
-        """合并后若 name 变化，重算 name_embedding（与更名流程一致；失败只告警不回滚）"""
+        """合并后若 name 变化，重算 name_embedding（与更名流程一致；失败只告警不回滚）。
+
+        Embedding 重算失败不中断合并，但记入 ``_embedding_errors`` 供步骤聚合为
+        MODEL_CALL_FAILED + Embedding，让告警能区分是 Embedding 模型出问题。
+        """
         old_name = keeper.get("name") or ""
         if not merged_name or merged_name == old_name:
             return
@@ -1327,14 +1415,20 @@ class Layer2Inspector:
             return
         try:
             emb = self.embedding_client.embed_query(merged_name)
-            if emb:
+        except Exception as e:
+            self._embedding_errors.append("entity_dedup_name_embedding")
+            logger.warning(f"合并后重算 name_embedding 失败 name={merged_name}: {e}")
+            return
+
+        if emb:
+            try:
                 await self.connector.execute_query(
                     REFLECTION_UPDATE_NAME_EMBEDDING,
                     entity_id=keeper.get("entity_id") or keeper.get("id"),
                     name_embedding=emb,
                 )
-        except Exception as e:
-            logger.warning(f"合并后重算 name_embedding 失败 name={merged_name}: {e}")
+            except Exception as e:
+                logger.warning(f"合并后写入 name_embedding 失败 name={merged_name}: {e}")
 
     async def _apply_direct_merge(
         self, pair, end_user_id: str, baseline: str,
@@ -1593,10 +1687,33 @@ class Layer2Inspector:
         resolved_count = 0
         forced_count = 0
         failed_count = 0
+        model_failure_count = 0
+        reason_codes: list[str] = []
+        model_types: list[str] = []
+        failed_operations: list[str] = []
         for i, result in enumerate(results):
-            if isinstance(result, Exception):
+            if isinstance(result, ReflectionBusinessError):
                 logger.error(
-                    f"未识别实体处理异常 statement={candidates[i].get('statement_id', '?')}: {result}"
+                    f"未识别实体处理业务失败 "
+                    f"statement={candidates[i].get('statement_id', '?')} "
+                    f"reason_code={result.reason_code.value} "
+                    f"failed_operation={result.failed_operation}"
+                )
+                failed_count += 1
+                model_failure_count += 1
+                if result.reason_code.value not in reason_codes:
+                    reason_codes.append(result.reason_code.value)
+                    model_types.append(result.model_type.value)
+                elif model_types[reason_codes.index(result.reason_code.value)] == \
+                        ReflectionModelType.UNKNOWN.value and result.model_type.value != \
+                        ReflectionModelType.UNKNOWN.value:
+                    model_types[reason_codes.index(result.reason_code.value)] = result.model_type.value
+                if result.failed_operation not in failed_operations:
+                    failed_operations.append(result.failed_operation)
+            elif isinstance(result, Exception):
+                logger.error(
+                    f"未识别实体处理异常 statement="
+                    f"{candidates[i].get('statement_id', '?')}"
                 )
                 failed_count += 1
             elif result is None:
@@ -1607,11 +1724,15 @@ class Layer2Inspector:
                 forced_count += 1
 
         return {
-            "status": "success",
+            "status": "error" if model_failure_count else "success",
             "total": len(candidates),
             "resolved": resolved_count,
             "forced": forced_count,
             "failed": failed_count,
+            "business_failure_count": model_failure_count,
+            "reason_codes": reason_codes,
+            "model_types": model_types,
+            "failed_operations": failed_operations,
         }
 
     async def _resolve_one_statement(self, stmt: Dict, end_user_id: str,
@@ -1902,17 +2023,38 @@ class Layer2Inspector:
         results = await asyncio.gather(*tasks, return_exceptions=True)
         merged_count = sum(1 for r in results if r is True)
         failed_count = sum(1 for r in results if isinstance(r, Exception))
+        model_failure_count = sum(
+            1 for r in results if isinstance(r, ReflectionBusinessError)
+        )
+        reason_codes: list[str] = []
+        model_types: list[str] = []
+        failed_operations: list[str] = []
 
         # 记录失败的异常
         for i, r in enumerate(results):
-            if isinstance(r, Exception):
-                logger.error(f"描述合并异常 entity={candidates[i].get('name', '?')}: {r}")
+            if isinstance(r, ReflectionBusinessError):
+                logger.error(
+                    f"描述合并业务失败 entity={candidates[i].get('name', '?')} "
+                    f"reason_code={r.reason_code.value} "
+                    f"failed_operation={r.failed_operation}"
+                )
+                if r.reason_code.value not in reason_codes:
+                    reason_codes.append(r.reason_code.value)
+                    model_types.append(r.model_type.value)
+                if r.failed_operation not in failed_operations:
+                    failed_operations.append(r.failed_operation)
+            elif isinstance(r, Exception):
+                logger.error(f"描述合并异常 entity={candidates[i].get('name', '?')}")
 
         return {
-            "status": "success",
+            "status": "error" if model_failure_count else "success",
             "candidate_count": len(candidates),
             "merged_count": merged_count,
             "failed_count": failed_count,
+            "business_failure_count": model_failure_count,
+            "reason_codes": reason_codes,
+            "model_types": model_types,
+            "failed_operations": failed_operations,
         }
 
     async def _merge_one_entity(self, entity: Dict, end_user_id: str,
@@ -1999,7 +2141,11 @@ class Layer2Inspector:
             logger.warning(
                 f"描述合并校验失败 entity={entity['name']}, reason={reason}, 跳过写入"
             )
-            return False
+            raise ReflectionBusinessError(
+                ReflectionFailureReason.RESULT_PARSE_FAILED,
+                "description_synthesis_result_validate",
+                model_type=ReflectionModelType.LLM,
+            )
         tracker.end_step("校验通过")
 
         # Step 4: 应用事件操作（企业版能力；社区版跳过，不记 tracker/快照）

--- a/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/alias_belongs_judge.py
@@ -9,6 +9,12 @@ from typing import Any, Dict, List
 from pydantic import BaseModel, Field
 from jinja2 import Environment, FileSystemLoader
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 # 加载模板（与 entity_dedup_batch_judge 同路径）
@@ -55,44 +61,52 @@ async def judge_alias_belongs(
     if not candidates:
         return []
 
+    template = _prompt_env.get_template("alias_belongs_judge.jinja2")
+    rendered_prompt = template.render(
+        canonical_entity=canonical,
+        candidates=candidates,
+        language=language,
+    )
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("alias_belongs_judge.jinja2")
-        rendered_prompt = template.render(
-            canonical_entity=canonical,
-            candidates=candidates,
-            language=language,
-        )
-        messages = [{"role": "user", "content": rendered_prompt}]
         response = await llm_client.call_structured(messages, AliasBatchJudgeOutput)
+    except Exception as exc:
+        logger.error("[AliasJudge] 别名校验模型调用失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "alias_merge_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
-        if not isinstance(response, AliasBatchJudgeOutput):
-            logger.warning("[AliasJudge] LLM 返回类型异常，整组按 skip 处理")
-            return []
+    if not isinstance(response, AliasBatchJudgeOutput):
+        logger.error("[AliasJudge] 别名校验返回结构无效")
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "alias_merge_result_parse",
+            model_type=ReflectionModelType.LLM,
+        )
 
-        # alias_index(1-based) → AliasJudgeItem
-        by_index: Dict[int, AliasJudgeItem] = {}
-        for item in response.results:
-            if 1 <= item.alias_index <= len(candidates):
-                by_index[item.alias_index] = item
+    # alias_index(1-based) → AliasJudgeItem
+    by_index: Dict[int, AliasJudgeItem] = {}
+    for item in response.results:
+        if 1 <= item.alias_index <= len(candidates):
+            by_index[item.alias_index] = item
 
-        decided: List[Dict[str, Any]] = []
-        for i, cand in enumerate(candidates, start=1):
-            item = by_index.get(i)
-            if item is None:
-                continue  # 未返回 → skip
-            try:
-                conf = float(item.confidence)
-            except (TypeError, ValueError):
-                continue  # 非法分数 → skip
-            if not (0.0 <= conf <= 1.0):
-                continue  # 越界 → skip
-            decided.append({
-                "alias_id": cand["alias_id"],
-                "decision": "merge" if conf >= threshold else "drop",
-                "confidence": conf,
-                "reason": (item.reason or "")[:200],
-            })
-        return decided
-    except Exception as e:
-        logger.error(f"[AliasJudge] 别名校验 LLM 判定失败，整组 skip: {e}")
-        return []
+    decided: List[Dict[str, Any]] = []
+    for i, cand in enumerate(candidates, start=1):
+        item = by_index.get(i)
+        if item is None:
+            continue  # 未返回 → skip
+        try:
+            conf = float(item.confidence)
+        except (TypeError, ValueError):
+            continue  # 非法分数 → skip
+        if not (0.0 <= conf <= 1.0):
+            continue  # 越界 → skip
+        decided.append({
+            "alias_id": cand["alias_id"],
+            "decision": "merge" if conf >= threshold else "drop",
+            "confidence": conf,
+            "reason": (item.reason or "")[:200],
+        })
+    return decided

--- a/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/description_synthesizer.py
@@ -7,6 +7,12 @@ from typing import List, Optional
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 _prompt_dir = os.path.join(
@@ -43,25 +49,33 @@ async def merge_description(
         language: 语言类型 "zh" | "en"
 
     Returns:
-        合并后的纯文本摘要，失败返回 None
+        合并后的纯文本摘要；失败时抛出受控业务异常
     """
+    template = _prompt_env.get_template("description_merge.jinja2")
+    json_schema = json.dumps(DescriptionMergeOutput.model_json_schema(), indent=2)
+
+    rendered_prompt = template.render(
+        entity_name=entity_name,
+        entity_type=entity_type,
+        summary=summary,
+        fragments=fragments,
+        parts_count=len(fragments) + (1 if summary else 0),
+        json_schema=json_schema,
+        language=language,
+    )
+
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("description_merge.jinja2")
-        json_schema = json.dumps(DescriptionMergeOutput.model_json_schema(), indent=2)
-
-        rendered_prompt = template.render(
-            entity_name=entity_name,
-            entity_type=entity_type,
-            summary=summary,
-            fragments=fragments,
-            parts_count=len(fragments) + (1 if summary else 0),
-            json_schema=json_schema,
-            language=language,
-        )
-
-        messages = [{"role": "user", "content": rendered_prompt}]
         response = await llm_client.call_structured(messages, DescriptionMergeOutput)
+    except Exception as exc:
+        logger.error("LLM 描述合并模型调用失败 entity=%s", entity_name, exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "description_merge_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
+    try:
         if isinstance(response, DescriptionMergeOutput):
             result = response.merged_description
         elif isinstance(response, dict):
@@ -69,16 +83,22 @@ async def merge_description(
         elif isinstance(response, BaseModel):
             result = response.model_dump().get("merged_description")
         else:
-            return None
+            raise ValueError("unsupported response type")
 
         # 后处理：将中文分号替换为逗号，避免与碎片分隔符 ；混淆
         if result:
             result = result.replace('；', '，')
-        return result or None
+        if not result:
+            raise ValueError("merged_description is empty")
+        return result
 
-    except Exception as e:
-        logger.error(f"LLM 描述合并失败 entity={entity_name}: {e}", exc_info=True)
-        return None
+    except Exception as exc:
+        logger.error("LLM 描述合并返回解析失败 entity=%s", entity_name, exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "description_merge_result_parse",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
 
 # ===== 新增：描述合并 + 事件提取 + 更名判断（一次调用） =====
@@ -202,27 +222,39 @@ async def summarize_extract_and_rename(
         language: 语言类型
 
     Returns:
-        SummarizeExtractRenameOutput 实例，失败返回 None
+        SummarizeExtractRenameOutput 实例；失败时抛出受控业务异常
     """
+    template = _prompt_env.get_template("reflection_summary_timeline.prompt.jinja2")
+
+    input_data = {
+        "entity_name": entity_name,
+        "entity_type": entity_type,
+        "description": description,
+        "description_summary": summary or "",
+        "event_timeline": _parse_timeline_full(event_timeline) if event_timeline else [],
+    }
+
+    rendered_prompt = template.render(
+        input_json=json.dumps(input_data, ensure_ascii=False, indent=2),
+        language=language,
+    )
+
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("reflection_summary_timeline.prompt.jinja2")
-
-        input_data = {
-            "entity_name": entity_name,
-            "entity_type": entity_type,
-            "description": description,
-            "description_summary": summary or "",
-            "event_timeline": _parse_timeline_full(event_timeline) if event_timeline else [],
-        }
-
-        rendered_prompt = template.render(
-            input_json=json.dumps(input_data, ensure_ascii=False, indent=2),
-            language=language,
-        )
-
-        messages = [{"role": "user", "content": rendered_prompt}]
         response = await llm_client.call_structured(messages, SummarizeExtractRenameOutput)
+    except Exception as exc:
+        logger.error(
+            "LLM 描述合并、事件提取和更名模型调用失败 entity=%s",
+            entity_name,
+            exc_info=True,
+        )
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "description_synthesis_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
+    try:
         if isinstance(response, SummarizeExtractRenameOutput):
             result = response
         elif isinstance(response, dict):
@@ -241,7 +273,7 @@ async def summarize_extract_and_rename(
                 suggested_entity_name=data.get("suggested_entity_name"),
             )
         else:
-            return None
+            raise ValueError("unsupported response type")
 
         # 后处理：summary 中的中文分号替换为逗号
         if result.description_summary:
@@ -253,6 +285,14 @@ async def summarize_extract_and_rename(
 
         return result
 
-    except Exception as e:
-        logger.error(f"LLM 描述合并+事件提取+更名失败 entity={entity_name}: {e}", exc_info=True)
-        return None
+    except Exception as exc:
+        logger.error(
+            "LLM 描述合并、事件提取和更名返回解析失败 entity=%s",
+            entity_name,
+            exc_info=True,
+        )
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "description_synthesis_result_parse",
+            model_type=ReflectionModelType.LLM,
+        ) from exc

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_batch_judge.py
@@ -8,6 +8,12 @@ from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel, Field
 from jinja2 import Environment, FileSystemLoader
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 # 加载模板
@@ -49,37 +55,48 @@ async def judge_batch_dedup(
     Returns:
         [(idx_a, idx_b, confidence, reason), ...] 索引从0开始（内部已转换）
     """
+    template = _prompt_env.get_template("entity_dedup_batch.jinja2")
+    rendered_prompt = template.render(
+        entities=entities,
+        entity_type=entity_type,
+        language=language,
+    )
+
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("entity_dedup_batch.jinja2")
-        rendered_prompt = template.render(
-            entities=entities,
-            entity_type=entity_type,
-            language=language,
+        response = await llm_client.call_structured(messages, BatchDedupOutput)
+    except Exception as exc:
+        logger.error("反思引擎实体去重方案B模型调用失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "dedup_full_scan_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
+
+    if not isinstance(response, BatchDedupOutput):
+        logger.error("反思引擎实体去重方案B返回结构无效")
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "dedup_full_scan_result_parse",
+            model_type=ReflectionModelType.LLM,
         )
 
-        messages = [{"role": "user", "content": rendered_prompt}]
-        response = await llm_client.call_structured(messages, BatchDedupOutput)
+    # 校验 + 转换索引 + 去重（每个实体最多出现在一个配对中）
+    results = []
+    seen_entities = set()
+    for item in response.results:
+        if len(item.pair) != 2:
+            continue
+        idx_a, idx_b = item.pair[0] - 1, item.pair[1] - 1  # 转为0-based
+        if not (0 <= idx_a < len(entities) and 0 <= idx_b < len(entities)):
+            continue
+        if not (0 <= item.confidence <= 1):
+            continue
+        if idx_a in seen_entities or idx_b in seen_entities:
+            continue
+        seen_entities.add(idx_a)
+        seen_entities.add(idx_b)
+        results.append((idx_a, idx_b, item.confidence, item.reason,
+                        item.new_name, item.new_aliases or []))
 
-        if not isinstance(response, BatchDedupOutput):
-            return []
-
-        # 校验 + 转换索引 + 去重（每个实体最多出现在一个配对中）
-        results = []
-        seen_entities = set()
-        for item in response.results:
-            if len(item.pair) != 2:
-                continue
-            idx_a, idx_b = item.pair[0] - 1, item.pair[1] - 1  # 转为0-based
-            if not (0 <= idx_a < len(entities) and 0 <= idx_b < len(entities)):
-                continue
-            if idx_a in seen_entities or idx_b in seen_entities:
-                continue
-            seen_entities.add(idx_a)
-            seen_entities.add(idx_b)
-            results.append((idx_a, idx_b, item.confidence, item.reason,
-                            item.new_name, item.new_aliases or []))
-
-        return results
-    except Exception as e:
-        logger.error(f"反思引擎 实体去重方案B LLM 分组判定失败: {e}")
-        return []
+    return results

--- a/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/entity_dedup_judge.py
@@ -10,6 +10,12 @@ from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel
 from jinja2 import Environment, FileSystemLoader
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 _prompt_dir = os.path.normpath(os.path.join(
@@ -51,45 +57,62 @@ async def judge_pair_for_dedup(
     直接渲染 entity_dedup_reflection.jinja2，把两路召回已计算好的分数传入。
     entity_a/entity_b 需有 name, entity_type, description, description_summary, aliases 属性。
     """
+    template = _prompt_env.get_template("entity_dedup_reflection.jinja2")
+    rendered_prompt = template.render(
+        entity_a={
+            "name": entity_a.name,
+            "entity_type": entity_a.entity_type,
+            "description_summary": getattr(entity_a, "description_summary", ""),
+            "description": getattr(entity_a, "description", ""),
+            "aliases": getattr(entity_a, "aliases", []),
+        },
+        entity_b={
+            "name": entity_b.name,
+            "entity_type": entity_b.entity_type,
+            "description_summary": getattr(entity_b, "description_summary", ""),
+            "description": getattr(entity_b, "description", ""),
+            "aliases": getattr(entity_b, "aliases", []),
+        },
+        language=language,
+        json_schema=json.dumps(DedupJudgeOutput.model_json_schema(), indent=2),
+    )
+
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("entity_dedup_reflection.jinja2")
-        rendered_prompt = template.render(
-            entity_a={
-                "name": entity_a.name,
-                "entity_type": entity_a.entity_type,
-                "description_summary": getattr(entity_a, "description_summary", ""),
-                "description": getattr(entity_a, "description", ""),
-                "aliases": getattr(entity_a, "aliases", []),
-            },
-            entity_b={
-                "name": entity_b.name,
-                "entity_type": entity_b.entity_type,
-                "description_summary": getattr(entity_b, "description_summary", ""),
-                "description": getattr(entity_b, "description", ""),
-                "aliases": getattr(entity_b, "aliases", []),
-            },
-            language=language,
-            json_schema=json.dumps(DedupJudgeOutput.model_json_schema(), indent=2),
+        response = await llm_client.call_structured(messages, DedupJudgeOutput)
+    except Exception as exc:
+        logger.error("LLM 去重模型调用失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "entity_dedup_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
+
+    if not isinstance(response, DedupJudgeOutput):
+        logger.error("LLM 去重返回结构无效")
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "entity_dedup_result_parse",
+            model_type=ReflectionModelType.LLM,
+        )
+    if response.canonical_idx not in (0, 1) or not (0 <= response.confidence <= 1):
+        logger.error("LLM 去重返回字段校验失败")
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "entity_dedup_result_parse",
+            model_type=ReflectionModelType.LLM,
         )
 
-        messages = [{"role": "user", "content": rendered_prompt}]
-        response = await llm_client.call_structured(messages, DedupJudgeOutput)
-
-        if isinstance(response, DedupJudgeOutput):
-            # new_name 为空时回退到 canonical_idx 对应实体名
-            fallback_name = entity_a.name if response.canonical_idx == 0 else entity_b.name
-            return DedupLLMDecision(
-                same_entity=response.same_entity,
-                confidence=response.confidence,
-                winner_id="a" if response.canonical_idx == 0 else "b",
-                merged_name=(response.new_name or fallback_name),
-                new_aliases=response.new_aliases or [],
-                reason=response.reason,
-            )
-        return None
-    except Exception as e:
-        logger.error(f"LLM 去重判定失败: {e}")
-        return None
+    # new_name 为空时回退到 canonical_idx 对应实体名
+    fallback_name = entity_a.name if response.canonical_idx == 0 else entity_b.name
+    return DedupLLMDecision(
+        same_entity=response.same_entity,
+        confidence=response.confidence,
+        winner_id="a" if response.canonical_idx == 0 else "b",
+        merged_name=(response.new_name or fallback_name),
+        new_aliases=response.new_aliases or [],
+        reason=response.reason,
+    )
 
 
 async def judge_batch(

--- a/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
+++ b/api/app/core/memory/storage_services/reflection_engine/llm/unresolved_resolver.py
@@ -8,6 +8,12 @@ from dataclasses import dataclass
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+
 logger = logging.getLogger(__name__)
 
 _prompt_dir = os.path.join(
@@ -115,42 +121,54 @@ async def resolve_unresolved_statement(
     language: str = "zh",
 ) -> Optional[UnresolvedResult]:
     """调用 LLM 对 unresolved statement 进行消解 + 三元组提取"""
+    template = _prompt_env.get_template("resolve_unresolved_triplet.jinja2")
+
+    input_json = {
+        "statement_id": statement["statement_id"],
+        "statement_text": statement["statement_text"],
+        "statement_type": statement.get("stmt_type", "FACT"),
+        "temporal_type": statement.get("temporal_info", "DYNAMIC"),
+        "supporting_context": context_chunks,
+        "speaker": statement.get("speaker", "user"),
+        "dialog_at": str(statement.get("dialog_at", "")),
+        "valid_at": str(statement.get("valid_at", "NULL")),
+        "invalid_at": str(statement.get("invalid_at", "NULL")),
+        "has_unsolved_reference": True,
+    }
+
+    rendered_prompt = template.render(
+        statement_text=statement["statement_text"],
+        speaker=statement.get("speaker", "user"),
+        input_json=json.dumps(input_json, ensure_ascii=False),
+        language=language,
+    )
+
+    messages = [{"role": "user", "content": rendered_prompt}]
     try:
-        template = _prompt_env.get_template("resolve_unresolved_triplet.jinja2")
-
-        input_json = {
-            "statement_id": statement["statement_id"],
-            "statement_text": statement["statement_text"],
-            "statement_type": statement.get("stmt_type", "FACT"),
-            "temporal_type": statement.get("temporal_info", "DYNAMIC"),
-            "supporting_context": context_chunks,
-            "speaker": statement.get("speaker", "user"),
-            "dialog_at": str(statement.get("dialog_at", "")),
-            "valid_at": str(statement.get("valid_at", "NULL")),
-            "invalid_at": str(statement.get("invalid_at", "NULL")),
-            "has_unsolved_reference": True,
-        }
-
-        rendered_prompt = template.render(
-            statement_text=statement["statement_text"],
-            speaker=statement.get("speaker", "user"),
-            input_json=json.dumps(input_json, ensure_ascii=False),
-            language=language,
-        )
-
-        messages = [{"role": "user", "content": rendered_prompt}]
         response = await llm_client.call_structured(messages, UnresolvedResult)
+    except Exception as exc:
+        logger.error(
+            "LLM 未识别实体消解模型调用失败 statement=%s",
+            statement.get("statement_id", "?"),
+            exc_info=True,
+        )
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.MODEL_CALL_FAILED,
+            "unresolved_resolver_model_call",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
+    try:
         if isinstance(response, UnresolvedResult):
             return response
-        elif isinstance(response, dict):
+        if isinstance(response, dict):
             return UnresolvedResult(
                 resolved=response.get("resolved", False),
                 resolution_note=response.get("resolution_note", ""),
                 entities=[EntityOutput(**e) for e in response.get("entities", [])],
                 triplets=[TripletOutput(**t) for t in response.get("triplets", [])],
             )
-        elif isinstance(response, BaseModel):
+        if isinstance(response, BaseModel):
             data = response.model_dump()
             return UnresolvedResult(
                 resolved=data.get("resolved", False),
@@ -158,12 +176,17 @@ async def resolve_unresolved_statement(
                 entities=[EntityOutput(**e) for e in data.get("entities", [])],
                 triplets=[TripletOutput(**t) for t in data.get("triplets", [])],
             )
-        else:
-            return None
+    except Exception as exc:
+        logger.error("LLM 未识别实体消解返回解析失败", exc_info=True)
+        raise ReflectionBusinessError(
+            ReflectionFailureReason.RESULT_PARSE_FAILED,
+            "unresolved_resolver_result_parse",
+            model_type=ReflectionModelType.LLM,
+        ) from exc
 
-    except Exception as e:
-        logger.error(
-            f"LLM 未识别实体消解失败 statement={statement.get('statement_id', '?')}: {e}",
-            exc_info=True,
-        )
-        return None
+    logger.error("LLM 未识别实体消解返回结构无效")
+    raise ReflectionBusinessError(
+        ReflectionFailureReason.RESULT_PARSE_FAILED,
+        "unresolved_resolver_result_parse",
+        model_type=ReflectionModelType.LLM,
+    )

--- a/api/app/core/memory/storage_services/reflection_engine/retry_registry.py
+++ b/api/app/core/memory/storage_services/reflection_engine/retry_registry.py
@@ -10,9 +10,15 @@ rc 为 None（Redis 不可用）时所有写接口安全 no-op（仅 warning）�
 import json
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Dict, List, Optional, Tuple
 
-from app.core.utils.datetime_utils import utcnow, to_timestamp_ms
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionFailureReason,
+    ReflectionModelType,
+)
+from app.core.utils.datetime_utils import to_timestamp_ms, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +31,38 @@ RETRY_BACKOFF_BASE = 1800       # 指数退避基数（秒），30 分钟
 RETRY_BACKOFF_CAP = 21600       # 退避封顶（秒），6 小时
 RETRY_TTL_SECONDS = 604800      # meta key TTL（秒），7 天，到期自动放弃永久不活跃用户
 RETRY_BATCH = 200               # 派发任务每轮每队列最多取多少到点用户，防集体失败灌爆队列
+
+
+class RetryRecordOutcome(StrEnum):
+    RETRY_SCHEDULED = "retry_scheduled"
+    EXHAUSTED = "exhausted"
+    REDIS_UNAVAILABLE = "redis_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class RetryRecordResult:
+    outcome: RetryRecordOutcome
+    last_failed_at_ms: int | None = None
+
+
+def _normalize_reason_code(value: object) -> ReflectionFailureReason | None:
+    try:
+        return ReflectionFailureReason(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_model_type(value: object) -> ReflectionModelType:
+    try:
+        return ReflectionModelType(value)
+    except (TypeError, ValueError):
+        return ReflectionModelType.UNKNOWN
+
+
+def _optional_reason_code(value: object) -> ReflectionFailureReason | None:
+    if value is None or value == "":
+        return None
+    return _normalize_reason_code(value)
 
 
 def _zkey(task_type: str) -> str:
@@ -99,75 +137,159 @@ def resolve(rc, task_type: str, uid: str) -> None:
         logger.warning(f"[ReflectionRetry] resolve 失败 task_type={task_type} uid={uid}: {e}")
 
 
-def record(rc, task_type: str, uid: str, completion: str, progressed: bool,
-           skipped_steps: Optional[List[str]] = None, last_error: str = "") -> None:
-    """completion==partial/failed：累计 retry_count（有推进则重置 0），指数退避更新 score；
-    达 REFLECTION_RETRY_MAX → exhausted 出队（meta 留待 TTL）。"""
+def record(
+    rc,
+    task_type: str,
+    uid: str,
+    completion: str,
+    progressed: bool,
+    skipped_steps: Optional[List[str]] = None,
+    reason_code: ReflectionFailureReason | str | None = None,
+    last_error: str = "",
+    model_type: ReflectionModelType | str | None = None,
+) -> RetryRecordResult:
+    """登记反思重试，并保留三类模型错误的结构化信息。"""
     if rc is None:
         logger.warning(f"[ReflectionRetry] Redis 不可用，跳过 record uid={uid}")
-        return
+        return RetryRecordResult(RetryRecordOutcome.REDIS_UNAVAILABLE)
     try:
         old = load_meta(rc, task_type, uid) or {}
-        retry_count = 0 if progressed else old.get("retry_count", 0) + 1
+        if old.get("completion") == "exhausted":
+            return RetryRecordResult(
+                RetryRecordOutcome.EXHAUSTED,
+                last_failed_at_ms=old.get("last_failed_at"),
+            )
+        selected_reason = _optional_reason_code(reason_code)
+        effective_progressed = progressed and selected_reason is None
+        retry_count = 0 if effective_progressed else old.get("retry_count", 0) + 1
+        last_failed_at_ms = to_timestamp_ms(utcnow())
         if retry_count >= RETRY_MAX:
-            _set_exhausted(rc, task_type, uid, old, last_error or "retry_max")
-            return
+            if selected_reason is not None:
+                return _set_exhausted(
+                    rc,
+                    task_type,
+                    uid,
+                    old,
+                    selected_reason,
+                    skipped_steps=skipped_steps,
+                    last_failed_at_ms=last_failed_at_ms,
+                    model_type=model_type,
+                )
+            _set_exhausted(
+                rc, task_type, uid, old, last_error or "retry_max",
+                last_failed_at_ms=last_failed_at_ms,
+            )
+            return RetryRecordResult(
+                RetryRecordOutcome.EXHAUSTED,
+                last_failed_at_ms=last_failed_at_ms,
+            )
         # 有推进：score=now，下次扫描立即可见；无推进：指数退避
         if progressed:
             score = time.time()
         else:
             backoff = min(RETRY_BACKOFF_BASE * (2 ** retry_count), RETRY_BACKOFF_CAP)
             score = time.time() + backoff
-        meta = {
+        meta: Dict[str, Any] = {
             **old,
             "completion": completion,
             "retry_count": retry_count,
             "skipped_steps": skipped_steps or [],
-            "last_error": last_error,
-            "last_failed_at": to_timestamp_ms(utcnow()),
+            "last_error": selected_reason.value if selected_reason else last_error,
+            "last_failed_at": last_failed_at_ms,
         }
+        if selected_reason is not None:
+            meta["model_type"] = _normalize_model_type(model_type).value
+        else:
+            meta.pop("model_type", None)
         pipe = rc.pipeline()
         pipe.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
                  ex=RETRY_TTL_SECONDS)
         pipe.zadd(_zkey(task_type), {uid: score})
         pipe.execute()
+        return RetryRecordResult(
+            RetryRecordOutcome.RETRY_SCHEDULED,
+            last_failed_at_ms=last_failed_at_ms,
+        )
     except Exception as e:
-        logger.warning(f"[ReflectionRetry] record 失败 task_type={task_type} uid={uid}: {e}")
+        logger.warning(
+            f"[ReflectionRetry] record 失败 task_type={task_type} uid={uid}: {e}",
+            exc_info=True,
+        )
+        return RetryRecordResult(RetryRecordOutcome.REDIS_UNAVAILABLE)
 
 
 def mark_dead(rc, task_type: str, uid: str) -> bool:
-    """租约到期且仍 in_progress：判定上次开工后进程死亡，dead_count+1。
-
-    未超 REFLECTION_RETRY_DEAD_MAX → 留在队列等重派，返回 True（可重派）；
-    达上限 → exhausted 出队，返回 False（不再重派）。
-    """
+    """登记过期 Worker 租约；进程异常不进入模型失败上报。"""
     if rc is None:
         return False
     try:
         old = load_meta(rc, task_type, uid) or {}
-        dead_count = old.get("dead_count", 0) + 1
-        if dead_count >= RETRY_DEAD_MAX:
-            _set_exhausted(rc, task_type, uid, old, "process_dead_max")
+        if old.get("completion") == "exhausted":
             return False
-        meta = {**old, "dead_count": dead_count, "last_failed_at": to_timestamp_ms(utcnow())}
+        dead_count = old.get("dead_count", 0) + 1
+        last_failed_at_ms = to_timestamp_ms(utcnow())
+        if dead_count >= RETRY_DEAD_MAX:
+            _set_exhausted(
+                rc, task_type, uid, old, "process_dead_max",
+                last_failed_at_ms=last_failed_at_ms,
+            )
+            return False
+        meta = {
+            **old,
+            "dead_count": dead_count,
+            "last_failed_at": last_failed_at_ms,
+        }
         rc.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
                ex=RETRY_TTL_SECONDS)
         return True
     except Exception as e:
-        logger.warning(f"[ReflectionRetry] mark_dead 失败 task_type={task_type} uid={uid}: {e}")
+        logger.warning(
+            f"[ReflectionRetry] mark_dead 失败 task_type={task_type} uid={uid}: {e}",
+            exc_info=True,
+        )
         return False
 
 
-def _set_exhausted(rc, task_type: str, uid: str, old: Dict[str, Any], last_error: str) -> None:
-    """置 exhausted、移出 ZSet；meta 保留（completion=exhausted）等 TTL 过期，便于查询。"""
-    meta = {**old, "completion": "exhausted", "last_error": last_error,
-            "last_failed_at": to_timestamp_ms(utcnow())}
+def _set_exhausted(
+    rc,
+    task_type: str,
+    uid: str,
+    old: Dict[str, Any],
+    last_error: ReflectionFailureReason | str,
+    *,
+    skipped_steps: Optional[List[str]] = None,
+    last_failed_at_ms: int | None = None,
+    model_type: ReflectionModelType | str | None = None,
+) -> RetryRecordResult:
+    """置 exhausted 并移出重试队列。"""
+
+    reason = _normalize_reason_code(last_error)
+    failed_at = last_failed_at_ms or to_timestamp_ms(utcnow())
+    meta = {
+        **old,
+        "completion": "exhausted",
+        "last_error": reason.value if reason else str(last_error),
+        "last_failed_at": failed_at,
+    }
+    if skipped_steps is not None:
+        meta["skipped_steps"] = skipped_steps
+    if reason is not None:
+        meta["model_type"] = _normalize_model_type(model_type).value
+    else:
+        meta.pop("model_type", None)
     pipe = rc.pipeline()
     pipe.set(_mkey(task_type, uid), json.dumps(meta, ensure_ascii=False),
              ex=RETRY_TTL_SECONDS)
     pipe.zrem(_zkey(task_type), uid)
     pipe.execute()
-    logger.warning(f"[ReflectionRetry] 置 exhausted 出队 task_type={task_type} uid={uid} reason={last_error}")
+    logger.warning(
+        f"[ReflectionRetry] 置 exhausted 出队 task_type={task_type} uid={uid} "
+        f"reason={meta['last_error']}"
+    )
+    return RetryRecordResult(
+        RetryRecordOutcome.EXHAUSTED,
+        last_failed_at_ms=failed_at,
+    )
 
 
 # ---- completion / progressed 解析（从 run() 返回的 results 读，不额外探测）----
@@ -177,18 +299,30 @@ _LAYER2_STEPS = ["unresolved_entity", "alias_merge", "entity_dedup",
 
 
 def completion_of_layer2(results: Dict[str, Any]) -> str:
-    """高频：任一步骤 status ∈ {timeout, skipped, error} → partial；否则 full。
-    条目级 failed_count 不算未完成（步骤 status 仍为 success）。"""
+    """根据步骤状态和业务失败判断高频反思是否完整完成。"""
+    if results.get("status") == "error":
+        return "partial"
+    if int(results.get("business_failure_count", 0) or 0) > 0:
+        return "partial"
     for k in _LAYER2_STEPS:
-        st = (results.get(k) or {}).get("status")
-        if st in ("timeout", "skipped", "error"):
+        step = results.get(k) or {}
+        if step.get("status") in ("timeout", "skipped", "error"):
+            return "partial"
+        if int(step.get("business_failure_count", 0) or 0) > 0:
             return "partial"
     return "full"
 
 
 def completion_of_dedup(r: Dict[str, Any]) -> str:
-    """低频：truncated 或 had_type_error → partial；否则 full。"""
-    if r.get("truncated") or r.get("had_type_error"):
+    """根据截断状态和业务失败判断低频去重是否完整完成。"""
+    if (
+        r.get("status") == "error"
+        or r.get("reason_code")
+        or r.get("truncated")
+        or r.get("had_type_error")
+        or int(r.get("business_failure_count", 0) or 0) > 0
+        or r.get("reason_codes")
+    ):
         return "partial"
     return "full"
 
@@ -218,6 +352,128 @@ def progressed_dedup(r: Dict[str, Any]) -> bool:
 
 
 def skipped_steps_of_layer2(results: Dict[str, Any]) -> List[str]:
-    """高频命中的未完成步骤名，供 record 记录便于排查。"""
-    return [k for k in _LAYER2_STEPS
-            if (results.get(k) or {}).get("status") in ("timeout", "skipped", "error")]
+    """返回未完成或失败步骤的固定操作名。"""
+    skipped: List[str] = list(results.get("failed_operations") or [])
+    for key in _LAYER2_STEPS:
+        step = results.get(key) or {}
+        if step.get("status") in ("timeout", "skipped", "error"):
+            skipped.append(key)
+        if int(step.get("business_failure_count", 0) or 0) > 0:
+            skipped.extend(step.get("failed_operations") or [key])
+    return list(dict.fromkeys(skipped))
+
+
+def reason_codes_of_layer2(results: Dict[str, Any]) -> List[str]:
+    return _layer2_codes_and_types(results)[0]
+
+
+def model_types_of_layer2(results: Dict[str, Any]) -> List[str]:
+    """与 ``reason_codes_of_layer2`` 同索引对齐的模型类型列表。"""
+    return _layer2_codes_and_types(results)[1]
+
+
+def _layer2_codes_and_types(results: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    """聚合 reason_code 与 model_type，两者同索引对齐（去重后仍保持一一对应）。
+
+    同一 reason 首次出现时记类型；若首次为 UNKNOWN 而后续出现具体类型，
+    用具体类型补齐。步骤或顶层未提供 model_types 时按 UNKNOWN 占位。
+    """
+    codes: List[str] = []
+    types: List[str] = []
+
+    def _merge(step_codes: List[str], step_types: List[str]) -> None:
+        for idx, code in enumerate(step_codes):
+            reason = _normalize_reason_code(code)
+            if reason is None:
+                continue
+            normalized = reason.value
+            model = _normalize_model_type(
+                step_types[idx] if idx < len(step_types) else None
+            ).value
+            if normalized not in codes:
+                codes.append(normalized)
+                types.append(model)
+            else:
+                existing = types[codes.index(normalized)]
+                if existing == ReflectionModelType.UNKNOWN.value and model != ReflectionModelType.UNKNOWN.value:
+                    types[codes.index(normalized)] = model
+
+    top_codes = list(results.get("reason_codes") or [])
+    if results.get("reason_code"):
+        top_codes = [*top_codes, results["reason_code"]]
+    top_types = list(results.get("model_types") or [])
+    if results.get("model_type"):
+        top_types = [*top_types, results["model_type"]]
+    _merge(top_codes, top_types)
+    for key in _LAYER2_STEPS:
+        step = results.get(key) or {}
+        _merge(list(step.get("reason_codes") or []), list(step.get("model_types") or []))
+    return codes, types
+
+
+def reason_codes_of_dedup(result: Dict[str, Any]) -> List[str]:
+    return _dedup_codes_and_types(result)[0]
+
+
+def model_types_of_dedup(result: Dict[str, Any]) -> List[str]:
+    """与 ``reason_codes_of_dedup`` 同索引对齐的模型类型列表。"""
+    return _dedup_codes_and_types(result)[1]
+
+
+def _dedup_codes_and_types(result: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    codes: List[str] = []
+    types: List[str] = []
+    reason_codes = list(result.get("reason_codes") or [])
+    if result.get("reason_code"):
+        reason_codes = [*reason_codes, result["reason_code"]]
+    model_types = list(result.get("model_types") or [])
+    if result.get("model_type"):
+        model_types = [*model_types, result["model_type"]]
+    for idx, code in enumerate(reason_codes):
+        reason = _normalize_reason_code(code)
+        if reason is None:
+            continue
+        normalized = reason.value
+        model = _normalize_model_type(
+            model_types[idx] if idx < len(model_types) else None
+        ).value
+        if normalized not in codes:
+            codes.append(normalized)
+            types.append(model)
+        else:
+            existing = types[codes.index(normalized)]
+            if existing == ReflectionModelType.UNKNOWN.value and model != ReflectionModelType.UNKNOWN.value:
+                types[codes.index(normalized)] = model
+    return codes, types
+
+
+def select_primary_reason(reason_codes: List[str]) -> str | None:
+    """在受控错误码中按固定优先级选择主原因。"""
+
+    priority = [
+        ReflectionFailureReason.REFLECTION_MODEL_UNAVAILABLE.value,
+        ReflectionFailureReason.MODEL_CALL_FAILED.value,
+        ReflectionFailureReason.RESULT_PARSE_FAILED.value,
+    ]
+    normalized = {
+        parsed.value
+        for reason in reason_codes
+        if (parsed := _normalize_reason_code(reason)) is not None
+    }
+    return next((reason for reason in priority if reason in normalized), None)
+
+
+def select_primary_model_type(
+    reason_codes: List[str],
+    model_types: List[str],
+    primary_reason: str | None,
+) -> str | None:
+    """返回主原因对应的模型类型；无主原因或类型未知时返回 None（正文省略该行）。"""
+    if primary_reason is None:
+        return None
+    for code, model in zip(reason_codes, model_types):
+        if code == primary_reason:
+            normalized = _normalize_model_type(model)
+            if normalized is not ReflectionModelType.UNKNOWN:
+                return normalized.value
+    return None

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -18,14 +18,19 @@ from celery.exceptions import Ignore, Retry
 from elasticsearch import AsyncElasticsearch
 from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
-from sqlalchemy import select, cast, String
+from sqlalchemy import String, cast, select
 
 from app.aioRedis import get_thread_safe_redis
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
-from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.memory.storage_services.reflection_engine import retry_registry as rr
+from app.core.memory.storage_services.reflection_engine.errors import (
+    ReflectionBusinessError,
+    ReflectionFailureReason,
+    ReflectionRetriesExhausted,
+)
+from app.core.models import RedBearEmbeddings, RedBearLLM
 from app.core.rag.chunk.hierarchy import GroupedChildChunks, validate_parent_child_result
 from app.core.rag.chunk.metadata import merge_parser_metadata
 from app.core.rag.chunk.parser.image_storage import cleanup_mineru_v3_images
@@ -88,8 +93,8 @@ from app.core.utils.datetime_utils import (
 )
 from app.db import get_db_context, get_db_read
 from app.models import App, AppRelease, Document, File, Knowledge, User, Workspace
-from app.models.file_model import FILE_ROLE_SOURCE
 from app.models.end_user_model import EndUser
+from app.models.file_model import FILE_ROLE_SOURCE
 from app.models.models_model import ModelType
 from app.repositories.end_user_repository import get_end_users_by_workspace
 from app.schemas import document_schema, file_schema
@@ -2989,6 +2994,39 @@ def scan_layer2_reflection(self) -> Dict[str, Any]:
             "skip_period_or_new": skip_period_or_new, "skip_inflight": skip_inflight}
 
 
+def _report_reflection_failure(
+    *,
+    task_type: str,
+    end_user_id: str,
+    workspace_id: str,
+    reason_code: str | None,
+    model_type: str | None,
+    failed_operations: List[str],
+    last_failed_at_ms: int | None,
+) -> None:
+    """把重试耗尽事件交给可选插件；社区版未注册时静默跳过。"""
+    if reason_code is None or last_failed_at_ms is None:
+        return
+
+    from app.plugins import get_plugin
+
+    reporter = get_plugin("reflection_failure_reporter")
+    if reporter is None:
+        return
+    try:
+        reporter.report(
+            task_type=task_type,
+            end_user_id=end_user_id,
+            workspace_id=workspace_id,
+            reason_code=reason_code,
+            model_type=model_type,
+            failed_operations=failed_operations,
+            last_failed_at_ms=last_failed_at_ms,
+        )
+    except Exception:
+        logger.error("反思最终失败上报插件执行失败", exc_info=True)
+
+
 @celery_app.task(
     name="app.tasks.do_layer2_reflection",
     bind=True,
@@ -3082,6 +3120,11 @@ def do_layer2_reflection(self, end_user_id: str | None = None, config_id: str = 
             dedup_info = r.get("entity_dedup", {})
             meta_info = r.get("metadata_extraction", {})
             merge_info = r.get("description_merge", {})
+            reason_codes = rr.reason_codes_of_layer2(r)
+            primary_reason = rr.select_primary_reason(reason_codes)
+            primary_model_type = rr.select_primary_model_type(
+                reason_codes, rr.model_types_of_layer2(r), primary_reason
+            )
 
             if completion == "full":
                 # 步骤4 完整跑完：刷新"上次反思时间"，注销重试登记
@@ -3113,8 +3156,30 @@ def do_layer2_reflection(self, end_user_id: str | None = None, config_id: str = 
                 with get_db_context() as db:
                     WorkspaceAppService(db).update_end_user_reflection_time(end_user_id)
             skipped_steps = rr.skipped_steps_of_layer2(r)
-            rr.record(_rc, "high_freq", end_user_id, completion, progressed,
-                      skipped_steps=skipped_steps)
+            record_result = rr.record(
+                _rc,
+                "high_freq",
+                end_user_id,
+                completion,
+                progressed,
+                skipped_steps=skipped_steps,
+                reason_code=primary_reason,
+                model_type=primary_model_type,
+            )
+            if record_result.outcome is rr.RetryRecordOutcome.EXHAUSTED:
+                _report_reflection_failure(
+                    task_type="high_freq",
+                    end_user_id=end_user_id,
+                    workspace_id=workspace_id,
+                    reason_code=primary_reason,
+                    model_type=primary_model_type,
+                    failed_operations=skipped_steps,
+                    last_failed_at_ms=record_result.last_failed_at_ms,
+                )
+                if primary_reason is not None:
+                    raise ReflectionRetriesExhausted(
+                        ReflectionFailureReason(primary_reason)
+                    )
             logger.warning(
                 f"反思高频do 未完整完成 user={end_user_id} completion={completion} "
                 f"progressed={progressed} skipped={skipped_steps} "
@@ -3136,12 +3201,44 @@ def do_layer2_reflection(self, end_user_id: str | None = None, config_id: str = 
     loop = set_asyncio_event_loop()
     try:
         result = loop.run_until_complete(_run())
+    except ReflectionRetriesExhausted:
+        raise
+    except ReflectionBusinessError as e:
+        logger.error(f"反思高频do 业务失败 user={end_user_id}: {e}", exc_info=True)
+        try:
+            _rc = get_sync_redis_client()
+            record_result = rr.record(
+                _rc,
+                "high_freq",
+                end_user_id,
+                "failed",
+                progressed=False,
+                skipped_steps=[e.failed_operation],
+                reason_code=e.reason_code,
+                model_type=e.model_type,
+            )
+            if record_result.outcome is rr.RetryRecordOutcome.EXHAUSTED:
+                _report_reflection_failure(
+                    task_type="high_freq",
+                    end_user_id=end_user_id,
+                    workspace_id=workspace_id,
+                    reason_code=e.reason_code.value,
+                    model_type=e.model_type.value,
+                    failed_operations=[e.failed_operation],
+                    last_failed_at_ms=record_result.last_failed_at_ms,
+                )
+        except Exception:
+            logger.error("反思高频do 业务失败登记失败", exc_info=True)
+        raise
     except Exception as e:
         # 真异常：run() 抛出未达 completion 逻辑，补登记 failed（无推进），再 re-raise（FAILURE + traceback，需排查）
         logger.error(f"反思高频do 失败 user={end_user_id}: {e}", exc_info=True)
         try:
             _rc = get_sync_redis_client()
-            rr.record(_rc, "high_freq", end_user_id, "failed", progressed=False, last_error=str(e))
+            rr.record(
+                _rc, "high_freq", end_user_id, "failed",
+                progressed=False, last_error=str(e),
+            )
         except Exception:
             pass
         raise
@@ -3294,6 +3391,10 @@ def do_layer2_dedup_full_scan(self, end_user_id: str | None = None, config_id: s
             completion = rr.completion_of_dedup(r)
             progressed = rr.progressed_dedup(r)
             merged = r.get("merged_count", 0)
+            primary_reason = rr.select_primary_reason(rr.reason_codes_of_dedup(r))
+            primary_model_type = rr.select_primary_model_type(
+                rr.reason_codes_of_dedup(r), rr.model_types_of_dedup(r), primary_reason
+            )
 
             if completion == "full":
                 rr.resolve(_rc, "dedup", end_user_id)
@@ -3305,7 +3406,31 @@ def do_layer2_dedup_full_scan(self, end_user_id: str | None = None, config_id: s
                 return {"status": "success", "merged_count": merged}
 
             # partial：truncated / had_type_error。低频不刷 reflection_time（靠 update_scan_time 续扫）。
-            rr.record(_rc, "dedup", end_user_id, completion, progressed)
+            record_result = rr.record(
+                _rc,
+                "dedup",
+                end_user_id,
+                completion,
+                progressed,
+                reason_code=primary_reason,
+                model_type=primary_model_type,
+            )
+            if record_result.outcome is rr.RetryRecordOutcome.EXHAUSTED:
+                _report_reflection_failure(
+                    task_type="dedup",
+                    end_user_id=end_user_id,
+                    workspace_id=workspace_id,
+                    reason_code=primary_reason,
+                    model_type=primary_model_type,
+                    failed_operations=[
+                        str(r["failed_operation"])
+                    ] if r.get("failed_operation") else [],
+                    last_failed_at_ms=record_result.last_failed_at_ms,
+                )
+                if primary_reason is not None:
+                    raise ReflectionRetriesExhausted(
+                        ReflectionFailureReason(primary_reason)
+                    )
             logger.warning(
                 f"反思低频去重do 未完整完成 user={end_user_id} completion={completion} "
                 f"progressed={progressed} truncated={r.get('truncated')} "
@@ -3328,11 +3453,43 @@ def do_layer2_dedup_full_scan(self, end_user_id: str | None = None, config_id: s
     loop = set_asyncio_event_loop()
     try:
         result = loop.run_until_complete(_run())
+    except ReflectionRetriesExhausted:
+        raise
+    except ReflectionBusinessError as e:
+        logger.error(f"反思低频去重do 业务失败 user={end_user_id}: {e}", exc_info=True)
+        try:
+            _rc = get_sync_redis_client()
+            record_result = rr.record(
+                _rc,
+                "dedup",
+                end_user_id,
+                "failed",
+                progressed=False,
+                skipped_steps=[e.failed_operation],
+                reason_code=e.reason_code,
+                model_type=e.model_type,
+            )
+            if record_result.outcome is rr.RetryRecordOutcome.EXHAUSTED:
+                _report_reflection_failure(
+                    task_type="dedup",
+                    end_user_id=end_user_id,
+                    workspace_id=workspace_id,
+                    reason_code=e.reason_code.value,
+                    model_type=e.model_type.value,
+                    failed_operations=[e.failed_operation],
+                    last_failed_at_ms=record_result.last_failed_at_ms,
+                )
+        except Exception:
+            logger.error("反思低频去重业务失败登记失败", exc_info=True)
+        raise
     except Exception as e:
         logger.error(f"反思低频去重do 失败 user={end_user_id}: {e}", exc_info=True)
         try:
             _rc = get_sync_redis_client()
-            rr.record(_rc, "dedup", end_user_id, "failed", progressed=False, last_error=str(e))
+            rr.record(
+                _rc, "dedup", end_user_id, "failed",
+                progressed=False, last_error=str(e),
+            )
         except Exception:
             pass
         raise
@@ -3398,7 +3555,7 @@ def scan_reflection_retry(self) -> Dict[str, Any]:
                 if meta.get("completion") == "exhausted":
                     continue
                 if meta.get("completion") == "in_progress":   # 租约到期 = 上次开工后进程死亡
-                    if not rr.mark_dead(rc, task_type, uid):   # 达 dead 上限置 exhausted 返回 False
+                    if not rr.mark_dead(rc, task_type, uid):
                         continue
                 # 仍走 inflight 锁，避免与正常 scan 派的同一用户撞车
                 if not rc.set(f"{inflight_prefix}:{uid}", "1", nx=True, ex=1500):


### PR DESCRIPTION
Adds Layer2 reflection failure reporting after retry exhaustion. Core emits failures through an optional plugin, while Enterprise handles notification delivery, retries, and JSON template rendering.

## Summary by Sourcery

添加结构化的反射失败分类与报告机制，并在 Layer2 反射任务的重试耗尽时发出最终失败通知。

New Features:
- 引入结构化的反射失败原因和模型类型，并通过 Layer2 反射结果和重试元数据对外暴露。
- 添加一个由插件驱动的钩子，当高频或去重反射重试耗尽时，用于报告最终反射失败。

Bug Fixes:
- 通过在记录耗尽后短路重试记账逻辑，防止已耗尽的反射任务被重新标记或再次重试。

Enhancements:
- 优化 Layer2 反射与去重流程的完成与进度检测，使其能够考虑业务层面的模型失败和向量嵌入问题。
- 在各个反射步骤中聚合并规范化失败原因代码、模型类型和失败操作，从而呈现一个主要失败原因及其受影响的模型。
- 收紧反射组件中的 LLM 调用点，将其改为抛出受控的业务错误而不是返回回退结果，从而提升错误处理的可观测性与一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add structured reflection failure classification and reporting, and emit final failure notifications when retries are exhausted for Layer2 reflection tasks.

New Features:
- Introduce structured reflection failure reasons and model types, and expose them through Layer2 reflection results and retry metadata.
- Add a plugin-driven hook to report final reflection failures when high-frequency or dedup reflection retries are exhausted.

Bug Fixes:
- Prevent exhausted reflection tasks from being re-marked or retried by short-circuiting retry bookkeeping once exhaustion is recorded.

Enhancements:
- Refine completion and progress detection for Layer2 reflection and dedup flows to account for business-level model failures and embedding issues.
- Aggregate and normalize reason codes, model types, and failed operations across reflection steps to surface a primary failure cause and affected model.
- Tighten LLM call sites in reflection components to raise controlled business errors instead of returning fallback results, improving observability and consistency of error handling.

</details>