### PR TITLE
Feature/message replace zy

### DIFF
--- a/web/src/components/Chat/ChatContent.tsx
+++ b/web/src/components/Chat/ChatContent.tsx
@@ -235,6 +235,7 @@ const ChatContent: FC<ChatContentProps> = ({
           const shouldShowMemoryRecall = hasMemoryRecall && (!isActiveStream || showMemoryRecall)
           const shouldShowStreamSpinner = isActiveStream && item?.content === '' && !renderRuntime && !shouldShowMemoryRecall
           if (!item) return null
+          const outputs = item.meta_data?.outputs?.filter(output => output.content && output.content.trim() !== '')
           return (
             <div key={index} className={clsx("rb:relative", {
               'rb:mt-6': index !== 0, // Add top margin for non-first messages
@@ -331,9 +332,9 @@ const ChatContent: FC<ChatContentProps> = ({
                         )}
                         {/* Render message content using Markdown component */}
                         {/* 一问多答区分展示 */}
-                        {item.meta_data?.outputs && item.meta_data?.outputs?.length > 1
+                        {outputs && outputs?.length > 1
                           ? <Flex vertical gap={8} align="start">
-                            {item.meta_data?.outputs?.map((output, idx: number) => (
+                            {outputs?.map((output, idx: number) => (
                               <div key={idx} className="rb:bg-[#F6F6F6] rb:rounded-xl rb:px-3 rb:pt-2.5 rb:pb-0.5">
                                 <div className="rb:text-[#5B6167] rb:text-[12px] rb:mb-3">{t('application.reply')} {idx + 1}</div>
                                 <Markdown

--- a/web/src/components/Chat/utils/messageOutputs.ts
+++ b/web/src/components/Chat/utils/messageOutputs.ts
@@ -40,6 +40,40 @@ export const appendOutputByNodeId = (
   })
 }
 
+/**
+ * message_replace event: replaces one node output when node_id is present.
+ * Without node_id, replaces the complete response and clears segmented outputs.
+ */
+export const replaceOutputByNodeId = (
+  prev: ChatList,
+  node_id?: string,
+  content: string = '',
+): ChatList =>
+  mapLastVersion(prev, (current) => {
+    if (current?.role !== 'assistant') return current
+    if (!node_id) {
+      return {
+        ...current,
+        content,
+        meta_data: { ...(current.meta_data || {}), outputs: undefined },
+      }
+    }
+
+    const outputs = [...(current.meta_data?.outputs || [])]
+    const outputIndex = outputs.findIndex(output => output.node_id === node_id)
+    if (outputIndex < 0) {
+      outputs.push({ node_id, content, status: 'running' })
+    } else {
+      outputs[outputIndex] = { ...outputs[outputIndex], content }
+    }
+
+    return {
+      ...current,
+      content: outputs.length === 1 ? outputs[0].content : current.content,
+      meta_data: { ...(current.meta_data || {}), outputs },
+    }
+  })
+
 /** On stream end, marks any still-running outputs segments of the last assistant message as success. */
 export const finalizeOutputs = (prev: ChatList): ChatList =>
   mapLastVersion(prev, (current) => {

--- a/web/src/i18n/en/applicationPart1.ts
+++ b/web/src/i18n/en/applicationPart1.ts
@@ -381,8 +381,6 @@ export const applicationPart1 = {
       add_questions: 'Add Option',
       citation: 'Citation and Attribution',
       citation_desc: 'Display the attribution of source documents and generated content',
-      multi_answer_mode: 'Multi-answer Reply',
-      multi_answer_mode_desc: 'Display content from multiple output nodes as separate segments within a single reply',
       allow_download: 'Allow downloading cited source text',
       invalidVariablesTitle: "The following undefined variables are referenced in the conversation opening. Do you want to save the opening configuration?",
       deep_thinking: 'Enable Deep Thinking',

--- a/web/src/i18n/zh/applicationPart1.ts
+++ b/web/src/i18n/zh/applicationPart1.ts
@@ -378,8 +378,6 @@ export const applicationPart1 = {
       add_questions: '添加选项',
       citation: '引用和归属',
       citation_desc: '显示源文档和生成内容的归属部分',
-      multi_answer_mode: '一问多答',
-      multi_answer_mode_desc: '同一次回答中，多个输出节点的内容分段展示',
       allow_download: '允许下载引用原文',
       invalidVariablesTitle: "对话开场白中引用了以下未定义的变量，是否保存开场白配置？",
       deep_thinking: '开启深度思考',

--- a/web/src/views/ApplicationConfig/TestChat/helpers.ts
+++ b/web/src/views/ApplicationConfig/TestChat/helpers.ts
@@ -283,12 +283,6 @@ export const addRunEndMessage = (prev: ChatList, data: any): ChatList => {
 export const appendWorkflowContent = (prev: ChatList, content: string): ChatList =>
   mapLastVersion(prev, (current) => ({ ...current, content: current.content + content }))
 
-/**
- * message_replace event: replaces the last assistant message content wholesale.
- */
-export const replaceWorkflowContent = (prev: ChatList, content: string): ChatList =>
-  mapLastVersion(prev, (current) => ({ ...current, content, meta_data: { ...(current.meta_data || {}), outputs: undefined } }))
-
 export const appendWorkflowIntervention = (
   prev: ChatList,
   data: Pick<NodeData, 'execution_id' | 'node_id' | 'node_name' | 'rendered_content' | 'form_fields' | 'actions' | 'timeout_at'>,

--- a/web/src/views/ApplicationConfig/TestChat/streamHandlers.ts
+++ b/web/src/views/ApplicationConfig/TestChat/streamHandlers.ts
@@ -13,7 +13,6 @@ import {
   applyMessageId,
   applyUserMessageId,
   appendWorkflowContent,
-  replaceWorkflowContent,
   appendWorkflowIntervention,
   markWorkflowInterventionTimeout,
   mergeWorkflowAgentLog,
@@ -26,6 +25,7 @@ import {
 import {
   appendOutputByNodeId as appendWorkflowOutputByNodeId,
   finalizeOutputs as finalizeWorkflowOutputs,
+  replaceOutputByNodeId as replaceWorkflowOutputByNodeId,
 } from '@/components/Chat/utils/messageOutputs'
 
 type SetChatList = Dispatch<SetStateAction<Array<ChatItem | ChatItem[]>>>
@@ -183,9 +183,9 @@ export const createWorkflowStreamHandler = (deps: WorkflowStreamDeps) => {
           setChatList(prev => appendWorkflowContent(prev, content))
           setChatList(prev => appendWorkflowOutputByNodeId(prev, node_id, content))
           break
-        // Replace the assistant message content wholesale and drop the segmented outputs
+        // Replace one node output, or replace the complete response when node_id is absent
         case 'message_replace':
-          setChatList(prev => replaceWorkflowContent(prev, content))
+          setChatList(prev => replaceWorkflowOutputByNodeId(prev, node_id, content))
           break
         case 'intervention_required':
           setChatList(prev => appendWorkflowIntervention(prev, {

--- a/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
+++ b/web/src/views/ApplicationConfig/components/FeaturesConfig/FeaturesConfigModal.tsx
@@ -237,13 +237,6 @@ const FeaturesConfigModal = forwardRef<FeaturesConfigModalRef, FeaturesConfigMod
                 <Button block onClick={() => handleSwitchContentModeration(true)}>{t('application.setting')}</Button>
               </>}
               </div>
-              <div className="rb:relative rb:border rb:border-[#DFE4ED] rb:p-3 rb:rounded-lg rb:bg-[#f5f7fc]">
-                <SwitchFormItem
-                  title={t('application.multi_answer_mode')}
-                  name={['multi_answer_mode', "enabled"]}
-                  desc={t('application.multi_answer_mode_desc')}
-                />
-              </div>
             </>}
 
             <div className="rb:relative rb:border rb:border-[#DFE4ED] rb:p-3 rb:rounded-lg rb:bg-[#f5f7fc]">

--- a/web/src/views/ApplicationConfig/types/features.ts
+++ b/web/src/views/ApplicationConfig/types/features.ts
@@ -77,9 +77,6 @@ export type FeaturesConfigForm = {
     search_engine: string | null;
   };
   sensitive_word_avoidance: ContentModerationConfig;
-  multi_answer_mode: {
-    enabled: boolean;
-  };
 }
 
 /**

--- a/web/src/views/Conversation/utils/chatConfig.ts
+++ b/web/src/views/Conversation/utils/chatConfig.ts
@@ -47,6 +47,7 @@ export const buildSharedChatProps = (ctx: ConversationCtx) => {
     deleteMsg: isSupportTools ? deleteMessage : undefined,
     reportMsg: isSupportTools ? reportMsg : undefined,
     regenerateMessages: isSupportTools ? regenerateMessages : undefined,
+    regenerateMaxCount: 5,
     handleVersionChange: isSupportTools ? handleVersionChange : undefined,
     handleInterventionActionClick,
   } satisfies Partial<ChatProps>

--- a/web/src/views/Conversation/utils/streamHandlers.ts
+++ b/web/src/views/Conversation/utils/streamHandlers.ts
@@ -5,7 +5,11 @@
  */
 import { type SSEMessage } from '@/utils/stream'
 import type { ChatItem, MemoryTraceEvent, MemoryTraceEventData } from '@/components/Chat/types'
-import { appendOutputByNodeId, finalizeOutputs } from '@/components/Chat/utils/messageOutputs'
+import {
+  appendOutputByNodeId,
+  finalizeOutputs,
+  replaceOutputByNodeId,
+} from '@/components/Chat/utils/messageOutputs'
 import type { StreamData } from '../types';
 
 /** start/node_start event: backfills the most recent user message's id with the real user_message_id */
@@ -236,7 +240,11 @@ export const createSendStreamHandler = (deps: StreamHandlerDeps) => {
           if (curId) currentConversationId = curId;
           break
         case 'message_replace':
-          updateAssistantMessage(content, audio_url, audio_url ? 'pending' : undefined, undefined, undefined, undefined, undefined, true)
+          if (streamLoadingRef.current) streamLoadingRef.current = false
+          setChatList(prev => replaceOutputByNodeId(prev, node_id, content))
+          if (audio_url) {
+            updateAssistantMessage('', audio_url, 'pending')
+          }
           if (curId) currentConversationId = curId;
           break
         case 'intervention_required': {
@@ -340,7 +348,11 @@ export const createRegenerateStreamHandler = (deps: StreamHandlerDeps & { messag
           if (curId) currentConversationId = curId;
           break
         case 'message_replace':
-          updateAssistantMessage(content, audio_url, audio_url ? 'pending' : undefined, undefined, undefined, undefined, messageId, true)
+          if (streamLoadingRef.current) streamLoadingRef.current = false
+          setChatList(prev => replaceOutputByNodeId(prev, node_id, content))
+          if (audio_url) {
+            updateAssistantMessage('', audio_url, 'pending', undefined, undefined, undefined, messageId)
+          }
           if (curId) currentConversationId = curId;
           break
         case 'intervention_required': {

--- a/web/src/views/Workflow/components/Chat/Chat.tsx
+++ b/web/src/views/Workflow/components/Chat/Chat.tsx
@@ -50,6 +50,7 @@ import ReportModal from '@/components/Chat/ReportModal'
 import type { ReportModalRef } from '@/views/Conversation/types'
 import { createWorkflowStreamHandler } from './streamHandler'
 import type { Data } from './types'
+import { replaceOutputByNodeId } from '@/components/Chat/utils/messageOutputs'
 import {
   flattenChatList,
   mapLastVersion,
@@ -204,17 +205,10 @@ const Chat = forwardRef<ChatRef, ChatProps>(({
   }, [])
 
   /**
-   * Replaces the last assistant message content
+   * Replaces the complete response or the response produced by a specific node.
    */
-  const replaceStreamContent = useCallback((content: string) => {
-    setChatList(prev => mapLastVersion(prev, (current) => ({
-      ...current,
-      content,
-      meta_data: {
-        ...(current.meta_data || {}),
-        outputs: undefined
-      }
-    })))
+  const replaceStreamContent = useCallback((content: string, nodeId?: string) => {
+    setChatList(prev => replaceOutputByNodeId(prev, nodeId, content))
   }, [])
 
   /**

--- a/web/src/views/Workflow/components/Chat/streamHandler.ts
+++ b/web/src/views/Workflow/components/Chat/streamHandler.ts
@@ -14,7 +14,7 @@ export interface WorkflowStreamDeps {
   executionId: string | null;
   getNodeContext: (node_id: string) => NodeContext;
   appendStreamContent: (content: string) => void;
-  replaceStreamContent: (content: string) => void;
+  replaceStreamContent: (content: string, nodeId?: string) => void;
   setChatList: React.Dispatch<React.SetStateAction<Array<ChatItem | ChatItem[]>>>;
   setStreamLoading: (loading: boolean) => void;
   setLoading: (loading: boolean) => void;
@@ -51,7 +51,7 @@ export const createWorkflowStreamHandler = (deps: WorkflowStreamDeps) => {
       const payload = item.data as StreamEventData
       const { event } = item
       const { conversation_id, message_id, user_message_id } = payload
-      const ctx = getNodeContext(payload.node_id)
+      const ctx = payload.node_id ? getNodeContext(payload.node_id) : {}
 
       switch (event) {
         case 'workflow_start': {
@@ -82,7 +82,7 @@ export const createWorkflowStreamHandler = (deps: WorkflowStreamDeps) => {
           setChatList(prev => appendOutputByNodeId(prev, payload.node_id, payload.content))
           break
         case 'message_replace':
-          replaceStreamContent(payload.content)
+          replaceStreamContent(payload.content, payload.node_id)
           break
         case 'intervention_required': {
           const { name, icon, type } = ctx

--- a/web/src/views/Workflow/components/Chat/types.ts
+++ b/web/src/views/Workflow/components/Chat/types.ts
@@ -18,7 +18,7 @@ export type StreamEventData = {
   conversation_id: string | null;
   cycle_id: string;
   cycle_idx: number;
-  node_id: string;
+  node_id?: string;
   node_name?: string;
   node_type?: string;
   process?: any;


### PR DESCRIPTION
## Sourcery 摘要

更新消息替换处理，以支持节点特定的响应，同时简化多答案配置并改进对话重新生成行为。

新功能：
- 支持在消息替换事件中替换单个工作流节点的输出，或替换完整的助手响应。
- 当替换事件包含音频内容时，保留音频播放处理。
- 允许不包含节点标识符的流式替换事件。

错误修复：
- 防止将空的分段输出渲染为单独的回复。

改进：
- 在对话、工作流和测试聊天的流式处理中，集中处理面向节点的输出替换。
- 从应用设置和类型中移除可配置的多答案回复功能。
- 将对话重新生成次数上限设置为五次。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update message replacement handling to support node-specific responses while simplifying multi-answer configuration and improving conversation regeneration behavior.

New Features:
- Support replacing either an individual workflow node output or the complete assistant response for message replacement events.
- Preserve audio playback handling when replacement events include audio content.
- Allow stream replacement events without a node identifier.

Bug Fixes:
- Prevent empty segmented outputs from being rendered as separate replies.

Enhancements:
- Centralize node-aware output replacement across conversation, workflow, and test-chat stream handling.
- Remove the configurable multi-answer reply feature from application settings and types.
- Set the conversation regeneration limit to five attempts.

</details>