### PR TITLE
feat(memory): Add retrieval observability to the Memory Retrieval page

### DIFF
--- a/api/app/controllers/memory_controller.py
+++ b/api/app/controllers/memory_controller.py
@@ -6,14 +6,15 @@
 路由前缀: /memory
 认证方式: JWT Token
 """
-import html
+import uuid
 
 from fastapi import APIRouter, Depends, Header
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse, StreamingResponse
 
-from app.core.error_codes import BizCode
+from app.core.error_codes import BizCode, HTTP_MAPPING
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
-from app.core.memory.enums import Neo4jNodeType, SearchStrategy
 from app.core.memory.memory_service import MemoryService
 from app.core.response_utils import fail, success
 from app.db import get_async_db_context
@@ -24,7 +25,7 @@ from app.schemas.response_schema import ApiResponse
 from app.services import workspace_service
 from app.services.memory_agent_service import MemoryAgentService
 from app.services.memory_config_service import MemoryConfigService
-from app.utils.tmp_session import ChatSessionCache
+from app.services.memory_validation_service import MemoryValidationService
 
 DEFAULT_STORAGE_TYPE = "neo4j"
 USER_RAG_MEMORY_KNOWLEDGE_NAME = "USER_RAG_MERORY"  # 注：原拼写保留，历史遗留
@@ -118,121 +119,55 @@ async def write_server_async(
         return fail(BizCode.INTERNAL_ERROR, "写入失败", str(e))
 
 
-@router.post("/read/sync", response_model=ApiResponse)
+@router.post("/read/sync", response_model=None)
 @cur_workspace_access_guard_self_db()
 async def read_server(
         user_input: UserInput,
         current_user: CurrentUserSnapshot = Depends(get_current_user_async)
-):
+) -> StreamingResponse | JSONResponse:
     """
-    Read service endpoint - processes read operations synchronously
+    记忆验证读取接口：请求保持不变，响应改为 SSE。
 
     search_switch values:
-    - "0": Requires verification
-    - "1": No verification, direct split
-    - "2": Direct answer based on context
+    - "0": Deep
+    - "1": Normal
+    - "2": Quick
+    - "5": Express
     """
-    config_id = user_input.config_id
-    workspace_id = current_user.current_workspace_id
-
-    async with get_async_db_context() as db:
-        storage_type = await workspace_service.get_workspace_storage_type_async(
-            db=db, workspace_id=workspace_id, user=current_user
+    request_id = str(uuid.uuid4())
+    try:
+        # 开流前完成参数和服务初始化，失败时仍返回普通 JSON 错误。
+        validation_service = await MemoryValidationService.create(
+            user_input,
+            request_id=request_id,
         )
-        if storage_type is None:
-            storage_type = DEFAULT_STORAGE_TYPE
-        user_rag_memory_id = ''
-        memory_config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(user_input.end_user_id)
-        if workspace_id:
-            knowledge = await knowledge_repository.get_knowledge_by_name_async(
-                db=db, name=USER_RAG_MEMORY_KNOWLEDGE_NAME, workspace_id=workspace_id,
-            )
-            if knowledge:
-                user_rag_memory_id = str(knowledge.id)
-
-    session_id = user_input.session_id.hex
+    except Exception as error:
+        api_logger.error(
+            "Unable to initialize memory read: request_id=%s, end_user=%s, error=%s",
+            request_id,
+            user_input.end_user_id,
+            str(error),
+            exc_info=True,
+        )
+        error_data = fail(BizCode.MEMORY_READ_FAILED, "回复对话消息失败")
+        return JSONResponse(
+            status_code=HTTP_MAPPING[BizCode.MEMORY_READ_FAILED],
+            content=jsonable_encoder(error_data),
+        )
 
     api_logger.info(
-        f"Read service: group={user_input.end_user_id}, storage_type={storage_type}, user_rag_memory_id={user_rag_memory_id}, workspace_id={workspace_id}, session_id={session_id}")
-    try:
-        service = await MemoryService.create(
-            memory_config_id,
-            end_user_id=user_input.end_user_id,
-            draft=True
-        )
-        session_cache = ChatSessionCache(session_id)
-        search_result = await service.read(
-            user_input.message,
-            SearchStrategy(user_input.search_switch),
-            history=await session_cache.get_history(),
-        )
-        intermediate_outputs = []
-        sub_queries = set()
-        for memory in search_result.memories:
-            sub_queries.add(str(memory.query))
-        idx = 0
-        if user_input.search_switch in [SearchStrategy.DEEP, SearchStrategy.NORMAL]:
-            intermediate_outputs.append({
-                "type": "problem_split",
-                "title": "问题拆分",
-                "data": [
-                    {
-                        "id": f"Q{(idx := idx + 1)}",
-                        "question": question
-                    }
-                    for question in sub_queries
-                    if question
-                ]
-            })
-        perceptual_data = [
-            memory.data
-            for memory in search_result.memories
-            if memory.source == Neo4jNodeType.PERCEPTUAL
-        ]
-
-        if len(perceptual_data):
-            intermediate_outputs.append({
-                "type": "perceptual_retrieve",
-                "title": "感知记忆检索",
-                "data": perceptual_data,
-                "total": len(perceptual_data),
-            })
-        intermediate_outputs.append({
-            "type": "search_result",
-            "title": f"合并检索结果 (共{len(sub_queries)}个查询,{len(search_result.memories)}条结果)",
-            "result": search_result.content,
-            "raw_result": search_result.memories,
-            "total": len(search_result.memories),
-        })
-        answer = await memory_agent_service.generate_summary_from_retrieve(
-            end_user_id=user_input.end_user_id,
-            retrieve_info=search_result.content,
-            history=[],
-            query=user_input.message,
-            config_id=config_id,
-        )
-        await session_cache.append_many(
-            [
-                {"role": "user", "content": user_input.message},
-                {"role": "assistant", "content": answer}
-            ]
-        )
-        for _ in intermediate_outputs:
-            if _["type"] == "search_result":
-                _["result"] = html.escape(_["result"])
-        result = {
-            'answer': answer,
-            "intermediate_outputs": intermediate_outputs,
-            "session_id": session_id,
-        }
-
-        return success(data=result, msg="回复对话消息成功")
-    except BaseException as e:
-        # Handle ExceptionGroup from TaskGroup (Python 3.11+) or BaseExceptionGroup
-        if hasattr(e, 'exceptions'):
-            error_messages = [f"{type(sub_e).__name__}: {str(sub_e)}" for sub_e in e.exceptions]
-            detailed_error = "; ".join(error_messages)
-            api_logger.error(f"Read operation error (TaskGroup): {detailed_error}", exc_info=True)
-            return fail(BizCode.INTERNAL_ERROR, "回复对话消息失败", detailed_error)
-        api_logger.error(f"Read operation error: {str(e)}", exc_info=True)
-        return fail(BizCode.INTERNAL_ERROR, "回复对话消息失败", str(e))
+        "Read service stream started: request_id=%s, group=%s, backend=%s, session_id=%s",
+        request_id,
+        user_input.end_user_id,
+        DEFAULT_STORAGE_TYPE,
+        validation_service.session_id,
+    )
+    return StreamingResponse(
+        validation_service.stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -5,6 +5,10 @@ from typing import Self
 from pydantic import BaseModel, Field, field_serializer, ConfigDict, computed_field
 
 from app.core.memory.enums import Neo4jNodeType, StorageType
+from app.core.memory.retrieval_trace.models import (
+    RetrievalExecutionTrace,
+    RetrievalScoreTrace,
+)
 from app.schemas.memory_config_schema import MemoryConfig
 
 
@@ -43,6 +47,7 @@ class Memory(BaseModel):
     data: dict = Field(default_factory=dict)
     query: str = Field(...)
     id: str = Field(...)
+    retrieval_trace: RetrievalScoreTrace | None = Field(default=None, exclude=True)
 
     @field_serializer("source")
     def serialize_source(self, v) -> str:
@@ -78,6 +83,7 @@ class MemorySearchResult(BaseModel):
     memories: list[Memory]
     relations: list[RelationMemory] = Field(default_factory=list)
     content_str: str = Field(default="")
+    execution_trace: RetrievalExecutionTrace | None = Field(default=None, exclude=True)
 
     @property
     def content(self) -> str:

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -22,6 +22,7 @@ from app.core.memory.read_services.search_engine.content_search import (
     MetaSearchService
 )
 from app.core.memory.retrieval_trace.stage_events import emit_memory_stage
+from app.core.memory.retrieval_trace.models import RetrievalExecutionTrace
 from app.core.memory.retrieval_trace.stage_projection import (
     project_memory_items,
     project_profile_data,
@@ -67,6 +68,64 @@ def _safe_merge_results(
         elif isinstance(result, MemorySearchResult):
             merged = merged + result
     return merged
+
+
+def _aggregate_branch_status(statuses: list[str]) -> str:
+    if not statuses:
+        return "skipped"
+    if all(status == "skipped" for status in statuses):
+        return "skipped"
+    if all(status == "failed" for status in statuses):
+        return "failed"
+    if any(status in {"failed", "degraded"} for status in statuses):
+        return "degraded"
+    return "completed"
+
+
+def _merge_execution_traces(results: list, *, merged_count: int) -> RetrievalExecutionTrace:
+    """聚合多 Query 的执行状态，不参与结果合并和排序。"""
+    traces = [
+        result.execution_trace
+        for result in results
+        if isinstance(result, MemorySearchResult) and result.execution_trace is not None
+    ]
+    reasons = [reason for trace in traces for reason in trace.degraded_reasons]
+    has_failed_subquery = any(isinstance(result, Exception) for result in results)
+    if has_failed_subquery:
+        reasons.append("subquery_failed")
+    keyword_status = _aggregate_branch_status([trace.keyword_status for trace in traces])
+    semantic_status = _aggregate_branch_status([trace.semantic_status for trace in traces])
+    if has_failed_subquery:
+        keyword_status = "failed" if keyword_status == "skipped" else "degraded"
+        semantic_status = "failed" if semantic_status == "skipped" else "degraded"
+    return RetrievalExecutionTrace(
+        keyword_status=keyword_status,
+        semantic_status=semantic_status,
+        rerank_status=_aggregate_branch_status([trace.rerank_status for trace in traces]),
+        keyword_hit_count=sum(trace.keyword_hit_count for trace in traces),
+        semantic_hit_count=sum(trace.semantic_hit_count for trace in traces),
+        raw_hit_count=sum(trace.raw_hit_count for trace in traces),
+        merged_count=merged_count,
+        degraded_reasons=list(dict.fromkeys(reasons)),
+    )
+
+
+def _attach_matched_queries(final_result: MemorySearchResult, source_results: list) -> None:
+    """给最终保留候选补充命中 Query，不改变原有去重和合并语义。"""
+    query_map: dict[tuple[str, str], list[str]] = {}
+    for result in source_results:
+        if not isinstance(result, MemorySearchResult):
+            continue
+        for memory in result.memories:
+            if memory.query:
+                key = (memory.source.value, str(memory.id))
+                query_map.setdefault(key, []).append(str(memory.query))
+    for memory in final_result.memories:
+        trace = memory.retrieval_trace
+        if trace is None:
+            continue
+        key = (memory.source.value, str(memory.id))
+        trace.matched_queries = list(dict.fromkeys(query_map.get(key, trace.matched_queries)))
 
 
 class ReadPipeLine(ModelClientMixin, BasePipeline):
@@ -120,7 +179,19 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         self._run_started_at = started_at
         self._retrieval_operation_id = retrieval_operation_id or uuid.uuid4().hex
         self._notification_error = None
+        original_query = query
         query = QueryPreprocessor.process(query)
+        if search_switch in {
+            SearchStrategy.DEEP,
+            SearchStrategy.NORMAL,
+            SearchStrategy.QUICK,
+            SearchStrategy.EXPRESS,
+        }:
+            await self._emit_stage("query_preprocessed", {
+                "original_query": original_query[:2000],
+                "processed_query": query[:2000],
+                "will_split": search_switch in {SearchStrategy.DEEP, SearchStrategy.NORMAL},
+            })
         # 展示用主问题必须在 deep/normal 的问题拆分之前固定下来
         display_query = clean_query_for_display(query)
 
@@ -162,6 +233,14 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
 
         if self._notification_error is not None:
             await self._enqueue_retrieval_alert(self._notification_error)
+
+        if res.execution_trace is None:
+            res.execution_trace = RetrievalExecutionTrace()
+        res.execution_trace.original_query = original_query
+        res.execution_trace.processed_query = query
+        res.execution_trace.search_switch = search_switch.value
+        res.execution_trace.backend = self.ctx.storage_type.value
+        res.execution_trace.limit = limit
 
         return res
 
@@ -402,6 +481,11 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             on_error=self._record_retrieval_error,
         )
         hybrid_search_res.memories.sort(key=lambda item: item.score, reverse=True)
+        _attach_matched_queries(hybrid_search_res, hybrid_results)
+        hybrid_execution_trace = _merge_execution_traces(
+            hybrid_results,
+            merged_count=len(hybrid_search_res.memories),
+        )
         relation_res.relations = list(relation_res.relations)
         await self._emit_stage("hybrid_searched", {
             "hit_count": self._raw_memory_count(hybrid_results),
@@ -545,6 +629,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         await self._emit_stage("context_prepared", {"memory_count": len(results.memories)})
 
         combined = memory_l0 + results
+        combined.execution_trace = hybrid_execution_trace
         await self._emit_stage("result_ready", {
             "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 1,
             "total_count": len(combined.memories),
@@ -591,6 +676,11 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             on_error=self._record_retrieval_error,
         )
         results.memories.sort(key=lambda x: x.score, reverse=True)
+        _attach_matched_queries(results, all_results)
+        results.execution_trace = _merge_execution_traces(
+            all_results,
+            merged_count=len(results.memories),
+        )
         await self._emit_stage("hybrid_searched", {
             "hit_count": self._raw_memory_count(all_results),
             "memory_count": len(results.memories),
@@ -616,6 +706,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             )
         await self._emit_stage("context_prepared", {"memory_count": len(results.memories)})
         combined = memory_l0 + results
+        combined.execution_trace = results.execution_trace
         items = project_result_items(memory_l0, results, limit=5)
         await self._emit_stage("result_ready", {
             "duration_ms": self._elapsed_ms() if hasattr(self, "_elapsed_ms") else 1,
@@ -638,7 +729,14 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         search_service = await self._get_search_service(includes, need_embedder=False, need_llm=False)
         express_res = await search_service.keyword_search(query, limit)
         memory_l0 = await meta_task
-        return memory_l0 + express_res
+        profile = project_profile_data(memory_l0)
+        await self._emit_stage("profile_loaded", {
+            "has_profile": profile_has_content(profile),
+            "profile": profile,
+        })
+        combined = memory_l0 + express_res
+        combined.execution_trace = express_res.execution_trace
+        return combined
 
     async def _quick_read(
             self,
@@ -655,7 +753,14 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         )
         quick_res = await search_service.hybrid_search(query, limit)
         memory_l0 = await meta_task
-        return memory_l0 + quick_res
+        profile = project_profile_data(memory_l0)
+        await self._emit_stage("profile_loaded", {
+            "has_profile": profile_has_content(profile),
+            "profile": profile,
+        })
+        combined = memory_l0 + quick_res
+        combined.execution_trace = quick_res.execution_trace
+        return combined
 
     async def _conv_history(self) -> MemorySearchResult:
         service = HistorySearchService(self.ctx)

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -27,6 +27,13 @@ from app.core.memory.exceptions import (
     MemoryRetrievalStage,
 )
 from app.core.memory.prompt import prompt_manager
+from app.core.memory.retrieval_trace.models import (
+    RetrievalExecutionTrace,
+    build_score_trace,
+    diagnostic_fusion_score,
+    finite_or_none,
+    normalized_keyword_score,
+)
 from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
 from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
@@ -98,6 +105,38 @@ class Neo4jSearchService:
         self.entity_search_tool = make_entity_search_tool(self.ctx)
         self.user_source_lookup_tool = make_user_source_lookup_tool(self.ctx)
         self._user_source_looked_up_ids = set()
+
+    def _build_score_sidecar(
+            self,
+            keyword_results: dict,
+            embedding_results: dict,
+    ) -> dict[tuple[Neo4jNodeType, str], dict]:
+        """旁路保留关键词、语义分数，不修改原始召回记录和排序。"""
+        sidecar: dict[tuple[Neo4jNodeType, str], dict] = {}
+        for node_type in self.includes:
+            for record in keyword_results.get(node_type, []):
+                node_id = str(record.get("id") or "")
+                if not node_id:
+                    continue
+                item = sidecar.setdefault((node_type, node_id), {})
+                item["keyword_hit"] = True
+                item["keyword_score"] = normalized_keyword_score(
+                    record.get("score"), self.fulltext_score_threshold
+                )
+            for record in embedding_results.get(node_type, []):
+                node_id = str(record.get("id") or "")
+                if not node_id:
+                    continue
+                item = sidecar.setdefault((node_type, node_id), {})
+                item["semantic_hit"] = True
+                item["semantic_score"] = finite_or_none(record.get("score")) or 0.0
+        for item in sidecar.values():
+            item["fusion_score"] = diagnostic_fusion_score(
+                item.get("keyword_score", 0.0),
+                item.get("semantic_score", 0.0),
+                self.alpha,
+            )
+        return sidecar
 
     async def _keyword_search(
             self,
@@ -181,7 +220,8 @@ class Neo4jSearchService:
             emb_results: dict,
             query: str,
             limit: int,
-    ) -> list[Memory]:
+            score_sidecar: dict[tuple[Neo4jNodeType, str], dict],
+    ) -> tuple[list[Memory], str, list[str]]:
         seen: dict[str, dict] = {}
         for node_type in self.includes:
             for record in kw_results.get(node_type, []):
@@ -198,20 +238,34 @@ class Neo4jSearchService:
                     seen[rid] = record
 
         if not seen:
-            return []
+            return [], "skipped", []
 
         memories: list[Memory] = []
         for record in seen.values():
             node_type = record.pop("_node_type")
             memory = data_builder_factory(node_type, record)
-            memories.append(Memory(
+            score_info = score_sidecar.get((node_type, str(memory.id)), {})
+            result_memory = Memory(
                 score=memory.score,
                 content=memory.content,
                 data=memory.data,
                 source=node_type,
                 query=query,
                 id=memory.id,
-            ))
+            )
+            result_memory.retrieval_trace = build_score_trace(
+                node_id=result_memory.id,
+                node_type=node_type.value,
+                final_score=result_memory.score,
+                rank_basis="input_order",
+                keyword_hit=bool(score_info.get("keyword_hit")),
+                semantic_hit=bool(score_info.get("semantic_hit")),
+                keyword_score=score_info.get("keyword_score"),
+                semantic_score=score_info.get("semantic_score"),
+                fusion_score=score_info.get("fusion_score"),
+                matched_queries=[query],
+            )
+            memories.append(result_memory)
 
         rerank_applied = False
         try:
@@ -251,6 +305,10 @@ class Neo4jSearchService:
                 for i, mem in enumerate(memories):
                     if i in index_to_score:
                         mem.score = index_to_score[i]
+                        if mem.retrieval_trace is not None:
+                            mem.retrieval_trace.rerank_score = finite_or_none(index_to_score[i])
+                            mem.retrieval_trace.final_score = float(mem.score)
+                            mem.retrieval_trace.rank_basis = "rerank_score"
             except Exception as e:
                 if self.on_error is not None:
                     self.on_error(
@@ -270,14 +328,28 @@ class Neo4jSearchService:
                 exc_info=True,
             )
 
+        degraded_reasons: list[str] = []
+        rerank_status = "completed" if rerank_applied else "degraded"
+        if not rerank_applied:
+            degraded_reasons.append("rerank_failed")
+        elif len(index_to_score) < len(memories):
+            rerank_status = "degraded"
+            degraded_reasons.append("rerank_partial_result")
+
+        for memory in memories:
+            if memory.retrieval_trace is not None:
+                memory.retrieval_trace.final_score = float(memory.score)
         memories.sort(key=lambda x: x.score, reverse=True)
         memories = memories[:limit]
         if rerank_applied:
             logger.info(
                 f"[Neo4jSearch] Model rerank applied: {len(documents)} → {len(memories)} memories"
             )
-        return memories
+        return memories, rerank_status, degraded_reasons
 
+    # WARNING: 下方 sigmoid 归一化公式与 retrieval_trace/models.py 的
+    # normalized_keyword_score 互为副本（此处是公式源头，驱动真实排序），
+    # _rerank 中的融合公式同理对应 diagnostic_fusion_score。改动任一侧前先同步另一侧。
     def _normalize_kw_scores(self, items: list[dict]) -> list[dict]:
         if not items:
             return items
@@ -303,7 +375,14 @@ class Neo4jSearchService:
                 all_records.append(record)
 
         if not all_records:
-            return MemorySearchResult(memories=[])
+            return MemorySearchResult(
+                memories=[],
+                execution_trace=RetrievalExecutionTrace(
+                    keyword_status="completed",
+                    semantic_status="skipped",
+                    rerank_status="skipped",
+                ),
+            )
 
         all_records = self._normalize_kw_scores(all_records)
 
@@ -318,15 +397,35 @@ class Neo4jSearchService:
         for record in all_records[:limit]:
             node_type = record.pop("_node_type")
             memory = data_builder_factory(node_type, record)
-            memories.append(Memory(
+            result_memory = Memory(
                 score=memory.score,
                 content=memory.content,
                 data=memory.data,
                 source=node_type,
                 query=query,
                 id=memory.id
-            ))
-        return MemorySearchResult(memories=memories)
+            )
+            result_memory.retrieval_trace = build_score_trace(
+                node_id=result_memory.id,
+                node_type=node_type.value,
+                final_score=result_memory.score,
+                rank_basis="keyword_score",
+                keyword_hit=True,
+                keyword_score=record.get("normalized_kw_score"),
+                matched_queries=[query],
+            )
+            memories.append(result_memory)
+        return MemorySearchResult(
+            memories=memories,
+            execution_trace=RetrievalExecutionTrace(
+                keyword_status="completed",
+                semantic_status="skipped",
+                rerank_status="skipped",
+                keyword_hit_count=len(all_records),
+                raw_hit_count=len(all_records),
+                merged_count=len(memories),
+            ),
+        )
 
     async def hybrid_search(
             self,
@@ -339,10 +438,12 @@ class Neo4jSearchService:
             emb_task = self._embedding_search(query, limit)
             kw_results, emb_results = await asyncio.gather(kw_task, emb_task, return_exceptions=True)
 
-        if isinstance(kw_results, Exception):
+        keyword_failed = isinstance(kw_results, Exception)
+        semantic_failed = isinstance(emb_results, Exception)
+        if keyword_failed:
             logger.warning(f"[MemorySearch] keyword search error: {kw_results}")
             kw_results = {}
-        if isinstance(emb_results, Exception):
+        if semantic_failed:
             logger.warning(f"[MemorySearch] embedding search error: {emb_results}")
             if self.on_error is not None:
                 self.on_error(
@@ -354,10 +455,19 @@ class Neo4jSearchService:
                 )
             emb_results = {}
 
+        score_sidecar = self._build_score_sidecar(kw_results, emb_results)
+        rerank_status = "skipped"
+        degraded_reasons: list[str] = []
+        if keyword_failed:
+            degraded_reasons.append("keyword_search_failed")
+        if semantic_failed:
+            degraded_reasons.append("semantic_search_failed")
+
         if self.reranker is not None:
-            memories = await self._hybrid_search_with_model_rerank(
-                kw_results, emb_results, query, limit
+            memories, rerank_status, rerank_reasons = await self._hybrid_search_with_model_rerank(
+                kw_results, emb_results, query, limit, score_sidecar
             )
+            degraded_reasons.extend(rerank_reasons)
         else:
             memories = []
             for node_type in self.includes:
@@ -368,18 +478,51 @@ class Neo4jSearchService:
                 )
                 for record in reranked:
                     memory = data_builder_factory(node_type, record)
-                    memories.append(Memory(
+                    result_memory = Memory(
                         score=memory.score,
                         content=memory.content,
                         data=memory.data,
                         source=node_type,
                         query=query,
                         id=memory.id
-                    ))
+                    )
+                    score_info = score_sidecar.get((node_type, str(memory.id)), {})
+                    fusion_score = finite_or_none(record.get("content_score"))
+                    rank_basis = (
+                        "source_adjusted_score"
+                        if fusion_score is not None and result_memory.score != fusion_score
+                        else "fusion_score"
+                    )
+                    result_memory.retrieval_trace = build_score_trace(
+                        node_id=result_memory.id,
+                        node_type=node_type.value,
+                        final_score=result_memory.score,
+                        rank_basis=rank_basis,
+                        keyword_hit=bool(score_info.get("keyword_hit")),
+                        semantic_hit=bool(score_info.get("semantic_hit")),
+                        keyword_score=record.get("kw_score"),
+                        semantic_score=record.get("embedding_score"),
+                        fusion_score=fusion_score,
+                        matched_queries=[query],
+                    )
+                    memories.append(result_memory)
             memories.sort(key=lambda x: x.score, reverse=True)
             memories = memories[:limit]
 
-        return MemorySearchResult(memories=memories)
+        return MemorySearchResult(
+            memories=memories,
+            execution_trace=RetrievalExecutionTrace(
+                keyword_status="failed" if keyword_failed else "completed",
+                semantic_status="failed" if semantic_failed else "completed",
+                rerank_status=rerank_status,
+                keyword_hit_count=sum(len(items) for items in kw_results.values()),
+                semantic_hit_count=sum(len(items) for items in emb_results.values()),
+                raw_hit_count=sum(len(items) for items in kw_results.values())
+                              + sum(len(items) for items in emb_results.values()),
+                merged_count=len(memories),
+                degraded_reasons=degraded_reasons,
+            ),
+        )
 
     async def _run_relation_agent(self, query: str) -> RelationSearchResult:
         system_prompt = prompt_manager.render(
@@ -840,17 +983,37 @@ class RAGSearchService:
         res = []
         try:
             for chunk in retrieve_chunks_result:
-                res.append(Memory(
+                memory = Memory(
                     content=chunk.page_content,
                     query=query,
                     score=chunk.metadata.get("score", 0.0),
                     source=Neo4jNodeType.RAG,
                     id=chunk.metadata.get("document_id"),
                     data=chunk.metadata,
-                ))
+                )
+                memory.retrieval_trace = build_score_trace(
+                    node_id=memory.id,
+                    node_type=Neo4jNodeType.RAG.value,
+                    final_score=memory.score,
+                    rank_basis="provider_score",
+                    backend="rag",
+                    matched_queries=[query],
+                )
+                res.append(memory)
             res.sort(key=lambda x: x.score, reverse=True)
             res = res[:limit]
-            return MemorySearchResult(memories=res)
+            return MemorySearchResult(
+                memories=res,
+                execution_trace=RetrievalExecutionTrace(
+                    backend="rag",
+                    keyword_status="skipped",
+                    semantic_status="completed",
+                    rerank_status="skipped",
+                    semantic_hit_count=len(res),
+                    raw_hit_count=len(res),
+                    merged_count=len(res),
+                ),
+            )
         except RuntimeError as e:
             logger.error(f"[MemorySearch] rag search error: {e}")
             return MemorySearchResult(memories=[])

--- a/api/app/core/memory/retrieval_trace/models.py
+++ b/api/app/core/memory/retrieval_trace/models.py
@@ -1,0 +1,132 @@
+"""记忆召回内部追踪模型和分数构造工具。"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+RetrievalType = Literal["keyword", "semantic", "hybrid", "provider"]
+RankBasis = Literal[
+    "keyword_score",
+    "fusion_score",
+    "source_adjusted_score",
+    "rerank_score",
+    "provider_score",
+    "input_order",
+]
+BranchStatus = Literal["completed", "degraded", "failed", "skipped"]
+
+
+class RetrievalScoreTrace(BaseModel):
+    """单条候选的分数组成和命中来源。"""
+
+    retrieval_type: RetrievalType
+    keyword_score: float | None = None
+    semantic_score: float | None = None
+    fusion_score: float | None = None
+    rerank_score: float | None = None
+    final_score: float
+    rank_basis: RankBasis
+    backend: Literal["neo4j", "rag"]
+    node_type: str
+    node_id: str
+    matched_queries: list[str] = Field(default_factory=list)
+
+
+class RetrievalExecutionTrace(BaseModel):
+    """请求级分支状态；仅供验证接口投影，不进入通用序列化。"""
+
+    original_query: str = ""
+    processed_query: str = ""
+    search_switch: str = ""
+    backend: Literal["neo4j", "rag"] = "neo4j"
+    limit: int = 10
+    keyword_status: BranchStatus = "skipped"
+    semantic_status: BranchStatus = "skipped"
+    rerank_status: BranchStatus = "skipped"
+    keyword_hit_count: int = 0
+    semantic_hit_count: int = 0
+    raw_hit_count: int = 0
+    merged_count: int = 0
+    degraded_reasons: list[str] = Field(default_factory=list)
+
+
+def finite_or_none(value: Any) -> float | None:
+    """保留 0 与缺失值的区别，并过滤 NaN、Infinity。"""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def normalized_keyword_score(raw_score: Any, threshold: float) -> float:
+    """仅用于记录，不参与二次排序。
+
+    WARNING: 本公式是 content_search.py Neo4jSearchService._normalize_kw_scores
+    中归一化公式的副本（公式源头在那里，驱动真实排序）。两处必须同步修改：
+    改动任一侧前，先 grep 另一侧，否则验证页展示的 keyword_score 将无法
+    解释实际排序。后续计划统一为单一实现。
+    """
+    score = finite_or_none(raw_score) or 0.0
+    return 1 / (1 + math.exp(-(score - threshold) / 2)) if score else 0.0
+
+
+def diagnostic_fusion_score(keyword_score: float, semantic_score: float, alpha: float) -> float:
+    """仅生成可观测值，不改变当前排序。
+
+    WARNING: 本公式是 content_search.py Neo4jSearchService._rerank 中融合公式
+    （含奖励项系数 0.1）的副本（公式源头在那里，驱动真实排序）。两处必须
+    同步修改：改动任一侧前，先 grep 另一侧，否则验证页展示的 fusion_score
+    将无法解释实际排序。后续计划统一为单一实现。
+    """
+    base = alpha * semantic_score + (1 - alpha) * keyword_score
+    return base + min(1 - base, 0.1 * keyword_score * semantic_score)
+
+
+def build_score_trace(
+    *,
+    node_id: str,
+    node_type: str,
+    final_score: Any,
+    rank_basis: RankBasis,
+    keyword_hit: bool = False,
+    semantic_hit: bool = False,
+    keyword_score: Any = None,
+    semantic_score: Any = None,
+    fusion_score: Any = None,
+    rerank_score: Any = None,
+    backend: Literal["neo4j", "rag"] = "neo4j",
+    matched_queries: Iterable[str] = (),
+) -> RetrievalScoreTrace:
+    """根据已确定的召回结果构造轨迹，不重新计算最终排序。"""
+    if backend == "rag":
+        retrieval_type: RetrievalType = "provider"
+    elif keyword_hit and semantic_hit:
+        retrieval_type = "hybrid"
+    elif semantic_hit:
+        retrieval_type = "semantic"
+    else:
+        retrieval_type = "keyword"
+
+    final = finite_or_none(final_score) or 0.0
+    queries = list(dict.fromkeys(str(query) for query in matched_queries if str(query)))
+    return RetrievalScoreTrace(
+        retrieval_type=retrieval_type,
+        keyword_score=finite_or_none(keyword_score) if keyword_hit else None,
+        semantic_score=finite_or_none(semantic_score) if semantic_hit else None,
+        fusion_score=finite_or_none(fusion_score),
+        rerank_score=finite_or_none(rerank_score),
+        final_score=final,
+        rank_basis=rank_basis,
+        backend=backend,
+        node_type=node_type,
+        node_id=str(node_id),
+        matched_queries=queries,
+    )

--- a/api/app/core/memory/retrieval_trace/stage_events.py
+++ b/api/app/core/memory/retrieval_trace/stage_events.py
@@ -18,9 +18,11 @@ _STAGE_SINK: ContextVar[MemoryStageSink | None] = ContextVar("memory_stage_sink"
 
 # Exact field sets form the public contract and prevent internal retrieval data from leaking.
 _STAGE_FIELDS = {
+    "query_preprocessed": {"original_query", "processed_query", "will_split"},
     "profile_loaded": {"has_profile", "profile"},
     "query_split": {"count", "questions"},
     "hybrid_searched": {"hit_count", "memory_count", "shown_count", "items"},
+    "keyword_searched": {"hit_count", "memory_count", "shown_count", "items"},
     "relation_searched": {"hit_count", "relation_count", "shown_count", "items"},
     "perceptual_processed": {"memory_count", "shown_count", "items"},
     "results_merged": {"memory_count", "relation_count"},
@@ -126,6 +128,14 @@ def _valid_relation_item(item: Any) -> bool:
 
 
 def _valid_stage_data(stage: str, data: dict[str, Any]) -> bool:
+    if stage == "query_preprocessed":
+        return (
+            isinstance(data["original_query"], str)
+            and len(data["original_query"]) <= 2000
+            and isinstance(data["processed_query"], str)
+            and len(data["processed_query"]) <= 2000
+            and isinstance(data["will_split"], bool)
+        )
     if stage == "profile_loaded":
         return isinstance(data["has_profile"], bool) and _valid_profile(data["profile"])
     if stage == "query_split":
@@ -137,9 +147,10 @@ def _valid_stage_data(stage: str, data: dict[str, Any]) -> bool:
             and all(len(question) <= 100 for question in data["questions"])
             and data["count"] >= len(data["questions"])
         )
-    if stage in {"hybrid_searched", "relation_searched", "result_ready"}:
+    if stage in {"hybrid_searched", "keyword_searched", "relation_searched", "result_ready"}:
         count_fields = {
             "hybrid_searched": ("hit_count", "memory_count", "shown_count"),
+            "keyword_searched": ("hit_count", "memory_count", "shown_count"),
             "relation_searched": ("hit_count", "relation_count", "shown_count"),
             "result_ready": ("total_count", "shown_count"),
         }[stage]

--- a/api/app/core/memory/retrieval_trace/stage_projection.py
+++ b/api/app/core/memory/retrieval_trace/stage_projection.py
@@ -17,6 +17,11 @@ from app.core.memory.models.service_models import (
     MemorySearchResult,
     RelationMemory,
 )
+from app.core.memory.retrieval_trace.models import (
+    RetrievalExecutionTrace,
+    build_score_trace,
+    finite_or_none,
+)
 
 _PROFILE_FIELDS = (
     "aliases_name",
@@ -232,3 +237,111 @@ def project_result_items(
     for index, item in enumerate(items, start=1):
         item["rank"] = index
     return items
+
+
+def project_retrieval_candidate(memory: Memory, rank: int) -> dict[str, Any]:
+    """将单条候选安全投影为记忆验证页 retrieval_trace 事件使用的带分数轨迹的
+    候选结构（区别于 project_memory_items 产出的仅含 rank/id/type/content 的
+    简化结构）。"""
+    source = memory.source.value if isinstance(memory.source, Neo4jNodeType) else str(memory.source)
+    trace = memory.retrieval_trace
+    if trace is None:
+        backend = "rag" if memory.source == Neo4jNodeType.RAG else "neo4j"
+        trace = build_score_trace(
+            node_id=memory.id,
+            node_type=source,
+            final_score=memory.score,
+            rank_basis="provider_score" if backend == "rag" else "input_order",
+            backend=backend,
+            matched_queries=[memory.query],
+        )
+    final_score = finite_or_none(trace.final_score)
+    if final_score is None:
+        final_score = 0.0
+    item: dict[str, Any] = {
+        "rank": rank,
+        "memory_id": str(memory.id),
+        "memory_type": memory_type(memory.source),
+        "source": source,
+        "content": _memory_content(memory, memory_type(memory.source), prefer_perceptual_display=True),
+        "retrieval_type": trace.retrieval_type,
+        "keyword_score": finite_or_none(trace.keyword_score),
+        "semantic_score": finite_or_none(trace.semantic_score),
+        "fusion_score": finite_or_none(trace.fusion_score),
+        "rerank_score": finite_or_none(trace.rerank_score),
+        "final_score": final_score,
+        "rank_basis": trace.rank_basis,
+        "hit_source": {
+            "backend": trace.backend,
+            "node_type": trace.node_type,
+            "node_id": trace.node_id,
+            "matched_queries": list(trace.matched_queries),
+        },
+    }
+    if memory.source == Neo4jNodeType.PERCEPTUAL:
+        data = memory.data if isinstance(memory.data, dict) else {}
+        file_data = {
+            "file_name": display_text(data.get("file_name"), 1000),
+            "file_path": display_text(data.get("file_path"), 2000),
+            "file_type": display_text(data.get("file_type"), 200),
+            "perceptual_type": _perceptual_type(data.get("perceptual_type")),
+        }
+        if any(value not in (None, "") for value in file_data.values()):
+            item["file"] = file_data
+    return item
+
+
+def _find_stage(stages: Iterable[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    return next((stage for stage in stages if stage.get("stage") == name), None)
+
+
+def _search_status(trace: RetrievalExecutionTrace) -> str:
+    active = [trace.keyword_status]
+    if trace.semantic_status != "skipped":
+        active.append(trace.semantic_status)
+    if active and all(status == "failed" for status in active):
+        return "failed"
+    if any(status in {"failed", "degraded"} for status in active):
+        return "degraded"
+    if trace.rerank_status == "degraded":
+        return "degraded"
+    if trace.degraded_reasons:
+        return "degraded"
+    return "completed"
+
+
+def build_validation_trace(
+    *,
+    request_id: str,
+    query: str,
+    search_switch: str,
+    end_user_id: str,
+    result: MemorySearchResult,
+    collected_stages: Iterable[dict[str, Any]] = (),
+    backend: str = "neo4j",
+    limit: int = 10,
+) -> dict[str, Any]:
+    """构造验证页最终轨迹，不修改 Agent 共用的阶段事件协议。"""
+    stages = list(collected_stages)
+    execution = result.execution_trace or RetrievalExecutionTrace(
+        original_query=query,
+        processed_query=query,
+        search_switch=search_switch,
+        backend=backend,
+        limit=limit,
+    )
+    ranked_memories = [memory for memory in result.memories if memory.id != end_user_id]
+    limited_memories = ranked_memories[:max(execution.limit, 0)]
+    candidates = [
+        project_retrieval_candidate(memory, rank)
+        for rank, memory in enumerate(limited_memories, start=1)
+    ]
+    search_status = _search_status(execution)
+    result_stage = _find_stage(stages, "result_ready")
+    duration = int(result_stage.get("data", {}).get("duration_ms", 0)) if result_stage else 0
+    return {
+        "request_id": request_id,
+        "status": search_status,
+        "duration_ms": duration,
+        "items": candidates,
+    }

--- a/api/app/services/memory_validation_service.py
+++ b/api/app/services/memory_validation_service.py
@@ -1,0 +1,337 @@
+"""记忆验证页的读取编排服务。"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import suppress
+from typing import Any
+
+from fastapi.encoders import jsonable_encoder
+
+from app.core.error_codes import BizCode
+from app.core.logging_config import get_api_logger
+from app.core.memory.enums import Neo4jNodeType, SearchStrategy
+from app.core.memory.memory_service import MemoryService
+from app.core.memory.models.service_models import MemorySearchResult
+from app.core.memory.retrieval_trace.stage_events import (
+    build_memory_stage_payload,
+    memory_stage_collector,
+)
+from app.core.memory.retrieval_trace.stage_projection import build_validation_trace, project_memory_items
+from app.db import get_async_db_context
+from app.schemas.memory_agent_schema import UserInput
+from app.services.memory_agent_service import MemoryAgentService
+from app.services.memory_config_service import MemoryConfigService
+from app.utils.sse_utils import format_sse_message
+from app.utils.tmp_session import ChatSessionCache
+
+DEFAULT_STORAGE_TYPE = "neo4j"
+SSE_HEARTBEAT_SECONDS = 15
+SSE_STAGE_POLL_SECONDS = 0.1
+
+SEARCH_MODE_NAMES = {
+    SearchStrategy.DEEP: "deep",
+    SearchStrategy.NORMAL: "normal",
+    SearchStrategy.QUICK: "quick",
+    SearchStrategy.EXPRESS: "express",
+}
+VALIDATION_MEMORY_STAGE_ALLOWLIST = frozenset({
+    "query_preprocessed",
+    "profile_loaded",
+    "query_split",
+    "hybrid_searched",
+    "keyword_searched",
+    "perceptual_processed",
+})
+
+logger = get_api_logger()
+
+
+def _format_event(event_type: str, data: dict[str, Any]) -> str:
+    """使用 FastAPI 的编码器处理 UUID、枚举和 Pydantic 模型。"""
+    return format_sse_message(event_type, jsonable_encoder(data))
+
+
+async def _stream_heartbeats(task: asyncio.Task[Any]) -> AsyncIterator[str]:
+    """长时间无业务事件时保持 SSE 连接。"""
+    while not task.done():
+        done, _ = await asyncio.wait({task}, timeout=SSE_HEARTBEAT_SECONDS)
+        if not done:
+            yield ": heartbeat\n\n"
+
+
+def _build_intermediate_outputs(
+        search_result: MemorySearchResult,
+        search_switch: str,
+) -> list[dict[str, Any]]:
+    """构造记忆验证页兼容的 intermediate_outputs。"""
+    intermediate_outputs: list[dict[str, Any]] = []
+    sub_queries = {str(memory.query) for memory in search_result.memories}
+    if search_switch in {SearchStrategy.DEEP, SearchStrategy.NORMAL}:
+        intermediate_outputs.append({
+            "type": "problem_split",
+            "title": "问题拆分",
+            "data": [
+                {"id": f"Q{index}", "question": question}
+                for index, question in enumerate(
+                    (question for question in sub_queries if question),
+                    start=1,
+                )
+            ],
+        })
+
+    perceptual_data = [
+        memory.data
+        for memory in search_result.memories
+        if memory.source == Neo4jNodeType.PERCEPTUAL
+    ]
+    if perceptual_data:
+        intermediate_outputs.append({
+            "type": "perceptual_retrieve",
+            "title": "感知记忆检索",
+            "data": perceptual_data,
+            "total": len(perceptual_data),
+        })
+
+    intermediate_outputs.append({
+        "type": "search_result",
+        "title": f"合并检索结果 (共{len(sub_queries)}个查询,{len(search_result.memories)}条结果)",
+        "result": html.escape(search_result.content),
+        "raw_result": search_result.memories,
+        "total": len(search_result.memories),
+    })
+    return intermediate_outputs
+
+
+def _build_fast_search_stage(
+        strategy: SearchStrategy,
+        end_user_id: str,
+        search_result: MemorySearchResult,
+) -> dict[str, Any] | None:
+    """为未产生实时检索阶段的快速模式投影公共 memory_stage。"""
+    stage = {
+        SearchStrategy.QUICK: "hybrid_searched",
+        SearchStrategy.EXPRESS: "keyword_searched",
+    }.get(strategy)
+    if stage is None:
+        return None
+    memories = [memory for memory in search_result.memories if memory.id != end_user_id]
+    items = project_memory_items(memories, limit=3)
+    execution = search_result.execution_trace
+    return build_memory_stage_payload(stage=stage, data={
+        "hit_count": execution.raw_hit_count if execution is not None else len(memories),
+        "memory_count": len(memories),
+        "shown_count": len(items),
+        "items": items,
+    })
+
+
+class MemoryValidationService:
+    """隔离记忆验证页的 SSE 与对话编排，不改共享检索链路。"""
+
+    def __init__(
+            self,
+            *,
+            user_input: UserInput,
+            memory_service: MemoryService,
+            session_cache: ChatSessionCache,
+            request_id: str,
+            answer_service: MemoryAgentService | None = None,
+    ) -> None:
+        self.user_input = user_input
+        self.memory_service = memory_service
+        self.session_cache = session_cache
+        self.request_id = request_id
+        self.answer_service = answer_service or MemoryAgentService()
+
+    @classmethod
+    async def create(
+            cls,
+            user_input: UserInput,
+            *,
+            request_id: str | None = None,
+    ) -> MemoryValidationService:
+        """在开流前完成参数校验和记忆服务初始化。"""
+        SearchStrategy(user_input.search_switch)
+        async with get_async_db_context() as db:
+            memory_config_id = await MemoryConfigService(db).get_config_id_by_end_user_async(
+                user_input.end_user_id
+            )
+        memory_service = await MemoryService.create(
+            memory_config_id,
+            end_user_id=user_input.end_user_id,
+            draft=True,
+        )
+        return cls(
+            user_input=user_input,
+            memory_service=memory_service,
+            session_cache=ChatSessionCache(user_input.session_id.hex),
+            request_id=request_id or str(uuid.uuid4()),
+        )
+
+    @property
+    def session_id(self) -> str:
+        return self.session_cache.session_id
+
+    async def stream(self) -> AsyncIterator[str]:
+        """按 start、召回阶段、详细轨迹、回答、end 顺序输出。"""
+        running_task: asyncio.Task[Any] | None = None
+        user_input = self.user_input
+        try:
+            strategy = SearchStrategy(user_input.search_switch)
+            yield _format_event("start", {
+                "request_id": self.request_id,
+                "session_id": self.session_id,
+                "search_switch": user_input.search_switch,
+                "mode": SEARCH_MODE_NAMES.get(strategy, "unknown"),
+                "backend": DEFAULT_STORAGE_TYPE,
+                "limit": 10,
+            })
+
+            running_task = asyncio.create_task(self.session_cache.get_history())
+            async for heartbeat in _stream_heartbeats(running_task):
+                yield heartbeat
+            history = await running_task
+            running_task = None
+
+            with memory_stage_collector() as retrieval_stages:
+                # ContextVar 会随 create_task 复制，Pipeline 仍只写入原有收集器。
+                running_task = asyncio.create_task(
+                    self.memory_service.read(user_input.message, strategy, history=history)
+                )
+                next_stage_index = 0
+                event_loop = asyncio.get_running_loop()
+                last_event_at = event_loop.time()
+                while True:
+                    while next_stage_index < len(retrieval_stages):
+                        stage = retrieval_stages[next_stage_index]
+                        next_stage_index += 1
+                        if stage.get("stage") not in VALIDATION_MEMORY_STAGE_ALLOWLIST:
+                            continue
+                        last_event_at = event_loop.time()
+                        yield _format_event("memory_stage", {
+                            "request_id": self.request_id,
+                            **stage,
+                        })
+                    if running_task.done():
+                        break
+                    await asyncio.wait({running_task}, timeout=SSE_STAGE_POLL_SECONDS)
+                    if event_loop.time() - last_event_at >= SSE_HEARTBEAT_SECONDS:
+                        last_event_at = event_loop.time()
+                        yield ": heartbeat\n\n"
+                search_result = await running_task
+                running_task = None
+
+            fast_search_stage = _build_fast_search_stage(
+                strategy,
+                user_input.end_user_id,
+                search_result,
+            )
+            if fast_search_stage is not None:
+                retrieval_stages.append(fast_search_stage)
+                yield _format_event("memory_stage", {
+                    "request_id": self.request_id,
+                    **fast_search_stage,
+                })
+
+            retrieval_trace = self._build_retrieval_trace(search_result, retrieval_stages)
+            yield _format_event("retrieval_trace", {
+                "request_id": self.request_id,
+                "trace": retrieval_trace,
+            })
+
+            intermediate_outputs = _build_intermediate_outputs(
+                search_result,
+                user_input.search_switch,
+            )
+            running_task = asyncio.create_task(
+                self.answer_service.generate_summary_from_retrieve(
+                    end_user_id=user_input.end_user_id,
+                    retrieve_info=search_result.content,
+                    history=[],
+                    query=user_input.message,
+                    config_id=user_input.config_id,
+                )
+            )
+            async for heartbeat in _stream_heartbeats(running_task):
+                yield heartbeat
+            answer = await running_task
+            running_task = None
+
+            running_task = asyncio.create_task(
+                self.session_cache.append_many([
+                    {"role": "user", "content": user_input.message},
+                    {"role": "assistant", "content": answer},
+                ])
+            )
+            async for heartbeat in _stream_heartbeats(running_task):
+                yield heartbeat
+            await running_task
+            running_task = None
+
+            yield _format_event("message", {
+                "request_id": self.request_id,
+                "content": answer,
+            })
+            yield _format_event("end", {
+                "request_id": self.request_id,
+                "session_id": self.session_id,
+                "intermediate_outputs": intermediate_outputs,
+            })
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            logger.error(
+                "Read operation error: request_id=%s, end_user=%s, error=%s",
+                self.request_id,
+                user_input.end_user_id,
+                str(error),
+                exc_info=True,
+            )
+            yield _format_event("error", {
+                "request_id": self.request_id,
+                "code": BizCode.MEMORY_READ_FAILED,
+                "message": "回复对话消息失败",
+            })
+        finally:
+            if running_task is not None and not running_task.done():
+                running_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await running_task
+
+    def _build_retrieval_trace(
+            self,
+            search_result: MemorySearchResult,
+            retrieval_stages: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """轨迹投影失败时降级为 null，不中断读取和回答。"""
+        try:
+            return build_validation_trace(
+                request_id=self.request_id,
+                query=self.user_input.message,
+                search_switch=self.user_input.search_switch,
+                end_user_id=self.user_input.end_user_id,
+                result=search_result,
+                collected_stages=retrieval_stages,
+                backend=(
+                    search_result.execution_trace.backend
+                    if search_result.execution_trace
+                    else DEFAULT_STORAGE_TYPE
+                ),
+                limit=(
+                    search_result.execution_trace.limit
+                    if search_result.execution_trace
+                    else 10
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Unable to build retrieval trace: request_id=%s, end_user=%s",
+                self.request_id,
+                self.user_input.end_user_id,
+                exc_info=True,
+            )
+            return None


### PR DESCRIPTION
Add retrieval observability for the memory validation page: /memory/read/sync now returns an SSE stream instead of plain JSON

The stream emits start → memory_stage → retrieval_trace → message → end events in order, with 15s heartbeats

A sidecar records keyword/semantic/fusion/rerank scores and hit sources per candidate; dedup/merge/ranking behavior and the shared memory_stage protocol are unchanged

## Sourcery 摘要

在不改变检索结果行为的情况下，为记忆验证读取端点添加流式检索可观测性。

新功能：
- 为记忆验证读取流程添加检索可观测性，包括每个候选项的评分、命中来源、排名依据和查询匹配项。
- 将记忆验证端点公开为 SSE 流，并按顺序发送生命周期、检索阶段、追踪、响应和完成事件。
- 为长时间运行的验证请求提供检索状态、命中数量、降级原因和心跳支持。

增强功能：
- 在收集诊断性检索元数据的同时，保留现有的记忆去重、合并、排名和共享记忆阶段行为。
- 通过验证专用契约传递检索诊断信息，同时避免通过通用记忆序列化暴露内部追踪字段。
- 在流式响应流程中保持兼容的中间输出和会话历史更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add streamed retrieval observability to the memory validation read endpoint without changing retrieval result behavior.

New Features:
- Add retrieval observability to the memory validation read flow, including per-candidate scores, hit sources, ranking basis, and query matches.
- Expose the memory validation endpoint as an SSE stream with ordered lifecycle, retrieval-stage, trace, response, and completion events.
- Provide retrieval status, hit counts, degradation reasons, and heartbeat support for long-running validation requests.

Enhancements:
- Preserve existing memory deduplication, merging, ranking, and shared memory-stage behavior while collecting diagnostic retrieval metadata.
- Project retrieval diagnostics through a validation-specific contract without exposing internal trace fields through general memory serialization.
- Maintain compatible intermediate outputs and session history updates within the streamed response flow.

</details>