### PR TITLE
feat(memory):writer router

### DIFF
--- a/api/app/core/memory/storage/outbox/clients.py
+++ b/api/app/core/memory/storage/outbox/clients.py
@@ -11,8 +11,8 @@ from redis.backoff import NoBackoff
 
 from app.core.config import settings
 from app.core.memory.storage.enums import MemoryNodeType
-from app.core.memory.storage.models import NodeFilter
-from app.core.memory.storage.outbox.types import ClaimedEvent
+from app.core.memory.storage.models import NodeFilter, StorageReadResult
+from app.core.memory.storage.outbox.types import ClaimedEvent, OutboxOperation
 from app.core.memory.storage.provider.elasticsearch.client import ElasticClient
 from app.core.memory.storage.provider.elasticsearch.config import (
     build_elasticsearch_client_config,
@@ -30,23 +30,39 @@ async def project_event(
     check_claim,
 ) -> None:
     label = MemoryNodeType(event.label)
+    operation = OutboxOperation(event.operation)
     node_filter = NodeFilter.eq("id", event.node_id)
-    nodes = await neo4j.get_node(label=label, node_filter=node_filter)
-    if not isinstance(nodes, list) or len(nodes) > 1:
+
+    if operation is OutboxOperation.DELETE:
+        # 物理删除事件不回读 Neo4j：节点已不存在，直接删除 ES 文档。
+        await check_claim()
+        await elastic.delete_node(label, node_filter, draft=False)
+        return
+
+    # upsert 与 draft_delete 都以 Neo4j 当前态为准；软删除节点仍然存在，
+    # 回读后会把 delete_at 一并覆盖写入 ES。
+    result = await neo4j.get_node(label=label, node_filter=node_filter)
+    if (
+        not isinstance(result, StorageReadResult)
+        or result.total != len(result.items)
+        or result.total > 1
+    ):
         raise ValueError("Invalid or ambiguous authoritative node result")
     document = None
-    if nodes:
+    if result.items:
+        candidate = result.items[0]
         if (
-            not isinstance(nodes[0], Mapping)
-            or nodes[0].get("id") != event.node_id
+            not isinstance(candidate, Mapping)
+            or candidate.get("id") != event.node_id
         ):
             raise ValueError("Authoritative node identity mismatch")
-        document = nodes[0]
+        document = candidate
     # 读错误绝不转化为 ES 删除。慢读后需重新校验租约归属。
     await check_claim()
     if document is not None:
         await elastic.save_node(label, document)
     else:
+        # 节点已被物理删除，投影收敛为删除 ES 文档。
         await elastic.delete_node(label, node_filter, draft=False)
 
 

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -104,6 +104,17 @@ class BaseClient(ABC):
     ) -> StorageReadResult:
         pass
 
+    async def save_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        source: str,
+        target: str,
+        data: dict,
+    ) -> StorageWriteResult:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support relationship writes"
+        )
+
     async def get_relationship(
         self,
         relationship_type: MemoryRelationshipType,

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -347,28 +347,32 @@ class Neo4jClient(BaseClient):
             MATCH (n:{label.value})
             WHERE ({predicate}) AND n.delete_at IS NULL
             SET n.delete_at = datetime()
-            RETURN count(n) AS deleted
+            RETURN n.id AS id
             """
         else:
             query = f"""
             MATCH (n:{label.value})
             WHERE {predicate}
+            WITH n, n.id AS id
             DETACH DELETE n
-            RETURN count(n) AS deleted
+            RETURN id
             """
 
         async with self.client.session() as session:
             stmt = await session.run(query, **filter_parameters)
             records = await stmt.data()
 
-        affected_count = (
-            int(records[0].get("deleted", 0))
-            if records
-            else 0
-        )
+        ids = [
+            str(record["id"])
+            for record in records
+            if record.get("id") is not None
+        ]
+        if len(ids) != len(records):
+            raise ValueError("Affected node is missing an id")
         return StorageWriteResult(
             backend=self.name,
-            affected_count=affected_count,
+            affected_count=len(records),
+            ids=ids,
         )
 
     async def search_by_embedding(

--- a/api/app/core/memory/storage/router/write_router.py
+++ b/api/app/core/memory/storage/router/write_router.py
@@ -1,1 +1,137 @@
-"""TODO"""
+"""节点主写与 outbox 投影事件入队；关系写固定走 Neo4j 且不产生事件。"""
+
+from __future__ import annotations
+
+from app.core.memory.storage.enums import (
+    MemoryNodeLabel,
+    MemoryRelationshipType,
+    StorageBackendType,
+)
+from app.core.memory.storage.models import (
+    NodeFilter,
+    RelationshipFilter,
+    StorageWriteResult,
+)
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.base import BaseClient
+from app.core.memory.storage.provider.factory import BackendFactory
+
+
+class WriteRouter:
+    def __init__(
+        self,
+        backend_factory: BackendFactory,
+        *,
+        outbox_repository: OutboxRepository | None = None,
+    ) -> None:
+        self.backend_factory = backend_factory
+        self.outbox_repository = outbox_repository
+
+    async def save_node(
+        self,
+        label: MemoryNodeLabel,
+        data: dict,
+    ) -> StorageWriteResult:
+        result = await self._write_client(label).save_node(label, data)
+        await self._enqueue_result(label, result, OutboxOperation.UPSERT)
+        return result
+
+    async def update_node(
+        self,
+        label: MemoryNodeLabel,
+        data: dict,
+        node_filter: NodeFilter,
+    ) -> StorageWriteResult:
+        result = await self._write_client(label).update_node(
+            label,
+            data,
+            node_filter,
+        )
+        await self._enqueue_result(label, result, OutboxOperation.UPSERT)
+        return result
+
+    async def delete_node(
+        self,
+        label: MemoryNodeLabel,
+        node_filter: NodeFilter,
+        draft: bool = False,
+    ) -> StorageWriteResult:
+        result = await self._write_client(label).delete_node(
+            label,
+            node_filter,
+            draft,
+        )
+        operation = (
+            OutboxOperation.DRAFT_DELETE if draft else OutboxOperation.DELETE
+        )
+        await self._enqueue_result(label, result, operation)
+        return result
+
+    async def save_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        source: str,
+        target: str,
+        data: dict,
+    ) -> StorageWriteResult:
+        return await self.backend_factory.get_relationship_client().save_relationship(
+            relationship_type,
+            source,
+            target,
+            data,
+        )
+
+    async def update_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        data: dict,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        return await self.backend_factory.get_relationship_client().update_relationship(
+            relationship_type,
+            data,
+            rel_filter,
+        )
+
+    async def delete_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        return await self.backend_factory.get_relationship_client().delete_relationship(
+            relationship_type,
+            rel_filter,
+        )
+
+    def _write_client(self, label: MemoryNodeLabel) -> BaseClient:
+        return self.backend_factory.get_write_client(
+            label,
+            StorageBackendType.GRAPH_MAIN_WRITE,
+        )
+
+    async def _enqueue_result(
+        self,
+        label: MemoryNodeLabel,
+        result: StorageWriteResult,
+        operation: OutboxOperation,
+    ) -> None:
+        node_ids = list(dict.fromkeys(result.ids))
+        if result.affected_count != len(node_ids):
+            raise ValueError(
+                "Storage write result must include one unique id per affected node"
+            )
+        if not node_ids:
+            return
+        await enqueue_events(
+            [
+                OutboxEventInput(
+                    label=label,
+                    node_id=node_id,
+                    operation=operation,
+                )
+                for node_id in node_ids
+            ],
+            repository=self.outbox_repository,
+        )

--- a/api/app/core/memory/storage/service.py
+++ b/api/app/core/memory/storage/service.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 from typing import Self
 
-from app.core.memory.storage.enums import MemoryNodeLabel
+from app.core.memory.storage.enums import MemoryNodeLabel, MemoryRelationshipType
 from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
+    RelationshipFilter,
     StorageReadResult,
+    StorageWriteResult,
 )
 from app.core.memory.storage.provider.factory import BackendFactory
 from app.core.memory.storage.router.read_router import ReadRouter
+from app.core.memory.storage.router.write_router import WriteRouter
 
 
 class MemoryStorageService:
     def __init__(self, backend_factory: BackendFactory) -> None:
         self._backend_factory = backend_factory
         self._read_router = ReadRouter(backend_factory)
+        self._write_router = WriteRouter(backend_factory)
 
     @classmethod
     async def create(cls) -> Self:
@@ -52,6 +56,65 @@ class MemoryStorageService:
             text,
             limit,
             projection,
+        )
+
+    async def save_node(
+        self,
+        label: MemoryNodeLabel,
+        data: dict,
+    ) -> StorageWriteResult:
+        return await self._write_router.save_node(label, data)
+
+    async def update_node(
+        self,
+        label: MemoryNodeLabel,
+        data: dict,
+        node_filter: NodeFilter,
+    ) -> StorageWriteResult:
+        return await self._write_router.update_node(label, data, node_filter)
+
+    async def delete_node(
+        self,
+        label: MemoryNodeLabel,
+        node_filter: NodeFilter,
+        draft: bool = False,
+    ) -> StorageWriteResult:
+        return await self._write_router.delete_node(label, node_filter, draft)
+
+    async def save_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        source: str,
+        target: str,
+        data: dict,
+    ) -> StorageWriteResult:
+        return await self._write_router.save_relationship(
+            relationship_type,
+            source,
+            target,
+            data,
+        )
+
+    async def update_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        data: dict,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        return await self._write_router.update_relationship(
+            relationship_type,
+            data,
+            rel_filter,
+        )
+
+    async def delete_relationship(
+        self,
+        relationship_type: MemoryRelationshipType,
+        rel_filter: RelationshipFilter,
+    ) -> StorageWriteResult:
+        return await self._write_router.delete_relationship(
+            relationship_type,
+            rel_filter,
         )
 
     async def close(self) -> None:

--- a/api/app/core/memory/storage/tests/test_filters.py
+++ b/api/app/core/memory/storage/tests/test_filters.py
@@ -15,6 +15,7 @@ from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
     NodeSort,
+    RelationshipFilter,
     SortDirection,
     SortField,
 )
@@ -161,12 +162,19 @@ class _FakeSession:
 
     async def run(self, query: str, **parameters: Any) -> _FakeResult:
         self.calls.append((query, parameters))
-        if "RETURN count(n) AS deleted" in query:
-            data = [{"deleted": 2}]
+        if "DELETE r" in query and "RETURN relationship_id, properties" in query:
+            data = [{
+                "relationship_id": "edge-1",
+                "properties": {"id": "edge-1", "weight": 0.8},
+            }]
+        elif "DETACH DELETE n" in query and "RETURN id" in query:
+            data = [{"id": "node-1"}, {"id": "node-2"}]
+        elif "SET n.delete_at" in query and "RETURN n.id AS id" in query:
+            data = [{"id": "node-1"}, {"id": "node-2"}]
         elif "RETURN r" in query:
             data = [{"r": parameters["properties"]}]
         elif "$properties" in query and "RETURN n" in query:
-            data = [{"n": parameters["properties"]}]
+            data = [{"n": {"id": "node-1", **parameters["properties"]}}]
         elif " AS n" in query:
             data = [{"n": {"id": 1}}]
         else:
@@ -301,6 +309,54 @@ async def test_neo4j_save_relationship_merges_by_id_and_sets_properties() -> Non
     assert result.data == [data]
 
 
+async def test_neo4j_delete_relationship_uses_scoped_filter() -> None:
+    driver = _FakeDriver()
+    client = Neo4jClient()
+    client.client = driver  # type: ignore[assignment]
+    rel_filter = RelationshipFilter(
+        relationship=NodeFilter.eq("id", "edge-1"),
+        source=NodeFilter.eq("tenant_id", "tenant-1"),
+    )
+
+    result = await client.delete_relationship(
+        MemoryRelationshipType.RELATES_TO,
+        rel_filter,
+    )
+
+    query, parameters = driver.calls[0]
+    assert "[r:`RELATES_TO`]" in query
+    assert "r[$relationship_filter_relationship_0_field]" in query
+    assert "source[$relationship_filter_source_0_field]" in query
+    assert "DELETE r" in query
+    assert "RETURN relationship_id, properties" in query
+    assert parameters == {
+        "relationship_filter_relationship_0_field": "id",
+        "relationship_filter_relationship_0_value": "edge-1",
+        "relationship_filter_source_0_field": "tenant_id",
+        "relationship_filter_source_0_value": "tenant-1",
+    }
+    assert result.backend == BackendType.NEO4J
+    assert result.affected_count == 1
+    assert result.ids == ["edge-1"]
+    assert result.data == [{"id": "edge-1", "weight": 0.8}]
+
+
+@pytest.mark.parametrize("relationship_type", ["RELATES_TO", "", None, 1])
+async def test_neo4j_delete_relationship_requires_relationship_type_enum(
+    relationship_type: Any,
+) -> None:
+    client = Neo4jClient()
+    rel_filter = RelationshipFilter(
+        relationship=NodeFilter.eq("id", "edge-1")
+    )
+
+    with pytest.raises(KeyError, match="relationship type.*not supported"):
+        await client.delete_relationship(
+            relationship_type,
+            rel_filter,
+        )
+
+
 def test_memory_relationship_type_covers_physical_graph_relationships() -> None:
     assert {item.value for item in MemoryRelationshipType} == {
         "BELONGS_TO_COMMUNITY",
@@ -370,8 +426,8 @@ async def test_neo4j_update_node_uses_custom_filter_without_data_id() -> None:
     }
     assert result.backend == BackendType.NEO4J
     assert result.affected_count == 1
-    assert result.ids == []
-    assert result.data == [{"change": True}]
+    assert result.ids == ["node-1"]
+    assert result.data == [{"id": "node-1", "change": True}]
 
 
 
@@ -613,7 +669,7 @@ def test_elasticsearch_sort_preserves_field_order_and_maps_direction() -> None:
     ]
 
 
-async def test_neo4j_delete_node_uses_parameterized_filter_and_returns_count() -> None:
+async def test_neo4j_delete_node_uses_parameterized_filter_and_returns_ids() -> None:
     driver = _FakeDriver()
     client = Neo4jClient()
     client.client = driver  # type: ignore[assignment]
@@ -634,8 +690,9 @@ async def test_neo4j_delete_node_uses_parameterized_filter_and_returns_count() -
         "WHERE (n[$filter_0_field] = $filter_0_value) AND "
         "(n[$filter_1_field] = $filter_1_value)"
     ) in query
+    assert "WITH n, n.id AS id" in query
     assert "DETACH DELETE n" in query
-    assert "RETURN count(n) AS deleted" in query
+    assert "RETURN id" in query
     assert unsafe_field not in query
     assert parameters == {
         "filter_0_field": unsafe_field,
@@ -645,6 +702,7 @@ async def test_neo4j_delete_node_uses_parameterized_filter_and_returns_count() -
     }
     assert result.backend == BackendType.NEO4J
     assert result.affected_count == 2
+    assert result.ids == ["node-1", "node-2"]
 
 
 async def test_neo4j_delete_node_draft_sets_delete_at_without_detaching() -> None:
@@ -671,7 +729,7 @@ async def test_neo4j_delete_node_draft_sets_delete_at_without_detaching() -> Non
     ) in query
     assert "SET n.delete_at = datetime()" in query
     assert "DETACH DELETE" not in query
-    assert "RETURN count(n) AS deleted" in query
+    assert "RETURN n.id AS id" in query
     assert parameters == {
         "filter_0_field": "external_id",
         "filter_0_value": "node-1",
@@ -680,6 +738,7 @@ async def test_neo4j_delete_node_draft_sets_delete_at_without_detaching() -> Non
     }
     assert result.backend == BackendType.NEO4J
     assert result.affected_count == 2
+    assert result.ids == ["node-1", "node-2"]
 
 
 def test_node_projection_accepts_structured_fields_and_keeps_strings() -> None:

--- a/api/app/core/memory/storage/tests/test_outbox.py
+++ b/api/app/core/memory/storage/tests/test_outbox.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
+from app.core.memory.storage.models import NodeFilter, StorageReadResult
 from app.core.memory.storage.outbox.clients import (
     ProjectionClients, project_event,
 )
@@ -21,6 +22,10 @@ from app.core.memory.storage.provider.elasticsearch.client import ElasticClient
 
 def event():
     return ClaimedEvent(uuid4(), 1, "Statement", "node-1", "upsert", 0, uuid4())
+
+
+def read_result(items):
+    return StorageReadResult.from_items(items)
 
 
 def repository():
@@ -165,12 +170,12 @@ async def test_cleanup_small_batches_and_bound():
     assert repo.cleanup.await_count == 100
 
 
-@pytest.mark.parametrize("operation", ["upsert", "delete", "draft_delete"])
-async def test_current_source_wins_over_event_operation(operation):
+@pytest.mark.parametrize("operation", ["upsert", "draft_delete"])
+async def test_current_source_wins_for_upsert_and_draft_delete(operation):
     item = replace(event(), operation=operation)
     source = {"id": item.node_id, "text": "current", "embedding": [1.0, 2.0],
               "delete_at": datetime(2026, 1, 1)}
-    neo = Mock(get_node=AsyncMock(return_value=[source]))
+    neo = Mock(get_node=AsyncMock(return_value=read_result([source])))
     es = Mock(save_node=AsyncMock(), delete_node=AsyncMock())
     check = AsyncMock()
     await project_event(item, neo, es, check_claim=check)
@@ -181,17 +186,57 @@ async def test_current_source_wins_over_event_operation(operation):
     check.assert_awaited_once()
 
 
+async def test_delete_event_removes_document_without_rereading_source():
+    item = replace(event(), operation="delete")
+    neo = Mock(get_node=AsyncMock())
+    es = Mock(save_node=AsyncMock(), delete_node=AsyncMock())
+    check = AsyncMock()
+    await project_event(item, neo, es, check_claim=check)
+    neo.get_node.assert_not_awaited()
+    es.save_node.assert_not_awaited()
+    assert es.delete_node.await_args.kwargs == {"draft": False}
+    assert es.delete_node.await_args.args[1] == NodeFilter.eq("id", item.node_id)
+    check.assert_awaited_once()
+
+
+async def test_delete_event_skips_es_when_lease_is_lost():
+    item = replace(event(), operation="delete")
+    es = Mock(save_node=AsyncMock(), delete_node=AsyncMock())
+    with pytest.raises(ClaimLostError):
+        await project_event(
+            item,
+            Mock(get_node=AsyncMock()),
+            es,
+            check_claim=AsyncMock(side_effect=ClaimLostError()),
+        )
+    es.delete_node.assert_not_awaited()
+
+
 async def test_missing_source_physically_deletes():
-    neo = Mock(get_node=AsyncMock(return_value=[]))
+    neo = Mock(get_node=AsyncMock(return_value=read_result([])))
     es = Mock(save_node=AsyncMock(), delete_node=AsyncMock())
     await project_event(event(), neo, es, check_claim=AsyncMock())
     assert es.delete_node.await_args.kwargs == {"draft": False}
     es.save_node.assert_not_awaited()
 
 
-@pytest.mark.parametrize("nodes", [None, [{"id": "wrong"}], [{"id": "node-1"}] * 2, [None]])
-async def test_incomplete_or_ambiguous_read_never_deletes(nodes):
-    neo = Mock(get_node=AsyncMock(return_value=nodes))
+@pytest.mark.parametrize(
+    "result",
+    [
+        None,
+        [{"id": "node-1"}],
+        read_result([{"id": "wrong"}]),
+        read_result([{"id": "node-1"}] * 2),
+        StorageReadResult.model_construct(
+            backend=None,
+            items=[None],
+            total=1,
+        ),
+        StorageReadResult(items=[], total=1),
+    ],
+)
+async def test_incomplete_or_ambiguous_read_never_deletes(result):
+    neo = Mock(get_node=AsyncMock(return_value=result))
     es = Mock(save_node=AsyncMock(), delete_node=AsyncMock())
     with pytest.raises(ValueError):
         await project_event(event(), neo, es, check_claim=AsyncMock())
@@ -205,7 +250,7 @@ async def test_read_failure_and_lease_loss_never_write_es():
     with pytest.raises(TimeoutError):
         await project_event(event(), neo, es, check_claim=AsyncMock())
     neo.get_node.side_effect = None
-    neo.get_node.return_value = []
+    neo.get_node.return_value = read_result([])
     with pytest.raises(ClaimLostError):
         await project_event(event(), neo, es, check_claim=AsyncMock(side_effect=ClaimLostError()))
     es.save_node.assert_not_awaited()
@@ -219,7 +264,8 @@ def test_diagnostics_do_not_leak_error_details():
 async def test_each_retry_rereads_source_instead_of_reusing_document():
     repo, item = repository(), event()
     neo = Mock(get_node=AsyncMock(side_effect=[
-        [{"id": item.node_id, "text": "old"}], [{"id": item.node_id, "text": "new"}],
+        read_result([{"id": item.node_id, "text": "old"}]),
+        read_result([{"id": item.node_id, "text": "new"}]),
     ]))
     es = Mock(save_node=AsyncMock(side_effect=[TimeoutError(), None]))
 
@@ -244,7 +290,10 @@ async def test_client_cleanup_closes_both_even_on_error():
 
 async def test_clients_reuse_index_initialization_and_own_redis_pool(monkeypatch):
     clients = ProjectionClients(30)
-    clients.neo4j = Mock(get_node=AsyncMock(return_value=[]), close=AsyncMock())
+    clients.neo4j = Mock(
+        get_node=AsyncMock(return_value=read_result([])),
+        close=AsyncMock(),
+    )
     clients.elastic = Mock(delete_node=AsyncMock(), close=AsyncMock())
     ensure = AsyncMock()
     redis = Mock(return_value=Mock(aclose=AsyncMock()))
@@ -261,10 +310,10 @@ async def test_clients_reuse_index_initialization_and_own_redis_pool(monkeypatch
 async def test_clients_use_provider_elastic_client_without_sdk_retries(monkeypatch):
     clients = ProjectionClients(7)
     clients.neo4j = Mock(
-        get_node=AsyncMock(return_value=[{
+        get_node=AsyncMock(return_value=read_result([{
             "id": "node-1",
             "delete_at": datetime(2026, 1, 1),
-        }]),
+        }])),
         close=AsyncMock(),
     )
     transport = Mock(

--- a/api/app/core/memory/storage/tests/test_write_router.py
+++ b/api/app/core/memory/storage/tests/test_write_router.py
@@ -1,0 +1,308 @@
+"""节点主写、关系主写与 outbox 入队的路由契约。"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.core.memory.storage.enums import (
+    BackendType,
+    MemoryNodeType,
+    MemoryRelationshipType,
+    StorageBackendType,
+)
+from app.core.memory.storage.models import (
+    NodeFilter,
+    RelationshipFilter,
+    StorageWriteResult,
+)
+from app.core.memory.storage.outbox.types import OutboxOperation
+from app.core.memory.storage.provider.factory import BackendFactory
+from app.core.memory.storage.router.write_router import WriteRouter
+from app.core.memory.storage.service import MemoryStorageService
+
+LABEL = MemoryNodeType.STATEMENT
+WRITE_DIMENSIONS = (
+    StorageBackendType.GRAPH_MAIN_WRITE,
+    StorageBackendType.TEXT_MAIN_WRITE,
+    StorageBackendType.VECTOR_MAIN_WRITE,
+)
+
+
+def write_result(*ids: str) -> StorageWriteResult:
+    return StorageWriteResult(
+        backend=BackendType.NEO4J,
+        affected_count=len(ids),
+        ids=list(ids),
+    )
+
+
+def neo4j_client(result: StorageWriteResult | None = None):
+    result = result or write_result()
+    return Mock(
+        save_node=AsyncMock(return_value=result),
+        update_node=AsyncMock(return_value=result),
+        delete_node=AsyncMock(return_value=result),
+        save_relationship=AsyncMock(return_value=result),
+        update_relationship=AsyncMock(return_value=result),
+        delete_relationship=AsyncMock(return_value=result),
+    )
+
+
+def factory(client):
+    instance = BackendFactory()
+    instance._clients = {
+        BackendType.NEO4J: client,
+        BackendType.ELASTIC: Mock(name="elastic-must-not-be-written"),
+    }
+    return instance
+
+
+def router(client, repository):
+    return WriteRouter(factory(client), outbox_repository=repository)
+
+
+def repository():
+    return Mock(
+        enqueue_many=AsyncMock(
+            side_effect=lambda events: [event.id for event in events]
+        )
+    )
+
+
+def enqueued(repo):
+    return [
+        (item.label, item.node_id, item.operation)
+        for call in repo.enqueue_many.await_args_list
+        for item in call.args[0]
+    ]
+
+
+@pytest.mark.parametrize("dimension", WRITE_DIMENSIONS)
+def test_all_write_dimensions_route_to_neo4j(dimension):
+    client = neo4j_client()
+    assert factory(client).get_write_client(LABEL, dimension) is client
+
+
+@pytest.mark.parametrize(
+    "dimension",
+    [StorageBackendType.GRAPH_MAIN_READ, StorageBackendType.TEXT_NODE],
+)
+def test_non_write_dimensions_are_rejected(dimension):
+    with pytest.raises(ValueError):
+        factory(neo4j_client()).get_write_client(LABEL, dimension)
+
+
+async def test_save_node_returns_provider_result_and_enqueues_upsert():
+    expected = write_result("node-1")
+    client, repo = neo4j_client(expected), repository()
+    data = {"id": "node-1", "text": "hello"}
+
+    result = await router(client, repo).save_node(LABEL, data)
+
+    assert result is expected
+    client.save_node.assert_awaited_once_with(LABEL, data)
+    assert enqueued(repo) == [(LABEL, "node-1", OutboxOperation.UPSERT)]
+
+
+async def test_update_node_uses_ids_returned_by_same_write():
+    expected = write_result("node-1", "node-2")
+    client, repo = neo4j_client(expected), repository()
+    node_filter = NodeFilter.eq("end_user_id", "user-1")
+    data = {"text": "updated"}
+
+    result = await router(client, repo).update_node(LABEL, data, node_filter)
+
+    assert result is expected
+    client.update_node.assert_awaited_once_with(LABEL, data, node_filter)
+    assert enqueued(repo) == [
+        (LABEL, "node-1", OutboxOperation.UPSERT),
+        (LABEL, "node-2", OutboxOperation.UPSERT),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("draft", "operation"),
+    [
+        (False, OutboxOperation.DELETE),
+        (True, OutboxOperation.DRAFT_DELETE),
+    ],
+)
+async def test_delete_node_enqueues_operation_for_provider_ids(draft, operation):
+    expected = write_result("node-1", "node-2")
+    client, repo = neo4j_client(expected), repository()
+    node_filter = NodeFilter.eq("end_user_id", "user-1")
+
+    result = await router(client, repo).delete_node(
+        LABEL,
+        node_filter,
+        draft=draft,
+    )
+
+    assert result is expected
+    client.delete_node.assert_awaited_once_with(LABEL, node_filter, draft)
+    assert enqueued(repo) == [
+        (LABEL, "node-1", operation),
+        (LABEL, "node-2", operation),
+    ]
+
+
+@pytest.mark.parametrize("method", ["save_node", "update_node", "delete_node"])
+async def test_empty_write_result_creates_no_event(method):
+    expected = write_result()
+    client, repo = neo4j_client(expected), repository()
+    write_router = router(client, repo)
+    node_filter = NodeFilter.eq("id", "missing")
+    arguments = {
+        "save_node": (LABEL, {"id": "missing"}),
+        "update_node": (LABEL, {"text": "x"}, node_filter),
+        "delete_node": (LABEL, node_filter),
+    }
+
+    assert await getattr(write_router, method)(*arguments[method]) is expected
+    repo.enqueue_many.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        StorageWriteResult(affected_count=1),
+        StorageWriteResult(affected_count=2, ids=["node-1"]),
+        StorageWriteResult(affected_count=2, ids=["node-1", "node-1"]),
+    ],
+)
+async def test_incomplete_or_duplicate_provider_ids_never_enqueue(result):
+    client, repo = neo4j_client(result), repository()
+
+    with pytest.raises(
+        ValueError,
+        match="one unique id per affected node",
+    ):
+        await router(client, repo).save_node(LABEL, {"id": "node-1"})
+
+    client.save_node.assert_awaited_once()
+    repo.enqueue_many.assert_not_awaited()
+
+
+async def test_save_relationship_uses_neo4j_and_creates_no_event():
+    expected = write_result("edge-1")
+    client, repo = neo4j_client(expected), repository()
+    data = {"id": "edge-1", "statement": "s"}
+
+    result = await router(client, repo).save_relationship(
+        MemoryRelationshipType.RELATES_TO,
+        "node-1",
+        "node-2",
+        data,
+    )
+
+    assert result is expected
+    client.save_relationship.assert_awaited_once_with(
+        MemoryRelationshipType.RELATES_TO,
+        "node-1",
+        "node-2",
+        data,
+    )
+    repo.enqueue_many.assert_not_awaited()
+
+
+async def test_update_relationship_uses_neo4j_and_creates_no_event():
+    expected = write_result("edge-1")
+    client, repo = neo4j_client(expected), repository()
+    rel_filter = RelationshipFilter(
+        relationship=NodeFilter.eq("id", "edge-1")
+    )
+    data = {"weight": 0.9}
+
+    result = await router(client, repo).update_relationship(
+        MemoryRelationshipType.RELATES_TO,
+        data,
+        rel_filter,
+    )
+
+    assert result is expected
+    client.update_relationship.assert_awaited_once_with(
+        MemoryRelationshipType.RELATES_TO,
+        data,
+        rel_filter,
+    )
+    repo.enqueue_many.assert_not_awaited()
+
+
+async def test_delete_relationship_uses_neo4j_and_creates_no_event():
+    expected = write_result("edge-1")
+    client, repo = neo4j_client(expected), repository()
+    rel_filter = RelationshipFilter(
+        relationship=NodeFilter.eq("id", "edge-1")
+    )
+
+    result = await router(client, repo).delete_relationship(
+        MemoryRelationshipType.RELATES_TO,
+        rel_filter,
+    )
+
+    assert result is expected
+    client.delete_relationship.assert_awaited_once_with(
+        MemoryRelationshipType.RELATES_TO,
+        rel_filter,
+    )
+    repo.enqueue_many.assert_not_awaited()
+
+
+async def test_enqueue_failure_surfaces_after_primary_commit():
+    from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+
+    client = neo4j_client(write_result("node-1"))
+    repo = Mock(enqueue_many=AsyncMock(side_effect=RuntimeError("secret SQL")))
+
+    with pytest.raises(OutboxEnqueueError) as caught:
+        await router(client, repo).save_node(LABEL, {"id": "node-1"})
+
+    client.save_node.assert_awaited_once()
+    assert caught.value.primary_committed is True
+    assert "secret" not in str(caught.value)
+
+
+RELATIONSHIP_FILTER = RelationshipFilter(
+    relationship=NodeFilter.eq("id", "edge-1")
+)
+
+WRITE_DELEGATIONS = [
+    ("save_node", (LABEL, {"id": "node-1"})),
+    ("update_node", (LABEL, {"text": "x"}, NodeFilter.eq("id", "node-1"))),
+    ("delete_node", (LABEL, NodeFilter.eq("id", "node-1"), True)),
+    (
+        "save_relationship",
+        (
+            MemoryRelationshipType.RELATES_TO,
+            "node-1",
+            "node-2",
+            {"id": "edge-1"},
+        ),
+    ),
+    (
+        "update_relationship",
+        (
+            MemoryRelationshipType.RELATES_TO,
+            {"weight": 0.9},
+            RELATIONSHIP_FILTER,
+        ),
+    ),
+    (
+        "delete_relationship",
+        (
+            MemoryRelationshipType.RELATES_TO,
+            RELATIONSHIP_FILTER,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("method,args", WRITE_DELEGATIONS)
+async def test_service_write_methods_delegate_to_write_router(method, args):
+    service = MemoryStorageService(factory(neo4j_client()))
+    expected = write_result("node-1")
+    delegate = AsyncMock(return_value=expected)
+    setattr(service._write_router, method, delegate)
+
+    assert await getattr(service, method)(*args) is expected
+    delegate.assert_awaited_once_with(*args)


### PR DESCRIPTION
## Sourcery 总结

引入集中式写入路由，将节点更改提交到 Neo4j，为 Elasticsearch 投影发布可靠的 outbox 事件，并确保关系写入仅限于图后端。

新功能：
- 添加用于节点和关系持久化的写入路由器及服务 API。
- 为节点 upsert、软删除和物理删除加入 outbox 事件，同时确保关系写入仅发送到 Neo4j。
- 将物理删除事件直接投影到 Elasticsearch，并为其他操作保留权威源读取。

错误修复：
- 确保节点写入结果返回受影响的 ID，以便为每个受影响的节点生成 outbox 事件。
- 防止将不明确或无效的权威读取转换为 Elasticsearch 删除操作。

增强功能：
- 在加入事件队列之前，验证写入结果是否为每个受影响的节点包含一个唯一 ID。
- 从 Neo4j 写入操作中返回受影响的关系和节点 ID。

测试：
- 增加对写入路由、outbox 事件生成、关系写入行为、受影响 ID 处理以及删除事件投影的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce centralized write routing that commits node changes to Neo4j, publishes reliable outbox events for Elasticsearch projection, and keeps relationship writes confined to the graph backend.

New Features:
- Add a write router and service APIs for node and relationship persistence.
- Enqueue outbox events for node upserts, soft deletes, and physical deletes while keeping relationship writes Neo4j-only.
- Project physical delete events directly to Elasticsearch and preserve authoritative source reads for other operations.

Bug Fixes:
- Ensure node write results return affected IDs so outbox events are generated for every affected node.
- Prevent ambiguous or invalid authoritative reads from being converted into Elasticsearch deletions.

Enhancements:
- Validate write results contain one unique ID per affected node before enqueueing events.
- Return affected relationship and node IDs from Neo4j write operations.

Tests:
- Add coverage for write routing, outbox event generation, relationship write behavior, affected-ID handling, and delete-event projection.

</details>