### PR TITLE
fix(web): kb modal add reset models

### DIFF
--- a/web/src/views/KnowledgeBase/components/CreateModal/index.tsx
+++ b/web/src/views/KnowledgeBase/components/CreateModal/index.tsx
@@ -33,7 +33,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({ refreshTa
   const [generatingEntityTypes, setGeneratingEntityTypes] = useState(false);
   const [isRebuildMode, setIsRebuildMode] = useState(false);
   const [originalType, setOriginalType] = useState<string>('');
-  const { customModels, dynamicTypeList, getTypeList } = useCreateModalModels({
+  const { customModels, dynamicTypeList, getTypeList, resetModelInfo } = useCreateModalModels({
     form,
     datasets,
     visible,
@@ -47,6 +47,7 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({ refreshTa
     setIsRebuildMode(false);
     setOriginalType('');
     setVisible(false);
+    resetModelInfo();
   };
 
   const generateEntityTypes = () => {
@@ -154,8 +155,8 @@ const CreateModal = forwardRef<CreateModalRef, CreateModalRefProps>(({ refreshTa
     setOriginalType(type || '');
     setCurrentStep(isRebuild ? 1 : 0);
     setBaseFields(record || null, actualType);
-    getTypeList();
     setVisible(true);
+    getTypeList();
   };
 
   const performSave = () => {

--- a/web/src/views/KnowledgeBase/components/CreateModal/useCreateModalModels.ts
+++ b/web/src/views/KnowledgeBase/components/CreateModal/useCreateModalModels.ts
@@ -91,12 +91,16 @@ const useCreateModalModels = ({ form, datasets, visible }: UseCreateModalModelsO
       const fieldKey = MODEL_TYPE_CONFIG[normalizedType]?.fieldKey || `${normalizedType}_id`;
       const workspaceField = WORKSPACE_MODEL_FIELD_BY_FORM_FIELD[fieldKey];
       const workspaceModelId = workspaceField ? workspaceModels[workspaceField] : undefined;
-      const options = normalizedType === 'llm'
+      const options = (normalizedType === 'llm'
         ? [...(modelOptionsByType.llm || []), ...(modelOptionsByType.chat || [])]
-        : modelOptionsByType[type] || [];
-      const defaultModelId = workspaceModelId || options[0]?.id || options[0]?.model_id;
+        : modelOptionsByType[type] || []);
 
-      if (defaultModelId && !form.getFieldValue(fieldKey as any)) {
+      const workspaceModel = workspaceModelId
+        ? options.find((model) => model.id === workspaceModelId || model.model_id === workspaceModelId)
+        : undefined;
+      const defaultModelId = workspaceModel?.id || options[0]?.id;
+
+      if (defaultModelId) {
         defaultValues[fieldKey] = defaultModelId;
       }
     });
@@ -123,11 +127,18 @@ const useCreateModalModels = ({ form, datasets, visible }: UseCreateModalModelsO
         setWorkspaceModels({});
       });
   };
+  const resetModelInfo = () => {
+    setCustomModels({});
+    setWorkspaceModels({});
+  };
+
+
 
   return {
     customModels,
     dynamicTypeList,
     getTypeList,
+    resetModelInfo,
   };
 };
 


### PR DESCRIPTION
## Sourcery 总结

重置并刷新知识库模态框的模型信息，确保每次创建或重建流程都以正确的模型选择开始。

Bug 修复：
- 关闭创建模态框时重置知识库模型状态，防止旧的模型选择被带入后续操作。
- 打开模态框时，确保根据当前工作区或可用选项刷新模型默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reset and refresh knowledge-base modal model information so each create or rebuild flow starts with the correct model selections.

Bug Fixes:
- Reset knowledge-base model state when closing the create modal to prevent stale model selections from carrying over.
- Ensure model defaults are refreshed from the current workspace or available options when opening the modal.

</details>