### PR TITLE
fix(api): rename page_size parameter to pagesize in release list API

### DIFF
--- a/api/app/controllers/prompt_optimizer_controller.py
+++ b/api/app/controllers/prompt_optimizer_controller.py
@@ -218,7 +218,7 @@ def delete_prompt(
 )
 def get_release_list(
         page: int = 1,
-        page_size: int = 20,
+        pagesize: int = 20,
         keyword: str | None = None,
         db: Session = Depends(get_db),
         current_user=Depends(get_current_user),
@@ -229,7 +229,7 @@ def get_release_list(
 
     Args:
         page (int): Page number (starting from 1)
-        page_size (int): Number of items per page (max 100)
+        pagesize (int): Number of items per page (max 100)
         keyword (str | None): Optional keyword to filter prompt titles
         db (Session): Database session
         current_user: Current logged-in user
@@ -241,7 +241,7 @@ def get_release_list(
     result = service.get_release_list(
         tenant_id=current_user.tenant_id,
         page=max(1, page),
-        page_size=min(max(1, page_size), 100),
+        page_size=min(max(1, pagesize), 100),
         filter_keyword=keyword
     )
     return success(data=result)

--- a/api/app/services/prompt_optimizer_service.py
+++ b/api/app/services/prompt_optimizer_service.py
@@ -553,7 +553,7 @@ class PromptOptimizerService:
             "page": {
                 "total": total,
                 "page": page,
-                "page_size": page_size,
+                "pagesize": page_size,
                 "hasnext": page * page_size < total
             },
             "keyword": filter_keyword,


### PR DESCRIPTION
- Rename query parameter `page_size` to `pagesize` in `get_release_list` endpoint
- Update service response key from `page_size` to `pagesize` to match frontend expectation
- Update docstring and parameter validation accordingly

## Summary by Sourcery

通过将 `page_size` 参数和响应键重命名为 `pagesize`，使提示发布列表 API 的请求与响应分页命名与前端保持一致。

Bug Fixes:
- 将 `get_release_list` 查询参数从 `page_size` 重命名为 `pagesize`，以符合前端预期。
- 将服务响应中的分页字段从 `page_size` 更新为 `pagesize`，以确保 API 输入与输出之间的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the prompt release list API request and response pagination naming with the frontend by renaming the page_size parameter and response key to pagesize.

Bug Fixes:
- Rename the get_release_list query parameter from page_size to pagesize to match frontend expectations.
- Update the service response pagination field from page_size to pagesize for consistency between API input and output.

</details>