### PR TITLE
feat(workspace): add is_deprecated field for model option

### DIFF
--- a/api/app/schemas/workspace_schema.py
+++ b/api/app/schemas/workspace_schema.py
@@ -244,6 +244,7 @@ class WorkspaceModelOptionItem(BaseModel):
     capability: list[str] = Field(default_factory=list)
     logo: str | None = None
     is_public: bool = False
+    is_deprecated: bool = False
 
 
 class WorkspaceDefaultModelPresetUpdate(BaseModel):

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.config.default_ontology_initializer import DefaultOntologyInitializer
 from app.core.config import settings
@@ -66,12 +66,18 @@ def _serialize_model_option(model: ModelConfig) -> dict:
         "capability": [getattr(item, "value", item) for item in (model.capability or [])],
         "logo": model.logo,
         "is_public": bool(model.is_public),
+        # 弃用标记存放在基础模型（model_bases）上，与 ModelConfig schema 的派生方式保持一致
+        "is_deprecated": bool(
+            getattr(model, "model_base", None) is not None
+            and getattr(model.model_base, "is_deprecated", False)
+        ),
     }
 
 
 def _get_accessible_workspace_models(db: Session, tenant_id: uuid.UUID) -> list[ModelConfig]:
     return (
         db.query(ModelConfig)
+        .options(joinedload(ModelConfig.model_base))
         .filter(ModelConfig.is_active.is_(True))
         .filter(
             or_(
@@ -89,6 +95,7 @@ def _get_accessible_workspace_models(db: Session, tenant_id: uuid.UUID) -> list[
 def _get_public_speedbear_models(db: Session) -> list[ModelConfig]:
     return (
         db.query(ModelConfig)
+        .options(joinedload(ModelConfig.model_base))
         .filter(ModelConfig.is_active.is_(True))
         .filter(ModelConfig.provider == ModelProvider.SPEEDBEAR)
         .filter(ModelConfig.is_public.is_(True))
@@ -155,6 +162,7 @@ def _build_workspace_preset_response(db: Session, preset: WorkspaceDefaultModelP
     model_ids = [model_id for model_id in slot_to_model_id.values() if model_id]
     models = (
         db.query(ModelConfig)
+        .options(joinedload(ModelConfig.model_base))
         .filter(ModelConfig.id.in_(model_ids))
         .all()
     )


### PR DESCRIPTION
1. Add is_deprecated field to WorkspaceModelOptionItem
2. Get deprecation status from the associated model_base when serializing model options
3. Add joinedload to preload the model_base relationship for related queries to optimize queries

## Sourcery 摘要

在工作区模型选项中公开模型弃用状态，并预加载相关模型元数据，以实现高效响应。

新功能：
- 通过工作区模型选项响应公开模型弃用状态。

增强功能：
- 在检索工作区模型选项和预设时预加载相关基础模型，以支持高效的弃用状态序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose model deprecation status in workspace model options and preload the associated model metadata for efficient responses.

New Features:
- Expose model deprecation status through workspace model option responses.

Enhancements:
- Preload associated base models when retrieving workspace model options and presets to support efficient deprecation status serialization.

</details>