### PR TITLE
fix(emotion): use dedicated driver in celery tasks to avoid loop conflicts

### DIFF
--- a/api/app/services/emotion_analytics_service.py
+++ b/api/app/services/emotion_analytics_service.py
@@ -50,9 +50,17 @@ class EmotionAnalyticsService:
         emotion_repo: 情绪数据仓储实例
     """
 
-    def __init__(self):
-        """初始化情绪分析服务"""
-        connector = Neo4jConnector(shared_driver=True)
+    def __init__(self, shared_driver: bool = True):
+        """初始化情绪分析服务
+
+        Args:
+            shared_driver: 是否使用进程级共享 driver。
+                FastAPI 进程（单事件循环）保持默认 True；
+                Celery 任务内因事件循环可能被其它任务的 asyncio.run() 更换
+                （共享 driver 绑定旧 loop 会报 "Future attached to a different
+                loop"），应传 False 使用任务级独立 driver，并在用完后 close。
+        """
+        connector = Neo4jConnector(shared_driver=shared_driver)
         self.emotion_repo = EmotionRepository(connector)
         logger.info("情绪分析服务初始化完成")
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -5199,7 +5199,11 @@ def do_implicit_emotions_for_user(self, end_user_id: str) -> Dict[str, Any]:
                 emotion_success = True
                 logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
             finally:
-                await emotion_service.emotion_repo.connector.close()
+                # 尽力清理：关闭失败仅记录，避免覆盖上方业务原始异常
+                try:
+                    await emotion_service.emotion_repo.connector.close()
+                except Exception as close_err:
+                    logger.warning(f"用户 {end_user_id} 关闭情绪分析独立 driver 失败: {close_err}")
         except Exception as e:
             errors.append(f"情绪建议更新失败: {str(e)}")
             logger.error(f"用户 {end_user_id} 情绪建议更新失败: {e}")
@@ -5577,7 +5581,11 @@ def update_implicit_emotions_storage(self) -> Dict[str, Any]:
                             emotion_success = True
                             logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
                         finally:
-                            await emotion_service.emotion_repo.connector.close()
+                            # 尽力清理：关闭失败仅记录，避免覆盖上方业务原始异常
+                            try:
+                                await emotion_service.emotion_repo.connector.close()
+                            except Exception as close_err:
+                                logger.warning(f"用户 {end_user_id} 关闭情绪分析独立 driver 失败: {close_err}")
                     except Exception as e:
                         error_msg = f"情绪建议更新失败: {str(e)}"
                         errors.append(error_msg)
@@ -5662,7 +5670,11 @@ def update_implicit_emotions_storage(self) -> Dict[str, Any]:
                             emotion_success = True
                             logger.info(f"成功初始化新用户 {end_user_id} 的情绪建议")
                         finally:
-                            await emotion_service.emotion_repo.connector.close()
+                            # 尽力清理：关闭失败仅记录，避免覆盖上方业务原始异常
+                            try:
+                                await emotion_service.emotion_repo.connector.close()
+                            except Exception as close_err:
+                                logger.warning(f"用户 {end_user_id} 关闭情绪分析独立 driver 失败: {close_err}")
                     except Exception as e:
                         errors.append(f"情绪建议初始化失败: {str(e)}")
                         logger.error(f"新用户 {end_user_id} 情绪建议初始化失败: {e}")
@@ -5843,7 +5855,11 @@ def init_implicit_emotions_for_users(self, end_user_ids: List[str]) -> Dict[str,
                             )
                         emotion_ok = True
                     finally:
-                        await emotion_service.emotion_repo.connector.close()
+                        # 尽力清理：关闭失败仅记录，避免覆盖上方业务原始异常
+                        try:
+                            await emotion_service.emotion_repo.connector.close()
+                        except Exception as close_err:
+                            logger.warning(f"用户 {end_user_id} 关闭情绪分析独立 driver 失败: {close_err}")
                 except Exception as e:
                     logger.error(f"用户 {end_user_id} 情绪建议初始化失败: {e}")
 

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -5180,20 +5180,26 @@ def do_implicit_emotions_for_user(self, end_user_id: str) -> Dict[str, Any]:
             logger.error(f"用户 {end_user_id} 隐性记忆更新失败: {e}")
 
         # --- 情绪建议 ---
+        # worker 进程内事件循环可能被其它任务的 asyncio.run() 更换，
+        # 共享 driver 绑定旧 loop 会报 "Future attached to a different loop"，
+        # 故与上方隐性记忆部分一致：任务级独立 driver，finally 中关闭。
         try:
-            emotion_service = EmotionAnalyticsService()
-            # db=None：内部自行开短 session 查 config → 关闭 → Neo4j + LLM
-            suggestions_data = await emotion_service.generate_emotion_suggestions(
-                end_user_id=end_user_id, language="zh"
-            )
-
-            # Session C：写回
-            with get_db_context() as db:
-                await emotion_service.save_suggestions_cache(
-                    end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
+            emotion_service = EmotionAnalyticsService(shared_driver=False)
+            try:
+                # db=None：内部自行开短 session 查 config → 关闭 → Neo4j + LLM
+                suggestions_data = await emotion_service.generate_emotion_suggestions(
+                    end_user_id=end_user_id, language="zh"
                 )
-            emotion_success = True
-            logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
+
+                # Session C：写回
+                with get_db_context() as db:
+                    await emotion_service.save_suggestions_cache(
+                        end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
+                    )
+                emotion_success = True
+                logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
+            finally:
+                await emotion_service.emotion_repo.connector.close()
         except Exception as e:
             errors.append(f"情绪建议更新失败: {str(e)}")
             logger.error(f"用户 {end_user_id} 情绪建议更新失败: {e}")
@@ -5554,21 +5560,24 @@ def update_implicit_emotions_storage(self) -> Dict[str, Any]:
                         errors.append(error_msg)
                         logger.error(f"用户 {end_user_id} {error_msg}")
 
-                    # 更新情绪建议
+                    # 更新情绪建议（独立 driver：loop 可能被其它任务的 asyncio.run() 更换）
                     try:
-                        emotion_service = EmotionAnalyticsService()
-                        suggestions_data = await emotion_service.generate_emotion_suggestions(
-                            end_user_id=end_user_id,
-                            db=db,
-                            language="zh"
-                        )
-                        await emotion_service.save_suggestions_cache(
-                            end_user_id=end_user_id,
-                            suggestions_data=suggestions_data,
-                            db=db
-                        )
-                        emotion_success = True
-                        logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
+                        emotion_service = EmotionAnalyticsService(shared_driver=False)
+                        try:
+                            suggestions_data = await emotion_service.generate_emotion_suggestions(
+                                end_user_id=end_user_id,
+                                db=db,
+                                language="zh"
+                            )
+                            await emotion_service.save_suggestions_cache(
+                                end_user_id=end_user_id,
+                                suggestions_data=suggestions_data,
+                                db=db
+                            )
+                            emotion_success = True
+                            logger.info(f"成功更新用户 {end_user_id} 的情绪建议")
+                        finally:
+                            await emotion_service.emotion_repo.connector.close()
                     except Exception as e:
                         error_msg = f"情绪建议更新失败: {str(e)}"
                         errors.append(error_msg)
@@ -5640,16 +5649,20 @@ def update_implicit_emotions_storage(self) -> Dict[str, Any]:
                         errors.append(f"隐性记忆初始化失败: {str(e)}")
                         logger.error(f"新用户 {end_user_id} 隐性记忆初始化失败: {e}")
 
+                    # 独立 driver：loop 可能被其它任务的 asyncio.run() 更换
                     try:
-                        emotion_service = EmotionAnalyticsService()
-                        suggestions_data = await emotion_service.generate_emotion_suggestions(
-                            end_user_id=end_user_id, db=db, language="zh"
-                        )
-                        await emotion_service.save_suggestions_cache(
-                            end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
-                        )
-                        emotion_success = True
-                        logger.info(f"成功初始化新用户 {end_user_id} 的情绪建议")
+                        emotion_service = EmotionAnalyticsService(shared_driver=False)
+                        try:
+                            suggestions_data = await emotion_service.generate_emotion_suggestions(
+                                end_user_id=end_user_id, db=db, language="zh"
+                            )
+                            await emotion_service.save_suggestions_cache(
+                                end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
+                            )
+                            emotion_success = True
+                            logger.info(f"成功初始化新用户 {end_user_id} 的情绪建议")
+                        finally:
+                            await emotion_service.emotion_repo.connector.close()
                     except Exception as e:
                         errors.append(f"情绪建议初始化失败: {str(e)}")
                         logger.error(f"新用户 {end_user_id} 情绪建议初始化失败: {e}")
@@ -5816,17 +5829,21 @@ def init_implicit_emotions_for_users(self, end_user_ids: List[str]) -> Dict[str,
                     logger.error(f"用户 {end_user_id} 隐性记忆初始化失败: {e}")
 
                 # --- 情绪建议：LLM 生成（内部自管理 session）---
+                # 独立 driver：loop 可能被其它任务的 asyncio.run() 更换
                 try:
-                    emotion_service = EmotionAnalyticsService()
-                    suggestions_data = await emotion_service.generate_emotion_suggestions(
-                        end_user_id=end_user_id, language="zh"
-                    )
-                    # Session C：写回
-                    with get_db_context() as db:
-                        await emotion_service.save_suggestions_cache(
-                            end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
+                    emotion_service = EmotionAnalyticsService(shared_driver=False)
+                    try:
+                        suggestions_data = await emotion_service.generate_emotion_suggestions(
+                            end_user_id=end_user_id, language="zh"
                         )
-                    emotion_ok = True
+                        # Session C：写回
+                        with get_db_context() as db:
+                            await emotion_service.save_suggestions_cache(
+                                end_user_id=end_user_id, suggestions_data=suggestions_data, db=db
+                            )
+                        emotion_ok = True
+                    finally:
+                        await emotion_service.emotion_repo.connector.close()
                 except Exception as e:
                     logger.error(f"用户 {end_user_id} 情绪建议初始化失败: {e}")
 


### PR DESCRIPTION
## Sourcery 总结

在 Celery 任务中使用专用且正确关闭的 Neo4j 驱动处理情绪分析，以避免事件循环冲突。

Bug 修复：
- 通过使用任务作用域的 Neo4j 驱动，防止情绪分析 Celery 任务遇到 asyncio 事件循环冲突。
- 确保任务作用域的情绪分析驱动在每个任务完成后关闭。

增强功能：
- 允许 EmotionAnalyticsService 调用方在共享 Neo4j 驱动和专用 Neo4j 驱动之间进行选择，同时默认保留共享驱动行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在 Celery 任务中使用专用且经过适当清理的 Neo4j 驱动程序进行情绪分析，以避免事件循环冲突。

错误修复：
- 在 Celery 任务中使用任务作用域的 Neo4j 驱动程序进行情绪分析，以防止事件循环冲突。
- 每个 Celery 任务完成后关闭任务作用域的情绪分析驱动程序，同时在清理失败时保留原始任务错误。

增强功能：
- 允许 EmotionAnalyticsService 的调用方在共享 Neo4j 驱动程序和专用 Neo4j 驱动程序之间进行选择，同时默认保留共享驱动程序行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use dedicated, properly cleaned-up Neo4j drivers for emotion analysis in Celery tasks to avoid event-loop conflicts.

Bug Fixes:
- Use task-scoped Neo4j drivers for emotion analysis in Celery tasks to prevent event-loop conflicts.
- Close task-scoped emotion analysis drivers after each Celery task completes, while preserving the original task error when cleanup fails.

Enhancements:
- Allow EmotionAnalyticsService callers to choose between shared and dedicated Neo4j drivers while retaining shared-driver behavior by default.

</details>

</details>