### PR TITLE
fix(rag): resolve public SpeedBear tenant bindings

### DIFF
--- a/mem-knowledge/src/models/references/__init__.py
+++ b/mem-knowledge/src/models/references/__init__.py
@@ -8,6 +8,7 @@ from .model_registry import (
     ModelConfig,
     ModelProvider,
     ModelType,
+    TenantSpeedBearBinding,
     model_config_api_key_association,
 )
 from .user import User
@@ -21,6 +22,7 @@ __all__ = [
     "ModelProvider",
     "ModelType",
     "ReferenceBase",
+    "TenantSpeedBearBinding",
     "User",
     "Workspace",
     "model_config_api_key_association",

--- a/mem-knowledge/src/models/references/model_registry.py
+++ b/mem-knowledge/src/models/references/model_registry.py
@@ -165,6 +165,16 @@ class ModelApiKey(ReferenceBase):
     priority = Column(String, default="1", comment="priority")
 
 
+class TenantSpeedBearBinding(ReferenceBase):
+    """Minimal read-only projection of the Platform tenant credential binding."""
+
+    __tablename__ = "tenant_speedbear_bindings"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    tenant_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    gateway_api_key = Column(Text, nullable=False)
+
+
 class ModelBase(ReferenceBase):
     __tablename__ = "model_bases"
 

--- a/mem-knowledge/src/repositories/model_registry.py
+++ b/mem-knowledge/src/repositories/model_registry.py
@@ -19,7 +19,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
-from ..models.references import ModelApiKey, ModelConfig
+from ..bootstrap import get_settings
+from ..models.references import ModelApiKey, ModelConfig, TenantSpeedBearBinding
 from ..models.references.model_registry import model_config_api_key_association
 from ..utils.datetime_utils import to_timestamp_ms
 
@@ -84,11 +85,28 @@ def _active_keys_query(model_config_id: uuid.UUID):
     )
 
 
+def _public_binding_snapshot(
+    binding: TenantSpeedBearBinding | None,
+    tenant_id: uuid.UUID,
+    provider: ModelProvider,
+    speedbear_base_url: str,
+) -> PublicModelBindingSnapshot | None:
+    if binding is None:
+        return None
+    return PublicModelBindingSnapshot(
+        tenant_id=tenant_id,
+        provider=provider,
+        api_key=SecretStr(binding.gateway_api_key),
+        base_url=f"{speedbear_base_url.rstrip('/')}/api/v1",
+    )
+
+
 class SyncSQLModelRegistry(ModelRegistryRepository):
     """Expose Platform model rows to synchronous worker task code."""
 
-    def __init__(self, db: Session):
+    def __init__(self, db: Session, *, speedbear_base_url: str | None = None):
         self.db = db
+        self.speedbear_base_url = speedbear_base_url or get_settings().speedbear_base_url
 
     def get_model_config(
         self,
@@ -114,8 +132,19 @@ class SyncSQLModelRegistry(ModelRegistryRepository):
         tenant_id: uuid.UUID,
         provider: ModelProvider,
     ) -> PublicModelBindingSnapshot | None:
-        del tenant_id, provider
-        return None
+        if provider is not ModelProvider.SPEEDBEAR:
+            return None
+        result = self.db.execute(
+            select(TenantSpeedBearBinding).where(
+                TenantSpeedBearBinding.tenant_id == tenant_id
+            )
+        )
+        return _public_binding_snapshot(
+            result.scalars().first(),
+            tenant_id,
+            provider,
+            self.speedbear_base_url,
+        )
 
     def record_key_usage(self, key_id: uuid.UUID) -> None:
         del key_id
@@ -125,8 +154,9 @@ class SyncSQLModelRegistry(ModelRegistryRepository):
 class AsyncSQLModelRegistry:
     """Expose Platform model rows as immutable scalar snapshots."""
 
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession, *, speedbear_base_url: str | None = None):
         self.db = db
+        self.speedbear_base_url = speedbear_base_url or get_settings().speedbear_base_url
 
     async def get_model_config(
         self,
@@ -155,8 +185,19 @@ class AsyncSQLModelRegistry:
         tenant_id: uuid.UUID,
         provider: ModelProvider,
     ) -> PublicModelBindingSnapshot | None:
-        del tenant_id, provider
-        return None
+        if provider is not ModelProvider.SPEEDBEAR:
+            return None
+        result = await self.db.execute(
+            select(TenantSpeedBearBinding).where(
+                TenantSpeedBearBinding.tenant_id == tenant_id
+            )
+        )
+        return _public_binding_snapshot(
+            result.scalars().first(),
+            tenant_id,
+            provider,
+            self.speedbear_base_url,
+        )
 
     async def record_key_usage(self, key_id: uuid.UUID) -> None:
         del key_id

--- a/packages/redbear-model/src/redbear_model/contracts.py
+++ b/packages/redbear-model/src/redbear_model/contracts.py
@@ -102,12 +102,8 @@ class ModelKeySnapshot(ContractModel):
 class PublicModelBindingSnapshot(ContractModel):
     tenant_id: UUID
     provider: ModelProvider
-    model_name: str = Field(min_length=1)
     api_key: SecretStr
     base_url: str | None = None
-    capabilities: tuple[ModelCapability, ...] = ()
-    is_omni: bool = False
-    config: dict[str, JsonValue] = Field(default_factory=dict)
 
 
 class ResolvedModelConfig(ContractModel):

--- a/packages/redbear-model/src/redbear_model/resolver.py
+++ b/packages/redbear-model/src/redbear_model/resolver.py
@@ -134,12 +134,12 @@ def _build_from_binding(
         key_id=None,
         tenant_id=tenant_id,
         provider=binding.provider,
-        model_name=binding.model_name,
+        model_name=config.display_name,
         api_key=binding.api_key,
         base_url=binding.base_url,
-        capabilities=binding.capabilities or config.capabilities,
-        is_omni=binding.is_omni or config.is_omni,
-        params=dict(binding.config or config.config),
+        capabilities=config.capabilities,
+        is_omni=config.is_omni,
+        params=dict(config.config),
         runtime_options=runtime_options,
     )
 


### PR DESCRIPTION
## Business Background

The independent Knowledge service could not resolve credentials for public SpeedBear models. Both model registry adapters returned no tenant binding, so document processing failed during preflight before parsing or vectorization.

## Summary

- Add a minimal read-only projection for `tenant_speedbear_bindings` in Knowledge.
- Resolve public SpeedBear tenant credentials in both synchronous and asynchronous model registry adapters.
- Keep public binding snapshots credential-only while deriving the model name, capabilities, Omni flag, and provider parameters from the model configuration, matching the existing API behavior.

## Changes

- 5 production files changed
- 64 insertions, 15 deletions
- No schema migration
- No external API route or response changes

## Risk

- The runtime now depends on the existing `tenant_speedbear_bindings` row for the calling tenant; a missing row continues to fail with the existing public-credential error.
- The reference projection intentionally maps only the fields Knowledge reads and does not own or mutate the Platform table.
- The plaintext gateway credential is wrapped in `SecretStr` immediately and is not added to logs.

## External API Key Impact

No external API Key endpoint or contract is changed. This restores internal Knowledge API and worker access to tenant-bound public SpeedBear credentials.

## Test Plan

- [x] `PYTHONPATH='mem-knowledge:packages/redbear-model/src' mem-knowledge/.venv/bin/pytest -q tests` — 4 passed
- [x] Scoped Ruff checks — passed
- [x] Public package import-boundary check — passed
- [x] PostgreSQL binding projection compile check — passed
- [x] `git diff --check origin/release/v0.4.4..HEAD` — passed

## Sourcery 摘要

通过共享绑定投影解析租户凭据，恢复对公开 SpeedBear 模型的访问。

Bug 修复：
- 恢复在同步和异步模型注册表中解析公开 SpeedBear 模型的租户绑定凭据。

增强功能：
- 添加租户 SpeedBear 绑定的只读 Knowledge 投影，并从模型配置中派生公开模型元数据，同时保持凭据快照的最小化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore public SpeedBear model access by resolving tenant credentials through the shared binding projection.

Bug Fixes:
- Restore resolution of tenant-bound credentials for public SpeedBear models in synchronous and asynchronous model registries.

Enhancements:
- Add a read-only Knowledge projection of tenant SpeedBear bindings and derive public model metadata from the model configuration while keeping credential snapshots minimal.

</details>