### PR TITLE
fix(rag): secure retrieval source contract

### DIFF
--- a/api/app/schemas/chunk_schema.py
+++ b/api/app/schemas/chunk_schema.py
@@ -5,7 +5,9 @@ from typing import Union
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.core.rag.models.chunk import QAChunk
-from app.integrations.knowledge.contracts import KnowledgeRetrievalSource
+from app.integrations.knowledge.contracts import (
+    KnowledgeRetrievalSource as KnowledgeRetrievalSource,
+)
 from app.schemas.knowledge_metadata_schema import FilterGroup, MetadataFilterMode
 from app.schemas.rerank_schema import RerankMode, RerankWeights
 
@@ -115,7 +117,6 @@ class ChunkUpdate(BaseModel):
 class ChunkRetrieve(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: KnowledgeRetrievalSource = Field(KnowledgeRetrievalSource.GENERAL)
     query: str
     kb_ids: list[uuid.UUID] = Field(default_factory=list)
     ex_ids: list[str] | None = Field(None)

--- a/api/openapi-baseline.json
+++ b/api/openapi-baseline.json
@@ -8076,10 +8076,6 @@
       },
       "ChunkRetrieve": {
         "properties": {
-          "source": {
-            "$ref": "#/components/schemas/KnowledgeRetrievalSource",
-            "default": "general"
-          },
           "query": {
             "type": "string",
             "title": "Query"
@@ -16902,21 +16898,6 @@
         ],
         "title": "VariableDefinition",
         "description": "变量定义"
-      },
-      "KnowledgeRetrievalSource": {
-        "type": "string",
-        "enum": [
-          "general",
-          "ex_api",
-          "in_api",
-          "agent",
-          "workflow",
-          "draft",
-          "sandbox",
-          "shared_chat"
-        ],
-        "title": "KnowledgeRetrievalSource",
-        "description": "Business source that initiated a knowledge retrieval."
       },
       "app__schemas__app_schema__KnowledgeBaseConfig": {
         "properties": {

--- a/mem-knowledge/src/api/schemas/chunk.py
+++ b/mem-knowledge/src/api/schemas/chunk.py
@@ -107,7 +107,6 @@ class ChunkUpdate(BaseModel):
 class ChunkRetrieve(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    source: KnowledgeRetrievalSource = KnowledgeRetrievalSource.GENERAL
     query: str
     kb_ids: list[uuid.UUID] = Field(default_factory=list)
     ex_ids: list[str] | None = None


### PR DESCRIPTION
## Business Background

Retrieval caller identity must come from authenticated route context, not from a user-controlled request body. The public retrieval DTO still exposed `source`, while the Apifox contract retained the older `caller` name.

## Summary

- Remove `source` from the public API and mem-knowledge `ChunkRetrieve` schemas.
- Keep source attribution on the trusted route/header path and internal `KnowledgeRetrievalRequest` only.
- Preserve backward compatibility by continuing to ignore unknown `source`/`caller` request keys.
- Keep `kb_ids`, `ex_ids`, and `knowledge_bases` as equivalent selectors whose union must be non-empty; `knowledge_bases`-only requests remain valid.
- Update the V1 OpenAPI baseline.

## Changes

- 3 files changed, 3 insertions, 22 deletions.
- No legacy knowledge retrieval implementation or response handling changes.

## Risk

- External API Key impact: `source` is removed from generated request documentation. Existing callers that send `source` or `caller` are not rejected because the public DTO retains `extra="ignore"`; those values are ignored and cannot override the authenticated route source.
- Runtime source propagation remains unchanged through `KnowledgeCallContext` and `X-KB-Source`.
- `knowledge_bases` as the sole selector is explicitly regression-tested.

## Test Plan

- [x] API retrieval contract/auth tests: `27 passed`
- [x] mem-knowledge rerank and retrieval contract tests: `72 passed`
- [x] API changed-scope fatal Ruff checks and compileall
- [x] mem-knowledge changed-scope Ruff checks and compileall
- [x] Apifox `ChunkRetrieve` export confirms no `caller`/`source` and retains `knowledge_bases`

## Sourcery 摘要

通过从公开请求契约中移除检索来源，并依赖可信的已认证上下文，确保检索来源归属安全。

Bug 修复：
- 从公开 API 和 mem-knowledge 请求架构中移除由用户控制的检索来源，使来源归属始终与已认证的路由上下文绑定。

增强功能：
- 通过忽略旧版的 source 和 caller 请求字段来保持向后兼容，同时保留等效的知识库选择器行为，包括仅包含 knowledge_bases 的请求。

文档：
- 更新 V1 OpenAPI 基线，以反映经过安全加固的检索请求契约。

测试：
- 增加对检索契约身份验证以及仅包含 knowledge_bases 的选择器请求的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure retrieval source attribution by removing it from public request contracts and relying on trusted authenticated context.

Bug Fixes:
- Remove the user-controlled retrieval source from public API and mem-knowledge request schemas so source attribution remains tied to authenticated route context.

Enhancements:
- Preserve backward compatibility by ignoring legacy source and caller request fields while retaining equivalent knowledge-base selector behavior, including knowledge_bases-only requests.

Documentation:
- Update the V1 OpenAPI baseline to reflect the secured retrieval request contract.

Tests:
- Add regression coverage for retrieval contract authentication and knowledge_bases-only selector requests.

</details>