### PR TITLE
feat(models): support custom base_url for DashScope embedding and rerank

### DIFF
--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -220,8 +220,8 @@ class RedBearModelFactory:
         if default_headers:
             logger.info(f"额外请求头已注入: {default_headers}")
 
-        # dashscope 的 omni 模型、以及配置了自定义 base_url 的 dashscope 模型，使用 OpenAI 兼容模式
-        if provider == ModelProvider.DASHSCOPE and (config.is_omni or config.base_url):
+        # dashscope 的 omni 模型使用 OpenAI 兼容模式
+        if provider == ModelProvider.DASHSCOPE and config.is_omni:
             if not config.base_url:
                 config.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
             timeout_config = httpx.Timeout(
@@ -493,8 +493,8 @@ def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelTy
     """根据模型提供商获取对应的模型类"""
     provider = config.provider.lower()
 
-    # dashscope 的 omni 模型、以及配置了自定义 base_url 的 dashscope 模型，走 OpenAI 兼容模式
-    if provider == ModelProvider.DASHSCOPE and (config.is_omni or config.base_url):
+    # dashscope的omni模型 和 volcano模型使用
+    if provider == ModelProvider.DASHSCOPE and config.is_omni:
         return CompatibleChatOpenAI
     if provider == ModelProvider.VOLCANO:
         return CompatibleChatOpenAI

--- a/api/app/core/models/base.py
+++ b/api/app/core/models/base.py
@@ -220,8 +220,8 @@ class RedBearModelFactory:
         if default_headers:
             logger.info(f"额外请求头已注入: {default_headers}")
 
-        # dashscope 的 omni 模型使用 OpenAI 兼容模式
-        if provider == ModelProvider.DASHSCOPE and config.is_omni:
+        # dashscope 的 omni 模型、以及配置了自定义 base_url 的 dashscope 模型，使用 OpenAI 兼容模式
+        if provider == ModelProvider.DASHSCOPE and (config.is_omni or config.base_url):
             if not config.base_url:
                 config.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
             timeout_config = httpx.Timeout(
@@ -493,8 +493,8 @@ def get_provider_llm_class(config: RedBearModelConfig, type: ModelType = ModelTy
     """根据模型提供商获取对应的模型类"""
     provider = config.provider.lower()
 
-    # dashscope的omni模型 和 volcano模型使用
-    if provider == ModelProvider.DASHSCOPE and config.is_omni:
+    # dashscope 的 omni 模型、以及配置了自定义 base_url 的 dashscope 模型，走 OpenAI 兼容模式
+    if provider == ModelProvider.DASHSCOPE and (config.is_omni or config.base_url):
         return CompatibleChatOpenAI
     if provider == ModelProvider.VOLCANO:
         return CompatibleChatOpenAI

--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -63,8 +63,24 @@ class RedBearEmbeddings(Embeddings):
     @staticmethod
     def _create_model(config: RedBearModelConfig) -> Embeddings:
         """根据配置创建 LangChain 模型"""
-        embedding_class = get_provider_embedding_class(config.provider)
         provider = config.provider.lower()
+
+        # dashscope 配置了自定义 base_url 时，走 OpenAI 兼容模式，确保真实 URL 生效
+        if provider == ModelProvider.DASHSCOPE and config.base_url:
+            from langchain_openai import OpenAIEmbeddings
+            import httpx
+            timeout = httpx.Timeout(timeout=config.timeout, connect=60.0)
+            return OpenAIEmbeddings(
+                model=config.model_name,
+                base_url=config.base_url,
+                api_key=config.api_key,
+                timeout=timeout,
+                max_retries=config.max_retries,
+                chunk_size=settings.EMBEDDING_BATCH_SIZE,
+                check_embedding_ctx_length=False,
+            )
+
+        embedding_class = get_provider_embedding_class(config.provider)
         # Embedding models only need connection params, never LLM-specific ones
         # (e.g. enable_thinking, model_kwargs) — build params directly.
         if provider in [

--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -63,24 +63,8 @@ class RedBearEmbeddings(Embeddings):
     @staticmethod
     def _create_model(config: RedBearModelConfig) -> Embeddings:
         """根据配置创建 LangChain 模型"""
-        provider = config.provider.lower()
-
-        # dashscope 配置了自定义 base_url 时，走 OpenAI 兼容模式，确保真实 URL 生效
-        if provider == ModelProvider.DASHSCOPE and config.base_url:
-            from langchain_openai import OpenAIEmbeddings
-            import httpx
-            timeout = httpx.Timeout(timeout=config.timeout, connect=60.0)
-            return OpenAIEmbeddings(
-                model=config.model_name,
-                base_url=config.base_url,
-                api_key=config.api_key,
-                timeout=timeout,
-                max_retries=config.max_retries,
-                chunk_size=settings.EMBEDDING_BATCH_SIZE,
-                check_embedding_ctx_length=False,
-            )
-
         embedding_class = get_provider_embedding_class(config.provider)
+        provider = config.provider.lower()
         # Embedding models only need connection params, never LLM-specific ones
         # (e.g. enable_thinking, model_kwargs) — build params directly.
         if provider in [

--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -33,17 +33,6 @@ def _normalize_jina_rerank_url(base_url: Optional[str]) -> str:
     return f"{url}/v1/rerank"
 
 
-_DASHSCOPE_RERANK_PATH = "services/rerank/text-rerank/text-rerank"
-
-
-def _normalize_dashscope_rerank_url(base_url: str) -> str:
-    """将 dashscope 原生 base_url（如 .../api/v1）规范化为 rerank 完整端点。"""
-    url = base_url.rstrip("/")
-    if url.endswith(f"/{_DASHSCOPE_RERANK_PATH}"):
-        return url
-    return f"{url}/{_DASHSCOPE_RERANK_PATH}"
-
-
 class _EndpointBoundSession:
     """Route a provider session to one immutable rerank endpoint."""
 
@@ -125,42 +114,6 @@ class RedBearRerank(BaseDocumentCompressor):
             report_model_gateway_failure(self._config, "rerank", exc, started)
             raise
 
-    def _dashscope_rerank_http(
-            self,
-            documents: Sequence[Union[str, Document, dict]],
-            query: str,
-            top_n: int,
-    ) -> List[Dict[str, Any]]:
-        """dashscope 配置了自定义 base_url 时，走原生 rerank 协议直接命中该 URL。
-
-        dashscope.TextReRank 底层只读全局 dashscope.base_http_api_url，无法按实例指定
-        base_url，因此这里用同样的原生协议（嵌套 input/parameters）直接请求配置的地址，
-        保证自定义 URL 真正生效。
-        """
-        import httpx
-
-        docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
-        effective_top_n = top_n if top_n > 0 else 3
-        body = {
-            "model": self._config.model_name,
-            "input": {"query": query, "documents": docs},
-            "parameters": {"top_n": effective_top_n, "return_documents": False},
-        }
-        headers = {
-            "Authorization": f"Bearer {self._config.api_key}",
-            "Content-Type": "application/json",
-        }
-        url = _normalize_dashscope_rerank_url(self._config.base_url)
-        with httpx.Client(timeout=self._config.timeout, follow_redirects=True) as client:
-            response = client.post(url, json=body, headers=headers)
-        response.raise_for_status()
-        payload = response.json()
-        results = ((payload.get("output") or {}).get("results")) or []
-        return [
-            {"index": int(item.get("index")), "relevance_score": item.get("relevance_score")}
-            for item in results
-        ]
-
     @network_retry
     def _rerank_with_retry(
             self,
@@ -174,8 +127,6 @@ class RedBearRerank(BaseDocumentCompressor):
             model_instance: JinaRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)
         if provider == ModelProvider.DASHSCOPE:
-            if self._config.base_url:
-                return self._dashscope_rerank_http(documents, query, top_n)
             from langchain_community.document_compressors.dashscope_rerank import DashScopeRerank
             model_instance: DashScopeRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)

--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -33,6 +33,14 @@ def _normalize_jina_rerank_url(base_url: Optional[str]) -> str:
     return f"{url}/v1/rerank"
 
 
+def _normalize_dashscope_rerank_url(base_url: str) -> str:
+    """将 OpenAI-compatible base_url 规范化为 rerank 完整端点。"""
+    url = base_url.rstrip("/")
+    if url.endswith("/reranks"):
+        return url
+    return f"{url}/reranks"
+
+
 class _EndpointBoundSession:
     """Route a provider session to one immutable rerank endpoint."""
 
@@ -114,6 +122,45 @@ class RedBearRerank(BaseDocumentCompressor):
             report_model_gateway_failure(self._config, "rerank", exc, started)
             raise
 
+    def _dashscope_rerank_http(
+            self,
+            documents: Sequence[Union[str, Document, dict]],
+            query: str,
+            top_n: Optional[int],
+    ) -> List[Dict[str, Any]]:
+        """DashScope 配置了自定义 base_url 时，直接请求 OpenAI-compatible rerank 接口。
+
+        DashScopeRerank 底层只读取全局服务地址，无法按实例使用数据库中的
+        base_url，因此在这里显式传入真实 URL 和 API key。
+        """
+        import httpx
+
+        docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
+        effective_top_n = top_n if top_n is not None and top_n > 0 else 3
+        body = {
+            "model": self._config.model_name,
+            "query": query,
+            "documents": docs,
+            "top_n": effective_top_n,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._config.api_key}",
+            "Content-Type": "application/json",
+        }
+        url = _normalize_dashscope_rerank_url(self._config.base_url)
+        with httpx.Client(timeout=self._config.timeout, follow_redirects=True) as client:
+            response = client.post(url, json=body, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+        results = payload.get("results") if isinstance(payload, dict) else None
+        if not isinstance(results, list) or not results:
+            detail = payload.get("message") if isinstance(payload, dict) else None
+            raise ValueError(detail or "DashScope rerank 响应中缺少有效的 results")
+        return [
+            {"index": int(item.get("index")), "relevance_score": item.get("relevance_score")}
+            for item in results
+        ]
+
     @network_retry
     def _rerank_with_retry(
             self,
@@ -127,6 +174,8 @@ class RedBearRerank(BaseDocumentCompressor):
             model_instance: JinaRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)
         if provider == ModelProvider.DASHSCOPE:
+            if self._config.base_url:
+                return self._dashscope_rerank_http(documents, query, top_n)
             from langchain_community.document_compressors.dashscope_rerank import DashScopeRerank
             model_instance: DashScopeRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)

--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -33,6 +33,17 @@ def _normalize_jina_rerank_url(base_url: Optional[str]) -> str:
     return f"{url}/v1/rerank"
 
 
+_DASHSCOPE_RERANK_PATH = "services/rerank/text-rerank/text-rerank"
+
+
+def _normalize_dashscope_rerank_url(base_url: str) -> str:
+    """将 dashscope 原生 base_url（如 .../api/v1）规范化为 rerank 完整端点。"""
+    url = base_url.rstrip("/")
+    if url.endswith(f"/{_DASHSCOPE_RERANK_PATH}"):
+        return url
+    return f"{url}/{_DASHSCOPE_RERANK_PATH}"
+
+
 class _EndpointBoundSession:
     """Route a provider session to one immutable rerank endpoint."""
 
@@ -114,6 +125,42 @@ class RedBearRerank(BaseDocumentCompressor):
             report_model_gateway_failure(self._config, "rerank", exc, started)
             raise
 
+    def _dashscope_rerank_http(
+            self,
+            documents: Sequence[Union[str, Document, dict]],
+            query: str,
+            top_n: int,
+    ) -> List[Dict[str, Any]]:
+        """dashscope 配置了自定义 base_url 时，走原生 rerank 协议直接命中该 URL。
+
+        dashscope.TextReRank 底层只读全局 dashscope.base_http_api_url，无法按实例指定
+        base_url，因此这里用同样的原生协议（嵌套 input/parameters）直接请求配置的地址，
+        保证自定义 URL 真正生效。
+        """
+        import httpx
+
+        docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
+        effective_top_n = top_n if top_n > 0 else 3
+        body = {
+            "model": self._config.model_name,
+            "input": {"query": query, "documents": docs},
+            "parameters": {"top_n": effective_top_n, "return_documents": False},
+        }
+        headers = {
+            "Authorization": f"Bearer {self._config.api_key}",
+            "Content-Type": "application/json",
+        }
+        url = _normalize_dashscope_rerank_url(self._config.base_url)
+        with httpx.Client(timeout=self._config.timeout, follow_redirects=True) as client:
+            response = client.post(url, json=body, headers=headers)
+        response.raise_for_status()
+        payload = response.json()
+        results = ((payload.get("output") or {}).get("results")) or []
+        return [
+            {"index": int(item.get("index")), "relevance_score": item.get("relevance_score")}
+            for item in results
+        ]
+
     @network_retry
     def _rerank_with_retry(
             self,
@@ -127,6 +174,8 @@ class RedBearRerank(BaseDocumentCompressor):
             model_instance: JinaRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)
         if provider == ModelProvider.DASHSCOPE:
+            if self._config.base_url:
+                return self._dashscope_rerank_http(documents, query, top_n)
             from langchain_community.document_compressors.dashscope_rerank import DashScopeRerank
             model_instance: DashScopeRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)


### PR DESCRIPTION
## Sourcery 总结

使 DashScope 嵌入和重排模型支持使用每个模型自定义的基础 URL。

新功能：
- 通过兼容 OpenAI 的接口，为嵌入模型支持自定义 DashScope 基础 URL。
- 为重排请求支持自定义 DashScope 基础 URL。

错误修复：
- 确保使用已配置的 DashScope 端点，而不是依赖全局提供商 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable DashScope embedding and rerank models to honor per-model custom base URLs.

New Features:
- Support custom DashScope base URLs for embedding models through the OpenAI-compatible interface.
- Support custom DashScope base URLs for reranking requests.

Bug Fixes:
- Ensure configured DashScope endpoints are used instead of relying on global provider URLs.

</details>