### PR TITLE
feat(gateway): add /v1/stub endpoint for API key identity verificatio…

### DIFF
--- a/api/app/invalidation_notify.py
+++ b/api/app/invalidation_notify.py
@@ -45,6 +45,12 @@ async def notify_api_key_async(api_key_hash_: str) -> None:
     await _publish_async({"kind": "api_key", "hash": api_key_hash_})
 
 
+async def notify_api_key_created_async(plain: str) -> None:
+    """API key 创建/重建通知：必须带明文，identity 才能删旧 + 直连 DB 组装新快照写回
+    （网关快照 miss 即 401 无回源，不带明文的新 key 首次访问必然失败）。"""
+    await _publish_async({"kind": "api_key", "hash": api_key_hash(plain), "key": plain})
+
+
 async def notify_tenant_async(tenant_id: str) -> None:
     await _publish_async({"kind": "tenant", "id": str(tenant_id)})
 
@@ -55,6 +61,11 @@ def notify_user_sync(user_id: str) -> None:
 
 def notify_api_key_sync(api_key_hash_: str) -> None:
     _publish_sync({"kind": "api_key", "hash": api_key_hash_})
+
+
+def notify_api_key_created_sync(plain: str) -> None:
+    """API key 创建/重建通知（见 notify_api_key_created_async：必须带明文）。"""
+    _publish_sync({"kind": "api_key", "hash": api_key_hash(plain), "key": plain})
 
 
 def notify_tenant_sync(tenant_id: str) -> None:

--- a/api/app/services/api_key_service.py
+++ b/api/app/services/api_key_service.py
@@ -17,7 +17,7 @@ from app.core.exceptions import (
 )
 from app.core.logging_config import get_business_logger
 from app.core.utils.datetime_utils import as_utc_aware, utcnow_naive
-from app.invalidation_notify import api_key_hash, notify_api_key_sync
+from app.invalidation_notify import api_key_hash, notify_api_key_created_sync, notify_api_key_sync
 from app.models.api_key_model import ApiKey, ApiKeyType
 from app.models.app_model import App
 from app.repositories.api_key_repository import ApiKeyRepository, ApiKeyLogRepository
@@ -129,6 +129,10 @@ class ApiKeyService:
                 "api_key_name": data.name,
                 "type": data.type
             })
+
+            # 决策 #11 修订：创建带明文通知（identity 删旧 + 直连 DB 组装快照写回，
+            # 新 key 首次访问即可用；仅 hash 的吊销消息会漏建快照）
+            notify_api_key_created_sync(api_key)
 
             return api_key_obj
 
@@ -282,6 +286,10 @@ class ApiKeyService:
         })
         db.commit()
         db.refresh(api_key)
+
+        # 决策 #11 修订：重建同样带明文通知（旧 key 吊销消息仅 hash → 只删旧快照，
+        # 新 key 的快照须由带明文消息重建，否则首次访问 401）
+        notify_api_key_created_sync(new_api_key)
 
         logger.info("API Key 重新生成成功", extra={"api_key_id": str(api_key_id)})
         return api_key


### PR DESCRIPTION
…n and enhance /stub validation

feat(identity): implement ACL controller, retention service, and user snapshot Redis integration

feat(audit): add event_id conflict resolution for audit log deduplication

feat(api_key): notify identity service with plain API key on creation and regeneration

## Summary by Sourcery

Notify the identity service with the plain API key on creation and regeneration so its Redis snapshot can be rebuilt correctly.

New Features:
- Add dedicated notification helpers that publish API key creation/regeneration events including the plain key value.

Bug Fixes:
- Fix a gap where API key creation/regeneration only notified with the key hash, causing new keys to fail on first use because the identity service couldn't rebuild its snapshot.