### PR TITLE
fix(memory): use short-lived db sessions in perceptual generation to avoid pg pool exhaustion

### DIFF
--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -1050,6 +1050,10 @@ class WritePipeline:
         4. 将 file_object.summary 以 <input-file-summary> 标签注入到 message["content"]
         5. 将 (file_object, file_type) 挂载到 message["file_content"]
 
+        连接管理：查重用一个短读事务，查完立刻归还；生成阶段不传 db，由
+        MemoryPerceptualService 内部按需开短事务，避免 PG 连接被多模态推理
+        长时间占用（memory_tasks 并发 100 > 连接池 70）。
+
         Args:
             messages: 消息列表，每条消息含 files 字段（List[FileInput dict]）。
                       函数会原地修改 content 和 file_content。
@@ -1057,7 +1061,7 @@ class WritePipeline:
         if not messages:
             return
 
-        from app.db import get_db_context
+        from app.db import get_db_read
         from app.repositories.memory_perceptual_repository import MemoryPerceptualRepository
         from app.schemas.app_schema import FileInput
         from app.services.memory_perceptual_service import MemoryPerceptualService, _PerceptualSnapshot
@@ -1089,20 +1093,18 @@ class WritePipeline:
                     continue
 
                 try:
-                    with get_db_context() as db:
-                        # 先查找已有的 Perceptual 记录
-                        repo = MemoryPerceptualRepository(db)
-                        memories = repo.get_by_url(self.end_user_id, url)
-
+                    # 用 DB：查已有 Perceptual 记录，命中则复用，不再调多模态模型
+                    file_object = None
+                    with get_db_read() as db:
+                        memories = MemoryPerceptualRepository(db).get_by_url(self.end_user_id, url)
                         if memories:
                             # 已存在，复用最新的一条
                             memory = max(
                                 memories,
                                 key=lambda m: m.created_time if m.created_time else datetime.min,
                             )
-                            # 在 Session 内提取所有需要的属性到一个简单对象中，
-                            # 彻底避免 DetachedInstanceError（使用模块级 _PerceptualSnapshot）
-                            snap = _PerceptualSnapshot(
+                            # 在 Session 内取成普通值，出块后不会 DetachedInstanceError
+                            file_object = _PerceptualSnapshot(
                                 id=memory.id,
                                 end_user_id=self.end_user_id,  # 使用当前 pipeline 的 end_user_id，确保 Perceptual 节点归属当前用户
                                 perceptual_type=memory.perceptual_type,
@@ -1113,49 +1115,31 @@ class WritePipeline:
                                 meta_data=memory.meta_data,
                                 created_time=memory.created_time,
                             )
-                            file_object = snap
-                        else:
-                            # 不存在，创建 Perceptual 记录
-                            perceptual_service = MemoryPerceptualService(db)
-                            # 补充 transfer_method（memory_messages.files 中可能缺失此字段）
-                            file_data = dict(file_info)
-                            if "transfer_method" not in file_data:
-                                file_data["transfer_method"] = "remote_url" if file_data.get("url") else "local_file"
-                            file_input = FileInput(**file_data)
-                            memory = await perceptual_service.generate_perceptual_memory(
-                                end_user_id=self.end_user_id,
-                                memory_config=self.memory_config,
-                                file=file_input,
-                                content=msg.get("content") or None,
-                            )
-                            # 在 Session 内提取属性到快照，避免 DetachedInstanceError
-                            if memory is not None:
-                                file_object = _PerceptualSnapshot(
-                                    id=memory.id,
-                                    end_user_id=self.end_user_id,
-                                    perceptual_type=memory.perceptual_type,
-                                    file_path=memory.file_path,
-                                    file_name=memory.file_name,
-                                    file_ext=memory.file_ext,
-                                    summary=memory.summary,
-                                    meta_data=memory.meta_data,
-                                    created_time=memory.created_time,
-                                )
-                            else:
-                                file_object = None
+                    # 未命中：生成并落库。不传 db，服务内部自己开短事务。
+                    if file_object is None:
+                        # 补充 transfer_method（memory_messages.files 中可能缺失此字段）
+                        file_data = dict(file_info)
+                        if "transfer_method" not in file_data:
+                            file_data["transfer_method"] = "remote_url" if file_data.get("url") else "local_file"
+                        file_object = await MemoryPerceptualService().generate_perceptual_memory(
+                            end_user_id=self.end_user_id,
+                            memory_config=self.memory_config,
+                            file=FileInput(**file_data),
+                            content=msg.get("content") or None,
+                        )
 
-                        if file_object is None:
-                            continue
+                    if file_object is None:
+                        continue
 
-                        # 注入 summary 到 content
-                        # 跳过已包含 summary 的情况（API 路径在写入 memory_messages 前已注入）
-                        if file_object.summary:
-                            summary_tag = f"<input-file-summary>{file_object.summary}</input-file-summary>"
-                            current_content = msg.get("content") or ""
-                            if summary_tag not in current_content:
-                                msg["content"] = current_content + summary_tag
+                    # 注入 summary 到 content
+                    # 跳过已包含 summary 的情况（API 路径在写入 memory_messages 前已注入）
+                    if file_object.summary:
+                        summary_tag = f"<input-file-summary>{file_object.summary}</input-file-summary>"
+                        current_content = msg.get("content") or ""
+                        if summary_tag not in current_content:
+                            msg["content"] = current_content + summary_tag
 
-                        msg["file_content"].append((file_object, file_info.get("type", "")))
+                    msg["file_content"].append((file_object, file_info.get("type", "")))
 
                 except Exception as e:
                     logger.warning(

--- a/api/app/services/memory_perceptual_service.py
+++ b/api/app/services/memory_perceptual_service.py
@@ -13,7 +13,7 @@ from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_business_logger
 from app.core.models import RedBearLLM, RedBearModelConfig
-from app.db import get_db_read
+from app.db import get_db_context, get_db_read
 from app.models import FileMetadata, ModelApiKey, ModelType
 from app.models.memory_perceptual_model import PerceptualType, FileStorageService
 from app.models.prompt_optimizer_model import RoleType
@@ -55,9 +55,16 @@ class _PerceptualSnapshot:
 
 
 class MemoryPerceptualService:
-    def __init__(self, db: Session):
+    def __init__(self, db: Optional[Session] = None):
+        """初始化感知记忆服务。
+
+        Args:
+            db: 查询类方法（get_memory_count / get_time_line / get_latest_* 等）必须传入。
+                若只调用 ``generate_perceptual_memory``，可以不传：该方法内部自行管理
+                短生命周期 Session，避免把 PG 连接持有到多模态推理结束。
+        """
         self.db = db
-        self.repository = MemoryPerceptualRepository(db)
+        self.repository = MemoryPerceptualRepository(db) if db is not None else None
 
     def get_memory_count(self, end_user_id: uuid.UUID) -> Dict[str, Any]:
         """Retrieve perceptual memory statistics for a user."""
@@ -223,32 +230,34 @@ class MemoryPerceptualService:
 
     def _get_mutlimodal_client(
             self,
+            db: Session,
             file_type: FileType,
             config: MemoryConfig,
             tenant_id: uuid.UUID,
     ) -> tuple[RedBearLLM | None, ModelApiKey | None]:
+        """取多模态模型客户端。db 由调用方在事务内传入。"""
         model_config = None
         if file_type == FileType.AUDIO:
             model_config = ModelApiKeyService.get_available_api_key(
-                self.db,
+                db,
                 config.audio_model_id,
                 tenant_id=tenant_id
             )
         elif file_type == FileType.VIDEO:
             model_config = ModelApiKeyService.get_available_api_key(
-                self.db,
+                db,
                 config.video_model_id,
                 tenant_id=tenant_id
             )
         elif file_type == FileType.DOCUMENT:
             model_config = ModelApiKeyService.get_available_api_key(
-                self.db,
+                db,
                 config.llm_model_id,
                 tenant_id=tenant_id
             )
         elif file_type == FileType.IMAGE:
             model_config = ModelApiKeyService.get_available_api_key(
-                self.db,
+                db,
                 config.vision_model_id,
                 tenant_id=tenant_id
             )
@@ -276,37 +285,48 @@ class MemoryPerceptualService:
     ):
         """生成感知记忆。
 
+        连接管理：每处用到 DB 都现开现还一个短 Session，绝不把 PG 连接持有到
+        LLM 推理结束（memory_tasks 并发 100 > 连接池 70，长持有会打满池）。
+        注意 ORM 对象出了 with 块就会 Detached，块内要先取成普通值。
+
         参数：
-            persist=True  — 默认，写入 memory_perceptual 表，返回 MemoryPerceptualModel。
-            persist=False — 试运行场景，不写库，返回 _PerceptualSnapshot 实例。
-                            同时绕开 end_user → workspace → tenant_id 的 DB 查询，
+            persist=True  — 默认，写入 memory_perceptual 表。
+            persist=False — 试运行场景，不写库。同时绕开
+                            end_user → workspace → tenant_id 的 DB 查询，
                             直接从 memory_config.tenant_id 取。
+
+        返回：
+            _PerceptualSnapshot | None（两种模式统一返回内存快照）
         """
-        if persist:
-            with get_db_read() as db:
+        # 用 DB：解析 tenant_id + 取模型配置。ModelApiKey 出块即废，块内固化成 ModelInfo。
+        with get_db_read() as db:
+            if persist:
                 end_user = get_end_user_by_id(db, end_user_id)
                 workspace_id = end_user.workspace_id
                 workspace = get_workspace_by_id(db, workspace_id)
                 tenant_id = workspace.tenant_id
-        else:
-            tenant_id = memory_config.tenant_id
-        llm, model_config = self._get_mutlimodal_client(file.type, memory_config, tenant_id)
-        if model_config is None or llm is None:
-            return None
-        multimodel_service = MultimodalService(self.db, ModelInfo(
-            model_name=model_config.model_name,
-            provider=model_config.provider,
-            api_key=model_config.api_key,
-            api_base=model_config.api_base,
-            is_omni=model_config.is_omni,
-            capability=model_config.capability,
-            model_type=ModelType.LLM
-        ))
-        file_message = await multimodel_service.process_files(
-            files=[file]
-        )
+            else:
+                tenant_id = memory_config.tenant_id
+            llm, model_config = self._get_mutlimodal_client(db, file.type, memory_config, tenant_id)
+            if model_config is None or llm is None:
+                return None
+            api_config = ModelInfo(
+                model_name=model_config.model_name,
+                provider=model_config.provider,
+                api_key=model_config.api_key,
+                api_base=model_config.api_base,
+                is_omni=model_config.is_omni,
+                capability=model_config.capability,
+                model_type=ModelType.LLM
+            )
+
+        # 用 DB：文件预处理（本地文件需查 FileMetadata 取文件名）
+        with get_db_read() as db:
+            file_message = await MultimodalService(db, api_config).process_files(
+                files=[file]
+            )
         if not file_message:
-            business_logger.warning(f"Unsupported file type {file}, model capability: {model_config.capability}")
+            business_logger.warning(f"Unsupported file type {file}, model capability: {api_config.capability}")
             return None
         file_message = file_message[0]
         try:
@@ -325,6 +345,7 @@ class MemoryPerceptualService:
                 {"type": "text", "text": "Generate a summary of the file's content"}
             ]}
         ]
+        # 不持有连接：多模态推理（最慢的一段）
         try:
             result = await llm.ainvoke(messages)
         except Exception as e:
@@ -354,11 +375,13 @@ class MemoryPerceptualService:
             stmt = select(FileMetadata).where(
                 FileMetadata.id == file_id
             )
-            file_obj = self.db.execute(stmt).scalar_one_or_none()
+            # 用 DB：回查本地文件真实名称（远程文件 filename 不是 UUID，走不到这）
+            with get_db_read() as db:
+                file_obj = db.execute(stmt).scalar_one_or_none()
 
-            if file_obj:
-                filename = file_obj.file_name
-                file_ext = file_obj.file_ext
+                if file_obj:
+                    filename = file_obj.file_name
+                    file_ext = file_obj.file_ext
         except ValueError:
             business_logger.debug(f"Remote file, file_id={filename}")
         if not file_ext:
@@ -406,17 +429,31 @@ class MemoryPerceptualService:
                 },
                 created_time=None,
             )
-        memory = self.repository.create_perceptual_memory(
-            end_user_id=uuid.UUID(end_user_id),
-            perceptual_type=PerceptualType.trans_from_file_type(file.type),
-            file_path=file.url,
-            file_name=filename,
-            file_ext=file_ext,
-            summary=content.get('summary', ""),
-            meta_data={
-                "content": file_content,
-                "modalities": file_modalities
-            }
-        )
-        self.db.commit()
-        return memory
+        # 用 DB：落库。返回快照而非 ORM 对象，否则调用方出块访问就 Detached。
+        with get_db_context() as db:
+            memory = MemoryPerceptualRepository(db).create_perceptual_memory(
+                end_user_id=uuid.UUID(end_user_id),
+                perceptual_type=PerceptualType.trans_from_file_type(file.type),
+                file_path=file.url,
+                file_name=filename,
+                file_ext=file_ext,
+                summary=content.get('summary', ""),
+                meta_data={
+                    "content": file_content,
+                    "modalities": file_modalities
+                }
+            )
+            # 在 commit 前取值：commit 会 expire 属性，之后访问需额外一次 SELECT
+            snapshot = _PerceptualSnapshot(
+                id=memory.id,
+                end_user_id=end_user_id,
+                perceptual_type=memory.perceptual_type,
+                file_path=memory.file_path,
+                file_name=memory.file_name,
+                file_ext=memory.file_ext,
+                summary=memory.summary,
+                meta_data=memory.meta_data,
+                created_time=memory.created_time,
+            )
+            db.commit()
+        return snapshot

--- a/api/app/services/pilot_run_service.py
+++ b/api/app/services/pilot_run_service.py
@@ -217,7 +217,7 @@ async def _generate_perceptual_snapshots(
     if not resolved_files:
         return []
 
-    # ── Phase 2: 并发生成感知记忆（每个协程独占一次 read session）──
+    # ── Phase 2: 并发生成感知记忆（不持有连接跨越多模态推理）──
     async def _snapshot_one(
         msg_idx: int,
         msg: WriteMessageItem,
@@ -226,14 +226,14 @@ async def _generate_perceptual_snapshots(
     ) -> Optional[PerceptualEntry]:
         try:
             file_for_perceptual = file.model_copy(update={"url": url})
-            with get_db_read() as db:
-                snapshot = await MemoryPerceptualService(db).generate_perceptual_memory(
-                    end_user_id=str(memory_config.workspace_id),
-                    memory_config=memory_config,
-                    file=file_for_perceptual,
-                    content=msg.content,
-                    persist=False,
-                )
+            # 不传 db：服务内部自己开短事务，避免每个协程各持一条连接直到推理结束
+            snapshot = await MemoryPerceptualService().generate_perceptual_memory(
+                end_user_id=str(memory_config.workspace_id),
+                memory_config=memory_config,
+                file=file_for_perceptual,
+                content=msg.content,
+                persist=False,
+            )
         except Exception as e:
             logger.warning(
                 f"[PILOT_RUN] 文件处理失败，跳过: msg_idx={msg_idx}, err={e}",


### PR DESCRIPTION
## Sourcery 摘要

在整个感知记忆生成过程中使用短生命周期的数据库会话，确保并发多模态处理不会在推理期间始终占用连接。

错误修复：
- 通过在多模态推理完成前释放数据库会话，防止感知记忆生成期间 PostgreSQL 连接池耗尽。

增强功能：
- 重构感知记忆生成逻辑，使用短生命周期的数据库会话，并返回可安全脱离会话使用的内存快照。
- 当生成过程未提供调用方会话时，允许感知记忆服务自行管理数据库会话。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use short-lived database sessions throughout perceptual-memory generation so concurrent multimodal processing does not hold connections for the duration of inference.

Bug Fixes:
- Prevent PostgreSQL connection pool exhaustion during perceptual-memory generation by releasing database sessions before multimodal inference completes.

Enhancements:
- Refactor perceptual-memory generation to use short-lived database sessions and return detached-safe in-memory snapshots.
- Allow perceptual-memory services to manage their own database sessions when generation is performed without a caller-provided session.

</details>