### PR TITLE
refactor(tasks): Inline end user query in memory count sync task

### DIFF
--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3732,12 +3732,16 @@ def sync_all_end_user_memory_counts(self) -> Dict[str, Any]:
         from app.core.memory.utils.memory_count_utils import (
             sync_end_user_memory_count_from_neo4j,
         )
-        from app.repositories.end_user_repository import EndUserRepository
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
         # 只读短 session 枚举活跃用户 ID，随后立即关闭
         with get_db_read() as db:
-            user_ids = [str(u.id) for u in EndUserRepository(db).get_all_active()]
+            user_ids = [
+                str(u.id)
+                for u in db.query(EndUser)
+                .filter(EndUser.is_active == True, EndUser.memory_count >= 300)
+                .all()
+            ]
 
         connector = Neo4jConnector()
         succeeded = 0


### PR DESCRIPTION
- Replace EndUserRepository.get_all_active with a direct SQLAlchemy query in sync_end_user_memory_count_from_neo4j
- Add filter for memory_count >= 300 to limit syncing to active users with significant memory usage

## 由 Sourcery 提供的摘要

将终端用户的记忆计数同步限制为具有大量记忆且处于活跃状态的用户。

增强内容：
- 将 Neo4j 的记忆计数同步限制为至少存有 300 条记忆的活跃用户。
- 通过在同步任务中直接查询符合条件的用户来简化活跃用户的筛选。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict end-user memory-count synchronization to active users with significant memory usage.

Enhancements:
- Limit Neo4j memory-count synchronization to active users with at least 300 stored memories.
- Simplify active-user selection by querying eligible users directly within the synchronization task.

</details>