### PR TITLE
feat(memory): add local_file upload endpoint and resolve upload file url in write pipeline

### DIFF
--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -8,7 +8,7 @@
 """
 import asyncio
 
-from fastapi import APIRouter, Body, Header, Request, Depends
+from fastapi import APIRouter, Body, Depends, File, Header, Request, UploadFile
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -18,6 +18,7 @@ from app.controllers import memory_controller
 from app.core.api_key_auth import require_api_key, require_api_key_self_db, get_current_api_key_auth
 from app.core.api_key_utils import get_current_user_snapshot_from_api_key_async, validate_end_user_in_workspace_async
 from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.memory.enums import Neo4jNodeType, SearchStrategy
 from app.core.memory.memory_service import MemoryService
@@ -28,6 +29,7 @@ from app.repositories.end_user_repository import EndUserRepository
 from app.schemas.api_key_schema import ApiKeyAuth
 from app.schemas.memory_agent_schema import Write_UserInput, InternalReadInput, ReadSyncInput, MergeEndUserInput
 from app.services.end_user_service import EndUserService
+from app.services.file_storage_service import FileStorageService, get_file_storage_service, upload_workspace_file
 from app.services.memory_config_service import MemoryConfigService
 
 router = APIRouter(prefix="/memory", tags=["V1 - Memory API"])
@@ -226,3 +228,34 @@ async def merge_memory(
     await EndUserService(db).merge_end_users(payload.end_user_ids, payload.target)
 
     return success(data={"end_user_id": payload.target.hex})
+
+
+@router.post("/files/upload")
+@require_api_key(scopes=["memory"])
+async def upload_memory_file(
+        request: Request,
+        file: UploadFile = File(...),
+        api_key_auth: ApiKeyAuth = None,
+        db: Session = Depends(get_db),
+        storage_service: FileStorageService = Depends(get_file_storage_service),
+):
+    """
+    上传文件到存储后端，供 /write 接口以 local_file 方式引用。
+
+    - 入参: multipart/form-data，字段 file
+    - 出参: {"file_id": "...", "file_key": "..."}
+    - 在 /write 的 files 字段中引用，例如:
+      {"type": "image", "transfer_method": "local_file", "upload_file_id": "<file_id>"}
+    """
+    tenant_id = api_key_auth.tenant_id
+    if not tenant_id:
+        raise BusinessException("Workspace not found", BizCode.NOT_FOUND)
+
+    upload_result = await upload_workspace_file(
+        db=db,
+        tenant_id=tenant_id,
+        workspace_id=api_key_auth.workspace_id,
+        file=file,
+        storage_service=storage_service,
+    )
+    return success(data=upload_result, msg="File upload successful")

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -1060,6 +1060,20 @@ class WritePipeline:
             for file_info in files:
                 url = file_info.get("url", "")
                 if not url:
+                    # local_file 场景：memory_messages.files 只带 upload_file_id
+                    # （FileInput.model_dump(exclude_none=True) 剔除了空 url），
+                    # 必须先解析为可访问 URL，否则整条感知记忆会被跳过。
+                    url = await self._resolve_upload_file_url(file_info)
+                    if url:
+                        file_info = {**file_info, "url": url}
+                if not url:
+                    logger.warning(
+                        "[WritePipeline] 文件缺少可访问 URL，跳过感知记忆: "
+                        "type=%s transfer_method=%s upload_file_id=%s",
+                        file_info.get("type"),
+                        file_info.get("transfer_method"),
+                        file_info.get("upload_file_id"),
+                    )
                     continue
 
                 try:
@@ -1136,6 +1150,40 @@ class WritePipeline:
                         f"[WritePipeline] 文件预处理失败: url={url}, err={e}",
                         exc_info=True,
                     )
+
+    async def _resolve_upload_file_url(self, file_info: dict) -> str:
+        """把 local_file 的 upload_file_id 解析为可访问 URL。
+
+        API 写入路径（/v1/memory/write）的 files 只带 upload_file_id，
+        与试运行路径 ``pilot_run_service._resolve_file_url`` 保持一致，这里补齐 URL。
+
+        Args:
+            file_info: memory_messages.files 中的单个文件 dict
+
+        Returns:
+            str: 可访问 URL；非 local_file 或解析失败时返回空串
+        """
+        upload_file_id = file_info.get("upload_file_id")
+        if not upload_file_id:
+            return ""
+
+        from app.db import get_db_read
+        from app.schemas.app_schema import FileInput
+        from app.services.multimodal_service import MultimodalService
+
+        try:
+            file_data = {k: v for k, v in file_info.items() if k != "url"}
+            file_input = FileInput(**file_data)
+            with get_db_read() as db:
+                url = await MultimodalService(db, api_config=None).get_file_url(file_input)
+            return url or ""
+        except Exception as e:
+            logger.warning(
+                "[WritePipeline] 文件 URL 解析失败: upload_file_id=%s err=%s",
+                upload_file_id,
+                e,
+            )
+            return ""
 
     # ──────────────────────────────────────────────
     # 辅助方法

--- a/api/app/services/memory_agent_service.py
+++ b/api/app/services/memory_agent_service.py
@@ -262,7 +262,7 @@ class MemoryAgentService:
             if msg.dialog_at:
                 msg_dict["dialog_at"] = msg.dialog_at
             if msg.files:
-                msg_dict["files"] = [f.model_dump(exclude_none=True) for f in msg.files]
+                msg_dict["files"] = [f.model_dump(mode="json", exclude_none=True) for f in msg.files]
             result.append(msg_dict)
 
         logger.info(f"Validation successful: Structured message list, count: {len(result)}")


### PR DESCRIPTION
…

## 由 Sourcery 提供的摘要

启用本地文件上传，并确保在内存写入管道中正确解析这些文件引用。

新功能：
- 添加一个内存 API 端点，用于上传工作区文件，以便通过 `local_file` 引用在内存写入中使用。

错误修复：
- 在写入预处理阶段解析已上传文件的 URL，这样在没有 URL 时，`local_file` 附件也能被处理，而不是被跳过。

增强改进：
- 在构建消息列表时，以 JSON 兼容的形式序列化内存消息文件的元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable local file uploads and ensure their references are resolved during the memory write pipeline.

New Features:
- Add a memory API endpoint for uploading workspace files for use in memory writes via local_file references.

Bug Fixes:
- Resolve uploaded file URLs during write preprocessing so local_file attachments can be processed instead of being skipped when no URL is present.

Enhancements:
- Serialize memory message file metadata in JSON-compatible form when constructing message lists.

</details>