### PR TITLE
feat(web): remove DeepDoc option

### DIFF
--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/ParameterStep.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/CreateDataset/ParameterStep.tsx
@@ -147,7 +147,6 @@ const ParameterStep = ({ form, fileIds, isParentChildMode }: ParameterStepProps)
         {pdfEnhancementEnabled && (
           <Form.Item name="pdfEnhancementMethod" noStyle>
             <Select className="rb:w-75!" options={[
-              { value: 'deepdoc', label: 'DeepDoc' },
               { value: 'mineru', label: 'MinerU' },
               { value: 'textln', label: 'TextLN' },
             ]} />


### PR DESCRIPTION
## Sourcery 总结

增强功能：
- 从网页数据集创建表单中移除 DeepDoc PDF 增强选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the DeepDoc PDF enhancement option from the web dataset creation form.

</details>