### PR TITLE
feat:add-skill_port_all_retrieved

### DIFF
--- a/api/app/controllers/service/memory_display_api_controller.py
+++ b/api/app/controllers/service/memory_display_api_controller.py
@@ -15,8 +15,13 @@ from starlette.responses import Response
 
 from app.controllers import memory_display_controller
 from app.core.api_key_auth import require_api_key_self_db
-from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async
+from app.core.api_key_utils import (
+    get_current_user_snapshot_from_api_key_async,
+    validate_end_user_in_workspace_async,
+)
+from app.core.error_codes import BizCode
 from app.core.logging_config import get_business_logger
+from app.core.response_utils import fail
 from app.db import get_async_db_context
 from app.schemas.api_key_schema import ApiKeyAuth
 
@@ -29,6 +34,23 @@ def _encode_result(result):
     if isinstance(result, Response):
         return result
     return jsonable_encoder(result)
+
+
+async def _validate_display_end_user(
+    db,
+    end_user_id: str,
+    workspace_id,
+) -> dict | None:
+    """Validate the end user shared by all V1 memory display endpoints."""
+    if not end_user_id or not end_user_id.strip():
+        return fail(
+            BizCode.MISSING_PARAMETER,
+            "end_user_id 不能为空",
+            "end_user_id is required",
+        )
+
+    await validate_end_user_in_workspace_async(db, end_user_id, workspace_id)
+    return None
 
 
 # ==================== 写入展示记录 ====================
@@ -52,11 +74,50 @@ async def get_written_memories(
     """
     async with get_async_db_context() as db:
         current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
+        error = await _validate_display_end_user(
+            db, end_user_id, api_key_auth.workspace_id
+        )
+        if error is not None:
+            return _encode_result(error)
 
     logger.info(f"V1 get written memories - workspace: {api_key_auth.workspace_id}")
 
     async with get_async_db_context() as db:
         result = await memory_display_controller.get_written_memories(
+            end_user_id=end_user_id,
+            page=page,
+            pagesize=pagesize,
+            current_user=current_user,
+            db=db,
+        )
+    return _encode_result(result)
+
+
+# ==================== 读取展示记录 ====================
+
+
+@router.get("/retrieved")
+@require_api_key_self_db(scopes=["memory"])
+async def get_retrieved_memories(
+    request: Request,
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    api_key_auth: ApiKeyAuth = None,
+):
+    """获取读取展示记录列表。"""
+    async with get_async_db_context() as db:
+        current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
+        error = await _validate_display_end_user(
+            db, end_user_id, api_key_auth.workspace_id
+        )
+        if error is not None:
+            return _encode_result(error)
+
+    logger.info(f"V1 get retrieved memories - workspace: {api_key_auth.workspace_id}")
+
+    async with get_async_db_context() as db:
+        result = await memory_display_controller.get_retrieved_memories(
             end_user_id=end_user_id,
             page=page,
             pagesize=pagesize,
@@ -97,6 +158,11 @@ async def get_engine_display_cards(
     """
     async with get_async_db_context() as db:
         current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
+        error = await _validate_display_end_user(
+            db, end_user_id, api_key_auth.workspace_id
+        )
+        if error is not None:
+            return _encode_result(error)
 
     logger.info(f"V1 get engine display cards - workspace: {api_key_auth.workspace_id}")
 
@@ -106,6 +172,50 @@ async def get_engine_display_cards(
             timezone=timezone,
             page=page,
             pagesize=pagesize,
+            language_type=language_type,
+            current_user=current_user,
+            db=db,
+        )
+    return _encode_result(result)
+
+
+# ==================== 全部展示记录 ====================
+
+
+@router.get("/all")
+@require_api_key_self_db(scopes=["memory"])
+async def get_all_memory_display(
+    request: Request,
+    end_user_id: str = Query(..., description="终端用户 ID"),
+    timezone: str = Header(
+        ...,
+        alias="X-Timezone",
+        description="IANA 时区名称，即使 include_engines=false 也必传",
+    ),
+    page: int = Query(1, ge=1, description="页码，从 1 开始"),
+    pagesize: int = Query(10, ge=1, le=100, description="每页数量"),
+    include_engines: bool = Query(True, description="是否包含引擎动态卡片"),
+    language_type: Optional[str] = Header(None, alias="X-Language-Type"),
+    api_key_auth: ApiKeyAuth = None,
+):
+    """获取写入、读取和引擎动态的统一时间线。"""
+    async with get_async_db_context() as db:
+        current_user = await get_current_user_snapshot_from_api_key_async(db, api_key_auth)
+        error = await _validate_display_end_user(
+            db, end_user_id, api_key_auth.workspace_id
+        )
+        if error is not None:
+            return _encode_result(error)
+
+    logger.info(f"V1 get all memory display - workspace: {api_key_auth.workspace_id}")
+
+    async with get_async_db_context() as db:
+        result = await memory_display_controller.get_all_memory_display(
+            end_user_id=end_user_id,
+            timezone=timezone,
+            page=page,
+            pagesize=pagesize,
+            include_engines=include_engines,
             language_type=language_type,
             current_user=current_user,
             db=db,


### PR DESCRIPTION
## Summary by Sourcery

扩展内存展示 API，以支持已检索和已整合的记录，同时在工作区范围内强制执行终端用户验证。

New Features:
- 添加 V1 端点，用于检索内存展示记录，并查看包含已写入、已检索以及（可选）由引擎生成记录的分页统一时间线。

Bug Fixes:
- 在所有内存展示端点中验证请求的终端用户是否存在于该 API 密钥所属的工作区内，并在缺失时返回清晰的缺少参数错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand memory display APIs to support retrieved and consolidated records while enforcing workspace-scoped end-user validation.

New Features:
- Add V1 endpoints for retrieving memory display records and viewing a paginated unified timeline of written, retrieved, and optionally engine-generated records.

Bug Fixes:
- Validate that the requested end user exists in the API key's workspace across memory display endpoints and return a clear missing-parameter error when absent.

</details>