### PR TITLE
Feat/temporary user expiration cleanup

### DIFF
--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -273,7 +273,10 @@ beat_schedule_config = {
     },
     "scan-expired-end-users": {
         "task": "app.tasks.scan_expired_end_users",
-        "schedule": crontab(hour=2, minute=0),
+        "schedule": crontab(
+            hour=settings.EXPIRED_END_USER_SCAN_HOUR,
+            minute=settings.EXPIRED_END_USER_SCAN_MINUTE,
+        ),
     },
     # "run-forgetting-cycle": {
     #     "task": "app.tasks.run_forgetting_cycle_task",

--- a/api/app/celery_app.py
+++ b/api/app/celery_app.py
@@ -148,6 +148,8 @@ celery_app.conf.update(
         'app.tasks.do_refresh_user_tags': {'queue': 'memory_heavy_tasks'},
         'app.tasks.scan_forget_candidates': {'queue': 'periodic_tasks'},
         'app.tasks.do_forget_for_user': {'queue': 'memory_heavy_tasks'},
+        'app.tasks.scan_expired_end_users': {'queue': 'periodic_tasks'},
+        'app.tasks.do_soft_delete_end_users': {'queue': 'memory_heavy_tasks'},
         # 'app.tasks.run_forgetting_cycle_task': {'queue': 'memory_heavy_tasks'},# NOTE：已废弃，保留路由防 unregistered
         'app.tasks.write_all_workspaces_memory_task': {'queue': 'memory_heavy_tasks'}, #NOTE：定时任务，记忆增量统计
         'app.tasks.write_total_memory_task': {'queue': 'memory_heavy_tasks'},  # NOTE：单 workspace 记忆增量统计
@@ -268,6 +270,10 @@ beat_schedule_config = {
     "scan-forget-candidates": {
         "task": "app.tasks.scan_forget_candidates",
         "schedule": forget_scan_schedule,
+    },
+    "scan-expired-end-users": {
+        "task": "app.tasks.scan_expired_end_users",
+        "schedule": crontab(hour=2, minute=0),
     },
     # "run-forgetting-cycle": {
     #     "task": "app.tasks.run_forgetting_cycle_task",

--- a/api/app/controllers/memory_dashboard_controller.py
+++ b/api/app/controllers/memory_dashboard_controller.py
@@ -97,7 +97,7 @@ async def get_workspace_end_users(
     background_tasks: BackgroundTasks,
     workspace_id: Optional[uuid.UUID] = Query(None, description="工作空间ID（可选，默认当前用户工作空间）"),
     keyword: Optional[str] = Query(None, description="搜索关键词（同时模糊匹配 other_name 和 id）"),
-    label: Optional[str] = Query(None, description="标签过滤（long=有名称, short=无名称）"),
+    label: Optional[str] = Query(None, description="标签过滤（long=长时记忆(confirmed), short=短时记忆(temporary)）"),
     page: int = Query(1, ge=1, description="页码，从1开始"),
     pagesize: int = Query(10, ge=1, description="每页数量"),
     db: Session = Depends(get_db),
@@ -106,6 +106,12 @@ async def get_workspace_end_users(
     """
     获取工作空间的宿主列表（分页查询，支持模糊搜索）
     
+    新增：长时/短时记忆判断（以 end_users.identity_status 为准）：
+        - confirmed：长时记忆（label="long"），返回 identity_features
+        - temporary：短时记忆（label="short"），返回 write_time（最后写入时间）和 expire_time
+          （expire_time = write_time + workspace.retention_days 天，
+            retention_days 或 write_time 为 NULL 时 expire_time 也为 NULL）
+
     新增：记忆数量过滤：
         Neo4j 模式：
         - 使用 end_users.memory_count 过滤 memory_count > 0 的宿主
@@ -148,8 +154,6 @@ async def get_workspace_end_users(
             keyword=keyword,
             label=label,
         )
-        raw_items = end_users_result.get("items", [])
-        end_users = [item["end_user"] for item in raw_items]
     else:
         end_users_result = memory_dashboard_service.get_workspace_end_users_paginated(
             db=db,
@@ -160,8 +164,10 @@ async def get_workspace_end_users(
             keyword=keyword,
             label=label,
         )
-        raw_items = end_users_result.get("items", [])
-        end_users = raw_items
+
+    # 两种模式统一返回 [{"end_user": ORM, "memory_count"(仅RAG): int, "expire_time": datetime|None}]
+    raw_items = end_users_result.get("items", [])
+    end_users = [item["end_user"] for item in raw_items]
 
     total = end_users_result.get("total", 0)
 
@@ -216,13 +222,23 @@ async def get_workspace_end_users(
             memory_total = int(getattr(end_user, "memory_count", 0) or 0)
 
         other_name = end_user.other_name
+        identity_status = getattr(end_user, "identity_status", None)
         end_user_info = {
             "id": user_id,
             "other_name": other_name,
-            "label": "long" if other_name else "short",
+            # 长时(confirmed)/短时(temporary)记忆以 identity_status 为准
+            "label": "long" if identity_status == "confirmed" else "short",
         }
         if other_name:
             end_user_info["other_id"] = end_user.other_id
+
+        if identity_status == "temporary":
+            # 短时记忆：最后写入时间 + 过期时间（毫秒级 UTC 时间戳；retention_days 或 write_time 为 NULL 时过期时间为 NULL）
+            end_user_info["write_time"] = to_timestamp_ms(end_user.write_time)
+            end_user_info["expire_time"] = to_timestamp_ms(raw_items[index].get("expire_time"))
+        elif identity_status == "confirmed":
+            # 长时记忆：跨渠道身份标识
+            end_user_info["identity_features"] = end_user.identity_features
 
         items.append({
             "end_user_id": user_id,

--- a/api/app/controllers/workspace_controller.py
+++ b/api/app/controllers/workspace_controller.py
@@ -37,6 +37,8 @@ from app.schemas.workspace_schema import (
     WorkspaceModelsConfig,
     WorkspaceModelsValidationResponse,
     WorkspaceModelsUpdate,
+    WorkspaceRetentionPolicyResponse,
+    WorkspaceRetentionPolicyUpdate,
     WorkspaceResponse,
     WorkspaceUpdate,
 )
@@ -176,6 +178,60 @@ def update_workspace(
     result_i18n = serializer.serialize(result_data, language)
     
     return success(data=result_i18n, msg=t("workspace.updated"))
+
+
+@router.get("/temporary-memory-retention", response_model=ApiResponse)
+@cur_workspace_access_guard()
+def get_workspace_retention_policy(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    t: callable = Depends(get_translator),
+):
+    """获取当前工作空间的临时身份保留策略。"""
+    workspace_id = current_user.current_workspace_id
+    api_logger.info(
+        f"用户 {current_user.username} 请求获取工作空间 {workspace_id} 的保留策略"
+    )
+    retention_days, end_user_count = workspace_service.get_workspace_retention_policy(
+        db=db,
+        workspace_id=workspace_id,
+        user=current_user,
+    )
+    return success(
+        data=WorkspaceRetentionPolicyResponse(
+            retention_days=retention_days,
+            end_user_count=end_user_count,
+        ).model_dump(),
+        msg=t("workspace.retention_policy.retrieved"),
+    )
+
+
+@router.put("/temporary-memory-retention", response_model=ApiResponse)
+@cur_workspace_access_guard()
+def update_workspace_retention_policy(
+    policy: WorkspaceRetentionPolicyUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    t: callable = Depends(get_translator),
+):
+    """更新当前工作空间的临时身份保留策略。"""
+    workspace_id = current_user.current_workspace_id
+    api_logger.info(
+        f"用户 {current_user.username} 请求更新工作空间 {workspace_id} 的保留策略"
+    )
+    retention_days = workspace_service.update_workspace_retention_policy(
+        db=db,
+        workspace_id=workspace_id,
+        retention_days=policy.retention_days,
+        user=current_user,
+    )
+    return success(
+        data=WorkspaceRetentionPolicyResponse(
+            retention_days=retention_days,
+        ).model_dump(exclude_none=True),
+        msg=t("workspace.retention_policy.updated"),
+    )
+
 
 @router.get("/members", response_model=ApiResponse)
 @cur_workspace_access_guard()

--- a/api/app/controllers/workspace_controller.py
+++ b/api/app/controllers/workspace_controller.py
@@ -228,7 +228,7 @@ def update_workspace_retention_policy(
     return success(
         data=WorkspaceRetentionPolicyResponse(
             retention_days=retention_days,
-        ).model_dump(exclude_none=True),
+        ).model_dump(exclude_unset=True),
         msg=t("workspace.retention_policy.updated"),
     )
 

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -378,6 +378,14 @@ class Settings:
         Annotated[int, Field(ge=1, description="forget candidates scan interval in minutes, must be >= 1")]
     ).validate_python(int(os.getenv("FORGET_SCAN_INTERVAL_MINUTES", "5")))
 
+    # 过期临时用户扫描时间（UTC，默认 18:00 = 北京时间次日 02:00）
+    EXPIRED_END_USER_SCAN_HOUR: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=23, description="expired end user scan cron hour (UTC) [0, 23]")]
+    ).validate_python(int(os.getenv("EXPIRED_END_USER_SCAN_HOUR", "18")))
+    EXPIRED_END_USER_SCAN_MINUTE: int = TypeAdapter(
+        Annotated[int, Field(ge=0, le=59, description="expired end user scan cron minute [0, 59]")]
+    ).validate_python(int(os.getenv("EXPIRED_END_USER_SCAN_MINUTE", "0")))
+
     IMPLICIT_EMOTIONS_UPDATE_HOUR: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_HOUR", "2"))
     # implicit_emotions_update: 每天几分执行（分钟，0-59）
     IMPLICIT_EMOTIONS_UPDATE_MINUTE: int = int(os.getenv("IMPLICIT_EMOTIONS_UPDATE_MINUTE", "0"))  

--- a/api/app/locales/en/workspace.json
+++ b/api/app/locales/en/workspace.json
@@ -9,6 +9,10 @@
   "permission_denied": "No permission to access this workspace",
   "name_required": "Workspace name is required",
   "invalid_name": "Invalid workspace name format",
+  "retention_policy": {
+    "retrieved": "Workspace retention policy retrieved successfully",
+    "updated": "Workspace retention policy updated successfully"
+  },
   "members": {
     "list_retrieved": "Workspace members list retrieved successfully",
     "role_updated": "Member role updated successfully",

--- a/api/app/locales/zh/workspace.json
+++ b/api/app/locales/zh/workspace.json
@@ -9,6 +9,10 @@
   "permission_denied": "没有权限访问此工作空间",
   "name_required": "工作空间名称不能为空",
   "invalid_name": "工作空间名称格式不正确",
+  "retention_policy": {
+    "retrieved": "工作空间保留策略获取成功",
+    "updated": "工作空间保留策略更新成功"
+  },
   "members": {
     "list_retrieved": "工作空间成员列表获取成功",
     "role_updated": "成员角色更新成功",

--- a/api/app/models/end_user_model.py
+++ b/api/app/models/end_user_model.py
@@ -30,6 +30,23 @@ class EndUser(Base):
             "other_id",
             postgresql_where=text("is_active = TRUE"),
         ),
+        Index(
+            "idx_end_users_ws_identity",
+            "workspace_id",
+            "identity_features",
+            postgresql_where=text("is_active = TRUE"),
+        ),
+        Index(
+            "idx_end_users_expiration_scan",
+            "workspace_id",
+            "write_time",
+            "id",
+            postgresql_where=text(
+                "is_active = TRUE "
+                "AND identity_status = 'temporary' "
+                "AND write_time IS NOT NULL"
+            ),
+        ),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, nullable=False, index=True)
@@ -39,12 +56,29 @@ class EndUser(Base):
     other_id = Column(String, nullable=True)  # Store original user_id
     other_name = Column(String, default="", nullable=False)
     other_address = Column(String, default="", nullable=False)
+    channel_source = Column(
+        String,
+        nullable=True,
+        comment="渠道来源（如 api / mcp / workflow / web 等）",
+    )
+    identity_features = Column(
+        String,
+        nullable=True,
+        comment="跨渠道身份标识（单个标识，带标识=长时，不带=临时）",
+    )
+    identity_status = Column(
+        String,
+        nullable=False,
+        default="temporary",
+        server_default="temporary",
+        comment="身份状态: temporary / confirmed / expired",
+    )
     is_active = Column(Boolean, default=True, server_default="true", nullable=False, comment="是否有效，False 表示已删除")
     reflection_time = Column(DateTime, nullable=True)
     write_time = Column(DateTime, nullable=True, comment="最后一次记忆写入时间")
     created_at = Column(DateTime, default=utcnow_naive)
     updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
-    
+
     # 用户档案字段 - User Profile Fields
     position = Column(String, nullable=True, comment="职位")
     department = Column(String, nullable=True, comment="部门")
@@ -52,15 +86,15 @@ class EndUser(Base):
     phone = Column(String, nullable=True, comment="电话")
     hire_date = Column(DateTime, nullable=True, comment="入职日期")
     updatetime_profile = Column(DateTime, nullable=True, comment="核心档案信息最后更新时间")
-    
+
     memory_config_id = Column(
-        UUID(as_uuid=True), 
-        ForeignKey("memory_config.config_id"), 
-        nullable=True, 
-        index=True, 
+        UUID(as_uuid=True),
+        ForeignKey("memory_config.config_id"),
+        nullable=True,
+        index=True,
         comment="关联的记忆配置ID"
     )
-    
+
     memory_count = Column(
         Integer,
         nullable=False,
@@ -87,7 +121,7 @@ class EndUser(Base):
         nullable=True,
         comment="用户名片Tag清洗后源数据SHA-256指纹",
     )
-    
+
     # 记忆洞察四个维度 - Memory Insight Four Dimensions
     memory_insight = Column(Text, nullable=True, comment="缓存的记忆洞察报告（总体概述）")
     behavior_pattern = Column(Text, nullable=True, comment="行为模式")
@@ -109,7 +143,7 @@ class EndUser(Base):
 
     # 与 WorkSpace 的反向关系
     workspace = relationship("Workspace", back_populates="end_users")
-    
+
     # 与 EndUserInfo 的反向关系
     info = relationship("EndUserInfo", back_populates="end_user", cascade="all, delete-orphan")
 

--- a/api/app/models/workspace_model.py
+++ b/api/app/models/workspace_model.py
@@ -1,7 +1,7 @@
 import uuid
 from enum import StrEnum
 
-from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, ForeignKey, Index, Integer, String, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -28,6 +28,12 @@ class Workspace(Base):
             "retention_days >= 0 AND retention_days <= 3650",
             name="ck_workspaces_retention_days_range",
         ),
+        Index(
+            "idx_workspaces_retention_enabled",
+            "id",
+            postgresql_include=["retention_days"],
+            postgresql_where=text("retention_days > 0"),
+        ),
     )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
@@ -49,7 +55,7 @@ class Workspace(Base):
     default_model_notice_pending = Column(Boolean, default=False, server_default="false", nullable=False)
     memory_config = Column(UUID(as_uuid=True), nullable=True)
     is_active = Column(Boolean, default=True)
-    retention_days = Column(Integer, nullable=False, default=0, server_default="0")
+    retention_days = Column(Integer, nullable=True)
 
     # Relationships
     tenant = relationship("Tenants", back_populates="owned_workspaces")  # belongs to tenant

--- a/api/app/models/workspace_model.py
+++ b/api/app/models/workspace_model.py
@@ -1,7 +1,7 @@
 import uuid
 from enum import StrEnum
 
-from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean
+from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
@@ -23,6 +23,12 @@ class InviteStatus(StrEnum):
 
 class Workspace(Base):
     __tablename__ = "workspaces"
+    __table_args__ = (
+        CheckConstraint(
+            "retention_days >= 0 AND retention_days <= 3650",
+            name="ck_workspaces_retention_days_range",
+        ),
+    )
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     name = Column(String, index=True, nullable=False)
@@ -43,6 +49,7 @@ class Workspace(Base):
     default_model_notice_pending = Column(Boolean, default=False, server_default="false", nullable=False)
     memory_config = Column(UUID(as_uuid=True), nullable=True)
     is_active = Column(Boolean, default=True)
+    retention_days = Column(Integer, nullable=False, default=0, server_default="0")
 
     # Relationships
     tenant = relationship("Tenants", back_populates="owned_workspaces")  # belongs to tenant

--- a/api/app/models/workspace_model.py
+++ b/api/app/models/workspace_model.py
@@ -25,14 +25,15 @@ class Workspace(Base):
     __tablename__ = "workspaces"
     __table_args__ = (
         CheckConstraint(
-            "retention_days >= 0 AND retention_days <= 3650",
+            "retention_days IS NULL OR "
+            "(retention_days >= 1 AND retention_days <= 3650)",
             name="ck_workspaces_retention_days_range",
         ),
         Index(
             "idx_workspaces_retention_enabled",
             "id",
             postgresql_include=["retention_days"],
-            postgresql_where=text("retention_days > 0"),
+            postgresql_where=text("retention_days IS NOT NULL"),
         ),
     )
 

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -19,8 +19,6 @@ from app.utils.redis_cache import redis_cache
 # 获取数据库专用日志器
 db_logger = get_db_logger()
 
-EXPIRED_END_USER_BATCH_SIZE = 100
-
 
 class UserTagRefreshCandidate(NamedTuple):
     """扫描阶段使用的轻量候选记录，避免批量加载完整 metadata。"""
@@ -72,19 +70,15 @@ class EndUserRepository:
             EndUser.is_active == sa.true(),
             EndUser.identity_status == "temporary",
             EndUser.write_time.is_not(None),
-            Workspace.retention_days > 0,
+            Workspace.retention_days.is_not(None),
             expires_at < func.now(),
         )
 
-    def get_expired_temporary_end_user_ids(
-            self,
-            limit: int = EXPIRED_END_USER_BATCH_SIZE,
-    ) -> List[uuid.UUID]:
-        """按空间有效期和最后写入时间稳定查询一批过期临时身份 ID。"""
-        safe_limit = max(1, min(int(limit), EXPIRED_END_USER_BATCH_SIZE))
+    def get_expired_temporary_end_user_ids(self) -> List[uuid.UUID]:
+        """按空间有效期和最后写入时间稳定查询全部过期临时身份 ID。"""
         retention_workspaces = (
             self.db.query(Workspace.id, Workspace.retention_days)
-            .filter(Workspace.retention_days > 0)
+            .filter(Workspace.retention_days.is_not(None))
             .all()
         )
         if not retention_workspaces:
@@ -104,13 +98,12 @@ class EndUserRepository:
                     EndUser.write_time < cutoff_time,
                 )
                 .order_by(EndUser.write_time.asc(), EndUser.id.asc())
-                .limit(safe_limit)
                 .all()
             )
             candidates.extend((row.id, row.write_time) for row in rows)
 
         candidates.sort(key=lambda candidate: (candidate[1], candidate[0].int))
-        return [end_user_id for end_user_id, _ in candidates[:safe_limit]]
+        return [end_user_id for end_user_id, _ in candidates]
 
     def is_expired_temporary_end_user(self, end_user_id: uuid.UUID) -> bool:
         """删除前重新确认身份仍为临时、活跃且已超过当前空间保留期。"""

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import List, NamedTuple, Optional, Set, TypedDict
 
 import sqlalchemy as sa
-from sqlalchemy import or_, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
@@ -18,6 +18,8 @@ from app.utils.redis_cache import redis_cache
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
+
+EXPIRED_END_USER_BATCH_SIZE = 100
 
 
 class UserTagRefreshCandidate(NamedTuple):
@@ -58,6 +60,50 @@ def is_uuid(value: str) -> bool:
 class EndUserRepository:
     def __init__(self, db: Session | AsyncSession):
         self.db = db
+
+    @staticmethod
+    def _expired_temporary_filter():
+        """构造临时身份过期条件。
+
+        PostgreSQL 使用 retention_days 乘以固定的一天 interval，避免拼接动态 SQL。
+        """
+        expires_at = EndUser.write_time + Workspace.retention_days * sa.text("INTERVAL '1 day'")
+        return (
+            EndUser.is_active.is_(True),
+            EndUser.identity_status == "temporary",
+            EndUser.write_time.is_not(None),
+            Workspace.retention_days > 0,
+            expires_at < func.now(),
+        )
+
+    def get_expired_temporary_end_user_ids(
+            self,
+            limit: int = EXPIRED_END_USER_BATCH_SIZE,
+    ) -> List[uuid.UUID]:
+        """按最后写入时间稳定查询一批过期临时身份 ID。"""
+        safe_limit = max(1, min(int(limit), EXPIRED_END_USER_BATCH_SIZE))
+        rows = (
+            self.db.query(EndUser.id)
+            .join(Workspace, Workspace.id == EndUser.workspace_id)
+            .filter(*self._expired_temporary_filter())
+            .order_by(EndUser.write_time.asc(), EndUser.id.asc())
+            .limit(safe_limit)
+            .all()
+        )
+        return [row[0] for row in rows]
+
+    def is_expired_temporary_end_user(self, end_user_id: uuid.UUID) -> bool:
+        """删除前重新确认身份仍为临时、活跃且已超过当前空间保留期。"""
+        return (
+            self.db.query(EndUser.id)
+            .join(Workspace, Workspace.id == EndUser.workspace_id)
+            .filter(
+                EndUser.id == end_user_id,
+                *self._expired_temporary_filter(),
+            )
+            .first()
+            is not None
+        )
 
     @contextmanager
     def _acquire_eu_lock(self, workspace_id, other_id):
@@ -139,6 +185,34 @@ class EndUserRepository:
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"查询工作空间 {workspace_id} 下终端用户时出错: {str(e)}")
+            raise
+
+    def get_temporary_end_users_count_by_workspace(
+            self,
+            workspace_id: uuid.UUID,
+    ) -> int:
+        """获取指定 workspace 下至少有一条记忆的有效临时 EndUser 数量。"""
+        try:
+            end_users_count = (
+                self.db.query(EndUser)
+                .filter(
+                    EndUser.workspace_id == workspace_id,
+                    EndUser.is_active.is_(True),
+                    EndUser.identity_status == "temporary",
+                    EndUser.memory_count >= 1,
+                )
+                .count()
+            )
+            db_logger.info(
+                f"成功查询工作空间 {workspace_id} 下的 "
+                f"{end_users_count} 个至少有一条记忆的有效临时终端用户"
+            )
+            return end_users_count
+        except Exception as e:
+            self.db.rollback()
+            db_logger.error(
+                f"查询工作空间 {workspace_id} 下有记忆的有效临时终端用户时出错: {str(e)}"
+            )
             raise
 
     def get_end_user_by_id(self, end_user_id: uuid.UUID) -> Optional[EndUser]:

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -1,6 +1,6 @@
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, NamedTuple, Optional, Set, TypedDict
 
 import sqlalchemy as sa
@@ -69,7 +69,7 @@ class EndUserRepository:
         """
         expires_at = EndUser.write_time + Workspace.retention_days * sa.text("INTERVAL '1 day'")
         return (
-            EndUser.is_active.is_(True),
+            EndUser.is_active == sa.true(),
             EndUser.identity_status == "temporary",
             EndUser.write_time.is_not(None),
             Workspace.retention_days > 0,
@@ -80,17 +80,37 @@ class EndUserRepository:
             self,
             limit: int = EXPIRED_END_USER_BATCH_SIZE,
     ) -> List[uuid.UUID]:
-        """按最后写入时间稳定查询一批过期临时身份 ID。"""
+        """按空间有效期和最后写入时间稳定查询一批过期临时身份 ID。"""
         safe_limit = max(1, min(int(limit), EXPIRED_END_USER_BATCH_SIZE))
-        rows = (
-            self.db.query(EndUser.id)
-            .join(Workspace, Workspace.id == EndUser.workspace_id)
-            .filter(*self._expired_temporary_filter())
-            .order_by(EndUser.write_time.asc(), EndUser.id.asc())
-            .limit(safe_limit)
+        retention_workspaces = (
+            self.db.query(Workspace.id, Workspace.retention_days)
+            .filter(Workspace.retention_days > 0)
             .all()
         )
-        return [row[0] for row in rows]
+        if not retention_workspaces:
+            return []
+
+        scan_time = utcnow_naive()
+        candidates: list[tuple[uuid.UUID, datetime]] = []
+        for workspace_id, retention_days in retention_workspaces:
+            cutoff_time = scan_time - timedelta(days=retention_days)
+            rows = (
+                self.db.query(EndUser.id, EndUser.write_time)
+                .filter(
+                    EndUser.workspace_id == workspace_id,
+                    EndUser.is_active == sa.true(),
+                    EndUser.identity_status == "temporary",
+                    EndUser.write_time.is_not(None),
+                    EndUser.write_time < cutoff_time,
+                )
+                .order_by(EndUser.write_time.asc(), EndUser.id.asc())
+                .limit(safe_limit)
+                .all()
+            )
+            candidates.extend((row.id, row.write_time) for row in rows)
+
+        candidates.sort(key=lambda candidate: (candidate[1], candidate[0].int))
+        return [end_user_id for end_user_id, _ in candidates[:safe_limit]]
 
     def is_expired_temporary_end_user(self, end_user_id: uuid.UUID) -> bool:
         """删除前重新确认身份仍为临时、活跃且已超过当前空间保留期。"""

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -60,12 +60,20 @@ class EndUserRepository:
         self.db = db
 
     @staticmethod
+    def _temporary_expires_at_expr():
+        """临时身份过期时间表达式：write_time + retention_days 天。
+
+        write_time 或 retention_days 任一为 NULL 时结果为 NULL。
+        """
+        return EndUser.write_time + Workspace.retention_days * sa.text("INTERVAL '1 day'")
+
+    @staticmethod
     def _expired_temporary_filter():
         """构造临时身份过期条件。
 
         PostgreSQL 使用 retention_days 乘以固定的一天 interval，避免拼接动态 SQL。
         """
-        expires_at = EndUser.write_time + Workspace.retention_days * sa.text("INTERVAL '1 day'")
+        expires_at = EndUserRepository._temporary_expires_at_expr()
         return (
             EndUser.is_active == sa.true(),
             EndUser.identity_status == "temporary",
@@ -2298,8 +2306,13 @@ class EndUserRepository:
             pagesize: int,
             keyword: Optional[str] = None,
             label: Optional[str] = None,
-    ) -> tuple[List[EndUser], int]:
+    ) -> tuple[list, int]:
         """Dashboard 专用：分页查询有记忆的宿主（memory_count > 0）
+
+        长时/短时记忆以 identity_status 为准：
+        - confirmed：长时记忆
+        - temporary：短时记忆（返回 write_time + retention_days 计算的过期时间，
+          write_time 或 retention_days 任一为 NULL 时过期时间为 NULL）
 
         返回结果按 created_at 从新到旧排序（NULL 值排在最后），
         只加载接口所需列以避免加载大 Text 字段。
@@ -2309,14 +2322,16 @@ class EndUserRepository:
             page: 页码（从1开始）
             pagesize: 每页数量
             keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
-            label: 标签过滤（可选，"long" 表示有 other_name，"short" 表示无 other_name）
+            label: 标签过滤（可选，"long" 表示长时记忆(confirmed)，"short" 表示短时记忆(temporary)）
 
         Returns:
-            tuple[List[EndUser], int]: (当前页宿主列表, 符合条件的总数)
+            tuple[list, int]: (items列表[{"end_user": ORM, "expire_time": datetime|None}], 总数)
         """
         from sqlalchemy import desc, String, cast
         from sqlalchemy.orm import load_only
         from sqlalchemy.sql.expression import nullslast
+
+        expires_at = self._temporary_expires_at_expr()
 
         columns = load_only(
             EndUser.id,
@@ -2327,25 +2342,28 @@ class EndUserRepository:
             EndUser.memory_config_id,
             EndUser.created_at,
             EndUser.workspace_id,
+            EndUser.identity_features,
+            EndUser.identity_status,
+            EndUser.write_time,
         )
-        query = self.db.query(EndUser).options(columns).filter(
-            EndUser.workspace_id == workspace_id,
-            EndUser.memory_count > 0,
-            EndUser.is_active == True,
+        query = (
+            self.db.query(
+                EndUser,
+                expires_at.label("expire_time"),
+            )
+            .options(columns)
+            .outerjoin(Workspace, Workspace.id == EndUser.workspace_id)
+            .filter(
+                EndUser.workspace_id == workspace_id,
+                EndUser.memory_count > 0,
+                EndUser.is_active == True,
+            )
         )
 
         if label == "long":
-            query = query.filter(
-                EndUser.other_name.isnot(None),
-                EndUser.other_name != "",
-            )
+            query = query.filter(EndUser.identity_status == "confirmed")
         elif label == "short":
-            query = query.filter(
-                or_(
-                    EndUser.other_name.is_(None),
-                    EndUser.other_name == "",
-                )
-            )
+            query = query.filter(EndUser.identity_status == "temporary")
 
         if keyword:
             keyword = keyword.strip()
@@ -2362,12 +2380,20 @@ class EndUserRepository:
         if total == 0:
             return [], 0
 
-        items = (
+        rows = (
             query.order_by(nullslast(desc(EndUser.created_at)), desc(EndUser.id))
             .offset((page - 1) * pagesize)
             .limit(pagesize)
             .all()
         )
+
+        items = [
+            {
+                "end_user": end_user_orm,
+                "expire_time": expire_time,
+            }
+            for end_user_orm, expire_time in rows
+        ]
         return items, total
 
     def get_paginated_with_memory_rag(
@@ -2385,21 +2411,28 @@ class EndUserRepository:
         - 只统计当前 workspace 下 permission_id="Memory" 的用户记忆知识库
         - 在 SQL 层过滤 chunk 总数为 0 的宿主
 
+        长时/短时记忆以 identity_status 为准：
+        - confirmed：长时记忆
+        - temporary：短时记忆（返回 write_time + retention_days 计算的过期时间，
+          write_time 或 retention_days 任一为 NULL 时过期时间为 NULL）
+
         Args:
             workspace_id: 工作空间ID
             page: 页码（从1开始）
             pagesize: 每页数量
             keyword: 搜索关键词（可选，同时模糊匹配 other_name 和 id）
-            label: 标签过滤（可选，"long" 表示有 other_name，"short" 表示无 other_name）
+            label: 标签过滤（可选，"long" 表示长时记忆(confirmed)，"short" 表示短时记忆(temporary)）
 
         Returns:
-            tuple[list, int]: (items列表[{"end_user": ORM, "memory_count": int}], 总数)
+            tuple[list, int]: (items列表[{"end_user": ORM, "memory_count": int, "expire_time": datetime|None}], 总数)
         """
         from sqlalchemy import desc, String, cast, func
         from sqlalchemy.orm import load_only
         from sqlalchemy.sql.expression import nullslast
         from app.models.document_model import Document
         from app.models.knowledge_model import Knowledge
+
+        expires_at = self._temporary_expires_at_expr()
 
         chunk_subquery = (
             self.db.query(
@@ -2426,14 +2459,19 @@ class EndUserRepository:
             EndUser.memory_config_id,
             EndUser.created_at,
             EndUser.workspace_id,
+            EndUser.identity_features,
+            EndUser.identity_status,
+            EndUser.write_time,
         )
 
         base_query = (
             self.db.query(
                 EndUser,
                 chunk_subquery.c.memory_count.label("memory_count"),
+                expires_at.label("expire_time"),
             )
             .options(columns)
+            .outerjoin(Workspace, Workspace.id == EndUser.workspace_id)
             .join(
                 chunk_subquery,
                 chunk_subquery.c.file_name == func.concat(cast(EndUser.id, String), ".txt"),
@@ -2446,17 +2484,9 @@ class EndUserRepository:
         )
 
         if label == "long":
-            base_query = base_query.filter(
-                EndUser.other_name.isnot(None),
-                EndUser.other_name != "",
-            )
+            base_query = base_query.filter(EndUser.identity_status == "confirmed")
         elif label == "short":
-            base_query = base_query.filter(
-                or_(
-                    EndUser.other_name.is_(None),
-                    EndUser.other_name == "",
-                )
-            )
+            base_query = base_query.filter(EndUser.identity_status == "temporary")
 
         if keyword:
             keyword = keyword.strip()
@@ -2481,10 +2511,11 @@ class EndUserRepository:
         )
 
         items = []
-        for end_user_orm, memory_count in rows:
+        for end_user_orm, memory_count, expire_time in rows:
             items.append({
                 "end_user": end_user_orm,
                 "memory_count": int(memory_count or 0),
+                "expire_time": expire_time,
             })
         return items, total
 

--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -47,9 +47,9 @@ class WorkspaceUpdate(BaseModel):
 class WorkspaceRetentionPolicyResponse(BaseModel):
     retention_days: int | None = Field(
         default=None,
-        ge=0,
+        ge=1,
         le=3650,
-        description="临时身份保留天数，null 表示尚未配置，0 表示永不过期",
+        description="临时身份保留天数，null 表示永不过期",
     )
     end_user_count: int | None = Field(
         default=None,
@@ -59,10 +59,10 @@ class WorkspaceRetentionPolicyResponse(BaseModel):
 
 
 class WorkspaceRetentionPolicyUpdate(BaseModel):
-    retention_days: int = Field(
-        ge=0,
+    retention_days: int | None = Field(
+        ge=1,
         le=3650,
-        description="临时身份保留天数，0 表示永不过期",
+        description="临时身份保留天数，null 表示永不过期",
     )
 
 

--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -44,6 +44,27 @@ class WorkspaceUpdate(BaseModel):
     rerank: str | None = Field(None)
 
 
+class WorkspaceRetentionPolicyResponse(BaseModel):
+    retention_days: int = Field(
+        ge=0,
+        le=3650,
+        description="临时身份保留天数，0 表示永不过期",
+    )
+    end_user_count: int | None = Field(
+        default=None,
+        ge=0,
+        description="当前工作空间中至少有一条记忆的有效临时 EndUser 数量",
+    )
+
+
+class WorkspaceRetentionPolicyUpdate(BaseModel):
+    retention_days: int = Field(
+        ge=0,
+        le=3650,
+        description="临时身份保留天数，0 表示永不过期",
+    )
+
+
 class Workspace(WorkspaceBase):
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -47,9 +47,9 @@ class WorkspaceUpdate(BaseModel):
 class WorkspaceRetentionPolicyResponse(BaseModel):
     retention_days: int | None = Field(
         default=None,
-        ge=1,
+        ge=0,
         le=3650,
-        description="临时身份保留天数，null 表示永不过期",
+        description="临时身份保留天数，null 表示未设置（不计算过期时间）",
     )
     end_user_count: int | None = Field(
         default=None,
@@ -60,9 +60,10 @@ class WorkspaceRetentionPolicyResponse(BaseModel):
 
 class WorkspaceRetentionPolicyUpdate(BaseModel):
     retention_days: int | None = Field(
-        ge=1,
+        default=None,
+        ge=0,
         le=3650,
-        description="临时身份保留天数，null 表示永不过期",
+        description="临时身份保留天数，null 表示清除策略（不计算过期时间）",
     )
 
 

--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -45,10 +45,11 @@ class WorkspaceUpdate(BaseModel):
 
 
 class WorkspaceRetentionPolicyResponse(BaseModel):
-    retention_days: int = Field(
+    retention_days: int | None = Field(
+        default=None,
         ge=0,
         le=3650,
-        description="临时身份保留天数，0 表示永不过期",
+        description="临时身份保留天数，null 表示尚未配置，0 表示永不过期",
     )
     end_user_count: int | None = Field(
         default=None,

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -1052,7 +1052,7 @@ def get_workspace_retention_policy(
         db: Session,
         workspace_id: uuid.UUID,
         user: User,
-) -> tuple[int, int]:
+) -> tuple[int | None, int]:
     """获取临时身份保留天数和至少有一条记忆的有效临时 EndUser 数量。"""
     db_workspace = _check_workspace_member_permission(db, workspace_id, user)
     end_user_count = (

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -1066,9 +1066,9 @@ def get_workspace_retention_policy(
 def update_workspace_retention_policy(
         db: Session,
         workspace_id: uuid.UUID,
-        retention_days: int,
+        retention_days: int | None,
         user: User,
-) -> int:
+) -> int | None:
     """以空间成员权限更新指定工作空间的临时身份保留天数。"""
     business_logger.info(
         f"更新工作空间保留策略: workspace_id={workspace_id}, "

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -24,6 +24,7 @@ from app.models.workspace_model import (
     WorkspaceRole,
 )
 from app.repositories import workspace_repository
+from app.repositories.end_user_repository import EndUserRepository
 from app.repositories.workspace_invite_repository import WorkspaceInviteRepository
 from app.schemas.workspace_schema import (
     InviteAcceptRequest,
@@ -1043,6 +1044,51 @@ def update_workspace(
         return db_workspace
     except Exception as e:
         business_logger.error(f"工作空间更新失败: workspace_id={workspace_id} - {str(e)}")
+        db.rollback()
+        raise
+
+
+def get_workspace_retention_policy(
+        db: Session,
+        workspace_id: uuid.UUID,
+        user: User,
+) -> tuple[int, int]:
+    """获取临时身份保留天数和至少有一条记忆的有效临时 EndUser 数量。"""
+    db_workspace = _check_workspace_member_permission(db, workspace_id, user)
+    end_user_count = (
+        EndUserRepository(db).get_temporary_end_users_count_by_workspace(
+            workspace_id
+        )
+    )
+    return db_workspace.retention_days, end_user_count
+
+
+def update_workspace_retention_policy(
+        db: Session,
+        workspace_id: uuid.UUID,
+        retention_days: int,
+        user: User,
+) -> int:
+    """以空间成员权限更新指定工作空间的临时身份保留天数。"""
+    business_logger.info(
+        f"更新工作空间保留策略: workspace_id={workspace_id}, "
+        f"retention_days={retention_days}, 操作者={user.username}"
+    )
+    db_workspace = _check_workspace_member_permission(db, workspace_id, user)
+    try:
+        db_workspace.retention_days = retention_days
+        db.add(db_workspace)
+        db.commit()
+        db.refresh(db_workspace)
+        business_logger.info(
+            f"工作空间保留策略更新成功: workspace_id={workspace_id}, "
+            f"retention_days={db_workspace.retention_days}"
+        )
+        return db_workspace.retention_days
+    except Exception as e:
+        business_logger.error(
+            f"工作空间保留策略更新失败: workspace_id={workspace_id} - {str(e)}"
+        )
         db.rollback()
         raise
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4653,7 +4653,7 @@ def _release_soft_delete_inflight(
     time_limit=600,
 )
 def scan_expired_end_users(self) -> Dict[str, Any]:
-    """扫描一批已超过空间保留期的临时身份并派发批量清理。"""
+    """扫描全部过期临时身份，并按每批最多 100 个派发清理任务。"""
     from app.repositories.end_user_repository import EndUserRepository
 
     started_at = time.time()
@@ -4661,9 +4661,7 @@ def scan_expired_end_users(self) -> Dict[str, Any]:
 
     try:
         with get_db_context() as db:
-            candidates = EndUserRepository(db).get_expired_temporary_end_user_ids(
-                limit=_SOFT_DELETE_BATCH_SIZE,
-            )
+            candidates = EndUserRepository(db).get_expired_temporary_end_user_ids()
     except Exception as e:
         logger.error(f"[ExpiredEndUserScan] 查询失败: {e}", exc_info=True)
         return {"status": "FAILED", "reason": "query_failed", "error": str(e)}
@@ -4689,35 +4687,48 @@ def scan_expired_end_users(self) -> Dict[str, Any]:
             "dispatched": 0,
         }
 
-    locked_ids: List[str] = []
+    locked_count = 0
     lock_conflicts = 0
-    try:
-        for candidate_id in candidates:
-            end_user_id = str(candidate_id)
-            acquired = redis_client.set(
-                _soft_delete_inflight_key(end_user_id),
-                batch_id,
-                nx=True,
-                ex=_SOFT_DELETE_INFLIGHT_TTL_SECONDS,
-            )
-            if acquired:
-                locked_ids.append(end_user_id)
-            else:
-                lock_conflicts += 1
-    except RedisError as e:
-        for end_user_id in locked_ids:
-            _release_soft_delete_inflight(redis_client, end_user_id, batch_id)
-        logger.error(f"[ExpiredEndUserScan] Redis 加锁失败: {e}", exc_info=True)
-        return {
-            "status": "FAILED",
-            "reason": "redis_lock_failed",
-            "batch_id": batch_id,
-            "candidates": len(candidates),
-            "locked": len(locked_ids),
-            "dispatched": 0,
-        }
+    dispatched_count = 0
+    dispatched_batches = 0
+    for batch_start in range(0, len(candidates), _SOFT_DELETE_BATCH_SIZE):
+        candidate_batch = candidates[
+            batch_start:batch_start + _SOFT_DELETE_BATCH_SIZE
+        ]
+        locked_ids: List[str] = []
+        try:
+            for candidate_id in candidate_batch:
+                end_user_id = str(candidate_id)
+                acquired = redis_client.set(
+                    _soft_delete_inflight_key(end_user_id),
+                    batch_id,
+                    nx=True,
+                    ex=_SOFT_DELETE_INFLIGHT_TTL_SECONDS,
+                )
+                if acquired:
+                    locked_ids.append(end_user_id)
+                    locked_count += 1
+                else:
+                    lock_conflicts += 1
+        except RedisError as e:
+            for end_user_id in locked_ids:
+                _release_soft_delete_inflight(redis_client, end_user_id, batch_id)
+            locked_count -= len(locked_ids)
+            logger.error(f"[ExpiredEndUserScan] Redis 加锁失败: {e}", exc_info=True)
+            return {
+                "status": "PARTIAL_FAILURE" if dispatched_count else "FAILED",
+                "reason": "redis_lock_failed",
+                "batch_id": batch_id,
+                "candidates": len(candidates),
+                "locked": locked_count,
+                "lock_conflicts": lock_conflicts,
+                "dispatched": dispatched_count,
+                "dispatched_batches": dispatched_batches,
+            }
 
-    if locked_ids:
+        if not locked_ids:
+            continue
+
         try:
             do_soft_delete_end_users.apply_async(
                 kwargs={"end_user_ids": locked_ids, "batch_id": batch_id},
@@ -4726,29 +4737,36 @@ def scan_expired_end_users(self) -> Dict[str, Any]:
         except Exception as e:
             for end_user_id in locked_ids:
                 _release_soft_delete_inflight(redis_client, end_user_id, batch_id)
+            locked_count -= len(locked_ids)
             logger.error(f"[ExpiredEndUserScan] 派发失败: {e}", exc_info=True)
             return {
-                "status": "FAILED",
+                "status": "PARTIAL_FAILURE" if dispatched_count else "FAILED",
                 "reason": "dispatch_failed",
                 "batch_id": batch_id,
                 "candidates": len(candidates),
-                "locked": len(locked_ids),
-                "dispatched": 0,
+                "locked": locked_count,
+                "lock_conflicts": lock_conflicts,
+                "dispatched": dispatched_count,
+                "dispatched_batches": dispatched_batches,
             }
+        dispatched_count += len(locked_ids)
+        dispatched_batches += 1
 
     elapsed = time.time() - started_at
     logger.info(
         f"[ExpiredEndUserScan] 完成: batch_id={batch_id}, "
-        f"candidates={len(candidates)}, locked={len(locked_ids)}, "
-        f"lock_conflicts={lock_conflicts}, elapsed={elapsed:.1f}s"
+        f"candidates={len(candidates)}, locked={locked_count}, "
+        f"lock_conflicts={lock_conflicts}, dispatched={dispatched_count}, "
+        f"batches={dispatched_batches}, elapsed={elapsed:.1f}s"
     )
     return {
         "status": "SUCCESS",
         "batch_id": batch_id,
         "candidates": len(candidates),
-        "locked": len(locked_ids),
+        "locked": locked_count,
         "lock_conflicts": lock_conflicts,
-        "dispatched": len(locked_ids),
+        "dispatched": dispatched_count,
+        "dispatched_batches": dispatched_batches,
         "elapsed_time": elapsed,
     }
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, List, Optional
 import logging
 
 import redis
+from billiard.exceptions import SoftTimeLimitExceeded
 from celery import states, current_task
 from celery.exceptions import Ignore, Retry
 from celery.signals import after_setup_logger
@@ -4610,6 +4611,268 @@ def do_refresh_user_tags(
 #     result["elapsed_time"] = time.time() - start_time
 #     result["task_id"] = self.request.id
 #     return result
+
+
+_SOFT_DELETE_INFLIGHT_PREFIX = "soft_delete:inflight:"
+_SOFT_DELETE_INFLIGHT_TTL_SECONDS = 86400
+_SOFT_DELETE_BATCH_SIZE = 100
+
+
+def _soft_delete_inflight_key(end_user_id: str) -> str:
+    return f"{_SOFT_DELETE_INFLIGHT_PREFIX}{end_user_id}"
+
+
+def _release_soft_delete_inflight(
+        redis_client: Optional[redis.StrictRedis],
+        end_user_id: str,
+        batch_id: str,
+) -> None:
+    """仅在锁仍属于当前批次时释放，避免误删后续批次的锁。"""
+    if redis_client is None:
+        return
+    try:
+        redis_client.eval(
+            UNLOCK_SCRIPT,
+            1,
+            _soft_delete_inflight_key(end_user_id),
+            batch_id,
+        )
+    except RedisError as e:
+        logger.warning(
+            f"[ExpiredEndUser] 释放 inflight 锁失败: end_user_id={end_user_id}, error={e}"
+        )
+
+
+@celery_app.task(
+    name="app.tasks.scan_expired_end_users",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+    soft_time_limit=540,
+    time_limit=600,
+)
+def scan_expired_end_users(self) -> Dict[str, Any]:
+    """扫描一批已超过空间保留期的临时身份并派发批量清理。"""
+    from app.repositories.end_user_repository import EndUserRepository
+
+    started_at = time.time()
+    batch_id = self.request.id or uuid.uuid4().hex
+
+    try:
+        with get_db_context() as db:
+            candidates = EndUserRepository(db).get_expired_temporary_end_user_ids(
+                limit=_SOFT_DELETE_BATCH_SIZE,
+            )
+    except Exception as e:
+        logger.error(f"[ExpiredEndUserScan] 查询失败: {e}", exc_info=True)
+        return {"status": "FAILED", "reason": "query_failed", "error": str(e)}
+
+    if not candidates:
+        return {
+            "status": "SUCCESS",
+            "batch_id": batch_id,
+            "candidates": 0,
+            "locked": 0,
+            "lock_conflicts": 0,
+            "dispatched": 0,
+        }
+
+    redis_client = get_sync_redis_client()
+    if redis_client is None:
+        logger.error("[ExpiredEndUserScan] Redis 不可用，取消派发")
+        return {
+            "status": "FAILED",
+            "reason": "redis_unavailable",
+            "batch_id": batch_id,
+            "candidates": len(candidates),
+            "dispatched": 0,
+        }
+
+    locked_ids: List[str] = []
+    lock_conflicts = 0
+    try:
+        for candidate_id in candidates:
+            end_user_id = str(candidate_id)
+            acquired = redis_client.set(
+                _soft_delete_inflight_key(end_user_id),
+                batch_id,
+                nx=True,
+                ex=_SOFT_DELETE_INFLIGHT_TTL_SECONDS,
+            )
+            if acquired:
+                locked_ids.append(end_user_id)
+            else:
+                lock_conflicts += 1
+    except RedisError as e:
+        for end_user_id in locked_ids:
+            _release_soft_delete_inflight(redis_client, end_user_id, batch_id)
+        logger.error(f"[ExpiredEndUserScan] Redis 加锁失败: {e}", exc_info=True)
+        return {
+            "status": "FAILED",
+            "reason": "redis_lock_failed",
+            "batch_id": batch_id,
+            "candidates": len(candidates),
+            "locked": len(locked_ids),
+            "dispatched": 0,
+        }
+
+    if locked_ids:
+        try:
+            do_soft_delete_end_users.apply_async(
+                kwargs={"end_user_ids": locked_ids, "batch_id": batch_id},
+                queue="memory_heavy_tasks",
+            )
+        except Exception as e:
+            for end_user_id in locked_ids:
+                _release_soft_delete_inflight(redis_client, end_user_id, batch_id)
+            logger.error(f"[ExpiredEndUserScan] 派发失败: {e}", exc_info=True)
+            return {
+                "status": "FAILED",
+                "reason": "dispatch_failed",
+                "batch_id": batch_id,
+                "candidates": len(candidates),
+                "locked": len(locked_ids),
+                "dispatched": 0,
+            }
+
+    elapsed = time.time() - started_at
+    logger.info(
+        f"[ExpiredEndUserScan] 完成: batch_id={batch_id}, "
+        f"candidates={len(candidates)}, locked={len(locked_ids)}, "
+        f"lock_conflicts={lock_conflicts}, elapsed={elapsed:.1f}s"
+    )
+    return {
+        "status": "SUCCESS",
+        "batch_id": batch_id,
+        "candidates": len(candidates),
+        "locked": len(locked_ids),
+        "lock_conflicts": lock_conflicts,
+        "dispatched": len(locked_ids),
+        "elapsed_time": elapsed,
+    }
+
+
+@celery_app.task(
+    name="app.tasks.do_soft_delete_end_users",
+    bind=True,
+    ignore_result=False,
+    max_retries=0,
+    acks_late=False,
+    soft_time_limit=1080,
+    time_limit=1200,
+)
+def do_soft_delete_end_users(
+        self,
+        end_user_ids: List[str],
+        batch_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """批量清理过期临时身份，逐用户隔离错误并兜底释放 inflight 锁。"""
+    from app.core.memory.memory_service import MemoryService
+    from app.repositories.end_user_repository import EndUserRepository
+
+    started_at = time.time()
+    effective_batch_id = batch_id or self.request.id or uuid.uuid4().hex
+    unique_ids = list(dict.fromkeys(str(item) for item in (end_user_ids or [])))
+    redis_client = get_sync_redis_client()
+    if len(unique_ids) > _SOFT_DELETE_BATCH_SIZE:
+        for end_user_id in unique_ids:
+            _release_soft_delete_inflight(
+                redis_client,
+                end_user_id,
+                effective_batch_id,
+            )
+        return {
+            "status": "FAILED",
+            "reason": "batch_too_large",
+            "batch_id": effective_batch_id,
+            "received": len(unique_ids),
+            "limit": _SOFT_DELETE_BATCH_SIZE,
+        }
+
+    success_count = 0
+    fail_count = 0
+    skipped_count = 0
+    failed_ids: List[str] = []
+    loop = set_asyncio_event_loop()
+
+    async def _delete_one(end_user_id: str) -> str:
+        if redis_client is None:
+            raise RuntimeError("Redis unavailable; memory write lock cannot be acquired")
+
+        parsed_id = uuid.UUID(end_user_id)
+        write_lock = RedisFairLock(
+            key=f"memory_write:{end_user_id}",
+            redis_client=redis_client,
+            expire=1200,
+            timeout=60,
+            auto_renewal=True,
+        )
+        with write_lock:
+            with get_db_context() as db:
+                if not EndUserRepository(db).is_expired_temporary_end_user(parsed_id):
+                    return "skipped"
+
+            await MemoryService.delete_all_nodes_by_end_user_id(end_user_id)
+
+            with get_db_context() as db:
+                repository = EndUserRepository(db)
+                repository.update_memory_count(parsed_id, 0)
+                if not repository.soft_delete_by_end_user_id(parsed_id):
+                    raise RuntimeError("EndUser was no longer active during soft delete")
+        return "success"
+
+    try:
+        for end_user_id in unique_ids:
+            try:
+                outcome = loop.run_until_complete(_delete_one(end_user_id))
+                if outcome == "success":
+                    success_count += 1
+                else:
+                    skipped_count += 1
+            except SoftTimeLimitExceeded:
+                logger.error(
+                    f"[ExpiredEndUserDelete] 达到软超时: batch_id={effective_batch_id}, "
+                    f"end_user_id={end_user_id}"
+                )
+                raise
+            except Exception as e:
+                fail_count += 1
+                failed_ids.append(end_user_id)
+                logger.error(
+                    f"[ExpiredEndUserDelete] 清理失败: end_user_id={end_user_id}, error={e}",
+                    exc_info=True,
+                )
+            finally:
+                _release_soft_delete_inflight(
+                    redis_client,
+                    end_user_id,
+                    effective_batch_id,
+                )
+    finally:
+        _shutdown_loop_gracefully(loop)
+        for end_user_id in unique_ids:
+            _release_soft_delete_inflight(
+                redis_client,
+                end_user_id,
+                effective_batch_id,
+            )
+
+    elapsed = time.time() - started_at
+    logger.info(
+        f"[ExpiredEndUserDelete] 批次完成: batch_id={effective_batch_id}, "
+        f"success={success_count}, failed={fail_count}, skipped={skipped_count}, "
+        f"elapsed={elapsed:.1f}s"
+    )
+    return {
+        "status": "SUCCESS" if fail_count == 0 else "PARTIAL_FAILURE",
+        "batch_id": effective_batch_id,
+        "success": success_count,
+        "failed": fail_count,
+        "skipped": skipped_count,
+        "failed_ids": failed_ids,
+        "elapsed_time": elapsed,
+    }
 
 
 @celery_app.task(

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -4785,8 +4785,7 @@ def do_soft_delete_end_users(
         end_user_ids: List[str],
         batch_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """批量清理过期临时身份，逐用户隔离错误并兜底释放 inflight 锁。"""
-    from app.core.memory.memory_service import MemoryService
+    """批量软删过期临时身份，逐用户隔离错误并兜底释放 inflight 锁。"""
     from app.repositories.end_user_repository import EndUserRepository
 
     started_at = time.time()
@@ -4812,9 +4811,8 @@ def do_soft_delete_end_users(
     fail_count = 0
     skipped_count = 0
     failed_ids: List[str] = []
-    loop = set_asyncio_event_loop()
 
-    async def _delete_one(end_user_id: str) -> str:
+    def _delete_one(end_user_id: str) -> str:
         if redis_client is None:
             raise RuntimeError("Redis unavailable; memory write lock cannot be acquired")
 
@@ -4828,14 +4826,9 @@ def do_soft_delete_end_users(
         )
         with write_lock:
             with get_db_context() as db:
-                if not EndUserRepository(db).is_expired_temporary_end_user(parsed_id):
-                    return "skipped"
-
-            await MemoryService.delete_all_nodes_by_end_user_id(end_user_id)
-
-            with get_db_context() as db:
                 repository = EndUserRepository(db)
-                repository.update_memory_count(parsed_id, 0)
+                if not repository.is_expired_temporary_end_user(parsed_id):
+                    return "skipped"
                 if not repository.soft_delete_by_end_user_id(parsed_id):
                     raise RuntimeError("EndUser was no longer active during soft delete")
         return "success"
@@ -4843,7 +4836,7 @@ def do_soft_delete_end_users(
     try:
         for end_user_id in unique_ids:
             try:
-                outcome = loop.run_until_complete(_delete_one(end_user_id))
+                outcome = _delete_one(end_user_id)
                 if outcome == "success":
                     success_count += 1
                 else:
@@ -4868,7 +4861,6 @@ def do_soft_delete_end_users(
                     effective_batch_id,
                 )
     finally:
-        _shutdown_loop_gracefully(loop)
         for end_user_id in unique_ids:
             _release_soft_delete_inflight(
                 redis_client,


### PR DESCRIPTION
## Sourcery 摘要

为临时终端用户实现可配置的保留策略和自动清理功能。

新功能：
- 添加用于配置和查看临时终端用户保留策略的工作区 API。
- 自动扫描已过期的临时终端用户，并批量分发清理任务。

增强功能：
- 跟踪终端用户身份状态和跨渠道身份元数据，并添加支持保留清理的索引。
- 在移除过期临时用户关联的记忆后，安全地软删除这些用户，同时提供并发保护和按用户隔离的失败处理。

维护：
- 为过期临时用户扫描添加可配置的调度功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

实现可配置的临时终端用户保留策略和自动清理功能。

新功能：
- 添加用于配置和查看临时终端用户保留策略的工作区 API。
- 自动扫描已过期的临时终端用户，并分批派发清理任务。
- 在仪表盘中展示临时用户的写入时间和过期时间，以及已确认用户的跨渠道身份元数据。

问题修复：
- 安全移除已过期的临时用户记忆，并在并发保护和按用户故障隔离机制下软删除用户。

改进：
- 跟踪终端用户的渠道身份、身份状态和与保留策略相关的元数据，并添加相应的数据库索引。
- 使用身份状态而不是显示名称是否存在来区分已确认的终端用户和临时终端用户。

杂项：
- 添加已过期临时用户扫描的可配置调度功能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为临时终端用户实现可配置的保留策略和自动清理功能。

新功能：
- 添加用于配置和查看临时终端用户保留策略的工作区 API。
- 在控制面板中展示临时终端用户的写入时间和过期时间，以及已确认用户的跨渠道身份元数据。
- 自动扫描已过期的临时终端用户，并分批派发清理任务。

Bug 修复：
- 安全地删除记忆，并在并发保护和按用户故障隔离的机制下软删除已过期的临时终端用户。

增强功能：
- 通过支持性索引跟踪终端用户的渠道身份、身份状态和保留元数据，并使用身份状态区分已确认用户和临时用户。

杂项：
- 为已过期临时终端用户扫描添加可配置的调度功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement configurable retention and automated cleanup for temporary end users.

New Features:
- Add workspace APIs for configuring and viewing temporary end-user retention policies.
- Expose temporary end-user write and expiration times, and confirmed users’ cross-channel identity metadata in the dashboard.
- Automatically scan for expired temporary end users and dispatch batched cleanup tasks.

Bug Fixes:
- Safely remove memories and soft-delete expired temporary end users with concurrency protection and per-user failure isolation.

Enhancements:
- Track end-user channel identity, identity status, and retention metadata with supporting indexes, using identity status to distinguish confirmed and temporary users.

Chores:
- Add configurable scheduling for expired temporary end-user scans.

</details>

</details>

</details>