### PR TITLE
feat(web): pure_workflow type support logs

### DIFF
--- a/web/src/api/application.ts
+++ b/web/src/api/application.ts
@@ -296,9 +296,13 @@ export const cancelSpaceShare = (target_workspace_id?: string) => {
 }
 // Application conversation logs
 export const getAppLogsUrl = (app_id: string) => `/apps/${app_id}/logs`
+export const getPureWorkflowAppLogsUrl = (app_id: string) => `/apps/${app_id}/workflow-executions`
 // Get full conversation message history
 export const getAppLogDetail = (app_id: string, conversation_id: string) => {
   return request.get(`/apps/${app_id}/logs/${conversation_id}`)
+}
+export const getPureWorkflowAppLogDetail = (app_id: string, execution_id: string) => {
+  return request.get(`/apps/${app_id}/workflow-executions/${execution_id}`)
 }
 // Reset agent model config to default
 export const resetAppModelConfig = (app_id: string) => {

--- a/web/src/views/ApplicationConfig/Logs.tsx
+++ b/web/src/views/ApplicationConfig/Logs.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom';
 import { Flex, Button, Form, Switch, Space, Divider, App, Dropdown, DatePicker, type SegmentedProps } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 
-import { getAppLogsUrl, getAnnotationsListUrl, getAnnotationsSettings, updateAnnotationsSettings, deleteAnnotations, deleteAllAnnotations, exportAnnotation, } from '@/api/application';
+import { getAppLogsUrl, getPureWorkflowAppLogsUrl, getAnnotationsListUrl, getAnnotationsSettings, updateAnnotationsSettings, deleteAnnotations, deleteAllAnnotations, exportAnnotation, } from '@/api/application';
 import Table, { type TableRef } from '@/components/Table'
 import { formatDateTime } from '@/utils/format';
 import type { LogItem, LogDetailModalRef, AnnotationItem, AnnotationSettingForm, AnnotationSettingModalRef, AnnotationFormModalRef, HitHistoryDetailRef } from './types'
@@ -73,6 +73,35 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
       key: 'action',
       fixed: 'right',
       width: 80,
+      render: (_, record) => (
+        <Flex wrap>
+          <Button
+            type="link"
+            onClick={() => handleViewDetail(record as LogItem)}
+          >
+            {t('common.view')}
+          </Button>
+        </Flex>
+      ),
+    },
+  ];
+  const pureWorkflowColumns: ColumnsType<LogItem> = [
+    {
+      title: t('application.execution_id'),
+      dataIndex: 'execution_id',
+      key: 'execution_id',
+      className: 'rb:text-[#212332]',
+    },
+    {
+      title: t('application.created_at'),
+      dataIndex: 'created_at',
+      key: 'created_at',
+      render: (createdAt: string) => formatDateTime(createdAt, 'YYYY-MM-DD HH:mm:ss'),
+    },
+    {
+      title: t('common.operation'),
+      key: 'action',
+      fixed: 'right',
       render: (_, record) => (
         <Flex wrap>
           <Button
@@ -334,12 +363,12 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
         </Form>
       </Flex>
       <div className="rb:flex-1">
-        {activeTab === 'logs' && <>
+        {activeTab === 'logs' && id && application?.type && <>
           <Table<LogItem>
-            apiUrl={getAppLogsUrl(id || '')}
+            apiUrl={application.type === 'pure_workflow' ? getPureWorkflowAppLogsUrl(id) : getAppLogsUrl(id)}
             apiParams={logsQuery}
-            columns={columns}
-            rowKey="id"
+            columns={application.type === 'pure_workflow' ? pureWorkflowColumns : columns}
+            rowKey={application.type === 'pure_workflow' ? 'execution_id' : "id"}
             isScroll={true}
             fillHeight={true}
           />

--- a/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
+++ b/web/src/views/ApplicationConfig/components/ConfigHeader.tsx
@@ -80,14 +80,13 @@ const ConfigHeader: FC<ConfigHeaderProps> = ({
    * Format tab items for display
    */
   const formatTabItems = useMemo(() => {
-    const isHideAnnotations = ['multi_agent', 'pure_workflow'].includes(application?.type as string) || source === 'sharing'
+    const isHideAnnotations = !application?.type || ['multi_agent', 'pure_workflow'].includes(application?.type as string) || source === 'sharing'
 
     const items = (source === 'sharing' ? sharingTabKeys : tabKeys).map(key => ({
       key,
       label: key === 'log' && !isHideAnnotations ? t('application.logAnnotations') : t(`application.${key}`),
     }))
     return items
-    return 
   }, [source, sharingTabKeys, tabKeys, application?.type])
   /**
    * Handle menu item click

--- a/web/src/views/ApplicationConfig/components/LogDetailModal.tsx
+++ b/web/src/views/ApplicationConfig/components/LogDetailModal.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { LogDetailModalRef, LogItem } from '../types'
 import RbModal from '@/components/RbModal'
-import { getAppLogDetail } from '@/api/application'
+import { getAppLogDetail, getPureWorkflowAppLogDetail } from '@/api/application'
 import ChatContent from '@/components/Chat/ChatContent'
 import { formatDateTime } from '@/utils/format'
 import type { ChatItem } from '@/components/Chat/types'
@@ -54,13 +54,14 @@ const LogDetailModal = forwardRef<LogDetailModalRef, { source: string; appType: 
     if (visible && vo) {
       getDetail()
     }
-  }, [visible, vo])
+  }, [visible, vo, appType])
 
   /** Fetch conversation log detail from API */
   const getDetail = () => {
-    if (!vo) return
+    if (!vo || !appType) return
     setLoading(true)
-    getAppLogDetail(vo.app_id, vo.id).then(res => {
+    const request = appType === 'pure_workflow' ? getPureWorkflowAppLogDetail(vo.app_id, vo.execution_id) : getAppLogDetail(vo.app_id, vo.id)
+    request.then(res => {
       const { node_executions_map, messages, pending_intervention, ...rest } = res as Data;
       let hasSubContentMessages = messages.map((item: any) => ({ ...item, status: item.role === 'user' ? null : item.status  }))
       if (messages && messages.length > 0 && (node_executions_map && Object.keys(node_executions_map).length > 0 || pending_intervention && Object.keys(pending_intervention).length > 0)) {

--- a/web/src/views/ApplicationConfig/types/log.ts
+++ b/web/src/views/ApplicationConfig/types/log.ts
@@ -14,6 +14,16 @@ export interface LogItem {
   updated_at: number;
   node_executions_map?: Record<string, ChatItem['subContent']>
   pending_intervention?: Record<string, { interventions: ChatItem['interventions'] }>
+
+
+  execution_id: string;
+  release_id: string;
+  trigger_type: string;
+  status: string;
+  elapsed_time: number;
+  error_message: null | string;
+  started_at: number;
+  completed_at: number;
 }
 
 export interface LogDetailModalRef {


### PR DESCRIPTION
## Sourcery 总结

支持将纯工作流执行日志与标准应用对话日志一起查看。

新功能：
- 支持使用工作流执行标识符列出和查看纯工作流应用的日志详情。

增强功能：
- 根据应用类型调整应用日志视图、列、行键和详情加载逻辑；当应用类型不可用时，隐藏不受支持的注释标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support viewing pure workflow execution logs alongside standard application conversation logs.

New Features:
- Add log listing and detail support for pure workflow applications using workflow execution identifiers.

Enhancements:
- Adapt application log views, columns, row keys, and detail loading based on application type while hiding unsupported annotation labels when the type is unavailable.

</details>