### PR TITLE
feat(rag): improve knowledge worker observability

### DIFF
--- a/mem-knowledge/scripts/check_import_boundaries.py
+++ b/mem-knowledge/scripts/check_import_boundaries.py
@@ -104,6 +104,34 @@ REMOVED_RUNTIME_MODULES = frozenset(
         "rag/knowledge_graph/rebuild_task_guard.py",
     }
 )
+OBSERVED_TASK_MODULES = frozenset(AUTHORIZED_TASKS_BY_MODULE)
+REQUIRED_WORKER_SIGNAL_NAMES = frozenset(
+    {
+        "celeryd_after_setup",
+        "celery_setup_logging",
+        "task_failure",
+        "task_postrun",
+        "task_prerun",
+        "task_received",
+        "task_retry",
+        "worker_process_init",
+        "worker_process_shutdown",
+        "worker_ready",
+        "worker_shutting_down",
+    }
+)
+FORBIDDEN_TASK_LOG_FIELDS = frozenset(
+    {
+        "args",
+        "kwargs",
+        "payload",
+        "contents",
+        "token",
+        "api_key",
+        "password",
+        "authorization",
+    }
+)
 
 
 def _top_level_imports(tree: ast.AST) -> set[str]:
@@ -382,6 +410,85 @@ def _scan_service_tree(root: Path, *, require_complete_registry: bool = False) -
     return errors
 
 
+def _literal_string_collection(tree: ast.Module, name: str) -> set[str] | None:
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            continue
+        value = node.value
+        if value is None:
+            return None
+        try:
+            raw = ast.literal_eval(value)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(raw, (tuple, list, set, frozenset)):
+            return {str(item) for item in raw}
+        if isinstance(raw, dict):
+            return {str(item) for item in raw}
+        return None
+    return None
+
+
+def _scan_worker_observability(root: Path) -> list[str]:
+    """Check finite source markers for the worker observability contract."""
+
+    errors: list[str] = []
+    for module_path in sorted(OBSERVED_TASK_MODULES):
+        path = root / module_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        names = {
+            node.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+        }
+        if "observe_task" not in names:
+            errors.append(f"{module_path}: task module does not use observe_task")
+        for node in tree.body:
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and node.module.startswith("services")
+            ):
+                errors.append(
+                    f"{module_path}:{node.lineno}: task module imports service at module scope"
+                )
+
+    worker_path = root / "tasks/celery_worker.py"
+    worker_source = worker_path.read_text(encoding="utf-8")
+    for signal_name in sorted(REQUIRED_WORKER_SIGNAL_NAMES):
+        if signal_name not in worker_source:
+            errors.append(f"tasks/celery_worker.py: missing worker signal: {signal_name}")
+    for role, queue in (
+        ("document_worker", "document_tasks"),
+        ("graphrag_worker", "graphrag_tasks"),
+        ("qa_import_worker", "qa_import"),
+    ):
+        if role not in worker_source or queue not in worker_source:
+            errors.append(
+                f"tasks/celery_worker.py: missing role/queue mapping: {role} -> {queue}"
+            )
+
+    observability_path = root / "tasks/observability.py"
+    observability_tree = ast.parse(
+        observability_path.read_text(encoding="utf-8"),
+        filename=str(observability_path),
+    )
+    task_log_fields = _literal_string_collection(observability_tree, "TASK_LOG_FIELDS")
+    if task_log_fields is None:
+        errors.append("tasks/observability.py: TASK_LOG_FIELDS must be a literal collection")
+    else:
+        forbidden = task_log_fields & FORBIDDEN_TASK_LOG_FIELDS
+        if forbidden:
+            errors.append(
+                "tasks/observability.py: forbidden task log fields: "
+                + ", ".join(sorted(forbidden))
+            )
+    return errors
+
+
 def _scan_python_tree(root: Path, forbidden_imports: set[str]) -> list[str]:
     errors: list[str] = []
     for path in sorted(root.rglob("*.py")):
@@ -428,6 +535,7 @@ def _scan_dockerfile() -> list[str]:
 
 def main() -> int:
     errors = _scan_service_tree(SOURCE_ROOT, require_complete_registry=True)
+    errors.extend(_scan_worker_observability(SOURCE_ROOT))
     runtime_reports = _scan_runtime_reachability(
         SOURCE_ROOT,
         runtime_roots=RUNTIME_ROOT_MODULES,

--- a/mem-knowledge/src/api/routes/chunk.py
+++ b/mem-knowledge/src/api/routes/chunk.py
@@ -440,6 +440,7 @@ async def import_qa_new_doc(
             await file_service.compensate_storage_upload(storage, plan.file_key)
         raise
     task_id = await dispatch_qa_import(
+        runtime,
         TaskDispatcher(),
         kb_id,
         resources.document_id,
@@ -480,6 +481,7 @@ async def import_qa_chunks(
             principal,
         )
     task_id = await dispatch_qa_import(
+        runtime,
         TaskDispatcher(),
         snapshot.knowledge_id,
         snapshot.document_id,

--- a/mem-knowledge/src/api/routes/document.py
+++ b/mem-knowledge/src/api/routes/document.py
@@ -226,7 +226,7 @@ async def parse_documents(
             file_name=file.file_name,
         )
     result = await document_service.claim_and_dispatch_parse(
-        await runtime.redis.client(),
+        runtime,
         TaskDispatcher(),
         snapshot,
     )

--- a/mem-knowledge/src/config.py
+++ b/mem-knowledge/src/config.py
@@ -332,6 +332,16 @@ class KnowledgeSettings(BaseSettings):
         ge=1,
         validation_alias="KB_WORKER_PREFETCH_MULTIPLIER",
     )
+    kb_task_heartbeat_seconds: float = Field(
+        default=30.0,
+        ge=10.0,
+        validation_alias="KB_TASK_HEARTBEAT_SECONDS",
+    )
+    kb_progress_flush_interval_seconds: float = Field(
+        default=3.0,
+        ge=1.0,
+        validation_alias="KB_PROGRESS_FLUSH_INTERVAL_SECONDS",
+    )
     kb_task_time_limit_seconds: int = Field(
         default=3600,
         ge=1,
@@ -484,4 +494,6 @@ class KnowledgeSettings(BaseSettings):
             "storage_type": self.storage_type,
             "db_pool_size": self.kb_db_pool_size,
             "max_document_pages": self.max_document_pages,
+            "task_heartbeat_seconds": self.kb_task_heartbeat_seconds,
+            "progress_flush_interval_seconds": self.kb_progress_flush_interval_seconds,
         }

--- a/mem-knowledge/src/rag/chunk/router.py
+++ b/mem-knowledge/src/rag/chunk/router.py
@@ -1,13 +1,5 @@
 import re
 
-from .pipeline.excel import ExcelChunkPipeline
-from .pipeline.text import (
-    HtmlChunkPipeline,
-    JsonChunkPipeline,
-    MarkdownChunkPipeline,
-    TextChunkPipeline,
-)
-
 
 class FileTypeRouter:
     def route(self, filename: str):
@@ -45,18 +37,28 @@ class FileTypeRouter:
 
             return PictureVideoChunkPipeline()
         if re.search(r"\.(csv|xlsx?)$", filename, re.IGNORECASE):
+            from .pipeline.excel import ExcelChunkPipeline
+
             return ExcelChunkPipeline()
         if re.search(
             r"\.(txt|py|js|java|c|cpp|h|php|go|ts|sh|cs|kt|sql)$",
             filename,
             re.IGNORECASE,
         ):
+            from .pipeline.text import TextChunkPipeline
+
             return TextChunkPipeline()
         if re.search(r"\.(md|markdown)$", filename, re.IGNORECASE):
+            from .pipeline.text import MarkdownChunkPipeline
+
             return MarkdownChunkPipeline()
         if re.search(r"\.(htm|html)$", filename, re.IGNORECASE):
+            from .pipeline.text import HtmlChunkPipeline
+
             return HtmlChunkPipeline()
         if re.search(r"\.(json|jsonl|ldjson)$", filename, re.IGNORECASE):
+            from .pipeline.text import JsonChunkPipeline
+
             return JsonChunkPipeline()
         if re.search(r"\.doc$", filename, re.IGNORECASE):
             from .pipeline.document import LegacyDocChunkPipeline

--- a/mem-knowledge/src/rag/knowledge_graph/config.py
+++ b/mem-knowledge/src/rag/knowledge_graph/config.py
@@ -9,6 +9,10 @@ class GraphPipelineConfigError(ValueError):
     """Raised when a managed graph pipeline configuration is invalid."""
 
 
+class GraphDocumentDeletionPending(RuntimeError):
+    """Graph cleanup must wait until document deletion is committed."""
+
+
 class GraphPipeline(StrEnum):
     LEGACY = "legacy"
     EVIDENCE = "evidence"

--- a/mem-knowledge/src/rag/knowledge_graph/index_pipeline.py
+++ b/mem-knowledge/src/rag/knowledge_graph/index_pipeline.py
@@ -7,8 +7,8 @@ import logging
 import time
 import unicodedata
 from collections import Counter, defaultdict
-from collections.abc import Mapping, Sequence
-from typing import Any
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, TypeVar
 
 from ...bootstrap import get_settings
 from .batching import build_extraction_batches, select_source_chunks
@@ -29,6 +29,8 @@ from .normalizer import (
 )
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
+GraphStageCallback = Callable[[str, str, int, Mapping[str, int]], None]
 
 
 def calculate_evidence_pageranks(
@@ -225,12 +227,66 @@ class KnowledgeGraphIndexPipeline:
         embedding: Any,
         lock_guard: Any,
         extraction_cache: GraphExtractionCache,
+        stage_callback: GraphStageCallback | None = None,
+        clock: Callable[[], float] = time.perf_counter,
     ) -> None:
         self._store = store
         self._extractor = extractor
         self._embedding = embedding
         self._lock_guard = lock_guard
         self._extraction_cache = extraction_cache
+        self._stage_callback = stage_callback
+        self._clock = clock
+
+    def _notify_stage(
+        self,
+        event: str,
+        stage: str,
+        duration_ms: int,
+        counts: Mapping[str, int] | None = None,
+    ) -> None:
+        if self._stage_callback is None:
+            return
+        try:
+            self._stage_callback(event, stage, duration_ms, counts or {})
+        except Exception as exc:  # noqa: BLE001 - observability must not alter graph work.
+            logger.error(
+                "[EvidenceGraph] stage_callback_failed stage=%s error_type=%s",
+                stage,
+                type(exc).__name__,
+            )
+
+    async def _run_async_stage(
+        self,
+        stage: str,
+        operation: Callable[[], Awaitable[T]],
+    ) -> T:
+        started_at = self._clock()
+        self._notify_stage("started", stage, 0)
+        try:
+            return await operation()
+        finally:
+            self._notify_stage(
+                "finished",
+                stage,
+                max(0, int(round((self._clock() - started_at) * 1000))),
+            )
+
+    def _run_sync_stage(
+        self,
+        stage: str,
+        operation: Callable[[], T],
+    ) -> T:
+        started_at = self._clock()
+        self._notify_stage("started", stage, 0)
+        try:
+            return operation()
+        finally:
+            self._notify_stage(
+                "finished",
+                stage,
+                max(0, int(round((self._clock() - started_at) * 1000))),
+            )
 
     async def sync_document(
         self,
@@ -244,60 +300,97 @@ class KnowledgeGraphIndexPipeline:
         stage = "ensure_graph_index"
         try:
             self._lock_guard.ensure_valid()
-            await self._store.ensure_graph_index(runtime.graph_index_name)
+            await self._run_async_stage(
+                stage,
+                lambda: self._store.ensure_graph_index(runtime.graph_index_name),
+            )
             stage = "refresh_sources"
             self._lock_guard.ensure_valid()
-            await self._store.refresh_sources(
-                runtime.chunk_index_name,
-                runtime.graph_index_name,
+            await self._run_async_stage(
+                stage,
+                lambda: self._store.refresh_sources(
+                    runtime.chunk_index_name,
+                    runtime.graph_index_name,
+                ),
             )
             stage = "load_document_chunks"
-            hits = (
-                await self._store.load_document_chunks(
-                    runtime.chunk_index_name,
-                    runtime.knowledge_id,
-                    document_id,
+            hits = []
+            if document_active:
+                hits = await self._run_async_stage(
+                    stage,
+                    lambda: self._store.load_document_chunks(
+                        runtime.chunk_index_name,
+                        runtime.knowledge_id,
+                        document_id,
+                    ),
                 )
-                if document_active
-                else []
-            )
             batches = build_extraction_batches(select_source_chunks(hits))
             stage = "extract_batches"
-            results = await self._extract_batches(batches, runtime)
+            results = await self._run_async_stage(
+                stage,
+                lambda: self._extract_batches(batches, runtime),
+            )
             stage = "materialize_evidence"
-            entity_evidence, relation_evidence = materialize_evidence(
-                runtime.knowledge_id,
-                document_id,
-                results,
+            entity_evidence, relation_evidence = self._run_sync_stage(
+                stage,
+                lambda: materialize_evidence(
+                    runtime.knowledge_id,
+                    document_id,
+                    results,
+                ),
             )
             stage = "replace_document_evidence"
             self._lock_guard.ensure_valid()
-            affected = await self._store.replace_document_evidence(
-                runtime.graph_index_name,
-                runtime.knowledge_id,
-                document_id,
-                entity_evidence,
-                relation_evidence,
-                ensure_valid=self._lock_guard.ensure_valid,
+            affected = await self._run_async_stage(
+                stage,
+                lambda: self._store.replace_document_evidence(
+                    runtime.graph_index_name,
+                    runtime.knowledge_id,
+                    document_id,
+                    entity_evidence,
+                    relation_evidence,
+                    ensure_valid=self._lock_guard.ensure_valid,
+                ),
             )
             stage = "rebuild_relation_projections"
-            await self._rebuild_relation_projections(runtime, affected.relation_keys)
+            await self._run_async_stage(
+                stage,
+                lambda: self._rebuild_relation_projections(
+                    runtime,
+                    affected.relation_keys,
+                ),
+            )
             stage = "rebuild_entity_projections"
-            await self._rebuild_entity_projections(runtime, affected.entity_keys)
+            await self._run_async_stage(
+                stage,
+                lambda: self._rebuild_entity_projections(
+                    runtime,
+                    affected.entity_keys,
+                ),
+            )
             stage = "finish_document_map"
-            await self._store.finish_document_map(
-                runtime.graph_index_name,
-                runtime.knowledge_id,
-                document_id,
-                entity_evidence,
-                relation_evidence,
-                ensure_valid=self._lock_guard.ensure_valid,
+            await self._run_async_stage(
+                stage,
+                lambda: self._store.finish_document_map(
+                    runtime.graph_index_name,
+                    runtime.knowledge_id,
+                    document_id,
+                    entity_evidence,
+                    relation_evidence,
+                    ensure_valid=self._lock_guard.ensure_valid,
+                ),
             )
             stage = "refresh_graph"
-            await self._store.refresh_graph(runtime.graph_index_name)
+            await self._run_async_stage(
+                stage,
+                lambda: self._store.refresh_graph(runtime.graph_index_name),
+            )
             if refresh_pageranks:
                 stage = "rebuild_graph_pageranks"
-                await self._rebuild_graph_pageranks(runtime)
+                await self._run_async_stage(
+                    stage,
+                    lambda: self._rebuild_graph_pageranks(runtime),
+                )
             logger.info(
                 "[EvidenceGraph] index_done kb_id=%s document_id=%s elapsed_ms=%d",
                 runtime.knowledge_id,
@@ -326,12 +419,18 @@ class KnowledgeGraphIndexPipeline:
         """Replace all Legacy and Evidence documents before rebuilding active inputs."""
 
         self._lock_guard.ensure_valid()
-        await self._store.ensure_graph_index(runtime.graph_index_name)
+        await self._run_async_stage(
+            "ensure_graph_index",
+            lambda: self._store.ensure_graph_index(runtime.graph_index_name),
+        )
         self._lock_guard.ensure_valid()
-        await self._store.clear_all_graph_documents(
-            runtime.graph_index_name,
-            runtime.knowledge_id,
-            ensure_valid=self._lock_guard.ensure_valid,
+        await self._run_async_stage(
+            "clear_graph_documents",
+            lambda: self._store.clear_all_graph_documents(
+                runtime.graph_index_name,
+                runtime.knowledge_id,
+                ensure_valid=self._lock_guard.ensure_valid,
+            ),
         )
         active_ids = tuple(dict.fromkeys(active_document_ids))
         for document_id in active_ids:
@@ -342,8 +441,14 @@ class KnowledgeGraphIndexPipeline:
                 refresh_pageranks=False,
             )
         self._lock_guard.ensure_valid()
-        await self._store.refresh_graph(runtime.graph_index_name)
-        await self._rebuild_graph_pageranks(runtime)
+        await self._run_async_stage(
+            "refresh_graph",
+            lambda: self._store.refresh_graph(runtime.graph_index_name),
+        )
+        await self._run_async_stage(
+            "rebuild_graph_pageranks",
+            lambda: self._rebuild_graph_pageranks(runtime),
+        )
 
     async def _extract_batches(
         self,

--- a/mem-knowledge/src/rag/knowledge_graph/lock.py
+++ b/mem-knowledge/src/rag/knowledge_graph/lock.py
@@ -6,6 +6,7 @@ import logging
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,15 @@ return 0
 
 
 class KnowledgeGraphLock:
-    def __init__(self, redis: Any, knowledge_id: str) -> None:
+    def __init__(
+        self,
+        redis: Any,
+        knowledge_id: str,
+        *,
+        on_wait: Callable[[str, int], None] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
         self._redis = redis
         self._knowledge_id = knowledge_id
         self._key = f"graphrag_task_{knowledge_id}"
@@ -38,10 +47,16 @@ class KnowledgeGraphLock:
         self._stop = threading.Event()
         self._renew_thread: threading.Thread | None = None
         self._valid = False
+        self._on_wait = on_wait
+        self._clock = clock
+        self._sleep = sleep
 
     def __enter__(self) -> KnowledgeGraphLock:
-        deadline = time.monotonic() + _LOCK_WAIT_SECONDS
-        while time.monotonic() < deadline:
+        started_at = self._clock()
+        deadline = started_at + _LOCK_WAIT_SECONDS
+        waiting_reported = False
+        last_wait_report_seconds = 0.0
+        while self._clock() < deadline:
             if self._redis.set(
                 self._key,
                 self._token,
@@ -59,8 +74,28 @@ class KnowledgeGraphLock:
                     "[EvidenceGraph] lock_acquired kb_id=%s",
                     self._knowledge_id,
                 )
+                if waiting_reported and self._on_wait is not None:
+                    self._on_wait(
+                        "lock_acquired",
+                        int((self._clock() - started_at) * 1000),
+                    )
                 return self
-            time.sleep(1)
+            waited_seconds = self._clock() - started_at
+            if not waiting_reported:
+                waiting_reported = True
+                if self._on_wait is not None:
+                    self._on_wait("lock_wait_started", 0)
+            elif (
+                self._on_wait is not None
+                and waited_seconds >= 10
+                and (
+                    last_wait_report_seconds == 0
+                    or waited_seconds - last_wait_report_seconds >= 30
+                )
+            ):
+                self._on_wait("lock_waiting", int(waited_seconds * 1000))
+                last_wait_report_seconds = waited_seconds
+            self._sleep(1)
         raise TimeoutError("knowledge graph lock acquisition timed out")
 
     def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
@@ -117,8 +152,17 @@ class KnowledgeGraphLock:
                 return
 
 
-def create_knowledge_graph_lock(runtime: Any, knowledge_id: str) -> KnowledgeGraphLock:
-    return KnowledgeGraphLock(runtime.redis.sync_client(), knowledge_id)
+def create_knowledge_graph_lock(
+    runtime: Any,
+    knowledge_id: str,
+    *,
+    on_wait: Callable[[str, int], None] | None = None,
+) -> KnowledgeGraphLock:
+    return KnowledgeGraphLock(
+        runtime.redis.sync_client(),
+        knowledge_id,
+        on_wait=on_wait,
+    )
 
 
 __all__ = ["KnowledgeGraphLock", "create_knowledge_graph_lock"]

--- a/mem-knowledge/src/rag/models/task_runtime.py
+++ b/mem-knowledge/src/rag/models/task_runtime.py
@@ -6,11 +6,12 @@ import uuid
 from typing import TYPE_CHECKING
 
 from redbear_model import ResolvedModelConfig, resolve_model
-from redbear_model.runtime import RedBearEmbeddings, RedBearLLM
 
 from ...repositories.model_registry import SyncSQLModelRegistry
 
 if TYPE_CHECKING:
+    from redbear_model.runtime import RedBearEmbeddings, RedBearLLM
+
     from ...runtime import ProcessRuntime
 
 
@@ -58,6 +59,8 @@ class TaskModelFactory:
         model_config_id: uuid.UUID,
         tenant_id: uuid.UUID,
     ) -> RedBearEmbeddings:
+        from redbear_model.runtime import RedBearEmbeddings
+
         config = self.resolve_embedding(model_config_id, tenant_id)
         try:
             return RedBearEmbeddings(
@@ -72,6 +75,8 @@ class TaskModelFactory:
         model_config_id: uuid.UUID,
         tenant_id: uuid.UUID,
     ) -> RedBearLLM:
+        from redbear_model.runtime import RedBearLLM
+
         config = self.resolve_chat(model_config_id, tenant_id)
         try:
             return RedBearLLM(config, client_pool=self._runtime.model_runtime.pool)

--- a/mem-knowledge/src/services/document.py
+++ b/mem-knowledge/src/services/document.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,13 +31,16 @@ from ..rag.knowledge_graph import (
 from ..rag.parser_config import normalize_document_parser_config
 from ..repositories import document as document_repository
 from ..tasks.dispatch import TaskDispatcher
-from ..utils.datetime_utils import utcnow_naive
+from ..utils.datetime_utils import to_iso_z, utcnow, utcnow_naive
 from . import file as file_service
 from . import knowledge as knowledge_service
 from .knowledge_file_storage import KnowledgeFileStorage
 from .qa_export import collection_name_for_knowledge
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..runtime import ProcessRuntime
 
 PARSE_TASK_KEY = "doc:{doc_id}:parse_task"
 PARSE_CANCEL_KEY = "doc:{doc_id}:parse_cancel"
@@ -336,17 +339,48 @@ async def _release_parse_claim(redis: Any, task_key: str) -> None:
         await redis.delete(task_key)
 
 
+async def _persist_parse_dispatch_state(
+    runtime: ProcessRuntime,
+    document_id: uuid.UUID,
+    *,
+    state: str,
+) -> None:
+    async with runtime.database.async_session() as db:
+        document = await db.get(Document, document_id)
+        if document is None:
+            raise ValueError(f"Document {document_id} not found while updating dispatch state")
+        timestamp = to_iso_z(utcnow())
+        if state == "queued":
+            document.progress = 0.0
+            document.progress_msg = f"{timestamp} Queued.\n"
+            document.process_duration = 0.0
+            document.run = 0
+        elif state == "failed":
+            document.progress = -1.0
+            document.progress_msg = f"{timestamp} Task dispatch failed.\n"
+            document.run = 0
+        else:
+            raise ValueError(f"Unsupported parse dispatch state: {state}")
+        await db.commit()
+
+
 async def claim_and_dispatch_parse(
-    redis: Any,
+    runtime: ProcessRuntime,
     dispatcher: TaskDispatcher,
     snapshot: ParseDocumentSnapshot,
 ) -> ParseDispatchResult:
+    redis = await runtime.redis.client()
     task_key = PARSE_TASK_KEY.format(doc_id=snapshot.document_id)
     claimed = await redis.set(task_key, "CLAIMED", ex=PARSE_TASK_TTL, nx=True)
     if not claimed:
         existing_task_id = await redis.get(task_key)
         return ParseDispatchResult(str(existing_task_id or "unknown"), False)
     try:
+        await _persist_parse_dispatch_state(
+            runtime,
+            snapshot.document_id,
+            state="queued",
+        )
         task_id = await dispatcher.send(
             PARSE_TASK_NAME,
             args=[snapshot.file_key, snapshot.document_id, snapshot.file_name],
@@ -354,6 +388,18 @@ async def claim_and_dispatch_parse(
         )
     except Exception:
         await _release_parse_claim(redis, task_key)
+        try:
+            await _persist_parse_dispatch_state(
+                runtime,
+                snapshot.document_id,
+                state="failed",
+            )
+        except Exception as state_exc:  # noqa: BLE001 - preserve dispatch failure.
+            logger.warning(
+                "Failed to persist parse dispatch failure: document=%s error_type=%s",
+                snapshot.document_id,
+                type(state_exc).__name__,
+            )
         raise
     await redis.set(task_key, task_id, ex=PARSE_TASK_TTL)
     return ParseDispatchResult(task_id, True)

--- a/mem-knowledge/src/services/document_processing.py
+++ b/mem-knowledge/src/services/document_processing.py
@@ -40,6 +40,7 @@ from ..rag.models.vision import QWenCV as ImageQWenCV
 from ..rag.vdb.vector_store import TaskVectorStore
 from ..runtime import ProcessRuntime
 from ..tasks.dispatch import TaskDispatcher
+from ..tasks.observability import BusinessOutcome, TaskRun
 from ..tasks.state import PARSE_CANCEL_KEY, PARSE_TASK_KEY
 from ..utils.datetime_utils import to_iso_z, to_timestamp_ms, utcnow, utcnow_naive
 from .knowledge_file_storage import KnowledgeFileStorage
@@ -714,6 +715,8 @@ def process_document(
     file_key: str,
     document_id: str | uuid.UUID,
     file_name: str = "",
+    *,
+    run: TaskRun,
 ) -> str:
     """Parse, vectorize, and persist one document with legacy task semantics."""
 
@@ -723,21 +726,25 @@ def process_document(
     normalized_document_id: uuid.UUID | None = None
     try:
         normalized_document_id = uuid.UUID(str(document_id))
-        snapshot = _load_snapshot(
-            runtime,
-            normalized_document_id,
-            file_name,
-        )
+        with run.stage("load_snapshot"):
+            snapshot = _load_snapshot(
+                runtime,
+                normalized_document_id,
+                file_name,
+            )
         document_label = snapshot.file_name or str(normalized_document_id)
-        preflight = _preflight_document(runtime, snapshot)
         _mark_running(runtime, normalized_document_id, progress_lines)
+        with run.stage("preflight"):
+            preflight = _preflight_document(runtime, snapshot)
         if _should_abort(runtime, normalized_document_id):
             raise _ParseAborted
 
-        file_binary = _download_file(runtime, file_key)
+        with run.stage("download_file"):
+            file_binary = _download_file(runtime, file_key)
         if not file_binary:
             raise OSError(f"Downloaded empty file from storage: {file_key}")
-        estimated_pages = _estimate_pages(snapshot.file_name, file_binary)
+        with run.stage("estimate_pages"):
+            estimated_pages = _estimate_pages(snapshot.file_name, file_binary)
         if estimated_pages is None:
             progress_lines.append(
                 f"{_progress_ts()} parse document '{document_label}' page number unavailable."
@@ -753,20 +760,41 @@ def process_document(
                 document.progress_msg = _progress_message(progress_lines)
 
             _update_document(runtime, normalized_document_id, mark_page_limit_failed)
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code="KB_DOC_PAGE_LIMIT_EXCEEDED",
+                detail="page_limit_exceeded",
+            )
             return f"parse document '{document_label}' failed: page limit exceeded"
 
         def progress_callback(prog=None, msg=None):
-            progress_lines.append(f"{_progress_ts()} parse progress: {prog} msg: {msg}.")
+            display_message = f"{_progress_ts()} parse progress: {prog} msg: {msg}."
+            progress_lines.append(display_message)
+            fraction = (
+                float(prog)
+                if isinstance(prog, (int, float))
+                and not isinstance(prog, bool)
+                and 0.0 <= float(prog) <= 1.0
+                else None
+            )
+            run.progress(
+                stage="parse",
+                fraction=fraction,
+                detail="parser_progress",
+                display_message=display_message,
+                force=fraction in {0.8, 1.0},
+            )
 
         if _should_abort(runtime, normalized_document_id):
             raise _ParseAborted
-        parsed = _parse_chunks(
-            runtime,
-            snapshot,
-            file_binary,
-            progress_callback,
-            preflight.vision_model,
-        )
+        with run.stage("parse"):
+            parsed = _parse_chunks(
+                runtime,
+                snapshot,
+                file_binary,
+                progress_callback,
+                preflight.vision_model,
+            )
         if snapshot.parent_child_mode:
             child_result, parent_result, parent_id_map = parsed
             if isinstance(child_result, GroupedChildChunks):
@@ -786,7 +814,8 @@ def process_document(
             document.progress = 0.8
             document.progress_msg = _progress_message(progress_lines)
 
-        _update_document(runtime, normalized_document_id, mark_parsed)
+        with run.stage("persist_document"):
+            _update_document(runtime, normalized_document_id, mark_parsed)
         if _should_abort(runtime, normalized_document_id):
             raise _ParseAborted
 
@@ -800,48 +829,54 @@ def process_document(
             progress_lines.append(f"{_progress_ts()} No chunks generated, skipping vectorization.")
         else:
             vector_store = preflight.vector_store
-            vector_store.delete_by_metadata_field(
-                "document_id",
-                str(normalized_document_id),
-            )
-            if snapshot.parent_child_mode:
-                all_chunks = _parent_child_chunks(
-                    snapshot,
-                    child_result,
-                    parent_result,
-                    parent_id_map,
+            with run.stage("delete_old_vectors"):
+                vector_store.delete_by_metadata_field(
+                    "document_id",
+                    str(normalized_document_id),
                 )
-                progress_lines.append(
-                    f"{_progress_ts()} Parent-child mode: {len(parent_result)} parent "
-                    f"chunks + {len(child_result)} child chunks prepared."
-                )
-            elif preflight.auto_questions_topn:
-                all_chunks = _auto_qa_chunks(
-                    runtime,
-                    snapshot,
-                    preflight.chat_model,
-                    child_result,
-                    preflight.auto_questions_topn,
-                    snapshot.parser_config.get("qa_prompt"),
-                )
-                qa_count = sum(chunk.metadata.get("chunk_type") == "qa" for chunk in all_chunks)
-                progress_lines.append(
-                    f"{_progress_ts()} QA pairs generated for {total_chunks} chunks "
-                    f"(workers={runtime.settings.auto_questions_max_workers})."
-                )
-                progress_lines.append(
-                    f"{_progress_ts()} QA mode: {total_chunks} source chunks + "
-                    f"{qa_count} QA chunks prepared."
-                )
-            else:
-                all_chunks = _normal_chunks(snapshot, child_result)
+            with run.stage("prepare_chunks"):
+                if snapshot.parent_child_mode:
+                    all_chunks = _parent_child_chunks(
+                        snapshot,
+                        child_result,
+                        parent_result,
+                        parent_id_map,
+                    )
+                    progress_lines.append(
+                        f"{_progress_ts()} Parent-child mode: {len(parent_result)} parent "
+                        f"chunks + {len(child_result)} child chunks prepared."
+                    )
+                elif preflight.auto_questions_topn:
+                    with run.stage("generate_qa"):
+                        all_chunks = _auto_qa_chunks(
+                            runtime,
+                            snapshot,
+                            preflight.chat_model,
+                            child_result,
+                            preflight.auto_questions_topn,
+                            snapshot.parser_config.get("qa_prompt"),
+                        )
+                    qa_count = sum(
+                        chunk.metadata.get("chunk_type") == "qa" for chunk in all_chunks
+                    )
+                    progress_lines.append(
+                        f"{_progress_ts()} QA pairs generated for {total_chunks} chunks "
+                        f"(workers={runtime.settings.auto_questions_max_workers})."
+                    )
+                    progress_lines.append(
+                        f"{_progress_ts()} QA mode: {total_chunks} source chunks + "
+                        f"{qa_count} QA chunks prepared."
+                    )
+                else:
+                    all_chunks = _normal_chunks(snapshot, child_result)
             batch_size = runtime.settings.embedding_batch_size
             batches = [
                 all_chunks[start : start + batch_size]
                 for start in range(0, len(all_chunks), batch_size)
             ]
             total_batches = len(batches)
-            _write_chunks_with_retry(runtime, vector_store, batches)
+            with run.stage("embedding"):
+                _write_chunks_with_retry(runtime, vector_store, batches)
             progress_lines.append(
                 f"{_progress_ts()} All {total_batches} batches embedded "
                 f"(workers={runtime.settings.embedding_max_workers})."
@@ -853,7 +888,8 @@ def process_document(
                 document.process_duration = time.time() - started_at
                 document.run = 0
 
-            _update_document(runtime, normalized_document_id, mark_vectorized)
+            with run.stage("persist_document"):
+                _update_document(runtime, normalized_document_id, mark_vectorized)
 
         progress_lines.append(f"{_progress_ts()} Indexing done.")
         process_duration = time.time() - started_at
@@ -866,17 +902,28 @@ def process_document(
             document.progress_msg = _progress_message(progress_lines)
             document.run = 0
 
-        _update_document(runtime, normalized_document_id, mark_done)
-        _dispatch_graph(runtime, snapshot, progress_lines)
+        with run.stage("persist_document"):
+            _update_document(runtime, normalized_document_id, mark_done)
+        with run.stage("dispatch_graph"):
+            _dispatch_graph(runtime, snapshot, progress_lines)
         logger.info(
             "Document parsing completed: document=%s duration=%.1f chunks=%s",
             normalized_document_id,
             process_duration,
             total_chunks,
         )
+        run.finish(
+            BusinessOutcome.SUCCESS,
+            counts={"chunks": total_chunks},
+        )
         return f"parse document '{snapshot.source_file_name}' processed successfully."
     except _ParseAborted:
         logger.info("Document parsing aborted: document=%s", normalized_document_id)
+        run.finish(
+            BusinessOutcome.ABORTED,
+            error_code="KB_DOC_PARSE_ABORTED",
+            detail="document_deleted_or_cancelled",
+        )
         return f"parse document '{document_label}' aborted (deleted or cancelled)."
     except Exception as exc:  # noqa: BLE001 - task returns a legacy failure string.
         logger.error(
@@ -902,9 +949,15 @@ def process_document(
                     normalized_document_id,
                     type(state_exc).__name__,
                 )
+        run.finish(
+            BusinessOutcome.FAILURE,
+            error_code="KB_DOC_PROCESSING_FAILED",
+            exc=exc,
+        )
         return f"parse document '{document_label}' failed."
     finally:
-        _clear_parse_state(runtime, normalized_document_id or document_id)
+        with run.stage("cleanup"):
+            _clear_parse_state(runtime, normalized_document_id or document_id)
 
 
 __all__ = ["ParseDocumentSnapshot", "process_document"]

--- a/mem-knowledge/src/services/evidence_graph.py
+++ b/mem-knowledge/src/services/evidence_graph.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import time
 import uuid
+from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import select
@@ -20,7 +22,7 @@ from ..rag.knowledge_graph.elasticsearch_store import (
 )
 from ..rag.knowledge_graph.extraction_cache import GraphExtractionCache
 from ..rag.knowledge_graph.extractor import LLMEntityRelationExtractor
-from ..rag.knowledge_graph.index_pipeline import KnowledgeGraphIndexPipeline
+from ..rag.knowledge_graph.index_pipeline import GraphStageCallback, KnowledgeGraphIndexPipeline
 from ..rag.knowledge_graph.lock import create_knowledge_graph_lock
 from ..rag.knowledge_graph.models import GraphTaskState
 from ..rag.knowledge_graph.runtime import GraphRuntimeDisabled, snapshot_graph_runtime
@@ -91,7 +93,12 @@ def load_graph_task_state(
         )
 
 
-async def _build_pipeline(runtime: Any, graph_runtime: Any, lock_guard: Any):
+async def _build_pipeline(
+    runtime: Any,
+    graph_runtime: Any,
+    lock_guard: Any,
+    stage_callback: GraphStageCallback | None = None,
+):
     from redbear_model.runtime import RedBearEmbeddings, RedBearLLM
 
     client = await runtime.elasticsearch.client()
@@ -112,6 +119,7 @@ async def _build_pipeline(runtime: Any, graph_runtime: Any, lock_guard: Any):
         embedding=embedding,
         lock_guard=lock_guard,
         extraction_cache=GraphExtractionCache(redis),
+        stage_callback=stage_callback,
     )
 
 
@@ -122,11 +130,17 @@ def execute_evidence_document(
     lock_guard: Any,
     *,
     document_active: bool,
+    stage_callback: GraphStageCallback | None = None,
 ) -> None:
     graph_runtime = snapshot_graph_runtime(runtime, state.knowledge_id)
 
     async def run() -> None:
-        pipeline = await _build_pipeline(runtime, graph_runtime, lock_guard)
+        pipeline = await _build_pipeline(
+            runtime,
+            graph_runtime,
+            lock_guard,
+            stage_callback,
+        )
         await pipeline.sync_document(graph_runtime, document_id, document_active)
 
     runtime.run_async(run)
@@ -136,11 +150,17 @@ def execute_evidence_rebuild(
     runtime: Any,
     state: GraphTaskState,
     lock_guard: Any,
+    stage_callback: GraphStageCallback | None = None,
 ) -> None:
     graph_runtime = snapshot_graph_runtime(runtime, state.knowledge_id)
 
     async def run() -> None:
-        pipeline = await _build_pipeline(runtime, graph_runtime, lock_guard)
+        pipeline = await _build_pipeline(
+            runtime,
+            graph_runtime,
+            lock_guard,
+            stage_callback,
+        )
         await pipeline.rebuild_knowledge(graph_runtime, state.active_document_ids)
 
     runtime.run_async(run)
@@ -168,10 +188,16 @@ def process_evidence_document(
     document_id: str,
     *,
     document_deleted: bool = False,
+    on_lock_wait: Callable[[str, int], None] | None = None,
+    on_stage: GraphStageCallback | None = None,
 ) -> dict[str, Any]:
     knowledge_id = _canonical_uuid(knowledge_id, "knowledge id")
     document_id = _canonical_uuid(document_id, "document id")
-    with create_knowledge_graph_lock(runtime, knowledge_id) as lock_guard:
+    with create_knowledge_graph_lock(
+        runtime,
+        knowledge_id,
+        on_wait=on_lock_wait,
+    ) as lock_guard:
         lock_guard.ensure_valid()
         state = load_graph_task_state(runtime, knowledge_id, document_id)
         if state.pipeline is not GraphPipeline.EVIDENCE:
@@ -187,6 +213,7 @@ def process_evidence_document(
                 document_id,
                 lock_guard,
                 document_active=(False if document_deleted else bool(state.document_active)),
+                stage_callback=on_stage,
             )
         except GraphRuntimeDisabled:
             return {"status": "skipped", "reason": "graph_disabled"}
@@ -198,9 +225,19 @@ def process_evidence_document(
         }
 
 
-def process_evidence_rebuild(runtime: Any, knowledge_id: str) -> dict[str, Any]:
+def process_evidence_rebuild(
+    runtime: Any,
+    knowledge_id: str,
+    *,
+    on_lock_wait: Callable[[str, int], None] | None = None,
+    on_stage: GraphStageCallback | None = None,
+) -> dict[str, Any]:
     knowledge_id = _canonical_uuid(knowledge_id, "knowledge id")
-    with create_knowledge_graph_lock(runtime, knowledge_id) as lock_guard:
+    with create_knowledge_graph_lock(
+        runtime,
+        knowledge_id,
+        on_wait=on_lock_wait,
+    ) as lock_guard:
         lock_guard.ensure_valid()
         state = load_graph_task_state(
             runtime,
@@ -212,7 +249,12 @@ def process_evidence_rebuild(runtime: Any, knowledge_id: str) -> dict[str, Any]:
         if not state.graph_enabled:
             return {"status": "skipped", "reason": "graph_disabled"}
         try:
-            execute_evidence_rebuild(runtime, state, lock_guard)
+            execute_evidence_rebuild(
+                runtime,
+                state,
+                lock_guard,
+                stage_callback=on_stage,
+            )
         except GraphRuntimeDisabled:
             return {"status": "skipped", "reason": "graph_disabled"}
         lock_guard.ensure_valid()
@@ -224,14 +266,32 @@ def process_clear_graph(
     knowledge_id: str,
     *,
     force: bool = False,
+    on_lock_wait: Callable[[str, int], None] | None = None,
+    on_stage: GraphStageCallback | None = None,
 ) -> dict[str, Any]:
     knowledge_id = _canonical_uuid(knowledge_id, "knowledge id")
-    with create_knowledge_graph_lock(runtime, knowledge_id) as lock_guard:
+    with create_knowledge_graph_lock(
+        runtime,
+        knowledge_id,
+        on_wait=on_lock_wait,
+    ) as lock_guard:
         lock_guard.ensure_valid()
         state = load_graph_task_state(runtime, knowledge_id)
         if state.graph_enabled and not force:
             return {"status": "skipped", "reason": "graph_reenabled"}
-        execute_evidence_clear(runtime, state, lock_guard)
+        started_at = time.perf_counter()
+        if on_stage is not None:
+            on_stage("started", "clear_graph_documents", 0, {})
+        try:
+            execute_evidence_clear(runtime, state, lock_guard)
+        finally:
+            if on_stage is not None:
+                on_stage(
+                    "finished",
+                    "clear_graph_documents",
+                    int((time.perf_counter() - started_at) * 1000),
+                    {},
+                )
         lock_guard.ensure_valid()
         return {"status": "cleared", "knowledge_id": knowledge_id}
 

--- a/mem-knowledge/src/services/evidence_graph.py
+++ b/mem-knowledge/src/services/evidence_graph.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 
 from ..models.owned import Document, Knowledge
 from ..rag.knowledge_graph.config import (
+    GraphDocumentDeletionPending,
     GraphPipeline,
     GraphPipelineConfigError,
     is_graph_enabled,
@@ -26,10 +27,6 @@ from ..rag.knowledge_graph.index_pipeline import GraphStageCallback, KnowledgeGr
 from ..rag.knowledge_graph.lock import create_knowledge_graph_lock
 from ..rag.knowledge_graph.models import GraphTaskState
 from ..rag.knowledge_graph.runtime import GraphRuntimeDisabled, snapshot_graph_runtime
-
-
-class GraphDocumentDeletionPending(RuntimeError):
-    """The graph cleanup must wait until document deletion is committed."""
 
 
 def _canonical_uuid(value: object, field_name: str) -> str:

--- a/mem-knowledge/src/services/knowledge_sync.py
+++ b/mem-knowledge/src/services/knowledge_sync.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import tempfile
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -29,6 +29,7 @@ from ..rag.integrations.yuque.models import YuqueDocInfo
 from ..rag.vdb.vector_store import TaskVectorStore
 from ..runtime import ProcessRuntime
 from ..tasks.dispatch import TaskDispatcher
+from ..tasks.observability import BusinessOutcome, TaskRun
 from ..utils.datetime_utils import utcnow_naive
 from .knowledge_file_storage import KnowledgeFileStorage, generate_kb_file_key
 
@@ -81,6 +82,22 @@ class _StaleFileSnapshot:
     file: _FileSnapshot
     document_id: uuid.UUID | None
     derived_files: tuple[_FileSnapshot, ...]
+
+
+@dataclass
+class KnowledgeSyncCounters:
+    """Safe aggregate counts for one synchronization task."""
+
+    discovered: int = 0
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    deleted: int = 0
+    parse_dispatched: int = 0
+    failed: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return asdict(self)
 
 
 def _snapshot_file(record: File) -> _FileSnapshot:
@@ -349,12 +366,13 @@ def _dispatch_parse(
     runtime: ProcessRuntime,
     file_record: _FileSnapshot | None,
     document: _DocumentSnapshot | None,
-) -> None:
+) -> bool:
     if file_record is not None and document is not None and file_record.file_key:
         _dispatcher(runtime).send_sync(
             "app.core.rag.tasks.parse_document",
             args=[file_record.file_key, str(document.id), file_record.file_name],
         )
+        return True
     elif file_record is not None and document is not None:
         logger.warning(
             "Skipping parse because synchronized file key is empty: document=%s",
@@ -365,6 +383,7 @@ def _dispatch_parse(
             "Skipping parse because synchronized document is missing: file=%s",
             file_record.id,
         )
+    return False
 
 
 def _snapshot_stale_files(
@@ -425,10 +444,10 @@ def _delete_stale_files(
     runtime: ProcessRuntime,
     kb_id: uuid.UUID,
     current_urls: set[str],
-) -> None:
+) -> int:
     stale_files = _snapshot_stale_files(runtime, kb_id, current_urls)
     if not stale_files:
-        return
+        return 0
     storage = KnowledgeFileStorage(runtime.storage)
     vector_store = TaskVectorStore(runtime.elasticsearch.sync_client(), kb_id, None)
     for stale in stale_files:
@@ -459,9 +478,15 @@ def _delete_stale_files(
         if legacy_path.exists():
             legacy_path.unlink()
     _delete_stale_records(runtime, stale_files)
+    return len(stale_files)
 
 
-def _sync_web(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
+def _sync_web(
+    runtime: ProcessRuntime,
+    knowledge: _KnowledgeSnapshot,
+    run: TaskRun,
+    counters: KnowledgeSyncCounters,
+) -> None:
     config = knowledge.parser_config
     crawler = WebCrawler(
         entry_url=config.get("entry_url", ""),
@@ -472,11 +497,14 @@ def _sync_web(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
     )
     current_urls: set[str] = set()
     for crawled in crawler.crawl():
+        counters.discovered += 1
         current_urls.add(crawled.url)
         if not crawled.content_length:
+            counters.unchanged += 1
             continue
         file_record = _find_source_file(runtime, knowledge.id, crawled.url)
         if file_record is not None and file_record.file_size == crawled.content_length:
+            counters.unchanged += 1
             continue
         is_new = file_record is None
         if is_new:
@@ -488,6 +516,9 @@ def _sync_web(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
                 file_size=crawled.content_length,
                 file_url=crawled.url,
             )
+            counters.created += 1
+        else:
+            counters.updated += 1
         assert file_record is not None
         content = crawled.content.encode("utf-8")
         _write_legacy_file(runtime, file_record, content, file_ext=".txt")
@@ -508,8 +539,15 @@ def _sync_web(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
             if is_new
             else existing_document
         )
-        _dispatch_parse(runtime, file_record, document)
-    _delete_stale_files(runtime, knowledge.id, current_urls)
+        if _dispatch_parse(runtime, file_record, document):
+            counters.parse_dispatched += 1
+        run.progress(
+            stage="sync_web",
+            fraction=None,
+            detail="source_item_processed",
+            counts=counters.as_dict(),
+        )
+    counters.deleted += _delete_stale_files(runtime, knowledge.id, current_urls)
 
 
 async def _list_yuque_documents(client: YuqueAPIClient) -> list[YuqueDocInfo]:
@@ -529,18 +567,26 @@ async def _download_yuque_document(
         return await opened.download_document(document, save_dir)
 
 
-def _sync_yuque(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
+def _sync_yuque(
+    runtime: ProcessRuntime,
+    knowledge: _KnowledgeSnapshot,
+    run: TaskRun,
+    counters: KnowledgeSyncCounters,
+) -> None:
     config = knowledge.parser_config
     client = YuqueAPIClient(
         user_id=config.get("yuque_user_id", ""),
         token=config.get("yuque_token", ""),
     )
-    documents = runtime.run_async(lambda: _list_yuque_documents(client))
+    with run.stage("list_remote_documents"):
+        documents = runtime.run_async(lambda: _list_yuque_documents(client))
+    counters.discovered += len(documents)
     current_urls: set[str] = set()
     for document in documents:
         current_urls.add(document.slug)
         file_record = _find_source_file(runtime, knowledge.id, document.slug)
         if file_record is not None and file_record.created_at == document.updated_at:
+            counters.unchanged += 1
             continue
         save_dir = os.path.join(
             str(runtime.settings.file_path),
@@ -548,13 +594,14 @@ def _sync_yuque(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
             str(knowledge.id),
         )
         Path(save_dir).mkdir(parents=True, exist_ok=True)
-        file_path = runtime.run_async(
-            lambda doc=document, directory=save_dir: _download_yuque_document(
-                client,
-                doc,
-                directory,
+        with run.stage("download_remote_document"):
+            file_path = runtime.run_async(
+                lambda doc=document, directory=save_dir: _download_yuque_document(
+                    client,
+                    doc,
+                    directory,
+                )
             )
-        )
         file_name = os.path.basename(file_path)
         file_ext = os.path.splitext(file_name)[1].lower()
         file_size = os.path.getsize(file_path)
@@ -569,6 +616,9 @@ def _sync_yuque(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
                 file_url=document.slug,
                 created_at=document.updated_at,
             )
+            counters.created += 1
+        else:
+            counters.updated += 1
         assert file_record is not None
         legacy_path = _copy_legacy_file(
             runtime,
@@ -596,8 +646,15 @@ def _sync_yuque(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
             if is_new
             else existing_document
         )
-        _dispatch_parse(runtime, file_record, synced_document)
-    _delete_stale_files(runtime, knowledge.id, current_urls)
+        if _dispatch_parse(runtime, file_record, synced_document):
+            counters.parse_dispatched += 1
+        run.progress(
+            stage="sync_yuque",
+            fraction=None,
+            detail="source_item_processed",
+            counts=counters.as_dict(),
+        )
+    counters.deleted += _delete_stale_files(runtime, knowledge.id, current_urls)
 
 
 async def _list_feishu_documents(
@@ -617,37 +674,46 @@ async def _download_feishu_document(
         return await opened.download_document(document, save_dir)
 
 
-def _sync_feishu(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
+def _sync_feishu(
+    runtime: ProcessRuntime,
+    knowledge: _KnowledgeSnapshot,
+    run: TaskRun,
+    counters: KnowledgeSyncCounters,
+) -> None:
     config = knowledge.parser_config
     client = FeishuAPIClient(
         app_id=config.get("feishu_app_id", ""),
         app_secret=config.get("feishu_app_secret", ""),
     )
-    files = runtime.run_async(
-        lambda: _list_feishu_documents(
-            client,
-            config.get("feishu_folder_token", ""),
+    with run.stage("list_remote_documents"):
+        files = runtime.run_async(
+            lambda: _list_feishu_documents(
+                client,
+                config.get("feishu_folder_token", ""),
+            )
         )
-    )
     documents = [
         record
         for record in files
         if record.type in {"doc", "docx", "sheet", "bitable", "file"}
     ]
+    counters.discovered += len(documents)
     current_urls: set[str] = set()
     for document in documents:
         current_urls.add(document.url)
         file_record = _find_source_file(runtime, knowledge.id, document.url)
         if file_record is not None and file_record.created_at == document.modified_time:
+            counters.unchanged += 1
             continue
         save_dir = tempfile.mkdtemp()
-        file_path = runtime.run_async(
-            lambda doc=document, directory=save_dir: _download_feishu_document(
-                client,
-                doc,
-                directory,
+        with run.stage("download_remote_document"):
+            file_path = runtime.run_async(
+                lambda doc=document, directory=save_dir: _download_feishu_document(
+                    client,
+                    doc,
+                    directory,
+                )
             )
-        )
         file_name = os.path.basename(file_path)
         file_ext = os.path.splitext(file_name)[1].lower()
         file_size = os.path.getsize(file_path)
@@ -662,6 +728,9 @@ def _sync_feishu(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None
                 file_url=document.url,
                 created_at=document.modified_time,
             )
+            counters.created += 1
+        else:
+            counters.updated += 1
         assert file_record is not None
         content = Path(file_path).read_bytes()
         file_key = _upload_content(runtime, file_record, content, file_ext=file_ext)
@@ -688,11 +757,23 @@ def _sync_feishu(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None
             if is_new
             else existing_document
         )
-        _dispatch_parse(runtime, file_record, synced_document)
-    _delete_stale_files(runtime, knowledge.id, current_urls)
+        if _dispatch_parse(runtime, file_record, synced_document):
+            counters.parse_dispatched += 1
+        run.progress(
+            stage="sync_feishu",
+            fraction=None,
+            detail="source_item_processed",
+            counts=counters.as_dict(),
+        )
+    counters.deleted += _delete_stale_files(runtime, knowledge.id, current_urls)
 
 
-def _sync_third_party(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) -> None:
+def _sync_third_party(
+    runtime: ProcessRuntime,
+    knowledge: _KnowledgeSnapshot,
+    run: TaskRun,
+    counters: KnowledgeSyncCounters,
+) -> int:
     config = knowledge.parser_config
     yuque_user_id = config.get("yuque_user_id", "")
     feishu_app_id = config.get("feishu_app_id", "")
@@ -703,14 +784,16 @@ def _sync_third_party(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) ->
     has_feishu = any(
         record.file_url and "feishu.cn" in record.file_url for record in existing_files
     )
+    failures = 0
     if (
         yuque_user_id
         and yuque_user_id not in {"User ID", ""}
         and (not existing_files or has_yuque)
     ):
         try:
-            _sync_yuque(runtime, knowledge)
+            _sync_yuque(runtime, knowledge, run, counters)
         except Exception as exc:
+            failures += 1
             logger.error(
                 "Yuque knowledge synchronization failed: error_type=%s",
                 type(exc).__name__,
@@ -721,41 +804,80 @@ def _sync_third_party(runtime: ProcessRuntime, knowledge: _KnowledgeSnapshot) ->
         and (not existing_files or has_feishu)
     ):
         try:
-            _sync_feishu(runtime, knowledge)
+            _sync_feishu(runtime, knowledge, run, counters)
         except Exception as exc:
+            failures += 1
             logger.error(
                 "Feishu knowledge synchronization failed: error_type=%s",
                 type(exc).__name__,
             )
+    return failures
 
 
-def process_knowledge_sync(runtime: ProcessRuntime, kb_id: uuid.UUID | str) -> str:
+def process_knowledge_sync(
+    runtime: ProcessRuntime,
+    kb_id: uuid.UUID | str,
+    *,
+    run: TaskRun,
+) -> str:
     """Synchronize one knowledge base while keeping slow work outside DB sessions."""
 
     knowledge: _KnowledgeSnapshot | None = None
+    counters = KnowledgeSyncCounters()
     try:
         knowledge_id = kb_id if isinstance(kb_id, uuid.UUID) else uuid.UUID(str(kb_id))
-        knowledge = _load_knowledge(runtime, knowledge_id)
+        with run.stage("load_knowledge"):
+            knowledge = _load_knowledge(runtime, knowledge_id)
         if knowledge is None:
             logger.error("Knowledge synchronization target not found: knowledge=%s", knowledge_id)
+            counters.failed += 1
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code="KB_SYNC_KNOWLEDGE_NOT_FOUND",
+                counts=counters.as_dict(),
+            )
             return "sync knowledge failed: knowledge not found"
         match knowledge.type:
             case "Web":
                 try:
-                    _sync_web(runtime, knowledge)
+                    with run.stage("sync_web"):
+                        _sync_web(runtime, knowledge, run, counters)
                 except Exception as exc:
+                    counters.failed += 1
                     logger.error(
                         "Web knowledge synchronization failed: error_type=%s",
                         type(exc).__name__,
                     )
             case "Third-party":
-                _sync_third_party(runtime, knowledge)
+                with run.stage("sync_third_party"):
+                    counters.failed += _sync_third_party(runtime, knowledge, run, counters)
             case _:
                 logger.info(
                     "Knowledge type requires no synchronization: knowledge=%s type=%s",
                     knowledge_id,
                     knowledge.type,
                 )
+                run.finish(
+                    BusinessOutcome.SKIPPED,
+                    detail="source_type_no_sync",
+                    counts=counters.as_dict(),
+                )
+                return f"sync knowledge '{knowledge.name}' processed successfully."
+        run.progress(
+            stage="complete",
+            fraction=None,
+            detail="sync_summary",
+            counts=counters.as_dict(),
+            force=True,
+        )
+        if counters.failed:
+            run.finish(
+                BusinessOutcome.PARTIAL_FAILURE,
+                error_code="KB_SYNC_SOURCE_PARTIAL_FAILURE",
+                counts=counters.as_dict(),
+            )
+        else:
+            run.finish(BusinessOutcome.SUCCESS, counts=counters.as_dict())
         return f"sync knowledge '{knowledge.name}' processed successfully."
     except Exception as exc:
         logger.error(
@@ -764,6 +886,13 @@ def process_knowledge_sync(runtime: ProcessRuntime, kb_id: uuid.UUID | str) -> s
             type(exc).__name__,
         )
         name = knowledge.name if knowledge is not None else kb_id
+        counters.failed += 1
+        run.finish(
+            BusinessOutcome.FAILURE,
+            error_code="KB_SYNC_PROCESSING_FAILED",
+            exc=exc,
+            counts=counters.as_dict(),
+        )
         return f"sync knowledge '{name}' failed: {exc}"
 
 

--- a/mem-knowledge/src/services/qa_import.py
+++ b/mem-knowledge/src/services/qa_import.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..api.dependencies import Principal
 from ..errors import KnowledgeError
+from ..models.owned import Document
 from ..tasks.dispatch import TaskDispatcher
+from ..utils.datetime_utils import to_iso_z, utcnow
 from . import file as file_service
 from .knowledge_file_storage import KnowledgeFileStorage
 
 QA_EXTENSIONS = {".csv", ".xlsx", ".xls"}
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ..runtime import ProcessRuntime
 
 
 @dataclass(frozen=True)
@@ -40,17 +48,55 @@ def validate_qa_upload(
 
 
 async def dispatch_qa_import(
+    runtime: ProcessRuntime,
     dispatcher: TaskDispatcher,
     kb_id: uuid.UUID,
     document_id: uuid.UUID,
     filename: str,
     content: bytes,
 ) -> str:
-    return await dispatcher.send(
-        "app.core.rag.tasks.import_qa_chunks",
-        args=[str(kb_id), str(document_id), filename, content],
-        queue="qa_import",
-    )
+    await _persist_qa_dispatch_state(runtime, document_id, state="queued")
+    try:
+        return await dispatcher.send(
+            "app.core.rag.tasks.import_qa_chunks",
+            args=[str(kb_id), str(document_id), filename, content],
+            queue="qa_import",
+        )
+    except Exception:
+        try:
+            await _persist_qa_dispatch_state(runtime, document_id, state="failed")
+        except Exception as state_exc:  # noqa: BLE001 - preserve dispatch failure.
+            logger.warning(
+                "Failed to persist QA dispatch failure: document=%s error_type=%s",
+                document_id,
+                type(state_exc).__name__,
+            )
+        raise
+
+
+async def _persist_qa_dispatch_state(
+    runtime: ProcessRuntime,
+    document_id: uuid.UUID,
+    *,
+    state: str,
+) -> None:
+    async with runtime.database.async_session() as db:
+        document = await db.get(Document, document_id)
+        if document is None:
+            raise ValueError(f"Document {document_id} not found while updating QA dispatch state")
+        timestamp = to_iso_z(utcnow())
+        if state == "queued":
+            document.progress = 0.0
+            document.progress_msg = f"{timestamp} Queued.\n"
+            document.process_duration = 0.0
+            document.run = 0
+        elif state == "failed":
+            document.progress = -1.0
+            document.progress_msg = f"{timestamp} QA task dispatch failed.\n"
+            document.run = 0
+        else:
+            raise ValueError(f"Unsupported QA dispatch state: {state}")
+        await db.commit()
 
 
 async def prepare_qa_import_resources(

--- a/mem-knowledge/src/services/qa_import_processing.py
+++ b/mem-knowledge/src/services/qa_import_processing.py
@@ -15,6 +15,7 @@ from ..rag.models.chunk import DocumentChunk
 from ..rag.models.task_runtime import TaskModelFactory
 from ..rag.vdb.vector_store import TaskVectorStore
 from ..runtime import ProcessRuntime
+from ..tasks.observability import BusinessOutcome, TaskRun
 from ..tasks.state import PARSE_TASK_KEY
 from ..utils.datetime_utils import to_iso_z, to_timestamp_ms, utcnow, utcnow_naive
 from .knowledge_file_storage import KnowledgeFileStorage
@@ -262,30 +263,41 @@ def process_qa_import(
     contents: bytes | None = None,
     file_key: str | None = None,
     clear_parse_task: bool = False,
+    *,
+    run: TaskRun,
 ) -> dict[str, object]:
     """Import QA rows while preserving the legacy task result and document state."""
 
     start_time = time.time()
     progress_lines = [f"{_progress_ts()} QA import task has been received."]
     normalized_document_id: uuid.UUID | None = None
+    error_code = "KB_QA_PROCESSING_FAILED"
     try:
         try:
             normalized_document_id = uuid.UUID(str(document_id))
             normalized_kb_id = uuid.UUID(str(kb_id))
         except ValueError:
             raise _SafeQAImportError("badly formed hexadecimal UUID string") from None
-        snapshot = _mark_running(
-            runtime,
-            normalized_kb_id,
-            normalized_document_id,
-            progress_lines,
-        )
+        with run.stage("load_document"):
+            snapshot = _mark_running(
+                runtime,
+                normalized_kb_id,
+                normalized_document_id,
+                progress_lines,
+            )
         if isinstance(snapshot, dict):
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code="KB_QA_DOCUMENT_NOT_FOUND",
+            )
             return snapshot
 
-        loaded_contents = _load_contents(runtime, contents, file_key)
+        with run.stage("load_contents"):
+            loaded_contents = _load_contents(runtime, contents, file_key)
+        error_code = "KB_QA_FILE_PARSE_FAILED"
         try:
-            pairs, failed_rows = _parse_qa_file(filename, loaded_contents)
+            with run.stage("parse_file"):
+                pairs, failed_rows = _parse_qa_file(filename, loaded_contents)
         except _SafeQAImportError:
             raise
         except Exception:
@@ -294,29 +306,42 @@ def process_qa_import(
             logger.warning("No valid QA pairs found: document=%s", normalized_document_id)
             raise _SafeQAImportError("No valid QA pairs found")
         progress_lines.append(f"{_progress_ts()} Parsed {len(pairs)} QA pairs.")
+        run.progress(
+            stage="parse_file",
+            fraction=0.3,
+            detail="qa_pairs_parsed",
+            display_message=progress_lines[-1],
+            counts={"chunks": len(pairs), "failed": len(failed_rows)},
+            force=True,
+        )
 
+        error_code = "KB_QA_MODEL_INIT_FAILED"
         try:
-            embeddings = TaskModelFactory(runtime).create_embeddings(
-                snapshot.embedding_id,
-                snapshot.tenant_id,
-            )
+            with run.stage("resolve_embedding"):
+                embeddings = TaskModelFactory(runtime).create_embeddings(
+                    snapshot.embedding_id,
+                    snapshot.tenant_id,
+                )
         except Exception:
             raise _SafeQAImportError("QA model initialization failed") from None
 
+        error_code = "KB_QA_VECTOR_WRITE_FAILED"
         try:
-            vector_store = TaskVectorStore(
-                runtime.elasticsearch.sync_client(),
-                normalized_kb_id,
-                embeddings,
-            )
+            with run.stage("prepare_batches"):
+                vector_store = TaskVectorStore(
+                    runtime.elasticsearch.sync_client(),
+                    normalized_kb_id,
+                    embeddings,
+                )
             sort_id = 0
             if not clear_parse_task:
-                _, items = vector_store.search_by_segment(
-                    document_id=str(normalized_document_id),
-                    pagesize=1,
-                    page=1,
-                    asc=False,
-                )
+                with run.stage("read_existing_sort"):
+                    _, items = vector_store.search_by_segment(
+                        document_id=str(normalized_document_id),
+                        pagesize=1,
+                        page=1,
+                        asc=False,
+                    )
                 if items:
                     sort_id = items[0].metadata["sort_id"]
 
@@ -336,29 +361,41 @@ def process_qa_import(
             if sum(batch.chunk_count for batch in prepared_batches) != len(chunks):
                 raise RuntimeError("Prepared chunk count does not match input count")
             if clear_parse_task:
-                vector_store.delete_by_metadata_field(
-                    "document_id",
-                    str(normalized_document_id),
-                )
-            vector_store.write_prepared_batches(prepared_batches)
+                with run.stage("delete_old_chunks"):
+                    vector_store.delete_by_metadata_field(
+                        "document_id",
+                        str(normalized_document_id),
+                    )
+            with run.stage("write_elasticsearch"):
+                vector_store.write_prepared_batches(prepared_batches)
         except Exception:
             raise _SafeQAImportError("QA vector processing failed") from None
 
-        completion_error = _mark_complete(
-            runtime,
-            normalized_document_id,
-            len(chunks),
-            clear_parse_task,
-            start_time,
-            progress_lines,
-        )
+        error_code = "KB_TASK_STATE_PERSIST_FAILED"
+        with run.stage("persist_document"):
+            completion_error = _mark_complete(
+                runtime,
+                normalized_document_id,
+                len(chunks),
+                clear_parse_task,
+                start_time,
+                progress_lines,
+            )
         if completion_error is not None:
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code=error_code,
+            )
             return completion_error
         logger.info(
             "QA import completed: document=%s imported=%s failed=%s",
             normalized_document_id,
             len(chunks),
             len(failed_rows),
+        )
+        run.finish(
+            BusinessOutcome.SUCCESS,
+            counts={"chunks": len(chunks), "failed": len(failed_rows)},
         )
         return {"imported": len(chunks), "failed_rows": failed_rows}
     except Exception as exc:
@@ -380,6 +417,11 @@ def process_qa_import(
                 start_time,
                 progress_lines,
             )
+        run.finish(
+            BusinessOutcome.FAILURE,
+            error_code=error_code,
+            exc=exc,
+        )
         return {"error": str(safe_error), "imported": 0}
     finally:
         if clear_parse_task:

--- a/mem-knowledge/src/tasks/celery_worker.py
+++ b/mem-knowledge/src/tasks/celery_worker.py
@@ -3,31 +3,257 @@
 from __future__ import annotations
 
 import logging
+import os
+import time
 
-from celery.signals import worker_process_init, worker_process_shutdown
+from celery.signals import (
+    celeryd_after_setup,
+    task_failure,
+    task_postrun,
+    task_prerun,
+    task_received,
+    task_retry,
+    worker_process_init,
+    worker_process_shutdown,
+    worker_ready,
+    worker_shutting_down,
+)
+from celery.signals import (
+    setup_logging as celery_setup_logging,
+)
+from celery.worker.state import active_requests
 
+from ..bootstrap import get_settings
+from ..logging import setup_logging as setup_knowledge_logging
 from ..runtime import reset_worker_runtime_after_fork, shutdown_worker_runtime_sync
 from . import document, evidence_graph, legacy_compat, qa_import
 from .celery_app import celery_app
+from .observability import record_task_prerun, reset_observability_after_fork
 
 logger = logging.getLogger(__name__)
+
+ROLE_QUEUE = {
+    "document_worker": "document_tasks",
+    "graphrag_worker": "graphrag_tasks",
+    "qa_import_worker": "qa_import",
+}
+
+
+class WorkerConfigurationError(RuntimeError):
+    """The declared worker role does not match its active queues."""
+
+
+def validate_worker_role_queues(role: str, queues: set[str]) -> None:
+    """Require each knowledge worker role to consume exactly one queue."""
+
+    expected = ROLE_QUEUE.get(role)
+    if expected is None or queues != {expected}:
+        raise WorkerConfigurationError(
+            f"role={role} queues={sorted(queues)} expected={expected or 'none'}"
+        )
+
+
+@celeryd_after_setup.connect
+def validate_worker_configuration(
+    *,
+    sender: object,
+    instance: object,
+    **kwargs: object,
+) -> None:
+    """Fail before consumption when the declared role and queues differ."""
+
+    del kwargs
+    queues = set(instance.app.amqp.queues)
+    role = get_settings().kb_process_role
+    try:
+        validate_worker_role_queues(role, queues)
+    except WorkerConfigurationError:
+        logger.critical(
+            "event=kb_worker_configuration_invalid role=%s queues=%s hostname=%s",
+            role,
+            ",".join(sorted(queues)),
+            sender,
+        )
+        raise SystemExit(78) from None
+
+
+@celery_setup_logging.connect
+def configure_worker_logging(**kwargs: object) -> None:
+    """Install the same redacting formatter used by the Knowledge API."""
+
+    del kwargs
+    setup_knowledge_logging(get_settings())
+
+
+@worker_ready.connect
+def handle_worker_ready(sender: object, **kwargs: object) -> None:
+    """Report the resolved runtime shape once the consumer is ready."""
+
+    del kwargs
+    app = getattr(sender, "app", celery_app)
+    queue_names = sorted(getattr(getattr(app, "amqp", None), "queues", {}))
+    controller = getattr(sender, "controller", None)
+    pool = getattr(controller, "pool", None)
+    logger.info(
+        "event=kb_worker_ready role=%s hostname=%s main_pid=%s queues=%s "
+        "pool=%s concurrency=%s prefetch_multiplier=%s",
+        get_settings().kb_process_role,
+        getattr(sender, "hostname", "unknown"),
+        os.getpid(),
+        ",".join(queue_names),
+        type(pool).__name__ if pool is not None else "unknown",
+        getattr(controller, "concurrency", "unknown"),
+        get_settings().kb_worker_prefetch_multiplier,
+    )
+
+
+@worker_shutting_down.connect
+def handle_worker_shutting_down(
+    sender: object,
+    sig: str,
+    how: str,
+    exitcode: int,
+    **kwargs: object,
+) -> None:
+    """Report why the worker main process is stopping."""
+
+    del kwargs
+    logger.info(
+        "event=kb_worker_shutdown_requested role=%s hostname=%s main_pid=%s "
+        "signal=%s mode=%s exitcode=%s active_tasks=%s",
+        get_settings().kb_process_role,
+        sender,
+        os.getpid(),
+        sig,
+        how,
+        exitcode,
+        len(active_requests),
+    )
 
 
 @worker_process_init.connect
 def initialize_worker_process(**kwargs: object) -> None:
     """Create fresh lazy resource owners after prefork."""
 
+    started_at = time.perf_counter()
     del kwargs
+    reset_observability_after_fork()
     reset_worker_runtime_after_fork()
+    logger.info(
+        "event=kb_worker_child_ready role=%s pid=%s init_duration_ms=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        int((time.perf_counter() - started_at) * 1000),
+    )
 
 
 @worker_process_shutdown.connect
 def shutdown_worker_process(**kwargs: object) -> None:
     """Release resources owned by the exiting worker process."""
 
-    del kwargs
+    started_at = time.perf_counter()
+    exitcode = kwargs.get("exitcode")
     shutdown_worker_runtime_sync()
-    logger.info("Knowledge worker process stopped")
+    logger.info(
+        "event=kb_worker_child_stopped role=%s pid=%s exitcode=%s cleanup_duration_ms=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        exitcode if exitcode is not None else "unknown",
+        int((time.perf_counter() - started_at) * 1000),
+    )
+
+
+@task_received.connect
+def handle_task_received(sender: object, request: object | None = None, **kwargs: object) -> None:
+    """Report broker receipt in the worker main process without task payloads."""
+
+    del kwargs
+    request = request or sender
+    delivery_info = getattr(request, "delivery_info", None)
+    routing_key = delivery_info.get("routing_key") if isinstance(delivery_info, dict) else None
+    logger.info(
+        "event=kb_task_received role=%s main_pid=%s task_name=%s task_id=%s queue=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        getattr(request, "name", "unknown"),
+        getattr(request, "id", "unknown"),
+        routing_key or "unknown",
+    )
+
+
+@task_prerun.connect
+def handle_task_prerun(
+    sender: object,
+    task_id: str,
+    **kwargs: object,
+) -> None:
+    """Capture child start before the task envelope performs lazy imports."""
+
+    del sender, kwargs
+    record_task_prerun(str(task_id))
+
+
+@task_postrun.connect
+def handle_task_postrun(
+    sender: object,
+    task_id: str,
+    state: str | None = None,
+    **kwargs: object,
+) -> None:
+    """Report Celery's terminal state separately from business outcome."""
+
+    del kwargs
+    logger.info(
+        "event=kb_task_postrun role=%s pid=%s task_name=%s task_id=%s "
+        "celery_outcome=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        getattr(sender, "name", "unknown"),
+        task_id,
+        str(state or "unknown").lower(),
+    )
+
+
+@task_retry.connect
+def handle_task_retry(
+    sender: object,
+    request: object | None = None,
+    reason: BaseException | None = None,
+    **kwargs: object,
+) -> None:
+    """Report retries without logging exception messages or task payloads."""
+
+    del kwargs
+    logger.warning(
+        "event=kb_task_retry role=%s pid=%s task_name=%s task_id=%s "
+        "error_type=%s attempt=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        getattr(sender, "name", "unknown"),
+        getattr(request, "id", "unknown"),
+        type(reason).__name__ if reason is not None else "unknown",
+        getattr(request, "retries", 0),
+    )
+
+
+@task_failure.connect
+def handle_task_failure(
+    sender: object,
+    task_id: str,
+    exception: BaseException | None = None,
+    **kwargs: object,
+) -> None:
+    """Report task failures without serializing exception messages."""
+
+    del kwargs
+    logger.error(
+        "event=kb_task_failure role=%s pid=%s task_name=%s task_id=%s error_type=%s",
+        get_settings().kb_process_role,
+        os.getpid(),
+        getattr(sender, "name", "unknown"),
+        task_id,
+        type(exception).__name__ if exception is not None else "unknown",
+    )
 
 
 __all__ = [
@@ -36,4 +262,9 @@ __all__ = [
     "evidence_graph",
     "legacy_compat",
     "qa_import",
+    "WorkerConfigurationError",
+    "handle_task_postrun",
+    "handle_worker_shutting_down",
+    "validate_worker_configuration",
+    "validate_worker_role_queues",
 ]

--- a/mem-knowledge/src/tasks/celery_worker.py
+++ b/mem-knowledge/src/tasks/celery_worker.py
@@ -53,6 +53,12 @@ def validate_worker_role_queues(role: str, queues: set[str]) -> None:
         )
 
 
+def _active_queue_names(app: object) -> set[str]:
+    queues = getattr(getattr(app, "amqp", None), "queues", {})
+    consume_from = getattr(queues, "consume_from", queues)
+    return set(consume_from)
+
+
 @celeryd_after_setup.connect
 def validate_worker_configuration(
     *,
@@ -63,7 +69,7 @@ def validate_worker_configuration(
     """Fail before consumption when the declared role and queues differ."""
 
     del kwargs
-    queues = set(instance.app.amqp.queues)
+    queues = _active_queue_names(instance.app)
     role = get_settings().kb_process_role
     try:
         validate_worker_role_queues(role, queues)
@@ -91,7 +97,7 @@ def handle_worker_ready(sender: object, **kwargs: object) -> None:
 
     del kwargs
     app = getattr(sender, "app", celery_app)
-    queue_names = sorted(getattr(getattr(app, "amqp", None), "queues", {}))
+    queue_names = sorted(_active_queue_names(app))
     controller = getattr(sender, "controller", None)
     pool = getattr(controller, "pool", None)
     logger.info(

--- a/mem-knowledge/src/tasks/dispatch.py
+++ b/mem-knowledge/src/tasks/dispatch.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Sequence
 from typing import Any
 
+from ..bootstrap import get_settings
 from ..errors import KnowledgeError
+from ..trace import get_trace_id
 from .celery_app import PUBLISHABLE_KNOWLEDGE_TASK_ROUTES, celery_app
+from .observability import current_parent_task_id
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +68,16 @@ class TaskDispatcher:
                 "args": list(args or ()),
                 "kwargs": dict(kwargs or {}),
                 "queue": expected_queue,
+                "headers": {
+                    key: value
+                    for key, value in {
+                        "kb_published_at_ms": int(time.time() * 1000),
+                        "kb_trace_id": get_trace_id() or None,
+                        "kb_parent_task_id": current_parent_task_id(),
+                        "kb_source_role": get_settings().kb_process_role,
+                    }.items()
+                    if value is not None
+                },
             }
             if task_id:
                 send_task_kwargs["task_id"] = task_id

--- a/mem-knowledge/src/tasks/document.py
+++ b/mem-knowledge/src/tasks/document.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from ..bootstrap import get_settings
 from ..runtime import get_worker_runtime
-from ..services.knowledge_sync import process_knowledge_sync
 from .celery_app import celery_app
 from .observability import (
     DocumentProgressSink,
@@ -26,6 +25,20 @@ def process_document(*args, **kwargs):
     """Compatibility helper that delegates to the lazy document processor."""
 
     return _load_document_processor()(*args, **kwargs)
+
+
+def _load_knowledge_sync_processor():
+    """Load external integration clients only when synchronization executes."""
+
+    from ..services.knowledge_sync import process_knowledge_sync as process
+
+    return process
+
+
+def process_knowledge_sync(*args, **kwargs):
+    """Compatibility helper that delegates to the lazy sync processor."""
+
+    return _load_knowledge_sync_processor()(*args, **kwargs)
 
 
 @celery_app.task(name="app.core.rag.tasks.parse_document")
@@ -62,7 +75,20 @@ def parse_document(file_key: str, document_id, file_name: str = ""):
 
 @celery_app.task(name="app.core.rag.tasks.sync_knowledge_for_kb")
 def sync_knowledge_for_kb(kb_id):
-    return process_knowledge_sync(get_worker_runtime(), kb_id)
+    settings = get_settings()
+    runtime = get_worker_runtime()
+    context = task_context_from_current_task(
+        role="document_worker",
+        knowledge_id=kb_id,
+    )
+    with observe_task(
+        context,
+        sinks=[StructuredLogSink()],
+        heartbeat_seconds=settings.kb_task_heartbeat_seconds,
+    ) as run:
+        with run.stage("lazy_import"):
+            process = _load_knowledge_sync_processor()
+        return process(runtime, kb_id, run=run)
 
 
 __all__ = ["parse_document", "sync_knowledge_for_kb"]

--- a/mem-knowledge/src/tasks/document.py
+++ b/mem-knowledge/src/tasks/document.py
@@ -2,27 +2,62 @@
 
 from __future__ import annotations
 
+from ..bootstrap import get_settings
 from ..runtime import get_worker_runtime
 from ..services.knowledge_sync import process_knowledge_sync
 from .celery_app import celery_app
+from .observability import (
+    DocumentProgressSink,
+    StructuredLogSink,
+    observe_task,
+    task_context_from_current_task,
+)
 
 
-def process_document(*args, **kwargs):
+def _load_document_processor():
     """Load the model-heavy document processor only when the task executes."""
 
     from ..services.document_processing import process_document as process
 
-    return process(*args, **kwargs)
+    return process
+
+
+def process_document(*args, **kwargs):
+    """Compatibility helper that delegates to the lazy document processor."""
+
+    return _load_document_processor()(*args, **kwargs)
 
 
 @celery_app.task(name="app.core.rag.tasks.parse_document")
 def parse_document(file_key: str, document_id, file_name: str = ""):
-    return process_document(
-        get_worker_runtime(),
-        file_key,
-        document_id,
-        file_name,
+    settings = get_settings()
+    runtime = get_worker_runtime()
+    context = task_context_from_current_task(
+        role="document_worker",
+        document_id=document_id,
     )
+    sinks = [
+        StructuredLogSink(),
+        DocumentProgressSink(
+            runtime=runtime,
+            document_id=str(document_id),
+            flush_interval_seconds=settings.kb_progress_flush_interval_seconds,
+        ),
+    ]
+    with observe_task(
+        context,
+        sinks=sinks,
+        heartbeat_seconds=settings.kb_task_heartbeat_seconds,
+    ) as run:
+        with run.stage("lazy_import"):
+            process = _load_document_processor()
+        return process(
+            runtime,
+            file_key,
+            document_id,
+            file_name,
+            run=run,
+        )
 
 
 @celery_app.task(name="app.core.rag.tasks.sync_knowledge_for_kb")

--- a/mem-knowledge/src/tasks/evidence_graph.py
+++ b/mem-knowledge/src/tasks/evidence_graph.py
@@ -67,6 +67,11 @@ def _retry_countdown(task: Any) -> int:
     return min(300, 2 ** int(task.request.retries or 0))
 
 
+def _retry_available(task: Any, *, max_retries: int | None = None) -> bool:
+    retry_limit = task.max_retries if max_retries is None else max_retries
+    return retry_limit is None or int(task.request.retries or 0) < retry_limit
+
+
 def _redacted_exception(exc: Exception) -> RuntimeError:
     return RuntimeError(f"{type(exc).__name__}: message redacted")
 
@@ -113,23 +118,45 @@ def _run_observed(
         retry_options = {}
         if isinstance(exc, GraphDocumentDeletionPending):
             retry_options["max_retries"] = 8
-        logger.warning(
-            "[EvidenceGraph] task_retry task=%s task_id=%s kb_id=%s "
-            "document_id=%s error_type=%s retry=%d countdown=%d elapsed_ms=%d",
-            task_name,
-            safe_task_id,
-            safe_knowledge_id,
-            safe_document_id,
-            type(exc).__name__,
-            retry,
-            countdown,
-            int((time.perf_counter() - started_at) * 1000),
+        will_retry = _retry_available(
+            task,
+            max_retries=retry_options.get("max_retries"),
         )
+        if will_retry:
+            logger.warning(
+                "[EvidenceGraph] task_retry task=%s task_id=%s kb_id=%s "
+                "document_id=%s error_type=%s retry=%d countdown=%d elapsed_ms=%d",
+                task_name,
+                safe_task_id,
+                safe_knowledge_id,
+                safe_document_id,
+                type(exc).__name__,
+                retry,
+                countdown,
+                int((time.perf_counter() - started_at) * 1000),
+            )
+        else:
+            logger.error(
+                "[EvidenceGraph] task_failed task=%s task_id=%s kb_id=%s "
+                "document_id=%s status=failure reason=retries_exhausted "
+                "error_type=%s retry=%d elapsed_ms=%d",
+                task_name,
+                safe_task_id,
+                safe_knowledge_id,
+                safe_document_id,
+                type(exc).__name__,
+                retry,
+                int((time.perf_counter() - started_at) * 1000),
+            )
         run.finish(
-            BusinessOutcome.RETRY,
-            error_code="KB_GRAPH_TASK_RETRY",
+            BusinessOutcome.RETRY if will_retry else BusinessOutcome.FAILURE,
+            error_code=(
+                "KB_GRAPH_TASK_RETRY"
+                if will_retry
+                else "KB_GRAPH_TASK_RETRIES_EXHAUSTED"
+            ),
             exc=exc,
-            detail=f"retry_countdown_{countdown}s",
+            detail=f"retry_countdown_{countdown}s" if will_retry else "retries_exhausted",
         )
         raise task.retry(
             exc=_redacted_exception(exc),
@@ -162,18 +189,31 @@ def _retry_guard(
     run: TaskRun,
 ) -> None:
     countdown = _retry_countdown(task)
-    logger.warning(
-        "[EvidenceGraph] task_guard_retry task=rebuild_knowledge kb_id=%s "
-        "error_type=%s countdown=%d",
-        _safe_identifier(knowledge_id),
-        type(exc).__name__,
-        countdown,
-    )
+    will_retry = _retry_available(task)
+    if will_retry:
+        logger.warning(
+            "[EvidenceGraph] task_guard_retry task=rebuild_knowledge kb_id=%s "
+            "error_type=%s countdown=%d",
+            _safe_identifier(knowledge_id),
+            type(exc).__name__,
+            countdown,
+        )
+    else:
+        logger.error(
+            "[EvidenceGraph] task_guard_failed task=rebuild_knowledge kb_id=%s "
+            "status=failure reason=retries_exhausted error_type=%s",
+            _safe_identifier(knowledge_id),
+            type(exc).__name__,
+        )
     run.finish(
-        BusinessOutcome.RETRY,
-        error_code="KB_GRAPH_GUARD_RETRY",
+        BusinessOutcome.RETRY if will_retry else BusinessOutcome.FAILURE,
+        error_code=(
+            "KB_GRAPH_GUARD_RETRY"
+            if will_retry
+            else "KB_GRAPH_GUARD_RETRIES_EXHAUSTED"
+        ),
         exc=exc,
-        detail=f"retry_countdown_{countdown}s",
+        detail=f"retry_countdown_{countdown}s" if will_retry else "retries_exhausted",
     )
     raise task.retry(exc=_redacted_exception(exc), countdown=countdown) from None
 

--- a/mem-knowledge/src/tasks/evidence_graph.py
+++ b/mem-knowledge/src/tasks/evidence_graph.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import logging
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from celery import states
 from celery.exceptions import Ignore, Retry
 
+from ..bootstrap import get_settings
 from ..rag.knowledge_graph.config import GraphPipelineConfigError
 from ..runtime import get_worker_runtime
 from ..services.evidence_graph import (
@@ -20,6 +21,14 @@ from ..services.evidence_graph import (
     process_evidence_rebuild,
 )
 from .celery_app import celery_app
+from .observability import (
+    BusinessOutcome,
+    CeleryStateSink,
+    StructuredLogSink,
+    TaskRun,
+    observe_task,
+    task_context_from_current_task,
+)
 from .state import (
     acquire_rebuild_execution,
     has_rebuild_terminal,
@@ -50,10 +59,12 @@ def _redacted_exception(exc: Exception) -> RuntimeError:
 def _run_observed(
     task: Any,
     *,
+    run: TaskRun,
     task_name: str,
     knowledge_id: str,
     operation: Callable[[], dict[str, Any]],
     document_id: str | None = None,
+    finish_success: bool = True,
 ) -> dict[str, Any]:
     started_at = time.perf_counter()
     task_id = str(getattr(task.request, "id", None) or "unknown")
@@ -62,7 +73,8 @@ def _run_observed(
     safe_document_id = _safe_identifier(document_id) if document_id is not None else "none"
     retry = int(getattr(task.request, "retries", 0) or 0)
     try:
-        result = operation()
+        with run.stage(task_name):
+            result = operation()
     except GraphPipelineConfigError as exc:
         logger.error(
             "[EvidenceGraph] task_failed task=%s task_id=%s kb_id=%s "
@@ -74,6 +86,11 @@ def _run_observed(
             type(exc).__name__,
             retry,
             int((time.perf_counter() - started_at) * 1000),
+        )
+        run.finish(
+            BusinessOutcome.FAILURE,
+            error_code="KB_GRAPH_CONFIG_INVALID",
+            exc=exc,
         )
         raise
     except Exception as exc:
@@ -93,6 +110,12 @@ def _run_observed(
             countdown,
             int((time.perf_counter() - started_at) * 1000),
         )
+        run.finish(
+            BusinessOutcome.RETRY,
+            error_code="KB_GRAPH_TASK_RETRY",
+            exc=exc,
+            detail=f"retry_countdown_{countdown}s",
+        )
         raise task.retry(
             exc=_redacted_exception(exc),
             countdown=countdown,
@@ -108,10 +131,21 @@ def _run_observed(
         str(result.get("status") or "completed"),
         int((time.perf_counter() - started_at) * 1000),
     )
+    status = str(result.get("status") or "completed")
+    if finish_success:
+        run.finish(
+            BusinessOutcome.SKIPPED if status == "skipped" else BusinessOutcome.SUCCESS,
+            detail=str(result.get("reason") or status),
+        )
     return result
 
 
-def _retry_guard(task: Any, knowledge_id: str, exc: Exception) -> None:
+def _retry_guard(
+    task: Any,
+    knowledge_id: str,
+    exc: Exception,
+    run: TaskRun,
+) -> None:
     countdown = _retry_countdown(task)
     logger.warning(
         "[EvidenceGraph] task_guard_retry task=rebuild_knowledge kb_id=%s "
@@ -119,6 +153,12 @@ def _retry_guard(task: Any, knowledge_id: str, exc: Exception) -> None:
         _safe_identifier(knowledge_id),
         type(exc).__name__,
         countdown,
+    )
+    run.finish(
+        BusinessOutcome.RETRY,
+        error_code="KB_GRAPH_GUARD_RETRY",
+        exc=exc,
+        detail=f"retry_countdown_{countdown}s",
     )
     raise task.retry(exc=_redacted_exception(exc), countdown=countdown) from None
 
@@ -172,7 +212,11 @@ def _finish_guard(
         )
 
 
-def _run_guarded_rebuild(task: Any, knowledge_id: str) -> dict[str, Any]:
+def _run_guarded_rebuild(
+    task: Any,
+    knowledge_id: str,
+    run: TaskRun,
+) -> dict[str, Any]:
     runtime = get_worker_runtime()
     redis = runtime.redis.sync_client()
     task_id = str(getattr(task.request, "id", None) or "unknown")
@@ -190,9 +234,13 @@ def _run_guarded_rebuild(task: Any, knowledge_id: str) -> dict[str, Any]:
             _safe_identifier(task_id),
             _safe_identifier(knowledge_id),
         )
+        run.finish(
+            BusinessOutcome.COALESCED,
+            detail="rebuild_job_coalesced",
+        )
         raise
     except Exception as exc:
-        _retry_guard(task, knowledge_id, exc)
+        _retry_guard(task, knowledge_id, exc, run)
 
     try:
         task.update_state(
@@ -204,14 +252,21 @@ def _run_guarded_rebuild(task: Any, knowledge_id: str) -> dict[str, Any]:
         )
     except Exception as exc:
         _release_execution(redis, knowledge_id, owner_token)
-        _retry_guard(task, knowledge_id, exc)
+        _retry_guard(task, knowledge_id, exc, run)
 
     try:
         result = _run_observed(
             task,
+            run=run,
             task_name="rebuild_knowledge",
             knowledge_id=knowledge_id,
-            operation=lambda: process_evidence_rebuild(runtime, knowledge_id),
+            operation=lambda: process_evidence_rebuild(
+                runtime,
+                knowledge_id,
+                on_lock_wait=_lock_wait_callback(run),
+                on_stage=_graph_stage_callback(run),
+            ),
+            finish_success=False,
         )
     except Retry:
         _release_execution(redis, knowledge_id, owner_token)
@@ -234,8 +289,64 @@ def _run_guarded_rebuild(task: Any, knowledge_id: str) -> dict[str, Any]:
             terminal="success",
         )
     except Exception as exc:
-        _retry_guard(task, knowledge_id, exc)
+        _retry_guard(task, knowledge_id, exc, run)
+    status = str(result.get("status") or "completed")
+    run.finish(
+        BusinessOutcome.SKIPPED if status == "skipped" else BusinessOutcome.SUCCESS,
+        detail=str(result.get("reason") or status),
+    )
     return result
+
+
+def _observe_graph_task(
+    task: Any,
+    *,
+    knowledge_id: object,
+    document_id: object | None = None,
+) -> TaskRun:
+    context = task_context_from_current_task(
+        role="graphrag_worker",
+        knowledge_id=knowledge_id,
+        document_id=document_id,
+    )
+    return observe_task(
+        context,
+        sinks=[StructuredLogSink(), CeleryStateSink(task.update_state)],
+        heartbeat_seconds=get_settings().kb_task_heartbeat_seconds,
+    )
+
+
+def _lock_wait_callback(run: TaskRun) -> Callable[[str, int], None]:
+    def report(detail: str, wait_duration_ms: int) -> None:
+        run.progress(
+            stage="lock_wait",
+            fraction=None,
+            detail=detail,
+            wait_duration_ms=wait_duration_ms,
+            force=True,
+        )
+
+    return report
+
+
+def _graph_stage_callback(
+    run: TaskRun,
+) -> Callable[[str, str, int, Mapping[str, int]], None]:
+    def report(
+        event: str,
+        stage: str,
+        duration_ms: int,
+        counts: Mapping[str, int],
+    ) -> None:
+        run.progress(
+            stage=stage,
+            fraction=None,
+            detail=f"stage_{event}",
+            duration_ms=duration_ms,
+            counts=counts,
+        )
+
+    return report
 
 
 @celery_app.task(
@@ -249,19 +360,27 @@ def sync_evidence_graph_document(
     document_id: str,
     document_deleted: bool = False,
 ) -> dict[str, Any]:
-    runtime = get_worker_runtime()
-    return _run_observed(
+    with _observe_graph_task(
         self,
-        task_name="sync_document",
-        knowledge_id=str(knowledge_id),
-        document_id=str(document_id),
-        operation=lambda: process_evidence_document(
-            runtime,
-            knowledge_id,
-            document_id,
-            document_deleted=document_deleted,
-        ),
-    )
+        knowledge_id=knowledge_id,
+        document_id=document_id,
+    ) as run:
+        runtime = get_worker_runtime()
+        return _run_observed(
+            self,
+            run=run,
+            task_name="sync_document",
+            knowledge_id=str(knowledge_id),
+            document_id=str(document_id),
+            operation=lambda: process_evidence_document(
+                runtime,
+                knowledge_id,
+                document_id,
+                document_deleted=document_deleted,
+                on_lock_wait=_lock_wait_callback(run),
+                on_stage=_graph_stage_callback(run),
+            ),
+        )
 
 
 @celery_app.task(
@@ -276,7 +395,8 @@ def rebuild_evidence_graph_knowledge(
     self: Any,
     knowledge_id: str,
 ) -> dict[str, Any]:
-    return _run_guarded_rebuild(self, str(knowledge_id))
+    with _observe_graph_task(self, knowledge_id=knowledge_id) as run:
+        return _run_guarded_rebuild(self, str(knowledge_id), run)
 
 
 @celery_app.task(
@@ -289,13 +409,21 @@ def clear_all_knowledge_graph_data(
     knowledge_id: str,
     force: bool = False,
 ) -> dict[str, Any]:
-    runtime = get_worker_runtime()
-    return _run_observed(
-        self,
-        task_name="clear_knowledge",
-        knowledge_id=str(knowledge_id),
-        operation=lambda: process_clear_graph(runtime, knowledge_id, force=force),
-    )
+    with _observe_graph_task(self, knowledge_id=knowledge_id) as run:
+        runtime = get_worker_runtime()
+        return _run_observed(
+            self,
+            run=run,
+            task_name="clear_knowledge",
+            knowledge_id=str(knowledge_id),
+            operation=lambda: process_clear_graph(
+                runtime,
+                knowledge_id,
+                force=force,
+                on_lock_wait=_lock_wait_callback(run),
+                on_stage=_graph_stage_callback(run),
+            ),
+        )
 
 
 __all__ = [

--- a/mem-knowledge/src/tasks/evidence_graph.py
+++ b/mem-knowledge/src/tasks/evidence_graph.py
@@ -12,14 +12,11 @@ from celery import states
 from celery.exceptions import Ignore, Retry
 
 from ..bootstrap import get_settings
-from ..rag.knowledge_graph.config import GraphPipelineConfigError
-from ..runtime import get_worker_runtime
-from ..services.evidence_graph import (
+from ..rag.knowledge_graph.config import (
     GraphDocumentDeletionPending,
-    process_clear_graph,
-    process_evidence_document,
-    process_evidence_rebuild,
+    GraphPipelineConfigError,
 )
+from ..runtime import get_worker_runtime
 from .celery_app import celery_app
 from .observability import (
     BusinessOutcome,
@@ -39,6 +36,24 @@ from .state import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def process_evidence_document(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    from ..services.evidence_graph import process_evidence_document as process
+
+    return process(*args, **kwargs)
+
+
+def process_evidence_rebuild(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    from ..services.evidence_graph import process_evidence_rebuild as process
+
+    return process(*args, **kwargs)
+
+
+def process_clear_graph(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    from ..services.evidence_graph import process_clear_graph as process
+
+    return process(*args, **kwargs)
 
 
 def _safe_identifier(value: object) -> str:

--- a/mem-knowledge/src/tasks/legacy_compat.py
+++ b/mem-knowledge/src/tasks/legacy_compat.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import logging
 import uuid
 
+from ..bootstrap import get_settings
 from .celery_app import celery_app
+from .observability import (
+    BusinessOutcome,
+    StructuredLogSink,
+    observe_task,
+    task_context_from_current_task,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,34 +24,61 @@ def _safe_identifier(value: object) -> str:
         return "invalid"
 
 
+def _observe_tombstone(
+    *,
+    knowledge_id: object,
+    document_id: object | None = None,
+):
+    context = task_context_from_current_task(
+        role="graphrag_worker",
+        knowledge_id=knowledge_id,
+        document_id=document_id,
+    )
+    return observe_task(
+        context,
+        sinks=[StructuredLogSink()],
+        heartbeat_seconds=get_settings().kb_task_heartbeat_seconds,
+    )
+
+
 @celery_app.task(name="app.core.rag.tasks.build_graphrag_for_kb")
 def build_graphrag_for_kb(kb_id: object) -> str:
-    logger.warning(
-        "Legacy task removed; skipped task=build_graphrag_for_kb kb_id=%s",
-        _safe_identifier(kb_id),
-    )
-    return "build knowledge graph skipped: legacy task removed"
+    with _observe_tombstone(knowledge_id=kb_id) as run:
+        logger.warning(
+            "Legacy task removed; skipped task=build_graphrag_for_kb kb_id=%s",
+            _safe_identifier(kb_id),
+        )
+        run.finish(BusinessOutcome.SKIPPED, detail="legacy_task_removed")
+        return "build knowledge graph skipped: legacy task removed"
 
 
 @celery_app.task(name="app.core.rag.tasks.build_graphrag_for_document")
 def build_graphrag_for_document(document_id: object, knowledge_id: object) -> str:
-    logger.warning(
-        "Legacy task removed; skipped task=build_graphrag_for_document kb_id=%s document_id=%s",
-        _safe_identifier(knowledge_id),
-        _safe_identifier(document_id),
-    )
-    safe_document_id = _safe_identifier(document_id)
-    return f"build_graphrag_for_document '{safe_document_id}' skipped: legacy task removed"
+    with _observe_tombstone(
+        knowledge_id=knowledge_id,
+        document_id=document_id,
+    ) as run:
+        logger.warning(
+            "Legacy task removed; skipped task=build_graphrag_for_document "
+            "kb_id=%s document_id=%s",
+            _safe_identifier(knowledge_id),
+            _safe_identifier(document_id),
+        )
+        safe_document_id = _safe_identifier(document_id)
+        run.finish(BusinessOutcome.SKIPPED, detail="legacy_task_removed")
+        return f"build_graphrag_for_document '{safe_document_id}' skipped: legacy task removed"
 
 
 @celery_app.task(name="app.core.rag.tasks.migrate_evidence_graph_knowledge")
 def migrate_evidence_graph_knowledge(knowledge_id: object) -> dict[str, str]:
-    logger.warning(
-        "Legacy task removed; skipped task=migrate_evidence_graph_knowledge kb_id=%s",
-        _safe_identifier(knowledge_id),
-    )
-    return {
-        "status": "skipped",
-        "reason": "legacy_task_removed",
-        "knowledge_id": _safe_identifier(knowledge_id),
-    }
+    with _observe_tombstone(knowledge_id=knowledge_id) as run:
+        logger.warning(
+            "Legacy task removed; skipped task=migrate_evidence_graph_knowledge kb_id=%s",
+            _safe_identifier(knowledge_id),
+        )
+        run.finish(BusinessOutcome.SKIPPED, detail="legacy_task_removed")
+        return {
+            "status": "skipped",
+            "reason": "legacy_task_removed",
+            "knowledge_id": _safe_identifier(knowledge_id),
+        }

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -553,7 +553,10 @@ class TaskRun(AbstractContextManager["TaskRun"]):
                 )
                 return
             self._terminal = True
-        event_name = "kb_task_failed" if outcome is BusinessOutcome.FAILURE else "kb_task_finished"
+        event_name = {
+            BusinessOutcome.FAILURE: "kb_task_failed",
+            BusinessOutcome.RETRY: "kb_task_retry",
+        }.get(outcome, "kb_task_finished")
         self._emit(
             TaskEvent(
                 event=event_name,

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -1,0 +1,558 @@
+"""Lightweight task observability primitives for knowledge workers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+import traceback
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import TracebackType
+from typing import Protocol, Self
+
+_OBSERVABILITY_LOGGER = logging.getLogger("knowledge.tasks.observability")
+
+
+class BusinessOutcome(StrEnum):
+    """Business terminal states independent from Celery task states."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL_FAILURE = "partial_failure"
+    RETRY = "retry"
+    SKIPPED = "skipped"
+    COALESCED = "coalesced"
+    ABORTED = "aborted"
+    REVOKED = "revoked"
+
+
+@dataclass(frozen=True)
+class TaskContext:
+    """Safe task identity propagated to all observability events."""
+
+    service: str
+    role: str
+    hostname: str
+    main_pid: int
+    pid: int
+    task_name: str
+    task_id: str
+    queue: str | None
+    attempt: int
+    knowledge_id: str | None = None
+    document_id: str | None = None
+    trace_id: str | None = None
+    parent_task_id: str | None = None
+    published_at_ms: int | None = None
+    received_at_ms: int | None = None
+    started_at_ms: int | None = None
+    cold_start: bool = False
+    child_task_index: int = 0
+
+
+@dataclass(frozen=True)
+class TaskEvent:
+    """One immutable worker or task event."""
+
+    event: str
+    context: TaskContext
+    stage: str | None = None
+    detail: str | None = None
+    business_outcome: BusinessOutcome | None = None
+    celery_outcome: str | None = None
+    duration_ms: int | None = None
+    queue_wait_ms: int | None = None
+    wait_duration_ms: int | None = None
+    retry_in_ms: int | None = None
+    progress: float | None = None
+    error_code: str | None = None
+    error_type: str | None = None
+    error_fingerprint: str | None = None
+    counts: Mapping[str, int] = field(default_factory=dict)
+    display_message: str | None = None
+    force_flush: bool = False
+    exception: BaseException | None = field(default=None, repr=False, compare=False)
+
+
+class TaskEventSink(Protocol):
+    """Consume task events without changing task behavior."""
+
+    def emit(self, event: TaskEvent) -> None: ...
+
+
+TASK_LOG_FIELDS = (
+    "event",
+    "service",
+    "role",
+    "hostname",
+    "main_pid",
+    "pid",
+    "task_name",
+    "task_id",
+    "queue",
+    "attempt",
+    "trace_id",
+    "parent_task_id",
+    "knowledge_id",
+    "document_id",
+    "stage",
+    "detail",
+    "business_outcome",
+    "celery_outcome",
+    "duration_ms",
+    "queue_wait_ms",
+    "wait_duration_ms",
+    "retry_in_ms",
+    "progress",
+    "error_code",
+    "error_type",
+    "error_fingerprint",
+)
+
+TASK_COUNT_FIELDS = (
+    "discovered",
+    "created",
+    "updated",
+    "unchanged",
+    "deleted",
+    "parse_dispatched",
+    "failed",
+    "documents",
+    "chunks",
+    "batches",
+)
+
+
+class StructuredLogSink:
+    """Emit one allowlisted key-value log line per task event."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or logging.getLogger("knowledge.tasks")
+
+    @staticmethod
+    def _encoded(value: object) -> str:
+        if isinstance(value, StrEnum):
+            value = value.value
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+        return json.dumps(str(value), ensure_ascii=False)
+
+    @staticmethod
+    def _fields(event: TaskEvent) -> dict[str, object]:
+        context = event.context
+        fields: dict[str, object] = {
+            "event": event.event,
+            "service": context.service,
+            "role": context.role,
+            "hostname": context.hostname,
+            "main_pid": context.main_pid,
+            "pid": context.pid,
+            "task_name": context.task_name,
+            "task_id": context.task_id,
+            "queue": context.queue,
+            "attempt": context.attempt,
+            "trace_id": context.trace_id,
+            "parent_task_id": context.parent_task_id,
+            "knowledge_id": context.knowledge_id,
+            "document_id": context.document_id,
+            "stage": event.stage,
+            "detail": event.detail,
+            "business_outcome": event.business_outcome,
+            "celery_outcome": event.celery_outcome,
+            "duration_ms": event.duration_ms,
+            "queue_wait_ms": event.queue_wait_ms,
+            "wait_duration_ms": event.wait_duration_ms,
+            "retry_in_ms": event.retry_in_ms,
+            "progress": event.progress,
+            "error_code": event.error_code,
+            "error_type": event.error_type,
+            "error_fingerprint": event.error_fingerprint,
+        }
+        for key in TASK_COUNT_FIELDS:
+            value = event.counts.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                fields[f"count_{key}"] = value
+        return {key: value for key, value in fields.items() if value is not None}
+
+    def emit(self, event: TaskEvent) -> None:
+        fields = self._fields(event)
+        message = " ".join(
+            f"{key}={self._encoded(value)}"
+            for key, value in fields.items()
+        )
+        level = logging.ERROR if event.event in {
+            "kb_task_failed",
+            "kb_task_implementation_error",
+        } else logging.INFO
+        exc_info = (
+            (type(event.exception), event.exception, event.exception.__traceback__)
+            if event.exception is not None
+            else None
+        )
+        self._logger.log(level, message, exc_info=exc_info)
+
+
+class DocumentProgressSink:
+    """Persist throttled task progress through short database sessions."""
+
+    _TERMINAL_EVENTS = {"kb_task_finished", "kb_task_failed"}
+
+    def __init__(
+        self,
+        *,
+        runtime: object,
+        document_id: str,
+        flush_interval_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._runtime = runtime
+        try:
+            self._document_id = uuid.UUID(str(document_id))
+        except (TypeError, ValueError):
+            self._document_id = None
+        self._flush_interval_seconds = flush_interval_seconds
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._last_flush_at: float | None = None
+        self._pending_messages: list[str] = []
+
+    @staticmethod
+    def _append_message(current: str | None, messages: Sequence[str]) -> str:
+        lines = [current.rstrip("\n")] if current else []
+        lines.extend(message.rstrip("\n") for message in messages if message)
+        return "\n".join(line for line in lines if line) + ("\n" if lines else "")
+
+    def _should_flush(self, event: TaskEvent, now: float) -> bool:
+        return (
+            event.force_flush
+            or event.event in self._TERMINAL_EVENTS
+            or self._last_flush_at is None
+            or now - self._last_flush_at >= self._flush_interval_seconds
+        )
+
+    def emit(self, event: TaskEvent) -> None:
+        if self._document_id is None:
+            return
+        now = self._clock()
+        with self._lock:
+            if event.display_message:
+                self._pending_messages.append(event.display_message)
+            if not self._should_flush(event, now):
+                return
+            pending_messages = tuple(self._pending_messages)
+            self._persist(event, pending_messages)
+            self._pending_messages.clear()
+            self._last_flush_at = now
+
+    def _persist(self, event: TaskEvent, messages: Sequence[str]) -> None:
+        from ..models.owned import Document
+        from ..utils.datetime_utils import utcnow_naive
+
+        database = self._runtime.database
+        with database.sync_session() as session:
+            document = session.get(Document, self._document_id)
+            if document is None:
+                return
+            if event.event == "kb_task_started":
+                document.run = 1
+                document.progress = 0.0
+                document.process_begin_at = utcnow_naive()
+            elif event.event == "kb_task_failed":
+                document.run = 0
+                document.progress = -1.0
+            elif event.event == "kb_task_finished":
+                document.run = 0
+                if event.business_outcome is BusinessOutcome.SUCCESS:
+                    document.progress = 1.0
+            else:
+                document.run = 1
+                if event.progress is not None:
+                    document.progress = float(event.progress)
+            if messages:
+                document.progress_msg = self._append_message(
+                    document.progress_msg,
+                    messages,
+                )
+            session.commit()
+
+
+class CeleryStateSink:
+    """Expose active task stages without replacing Celery terminal states."""
+
+    _ACTIVE_EVENTS = {
+        "kb_task_started",
+        "kb_task_stage_started",
+        "kb_task_stage_finished",
+        "kb_task_progress",
+    }
+
+    def __init__(self, update_state: Callable[..., None]) -> None:
+        self._update_state = update_state
+
+    def emit(self, event: TaskEvent) -> None:
+        if event.event not in self._ACTIVE_EVENTS:
+            return
+        meta: dict[str, object] = {}
+        for key in (
+            "stage",
+            "detail",
+            "duration_ms",
+            "wait_duration_ms",
+            "progress",
+        ):
+            value = getattr(event, key)
+            if value is not None:
+                meta[key] = value
+        for key in TASK_COUNT_FIELDS:
+            value = event.counts.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                meta[f"count_{key}"] = value
+        if not meta:
+            return
+        self._update_state(state="STARTED", meta=meta)
+
+
+def error_fingerprint(exc: BaseException) -> str:
+    """Group failures by exception type and stable Knowledge source frames."""
+
+    frames = traceback.extract_tb(exc.__traceback__)
+    normalized_frames = [
+        f"{frame.filename.rsplit('/mem-knowledge/src/', 1)[-1]}:{frame.lineno}:{frame.name}"
+        for frame in frames
+        if "/mem-knowledge/src/" in frame.filename
+    ]
+    source = "|".join([type(exc).__name__, *normalized_frames[-5:]])
+    return hashlib.sha256(source.encode()).hexdigest()[:16]
+
+
+class TaskRun(AbstractContextManager["TaskRun"]):
+    """Track one task's stages and exactly one business terminal state."""
+
+    def __init__(
+        self,
+        context: TaskContext,
+        *,
+        sinks: Sequence[TaskEventSink],
+        heartbeat_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.context = context
+        self._sinks = tuple(sinks)
+        self._heartbeat_seconds = heartbeat_seconds
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._started_at = clock()
+        self._terminal = False
+        self._current_stage: str | None = None
+        self._current_stage_started_at: float | None = None
+        self._heartbeat_stop = threading.Event()
+        self._heartbeat_thread: threading.Thread | None = None
+
+    def _emit(self, event: TaskEvent) -> None:
+        for sink in self._sinks:
+            try:
+                sink.emit(event)
+            except Exception as exc:  # noqa: BLE001 - observability must not alter task behavior.
+                _OBSERVABILITY_LOGGER.error(
+                    "event=kb_task_observability_sink_failed sink_type=%s "
+                    "error_type=%s source_event=%s",
+                    type(sink).__name__,
+                    type(exc).__name__,
+                    event.event,
+                )
+
+    @staticmethod
+    def _validated_counts(counts: Mapping[str, int] | None) -> dict[str, int]:
+        values = dict(counts or {})
+        if any(not isinstance(value, int) or isinstance(value, bool) for value in values.values()):
+            raise ValueError("progress counts must contain integer values")
+        return values
+
+    def __enter__(self) -> Self:
+        self._emit(TaskEvent(event="kb_task_started", context=self.context))
+        if self._heartbeat_seconds > 0:
+            self._heartbeat_thread = threading.Thread(
+                target=self._heartbeat_loop,
+                name=f"kb-task-heartbeat-{self.context.task_id[-8:]}",
+                daemon=True,
+            )
+            self._heartbeat_thread.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        del exc_type, traceback
+        try:
+            if exc is not None and not self._terminal:
+                self.finish(BusinessOutcome.FAILURE, exc=exc)
+            elif exc is None and not self._terminal:
+                self.finish(
+                    BusinessOutcome.FAILURE,
+                    error_code="KB_TASK_TERMINAL_MISSING",
+                    detail="task_returned_without_business_terminal",
+                )
+        finally:
+            self._heartbeat_stop.set()
+            heartbeat_thread = self._heartbeat_thread
+            if heartbeat_thread is not None:
+                heartbeat_thread.join(timeout=max(1.0, self._heartbeat_seconds * 2))
+        return False
+
+    def _heartbeat_loop(self) -> None:
+        while not self._heartbeat_stop.wait(self._heartbeat_seconds):
+            with self._lock:
+                if self._terminal:
+                    continue
+                stage = self._current_stage
+                stage_started_at = self._current_stage_started_at
+            if stage is None or stage_started_at is None:
+                continue
+            self._emit(
+                TaskEvent(
+                    event="kb_task_progress",
+                    context=self.context,
+                    stage=stage,
+                    detail="heartbeat",
+                    wait_duration_ms=max(
+                        0,
+                        int(round((self._clock() - stage_started_at) * 1000)),
+                    ),
+                )
+            )
+
+    @contextmanager
+    def stage(self, name: str):
+        started_at = self._clock()
+        with self._lock:
+            previous_stage = self._current_stage
+            previous_stage_started_at = self._current_stage_started_at
+            self._current_stage = name
+            self._current_stage_started_at = started_at
+        self._emit(TaskEvent(event="kb_task_stage_started", context=self.context, stage=name))
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._current_stage = previous_stage
+                self._current_stage_started_at = previous_stage_started_at
+            duration_ms = max(0, int(round((self._clock() - started_at) * 1000)))
+            self._emit(
+                TaskEvent(
+                    event="kb_task_stage_finished",
+                    context=self.context,
+                    stage=name,
+                    duration_ms=duration_ms,
+                )
+            )
+
+    def progress(
+        self,
+        *,
+        stage: str,
+        fraction: float | None,
+        detail: str,
+        display_message: str | None = None,
+        counts: Mapping[str, int] | None = None,
+        force: bool = False,
+    ) -> None:
+        if (
+            fraction is not None
+            and (
+                isinstance(fraction, bool)
+                or not isinstance(fraction, (int, float))
+                or not 0.0 <= fraction <= 1.0
+            )
+        ):
+            raise ValueError("progress fraction must be between 0 and 1")
+        self._emit(
+            TaskEvent(
+                event="kb_task_progress",
+                context=self.context,
+                stage=stage,
+                detail=detail,
+                progress=fraction,
+                counts=self._validated_counts(counts),
+                display_message=display_message,
+                force_flush=force,
+            )
+        )
+
+    def finish(
+        self,
+        outcome: BusinessOutcome,
+        *,
+        error_code: str | None = None,
+        exc: BaseException | None = None,
+        detail: str | None = None,
+        counts: Mapping[str, int] | None = None,
+    ) -> None:
+        with self._lock:
+            if self._terminal:
+                self._emit(
+                    TaskEvent(
+                        event="kb_task_implementation_error",
+                        context=self.context,
+                        detail="duplicate_business_terminal",
+                        error_code=error_code,
+                    )
+                )
+                return
+            self._terminal = True
+        event_name = "kb_task_failed" if outcome is BusinessOutcome.FAILURE else "kb_task_finished"
+        self._emit(
+            TaskEvent(
+                event=event_name,
+                context=self.context,
+                detail=detail,
+                business_outcome=outcome,
+                duration_ms=max(0, int(round((self._clock() - self._started_at) * 1000))),
+                error_code=error_code,
+                error_type=type(exc).__name__ if exc is not None else None,
+                error_fingerprint=error_fingerprint(exc) if exc is not None else None,
+                counts=self._validated_counts(counts),
+                exception=exc,
+            )
+        )
+
+
+def observe_task(
+    context: TaskContext,
+    *,
+    sinks: Sequence[TaskEventSink],
+    heartbeat_seconds: float,
+    clock: Callable[[], float] = time.monotonic,
+) -> TaskRun:
+    """Create one task run without initializing external resources."""
+
+    return TaskRun(
+        context,
+        sinks=sinks,
+        heartbeat_seconds=heartbeat_seconds,
+        clock=clock,
+    )
+
+
+__all__ = [
+    "BusinessOutcome",
+    "CeleryStateSink",
+    "DocumentProgressSink",
+    "StructuredLogSink",
+    "TASK_COUNT_FIELDS",
+    "TASK_LOG_FIELDS",
+    "TaskContext",
+    "TaskEvent",
+    "TaskEventSink",
+    "TaskRun",
+    "error_fingerprint",
+    "observe_task",
+]

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -247,6 +247,13 @@ class DocumentProgressSink:
     def emit(self, event: TaskEvent) -> None:
         if self._document_id is None:
             return
+        if (
+            event.event not in self._TERMINAL_EVENTS
+            and event.event != "kb_task_started"
+            and event.progress is None
+            and not event.display_message
+        ):
+            return
         now = self._clock()
         with self._lock:
             if event.display_message:
@@ -359,6 +366,7 @@ class TaskRun(AbstractContextManager["TaskRun"]):
         self._terminal = False
         self._current_stage: str | None = None
         self._current_stage_started_at: float | None = None
+        self._failed_stage: str | None = None
         self._heartbeat_stop = threading.Event()
         self._heartbeat_thread: threading.Thread | None = None
 
@@ -458,6 +466,10 @@ class TaskRun(AbstractContextManager["TaskRun"]):
         self._emit(TaskEvent(event="kb_task_stage_started", context=self.context, stage=name))
         try:
             yield
+        except BaseException:
+            with self._lock:
+                self._failed_stage = name
+            raise
         finally:
             with self._lock:
                 self._current_stage = previous_stage
@@ -530,6 +542,11 @@ class TaskRun(AbstractContextManager["TaskRun"]):
             TaskEvent(
                 event=event_name,
                 context=self.context,
+                stage=(
+                    self._failed_stage
+                    if outcome in {BusinessOutcome.FAILURE, BusinessOutcome.RETRY}
+                    else None
+                ),
                 detail=detail,
                 business_outcome=outcome,
                 duration_ms=max(0, int(round((self._clock() - self._started_at) * 1000))),

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -210,6 +210,7 @@ class DocumentProgressSink:
     """Persist throttled task progress through short database sessions."""
 
     _TERMINAL_EVENTS = {"kb_task_finished", "kb_task_failed"}
+    _ABORTED_MESSAGE = "Task aborted (deleted or cancelled)."
 
     def __init__(
         self,
@@ -258,6 +259,11 @@ class DocumentProgressSink:
         with self._lock:
             if event.display_message:
                 self._pending_messages.append(event.display_message)
+            elif (
+                event.event == "kb_task_finished"
+                and event.business_outcome is BusinessOutcome.ABORTED
+            ):
+                self._pending_messages.append(self._ABORTED_MESSAGE)
             if not self._should_flush(event, now):
                 return
             pending_messages = tuple(self._pending_messages)

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -492,6 +492,8 @@ class TaskRun(AbstractContextManager["TaskRun"]):
         detail: str,
         display_message: str | None = None,
         counts: Mapping[str, int] | None = None,
+        duration_ms: int | None = None,
+        wait_duration_ms: int | None = None,
         force: bool = False,
     ) -> None:
         if (
@@ -503,6 +505,18 @@ class TaskRun(AbstractContextManager["TaskRun"]):
             )
         ):
             raise ValueError("progress fraction must be between 0 and 1")
+        if wait_duration_ms is not None and (
+            not isinstance(wait_duration_ms, int)
+            or isinstance(wait_duration_ms, bool)
+            or wait_duration_ms < 0
+        ):
+            raise ValueError("wait duration must be a non-negative integer")
+        if duration_ms is not None and (
+            not isinstance(duration_ms, int)
+            or isinstance(duration_ms, bool)
+            or duration_ms < 0
+        ):
+            raise ValueError("stage duration must be a non-negative integer")
         self._emit(
             TaskEvent(
                 event="kb_task_progress",
@@ -510,6 +524,8 @@ class TaskRun(AbstractContextManager["TaskRun"]):
                 stage=stage,
                 detail=detail,
                 progress=fraction,
+                duration_ms=duration_ms,
+                wait_duration_ms=wait_duration_ms,
                 counts=self._validated_counts(counts),
                 display_message=display_message,
                 force_flush=force,

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import re
+import socket
 import threading
 import time
 import traceback
@@ -17,6 +20,11 @@ from types import TracebackType
 from typing import Protocol, Self
 
 _OBSERVABILITY_LOGGER = logging.getLogger("knowledge.tasks.observability")
+_MAIN_PID = os.getpid()
+_TASK_TIMING_LOCK = threading.Lock()
+_TASK_PRERUN_TIMING: dict[str, tuple[int, int]] = {}
+_CHILD_TASK_INDEX = 0
+_SAFE_HEADER_TEXT = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 
 
 class BusinessOutcome(StrEnum):
@@ -375,7 +383,16 @@ class TaskRun(AbstractContextManager["TaskRun"]):
         return values
 
     def __enter__(self) -> Self:
-        self._emit(TaskEvent(event="kb_task_started", context=self.context))
+        queue_wait_ms = None
+        if self.context.published_at_ms is not None and self.context.started_at_ms is not None:
+            queue_wait_ms = max(0, self.context.started_at_ms - self.context.published_at_ms)
+        self._emit(
+            TaskEvent(
+                event="kb_task_started",
+                context=self.context,
+                queue_wait_ms=queue_wait_ms,
+            )
+        )
         if self._heartbeat_seconds > 0:
             self._heartbeat_thread = threading.Thread(
                 target=self._heartbeat_loop,
@@ -542,6 +559,111 @@ def observe_task(
     )
 
 
+def current_parent_task_id() -> str | None:
+    """Return the current Celery task ID when dispatching a child task."""
+
+    try:
+        from celery import current_task
+    except ImportError:
+        return None
+    request = getattr(current_task, "request", None)
+    task_id = getattr(request, "id", None)
+    return str(task_id) if task_id else None
+
+
+def reset_observability_after_fork() -> None:
+    """Reset child-local timing without changing the inherited main PID."""
+
+    global _CHILD_TASK_INDEX
+    with _TASK_TIMING_LOCK:
+        _CHILD_TASK_INDEX = 0
+        _TASK_PRERUN_TIMING.clear()
+
+
+def record_task_prerun(task_id: str, *, started_at_ms: int | None = None) -> None:
+    """Capture task start before the task envelope imports business modules."""
+
+    global _CHILD_TASK_INDEX
+    if not task_id:
+        return
+    with _TASK_TIMING_LOCK:
+        _CHILD_TASK_INDEX += 1
+        _TASK_PRERUN_TIMING[str(task_id)] = (
+            started_at_ms if started_at_ms is not None else int(time.time() * 1000),
+            _CHILD_TASK_INDEX,
+        )
+
+
+def _consume_task_prerun(task_id: str) -> tuple[int, int]:
+    global _CHILD_TASK_INDEX
+    with _TASK_TIMING_LOCK:
+        timing = _TASK_PRERUN_TIMING.pop(task_id, None)
+        if timing is not None:
+            return timing
+        _CHILD_TASK_INDEX += 1
+        return int(time.time() * 1000), _CHILD_TASK_INDEX
+
+
+def _safe_uuid(value: object | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        return str(uuid.UUID(str(value)))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _safe_header_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if _SAFE_HEADER_TEXT.fullmatch(text) else None
+
+
+def task_context_from_current_task(
+    *,
+    role: str,
+    knowledge_id: object | None = None,
+    document_id: object | None = None,
+) -> TaskContext:
+    """Build a safe task context from Celery's current task proxy."""
+
+    from celery import current_task
+
+    request = getattr(current_task, "request", None)
+    task_id = str(getattr(request, "id", None) or "unknown")
+    started_at_ms, child_task_index = _consume_task_prerun(task_id)
+    headers = getattr(request, "headers", None)
+    headers = headers if isinstance(headers, Mapping) else {}
+    delivery_info = getattr(request, "delivery_info", None)
+    delivery_info = delivery_info if isinstance(delivery_info, Mapping) else {}
+    raw_published_at = headers.get("kb_published_at_ms")
+    published_at_ms = (
+        int(raw_published_at)
+        if isinstance(raw_published_at, (int, float)) and not isinstance(raw_published_at, bool)
+        else None
+    )
+    return TaskContext(
+        service="mem-knowledge",
+        role=role,
+        hostname=str(getattr(request, "hostname", None) or socket.gethostname()),
+        main_pid=_MAIN_PID,
+        pid=os.getpid(),
+        task_name=str(getattr(current_task, "name", None) or "unknown"),
+        task_id=task_id,
+        queue=_safe_header_text(delivery_info.get("routing_key")),
+        attempt=int(getattr(request, "retries", 0) or 0),
+        knowledge_id=_safe_uuid(knowledge_id),
+        document_id=_safe_uuid(document_id),
+        trace_id=_safe_header_text(headers.get("kb_trace_id")),
+        parent_task_id=_safe_uuid(headers.get("kb_parent_task_id")),
+        published_at_ms=published_at_ms,
+        started_at_ms=started_at_ms,
+        cold_start=child_task_index == 1,
+        child_task_index=child_task_index,
+    )
+
+
 __all__ = [
     "BusinessOutcome",
     "CeleryStateSink",
@@ -553,6 +675,10 @@ __all__ = [
     "TaskEvent",
     "TaskEventSink",
     "TaskRun",
+    "current_parent_task_id",
     "error_fingerprint",
     "observe_task",
+    "record_task_prerun",
+    "reset_observability_after_fork",
+    "task_context_from_current_task",
 ]

--- a/mem-knowledge/src/tasks/qa_import.py
+++ b/mem-knowledge/src/tasks/qa_import.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from ..bootstrap import get_settings
 from ..runtime import get_worker_runtime
 from .celery_app import celery_app
+from .observability import (
+    DocumentProgressSink,
+    StructuredLogSink,
+    observe_task,
+    task_context_from_current_task,
+)
 
 
-def process_qa_import(*args, **kwargs):
+def _load_qa_processor():
     """Load the model-heavy QA processor only when the task executes."""
 
     from ..services.qa_import_processing import process_qa_import as process
 
-    return process(*args, **kwargs)
+    return process
+
+
+def process_qa_import(*args, **kwargs):
+    """Compatibility helper that delegates to the lazy QA processor."""
+
+    return _load_qa_processor()(*args, **kwargs)
 
 
 @celery_app.task(name="app.core.rag.tasks.import_qa_chunks", queue="qa_import")
@@ -23,15 +36,38 @@ def import_qa_chunks(
     file_key: str | None = None,
     clear_parse_task: bool = False,
 ):
-    return process_qa_import(
-        get_worker_runtime(),
-        kb_id,
-        document_id,
-        filename,
-        contents=contents,
-        file_key=file_key,
-        clear_parse_task=clear_parse_task,
+    settings = get_settings()
+    runtime = get_worker_runtime()
+    context = task_context_from_current_task(
+        role="qa_import_worker",
+        knowledge_id=kb_id,
+        document_id=document_id,
     )
+    sinks = [
+        StructuredLogSink(),
+        DocumentProgressSink(
+            runtime=runtime,
+            document_id=str(document_id),
+            flush_interval_seconds=settings.kb_progress_flush_interval_seconds,
+        ),
+    ]
+    with observe_task(
+        context,
+        sinks=sinks,
+        heartbeat_seconds=settings.kb_task_heartbeat_seconds,
+    ) as run:
+        with run.stage("lazy_import"):
+            process = _load_qa_processor()
+        return process(
+            runtime,
+            kb_id,
+            document_id,
+            filename,
+            contents=contents,
+            file_key=file_key,
+            clear_parse_task=clear_parse_task,
+            run=run,
+        )
 
 
 __all__ = ["import_qa_chunks"]


### PR DESCRIPTION
## Business Background
After the knowledge workers were migrated out of the API service, operators lost timely runtime signals. A task could be received while `progress_msg` remained empty for a long time, and the document, QA import, and GraphRAG workers did not consistently expose startup, queue selection, stage transitions, lock waits, heartbeat, business outcome, and shutdown events.

## Summary
- add a shared structured observability layer for knowledge tasks, including lifecycle, stage, heartbeat, duration, business outcome, and Celery outcome events
- publish `Queued` and intermediate progress for document parsing and QA import before long-running work starts
- instrument document synchronization, Evidence Graph operations, GraphRAG lock waits, retries, skips, partial failures, and terminal outcomes
- validate worker role and selected queues at startup and reduce cold imports for dedicated workers
- add static import-boundary guards and focused observability contract coverage

## Changes
- 22 files changed
- 2,186 insertions and 289 deletions
- scope is limited to `mem-knowledge`

## Risk
- Existing task registration names, queue routing, task arguments, acknowledgement behavior, and retry behavior are preserved.
- Document and QA result semantics are preserved; business outcomes are logged separately from Celery execution outcomes.
- User-visible progress is intentionally populated earlier and updated at additional stages.
- No database migration is required.
- External API Key endpoints under `api/app/controllers/service/rag_api_*_controller.py` are not changed.
- Production database, Elasticsearch, MinerU, model, and upstream successful-business integrations were not exercised in this checkout; the isolated broker/worker validation covers worker lifecycle and failure/skip paths.

## Test Plan
- [x] `PYTHONPATH=mem-knowledge uv run --project mem-knowledge --frozen pytest -q /tmp/memorybear-knowledge-observability-tdd.BL97xE/test_*.py` — 49 passed
- [x] `uv run --project mem-knowledge --frozen ruff check mem-knowledge` — passed
- [x] `uv lock --project mem-knowledge --check` — resolved 144 packages
- [x] `uv run --project mem-knowledge --frozen python mem-knowledge/scripts/check_import_boundaries.py` — passed
- [x] source, wheel, installed-package, and container-rootfs artifact/import scans — passed
- [x] Python 3.12 fresh-environment wheel import and nine-task registry check — passed
- [x] document, GraphRAG, and QA prefork worker startup/shutdown plus role/queue mismatch rejection — passed
- [x] isolated RabbitMQ/Redis execution smoke for document failure, QA failure, GraphRAG skip/failure, lifecycle counts, and graceful shutdown — passed

## Sourcery 摘要

通过结构化生命周期信号、持久化进度更新、阶段埋点以及更安全的 worker 启动验证，提升知识工作者的可观测性。

新功能：
- 为知识工作者任务的生命周期、阶段、进度、心跳、队列耗时、重试和业务结果添加结构化可观测性。
- 暴露文档解析和 QA 导入任务更早的排队状态及中间进度。
- 为 GraphRAG 同步、锁等待、阶段耗时、跳过、重试、合并处理和部分失败添加埋点。

错误修复：
- 将文档和 QA 分发失败显示在持久化进度状态中，避免任务长时间没有及时状态。

增强功能：
- 在启动时根据配置的队列验证 worker 角色，并报告 worker 生命周期事件。
- 减少专用 worker 的冷启动导入，同时保留任务注册、路由、确认和重试行为。
- 传递安全的任务元数据，例如 trace、parent-task、queue 和 source-role 上下文，同时排除敏感的负载字段。

测试：
- 添加针对性的可观测性契约覆盖、导入边界检查、worker 启动验证，以及隔离的 broker/worker 生命周期和失败路径测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过结构化任务信号、持久化进度更新、阶段埋点以及更安全的 Worker 启动验证，提升知识工作者的可观测性。

新功能：
- 为文档、QA 导入、同步和 GraphRAG 任务添加结构化的生命周期、阶段、心跳、进度、计时、重试和业务结果可观测性。
- 暴露文档解析和 QA 导入过程中更早的排队状态及中间持久化进度。
- 使用安全的任务元数据报告 GraphRAG 阶段执行、锁等待、跳过、重试、合并处理及部分结果。

Bug 修复：
- 持久化文档和 QA 分发失败状态，避免任务长时间没有及时的状态更新。

增强功能：
- 在启动时根据配置的队列验证 Worker 角色，并发出 Worker 生命周期和 Celery 执行信号。
- 减少专用 Worker 的冷启动导入，同时保留任务注册、路由、确认、参数和重试行为。
- 传递经过清理的追踪信息和父任务上下文，同时防止敏感的任务负载字段进入可观测性日志。

测试：
- 添加可观测性契约测试、导入边界保护、Worker 启动验证，以及隔离的 Broker/Worker 生命周期和失败路径覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过结构化任务信号、更早持久化进度、详细的阶段级监控，以及更安全的 Worker 启动验证，提升知识工作者任务的可观测性。

新功能：
- 为文档、QA 导入、同步和 GraphRAG 任务添加结构化的生命周期、阶段、心跳、进度、计时、重试和业务结果可观测性。
- 暴露文档解析和 QA 导入任务更早的排队状态及中间持久化进度。
- 在安全的任务上下文中报告 GraphRAG 阶段执行、锁等待、跳过、重试、合并处理和部分结果。

错误修复：
- 持久化文档和 QA 分发失败状态，避免任务长时间没有及时的状态更新。

增强：
- 在启动时根据配置的队列验证 Worker 角色，并报告 Worker 和 Celery 的生命周期事件。
- 减少专用 Worker 冷启动时的导入，同时保留任务注册、路由、确认、参数和重试行为。
- 传递经过清理的追踪信息和父任务元数据，同时从可观测性输出中排除敏感的任务负载字段。

测试：
- 添加可观测性契约测试、导入边界保护测试、Worker 启动验证测试，以及隔离的 Broker/Worker 生命周期和失败路径覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过结构化任务信号、持久化进度更新、阶段埋点以及更安全的 Worker 启动验证，提升知识工作者的可观测性。

新功能：
- 为文档、QA 导入、同步和 GraphRAG 任务新增结构化的生命周期、阶段、心跳、进度、耗时、重试和业务结果可观测性。
- 为文档解析和 QA 导入暴露更早的排队状态和中间进度，包括持久化的调度失败信息。
- 在安全的任务上下文中报告 GraphRAG 阶段执行、锁等待、跳过、重试、合并以及部分结果。

Bug 修复：
- 持久化文档和 QA 调度失败信息，使任务状态能够及时更新，而不是一直为空。

增强功能：
- 在启动时根据 Worker 配置的队列验证其角色，并发出 Worker 和 Celery 生命周期信号。
- 减少专用 Worker 冷启动时的导入操作，同时保留任务注册、路由、参数、确认和重试行为。
- 传递经过清理的跟踪信息和父任务元数据，同时将敏感的任务负载字段排除在可观测性输出之外。

测试：
- 新增可观测性契约测试、导入边界保护测试、Worker 启动验证，以及隔离的 Broker/Worker 生命周期和失败路径覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve knowledge worker observability with structured task signals, persisted progress updates, stage instrumentation, and safer worker startup validation.

New Features:
- Add structured lifecycle, stage, heartbeat, progress, timing, retry, and business-outcome observability for document, QA import, synchronization, and GraphRAG tasks.
- Expose earlier queued and intermediate progress for document parsing and QA imports, including persisted dispatch failures.
- Report GraphRAG stage execution, lock waits, skips, retries, coalescing, and partial outcomes with safe task context.

Bug Fixes:
- Persist document and QA dispatch failures so task status is updated promptly instead of remaining empty.

Enhancements:
- Validate worker roles against their configured queues at startup and emit worker and Celery lifecycle signals.
- Reduce dedicated worker cold-start imports while preserving task registration, routing, arguments, acknowledgements, and retry behavior.
- Propagate sanitized trace and parent-task metadata while excluding sensitive task payload fields from observability output.

Tests:
- Add observability contract tests, import-boundary guards, worker startup validation, and isolated broker/worker lifecycle and failure-path coverage.

</details>

</details>

</details>

</details>