### PR TITLE
fix(web): PageScrollList id

### DIFF
--- a/web/src/components/PageScrollList/index.tsx
+++ b/web/src/components/PageScrollList/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 15:18:19 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-03-31 15:31:18
+ * @Last Modified time: 2026-08-17 10:32:44
  */
 /**
  * PageScrollList Component
@@ -16,7 +16,7 @@
  * @component
  */
 
-import React, { useEffect, useState, useRef, forwardRef, useImperativeHandle } from 'react';
+import React, { useEffect, useState, useRef, useId, forwardRef, useImperativeHandle } from 'react';
 import { Row, Col } from 'antd';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
@@ -41,6 +41,7 @@ interface ApiResponse<T> {
 /** Ref methods exposed to parent component */
 export interface PageScrollListRef {
   refresh: () => void;
+  total: number;
 }
 
 /** Props interface for PageScrollList component */
@@ -80,15 +81,18 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   onTotalChange,
   empty,
 }: PageScrollListProps<T, Q>, ref: React.Ref<PageScrollListRef>) => {
+  const scrollableTargetId = `page-scroll-list-${useId().replace(/:/g, '')}`;
   /** Expose refresh method to parent component */
   useImperativeHandle(ref, () => ({
     refresh: () => {
       pageRef.current = 1;
       loadingRef.current = false;
+      hasMoreRef.current = true;
       setHasMore(true);
       setData([]);
       loadMoreData(true);
     },
+    total,
   }));
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<T[]>([]);
@@ -150,38 +154,37 @@ const PageScrollList = forwardRef(<T, Q = Record<string, unknown>>({
   }, [queryKey]);
 
   return (
-    <>
-      <div
-        ref={scrollRef}
-        id="scrollableDiv"
-        className={`rb:overflow-y-auto rb:overflow-x-hidden ${heightClass || defaultHeightClass} ${className}`}
+    <div
+      ref={scrollRef}
+      id={scrollableTargetId}
+      className={`rb:overflow-y-auto rb:overflow-x-hidden rb:min-h-0! ${heightClass || defaultHeightClass} ${className}`}
+    >
+      <InfiniteScroll
+        dataLength={data.length}
+        next={() => loadMoreData()}
+        hasMore={hasMore}
+        loader={loading && needLoading ? <PageLoading className={heightClass || defaultHeightClass} /> : false}
+        // endMessage={<Divider plain>It is all, nothing more 🤐</Divider>}
+        scrollThreshold={0.9}
+        scrollableTarget={scrollableTargetId}
+        style={{ overflow: 'visible', width: '100%' }}
       >
-        <InfiniteScroll
-          dataLength={data.length}
-          next={() => loadMoreData()}
-          hasMore={hasMore}
-          loader={loading && needLoading ? <PageLoading className={heightClass || defaultHeightClass} /> : false}
-          // endMessage={<Divider plain>It is all, nothing more 🤐</Divider>}
-          scrollableTarget="scrollableDiv"
-          className='rb:h-full!'
-        >
-          {/* Render grid list or empty state */}
-          {data.length > 0 ? (
-            renderItems
-            ? renderItems(data)
-            : (
-              <Row gutter={gutter}>
-                {data.map((item, index) => (
-                  <Col key={(item as any).id || index} span={24/column}>
-                    {renderItem(item, index)}
-                  </Col>
-                ))}
-              </Row>
-            )
-          ) : !loading ? empty || <PageEmpty className={heightClass || defaultHeightClass} /> : null}
-        </InfiniteScroll>
-      </div>
-    </>
+        {/* Render grid list or empty state */}
+        {data.length > 0 ? (
+          renderItems
+          ? renderItems(data)
+          : (
+            <Row gutter={gutter}>
+              {data.map((item, index) => (
+                <Col key={(item as any).id || index} span={24/column}>
+                  {renderItem(item, index)}
+                </Col>
+              ))}
+            </Row>
+          )
+        ) : !loading ? empty || <PageEmpty className={heightClass || defaultHeightClass} /> : null}
+      </InfiniteScroll>
+    </div>
   );
 }) as <T = Record<string, unknown>, Q = Record<string, unknown>>(props: PageScrollListProps<T, Q> & { ref?: React.Ref<PageScrollListRef> }) => React.ReactElement;
 


### PR DESCRIPTION
## Summary by Sourcery

确保 PageScrollList 使用唯一的滚动容器 ID，并通过其 ref 暴露总数量，同时改进刷新行为和布局。

新功能：
- 通过 PageScrollList 的 ref API 暴露项目总数。

错误修复：
- 为每个 PageScrollList 实例分配唯一的可滚动容器 ID，以避免与 InfiniteScroll 的目标和滚动行为冲突。
- 在触发刷新时重置 hasMore 状态，以便在刷新后允许后续分页。

增强改进：
- 简化 PageScrollList 的 DOM 结构，并调整类名，以更好地支持灵活高度和滚动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure PageScrollList uses a unique scroll container ID and exposes total count via its ref while improving refresh behavior and layout.

New Features:
- Expose the total item count through the PageScrollList ref API.

Bug Fixes:
- Assign a unique scrollable container ID per PageScrollList instance to avoid conflicts with InfiniteScroll targeting and scrolling behavior.
- Reset hasMore state when refresh is triggered to allow subsequent pagination after a refresh.

Enhancements:
- Simplify the PageScrollList DOM structure and adjust classes to better support flexible height and scrolling behavior.

</details>