### PR TITLE
fix(web): end user identity

### DIFF
--- a/web/src/views/UserMemory/components/MemorySubjectDetailModal.tsx
+++ b/web/src/views/UserMemory/components/MemorySubjectDetailModal.tsx
@@ -108,7 +108,7 @@ const MemorySubjectDetailModal = forwardRef<MemorySubjectDetailModalRef>((_, ref
         <div className="rb:mb-3 rb:rounded-xl rb:bg-[rgba(21,94,239,0.08)] rb:p-3">
           <DetailField
             label={t('userMemory.identity')}
-            value={item?.end_user?.other_id || t('userMemory.unboundIdentity')}
+            value={item?.end_user?.identity_features || t('userMemory.unboundIdentity')}
           />
         </div>
 

--- a/web/src/views/UserMemory/types.ts
+++ b/web/src/views/UserMemory/types.ts
@@ -18,6 +18,7 @@ export interface Data {
     other_id: string;
     write_time: number;
     expire_time: number;
+    identity_features: string;
   },
   memory_num: {
     total: number;


### PR DESCRIPTION
## Sourcery 摘要

更正用户记忆详情中显示的最终用户身份。

错误修复：
- 在用户记忆详情中显示身份特征字段中的最终用户身份；如果不可用，则回退到未绑定身份标签。

增强功能：
- 更新用户记忆数据类型，以包含最终用户身份特征。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the end-user identity shown in user memory details.

Bug Fixes:
- Display the end-user identity from the identity features field in user memory details, falling back to the unbound identity label when unavailable.

Enhancements:
- Update user memory data types to include end-user identity features.

</details>