### PR TITLE
docs: fix broken star history charts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,6 @@ This project is licensed under the [Apache License 2.0](LICENSE).
 
 - **Star History**:
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SuanmoSuanyangTechnology/MemoryBear&type=Date)](https://star-history.com/#SuanmoSuanyangTechnology/MemoryBear&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=SuanmoSuanyangTechnology/MemoryBear&type=Date)](https://star-history.dera.page/#SuanmoSuanyangTechnology/MemoryBear&type=Date)
 
 - **Contact**: jiezhimin@redbearai.com

--- a/README_CN.md
+++ b/README_CN.md
@@ -473,6 +473,6 @@ Step 8  使用管理员账号登录前端页面
 
 - **Star 历史**：
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SuanmoSuanyangTechnology/MemoryBear&type=Date)](https://star-history.com/#SuanmoSuanyangTechnology/MemoryBear&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=SuanmoSuanyangTechnology/MemoryBear&type=Date)](https://star-history.dera.page/#SuanmoSuanyangTechnology/MemoryBear&type=Date)
 
 - **联系我们**：jiezhimin@redbearai.com


### PR DESCRIPTION
The star history charts in the README files are currently broken because the underlying GitHub stargazer API is restricted.

This PR swaps the charts over to a working alternative that needs no API token, restoring the history graphs in README.md and README_CN.md.

## Summary by Sourcery

文档：
- 将 README.md 和 README_CN.md 中的 star history 图表链接切换为无需令牌、可正常使用的 star history 服务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Switch star history chart links in README.md and README_CN.md to a non-token, functioning star history service.

</details>