### PR TITLE
fix(rag): stop invalid graph retries and state errors

### DIFF
--- a/mem-knowledge/src/api/routes/knowledge.py
+++ b/mem-knowledge/src/api/routes/knowledge.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Mapping
 from typing import Annotated, Any
 from urllib.parse import quote
 
@@ -60,6 +61,54 @@ from ..schemas.knowledge import KnowledgeCreate, KnowledgeUpdate
 router = APIRouter(prefix="/knowledges", tags=["knowledges"])
 
 logger = logging.getLogger(__name__)
+
+_MODEL_UNAVAILABLE_STATUS_REASONS = {
+    401: "Invalid API key for the selected model",
+    403: "The selected model API key is not authorized",
+    404: "The selected model is not available from the provider",
+    429: "The selected model is currently rate limited",
+}
+
+
+def _provider_status_code(exc: BaseException) -> int | None:
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        response = getattr(current, "response", None)
+        status = getattr(current, "status_code", None)
+        if status is None:
+            status = getattr(response, "status_code", None)
+        if status is None and isinstance(response, Mapping):
+            status = response.get("status_code")
+        try:
+            if status is not None:
+                return int(status)
+        except (TypeError, ValueError):
+            pass
+        for wrapped in (current.__cause__, current.__context__):
+            if isinstance(wrapped, BaseException):
+                pending.append(wrapped)
+    return None
+
+
+def _model_unavailable_reason(exc: BaseException) -> str:
+    status_code = _provider_status_code(exc)
+    if status_code in _MODEL_UNAVAILABLE_STATUS_REASONS:
+        return _MODEL_UNAVAILABLE_STATUS_REASONS[status_code]
+    error_type = type(exc).__name__.lower()
+    if "timeout" in error_type:
+        return "The selected model request timed out"
+    if "connection" in error_type:
+        return "Unable to connect to the selected model provider"
+    if "validation" in error_type:
+        return "The selected model returned an invalid response"
+    if status_code is not None:
+        return f"The selected model provider rejected the request (HTTP {status_code})"
+    return "The selected model is unavailable"
 
 
 def _success(
@@ -131,7 +180,20 @@ async def get_knowledge_graph_entity_types(
                 response_code=400,
                 response_style="http",
             ) from exc
-    result = await graph_service.graph_entity_types(runtime, resolved, scenario)
+    try:
+        result = await graph_service.graph_entity_types(runtime, resolved, scenario)
+    except KnowledgeError:
+        raise
+    except Exception as exc:
+        reason = _model_unavailable_reason(exc)
+        logger.warning(
+            "Graph entity type model unavailable llm_id=%s error_type=%s "
+            "provider_status=%s",
+            llm_id,
+            type(exc).__name__,
+            _provider_status_code(exc),
+        )
+        raise KnowledgeError.from_code("KB_MODEL_UNAVAILABLE", reason) from exc
     return _success(
         request,
         result,

--- a/mem-knowledge/src/errors.py
+++ b/mem-knowledge/src/errors.py
@@ -28,7 +28,7 @@ ERROR_DEFINITIONS = {
     "KB_TASK_DISPATCH_FAILED": ErrorDefinition(500, True, 10001, "internal"),
     "KB_STORAGE_UNAVAILABLE": ErrorDefinition(500, True, 10001, "internal"),
     "KB_SEARCH_UNAVAILABLE": ErrorDefinition(500, True, 10001, "internal"),
-    "KB_MODEL_UNAVAILABLE": ErrorDefinition(500, True, 10001, "internal"),
+    "KB_MODEL_UNAVAILABLE": ErrorDefinition(400, False, 400, "http"),
     "KB_DATABASE_UNAVAILABLE": ErrorDefinition(500, True, 10001, "internal"),
     "KB_INTERNAL_ERROR": ErrorDefinition(500, False, 10001, "internal"),
 }

--- a/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
+++ b/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
@@ -192,7 +192,12 @@ class GraphElasticsearchStore:
             ],
             sort=[
                 {"metadata.sort_id": {"order": "asc", "unmapped_type": "long"}},
-                {"metadata.doc_id": {"order": "asc"}},
+                {
+                    "metadata.doc_id": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load graph source document",
         )
@@ -250,10 +255,35 @@ class GraphElasticsearchStore:
                 "relation_key_kwd",
             ],
             sort=[
-                {"knowledge_graph_kwd": {"order": "asc"}},
-                {"entity_key_kwd": {"order": "asc", "missing": "_last"}},
-                {"relation_key_kwd": {"order": "asc", "missing": "_last"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"knowledge_graph_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "entity_key_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "relation_key_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load graph document evidence keys",
         )
@@ -358,8 +388,21 @@ class GraphElasticsearchStore:
                 [{"terms": {"entity_key_kwd": list(entity_keys)}}],
             ),
             sort=[
-                {"entity_key_kwd": {"order": "asc"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"entity_key_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context="load entity evidence",
         )
@@ -1341,8 +1384,21 @@ class GraphElasticsearchStore:
             index_name=index_name,
             query=self._graph_query(knowledge_id, RELATION_EVIDENCE, extra_filters),
             sort=[
-                {"relation_key_kwd": {"order": "asc"}},
-                {"source_chunk_id_kwd": {"order": "asc", "missing": "_last"}},
+                {"relation_key_kwd": {"order": "asc", "unmapped_type": "keyword"}},
+                {
+                    "source_chunk_id_kwd": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "missing": "_last",
+                        "unmapped_type": "keyword",
+                    }
+                },
             ],
             context=context,
         )

--- a/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
+++ b/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
@@ -525,7 +525,14 @@ class GraphElasticsearchStore:
         hits = await self._collect_search_after_hits(
             index_name=index_name,
             query=self._graph_query(knowledge_id, DOCUMENT_PROJECTION_MAP),
-            sort=[{"document_id": {"order": "asc"}}],
+            sort=[
+                {
+                    "document_id": {
+                        "order": "asc",
+                        "unmapped_type": "keyword",
+                    }
+                }
+            ],
             context="list graph document maps",
         )
         return [dict(source) for hit in hits if isinstance((source := hit.get("_source")), Mapping)]

--- a/mem-knowledge/src/rag/knowledge_graph/extractor.py
+++ b/mem-knowledge/src/rag/knowledge_graph/extractor.py
@@ -4,6 +4,8 @@ import asyncio
 import unicodedata
 from typing import Any, Protocol
 
+from redbear_model.errors import is_provider_rate_limit_error
+
 from .models import ExtractionBatch, ExtractionResult
 from .prompts import EXTRACTION_SYSTEM_PROMPT, build_extraction_prompt
 from .structured_output import unwrap_structured_result
@@ -46,8 +48,8 @@ class LLMEntityRelationExtractor:
                     unwrap_structured_result(raw_result, ExtractionResult),
                     batch,
                 )
-            except Exception:
-                if attempt == 1:
+            except Exception as exc:
+                if is_provider_rate_limit_error(exc) or attempt == 1:
                     raise
                 await asyncio.sleep(0.25)
         raise RuntimeError("unreachable extraction retry state")

--- a/mem-knowledge/src/tasks/evidence_graph.py
+++ b/mem-knowledge/src/tasks/evidence_graph.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from celery import states
 from celery.exceptions import Ignore, Retry
+from redbear_model.errors import is_provider_rate_limit_error
 
 from ..bootstrap import get_settings
 from ..rag.knowledge_graph.config import (
@@ -114,6 +115,26 @@ def _run_observed(
         )
         raise
     except Exception as exc:
+        if is_provider_rate_limit_error(exc):
+            logger.error(
+                "[EvidenceGraph] task_failed task=%s task_id=%s kb_id=%s "
+                "document_id=%s status=failure reason=rate_limited "
+                "error_type=%s retry=%d elapsed_ms=%d",
+                task_name,
+                safe_task_id,
+                safe_knowledge_id,
+                safe_document_id,
+                type(exc).__name__,
+                retry,
+                int((time.perf_counter() - started_at) * 1000),
+            )
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code="KB_GRAPH_RATE_LIMITED",
+                exc=exc,
+                detail="provider_rate_limited",
+            )
+            raise _redacted_exception(exc) from None
         countdown = _retry_countdown(task)
         retry_options = {}
         if isinstance(exc, GraphDocumentDeletionPending):

--- a/mem-knowledge/src/tasks/evidence_graph.py
+++ b/mem-knowledge/src/tasks/evidence_graph.py
@@ -10,7 +10,10 @@ from typing import Any
 
 from celery import states
 from celery.exceptions import Ignore, Retry
-from redbear_model.errors import is_provider_rate_limit_error
+from redbear_model.errors import (
+    PublicCredentialUnavailableError,
+    is_provider_rate_limit_error,
+)
 
 from ..bootstrap import get_settings
 from ..rag.knowledge_graph.config import (
@@ -115,6 +118,26 @@ def _run_observed(
         )
         raise
     except Exception as exc:
+        if isinstance(exc, PublicCredentialUnavailableError):
+            logger.error(
+                "[EvidenceGraph] task_failed task=%s task_id=%s kb_id=%s "
+                "document_id=%s status=failure reason=model_unavailable "
+                "error_type=%s retry=%d elapsed_ms=%d",
+                task_name,
+                safe_task_id,
+                safe_knowledge_id,
+                safe_document_id,
+                type(exc).__name__,
+                retry,
+                int((time.perf_counter() - started_at) * 1000),
+            )
+            run.finish(
+                BusinessOutcome.FAILURE,
+                error_code="KB_GRAPH_MODEL_UNAVAILABLE",
+                exc=exc,
+                detail="model_unavailable",
+            )
+            raise _redacted_exception(exc) from None
         if is_provider_rate_limit_error(exc):
             logger.error(
                 "[EvidenceGraph] task_failed task=%s task_id=%s kb_id=%s "
@@ -387,7 +410,10 @@ def _observe_graph_task(
     )
     return observe_task(
         context,
-        sinks=[StructuredLogSink(), CeleryStateSink(task.update_state)],
+        sinks=[
+            StructuredLogSink(),
+            CeleryStateSink(task.update_state, task_id=context.task_id),
+        ],
         heartbeat_seconds=get_settings().kb_task_heartbeat_seconds,
     )
 

--- a/mem-knowledge/src/tasks/observability.py
+++ b/mem-knowledge/src/tasks/observability.py
@@ -316,8 +316,9 @@ class CeleryStateSink:
         "kb_task_progress",
     }
 
-    def __init__(self, update_state: Callable[..., None]) -> None:
+    def __init__(self, update_state: Callable[..., None], *, task_id: str) -> None:
         self._update_state = update_state
+        self._task_id = task_id
 
     def emit(self, event: TaskEvent) -> None:
         if event.event not in self._ACTIVE_EVENTS:
@@ -339,7 +340,7 @@ class CeleryStateSink:
                 meta[f"count_{key}"] = value
         if not meta:
             return
-        self._update_state(state="STARTED", meta=meta)
+        self._update_state(task_id=self._task_id, state="STARTED", meta=meta)
 
 
 def error_fingerprint(exc: BaseException) -> str:

--- a/packages/redbear-model/src/redbear_model/errors.py
+++ b/packages/redbear-model/src/redbear_model/errors.py
@@ -2,7 +2,38 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from uuid import UUID
+
+
+def _status_code(value: object) -> int | None:
+    status = getattr(value, "status_code", None)
+    if status is None and isinstance(value, Mapping):
+        status = value.get("status_code")
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def is_provider_rate_limit_error(exc: BaseException) -> bool:
+    """Return whether an exception chain contains a provider HTTP 429."""
+
+    pending: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        if _status_code(current) == 429 or _status_code(
+            getattr(current, "response", None)
+        ) == 429:
+            return True
+        for wrapped in (current.__cause__, current.__context__):
+            if isinstance(wrapped, BaseException):
+                pending.append(wrapped)
+    return False
 
 
 class RedBearModelError(Exception):

--- a/packages/redbear-model/src/redbear_model/runtime/llm.py
+++ b/packages/redbear-model/src/redbear_model/runtime/llm.py
@@ -18,7 +18,10 @@ from langchain_core.outputs import GenerationChunk, LLMResult
 from langchain_core.runnables import Runnable
 
 from redbear_model.contracts import ModelProvider, ModelType, ResolvedModelConfig
-from redbear_model.errors import UnsupportedModelProviderError
+from redbear_model.errors import (
+    UnsupportedModelProviderError,
+    is_provider_rate_limit_error,
+)
 from redbear_model.providers.bedrock import (
     build_bedrock_params,
     load_bedrock_chat_class,
@@ -407,7 +410,9 @@ class RedBearLLM(BaseLLM):
             result = await self.with_structured_output(schema, **kwargs).ainvoke(input)
             if result is not None:
                 return result
-        except Exception:
+        except Exception as exc:
+            if is_provider_rate_limit_error(exc):
+                raise
             logger.warning(
                 "Structured output fallback activated for provider=%s model=%s",
                 self._config.provider.value,


### PR DESCRIPTION
## Business Background
Evidence Graph jobs could retry deterministic provider failures, fail on fresh Elasticsearch indices with unmapped sort fields, and emit repeated Celery state-update errors. Model failures in the graph entity-type endpoint were also surfaced as generic server errors.

## Summary
- Stop Evidence Graph retries for provider rate limits and unavailable public model credentials.
- Return HTTP 400 with KB_MODEL_UNAVAILABLE and a stable reason for graph entity-type model failures.
- Restore empty-index sort safeguards migrated from the legacy API implementation.
- Pass the explicit Celery task ID when publishing progress state.

## Changes
- 8 production files changed.
- 230 insertions and 19 deletions.
- No database migration, frontend change, documentation, or committed test files.

## Risk
- Deterministic model-unavailable and provider-rate-limit failures now terminate immediately instead of consuming all Celery retries.
- The internal graph entity-type endpoint now returns a structured HTTP 400 instead of a generic HTTP 500 or legacy empty success.
- Elasticsearch sort changes only affect indices where dynamic fields are not mapped yet.

## External API Key Impact
No external API Key or /v1 endpoint surface is added or changed. The response behavior change is limited to the proxied internal knowledge graph entity-type endpoint.

## Test Plan
- [x] 21 focused tests passed.
- [x] Ruff passed for all changed production files and local regression tests.
- [x] Python compileall passed for mem-knowledge and redbear-model.
- [x] git diff --check passed against origin/release/v0.4.4.
- [x] Local prefork graph rebuild completed on attempt 0 without retry or CeleryStateSink errors; the graph API returned nodes, edges, and source IDs.

## Sourcery 摘要

防止确定性的 Evidence Graph 模型失败和空索引 Elasticsearch 查询触发重试或通用错误。

Bug 修复：
- 停止 Evidence Graph 作业因确定性的提供商速率限制和公共模型凭据不可用错误而重试。
- 针对图实体类型模型失败，返回包含稳定原因的结构化 HTTP 400 `KB_MODEL_UNAVAILABLE` 错误。
- 通过添加未映射字段的排序保护，防止 Elasticsearch 查询在新建或部分完成映射的索引上失败。
- 通过提供明确的任务 ID，消除 Celery 进度状态重复更新错误。

增强功能：
- 在模型运行时和图处理之间集中统一提供商速率限制检测，以保留立即失败行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent deterministic Evidence Graph model failures and empty-index Elasticsearch queries from triggering retries or generic errors.

Bug Fixes:
- Stop Evidence Graph jobs from retrying deterministic provider rate-limit and unavailable public-model credential failures.
- Return structured HTTP 400 KB_MODEL_UNAVAILABLE errors with stable reasons for graph entity-type model failures.
- Prevent Elasticsearch queries from failing on fresh or partially mapped indices by adding unmapped sort safeguards.
- Eliminate repeated Celery progress-state update errors by supplying the explicit task ID.

Enhancements:
- Centralize provider rate-limit detection across model runtime and graph processing to preserve immediate failure behavior.

</details>