### PR TITLE
Feat/memory timeline time type filter

### DIFF
--- a/api/app/controllers/user_memory_controllers.py
+++ b/api/app/controllers/user_memory_controllers.py
@@ -15,7 +15,7 @@ from app.dependencies import get_current_user_async, CurrentUserSnapshot
 from app.repositories.workspace_repository import WorkspaceRepository
 from app.schemas.memory_storage_schema import DeleteNodeRequest
 from app.schemas.response_schema import ApiResponse
-from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction
+from app.services.memory_entity_relationship_service import MemoryEntityService, MemoryEmotion, MemoryInteraction, TimelineSort
 from app.services.user_memory_service import UserMemoryService
 
 # Get API logger
@@ -106,9 +106,9 @@ async def memory_space_entity_timeline(
         id: ExtractedEntity 节点的 Neo4j elementId
         type: 来源筛选，all/key_node/statement/memory_summary，默认 all
         sort: 排序方式，默认 time_desc（时间倒序）
-              time_asc/time_desc: key_node 按发生时间，statement/memory_summary 按记录时间
-              occurred_asc/occurred_desc: 全部按发生时间
-              recorded_asc/recorded_desc: 全部按记录时间
+              time_asc/time_desc: 全部按 created_at 排序（key_node=发生时间，statement/memory_summary=记录时间）
+              occurred_asc/occurred_desc: 仅 key_node 按发生时间排序，其余无发生时间排最后
+              recorded_asc/recorded_desc: 仅 statement/memory_summary 按记录时间排序，key_node 无记录时间排最后
         from_ts: 时间范围起始（UTC 毫秒），前端 dayjs.tz(date, timezone).startOf('day').valueOf()
         to_ts: 时间范围结束（UTC 毫秒），前端 dayjs.tz(date, timezone).endOf('day').valueOf()
         page: 页码（从 1 开始）
@@ -120,8 +120,12 @@ async def memory_space_entity_timeline(
     if type not in allowed:
         return fail(BizCode.INVALID_PARAMETER, "type 取值非法", f"type={type}")
 
-    if sort not in MemoryEntityService.VALID_SORTS:
+    if sort not in TimelineSort.values():
         return fail(BizCode.INVALID_PARAMETER, "sort 取值非法", f"sort={sort}")
+
+    # 校验日期区间：from_ts 必须 <= to_ts，否则返回明确错误而非空结果
+    if from_ts is not None and to_ts is not None and from_ts > to_ts:
+        return fail(BizCode.INVALID_PARAMETER, "from_ts 不能大于 to_ts", f"from_ts={from_ts}, to_ts={to_ts}")
 
     memory_entity = MemoryEntityService(id, "ExtractedEntity")
     result = await memory_entity.get_unified_timeline(

--- a/api/app/services/memory_entity_relationship_service.py
+++ b/api/app/services/memory_entity_relationship_service.py
@@ -20,8 +20,41 @@ from datetime import datetime
 from app.schemas.memory_episodic_schema import EmotionType
 from app.core.utils.datetime_utils import parse_iso_to_utc_naive, to_timestamp_ms
 from app.core.memory.models.event_category_models import EVENT_CATEGORY_NAMES, EVENT_CATEGORY_NAME_TO_ID
+from enum import Enum
 
 logger = logging.getLogger(__name__)
+
+
+class TimelineSort(Enum):
+    """记忆时间线排序枚举。
+
+    成员值即对外 API 的 sort 参数字符串。
+    - time_*: 全部按 created_at 排序（key_node=发生时间，其他=记录时间）
+    - occurred_*: 仅 key_node 按发生时间排序，其余无发生时间排最后
+    - recorded_*: 仅 statement/memory_summary 按记录时间排序，key_node 无记录时间排最后
+    """
+
+    TIME_ASC = "time_asc"
+    TIME_DESC = "time_desc"
+    OCCURRED_ASC = "occurred_asc"
+    OCCURRED_DESC = "occurred_desc"
+    RECORDED_ASC = "recorded_asc"
+    RECORDED_DESC = "recorded_desc"
+
+    @property
+    def sort_mode(self) -> str:
+        """排序字段模式：time / occurred / recorded。"""
+        return self.value.rsplit("_", 1)[0]
+
+    @property
+    def is_asc(self) -> bool:
+        """是否升序。"""
+        return self.value.endswith("_asc")
+
+    @classmethod
+    def values(cls) -> set:
+        """返回所有合法 sort 字符串集合，供校验使用。"""
+        return {member.value for member in cls}
 
 
 class MemoryEntityService:
@@ -207,20 +240,6 @@ class MemoryEntityService:
         events.sort(key=lambda e: e["valid_at"], reverse=True)
         return events
 
-    # 排序模式常量
-    SORT_TIME_ASC = "time_asc"
-    SORT_TIME_DESC = "time_desc"
-    SORT_OCCURRED_ASC = "occurred_asc"
-    SORT_OCCURRED_DESC = "occurred_desc"
-    SORT_RECORDED_ASC = "recorded_asc"
-    SORT_RECORDED_DESC = "recorded_desc"
-
-    VALID_SORTS = frozenset({
-        SORT_TIME_ASC, SORT_TIME_DESC,
-        SORT_OCCURRED_ASC, SORT_OCCURRED_DESC,
-        SORT_RECORDED_ASC, SORT_RECORDED_DESC,
-    })
-
     async def get_unified_timeline(
         self,
         source_type: str = "all",
@@ -380,21 +399,15 @@ class MemoryEntityService:
 
         sort_mode: "time" | "occurred" | "recorded"
         sort_asc: True 表示升序，False 表示降序
+
+        非法值直接抛 ValueError，不再静默回退默认值；HTTP 层（controller）
+        已用 ``TimelineSort.values()`` 做同样校验，此处保持行为一致。
         """
-        if sort not in MemoryEntityService.VALID_SORTS:
-            sort = MemoryEntityService.SORT_TIME_DESC
-
-        if sort.startswith("time_"):
-            mode = "time"
-        elif sort.startswith("occurred_"):
-            mode = "occurred"
-        elif sort.startswith("recorded_"):
-            mode = "recorded"
-        else:
-            mode = "time"
-
-        asc = sort.endswith("_asc")
-        return mode, asc
+        try:
+            member = TimelineSort(sort)
+        except ValueError:
+            raise ValueError(f"非法的 sort 值: {sort}")
+        return member.sort_mode, member.is_asc
 
     @staticmethod
     def _get_sort_key(item: dict, sort_mode: str, sort_asc: bool) -> tuple:


### PR DESCRIPTION
GitHub 建议处理
修正 controller docstring 的排序描述
统一 sort 校验逻辑（_parse_sort 非法值改抛异常，不再静默回退）
增加日期反向区间校验（from_ts > to_ts 返回明确错误）
sort 枚举改造
新增 TimelineSort 枚举（6 个值 + sort_mode/is_asc/values() 辅助方法），放在 service 文件顶部
删除旧的 SORT_* 字符串常量和 VALID_SORTS
controller 校验和 service 解析都改用这个枚举

## Summary by Sourcery

为内存时间线引入专用的 `TimelineSort` 枚举，并将控制器和服务的校验逻辑与更严格的排序和日期范围检查对齐。

New Features:
- 添加 `TimelineSort` 枚举以表示支持的内存时间线排序选项，并提供用于模式、方向和有效值的辅助方法。

Bug Fixes:
- 在控制器和服务中拒绝无效的排序值，而不是在静默情况下回退到默认值。
- 对内存时间线的日期范围进行校验，当 `from_ts` 大于 `to_ts` 时返回明确的错误。

Enhancements:
- 更新内存时间线排序的控制器文档字符串，以反映新的排序语义和基于 `created_at` 的排序规则。
- 重构内存时间线排序逻辑，使用 `TimelineSort` 枚举替代旧的字符串常量，以提升一致性和可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated TimelineSort enum for memory timelines and align controller and service validation with stricter sort and date range checks.

New Features:
- Add TimelineSort enum to represent supported memory timeline sort options and expose helper methods for mode, direction, and valid values.

Bug Fixes:
- Reject invalid sort values in both controller and service instead of silently falling back to defaults.
- Validate memory timeline date ranges by returning an explicit error when from_ts is greater than to_ts.

Enhancements:
- Update controller docstring for memory timeline sorting to reflect the new sort semantics and created_at-based ordering.
- Refactor memory timeline sorting to use the TimelineSort enum in place of legacy string constants for better consistency and maintainability.

</details>