### PR TITLE
Feat/add grace period

### DIFF
--- a/api/app/models/end_user_model.py
+++ b/api/app/models/end_user_model.py
@@ -82,6 +82,11 @@ class EndUser(Base):
     is_active = Column(Boolean, default=True, server_default="true", nullable=False, comment="是否有效，False 表示已删除")
     reflection_time = Column(DateTime, nullable=True)
     write_time = Column(DateTime, nullable=True, comment="最后一次记忆写入时间")
+    grace_period_until = Column(
+        DateTime,
+        nullable=True,
+        comment="宽限期截止时间，NULL 表示未触发宽限期",
+    )
     created_at = Column(DateTime, default=utcnow_naive)
     updated_at = Column(DateTime, default=utcnow_naive, onupdate=utcnow_naive)
 

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -18,6 +18,7 @@ from app.utils.redis_cache import redis_cache
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
+_GRACE_PERIOD_UPDATE_BATCH_SIZE = 1000
 
 
 class UserTagRefreshCandidate(NamedTuple):
@@ -69,10 +70,7 @@ class EndUserRepository:
 
     @staticmethod
     def _expired_temporary_filter():
-        """构造临时身份过期条件。
-
-        PostgreSQL 使用 retention_days 乘以固定的一天 interval，避免拼接动态 SQL。
-        """
+        """Build the filter for temporary identities eligible for deletion."""
         expires_at = EndUserRepository._temporary_expires_at_expr()
         return (
             EndUser.is_active == sa.true(),
@@ -80,7 +78,76 @@ class EndUserRepository:
             EndUser.write_time.is_not(None),
             Workspace.retention_days.is_not(None),
             expires_at < func.now(),
+            or_(
+                EndUser.grace_period_until.is_(None),
+                EndUser.grace_period_until < func.now(),
+            ),
         )
+
+    def mark_grace_period_for_expired_users(
+            self,
+            workspace_id: uuid.UUID,
+            retention_days: int,
+            grace_period_until: datetime,
+            reference_time: datetime,
+    ) -> int:
+        """Mark currently expired temporary identities with a grace deadline.
+
+        Args:
+            workspace_id: Workspace whose temporary identities are evaluated.
+            retention_days: New retention duration in whole days.
+            grace_period_until: Naive UTC deadline assigned to affected identities.
+            reference_time: Naive UTC timestamp used for a consistent expiry cutoff.
+        """
+        cutoff_time = reference_time - timedelta(days=retention_days)
+        affected_count = 0
+        last_write_time: datetime | None = None
+        last_end_user_id: uuid.UUID | None = None
+
+        while True:
+            candidates_query = self.db.query(EndUser.id, EndUser.write_time).filter(
+                EndUser.workspace_id == workspace_id,
+                EndUser.is_active == sa.true(),
+                EndUser.identity_status == "temporary",
+                EndUser.write_time.is_not(None),
+                EndUser.write_time < cutoff_time,
+            )
+            if last_write_time is not None and last_end_user_id is not None:
+                candidates_query = candidates_query.filter(
+                    sa.tuple_(EndUser.write_time, EndUser.id)
+                    > sa.tuple_(last_write_time, last_end_user_id)
+                )
+
+            candidates = (
+                candidates_query
+                .order_by(EndUser.write_time.asc(), EndUser.id.asc())
+                .limit(_GRACE_PERIOD_UPDATE_BATCH_SIZE)
+                .all()
+            )
+            if not candidates:
+                break
+
+            candidate_ids = [candidate.id for candidate in candidates]
+            result = self.db.execute(
+                update(EndUser)
+                .where(
+                    EndUser.id.in_(candidate_ids),
+                    EndUser.workspace_id == workspace_id,
+                    EndUser.is_active == sa.true(),
+                    EndUser.identity_status == "temporary",
+                    EndUser.write_time.is_not(None),
+                    EndUser.write_time < cutoff_time,
+                )
+                .values(grace_period_until=grace_period_until)
+            )
+            affected_count += max(result.rowcount or 0, 0)
+            last_write_time = candidates[-1].write_time
+            last_end_user_id = candidates[-1].id
+
+            if len(candidates) < _GRACE_PERIOD_UPDATE_BATCH_SIZE:
+                break
+
+        return affected_count
 
     def get_expired_temporary_end_user_ids(self) -> List[uuid.UUID]:
         """按空间有效期和最后写入时间稳定查询全部过期临时身份 ID。"""
@@ -104,6 +171,10 @@ class EndUserRepository:
                     EndUser.identity_status == "temporary",
                     EndUser.write_time.is_not(None),
                     EndUser.write_time < cutoff_time,
+                    or_(
+                        EndUser.grace_period_until.is_(None),
+                        EndUser.grace_period_until < scan_time,
+                    ),
                 )
                 .order_by(EndUser.write_time.asc(), EndUser.id.asc())
                 .all()

--- a/api/app/repositories/workspace_repository.py
+++ b/api/app/repositories/workspace_repository.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timedelta
 from typing import List, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,12 +7,14 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import select
 
 from app.core.logging_config import get_db_logger
+from app.core.utils.datetime_utils import utcnow_naive
 from app.models.user_model import User
 from app.models.workspace_model import Workspace, WorkspaceMember, WorkspaceRole
 from app.schemas.workspace_schema import WorkspaceCreate
 
 # 获取数据库专用日志器
 db_logger = get_db_logger()
+_RETENTION_GRACE_PERIOD_DAYS = 3
 
 
 class WorkspaceRepository:
@@ -87,20 +90,51 @@ class WorkspaceRepository:
             workspace_id: uuid.UUID,
             retention_days: int | None,
     ) -> int | None:
-        """更新工作空间的临时身份保留天数并提交事务。"""
+        """Update retention and mark newly expired identities in one transaction.
+
+        Args:
+            workspace_id: Workspace whose retention policy is updated.
+            retention_days: New retention duration, or ``None`` for no expiration.
+        """
         try:
             workspace = (
                 self.db.query(Workspace)
                 .filter(Workspace.id == workspace_id)
+                .with_for_update()
                 .first()
             )
             if workspace is None:
                 raise ValueError(f"Workspace not found: {workspace_id}")
 
+            old_retention_days = workspace.retention_days
+            grace_period_affected_count = 0
+            if retention_days is not None and (
+                    old_retention_days is None
+                    or retention_days < old_retention_days
+            ):
+                from app.repositories.end_user_repository import EndUserRepository
+
+                reference_time = utcnow_naive()
+                grace_period_affected_count = EndUserRepository(
+                    self.db
+                ).mark_grace_period_for_expired_users(
+                    workspace_id=workspace_id,
+                    retention_days=retention_days,
+                    grace_period_until=(
+                        reference_time + timedelta(days=_RETENTION_GRACE_PERIOD_DAYS)
+                    ),
+                    reference_time=reference_time,
+                )
+
             workspace.retention_days = retention_days
             self.db.add(workspace)
             self.db.commit()
             self.db.refresh(workspace)
+            db_logger.info(
+                f"更新工作空间保留天数成功: workspace_id={workspace_id}, "
+                f"retention_days={workspace.retention_days}, "
+                f"grace_period_affected_count={grace_period_affected_count}"
+            )
             return workspace.retention_days
         except Exception as e:
             self.db.rollback()

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 import uuid
+from datetime import timedelta
 from typing import List, Optional
 
 from sqlalchemy import or_, select
@@ -55,6 +56,7 @@ business_logger = get_business_logger()
 DEFAULT_PRESET_KEY = "default"
 _WORKSPACE_MODEL_SLOTS = ("llm", "embedding", "rerank", "vision", "audio", "video")
 _REQUIRED_WORKSPACE_MODEL_SLOTS = ("llm", "embedding", "rerank")
+_RETENTION_GRACE_PERIOD_DAYS = 3
 
 
 def _serialize_model_option(model: ModelConfig) -> dict:
@@ -1123,24 +1125,59 @@ def update_workspace_retention_policy(
         retention_days: int | None,
         user: User,
 ) -> int | None:
-    """以空间成员权限更新指定工作空间的临时身份保留天数。"""
+    """Update temporary-memory retention and protect newly expired identities.
+
+    Args:
+        db: Active synchronous database session.
+        workspace_id: Workspace whose retention policy is updated.
+        retention_days: New retention duration, or ``None`` for no expiration.
+        user: User requesting the policy update.
+    """
     business_logger.info(
         f"更新工作空间保留策略: workspace_id={workspace_id}, "
         f"retention_days={retention_days}, 操作者={user.username}"
     )
     _check_workspace_member_permission(db, workspace_id, user)
     try:
-        updated_retention_days = workspace_repository.update_workspace_retention_days(
-            db=db,
-            workspace_id=workspace_id,
-            retention_days=retention_days,
+        workspace = (
+            db.query(Workspace)
+            .filter(Workspace.id == workspace_id)
+            .with_for_update()
+            .first()
         )
+        if workspace is None:
+            raise ValueError(f"Workspace not found: {workspace_id}")
+
+        old_retention_days = workspace.retention_days
+        grace_period_affected_count = 0
+        if retention_days is not None and (
+                old_retention_days is None
+                or retention_days < old_retention_days
+        ):
+            reference_time = utcnow_naive()
+            grace_period_affected_count = EndUserRepository(
+                db
+            ).mark_grace_period_for_expired_users(
+                workspace_id=workspace_id,
+                retention_days=retention_days,
+                grace_period_until=(
+                    reference_time + timedelta(days=_RETENTION_GRACE_PERIOD_DAYS)
+                ),
+                reference_time=reference_time,
+            )
+
+        workspace.retention_days = retention_days
+        db.add(workspace)
+        db.commit()
+        db.refresh(workspace)
         business_logger.info(
             f"工作空间保留策略更新成功: workspace_id={workspace_id}, "
-            f"retention_days={updated_retention_days}"
+            f"retention_days={workspace.retention_days}, "
+            f"grace_period_affected_count={grace_period_affected_count}"
         )
-        return updated_retention_days
+        return workspace.retention_days
     except Exception as e:
+        db.rollback()
         business_logger.error(
             f"工作空间保留策略更新失败: workspace_id={workspace_id} - {str(e)}"
         )

--- a/api/app/services/workspace_service.py
+++ b/api/app/services/workspace_service.py
@@ -1,7 +1,6 @@
 import hashlib
 import secrets
 import uuid
-from datetime import timedelta
 from typing import List, Optional
 
 from sqlalchemy import or_, select
@@ -56,7 +55,6 @@ business_logger = get_business_logger()
 DEFAULT_PRESET_KEY = "default"
 _WORKSPACE_MODEL_SLOTS = ("llm", "embedding", "rerank", "vision", "audio", "video")
 _REQUIRED_WORKSPACE_MODEL_SLOTS = ("llm", "embedding", "rerank")
-_RETENTION_GRACE_PERIOD_DAYS = 3
 
 
 def _serialize_model_option(model: ModelConfig) -> dict:
@@ -1139,45 +1137,17 @@ def update_workspace_retention_policy(
     )
     _check_workspace_member_permission(db, workspace_id, user)
     try:
-        workspace = (
-            db.query(Workspace)
-            .filter(Workspace.id == workspace_id)
-            .with_for_update()
-            .first()
+        updated_retention_days = workspace_repository.update_workspace_retention_days(
+            db=db,
+            workspace_id=workspace_id,
+            retention_days=retention_days,
         )
-        if workspace is None:
-            raise ValueError(f"Workspace not found: {workspace_id}")
-
-        old_retention_days = workspace.retention_days
-        grace_period_affected_count = 0
-        if retention_days is not None and (
-                old_retention_days is None
-                or retention_days < old_retention_days
-        ):
-            reference_time = utcnow_naive()
-            grace_period_affected_count = EndUserRepository(
-                db
-            ).mark_grace_period_for_expired_users(
-                workspace_id=workspace_id,
-                retention_days=retention_days,
-                grace_period_until=(
-                    reference_time + timedelta(days=_RETENTION_GRACE_PERIOD_DAYS)
-                ),
-                reference_time=reference_time,
-            )
-
-        workspace.retention_days = retention_days
-        db.add(workspace)
-        db.commit()
-        db.refresh(workspace)
         business_logger.info(
             f"工作空间保留策略更新成功: workspace_id={workspace_id}, "
-            f"retention_days={workspace.retention_days}, "
-            f"grace_period_affected_count={grace_period_affected_count}"
+            f"retention_days={updated_retention_days}"
         )
-        return workspace.retention_days
+        return updated_retention_days
     except Exception as e:
-        db.rollback()
         business_logger.error(
             f"工作空间保留策略更新失败: workspace_id={workspace_id} - {str(e)}"
         )


### PR DESCRIPTION
## Sourcery 摘要

当工作区保留策略缩短时，为新近过期的临时身份提供宽限期保护。

新功能：
- 为因工作区保留策略缩短而过期的临时身份增加三天宽限期。

错误修复：
- 在宽限期内，暂不删除临时身份。

增强功能：
- 当保留设置变得更加严格时，以事务方式更新受影响的身份，并分批处理以提高可扩展性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Protect newly expired temporary identities with a grace period when workspace retention policies are reduced.

New Features:
- Add a three-day grace period for temporary identities that become expired after a workspace retention policy is shortened.

Bug Fixes:
- Exclude temporary identities from deletion while their grace period is active.

Enhancements:
- Update affected identities transactionally when retention settings become more restrictive and process them in batches for scalability.

</details>