### PR TITLE
feat(web): messages add filters

### DIFF
--- a/web/src/api/memory.ts
+++ b/web/src/api/memory.ts
@@ -282,8 +282,8 @@ export const getConversations = (end_user_id: string, page = 1, pagesize = 20) =
   return request.get(`/memory/work/${end_user_id}/conversations`, { page, pagesize })
 }
 // Work Memory Conversation Messages
-export const getConversationMessages = (end_user_id: string, conversation_id: string) => {
-  return request.get(`/memory/work/${end_user_id}/messages`, { conversation_id })
+export const getConversationMessages = (end_user_id: string, data: { conversation_id: string; start_date?: number; end_date?: number; keyword?: string }) => {
+  return request.get(`/memory/work/${end_user_id}/messages`, data)
 }
 // Work Memory Conversation Detail
 export const getConversationDetail = (end_user_id: string, conversation_id: string) => {
@@ -294,7 +294,7 @@ export const getApiMcpDataSources = (end_user_id: string) => {
   return request.get(`/memory/work/${end_user_id}/sources`)
 }
 // Work Memory API/MCP Messages Record
-export const getApiMcpMessages = (end_user_id: string, data: { source: 'mcp' | 'service_api'; limit: number; }) => {
+export const getApiMcpMessages = (end_user_id: string, data: { source: 'mcp' | 'service_api'; page?: number; pagesize?: number; start_date?: number; end_date?: number; keyword?: string }) => {
   return request.get(`/memory/work/${end_user_id}/source_messages`, data)
 }
 export const forgetTrigger = (data: { max_merge_batch_size: number; min_days_since_access: number; end_user_id: string;}) => {

--- a/web/src/i18n/en/detail.ts
+++ b/web/src/i18n/en/detail.ts
@@ -157,7 +157,9 @@ export const detail = {
       successfulTitle: 'Successful Experience',
       question: 'Lessons Learned',
       summary: 'Core Insights',
-      none: 'None'
+      searchPlaceholder: 'Search keyword',
+      none: 'None',
+      total: 'Total {{total}} Messages',
     },
     ontology: {
       searchPlaceholder: 'Search scenarios',

--- a/web/src/i18n/zh/detail.ts
+++ b/web/src/i18n/zh/detail.ts
@@ -157,7 +157,9 @@ export const detail = {
       successfulTitle: '成功经验',
       question: '踩过的坑',
       summary: '核心洞察',
-      none: '无'
+      searchPlaceholder: '搜索关键词',
+      none: '无',
+      total: '共 {{total}} 条聊天记录',
     },
     ontology: {
       searchPlaceholder: '搜索场景',

--- a/web/src/views/UserMemoryDetail/components/ApiMcpMessageList.tsx
+++ b/web/src/views/UserMemoryDetail/components/ApiMcpMessageList.tsx
@@ -23,17 +23,24 @@ interface ApiMcpMessagesResponse {
   items: ApiMcpMessageItem[];
   page: {
     hasnext: boolean;
+    total: number;
   };
 }
 
 export interface ApiMcpMessageListRef {
   refresh: () => void;
+  total: number;
 }
 
 interface ApiMcpMessageListProps {
   endUserId: string;
   source: ApiMcpSource;
   onMessagesChange?: (messages: ApiMcpMessageItem[]) => void;
+  filterParams?: {
+    start_date?: number;
+    end_date?: number;
+    keyword?: string;
+  }
 }
 
 const PAGE_SIZE = 20
@@ -42,6 +49,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
   endUserId,
   source,
   onMessagesChange,
+  filterParams = {},
 }, ref) => {
   const { t } = useTranslation()
   const [messages, setMessages] = useState<ApiMcpMessageItem[]>([])
@@ -52,6 +60,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
   const loadingRef = useRef<boolean>(false)
   const requestRef = useRef<number>(0)
   const scrollableTarget = `api-mcp-message-list-${source}`
+  const [total, setTotal] = useState<number>(0)
 
   const refresh = useCallback(() => {
     const requestId = ++requestRef.current
@@ -67,6 +76,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
       source,
       page: 1,
       pagesize: PAGE_SIZE,
+      ...filterParams,
     })
       .then(res => {
         if (requestId !== requestRef.current) return
@@ -76,6 +86,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
         setMessages(nextMessages)
         setHasMore(Boolean(response.page?.hasnext))
         onMessagesChange?.(nextMessages)
+        setTotal(response.page?.total || 0)
       })
       .catch(() => {
         if (requestId === requestRef.current) {
@@ -87,7 +98,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
         loadingRef.current = false
         setLoading(false)
       })
-  }, [endUserId, onMessagesChange, source])
+  }, [endUserId, onMessagesChange, source, filterParams])
 
   const loadMore = useCallback(() => {
     if (loadingRef.current || !hasMore) return
@@ -100,6 +111,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
       source,
       page: nextPage,
       pagesize: PAGE_SIZE,
+      ...filterParams,
     })
       .then(res => {
         if (requestId !== requestRef.current) return
@@ -110,6 +122,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
         setMessages(nextMessages)
         setHasMore(Boolean(response.page?.hasnext))
         onMessagesChange?.(nextMessages)
+        setTotal(response.page?.total || 0)
       })
       .catch(() => {
         if (requestId === requestRef.current) {
@@ -121,9 +134,12 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
           loadingRef.current = false
         }
       })
-  }, [endUserId, hasMore, onMessagesChange, source])
+  }, [endUserId, hasMore, onMessagesChange, source, filterParams])
 
-  useImperativeHandle(ref, () => ({ refresh }), [refresh])
+  useImperativeHandle(ref, () => ({
+    refresh,
+    total,
+  }), [refresh, total])
 
   useEffect(() => {
     refresh()
@@ -139,7 +155,7 @@ const ApiMcpMessageList = forwardRef<ApiMcpMessageListRef, ApiMcpMessageListProp
   return (
     <div
       id={scrollableTarget}
-      className="rb:mt-5! rb:h-[calc(100%-89px)]! rb:overflow-y-auto! rb:w-full! rb:overflow-x-hidden!"
+      className="rb:mt-5! rb:flex-1! rb:min-h-0! rb:overflow-y-auto! rb:w-full! rb:overflow-x-hidden!"
     >
       <InfiniteScroll
         dataLength={messages.length}

--- a/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
+++ b/web/src/views/UserMemoryDetail/pages/WorkingDetail.tsx
@@ -4,12 +4,13 @@
  * @Last Modified by: ZhaoYing
  * @Last Modified time: 2026-08-14 14:51:27
  */
-import { type FC, useEffect, useState, useMemo, useRef, Fragment } from 'react'
+import { type FC, useEffect, useState, useMemo, useRef, useCallback, Fragment } from 'react'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
-import { Row, Col, Skeleton, Button, Divider, Tooltip, Flex } from 'antd'
+import { Row, Col, Skeleton, Button, Divider, Tooltip, Flex, DatePicker, Form } from 'antd'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import type { Dayjs } from 'dayjs'
 
 import RbCard from '@/components/RbCard/Card'
 import {
@@ -24,6 +25,7 @@ import { formatDateTime } from '@/utils/format'
 import Empty from '@/components/Empty'
 import RbAlert from '@/components/RbAlert'
 import ChatContent from '@/components/Chat/ChatContent'
+import SearchInput from '@/components/SearchInput'
 import type { ChatItem } from '@/components/Chat/types'
 import PageLoading from '@/components/Empty/PageLoading'
 import type { Data as SummaryData } from '../components/AboutMe'
@@ -94,6 +96,22 @@ const WorkingDetail: FC = () => {
   const [summary, setSummary] = useState<SummaryData>({} as SummaryData)
   const [selected, setSelected] = useState<Conversation | ApiMcpListItem | null>(null)
   const apiMcpMessageListRef = useRef<ApiMcpMessageListRef>(null)
+  const [filterForm] = Form.useForm<{ range?: [Dayjs, Dayjs] | null; keyword?: string; }>()
+  const formValues = Form.useWatch([], filterForm)
+
+  /** Date range + keyword filters applied to the conversation message stream. */
+  const filterParams = useMemo(() => {
+    const params: { start_date?: number; end_date?: number; keyword?: string } = {}
+    const range = formValues?.range
+    if (range && range[0] && range[1]) {
+      params.start_date = range[0].startOf('day').valueOf()
+      params.end_date = range[1].endOf('day').valueOf()
+    }
+    if (formValues?.keyword) params.keyword = formValues.keyword
+    return params
+  }, [formValues])
+  const filterParamsRef = useRef(filterParams)
+  filterParamsRef.current = filterParams
 
   /* Fetch conversation list + api/mcp data sources whenever the route user ID changes. */
   useEffect(() => {
@@ -104,6 +122,7 @@ const WorkingDetail: FC = () => {
     setData([])
     setApiMcpList([])
     setHasMore(true)
+    filterForm.resetFields()
     pageRef.current = 1
     Promise.all([getApiMcpList(), getData()])
       .then(([apiMcpItems, conversations]) => {
@@ -113,7 +132,7 @@ const WorkingDetail: FC = () => {
       .finally(() => {
         setLoading(false)
       })
-  }, [id])
+  }, [id, filterForm])
 
   const [apiMcpList, setApiMcpList] = useState<ApiMcpListItem[]>([])
   /** Load api/mcp data sources; resolves with the fetched list. */
@@ -177,10 +196,34 @@ const WorkingDetail: FC = () => {
     })
   }
 
+  const prevSelectedRef = useRef<Conversation | ApiMcpListItem | null>(null)
+  // Merged selection + filter effect: handleSelect batches resetFields + setSelected, which would
+  // otherwise fire both the selection effect and the filter effect in the same render and call
+  // fetchMessages twice. Branch on whether the selection actually changed to fetch only once.
   useEffect(() => {
     if (!id || !selected || (!(selected as Conversation)?.id && !(selected as ApiMcpListItem)?.source)) return
-    getDetail(selected)
-  }, [id, selected])
+    if (selected !== prevSelectedRef.current) {
+      prevSelectedRef.current = selected
+      getDetail(selected)
+    } else {
+      fetchMessages(selected)
+    }
+  }, [id, selected, filterParams])
+
+  /** Fetch chat messages for a conversation, applying the current date/keyword filters. */
+  const fetchMessages = useCallback((conversation: Conversation | ApiMcpListItem) => {
+    if (!id) return
+    const conversationId = (conversation as Conversation).id
+    if (!conversationId) return
+    setMessagesLoading(true)
+    getConversationMessages(id, { conversation_id: conversationId, ...filterParamsRef.current })
+      .then(res => {
+        setMessages(res as ChatItem[])
+      })
+      .finally(() => {
+        setMessagesLoading(false)
+      })
+  }, [id, filterParamsRef.current])
 
   /**
    * Fetch the chat messages for the selected conversation. For `conversation`-type
@@ -195,14 +238,7 @@ const WorkingDetail: FC = () => {
     setMessages([])
     if (conversationId) {
       setDetailLoading(true)
-      setMessagesLoading(true)
-      getConversationMessages(id, conversationId)
-        .then(res => {
-          setMessages(res as ChatItem[])
-        })
-        .finally(() => {
-          setMessagesLoading(false)
-        })
+      fetchMessages(conversation)
       getConversationDetail(id, conversationId)
         .then(res => {
           setDetail(res as Detail)
@@ -218,12 +254,19 @@ const WorkingDetail: FC = () => {
   }
 
   const handleRefresh = () => {
-    if ((selected as ApiMcpListItem)?.source) {
-      apiMcpMessageListRef.current?.refresh()
-      getUserInsight()
-    } else if (selected) {
-      getDetail(selected)
-    }
+    filterForm.resetFields()
+    setTimeout(() => {
+      if ((selected as ApiMcpListItem)?.source) {
+        apiMcpMessageListRef.current?.refresh()
+        getUserInsight()
+      } else if (selected) {
+        getDetail(selected)
+      }
+    }, 0)
+  }
+  const handleSelect = (conversation: Conversation | ApiMcpListItem) => {
+    filterForm.resetFields()
+    setSelected(conversation)
   }
   /** Derive a human-readable date range (e.g. "2024.01 - 2024.03") from message timestamps. */
   const timeRange = useMemo(() => {
@@ -281,7 +324,7 @@ const WorkingDetail: FC = () => {
                           className={clsx("rb:cursor-pointer rb:rounded-xl rb:h-12 rb:py-1! rb:px-3! rb:hover:bg-[#F6F6F6]", {
                             'rb:bg-[#171719] rb:hover:bg-[#171719]! rb:text-white': item.source === (selected as ApiMcpListItem)?.source,
                           })}
-                          onClick={() => setSelected(item)}
+                          onClick={() => handleSelect(item)}
                         >
                           <div className="rb:leading-5 rb:break-all rb:line-clamp-2 rb:flex-1">
                             {t(`userMemory.${item.source}`)}
@@ -296,7 +339,7 @@ const WorkingDetail: FC = () => {
                           className={clsx("rb:cursor-pointer rb:rounded-xl rb:h-12 rb:py-1! rb:px-3! rb:hover:bg-[#F6F6F6]", {
                             'rb:bg-[#171719] rb:hover:bg-[#171719]! rb:text-white': item.id === (selected as Conversation)?.id,
                           })}
-                          onClick={() => setSelected(item)}
+                          onClick={() => handleSelect(item)}
                         >
                           <div className="rb:size-6 rb:bg-cover rb:bg-[url('@/assets/images/userMemory/chat.svg')]"></div>
                           <Tooltip title={item.title}>
@@ -334,11 +377,27 @@ const WorkingDetail: FC = () => {
                   className="rb:h-full!"
                 >
                   <Flex vertical className="rb:h-full! rb:overflow-y-hidden!">
-                    <div className="rb:text-[#5B6167] rb:leading-4.5 rb:text-[12px]">{timeRange}</div>
-                    <Flex justify="space-between" align="center" className="rb:bg-[#F6F6F6] rb:rounded-lg rb:py-2.5! rb:pr-2.5! rb:pl-3.25! rb:mt-3!">
-                      {t('workingDetail.conversationStream')}
-                      <Button className="rb:h-6!" onClick={handleRefresh}>{t('workingDetail.refresh')}</Button>
+                    <Flex align="center" justify="space-between">
+                      <div className="rb:text-[#5B6167] rb:leading-4.5 rb:text-[12px]">{timeRange}</div>
+                      <span className="rb:text-[12px] rb:text-[#5B6167]">
+                        {t('workingDetail.total', { total: (selected as ApiMcpListItem).source ? apiMcpMessageListRef.current?.total || 0 : messages.length })}
+                      </span>
                     </Flex>
+                    <Form form={filterForm} initialValues={{ keyword: undefined, range: undefined}}>
+                      <Flex gap={8} align="center" justify="end" className="rb:bg-[#F6F6F6] rb:rounded-lg rb:py-2.5! rb:pr-2.5! rb:pl-3.25! rb:my-3!">
+                        <Form.Item name="keyword" noStyle>
+                          <SearchInput
+                            placeholder={t('workingDetail.searchPlaceholder')}
+                            variant="outlined"
+                            className="rb:w-40! rb:shrink-0!"
+                          />
+                        </Form.Item>
+                        <Form.Item name="range" noStyle>
+                          <DatePicker.RangePicker allowClear className="rb:max-w-[240px] rb:flex-1!" />
+                        </Form.Item>
+                        <Button onClick={handleRefresh}>{t('common.reset')}</Button>
+                      </Flex>
+                    </Form>
                     {(selected as ApiMcpListItem).source && id
                       ? (
                         <ApiMcpMessageList
@@ -346,6 +405,7 @@ const WorkingDetail: FC = () => {
                           endUserId={id}
                           source={(selected as ApiMcpListItem).source}
                           onMessagesChange={setMessages}
+                          filterParams={filterParams}
                         />
                       )
                       : messagesLoading


### PR DESCRIPTION
## Sourcery 摘要

为工作记忆详情视图添加支持搜索和日期筛选的消息流。

新功能：
- 为对话和 API/MCP 消息视图添加关键词和日期范围筛选。
- 显示筛选后的消息总数，并提供本地化的搜索和计数标签。

增强功能：
- 更新消息检索 API，以支持可选的筛选和分页参数。
- 切换记录、刷新或更换用户时重置筛选条件，同时保留 API/MCP 消息的无限滚动功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add searchable, date-filtered message streams to the working memory detail view.

New Features:
- Add keyword and date-range filtering to conversation and API/MCP message views.
- Display filtered message totals and provide localized search and count labels.

Enhancements:
- Update message retrieval APIs to support optional filtering and pagination parameters.
- Reset filters when switching records, refreshing, or changing users while preserving infinite scrolling for API/MCP messages.

</details>