### PR TITLE
feat(memory): add deterministic dedup and entity quota for QUICK/EXPRESS

### DIFF
--- a/api/app/core/memory/models/service_models.py
+++ b/api/app/core/memory/models/service_models.py
@@ -84,6 +84,8 @@ class MemorySearchResult(BaseModel):
     relations: list[RelationMemory] = Field(default_factory=list)
     content_str: str = Field(default="")
     execution_trace: RetrievalExecutionTrace | None = Field(default=None, exclude=True)
+    # QUICK 在全局截断前执行的同源去重摘要，仅供日志使用，不对外输出。
+    dedup_summary: dict = Field(default_factory=dict, exclude=True)
 
     @property
     def content(self) -> str:

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -9,6 +9,10 @@ from app.core.memory.enums import Neo4jNodeType, SearchStrategy, StorageType
 from app.core.memory.models.service_models import MemorySearchResult
 from app.core.memory.pipelines.base_pipeline import BasePipeline, ModelClientMixin
 from app.core.memory.alerts import enqueue_memory_retrieval_alert_safely
+from app.core.memory.read_services.search_engine.quick_retrieval_dedup import (
+    QUICK_SEARCH_ENTITY_LIMIT,
+    log_quick_retrieval_dedup_safely,
+)
 from app.core.memory.exceptions import (
     MemoryRetrievalBusinessError,
     MemoryRetrievalImpact,
@@ -221,6 +225,17 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             if self._notification_error is not None:
                 await self._enqueue_retrieval_alert(self._notification_error)
             raise
+
+        # 同源去重已在检索层的全局截断前完成，这里只负责写日志：
+        # operation_id 只有 pipeline 层持有。
+        if search_switch in {SearchStrategy.QUICK, SearchStrategy.EXPRESS} and res.dedup_summary:
+            log_quick_retrieval_dedup_safely(
+                operation_id=self._retrieval_operation_id,
+                search_mode=search_switch.name.lower(),
+                before_count=res.dedup_summary.get("before_count", 0),
+                after_count=res.dedup_summary.get("after_count", 0),
+                suppression_records=res.dedup_summary.get("suppression_records", []),
+            )
 
         if search_switch in [SearchStrategy.QUICK, SearchStrategy.EXPRESS, SearchStrategy.META]:
             await self._emit_result_ready(res, started_at)
@@ -727,7 +742,15 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             ]
         meta_task = asyncio.ensure_future(self._user_meta())
         search_service = await self._get_search_service(includes, need_embedder=False, need_llm=False)
-        express_res = await search_service.keyword_search(query, limit)
+        if isinstance(search_service, Neo4jSearchService):
+            express_res = await search_service.keyword_search(
+                query,
+                limit,
+                entity_limit=QUICK_SEARCH_ENTITY_LIMIT,
+                apply_source_dedup=True,
+            )
+        else:
+            express_res = await search_service.keyword_search(query, limit)
         memory_l0 = await meta_task
         profile = project_profile_data(memory_l0)
         await self._emit_stage("profile_loaded", {
@@ -736,6 +759,8 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         })
         combined = memory_l0 + express_res
         combined.execution_trace = express_res.execution_trace
+        # __add__ 只合并 memories/relations/content_str，其余字段必须显式传递。
+        combined.dedup_summary = express_res.dedup_summary
         return combined
 
     async def _quick_read(
@@ -751,7 +776,15 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             need_llm=False,
             enable_rerank=enable_rerank
         )
-        quick_res = await search_service.hybrid_search(query, limit)
+        if isinstance(search_service, Neo4jSearchService):
+            quick_res = await search_service.hybrid_search(
+                query,
+                limit,
+                entity_limit=QUICK_SEARCH_ENTITY_LIMIT,
+                apply_source_dedup=True,
+            )
+        else:
+            quick_res = await search_service.hybrid_search(query, limit)
         memory_l0 = await meta_task
         profile = project_profile_data(memory_l0)
         await self._emit_stage("profile_loaded", {
@@ -760,6 +793,8 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
         })
         combined = memory_l0 + quick_res
         combined.execution_trace = quick_res.execution_trace
+        # __add__ 只合并 memories/relations/content_str，其余字段必须显式传递。
+        combined.dedup_summary = quick_res.dedup_summary
         return combined
 
     async def _conv_history(self) -> MemorySearchResult:

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -340,13 +340,19 @@ class Neo4jSearchService:
             reranked = []
             if documents:
                 try:
-                    # 需要全部候选都拿到 rerank 分：Entity 配额在打分后裁剪，
-                    # 若只给前 limit 个打分，被裁掉的名额会由 0 分候选补位。
+                    # 启用 Entity 配额时必须让全部候选拿到 rerank 分：配额在打分后
+                    # 裁剪，若只给前 limit 个打分，被裁掉的名额会由 0 分候选补位。
+                    # 未启用配额的模式（DEEP/NORMAL）保持基线的 min(limit, ...)。
+                    requested_top_n = (
+                        len(documents)
+                        if entity_limit is not None
+                        else min(limit, len(documents))
+                    )
                     reranked = await asyncio.to_thread(
                         self.reranker.compress_documents,
                         documents,
                         query,
-                        top_n=len(documents)
+                        top_n=requested_top_n
                     )
                 except Exception as e:
                     if self.on_error is not None:
@@ -395,7 +401,9 @@ class Neo4jSearchService:
         rerank_status = "completed" if rerank_applied else "degraded"
         if not rerank_applied:
             degraded_reasons.append("rerank_failed")
-        elif len(index_to_score) < len(memories):
+        elif len(index_to_score) < min(limit, len(memories)):
+            # 与实际请求的 top_n 比较：模型返回数少于被要求的数量才算部分结果，
+            # 否则未开启 Entity 配额时会因 top_n=limit 恒判为 degraded。
             rerank_status = "degraded"
             degraded_reasons.append("rerank_partial_result")
 

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -34,6 +34,9 @@ from app.core.memory.retrieval_trace.models import (
     finite_or_none,
     normalized_keyword_score,
 )
+from app.core.memory.read_services.search_engine.quick_retrieval_dedup import (
+    filter_quick_retrieval_memories,
+)
 from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
 from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
@@ -161,6 +164,55 @@ class Neo4jSearchService:
             include=self.includes
         )
 
+    @staticmethod
+    def _candidate_limit(
+            node_type: Neo4jNodeType,
+            limit: int,
+            entity_limit: int | None,
+    ) -> int:
+        if node_type == Neo4jNodeType.EXTRACTEDENTITY and entity_limit is not None:
+            return min(limit, entity_limit)
+        return limit
+
+    @staticmethod
+    def _apply_entity_quota(
+            memories: list[Memory],
+            entity_limit: int | None,
+    ) -> list[Memory]:
+        """按当前排序保留前 entity_limit 个 ExtractedEntity，其他类型不受影响。
+
+        供模型 rerank 路径在打分后使用：此时列表已按 rerank 分排序，
+        因此保留的是模型认为最相关的 Entity，而非本地融合分最高的。
+        """
+        if entity_limit is None:
+            return memories
+        kept: list[Memory] = []
+        entity_count = 0
+        for memory in memories:
+            if memory.source == Neo4jNodeType.EXTRACTEDENTITY:
+                if entity_count >= entity_limit:
+                    continue
+                entity_count += 1
+            kept.append(memory)
+        return kept
+
+    def _apply_source_dedup(self, memories: list[Memory]) -> tuple[list[Memory], dict]:
+        """在全局截断前执行同源去重，避免被抑制节点占用 limit 名额。
+
+        返回过滤后的列表和供 pipeline 写日志的摘要；摘要计数针对候选池，
+        不是最终返回条数。
+        """
+        before_count = len(memories)
+        kept, suppression_records = filter_quick_retrieval_memories(
+            memories,
+            end_user_id=str(self.ctx.end_user_id),
+        )
+        return kept, {
+            "before_count": before_count,
+            "after_count": len(kept),
+            "suppression_records": suppression_records,
+        }
+
     def _rerank(
             self,
             keyword_results: list[dict],
@@ -221,7 +273,10 @@ class Neo4jSearchService:
             query: str,
             limit: int,
             score_sidecar: dict[tuple[Neo4jNodeType, str], dict],
-    ) -> tuple[list[Memory], str, list[str]]:
+            entity_limit: int | None = None,
+            apply_source_dedup: bool = False,
+    ) -> tuple[list[Memory], str, list[str], dict]:
+        # 所有类型平等进入模型；Entity 配额改由模型打分后裁剪，见 _apply_entity_quota。
         seen: dict[str, dict] = {}
         for node_type in self.includes:
             for record in kw_results.get(node_type, []):
@@ -238,7 +293,7 @@ class Neo4jSearchService:
                     seen[rid] = record
 
         if not seen:
-            return [], "skipped", []
+            return [], "skipped", [], {}
 
         memories: list[Memory] = []
         for record in seen.values():
@@ -267,6 +322,12 @@ class Neo4jSearchService:
             )
             memories.append(result_memory)
 
+        # 同源去重必须在送入模型前完成：被抑制节点既不该消耗 rerank 名额，
+        # 也不该在模型打分后才被删除而让最终结果少于 limit。
+        dedup_summary: dict = {}
+        if apply_source_dedup:
+            memories, dedup_summary = self._apply_source_dedup(memories)
+
         rerank_applied = False
         try:
             documents = [
@@ -279,11 +340,13 @@ class Neo4jSearchService:
             reranked = []
             if documents:
                 try:
+                    # 需要全部候选都拿到 rerank 分：Entity 配额在打分后裁剪，
+                    # 若只给前 limit 个打分，被裁掉的名额会由 0 分候选补位。
                     reranked = await asyncio.to_thread(
                         self.reranker.compress_documents,
                         documents,
                         query,
-                        top_n=min(limit, len(documents))
+                        top_n=len(documents)
                     )
                 except Exception as e:
                     if self.on_error is not None:
@@ -340,12 +403,13 @@ class Neo4jSearchService:
             if memory.retrieval_trace is not None:
                 memory.retrieval_trace.final_score = float(memory.score)
         memories.sort(key=lambda x: x.score, reverse=True)
+        memories = self._apply_entity_quota(memories, entity_limit)
         memories = memories[:limit]
         if rerank_applied:
             logger.info(
                 f"[Neo4jSearch] Model rerank applied: {len(documents)} → {len(memories)} memories"
             )
-        return memories, rerank_status, degraded_reasons
+        return memories, rerank_status, degraded_reasons, dedup_summary
 
     # WARNING: 下方 sigmoid 归一化公式与 retrieval_trace/models.py 的
     # normalized_keyword_score 互为副本（此处是公式源头，驱动真实排序），
@@ -362,15 +426,19 @@ class Neo4jSearchService:
             self,
             query: str,
             limit: int = 10,
+            entity_limit: int | None = None,
+            apply_source_dedup: bool = False,
     ) -> MemorySearchResult:
         """仅全文检索，不做 embedding / rerank / 关系检索。"""
         async with Neo4jConnector(shared_driver=True) as connector:
             self.connector = connector
             kw_results = await self._keyword_search(query, limit)
 
+        # Entity 配额在汇总时按类型截取，因此天然早于跨类型全局排名。
         all_records = []
         for node_type in self.includes:
-            for record in kw_results.get(node_type, []):
+            type_limit = self._candidate_limit(node_type, limit, entity_limit)
+            for record in kw_results.get(node_type, [])[:type_limit]:
                 record["_node_type"] = node_type
                 all_records.append(record)
 
@@ -393,8 +461,10 @@ class Neo4jSearchService:
 
         all_records.sort(key=lambda x: x["score"], reverse=True)
 
+        # 同源去重只能在 Memory 形态上执行，因此先按排序全量构建再截断。
+        # 若沿用「先截断再去重」，被抑制节点腾出的名额无法回填，结果会少于 limit。
         memories = []
-        for record in all_records[:limit]:
+        for record in all_records:
             node_type = record.pop("_node_type")
             memory = data_builder_factory(node_type, record)
             result_memory = Memory(
@@ -415,8 +485,15 @@ class Neo4jSearchService:
                 matched_queries=[query],
             )
             memories.append(result_memory)
+
+        dedup_summary: dict = {}
+        if apply_source_dedup:
+            memories, dedup_summary = self._apply_source_dedup(memories)
+        memories = memories[:limit]
+
         return MemorySearchResult(
             memories=memories,
+            dedup_summary=dedup_summary,
             execution_trace=RetrievalExecutionTrace(
                 keyword_status="completed",
                 semantic_status="skipped",
@@ -431,6 +508,8 @@ class Neo4jSearchService:
             self,
             query: str,
             limit: int = 10,
+            entity_limit: int | None = None,
+            apply_source_dedup: bool = False,
     ) -> MemorySearchResult:
         async with Neo4jConnector(shared_driver=True) as connector:
             self.connector = connector
@@ -464,17 +543,18 @@ class Neo4jSearchService:
             degraded_reasons.append("semantic_search_failed")
 
         if self.reranker is not None:
-            memories, rerank_status, rerank_reasons = await self._hybrid_search_with_model_rerank(
-                kw_results, emb_results, query, limit, score_sidecar
+            memories, rerank_status, rerank_reasons, dedup_summary = await self._hybrid_search_with_model_rerank(
+                kw_results, emb_results, query, limit, score_sidecar, entity_limit, apply_source_dedup
             )
             degraded_reasons.extend(rerank_reasons)
         else:
             memories = []
+            dedup_summary = {}
             for node_type in self.includes:
                 reranked = self._rerank(
                     kw_results.get(node_type, []),
                     emb_results.get(node_type, []),
-                    limit
+                    self._candidate_limit(node_type, limit, entity_limit)
                 )
                 for record in reranked:
                     memory = data_builder_factory(node_type, record)
@@ -506,11 +586,14 @@ class Neo4jSearchService:
                         matched_queries=[query],
                     )
                     memories.append(result_memory)
+            if apply_source_dedup:
+                memories, dedup_summary = self._apply_source_dedup(memories)
             memories.sort(key=lambda x: x.score, reverse=True)
             memories = memories[:limit]
 
         return MemorySearchResult(
             memories=memories,
+            dedup_summary=dedup_summary,
             execution_trace=RetrievalExecutionTrace(
                 keyword_status="failed" if keyword_failed else "completed",
                 semantic_status="failed" if semantic_failed else "completed",

--- a/api/app/core/memory/read_services/search_engine/quick_retrieval_dedup.py
+++ b/api/app/core/memory/read_services/search_engine/quick_retrieval_dedup.py
@@ -20,6 +20,9 @@ if (
 ):
     raise ValueError("QUICK_SEARCH_ENTITY_LIMIT must be a non-negative integer")
 
+# 用户画像节点的 entity_type 取值，与 SEARCH_USER_METADATA 的定位条件保持一致。
+USER_PROFILE_ENTITY_TYPE = "用户"
+
 SuppressionReason = Literal[
     "CHUNK_REPLACED_BY_SUMMARY",
     "STATEMENT_REPLACED_BY_SUMMARY",
@@ -38,15 +41,28 @@ class SuppressionRecord(TypedDict):
 
 
 def is_user_profile(memory: Memory, end_user_id: str) -> bool:
-    """通过节点类型和用户 ID 识别合成画像，不依赖列表位置。"""
-    return (
-        memory.source == Neo4jNodeType.EXTRACTEDENTITY
-        and memory.id == end_user_id
-    )
+    """识别用户画像节点，不依赖列表位置。
+
+    覆盖两个来源：
+
+    - 合成画像：`MetaSearchService` 以 `end_user_id` 作为 `id` 构造，
+      图中并不存在该节点，该 ID 契约由构造方保证；
+    - 画像原节点：图中 `entity_type='用户'` 的真实 `ExtractedEntity`，
+      判据与 `SEARCH_USER_METADATA` 的 WHERE 条件一致。用 `entity_type`
+      而非 `name` 是为了兼容 name 为“我”/“User”等历史变体的节点。
+
+    `end_user_id` 为空时不做 ID 比对，避免 `id` 为空的实体被误判。
+    """
+
+    if memory.source != Neo4jNodeType.EXTRACTEDENTITY:
+        return False
+    if end_user_id and memory.id == end_user_id:
+        return True
+    return memory.data.get("entity_type") == USER_PROFILE_ENTITY_TYPE
 
 
 def count_non_profile_memories(memories: list[Memory], end_user_id: str) -> int:
-    """统计普通候选数量，不包含合成的用户画像节点。"""
+    """统计普通候选数量，不包含用户画像节点。"""
 
     return sum(not is_user_profile(memory, end_user_id) for memory in memories)
 

--- a/api/app/core/memory/read_services/search_engine/quick_retrieval_dedup.py
+++ b/api/app/core/memory/read_services/search_engine/quick_retrieval_dedup.py
@@ -1,0 +1,228 @@
+"""QUICK 与 EXPRESS 检索结果的确定性后处理。"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Literal, TypedDict
+
+from app.core.memory.enums import Neo4jNodeType
+from app.core.memory.models.service_models import Memory
+
+logger = logging.getLogger(__name__)
+
+# QUICK/EXPRESS 在跨类型排名前允许 ExtractedEntity 提供的候选数。
+QUICK_SEARCH_ENTITY_LIMIT = 2
+if (
+    not isinstance(QUICK_SEARCH_ENTITY_LIMIT, int)
+    or isinstance(QUICK_SEARCH_ENTITY_LIMIT, bool)
+    or QUICK_SEARCH_ENTITY_LIMIT < 0
+):
+    raise ValueError("QUICK_SEARCH_ENTITY_LIMIT must be a non-negative integer")
+
+SuppressionReason = Literal[
+    "CHUNK_REPLACED_BY_SUMMARY",
+    "STATEMENT_REPLACED_BY_SUMMARY",
+    "CHUNK_REPLACED_BY_STATEMENT",
+]
+
+
+class SuppressionRecord(TypedDict):
+    """单个被抑制节点的可追溯记录。"""
+
+    node_type: str
+    node_id: str
+    reason: SuppressionReason
+    source_chunk_id: str | None
+    representative_ids: list[str]
+
+
+def is_user_profile(memory: Memory, end_user_id: str) -> bool:
+    """通过节点类型和用户 ID 识别合成画像，不依赖列表位置。"""
+    return (
+        memory.source == Neo4jNodeType.EXTRACTEDENTITY
+        and memory.id == end_user_id
+    )
+
+
+def count_non_profile_memories(memories: list[Memory], end_user_id: str) -> int:
+    """统计普通候选数量，不包含合成的用户画像节点。"""
+
+    return sum(not is_user_profile(memory, end_user_id) for memory in memories)
+
+
+def _chunk_id(value: object) -> str | None:
+    """将来源 Chunk ID 归一化为非空字符串。"""
+
+    if value is None:
+        return None
+    normalized = str(value)
+    return normalized or None
+
+
+def _summary_chunk_ids(memory: Memory) -> list[str]:
+    """读取 Summary 的合法来源 Chunk ID；非列表字段按无来源处理。"""
+
+    raw_chunk_ids = memory.data.get("chunk_ids", [])
+    if not isinstance(raw_chunk_ids, list):
+        return []
+    return [chunk_id for value in raw_chunk_ids if (chunk_id := _chunk_id(value))]
+
+
+def _append_representative(
+    index: dict[str, list[str]],
+    chunk_id: str,
+    representative_id: str,
+) -> None:
+    """按首次出现顺序记录代表节点 ID，并避免重复记录。"""
+
+    representatives = index.setdefault(chunk_id, [])
+    if representative_id not in representatives:
+        representatives.append(representative_id)
+
+
+def filter_quick_retrieval_memories(
+    memories: list[Memory],
+    *,
+    end_user_id: str,
+) -> tuple[list[Memory], list[SuppressionRecord]]:
+    """按来源优先级过滤，同时保持节点原相对顺序。"""
+
+    summaries_by_chunk: dict[str, list[str]] = {}
+    statements_by_chunk: dict[str, list[str]] = {}
+
+    # 第一遍扫描完整输入，建立来源索引；代表节点可能出现在被抑制节点之后。
+    for memory in memories:
+        if memory.source == Neo4jNodeType.STATEMENT:
+            chunk_id = _chunk_id(memory.data.get("chunk_id"))
+            if chunk_id:
+                _append_representative(statements_by_chunk, chunk_id, memory.id)
+        elif memory.source == Neo4jNodeType.MEMORYSUMMARY:
+            for chunk_id in _summary_chunk_ids(memory):
+                _append_representative(summaries_by_chunk, chunk_id, memory.id)
+
+    kept_memories: list[Memory] = []
+    suppression_records: list[SuppressionRecord] = []
+
+    def keep(memory: Memory) -> None:
+        kept_memories.append(memory)
+
+    def suppress(
+        memory: Memory,
+        reason: SuppressionReason,
+        *,
+        source_chunk_id: str | None,
+        representative_ids: list[str],
+    ) -> None:
+        suppression_records.append({
+            "node_type": memory.source.value,
+            "node_id": memory.id,
+            "reason": reason,
+            "source_chunk_id": source_chunk_id,
+            "representative_ids": list(representative_ids),
+        })
+
+    # 第二遍严格按输入顺序决策，保证保留节点和抑制记录的顺序确定。
+    for memory in memories:
+        if is_user_profile(memory, end_user_id):
+            # 用户画像始终保留，且不占普通 Entity 名额。
+            keep(memory)
+        elif memory.source == Neo4jNodeType.MEMORYSUMMARY:
+            keep(memory)
+        elif memory.source == Neo4jNodeType.STATEMENT:
+            chunk_id = _chunk_id(memory.data.get("chunk_id"))
+            summary_ids = summaries_by_chunk.get(chunk_id, []) if chunk_id else []
+            if summary_ids:
+                suppress(
+                    memory,
+                    "STATEMENT_REPLACED_BY_SUMMARY",
+                    source_chunk_id=chunk_id,
+                    representative_ids=summary_ids,
+                )
+            else:
+                keep(memory)
+        elif memory.source == Neo4jNodeType.CHUNK:
+            chunk_id = _chunk_id(memory.id)
+            summary_ids = summaries_by_chunk.get(chunk_id, []) if chunk_id else []
+            statement_ids = statements_by_chunk.get(chunk_id, []) if chunk_id else []
+            if summary_ids:
+                suppress(
+                    memory,
+                    "CHUNK_REPLACED_BY_SUMMARY",
+                    source_chunk_id=chunk_id,
+                    representative_ids=summary_ids,
+                )
+            elif statement_ids:
+                suppress(
+                    memory,
+                    "CHUNK_REPLACED_BY_STATEMENT",
+                    source_chunk_id=chunk_id,
+                    representative_ids=statement_ids,
+                )
+            else:
+                keep(memory)
+        elif memory.source == Neo4jNodeType.EXTRACTEDENTITY:
+            # Entity 类型配额已在跨类型排名前执行；后处理不再删除或记录 Entity。
+            keep(memory)
+        else:
+            # Perceptual、Dialogue、Rag 等规则外节点原样透传。
+            keep(memory)
+
+    return kept_memories, suppression_records
+
+
+def _write_quick_retrieval_dedup_log(
+    *,
+    operation_id: str,
+    search_mode: str,
+    before_count: int,
+    after_count: int,
+    suppression_records: list[SuppressionRecord],
+) -> None:
+    """序列化并写入单次检索的结构化去重日志。"""
+
+    payload = {
+        "event": "quick_retrieval_dedup",
+        "operation_id": operation_id,
+        "search_mode": search_mode,
+        "before_count": before_count,
+        "after_count": after_count,
+        "suppressed_count": len(suppression_records),
+        "suppression_records": suppression_records,
+    }
+    logger.info(
+        "[QuickRetrievalDedup] %s",
+        json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+    )
+
+
+def log_quick_retrieval_dedup_safely(
+    *,
+    operation_id: str,
+    search_mode: str,
+    before_count: int,
+    after_count: int,
+    suppression_records: list[SuppressionRecord],
+) -> None:
+    """尽力写入日志；任何日志异常都不得改变检索结果。"""
+
+    try:
+        _write_quick_retrieval_dedup_log(
+            operation_id=operation_id,
+            search_mode=search_mode,
+            before_count=before_count,
+            after_count=after_count,
+            suppression_records=suppression_records,
+        )
+    except Exception:
+        # 完整日志失败后只记录最小上下文；降级日志失败时也必须吞掉异常。
+        try:
+            logger.warning(
+                "[QuickRetrievalDedup] log failed and ignored: "
+                "operation_id=%s search_mode=%s",
+                operation_id,
+                search_mode,
+                exc_info=True,
+            )
+        except Exception:
+            pass

--- a/api/app/core/memory/read_services/search_engine/result_builder.py
+++ b/api/app/core/memory/read_services/search_engine/result_builder.py
@@ -85,6 +85,8 @@ class EntityBuilder(BaseBuilder):
             "id": self.record.get("id"),
             "name": self.record.get("name"),
             "aliases_name": self.record.get("aliases", []),
+            # 召回 Cypher 已返回 entity_type，用于识别画像原节点
+            "entity_type": self.record.get("entity_type"),
             "description": self.record.get("description"),
             "description_summary": self.record.get("description_summary"),
             "event_timeline": self.record.get("event_timeline"),


### PR DESCRIPTION
## Sourcery 摘要

通过确定性来源去重、实体配额和安全的去重日志记录，改进 QUICK 和 EXPRESS 检索。

新功能：
- 为 QUICK 和 EXPRESS 检索结果添加基于来源的确定性去重。
- 为 QUICK 和 EXPRESS 搜索强制执行可配置的 `ExtractedEntity` 候选数量上限（两个），同时保留用户配置文件。
- 输出结构化、非阻塞的检索去重摘要，以便进行可观测性分析。

错误修复：
- 防止被抑制的区块或语句占用结果数量限制名额，使替代候选能够填充最终结果。
- 在模型重新排序后应用实体配额，以保留排名最高的实体。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过确定性的来源去重、实体配额和安全的可观测性日志，改进 QUICK 和 EXPRESS 检索。

新功能：
- 为 QUICK 和 EXPRESS 检索结果添加基于来源的确定性去重。
- 强制限制最多两个非用户资料的 `ExtractedEntity` 候选，同时保留用户资料。
- 输出结构化、非阻塞的去重摘要，用于检索可观测性。

错误修复：
- 防止被抑制的分块和语句占用结果限制名额，使替代候选能够填充结果。
- 在模型重新排序后应用实体配额，以保留排名最高的实体。

增强功能：
- 在组合的记忆搜索结果中保留去重元数据，但不在 API 响应中公开这些元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过确定性来源去重、实体配额和安全的可观测性日志记录，改进 QUICK 和 EXPRESS 检索。

新功能：
- 为 QUICK 和 EXPRESS 检索结果添加基于来源的确定性去重。
- 最多保留两个非个人资料的 ExtractedEntity 候选，同时保留用户个人资料实体。
- 为检索可观测性输出结构化、非阻塞的去重摘要。

错误修复：
- 防止被抑制的块和语句占用结果限制名额，以便替补候选填充结果。
- 在模型重新排序后应用实体配额，从而保留排名最高的实体。

增强功能：
- 在合并记忆搜索结果时，在内部保留去重元数据，但不通过 API 响应将其公开。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve QUICK and EXPRESS retrieval with deterministic source deduplication, entity quotas, and safe observability logging.

New Features:
- Add deterministic source-based deduplication to QUICK and EXPRESS retrieval results.
- Enforce a maximum of two non-profile ExtractedEntity candidates while preserving user profile entities.
- Emit structured, non-blocking deduplication summaries for retrieval observability.

Bug Fixes:
- Prevent suppressed chunks and statements from consuming result-limit slots, allowing replacement candidates to fill the results.
- Apply entity quotas after model reranking so the highest-ranked entities are retained.

Enhancements:
- Preserve deduplication metadata internally when combining memory search results without exposing it through API responses.

</details>

</details>

</details>