### PR TITLE
fix(rag): preserve public SpeedBear runtime contract

### DIFF
--- a/packages/redbear-model/src/redbear_model/resolver.py
+++ b/packages/redbear-model/src/redbear_model/resolver.py
@@ -139,7 +139,7 @@ def _build_from_binding(
         base_url=binding.base_url,
         capabilities=config.capabilities,
         is_omni=config.is_omni,
-        params=dict(config.config),
+        params={},
         runtime_options=runtime_options,
     )
 


### PR DESCRIPTION
## Business Background

Public SpeedBear models work in the API through `ModelApiKeyService.get_available_api_key()`, but mem-knowledge resolved `ModelConfig.config` as provider runtime parameters. Enterprise model-management metadata such as `upstream_model_id` was therefore forwarded to the OpenAI SDK, which failed before sending an HTTP request with `AsyncCompletions.create() got an unexpected keyword argument`.

## Summary

- Keep tenant-specific SpeedBear credential and endpoint resolution unchanged.
- Preserve model name, capabilities, and Omni flags from the public model config.
- Do not forward public model-management metadata as provider runtime parameters.

## Changes

- `packages/redbear-model/src/redbear_model/resolver.py`: public binding resolution now produces empty provider params, matching the existing API runtime contract.

## Risk

- Scope is limited to public SpeedBear binding resolution.
- Ordinary models and their key/config provider parameters are unchanged.
- No database, API schema, authentication, tenant/workspace, Dockerfile, dependency, or migration changes.
- External API Key interface impact: none.
- Deployed SpeedBear runtime recovery remains pending until an image containing this commit completes real model calls.

## Test Plan

- [x] TDD RED reproduced sync/async metadata leakage and the exact graph-runtime `upstream_model_id` TypeError.
- [x] Focused resolver/repository/runtime tests: `9 passed`.
- [x] Original fake-gateway regression passed three consecutive runs.
- [x] Ruff and compileall passed.
- [x] Public-package and mem-knowledge import-boundary checks passed.
- [x] `docker build -f mem-knowledge/Dockerfile -t mem-knowledge:speedbear-runtime-contract .` passed from the open-source repository root.
- [x] The built container passed the public SpeedBear resolver contract check.
- [ ] Real deployed LLM/embedding smoke test.

## Sourcery 总结

通过将模型管理元数据与提供商运行时参数分离，恢复公开 SpeedBear 运行时的兼容性。

错误修复：
- 防止将公开 SpeedBear 模型管理元数据传递给提供商运行时，从而避免模型调用期间出现运行时错误。

增强功能：
- 在保留租户特定凭据、端点、模型名称、功能以及 Omni 标志的同时，维持现有的公开 SpeedBear 运行时契约。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore public SpeedBear runtime compatibility by separating model-management metadata from provider runtime parameters.

Bug Fixes:
- Prevent public SpeedBear model-management metadata from being passed to provider runtimes, avoiding runtime errors during model calls.

Enhancements:
- Preserve the existing public SpeedBear runtime contract while retaining tenant-specific credentials, endpoints, model names, capabilities, and Omni flags.

</details>