### PR TITLE
Feat/memory engine config llm response

### DIFF
--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -9,8 +9,9 @@ from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
 from app.core.response_utils import fail, success
 from app.db import get_async_db_context
-from app.dependencies import get_current_user_async, CurrentUserSnapshot
+from app.dependencies import cur_workspace_access_guard_async, get_current_user_async, CurrentUserSnapshot
 from app.schemas.memory_storage_schema import (
+    DebugChatInput,
     PilotRunInput,
 )
 from app.schemas.response_schema import ApiResponse
@@ -30,7 +31,7 @@ from app.services.memory_storage_service import (
     search_statement,
 )
 
-from app.utils.config_utils import resolve_config_id
+from app.utils.config_utils import resolve_config_id, resolve_config_id_async
 
 # Get API logger
 api_logger = get_api_logger()
@@ -94,6 +95,44 @@ async def pilot_run(
     svc = DataConfigService()
     return StreamingResponse(
         svc.pilot_run_stream(payload, language=language),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/chat", response_model=None)
+@cur_workspace_access_guard_async()
+async def debug_chat_stream(
+        payload: DebugChatInput,
+        language_type: str = Header(default=None, alias="X-Language-Type"),
+        current_user: CurrentUserSnapshot = Depends(get_current_user_async),
+) -> StreamingResponse:
+    """萃取调试界面使用的无状态多模态流式对话。"""
+    language = get_language_from_header(language_type)
+    async with get_async_db_context() as db:
+        payload.config_id = await resolve_config_id_async(payload.config_id, db)
+
+    history_files_count = sum(len(message.files) for message in payload.history)
+    api_logger.info(
+        "Debug chat requested: config_id=%s, history_count=%s, files_count=%s, workspace_id=%s",
+        payload.config_id,
+        len(payload.history),
+        len(payload.files) + history_files_count,
+        current_user.current_workspace_id,
+    )
+
+    svc = DataConfigService()
+    return StreamingResponse(
+        svc.debug_chat_stream(
+            payload,
+            language=language,
+            workspace_id=current_user.current_workspace_id,
+            tenant_id=current_user.tenant_id,
+        ),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -11,7 +11,7 @@ from app.core.response_utils import fail, success
 from app.db import get_async_db_context
 from app.dependencies import cur_workspace_access_guard_async, get_current_user_async, CurrentUserSnapshot
 from app.schemas.memory_storage_schema import (
-    DebugChatInput,
+    TrialRunChatInput,
     PilotRunInput,
 )
 from app.schemas.response_schema import ApiResponse
@@ -106,28 +106,27 @@ async def pilot_run(
 
 @router.post("/chat", response_model=None)
 @cur_workspace_access_guard_async()
-async def debug_chat_stream(
-        payload: DebugChatInput,
+async def trial_run_chat_stream(
+        payload: TrialRunChatInput,
         language_type: str = Header(default=None, alias="X-Language-Type"),
         current_user: CurrentUserSnapshot = Depends(get_current_user_async),
 ) -> StreamingResponse:
-    """萃取调试界面使用的无状态多模态流式对话。"""
+    """萃取试运行界面使用的无状态多模态流式对话。"""
     language = get_language_from_header(language_type)
     async with get_async_db_context() as db:
         payload.config_id = await resolve_config_id_async(payload.config_id, db)
 
-    history_files_count = sum(len(message.files) for message in payload.history)
     api_logger.info(
-        "Debug chat requested: config_id=%s, history_count=%s, files_count=%s, workspace_id=%s",
+        "Trial-run chat requested: config_id=%s, history_count=%s, files_count=%s, workspace_id=%s",
         payload.config_id,
         len(payload.history),
-        len(payload.files) + history_files_count,
+        len(payload.files),
         current_user.current_workspace_id,
     )
 
     svc = DataConfigService()
     return StreamingResponse(
-        svc.debug_chat_stream(
+        svc.trial_run_chat_stream(
             payload,
             language=language,
             workspace_id=current_user.current_workspace_id,

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -352,12 +352,15 @@ class PilotRunInput(BaseModel):  # 试运行触发请求模型（QA 消息格式
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class DebugChatHistoryMessage(BaseModel):
-    """萃取调试对话的显式历史消息。"""
+class TrialRunChatHistoryMessage(BaseModel):
+    """萃取试运行对话的显式历史消息。"""
 
     role: Literal["user", "assistant"] = Field(..., description="消息角色")
     content: str = Field(..., min_length=1, description="文本内容")
-    files: List[FileInput] = Field(default_factory=list, description="该条历史用户消息的附件")
+    files: List[FileInput] = Field(
+        default_factory=list,
+        description="历史附件仅为请求格式兼容保留，试运行对话不会解析",
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -368,13 +371,13 @@ class DebugChatHistoryMessage(BaseModel):
         return self
 
 
-class DebugChatInput(BaseModel):
-    """萃取调试 AI 对话请求。"""
+class TrialRunChatInput(BaseModel):
+    """萃取试运行 AI 对话请求。"""
 
     config_id: Union[uuid.UUID, int, str] = Field(..., description="萃取引擎配置 ID")
     message: str = Field(..., min_length=1, description="当前用户消息")
     files: List[FileInput] = Field(default_factory=list, description="当前消息附件")
-    history: List[DebugChatHistoryMessage] = Field(default_factory=list, description="显式对话上下文")
+    history: List[TrialRunChatHistoryMessage] = Field(default_factory=list, description="显式对话上下文")
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 

--- a/api/app/schemas/memory_storage_schema.py
+++ b/api/app/schemas/memory_storage_schema.py
@@ -8,6 +8,7 @@ import uuid
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 from app.core.utils.datetime_utils import to_iso_z, utcnow_naive
+from app.schemas.app_schema import FileInput
 from app.schemas.memory_agent_schema import WriteMessageItem
 
 
@@ -349,6 +350,41 @@ class PilotRunInput(BaseModel):  # 试运行触发请求模型（QA 消息格式
         description="QA 格式消息列表，role 为 user/assistant，files 可选",
     )
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class DebugChatHistoryMessage(BaseModel):
+    """萃取调试对话的显式历史消息。"""
+
+    role: Literal["user", "assistant"] = Field(..., description="消息角色")
+    content: str = Field(..., min_length=1, description="文本内容")
+    files: List[FileInput] = Field(default_factory=list, description="该条历史用户消息的附件")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_history_files(self):
+        if self.role == "assistant" and self.files:
+            raise ValueError("assistant 历史消息不能包含附件")
+        return self
+
+
+class DebugChatInput(BaseModel):
+    """萃取调试 AI 对话请求。"""
+
+    config_id: Union[uuid.UUID, int, str] = Field(..., description="萃取引擎配置 ID")
+    message: str = Field(..., min_length=1, description="当前用户消息")
+    files: List[FileInput] = Field(default_factory=list, description="当前消息附件")
+    history: List[DebugChatHistoryMessage] = Field(default_factory=list, description="显式对话上下文")
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    @field_validator("message")
+    @classmethod
+    def validate_message(cls, value: str) -> str:
+        message = value.strip()
+        if not message:
+            raise ValueError("消息内容不能为空")
+        return message
 
 
 class ConfigFilter(BaseModel):  # 查询配置参数时使用的模型

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -5,6 +5,7 @@ Handles business logic for memory storage operations.
 """
 
 import asyncio
+import base64
 import json
 import os
 import time
@@ -29,11 +30,13 @@ from app.models import Workspace
 from app.models.user_model import User
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.schemas.app_schema import FileType, TransferMethod
 from app.schemas.memory_config_schema import ConfigurationError
 from app.schemas.memory_storage_schema import (
     ConfigKey,
     ConfigParamsCreate,
     ConfigParamsDelete,
+    DebugChatInput,
     PilotRunInput,
     ConfigUpdate,
     ConfigUpdateExtracted,
@@ -47,6 +50,19 @@ config_logger = get_config_logger()
 # Load environment variables for Neo4j connector
 load_dotenv()
 _neo4j_connector = Neo4jConnector(shared_driver=True)
+
+DEBUG_CHAT_SYSTEM_PROMPT = """
+You are a neutral and helpful AI assistant in a debugging conversation. Answer
+general questions normally using your own general knowledge. Use the explicit
+conversation history and attachments in both historical and current user messages
+as additional context when they are relevant. Attachment marker text identifies
+the position and type of every attachment. When asked about multiple attachments,
+account for every marker; if an attachment cannot be understood, say so instead of
+silently omitting it. Do not claim to have accessed long-term memory, a private
+knowledge base, tools, or skills. If a question requires unavailable private or
+up-to-date information, state that limitation clearly. Reply in the language used
+by the user; when it is unclear, use the requested interface language.
+""".strip()
 
 
 class MemoryStorageService:
@@ -288,6 +304,444 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             data_list.append(config_dict)
 
         return data_list
+
+    @staticmethod
+    def _resolve_chat_model_id(memory_config, files) -> uuid.UUID:
+        """按当前消息的最高多模态需求选择模型，专用模型缺失时回退 LLM。"""
+        file_types = {file.type for file in files or []}
+        if FileType.VIDEO in file_types:
+            return memory_config.video_model_id or memory_config.llm_model_id
+        if FileType.AUDIO in file_types:
+            return memory_config.audio_model_id or memory_config.llm_model_id
+        if FileType.IMAGE in file_types:
+            return memory_config.vision_model_id or memory_config.llm_model_id
+        return memory_config.llm_model_id
+
+    @staticmethod
+    def _normalize_capabilities(capabilities) -> set[str]:
+        return {
+            str(getattr(capability, "value", capability)).lower()
+            for capability in capabilities or []
+        }
+
+    @staticmethod
+    def _unsupported_file_part(file_type: FileType, language: str) -> dict[str, str]:
+        labels = {
+            "zh": {
+                FileType.IMAGE: "图片",
+                FileType.AUDIO: "音频",
+                FileType.VIDEO: "视频",
+            },
+            "en": {
+                FileType.IMAGE: "image",
+                FileType.AUDIO: "audio",
+                FileType.VIDEO: "video",
+            },
+        }
+        locale = "en" if language == "en" else "zh"
+        label = labels[locale].get(file_type, str(file_type))
+        if locale == "en":
+            text = f"[The selected model does not support this {label} attachment.]"
+        else:
+            text = f"[当前选中的模型不支持该{label}附件。]"
+        return {"type": "text", "text": text}
+
+    @staticmethod
+    def _local_file_error_part(language: str) -> dict[str, str]:
+        if language == "en":
+            text = "[The local attachment could not be loaded.]"
+        else:
+            text = "[本地附件加载失败。]"
+        return {"type": "text", "text": text}
+
+    @staticmethod
+    def _file_marker_part(file, position: int, language: str) -> dict[str, str]:
+        """为每个附件添加稳定的顺序和类型标记，避免模型静默忽略媒体块。"""
+        file_type = str(getattr(file.type, "value", file.type))
+        file_name = file.name or str(file.upload_file_id or file.url or "")
+        if language == "en":
+            text = f"[Attachment {position}: type={file_type}, name={file_name}]"
+        else:
+            text = f"[附件 {position}：类型={file_type}，名称={file_name}]"
+        return {"type": "text", "text": text}
+
+    @staticmethod
+    def _replace_local_media_url(
+            parts: list[dict[str, Any]],
+            content: bytes,
+            mime_type: str,
+    ) -> None:
+        """将 URL 型多模态 part 中的本地地址替换为 Base64 Data URL。"""
+        data_url: str | None = None
+
+        def get_data_url() -> str:
+            nonlocal data_url
+            if data_url is None:
+                encoded = base64.b64encode(content).decode("ascii")
+                data_url = f"data:{mime_type};base64,{encoded}"
+            return data_url
+
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "image_url" and isinstance(part.get("image_url"), dict):
+                part["image_url"]["url"] = get_data_url()
+            elif part_type == "image" and isinstance(part.get("image"), str):
+                part["image"] = get_data_url()
+            elif part_type == "audio_url" and isinstance(part.get("audio_url"), dict):
+                part["audio_url"]["url"] = get_data_url()
+            elif part_type == "audio" and isinstance(part.get("audio"), str):
+                part["audio"] = get_data_url()
+            elif part_type == "video_url" and isinstance(part.get("video_url"), dict):
+                part["video_url"]["url"] = get_data_url()
+            elif part_type == "video" and isinstance(part.get("video"), str):
+                part["video"] = get_data_url()
+
+    @staticmethod
+    async def _load_debug_local_file(
+            file,
+            multimodal_service,
+            workspace_id: uuid.UUID,
+            tenant_id: uuid.UUID,
+    ) -> tuple[bytes, str]:
+        """校验本地附件归属并从配置的存储后端读取原始字节。"""
+        import magic
+        from app.services.file_storage_service import FileStorageService
+
+        metadata = await multimodal_service._get_file_metadata(
+            file.upload_file_id,
+            completed_only=True,
+        )
+        if (
+                metadata is None
+                or metadata.workspace_id != workspace_id
+                or metadata.tenant_id != tenant_id
+        ):
+            raise ValueError("local attachment is unavailable in the current workspace")
+
+        content = await FileStorageService().download_file(metadata.file_key)
+        if not content:
+            raise ValueError("local attachment is empty")
+
+        detected_mime = magic.from_buffer(content, mime=True)
+        mime_type = detected_mime or metadata.content_type or "application/octet-stream"
+        file.set_content(content)
+        if file.type == FileType.AUDIO and metadata.file_ext:
+            audio_ext = metadata.file_ext.lstrip(".").lower()
+            file.file_type = f"audio/{audio_ext}"
+        else:
+            file.file_type = mime_type
+        if not file.name:
+            file.name = metadata.file_name
+        return content, mime_type
+
+    @classmethod
+    async def _process_debug_files(
+            cls,
+            files,
+            multimodal_service,
+            workspace_id: uuid.UUID,
+            tenant_id: uuid.UUID,
+            capabilities,
+            language: str,
+    ) -> list[dict[str, Any]]:
+        """按请求顺序处理附件，对模型不支持的类型生成可见文本提示。"""
+        normalized_capabilities = cls._normalize_capabilities(capabilities)
+        required_capabilities = {
+            FileType.IMAGE: "vision",
+            FileType.AUDIO: "audio",
+            FileType.VIDEO: "video",
+        }
+        processed_parts: list[dict[str, Any]] = []
+        for position, file in enumerate(files or [], start=1):
+            required = required_capabilities.get(file.type)
+            if required and required not in normalized_capabilities:
+                processed_parts.append(cls._file_marker_part(file, position, language))
+                processed_parts.append(cls._unsupported_file_part(file.type, language))
+                continue
+
+            local_media: tuple[bytes, str] | None = None
+            if file.transfer_method == TransferMethod.LOCAL_FILE:
+                try:
+                    content, mime_type = await cls._load_debug_local_file(
+                        file,
+                        multimodal_service,
+                        workspace_id,
+                        tenant_id,
+                    )
+                    if file.type in {FileType.IMAGE, FileType.AUDIO, FileType.VIDEO}:
+                        local_media = (content, mime_type)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.error(
+                        "[DEBUG_CHAT_STREAM] Failed to load local attachment: file_id=%s",
+                        file.upload_file_id,
+                        exc_info=True,
+                    )
+                    processed_parts.append(cls._file_marker_part(file, position, language))
+                    processed_parts.append(cls._local_file_error_part(language))
+                    continue
+
+            parts = await multimodal_service.process_files(
+                [file],
+                workspace_id=workspace_id,
+                document_image_recognition=False,
+                include_processing_errors=True,
+            )
+            if local_media:
+                cls._replace_local_media_url(parts, *local_media)
+            processed_parts.append(cls._file_marker_part(file, position, language))
+            processed_parts.extend(parts)
+        return processed_parts
+
+    @staticmethod
+    def _stream_content_to_texts(content: Any) -> list[str]:
+        """从不同 provider 的流式 content 形态中提取文本块。"""
+        if isinstance(content, str):
+            return [content] if content else []
+        if isinstance(content, dict):
+            text = content.get("text")
+            return [str(text)] if text else []
+        if not isinstance(content, list):
+            return []
+
+        texts: list[str] = []
+        for item in content:
+            if isinstance(item, str) and item:
+                texts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if text:
+                    texts.append(str(text))
+        return texts
+
+    @staticmethod
+    def _extract_message_from_event_output(output: Any) -> Any | None:
+        if output is None:
+            return None
+        if getattr(output, "usage_metadata", None) or getattr(output, "response_metadata", None):
+            return output
+        if isinstance(output, dict):
+            value = output.get("message") or output.get("output")
+            if value is not None and not isinstance(value, (dict, list, str)):
+                return value
+            generations = output.get("generations")
+            if isinstance(generations, list):
+                for generation_group in generations:
+                    items = generation_group if isinstance(generation_group, list) else [generation_group]
+                    for generation in items:
+                        message = getattr(generation, "message", None)
+                        if message is not None:
+                            return message
+        return getattr(output, "message", None)
+
+    @staticmethod
+    def _extract_total_tokens(message: Any) -> int:
+        if message is None:
+            return 0
+        response_metadata = getattr(message, "response_metadata", None)
+        if isinstance(response_metadata, dict):
+            usage = response_metadata.get("token_usage") or response_metadata.get("usage") or {}
+            if isinstance(usage, dict) and usage.get("total_tokens"):
+                return int(usage["total_tokens"])
+        usage_metadata = getattr(message, "usage_metadata", None)
+        if isinstance(usage_metadata, dict):
+            return int(usage_metadata.get("total_tokens") or 0)
+        return int(getattr(usage_metadata, "total_tokens", 0) or 0)
+
+    @staticmethod
+    def _debug_chat_error_data(language: str, kind: str = "generation") -> dict[str, Any]:
+        english = language == "en"
+        if kind == "model":
+            message = "Model unavailable" if english else "模型不可用"
+            error = "no available api key"
+        elif kind == "access":
+            message = "Configuration access denied" if english else "无权访问该配置"
+            error = "configuration access denied"
+        else:
+            message = "Chat generation failed" if english else "对话生成失败"
+            error = "debug chat generation failed"
+        return {"code": 5000, "message": message, "error": error}
+
+    async def debug_chat_stream(
+            self,
+            payload: DebugChatInput,
+            language: str = "zh",
+            workspace_id: uuid.UUID | None = None,
+            tenant_id: uuid.UUID | None = None,
+    ) -> AsyncGenerator[str, None]:
+        """执行无记忆、无工具的萃取调试流式对话。"""
+        from app.core.models import RedBearLLM, RedBearModelConfig
+        from app.db import get_async_db_context
+        from app.models.models_model import ModelType
+        from app.schemas.model_schema import ModelInfo
+        from app.services.model_service import ModelApiKeyService
+        from app.services.multimodal_service import MultimodalService
+        from langchain.agents import create_agent
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        start_time = time.perf_counter()
+        api_key_obj = None
+        api_key_id: uuid.UUID | None = None
+        try:
+            async with get_async_db_context() as db:
+                memory_config = await MemoryConfigService(db).load_memory_config_async(payload.config_id)
+                if (
+                        workspace_id is None
+                        or tenant_id is None
+                        or memory_config.workspace_id != workspace_id
+                        or memory_config.tenant_id != tenant_id
+                ):
+                    logger.warning(
+                        "Debug chat configuration access denied: config_id=%s, config_workspace=%s, request_workspace=%s",
+                        payload.config_id,
+                        memory_config.workspace_id,
+                        workspace_id,
+                    )
+                    yield format_sse_message("error", self._debug_chat_error_data(language, "access"))
+                    return
+
+                all_files = [
+                    file
+                    for history_message in payload.history
+                    for file in history_message.files
+                ]
+                all_files.extend(payload.files)
+                model_config_id = self._resolve_chat_model_id(memory_config, all_files)
+                api_key_obj = await ModelApiKeyService.get_available_api_key_bridge_async(
+                    db,
+                    model_config_id,
+                    tenant_id=memory_config.tenant_id,
+                )
+                if not api_key_obj:
+                    yield format_sse_message("error", self._debug_chat_error_data(language, "model"))
+                    return
+
+                # get_async_db_context exits with a rollback for read-only transactions,
+                # which expires ORM attributes. Keep the scalar id before the object is
+                # detached so the post-stream usage update never touches api_key_obj.
+                api_key_id = api_key_obj.id
+
+                model_info = ModelInfo(
+                    model_name=api_key_obj.model_name,
+                    provider=api_key_obj.provider,
+                    api_key=api_key_obj.api_key,
+                    api_base=api_key_obj.api_base,
+                    is_omni=api_key_obj.is_omni,
+                    model_type=ModelType.LLM,
+                    capability=api_key_obj.capability or [],
+                )
+
+            llm = RedBearLLM(
+                RedBearModelConfig(
+                    model_name=model_info.model_name,
+                    provider=model_info.provider,
+                    api_key=model_info.api_key,
+                    base_url=model_info.api_base,
+                    is_omni=model_info.is_omni,
+                    capability=model_info.capability,
+                    extra_params={"temperature": 0.7, "max_tokens": 2000, "streaming": True},
+                ),
+                type=ModelType.CHAT,
+            )
+            requested_language = "English" if language == "en" else "Chinese"
+            system_prompt = f"{DEBUG_CHAT_SYSTEM_PROMPT}\nThe requested interface language is {requested_language}."
+            agent = create_agent(model=llm, tools=[], system_prompt=system_prompt)
+
+            yield format_sse_message("start", {
+                "conversation_id": "",
+                "message_id": str(uuid.uuid4()),
+                "user_message_id": str(uuid.uuid4()),
+            })
+
+            processed_history_files: list[list[dict[str, Any]]] = [
+                [] for _ in payload.history
+            ]
+            processed_files: list[dict[str, Any]] = []
+            if any(history_message.files for history_message in payload.history) or payload.files:
+                async with get_async_db_context() as db:
+                    multimodal_service = MultimodalService(db, model_info)
+                    for index, history_message in enumerate(payload.history):
+                        if history_message.files:
+                            processed_history_files[index] = await self._process_debug_files(
+                                history_message.files,
+                                multimodal_service,
+                                memory_config.workspace_id,
+                                memory_config.tenant_id,
+                                model_info.capability,
+                                language,
+                            )
+                    processed_files = await self._process_debug_files(
+                        payload.files,
+                        multimodal_service,
+                        memory_config.workspace_id,
+                        memory_config.tenant_id,
+                        model_info.capability,
+                        language,
+                    )
+
+            messages: list[Any] = []
+            for index, history_message in enumerate(payload.history):
+                if history_message.role == "user":
+                    history_file_parts = processed_history_files[index]
+                    history_content: str | list[dict[str, Any]]
+                    if history_file_parts:
+                        history_content = [
+                            {"type": "text", "text": history_message.content},
+                            *history_file_parts,
+                        ]
+                    else:
+                        history_content = history_message.content
+                    messages.append(HumanMessage(content=history_content))
+                else:
+                    messages.append(AIMessage(content=history_message.content))
+
+            if processed_files:
+                current_content: str | list[dict[str, Any]] = [
+                    {"type": "text", "text": payload.message},
+                    *processed_files,
+                ]
+            else:
+                current_content = payload.message
+            messages.append(HumanMessage(content=current_content))
+
+            full_content = ""
+            total_tokens = 0
+            async for event in agent.astream_events({"messages": messages}, version="v2"):
+                event_type = event.get("event")
+                if event_type == "on_chat_model_stream":
+                    chunk = event.get("data", {}).get("chunk")
+                    for text_chunk in self._stream_content_to_texts(getattr(chunk, "content", None)):
+                        full_content += text_chunk
+                        yield format_sse_message("message", {"content": text_chunk})
+                elif event_type == "on_chat_model_end":
+                    output = event.get("data", {}).get("output")
+                    message = self._extract_message_from_event_output(output)
+                    total_tokens = max(total_tokens, self._extract_total_tokens(message))
+
+            try:
+                async with get_async_db_context() as db:
+                    await ModelApiKeyService.record_api_key_usage_bridge_async(db, api_key_id)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Usage accounting is observability metadata. A write failure here must
+                # not turn an already completed model response into an SSE error event.
+                logger.error("[DEBUG_CHAT_STREAM] Failed to record API key usage", exc_info=True)
+
+            yield format_sse_message("end", {
+                "elapsed_time": time.perf_counter() - start_time,
+                "message_length": len(full_content),
+                "usage": {"total_tokens": total_tokens},
+            })
+        except asyncio.CancelledError:
+            logger.info("[DEBUG_CHAT_STREAM] Client disconnected during streaming")
+            raise
+        except Exception:
+            logger.error("[DEBUG_CHAT_STREAM] Error during streaming", exc_info=True)
+            yield format_sse_message("error", self._debug_chat_error_data(language))
 
     async def pilot_run_stream(self, payload: PilotRunInput, language: str = "zh") -> AsyncGenerator[str, None]:
         """

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -27,6 +27,7 @@ from app.core.memory.analytics.hot_memory_tags import (
 from app.core.memory.analytics.recent_activity_stats import get_recent_activity_stats
 from app.core.utils.datetime_utils import to_timestamp_ms
 from app.models import Workspace
+from app.models.file_metadata_model import FileMetadata
 from app.models.user_model import User
 from app.repositories.memory_config_repository import MemoryConfigRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
@@ -36,7 +37,7 @@ from app.schemas.memory_storage_schema import (
     ConfigKey,
     ConfigParamsCreate,
     ConfigParamsDelete,
-    DebugChatInput,
+    TrialRunChatInput,
     PilotRunInput,
     ConfigUpdate,
     ConfigUpdateExtracted,
@@ -51,26 +52,32 @@ config_logger = get_config_logger()
 load_dotenv()
 _neo4j_connector = Neo4jConnector(shared_driver=True)
 
-DEBUG_CHAT_SYSTEM_PROMPT = """
-You are a neutral and helpful AI assistant in a debugging conversation. Answer
+TRIAL_RUN_CHAT_SYSTEM_PROMPT = """
+You are a neutral and helpful AI assistant in a trial-run conversation. Answer
 general questions normally using your own general knowledge. Use the explicit
 conversation history and the supplied attachment analysis results as additional
-context when they are relevant. Attachment labels identify the original message,
-position, and type of every attachment. When asked about multiple attachments,
-account for every label; if an attachment could not be understood, say so instead
-of silently omitting it. Do not claim to have accessed long-term memory, a private
-knowledge base, tools, or skills. If a question requires unavailable private or
-up-to-date information, state that limitation clearly. Reply in the language used
-by the user; when it is unclear, use the requested interface language.
+context when they are relevant. Attachment labels identify every current-message
+attachment. Answer the user's question directly, but do not reproduce the complete
+attachment analyses or add an attachment-details appendix; the backend appends the
+original analyses after your answer. If an attachment could not be understood, say
+so instead of silently omitting it. Do not claim to have accessed long-term memory,
+a private knowledge base, tools, or skills. If a question requires unavailable
+private or up-to-date information, state that limitation clearly. Reply in the
+language used by the user; when it is unclear, use the requested interface language.
 """.strip()
 
-DEBUG_ATTACHMENT_ANALYSIS_PROMPT = """
-Analyze every supplied attachment independently and return concise plain-text
-descriptions. Preserve each attachment label exactly so another language model can
-reliably associate the description with the original conversation message. Do not
-answer the user's overall question and do not omit an attachment. If an attachment
-cannot be understood, state the failure under that attachment label.
+TRIAL_RUN_ATTACHMENT_ANALYSIS_PROMPT = """
+Analyze every supplied attachment independently and return detailed plain-text
+descriptions. Preserve each attachment label exactly. For images, cover visible
+objects, text, layout, and relevant context. For audio, cover speech, speakers,
+important sounds, and sequence. For video, cover scenes, actions, visible text,
+speech or audio, and the timeline. Do not answer the user's overall question and do
+not omit an attachment. If an attachment cannot be understood, state the failure
+under that attachment label.
 """.strip()
+
+TRIAL_RUN_CHAT_DEFAULT_HISTORY_ROUNDS = 20
+TRIAL_RUN_CHAT_HISTORY_ROUNDS_ENV = "TRIAL_RUN_CHAT_HISTORY_ROUNDS"
 
 
 class MemoryStorageService:
@@ -314,7 +321,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         return data_list
 
     @staticmethod
-    def _debug_media_model_id(memory_config, file_type: FileType) -> uuid.UUID:
+    def _trial_run_media_model_id(memory_config, file_type: FileType) -> uuid.UUID:
         """返回某一媒体类型的专用模型，未配置时回退文本模型。"""
         if file_type == FileType.IMAGE:
             return memory_config.vision_model_id or memory_config.llm_model_id
@@ -323,6 +330,39 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         if file_type == FileType.VIDEO:
             return memory_config.video_model_id or memory_config.llm_model_id
         return memory_config.llm_model_id
+
+    @staticmethod
+    def _trial_run_history_round_limit() -> int:
+        """返回试运行对话保留的最新用户轮次数。"""
+        raw_limit = os.getenv(
+            TRIAL_RUN_CHAT_HISTORY_ROUNDS_ENV,
+            str(TRIAL_RUN_CHAT_DEFAULT_HISTORY_ROUNDS),
+        )
+        try:
+            return max(0, int(raw_limit))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid %s=%r; falling back to %s",
+                TRIAL_RUN_CHAT_HISTORY_ROUNDS_ENV,
+                raw_limit,
+                TRIAL_RUN_CHAT_DEFAULT_HISTORY_ROUNDS,
+            )
+            return TRIAL_RUN_CHAT_DEFAULT_HISTORY_ROUNDS
+
+    @staticmethod
+    def _latest_trial_run_history(history: list[Any], max_rounds: int) -> list[Any]:
+        """以 user 消息为一轮的起点，保留最新 max_rounds 轮及其后续回复。"""
+        if max_rounds <= 0:
+            return []
+
+        user_rounds = 0
+        for index in range(len(history) - 1, -1, -1):
+            if history[index].role != "user":
+                continue
+            user_rounds += 1
+            if user_rounds == max_rounds:
+                return list(history[index:])
+        return list(history)
 
     @staticmethod
     def _normalize_capabilities(capabilities) -> set[str]:
@@ -406,45 +446,51 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 part["video"] = get_data_url()
 
     @staticmethod
-    async def _load_debug_local_file(
+    async def _load_trial_run_local_file(
             file,
-            multimodal_service,
             workspace_id: uuid.UUID,
             tenant_id: uuid.UUID,
     ) -> tuple[bytes, str]:
         """校验本地附件归属并从配置的存储后端读取原始字节。"""
         import magic
+        from app.db import get_async_db_context
         from app.services.file_storage_service import FileStorageService
 
-        metadata = await multimodal_service._get_file_metadata(
-            file.upload_file_id,
-            completed_only=True,
-        )
-        if (
-                metadata is None
-                or metadata.workspace_id != workspace_id
-                or metadata.tenant_id != tenant_id
-        ):
-            raise ValueError("local attachment is unavailable in the current workspace")
+        async with get_async_db_context() as db:
+            metadata = await db.scalar(
+                select(FileMetadata).where(
+                    FileMetadata.id == file.upload_file_id,
+                    FileMetadata.status == "completed",
+                    FileMetadata.workspace_id == workspace_id,
+                    FileMetadata.tenant_id == tenant_id,
+                )
+            )
+            if metadata is None:
+                raise ValueError("local attachment is unavailable in the current workspace")
+            file_key = metadata.file_key
+            metadata_content_type = metadata.content_type
+            metadata_file_ext = metadata.file_ext
+            metadata_file_name = metadata.file_name
 
-        content = await FileStorageService().download_file(metadata.file_key)
+        content = await FileStorageService().download_file(file_key)
         if not content:
             raise ValueError("local attachment is empty")
 
         detected_mime = magic.from_buffer(content, mime=True)
-        mime_type = detected_mime or metadata.content_type or "application/octet-stream"
+        mime_type = detected_mime or metadata_content_type or "application/octet-stream"
         file.set_content(content)
-        if file.type == FileType.AUDIO and metadata.file_ext:
-            audio_ext = metadata.file_ext.lstrip(".").lower()
+        file.url = file.url or f"local-file://{file.upload_file_id}"
+        if file.type == FileType.AUDIO and metadata_file_ext:
+            audio_ext = metadata_file_ext.lstrip(".").lower()
             file.file_type = f"audio/{audio_ext}"
         else:
             file.file_type = mime_type
         if not file.name:
-            file.name = metadata.file_name
+            file.name = metadata_file_name
         return content, mime_type
 
     @classmethod
-    async def _process_debug_files(
+    async def _process_trial_run_files(
             cls,
             files,
             multimodal_service,
@@ -471,9 +517,8 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             local_media: tuple[bytes, str] | None = None
             if file.transfer_method == TransferMethod.LOCAL_FILE:
                 try:
-                    content, mime_type = await cls._load_debug_local_file(
+                    content, mime_type = await cls._load_trial_run_local_file(
                         file,
-                        multimodal_service,
                         workspace_id,
                         tenant_id,
                     )
@@ -483,7 +528,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     raise
                 except Exception:
                     logger.error(
-                        "[DEBUG_CHAT_STREAM] Failed to load local attachment: file_id=%s",
+                        "[TRIAL_RUN_CHAT_STREAM] Failed to load local attachment: file_id=%s",
                         file.upload_file_id,
                         exc_info=True,
                     )
@@ -559,7 +604,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         return int(getattr(usage_metadata, "total_tokens", 0) or 0)
 
     @staticmethod
-    def _debug_chat_error_data(language: str, kind: str = "generation") -> dict[str, Any]:
+    def _trial_run_chat_error_data(language: str, kind: str = "generation") -> dict[str, Any]:
         english = language == "en"
         if kind == "model":
             message = "Model unavailable" if english else "模型不可用"
@@ -569,12 +614,12 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             error = "configuration access denied"
         else:
             message = "Chat generation failed" if english else "对话生成失败"
-            error = "debug chat generation failed"
+            error = "trial run chat generation failed"
         return {"code": 5000, "message": message, "error": error}
 
-    async def debug_chat_stream(
+    async def trial_run_chat_stream(
             self,
-            payload: DebugChatInput,
+            payload: TrialRunChatInput,
             language: str = "zh",
             workspace_id: uuid.UUID | None = None,
             tenant_id: uuid.UUID | None = None,
@@ -597,19 +642,12 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             FileType.VIDEO: [],
             FileType.DOCUMENT: [],
         }
-        for message_index, history_message in enumerate(payload.history):
-            for file_index, file in enumerate(history_message.files):
-                attachment_groups[file.type].append({
-                    "scope": "history",
-                    "message_index": message_index,
-                    "file_index": file_index,
-                    "file": file,
-                })
+        attachment_type_counts = {file_type: 0 for file_type in attachment_groups}
         for file_index, file in enumerate(payload.files):
+            attachment_type_counts[file.type] += 1
             attachment_groups[file.type].append({
-                "scope": "current",
-                "message_index": None,
                 "file_index": file_index,
+                "type_index": attachment_type_counts[file.type],
                 "file": file,
             })
 
@@ -617,15 +655,17 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             file = ref["file"]
             file_type = str(getattr(file.type, "value", file.type))
             name = file.name or str(file.upload_file_id or file.url or "")
-            if ref["scope"] == "history":
-                location_zh = f"历史消息 {ref['message_index'] + 1} 的附件 {ref['file_index'] + 1}"
-                location_en = f"history message {ref['message_index'] + 1}, attachment {ref['file_index'] + 1}"
-            else:
-                location_zh = f"当前消息的附件 {ref['file_index'] + 1}"
-                location_en = f"current message, attachment {ref['file_index'] + 1}"
+            type_labels_zh = {
+                FileType.IMAGE: "图片文件",
+                FileType.AUDIO: "音频文件",
+                FileType.VIDEO: "视频文件",
+                FileType.DOCUMENT: "文档文件",
+            }
+            location_zh = f"{type_labels_zh[file.type]} {ref['type_index']}"
+            location_en = f"{file_type} file {ref['type_index']}"
             if language == "en":
-                return f"[{location_en}: type={file_type}, name={name}]"
-            return f"[{location_zh}：类型={file_type}，名称={name}]"
+                return f"[Details of {location_en}: name={name}]"
+            return f"[{location_zh}的详细内容：名称={name}]"
 
         def group_failure_text(refs: list[dict[str, Any]], reason: str) -> str:
             return "\n".join(f"{attachment_label(ref)}\n{reason}" for ref in refs)
@@ -672,12 +712,12 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                         or memory_config.tenant_id != tenant_id
                 ):
                     logger.warning(
-                        "Debug chat configuration access denied: config_id=%s, config_workspace=%s, request_workspace=%s",
+                        "Trial-run chat configuration access denied: config_id=%s, config_workspace=%s, request_workspace=%s",
                         payload.config_id,
                         memory_config.workspace_id,
                         workspace_id,
                     )
-                    yield format_sse_message("error", self._debug_chat_error_data(language, "access"))
+                    yield format_sse_message("error", self._trial_run_chat_error_data(language, "access"))
                     return
 
                 runtime_cache: dict[uuid.UUID, tuple[ModelInfo, uuid.UUID] | None] = {}
@@ -696,7 +736,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
                 final_runtime = await get_runtime(memory_config.llm_model_id)
                 if final_runtime is None:
-                    yield format_sse_message("error", self._debug_chat_error_data(language, "model"))
+                    yield format_sse_message("error", self._trial_run_chat_error_data(language, "model"))
                     return
 
                 media_runtimes: dict[FileType, tuple[ModelInfo, uuid.UUID] | None] = {}
@@ -708,7 +748,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 for file_type in (FileType.IMAGE, FileType.AUDIO, FileType.VIDEO):
                     if not attachment_groups[file_type]:
                         continue
-                    model_config_id = self._debug_media_model_id(memory_config, file_type)
+                    model_config_id = self._trial_run_media_model_id(memory_config, file_type)
                     runtime = await get_runtime(model_config_id)
                     required = required_capabilities[file_type]
                     if runtime is not None and required not in self._normalize_capabilities(runtime[0].capability):
@@ -743,16 +783,16 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
                 model_info, api_key_id = runtime
                 try:
-                    async with get_async_db_context() as db:
-                        multimodal_service = MultimodalService(db, model_info)
-                        parts = await self._process_debug_files(
-                            [ref["file"] for ref in refs],
-                            multimodal_service,
-                            config_workspace_id,
-                            config_tenant_id,
-                            model_info.capability,
-                            language,
-                        )
+                    # 本地文件已由短会话加载，远程文件已有 URL；后续格式化不需要数据库。
+                    multimodal_service = MultimodalService(None, model_info)
+                    parts = await self._process_trial_run_files(
+                        [ref["file"] for ref in refs],
+                        multimodal_service,
+                        config_workspace_id,
+                        config_tenant_id,
+                        model_info.capability,
+                        language,
+                    )
 
                     mapping = "\n".join(
                         f"Attachment {index} = {attachment_label(ref)}"
@@ -760,7 +800,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     )
                     requested_language = "English" if language == "en" else "Chinese"
                     parser_prompt = (
-                        f"{DEBUG_ATTACHMENT_ANALYSIS_PROMPT}\n"
+                        f"{TRIAL_RUN_ATTACHMENT_ANALYSIS_PROMPT}\n"
                         f"Reply in {requested_language}.\n{mapping}"
                     )
                     parser_llm = build_llm(model_info, streaming=False, max_tokens=2000)
@@ -783,7 +823,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     raise
                 except Exception:
                     logger.error(
-                        "[DEBUG_CHAT_STREAM] %s attachment analysis failed",
+                        "[TRIAL_RUN_CHAT_STREAM] %s attachment analysis failed",
                         file_type.value,
                         exc_info=True,
                     )
@@ -793,29 +833,28 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             async def extract_document_group() -> dict[str, Any]:
                 refs = attachment_groups[FileType.DOCUMENT]
                 documents: list[str] = []
-                async with get_async_db_context() as db:
-                    multimodal_service = MultimodalService(db, final_model_info)
-                    for ref in refs:
-                        file = ref["file"]
-                        try:
-                            if file.transfer_method == TransferMethod.LOCAL_FILE:
-                                await self._load_debug_local_file(
-                                    file,
-                                    multimodal_service,
-                                    config_workspace_id,
-                                    config_tenant_id,
-                                )
-                            text = await multimodal_service.extract_document_text(file)
-                            documents.append(f"{attachment_label(ref)}\n{text}")
-                        except asyncio.CancelledError:
-                            raise
-                        except Exception:
-                            logger.error(
-                                "[DEBUG_CHAT_STREAM] Document extraction failed",
-                                exc_info=True,
+                # 文档字节在短会话关闭后下载和解析，避免长时间占用连接。
+                multimodal_service = MultimodalService(None, final_model_info)
+                for ref in refs:
+                    file = ref["file"]
+                    try:
+                        if file.transfer_method == TransferMethod.LOCAL_FILE:
+                            await self._load_trial_run_local_file(
+                                file,
+                                config_workspace_id,
+                                config_tenant_id,
                             )
-                            reason = "[Document extraction failed.]" if language == "en" else "[文档解析失败。]"
-                            documents.append(f"{attachment_label(ref)}\n{reason}")
+                        text = await multimodal_service.extract_document_text(file)
+                        documents.append(f"{attachment_label(ref)}\n{text}")
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        logger.error(
+                            "[TRIAL_RUN_CHAT_STREAM] Document extraction failed",
+                            exc_info=True,
+                        )
+                        reason = "[Document extraction failed.]" if language == "en" else "[文档解析失败。]"
+                        documents.append(f"{attachment_label(ref)}\n{reason}")
                 return {"text": "\n\n".join(documents), "tokens": 0, "api_key_id": None}
 
             analysis_tasks = [
@@ -837,8 +876,21 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 if result.get("api_key_id") is not None
             ]
 
+            history_round_limit = self._trial_run_history_round_limit()
+            limited_history = self._latest_trial_run_history(
+                payload.history,
+                history_round_limit,
+            )
+            if len(limited_history) < len(payload.history):
+                logger.info(
+                    "[TRIAL_RUN_CHAT_STREAM] History truncated: original_messages=%s, retained_messages=%s, max_rounds=%s",
+                    len(payload.history),
+                    len(limited_history),
+                    history_round_limit,
+                )
+
             messages: list[Any] = []
-            for history_message in payload.history:
+            for history_message in limited_history:
                 if history_message.role == "user":
                     messages.append(HumanMessage(content=history_message.content))
                 else:
@@ -855,7 +907,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
             final_llm = build_llm(final_model_info, streaming=True, max_tokens=2000)
             requested_language = "English" if language == "en" else "Chinese"
-            system_prompt = f"{DEBUG_CHAT_SYSTEM_PROMPT}\nThe requested interface language is {requested_language}."
+            system_prompt = f"{TRIAL_RUN_CHAT_SYSTEM_PROMPT}\nThe requested interface language is {requested_language}."
             agent = create_agent(model=final_llm, tools=[], system_prompt=system_prompt)
 
             full_content = ""
@@ -872,6 +924,21 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     message = self._extract_message_from_event_output(output)
                     final_tokens = max(final_tokens, self._extract_total_tokens(message))
 
+            if attachment_context:
+                details_title = (
+                    "Current attachment details"
+                    if language == "en"
+                    else "当前附件详细信息"
+                )
+                attachment_details = (
+                    f"\n\n---\n\n## {details_title}\n\n"
+                    f"{attachment_context}"
+                )
+                for offset in range(0, len(attachment_details), 2000):
+                    details_chunk = attachment_details[offset:offset + 2000]
+                    full_content += details_chunk
+                    yield format_sse_message("message", {"content": details_chunk})
+
             total_tokens += final_tokens
             usage_api_key_ids.append(final_api_key_id)
 
@@ -884,7 +951,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             except Exception:
                 # Usage accounting is observability metadata. A write failure here must
                 # not turn an already completed model response into an SSE error event.
-                logger.error("[DEBUG_CHAT_STREAM] Failed to record API key usage", exc_info=True)
+                logger.error("[TRIAL_RUN_CHAT_STREAM] Failed to record API key usage", exc_info=True)
 
             yield format_sse_message("end", {
                 "elapsed_time": time.perf_counter() - start_time,
@@ -892,11 +959,11 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 "usage": {"total_tokens": total_tokens},
             })
         except asyncio.CancelledError:
-            logger.info("[DEBUG_CHAT_STREAM] Client disconnected during streaming")
+            logger.info("[TRIAL_RUN_CHAT_STREAM] Client disconnected during streaming")
             raise
         except Exception:
-            logger.error("[DEBUG_CHAT_STREAM] Error during streaming", exc_info=True)
-            yield format_sse_message("error", self._debug_chat_error_data(language))
+            logger.error("[TRIAL_RUN_CHAT_STREAM] Error during streaming", exc_info=True)
+            yield format_sse_message("error", self._trial_run_chat_error_data(language))
 
     async def pilot_run_stream(self, payload: PilotRunInput, language: str = "zh") -> AsyncGenerator[str, None]:
         """

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -54,14 +54,22 @@ _neo4j_connector = Neo4jConnector(shared_driver=True)
 DEBUG_CHAT_SYSTEM_PROMPT = """
 You are a neutral and helpful AI assistant in a debugging conversation. Answer
 general questions normally using your own general knowledge. Use the explicit
-conversation history and attachments in both historical and current user messages
-as additional context when they are relevant. Attachment marker text identifies
-the position and type of every attachment. When asked about multiple attachments,
-account for every marker; if an attachment cannot be understood, say so instead of
-silently omitting it. Do not claim to have accessed long-term memory, a private
+conversation history and the supplied attachment analysis results as additional
+context when they are relevant. Attachment labels identify the original message,
+position, and type of every attachment. When asked about multiple attachments,
+account for every label; if an attachment could not be understood, say so instead
+of silently omitting it. Do not claim to have accessed long-term memory, a private
 knowledge base, tools, or skills. If a question requires unavailable private or
 up-to-date information, state that limitation clearly. Reply in the language used
 by the user; when it is unclear, use the requested interface language.
+""".strip()
+
+DEBUG_ATTACHMENT_ANALYSIS_PROMPT = """
+Analyze every supplied attachment independently and return concise plain-text
+descriptions. Preserve each attachment label exactly so another language model can
+reliably associate the description with the original conversation message. Do not
+answer the user's overall question and do not omit an attachment. If an attachment
+cannot be understood, state the failure under that attachment label.
 """.strip()
 
 
@@ -306,15 +314,14 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         return data_list
 
     @staticmethod
-    def _resolve_chat_model_id(memory_config, files) -> uuid.UUID:
-        """按当前消息的最高多模态需求选择模型，专用模型缺失时回退 LLM。"""
-        file_types = {file.type for file in files or []}
-        if FileType.VIDEO in file_types:
-            return memory_config.video_model_id or memory_config.llm_model_id
-        if FileType.AUDIO in file_types:
-            return memory_config.audio_model_id or memory_config.llm_model_id
-        if FileType.IMAGE in file_types:
+    def _debug_media_model_id(memory_config, file_type: FileType) -> uuid.UUID:
+        """返回某一媒体类型的专用模型，未配置时回退文本模型。"""
+        if file_type == FileType.IMAGE:
             return memory_config.vision_model_id or memory_config.llm_model_id
+        if file_type == FileType.AUDIO:
+            return memory_config.audio_model_id or memory_config.llm_model_id
+        if file_type == FileType.VIDEO:
+            return memory_config.video_model_id or memory_config.llm_model_id
         return memory_config.llm_model_id
 
     @staticmethod
@@ -572,7 +579,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
             workspace_id: uuid.UUID | None = None,
             tenant_id: uuid.UUID | None = None,
     ) -> AsyncGenerator[str, None]:
-        """执行无记忆、无工具的萃取调试流式对话。"""
+        """按附件类型分别解析，再由文本模型合并生成流式回答。"""
         from app.core.models import RedBearLLM, RedBearModelConfig
         from app.db import get_async_db_context
         from app.models.models_model import ModelType
@@ -580,11 +587,81 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         from app.services.model_service import ModelApiKeyService
         from app.services.multimodal_service import MultimodalService
         from langchain.agents import create_agent
-        from langchain_core.messages import AIMessage, HumanMessage
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
         start_time = time.perf_counter()
-        api_key_obj = None
-        api_key_id: uuid.UUID | None = None
+
+        attachment_groups: dict[FileType, list[dict[str, Any]]] = {
+            FileType.IMAGE: [],
+            FileType.AUDIO: [],
+            FileType.VIDEO: [],
+            FileType.DOCUMENT: [],
+        }
+        for message_index, history_message in enumerate(payload.history):
+            for file_index, file in enumerate(history_message.files):
+                attachment_groups[file.type].append({
+                    "scope": "history",
+                    "message_index": message_index,
+                    "file_index": file_index,
+                    "file": file,
+                })
+        for file_index, file in enumerate(payload.files):
+            attachment_groups[file.type].append({
+                "scope": "current",
+                "message_index": None,
+                "file_index": file_index,
+                "file": file,
+            })
+
+        def attachment_label(ref: dict[str, Any]) -> str:
+            file = ref["file"]
+            file_type = str(getattr(file.type, "value", file.type))
+            name = file.name or str(file.upload_file_id or file.url or "")
+            if ref["scope"] == "history":
+                location_zh = f"历史消息 {ref['message_index'] + 1} 的附件 {ref['file_index'] + 1}"
+                location_en = f"history message {ref['message_index'] + 1}, attachment {ref['file_index'] + 1}"
+            else:
+                location_zh = f"当前消息的附件 {ref['file_index'] + 1}"
+                location_en = f"current message, attachment {ref['file_index'] + 1}"
+            if language == "en":
+                return f"[{location_en}: type={file_type}, name={name}]"
+            return f"[{location_zh}：类型={file_type}，名称={name}]"
+
+        def group_failure_text(refs: list[dict[str, Any]], reason: str) -> str:
+            return "\n".join(f"{attachment_label(ref)}\n{reason}" for ref in refs)
+
+        def snapshot_runtime(api_key_obj) -> tuple[ModelInfo, uuid.UUID]:
+            return (
+                ModelInfo(
+                    model_name=api_key_obj.model_name,
+                    provider=api_key_obj.provider,
+                    api_key=api_key_obj.api_key,
+                    api_base=api_key_obj.api_base or "",
+                    is_omni=api_key_obj.is_omni,
+                    model_type=ModelType.LLM,
+                    capability=api_key_obj.capability or [],
+                ),
+                api_key_obj.id,
+            )
+
+        def build_llm(model_info: ModelInfo, *, streaming: bool, max_tokens: int) -> RedBearLLM:
+            return RedBearLLM(
+                RedBearModelConfig(
+                    model_name=model_info.model_name,
+                    provider=model_info.provider,
+                    api_key=model_info.api_key,
+                    base_url=model_info.api_base,
+                    is_omni=model_info.is_omni,
+                    capability=model_info.capability,
+                    extra_params={
+                        "temperature": 0.2 if not streaming else 0.7,
+                        "max_tokens": max_tokens,
+                        "streaming": streaming,
+                    },
+                ),
+                type=ModelType.CHAT,
+            )
+
         try:
             async with get_async_db_context() as db:
                 memory_config = await MemoryConfigService(db).load_memory_config_async(payload.config_id)
@@ -603,52 +680,49 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     yield format_sse_message("error", self._debug_chat_error_data(language, "access"))
                     return
 
-                all_files = [
-                    file
-                    for history_message in payload.history
-                    for file in history_message.files
-                ]
-                all_files.extend(payload.files)
-                model_config_id = self._resolve_chat_model_id(memory_config, all_files)
-                api_key_obj = await ModelApiKeyService.get_available_api_key_bridge_async(
-                    db,
-                    model_config_id,
-                    tenant_id=memory_config.tenant_id,
-                )
-                if not api_key_obj:
+                runtime_cache: dict[uuid.UUID, tuple[ModelInfo, uuid.UUID] | None] = {}
+
+                async def get_runtime(model_config_id: uuid.UUID):
+                    if model_config_id not in runtime_cache:
+                        api_key_obj = await ModelApiKeyService.get_available_api_key_bridge_async(
+                            db,
+                            model_config_id,
+                            tenant_id=memory_config.tenant_id,
+                        )
+                        runtime_cache[model_config_id] = (
+                            snapshot_runtime(api_key_obj) if api_key_obj else None
+                        )
+                    return runtime_cache[model_config_id]
+
+                final_runtime = await get_runtime(memory_config.llm_model_id)
+                if final_runtime is None:
                     yield format_sse_message("error", self._debug_chat_error_data(language, "model"))
                     return
 
-                # get_async_db_context exits with a rollback for read-only transactions,
-                # which expires ORM attributes. Keep the scalar id before the object is
-                # detached so the post-stream usage update never touches api_key_obj.
-                api_key_id = api_key_obj.id
+                media_runtimes: dict[FileType, tuple[ModelInfo, uuid.UUID] | None] = {}
+                required_capabilities = {
+                    FileType.IMAGE: "vision",
+                    FileType.AUDIO: "audio",
+                    FileType.VIDEO: "video",
+                }
+                for file_type in (FileType.IMAGE, FileType.AUDIO, FileType.VIDEO):
+                    if not attachment_groups[file_type]:
+                        continue
+                    model_config_id = self._debug_media_model_id(memory_config, file_type)
+                    runtime = await get_runtime(model_config_id)
+                    required = required_capabilities[file_type]
+                    if runtime is not None and required not in self._normalize_capabilities(runtime[0].capability):
+                        runtime = None
+                    if runtime is None and model_config_id != memory_config.llm_model_id:
+                        fallback = final_runtime
+                        if required in self._normalize_capabilities(fallback[0].capability):
+                            runtime = fallback
+                    media_runtimes[file_type] = runtime
 
-                model_info = ModelInfo(
-                    model_name=api_key_obj.model_name,
-                    provider=api_key_obj.provider,
-                    api_key=api_key_obj.api_key,
-                    api_base=api_key_obj.api_base,
-                    is_omni=api_key_obj.is_omni,
-                    model_type=ModelType.LLM,
-                    capability=api_key_obj.capability or [],
-                )
+                config_workspace_id = memory_config.workspace_id
+                config_tenant_id = memory_config.tenant_id
 
-            llm = RedBearLLM(
-                RedBearModelConfig(
-                    model_name=model_info.model_name,
-                    provider=model_info.provider,
-                    api_key=model_info.api_key,
-                    base_url=model_info.api_base,
-                    is_omni=model_info.is_omni,
-                    capability=model_info.capability,
-                    extra_params={"temperature": 0.7, "max_tokens": 2000, "streaming": True},
-                ),
-                type=ModelType.CHAT,
-            )
-            requested_language = "English" if language == "en" else "Chinese"
-            system_prompt = f"{DEBUG_CHAT_SYSTEM_PROMPT}\nThe requested interface language is {requested_language}."
-            agent = create_agent(model=llm, tools=[], system_prompt=system_prompt)
+            final_model_info, final_api_key_id = final_runtime
 
             yield format_sse_message("start", {
                 "conversation_id": "",
@@ -656,59 +730,136 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 "user_message_id": str(uuid.uuid4()),
             })
 
-            processed_history_files: list[list[dict[str, Any]]] = [
-                [] for _ in payload.history
-            ]
-            processed_files: list[dict[str, Any]] = []
-            if any(history_message.files for history_message in payload.history) or payload.files:
-                async with get_async_db_context() as db:
-                    multimodal_service = MultimodalService(db, model_info)
-                    for index, history_message in enumerate(payload.history):
-                        if history_message.files:
-                            processed_history_files[index] = await self._process_debug_files(
-                                history_message.files,
-                                multimodal_service,
-                                memory_config.workspace_id,
-                                memory_config.tenant_id,
-                                model_info.capability,
-                                language,
-                            )
-                    processed_files = await self._process_debug_files(
-                        payload.files,
-                        multimodal_service,
-                        memory_config.workspace_id,
-                        memory_config.tenant_id,
-                        model_info.capability,
-                        language,
+            async def analyze_media_group(file_type: FileType) -> dict[str, Any]:
+                refs = attachment_groups[file_type]
+                runtime = media_runtimes.get(file_type)
+                if runtime is None:
+                    reason = (
+                        "[No configured model can process this attachment type.]"
+                        if language == "en"
+                        else "[当前配置中没有能够处理该附件类型的模型。]"
                     )
+                    return {"text": group_failure_text(refs, reason), "tokens": 0, "api_key_id": None}
+
+                model_info, api_key_id = runtime
+                try:
+                    async with get_async_db_context() as db:
+                        multimodal_service = MultimodalService(db, model_info)
+                        parts = await self._process_debug_files(
+                            [ref["file"] for ref in refs],
+                            multimodal_service,
+                            config_workspace_id,
+                            config_tenant_id,
+                            model_info.capability,
+                            language,
+                        )
+
+                    mapping = "\n".join(
+                        f"Attachment {index} = {attachment_label(ref)}"
+                        for index, ref in enumerate(refs, start=1)
+                    )
+                    requested_language = "English" if language == "en" else "Chinese"
+                    parser_prompt = (
+                        f"{DEBUG_ATTACHMENT_ANALYSIS_PROMPT}\n"
+                        f"Reply in {requested_language}.\n{mapping}"
+                    )
+                    parser_llm = build_llm(model_info, streaming=False, max_tokens=2000)
+                    response = await parser_llm.ainvoke([
+                        SystemMessage(content=parser_prompt),
+                        HumanMessage(content=parts),
+                    ])
+                    response_text = "".join(
+                        self._stream_content_to_texts(getattr(response, "content", None))
+                    ).strip()
+                    if not response_text:
+                        reason = "[Attachment analysis returned no text.]" if language == "en" else "[附件解析未返回文本。]"
+                        response_text = group_failure_text(refs, reason)
+                    return {
+                        "text": response_text,
+                        "tokens": self._extract_total_tokens(response),
+                        "api_key_id": api_key_id,
+                    }
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.error(
+                        "[DEBUG_CHAT_STREAM] %s attachment analysis failed",
+                        file_type.value,
+                        exc_info=True,
+                    )
+                    reason = "[Attachment analysis failed.]" if language == "en" else "[附件解析失败。]"
+                    return {"text": group_failure_text(refs, reason), "tokens": 0, "api_key_id": None}
+
+            async def extract_document_group() -> dict[str, Any]:
+                refs = attachment_groups[FileType.DOCUMENT]
+                documents: list[str] = []
+                async with get_async_db_context() as db:
+                    multimodal_service = MultimodalService(db, final_model_info)
+                    for ref in refs:
+                        file = ref["file"]
+                        try:
+                            if file.transfer_method == TransferMethod.LOCAL_FILE:
+                                await self._load_debug_local_file(
+                                    file,
+                                    multimodal_service,
+                                    config_workspace_id,
+                                    config_tenant_id,
+                                )
+                            text = await multimodal_service.extract_document_text(file)
+                            documents.append(f"{attachment_label(ref)}\n{text}")
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            logger.error(
+                                "[DEBUG_CHAT_STREAM] Document extraction failed",
+                                exc_info=True,
+                            )
+                            reason = "[Document extraction failed.]" if language == "en" else "[文档解析失败。]"
+                            documents.append(f"{attachment_label(ref)}\n{reason}")
+                return {"text": "\n\n".join(documents), "tokens": 0, "api_key_id": None}
+
+            analysis_tasks = [
+                analyze_media_group(file_type)
+                for file_type in (FileType.IMAGE, FileType.AUDIO, FileType.VIDEO)
+                if attachment_groups[file_type]
+            ]
+            if attachment_groups[FileType.DOCUMENT]:
+                analysis_tasks.append(extract_document_group())
+
+            analysis_results = await asyncio.gather(*analysis_tasks) if analysis_tasks else []
+            attachment_context = "\n\n".join(
+                result["text"] for result in analysis_results if result.get("text")
+            )
+            total_tokens = sum(int(result.get("tokens") or 0) for result in analysis_results)
+            usage_api_key_ids = [
+                result["api_key_id"]
+                for result in analysis_results
+                if result.get("api_key_id") is not None
+            ]
 
             messages: list[Any] = []
-            for index, history_message in enumerate(payload.history):
+            for history_message in payload.history:
                 if history_message.role == "user":
-                    history_file_parts = processed_history_files[index]
-                    history_content: str | list[dict[str, Any]]
-                    if history_file_parts:
-                        history_content = [
-                            {"type": "text", "text": history_message.content},
-                            *history_file_parts,
-                        ]
-                    else:
-                        history_content = history_message.content
-                    messages.append(HumanMessage(content=history_content))
+                    messages.append(HumanMessage(content=history_message.content))
                 else:
                     messages.append(AIMessage(content=history_message.content))
 
-            if processed_files:
-                current_content: str | list[dict[str, Any]] = [
-                    {"type": "text", "text": payload.message},
-                    *processed_files,
-                ]
-            else:
-                current_content = payload.message
+            current_content = payload.message
+            if attachment_context:
+                current_content += (
+                    "\n\n<attachment_analysis_results>\n"
+                    f"{attachment_context}\n"
+                    "</attachment_analysis_results>"
+                )
             messages.append(HumanMessage(content=current_content))
 
+            final_llm = build_llm(final_model_info, streaming=True, max_tokens=2000)
+            requested_language = "English" if language == "en" else "Chinese"
+            system_prompt = f"{DEBUG_CHAT_SYSTEM_PROMPT}\nThe requested interface language is {requested_language}."
+            agent = create_agent(model=final_llm, tools=[], system_prompt=system_prompt)
+
             full_content = ""
-            total_tokens = 0
+            final_tokens = 0
             async for event in agent.astream_events({"messages": messages}, version="v2"):
                 event_type = event.get("event")
                 if event_type == "on_chat_model_stream":
@@ -719,11 +870,15 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 elif event_type == "on_chat_model_end":
                     output = event.get("data", {}).get("output")
                     message = self._extract_message_from_event_output(output)
-                    total_tokens = max(total_tokens, self._extract_total_tokens(message))
+                    final_tokens = max(final_tokens, self._extract_total_tokens(message))
+
+            total_tokens += final_tokens
+            usage_api_key_ids.append(final_api_key_id)
 
             try:
                 async with get_async_db_context() as db:
-                    await ModelApiKeyService.record_api_key_usage_bridge_async(db, api_key_id)
+                    for api_key_id in usage_api_key_ids:
+                        await ModelApiKeyService.record_api_key_usage_bridge_async(db, api_key_id)
             except asyncio.CancelledError:
                 raise
             except Exception:


### PR DESCRIPTION
## Summary by Sourcery

启用流式试运行对话，将可配置的 LLM 响应与显式历史记录和附件分析相结合。

新功能：
- 添加一个受工作区保护的流式试运行聊天端点，用于无状态对话，并支持可配置的 memory-engine LLM 设置。
- 在试运行对话中支持显式聊天历史、多语言响应，以及图像、音频、视频和文档附件。

增强内容：
- 通过合适且已配置的媒体模型路由附件，提供可见的回退错误提示，通过可配置的对话轮数限制保留的历史记录，并报告模型使用的元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable streaming trial-run conversations that combine configurable LLM responses with explicit history and attachment analysis.

New Features:
- Add a workspace-protected streaming trial chat endpoint for stateless conversations with configurable memory-engine LLM settings.
- Support explicit chat history, multilingual responses, and image, audio, video, and document attachments in trial conversations.

Enhancements:
- Route attachments through suitable configured media models, provide visible fallback errors, limit retained history by configurable conversation rounds, and report model usage metadata.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

启用流式试运行对话，将可配置的 LLM 响应与显式历史记录和附件分析相结合。

新功能：
- 添加一个受工作区保护的流式试运行聊天端点，用于无状态对话，并支持可配置的 memory-engine LLM 设置。
- 在试运行对话中支持显式聊天历史、多语言响应，以及图像、音频、视频和文档附件。

增强内容：
- 通过合适且已配置的媒体模型路由附件，提供可见的回退错误提示，通过可配置的对话轮数限制保留的历史记录，并报告模型使用的元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable streaming trial-run conversations that combine configurable LLM responses with explicit history and attachment analysis.

New Features:
- Add a workspace-protected streaming trial chat endpoint for stateless conversations with configurable memory-engine LLM settings.
- Support explicit chat history, multilingual responses, and image, audio, video, and document attachments in trial conversations.

Enhancements:
- Route attachments through suitable configured media models, provide visible fallback errors, limit retained history by configurable conversation rounds, and report model usage metadata.

</details>

</details>