### PR TITLE
fix(models): remove custom base_url handling for DashScope embedding …

### DIFF
--- a/api/app/core/models/embedding.py
+++ b/api/app/core/models/embedding.py
@@ -63,24 +63,8 @@ class RedBearEmbeddings(Embeddings):
     @staticmethod
     def _create_model(config: RedBearModelConfig) -> Embeddings:
         """根据配置创建 LangChain 模型"""
-        provider = config.provider.lower()
-
-        # dashscope 配置了自定义 base_url 时，走 OpenAI 兼容模式，确保真实 URL 生效
-        if provider == ModelProvider.DASHSCOPE and config.base_url:
-            from langchain_openai import OpenAIEmbeddings
-            import httpx
-            timeout = httpx.Timeout(timeout=config.timeout, connect=60.0)
-            return OpenAIEmbeddings(
-                model=config.model_name,
-                base_url=config.base_url,
-                api_key=config.api_key,
-                timeout=timeout,
-                max_retries=config.max_retries,
-                chunk_size=settings.EMBEDDING_BATCH_SIZE,
-                check_embedding_ctx_length=False,
-            )
-
         embedding_class = get_provider_embedding_class(config.provider)
+        provider = config.provider.lower()
         # Embedding models only need connection params, never LLM-specific ones
         # (e.g. enable_thinking, model_kwargs) — build params directly.
         if provider in [

--- a/api/app/core/models/rerank.py
+++ b/api/app/core/models/rerank.py
@@ -33,14 +33,6 @@ def _normalize_jina_rerank_url(base_url: Optional[str]) -> str:
     return f"{url}/v1/rerank"
 
 
-def _normalize_dashscope_rerank_url(base_url: str) -> str:
-    """将 OpenAI-compatible base_url 规范化为 rerank 完整端点。"""
-    url = base_url.rstrip("/")
-    if url.endswith("/reranks"):
-        return url
-    return f"{url}/reranks"
-
-
 class _EndpointBoundSession:
     """Route a provider session to one immutable rerank endpoint."""
 
@@ -122,45 +114,6 @@ class RedBearRerank(BaseDocumentCompressor):
             report_model_gateway_failure(self._config, "rerank", exc, started)
             raise
 
-    def _dashscope_rerank_http(
-            self,
-            documents: Sequence[Union[str, Document, dict]],
-            query: str,
-            top_n: Optional[int],
-    ) -> List[Dict[str, Any]]:
-        """DashScope 配置了自定义 base_url 时，直接请求 OpenAI-compatible rerank 接口。
-
-        DashScopeRerank 底层只读取全局服务地址，无法按实例使用数据库中的
-        base_url，因此在这里显式传入真实 URL 和 API key。
-        """
-        import httpx
-
-        docs = [doc.page_content if isinstance(doc, Document) else doc for doc in documents]
-        effective_top_n = top_n if top_n is not None and top_n > 0 else 3
-        body = {
-            "model": self._config.model_name,
-            "query": query,
-            "documents": docs,
-            "top_n": effective_top_n,
-        }
-        headers = {
-            "Authorization": f"Bearer {self._config.api_key}",
-            "Content-Type": "application/json",
-        }
-        url = _normalize_dashscope_rerank_url(self._config.base_url)
-        with httpx.Client(timeout=self._config.timeout, follow_redirects=True) as client:
-            response = client.post(url, json=body, headers=headers)
-        response.raise_for_status()
-        payload = response.json()
-        results = payload.get("results") if isinstance(payload, dict) else None
-        if not isinstance(results, list) or not results:
-            detail = payload.get("message") if isinstance(payload, dict) else None
-            raise ValueError(detail or "DashScope rerank 响应中缺少有效的 results")
-        return [
-            {"index": int(item.get("index")), "relevance_score": item.get("relevance_score")}
-            for item in results
-        ]
-
     @network_retry
     def _rerank_with_retry(
             self,
@@ -174,8 +127,6 @@ class RedBearRerank(BaseDocumentCompressor):
             model_instance: JinaRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)
         if provider == ModelProvider.DASHSCOPE:
-            if self._config.base_url:
-                return self._dashscope_rerank_http(documents, query, top_n)
             from langchain_community.document_compressors.dashscope_rerank import DashScopeRerank
             model_instance: DashScopeRerank = self._model
             return model_instance.rerank(documents=documents, query=query, top_n=top_n)


### PR DESCRIPTION
…and rerank

- Remove OpenAI-compatible base_url workaround from RedBearEmbeddings
- Remove _dashscope_rerank_http method and related custom HTTP rerank logic
- Remove _normalize_dashscope_rerank_url helper function
- Simplify provider routing to use standard LangChain provider implementations
- DashScope now handles base_url configuration through native provider support

## Sourcery 摘要

使用原生 LangChain 提供商支持来处理 DashScope 嵌入和重排序，而不是使用自定义基础 URL 和 HTTP 处理。

错误修复：
- 移除自定义的 DashScope 嵌入和重排序 URL 处理，以便通过原生提供商集成正确处理已配置的端点。

增强功能：
- 依靠标准的 LangChain 嵌入和重排序实现，简化 DashScope 提供商路由。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use native LangChain provider support for DashScope embeddings and reranking instead of custom base URL and HTTP handling.

Bug Fixes:
- Remove custom DashScope embedding and reranking URL handling so configured endpoints are processed correctly by the native provider integrations.

Enhancements:
- Simplify DashScope provider routing by relying on standard LangChain embedding and reranking implementations.

</details>