### PR TITLE
feat(rag): add service-owned plain PDF parser

### DIFF
--- a/mem-knowledge/scripts/check_worker_artifacts.py
+++ b/mem-knowledge/scripts/check_worker_artifacts.py
@@ -71,8 +71,6 @@ def _forbidden_path_marker(path: str | PurePosixPath) -> str | None:
             return part
         if "deepdoc" in stem:
             return "deepdoc"
-        if stem in {"plain_pdf", "plainpdf"}:
-            return stem
         if stem == "graphrag":
             return "graphrag"
         if not PurePosixPath(part).suffix:
@@ -127,8 +125,6 @@ def _forbidden_import_marker(module: str) -> str | None:
         first == "rag" and second == "app" for first, second in zip(parts, parts[1:], strict=False)
     ):
         return "rag.app"
-    if any(part in {"plain_pdf", "plainpdf"} for part in parts):
-        return "plain_pdf"
     if "graphrag" in parts:
         return "graphrag"
     return FORBIDDEN_IMPORT_ROOTS.get(parts[0])

--- a/mem-knowledge/src/rag/chunk/context.py
+++ b/mem-knowledge/src/rag/chunk/context.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any
 
 DEFAULT_PARSER_CONFIG = {
-    "layout_recognize": "mineru",
+    "layout_recognize": "plain",
     "chunk_token_num": 512,
     "delimiter": "\n!?。；！？",
     "analyze_hyperlink": True,

--- a/mem-knowledge/src/rag/chunk/parser/pdf/__init__.py
+++ b/mem-knowledge/src/rag/chunk/parser/pdf/__init__.py
@@ -1,5 +1,6 @@
 """PDF parser adapters supported by the knowledge worker."""
 
+from .plain import PlainPdfParser
 from .textln import TextLnPdfParser
 
-__all__ = ["TextLnPdfParser"]
+__all__ = ["PlainPdfParser", "TextLnPdfParser"]

--- a/mem-knowledge/src/rag/chunk/parser/pdf/plain.py
+++ b/mem-knowledge/src/rag/chunk/parser/pdf/plain.py
@@ -1,0 +1,61 @@
+"""Service-owned plain-text PDF parser."""
+
+from __future__ import annotations
+
+import logging
+from io import BytesIO
+from pathlib import Path
+
+from pypdf import PdfReader
+
+from ...context import ParsedBlock, ParsedBlockType, ParseResult
+from ..base import DocumentParser
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PlainPdfParser(DocumentParser):
+    def parse(self, ctx) -> ParseResult:
+        page_number: int | None = None
+        try:
+            reader = PdfReader(BytesIO(self._read_binary(ctx)))
+            start = max(int(ctx.from_page), 0)
+            end = min(max(int(ctx.to_page), 0), len(reader.pages))
+            page_texts: list[str] = []
+            for page_number in range(start, end):
+                text = reader.pages[page_number].extract_text()
+                if text and text.strip():
+                    page_texts.append(text.strip())
+        except Exception as exc:  # noqa: BLE001 - normalize third-party PDF errors.
+            LOGGER.warning(
+                "Plain PDF parsing failed page=%s error_type=%s",
+                page_number,
+                type(exc).__name__,
+            )
+            raise RuntimeError("Plain PDF parsing failed") from exc
+
+        content = "\n\n".join(page_texts)
+        if not content:
+            LOGGER.warning("Plain PDF contains no extractable text")
+            return ParseResult(blocks=[], merge_strategy="blocks")
+        return ParseResult(
+            blocks=[
+                ParsedBlock(
+                    type=ParsedBlockType.TEXT,
+                    content=content,
+                    seq=0,
+                    start_line=1,
+                    end_line=content.count("\n") + 1,
+                )
+            ],
+            merge_strategy="blocks",
+        )
+
+    @staticmethod
+    def _read_binary(ctx) -> bytes:
+        if ctx.binary is not None:
+            return ctx.binary
+        return Path(ctx.filename).read_bytes()
+
+
+__all__ = ["PlainPdfParser"]

--- a/mem-knowledge/src/rag/chunk/pipeline/pdf.py
+++ b/mem-knowledge/src/rag/chunk/pipeline/pdf.py
@@ -1,4 +1,4 @@
-"""Explicit MinerU/TextLn PDF pipeline with no fallback."""
+"""Explicit Plain/MinerU/TextLn PDF pipeline with no fallback."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from ...parser_config import resolve_layout_recognize
 from ..context import ChunkContext, ParseResult
 from ..file_utils import extract_links_from_pdf
 from ..parser.mineru_v3 import MinerUV3Parser
+from ..parser.pdf.plain import PlainPdfParser
 from ..parser.pdf.textln import TextLnPdfParser
 from .base import ChunkPipeline
 
@@ -20,7 +21,9 @@ class PdfChunkPipeline(ChunkPipeline):
             urls = extract_links_from_pdf(binary)
         self._callback(ctx, 0.1, "Start to parse.")
         layout = resolve_layout_recognize(ctx.parser_config)
-        if layout == "mineru":
+        if layout == "plain":
+            result = PlainPdfParser().parse(ctx)
+        elif layout == "mineru":
             result = MinerUV3Parser().parse(ctx)
         else:
             result = TextLnPdfParser().parse(ctx)

--- a/mem-knowledge/src/rag/parser_config.py
+++ b/mem-knowledge/src/rag/parser_config.py
@@ -26,16 +26,24 @@ def _default_graph_config() -> dict[str, Any]:
 
 def resolve_layout_recognize(
     parser_config: Mapping[str, Any] | None,
-) -> Literal["mineru", "textln"]:
+) -> Literal["plain", "mineru", "textln"]:
     if parser_config is None or "layout_recognize" not in parser_config:
-        return "mineru"
+        return "plain"
     raw_value = parser_config["layout_recognize"]
     if not isinstance(raw_value, str):
         raise GraphPipelineConfigError(f"unsupported layout_recognize: {raw_value!r}")
     normalized = raw_value.strip().lower()
-    if normalized not in {"mineru", "textln"}:
-        raise GraphPipelineConfigError(f"unsupported layout_recognize: {raw_value}")
-    return "mineru" if normalized == "mineru" else "textln"
+    aliases = {
+        "plain": "plain",
+        "plaintext": "plain",
+        "plain text": "plain",
+        "mineru": "mineru",
+        "textln": "textln",
+    }
+    try:
+        return aliases[normalized]
+    except KeyError:
+        raise GraphPipelineConfigError(f"unsupported layout_recognize: {raw_value}") from None
 
 
 def build_default_knowledge_parser_config() -> dict[str, Any]:
@@ -51,7 +59,7 @@ def build_default_knowledge_parser_config() -> dict[str, Any]:
         "feishu_app_secret": "App Secret",
         "feishu_folder_token": "Folder Token",
         "sync_cron": "30 7 * * 1-5",
-        "layout_recognize": "mineru",
+        "layout_recognize": "plain",
         "chunk_token_num": 128,
         "delimiter": "\n",
         "auto_keywords": 0,
@@ -66,7 +74,7 @@ def build_default_knowledge_parser_config() -> dict[str, Any]:
 
 def build_default_document_parser_config() -> dict[str, Any]:
     return {
-        "layout_recognize": "mineru",
+        "layout_recognize": "plain",
         "chunk_token_num": 130,
         "delimiter": "\n",
         "auto_keywords": 0,

--- a/mem-knowledge/src/services/file.py
+++ b/mem-knowledge/src/services/file.py
@@ -194,7 +194,7 @@ async def create_folder(
 
 def _document_parser_config(knowledge: Knowledge, *, inherit: bool) -> dict[str, Any]:
     config = {
-        "layout_recognize": "mineru",
+        "layout_recognize": "plain",
         "chunk_token_num": 128,
         "delimiter": "\n",
         "auto_keywords": 0,

--- a/mem-knowledge/src/services/knowledge_sync.py
+++ b/mem-knowledge/src/services/knowledge_sync.py
@@ -35,7 +35,7 @@ from .knowledge_file_storage import KnowledgeFileStorage, generate_kb_file_key
 logger = logging.getLogger(__name__)
 
 DEFAULT_SYNC_PARSER_CONFIG = {
-    "layout_recognize": "mineru",
+    "layout_recognize": "plain",
     "chunk_token_num": 130,
     "delimiter": "\n",
     "auto_keywords": 0,


### PR DESCRIPTION
## Business Background
The independent knowledge service removed DeepDoc and temporarily defaulted PDFs without `layout_recognize` to MinerU. Users still need a lightweight plain-text PDF path that does not depend on external parsing services.

## Summary
- add a service-owned Plain PDF parser backed by the existing `pypdf` dependency
- restore missing `layout_recognize` to plain parsing while preserving explicit MinerU and TextLn behavior
- reuse the TXT `BlockMerger -> TextMerger` path for chunking

## Changes
- add `PlainPdfParser` with binary/file input, page-range extraction, empty-text handling, and normalized parse errors
- accept `plain`, `plaintext`, and `Plain Text`, persisted as canonical `plain`
- update all knowledge-service parser defaults from `mineru` to `plain`
- add explicit Plain/MinerU/TextLn routing with no fallback
- remove only the stale Plain PDF artifact prohibition while retaining DeepDoc and heavy-dependency guards
- 8 files changed, 86 insertions, 17 deletions

## Risk
- PDFs without a text layer produce no PDF text chunks; Plain mode intentionally performs no OCR and does not fall back
- missing `layout_recognize` now resolves to `plain`; existing explicit `mineru` and `textln` configurations are unchanged
- no automatic migration or reparse is performed
- internal and API Key HTTP routes, schemas, authentication, tenant, and workspace semantics are unchanged

## Test Plan
- [x] `31 passed` focused config, parser, pipeline, TXT-equivalence, parent-child, no-fallback, and artifact-guard tests
- [x] `uv run --frozen ruff check src scripts`
- [x] `uv lock --check`
- [x] clean source artifact boundary scan
- [x] fresh wheel build and wheel artifact boundary scan

## Sourcery 摘要

将服务自有的纯文本 PDF 解析作为默认路径，同时保留显式的替代解析器选择和禁用回退行为。

新功能：
- 添加服务自有的纯文本 PDF 解析器，无需外部解析服务即可提取文本。
- 支持通过规范值和常见别名配置纯文本 PDF 解析器，并明确路由至 Plain、MinerU 和 TextLn。

Bug 修复：
- 当未指定版面识别时，恢复默认使用纯文本解析，同时保留显式配置的解析器行为。

增强功能：
- 将知识服务的 PDF 解析器默认设置为纯文本解析，并允许无法提取文本的 PDF 返回空结果，而不进行回退。

日常维护：
- 移除针对新支持的纯文本 PDF 解析器的过时构建产物限制，同时保留对禁止组件的保护。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce service-owned plain PDF parsing as the default path while preserving explicit alternative parser selection and no-fallback behavior.

New Features:
- Add a service-owned plain-text PDF parser for extracting text without external parsing services.
- Support plain PDF parser configuration through canonical and common alias values with explicit Plain, MinerU, and TextLn routing.

Bug Fixes:
- Restore plain parsing as the default when layout recognition is unspecified while preserving explicitly configured parser behavior.

Enhancements:
- Set knowledge-service PDF parser defaults to plain parsing and allow PDFs without extractable text to return empty results without fallback.

Chores:
- Remove stale artifact restrictions for the newly supported plain PDF parser while retaining protections for prohibited components.

</details>