### PR TITLE
fix(web): ui

### DIFF
--- a/web/src/views/UserMemoryDetail/components/AboutMe.tsx
+++ b/web/src/views/UserMemoryDetail/components/AboutMe.tsx
@@ -82,26 +82,27 @@ const AboutMe = forwardRef<AboutMeRef, { className?: string; }>(({ className }, 
                   <Tag key={index} color="default">{tag}</Tag>
                 ))}
               </Flex>
+              <Divider className="rb:my-4!" />
             </>}
             {data.user_summary && <>
-              <Divider className="rb:my-4!" />
               <div className="rb:font-regular rb:leading-5 rb:text-[#5B6167]">
                 {data.user_summary}
               </div>
+              <Divider className="rb:my-4!" />
             </>}
             {data.personality && <>
-              <Divider className="rb:my-4!" />
               <div className="rb:font-medium rb:leading-5">{t('userMemory.personality')}</div>
               <div className="rb:font-regular rb:leading-5 rb:text-[#5B6167] rb:mt-2">
                 {data.personality}
               </div>
+              <Divider className="rb:my-4!" />
             </>}
             {data.core_values && <>
-              <Divider className="rb:my-4!" />
               <div className="rb:font-medium rb:leading-5">{t('userMemory.core_values')}</div>
               <div className="rb:font-regular rb:leading-5 rb:text-[#5B6167] rb:mt-2">
                 {data.core_values}
               </div>
+              <Divider className="rb:my-4!" />
             </>}
             {data.one_sentence && 
               <RbAlert className="rb:mt-4! rb:text-[14px]!">{data.one_sentence}</RbAlert>


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 修正用户记忆“关于我”视图中分隔线的位置，使分隔线显示在每个已填充的分区之后。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the placement of section dividers in the user memory About Me view so separators appear after each populated section.

</details>