### PR TITLE
feat(memory): add process-wide storage service and node query helpers

### DIFF
--- a/api/app/core/logging_config.py
+++ b/api/app/core/logging_config.py
@@ -147,8 +147,11 @@ class LoggingConfig:
             neo4j_logger = logging.getLogger(neo4j_logger_name)
             neo4j_logger.addFilter(neo4j_filter)
 
-        # 压制 httpx / httpcore 的请求级日志（大量 HTTP Request: POST ... 噪音）
-        for noisy_logger in ["httpx", "httpcore", "httpcore.http11", "httpcore.connection"]:
+        # 压制 httpx / httpcore / elastic_transport 的请求级日志（大量 HTTP Request: POST ... 噪音）
+        for noisy_logger in [
+            "httpx", "httpcore", "httpcore.http11", "httpcore.connection",
+            "elastic_transport", "elastic_transport.transport",
+        ]:
             logging.getLogger(noisy_logger).setLevel(logging.WARNING)
         
         # 创建格式化器

--- a/api/app/core/memory/exceptions.py
+++ b/api/app/core/memory/exceptions.py
@@ -134,7 +134,7 @@ class MemoryRetrievalBusinessError(Exception):
     def model_call_failed(
         cls,
         stage: MemoryRetrievalStage,
-        cause: Exception,
+        cause: BaseException,
         *,
         model_type: MemoryModelType,
         impact: MemoryRetrievalImpact = MemoryRetrievalImpact.INCOMPLETE,

--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -5,6 +5,7 @@ from typing import Self
 from pydantic import BaseModel, Field, field_serializer, ConfigDict, computed_field
 
 from app.core.memory.enums import Neo4jNodeType, StorageType
+from app.core.memory.storage.enums import MemoryNodeLabel
 from app.core.memory.retrieval_trace.models import (
     RetrievalExecutionTrace,
     RetrievalScoreTrace,
@@ -41,7 +42,7 @@ class MemoryContext(BaseModel):
 
 
 class Memory(BaseModel):
-    source: Neo4jNodeType = Field(...)
+    source: Neo4jNodeType | MemoryNodeLabel = Field(...)
     score: float = Field(default=0.0)
     content: str = Field(default="")
     data: dict = Field(default_factory=dict)

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -30,6 +30,7 @@ from app.core.memory.retrieval_trace.stage_projection import (
     project_relation_items,
     project_result_items,
 )
+from app.core.memory.storage.enums import MemoryNodeType
 from app.core.models import RedBearLLM
 from app.core.utils.datetime_utils import utcnow, utcnow_naive
 from app.db import get_async_db_context
@@ -720,10 +721,10 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         """仅全文检索模式：不做 embedding、关系检索、query 拆分、摘要生成。"""
         if includes is None:
             includes = [
-                Neo4jNodeType.CHUNK,
-                Neo4jNodeType.STATEMENT,
-                Neo4jNodeType.EXTRACTEDENTITY,
-                Neo4jNodeType.DIALOGUE,
+                MemoryNodeType.CHUNK,
+                MemoryNodeType.STATEMENT,
+                MemoryNodeType.EXTRACTED_ENTITY,
+                MemoryNodeType.DIALOGUE,
             ]
         meta_task = asyncio.ensure_future(self._user_meta())
         search_service = await self._get_search_service(includes, need_embedder=False, need_llm=False)

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -12,6 +12,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.memory.enums import Neo4jNodeType, TripletPredicate, StorageType
+from app.core.memory.exceptions import (
+    MemoryModelType,
+    MemoryRetrievalBusinessError,
+    MemoryRetrievalImpact,
+    MemoryRetrievalStage,
+)
 from app.core.memory.models.service_models import (
     Memory,
     MemorySearchResult,
@@ -20,13 +26,11 @@ from app.core.memory.models.service_models import (
     EntityPair
 )
 from app.core.memory.models.service_models import MemoryContext
-from app.core.memory.exceptions import (
-    MemoryModelType,
-    MemoryRetrievalBusinessError,
-    MemoryRetrievalImpact,
-    MemoryRetrievalStage,
-)
 from app.core.memory.prompt import prompt_manager
+from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
+from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
+from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
+    make_user_source_lookup_tool
 from app.core.memory.retrieval_trace.models import (
     RetrievalExecutionTrace,
     build_score_trace,
@@ -34,10 +38,10 @@ from app.core.memory.retrieval_trace.models import (
     finite_or_none,
     normalized_keyword_score,
 )
-from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
-from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
-from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
-    make_user_source_lookup_tool
+from app.core.memory.storage.enums import MemoryNodeType, MemoryNodeLabel
+from app.core.memory.storage.models import NodeFilter, StorageReadResult, FilterLogic, FilterCondition, FilterOperator
+from app.core.memory.storage.models.dto import StorageItem
+from app.core.memory.storage.service import get_storage_service
 from app.core.models import RedBearEmbeddings, RedBearLLM, RedBearRerank
 from app.core.models.llm import StructResponse
 from app.core.rag.nlp.search import knowledge_retrieval
@@ -92,12 +96,12 @@ class Neo4jSearchService:
         self.includes = includes
         if includes is None:
             self.includes = [
-                Neo4jNodeType.STATEMENT,
-                Neo4jNodeType.CHUNK,
-                Neo4jNodeType.EXTRACTEDENTITY,
-                Neo4jNodeType.MEMORYSUMMARY,
-                Neo4jNodeType.PERCEPTUAL,
-                Neo4jNodeType.DIALOGUE,
+                MemoryNodeType.STATEMENT,
+                MemoryNodeType.CHUNK,
+                MemoryNodeType.EXTRACTED_ENTITY,
+                MemoryNodeType.MEMORY_SUMMARY,
+                MemoryNodeType.PERCEPTUAL,
+                MemoryNodeType.DIALOGUE,
                 # Neo4jNodeType.COMMUNITY
             ]
 
@@ -105,31 +109,31 @@ class Neo4jSearchService:
         self.entity_search_tool = make_entity_search_tool(self.ctx)
         self.user_source_lookup_tool = make_user_source_lookup_tool(self.ctx)
         self._user_source_looked_up_ids = set()
+        self.service = get_storage_service()
 
     def _build_score_sidecar(
             self,
-            keyword_results: dict,
-            embedding_results: dict,
-    ) -> dict[tuple[Neo4jNodeType, str], dict]:
+            keyword_results: StorageReadResult,
+            embedding_results: StorageReadResult,
+    ) -> dict[tuple[MemoryNodeLabel | None, str], dict]:
         """旁路保留关键词、语义分数，不修改原始召回记录和排序。"""
-        sidecar: dict[tuple[Neo4jNodeType, str], dict] = {}
-        for node_type in self.includes:
-            for record in keyword_results.get(node_type, []):
-                node_id = str(record.get("id") or "")
-                if not node_id:
-                    continue
-                item = sidecar.setdefault((node_type, node_id), {})
-                item["keyword_hit"] = True
-                item["keyword_score"] = normalized_keyword_score(
-                    record.get("score"), self.fulltext_score_threshold
-                )
-            for record in embedding_results.get(node_type, []):
-                node_id = str(record.get("id") or "")
-                if not node_id:
-                    continue
-                item = sidecar.setdefault((node_type, node_id), {})
-                item["semantic_hit"] = True
-                item["semantic_score"] = finite_or_none(record.get("score")) or 0.0
+        sidecar: dict[tuple[MemoryNodeLabel | None, str], dict] = {}
+        for record in keyword_results.items:
+            node_id = str(record.data.get("id") or "")
+            if not node_id:
+                continue
+            item = sidecar.setdefault((record.label, node_id), {})
+            item["keyword_hit"] = True
+            item["keyword_score"] = normalized_keyword_score(
+                record.data.get("score"), self.fulltext_score_threshold
+            )
+        for record in embedding_results.items:
+            node_id = str(record.data.get("id") or "")
+            if not node_id:
+                continue
+            item = sidecar.setdefault((record.label, node_id), {})
+            item["semantic_hit"] = True
+            item["semantic_score"] = finite_or_none(record.data.get("score")) or 0.0
         for item in sidecar.values():
             item["fusion_score"] = diagnostic_fusion_score(
                 item.get("keyword_score", 0.0),
@@ -142,7 +146,19 @@ class Neo4jSearchService:
             self,
             query: str,
             limit: int
-    ):
+    ) -> StorageReadResult:
+        return await self.service.search_by_fulltext(
+            labels=self.includes,
+            node_filter=NodeFilter(
+                logic=FilterLogic.AND,
+                conditions=(
+                    FilterCondition(field="end_user_id", operator=FilterOperator.EQ, value=self.ctx.end_user_id),
+                    FilterCondition(field="delete_at", operator=FilterOperator.EXISTS, value=False)
+                )
+            ),
+            text=query,
+            pre_limit=limit
+        )
         return await search_graph(
             connector=self.connector,
             query=query,
@@ -151,7 +167,24 @@ class Neo4jSearchService:
             include=self.includes
         )
 
-    async def _embedding_search(self, query, limit):
+    async def _embedding_search(
+            self,
+            query: str,
+            limit: int
+    ) -> StorageReadResult:
+        query_embed = await self.embedder.aembed_query(query)
+        return await self.service.search_by_embedding(
+            labels=self.includes,
+            node_filter=NodeFilter(
+                logic=FilterLogic.AND,
+                conditions=(
+                    FilterCondition(field="end_user_id", operator=FilterOperator.EQ, value=self.ctx.end_user_id),
+                    FilterCondition(field="delete_at", operator=FilterOperator.EXISTS, value=False)
+                )
+            ),
+            embed=query_embed,
+            pre_limit=limit
+        )
         return await search_graph_by_embedding(
             connector=self.connector,
             embedder_client=self.embedder,
@@ -163,99 +196,103 @@ class Neo4jSearchService:
 
     def _rerank(
             self,
-            keyword_results: list[dict],
-            embedding_results: list[dict],
+            keyword_results: StorageReadResult,
+            embedding_results: StorageReadResult,
             limit: int,
-    ) -> list[dict]:
-        keyword_results = self._normalize_kw_scores(keyword_results)
+    ) -> StorageReadResult:
+        keyword_items = self._normalize_kw_scores(keyword_results.items)
 
         kw_norm_map = {}
-        for item in keyword_results:
-            item_id = item["id"]
-            kw_norm_map[item_id] = float(item.get("normalized_kw_score", 0))
+        for item in keyword_items:
+            item_id = item.data["id"]
+            kw_norm_map[item_id] = float(item.data.get("normalized_kw_score", 0))
 
         emb_norm_map = {}
-        for item in embedding_results:
-            item_id = item["id"]
-            emb_norm_map[item_id] = float(item.get("score", 0))
+        for item in embedding_results.items:
+            item_id = item.data["id"]
+            emb_norm_map[item_id] = float(item.data.get("score", 0))
 
-        combined = {}
-        for item in keyword_results:
-            item_id = item["id"]
-            combined[item_id] = item.copy()
+        combined: dict[str, dict] = {}
+        label_map: dict[str, MemoryNodeLabel | None] = {}
+        for item in keyword_items:
+            item_id = item.data["id"]
+            combined[item_id] = item.data.copy()
             combined[item_id]["kw_score"] = kw_norm_map.get(item_id, 0)
             combined[item_id]["embedding_score"] = emb_norm_map.get(item_id, 0)
+            label_map[item_id] = item.label
 
-        for item in embedding_results:
-            item_id = item["id"]
+        for item in embedding_results.items:
+            item_id = item.data["id"]
             if item_id in combined:
                 combined[item_id]["embedding_score"] = emb_norm_map.get(item_id, 0)
             else:
-                combined[item_id] = item.copy()
+                combined[item_id] = item.data.copy()
                 combined[item_id]["kw_score"] = kw_norm_map.get(item_id, 0)
                 combined[item_id]["embedding_score"] = emb_norm_map.get(item_id, 0)
+                label_map[item_id] = item.label
 
         for item in combined.values():
-            item_id = item["id"]
-            kw = float(combined[item_id].get("kw_score", 0) or 0)
-            emb = float(combined[item_id].get("embedding_score", 0) or 0)
+            kw = float(item.get("kw_score", 0) or 0)
+            emb = float(item.get("embedding_score", 0) or 0)
             base = self.alpha * emb + (1 - self.alpha) * kw
-            combined[item_id]["content_score"] = base + min(1 - base, 0.1 * kw * emb)
-        results = sorted(combined.values(), key=lambda x: x["content_score"], reverse=True)
+            item["content_score"] = base + min(1 - base, 0.1 * kw * emb)
+
+        results = sorted(
+            combined.values(), key=lambda x: x["content_score"], reverse=True
+        )
         # results = [
         #     res for res in results
         #     if res["content_score"] > self.content_score_threshold
         # ]
         results = results[:limit]
 
+        items = [
+            StorageItem(label=label_map.get(merged["id"]), data=merged)
+            for merged in results
+        ]
+
         logger.debug(
-            f"[MemorySearch] rerank: merged={len(combined)}, after_threshold={len(results)} "
+            f"[MemorySearch] rerank: merged={len(combined)}, after_threshold={len(items)} "
             f"(alpha={self.alpha})"
         )
-        return results
+        return StorageReadResult(items=items, total=len(items))
 
     async def _hybrid_search_with_model_rerank(
             self,
-            kw_results: dict,
-            emb_results: dict,
+            kw_results: StorageReadResult,
+            emb_results: StorageReadResult,
             query: str,
             limit: int,
-            score_sidecar: dict[tuple[Neo4jNodeType, str], dict],
+            score_sidecar: dict[tuple[MemoryNodeLabel | None, str], dict],
     ) -> tuple[list[Memory], str, list[str]]:
-        seen: dict[str, dict] = {}
-        for node_type in self.includes:
-            for record in kw_results.get(node_type, []):
-                rid = record.get("id", "")
-                if rid and rid not in seen:
-                    record["_node_type"] = node_type
-                    record["_source"] = "keyword"
-                    seen[rid] = record
-            for record in emb_results.get(node_type, []):
-                rid = record.get("id", "")
-                if rid and rid not in seen:
-                    record["_node_type"] = node_type
-                    record["_source"] = "embedding"
-                    seen[rid] = record
+        seen: dict[str, StorageItem] = {}
+        for record in kw_results.items:
+            rid = record.data.get("id", "")
+            if rid and rid not in seen:
+                seen[rid] = record
+        for record in emb_results.items:
+            rid = record.data.get("id", "id")
+            if rid and rid not in seen:
+                seen[rid] = record
 
         if not seen:
             return [], "skipped", []
 
         memories: list[Memory] = []
         for record in seen.values():
-            node_type = record.pop("_node_type")
-            memory = data_builder_factory(node_type, record)
-            score_info = score_sidecar.get((node_type, str(memory.id)), {})
+            memory = data_builder_factory(record.label, record.data)
+            score_info = score_sidecar.get((record.label, str(memory.id)), {})
             result_memory = Memory(
                 score=memory.score,
                 content=memory.content,
                 data=memory.data,
-                source=node_type,
+                source=record.label,
                 query=query,
                 id=memory.id,
             )
             result_memory.retrieval_trace = build_score_trace(
                 node_id=result_memory.id,
-                node_type=node_type.value,
+                node_type=record.label.value,
                 final_score=result_memory.score,
                 rank_basis="input_order",
                 keyword_hit=bool(score_info.get("keyword_hit")),
@@ -268,6 +305,7 @@ class Neo4jSearchService:
             memories.append(result_memory)
 
         rerank_applied = False
+        documents = []
         try:
             documents = [
                 Document(
@@ -327,6 +365,7 @@ class Neo4jSearchService:
                 f"[Neo4jSearch] Model rerank failed, falling back to content_score: {e}",
                 exc_info=True,
             )
+            index_to_score = {}
 
         degraded_reasons: list[str] = []
         rerank_status = "completed" if rerank_applied else "degraded"
@@ -347,15 +386,12 @@ class Neo4jSearchService:
             )
         return memories, rerank_status, degraded_reasons
 
-    # WARNING: 下方 sigmoid 归一化公式与 retrieval_trace/models.py 的
-    # normalized_keyword_score 互为副本（此处是公式源头，驱动真实排序），
-    # _rerank 中的融合公式同理对应 diagnostic_fusion_score。改动任一侧前先同步另一侧。
-    def _normalize_kw_scores(self, items: list[dict]) -> list[dict]:
+    def _normalize_kw_scores(self, items: list[StorageItem]) -> list[StorageItem]:
         if not items:
-            return items
-        scores = [float(it.get("score", 0) or 0) for it in items]
+            return []
+        scores = [float(it.data.get("score", 0) or 0) for it in items]
         for it, s in zip(items, scores):
-            it[f"normalized_kw_score"] = 1 / (1 + math.exp(-(s - self.fulltext_score_threshold) / 2)) if s else 0
+            it.data[f"normalized_kw_score"] = 1 / (1 + math.exp(-(s - self.fulltext_score_threshold) / 2)) if s else 0
         return items
 
     async def keyword_search(
@@ -368,13 +404,7 @@ class Neo4jSearchService:
             self.connector = connector
             kw_results = await self._keyword_search(query, limit)
 
-        all_records = []
-        for node_type in self.includes:
-            for record in kw_results.get(node_type, []):
-                record["_node_type"] = node_type
-                all_records.append(record)
-
-        if not all_records:
+        if kw_results.total == 0:
             return MemorySearchResult(
                 memories=[],
                 execution_trace=RetrievalExecutionTrace(
@@ -384,34 +414,33 @@ class Neo4jSearchService:
                 ),
             )
 
-        all_records = self._normalize_kw_scores(all_records)
+        all_records = self._normalize_kw_scores(kw_results.items)
 
         for r in all_records:
-            cs = float(r.get("normalized_kw_score", 0))
-            r["content_score"] = cs
-            r["score"] = cs
+            cs = float(r.data.get("normalized_kw_score", 0))
+            r.data["content_score"] = cs
+            r.data["score"] = cs
 
-        all_records.sort(key=lambda x: x["score"], reverse=True)
+        all_records.sort(key=lambda x: x.data["score"], reverse=True)
 
         memories = []
         for record in all_records[:limit]:
-            node_type = record.pop("_node_type")
-            memory = data_builder_factory(node_type, record)
+            memory = data_builder_factory(record.label, record.data)
             result_memory = Memory(
                 score=memory.score,
                 content=memory.content,
                 data=memory.data,
-                source=node_type,
+                source=record.label,
                 query=query,
                 id=memory.id
             )
             result_memory.retrieval_trace = build_score_trace(
                 node_id=result_memory.id,
-                node_type=node_type.value,
+                node_type=record.label.value,
                 final_score=result_memory.score,
                 rank_basis="keyword_score",
                 keyword_hit=True,
-                keyword_score=record.get("normalized_kw_score"),
+                keyword_score=record.data.get("normalized_kw_score"),
                 matched_queries=[query],
             )
             memories.append(result_memory)
@@ -421,8 +450,8 @@ class Neo4jSearchService:
                 keyword_status="completed",
                 semantic_status="skipped",
                 rerank_status="skipped",
-                keyword_hit_count=len(all_records),
-                raw_hit_count=len(all_records),
+                keyword_hit_count=kw_results.total,
+                raw_hit_count=kw_results.total,
                 merged_count=len(memories),
             ),
         )
@@ -438,11 +467,11 @@ class Neo4jSearchService:
             emb_task = self._embedding_search(query, limit)
             kw_results, emb_results = await asyncio.gather(kw_task, emb_task, return_exceptions=True)
 
-        keyword_failed = isinstance(kw_results, Exception)
-        semantic_failed = isinstance(emb_results, Exception)
+        keyword_failed = isinstance(kw_results, BaseException)
+        semantic_failed = isinstance(emb_results, BaseException)
         if keyword_failed:
             logger.warning(f"[MemorySearch] keyword search error: {kw_results}")
-            kw_results = {}
+            kw_results = StorageReadResult()
         if semantic_failed:
             logger.warning(f"[MemorySearch] embedding search error: {emb_results}")
             if self.on_error is not None:
@@ -453,7 +482,7 @@ class Neo4jSearchService:
                         model_type=MemoryModelType.EMBEDDING,
                     )
                 )
-            emb_results = {}
+            emb_results = StorageReadResult()
 
         score_sidecar = self._build_score_sidecar(kw_results, emb_results)
         rerank_status = "skipped"
@@ -470,42 +499,42 @@ class Neo4jSearchService:
             degraded_reasons.extend(rerank_reasons)
         else:
             memories = []
-            for node_type in self.includes:
-                reranked = self._rerank(
-                    kw_results.get(node_type, []),
-                    emb_results.get(node_type, []),
-                    limit
+            reranked = self._rerank(
+                kw_results,
+                emb_results,
+                limit
+            )
+            for record in reranked.items:
+                node_type = record.label
+                memory = data_builder_factory(node_type, record.data)
+                result_memory = Memory(
+                    score=memory.score,
+                    content=memory.content,
+                    data=memory.data,
+                    source=node_type,
+                    query=query,
+                    id=memory.id
                 )
-                for record in reranked:
-                    memory = data_builder_factory(node_type, record)
-                    result_memory = Memory(
-                        score=memory.score,
-                        content=memory.content,
-                        data=memory.data,
-                        source=node_type,
-                        query=query,
-                        id=memory.id
-                    )
-                    score_info = score_sidecar.get((node_type, str(memory.id)), {})
-                    fusion_score = finite_or_none(record.get("content_score"))
-                    rank_basis = (
-                        "source_adjusted_score"
-                        if fusion_score is not None and result_memory.score != fusion_score
-                        else "fusion_score"
-                    )
-                    result_memory.retrieval_trace = build_score_trace(
-                        node_id=result_memory.id,
-                        node_type=node_type.value,
-                        final_score=result_memory.score,
-                        rank_basis=rank_basis,
-                        keyword_hit=bool(score_info.get("keyword_hit")),
-                        semantic_hit=bool(score_info.get("semantic_hit")),
-                        keyword_score=record.get("kw_score"),
-                        semantic_score=record.get("embedding_score"),
-                        fusion_score=fusion_score,
-                        matched_queries=[query],
-                    )
-                    memories.append(result_memory)
+                score_info = score_sidecar.get((node_type, str(memory.id)), {})
+                fusion_score = finite_or_none(record.data.get("content_score"))
+                rank_basis = (
+                    "source_adjusted_score"
+                    if fusion_score is not None and result_memory.score != fusion_score
+                    else "fusion_score"
+                )
+                result_memory.retrieval_trace = build_score_trace(
+                    node_id=result_memory.id,
+                    node_type=node_type.value,
+                    final_score=result_memory.score,
+                    rank_basis=rank_basis,
+                    keyword_hit=bool(score_info.get("keyword_hit")),
+                    semantic_hit=bool(score_info.get("semantic_hit")),
+                    keyword_score=record.data.get("kw_score"),
+                    semantic_score=record.data.get("embedding_score"),
+                    fusion_score=fusion_score,
+                    matched_queries=[query],
+                )
+                memories.append(result_memory)
             memories.sort(key=lambda x: x.score, reverse=True)
             memories = memories[:limit]
 
@@ -515,10 +544,9 @@ class Neo4jSearchService:
                 keyword_status="failed" if keyword_failed else "completed",
                 semantic_status="failed" if semantic_failed else "completed",
                 rerank_status=rerank_status,
-                keyword_hit_count=sum(len(items) for items in kw_results.values()),
-                semantic_hit_count=sum(len(items) for items in emb_results.values()),
-                raw_hit_count=sum(len(items) for items in kw_results.values())
-                              + sum(len(items) for items in emb_results.values()),
+                keyword_hit_count=kw_results.total,
+                semantic_hit_count=emb_results.total,
+                raw_hit_count=kw_results.total + emb_results.total,
                 merged_count=len(memories),
                 degraded_reasons=degraded_reasons,
             ),

--- a/api/app/core/memory/storage/custom/__init__.py
+++ b/api/app/core/memory/storage/custom/__init__.py
@@ -3,3 +3,7 @@ Provide a repository layer within this package to centralize data access
 and query construction, avoiding scattered query logic across the codebase
 and reducing maintenance complexity.
 """
+
+from app.core.memory.storage.custom.node_queries import get_node_by_id
+
+__all__ = ["get_node_by_id"]

--- a/api/app/core/memory/storage/custom/node_queries.py
+++ b/api/app/core/memory/storage/custom/node_queries.py
@@ -1,0 +1,35 @@
+"""Centralized node query helpers.
+
+Wraps the process-wide ``MemoryStorageService`` behind a small repository layer
+so that filter/projection construction for common lookups lives in one place
+instead of being scattered across callers.
+"""
+
+from __future__ import annotations
+
+from app.core.memory.storage.enums import MemoryNodeLabel
+from app.core.memory.storage.models import NodeFilter, NodeProjection
+from app.core.memory.storage.service import get_storage_service
+
+
+async def get_node_by_id(
+        label: MemoryNodeLabel,
+        node_id: str,
+        projection: NodeProjection | None = None,
+) -> dict | None:
+    """Fetch a single node by its ``id`` field.
+
+    Args:
+        label: Node type to query.
+        node_id: Value of the node's ``id`` field.
+        projection: Optional projection; ``None`` returns the full node.
+
+    Returns:
+        The node's raw data dict, or ``None`` when no matching node exists.
+    """
+    service = get_storage_service()
+    node_filter = NodeFilter.eq("id", node_id)
+    result = await service.get_node(label, node_filter, projection, None)
+    if not result.items:
+        return None
+    return result.items[0].data

--- a/api/app/core/memory/storage/models/dto.py
+++ b/api/app/core/memory/storage/models/dto.py
@@ -4,13 +4,18 @@ from typing import Any, Iterable, Self
 
 from pydantic import BaseModel, Field
 
-from app.core.memory.storage.enums import BackendType
+from app.core.memory.storage.enums import BackendType, MemoryNodeLabel
 
 
 class StorageResult(BaseModel):
     """Base result returned by storage providers and routers."""
 
     backend: BackendType | None = None
+
+
+class StorageItem(BaseModel):
+    label: MemoryNodeLabel | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
 
 
 class StorageWriteResult(StorageResult):
@@ -24,16 +29,17 @@ class StorageWriteResult(StorageResult):
 class StorageReadResult(StorageResult):
     """Normalized result for get and search operations."""
 
-    items: list[dict[str, Any]] = Field(default_factory=list)
+    items: list[StorageItem] = Field(default_factory=list)
     total: int = Field(default=0, ge=0)
 
     @classmethod
     def from_items(
             cls,
             items: Iterable[dict[str, Any]],
+            label: MemoryNodeLabel | None = None,
             backend: BackendType | None = None,
     ) -> Self:
-        materialized = list(items)
+        materialized = [StorageItem(label=label, data=it) for it in items]
         return cls(
             backend=backend,
             items=materialized,

--- a/api/app/core/memory/storage/models/projection.py
+++ b/api/app/core/memory/storage/models/projection.py
@@ -2,6 +2,8 @@ from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from app.core.memory.storage.enums import MemoryNodeType
+
 
 class ProjectionField(BaseModel):
     model_config = ConfigDict(frozen=True)
@@ -67,8 +69,8 @@ class NodeProjection(BaseModel):
     @field_validator("fields")
     @classmethod
     def validate_string_fields(
-        cls,
-        fields: tuple[ProjectionItem, ...],
+            cls,
+            fields: tuple[ProjectionItem, ...],
     ) -> tuple[ProjectionItem, ...]:
         if any(isinstance(field, str) and not field.strip() for field in fields):
             raise ValueError("projection fields cannot be blank")
@@ -96,3 +98,37 @@ class NodeProjection(BaseModel):
     @classmethod
     def of(cls, *fields: ProjectionItem) -> Self:
         return cls(fields=fields)
+
+
+DEFAULT_PROJECTION = {
+    MemoryNodeType.EXTRACTED_ENTITY: NodeProjection(
+        fields=(
+            "id", "name", CoalesceProjectionField(fields=("aliases",), default=[], alias="aliases"),
+            "description", "description_summary", "event_timeline", "created_at", "score"
+        )
+    ),
+    MemoryNodeType.CHUNK: NodeProjection(
+        fields=("id", "content", "created_at", "score")
+    ),
+    MemoryNodeType.STATEMENT: NodeProjection(
+        fields=("id", "statement", "created_at", "score")
+    ),
+    MemoryNodeType.MEMORY_SUMMARY: NodeProjection(
+        fields=("id", "name", " content", "created_at", "score")
+    ),
+    MemoryNodeType.PERCEPTUAL: NodeProjection(
+        fields=(
+            "id", "perceptual_type", "file_path", "file_name", "file_ext", "summary",
+            "keywords", "topic", "domain", "created_at", "file_type", "score"
+        )
+    ),
+    MemoryNodeType.COMMUNITY: NodeProjection(
+        fields=(
+            ProjectionField(field="community_id", alias="id"), "name",
+            ProjectionField(field="summary"), "core_entities", "updated_at", "score"
+        )
+    ),
+    MemoryNodeType.DIALOGUE: NodeProjection(
+        fields=("id", "content", "created_at", "score")
+    )
+}

--- a/api/app/core/memory/storage/outbox/clients.py
+++ b/api/app/core/memory/storage/outbox/clients.py
@@ -51,12 +51,13 @@ async def project_event(
     document = None
     if result.items:
         candidate = result.items[0]
+        data = candidate.data if candidate is not None else None
         if (
-            not isinstance(candidate, Mapping)
-            or candidate.get("id") != event.node_id
+            not isinstance(data, Mapping)
+            or data.get("id") != event.node_id
         ):
             raise ValueError("Authoritative node identity mismatch")
-        document = candidate
+        document = data
     # 读错误绝不转化为 ES 删除。慢读后需重新校验租约归属。
     await check_claim()
     if document is not None:

--- a/api/app/core/memory/storage/provider/elasticsearch/client.py
+++ b/api/app/core/memory/storage/provider/elasticsearch/client.py
@@ -4,9 +4,9 @@ from numbers import Real
 from typing import Any, Callable, Self
 
 from elastic_transport import ObjectApiResponse
-from elasticsearch import AsyncElasticsearch, Elasticsearch
+from elasticsearch import AsyncElasticsearch
 
-from app.core.memory.storage.enums import BackendType, MemoryNodeLabel, MemoryNodeType
+from app.core.memory.storage.enums import BackendType, MemoryNodeLabel
 from app.core.memory.storage.exceptions import UnsupportedQueryError
 from app.core.memory.storage.models import (
     FilterCondition,
@@ -16,8 +16,7 @@ from app.core.memory.storage.models import (
     NodeSort,
     ProjectionField,
     StorageReadResult,
-    StorageWriteResult,
-)
+    StorageWriteResult, )
 from app.core.memory.storage.provider.base import BaseClient
 from app.core.memory.storage.provider.elasticsearch.compiler.filter_compiler import (
     compile_elasticsearch_filter,
@@ -407,7 +406,7 @@ class ElasticClient(BaseClient):
                 search_options["search_after"] = list(search_after)
         finally:
             await client.close_point_in_time(id=pit_id)
-        return StorageReadResult.from_items(nodes, backend=self.name)
+        return StorageReadResult.from_items(nodes, label=label, backend=self.name)
 
     async def search_by_embedding(
             self,
@@ -460,7 +459,7 @@ class ElasticClient(BaseClient):
             source_required=source_required,
             score_transform=lambda score: (2.0 * score) - 1.0,
         )
-        return StorageReadResult.from_items(items, backend=self.name)
+        return StorageReadResult.from_items(items, label=label, backend=self.name)
 
     async def search_by_fulltext(
             self,
@@ -509,33 +508,35 @@ class ElasticClient(BaseClient):
             "fulltext search",
             source_required=source_required,
         )
-        return StorageReadResult.from_items(items, backend=self.name)
+        return StorageReadResult.from_items(items, label=label, backend=self.name)
 
 
 # async def dev():
 #     client = await ElasticClient.create()
 #     await client.save_node(
-#         MemoryNodeType.EXTRACTED_ENTITY,
+#         MemoryNodeType.STATEMENT,
 #         {
 #             "access_count": 0,
-#             "id": "844773314c314275bd23c4bc54230e29",
-#             "access_history": [],
-#             "aliases": [],
-#             "description": "[2026-05-29T18:07:04.150123] 表达对小米yu7这台车有喜好的说话者；[2026-08-04T08:16:58.936996+00:00] 计划买车的说话者；[2026-08-04T08:16:59.343820+00:00] 喜欢小米SU7这台车的说话者",
-#             "beliefs_or_stances": [],
-#             "connect_strength": "Strong",
-#             "core_facts": ["位于杭州红熊智能科技有限公司（城北万象城）,名字为AAA"],
-#             "created_at": 1787550740,
-#             "name_embedding": []  # embedding demo
+#             "id": "df1e7ddf705c4ba1ae81f3b6ed069b80",
+#             "end_user_id": "b237ec06-44a4-4d56-944f-cfbab605b577",
+#             "statement": "[2026-05-29T18:07:04.150123] 表达对小米yu7这台车有喜好的说话者；[2026-08-04T08:16:58.936996+00:00] 计划买车的说话者；[2026-08-04T08:16:59.343820+00:00] 喜欢小米SU7这台车的说话者",
+#             "created_at": 1787550740
 #         }
 #     )
 #     cost = time.perf_counter()
 #     res = await client.search_by_fulltext(
-#         MemoryNodeType.EXTRACTED_ENTITY,
-#         NodeFilter.eq("id", "844773314c314275bd23c4bc54230e29"),
+#         MemoryNodeType.STATEMENT,
+#         NodeFilter(
+#             logic=FilterLogic.AND,
+#             conditions=(
+#                 FilterCondition(field="end_user_id", operator=FilterOperator.EQ, value="b237ec06-44a4-4d56-944f-cfbab605b577"),
+#                 FilterCondition(field="delete_at", operator=FilterOperator.EXISTS, value=False)
+#             )
+#         ),
+#         # NodeFilter.eq("end_user_id", "b237ec06-44a4-4d56-944f-cfbab605b577"),
 #
-#         text="小米yu7",
-#         projection=NodeProjection(fields=("id", 'core_facts', 'score')),
+#         text="表达对小米yu7这台车有喜好的说话者",
+#         projection=NodeProjection(fields=("id", 'statement', 'score')),
 #         limit=10
 #     )
 #     cost = time.perf_counter() - cost

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -332,7 +332,7 @@ class Neo4jClient(BaseClient):
             stmt = await session.run(query, **parameters)
             records = await stmt.data()
             items = [_to_native(record["n"]) for record in records]
-        return StorageReadResult.from_items(items, backend=self.name)
+        return StorageReadResult.from_items(items, label=label, backend=self.name)
 
     async def delete_node(
             self,
@@ -461,11 +461,11 @@ class Neo4jClient(BaseClient):
                 if not isinstance(field, str) and field.field == "score"
             } if projection is not None else set()
             include_score = (
-                projection is not None
-                and any(
-                    field == "score" if isinstance(field, str) else field.field == "score"
-                    for field in projection.fields
-                )
+                    projection is not None
+                    and any(
+                field == "score" if isinstance(field, str) else field.field == "score"
+                for field in projection.fields
+            )
             )
             if projection is not None and "score" in {
                 field for field in projection.fields if isinstance(field, str)
@@ -497,7 +497,7 @@ class Neo4jClient(BaseClient):
                     res.append(node)
         except Exception:
             res = []
-        return StorageReadResult.from_items(res, backend=self.name)
+        return StorageReadResult.from_items(res, label=label, backend=self.name)
 
     async def search_by_fulltext(
             self,
@@ -539,8 +539,7 @@ class Neo4jClient(BaseClient):
             )
             records = await stmt.data()
             items = [_to_native(record["n"]) for record in records]
-        return StorageReadResult.from_items(items, backend=self.name)
-
+        return StorageReadResult.from_items(items, label=label, backend=self.name)
 
 # async def dev():
 #     from app.core.memory.storage.models import FilterCondition

--- a/api/app/core/memory/storage/router/read_router.py
+++ b/api/app/core/memory/storage/router/read_router.py
@@ -3,27 +3,30 @@ import asyncio
 from app.core.memory.storage.enums import (
     MemoryNodeLabel,
     MemoryRelationshipType,
-    StorageBackendType,
+    StorageBackendType, MemoryNodeType,
 )
 from app.core.memory.storage.models import (
+    FilterCondition,
+    FilterOperator,
     NodeFilter,
     NodeProjection,
     NodeSort,
     RelationshipFilter,
     StorageReadResult,
 )
+from app.core.memory.storage.models.projection import DEFAULT_PROJECTION
 from app.core.memory.storage.provider.factory import BackendFactory
 
 
 def _merge_read_results(
-    results: list[StorageReadResult],
+        results: list[StorageReadResult],
 ) -> StorageReadResult:
     items = [item for result in results for item in result.items]
     backend = (
         results[0].backend
         if results
-        and results[0].backend is not None
-        and all(result.backend == results[0].backend for result in results)
+           and results[0].backend is not None
+           and all(result.backend == results[0].backend for result in results)
         else None
     )
     return StorageReadResult(
@@ -37,60 +40,105 @@ class ReadRouter:
     def __init__(self, backend_factory: BackendFactory) -> None:
         self.backend_factory = backend_factory
 
-    async def search_by_embedding(
-        self,
-        labels: list[MemoryNodeLabel],
-        node_filter: NodeFilter,
-        embed: list,
-        limit: int,
-        projection: NodeProjection | None = None,
+    async def get_node(
+            self,
+            label: MemoryNodeLabel,
+            node_filter: NodeFilter,
+            projection: NodeProjection | None = None,
+            node_sort: NodeSort | None = None,
     ) -> StorageReadResult:
-        tasks = [
-            self.backend_factory.get_read_client(
-                label,
-                StorageBackendType.VECTOR_MAIN_READ,
-            ).search_by_embedding(
-                label,
-                node_filter,
-                embed,
-                limit,
-                projection,
+        client = self.backend_factory.get_read_client(
+            label,
+            StorageBackendType.GRAPH_MAIN_READ,
+        )
+        return await client.get_node(label, node_filter, projection, node_sort)
+
+    async def search_by_embedding(
+            self,
+            labels: list[MemoryNodeLabel],
+            node_filter: NodeFilter,
+            embed: list,
+            pre_limit: int,
+            projection: NodeProjection | None = None,
+    ) -> StorageReadResult:
+        tasks = []
+        for label in labels:
+            if label == MemoryNodeType.DIALOGUE:
+                node_filter = NodeFilter(
+                    logic=node_filter.logic,
+                    conditions=tuple(
+                        list(node_filter.conditions)
+                        + [
+                            FilterCondition(
+                                field="write_mode",
+                                operator=FilterOperator.EQ,
+                                value="fast",
+                            )
+                        ]
+                    ),
+                )
+
+            tasks.append(
+                self.backend_factory.get_read_client(
+                    label,
+                    StorageBackendType.VECTOR_MAIN_READ,
+                ).search_by_embedding(
+                    label,
+                    node_filter,
+                    embed,
+                    pre_limit,
+                    projection if projection else DEFAULT_PROJECTION[label]
+                )
             )
-            for label in labels
-        ]
-        results = await asyncio.gather(*tasks)
+        results: list[StorageReadResult] = list(await asyncio.gather(*tasks))
         return _merge_read_results(results)
 
     async def search_by_fulltext(
-        self,
-        labels: list[MemoryNodeLabel],
-        node_filter: NodeFilter,
-        text: str,
-        limit: int,
-        projection: NodeProjection | None = None,
+            self,
+            labels: list[MemoryNodeLabel],
+            node_filter: NodeFilter,
+            text: str,
+            pre_limit: int,
+            projection: NodeProjection | None = None,
     ) -> StorageReadResult:
-        tasks = [
-            self.backend_factory.get_read_client(
-                label,
-                StorageBackendType.TEXT_MAIN_READ,
-            ).search_by_fulltext(
-                label,
-                node_filter,
-                text,
-                limit,
-                projection,
+        tasks = []
+        for label in labels:
+            if label == MemoryNodeType.DIALOGUE:
+                node_filter = NodeFilter(
+                    logic=node_filter.logic,
+                    conditions=tuple(
+                        list(node_filter.conditions)
+                        + [
+                            FilterCondition(
+                                field="write_mode",
+                                operator=FilterOperator.EQ,
+                                value="fast",
+                            )
+                        ]
+                    ),
+                )
+
+            tasks.append(
+                self.backend_factory.get_read_client(
+                    label,
+                    StorageBackendType.TEXT_MAIN_READ,
+                ).search_by_fulltext(
+                    label,
+                    node_filter,
+                    text,
+                    pre_limit,
+                    projection if projection else DEFAULT_PROJECTION[label]
+                )
             )
-            for label in labels
-        ]
-        results = await asyncio.gather(*tasks)
+        results: list[StorageReadResult] = list(await asyncio.gather(*tasks))
         return _merge_read_results(results)
 
     async def search_relationships_by_graph(
-        self,
-        relationship_type: MemoryRelationshipType,
-        rel_filter: RelationshipFilter,
-        projection: NodeProjection | None = None,
-        sort: NodeSort | None = None,
+            self,
+            relationship_type: MemoryRelationshipType,
+            rel_filter: RelationshipFilter,
+            projection: NodeProjection | None = None,
+            sort: NodeSort | None = None,
     ) -> StorageReadResult:
         client = self.backend_factory.get_relationship_client()
         return await client.get_relationship(

--- a/api/app/core/memory/storage/service.py
+++ b/api/app/core/memory/storage/service.py
@@ -15,6 +15,8 @@ from app.core.memory.storage.provider.factory import BackendFactory
 from app.core.memory.storage.router.read_router import ReadRouter
 from app.core.memory.storage.router.write_router import WriteRouter
 
+memory_storage_service: "MemoryStorageService | None" = None
+
 
 class MemoryStorageService:
     def __init__(self, backend_factory: BackendFactory) -> None:
@@ -32,14 +34,14 @@ class MemoryStorageService:
             labels: list[MemoryNodeLabel],
             node_filter: NodeFilter,
             embed: list,
-            limit: int,
+            pre_limit: int,
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
         return await self._read_router.search_by_embedding(
             labels,
             node_filter,
             embed,
-            limit,
+            pre_limit,
             projection,
         )
 
@@ -48,15 +50,30 @@ class MemoryStorageService:
             labels: list[MemoryNodeLabel],
             node_filter: NodeFilter,
             text: str,
-            limit: int,
+            pre_limit: int,
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
         return await self._read_router.search_by_fulltext(
             labels,
             node_filter,
             text,
-            limit,
+            pre_limit,
             projection,
+        )
+
+    async def get_node(
+            self,
+            label: MemoryNodeLabel,
+            node_filter: NodeFilter,
+            projection: NodeProjection | None = None,
+            node_sort: NodeSort | None = None,
+    ) -> StorageReadResult:
+        """Read nodes through the read router."""
+        return await self._read_router.get_node(
+            label,
+            node_filter,
+            projection,
+            node_sort,
         )
 
     async def search_relationships_by_graph(
@@ -134,3 +151,29 @@ class MemoryStorageService:
 
     async def close(self) -> None:
         await self._backend_factory.close()
+
+
+async def initialize_storage_service() -> MemoryStorageService:
+    """Initialize and return the process-wide storage service singleton."""
+    global memory_storage_service
+    if memory_storage_service is None:
+        memory_storage_service = await MemoryStorageService.create()
+    return memory_storage_service
+
+
+def get_storage_service() -> MemoryStorageService:
+    """Return the initialized process-wide storage service."""
+    if memory_storage_service is None:
+        raise RuntimeError(
+            "MemoryStorageService is not initialized; initialize it in the API lifespan first"
+        )
+    return memory_storage_service
+
+
+async def close_storage_service() -> None:
+    """Close and clear the process-wide storage service singleton."""
+    global memory_storage_service
+    if memory_storage_service is not None:
+        service = memory_storage_service
+        memory_storage_service = None
+        await service.close()

--- a/api/app/core/memory/storage/tests/test_elasticsearch_client.py
+++ b/api/app/core/memory/storage/tests/test_elasticsearch_client.py
@@ -9,6 +9,7 @@ from elasticsearch import AsyncElasticsearch
 from app.core.config import settings
 from app.core.memory.storage.enums import BackendType, MemoryNodeType
 from app.core.memory.storage.models import NodeFilter, NodeProjection, NodeSort
+from app.core.memory.storage.models.dto import StorageItem
 from app.core.memory.storage.provider.elasticsearch import index as elasticsearch_index
 from app.core.memory.storage.provider.elasticsearch.client import (
     PIT_KEEP_ALIVE,
@@ -826,8 +827,14 @@ async def test_elastic_client_get_node_uses_filter_projection_and_sort() -> None
     ]
     assert fake.close_point_in_time_calls == [{"id": "pit-1"}]
     assert result.items == [
-        {"id": "node-2", "status": "active"},
-        {"id": "node-1", "status": "active"},
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "node-2", "status": "active"},
+        ),
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "node-1", "status": "active"},
+        ),
     ]
 
 
@@ -1412,7 +1419,10 @@ async def test_elastic_client_get_node_reads_all_pit_pages() -> None:
 
     assert result.total == SEARCH_BATCH_SIZE + 1
     assert len(result.items) == result.total
-    assert result.items[-1] == {"id": "last-node"}
+    assert result.items[-1] == StorageItem(
+        label=TEST_INDEX_LABEL,
+        data={"id": "last-node"},
+    )
     assert len(fake.search_calls) == 2
     assert fake.search_calls[0]["sort"] == [{"_shard_doc": "asc"}]
     assert fake.search_calls[0]["pit"] == {
@@ -1510,7 +1520,12 @@ async def test_elastic_client_get_node_applies_projection_aliases() -> None:
     )
 
     assert fake.search_calls[0]["source_includes"] == ["id", "name"]
-    assert result.items == [{"id": "node-1", "display_name": "Alice"}]
+    assert result.items == [
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "node-1", "display_name": "Alice"},
+        ),
+    ]
 
 
 
@@ -1555,8 +1570,14 @@ async def test_elastic_client_get_node_evaluates_coalesce_projection() -> None:
         "name",
     ]
     assert result.items == [
-        {"id": "node-1", "display_name": "Alice"},
-        {"id": "node-2", "display_name": "Unknown"},
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "node-1", "display_name": "Alice"},
+        ),
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "node-2", "display_name": "Unknown"},
+        ),
     ]
 
 
@@ -1608,8 +1629,8 @@ async def test_elastic_client_embedding_search_uses_knn_prefilter_and_score() ->
             "source_includes": ["id"],
         }
     ]
-    assert result.items[0]["id"] == "node-1"
-    assert result.items[0]["similarity"] == pytest.approx(0.8)
+    assert result.items[0].data["id"] == "node-1"
+    assert result.items[0].data["similarity"] == pytest.approx(0.8)
 
 
 async def test_elastic_client_embedding_search_does_not_add_unrequested_score() -> None:
@@ -1631,7 +1652,9 @@ async def test_elastic_client_embedding_search_does_not_add_unrequested_score() 
         1,
     )
 
-    assert result.items == [{"id": "node-1"}]
+    assert result.items == [
+        StorageItem(label=MemoryNodeType.CHUNK, data={"id": "node-1"}),
+    ]
 
 
 async def test_elastic_client_fulltext_search_uses_multi_match_filter_and_score() -> None:
@@ -1689,7 +1712,12 @@ async def test_elastic_client_fulltext_search_uses_multi_match_filter_and_score(
             "source_includes": ["id"],
         }
     ]
-    assert result.items == [{"id": "entity-1", "score": 3.25}]
+    assert result.items == [
+        StorageItem(
+            label=MemoryNodeType.EXTRACTED_ENTITY,
+            data={"id": "entity-1", "score": 3.25},
+        ),
+    ]
 
 
 async def test_elastic_client_search_supports_score_only_projection() -> None:
@@ -1712,7 +1740,9 @@ async def test_elastic_client_search_supports_score_only_projection() -> None:
 
     assert fake.search_calls[0]["source"] is False
     assert "source_includes" not in fake.search_calls[0]
-    assert result.items == [{"rank": 2.5}]
+    assert result.items == [
+        StorageItem(label=MemoryNodeType.STATEMENT, data={"rank": 2.5}),
+    ]
 
 
 @pytest.mark.parametrize("limit", [0, -1, True, 10_001])

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -116,6 +116,9 @@ async def lifespan(app: FastAPI):
     from app.services.memory_retrieval_display_queue import MemoryRetrievalDisplayQueue
     await MemoryRetrievalDisplayQueue.start()
 
+    from app.core.memory.storage.service import initialize_storage_service
+    await initialize_storage_service()
+
     logger.info("应用程序启动完成")
 
     async with mcp_app.lifespan(app):
@@ -137,6 +140,9 @@ async def lifespan(app: FastAPI):
     from app.services.memory_retrieval_display_queue import MemoryRetrievalDisplayQueue
     await MemoryRetrievalDisplayQueue.flush()
     await MemoryRetrievalDisplayQueue.stop()
+
+    from app.core.memory.storage.service import close_storage_service
+    await close_storage_service()
 
     from app.repositories.neo4j.neo4j_connector import Neo4jConnector
     await Neo4jConnector.shutdown()


### PR DESCRIPTION
- Introduce a singleton MemoryStorageService initialized during API lifespan
- Add get_node_by_id repository helper to centralize node lookups
- Extend read router and storage clients with get_node support
- Propagate node label through StorageReadResult for better tracing
- Relax exception cause type to BaseException for broader compatibility

## Sourcery 总结

集中管理内存存储访问，并通过节点元数据丰富检索结果。

新功能：
- 添加进程级内存存储服务生命周期管理和集中式节点查找支持。
- 扩展存储读取和内存检索，使其在受支持的后端中返回带节点标签的结果。

错误修复：
- 扩大模型调用失败的处理范围，以保留非 `Exception` 类型的原因，并提升与异步失败的兼容性。

增强功能：
- 统一通过存储服务执行内存搜索，并支持默认投影、节点过滤器和带标签的存储项。
- 减少 Elasticsearch 传输请求日志的冗余输出。

测试：
- 更新 Elasticsearch 存储测试，以适配带标签的 `StorageItem` 结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize memory storage access and enrich retrieval results with node metadata.

New Features:
- Add process-wide memory storage service lifecycle management and centralized node lookup support.
- Extend storage reads and memory retrieval to return node-labeled results across supported backends.

Bug Fixes:
- Broaden model-call failure handling to preserve non-Exception causes and improve compatibility with asynchronous failures.

Enhancements:
- Standardize memory search on the storage service with default projections, node filters, and labeled storage items.
- Reduce noisy Elasticsearch transport request logging.

Tests:
- Update Elasticsearch storage tests for labeled StorageItem results.

</details>