### PR TITLE
fix(web): pure_workflow logs hide keyword

### DIFF
--- a/web/src/views/ApplicationConfig/Logs.tsx
+++ b/web/src/views/ApplicationConfig/Logs.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-03-24 15:41:20 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-08-14 17:02:49
+ * @Last Modified time: 2026-09-02 17:55:40
  */
 import { type FC, useRef, useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -259,6 +259,10 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
       ...reset,
     }
   }, [values])
+
+  const isPureWorkflow = useMemo(() => {
+    return application?.type === 'pure_workflow'
+  }, [application.type])
   return (
     <Flex vertical className="rb:bg-white rb:rounded-lg rb:pt-3! rb:px-3! rb:h-full! rb:overflow-hidden!">
       <Flex justify={!isHideAnnotations ? "space-between" : 'flex-end'} className="rb:mb-3!">
@@ -273,12 +277,14 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
           <Space size={8}>
             {activeTab === 'logs' &&
               <>
-                <Form.Item name="keyword" noStyle>
-                  <SearchInput
-                    placeholder={t(`application.${activeTab}SearchPlaceholder`)}
-                    variant="outlined"
-                  />
-                </Form.Item>
+                {!isPureWorkflow &&
+                  <Form.Item name="keyword" noStyle>
+                    <SearchInput
+                      placeholder={t(`application.${activeTab}SearchPlaceholder`)}
+                      variant="outlined"
+                    />
+                  </Form.Item>
+                }
                 <Form.Item name="dateRange" noStyle>
                   <RangePicker
                     className="rb:w-70"
@@ -365,10 +371,10 @@ const Logs: FC<{ application: Application; }> = ({ application }) => {
       <div className="rb:flex-1">
         {activeTab === 'logs' && id && application?.type && <>
           <Table<LogItem>
-            apiUrl={application.type === 'pure_workflow' ? getPureWorkflowAppLogsUrl(id) : getAppLogsUrl(id)}
+            apiUrl={isPureWorkflow ? getPureWorkflowAppLogsUrl(id) : getAppLogsUrl(id)}
             apiParams={logsQuery}
-            columns={application.type === 'pure_workflow' ? pureWorkflowColumns : columns}
-            rowKey={application.type === 'pure_workflow' ? 'execution_id' : "id"}
+            columns={isPureWorkflow ? pureWorkflowColumns : columns}
+            rowKey={isPureWorkflow ? 'execution_id' : "id"}
             isScroll={true}
             fillHeight={true}
           />


### PR DESCRIPTION
## Sourcery 摘要

防止不支持的关键字筛选出现在纯工作流日志中。

错误修复：
- 对于不支持关键字筛选的纯工作流应用，隐藏日志关键字搜索字段。

增强功能：
- 集中处理纯工作流检测，以统一日志表配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent unsupported keyword filtering from appearing in pure workflow logs.

Bug Fixes:
- Hide the log keyword search field for pure workflow applications, where keyword filtering is not supported.

Enhancements:
- Centralize pure workflow detection for consistent log table configuration.

</details>