### PR TITLE
feat(neo4j): add relationship query support

### DIFF
--- a/api/app/core/memory/storage/models/__init__.py
+++ b/api/app/core/memory/storage/models/__init__.py
@@ -9,8 +9,6 @@ from app.core.memory.storage.models.filter import (
     FilterOperator,
     NodeFilter,
     RelationshipFilter,
-    RelationshipFilterScope,
-    ScopedNodeFilter,
 )
 from app.core.memory.storage.models.projection import (
     CoalesceProjectionField,
@@ -33,8 +31,6 @@ __all__ = [
     "FilterOperator",
     "NodeFilter",
     "RelationshipFilter",
-    "RelationshipFilterScope",
-    "ScopedNodeFilter",
 
     "CoalesceProjectionField",
     "NodeProjection",

--- a/api/app/core/memory/storage/models/__init__.py
+++ b/api/app/core/memory/storage/models/__init__.py
@@ -8,6 +8,9 @@ from app.core.memory.storage.models.filter import (
     FilterLogic,
     FilterOperator,
     NodeFilter,
+    RelationshipFilter,
+    RelationshipFilterScope,
+    ScopedNodeFilter,
 )
 from app.core.memory.storage.models.projection import (
     CoalesceProjectionField,
@@ -29,6 +32,9 @@ __all__ = [
     "FilterLogic",
     "FilterOperator",
     "NodeFilter",
+    "RelationshipFilter",
+    "RelationshipFilterScope",
+    "ScopedNodeFilter",
 
     "CoalesceProjectionField",
     "NodeProjection",

--- a/api/app/core/memory/storage/models/filter.py
+++ b/api/app/core/memory/storage/models/filter.py
@@ -79,3 +79,65 @@ class NodeFilter(BaseModel):
     @classmethod
     def any_of(cls, *conditions: FilterCondition | NodeFilter) -> Self:
         return cls(logic=FilterLogic.OR, conditions=conditions)
+
+
+class RelationshipFilterScope(StrEnum):
+    SOURCE = "source"
+    RELATIONSHIP = "relationship"
+    TARGET = "target"
+
+
+class ScopedNodeFilter(BaseModel):
+
+    model_config = ConfigDict(frozen=True)
+
+    scope: RelationshipFilterScope
+    node_filter: NodeFilter
+
+
+class RelationshipFilter(BaseModel):
+
+    model_config = ConfigDict(frozen=True)
+
+    conditions: tuple[ScopedNodeFilter | RelationshipFilter, ...] = Field(
+        min_length=1
+    )
+    logic: FilterLogic = FilterLogic.AND
+
+    @classmethod
+    def all_of(
+            cls,
+            *conditions: ScopedNodeFilter | RelationshipFilter,
+    ) -> Self:
+        return cls(logic=FilterLogic.AND, conditions=conditions)
+
+    @classmethod
+    def any_of(
+            cls,
+            *conditions: ScopedNodeFilter | RelationshipFilter,
+    ) -> Self:
+        return cls(logic=FilterLogic.OR, conditions=conditions)
+
+    @staticmethod
+    def source(node_filter: NodeFilter) -> ScopedNodeFilter:
+        """将节点过滤器绑定到关系的起点节点（Cypher 变量 source）。"""
+        return ScopedNodeFilter(
+            scope=RelationshipFilterScope.SOURCE,
+            node_filter=node_filter,
+        )
+
+    @staticmethod
+    def relationship(node_filter: NodeFilter) -> ScopedNodeFilter:
+        """将节点过滤器绑定到关系本身（Cypher 变量 r）。"""
+        return ScopedNodeFilter(
+            scope=RelationshipFilterScope.RELATIONSHIP,
+            node_filter=node_filter,
+        )
+
+    @staticmethod
+    def target(node_filter: NodeFilter) -> ScopedNodeFilter:
+        """将节点过滤器绑定到关系的终点节点（Cypher 变量 target）。"""
+        return ScopedNodeFilter(
+            scope=RelationshipFilterScope.TARGET,
+            node_filter=node_filter,
+        )

--- a/api/app/core/memory/storage/models/filter.py
+++ b/api/app/core/memory/storage/models/filter.py
@@ -81,63 +81,19 @@ class NodeFilter(BaseModel):
         return cls(logic=FilterLogic.OR, conditions=conditions)
 
 
-class RelationshipFilterScope(StrEnum):
-    SOURCE = "source"
-    RELATIONSHIP = "relationship"
-    TARGET = "target"
-
-
-class ScopedNodeFilter(BaseModel):
-
-    model_config = ConfigDict(frozen=True)
-
-    scope: RelationshipFilterScope
-    node_filter: NodeFilter
-
-
 class RelationshipFilter(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    conditions: tuple[ScopedNodeFilter | RelationshipFilter, ...] = Field(
-        min_length=1
-    )
+    relationship: NodeFilter | None = None
+    source: NodeFilter | None = None
+    target: NodeFilter | None = None
     logic: FilterLogic = FilterLogic.AND
 
-    @classmethod
-    def all_of(
-            cls,
-            *conditions: ScopedNodeFilter | RelationshipFilter,
-    ) -> Self:
-        return cls(logic=FilterLogic.AND, conditions=conditions)
-
-    @classmethod
-    def any_of(
-            cls,
-            *conditions: ScopedNodeFilter | RelationshipFilter,
-    ) -> Self:
-        return cls(logic=FilterLogic.OR, conditions=conditions)
-
-    @staticmethod
-    def source(node_filter: NodeFilter) -> ScopedNodeFilter:
-        """将节点过滤器绑定到关系的起点节点（Cypher 变量 source）。"""
-        return ScopedNodeFilter(
-            scope=RelationshipFilterScope.SOURCE,
-            node_filter=node_filter,
-        )
-
-    @staticmethod
-    def relationship(node_filter: NodeFilter) -> ScopedNodeFilter:
-        """将节点过滤器绑定到关系本身（Cypher 变量 r）。"""
-        return ScopedNodeFilter(
-            scope=RelationshipFilterScope.RELATIONSHIP,
-            node_filter=node_filter,
-        )
-
-    @staticmethod
-    def target(node_filter: NodeFilter) -> ScopedNodeFilter:
-        """将节点过滤器绑定到关系的终点节点（Cypher 变量 target）。"""
-        return ScopedNodeFilter(
-            scope=RelationshipFilterScope.TARGET,
-            node_filter=node_filter,
-        )
+    @model_validator(mode="after")
+    def validate_scope_filter(self) -> Self:
+        if not any((self.relationship, self.source, self.target)):
+            raise ValueError(
+                "relationship filter requires at least one scoped node filter"
+            )
+        return self

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -7,6 +7,7 @@ from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
     NodeSort,
+    RelationshipFilter,
     StorageReadResult,
     StorageWriteResult,
 )
@@ -112,6 +113,7 @@ class BaseClient(ABC):
         *,
         source_filter: NodeFilter | None = None,
         target_filter: NodeFilter | None = None,
+        relationship_filter: RelationshipFilter | None = None,
     ) -> StorageReadResult:
         raise NotImplementedError(
             f"{type(self).__name__} does not support relationship queries"

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 from typing import Self
 
-from app.core.memory.storage.enums import MemoryNodeLabel
+from app.core.memory.storage.enums import MemoryNodeLabel, MemoryRelationshipType
 from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
@@ -102,3 +102,14 @@ class BaseClient(ABC):
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
         pass
+
+    async def get_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        rel_filter: NodeFilter,
+        projection: NodeProjection | None = None,
+        sort: NodeSort | None = None,
+    ) -> StorageReadResult:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support relationship queries"
+        )

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -106,9 +106,12 @@ class BaseClient(ABC):
     async def get_relationship(
         self,
         relationship_type: MemoryRelationshipType,
-        rel_filter: NodeFilter,
+        rel_filter: NodeFilter | None = None,
         projection: NodeProjection | None = None,
         sort: NodeSort | None = None,
+        *,
+        source_filter: NodeFilter | None = None,
+        target_filter: NodeFilter | None = None,
     ) -> StorageReadResult:
         raise NotImplementedError(
             f"{type(self).__name__} does not support relationship queries"

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -107,13 +107,9 @@ class BaseClient(ABC):
     async def get_relationship(
         self,
         relationship_type: MemoryRelationshipType,
-        rel_filter: NodeFilter | None = None,
+        rel_filter: RelationshipFilter,
         projection: NodeProjection | None = None,
         sort: NodeSort | None = None,
-        *,
-        source_filter: NodeFilter | None = None,
-        target_filter: NodeFilter | None = None,
-        relationship_filter: RelationshipFilter | None = None,
     ) -> StorageReadResult:
         raise NotImplementedError(
             f"{type(self).__name__} does not support relationship queries"

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -114,3 +114,22 @@ class BaseClient(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not support relationship queries"
         )
+
+    async def update_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        data: dict,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support relationship updates"
+        )
+
+    async def delete_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support relationship deletes"
+        )

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -150,73 +150,20 @@ class Neo4jClient(BaseClient):
     async def get_relationship(
             self,
             relationship_type: MemoryRelationshipType,
-            rel_filter: NodeFilter | None = None,
+            rel_filter: RelationshipFilter,
             projection: NodeProjection | None = None,
             sort: NodeSort | None = None,
-            *,
-            source_filter: NodeFilter | None = None,
-            target_filter: NodeFilter | None = None,
-            relationship_filter: RelationshipFilter | None = None,
     ) -> StorageReadResult:
-        """Query relationships with legacy filters or a relationship filter tree."""
+        """Query relationships using relationship and endpoint filters."""
         if not isinstance(relationship_type, MemoryRelationshipType):
             raise KeyError(
                 f"relationship type - {relationship_type} not supported"
             )
-        if relationship_filter is not None and any(
-                query_filter is not None
-                for query_filter in (rel_filter, source_filter, target_filter)
-        ):
-            raise ValueError(
-                "relationship_filter cannot be combined with rel_filter, "
-                "source_filter, or target_filter"
-            )
 
         escaped_type = relationship_type.value.replace("`", "``")
-        use_named_endpoints = (
-            relationship_filter is not None
-            or source_filter is not None
-            or target_filter is not None
+        predicate, parameters = compile_neo4j_relationship_filter(
+            rel_filter
         )
-        match_pattern = (
-            f"(source)-[r:`{escaped_type}`]->(target)"
-            if use_named_endpoints
-            else f"()-[r:`{escaped_type}`]->()"
-        )
-
-        if relationship_filter is not None:
-            predicate, parameters = compile_neo4j_relationship_filter(
-                relationship_filter
-            )
-            where_clause = f"WHERE {predicate}"
-        else:
-            predicates: list[str] = []
-            parameters: dict[str, Any] = {}
-            filters = (
-                (rel_filter, "r", "filter"),
-                (source_filter, "source", "source_filter"),
-                (target_filter, "target", "target_filter"),
-            )
-            for query_filter, variable, parameter_prefix in filters:
-                if query_filter is None:
-                    continue
-                predicate, filter_parameters = compile_neo4j_filter(
-                    query_filter,
-                    variable=variable,
-                    parameter_prefix=parameter_prefix,
-                )
-                predicates.append(predicate)
-                parameters.update(filter_parameters)
-
-            if len(predicates) == 1:
-                where_clause = f"WHERE {predicates[0]}"
-            elif predicates:
-                grouped_predicates = (
-                    f"({predicate})" for predicate in predicates
-                )
-                where_clause = f"WHERE {' AND '.join(grouped_predicates)}"
-            else:
-                where_clause = ""
 
         return_expression, projection_parameters = compile_neo4j_projection(
             projection, variable="r"
@@ -224,8 +171,8 @@ class Neo4jClient(BaseClient):
         order_by, sort_parameters = compile_neo4j_sort(sort, variable="r")
         sort_clause = f"WITH r\n        {order_by}" if order_by else ""
         query = f"""
-        MATCH {match_pattern}
-        {where_clause}
+        MATCH (source)-[r:`{escaped_type}`]->(target)
+        WHERE {predicate}
         {sort_clause}
         RETURN {return_expression}
         """

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -190,6 +190,87 @@ class Neo4jClient(BaseClient):
         ]
         return StorageReadResult.from_items(items, backend=self.name)
 
+    async def update_relationship(
+            self,
+            relationship_type: MemoryRelationshipType,
+            data: dict,
+            rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        if not isinstance(relationship_type, MemoryRelationshipType):
+            raise KeyError(
+                f"relationship type - {relationship_type} not supported"
+            )
+        if "id" in data:
+            raise ValueError("Relationship id cannot be updated")
+
+        escaped_type = relationship_type.value.replace("`", "``")
+        predicate, filter_parameters = compile_neo4j_relationship_filter(
+            rel_filter
+        )
+        query = f"""
+        MATCH (source)-[r:`{escaped_type}`]->(target)
+        WHERE {predicate}
+        SET r += $properties
+        RETURN r
+        """
+        parameters = {"properties": data, **filter_parameters}
+
+        async with self.client.session() as session:
+            stmt = await session.run(query, **parameters)
+            records = await stmt.data()
+
+        items = [
+            _to_native(record["r"])
+            for record in records
+            if "r" in record
+        ]
+        return StorageWriteResult(
+            backend=self.name,
+            affected_count=len(items),
+            ids=[str(item["id"]) for item in items if "id" in item],
+            data=items,
+        )
+
+    async def delete_relationship(
+            self,
+            relationship_type: MemoryRelationshipType,
+            rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        if not isinstance(relationship_type, MemoryRelationshipType):
+            raise KeyError(
+                f"relationship type - {relationship_type} not supported"
+            )
+
+        escaped_type = relationship_type.value.replace("`", "``")
+        predicate, parameters = compile_neo4j_relationship_filter(rel_filter)
+        query = f"""
+        MATCH (source)-[r:`{escaped_type}`]->(target)
+        WHERE {predicate}
+        WITH r, r.id AS relationship_id, properties(r) AS properties
+        DELETE r
+        RETURN relationship_id, properties
+        """
+
+        async with self.client.session() as session:
+            stmt = await session.run(query, **parameters)
+            records = await stmt.data()
+
+        items = [
+            _to_native(record["properties"])
+            for record in records
+            if "properties" in record
+        ]
+        return StorageWriteResult(
+            backend=self.name,
+            affected_count=len(records),
+            ids=[
+                str(record["relationship_id"])
+                for record in records
+                if record.get("relationship_id") is not None
+            ],
+            data=items,
+        )
+
     async def update_node(
             self,
             label: MemoryNodeLabel,

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -143,6 +143,48 @@ class Neo4jClient(BaseClient):
             data=items,
         )
 
+    async def get_relationship(
+            self,
+            relationship_type: MemoryRelationshipType,
+            rel_filter: NodeFilter,
+            projection: NodeProjection | None = None,
+            sort: NodeSort | None = None,
+    ) -> StorageReadResult:
+        if not isinstance(relationship_type, MemoryRelationshipType):
+            raise KeyError(
+                f"relationship type - {relationship_type} not supported"
+            )
+
+        escaped_type = relationship_type.value.replace("`", "``")
+        predicate, filter_parameters = compile_neo4j_filter(rel_filter, variable="r")
+        return_expression, projection_parameters = compile_neo4j_projection(
+            projection, variable="r"
+        )
+        order_by, sort_parameters = compile_neo4j_sort(sort, variable="r")
+        sort_clause = f"WITH r\n        {order_by}" if order_by else ""
+        query = f"""
+        MATCH ()-[r:`{escaped_type}`]->()
+        WHERE {predicate}
+        {sort_clause}
+        RETURN {return_expression}
+        """
+        parameters = {
+            **filter_parameters,
+            **sort_parameters,
+            **projection_parameters,
+        }
+
+        async with self.client.session() as session:
+            stmt = await session.run(query, **parameters)
+            records = await stmt.data()
+
+        items = [
+            _to_native(record["r"])
+            for record in records
+            if "r" in record
+        ]
+        return StorageReadResult.from_items(items, backend=self.name)
+
     async def update_node(
             self,
             label: MemoryNodeLabel,

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -146,33 +146,53 @@ class Neo4jClient(BaseClient):
     async def get_relationship(
             self,
             relationship_type: MemoryRelationshipType,
-            rel_filter: NodeFilter,
+            rel_filter: NodeFilter | None = None,
             projection: NodeProjection | None = None,
             sort: NodeSort | None = None,
+            *,
+            source_filter: NodeFilter | None = None,
+            target_filter: NodeFilter | None = None,
     ) -> StorageReadResult:
+        """Query relationships, optionally constrained by either endpoint."""
         if not isinstance(relationship_type, MemoryRelationshipType):
             raise KeyError(
                 f"relationship type - {relationship_type} not supported"
             )
 
         escaped_type = relationship_type.value.replace("`", "``")
-        predicate, filter_parameters = compile_neo4j_filter(rel_filter, variable="r")
+        predicates: list[str] = []
+        parameters: dict[str, Any] = {}
+
+        filters = (
+            (rel_filter, "r", "filter"),
+            (source_filter, "source", "source_filter"),
+            (target_filter, "target", "target_filter"),
+        )
+        for query_filter, variable, parameter_prefix in filters:
+            if query_filter is None:
+                continue
+            predicate, filter_parameters = compile_neo4j_filter(
+                query_filter,
+                variable=variable,
+                parameter_prefix=parameter_prefix,
+            )
+            predicates.append(f"({predicate})")
+            parameters.update(filter_parameters)
+
         return_expression, projection_parameters = compile_neo4j_projection(
             projection, variable="r"
         )
         order_by, sort_parameters = compile_neo4j_sort(sort, variable="r")
         sort_clause = f"WITH r\n        {order_by}" if order_by else ""
+        where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
         query = f"""
-        MATCH ()-[r:`{escaped_type}`]->()
-        WHERE {predicate}
+        MATCH (source)-[r:`{escaped_type}`]->(target)
+        {where_clause}
         {sort_clause}
         RETURN {return_expression}
         """
-        parameters = {
-            **filter_parameters,
-            **sort_parameters,
-            **projection_parameters,
-        }
+        parameters.update(sort_parameters)
+        parameters.update(projection_parameters)
 
         async with self.client.session() as session:
             stmt = await session.run(query, **parameters)

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -17,11 +17,15 @@ from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
     NodeSort,
+    RelationshipFilter,
     StorageReadResult,
     StorageWriteResult,
 )
 from app.core.memory.storage.provider.base import BaseClient
-from app.core.memory.storage.provider.neo4j.compiler.filter_compiler import compile_neo4j_filter
+from app.core.memory.storage.provider.neo4j.compiler.filter_compiler import (
+    compile_neo4j_filter,
+    compile_neo4j_relationship_filter,
+)
 from app.core.memory.storage.provider.neo4j.compiler.projection_compiler import (
     compile_neo4j_projection,
 )
@@ -152,41 +156,75 @@ class Neo4jClient(BaseClient):
             *,
             source_filter: NodeFilter | None = None,
             target_filter: NodeFilter | None = None,
+            relationship_filter: RelationshipFilter | None = None,
     ) -> StorageReadResult:
-        """Query relationships, optionally constrained by either endpoint."""
+        """Query relationships with legacy filters or a relationship filter tree."""
         if not isinstance(relationship_type, MemoryRelationshipType):
             raise KeyError(
                 f"relationship type - {relationship_type} not supported"
             )
+        if relationship_filter is not None and any(
+                query_filter is not None
+                for query_filter in (rel_filter, source_filter, target_filter)
+        ):
+            raise ValueError(
+                "relationship_filter cannot be combined with rel_filter, "
+                "source_filter, or target_filter"
+            )
 
         escaped_type = relationship_type.value.replace("`", "``")
-        predicates: list[str] = []
-        parameters: dict[str, Any] = {}
-
-        filters = (
-            (rel_filter, "r", "filter"),
-            (source_filter, "source", "source_filter"),
-            (target_filter, "target", "target_filter"),
+        use_named_endpoints = (
+            relationship_filter is not None
+            or source_filter is not None
+            or target_filter is not None
         )
-        for query_filter, variable, parameter_prefix in filters:
-            if query_filter is None:
-                continue
-            predicate, filter_parameters = compile_neo4j_filter(
-                query_filter,
-                variable=variable,
-                parameter_prefix=parameter_prefix,
+        match_pattern = (
+            f"(source)-[r:`{escaped_type}`]->(target)"
+            if use_named_endpoints
+            else f"()-[r:`{escaped_type}`]->()"
+        )
+
+        if relationship_filter is not None:
+            predicate, parameters = compile_neo4j_relationship_filter(
+                relationship_filter
             )
-            predicates.append(f"({predicate})")
-            parameters.update(filter_parameters)
+            where_clause = f"WHERE {predicate}"
+        else:
+            predicates: list[str] = []
+            parameters: dict[str, Any] = {}
+            filters = (
+                (rel_filter, "r", "filter"),
+                (source_filter, "source", "source_filter"),
+                (target_filter, "target", "target_filter"),
+            )
+            for query_filter, variable, parameter_prefix in filters:
+                if query_filter is None:
+                    continue
+                predicate, filter_parameters = compile_neo4j_filter(
+                    query_filter,
+                    variable=variable,
+                    parameter_prefix=parameter_prefix,
+                )
+                predicates.append(predicate)
+                parameters.update(filter_parameters)
+
+            if len(predicates) == 1:
+                where_clause = f"WHERE {predicates[0]}"
+            elif predicates:
+                grouped_predicates = (
+                    f"({predicate})" for predicate in predicates
+                )
+                where_clause = f"WHERE {' AND '.join(grouped_predicates)}"
+            else:
+                where_clause = ""
 
         return_expression, projection_parameters = compile_neo4j_projection(
             projection, variable="r"
         )
         order_by, sort_parameters = compile_neo4j_sort(sort, variable="r")
         sort_clause = f"WITH r\n        {order_by}" if order_by else ""
-        where_clause = f"WHERE {' AND '.join(predicates)}" if predicates else ""
         query = f"""
-        MATCH (source)-[r:`{escaped_type}`]->(target)
+        MATCH {match_pattern}
         {where_clause}
         {sort_clause}
         RETURN {return_expression}

--- a/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
+++ b/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
@@ -11,6 +11,7 @@ from app.core.memory.storage.models import (
 def compile_neo4j_filter(
     node_filter: NodeFilter,
     variable: str = "n",
+    parameter_prefix: str = "filter",
 ) -> tuple[str, dict[str, Any]]:
     parameters: dict[str, Any] = {}
     predicate = _compile_group(
@@ -18,6 +19,7 @@ def compile_neo4j_filter(
         variable=variable,
         parameters=parameters,
         path=(),
+        parameter_prefix=parameter_prefix,
     )
     return predicate, parameters
 
@@ -28,6 +30,7 @@ def _compile_group(
     variable: str,
     parameters: dict[str, Any],
     path: tuple[int, ...],
+    parameter_prefix: str,
 ) -> str:
     predicates: list[str] = []
 
@@ -39,11 +42,14 @@ def _compile_group(
                 variable=variable,
                 parameters=parameters,
                 path=expression_path,
+                parameter_prefix=parameter_prefix,
             )
         else:
-            parameter_prefix = "filter_" + "_".join(map(str, expression_path))
-            field_parameter = f"{parameter_prefix}_field"
-            value_parameter = f"{parameter_prefix}_value"
+            condition_prefix = (
+                f"{parameter_prefix}_" + "_".join(map(str, expression_path))
+            )
+            field_parameter = f"{condition_prefix}_field"
+            value_parameter = f"{condition_prefix}_value"
             property_expression = f"{variable}[${field_parameter}]"
             parameters[field_parameter] = expression.field
             predicate = _compile_condition(

--- a/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
+++ b/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
@@ -5,7 +5,16 @@ from app.core.memory.storage.models import (
     FilterLogic,
     FilterOperator,
     NodeFilter,
+    RelationshipFilter,
+    RelationshipFilterScope,
 )
+
+
+_RELATIONSHIP_VARIABLES = {
+    RelationshipFilterScope.SOURCE: "source",
+    RelationshipFilterScope.RELATIONSHIP: "r",
+    RelationshipFilterScope.TARGET: "target",
+}
 
 
 def compile_neo4j_filter(
@@ -22,6 +31,62 @@ def compile_neo4j_filter(
         parameter_prefix=parameter_prefix,
     )
     return predicate, parameters
+
+
+def compile_neo4j_relationship_filter(
+    relationship_filter: RelationshipFilter,
+    parameter_prefix: str = "relationship_filter",
+) -> tuple[str, dict[str, Any]]:
+    """将关系过滤树编译为 Cypher WHERE 谓词及其参数字典。"""
+    parameters: dict[str, Any] = {}
+    predicate = _compile_relationship_group(
+        relationship_filter,
+        parameters=parameters,
+        path=(),
+        parameter_prefix=parameter_prefix,
+    )
+    return predicate, parameters
+
+
+def _compile_relationship_group(
+    relationship_filter: RelationshipFilter,
+    *,
+    parameters: dict[str, Any],
+    path: tuple[int, ...],
+    parameter_prefix: str,
+) -> str:
+    """递归编译一个关系过滤分组，并将叶子参数汇总到共享参数字典。"""
+    predicates: list[str] = []
+
+    for index, expression in enumerate(relationship_filter.conditions):
+        expression_path = (*path, index)
+        if isinstance(expression, RelationshipFilter):
+            predicate = _compile_relationship_group(
+                expression,
+                parameters=parameters,
+                path=expression_path,
+                parameter_prefix=parameter_prefix,
+            )
+        else:
+            scope_path = "_".join(map(str, expression_path))
+            scope_prefix = (
+                f"{parameter_prefix}_{scope_path}_{expression.scope.value}"
+            )
+            predicate, scoped_parameters = compile_neo4j_filter(
+                expression.node_filter,
+                variable=_RELATIONSHIP_VARIABLES[expression.scope],
+                parameter_prefix=scope_prefix,
+            )
+            parameters.update(scoped_parameters)
+
+        predicates.append(f"({predicate})")
+
+    conjunction = (
+        " AND "
+        if relationship_filter.logic == FilterLogic.AND
+        else " OR "
+    )
+    return conjunction.join(predicates)
 
 
 def _compile_group(

--- a/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
+++ b/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
@@ -6,15 +6,7 @@ from app.core.memory.storage.models import (
     FilterOperator,
     NodeFilter,
     RelationshipFilter,
-    RelationshipFilterScope,
 )
-
-
-_RELATIONSHIP_VARIABLES = {
-    RelationshipFilterScope.SOURCE: "source",
-    RelationshipFilterScope.RELATIONSHIP: "r",
-    RelationshipFilterScope.TARGET: "target",
-}
 
 
 def compile_neo4j_filter(
@@ -37,56 +29,31 @@ def compile_neo4j_relationship_filter(
     relationship_filter: RelationshipFilter,
     parameter_prefix: str = "relationship_filter",
 ) -> tuple[str, dict[str, Any]]:
-    """将关系过滤树编译为 Cypher WHERE 谓词及其参数字典。"""
+    """编译关系、起点和终点过滤条件。"""
     parameters: dict[str, Any] = {}
-    predicate = _compile_relationship_group(
-        relationship_filter,
-        parameters=parameters,
-        path=(),
-        parameter_prefix=parameter_prefix,
-    )
-    return predicate, parameters
-
-
-def _compile_relationship_group(
-    relationship_filter: RelationshipFilter,
-    *,
-    parameters: dict[str, Any],
-    path: tuple[int, ...],
-    parameter_prefix: str,
-) -> str:
-    """递归编译一个关系过滤分组，并将叶子参数汇总到共享参数字典。"""
     predicates: list[str] = []
-
-    for index, expression in enumerate(relationship_filter.conditions):
-        expression_path = (*path, index)
-        if isinstance(expression, RelationshipFilter):
-            predicate = _compile_relationship_group(
-                expression,
-                parameters=parameters,
-                path=expression_path,
-                parameter_prefix=parameter_prefix,
-            )
-        else:
-            scope_path = "_".join(map(str, expression_path))
-            scope_prefix = (
-                f"{parameter_prefix}_{scope_path}_{expression.scope.value}"
-            )
-            predicate, scoped_parameters = compile_neo4j_filter(
-                expression.node_filter,
-                variable=_RELATIONSHIP_VARIABLES[expression.scope],
-                parameter_prefix=scope_prefix,
-            )
-            parameters.update(scoped_parameters)
-
+    scoped_filters = (
+        ("relationship", "r", relationship_filter.relationship),
+        ("source", "source", relationship_filter.source),
+        ("target", "target", relationship_filter.target),
+    )
+    for scope, variable, node_filter in scoped_filters:
+        if node_filter is None:
+            continue
+        predicate, scoped_parameters = compile_neo4j_filter(
+            node_filter,
+            variable=variable,
+            parameter_prefix=f"{parameter_prefix}_{scope}",
+        )
         predicates.append(f"({predicate})")
+        parameters.update(scoped_parameters)
 
     conjunction = (
         " AND "
         if relationship_filter.logic == FilterLogic.AND
         else " OR "
     )
-    return conjunction.join(predicates)
+    return conjunction.join(predicates), parameters
 
 
 def _compile_group(


### PR DESCRIPTION
extend get_relationship in neo4j client

## Sourcery 摘要

支持通过存储提供程序 API 和 Neo4j 后端检索类型化关系。

新功能：
- 为 Neo4j 存储客户端添加关系查询支持，包括过滤、投影和排序。

增强功能：
- 定义用于检索关系的通用存储提供程序接口，并默认提供明确的不支持操作错误。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持跨存储提供商 API 和 Neo4j 后端的类型化关系查询。

新功能：
- 向 Neo4j 存储客户端添加关系检索功能，支持端点和关系过滤、投影及排序。

增强功能：
- 定义通用的存储提供商关系查询接口，并提供明确的默认“不支持的操作”错误。
- 扩展 Neo4j 过滤器编译功能，以支持多个过滤目标使用不同的参数前缀。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持通过存储提供程序接口和 Neo4j 后端检索类型化关系。

新功能：
- 为存储提供程序 API 和 Neo4j 客户端添加类型化关系查询，包括端点和关系筛选器、投影以及排序。

增强功能：
- 引入可组合且支持作用域感知的关系筛选器，用于源节点、关系和目标节点。
- 改进 Neo4j 筛选器编译，以支持在多个筛选目标之间使用不同的参数前缀。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持跨存储提供程序接口和 Neo4j 后端查询类型化关系。

新功能：
- 通过存储提供程序 API 和 Neo4j 后端添加类型化关系检索，包括关系和端点过滤、投影及排序。

增强功能：
- 为源节点、关系和目标节点引入作用域关系过滤器，并为 Neo4j 编译使用独立的参数命名空间。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在存储提供程序 API 和 Neo4j 后端中启用类型化关系操作。

新功能：
- 为 Neo4j 存储客户端添加类型化关系查询、更新和删除功能，支持关系和端点过滤、投影及排序。

增强功能：
- 引入涵盖源、关系和目标范围的共享关系过滤器模型。
- 扩展存储提供程序接口，支持关系操作并提供明确的不支持操作错误。
- 在编译多个 Neo4j 关系过滤器范围时，支持使用独立的参数命名空间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable typed relationship operations across the storage provider API and Neo4j backend.

New Features:
- Add typed relationship querying, updating, and deletion to the Neo4j storage client with relationship and endpoint filtering, projections, and sorting.

Enhancements:
- Introduce a shared relationship filter model covering source, relationship, and target scopes.
- Extend the storage provider interface with relationship operations and explicit unsupported-operation errors.
- Support distinct parameter namespaces when compiling multiple Neo4j relationship filter scopes.

</details>

</details>

</details>

</details>

</details>