### PR TITLE
feat: Implement workflow node execution record retention policy, add multilingual model configuration validation

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -431,6 +431,15 @@ class Settings:
     WORKFLOW_IMPORT_CACHE_TIMEOUT: int = int(os.getenv("WORKFLOW_IMPORT_CACHE_TIMEOUT", 1800))
     WORKFLOW_NODE_TIMEOUT: int = int(os.getenv("WORKFLOW_NODE_TIMEOUT", 600))
 
+    # workflow_node_executions 保留策略开关。
+    # 开启后该表只保留「最近一次」记录：
+    #   - 完整工作流：同 app_id + workflow_config_id 下最近 1 次终态执行的全部节点行
+    #   - 单节点调试：同 app_id + workflow_config_id + node_id 下最近 1 条
+    # 历史明细的权威数据源是 workflow_executions.output_data["node_outputs"]，不受影响。
+    WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED: bool = os.getenv(
+        "WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED", "true"
+    ).lower() == "true"
+
     # ========================================================================
     # General Ontology Type Configuration
     # ========================================================================

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -434,7 +434,8 @@ class Settings:
 
     # workflow_node_executions 保留策略开关。
     # 开启后该表只保留「最近一次」记录：
-    #   - 完整工作流：同 app_id + workflow_config_id 下最近 1 次终态执行的全部节点行
+    #   - 完整工作流：同 app_id + workflow_config_id 下按执行开始时间最近 1 次的全部节点行
+    #     （包括 waiting_human；较旧人工介入执行恢复时也不会覆盖更新执行）
     #   - 单节点调试：同 app_id + workflow_config_id + node_id 下最近 1 条
     # 历史明细的权威数据源是 workflow_executions.output_data["node_outputs"]，不受影响。
     WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED: bool = os.getenv(

--- a/api/app/core/workflow/engine/variable_pool.py
+++ b/api/app/core/workflow/engine/variable_pool.py
@@ -379,6 +379,13 @@ class VariablePool:
                 await self.set(f"{namespace}.{key}", value)
             except KeyError:
                 pass
+            except TypeError:
+                # The existing instance may be a placeholder of a different
+                # type (e.g. STRING placeholders pre-populated from graph
+                # state during workflow resume). It is replaced by the
+                # correctly-typed instance created below, so a type mismatch
+                # on the stale instance must not abort node execution.
+                pass
         instance = create_variable_instance(var_type, value)
         variable_struct = VariableStruct(type=var_type, instance=instance, mut=mut)
         namespace_variable = self.variables.get(namespace)

--- a/api/app/locales/en/workspace.json
+++ b/api/app/locales/en/workspace.json
@@ -41,6 +41,26 @@
     "config_updated": "Model configuration updated successfully",
     "invalid_config": "Invalid model configuration",
     "config_verified": "Model configuration verified",
-    "default_config_updated_notice": "The workspace default model configuration has been updated."
+    "default_config_updated_notice": "The workspace default model configuration has been updated.",
+    "slots": {
+      "llm": "LLM model",
+      "embedding": "Embedding model",
+      "rerank": "Rerank model",
+      "vision": "Vision model",
+      "audio": "Audio model",
+      "video": "Video model"
+    },
+    "errors": {
+      "save_failed": "Failed to save model configuration ({count} issue(s)): {reasons}",
+      "not_configured": "{slot} is not configured, please select an available model",
+      "not_found": "{slot}: the selected model does not exist (model id: {model_id})",
+      "inactive": "{slot}: the selected model \"{model_name}\" is disabled, please enable it in Model Management first",
+      "not_accessible": "{slot}: the selected model \"{model_name}\" is not available for the current tenant, please choose another one",
+      "deprecated": "{slot}: the selected model \"{model_name}\" is deprecated, please choose another one",
+      "capability_mismatch": "{slot} does not support the selected model \"{model_name}\" (model type: {model_type}), please choose a matching model",
+      "no_api_key": "{slot} \"{model_name}\" has no available API key, please configure one in Model Management",
+      "api_verify_failed": "{slot} \"{model_name}\" connectivity check failed: {error}",
+      "verify_failed": "{slot} \"{model_name}\" validation error: {error}"
+    }
   }
 }

--- a/api/app/locales/zh/workspace.json
+++ b/api/app/locales/zh/workspace.json
@@ -41,6 +41,26 @@
     "config_updated": "模型配置更新成功",
     "invalid_config": "无效的模型配置",
     "config_verified": "模型配置已校验",
-    "default_config_updated_notice": "空间默认配置模型有更新。"
+    "default_config_updated_notice": "空间默认配置模型有更新。",
+    "slots": {
+      "llm": "对话模型",
+      "embedding": "嵌入模型",
+      "rerank": "重排序模型",
+      "vision": "视觉模型",
+      "audio": "音频模型",
+      "video": "视频模型"
+    },
+    "errors": {
+      "save_failed": "模型配置保存失败（{count} 项）：{reasons}",
+      "not_configured": "{slot}未配置，请选择一个可用模型",
+      "not_found": "{slot}选择的模型不存在（模型ID: {model_id}）",
+      "inactive": "{slot}「{model_name}」已被禁用，请先在模型管理中启用",
+      "not_accessible": "{slot}「{model_name}」不在当前租户可用范围内，请重新选择",
+      "deprecated": "{slot}「{model_name}」已弃用，请更换为其他模型",
+      "capability_mismatch": "{slot}与所选模型「{model_name}」不匹配（模型类型: {model_type}），请重新选择",
+      "no_api_key": "{slot}「{model_name}」没有可用的 API 密钥，请先在模型管理中配置密钥",
+      "api_verify_failed": "{slot}「{model_name}」连通性校验失败：{error}",
+      "verify_failed": "{slot}「{model_name}」校验异常：{error}"
+    }
   }
 }

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -155,7 +155,8 @@ class WorkflowNodeExecution(Base):
     """工作流节点执行记录表
 
     保留策略：本表只保留「最近一次」执行明细，不保存历史。
-      - 完整工作流：同 app_id + workflow_config_id 下最近 1 次终态执行的全部节点行
+      - 完整工作流：同 app_id + workflow_config_id 下按执行开始时间最近 1 次的全部节点行
+        （包括 waiting_human，且较旧人工介入执行恢复时不会覆盖更新执行）
       - 单节点调试：同 app_id + workflow_config_id + node_id 下最近 1 条
     历史节点明细的权威数据源是 workflow_executions.output_data["node_outputs"]。
     由 settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED 控制。

--- a/api/app/models/workflow_model.py
+++ b/api/app/models/workflow_model.py
@@ -152,7 +152,14 @@ class WorkflowExecution(Base):
 
 
 class WorkflowNodeExecution(Base):
-    """工作流节点执行记录表"""
+    """工作流节点执行记录表
+
+    保留策略：本表只保留「最近一次」执行明细，不保存历史。
+      - 完整工作流：同 app_id + workflow_config_id 下最近 1 次终态执行的全部节点行
+      - 单节点调试：同 app_id + workflow_config_id + node_id 下最近 1 条
+    历史节点明细的权威数据源是 workflow_executions.output_data["node_outputs"]。
+    由 settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED 控制。
+    """
     __tablename__ = "workflow_node_executions"
 
     # 主键

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -17,6 +17,44 @@ from app.models.workflow_model import (
 )
 from app.db import get_db
 
+# 工作流执行的终态。只有终态执行的节点行才允许被保留策略清理，
+# pending / running / waiting_human 一律保留，避免破坏正在运行的执行与人工介入恢复链路。
+WORKFLOW_EXECUTION_TERMINAL_STATUSES: tuple[str, ...] = (
+    "completed",
+    "failed",
+    "timeout",
+    "cancelled",
+)
+
+# 单节点调试记录在 meta_data.source 中的标识
+SINGLE_NODE_DEBUG_SOURCE = "single_node_debug"
+
+# 终态状态的 SQL 字面量列表。取值来自上面的代码内常量元组，不含外部输入。
+_TERMINAL_STATUSES_SQL = ", ".join(f"'{status}'" for status in WORKFLOW_EXECUTION_TERMINAL_STATUSES)
+
+# 完整工作流节点行的保留策略清理 SQL（异步队列落库路径使用）。
+#
+# 语义：当前 execution（:eid）已处于终态时，删除同一 app_id + workflow_config_id 下
+# 其他终态 execution 的节点行。
+#
+# 安全性：
+#   - cur.status 限定终态：执行中的 execution 不触发清理
+#   - stale_exec.status 限定终态：不会删掉 running / pending / waiting_human 的节点行
+#   - stale.execution_id = stale_exec.id 天然排除单节点调试行（execution_id IS NULL）
+#   - 必须在 INSERT 成功之后执行，否则写入失败时会连「上次执行记录」一起丢失
+NODE_EXECUTION_RETENTION_SQL = f"""
+DELETE FROM workflow_node_executions AS stale
+USING workflow_executions AS stale_exec,
+      workflow_executions AS cur
+WHERE cur.id = CAST(:eid AS uuid)
+  AND cur.status IN ({_TERMINAL_STATUSES_SQL})
+  AND stale.execution_id = stale_exec.id
+  AND stale_exec.id <> cur.id
+  AND stale_exec.app_id = cur.app_id
+  AND stale_exec.workflow_config_id = cur.workflow_config_id
+  AND stale_exec.status IN ({_TERMINAL_STATUSES_SQL})
+"""
+
 
 class WorkflowConfigRepository:
     """工作流配置仓储"""
@@ -270,6 +308,90 @@ class WorkflowNodeExecutionRepository:
             WorkflowNodeExecution.execution_id == execution_id
         )
         self.db.execute(stmt)
+
+    def delete_stale_workflow_executions(
+        self,
+        *,
+        app_id: uuid.UUID,
+        workflow_config_id: uuid.UUID,
+        keep_execution_id: uuid.UUID,
+    ) -> int:
+        """清理同一工作流下除 keep_execution_id 外、其他终态执行的节点记录。
+
+        仅清理终态执行；running / pending / waiting_human 一律保留。
+        keep_execution_id 自身未进入终态时不做任何清理。
+        必须在当前执行的节点行写入成功之后调用。
+
+        Args:
+            app_id: 应用 ID
+            workflow_config_id: 工作流配置 ID
+            keep_execution_id: 需要保留的执行 ID（本次执行）
+
+        Returns:
+            删除的行数
+        """
+        keep_is_terminal = (
+            select(WorkflowExecution.id)
+            .where(
+                WorkflowExecution.id == keep_execution_id,
+                WorkflowExecution.status.in_(WORKFLOW_EXECUTION_TERMINAL_STATUSES),
+            )
+            .exists()
+        )
+        stale_execution_ids = select(WorkflowExecution.id).where(
+            WorkflowExecution.app_id == app_id,
+            WorkflowExecution.workflow_config_id == workflow_config_id,
+            WorkflowExecution.id != keep_execution_id,
+            WorkflowExecution.status.in_(WORKFLOW_EXECUTION_TERMINAL_STATUSES),
+        )
+        stmt = delete(WorkflowNodeExecution).where(
+            keep_is_terminal,
+            WorkflowNodeExecution.execution_id.in_(stale_execution_ids),
+        )
+        result = self.db.execute(
+            stmt,
+            execution_options={"synchronize_session": False},
+        )
+        return result.rowcount or 0
+
+    def delete_stale_single_node_debug(
+        self,
+        *,
+        app_id: uuid.UUID,
+        workflow_config_id: uuid.UUID,
+        node_id: str,
+        keep_id: uuid.UUID,
+    ) -> int:
+        """清理同一节点除 keep_id 外的历史单节点调试记录。
+
+        过滤条件必须同时满足，否则会误删完整工作流的节点行：
+          execution_id IS NULL
+          meta_data['source'] == 'single_node_debug'
+          id != keep_id
+
+        Args:
+            app_id: 应用 ID
+            workflow_config_id: 工作流配置 ID
+            node_id: 节点 ID
+            keep_id: 需要保留的记录 ID（本次调试新写入的行）
+
+        Returns:
+            删除的行数
+        """
+        stmt = delete(WorkflowNodeExecution).where(
+            WorkflowNodeExecution.app_id == app_id,
+            WorkflowNodeExecution.workflow_config_id == workflow_config_id,
+            WorkflowNodeExecution.node_id == node_id,
+            WorkflowNodeExecution.execution_id.is_(None),
+            WorkflowNodeExecution.meta_data["source"].as_string() == SINGLE_NODE_DEBUG_SOURCE,
+            WorkflowNodeExecution.id != keep_id,
+        )
+        result = self.db.execute(
+            stmt,
+            execution_options={"synchronize_session": False},
+        )
+        return result.rowcount or 0
+
     
     def get_by_execution_id(
         self,

--- a/api/app/repositories/workflow_repository.py
+++ b/api/app/repositories/workflow_repository.py
@@ -17,42 +17,41 @@ from app.models.workflow_model import (
 )
 from app.db import get_db
 
-# 工作流执行的终态。只有终态执行的节点行才允许被保留策略清理，
-# pending / running / waiting_human 一律保留，避免破坏正在运行的执行与人工介入恢复链路。
-WORKFLOW_EXECUTION_TERMINAL_STATUSES: tuple[str, ...] = (
-    "completed",
-    "failed",
-    "timeout",
-    "cancelled",
-)
-
 # 单节点调试记录在 meta_data.source 中的标识
 SINGLE_NODE_DEBUG_SOURCE = "single_node_debug"
 
-# 终态状态的 SQL 字面量列表。取值来自上面的代码内常量元组，不含外部输入。
-_TERMINAL_STATUSES_SQL = ", ".join(f"'{status}'" for status in WORKFLOW_EXECUTION_TERMINAL_STATUSES)
-
 # 完整工作流节点行的保留策略清理 SQL（异步队列落库路径使用）。
 #
-# 语义：当前 execution（:eid）已处于终态时，删除同一 app_id + workflow_config_id 下
-# 其他终态 execution 的节点行。
+# 语义：每次成功写入节点投影后，按 started_at / created_at / id 确定
+# 同一 app_id + workflow_config_id 下真正最新的 execution，只保留它的节点行。
 #
-# 安全性：
-#   - cur.status 限定终态：执行中的 execution 不触发清理
-#   - stale_exec.status 限定终态：不会删掉 running / pending / waiting_human 的节点行
-#   - stale.execution_id = stale_exec.id 天然排除单节点调试行（execution_id IS NULL）
-#   - 必须在 INSERT 成功之后执行，否则写入失败时会连「上次执行记录」一起丢失
-NODE_EXECUTION_RETENTION_SQL = f"""
+# 不能简单保留本次写入的 execution：较旧的 waiting_human 执行可能在较新的执行
+# 之后恢复并再次写入；如果固定保留本次 execution，会错误淘汰真正最新的执行。
+# 本清理只处理 execution_id 非空的整图执行行，不影响单节点调试行。
+NODE_EXECUTION_RETENTION_SQL = """
+WITH current_scope AS (
+    SELECT app_id, workflow_config_id
+    FROM workflow_executions
+    WHERE id = CAST(:eid AS uuid)
+),
+latest_execution AS (
+    SELECT candidate.id
+    FROM workflow_executions AS candidate
+    JOIN current_scope AS scope
+      ON candidate.app_id = scope.app_id
+     AND candidate.workflow_config_id = scope.workflow_config_id
+    ORDER BY candidate.started_at DESC,
+             candidate.created_at DESC,
+             candidate.id DESC
+    LIMIT 1
+)
 DELETE FROM workflow_node_executions AS stale
 USING workflow_executions AS stale_exec,
-      workflow_executions AS cur
-WHERE cur.id = CAST(:eid AS uuid)
-  AND cur.status IN ({_TERMINAL_STATUSES_SQL})
-  AND stale.execution_id = stale_exec.id
-  AND stale_exec.id <> cur.id
-  AND stale_exec.app_id = cur.app_id
-  AND stale_exec.workflow_config_id = cur.workflow_config_id
-  AND stale_exec.status IN ({_TERMINAL_STATUSES_SQL})
+      current_scope AS scope
+WHERE stale.execution_id = stale_exec.id
+  AND stale_exec.app_id = scope.app_id
+  AND stale_exec.workflow_config_id = scope.workflow_config_id
+  AND stale_exec.id <> (SELECT id FROM latest_execution)
 """
 
 
@@ -316,36 +315,43 @@ class WorkflowNodeExecutionRepository:
         workflow_config_id: uuid.UUID,
         keep_execution_id: uuid.UUID,
     ) -> int:
-        """清理同一工作流下除 keep_execution_id 外、其他终态执行的节点记录。
+        """只保留同一工作流真正最新一次整图执行的节点记录。
 
-        仅清理终态执行；running / pending / waiting_human 一律保留。
-        keep_execution_id 自身未进入终态时不做任何清理。
-        必须在当前执行的节点行写入成功之后调用。
-
-        Args:
-            app_id: 应用 ID
-            workflow_config_id: 工作流配置 ID
-            keep_execution_id: 需要保留的执行 ID（本次执行）
-
-        Returns:
-            删除的行数
+        最新执行按 started_at、created_at、id 倒序确定，不要求执行已进入终态。
+        这样 waiting_human 记录也受保留策略约束，并避免较旧的人工介入执行
+        稍后恢复时淘汰更新执行的节点记录。单节点调试行的 execution_id 为空，
+        不会被本方法删除。
         """
-        keep_is_terminal = (
+        current_execution_exists = (
             select(WorkflowExecution.id)
             .where(
                 WorkflowExecution.id == keep_execution_id,
-                WorkflowExecution.status.in_(WORKFLOW_EXECUTION_TERMINAL_STATUSES),
+                WorkflowExecution.app_id == app_id,
+                WorkflowExecution.workflow_config_id == workflow_config_id,
             )
             .exists()
+        )
+        latest_execution_id = (
+            select(WorkflowExecution.id)
+            .where(
+                WorkflowExecution.app_id == app_id,
+                WorkflowExecution.workflow_config_id == workflow_config_id,
+            )
+            .order_by(
+                desc(WorkflowExecution.started_at),
+                desc(WorkflowExecution.created_at),
+                desc(WorkflowExecution.id),
+            )
+            .limit(1)
+            .scalar_subquery()
         )
         stale_execution_ids = select(WorkflowExecution.id).where(
             WorkflowExecution.app_id == app_id,
             WorkflowExecution.workflow_config_id == workflow_config_id,
-            WorkflowExecution.id != keep_execution_id,
-            WorkflowExecution.status.in_(WORKFLOW_EXECUTION_TERMINAL_STATUSES),
+            WorkflowExecution.id != latest_execution_id,
         )
         stmt = delete(WorkflowNodeExecution).where(
-            keep_is_terminal,
+            current_execution_exists,
             WorkflowNodeExecution.execution_id.in_(stale_execution_ids),
         )
         result = self.db.execute(

--- a/api/app/services/batch_persist_queue.py
+++ b/api/app/services/batch_persist_queue.py
@@ -571,8 +571,14 @@ async def _handle_save_node_executions(
     items: list[dict[str, Any]],
     **kwargs: Any,
 ) -> None:
-    """Batch persist workflow node execution records."""
+    """Batch persist workflow node execution records.
+
+    Retention policy: this table only keeps the most recent execution per
+    ``app_id + workflow_config_id``. Historical node detail stays available via
+    ``workflow_executions.output_data["node_outputs"]``.
+    """
     from app.models.workflow_model import WorkflowNodeExecution
+    from app.repositories.workflow_repository import NODE_EXECUTION_RETENTION_SQL
 
     if not items:
         return
@@ -581,6 +587,21 @@ async def _handle_save_node_executions(
         {"eid": execution_id},
     )
     await db.execute(sa_insert(WorkflowNodeExecution).values(items))
+
+    if not settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED:
+        return
+    # Runs after the INSERT above, inside the same batch transaction: if the
+    # write fails we must not lose the previous execution's records either.
+    result = await db.execute(
+        sa_text(NODE_EXECUTION_RETENTION_SQL),
+        {"eid": str(execution_id)},
+    )
+    if result.rowcount:
+        logger.debug(
+            "node execution retention removed %s stale rows (execution_id=%s)",
+            result.rowcount,
+            execution_id,
+        )
 
 
 _TASK_HANDLERS: dict[str, Any] = {

--- a/api/app/services/intervention_timeout_scheduler.py
+++ b/api/app/services/intervention_timeout_scheduler.py
@@ -185,6 +185,17 @@ async def _terminate_timed_out_workflow(entry):
         intervention_ctx = (execution.context or {}).get("human_intervention", {})
         checkpoint_thread_id = intervention_ctx.get("checkpoint_thread_id", "")
 
+    # The fallback bypasses the normal resume stream, so explicitly refresh the
+    # node-execution projection after the terminal output_data has committed.
+    try:
+        from app.services.workflow_service import WorkflowService
+        await WorkflowService()._persist_execution_artifacts_async(entry.execution_id)
+    except Exception as persist_err:
+        logger.warning(
+            f"Failed to persist node executions after intervention timeout: {persist_err}",
+            exc_info=True,
+        )
+
     # Clean up registries and checkpoint
     InterventionRegistry.cleanup(entry.execution_id)
 

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -171,7 +171,8 @@ class WorkflowService:
     DEBUG_STATE_NODE_TYPE = "debug-state"
     DEBUG_STATE_NODE_NAME = "Workflow Debug State"
     DEBUG_STATE_SOURCE = "debug_state"
-    SKIP_EXECUTION_ARTIFACT_PERSIST_FOR_EXPERIMENT = True
+    # 节点执行投影必须正常落库；历史明细仍以 WorkflowExecution.output_data 为准。
+    SKIP_EXECUTION_ARTIFACT_PERSIST_FOR_EXPERIMENT = False
 
     # 重新生成版本上限：同一轮（同 parent_message_id）允许的最大 assistant 版本数（含原始回复）
     MAX_REGENERATE_VERSIONS = 5
@@ -2954,7 +2955,7 @@ class WorkflowService:
             )
         self.node_execution_repo.bulk_create(items)
         if settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED:
-            # 写入成功后再清理同工作流下其他终态执行的节点行
+            # 写入成功后，按执行开始时间只保留同工作流真正最新一次执行的节点行。
             self.db.flush()
             self.node_execution_repo.delete_stale_workflow_executions(
                 app_id=execution.app_id,
@@ -7902,6 +7903,22 @@ class WorkflowService:
                             execution.execution_id,
                             output_data=execution.output_data,
                         )
+
+                    # 普通流式执行此前只更新 workflow_executions，遗漏了节点投影。
+                    # 必须在 cycle_items 合并完成后、workflow_end 返回客户端前入队，
+                    # 让试运行和体验分享都能写入 workflow_node_executions。
+                    if status in ("completed", "failed"):
+                        try:
+                            await self._persist_execution_artifacts_async(
+                                execution.execution_id,
+                                config,
+                            )
+                        except Exception as persist_err:
+                            logger.warning(
+                                "Failed to persist node executions on workflow end: %s",
+                                persist_err,
+                                exc_info=True,
+                            )
                 elif event.get("event") == "workflow_start":
                     event["data"]["message_id"] = str(message_id)
                     if user_message_id:

--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -178,10 +178,13 @@ class WorkflowService:
 
     def __init__(self, db: Session | AsyncSession | None = None):
         self.db = db
-        self.config_repo = WorkflowConfigRepository(db) if db is not None else None
-        self.execution_repo = WorkflowExecutionRepository(db) if db is not None else None
-        self.node_execution_repo = WorkflowNodeExecutionRepository(db) if db is not None else None
-        self.node_cache_repo = WorkflowNodeCacheRepository(db) if db is not None else None
+        # Sync repositories only work with a sync Session; for AsyncSession
+        # (or no db) we use async DB contexts in the methods that need them.
+        self._is_async_db = isinstance(db, AsyncSession)
+        self.config_repo = WorkflowConfigRepository(db) if (db is not None and not self._is_async_db) else None
+        self.execution_repo = WorkflowExecutionRepository(db) if (db is not None and not self._is_async_db) else None
+        self.node_execution_repo = WorkflowNodeExecutionRepository(db) if (db is not None and not self._is_async_db) else None
+        self.node_cache_repo = WorkflowNodeCacheRepository(db) if (db is not None and not self._is_async_db) else None
         self.conversation_service = ConversationService(db) if db is not None else None
         self.multimodal_service = MultimodalService(db) if db is not None else None
 
@@ -1855,6 +1858,46 @@ class WorkflowService:
             )
         }
 
+    # output_data["node_outputs"][node_id] 中属于节点元信息的键。
+    # 剥离这些键后剩余的部分才是节点输出变量（与 _build_node_execution_record 的取值规则一致）。
+    _NODE_OUTPUT_META_KEYS = frozenset({
+        "node_type",
+        "node_name",
+        "status",
+        "error",
+        "input",
+        "output",
+        "execution_order",
+        "retry_count",
+        "elapsed_time",
+        "token_usage",
+        "process",
+        "agent_log",
+        "cache_hit",
+        "cache_key",
+    })
+
+    @classmethod
+    def _extract_node_output_value(cls, node_data: Any) -> Any:
+        """从 output_data["node_outputs"][node_id] 中取节点输出值。
+
+        取值规则与 _build_node_execution_record() 保持一致：
+        存在 "output" 键时取其值，否则取剥离元信息键后的剩余部分。
+
+        Returns:
+            节点输出值；None 表示没有可用值（调用方需保留原有占位逻辑）
+        """
+        if not isinstance(node_data, dict):
+            return node_data
+        if "output" in node_data:
+            return node_data.get("output")
+        remainder = {
+            key: value
+            for key, value in node_data.items()
+            if key not in cls._NODE_OUTPUT_META_KEYS
+        }
+        return remainder or None
+
     @classmethod
     def _build_ordered_node_snapshots(
             cls,
@@ -1862,9 +1905,24 @@ class WorkflowService:
             node_executions: list[WorkflowNodeExecution],
             raw_node_vars: Any,
             node_type_maps: dict[str, dict[str, str]],
+            node_outputs: Any = None,
     ) -> dict[str, Any]:
+        """组装快照中的 nodes 分组。
+
+        取值优先级：
+            output_data.snapshot.nodes[node_id]
+              → workflow_node_executions.output_data
+                → output_data.node_outputs[node_id].output
+                  → 按类型定义补缺失值占位
+
+        node_outputs 兜底用于节点表按保留策略清理后的历史执行：此时 node_executions 为空，
+        节点顺序与取值都从父执行的 node_outputs 重建。
+        """
         ordered_node_vars: dict[str, Any] = {}
         serialized_raw_node_vars = cls._serialize_execution_value(raw_node_vars or {})
+        serialized_node_outputs = cls._serialize_execution_value(node_outputs or {})
+        if not isinstance(serialized_node_outputs, dict):
+            serialized_node_outputs = {}
 
         for node_execution in node_executions:
             node_id = node_execution.node_id
@@ -1877,11 +1935,41 @@ class WorkflowService:
                     type_map=node_type_map,
                 )
                 continue
-            serialized_output = cls._serialize_execution_value(node_execution.output_data or {})
-            if isinstance(serialized_output, dict) and "output" in serialized_output:
-                serialized_output = serialized_output.get("output")
+            if node_execution.output_data:
+                serialized_output = cls._serialize_execution_value(node_execution.output_data)
+                if isinstance(serialized_output, dict) and "output" in serialized_output:
+                    serialized_output = serialized_output.get("output")
+            else:
+                # 节点行存在但 output_data 为空时继续往 node_outputs 兜底；
+                # 两者都没有则保持原有的空分组行为，交给下面的占位补齐。
+                fallback_output = cls._extract_node_output_value(
+                    serialized_node_outputs.get(node_id)
+                )
+                serialized_output = fallback_output if fallback_output is not None else {}
             ordered_node_vars[node_id] = cls._build_typed_node_snapshot(
                 serialized_output,
+                type_map=node_type_map,
+            )
+
+        # 节点表已按保留策略清理时，从 node_outputs 按 execution_order 重建顺序与取值
+        for node_id, node_data in sorted(
+                serialized_node_outputs.items(),
+                key=cls._node_output_sort_key,
+        ):
+            if node_id in ordered_node_vars:
+                continue
+            node_type_map = node_type_maps.get(node_id)
+            if isinstance(serialized_raw_node_vars, dict) and node_id in serialized_raw_node_vars:
+                ordered_node_vars[node_id] = cls._build_typed_node_snapshot(
+                    serialized_raw_node_vars[node_id],
+                    type_map=node_type_map,
+                )
+                continue
+            fallback_output = cls._extract_node_output_value(node_data)
+            if fallback_output is None:
+                continue
+            ordered_node_vars[node_id] = cls._build_typed_node_snapshot(
+                fallback_output,
                 type_map=node_type_map,
             )
 
@@ -1918,6 +2006,7 @@ class WorkflowService:
             node_executions=node_executions,
             raw_node_vars=raw_groups["nodes"],
             node_type_maps=type_maps["nodes"],
+            node_outputs=output_data.get("node_outputs") if isinstance(output_data, dict) else None,
         )
         return {
             "system": self._normalize_typed_group(
@@ -1953,6 +2042,7 @@ class WorkflowService:
             node_executions=node_executions,
             raw_node_vars=raw_groups["nodes"],
             node_type_maps=type_maps["nodes"],
+            node_outputs=output_data.get("node_outputs") if isinstance(output_data, dict) else None,
         )
         return {
             "conversation": self._normalize_typed_group(
@@ -2774,6 +2864,68 @@ class WorkflowService:
             }
         }
 
+    def _build_node_executions_from_output_data(
+            self,
+            output_data: dict[str, Any],
+            *,
+            execution: WorkflowExecution,
+            workflow_config: WorkflowConfig | None = None,
+    ) -> list[dict[str, Any]]:
+        """从 workflow_executions.output_data["node_outputs"] 重建执行详情的节点明细。
+
+        workflow_node_executions 按保留策略只保留最近一次执行，历史执行直读节点表会得到空列表，
+        因此需要从父执行的 node_outputs 兜底重建。
+
+        复用 _build_node_execution_record() 的字段映射规则（节点表写入时用的就是它），
+        保证输出与直读节点表的结果逐字段同构，避免两套解析逻辑漂移。
+
+        Args:
+            output_data: 已序列化的父执行 output_data
+            execution: 父执行记录（提供 started_at / completed_at / app_id 等基准值）
+            workflow_config: 工作流配置，用于补 node_name
+
+        Returns:
+            与 get_execution_detail 中 node_executions 元素同构的字典列表（按 execution_order 排序）
+        """
+        node_outputs = output_data.get("node_outputs") if isinstance(output_data, dict) else None
+        if not isinstance(node_outputs, dict) or not node_outputs:
+            return []
+
+        ordered_node_outputs = sorted(node_outputs.items(), key=self._node_output_sort_key)
+        payload: list[dict[str, Any]] = []
+        for index, (node_id, node_data) in enumerate(ordered_node_outputs, start=1):
+            if not isinstance(node_data, dict):
+                continue
+            record = self._build_node_execution_record(
+                execution=execution,
+                node_id=node_id,
+                node_data=node_data,
+                source="workflow_execution",
+                fallback_execution_order=index,
+                fallback_node_name=self._get_node_name_from_config(workflow_config, node_id),
+            )
+            record_meta_data = record.get("meta_data") or {}
+            payload.append({
+                "node_id": record["node_id"],
+                "node_type": record["node_type"],
+                "node_name": record["node_name"],
+                "execution_order": record["execution_order"],
+                "retry_count": record["retry_count"],
+                "status": record["status"],
+                "input_data": self._serialize_execution_value(record["input_data"] or {}),
+                "output_data": self._serialize_execution_value(record["output_data"] or {}),
+                "agent_log": self._serialize_execution_value(record_meta_data.get("agent_log")),
+                "error_message": record["error_message"],
+                "started_at": to_iso_z(record["started_at"]),
+                "completed_at": to_iso_z(record["completed_at"]),
+                "elapsed_time": record["elapsed_time"],
+                "token_usage": self._serialize_execution_value(record["token_usage"]),
+                "cache_hit": record["cache_hit"],
+                "cache_key": record["cache_key"],
+                "meta_data": self._serialize_execution_value(record_meta_data),
+            })
+        return payload
+
     def _persist_workflow_node_executions(
             self,
             execution: WorkflowExecution,
@@ -2801,6 +2953,14 @@ class WorkflowService:
                 )
             )
         self.node_execution_repo.bulk_create(items)
+        if settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED:
+            # 写入成功后再清理同工作流下其他终态执行的节点行
+            self.db.flush()
+            self.node_execution_repo.delete_stale_workflow_executions(
+                app_id=execution.app_id,
+                workflow_config_id=execution.workflow_config_id,
+                keep_execution_id=execution.id,
+            )
         self.db.commit()
 
     @staticmethod
@@ -2856,6 +3016,23 @@ class WorkflowService:
                 "debug_input": normalize_cache_value(debug_input_data or {}),
             },
         )
+        if settings.WORKFLOW_NODE_EXECUTION_RETENTION_ENABLED:
+            # 先 flush 拿到新行 id，再清理同节点历史调试行：
+            # 保证写入成功后才删除旧记录，失败时不会连上一条调试记录一起丢掉。
+            self.db.flush()
+            removed = self.node_execution_repo.delete_stale_single_node_debug(
+                app_id=app_id,
+                workflow_config_id=workflow_config.id,
+                node_id=node_id,
+                keep_id=node_execution.id,
+            )
+            if removed:
+                logger.debug(
+                    "single node debug retention removed %s stale rows (app_id=%s node_id=%s)",
+                    removed,
+                    app_id,
+                    node_id,
+                )
         self.db.commit()
         self.db.refresh(node_execution)
         return node_execution
@@ -3376,9 +3553,13 @@ class WorkflowService:
             invalidate_cache: bool = False,
             bypass_cache: bool = False,
     ) -> dict[str, Any]:
+        # 必须按 source 过滤：本方法语义是「基于最近一次单节点调试输入重跑」，
+        # 不加过滤会取到最近一次完整工作流执行的节点行，与
+        # _has_single_node_debug_input 的判定不一致。
         node_execution = self.node_execution_repo.get_latest_by_app_node(
             app_id=app_id,
             node_id=node_id,
+            source="single_node_debug",
         )
         if not node_execution:
             raise BusinessException("没有可用于重跑的单节点调试输入", BizCode.NOT_FOUND)
@@ -3421,6 +3602,7 @@ class WorkflowService:
         input_data = self._serialize_execution_value(execution.input_data or {})
         output_data = self._serialize_execution_value(execution.output_data or {})
         meta_data = self._serialize_execution_value(execution.meta_data or {})
+        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
         snapshot = self._build_execution_snapshot_from_record(execution)
         if self._get_execution_source(execution) == "single_node_debug":
             base_execution = self._resolve_base_execution(
@@ -3451,30 +3633,41 @@ class WorkflowService:
             "completed_at": to_iso_z(execution.completed_at),
             "elapsed_time": execution.elapsed_time,
             "token_usage": self._serialize_execution_value(execution.token_usage),
-            "node_executions": [
-                {
-                    "node_id": node_execution.node_id,
-                    "node_type": node_execution.node_type,
-                    "node_name": node_execution.node_name,
-                    "execution_order": node_execution.execution_order,
-                    "retry_count": node_execution.retry_count,
-                    "status": node_execution.status,
-                    "input_data": self._serialize_execution_value(node_execution.input_data or {}),
-                    "output_data": self._serialize_execution_value(node_execution.output_data or {}),
-                    "agent_log": self._serialize_execution_value((node_execution.meta_data or {}).get("agent_log")),
-                    "error_message": node_execution.error_message,
-                    "started_at": to_iso_z(node_execution.started_at),
-                    "completed_at": to_iso_z(node_execution.completed_at),
-                    "elapsed_time": node_execution.elapsed_time,
-                    "token_usage": self._serialize_execution_value(node_execution.token_usage),
-                    "cache_hit": node_execution.cache_hit,
-                    "cache_key": node_execution.cache_key,
-                    "meta_data": self._serialize_execution_value(node_execution.meta_data or {}),
-                }
-                for node_execution in node_executions
-            ],
+            "node_executions": (
+                [
+                    {
+                        "node_id": node_execution.node_id,
+                        "node_type": node_execution.node_type,
+                        "node_name": node_execution.node_name,
+                        "execution_order": node_execution.execution_order,
+                        "retry_count": node_execution.retry_count,
+                        "status": node_execution.status,
+                        "input_data": self._serialize_execution_value(node_execution.input_data or {}),
+                        "output_data": self._serialize_execution_value(node_execution.output_data or {}),
+                        "agent_log": self._serialize_execution_value(
+                            (node_execution.meta_data or {}).get("agent_log")
+                        ),
+                        "error_message": node_execution.error_message,
+                        "started_at": to_iso_z(node_execution.started_at),
+                        "completed_at": to_iso_z(node_execution.completed_at),
+                        "elapsed_time": node_execution.elapsed_time,
+                        "token_usage": self._serialize_execution_value(node_execution.token_usage),
+                        "cache_hit": node_execution.cache_hit,
+                        "cache_key": node_execution.cache_key,
+                        "meta_data": self._serialize_execution_value(node_execution.meta_data or {}),
+                    }
+                    for node_execution in node_executions
+                ]
+                if node_executions
+                # 节点表按保留策略只保留最近一次执行，历史执行从父执行的
+                # output_data["node_outputs"] 重建，保证节点明细不为空。
+                else self._build_node_executions_from_output_data(
+                    output_data,
+                    execution=execution,
+                    workflow_config=workflow_config,
+                )
+            ),
         }
-        workflow_config = execution.workflow_config or self.db.get(WorkflowConfig, execution.workflow_config_id)
         secret_values = self._extract_secret_values_from_environment_variables(
             workflow_config.environment_variables if workflow_config else []
         )
@@ -7656,7 +7849,7 @@ class WorkflowService:
                                 role="assistant",
                                 content="",
                                 meta_data={"waiting_human": True, "execution_id": execution.execution_id},
-                                parent_message_id=_hitl_user_msg.id if _hitl_user_msg else None,
+                                parent_message_id=user_message_id if _hitl_user_msg else None,
                             )
 
                         # message_id is already saved in execution.context["human_intervention"]["message_id"]
@@ -8282,7 +8475,24 @@ class WorkflowService:
         )
         from app.core.workflow.nodes.human_intervention.node import InterventionRegistry as _IR
 
-        execution = self.get_execution(execution_id)
+        if self.execution_repo is None:
+            async with get_async_db_context() as db:
+                _stmt = (
+                    select(WorkflowExecution)
+                    .options(selectinload(WorkflowExecution.app))
+                    .where(WorkflowExecution.execution_id == execution_id)
+                )
+                execution = (await db.execute(_stmt)).scalar_one_or_none()
+                if not execution:
+                    runtime_execution = await self._get_runtime_execution_snapshot_async(execution_id)
+                    if runtime_execution:
+                        execution = self._build_execution_record_from_ref(runtime_execution)
+                if execution:
+                    db.expunge(execution)
+                    if execution.app is not None:
+                        db.expunge(execution.app)
+        else:
+            execution = self.get_execution(execution_id)
         if not execution:
             raise BusinessException("执行记录不存在", BizCode.NOT_FOUND)
         if execution.status != "waiting_human":
@@ -8392,7 +8602,10 @@ class WorkflowService:
             resolved_node_ids.add(node_id)
             all_intervention_node_ids.update(resolved_node_ids)
 
-        config = self.get_workflow_config(app_id)
+        if self.config_repo is None:
+            config = await self.get_workflow_config_snapshot_async(app_id)
+        else:
+            config = self.get_workflow_config(app_id)
         if not config:
             raise BusinessException("工作流配置不存在", BizCode.CONFIG_MISSING)
 
@@ -8713,7 +8926,10 @@ class WorkflowService:
         from app.core.workflow.nodes.node_factory import NodeFactory
 
         if not config:
-            config = self.get_workflow_config(app_id)
+            if self.config_repo is None:
+                config = await self.get_workflow_config_snapshot_async(app_id)
+            else:
+                config = self.get_workflow_config(app_id)
         if not config:
             raise BusinessException(code=BizCode.CONFIG_MISSING, message="工作流配置不存在")
 
@@ -9218,14 +9434,38 @@ class WorkflowService:
         from app.core.workflow.engine.runtime_schema import ExecutionContext
         from app.core.workflow.engine.variable_pool import VariablePoolInitializer
 
-        execution = self.get_execution(execution_id)
+        # When WorkflowService is created without a db (e.g. streaming path in
+        # app_controller that uses WorkflowService()), the sync repos are None.
+        # Use async DB context in that case; eager-load the App relationship so
+        # that execution.app.workspace_id is accessible after the session closes.
+        if self.execution_repo is None:
+            async with get_async_db_context() as db:
+                _stmt = (
+                    select(WorkflowExecution)
+                    .options(selectinload(WorkflowExecution.app))
+                    .where(WorkflowExecution.execution_id == execution_id)
+                )
+                execution = (await db.execute(_stmt)).scalar_one_or_none()
+                if not execution:
+                    runtime_execution = await self._get_runtime_execution_snapshot_async(execution_id)
+                    if runtime_execution:
+                        execution = self._build_execution_record_from_ref(runtime_execution)
+                if execution:
+                    db.expunge(execution)
+                    if execution.app is not None:
+                        db.expunge(execution.app)
+        else:
+            execution = self.get_execution(execution_id)
         if not execution:
             raise BusinessException("执行记录不存在", BizCode.NOT_FOUND)
 
         intervention_ctx = (execution.context or {}).get("human_intervention", {})
         thread_id_str = intervention_ctx.get("checkpoint_thread_id")
 
-        config = self.get_workflow_config(app_id)
+        if self.config_repo is None:
+            config = await self.get_workflow_config_snapshot_async(app_id)
+        else:
+            config = self.get_workflow_config(app_id)
         if not config:
             raise BusinessException("工作流配置不存在", BizCode.CONFIG_MISSING)
 

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -34,7 +34,6 @@ from app.schemas.workspace_schema import (
     WorkspaceModelsUpdate,
     WorkspaceUpdate,
 )
-from app.schemas.memory_config_schema import ConfigurationError
 from app.i18n import t
 from app.services.memory_config_service import MemoryConfigService
 from app.services.session_service import SessionService
@@ -169,31 +168,208 @@ def _build_workspace_preset_response(db: Session, preset: WorkspaceDefaultModelP
     return result
 
 
-def _validate_workspace_model_selection(
+def _slot_label(slot: str, locale: str = "zh") -> str:
+    """获取模型位的可读名称（如 llm -> 对话模型），缺少翻译时回退为原始 slot。"""
+    key = f"workspace.models.slots.{slot}"
+    label = t(key, locale=locale)
+    return slot if label == key else label
+
+
+def _display_model_id(model_id: uuid.UUID | str | None) -> str:
+    """返回用于消息展示的短模型 ID（完整 UUID 会被敏感信息过滤器脱敏）。"""
+    if not model_id:
+        return "-"
+    text = str(model_id)
+    return text[:8] if len(text) > 8 else text
+
+
+def _model_issue(
+    slot: str,
+    *,
+    reason: str,
+    locale: str = "zh",
+    model_id: uuid.UUID | str | None = None,
+    model_name: str | None = None,
+    provider: str | None = None,
+    model_type: str | None = None,
+    detail: str | None = None,
+) -> dict:
+    """构造一条结构化的模型配置问题，供告警/错误详情返回给前端。
+
+    Args:
+        slot: 模型位（llm / embedding / rerank / vision / audio / video）
+        reason: 问题原因码（not_configured / not_found / inactive / not_accessible /
+            deprecated / capability_mismatch / no_api_key / api_verify_failed / verify_failed）
+        locale: 语言代码（zh / en）
+        model_id: 出问题的模型 ID
+        model_name: 出问题的模型名称
+        provider: 模型提供商
+        model_type: 模型类型（用于能力不匹配提示）
+        detail: 底层错误详情
+
+    Returns:
+        dict: 包含 slot / slot_label / model_id / model_name / reason / message 的问题详情
+    """
+    slot_label = _slot_label(slot, locale)
+    display_name = model_name or (_display_model_id(model_id) if model_id else "-")
+    message = t(
+        f"workspace.models.errors.{reason}",
+        locale=locale,
+        slot=slot_label,
+        model_id=_display_model_id(model_id) if model_id else "-",
+        model_name=display_name,
+        model_type=model_type or "-",
+        error=detail or "-",
+    )
+    return {
+        "slot": slot,
+        # 兼容旧字段名，前端/调用方可继续使用 model_type 定位模型位
+        "model_type": slot,
+        "slot_label": slot_label,
+        "model_id": str(model_id) if model_id else None,
+        "model_name": model_name,
+        "provider": provider,
+        "reason": reason,
+        "message": message,
+        "detail": detail,
+    }
+
+
+def _issue_summary_message(issues: list[dict], locale: str = "zh") -> str:
+    separator = "；" if str(locale).lower().startswith("zh") else "; "
+    return t(
+        "workspace.models.errors.save_failed",
+        locale=locale,
+        count=len(issues),
+        reasons=separator.join(issue["message"] for issue in issues),
+    )
+
+
+def _raise_model_config_error(
+    issues: list[dict],
+    locale: str = "zh",
+    *,
+    code: BizCode = BizCode.INVALID_PARAMETER,
+) -> None:
+    """将模型配置问题聚合为一条 BusinessException 抛出，并携带结构化详情。"""
+    raise BusinessException(
+        _issue_summary_message(issues, locale),
+        code,
+        context={"error_details": {"errors": issues}},
+    )
+
+
+def _serialize_provider(model: ModelConfig) -> str | None:
+    provider = getattr(model, "provider", None)
+    return getattr(provider, "value", provider)
+
+
+def _diagnose_unavailable_model(
+    db: Session | None,
+    slot: str,
+    model_id: str,
+    tenant_id: uuid.UUID | None,
+    locale: str,
+) -> dict:
+    """诊断不在可选范围内的模型：不存在 / 已禁用 / 不属于当前租户 / 已弃用。"""
+    model = None
+    if db is not None:
+        try:
+            model = db.query(ModelConfig).filter(ModelConfig.id == uuid.UUID(str(model_id))).first()
+        except Exception:  # 无效 UUID 或查询异常时按“不存在”处理
+            model = None
+
+    if model is None:
+        return _model_issue(slot, reason="not_found", locale=locale, model_id=model_id)
+
+    common = {
+        "locale": locale,
+        "model_id": model_id,
+        "model_name": model.name,
+        "provider": _serialize_provider(model),
+        "model_type": str(getattr(model.type, "value", model.type)),
+    }
+    is_tenant_model = tenant_id is None or model.tenant_id == tenant_id
+    is_public_speedbear = (
+        model.provider == ModelProvider.SPEEDBEAR and bool(model.is_public)
+    )
+    if not (is_tenant_model or is_public_speedbear):
+        # 跨租户模型只返回请求中的模型 ID，不泄露名称、供应商或状态。
+        return _model_issue(slot, reason="not_accessible", locale=locale, model_id=model_id)
+    if not model.is_active:
+        return _model_issue(slot, reason="inactive", **common)
+    if getattr(model, "model_base", None) is not None and getattr(model.model_base, "is_deprecated", False):
+        return _model_issue(slot, reason="deprecated", **common)
+    return _model_issue(slot, reason="not_accessible", **common)
+
+
+def _collect_workspace_model_selection_issues(
     available_models: list[ModelConfig],
     selection: dict[str, uuid.UUID | str | None],
     *,
     require_all_slots: bool,
-) -> dict[str, str | None]:
+    locale: str = "zh",
+    db: Session | None = None,
+    tenant_id: uuid.UUID | None = None,
+) -> tuple[dict[str, str | None], list[dict]]:
+    """校验模型位与模型的匹配关系，收集全部问题而非遇错即停。"""
     model_map = {str(model.id): model for model in available_models}
     normalized: dict[str, str | None] = {}
+    issues: list[dict] = []
 
     for slot in _WORKSPACE_MODEL_SLOTS:
         raw_value = selection.get(slot)
         if raw_value is None:
             if require_all_slots or slot in _REQUIRED_WORKSPACE_MODEL_SLOTS:
-                raise BusinessException(f"{slot} 模型未配置", BizCode.INVALID_PARAMETER)
+                issues.append(_model_issue(slot, reason="not_configured", locale=locale))
             normalized[slot] = None
             continue
 
         model_id = str(raw_value)
         model = model_map.get(model_id)
         if not model:
-            raise BusinessException(f"{slot} 模型不存在或不可用", BizCode.MODEL_NOT_FOUND)
+            issues.append(_diagnose_unavailable_model(db, slot, model_id, tenant_id, locale))
+            normalized[slot] = None
+            continue
         if not _slot_matches_model(slot, model):
-            raise BusinessException(f"{slot} 模型能力不匹配", BizCode.INVALID_PARAMETER)
+            issues.append(
+                _model_issue(
+                    slot,
+                    reason="capability_mismatch",
+                    locale=locale,
+                    model_id=model_id,
+                    model_name=model.name,
+                    provider=_serialize_provider(model),
+                    model_type=str(getattr(model.type, "value", model.type)),
+                )
+            )
+            normalized[slot] = None
+            continue
         normalized[slot] = model_id
 
+    return normalized, issues
+
+
+def _validate_workspace_model_selection(
+    available_models: list[ModelConfig],
+    selection: dict[str, uuid.UUID | str | None],
+    *,
+    require_all_slots: bool,
+    locale: str = "zh",
+    db: Session | None = None,
+    tenant_id: uuid.UUID | None = None,
+) -> dict[str, str | None]:
+    normalized, issues = _collect_workspace_model_selection_issues(
+        available_models,
+        selection,
+        require_all_slots=require_all_slots,
+        locale=locale,
+        db=db,
+        tenant_id=tenant_id,
+    )
+    if issues:
+        business_logger.warning(f"工作空间模型选择校验失败: {[issue['message'] for issue in issues]}")
+        _raise_model_config_error(issues, locale)
     return normalized
 
 
@@ -245,9 +421,17 @@ def _resolve_workspace_model_update_target(
     db: Session,
     workspace: Workspace,
     models_update: WorkspaceModelsUpdate | None,
-) -> tuple[bool, dict[str, str | None], tuple[str, ...]]:
+    *,
+    locale: str = "zh",
+) -> tuple[bool, dict[str, str | None], tuple[str, ...], list[dict]]:
+    """解析本次更新的目标配置。
+
+    Returns:
+        (是否使用默认配置, 归一化后的模型选择, 需要运行时校验的模型位, 静态校验问题列表)
+    """
     selection = _extract_workspace_model_values(workspace)
     target_is_default = bool(workspace.is_default_config)
+    issues: list[dict] = []
 
     if models_update:
         mode_explicit = models_update.is_default_config is not None
@@ -270,16 +454,19 @@ def _resolve_workspace_model_update_target(
                 )
                 for slot in _WORKSPACE_MODEL_SLOTS
             }
-            selection = _validate_workspace_model_selection(
+            selection, issues = _collect_workspace_model_selection_issues(
                 _get_accessible_workspace_models(db, workspace.tenant_id),
                 merged_selection,
+                locale=locale,
+                db=db,
+                tenant_id=workspace.tenant_id,
                 require_all_slots=False,
             )
 
     validation_slots = (
         _WORKSPACE_MODEL_SLOTS if target_is_default else _REQUIRED_WORKSPACE_MODEL_SLOTS
     )
-    return target_is_default, selection, validation_slots
+    return target_is_default, selection, validation_slots, issues
 
 
 def _sync_workspace_default_memory_config(workspace: Workspace, memory_config) -> None:
@@ -318,6 +505,96 @@ def _sync_default_config_workspaces(
         _sync_workspace_default_memory_config(workspace, default_memory_config)
 
 
+_VALIDATE_AS_LLM_SLOTS = {"vision", "video", "audio"}
+
+
+async def _validate_workspace_slot_runtime(
+    async_db: AsyncSession,
+    slot: str,
+    model_id: str,
+    tenant_id: uuid.UUID | None,
+    *,
+    locale: str,
+) -> dict | None:
+    """校验单个模型位的运行时可用性，返回精确的问题详情（可用则返回 None）。
+
+    区分以下失败原因：模型不存在/已弃用/无权访问、缺少可用 API Key、API 连通性校验失败。
+    """
+    from app.services.model_service import ModelApiKeyService
+    from app.services.model_service import ModelConfigService as ModelSvc
+
+    try:
+        model_config = await ModelSvc.get_model_by_id_async(async_db, uuid.UUID(str(model_id)), tenant_id)
+    except BusinessException as exc:
+        reason = "deprecated" if exc.code == BizCode.MODEL_DEPRECATED else "not_found"
+        return _model_issue(slot, reason=reason, locale=locale, model_id=model_id, detail=exc.message)
+    except Exception as exc:  # 无效 ID / 数据库异常等
+        return _model_issue(slot, reason="not_found", locale=locale, model_id=model_id, detail=str(exc))
+
+    model_name = model_config.name
+    provider = _serialize_provider(model_config)
+
+    try:
+        api_key_config = await ModelApiKeyService.get_available_api_key_async(
+            async_db, model_config.id, tenant_id
+        )
+    except Exception as exc:
+        return _model_issue(
+            slot,
+            reason="verify_failed",
+            locale=locale,
+            model_id=model_id,
+            model_name=model_name,
+            provider=provider,
+            detail=str(exc),
+        )
+
+    if not api_key_config:
+        return _model_issue(
+            slot,
+            reason="no_api_key",
+            locale=locale,
+            model_id=model_id,
+            model_name=model_name,
+            provider=provider,
+        )
+
+    validate_type = "llm" if slot in _VALIDATE_AS_LLM_SLOTS else slot
+    try:
+        result = await ModelSvc.validate_model_config(
+            async_db,
+            model_name=api_key_config.model_name,
+            provider=api_key_config.provider,
+            api_key=api_key_config.api_key,
+            api_base=api_key_config.api_base,
+            model_type=validate_type,
+            is_omni=api_key_config.is_omni,
+            capability=api_key_config.capability,
+        )
+    except Exception as exc:
+        return _model_issue(
+            slot,
+            reason="verify_failed",
+            locale=locale,
+            model_id=model_id,
+            model_name=api_key_config.model_name or model_name,
+            provider=provider,
+            detail=str(exc),
+        )
+
+    if not result.get("valid"):
+        return _model_issue(
+            slot,
+            reason="api_verify_failed",
+            locale=locale,
+            model_id=model_id,
+            model_name=api_key_config.model_name or model_name,
+            provider=provider,
+            detail=str(result.get("error") or result.get("message") or "Unknown error"),
+        )
+    return None
+
+
 async def _validate_workspace_model_runtime(
     db: Session,
     values: dict[str, str | None],
@@ -327,52 +604,41 @@ async def _validate_workspace_model_runtime(
     locale: str,
     slots_to_validate: tuple[str, ...],
 ) -> list[dict]:
+    """校验各模型位的运行时可用性，收集全部问题（不中断）。"""
     from app.db import get_async_db_context
 
+    _ = db  # 运行时校验使用独立的异步会话
+    warnings: list[dict] = []
+
     async with get_async_db_context() as async_db:
-        service = MemoryConfigService(async_db)
-        warnings: list[dict] = []
-        validate_as_llm = {"vision", "video", "audio"}
-
-        async def _validate_one(model_type: str, model_id: str) -> dict | None:
-            validate_type = "llm" if model_type in validate_as_llm else model_type
-            try:
-                await service._validate_model_connectivity(
-                    model_id,
-                    validate_type,
-                    tenant_id,
-                    None,
-                    workspace_id,
-                    locale=locale,
-                )
-                return None
-            except ConfigurationError as exc:
-                return {
-                    "model_type": model_type,
-                    "model_id": str(model_id),
-                    "message": exc.err_message,
-                }
-
         for slot in slots_to_validate:
             if not values.get(slot):
-                warnings.append({
-                    "model_type": slot,
-                    "model_id": None,
-                    "message": t("memory_config.model.not_configured", locale=locale, model_type=slot),
-                })
+                warnings.append(_model_issue(slot, reason="not_configured", locale=locale))
 
         for slot in slots_to_validate:
             model_id = values.get(slot)
             if not model_id:
                 continue
-            result = await _validate_one(slot, model_id)
-            if result is not None:
-                warnings.append(result)
+            issue = await _validate_workspace_slot_runtime(
+                async_db, slot, str(model_id), tenant_id, locale=locale
+            )
+            if issue is not None:
+                business_logger.warning(
+                    f"工作空间模型校验失败: workspace_id={workspace_id}, slot={slot}, "
+                    f"model_id={model_id}, reason={issue['reason']}, detail={issue.get('detail')}"
+                )
+                warnings.append(issue)
 
     return warnings
 
 
-def _resolve_workspace_create_payload(db: Session, workspace: WorkspaceCreate, tenant_id: uuid.UUID) -> WorkspaceCreate:
+def _resolve_workspace_create_payload(
+    db: Session,
+    workspace: WorkspaceCreate,
+    tenant_id: uuid.UUID,
+    *,
+    locale: str = "zh",
+) -> WorkspaceCreate:
     if workspace.is_default_config:
         return workspace.model_copy(update=_get_default_workspace_model_values(db))
 
@@ -387,6 +653,9 @@ def _resolve_workspace_create_payload(db: Session, workspace: WorkspaceCreate, t
             "video": workspace.video,
         },
         require_all_slots=False,
+        locale=locale,
+        db=db,
+        tenant_id=tenant_id,
     )
     return workspace.model_copy(update=validated)
 
@@ -401,7 +670,7 @@ def get_default_workspace_models(db: Session, *, allow_empty: bool = False) -> d
     return _build_workspace_preset_response(db, preset)
 
 
-def update_default_workspace_models(db: Session, data) -> dict:
+def update_default_workspace_models(db: Session, data, *, locale: str = "zh") -> dict:
     validated = _validate_workspace_model_selection(
         _get_public_speedbear_models(db),
         {
@@ -413,6 +682,8 @@ def update_default_workspace_models(db: Session, data) -> dict:
             "video": data.video,
         },
         require_all_slots=True,
+        locale=locale,
+        db=db,
     )
     preset = (
         db.query(WorkspaceDefaultModelPreset)
@@ -571,10 +842,14 @@ async def create_workspace(
             message="同名工作空间已存在",
             code=BizCode.RESOURCE_ALREADY_EXISTS
         )
-    workspace = _resolve_workspace_create_payload(db, workspace, user.tenant_id)
+    workspace = _resolve_workspace_create_payload(db, workspace, user.tenant_id, locale=language)
 
-    validation_slots = _WORKSPACE_MODEL_SLOTS if workspace.is_default_config else _REQUIRED_WORKSPACE_MODEL_SLOTS
     selection = _extract_workspace_model_values(workspace)
+    validation_slots = (
+        _WORKSPACE_MODEL_SLOTS
+        if workspace.is_default_config
+        else _REQUIRED_WORKSPACE_MODEL_SLOTS
+    )
     warnings = await _validate_workspace_model_runtime(
         db,
         selection,
@@ -584,7 +859,7 @@ async def create_workspace(
         slots_to_validate=validation_slots,
     )
     if warnings:
-        raise BusinessException(warnings[0]["message"], BizCode.INVALID_PARAMETER)
+        _raise_model_config_error(warnings, language)
 
     llm = workspace.llm
     embedding = workspace.embedding
@@ -1490,19 +1765,24 @@ async def validate_workspace_models_configs(
         models_update: WorkspaceModelsUpdate | None = None,
 ) -> dict:
     db_workspace = _check_workspace_member_permission(db, workspace_id, user)
-    target_is_default, selection, validation_slots = _resolve_workspace_model_update_target(
+    target_is_default, selection, validation_slots, selection_issues = _resolve_workspace_model_update_target(
         db,
         db_workspace,
         models_update,
-    )
-    warnings = await _validate_workspace_model_runtime(
-        db,
-        selection,
-        db_workspace.tenant_id,
-        db_workspace.id,
         locale=locale,
-        slots_to_validate=validation_slots,
     )
+    if selection_issues:
+        # 选择本身不合法（模型不存在/已禁用/能力不匹配）时无需再做连通性校验
+        warnings = selection_issues
+    else:
+        warnings = await _validate_workspace_model_runtime(
+            db,
+            selection,
+            db_workspace.tenant_id,
+            db_workspace.id,
+            locale=locale,
+            slots_to_validate=validation_slots,
+        )
     workspace_payload = _build_workspace_models_response(
         {
             **selection,
@@ -1546,11 +1826,15 @@ async def update_workspace_models_configs(
     default_memory_config = MemoryConfigService(db).get_workspace_default_config(workspace_id=workspace_id)
 
     try:
-        use_default_config, resolved_models, validation_slots = _resolve_workspace_model_update_target(
+        use_default_config, resolved_models, validation_slots, selection_issues = _resolve_workspace_model_update_target(
             db,
             db_workspace,
             models_update,
+            locale=locale,
         )
+        if selection_issues:
+            _raise_model_config_error(selection_issues, locale)
+
         warnings = await _validate_workspace_model_runtime(
             db,
             resolved_models,
@@ -1560,7 +1844,7 @@ async def update_workspace_models_configs(
             slots_to_validate=validation_slots,
         )
         if warnings:
-            raise BusinessException(warnings[0]["message"], BizCode.INVALID_PARAMETER)
+            _raise_model_config_error(warnings, locale)
 
         _assign_workspace_models(db_workspace, resolved_models, is_default_config=use_default_config)
 


### PR DESCRIPTION
## Summary by Sourcery

实现节点执行记录的保留机制（带输出数据回退），并改进多语言工作区模型配置的校验与错误报告。

新功能：
- 增加可配置的工作流节点执行记录保留策略，仅保留最新的完整工作流执行记录或单节点调试记录，同时在执行输出数据中保留历史细节。
- 为工作区模型选择增加本地化、结构化的校验与诊断信息，包括可用性、能力支持、API Key、弃用状态以及连接性等问题。

缺陷修复：
- 恢复对已完成和失败的流式工作流，以及干预超时之后的节点执行产物（artifact）持久化。
- 当已保留的节点记录被删除时，从工作流输出数据中重建历史节点执行细节和快照。
- 防止过期的变量类型不匹配导致已恢复的节点执行中止，并确保节点重新运行时使用最新的单节点调试输入。

功能增强：
- 支持由异步数据库会话驱动的工作流服务执行路径，包括干预恢复和工作流恢复流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement node execution record retention with output-data fallbacks and improve multilingual workspace model configuration validation and error reporting.

New Features:
- Add configurable retention of workflow node execution records, keeping only the latest full workflow execution or single-node debug record while preserving historical details in execution output data.
- Add localized, structured validation and diagnostics for workspace model selections, including availability, capability, API key, deprecation, and connectivity issues.

Bug Fixes:
- Restore node execution artifact persistence for completed and failed streaming workflows and after intervention timeouts.
- Rebuild historical node execution details and snapshots from workflow output data when retained node records have been removed.
- Prevent stale variable type mismatches from aborting resumed node execution and ensure node reruns use the latest single-node debug input.

Enhancements:
- Support workflow service execution paths backed by asynchronous database sessions, including intervention resume and workflow resume flows.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

实现节点执行记录的保留机制（带输出数据回退），并改进多语言工作区模型配置的校验与错误报告。

新功能：
- 增加可配置的工作流节点执行记录保留策略，仅保留最新的完整工作流执行记录或单节点调试记录，同时在执行输出数据中保留历史细节。
- 为工作区模型选择增加本地化、结构化的校验与诊断信息，包括可用性、能力支持、API Key、弃用状态以及连接性等问题。

缺陷修复：
- 恢复对已完成和失败的流式工作流，以及干预超时之后的节点执行产物（artifact）持久化。
- 当已保留的节点记录被删除时，从工作流输出数据中重建历史节点执行细节和快照。
- 防止过期的变量类型不匹配导致已恢复的节点执行中止，并确保节点重新运行时使用最新的单节点调试输入。

功能增强：
- 支持由异步数据库会话驱动的工作流服务执行路径，包括干预恢复和工作流恢复流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement node execution record retention with output-data fallbacks and improve multilingual workspace model configuration validation and error reporting.

New Features:
- Add configurable retention of workflow node execution records, keeping only the latest full workflow execution or single-node debug record while preserving historical details in execution output data.
- Add localized, structured validation and diagnostics for workspace model selections, including availability, capability, API key, deprecation, and connectivity issues.

Bug Fixes:
- Restore node execution artifact persistence for completed and failed streaming workflows and after intervention timeouts.
- Rebuild historical node execution details and snapshots from workflow output data when retained node records have been removed.
- Prevent stale variable type mismatches from aborting resumed node execution and ensure node reruns use the latest single-node debug input.

Enhancements:
- Support workflow service execution paths backed by asynchronous database sessions, including intervention resume and workflow resume flows.

</details>

</details>