### PR TITLE
fix(rag): unblock Evidence Graph builds on empty indices and schema mismatches

### DIFF
--- a/api/app/core/rag/knowledge_graph/elasticsearch_store.py
+++ b/api/app/core/rag/knowledge_graph/elasticsearch_store.py
@@ -186,7 +186,12 @@ class GraphElasticsearchStore:
             ],
             sort=[
                 {"metadata.sort_id": {"order": "asc", "unmapped_type": "long"}},
-                {"metadata.doc_id": {"order": "asc"}},
+                {
+                    "metadata.doc_id": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load graph source document",
         )
@@ -247,11 +252,35 @@ class GraphElasticsearchStore:
                 "relation_key_kwd",
             ],
             sort=[
-                {"knowledge_graph_kwd": {"order": "asc"}},
-                {"entity_key_kwd": {"order": "asc", "missing": "_last"}},
-                {"relation_key_kwd": {"order": "asc", "missing": "_last"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
-                {"document_id": {"order": "asc", "missing": "_last"}},
+                {"knowledge_graph_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "entity_key_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "relation_key_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load graph document evidence keys",
         )
@@ -373,9 +402,21 @@ class GraphElasticsearchStore:
                 [{"terms": {"entity_key_kwd": list(entity_keys)}}],
             ),
             sort=[
-                {"entity_key_kwd": {"order": "asc"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
-                {"document_id": {"order": "asc", "missing": "_last"}},
+                {"entity_key_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load entity evidence",
         )
@@ -550,7 +591,7 @@ class GraphElasticsearchStore:
         hits = await self._collect_search_after_hits(
             index_name=index_name,
             query=self._graph_query(knowledge_id, DOCUMENT_PROJECTION_MAP),
-            sort=[{"document_id": {"order": "asc"}}],
+            sort=[{"document_id": {"order": "asc", "unmapped_type": "keyword"}}],
             context="list graph document maps",
             batch_size=GRAPH_METRIC_SCAN_BATCH_SIZE,
         )
@@ -1130,7 +1171,7 @@ class GraphElasticsearchStore:
                                     "unmapped_type": "float",
                                 }
                             },
-                            {"source_chunk_id_kwd": {"order": "asc"}},
+                            {"source_chunk_id_kwd": {"order": "asc", "unmapped_type": "keyword"}},
                         ],
                     },
                 ]
@@ -1297,7 +1338,12 @@ class GraphElasticsearchStore:
             },
             sort=[
                 {"_score": {"order": "desc"}},
-                {"metadata.doc_id": {"order": "asc"}},
+                {
+                    "metadata.doc_id": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
         )
         raise_on_shard_failures(result, "rank graph source chunks")
@@ -1425,9 +1471,21 @@ class GraphElasticsearchStore:
                 extra_filters,
             ),
             sort=[
-                {"relation_key_kwd": {"order": "asc"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
-                {"document_id": {"order": "asc", "missing": "_last"}},
+                {"relation_key_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context=context,
         )

--- a/api/app/core/rag/knowledge_graph/prompts.py
+++ b/api/app/core/rag/knowledge_graph/prompts.py
@@ -22,7 +22,31 @@ Each relation: "from_ref" (string entity ref), "to_ref" (string entity ref),
 grounded in the source). Optional: "keywords" (string array), "directed"
 (boolean), "confidence" (number 0-1).
 Example:
-{"entities": [{"ref": "e1", "name": "Acme Corp", "entity_type": "organization", "description": "Semiconductor company headquartered in Hsinchu."}, {"ref": "e2", "name": "Zeta", "entity_type": "product", "description": "AI accelerator chip launched by Acme Corp in 2025."}], "relations": [{"from_ref": "e1", "to_ref": "e2", "predicate": "launched", "description": "Acme Corp launched the Zeta chip in 2025.", "keywords": ["product launch"]}]}
+{
+  "entities": [
+    {
+      "ref": "e1",
+      "name": "Acme Corp",
+      "entity_type": "organization",
+      "description": "Semiconductor company headquartered in Hsinchu."
+    },
+    {
+      "ref": "e2",
+      "name": "Zeta",
+      "entity_type": "product",
+      "description": "AI accelerator chip launched by Acme Corp in 2025."
+    }
+  ],
+  "relations": [
+    {
+      "from_ref": "e1",
+      "to_ref": "e2",
+      "predicate": "launched",
+      "description": "Acme Corp launched the Zeta chip in 2025.",
+      "keywords": ["product launch"]
+    }
+  ]
+}
 """.strip()
 
 EXTRACTION_PROMPT_VERSION = "2026-07-27-v1"

--- a/api/app/core/rag/knowledge_graph/prompts.py
+++ b/api/app/core/rag/knowledge_graph/prompts.py
@@ -11,6 +11,18 @@ the user, build communities, summarize a whole graph, or infer missing facts.
 Return a valid JSON object only. The JSON object must contain "entities" and
 "relations" arrays. Use empty arrays when no direct evidence is present. Do not
 return markdown, code fences, comments, or explanatory text.
+Use exactly the field names below; never substitute alternatives such as
+"type", "source", or "target".
+Each entity: "ref" (string, unique within this response, e.g. "e1"), "name"
+(string), "entity_type" (string, one of the allowed types), "description"
+(string, one or two sentences grounded in the source). Optional: "aliases"
+(string array), "confidence" (number 0-1).
+Each relation: "from_ref" (string entity ref), "to_ref" (string entity ref),
+"predicate" (string, short verb phrase), "description" (string, one sentence
+grounded in the source). Optional: "keywords" (string array), "directed"
+(boolean), "confidence" (number 0-1).
+Example:
+{"entities": [{"ref": "e1", "name": "Acme Corp", "entity_type": "organization", "description": "Semiconductor company headquartered in Hsinchu."}, {"ref": "e2", "name": "Zeta", "entity_type": "product", "description": "AI accelerator chip launched by Acme Corp in 2025."}], "relations": [{"from_ref": "e1", "to_ref": "e2", "predicate": "launched", "description": "Acme Corp launched the Zeta chip in 2025.", "keywords": ["product launch"]}]}
 """.strip()
 
 EXTRACTION_PROMPT_VERSION = "2026-07-27-v1"


### PR DESCRIPTION
## Business Background

Evidence Graph construction can be blocked in two independent stages. Fresh workspace indices do not yet have dynamic mappings for graph sort fields, which causes Elasticsearch to reject sorted scans. Some OpenAI-compatible model endpoints also return structurally valid JSON with alternative field names when the extraction prompt does not document the expected schema.

## Summary

- Add `unmapped_type` guards to Evidence Graph and source-chunk sort fields used by empty-index reads.
- Document the complete entity and relation output fields in the extraction system prompt, including a valid JSON example.
- Preserve the existing extraction schema, prompt cache version, API contracts, database models, and task routing.

## Changes

- `api/app/core/rag/knowledge_graph/elasticsearch_store.py`: 73 insertions, 15 deletions.
- `api/app/core/rag/knowledge_graph/prompts.py`: 12 insertions.

## Risk

- Sort behavior changes only when a field has no mapping; existing mapped indices retain their current behavior.
- Prompt text changes may affect model output, but the structured response schema and cache key version remain unchanged.
- No database migration or external API Key route change is included.

## Test Plan

- [x] `PYTHONPATH=. uv run --frozen pytest -q` for the focused empty-index, source-loading, extractor, cache, ranking, and evidence lookup coverage: 22 passed.
- [x] `PYTHONPATH=. uv run --frozen python -m compileall -q app/core/rag/knowledge_graph app/core/models`.
- [x] `git diff --check origin/develop..HEAD`.
- [ ] Live empty-index Elasticsearch validation was not run because the local Docker daemon is unavailable.
- [ ] Live qwen3.6-plus extraction validation requires a deployed model/runtime environment.

## External API Key Impact

None. The change does not modify `api/app/controllers/service/rag_api_*` routes or external response contracts.

## Summary by Sourcery

使 Evidence Graph 的构建在排序字段未映射时仍具备鲁棒性，并引导抽取模型遵循现有的结构化输出模式。

Bug Fixes:
- 当在空的或新初始化的 Elasticsearch 索引中，排序字段尚未映射时，防止 Evidence Graph 读取和源片段排名过程发生失败。
- 通过文档化所需的实体与关系字段名称，并提供有效的 JSON 示例，提高对 OpenAI 兼容模型的抽取可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Evidence Graph construction resilient to unmapped sort fields and guide extraction models toward the existing structured output schema.

Bug Fixes:
- Prevent Evidence Graph reads and source-chunk ranking from failing when sort fields are unmapped in empty or freshly initialized Elasticsearch indices.
- Improve extraction reliability for OpenAI-compatible models by documenting the required entity and relation field names and providing a valid JSON example.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 Evidence Graph 的构建在排序字段未映射时仍具备鲁棒性，并引导抽取模型遵循现有的结构化输出模式。

Bug Fixes:
- 当在空的或新初始化的 Elasticsearch 索引中，排序字段尚未映射时，防止 Evidence Graph 读取和源片段排名过程发生失败。
- 通过文档化所需的实体与关系字段名称，并提供有效的 JSON 示例，提高对 OpenAI 兼容模型的抽取可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Evidence Graph construction resilient to unmapped sort fields and guide extraction models toward the existing structured output schema.

Bug Fixes:
- Prevent Evidence Graph reads and source-chunk ranking from failing when sort fields are unmapped in empty or freshly initialized Elasticsearch indices.
- Improve extraction reliability for OpenAI-compatible models by documenting the required entity and relation field names and providing a valid JSON example.

</details>

</details>