### PR TITLE
Feat/lbb mywork

### DIFF
--- a/api/app/models/dialogue_emotion_raw_model.py
+++ b/api/app/models/dialogue_emotion_raw_model.py
@@ -22,7 +22,7 @@ class DialogueEmotionRaw(Base):
 
     __tablename__ = "dialogue_emotion_raw"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, comment="主键（Neo4j Dialogue.id 的 uuid，幂等 Upsert 依据）")
+    id = Column(String(255), primary_key=True, comment="主键（Neo4j Dialogue.id 原始字符串，如 Dialog_<uuid>_<n>，幂等 Upsert 依据）")
     end_user_id = Column(UUID(as_uuid=True), nullable=False, comment="终端用户ID")
     created_at = Column(DateTime, nullable=False, comment="对话原始时刻（naive UTC，不预切日）")
     emotion = Column(String(50), nullable=False, comment="情绪枚举（BERT 十分类英文 code）")

--- a/api/app/models/dialogue_emotion_raw_model.py
+++ b/api/app/models/dialogue_emotion_raw_model.py
@@ -22,7 +22,8 @@ class DialogueEmotionRaw(Base):
 
     __tablename__ = "dialogue_emotion_raw"
 
-    id = Column(String(255), primary_key=True, comment="主键（Neo4j Dialogue.id 原始字符串，如 Dialog_<uuid>_<n>，幂等 Upsert 依据）")
+    id = Column(UUID(as_uuid=True), primary_key=True, comment="主键（由 dialogue_id 经 uuid5 确定性生成，幂等 Upsert 依据）")
+    dialogue_id = Column(String(255), nullable=False, unique=True, comment="Neo4j Dialogue.id 原始字符串（格式如 Dialog_<uuid>_<n>，非纯 uuid）")
     end_user_id = Column(UUID(as_uuid=True), nullable=False, comment="终端用户ID")
     created_at = Column(DateTime, nullable=False, comment="对话原始时刻（naive UTC，不预切日）")
     emotion = Column(String(50), nullable=False, comment="情绪枚举（BERT 十分类英文 code）")

--- a/api/app/repositories/dialogue_emotion_raw_repository.py
+++ b/api/app/repositories/dialogue_emotion_raw_repository.py
@@ -124,7 +124,7 @@ class DialogueEmotionRawRepository:
             return 0
         values = [
             {
-                "id": _as_uuid(r["id"]),
+                "id": r["id"],
                 "end_user_id": _as_uuid(r["end_user_id"]),
                 "created_at": r["created_at"],
                 "emotion": r["emotion"],

--- a/api/app/repositories/dialogue_emotion_raw_repository.py
+++ b/api/app/repositories/dialogue_emotion_raw_repository.py
@@ -40,6 +40,17 @@ def _as_uuid(value: Any) -> Optional[uuid_lib.UUID]:
     return uuid_lib.UUID(str(value))
 
 
+def dialogue_row_uuid(dialogue_id: Any) -> uuid_lib.UUID:
+    """Neo4j Dialogue.id → 确定性 uuid 主键（uuid5，同一对话恒同一主键）
+
+    Neo4j Dialogue.id 为 Dialog_<uuid>_<n> 格式的非纯 uuid 字符串，
+    不能直接存 uuid 列；用 uuid5 由其确定性生成主键，幂等 Upsert
+    仍按主键冲突判断。独立脚本 scripts/init_emotion_stats.py 内
+    使用完全相同的算法，保证两条写入链路主键一致。
+    """
+    return uuid_lib.uuid5(uuid_lib.NAMESPACE_URL, str(dialogue_id))
+
+
 class DialogueEmotionRawRepository:
     """对话情绪原始明细仓储类"""
 
@@ -115,6 +126,8 @@ class DialogueEmotionRawRepository:
 
         Args:
             rows: [{id, end_user_id, created_at, emotion}] 列表，
+                  id 为 Neo4j Dialogue.id 原始字符串（内部经 uuid5
+                  确定性转换为 uuid 主键，原样存 dialogue_id 列），
                   created_at 为 naive UTC，end_user_id 为 uuid 或其字符串
 
         Returns:
@@ -124,7 +137,8 @@ class DialogueEmotionRawRepository:
             return 0
         values = [
             {
-                "id": r["id"],
+                "id": dialogue_row_uuid(r["id"]),
+                "dialogue_id": str(r["id"]),
                 "end_user_id": _as_uuid(r["end_user_id"]),
                 "created_at": r["created_at"],
                 "emotion": r["emotion"],


### PR DESCRIPTION
## Sourcery 摘要

使用从 Neo4j 对话 ID 派生的稳定 UUID，支持对原始对话情绪进行确定性、幂等性的持久化。

错误修复：
- 在保持情绪记录幂等更新插入的同时，保留无效 UUID 的 Neo4j 对话标识符。

增强功能：
- 从对话标识符派生稳定的 UUID 主键，并存储原始标识符，以便追溯并确保唯一性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support deterministic, idempotent persistence of raw dialogue emotions using stable UUIDs derived from Neo4j dialogue IDs.

Bug Fixes:
- Preserve Neo4j dialogue identifiers that are not valid UUIDs while maintaining idempotent emotion-record upserts.

Enhancements:
- Derive stable UUID primary keys from dialogue identifiers and store the original identifiers for traceability and uniqueness.

</details>