### PR TITLE
add_throw_exception

### DIFF
--- a/api/app/locales/en/errors.json
+++ b/api/app/locales/en/errors.json
@@ -15,6 +15,29 @@
     "database_error": "Database operation failed",
     "file_operation_error": "File operation failed"
   },
+  "llm": {
+    "authentication_failed": "Invalid API Key, please check your configuration",
+    "permission_denied": "API Key permission denied or locked",
+    "quota_exceeded": "Model quota exhausted, please contact admin to top up",
+    "rate_limited": "Too many requests, please try again later",
+    "timeout": "Model response timed out, please try again later",
+    "connection_failed": "Failed to connect to model service, please check URL configuration",
+    "invalid_request": "Invalid request parameters, please check your input or configuration",
+    "model_not_found": "Model not found or has been taken offline",
+    "capability_mismatch": "Model does not support this capability, please check configuration",
+    "server_error": "Model service error, please try again later",
+    "unknown": "An unknown error occurred during model invocation",
+    "api_key_missing": "No available API Key in the current configuration",
+    "empty_response": "Model did not return valid content",
+    "attachment_prefix": "Attachment parsing failed: ",
+    "subjects": {
+      "model": "Model",
+      "image": "Image",
+      "audio": "Audio",
+      "video": "Video",
+      "document": "Document"
+    }
+  },
   "auth": {
     "invalid_credentials": "Invalid username or password",
     "token_expired": "Session expired, please login again",

--- a/api/app/locales/zh/errors.json
+++ b/api/app/locales/zh/errors.json
@@ -15,6 +15,29 @@
     "database_error": "数据库操作失败",
     "file_operation_error": "文件操作失败"
   },
+  "llm": {
+    "authentication_failed": "API Key 无效，请检查配置",
+    "permission_denied": "API Key 权限不足或已被锁定",
+    "quota_exceeded": "模型额度已用尽，请联系管理员充值",
+    "rate_limited": "请求过于频繁，请稍后重试",
+    "timeout": "模型响应超时，请稍后重试",
+    "connection_failed": "模型服务连接失败，请检查 URL 配置",
+    "invalid_request": "请求参数错误，请检查输入或配置",
+    "model_not_found": "模型不存在或已下线",
+    "capability_mismatch": "模型不支持该能力，请检查配置",
+    "server_error": "模型服务异常，请稍后重试",
+    "unknown": "模型调用出现未知错误",
+    "api_key_missing": "当前配置没有可用的 API Key",
+    "empty_response": "模型未返回有效内容",
+    "attachment_prefix": "附件解析失败：",
+    "subjects": {
+      "model": "模型",
+      "image": "图片",
+      "audio": "音频",
+      "video": "视频",
+      "document": "文档"
+    }
+  },
   "auth": {
     "invalid_credentials": "用户名或密码错误",
     "token_expired": "登录已过期，请重新登录",

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -12,7 +12,9 @@ import time
 import uuid
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
+import httpx
 from dotenv import load_dotenv
+from openai import APIConnectionError, APITimeoutError, AuthenticationError, BadRequestError, PermissionDeniedError, RateLimitError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -47,6 +49,70 @@ from app.utils.sse_utils import format_sse_message
 
 logger = get_logger(__name__)
 config_logger = get_config_logger()
+
+
+def classify_llm_error(e: Exception, prefix: str = "llm") -> tuple[str, str]:
+    """
+    渐进式判断错误类型，兼容多个供应商。
+    判断顺序：异常类型 → HTTP 状态码 → 关键词匹配 → 兜底
+    """
+    # 优先级 1：异常类型（最可靠）
+    if isinstance(e, AuthenticationError):
+        return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
+    if isinstance(e, PermissionDeniedError):
+        return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或权限不足")
+    if isinstance(e, RateLimitError):
+        return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
+    if isinstance(e, APITimeoutError):
+        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
+    if isinstance(e, APIConnectionError):
+        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接失败，请检查 URL 配置")
+    if isinstance(e, BadRequestError):
+        return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
+
+    # 优先级 2：HTTP 状态码
+    if isinstance(e, httpx.HTTPStatusError):
+        status = e.response.status_code
+        if status == 400:
+            return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
+        if status == 401:
+            return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
+        if status == 403:
+            return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或过期")
+        if status in (408, 504):
+            return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
+        if status == 429:
+            return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
+        if status == 404:
+            return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务地址不存在，请检查 URL 配置")
+        if status >= 500:
+            return (f"{prefix}_server_error", f"{prefix} 解析失败：模型服务异常，请稍后重试")
+
+    # 优先级 3：关键词匹配（兜底）
+    error_msg = str(e).lower()
+    if any(kw in error_msg for kw in ["auth", "unauthorized", "invalid_api_key", "incorrect_api_key", "401"]):
+        return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
+    if any(kw in error_msg for kw in ["expired", "disabled", "locked", "forbidden", "403"]):
+        return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或过期")
+    if any(kw in error_msg for kw in ["arrearage", "欠费", "insufficient", "balance", "quota"]):
+        return (f"{prefix}_key_arrearage", f"{prefix} 解析失败：账户欠费或额度不足，请充值")
+    if any(kw in error_msg for kw in ["content-length", "content_length", "missing", "invalid_parameter", "400"]):
+        return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
+    if any(kw in error_msg for kw in ["timeout", "timed out"]):
+        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
+    if any(kw in error_msg for kw in ["connect", "connection", "unreachable", "name resolution", "not found", "404"]):
+        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接失败，请检查 URL 配置")
+    if any(kw in error_msg for kw in ["rate limit", "too many request", "429"]):
+        return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
+    if any(kw in error_msg for kw in ["not support", "unsupported", "capability", "modality"]):
+        return (f"{prefix}_capability_mismatch", f"{prefix} 解析失败：模型不支持该能力，请检查配置")
+    if any(kw in error_msg for kw in ["internal", "server error", "500", "502", "503"]):
+        return (f"{prefix}_server_error", f"{prefix} 解析失败：模型服务异常，请稍后重试")
+
+    # 优先级 4：无法识别，返回友好的默认提示（不暴露原始异常内容）
+    if prefix == "llm":
+        return (f"{prefix}_unknown_error", "模型调用失败，请稍后重试或联系管理员")
+    return (f"{prefix}_unknown_error", f"{prefix} 解析失败，请稍后重试或联系管理员")
 
 # Load environment variables for Neo4j connector
 load_dotenv()
@@ -774,12 +840,13 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 refs = attachment_groups[file_type]
                 runtime = media_runtimes.get(file_type)
                 if runtime is None:
-                    reason = (
-                        "[No configured model can process this attachment type.]"
-                        if language == "en"
-                        else "[当前配置中没有能够处理该附件类型的模型。]"
-                    )
-                    return {"text": group_failure_text(refs, reason), "tokens": 0, "api_key_id": None}
+                    # 返回错误标记
+                    return {
+                        "error": True,
+                        "type": file_type.value.upper(),
+                        "error_field": f"{file_type.value.upper()}_model_unavailable",
+                        "message": f"{file_type.value.upper()} 附件：没有可用的处理模型",
+                    }
 
                 model_info, api_key_id = runtime
                 try:
@@ -812,8 +879,13 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                         self._stream_content_to_texts(getattr(response, "content", None))
                     ).strip()
                     if not response_text:
-                        reason = "[Attachment analysis returned no text.]" if language == "en" else "[附件解析未返回文本。]"
-                        response_text = group_failure_text(refs, reason)
+                        # 返回空文本也视为错误
+                        return {
+                            "error": True,
+                            "type": file_type.value,
+                            "error_field": f"{file_type.value}_empty_response",
+                            "message": f"{file_type.value} 附件解析未返回文本",
+                        }
                     return {
                         "text": response_text,
                         "tokens": self._extract_total_tokens(response),
@@ -821,14 +893,20 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                     }
                 except asyncio.CancelledError:
                     raise
-                except Exception:
+                except Exception as e:
                     logger.error(
                         "[TRIAL_RUN_CHAT_STREAM] %s attachment analysis failed",
                         file_type.value,
                         exc_info=True,
                     )
-                    reason = "[Attachment analysis failed.]" if language == "en" else "[附件解析失败。]"
-                    return {"text": group_failure_text(refs, reason), "tokens": 0, "api_key_id": None}
+                    # 使用错误分类，前缀使用大写
+                    error_field, message = classify_llm_error(e, prefix=file_type.value.upper())
+                    return {
+                        "error": True,
+                        "type": file_type.value.upper(),
+                        "error_field": error_field,
+                        "message": message,
+                    }
 
             async def extract_document_group() -> dict[str, Any]:
                 refs = attachment_groups[FileType.DOCUMENT]
@@ -848,13 +926,19 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                         documents.append(f"{attachment_label(ref)}\n{text}")
                     except asyncio.CancelledError:
                         raise
-                    except Exception:
+                    except Exception as e:
                         logger.error(
                             "[TRIAL_RUN_CHAT_STREAM] Document extraction failed",
                             exc_info=True,
                         )
-                        reason = "[Document extraction failed.]" if language == "en" else "[文档解析失败。]"
-                        documents.append(f"{attachment_label(ref)}\n{reason}")
+                        # 使用错误分类
+                        error_field, message = classify_llm_error(e, prefix="DOCUMENT")
+                        return {
+                            "error": True,
+                            "type": "DOCUMENT",
+                            "error_field": error_field,
+                            "message": message,
+                        }
                 return {"text": "\n\n".join(documents), "tokens": 0, "api_key_id": None}
 
             analysis_tasks = [
@@ -866,6 +950,27 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 analysis_tasks.append(extract_document_group())
 
             analysis_results = await asyncio.gather(*analysis_tasks) if analysis_tasks else []
+
+            # 收集所有错误
+            error_messages = []
+            first_error_field = "attachment_parse_failed"
+            for result in analysis_results:
+                if isinstance(result, dict) and result.get("error"):
+                    error_messages.append(result["message"])
+                    if first_error_field == "attachment_parse_failed":
+                        first_error_field = result["error_field"]
+
+            # 如果有错误，一次性返回，所有信息合并到 message 中
+            if error_messages:
+                combined_message = "附件解析失败：" + "；".join(error_messages)
+                yield format_sse_message("error", {
+                    "code": 5000,
+                    "error": first_error_field,
+                    "message": combined_message,
+                })
+                return
+
+            # 继续原有逻辑
             attachment_context = "\n\n".join(
                 result["text"] for result in analysis_results if result.get("text")
             )
@@ -961,9 +1066,24 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         except asyncio.CancelledError:
             logger.info("[TRIAL_RUN_CHAT_STREAM] Client disconnected during streaming")
             raise
-        except Exception:
+        except Exception as e:
             logger.error("[TRIAL_RUN_CHAT_STREAM] Error during streaming", exc_info=True)
-            yield format_sse_message("error", self._trial_run_chat_error_data(language))
+            error_msg = str(e).lower()
+            # 区分配置错误和 LLM 错误
+            if "configuration not found" in error_msg or "config" in error_msg and "not found" in error_msg:
+                yield format_sse_message("error", {
+                    "code": 5000,
+                    "error": "config_error",
+                    "message": "配置读取失败",
+                })
+            else:
+                # 使用错误分类
+                error_field, message = classify_llm_error(e, prefix="llm")
+                yield format_sse_message("error", {
+                    "code": 5000,
+                    "error": error_field,
+                    "message": message,
+                })
 
     async def pilot_run_stream(self, payload: PilotRunInput, language: str = "zh") -> AsyncGenerator[str, None]:
         """

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -71,8 +71,8 @@ def classify_llm_error(e: Exception, prefix: str = "llm") -> tuple[str, str]:
         return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
 
     # 优先级 2：HTTP 状态码
-    if isinstance(e, httpx.HTTPStatusError):
-        status = e.response.status_code
+    status = e.response.status_code if isinstance(e, httpx.HTTPStatusError) else getattr(e, "status_code", None)
+    if status is not None:
         if status == 400:
             return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
         if status == 401:

--- a/api/app/services/memory_storage_service.py
+++ b/api/app/services/memory_storage_service.py
@@ -12,13 +12,12 @@ import time
 import uuid
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
-import httpx
 from dotenv import load_dotenv
-from openai import APIConnectionError, APITimeoutError, AuthenticationError, BadRequestError, PermissionDeniedError, RateLimitError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
+from app.core.error_codes import BizCode
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_config_logger, get_logger
 from app.i18n.service import t
@@ -45,74 +44,12 @@ from app.schemas.memory_storage_schema import (
     ConfigUpdateExtracted,
 )
 from app.services.memory_config_service import MemoryConfigService
+from app.utils.llm_error_utils import ClassifiedLLMError, classify_llm_error
 from app.utils.sse_utils import format_sse_message
 
 logger = get_logger(__name__)
 config_logger = get_config_logger()
 
-
-def classify_llm_error(e: Exception, prefix: str = "llm") -> tuple[str, str]:
-    """
-    渐进式判断错误类型，兼容多个供应商。
-    判断顺序：异常类型 → HTTP 状态码 → 关键词匹配 → 兜底
-    """
-    # 优先级 1：异常类型（最可靠）
-    if isinstance(e, AuthenticationError):
-        return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
-    if isinstance(e, PermissionDeniedError):
-        return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或权限不足")
-    if isinstance(e, RateLimitError):
-        return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
-    if isinstance(e, APITimeoutError):
-        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
-    if isinstance(e, APIConnectionError):
-        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接失败，请检查 URL 配置")
-    if isinstance(e, BadRequestError):
-        return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
-
-    # 优先级 2：HTTP 状态码
-    status = e.response.status_code if isinstance(e, httpx.HTTPStatusError) else getattr(e, "status_code", None)
-    if status is not None:
-        if status == 400:
-            return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
-        if status == 401:
-            return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
-        if status == 403:
-            return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或过期")
-        if status in (408, 504):
-            return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
-        if status == 429:
-            return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
-        if status == 404:
-            return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务地址不存在，请检查 URL 配置")
-        if status >= 500:
-            return (f"{prefix}_server_error", f"{prefix} 解析失败：模型服务异常，请稍后重试")
-
-    # 优先级 3：关键词匹配（兜底）
-    error_msg = str(e).lower()
-    if any(kw in error_msg for kw in ["auth", "unauthorized", "invalid_api_key", "incorrect_api_key", "401"]):
-        return (f"{prefix}_key_invalid", f"{prefix} 解析失败：API Key 无效，请检查配置")
-    if any(kw in error_msg for kw in ["expired", "disabled", "locked", "forbidden", "403"]):
-        return (f"{prefix}_key_locked", f"{prefix} 解析失败：API Key 已被锁定或过期")
-    if any(kw in error_msg for kw in ["arrearage", "欠费", "insufficient", "balance", "quota"]):
-        return (f"{prefix}_key_arrearage", f"{prefix} 解析失败：账户欠费或额度不足，请充值")
-    if any(kw in error_msg for kw in ["content-length", "content_length", "missing", "invalid_parameter", "400"]):
-        return (f"{prefix}_bad_request", f"{prefix} 解析失败：请求参数错误，请检查文件格式或 URL 是否可访问")
-    if any(kw in error_msg for kw in ["timeout", "timed out"]):
-        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接超时，请检查网络或 URL 配置")
-    if any(kw in error_msg for kw in ["connect", "connection", "unreachable", "name resolution", "not found", "404"]):
-        return (f"{prefix}_connection_failed", f"{prefix} 解析失败：模型服务连接失败，请检查 URL 配置")
-    if any(kw in error_msg for kw in ["rate limit", "too many request", "429"]):
-        return (f"{prefix}_rate_limited", f"{prefix} 解析失败：请求过于频繁，请稍后重试")
-    if any(kw in error_msg for kw in ["not support", "unsupported", "capability", "modality"]):
-        return (f"{prefix}_capability_mismatch", f"{prefix} 解析失败：模型不支持该能力，请检查配置")
-    if any(kw in error_msg for kw in ["internal", "server error", "500", "502", "503"]):
-        return (f"{prefix}_server_error", f"{prefix} 解析失败：模型服务异常，请稍后重试")
-
-    # 优先级 4：无法识别，返回友好的默认提示（不暴露原始异常内容）
-    if prefix == "llm":
-        return (f"{prefix}_unknown_error", "模型调用失败，请稍后重试或联系管理员")
-    return (f"{prefix}_unknown_error", f"{prefix} 解析失败，请稍后重试或联系管理员")
 
 # Load environment variables for Neo4j connector
 load_dotenv()
@@ -670,18 +607,24 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         return int(getattr(usage_metadata, "total_tokens", 0) or 0)
 
     @staticmethod
-    def _trial_run_chat_error_data(language: str, kind: str = "generation") -> dict[str, Any]:
-        english = language == "en"
-        if kind == "model":
-            message = "Model unavailable" if english else "模型不可用"
-            error = "no available api key"
-        elif kind == "access":
-            message = "Configuration access denied" if english else "无权访问该配置"
-            error = "configuration access denied"
-        else:
-            message = "Chat generation failed" if english else "对话生成失败"
-            error = "trial run chat generation failed"
-        return {"code": 5000, "message": message, "error": error}
+    def _classified_llm_error_data(
+            classified: ClassifiedLLMError,
+            language: str,
+            message: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "code": int(classified.biz_code),
+            "error": classified.error,
+            "message": message or t(classified.i18n_key, locale=language),
+        }
+
+    @staticmethod
+    def _trial_run_chat_error_data(language: str) -> dict[str, Any]:
+        return {
+            "code": int(BizCode.API_KEY_MISSING),
+            "error": "api_key_missing",
+            "message": t("errors.llm.api_key_missing", locale=language),
+        }
 
     async def trial_run_chat_stream(
             self,
@@ -771,21 +714,6 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         try:
             async with get_async_db_context() as db:
                 memory_config = await MemoryConfigService(db).load_memory_config_async(payload.config_id)
-                if (
-                        workspace_id is None
-                        or tenant_id is None
-                        or memory_config.workspace_id != workspace_id
-                        or memory_config.tenant_id != tenant_id
-                ):
-                    logger.warning(
-                        "Trial-run chat configuration access denied: config_id=%s, config_workspace=%s, request_workspace=%s",
-                        payload.config_id,
-                        memory_config.workspace_id,
-                        workspace_id,
-                    )
-                    yield format_sse_message("error", self._trial_run_chat_error_data(language, "access"))
-                    return
-
                 runtime_cache: dict[uuid.UUID, tuple[ModelInfo, uuid.UUID] | None] = {}
 
                 async def get_runtime(model_config_id: uuid.UUID):
@@ -802,7 +730,7 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
                 final_runtime = await get_runtime(memory_config.llm_model_id)
                 if final_runtime is None:
-                    yield format_sse_message("error", self._trial_run_chat_error_data(language, "model"))
+                    yield format_sse_message("error", self._trial_run_chat_error_data(language))
                     return
 
                 media_runtimes: dict[FileType, tuple[ModelInfo, uuid.UUID] | None] = {}
@@ -840,57 +768,44 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 refs = attachment_groups[file_type]
                 runtime = media_runtimes.get(file_type)
                 if runtime is None:
-                    # 返回错误标记
+                    classified = ClassifiedLLMError(
+                        "model_not_found",
+                        BizCode.MODEL_NOT_FOUND,
+                        "errors.llm.model_not_found",
+                    )
                     return {
                         "error": True,
-                        "type": file_type.value.upper(),
-                        "error_field": f"{file_type.value.upper()}_model_unavailable",
-                        "message": f"{file_type.value.upper()} 附件：没有可用的处理模型",
+                        "subject": file_type.value.lower(),
+                        "classified": classified,
                     }
 
                 model_info, api_key_id = runtime
-                try:
-                    # 本地文件已由短会话加载，远程文件已有 URL；后续格式化不需要数据库。
-                    multimodal_service = MultimodalService(None, model_info)
-                    parts = await self._process_trial_run_files(
-                        [ref["file"] for ref in refs],
-                        multimodal_service,
-                        config_workspace_id,
-                        config_tenant_id,
-                        model_info.capability,
-                        language,
-                    )
+                # 附件在进入试运行前已经完成输入校验，加载与格式化异常不在这里转换为 LLM 错误。
+                multimodal_service = MultimodalService(None, model_info)
+                parts = await self._process_trial_run_files(
+                    [ref["file"] for ref in refs],
+                    multimodal_service,
+                    config_workspace_id,
+                    config_tenant_id,
+                    model_info.capability,
+                    language,
+                )
 
-                    mapping = "\n".join(
-                        f"Attachment {index} = {attachment_label(ref)}"
-                        for index, ref in enumerate(refs, start=1)
-                    )
-                    requested_language = "English" if language == "en" else "Chinese"
-                    parser_prompt = (
-                        f"{TRIAL_RUN_ATTACHMENT_ANALYSIS_PROMPT}\n"
-                        f"Reply in {requested_language}.\n{mapping}"
-                    )
-                    parser_llm = build_llm(model_info, streaming=False, max_tokens=2000)
+                mapping = "\n".join(
+                    f"Attachment {index} = {attachment_label(ref)}"
+                    for index, ref in enumerate(refs, start=1)
+                )
+                requested_language = "English" if language == "en" else "Chinese"
+                parser_prompt = (
+                    f"{TRIAL_RUN_ATTACHMENT_ANALYSIS_PROMPT}\n"
+                    f"Reply in {requested_language}.\n{mapping}"
+                )
+                parser_llm = build_llm(model_info, streaming=False, max_tokens=2000)
+                try:
                     response = await parser_llm.ainvoke([
                         SystemMessage(content=parser_prompt),
                         HumanMessage(content=parts),
                     ])
-                    response_text = "".join(
-                        self._stream_content_to_texts(getattr(response, "content", None))
-                    ).strip()
-                    if not response_text:
-                        # 返回空文本也视为错误
-                        return {
-                            "error": True,
-                            "type": file_type.value,
-                            "error_field": f"{file_type.value}_empty_response",
-                            "message": f"{file_type.value} 附件解析未返回文本",
-                        }
-                    return {
-                        "text": response_text,
-                        "tokens": self._extract_total_tokens(response),
-                        "api_key_id": api_key_id,
-                    }
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:
@@ -899,14 +814,30 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                         file_type.value,
                         exc_info=True,
                     )
-                    # 使用错误分类，前缀使用大写
-                    error_field, message = classify_llm_error(e, prefix=file_type.value.upper())
                     return {
                         "error": True,
-                        "type": file_type.value.upper(),
-                        "error_field": error_field,
-                        "message": message,
+                        "subject": file_type.value.lower(),
+                        "classified": classify_llm_error(e, provider=model_info.provider),
                     }
+                response_text = "".join(
+                    self._stream_content_to_texts(getattr(response, "content", None))
+                ).strip()
+                if not response_text:
+                    classified = ClassifiedLLMError(
+                        "empty_response",
+                        BizCode.LLM_ERROR,
+                        "errors.llm.empty_response",
+                    )
+                    return {
+                        "error": True,
+                        "subject": file_type.value.lower(),
+                        "classified": classified,
+                    }
+                return {
+                    "text": response_text,
+                    "tokens": self._extract_total_tokens(response),
+                    "api_key_id": api_key_id,
+                }
 
             async def extract_document_group() -> dict[str, Any]:
                 refs = attachment_groups[FileType.DOCUMENT]
@@ -915,30 +846,14 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
                 multimodal_service = MultimodalService(None, final_model_info)
                 for ref in refs:
                     file = ref["file"]
-                    try:
-                        if file.transfer_method == TransferMethod.LOCAL_FILE:
-                            await self._load_trial_run_local_file(
-                                file,
-                                config_workspace_id,
-                                config_tenant_id,
-                            )
-                        text = await multimodal_service.extract_document_text(file)
-                        documents.append(f"{attachment_label(ref)}\n{text}")
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as e:
-                        logger.error(
-                            "[TRIAL_RUN_CHAT_STREAM] Document extraction failed",
-                            exc_info=True,
+                    if file.transfer_method == TransferMethod.LOCAL_FILE:
+                        await self._load_trial_run_local_file(
+                            file,
+                            config_workspace_id,
+                            config_tenant_id,
                         )
-                        # 使用错误分类
-                        error_field, message = classify_llm_error(e, prefix="DOCUMENT")
-                        return {
-                            "error": True,
-                            "type": "DOCUMENT",
-                            "error_field": error_field,
-                            "message": message,
-                        }
+                    text = await multimodal_service.extract_document_text(file)
+                    documents.append(f"{attachment_label(ref)}\n{text}")
                 return {"text": "\n\n".join(documents), "tokens": 0, "api_key_id": None}
 
             analysis_tasks = [
@@ -951,23 +866,32 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
             analysis_results = await asyncio.gather(*analysis_tasks) if analysis_tasks else []
 
-            # 收集所有错误
-            error_messages = []
-            first_error_field = "attachment_parse_failed"
+            attachment_errors: list[tuple[str, ClassifiedLLMError]] = []
             for result in analysis_results:
                 if isinstance(result, dict) and result.get("error"):
-                    error_messages.append(result["message"])
-                    if first_error_field == "attachment_parse_failed":
-                        first_error_field = result["error_field"]
+                    attachment_errors.append((result["subject"], result["classified"]))
 
-            # 如果有错误，一次性返回，所有信息合并到 message 中
-            if error_messages:
-                combined_message = "附件解析失败：" + "；".join(error_messages)
-                yield format_sse_message("error", {
-                    "code": 5000,
-                    "error": first_error_field,
-                    "message": combined_message,
-                })
+            if attachment_errors:
+                parts = [
+                    f"{t(f'errors.llm.subjects.{subject}', locale=language)} "
+                    f"{t(classified.i18n_key, locale=language)}"
+                    for subject, classified in attachment_errors
+                ]
+                combined_message = parts[0]
+                if len(parts) > 1:
+                    combined_message = (
+                        t("errors.llm.attachment_prefix", locale=language)
+                        + "；".join(parts)
+                    )
+                first_classified = attachment_errors[0][1]
+                yield format_sse_message(
+                    "error",
+                    self._classified_llm_error_data(
+                        first_classified,
+                        language,
+                        message=combined_message,
+                    ),
+                )
                 return
 
             # 继续原有逻辑
@@ -1017,17 +941,28 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
 
             full_content = ""
             final_tokens = 0
-            async for event in agent.astream_events({"messages": messages}, version="v2"):
-                event_type = event.get("event")
-                if event_type == "on_chat_model_stream":
-                    chunk = event.get("data", {}).get("chunk")
-                    for text_chunk in self._stream_content_to_texts(getattr(chunk, "content", None)):
-                        full_content += text_chunk
-                        yield format_sse_message("message", {"content": text_chunk})
-                elif event_type == "on_chat_model_end":
-                    output = event.get("data", {}).get("output")
-                    message = self._extract_message_from_event_output(output)
-                    final_tokens = max(final_tokens, self._extract_total_tokens(message))
+            try:
+                async for event in agent.astream_events({"messages": messages}, version="v2"):
+                    event_type = event.get("event")
+                    if event_type == "on_chat_model_stream":
+                        chunk = event.get("data", {}).get("chunk")
+                        for text_chunk in self._stream_content_to_texts(getattr(chunk, "content", None)):
+                            full_content += text_chunk
+                            yield format_sse_message("message", {"content": text_chunk})
+                    elif event_type == "on_chat_model_end":
+                        output = event.get("data", {}).get("output")
+                        message = self._extract_message_from_event_output(output)
+                        final_tokens = max(final_tokens, self._extract_total_tokens(message))
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error("[TRIAL_RUN_CHAT_STREAM] Final LLM generation failed", exc_info=True)
+                classified = classify_llm_error(e, provider=final_model_info.provider)
+                yield format_sse_message(
+                    "error",
+                    self._classified_llm_error_data(classified, language),
+                )
+                return
 
             if attachment_context:
                 details_title = (
@@ -1066,24 +1001,13 @@ class DataConfigService:  # 数据配置服务类（PostgreSQL）
         except asyncio.CancelledError:
             logger.info("[TRIAL_RUN_CHAT_STREAM] Client disconnected during streaming")
             raise
-        except Exception as e:
-            logger.error("[TRIAL_RUN_CHAT_STREAM] Error during streaming", exc_info=True)
-            error_msg = str(e).lower()
-            # 区分配置错误和 LLM 错误
-            if "configuration not found" in error_msg or "config" in error_msg and "not found" in error_msg:
-                yield format_sse_message("error", {
-                    "code": 5000,
-                    "error": "config_error",
-                    "message": "配置读取失败",
-                })
-            else:
-                # 使用错误分类
-                error_field, message = classify_llm_error(e, prefix="llm")
-                yield format_sse_message("error", {
-                    "code": 5000,
-                    "error": error_field,
-                    "message": message,
-                })
+        except ConfigurationError:
+            logger.error("[TRIAL_RUN_CHAT_STREAM] Configuration loading failed", exc_info=True)
+            yield format_sse_message("error", {
+                "code": int(BizCode.MEMORY_CONFIG_NOT_FOUND),
+                "error": "config_error",
+                "message": "Configuration loading failed" if language == "en" else "配置读取失败",
+            })
 
     async def pilot_run_stream(self, payload: PilotRunInput, language: str = "zh") -> AsyncGenerator[str, None]:
         """

--- a/api/app/utils/llm_error_utils.py
+++ b/api/app/utils/llm_error_utils.py
@@ -1,0 +1,518 @@
+"""Normalize LLM provider exceptions into stable application errors."""
+
+from dataclasses import dataclass, replace
+from typing import Any, Protocol
+
+import httpx
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    OpenAIError,
+    PermissionDeniedError,
+    RateLimitError,
+)
+
+from app.core.error_codes import BizCode
+
+
+@dataclass(frozen=True)
+class ClassifiedLLMError:
+    """Stable error contract consumed by the service and frontend."""
+
+    error: str
+    biz_code: BizCode
+    i18n_key: str
+
+
+@dataclass(frozen=True)
+class ProviderErrorInfo:
+    """Structured provider diagnostics extracted before normalization."""
+
+    provider: str | None
+    sdk_error_type: str
+    http_status: int | None
+    provider_code: str | None
+    request_id: str | None
+    retry_after: float | None
+    message: str
+
+
+class ProviderErrorAdapter(Protocol):
+    """Contract for provider-specific error normalizers."""
+
+    def classify(
+            self,
+            info: ProviderErrorInfo,
+            exception_chain: tuple[Exception, ...],
+    ) -> ClassifiedLLMError | None:
+        """Return a classification when this adapter recognizes the error."""
+
+
+_CLASSIFICATIONS = {
+    "authentication_failed": ClassifiedLLMError(
+        "authentication_failed", BizCode.API_KEY_INVALID, "errors.llm.authentication_failed"
+    ),
+    "permission_denied": ClassifiedLLMError(
+        "permission_denied", BizCode.PERMISSION_DENIED, "errors.llm.permission_denied"
+    ),
+    "quota_exceeded": ClassifiedLLMError(
+        "quota_exceeded", BizCode.QUOTA_EXCEEDED, "errors.llm.quota_exceeded"
+    ),
+    "rate_limited": ClassifiedLLMError(
+        "rate_limited", BizCode.RATE_LIMIT_EXCEEDED, "errors.llm.rate_limited"
+    ),
+    "timeout": ClassifiedLLMError(
+        "timeout", BizCode.SERVICE_UNAVAILABLE, "errors.llm.timeout"
+    ),
+    "connection_failed": ClassifiedLLMError(
+        "connection_failed", BizCode.SERVICE_UNAVAILABLE, "errors.llm.connection_failed"
+    ),
+    "invalid_request": ClassifiedLLMError(
+        "invalid_request", BizCode.INVALID_PARAMETER, "errors.llm.invalid_request"
+    ),
+    "model_not_found": ClassifiedLLMError(
+        "model_not_found", BizCode.MODEL_NOT_FOUND, "errors.llm.model_not_found"
+    ),
+    "capability_mismatch": ClassifiedLLMError(
+        "capability_mismatch", BizCode.MODEL_CONFIG_INVALID, "errors.llm.capability_mismatch"
+    ),
+    "server_error": ClassifiedLLMError(
+        "server_error", BizCode.SERVICE_UNAVAILABLE, "errors.llm.server_error"
+    ),
+    "unknown": ClassifiedLLMError(
+        "unknown", BizCode.LLM_ERROR, "errors.llm.unknown"
+    ),
+}
+
+_PROVIDER_CODE_MAP = {
+    "invalid_api_key": "authentication_failed",
+    "authentication_error": "authentication_failed",
+    "permission_denied": "permission_denied",
+    "insufficient_permissions": "permission_denied",
+    "insufficient_quota": "quota_exceeded",
+    "quota_exceeded": "quota_exceeded",
+    "billing_not_active": "quota_exceeded",
+    "rate_limit_exceeded": "rate_limited",
+    "model_not_found": "model_not_found",
+    "unsupported_model": "model_not_found",
+    "unsupported_parameter": "capability_mismatch",
+    "unsupported_value": "capability_mismatch",
+    "invalid_request": "invalid_request",
+    "invalid_request_error": "invalid_request",
+    "request_timeout": "timeout",
+    "server_error": "server_error",
+    "internal_server_error": "server_error",
+}
+
+_DASHSCOPE_CODE_MAP = {
+    "invalidapikey": "authentication_failed",
+    "accessdenied": "permission_denied",
+    "modelaccessdenied": "permission_denied",
+    "arrearage": "quota_exceeded",
+    "throttling": "rate_limited",
+    "ratelimit": "rate_limited",
+    "invalidparameter": "invalid_request",
+    "invalidinput": "invalid_request",
+    "modelnotfound": "model_not_found",
+    "invalidmodel": "model_not_found",
+    "unsupportedmodel": "model_not_found",
+    "requesttimeout": "timeout",
+    "internalerror": "server_error",
+    "serviceunavailable": "server_error",
+}
+
+_QUOTA_PHRASES = (
+    "arrearage",
+    "欠费",
+    "余额不足",
+    "额度不足",
+    "insufficient balance",
+    "insufficient quota",
+    "insufficient credit",
+    "quota exceeded",
+    "quota exhausted",
+    "billing limit",
+    "credit balance",
+    "out of funds",
+)
+
+_CAPABILITY_PHRASES = (
+    "does not support",
+    "not supported",
+    "unsupported capability",
+    "unsupported modality",
+    "capability mismatch",
+)
+
+_KEYWORD_RULES = (
+    (
+        "authentication_failed",
+        (
+            "invalid_api_key",
+            "incorrect_api_key",
+            "invalid api key",
+            "authentication failed",
+            "authentication error",
+            "unauthorized",
+        ),
+    ),
+    (
+        "permission_denied",
+        (
+            "api key expired",
+            "api key disabled",
+            "api key locked",
+            "forbidden",
+            "permission denied",
+            "insufficient permission",
+            "access denied",
+        ),
+    ),
+    ("quota_exceeded", _QUOTA_PHRASES),
+    ("rate_limited", ("rate limit", "too many requests", "too many request")),
+    ("model_not_found", ("model not found", "unknown model", "model_not_found")),
+    ("capability_mismatch", _CAPABILITY_PHRASES),
+    ("invalid_request", ("invalid_parameter", "bad request", "content-length", "content_length")),
+    ("timeout", ("request timeout", "timed out", "timeout")),
+    ("connection_failed", ("connection failed", "connection error", "unreachable", "name resolution")),
+    ("server_error", ("internal server error", "provider server error", "service unavailable")),
+)
+
+_PROVIDER_ADAPTERS: dict[str, ProviderErrorAdapter] = {}
+
+
+def register_provider_error_adapter(provider: str, adapter: ProviderErrorAdapter) -> None:
+    """Register or replace the adapter for a normalized provider name."""
+    normalized = _normalize_provider(provider)
+    if not normalized:
+        raise ValueError("provider must not be empty")
+    _PROVIDER_ADAPTERS[normalized] = adapter
+
+
+def _normalize_provider(provider: Any | None) -> str | None:
+    """Normalize a provider enum or string for registry lookup."""
+    if provider is None:
+        return None
+    value = getattr(provider, "value", provider)
+    normalized = str(value).strip().lower()
+    return normalized or None
+
+
+def _normalize_code(code: Any | None) -> str | None:
+    """Normalize a scalar provider code while preserving meaningful separators."""
+    if code is None or isinstance(code, (dict, list, tuple)):
+        return None
+    normalized = str(code).strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized or None
+
+
+def _as_int(value: Any | None) -> int | None:
+    """Convert integer-like status values without accepting booleans."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def _exception_chain(error: Exception) -> tuple[Exception, ...]:
+    """Collect a bounded, cycle-safe exception cause/context chain."""
+    chain: list[Exception] = []
+    seen: set[int] = set()
+    current: Exception | None = error
+    while current is not None and id(current) not in seen and len(chain) < 8:
+        chain.append(current)
+        seen.add(id(current))
+        cause = current.__cause__ or current.__context__
+        current = cause if isinstance(cause, Exception) else None
+    return tuple(chain)
+
+
+def _response_mapping(error: Exception) -> dict[str, Any] | None:
+    """Extract a dictionary response body from common SDK exception shapes."""
+    body = getattr(error, "body", None)
+    if isinstance(body, dict):
+        return body
+
+    response = getattr(error, "response", None)
+    if isinstance(response, dict):
+        return response
+    response_json = getattr(response, "json", None)
+    if callable(response_json):
+        try:
+            data = response_json()
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+    return None
+
+
+def _mapping_error_code(data: dict[str, Any] | None) -> str | None:
+    """Read a machine error code from common flat or nested response bodies."""
+    if not data:
+        return None
+    nested = data.get("error") or data.get("Error")
+    if isinstance(nested, dict):
+        code = nested.get("code") or nested.get("Code")
+        if normalized := _normalize_code(code):
+            return normalized
+    return _normalize_code(data.get("code") or data.get("Code"))
+
+
+def _mapping_error_message(data: dict[str, Any] | None) -> str | None:
+    """Read a human diagnostic message from common response body shapes."""
+    if not data:
+        return None
+    nested = data.get("error") or data.get("Error")
+    if isinstance(nested, str):
+        return nested.strip() or None
+    if isinstance(nested, dict):
+        message = nested.get("message") or nested.get("Message")
+        if message:
+            return str(message).strip() or None
+    message = data.get("message") or data.get("Message")
+    return str(message).strip() if message else None
+
+
+def _headers(error: Exception) -> Any | None:
+    """Return response headers when the wrapped response exposes them."""
+    response = getattr(error, "response", None)
+    if isinstance(response, httpx.Response):
+        return response.headers
+    return getattr(response, "headers", None)
+
+
+def _header_value(headers: Any | None, *names: str) -> str | None:
+    """Read the first non-empty value from a case-insensitive header mapping."""
+    if headers is None or not hasattr(headers, "get"):
+        return None
+    for name in names:
+        value = headers.get(name)
+        if value:
+            return str(value)
+    return None
+
+
+def extract_provider_error_info(
+        error: Exception,
+        provider: str | None = None,
+) -> tuple[ProviderErrorInfo, tuple[Exception, ...]]:
+    """Extract structured diagnostics from an exception and its cause chain."""
+    chain = _exception_chain(error)
+    http_status: int | None = None
+    provider_code: str | None = None
+    request_id: str | None = None
+    retry_after: float | None = None
+    structured_messages: list[str] = []
+
+    for item in chain:
+        response = getattr(item, "response", None)
+        status = _as_int(getattr(item, "status_code", None))
+        if status is None:
+            status = _as_int(getattr(response, "status_code", None))
+        if status is None and isinstance(response, dict):
+            metadata = response.get("ResponseMetadata") or {}
+            if isinstance(metadata, dict):
+                status = _as_int(metadata.get("HTTPStatusCode"))
+        http_status = http_status or status
+
+        response_data = _response_mapping(item)
+        provider_code = provider_code or _normalize_code(getattr(item, "code", None))
+        provider_code = provider_code or _mapping_error_code(response_data)
+        if structured_message := _mapping_error_message(response_data):
+            structured_messages.append(structured_message)
+
+        request_id = request_id or getattr(item, "request_id", None)
+        if isinstance(response_data, dict):
+            request_id = request_id or response_data.get("request_id") or response_data.get("requestId")
+        headers = _headers(item)
+        request_id = request_id or _header_value(headers, "x-request-id", "request-id")
+        retry_after_value = _header_value(headers, "retry-after")
+        if retry_after is None and retry_after_value is not None:
+            try:
+                retry_after = float(retry_after_value)
+            except ValueError:
+                pass
+
+        if isinstance(response, dict):
+            metadata = response.get("ResponseMetadata") or {}
+            if isinstance(metadata, dict):
+                request_id = request_id or metadata.get("RequestId")
+
+    messages = [str(item).strip() for item in chain if str(item).strip()]
+    messages.extend(message for message in structured_messages if message not in messages)
+    info = ProviderErrorInfo(
+        provider=_normalize_provider(provider),
+        sdk_error_type=type(chain[-1]).__name__ if len(chain) > 1 else type(error).__name__,
+        http_status=http_status,
+        provider_code=provider_code,
+        request_id=str(request_id) if request_id else None,
+        retry_after=retry_after,
+        message=" | ".join(messages).lower(),
+    )
+    return info, chain
+
+
+def _contains_any(message: str, phrases: tuple[str, ...]) -> bool:
+    """Return whether a normalized diagnostic contains any strict fallback phrase."""
+    return any(phrase in message for phrase in phrases)
+
+
+def _classification_for_provider_code(code: str | None) -> ClassifiedLLMError | None:
+    """Map a provider-neutral machine code to the internal error contract."""
+    key = _PROVIDER_CODE_MAP.get(code or "")
+    return _CLASSIFICATIONS[key] if key else None
+
+
+def _parse_dashscope_error_fields(exception_chain: tuple[Exception, ...]) -> dict[str, str]:
+    """Parse the stable multiline error format emitted by ChatTongyi for 400/401 responses."""
+    fields: dict[str, str] = {}
+    supported_fields = {"request_id", "status_code", "code", "message"}
+    for error in exception_chain:
+        for line in str(error).splitlines():
+            key, separator, value = line.strip().partition(":")
+            normalized_key = key.strip().lower()
+            if separator and normalized_key in supported_fields and value.strip():
+                fields.setdefault(normalized_key, value.strip())
+    return fields
+
+
+def _classification_for_dashscope_code(code: str | None) -> ClassifiedLLMError | None:
+    """Map a native DashScope machine code to the internal stable classification."""
+    key = _DASHSCOPE_CODE_MAP.get(code or "")
+    return _CLASSIFICATIONS[key] if key else None
+
+
+class _OpenAIErrorAdapter:
+    def classify(
+            self,
+            info: ProviderErrorInfo,
+            exception_chain: tuple[Exception, ...],
+    ) -> ClassifiedLLMError | None:
+        """Normalize exceptions produced by the OpenAI Python SDK family."""
+        if classified := _classification_for_provider_code(info.provider_code):
+            return classified
+        for error in exception_chain:
+            if isinstance(error, AuthenticationError):
+                return _CLASSIFICATIONS["authentication_failed"]
+            if isinstance(error, PermissionDeniedError):
+                return _CLASSIFICATIONS["permission_denied"]
+            if isinstance(error, RateLimitError):
+                key = "quota_exceeded" if _contains_any(info.message, _QUOTA_PHRASES) else "rate_limited"
+                return _CLASSIFICATIONS[key]
+            if isinstance(error, APITimeoutError):
+                return _CLASSIFICATIONS["timeout"]
+            if isinstance(error, APIConnectionError):
+                return _CLASSIFICATIONS["connection_failed"]
+            if isinstance(error, BadRequestError):
+                if _contains_any(info.message, _CAPABILITY_PHRASES):
+                    return _CLASSIFICATIONS["capability_mismatch"]
+                return _CLASSIFICATIONS["invalid_request"]
+        return None
+
+
+class _GenericHTTPErrorAdapter:
+    def classify(
+            self,
+            info: ProviderErrorInfo,
+            exception_chain: tuple[Exception, ...],
+    ) -> ClassifiedLLMError | None:
+        """Normalize structured HTTP status failures shared across providers."""
+        del exception_chain
+        if classified := _classification_for_provider_code(info.provider_code):
+            return classified
+
+        status = info.http_status
+        if status == 400:
+            if _contains_any(info.message, _CAPABILITY_PHRASES):
+                return _CLASSIFICATIONS["capability_mismatch"]
+            return _CLASSIFICATIONS["invalid_request"]
+        if status == 401:
+            return _CLASSIFICATIONS["authentication_failed"]
+        if status == 402:
+            return _CLASSIFICATIONS["quota_exceeded"]
+        if status == 403:
+            return _CLASSIFICATIONS["permission_denied"]
+        if status == 404:
+            model_phrases = ("model not found", "unknown model", "model_not_found")
+            if _contains_any(info.message, model_phrases):
+                return _CLASSIFICATIONS["model_not_found"]
+            return _CLASSIFICATIONS["connection_failed"]
+        if status in (408, 504):
+            return _CLASSIFICATIONS["timeout"]
+        if status == 409:
+            return _CLASSIFICATIONS["server_error"]
+        if status == 422:
+            return _CLASSIFICATIONS["invalid_request"]
+        if status == 429:
+            key = "quota_exceeded" if _contains_any(info.message, _QUOTA_PHRASES) else "rate_limited"
+            return _CLASSIFICATIONS[key]
+        if status is not None and 500 <= status < 600:
+            return _CLASSIFICATIONS["server_error"]
+        return None
+
+
+class _DashScopeErrorAdapter:
+    def classify(
+            self,
+            info: ProviderErrorInfo,
+            exception_chain: tuple[Exception, ...],
+    ) -> ClassifiedLLMError | None:
+        """Normalize native ChatTongyi errors without affecting DashScope Omni OpenAI errors."""
+        fields = _parse_dashscope_error_fields(exception_chain)
+        provider_code = info.provider_code or _normalize_code(fields.get("code"))
+        if classified := _classification_for_dashscope_code(provider_code):
+            return classified
+
+        http_status = info.http_status or _as_int(fields.get("status_code"))
+        request_id = info.request_id or fields.get("request_id")
+        message = info.message
+        if field_message := fields.get("message"):
+            normalized_message = field_message.lower()
+            if normalized_message not in message:
+                message = f"{message} | {normalized_message}"
+
+        enriched_info = replace(
+            info,
+            http_status=http_status,
+            provider_code=provider_code,
+            request_id=request_id,
+            message=message,
+        )
+        return _GENERIC_HTTP_ADAPTER.classify(enriched_info, exception_chain)
+
+
+_OPENAI_ADAPTER = _OpenAIErrorAdapter()
+_GENERIC_HTTP_ADAPTER = _GenericHTTPErrorAdapter()
+_DASHSCOPE_ADAPTER = _DashScopeErrorAdapter()
+
+register_provider_error_adapter("dashscope", _DASHSCOPE_ADAPTER)
+
+
+def classify_llm_error(
+        error: Exception,
+        provider: str | None = None,
+) -> ClassifiedLLMError:
+    """Normalize one provider exception using structured adapters and strict fallbacks."""
+    info, chain = extract_provider_error_info(error, provider)
+
+    if any(isinstance(item, OpenAIError) for item in chain):
+        if classified := _OPENAI_ADAPTER.classify(info, chain):
+            return classified
+
+    provider_adapter = _PROVIDER_ADAPTERS.get(info.provider or "")
+    if provider_adapter is not None:
+        if classified := provider_adapter.classify(info, chain):
+            return classified
+
+    if classified := _GENERIC_HTTP_ADAPTER.classify(info, chain):
+        return classified
+
+    for key, phrases in _KEYWORD_RULES:
+        if _contains_any(info.message, phrases):
+            return _CLASSIFICATIONS[key]
+    return _CLASSIFICATIONS["unknown"]


### PR DESCRIPTION
## Sourcery 摘要

为附件解析和 LLM 失败返回一致且可操作的错误响应。

新功能：
- 对 LLM、模型和附件解析失败进行结构化分类，以返回面向用户的错误响应。

错误修复：
- 当附件模型不可用、产生空输出或在分析过程中失败时，返回明确的 SSE 错误，而不是静默地嵌入备用文本。

增强功能：
- 将并行附件分析中的错误汇总为单个响应，并区分配置失败与其他模型错误。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为附件解析和 LLM 失败返回一致且可操作的错误响应。

错误修复：
- 当附件模型不可用、生成空输出或在分析过程中失败时，返回明确的结构化 SSE 错误，而不是静默插入备用文本。

增强功能：
- 将 LLM 和附件解析失败归类为可操作的类别，并将并行附件分析中的错误汇总为单个响应。
- 在流式响应中，将配置查找失败与其他 LLM 错误区分开来。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为配置、附件和 LLM 失败返回一致、本地化且可操作的 SSE 错误。

新功能：
- 为 LLM、模型和附件处理失败添加稳定且本地化的错误响应。

错误修复：
- 当附件分析失败、产生空输出或缺少合适的模型时，返回明确的 SSE 错误，而不是静默地嵌入备用文本。
- 将配置加载失败与其他流式生成错误区分开来。

增强功能：
- 将并行附件分析中的失败聚合为单个可操作的响应。
- 将特定于提供商的 LLM 异常规范化为一致的应用程序错误类别和业务代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Return consistent, localized, and actionable SSE errors for configuration, attachment, and LLM failures.

New Features:
- Add stable, localized error responses for LLM, model, and attachment-processing failures.

Bug Fixes:
- Return explicit SSE errors instead of silently embedding fallback text when attachment analysis fails, produces empty output, or lacks a suitable model.
- Distinguish configuration-loading failures from other streaming-generation errors.

Enhancements:
- Aggregate failures from parallel attachment analysis into a single actionable response.
- Normalize provider-specific LLM exceptions into consistent application error categories and business codes.

</details>

</details>

</details>