### PR TITLE
fix(workflow): prevent DetachedInstanceError and block event loop in embedding generation

### DIFF
--- a/api/app/services/workflow_service.py
+++ b/api/app/services/workflow_service.py
@@ -1099,17 +1099,31 @@ class WorkflowService:
                 if not api_key_obj:
                     return None
 
+                # Snapshot ORM-backed fields before the async session closes. The
+                # session context may expire attributes on rollback/close, and using
+                # api_key_obj afterwards would raise DetachedInstanceError.
+                api_key_data = {
+                    "model_name": api_key_obj.model_name,
+                    "provider": api_key_obj.provider,
+                    "api_key": api_key_obj.api_key,
+                    "api_base": api_key_obj.api_base,
+                }
+
             config = RedBearModelConfig(
-                model_name=api_key_obj.model_name,
-                provider=api_key_obj.provider,
-                api_key=api_key_obj.api_key,
-                base_url=api_key_obj.api_base or None,
+                model_name=api_key_data["model_name"],
+                provider=api_key_data["provider"],
+                api_key=api_key_data["api_key"],
+                base_url=api_key_data["api_base"] or None,
                 timeout=60,
                 max_retries=3,
             )
 
-            # ponytail: this helper only needs pure math; don't keep a DB session around for it.
-            query_embedding = AnnotationService.generate_embedding(message, config)
+            # Embedding clients are synchronous; keep them off the async event loop.
+            query_embedding = await asyncio.to_thread(
+                AnnotationService.generate_embedding,
+                message,
+                config,
+            )
             best_match = None
             best_similarity = 0.0
             for annotation in annotations:


### PR DESCRIPTION
- Snapshot ORM-backed API key fields before async session closes to prevent DetachedInstanceError when accessing attributes after session context expires
- Move embedding generation to thread pool using asyncio.to_thread() to keep synchronous embedding clients off the async event loop
- Improve _supports_conversation() robustness by handling null workflow_type values from older release snapshots, treating them as missing values to preserve model/database defaults
- Add comprehensive docstring to _supports_conversation() explaining backward compatibility handling for workflow_type enum values

## Summary by Sourcery

加强工作流注解匹配逻辑，以防止使用过期的 ORM 状态，同时避免阻塞嵌入客户端，并正确处理旧版 workflow type 的取值。

Bug 修复：
- 通过在数据库会话关闭前保留 API key 配置，防止在注解匹配过程中发生 DetachedInstanceError。
- 防止同步嵌入生成阻塞异步事件循环。
- 将空的旧版 workflow type 值视为缺失值处理，以保留模型和数据库的默认值。

增强：
- 为 workflow type 的处理行为编写向后兼容性文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden workflow annotation matching against expired ORM state, blocking embedding clients, and legacy workflow type values.

Bug Fixes:
- Prevent DetachedInstanceError during annotation matching by preserving API key configuration before the database session closes.
- Prevent synchronous embedding generation from blocking the asynchronous event loop.
- Handle null legacy workflow type values as missing values to preserve model and database defaults.

Enhancements:
- Document backward-compatibility behavior for workflow type handling.

</details>