### PR TITLE
fix(rag): skip empty parent child groups

### DIFF
--- a/mem-knowledge/src/rag/chunk/postprocessor.py
+++ b/mem-knowledge/src/rag/chunk/postprocessor.py
@@ -70,6 +70,18 @@ class ChunkPostProcessor:
                 ctx, group.parent, merge_result, len(parent_chunks)
             )
             if parent_chunk is None:
+                has_serializable_child = any(
+                    self._serialize_chunk(
+                        ctx,
+                        child,
+                        merge_result,
+                        len(child_chunks) + child_offset,
+                    )
+                    is not None
+                    for child_offset, child in enumerate(group.children)
+                )
+                if not has_serializable_child:
+                    continue
                 raise ValueError(
                     f"Invalid {mode} hierarchy: parent group {group_index} "
                     "was removed during serialization."


### PR DESCRIPTION
## Business Background
Parent-child document import fails before vectorization when a parser emits a group whose parent and all children become empty after serialization cleanup, such as an empty image description or zero-width-only text.

## Summary
- Skip a parent-child group only when its parent and every child are non-serializable.
- Preserve strict validation when a child survives without its parent.
- Preserve strict validation when a valid parent has no serializable children.
- Keep child-to-parent indexes compact after skipped groups.

## Changes
- mem-knowledge/src/rag/chunk/postprocessor.py: add the empty-group check before raising the invalid-parent hierarchy error.

## Risk
Low and limited to parent-child serialization. A fully empty group no longer aborts the whole import. Partially valid or structurally invalid groups continue to fail explicitly. No database, Dockerfile, model-provider, authentication, or external API Key contract changes.

## Test Plan
- [x] 4 focused regression scenarios passed, including empty image and zero-width-only full-pipeline cases.
- [x] Ruff check passed for the changed module.
- [x] Python compileall passed for the chunk package.
- [x] Knowledge-service import boundary check passed.
- [x] git diff --check passed for the PR range.
- [x] Open-source mem-knowledge Dockerfile build passed.
- [x] Container-level parent hierarchy contract passed.

## Sourcery 总结

允许父子导入忽略不包含可序列化父项或子项的组，同时保留对无效层级结构的验证。

错误修复：
- 跳过完全不可序列化的父子组，而不是中止导入。
- 对部分有效或结构无效的父子组继续执行严格的层级结构验证。

增强功能：
- 跳过空组时，保持子项到父项的索引紧凑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow parent-child imports to ignore groups that contain no serializable parent or children while preserving validation for invalid hierarchies.

Bug Fixes:
- Skip fully non-serializable parent-child groups instead of aborting the import.
- Retain strict hierarchy validation for partially valid or structurally invalid parent-child groups.

Enhancements:
- Keep child-to-parent indexes compact when empty groups are skipped.

</details>