### PR TITLE
feat(web): create kb use space config models

### DIFF
--- a/web/src/views/KnowledgeBase/components/CreateModal/useCreateModalModels.ts
+++ b/web/src/views/KnowledgeBase/components/CreateModal/useCreateModalModels.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { FormInstance } from 'antd';
-import { getCustomWorkspaceModels } from '@/api/workspaces';
+import { getCustomWorkspaceModels, getWorkspaceModels } from '@/api/workspaces';
 import type { KnowledgeBaseFormData, KnowledgeBaseListItem } from '@/views/KnowledgeBase/types';
 import type { Model } from '@/views/ModelManagement/types';
 
@@ -24,8 +24,17 @@ export const MODEL_TYPE_CONFIG: Record<string, ModelTypeConfig> = {
   chat: { fieldKey: 'chat_id', modelType: 'chat' },
 };
 
+const WORKSPACE_MODEL_FIELD_BY_FORM_FIELD: Record<string, string> = {
+  llm_id: 'llm',
+  embedding_id: 'embedding',
+  reranker_id: 'rerank',
+  image2text_id: 'vision',
+  chat_id: 'chat',
+};
+
 const useCreateModalModels = ({ form, datasets, visible }: UseCreateModalModelsOptions) => {
   const [customModels, setCustomModels] = useState<Record<string, Model[]>>({});
+  const [workspaceModels, setWorkspaceModels] = useState<Record<string, string>>({});
 
   const modelTypeList = useMemo(
     () => [...new Set(
@@ -80,19 +89,22 @@ const useCreateModalModels = ({ form, datasets, visible }: UseCreateModalModelsO
     modelTypeList.forEach((type) => {
       const normalizedType = type.toLowerCase();
       const fieldKey = MODEL_TYPE_CONFIG[normalizedType]?.fieldKey || `${normalizedType}_id`;
+      const workspaceField = WORKSPACE_MODEL_FIELD_BY_FORM_FIELD[fieldKey];
+      const workspaceModelId = workspaceField ? workspaceModels[workspaceField] : undefined;
       const options = normalizedType === 'llm'
         ? [...(modelOptionsByType.llm || []), ...(modelOptionsByType.chat || [])]
         : modelOptionsByType[type] || [];
+      const defaultModelId = workspaceModelId || options[0]?.id || options[0]?.model_id;
 
-      if (options.length > 0 && !form.getFieldValue(fieldKey as any)) {
-        defaultValues[fieldKey] = options[0].id;
+      if (defaultModelId && !form.getFieldValue(fieldKey as any)) {
+        defaultValues[fieldKey] = defaultModelId;
       }
     });
 
     if (Object.keys(defaultValues).length) {
       form.setFieldsValue(defaultValues as any);
     }
-  }, [customModels, datasets, form, modelOptionsByType, modelTypeList, visible]);
+  }, [customModels, datasets, form, modelOptionsByType, modelTypeList, visible, workspaceModels]);
 
   const dynamicTypeList = useMemo(
     () => modelTypeList.filter((type) => (modelOptionsByType[type] || []).length),
@@ -100,13 +112,15 @@ const useCreateModalModels = ({ form, datasets, visible }: UseCreateModalModelsO
   );
 
   const getTypeList = () => {
-    getCustomWorkspaceModels()
-      .then((response) => {
-        setCustomModels((response || {}) as Record<string, Model[]>);
+    Promise.all([getCustomWorkspaceModels(), getWorkspaceModels()])
+      .then(([modelsResponse, workspaceResponse]) => {
+        setCustomModels((modelsResponse || {}) as Record<string, Model[]>);
+        setWorkspaceModels((workspaceResponse || {}) as Record<string, string>);
       })
       .catch((error) => {
-        console.error('Failed to fetch models:', error);
+        console.error('Failed to fetch knowledge base models:', error);
         setCustomModels({});
+        setWorkspaceModels({});
       });
   };
 


### PR DESCRIPTION
## Sourcery 总结

使用工作区模型配置来选择默认知识库模型。

新功能：
- 创建知识库时使用工作区配置的模型选择；如果未配置，则回退到第一个可用模型。

增强：
- 在获取自定义工作区模型的同时获取工作区模型配置，并将其应用于知识库表单默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use workspace model configuration to select default knowledge base models.

New Features:
- Use workspace-configured model selections when creating knowledge bases, with fallback to the first available model.

Enhancements:
- Fetch workspace model configuration alongside custom workspace models and apply it to knowledge base form defaults.

</details>