### PR TITLE
fix(memory): adjust forgetting priority

### DIFF
--- a/api/app/core/memory/constants/value_weight_constants.py
+++ b/api/app/core/memory/constants/value_weight_constants.py
@@ -2,6 +2,11 @@
 
 G_WEIGHT = 0.75
 T_WEIGHT = 0.25
+
+# 自动遗忘核心池当前只按时间新近度排序，但仍显式保留 G/T 公式，
+# 便于后续直接调整权重而无需重写候选查询。
+FORGET_CORE_G_WEIGHT = 0.0
+FORGET_CORE_T_WEIGHT = 1.0
 T_HALF_LIFE_MS = 2_592_000_000.0
 
 # 调用方必须提供 created_epoch 和 $evaluated_at_ms；使用前需过滤非法时间。

--- a/api/app/core/memory/storage_services/forgetting_engine/constants.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/constants.py
@@ -5,6 +5,3 @@ DIALOGUE_AUDIT_CONTENT_MAX_LENGTH = 2_000
 
 # 核心池每批候选上限（设计 §4.2「核心每批 ≤50」）。
 FORGET_CORE_BATCH_SIZE = 50
-
-# 单轮辅助池删除上限（设计 §4.2 的 AUXILIARY_MAX_PER_RUN，整轮上限而非每批上限）。
-AUXILIARY_MAX_PER_RUN = 100

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import uuid
 from collections import defaultdict
 from datetime import datetime
@@ -8,7 +7,6 @@ from typing import Any
 from app.core.memory.enums import Neo4jNodeType
 from app.core.memory.models.service_models import ForgetLog, MemoryContext
 from app.core.memory.storage_services.forgetting_engine.constants import (
-    AUXILIARY_MAX_PER_RUN,
     DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
     FORGET_CORE_BATCH_SIZE,
 )
@@ -30,10 +28,11 @@ logger = logging.getLogger(__name__)
 
 
 class ForgetService:
-    """执行一次基于记忆价值的双池遗忘。
+    """执行一次由辅助池驱动、核心池配额收敛的软删除遗忘。
 
-    核心池负责释放配额，辅助池按照核心池的实际释放比例清理
-    ``MemorySummary`` 和 ``Dialogue``。所有删除均为软删除并写入审计日志。
+    优先删除无有效关系的核心节点；配额不足时按创建时间清理辅助池，
+    再删除由此产生的离散核心节点；辅助池耗尽后按 G/T 公式兜底。
+    所有删除均为软删除并写入审计日志。
     """
 
     BATCH_SIZE = FORGET_CORE_BATCH_SIZE
@@ -60,6 +59,7 @@ class ForgetService:
 
         config = self.ctx.memory_config
         lambda_mem = float(getattr(config, "lambda_mem", 0.5))
+        # lambda_mem 表示遗忘比例，目标保留比例为 1 - lambda_mem。
         self.target_ratio = 1 - lambda_mem
         self.target_count = max(int(memory_limit * self.target_ratio), 50)
 
@@ -68,15 +68,17 @@ class ForgetService:
         self._released_count = 0
         self._node_type_counts: defaultdict[str, int] = defaultdict(int)
         self._core_candidate_query_empty = False
+        self._isolated_released_count = 0
+        self._fallback_released_count = 0
         self._auxiliary_released_count = 0
+        self._auxiliary_candidate_query_empty = False
         self._auxiliary_node_type_counts: defaultdict[str, int] = defaultdict(int)
 
     async def run(self) -> dict[str, Any]:
-        """执行核心池和辅助池遗忘并返回本轮删除摘要。
+        """执行离散优先、辅助驱动、时间价值兜底的遗忘。
 
-        核心池未超过配额时直接返回；超过配额时先按价值从低到高删除，
-        再根据核心池实际释放比例计算辅助池预算。核心池无候选时返回
-        ``no_candidate=True``，由上层写入冷却键。
+        核心池未超过配额时直接返回。超过配额时，核心池实际软删除数
+        始终受剩余预算约束，避免越过目标水位。
         """
         self._reset_run_state()
         async with Neo4jConnector() as connector:
@@ -106,25 +108,33 @@ class ForgetService:
                 self.BATCH_SIZE,
             )
 
-            budget = await self._mixed_clean(budget)
-
             auxiliary_active_count = await forget_count_auxiliary_active_nodes(
                 connector, self.ctx.end_user_id
             )
-            release_ratio = (
-                self._released_count / active_count
-                if active_count and self._released_count
-                else 0.0
+
+            # 第一优先级：先清理执行前已经完全没有有效关系的核心节点。
+            budget = await self._core_clean(
+                budget, isolated_only=True, phase="isolated"
             )
-            auxiliary_budget = min(
-                math.ceil(auxiliary_active_count * release_ratio),
-                self._released_count,
-                AUXILIARY_MAX_PER_RUN,
-            )
-            auxiliary_remaining_budget = auxiliary_budget
-            if auxiliary_budget > 0:
-                auxiliary_remaining_budget = await self._auxiliary_clean(
-                    auxiliary_budget
+
+            # 第二优先级：辅助池按 created_at 分批软删除；每批之后重新寻找
+            # 因辅助端点失效而变成离散状态的核心节点。
+            auxiliary_budget = auxiliary_active_count if budget > 0 else 0
+            while budget > 0:
+                auxiliary_deleted = await self._auxiliary_clean_batch(
+                    min(self.BATCH_SIZE, budget)
+                )
+                if auxiliary_deleted == 0:
+                    break
+                budget = await self._core_clean(
+                    budget, isolated_only=True, phase="isolated"
+                )
+
+            # 第三优先级：辅助候选耗尽后，按保留的 G/T 公式清理普通核心
+            # 候选直到配额或候选耗尽。目前权重为 0*G + 1*T。
+            if budget > 0:
+                budget = await self._core_clean(
+                    budget, isolated_only=False, phase="fallback"
                 )
 
             final_count = await forget_count_active_nodes(
@@ -134,8 +144,16 @@ class ForgetService:
                 connector, self.ctx.end_user_id
             )
             net_active_change = active_count - final_count
+            budget = max(0, final_count - self.target_count)
+            release_ratio = (
+                self._released_count / active_count
+                if active_count and self._released_count
+                else 0.0
+            )
             no_candidate = (
-                self._released_count == 0 and self._core_candidate_query_empty
+                budget > 0
+                and self._released_count == 0
+                and self._core_candidate_query_empty
             )
 
             summary.update(
@@ -143,6 +161,8 @@ class ForgetService:
                     "deleted": self._released_count,
                     "scanned_count": self._scanned_count,
                     "node_type_counts": dict(self._node_type_counts),
+                    "isolated_deleted": self._isolated_released_count,
+                    "fallback_deleted": self._fallback_released_count,
                     "net_active_change": net_active_change,
                     "budget": max(budget, 0),
                     "final_count": final_count,
@@ -152,9 +172,10 @@ class ForgetService:
                     "auxiliary_budget": auxiliary_budget,
                     "auxiliary_deleted": self._auxiliary_released_count,
                     "auxiliary_remaining_budget": max(
-                        auxiliary_remaining_budget, 0
+                        auxiliary_budget - self._auxiliary_released_count, 0
                     ),
                     "auxiliary_final_count": auxiliary_final_count,
+                    "auxiliary_exhausted": self._auxiliary_candidate_query_empty,
                     "auxiliary_node_type_counts": dict(
                         self._auxiliary_node_type_counts
                     ),
@@ -184,7 +205,10 @@ class ForgetService:
         self._released_count = 0
         self._node_type_counts = defaultdict(int)
         self._core_candidate_query_empty = False
+        self._isolated_released_count = 0
+        self._fallback_released_count = 0
         self._auxiliary_released_count = 0
+        self._auxiliary_candidate_query_empty = False
         self._auxiliary_node_type_counts = defaultdict(int)
 
     def _initial_summary(self, active_count: int) -> dict[str, Any]:
@@ -204,6 +228,8 @@ class ForgetService:
             "deleted": 0,
             "scanned_count": 0,
             "node_type_counts": {},
+            "isolated_deleted": 0,
+            "fallback_deleted": 0,
             "net_active_change": 0,
             "budget": 0,
             "final_count": active_count,
@@ -214,12 +240,19 @@ class ForgetService:
             "auxiliary_deleted": 0,
             "auxiliary_remaining_budget": 0,
             "auxiliary_final_count": 0,
+            "auxiliary_exhausted": False,
             "auxiliary_node_type_counts": {},
             "release_ratio": 0.0,
         }
 
-    async def _mixed_clean(self, budget: int) -> int:
-        """按记忆价值从低到高清理核心池。
+    async def _core_clean(
+        self,
+        budget: int,
+        *,
+        isolated_only: bool,
+        phase: str,
+    ) -> int:
+        """按阶段清理核心池，并严格限制实际软删除数不超过预算。
 
         Args:
             budget: 本轮最多释放的核心节点数。
@@ -243,9 +276,11 @@ class ForgetService:
                 batch_size,
                 self.ENTITY_PROTECTION_THRESHOLD,
                 self.evaluated_at_ms,
+                isolated_only=isolated_only,
             )
             if not candidates:
-                self._core_candidate_query_empty = True
+                if not isolated_only:
+                    self._core_candidate_query_empty = True
                 break
 
             element_ids = [row["element_id"] for row in candidates]
@@ -257,6 +292,8 @@ class ForgetService:
                 self.ctx.end_user_id,
                 element_ids,
                 to_iso_z(now),
+                protection_threshold=self.ENTITY_PROTECTION_THRESHOLD,
+                require_isolated=isolated_only,
             )
             deleted_id_set = set(deleted_element_ids)
             deleted_rows = [
@@ -265,6 +302,10 @@ class ForgetService:
             deleted_in_batch = len(deleted_rows)
             total_deleted += deleted_in_batch
             self._released_count += deleted_in_batch
+            if phase == "isolated":
+                self._isolated_released_count += deleted_in_batch
+            else:
+                self._fallback_released_count += deleted_in_batch
             budget -= deleted_in_batch
 
             for row in deleted_rows:
@@ -273,8 +314,9 @@ class ForgetService:
                 audit.append(self._build_audit(row, now))
 
             logger.info(
-                "ForgetService core: batch=%d deleted=%d/%d remaining_budget=%d "
-                "types=%s",
+                "ForgetService core: phase=%s batch=%d deleted=%d/%d "
+                "remaining_budget=%d types=%s",
+                phase,
                 len(element_ids),
                 deleted_in_batch,
                 total_deleted,
@@ -307,66 +349,63 @@ class ForgetService:
         )
         return new_budget
 
-    async def _auxiliary_clean(self, budget: int) -> int:
-        """按创建时间从旧到新清理辅助池。
+    async def _auxiliary_clean_batch(self, batch_size: int) -> int:
+        """按创建时间从旧到新软删除一批辅助节点。
 
         Args:
-            budget: 根据核心池实际释放比例计算出的辅助池预算。
+            batch_size: 本批最多软删除的辅助节点数。
 
         Returns:
-            尚未使用的辅助池预算。
+            本批实际软删除数；返回 0 表示辅助候选已耗尽或写入未生效。
         """
-        if budget <= 0:
-            return budget
+        if batch_size <= 0:
+            return 0
         connector = self._connector
         if connector is None:
             raise RuntimeError("ForgetService connector is not initialized")
 
+        candidates = await forget_get_auxiliary_candidates(
+            connector,
+            self.ctx.end_user_id,
+            batch_size,
+            DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
+        )
+        if not candidates:
+            self._auxiliary_candidate_query_empty = True
+            return 0
+
+        element_ids = [row["element_id"] for row in candidates]
+        now = utcnow()
+        deleted_element_ids = await forget_soft_delete_by_element_ids(
+            connector,
+            self.ctx.end_user_id,
+            element_ids,
+            to_iso_z(now),
+            protection_threshold=self.ENTITY_PROTECTION_THRESHOLD,
+            require_isolated=False,
+        )
+        deleted_id_set = set(deleted_element_ids)
+        deleted_rows = [
+            row for row in candidates if row["element_id"] in deleted_id_set
+        ]
+        deleted_in_batch = len(deleted_rows)
+        self._auxiliary_released_count += deleted_in_batch
+
         audit: list[ForgetLog] = []
-        while budget > 0:
-            batch_size = min(self.BATCH_SIZE, budget)
-            candidates = await forget_get_auxiliary_candidates(
-                connector,
-                self.ctx.end_user_id,
-                batch_size,
-                DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
-            )
-            if not candidates:
-                break
-
-            element_ids = [row["element_id"] for row in candidates]
-            now = utcnow()
-            deleted_element_ids = await forget_soft_delete_by_element_ids(
-                connector,
-                self.ctx.end_user_id,
-                element_ids,
-                to_iso_z(now),
-            )
-            deleted_id_set = set(deleted_element_ids)
-            deleted_rows = [
-                row for row in candidates if row["element_id"] in deleted_id_set
-            ]
-            deleted_in_batch = len(deleted_rows)
-            self._auxiliary_released_count += deleted_in_batch
-            budget -= deleted_in_batch
-
-            for row in deleted_rows:
-                node_type = row.get("node_type", "unknown")
-                self._auxiliary_node_type_counts[node_type] += 1
-                audit.append(self._build_audit(row, now))
-            logger.info(
-                "ForgetService auxiliary: batch=%d deleted=%d remaining_budget=%d "
-                "types=%s",
-                len(element_ids),
-                deleted_in_batch,
-                budget,
-                dict(self._auxiliary_node_type_counts),
-            )
-            if deleted_in_batch < len(element_ids):
-                break
-
+        for row in deleted_rows:
+            node_type = row.get("node_type", "unknown")
+            self._auxiliary_node_type_counts[node_type] += 1
+            audit.append(self._build_audit(row, now))
         self._sync_audit(audit)
-        return budget
+        logger.info(
+            "ForgetService auxiliary: batch=%d deleted=%d total_deleted=%d "
+            "types=%s",
+            len(element_ids),
+            deleted_in_batch,
+            self._auxiliary_released_count,
+            dict(self._auxiliary_node_type_counts),
+        )
+        return deleted_in_batch
 
     def _build_audit(self, row: dict[str, Any], now: datetime) -> ForgetLog:
         """把一个实际软删除的 Neo4j 节点转换为 PostgreSQL 审计记录。"""

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -4,6 +4,8 @@ from app.core.memory.constants.graph_data_constants import (
     _DEFAULT_FIELDS,
 )
 from app.core.memory.constants.value_weight_constants import (
+    FORGET_CORE_G_WEIGHT,
+    FORGET_CORE_T_WEIGHT,
     G_WEIGHT,
     T_CYPHER_EXPR,
     T_WEIGHT,
@@ -3138,7 +3140,33 @@ FORGET_SOFT_DELETE_BY_ELEMENT_IDS = """
     MATCH (n {end_user_id: $end_user_id})
     WHERE n.delete_at IS NULL
       AND elementId(n) IN $element_ids
+      AND (n:Statement OR n:Chunk OR n:ExtractedEntity OR n:MemorySummary OR n:Dialogue)
       AND (NOT n:Statement OR coalesce(n.is_permanent, false) = false)
+      AND (NOT n:ExtractedEntity OR (
+          coalesce(n.extraction_count, 0) < $protection_threshold
+          AND n.name <> '用户'
+      ))
+      AND (
+          NOT (n:Statement OR n:Chunk OR n:ExtractedEntity) OR (
+              n.topology_score IS NOT NULL
+              AND (
+                  toFloat(n.topology_score) IS NULL
+                  OR isNaN(toFloat(n.topology_score))
+                  OR toFloat(n.topology_score) < 1.0
+              )
+          )
+      )
+      AND (
+          NOT $require_isolated OR (
+              (n:Statement OR n:Chunk OR n:ExtractedEntity)
+              AND NOT EXISTS {
+                  MATCH (n)--(related)
+                  WHERE related <> n
+                    AND related.end_user_id = $end_user_id
+                    AND related.delete_at IS NULL
+              }
+          )
+      )
     SET n.delete_at = datetime($now)
     RETURN collect(elementId(n)) AS deleted_element_ids
 """
@@ -3158,6 +3186,14 @@ CALL () {{
     MATCH (c:Chunk {{end_user_id: $end_user_id}})
     WHERE c.delete_at IS NULL
       AND c.topology_score IS NOT NULL
+      AND (
+          NOT $isolated_only OR NOT EXISTS {{
+              MATCH (c)--(related)
+              WHERE related <> c
+                AND related.end_user_id = $end_user_id
+                AND related.delete_at IS NULL
+          }}
+      )
     WITH c, elementId(c) AS element_id,
          CASE
            WHEN coalesce(toString(c.created_at) =~ $iso_datetime_pattern, false)
@@ -3172,9 +3208,11 @@ CALL () {{
            WHEN raw_g > 1.0 THEN 1.0
            ELSE raw_g
          END AS g
+    WITH c, element_id, created_epoch, g
+    WHERE g < 1.0
     WITH c, element_id, created_epoch, g, {T_CYPHER_EXPR} AS t
     WITH c, element_id, created_epoch,
-         {G_WEIGHT} * g + {T_WEIGHT} * t AS forgetting_activation
+         {FORGET_CORE_G_WEIGHT} * g + {FORGET_CORE_T_WEIGHT} * t AS forgetting_activation
     RETURN 'Chunk' AS node_type, element_id, coalesce(c.content, '') AS content,
            forgetting_activation, created_epoch
     ORDER BY forgetting_activation ASC, created_epoch ASC, element_id ASC
@@ -3186,6 +3224,14 @@ CALL () {{
     WHERE s.delete_at IS NULL
       AND coalesce(s.is_permanent, false) = false
       AND s.topology_score IS NOT NULL
+      AND (
+          NOT $isolated_only OR NOT EXISTS {{
+              MATCH (s)--(related)
+              WHERE related <> s
+                AND related.end_user_id = $end_user_id
+                AND related.delete_at IS NULL
+          }}
+      )
     WITH s, elementId(s) AS element_id,
          CASE
            WHEN coalesce(toString(s.created_at) =~ $iso_datetime_pattern, false)
@@ -3200,9 +3246,11 @@ CALL () {{
            WHEN raw_g > 1.0 THEN 1.0
            ELSE raw_g
          END AS g
+    WITH s, element_id, created_epoch, g
+    WHERE g < 1.0
     WITH s, element_id, created_epoch, g, {T_CYPHER_EXPR} AS t
     WITH s, element_id, created_epoch,
-         {G_WEIGHT} * g + {T_WEIGHT} * t AS forgetting_activation
+         {FORGET_CORE_G_WEIGHT} * g + {FORGET_CORE_T_WEIGHT} * t AS forgetting_activation
     RETURN 'Statement' AS node_type, element_id, coalesce(s.statement, '') AS content,
            forgetting_activation, created_epoch
     ORDER BY forgetting_activation ASC, created_epoch ASC, element_id ASC
@@ -3215,6 +3263,14 @@ CALL () {{
       AND coalesce(e.extraction_count, 0) < $protection_threshold
       AND e.name <> '用户'
       AND e.topology_score IS NOT NULL
+      AND (
+          NOT $isolated_only OR NOT EXISTS {{
+              MATCH (e)--(related)
+              WHERE related <> e
+                AND related.end_user_id = $end_user_id
+                AND related.delete_at IS NULL
+          }}
+      )
     WITH e, elementId(e) AS element_id,
          CASE
            WHEN coalesce(toString(e.created_at) =~ $iso_datetime_pattern, false)
@@ -3229,9 +3285,11 @@ CALL () {{
            WHEN raw_g > 1.0 THEN 1.0
            ELSE raw_g
          END AS g
+    WITH e, element_id, created_epoch, g
+    WHERE g < 1.0
     WITH e, element_id, created_epoch, g, {T_CYPHER_EXPR} AS t
     WITH e, element_id, created_epoch,
-         {G_WEIGHT} * g + {T_WEIGHT} * t AS forgetting_activation
+         {FORGET_CORE_G_WEIGHT} * g + {FORGET_CORE_T_WEIGHT} * t AS forgetting_activation
     RETURN 'ExtractedEntity' AS node_type, element_id, coalesce(e.name, '') AS content,
            forgetting_activation, created_epoch
     ORDER BY forgetting_activation ASC, created_epoch ASC, element_id ASC

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -1159,8 +1159,10 @@ async def forget_get_core_candidates(
         batch_size: int,
         protection_threshold: int,
         evaluated_at_ms: int,
+        *,
+        isolated_only: bool = False,
 ) -> list[dict[str, Any]]:
-    """Return active core candidates ordered by low memory value."""
+    """Return protected core candidates ordered by the configured G/T formula."""
     from app.repositories.neo4j.cypher_queries import FORGET_CORE_CANDIDATES
     return await connector.execute_query(
         FORGET_CORE_CANDIDATES,
@@ -1168,6 +1170,7 @@ async def forget_get_core_candidates(
         batch_size=batch_size,
         protection_threshold=protection_threshold,
         evaluated_at_ms=evaluated_at_ms,
+        isolated_only=isolated_only,
         iso_datetime_pattern=FORGET_ISO_DATETIME_PATTERN,
     )
 
@@ -1207,14 +1210,19 @@ async def forget_soft_delete_by_element_ids(
         end_user_id: str,
         element_ids: list[str],
         now: str,
+        *,
+        protection_threshold: int,
+        require_isolated: bool = False,
 ) -> list[str]:
-    """软删除指定节点并返回实际被删除的 element ID。"""
+    """复检节点类型及保护规则后软删除，并返回实际删除的 element ID。"""
     from app.repositories.neo4j.cypher_queries import FORGET_SOFT_DELETE_BY_ELEMENT_IDS
     result = await connector.execute_query(
         FORGET_SOFT_DELETE_BY_ELEMENT_IDS,
         end_user_id=end_user_id,
         element_ids=element_ids,
         now=now,
+        protection_threshold=protection_threshold,
+        require_isolated=require_isolated,
     )
     if not result:
         return []

--- a/api/app/services/memory_forget_service.py
+++ b/api/app/services/memory_forget_service.py
@@ -10,7 +10,6 @@
 所有业务逻辑从控制器层分离到此服务层。
 """
 
-import math
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any, Tuple
 from uuid import UUID
@@ -21,7 +20,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.logging_config import get_api_logger
 from app.core.memory.storage_services.forgetting_engine.actr_calculator import ACTRCalculator
 from app.core.memory.storage_services.forgetting_engine.constants import (
-    AUXILIARY_MAX_PER_RUN,
     DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
 )
 from app.core.memory.storage_services.forgetting_engine.config_utils import (
@@ -1025,25 +1023,21 @@ async def compute_forgetting_candidates(end_user_id: str) -> list[dict]:
             return []
 
         evaluated_at_ms = to_timestamp_ms(utcnow_naive())
-        core_items = await forget_get_core_candidates(
+        isolated_items = await forget_get_core_candidates(
             conn,
             end_user_id,
             budget,
             protection_threshold=10,
             evaluated_at_ms=evaluated_at_ms,
+            isolated_only=True,
         )
-        planned_core_deleted = min(len(core_items), budget)
+        remaining_budget = max(0, budget - len(isolated_items))
         auxiliary_active_count = await forget_count_auxiliary_active_nodes(
             conn, end_user_id
         )
-        release_ratio = (
-            planned_core_deleted / active_count if planned_core_deleted else 0.0
-        )
-        auxiliary_budget = min(
-            math.ceil(auxiliary_active_count * release_ratio),
-            planned_core_deleted,
-            AUXILIARY_MAX_PER_RUN,
-        )
+        # 预览无法模拟辅助节点软删除后的图断开结果，只展示下一阶段将按
+        # created_at 处理的辅助候选；辅助池为空时再展示时间价值兜底候选。
+        auxiliary_budget = min(auxiliary_active_count, remaining_budget)
         auxiliary_items = (
             await forget_get_auxiliary_candidates(
                 conn,
@@ -1052,6 +1046,18 @@ async def compute_forgetting_candidates(end_user_id: str) -> list[dict]:
                 content_max_len=DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
             )
             if auxiliary_budget > 0
+            else []
+        )
+        fallback_items = (
+            await forget_get_core_candidates(
+                conn,
+                end_user_id,
+                remaining_budget,
+                protection_threshold=10,
+                evaluated_at_ms=evaluated_at_ms,
+                isolated_only=False,
+            )
+            if remaining_budget > 0 and not auxiliary_items
             else []
         )
 
@@ -1063,7 +1069,7 @@ async def compute_forgetting_candidates(end_user_id: str) -> list[dict]:
             "content": item.get("content") or "",
             "forgetting_activation": item.get("forgetting_activation"),
         }
-        for item in core_items[:budget]
+        for item in (isolated_items + fallback_items)[:budget]
     ]
     auxiliary_preview = [
         {


### PR DESCRIPTION
Refines the memory forgetting flow:

- Prioritizes isolated core nodes for soft deletion
- Deletes auxiliary nodes by `created_at` and re-evaluates disconnected core nodes
- Uses time-based ranking as the fallback while preserving protected nodes
- Calculates the target quota from the forgetting ratio and retains audit records

## Sourcery 摘要

优化记忆遗忘优先级，使其在保留受保护节点和删除审计记录的同时，逐步达到配置的保留配额。

Bug 修复：
- 调整记忆遗忘逻辑，优先处理孤立的核心节点，并在移除辅助节点后重新评估核心节点的连通性。

增强功能：
- 使用遗忘比例计算目标活跃记忆配额，并在不超出该配额的前提下执行删除预算。
- 在辅助节点候选项耗尽后，回退到按时间排序删除核心节点，同时保留受保护节点。
- 扩展遗忘摘要和预览，加入孤立节点、回退处理、辅助节点耗尽和配额信息。

杂项：
- 在修订后的遗忘流程中，保留所有实际被软删除节点的审计记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine memory forgetting priorities to converge on the configured retention quota while preserving protected nodes and deletion audits.

Bug Fixes:
- Adjust memory forgetting to prioritize isolated core nodes and re-evaluate core connectivity after auxiliary nodes are removed.

Enhancements:
- Use the forgetting ratio to calculate the target active-memory quota and enforce deletion budgets without exceeding it.
- Fall back to time-ranked core-node deletion after auxiliary candidates are exhausted while preserving protected nodes.
- Expand forgetting summaries and previews with isolated, fallback, auxiliary-exhaustion, and quota information.

Chores:
- Retain audit records for all nodes actually soft-deleted during the revised forgetting flow.

</details>