### PR TITLE
feat(web): space config switch embedding add confirm

### DIFF
--- a/web/src/i18n/en/space.ts
+++ b/web/src/i18n/en/space.ts
@@ -27,6 +27,8 @@ export const space = {
       multimodalModelDesc: 'Enable on demand to process image / audio / video content',
       optional: '(Optional)',
       configAlert: 'Space model configuration ensures that the space can correctly call the corresponding models to process business data during runtime.',
+      embeddingSwitchConfirmTitle: 'Switch Embedding Model',
+      embeddingSwitchConfirmContent: 'Switching the embedding model may degrade the performance of related retrieval features. Are you sure you want to continue?',
 
       basic: 'Basic Config',
       models: 'Model Configuration',

--- a/web/src/i18n/zh/space.ts
+++ b/web/src/i18n/zh/space.ts
@@ -27,6 +27,8 @@ export const space = {
       multimodalModelDesc: '按需启用，处理图像 / 音频 / 视频内容',
       optional: '（选填）',
       configAlert: '空间模型配置为空间的模型模型，保障空间运行时能正确的调用到相应的模型来处理业务数据。',
+      embeddingSwitchConfirmTitle: '切换 Embedding 模型确认',
+      embeddingSwitchConfirmContent: '切换 embedding 模型可能导致相关检索功能效果下降，确定要切换吗？',
 
       basic: '基础配置',
       models: '模型配置',

--- a/web/src/views/SpaceConfig/index.tsx
+++ b/web/src/views/SpaceConfig/index.tsx
@@ -9,7 +9,7 @@
  * Configures default models for workspace (LLM, embedding, rerank)
  */
 
-import { type FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import { Form, App, Button, Skeleton, Flex } from 'antd';
 import { useTranslation } from 'react-i18next';
 
@@ -36,10 +36,11 @@ const multimodalModelFields: { name: string; label: string; capability: Capabili
 
 const SpaceConfig: FC = () => {
   const { t } = useTranslation();
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
   const [pageLoading, setPageLoading] = useState(false)
   const [form] = Form.useForm<SpaceConfigData>();
   const [loading, setLoading] = useState(false)
+  const lastConfirmedEmbeddingRef = useRef<SpaceConfigData['embedding']>(undefined)
 
   const values = Form.useWatch([], form);
 
@@ -92,6 +93,27 @@ const SpaceConfig: FC = () => {
     handleGetDefaultModels()
     handleGetCustomModels()
   }, [])
+
+  useEffect(() => {
+    lastConfirmedEmbeddingRef.current = lastConfig.embedding
+  }, [lastConfig.embedding])
+
+  const handleEmbeddingChange = (newValue: SpaceConfigData['embedding']) => {
+    const prevValue = lastConfirmedEmbeddingRef.current
+    if (newValue === prevValue) return
+    modal.confirm({
+      title: t('space.embeddingSwitchConfirmTitle'),
+      content: t('space.embeddingSwitchConfirmContent'),
+      okText: t('common.confirm'),
+      cancelText: t('common.cancel'),
+      onOk: () => {
+        lastConfirmedEmbeddingRef.current = newValue
+      },
+      onCancel: () => {
+        form.setFieldsValue({ embedding: prevValue })
+      },
+    })
+  }
   /** Save configuration */
   const handleSave = () => {
     form
@@ -170,6 +192,7 @@ const SpaceConfig: FC = () => {
                     isAutoFetch={false}
                     initialData={customModels[field.name]}
                     className="rb:w-137.5!"
+                    {...(field.name === 'embedding' ? { onChange: handleEmbeddingChange } : {})}
                   />
                 </Form.Item>
               ))}


### PR DESCRIPTION
## Summary by Sourcery

在网页空间配置视图中，当切换空间的嵌入模型时，新增确认流程。

新特性：
- 在空间配置中更改嵌入模型之前，弹出确认模态窗口提示用户。

增强功能：
- 记录上一次已确认的嵌入配置，以防止误操作，并在取消时保留之前的数值。

文档：
- 扩展英文和中文的空间配置文案，加入说明切换嵌入模型所带来的影响的文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a confirmation flow when switching the space embedding model in the web space configuration view.

New Features:
- Prompt users with a confirmation modal before applying changes to the embedding model in space configuration.

Enhancements:
- Track last confirmed embedding configuration to prevent accidental changes and preserve previous value on cancellation.

Documentation:
- Extend English and Chinese space configuration copy with texts explaining the implications of switching the embedding model.

</details>