### PR TITLE
Feat/api mcp add time keyword filter

### DIFF
--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -1,12 +1,14 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, Query
 
+from app.core.error_codes import BizCode
+from app.core.exceptions import BusinessException
 from app.core.logging_config import get_api_logger
 from app.core.memory.enums import MemoryMessageSource
 from app.core.response_utils import success
-from app.core.utils.datetime_utils import to_timestamp_ms
+from app.core.utils.datetime_utils import parse_timestamp_to_utc_naive, to_timestamp_ms
 from app.db import get_async_db_context
 from app.dependencies import get_current_user_async, CurrentUserSnapshot
 from app.repositories.memory_message_repository import MemoryMessageRepository
@@ -72,6 +74,9 @@ async def get_conversations(
 @router.get("/{end_user_id}/messages", response_model=ApiResponse)
 async def get_messages(
         conversation_id: uuid.UUID,
+        keyword: str | None = Query(default=None, description="消息正文关键词"),
+        start_date: int | None = Query(default=None, ge=0, description="开始时间（毫秒时间戳，UTC）"),
+        end_date: int | None = Query(default=None, ge=0, description="结束时间（毫秒时间戳，UTC）"),
         current_user: CurrentUserSnapshot = Depends(get_current_user_async),
 ):
     """
@@ -79,6 +84,9 @@ async def get_messages(
 
     Args:
         conversation_id (UUID): The ID of the conversation to fetch messages from.
+        keyword (str | None): Optional keyword matched against message content.
+        start_date (int | None): Optional inclusive UTC start time in milliseconds.
+        end_date (int | None): Optional inclusive UTC end time in milliseconds.
         current_user (CurrentUserSnapshot, optional): The authenticated user.
 
     Returns:
@@ -89,10 +97,19 @@ async def get_messages(
         - Consider paginating results if message history is large.
         - Logging can be added for audit and debugging.
     """
+    keyword, start_at, end_at_exclusive = _normalize_message_filters(
+        keyword=keyword,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
     async with get_async_db_context() as db:
         conversation_service = ConversationService(db)
         messages_obj = await conversation_service.get_messages_async(
             conversation_id,
+            keyword=keyword,
+            start_at=start_at,
+            end_at_exclusive=end_at_exclusive,
         )
         messages = [
             conversation_schema.Message.model_validate(message)
@@ -152,6 +169,37 @@ def _parse_dialog_at_to_ms(dialog_at: str | None) -> int | None:
         return None
 
 
+def _normalize_message_filters(
+        keyword: str | None,
+        start_date: int | None,
+        end_date: int | None,
+) -> tuple[str | None, datetime | None, datetime | None]:
+    """Normalize shared message keyword and inclusive timestamp filters.
+
+    Args:
+        keyword: Optional message-content keyword.
+        start_date: Optional inclusive UTC start time in milliseconds.
+        end_date: Optional inclusive UTC end time in milliseconds.
+
+    Returns:
+        A normalized keyword, inclusive start datetime, and exclusive end datetime.
+
+    Raises:
+        BusinessException: If the start timestamp is greater than the end timestamp.
+    """
+    if start_date is not None and end_date is not None and start_date > end_date:
+        raise BusinessException("start_date 不能大于 end_date", BizCode.INVALID_PARAMETER)
+
+    normalized_keyword = keyword.strip() if keyword is not None else None
+    if normalized_keyword == "":
+        normalized_keyword = None
+
+    start_at = parse_timestamp_to_utc_naive(start_date)
+    end_at = parse_timestamp_to_utc_naive(end_date)
+    end_at_exclusive = end_at + timedelta(milliseconds=1) if end_at is not None else None
+    return normalized_keyword, start_at, end_at_exclusive
+
+
 @router.get("/{end_user_id}/sources", response_model=ApiResponse)
 async def get_sources(
         end_user_id: uuid.UUID,
@@ -182,6 +230,9 @@ async def get_source_messages(
         source: str = Query(..., description="来源：service_api 或 mcp"),
         page: int = Query(default=1, ge=1, description="页码，从 1 开始"),
         pagesize: int = Query(default=20, ge=1, le=100, description="每页数量，最大 100"),
+        keyword: str | None = Query(default=None, description="消息正文关键词"),
+        start_date: int | None = Query(default=None, ge=0, description="开始时间（毫秒时间戳，UTC）"),
+        end_date: int | None = Query(default=None, ge=0, description="结束时间（毫秒时间戳，UTC）"),
         current_user: CurrentUserSnapshot = Depends(get_current_user_async),
 ):
     """按来源分页获取工作记忆消息，按 created_at 从旧到新排列，形成连贯对话流。
@@ -196,7 +247,17 @@ async def get_source_messages(
         source: service_api 或 mcp
         page: 页码（默认 1，最小 1）
         pagesize: 每页数量（默认 20，最小 1，最大 100）
+        keyword: Optional message-content keyword.
+        start_date: Optional inclusive UTC start time in milliseconds.
+        end_date: Optional inclusive UTC end time in milliseconds.
+        current_user: The authenticated user snapshot.
     """
+    keyword, start_at, end_at_exclusive = _normalize_message_filters(
+        keyword=keyword,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
     allowed_sources = {MemoryMessageSource.SERVICE_API.value, MemoryMessageSource.MCP.value}
     if source not in allowed_sources:
         return success(
@@ -216,6 +277,9 @@ async def get_source_messages(
             source=source,
             page=page,
             pagesize=pagesize,
+            keyword=keyword,
+            start_at=start_at,
+            end_at_exclusive=end_at_exclusive,
         )
         items = [
             {

--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -263,7 +263,6 @@ async def get_source_messages(
         return success(
             data={
                 "items": [],
-                "total": 0,
                 "source": source,
                 "page": {"page": page, "pagesize": pagesize, "total": 0, "hasnext": False},
             },
@@ -294,7 +293,6 @@ async def get_source_messages(
     return success(
         data={
             "items": items,
-            "total": total,
             "source": source,
             "page": {
                 "page": page,

--- a/api/app/controllers/memory_working_controller.py
+++ b/api/app/controllers/memory_working_controller.py
@@ -74,6 +74,8 @@ async def get_conversations(
 @router.get("/{end_user_id}/messages", response_model=ApiResponse)
 async def get_messages(
         conversation_id: uuid.UUID,
+        page: int = Query(default=1, ge=1, description="页码，从 1 开始"),
+        pagesize: int = Query(default=20, ge=1, le=100, description="每页数量，最大 100"),
         keyword: str | None = Query(default=None, description="消息正文关键词"),
         start_date: int | None = Query(default=None, ge=0, description="开始时间（毫秒时间戳，UTC）"),
         end_date: int | None = Query(default=None, ge=0, description="结束时间（毫秒时间戳，UTC）"),
@@ -84,17 +86,18 @@ async def get_messages(
 
     Args:
         conversation_id (UUID): The ID of the conversation to fetch messages from.
+        page (int): One-based page number.
+        pagesize (int): Number of messages per page.
         keyword (str | None): Optional keyword matched against message content.
         start_date (int | None): Optional inclusive UTC start time in milliseconds.
         end_date (int | None): Optional inclusive UTC end time in milliseconds.
         current_user (CurrentUserSnapshot, optional): The authenticated user.
 
     Returns:
-        ApiResponse: Contains the list of messages in the conversation.
+        ApiResponse: Contains paginated messages and page metadata.
 
     Notes:
         - Uses ConversationService to fetch messages.
-        - Consider paginating results if message history is large.
         - Logging can be added for audit and debugging.
     """
     keyword, start_at, end_at_exclusive = _normalize_message_filters(
@@ -105,8 +108,10 @@ async def get_messages(
 
     async with get_async_db_context() as db:
         conversation_service = ConversationService(db)
-        messages_obj = await conversation_service.get_messages_async(
+        messages_obj, total = await conversation_service.get_messages_async(
             conversation_id,
+            page=page,
+            pagesize=pagesize,
             keyword=keyword,
             start_at=start_at,
             end_at_exclusive=end_at_exclusive,
@@ -115,7 +120,18 @@ async def get_messages(
             conversation_schema.Message.model_validate(message)
             for message in messages_obj
         ]
-    return success(data=messages, msg="get conversation history success")
+    return success(
+        data={
+            "items": messages,
+            "page": {
+                "page": page,
+                "pagesize": pagesize,
+                "total": total,
+                "hasnext": (page * pagesize) < total,
+            },
+        },
+        msg="get conversation history success",
+    )
 
 
 @router.get("/{end_user_id}/detail", response_model=ApiResponse)

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -593,8 +593,24 @@ class MessageRepository:
             self,
             conversation_id: uuid.UUID,
             limit: Optional[int] = None,
-            current_only: bool = True
+            current_only: bool = True,
+            keyword: str | None = None,
+            start_at: datetime | None = None,
+            end_at_exclusive: datetime | None = None,
     ) -> list[Message]:
+        """Retrieve filtered messages for a conversation asynchronously.
+
+        Args:
+            conversation_id: Conversation UUID.
+            limit: Optional maximum number of messages.
+            current_only: Whether to return only current message versions.
+            keyword: Optional keyword matched against message content.
+            start_at: Optional inclusive creation-time lower bound.
+            end_at_exclusive: Optional exclusive creation-time upper bound.
+
+        Returns:
+            Messages ordered by creation time.
+        """
         stmt = select(Message).where(
             Message.conversation_id == conversation_id,
             Message.is_deleted.is_not(True),
@@ -602,6 +618,13 @@ class MessageRepository:
 
         if current_only:
             stmt = stmt.where(Message.is_current.is_not(False))
+
+        if keyword is not None:
+            stmt = stmt.where(Message.content.ilike(f"%{keyword}%"))
+        if start_at is not None:
+            stmt = stmt.where(Message.created_at >= start_at)
+        if end_at_exclusive is not None:
+            stmt = stmt.where(Message.created_at < end_at_exclusive)
 
         stmt = stmt.order_by(Message.created_at)
 

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -594,45 +594,62 @@ class MessageRepository:
             conversation_id: uuid.UUID,
             limit: Optional[int] = None,
             current_only: bool = True,
+            offset: Optional[int] = None,
             keyword: str | None = None,
             start_at: datetime | None = None,
             end_at_exclusive: datetime | None = None,
-    ) -> list[Message]:
+    ) -> tuple[list[Message], int]:
         """Retrieve filtered messages for a conversation asynchronously.
 
         Args:
             conversation_id: Conversation UUID.
             limit: Optional maximum number of messages.
             current_only: Whether to return only current message versions.
+            offset: Optional number of messages to skip.
             keyword: Optional keyword matched against message content.
             start_at: Optional inclusive creation-time lower bound.
             end_at_exclusive: Optional exclusive creation-time upper bound.
 
         Returns:
-            Messages ordered by creation time.
+            Messages ordered by creation time and the filtered total count.
         """
-        stmt = select(Message).where(
+        base_filter = [
             Message.conversation_id == conversation_id,
             Message.is_deleted.is_not(True),
-        )
-
+        ]
         if current_only:
-            stmt = stmt.where(Message.is_current.is_not(False))
-
+            base_filter.append(Message.is_current.is_not(False))
         if keyword is not None:
-            escaped_keyword = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            stmt = stmt.where(Message.content.ilike(f"%{escaped_keyword}%", escape="\\"))
+            base_filter.append(Message.content.icontains(keyword, autoescape=True))
         if start_at is not None:
-            stmt = stmt.where(Message.created_at >= start_at)
+            base_filter.append(Message.created_at >= start_at)
         if end_at_exclusive is not None:
-            stmt = stmt.where(Message.created_at < end_at_exclusive)
+            base_filter.append(Message.created_at < end_at_exclusive)
 
-        stmt = stmt.order_by(Message.created_at)
-
-        if limit:
+        stmt = (
+            select(
+                Message,
+                func.count().over().label("total"),
+            )
+            .where(*base_filter)
+            .order_by(Message.created_at.asc())
+        )
+        if offset is not None:
+            stmt = stmt.offset(offset)
+        if limit is not None:
             stmt = stmt.limit(limit)
 
-        messages = list((await self.db.scalars(stmt)).all())
+        rows_result = await self.db.execute(stmt)
+        rows_with_total = rows_result.all()
+        if rows_with_total:
+            total = int(rows_with_total[0].total)
+            messages = [row[0] for row in rows_with_total]
+        else:
+            total_result = await self.db.execute(
+                select(func.count(Message.id)).where(*base_filter)
+            )
+            total = int(total_result.scalar_one())
+            messages = []
 
         logger.info(
             "Fetched messages successfully",
@@ -642,7 +659,7 @@ class MessageRepository:
                 "current_only": current_only
             }
         )
-        return messages
+        return messages, total
 
     def get_messages_since(
             self,

--- a/api/app/repositories/conversation_repository.py
+++ b/api/app/repositories/conversation_repository.py
@@ -620,7 +620,8 @@ class MessageRepository:
             stmt = stmt.where(Message.is_current.is_not(False))
 
         if keyword is not None:
-            stmt = stmt.where(Message.content.ilike(f"%{keyword}%"))
+            escaped_keyword = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            stmt = stmt.where(Message.content.ilike(f"%{escaped_keyword}%", escape="\\"))
         if start_at is not None:
             stmt = stmt.where(Message.created_at >= start_at)
         if end_at_exclusive is not None:

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -353,8 +353,7 @@ class MemoryMessageRepository:
             MemoryMessage.source == source,
         ]
         if keyword is not None:
-            escaped_keyword = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            base_filter.append(MemoryMessage.content.ilike(f"%{escaped_keyword}%", escape="\\"))
+            base_filter.append(MemoryMessage.content.icontains(keyword, autoescape=True))
         if start_at is not None:
             base_filter.append(MemoryMessage.created_at >= start_at)
         if end_at_exclusive is not None:

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -13,6 +13,7 @@ MemoryMessageRepository — memory_messages 表的数据访问层
 import logging
 import uuid
 from contextlib import contextmanager
+from datetime import datetime
 from typing import List, Optional
 
 import sqlalchemy as sa
@@ -328,20 +329,35 @@ class MemoryMessageRepository:
         source: str,
         page: int = 1,
         pagesize: int = 20,
+        keyword: str | None = None,
+        start_at: datetime | None = None,
+        end_at_exclusive: datetime | None = None,
     ) -> tuple[list[MemoryMessage], int]:
-        """按来源分页获取消息 + 该来源总条数（异步版本）。
+        """Fetch a filtered page of messages and the matching total for a source.
 
-        分页语义（service_api / mcp 两种来源完全一致）：
-        - 使用 page / pagesize 分页，page 从 1 开始
-        - 仅按 created_at ASC 排序：入库时间从早到晚，即消息从旧到新
-        - total 通过窗口函数 count(*) OVER () 与数据同一条 SQL 返回，
-          避免独立的 COUNT 往返；页码越界时回退一次 COUNT 保证 total 准确
+        Args:
+            end_user_id: End-user identifier owning the messages.
+            source: Message source to match.
+            page: One-based page number.
+            pagesize: Maximum messages per page.
+            keyword: Optional keyword matched against message content.
+            start_at: Optional inclusive creation-time lower bound.
+            end_at_exclusive: Optional exclusive creation-time upper bound.
+
+        Returns:
+            The messages ordered by creation time and the filtered total count.
         """
         base_filter = [
             MemoryMessage.end_user_id == end_user_id,
             MemoryMessage.conversation_id.is_(None),
             MemoryMessage.source == source,
         ]
+        if keyword is not None:
+            base_filter.append(MemoryMessage.content.ilike(f"%{keyword}%"))
+        if start_at is not None:
+            base_filter.append(MemoryMessage.created_at >= start_at)
+        if end_at_exclusive is not None:
+            base_filter.append(MemoryMessage.created_at < end_at_exclusive)
 
         offset = (page - 1) * pagesize
         rows_result = await self.db.execute(

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -353,7 +353,8 @@ class MemoryMessageRepository:
             MemoryMessage.source == source,
         ]
         if keyword is not None:
-            base_filter.append(MemoryMessage.content.ilike(f"%{keyword}%"))
+            escaped_keyword = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            base_filter.append(MemoryMessage.content.ilike(f"%{escaped_keyword}%", escape="\\"))
         if start_at is not None:
             base_filter.append(MemoryMessage.created_at >= start_at)
         if end_at_exclusive is not None:

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -1,7 +1,7 @@
 """会话服务"""
 import asyncio
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Annotated
 from typing import Optional, List, Tuple, Dict, Any
@@ -566,12 +566,31 @@ class ConversationService:
             self,
             conversation_id: uuid.UUID,
             limit: Optional[int] = None,
-            current_only: bool = True
+            current_only: bool = True,
+            keyword: str | None = None,
+            start_at: datetime | None = None,
+            end_at_exclusive: datetime | None = None,
     ) -> List[Message]:
+        """Retrieve filtered messages for a conversation asynchronously.
+
+        Args:
+            conversation_id: Conversation UUID.
+            limit: Optional maximum number of messages.
+            current_only: Whether to return only current message versions.
+            keyword: Optional keyword matched against message content.
+            start_at: Optional inclusive creation-time lower bound.
+            end_at_exclusive: Optional exclusive creation-time upper bound.
+
+        Returns:
+            Messages ordered by creation time.
+        """
         return await self.message_repo.get_message_by_conversation_id_async(
             conversation_id,
             limit,
-            current_only=current_only
+            current_only=current_only,
+            keyword=keyword,
+            start_at=start_at,
+            end_at_exclusive=end_at_exclusive,
         )
 
     def _resolve_v1_internal_user_id(

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -565,28 +565,31 @@ class ConversationService:
     async def get_messages_async(
             self,
             conversation_id: uuid.UUID,
-            limit: Optional[int] = None,
+            page: int = 1,
+            pagesize: int = 20,
             current_only: bool = True,
             keyword: str | None = None,
             start_at: datetime | None = None,
             end_at_exclusive: datetime | None = None,
-    ) -> List[Message]:
-        """Retrieve filtered messages for a conversation asynchronously.
+    ) -> tuple[List[Message], int]:
+        """Retrieve a filtered page of messages for a conversation asynchronously.
 
         Args:
             conversation_id: Conversation UUID.
-            limit: Optional maximum number of messages.
+            page: One-based page number.
+            pagesize: Maximum messages per page.
             current_only: Whether to return only current message versions.
             keyword: Optional keyword matched against message content.
             start_at: Optional inclusive creation-time lower bound.
             end_at_exclusive: Optional exclusive creation-time upper bound.
 
         Returns:
-            Messages ordered by creation time.
+            Messages ordered by creation time and the filtered total count.
         """
         return await self.message_repo.get_message_by_conversation_id_async(
-            conversation_id,
-            limit,
+            conversation_id=conversation_id,
+            limit=pagesize,
+            offset=(page - 1) * pagesize,
             current_only=current_only,
             keyword=keyword,
             start_at=start_at,
@@ -818,7 +821,7 @@ class ConversationService:
             raise BusinessException("会话不存在", BizCode.NOT_FOUND)
 
         try:
-            messages = await self.message_repo.get_message_by_conversation_id_async(
+            messages, _ = await self.message_repo.get_message_by_conversation_id_async(
                 conversation_id,
                 limit=limit,
                 current_only=True,
@@ -1076,7 +1079,7 @@ class ConversationService:
         Returns:
             List[dict]: List of message dictionaries with keys 'role' and 'content'.
         """
-        messages = await self.message_repo.get_message_by_conversation_id_async(
+        messages, _ = await self.message_repo.get_message_by_conversation_id_async(
             conversation_id,
             limit=max_history
         )


### PR DESCRIPTION
## Sourcery 总结

支持在对话查询和来源查询中，对工作记忆消息进行搜索和时间范围筛选。

新功能：
- 为基于对话和来源的工作记忆消息 API 添加可选的关键词和 UTC 时间戳范围筛选条件。

增强功能：
- 规范化筛选输入并验证时间戳范围，同时保留结束日期的包含语义。
- 通过服务层和存储库层一致地应用消息内容和创建时间筛选。
- 根据筛选后的消息集返回分页总数。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为工作记忆消息查询添加关键词和时间范围过滤功能。

新功能：
- 为会话和基于来源的工作记忆消息 API 添加可选的关键词和 UTC 时间戳范围过滤器。

增强功能：
- 规范化过滤器输入、验证时间戳范围、保留结束日期的包含行为，并在服务层和仓储层一致地应用过滤器。
- 根据过滤后的消息集合报告分页总数。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为工作记忆消息查询添加关键词和时间范围过滤功能。

新功能：
- 为基于对话和来源的工作记忆消息 API 添加可选的关键词和 UTC 时间范围过滤器。

增强功能：
- 返回分页的对话结果，并根据过滤后的消息集计算总数。
- 规范化过滤器输入、验证时间戳范围，并在服务层和存储库层保持结束日期包含在内的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add keyword and time-range filtering to working-memory message queries.

New Features:
- Add optional keyword and UTC time-range filters to conversation and source-based working-memory message APIs.

Enhancements:
- Return paginated conversation results with totals calculated from the filtered message set.
- Normalize filter inputs, validate timestamp ranges, and preserve inclusive end-date semantics across service and repository layers.

</details>

</details>

</details>