### PR TITLE
fix(memory): fix Cypher CALL clause to bind node variable

### DIFF
--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -1285,7 +1285,7 @@ MATCH (n)
 WHERE elementId(n) = $id
   AND n.delete_at IS NULL
 
-CALL () {
+CALL (n) {
   WITH n
   MATCH (n)-[]-(m:ExtractedEntity)
   WHERE NOT m:MemorySummary AND NOT m:Chunk
@@ -1299,7 +1299,7 @@ CALL () {
   ) AS ExtractedEntity
 }
 
-CALL () {
+CALL (n) {
   WITH n
   MATCH (n)-[]-(m:MemorySummary)
   WHERE NOT m:Chunk


### PR DESCRIPTION
- Update `CALL ()` to `CALL (n)` in cypher_queries.py to correctly pass the node variable into the subquery.
- This resolves potential scoping issues in Neo4j queries.

## Summary by Sourcery

Bug Fixes:
- 修复 Cypher 子查询的作用域问题，以便在处理提取的实体和内存摘要时，节点变量能够被正确绑定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Cypher subquery scoping so node variables are correctly bound when processing extracted entities and memory summaries.

</details>