### PR TITLE
feat(rag): add knowledge request lifecycle logs

### DIFF
--- a/mem-knowledge/src/api/routes/knowledge.py
+++ b/mem-knowledge/src/api/routes/knowledge.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Annotated, Any
 from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Body, Depends, Query, Request
 from fastapi.responses import StreamingResponse
 from redbear_model import (
     ModelConfigNotFoundError,
@@ -521,9 +521,12 @@ async def export_knowledge_qa_csv(
 @router.post("/{kb_id}/batch-download")
 async def kb_batch_download(
     kb_id: uuid.UUID,
-    request_body: KBBatchDownloadRequest,
     principal: Annotated[Principal, Depends(get_principal)],
     runtime: Annotated[ProcessRuntime, Depends(get_runtime)],
+    request_body: Annotated[
+        KBBatchDownloadRequest,
+        Body(default_factory=KBBatchDownloadRequest),
+    ],
 ) -> StreamingResponse:
     async with runtime.database.async_session() as db:
         knowledge = await knowledge_service.get_knowledge(db, kb_id, principal)

--- a/mem-knowledge/src/main.py
+++ b/mem-knowledge/src/main.py
@@ -118,7 +118,7 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
             route_path = f"/internal/v1{route_path}"
         validation_errors = [
             {
-                "loc": ".".join(str(part) for part in tuple(error.get("loc", ()))[:2]),
+                "loc": str((tuple(error.get("loc", ())) or ("unknown",))[0]),
                 "type": str(error.get("type", "")),
                 "msg": "Request validation failed",
             }

--- a/mem-knowledge/src/main.py
+++ b/mem-knowledge/src/main.py
@@ -8,6 +8,8 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, Request
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -102,6 +104,34 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
     application.state.runtime = runtime
     application.add_middleware(TraceIdMiddleware)
     application.include_router(internal_v1_router)
+
+    @application.exception_handler(RequestValidationError)
+    async def request_validation_error_handler(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        trace_id = getattr(request.state, "trace_id", get_trace_id())
+        validation_errors = [
+            {
+                "loc": ".".join(str(part) for part in error.get("loc", ())),
+                "type": str(error.get("type", "")),
+                "msg": str(error.get("msg", "")),
+            }
+            for error in exc.errors()
+        ]
+        logger.warning(
+            "Knowledge request validation failed trace_id=%s method=%s path=%s "
+            "actor_id=%s tenant_id=%s workspace_id=%s source=%s errors=%s",
+            trace_id,
+            request.method,
+            request.url.path,
+            request.headers.get("X-KB-Actor-ID"),
+            request.headers.get("X-KB-Tenant-ID"),
+            request.headers.get("X-KB-Workspace-ID"),
+            request.headers.get("X-KB-Source"),
+            validation_errors,
+        )
+        return await request_validation_exception_handler(request, exc)
 
     @application.exception_handler(KnowledgeError)
     async def knowledge_error_handler(

--- a/mem-knowledge/src/main.py
+++ b/mem-knowledge/src/main.py
@@ -19,6 +19,7 @@ from .bootstrap import get_settings
 from .config import KnowledgeSettings
 from .errors import KnowledgeError
 from .logging import setup_logging
+from .request_logging import RequestLoggingFastAPI, request_route_template
 from .runtime import ProcessRuntime
 from .trace import TRACE_ID_HEADER, TraceIdMiddleware, get_trace_id
 
@@ -92,7 +93,7 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
             await application.state.runtime.aclose()
             logger.info("Knowledge service stopped")
 
-    application = FastAPI(
+    application = RequestLoggingFastAPI(
         title="MemoryBear Knowledge Service",
         description="Internal MemoryBear knowledge service API",
         version="0.1.0",
@@ -111,11 +112,7 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
         exc: RequestValidationError,
     ) -> JSONResponse:
         trace_id = getattr(request.state, "trace_id", get_trace_id())
-        route_path = getattr(request.scope.get("route"), "path", "<unresolved>")
-        if request.url.path.startswith("/internal/v1/") and not route_path.startswith(
-            "/internal/v1/"
-        ):
-            route_path = f"/internal/v1{route_path}"
+        route_path = request_route_template(request.scope)
         validation_errors = [
             {
                 "loc": str((tuple(error.get("loc", ())) or ("unknown",))[0]),
@@ -124,7 +121,7 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
             }
             for error in exc.errors()
         ]
-        logger.warning(
+        logger.error(
             "Knowledge request validation failed trace_id=%s method=%s path=%s "
             "actor_id=%s tenant_id=%s workspace_id=%s source=%s errors=%s",
             trace_id,

--- a/mem-knowledge/src/main.py
+++ b/mem-knowledge/src/main.py
@@ -111,11 +111,16 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
         exc: RequestValidationError,
     ) -> JSONResponse:
         trace_id = getattr(request.state, "trace_id", get_trace_id())
+        route_path = getattr(request.scope.get("route"), "path", "<unresolved>")
+        if request.url.path.startswith("/internal/v1/") and not route_path.startswith(
+            "/internal/v1/"
+        ):
+            route_path = f"/internal/v1{route_path}"
         validation_errors = [
             {
-                "loc": ".".join(str(part) for part in error.get("loc", ())),
+                "loc": ".".join(str(part) for part in tuple(error.get("loc", ()))[:2]),
                 "type": str(error.get("type", "")),
-                "msg": str(error.get("msg", "")),
+                "msg": "Request validation failed",
             }
             for error in exc.errors()
         ]
@@ -124,7 +129,7 @@ def create_app(settings: KnowledgeSettings | None = None) -> FastAPI:
             "actor_id=%s tenant_id=%s workspace_id=%s source=%s errors=%s",
             trace_id,
             request.method,
-            request.url.path,
+            route_path,
             request.headers.get("X-KB-Actor-ID"),
             request.headers.get("X-KB-Tenant-ID"),
             request.headers.get("X-KB-Workspace-ID"),

--- a/mem-knowledge/src/request_logging.py
+++ b/mem-knowledge/src/request_logging.py
@@ -1,0 +1,128 @@
+"""HTTP request lifecycle logging without buffering request or response bodies."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from fastapi import FastAPI
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+def request_route_template(scope: Scope) -> str:
+    route_path = getattr(scope.get("route"), "path", None)
+    if not isinstance(route_path, str) or not route_path:
+        return "<unresolved>"
+    request_path = str(scope.get("path", ""))
+    if request_path.startswith("/internal/v1/") and not route_path.startswith("/internal/v1/"):
+        return f"/internal/v1{route_path}"
+    return route_path
+
+
+def _trace_id(scope: Scope) -> str:
+    state = scope.get("state")
+    if isinstance(state, dict):
+        value = state.get("trace_id")
+        if isinstance(value, str) and value:
+            return value
+    return "<unresolved>"
+
+
+def _completion_level(status_code: int, completion: str) -> int:
+    if completion in {"cancelled", "error"}:
+        return logging.ERROR
+    if status_code >= 500:
+        return logging.ERROR
+    if completion == "closed_early":
+        return logging.WARNING
+    if status_code >= 400:
+        return logging.WARNING
+    return logging.INFO
+
+
+class RequestLoggingMiddleware:
+    """Emit one completion record for each HTTP request."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        started_at = time.perf_counter_ns()
+        status_code: int | None = None
+        response_bytes = 0
+        response_complete = False
+        completion = "closed_early"
+        headers = Headers(scope=scope)
+
+        async def send_with_metrics(message: Message) -> None:
+            nonlocal status_code, response_bytes, response_complete
+            await send(message)
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+            elif message["type"] == "http.response.body":
+                response_bytes += len(message.get("body", b""))
+            if message["type"] == "http.response.body" and not message.get("more_body", False):
+                response_complete = True
+
+        try:
+            await self.app(scope, receive, send_with_metrics)
+            if response_complete:
+                completion = "complete"
+        except asyncio.CancelledError:
+            completion = "cancelled"
+            raise
+        except Exception:
+            completion = "error"
+            raise
+        finally:
+            if status_code is not None:
+                final_status = status_code
+            elif completion == "error":
+                final_status = 500
+            else:
+                final_status = 0
+            duration_ms = max(0, (time.perf_counter_ns() - started_at) // 1_000_000)
+            trace_id = _trace_id(scope)
+            try:
+                logger.log(
+                    _completion_level(final_status, completion),
+                    "request_completed service=mem-knowledge trace_id=%s method=%s "
+                    "route=%s status=%s duration_ms=%s response_bytes=%s completion=%s "
+                    "actor_id=%s tenant_id=%s workspace_id=%s source=%s",
+                    trace_id,
+                    scope.get("method", "<unknown>"),
+                    request_route_template(scope),
+                    final_status,
+                    duration_ms,
+                    response_bytes,
+                    completion,
+                    headers.get("X-KB-Actor-ID"),
+                    headers.get("X-KB-Tenant-ID"),
+                    headers.get("X-KB-Workspace-ID"),
+                    headers.get("X-KB-Source"),
+                    extra={"trace_id": trace_id},
+                )
+            except Exception:
+                pass
+
+
+class RequestLoggingFastAPI(FastAPI):
+    """Place request logging outside FastAPI's complete middleware stack."""
+
+    def build_middleware_stack(self) -> ASGIApp:
+        return RequestLoggingMiddleware(super().build_middleware_stack())
+
+
+__all__ = [
+    "RequestLoggingFastAPI",
+    "RequestLoggingMiddleware",
+    "request_route_template",
+]


### PR DESCRIPTION
## Business Background

After the knowledge API was split into `mem-knowledge`, Uvicorn access logs only exposed the method, raw path, and HTTP status. They did not provide enough service-owned evidence to identify the caller context, correlate a trace, distinguish validation failures, or measure the full lifecycle of streaming downloads.

## Summary

- Preserve legacy batch-download behavior by accepting an omitted JSON body.
- Log internal request validation failures with the propagated trace and trusted knowledge caller context while excluding raw inputs and sensitive values.
- Add service-owned HTTP lifecycle logs for successful, failed, cancelled, and streaming responses.

## Changes

- `mem-knowledge/src/api/routes/knowledge.py`
  - Use an empty `KBBatchDownloadRequest` when the caller omits the request body.
- `mem-knowledge/src/main.py`
  - Register request lifecycle logging around the complete FastAPI middleware stack.
  - Record internal `RequestValidationError` details at ERROR while preserving the default 422 response.
- `mem-knowledge/src/request_logging.py`
  - Add a pure ASGI middleware that records `service`, `trace_id`, method, safe route template, status, `duration_ms`, response bytes, completion state, and forwarded actor/tenant/workspace/source fields.
  - Measure streaming responses through the final ASGI body message without buffering request or response bodies.
  - Keep logging failures isolated from business responses and preserve cancellation/error propagation.

```text
 mem-knowledge/src/api/routes/knowledge.py |   7 +-
 mem-knowledge/src/main.py                 |  34 +++++++-
 mem-knowledge/src/request_logging.py      | 128 ++++++++++++++++++++++++++++++
 3 files changed, 166 insertions(+), 3 deletions(-)
```

## Impact and Compatibility

- No database, Redis, Elasticsearch, storage, Celery, or worker behavior changes.
- No response schema, response body, response header, or streaming protocol changes.
- The batch-download request contract is relaxed to match the existing API behavior; callers that already send JSON remain compatible.
- No change to API Key-facing routes under `api/app/controllers/service/rag_api_*_controller.py`.
- No global `KB_LOG_LEVEL`, Uvicorn access-log, or API-service logging changes.

## Risk

- INFO/WARNING lifecycle records remain subject to the existing `KB_LOG_LEVEL` threshold. Validation details and 5xx lifecycle records are visible at ERROR.
- Uvicorn access logs remain enabled, so request completion logs coexist with the existing access line in this iteration.
- Synchronous Python logging has a measurable fixed CPU cost. An in-process synthetic health benchmark measured a `0.028ms` p95 increase, `9.47%` sequential throughput reduction, and `12.59%` reduction at 50 concurrent requests. The same middleware with logging disabled measured a `0.001ms` p95 increase and `1.06%` throughput reduction. An 8 MiB / 128-chunk stream measured a `0.039ms` p95 increase, and peak middleware memory did not grow between 1 MiB and 64 MiB streams. These synthetic throughput results do not satisfy the approximately 2% logging-enabled target and are recorded as an explicit review/release tradeoff; no asynchronous logging queue is introduced in this scope.

## Test Plan

- [x] Local request lifecycle and validation regressions: `14 passed`
- [x] `ruff check` for all changed production files
- [x] `ruff format --check` for all changed production files
- [x] Python bytecode compilation for all changed production files
- [x] Legacy/OpenAPI contract gate: `58/58` operations, `54/54` JSON envelopes, `58/58` error envelopes
- [x] Independent code review: no remaining Critical or Important code findings

Repository policy prohibits committing files under test directories, so the TDD regressions were executed locally and are not included in this PR.

## Sourcery 总结

为知识服务添加可追踪的请求生命周期和验证日志，同时保持现有响应行为和批量下载兼容性。

新功能：
- 添加由服务管理的 HTTP 生命周期日志，涵盖请求标识、路由、状态、耗时、响应大小、完成状态和调用方上下文，包括流式响应。
- 记录经过清理的请求验证失败信息，以及追踪信息和调用方上下文，同时保持标准的 422 响应。

错误修复：
- 允许批量下载请求省略 JSON 请求体，以兼容现有 API 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add traceable request lifecycle and validation logging to the knowledge service while preserving existing response behavior and batch-download compatibility.

New Features:
- Add service-owned HTTP lifecycle logs covering request identity, route, status, duration, response size, completion state, and caller context, including streaming responses.
- Log sanitized request validation failures with trace and caller context while preserving the standard 422 response.

Bug Fixes:
- Allow batch-download requests to omit the JSON body for compatibility with existing API behavior.

</details>