### PR TITLE
fix(rag): preserve direct image fallback in mixed mode

### DIFF
--- a/api/app/core/rag/chunk/pipeline/image.py
+++ b/api/app/core/rag/chunk/pipeline/image.py
@@ -67,10 +67,17 @@ class ImageChunkPipeline(ChunkPipeline):
             "\n\n".join(markdown_parts),
             source_image_url,
         )
-        blocks.extend(mineru_blocks)
         has_ocr_text = self._has_content(
             [block for block in mineru_blocks if block.type is not ParsedBlockType.IMAGE]
         )
+        if (
+            mode == 1
+            and not has_ocr_text
+            and len(mineru_blocks) == 1
+            and mineru_blocks[0].type is ParsedBlockType.IMAGE
+        ):
+            mineru_blocks = []
+        blocks.extend(mineru_blocks)
         if mode in {1, 2}:
             source_image_block.image = source_image
             source_image_block.image_vision_scope = ImageVisionScope.DIRECT


### PR DESCRIPTION
## Business Background

When MinerU returns only the uploaded image tag, Mode 1 merges the duplicate tag with the direct source image. The merged result is no longer an eligible direct-image chunk, so visual description is skipped and document import fails.

## Summary

- Remove the MinerU image block only when Mode 1 has no OCR text and exactly one MinerU image block.
- Preserve existing Mode 0, Mode 2, OCR-text, and multi-image behavior.

## Changes

- `api/app/core/rag/chunk/pipeline/image.py`: 8 additions, 1 deletion.

## Risk

The condition is intentionally narrow. It changes only the confirmed duplicate-original-image fallback case; no schema, queue, model configuration, or API behavior changes.

## Test Plan

- [x] `PYTHONPATH=. uv run pytest tests/core/rag/chunk/test_image_pipeline.py -q` (5 passed)
- [x] `uv run ruff check app/core/rag/chunk/pipeline/image.py`
- [x] `uv run python -m compileall -q app/core/rag/chunk/pipeline/image.py`
- [x] `git diff --check origin/release/v0.4.2..HEAD`

## External API Key Impact

No `/v1` API Key route, authentication, request, or response contract changes.

## Summary by Sourcery

错误修复：
- 在混合模式下，当 MinerU 仅返回没有 OCR 文本的重复图像块时，保留直接源图像回退策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Preserve the direct source-image fallback in mixed mode when MinerU returns only a duplicate image block without OCR text.

</details>