### PR TITLE
fix(llm): Handle dict blocks with direct text field in LLM response

### DIFF
--- a/api/app/core/models/llm.py
+++ b/api/app/core/models/llm.py
@@ -79,6 +79,8 @@ class StructResponse:
                 for block in content:
                     if isinstance(block, dict) and block.get("type") == "text":
                         text += block.get("text", "")
+                    elif isinstance(block, dict) and block.get("text"):
+                        text += block.get("text")
                 return text
             return str(content) if content else ""
         raise RuntimeError(f"Unsupported struct type {type(other)}")

--- a/api/app/core/models/llm.py
+++ b/api/app/core/models/llm.py
@@ -75,13 +75,15 @@ class StructResponse:
             if isinstance(content, str):
                 return content
             if isinstance(content, list):
-                text = ""
+                parts: list[str] = []
                 for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text += block.get("text", "")
-                    elif isinstance(block, dict) and block.get("text"):
-                        text += block.get("text")
-                return text
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "text":
+                        parts.append(block.get("text") or "")
+                    elif block.get("text"):
+                        parts.append(block.get("text") or "")
+                return "".join(parts)
             return str(content) if content else ""
         raise RuntimeError(f"Unsupported struct type {type(other)}")
 

--- a/packages/redbear-model/src/redbear_model/runtime/llm.py
+++ b/packages/redbear-model/src/redbear_model/runtime/llm.py
@@ -65,11 +65,15 @@ class StructResponse:
             if isinstance(content, str):
                 return content
             if isinstance(content, list):
-                return "".join(
-                    str(block.get("text", ""))
-                    for block in content
-                    if isinstance(block, dict) and block.get("type") == "text"
-                )
+                parts: list[str] = []
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "text":
+                        parts.append(block.get("text") or "")
+                    elif block.get("text"):
+                        parts.append(block.get("text") or "")
+                return "".join(parts)
             return str(content) if content else ""
         raise RuntimeError(f"Unsupported structured response type: {type(other)}")
 


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 处理在字典中直接提供文本、但未显式包含 `type` 字段的 LLM 响应块。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 支持从直接提供 `text` 字段但未明确指定 `type` 的 LLM 响应块中提取文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Support extracting text from LLM response blocks that provide a direct `text` field without an explicit `type`.

</details>

</details>