### PR TITLE
copy pr#1918: add MiniMax provider catalog support

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -529,7 +529,6 @@ def get_provider_embedding_class(provider: str) -> type[Embeddings]:
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
-        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         from langchain_openai import OpenAIEmbeddings

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -280,6 +280,7 @@ class RedBearModelFactory:
             ModelProvider.OPENAI,
             ModelProvider.XINFERENCE,
             ModelProvider.GPUSTACK,
+            ModelProvider.MINIMAX,
             ModelProvider.OLLAMA,
             ModelProvider.VOLCANO,
             ModelProvider.SPEEDBEAR,
@@ -501,6 +502,7 @@ def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelTy
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
+        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         return CompatibleChatOpenAI
@@ -527,6 +529,7 @@ def get_provider_embedding_class(provider: str) -> type[Embeddings]:
         ModelProvider.OPENAI,
         ModelProvider.XINFERENCE,
         ModelProvider.GPUSTACK,
+        ModelProvider.MINIMAX,
         ModelProvider.SPEEDBEAR,
     ]:
         from langchain_openai import OpenAIEmbeddings

--- a/api/app/core/models/scripts/minimax_models.yaml
+++ b/api/app/core/models/scripts/minimax_models.yaml
@@ -1,0 +1,31 @@
+provider: minimax
+models:
+- name: MiniMax-M3
+  type: llm
+  provider: minimax
+  description: MiniMax-M3 multimodal large language model with a 1,000,000 token context window, image input, video input, and adaptive thinking.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - vision
+  - video
+  - thinking
+  is_omni: false
+  tags:
+  - large-language-model
+  - multimodal
+  - vision
+  - video
+  - thinking
+- name: MiniMax-M2.7
+  type: llm
+  provider: minimax
+  description: MiniMax-M2.7 large language model with a 204,800 token context window and always-on thinking.
+  is_deprecated: false
+  is_official: true
+  capability:
+  - thinking_only
+  is_omni: false
+  tags:
+  - large-language-model
+  - thinking

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -487,7 +487,6 @@ _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
 _MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
     ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
     ModelProvider.VOLCANO, ModelProvider.SPEEDBEAR,
-    ModelProvider.MINIMAX,
     ModelProvider.OLLAMA,
     ModelProvider.BEDROCK,
 })

--- a/api/app/core/workflow/nodes/llm/config.py
+++ b/api/app/core/workflow/nodes/llm/config.py
@@ -487,6 +487,7 @@ _PARAM_PROVIDER_WARNINGS: dict[str, str] = {
 _MULTIMODAL_COMPATIBLE_PROVIDERS = frozenset({
     ModelProvider.OPENAI, ModelProvider.XINFERENCE, ModelProvider.GPUSTACK,
     ModelProvider.VOLCANO, ModelProvider.SPEEDBEAR,
+    ModelProvider.MINIMAX,
     ModelProvider.OLLAMA,
     ModelProvider.BEDROCK,
 })

--- a/api/app/models/models_model.py
+++ b/api/app/models/models_model.py
@@ -48,6 +48,7 @@ class ModelProvider(StrEnum):
     """模型提供商枚举"""
     OPENAI = "openai"
     SPEEDBEAR = "speedbear"
+    MINIMAX = "minimax"
     # ANTHROPIC = "anthropic"
     # GOOGLE = "google"
     # BAIDU = "baidu"


### PR DESCRIPTION
> Copied from external PR #1918, target to develop branch.
> Original PR target main.

## Summary by Sourcery

添加 MiniMax 提供商目录支持，并公开其可用的语言模型。

新功能：
- 将 MiniMax 添加为受支持的模型提供商，并为 MiniMax-M3 和 MiniMax-M2.7 提供目录条目。

增强功能：
- 将 MiniMax 集成到现有的兼容聊天模型处理和提供商参数配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MiniMax provider catalog support and expose its available language models.

New Features:
- Add MiniMax as a supported model provider with catalog entries for MiniMax-M3 and MiniMax-M2.7.

Enhancements:
- Integrate MiniMax with the existing compatible chat model handling and provider parameter configuration.

</details>