### PR TITLE
fix(rag): avoid duplicate document progress messages

### DIFF
--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -233,9 +233,12 @@ class DocumentProgressSink:
 
     @staticmethod
     def _append_message(current: str | None, messages: Sequence[str]) -> str:
-        lines = [current.rstrip("\n")] if current else []
-        lines.extend(message.rstrip("\n") for message in messages if message)
-        return "\n".join(line for line in lines if line) + ("\n" if lines else "")
+        current_text = current.rstrip("\n") if current else ""
+        pending_text = "\n".join(message.rstrip("\n") for message in messages if message)
+        # Legacy processors may persist the complete snapshot before terminal flush.
+        if pending_text and f"\n{pending_text}\n" not in f"\n{current_text}\n":
+            current_text = "\n".join(text for text in (current_text, pending_text) if text)
+        return f"{current_text}\n" if current_text else ""
 
     def _should_flush(self, event: TaskEvent, now: float) -> bool:
         return (


### PR DESCRIPTION
## Business Background
Fast direct-image OCR failures can persist the full failure progress snapshot before the throttled document progress sink flushes its pending callback messages. The terminal flush then appends the same parser progress block again.

## Summary
- Make document progress message appends idempotent when the exact pending batch is already present.
- Preserve the existing append behavior for messages that have not been persisted.
- Prevent image OCR empty-text failures from repeating parser progress entries.

## Changes
- `mem-knowledge/src/tasks/observability.py`: 6 insertions, 3 deletions.

## Risk
- Low: deduplication is limited to an exact, line-bounded pending message batch.
- Distinct progress messages continue to append normally.
- No database, configuration, routing, or API schema changes.
- External API Key impact: none; authentication and public API contracts are unchanged.

## Test Plan
- [x] `uv run pytest ../tests/mem_knowledge/tasks/test_document_progress_sink.py -q` — 2 passed.
- [x] `uv run ruff check src/tasks/observability.py ../tests/mem_knowledge/tasks/test_document_progress_sink.py`.
- [x] `uv run python -m compileall -q src/tasks/observability.py`.
- [x] `git diff --check origin/release/v0.4.4..HEAD`.
- [ ] The broader local `tests/mem_knowledge` run still has two unrelated pre-existing SpeedBear binding failures because `PublicModelBindingSnapshot.model_name` is missing.

## Sourcery 总结

防止文档进度接收器在终端故障刷新期间重复解析器进度消息。

错误修复：
- 当持久化的故障快照已包含待处理的进度批次时，防止重复添加文档进度条目。

增强功能：
- 对不同的文档进度消息保留正常追加行为，同时使完全相同的待处理批次具备幂等性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent document progress sinks from duplicating parser progress messages during terminal failure flushes.

Bug Fixes:
- Prevent duplicate document progress entries when a persisted failure snapshot already contains the pending progress batch.

Enhancements:
- Preserve normal appending for distinct document progress messages while making exact pending batches idempotent.

</details>