### PR TITLE
fix(web): unread messages max display

### DIFF
--- a/web/src/components/NotificationCenter/index.tsx
+++ b/web/src/components/NotificationCenter/index.tsx
@@ -248,8 +248,8 @@ const NotificationPanel = ({ open }: NotificationPanelProps) => {
               </div>
             )}
             {!pagination.loadingMore && !pagination.hasMore && (
-              <div className="rb:py-2 rb:text-center rb:text-[11px] rb:text-[#B8BAC0]">
-                — {t('notificationCenter.empty.noMore', { defaultValue: '没有更多了' })} —
+              <div key="end" className="rb:py-2 rb:text-center rb:text-[11px] rb:text-[#B8BAC0]">
+                — {unreadOnly && pagination.has_more ? t('notificationCenter.empty.hasMore', { total: pagination.total }) : t('notificationCenter.empty.noMore')} —
               </div>
             )}
           </>

--- a/web/src/i18n/en/notificationCenter.ts
+++ b/web/src/i18n/en/notificationCenter.ts
@@ -25,6 +25,8 @@ export const notificationCenter = {
     empty: {
       all: 'No messages',
       unread: 'No unread messages',
+      noMore: 'No more messages',
+      hasMore: 'Up to {{total}} unread messages are displayed',
     },
     detail: {
       title: 'Message Details',

--- a/web/src/i18n/zh/notificationCenter.ts
+++ b/web/src/i18n/zh/notificationCenter.ts
@@ -26,6 +26,8 @@ export const notificationCenter = {
     empty: {
       all: '暂无消息',
       unread: '没有未读消息',
+      noMore: '没有更多了',
+      hasMore: '未读消息最多展示{{total}}条',
     },
     detail: {
       title: '消息详情',

--- a/web/src/store/notification.ts
+++ b/web/src/store/notification.ts
@@ -84,11 +84,12 @@ export const useNotification = create<NotificationState>((set, get) => {
           page,
           pagesize: pageSize,
         });
-        const { messages, hasMore } = extractPaginatedMessages(response, pageSize);
+        const { messages, hasMore, ...rest } = extractPaginatedMessages(response, pageSize);
         set((state) => ({
           messages,
           pagination: {
             ...state.pagination,
+            ...rest,
             page,
             pageSize,
             hasMore,

--- a/web/src/store/notification/types.ts
+++ b/web/src/store/notification/types.ts
@@ -86,6 +86,9 @@ export interface PaginationState {
   pageSize: number;
   hasMore: boolean;
   loadingMore: boolean;
+  has_more: boolean;
+  pagesize: number;
+  total: number;
 }
 
 export interface NotificationState {

--- a/web/src/store/notification/utils.ts
+++ b/web/src/store/notification/utils.ts
@@ -80,9 +80,12 @@ export const emptyPagination = (
   pageSize: number = NOTIFICATION_PAGE_SIZE,
 ): PaginationState => ({
   page: 1,
+  pagesize: pageSize,
   pageSize,
   hasMore: true,
   loadingMore: false,
+  total: 0,
+  has_more: false,
 });
 
 export const extractPaginatedMessages = (
@@ -109,7 +112,6 @@ export const extractPaginatedMessages = (
 
   if (!isRecord(response)) return empty;
   const root = response as NotificationListResponse & Record<string, unknown>;
-
   let payload: NotificationListResponse = root;
   if (isRecord(root.data)) {
     payload = root.data as NotificationListResponse;
@@ -118,7 +120,8 @@ export const extractPaginatedMessages = (
     return {
       ...empty,
       messages,
-      hasMore: messages.length >= requestedPageSize,
+      ...root.page,
+      hasMore: root.page?.hasnext ?? false,
       total: messages.length,
     };
   }


### PR DESCRIPTION
## Summary by Sourcery

修复通知分页，并阐明在何种情况下已达到未读消息显示上限。

Bug 修复：
- 更正未读通知的分页逻辑，使 UI 能准确指示何时已显示最大数量的未读消息。

增强功能：
- 传递服务器提供的分页元数据，并为未读通知显示本地化的列表末尾提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix notification pagination and clarify when the unread-message display limit has been reached.

Bug Fixes:
- Correct unread notification pagination so the UI accurately indicates when the maximum number of unread messages has been displayed.

Enhancements:
- Propagate server-provided pagination metadata and show localized end-of-list messaging for unread notifications.

</details>