### PR TITLE
feat(api): add trace ID to request logging and responses

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -262,7 +262,7 @@ class Settings:
 
     # Logging settings
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
-    LOG_FORMAT: str = os.getenv("LOG_FORMAT", "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    LOG_FORMAT: str = os.getenv("LOG_FORMAT", "%(asctime)s - [%(trace_id)s] -%(name)s - %(levelname)s - %(message)s")
     LOG_FILE_PATH: str = os.getenv("LOG_FILE_PATH", "logs/app.log")
     LOG_MAX_SIZE: int = int(os.getenv("LOG_MAX_SIZE", "10485760"))  # 10MB
     LOG_BACKUP_COUNT: int = int(os.getenv("LOG_BACKUP_COUNT", "5"))

--- a/api/app/core/logging_config.py
+++ b/api/app/core/logging_config.py
@@ -7,6 +7,7 @@ from typing import Optional
 from app.core.config import settings
 from app.core.utils.datetime_utils import utcnow_naive
 from app.core.sensitive_filter import SensitiveDataFilter
+from app.core.trace import get_trace_id
 
 
 class SensitiveDataLoggingFilter(logging.Filter):
@@ -36,6 +37,20 @@ class SensitiveDataLoggingFilter(logging.Filter):
                     for arg in record.args
                 )
         
+        return True
+
+
+class TraceIdFilter(logging.Filter):
+    """日志过滤器：将请求上下文中的 trace_id 注入 LogRecord。
+
+    在 handler 格式化之前执行，把 ContextVar 中的 trace_id 写入
+    record.trace_id，使 LOG_FORMAT 中的 %(trace_id)s 能取到值。
+    无请求上下文（如后台任务）时 trace_id 为空字符串。
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not hasattr(record, "trace_id"):
+            record.trace_id = get_trace_id()
         return True
 
 
@@ -144,6 +159,9 @@ class LoggingConfig:
         
         # 创建敏感信息过滤器
         sensitive_filter = SensitiveDataLoggingFilter()
+
+        # 创建 trace_id 过滤器（将请求上下文中的 trace_id 注入每条日志）
+        trace_id_filter = TraceIdFilter()
         
         # 控制台处理器
         if settings.LOG_TO_CONSOLE:
@@ -151,6 +169,7 @@ class LoggingConfig:
             console_handler.setFormatter(formatter)
             console_handler.setLevel(getattr(logging, settings.LOG_LEVEL.upper()))
             console_handler.addFilter(sensitive_filter)
+            console_handler.addFilter(trace_id_filter)
             console_handler.addFilter(neo4j_filter)
             root_logger.addHandler(console_handler)
         
@@ -165,6 +184,7 @@ class LoggingConfig:
             file_handler.setFormatter(formatter)
             file_handler.setLevel(getattr(logging, settings.LOG_LEVEL.upper()))
             file_handler.addFilter(sensitive_filter)
+            file_handler.addFilter(trace_id_filter)
             file_handler.addFilter(neo4j_filter)
             root_logger.addHandler(file_handler)
         

--- a/api/app/core/trace.py
+++ b/api/app/core/trace.py
@@ -1,0 +1,18 @@
+from contextvars import ContextVar, Token
+
+_trace_id_var: ContextVar[str] = ContextVar("request_trace_id", default="")
+
+
+def get_trace_id() -> str:
+    """获取当前请求上下文的 trace_id，无请求上下文时返回空字符串。"""
+    return _trace_id_var.get()
+
+
+def set_trace_id(trace_id: str) -> Token:
+    """设置当前请求上下文的 trace_id，返回用于 reset 的 token。"""
+    return _trace_id_var.set(trace_id)
+
+
+def reset_trace_id(token: Token) -> None:
+    """还原 trace_id 到进入上下文前的值。"""
+    _trace_id_var.reset(token)

--- a/api/app/core/trace_middleware.py
+++ b/api/app/core/trace_middleware.py
@@ -1,0 +1,26 @@
+import logging
+import uuid
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.core.trace import reset_trace_id, set_trace_id
+
+logger = logging.getLogger(__name__)
+
+TRACE_ID_HEADER = "X-Trace-Id"
+
+
+class TraceIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        trace_id = uuid.uuid4().hex
+
+        token = set_trace_id(trace_id)
+        request.state.trace_id = trace_id
+        try:
+            response = await call_next(request)
+        finally:
+            reset_trace_id(token)
+
+        response.headers[TRACE_ID_HEADER] = trace_id
+        return response

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -172,6 +172,10 @@ app.add_middleware(LanguageMiddleware)
 # MCP API Key 鉴权中间件（仅拦截 /mcp/* 路径）
 app.add_middleware(MCPAuthMiddleware)
 
+# Trace ID 中间件（最外层：为每个请求生成 trace_id，注入日志上下文并在响应头回传）
+from app.core.trace_middleware import TraceIdMiddleware
+app.add_middleware(TraceIdMiddleware)
+
 logger.info("FastAPI应用程序启动")
 
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -11,10 +11,12 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
+import logging
 
 import redis
-from celery import states
+from celery import states, current_task
 from celery.exceptions import Ignore, Retry
+from celery.signals import after_setup_logger
 from elasticsearch import AsyncElasticsearch
 from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
@@ -102,6 +104,28 @@ from app.services.memory_config_service import MemoryConfigService
 from app.services.memory_forget_service import MemoryForgetService
 from app.services.model_service import ModelApiKeyService
 from app.utils.redis_lock import RedisFairLock
+
+
+class CeleryTaskIdFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            record.task_id = current_task.request.id
+        except Exception:
+            record.task_id = "-"
+        return True
+
+
+@after_setup_logger.connect
+def setup_logger(logger, *args, **kwargs):
+    formatter = logging.Formatter(
+        "[%(asctime)s: %(levelname)s/%(processName)s] "
+        "[task_id=%(task_id)s] %(message)s"
+    )
+
+    for handler in logger.handlers:
+        handler.setFormatter(formatter)
+        handler.addFilter(CeleryTaskIdFilter())
+
 
 logger = get_logger(__name__)
 
@@ -3002,14 +3026,14 @@ def scan_layer2_reflection(self) -> Dict[str, Any]:
 
 
 def _report_reflection_failure(
-    *,
-    task_type: str,
-    end_user_id: str,
-    workspace_id: str,
-    reason_code: str | None,
-    model_type: str | None,
-    failed_operations: List[str],
-    last_failed_at_ms: int | None,
+        *,
+        task_type: str,
+        end_user_id: str,
+        workspace_id: str,
+        reason_code: str | None,
+        model_type: str | None,
+        failed_operations: List[str],
+        last_failed_at_ms: int | None,
 ) -> None:
     """把重试耗尽事件交给可选插件；社区版未注册时静默跳过。"""
     if reason_code is None or last_failed_at_ms is None:
@@ -3561,7 +3585,7 @@ def scan_reflection_retry(self) -> Dict[str, Any]:
                     continue
                 if meta.get("completion") == "exhausted":
                     continue
-                if meta.get("completion") == "in_progress":   # 租约到期 = 上次开工后进程死亡
+                if meta.get("completion") == "in_progress":  # 租约到期 = 上次开工后进程死亡
                     if not rr.mark_dead(rc, task_type, uid):
                         continue
                 # 仍走 inflight 锁，避免与正常 scan 派的同一用户撞车


### PR DESCRIPTION
- Introduce a contextvar-based trace ID utility and a middleware that generates a UUID per request, stores it in the request context, and returns it in the X-Trace-Id response header
- Add a logging filter that injects the trace ID into every log record and include it in the default log format
- Configure Celery task logging to include the task ID in log messages for better correlation

## Summary by Sourcery

通过中间件和日志添加按请求的 Trace ID 传播，并改进 Celery 任务日志关联。

新功能：
- 引入基于上下文的 Trace ID 工具和中间件，为每个 HTTP 请求生成一个 UUID，将其存储在请求上下文中，并通过 `X-Trace-Id` 响应头对外暴露。

增强：
- 在应用日志中增加 Trace ID 字段，将其注入到日志记录中，并包含在默认日志格式中，用于按请求级别进行关联。
- 配置 Celery 任务日志，使用自定义过滤器和格式化器在日志消息中包含任务 ID，以便更好地跟踪后台作业。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-request trace ID propagation through middleware and logging, and improve Celery task log correlation.

New Features:
- Introduce a context-based trace ID utility and middleware that generates a UUID per HTTP request, stores it in the request context, and exposes it via the X-Trace-Id response header.

Enhancements:
- Augment application logging with a trace ID field injected into log records and included in the default log format for request-level correlation.
- Configure Celery task logging with a custom filter and formatter to include the task ID in log messages for better tracking of background jobs.

</details>