### PR TITLE
fix(web): features file count

### DIFF
--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
@@ -34,7 +34,6 @@ interface FeaturesConfigModalProps {
   capability?: Capability[];
   chatVariables: Variable[];
 }
-const max_file_count = 1;
 /**
  * Modal for copying applications
  */
@@ -275,7 +274,7 @@ const FeaturesConfigModal = forwardRef<FeaturesConfigModalRef, FeaturesConfigMod
                     </div>
                     <div>
                       <div className="rb:text-[12px] rb:text-[#5B6167] rb:py-1">{t('application.maxCount')}</div>
-                      {max_file_count} {t('application.unix')}
+                      {values?.file_upload.max_file_count} {t('application.unix')}
                     </div>
                   </Flex>
                   <Button block onClick={handleOpenSettings}>{t('application.setting')}</Button>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复功能配置模态框中显示的最大文件数量，使其与实际的 `file_upload.max_file_count` 设置保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the displayed maximum file count in the features configuration modal to reflect the actual file_upload.max_file_count setting.

</details>