### PR TITLE
feat(web): localStorage removeItem  with userId

### DIFF
--- a/web/src/views/Conversation/hooks/useConversation.ts
+++ b/web/src/views/Conversation/hooks/useConversation.ts
@@ -132,8 +132,13 @@ export function useConversation() {
 
   useEffect(() => {
     if (!token) return
-    const localShareToken = localStorage.getItem(`shareToken_${token}`)
-    setShareToken(localShareToken)
+    let localShareToken = null
+    if (source === 'MemorySkills' && userId) {
+      localStorage.removeItem(`shareToken_${token}`)
+    } else {
+      localShareToken = localStorage.getItem(`shareToken_${token}`)
+      setShareToken(localShareToken)
+    }
     if (localShareToken && localShareToken !== '') return
     getShareToken(token as string, userId || randomString(12, false))
       .then(res => {
@@ -141,7 +146,7 @@ export function useConversation() {
         localStorage.setItem(`shareToken_${token}`, response.access_token ?? '')
         setShareToken(response.access_token ?? '')
       })
-  }, [token])
+  }, [token, source, userId])
 
   useEffect(() => {
     if (page === 1 && hasMore && historyList.length === 0 && shareToken) {


### PR DESCRIPTION
## Summary by Sourcery

在保持其他会话来源已缓存令牌不变的前提下，为特定用户的 MemorySkills 会话刷新共享令牌。

Bug Fixes:
- 确保带有用户 ID 的 MemorySkills 会话在请求新共享令牌之前会丢弃任何先前存储的共享令牌。

Enhancements:
- 当共享令牌、来源或用户 ID 发生变化时，刷新会话的共享令牌处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh share tokens for user-specific MemorySkills conversations while preserving cached tokens for other conversation sources.

Bug Fixes:
- Ensure MemorySkills conversations with a user ID discard any previously stored share token before requesting a fresh one.

Enhancements:
- Refresh conversation share-token handling when the token, source, or user ID changes.

</details>