### PR TITLE
fix(web): unread messages max display

### DIFF
--- a/web/src/components/NotificationCenter/index.tsx
+++ b/web/src/components/NotificationCenter/index.tsx
@@ -107,6 +107,7 @@ const NotificationPanel = ({ open }: NotificationPanelProps) => {
     snoozeModalMessage(selected.id, 1);
     setSelected(null);
   };
+  console.log('pagination', pagination)
 
   return (
     <div className={styles.panel}>
@@ -168,7 +169,7 @@ const NotificationPanel = ({ open }: NotificationPanelProps) => {
             endMessage={
               pagination.hasMore ? null : (
                 <div key="end" className="rb:py-2 rb:text-center rb:text-[11px] rb:text-[#B8BAC0]">
-                  — {t('notificationCenter.empty.noMore', { defaultValue: '没有更多了' })} —
+                  — {unreadOnly && pagination.has_more ? t('notificationCenter.empty.hasMore', { total: pagination.total }) : t('notificationCenter.empty.noMore')} —
                 </div>
               )
             }

--- a/web/src/i18n/en/notificationCenter.ts
+++ b/web/src/i18n/en/notificationCenter.ts
@@ -25,6 +25,8 @@ export const notificationCenter = {
     empty: {
       all: 'No messages',
       unread: 'No unread messages',
+      noMore: 'No more messages',
+      hasMore: 'Up to {{total}} unread messages are displayed',
     },
     detail: {
       title: 'Message Details',

--- a/web/src/i18n/zh/notificationCenter.ts
+++ b/web/src/i18n/zh/notificationCenter.ts
@@ -26,6 +26,8 @@ export const notificationCenter = {
     empty: {
       all: '暂无消息',
       unread: '没有未读消息',
+      noMore: '没有更多了',
+      hasMore: '未读消息最多展示{{total}}条',
     },
     detail: {
       title: '消息详情',

--- a/web/src/store/notification.ts
+++ b/web/src/store/notification.ts
@@ -84,11 +84,13 @@ export const useNotification = create<NotificationState>((set, get) => {
           page,
           pagesize: pageSize,
         });
-        const { messages, hasMore } = extractPaginatedMessages(response, pageSize);
+        const { messages, hasMore, ...rest } = extractPaginatedMessages(response, pageSize);
+        console.log('rest', rest)
         set((state) => ({
           messages,
           pagination: {
             ...state.pagination,
+            ...rest,
             page,
             pageSize,
             hasMore,

--- a/web/src/store/notification/types.ts
+++ b/web/src/store/notification/types.ts
@@ -86,6 +86,9 @@ export interface PaginationState {
   pageSize: number;
   hasMore: boolean;
   loadingMore: boolean;
+  has_more: boolean;
+  pagesize: number;
+  total: number;
 }
 
 export interface NotificationState {

--- a/web/src/store/notification/utils.ts
+++ b/web/src/store/notification/utils.ts
@@ -35,6 +35,7 @@ interface PaginatedMessages {
   page: number;
   pageSize: number;
   total: number;
+  has_more: boolean;
 }
 
 export const NOTIFICATION_PAGE_SIZE = 10;
@@ -80,9 +81,12 @@ export const emptyPagination = (
   pageSize: number = NOTIFICATION_PAGE_SIZE,
 ): PaginationState => ({
   page: 1,
+  pagesize: pageSize,
   pageSize,
   hasMore: true,
   loadingMore: false,
+  total: 0,
+  has_more: false,
 });
 
 export const extractPaginatedMessages = (
@@ -95,6 +99,7 @@ export const extractPaginatedMessages = (
     page: 1,
     pageSize: requestedPageSize,
     total: 0,
+    has_more: false,
   };
 
   if (Array.isArray(response)) {
@@ -109,7 +114,6 @@ export const extractPaginatedMessages = (
 
   if (!isRecord(response)) return empty;
   const root = response as NotificationListResponse & Record<string, unknown>;
-
   let payload: NotificationListResponse = root;
   if (isRecord(root.data)) {
     payload = root.data as NotificationListResponse;
@@ -118,7 +122,8 @@ export const extractPaginatedMessages = (
     return {
       ...empty,
       messages,
-      hasMore: messages.length >= requestedPageSize,
+      ...root.page,
+      hasMore: root.page?.hasnext ?? false,
       total: messages.length,
     };
   }
@@ -130,6 +135,7 @@ export const extractPaginatedMessages = (
     : []
   ) as NotificationMessage[];
 
+  const has_more = payload.has_more ?? false;
   const pageMeta = isRecord(payload.page) ? payload.page as PageMeta : undefined;
   const page = isFiniteNumber(pageMeta?.page) ? pageMeta.page : 1;
   const pageSize = isFiniteNumber(pageMeta?.pagesize)
@@ -157,7 +163,7 @@ export const extractPaginatedMessages = (
         ? payload.has_next
         : messages.length >= pageSize;
 
-  return { messages, hasMore, page, pageSize, total };
+  return { messages, hasMore, page, pageSize, total, has_more };
 };
 
 export const isNotificationGeneration = (


### PR DESCRIPTION
## Summary by Sourcery

修复未读通知分页问题，并澄清当前显示的未读消息上限规则。

Bug Fixes（错误修复）:
- 修正未读通知分页处理和列表末尾提示信息，使最大可显示的未读数量能够被准确告知用户。

Enhancements（功能增强）:
- 将通知响应中的分页元数据传递到通知状态中，并为“未读结果被耗尽或达到上限”的情况提供本地化提示信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unread notification pagination and clarify when the displayed unread messages are capped.

Bug Fixes:
- Correct unread notification pagination handling and end-of-list messaging so the maximum displayed unread count is communicated accurately.

Enhancements:
- Propagate pagination metadata from notification responses into notification state and present localized messages for exhausted or capped unread results.

</details>