### PR TITLE
refactor(memory): Move forgetting queries into storage custom layer

### DIFF
--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -377,7 +377,7 @@ class Settings:
 
     REFLECTION_INTERVAL_SECONDS: float = float(os.getenv("REFLECTION_INTERVAL_SECONDS", "300"))
     HEALTH_CHECK_SECONDS: float = float(os.getenv("HEALTH_CHECK_SECONDS", "600"))
-    REFLECTION_INTERVAL_TIME: Optional[str] = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
+    REFLECTION_INTERVAL_TIME: int = int(os.getenv("REFLECTION_INTERVAL_TIME", 30))
 
     # Celery Beat Schedule Configuration (定时任务执行频率)
     MEMORY_INCREMENT_HOUR: int = TypeAdapter(

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -1,17 +1,15 @@
 import logging
 import uuid
 
-from app.core.memory.models.service_models import ForgetLog
 from app.core.memory.pipelines.base_pipeline import BasePipeline
+from app.core.memory.storage.custom.manual_node_delete import (
+    delete_manual_node_by_element_id as delete_manual_node,
+)
 from app.core.memory.storage_services.forgetting_engine.forget_service import ForgetService
 from app.core.memory.utils.memory_count_utils import sync_end_user_memory_count_from_neo4j
 from app.core.quota_manager import get_end_user_memory_limit
-from app.core.utils.datetime_utils import utcnow
 from app.db import get_db_context
-from app.models.memory_forget_model import ForgetTrigger
 from app.repositories.end_user_repository import get_tenant_id_by_end_user_id
-from app.repositories.forget_log_repository import ForgetLogRepository
-from app.repositories.neo4j.cypher_queries import DELETE_NODE_BY_ELEMENT_ID
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 logger = logging.getLogger(__name__)
@@ -55,52 +53,12 @@ class ForgettingPipeline(BasePipeline):
         end_user_id: str,
         operator: uuid.UUID,
     ) -> bool:
-        """通过 elementId 删除 Neo4j 图节点并同步审计日志。
-
-        Args:
-            element_id: Neo4j 内部元素 ID。
-            end_user_id: 终端用户 ID。
-            operator: 执行删除操作的用户 ID。
-        """
-        async with Neo4jConnector() as connector:
-            result = await connector.execute_query(
-                DELETE_NODE_BY_ELEMENT_ID,
-                element_id=element_id,
-                end_user_id=end_user_id,
-            )
-
-        if not result or result[0]["deleted"] == 0:
-            return False
-
-        row = result[0]
-        labels = row.get("labels", [])
-        node_type = next(
-            (label for label in labels if label != "Memory"), "unknown",
-        )
-
-        content = (
-            row.get("content") or row.get("statement") or row.get("text")
-            or row.get("name") or ""
-        )
-
-        log = ForgetLog(
-            node_id=row["node_id"],
-            end_user_id=uuid.UUID(end_user_id),
-            node_type=node_type,
-            content=content,
-            trigger=ForgetTrigger.Manual.value,
-            reason="manual",
-            recoverable=False,
+        """Delegate manual deletion to the storage custom operation."""
+        return await delete_manual_node(
+            element_id=element_id,
+            end_user_id=end_user_id,
             operator=operator,
-            delete_at=utcnow(),
-            is_recovered=False,
         )
-
-        with get_db_context() as db:
-            ForgetLogRepository.sync_logs(db, [log])
-            db.commit()
-
-        return True
 
     @staticmethod
     async def delete_all_nodes_by_end_user_id(end_user_id: str) -> int:

--- a/api/app/core/memory/storage/custom/__init__.py
+++ b/api/app/core/memory/storage/custom/__init__.py
@@ -10,6 +10,7 @@ from app.core.memory.storage.custom.node_queries import (
     get_user_entity_id,
     get_user_metadata,
     search_entities_by_name,
+    update_user_entity_aliases,
 )
 
 from app.core.memory.storage.custom.relationship_queries import (
@@ -17,8 +18,33 @@ from app.core.memory.storage.custom.relationship_queries import (
     get_user_sources_for_entities,
     search_related_entities,
 )
+from app.core.memory.storage.custom.automatic_forgetting import (
+    AutomaticForgetOutboxError,
+    ForgottenNodeIdentity,
+    soft_delete_forgetting_nodes,
+)
+from app.core.memory.storage.custom.manual_node_delete import (
+    ManualDeleteTarget,
+    delete_manual_node_by_element_id,
+    resolve_manual_delete_target,
+)
+from app.core.memory.storage.custom.topology_score import compute_topology_score
+from app.core.memory.storage.custom.forget_recovery import (
+    ForgetRecoveryTarget,
+    recover_forgotten_node_by_element_id,
+    resolve_forget_recovery_target,
+)
 
 __all__ = [
+    "AutomaticForgetOutboxError",
+    "ForgottenNodeIdentity",
+    "ForgetRecoveryTarget",
+    "ManualDeleteTarget",
+    "compute_topology_score",
+    "delete_manual_node_by_element_id",
+    "resolve_manual_delete_target",
+    "recover_forgotten_node_by_element_id",
+    "resolve_forget_recovery_target",
     "get_active_entities_by_ids",
     "get_entity_pair_relations",
     "get_node_by_id",
@@ -27,4 +53,6 @@ __all__ = [
     "get_user_sources_for_entities",
     "search_entities_by_name",
     "search_related_entities",
+    "soft_delete_forgetting_nodes",
+    "update_user_entity_aliases",
 ]

--- a/api/app/core/memory/storage/custom/automatic_forgetting.py
+++ b/api/app/core/memory/storage/custom/automatic_forgetting.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+
+FORGETTABLE_NODE_TYPES = (
+    MemoryNodeType.STATEMENT,
+    MemoryNodeType.CHUNK,
+    MemoryNodeType.EXTRACTED_ENTITY,
+    MemoryNodeType.MEMORY_SUMMARY,
+    MemoryNodeType.DIALOGUE,
+)
+
+FORGET_SOFT_DELETE_WITH_IDENTITIES = """
+MATCH (n {end_user_id: $end_user_id})
+WHERE n.delete_at IS NULL
+  AND elementId(n) IN $element_ids
+  AND any(label IN labels(n) WHERE label IN $supported_labels)
+  AND n.id IS NOT NULL
+  AND (NOT n:Statement OR coalesce(n.is_permanent, false) = false)
+  AND (NOT n:ExtractedEntity OR (
+      coalesce(n.extraction_count, 0) < $protection_threshold
+      AND n.name <> '用户'
+  ))
+  AND (
+      NOT (n:Statement OR n:Chunk OR n:ExtractedEntity) OR (
+          n.topology_score IS NOT NULL
+          AND (
+              toFloat(n.topology_score) IS NULL
+              OR isNaN(toFloat(n.topology_score))
+              OR toFloat(n.topology_score) < 1.0
+          )
+      )
+  )
+  AND (
+      NOT $require_isolated OR (
+          (n:Statement OR n:Chunk OR n:ExtractedEntity)
+          AND NOT EXISTS {
+              MATCH (n)--(related)
+              WHERE related <> n
+                AND related.end_user_id = $end_user_id
+                AND related.delete_at IS NULL
+          }
+      )
+  )
+WITH n,
+     elementId(n) AS element_id,
+     toString(n.id) AS node_id,
+     head([
+         label IN $supported_labels
+         WHERE label IN labels(n)
+     ]) AS label
+SET n.delete_at = datetime($now)
+RETURN element_id, node_id, label
+ORDER BY element_id
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class ForgottenNodeIdentity:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+
+
+class AutomaticForgetOutboxError(OutboxEnqueueError):
+    """Outbox failed after Neo4j committed automatic soft deletes."""
+
+    def __init__(
+        self,
+        cause: OutboxEnqueueError,
+        affected_nodes: list[ForgottenNodeIdentity],
+    ) -> None:
+        super().__init__(list(cause.event_ids), cause.reason)
+        self.affected_nodes = tuple(affected_nodes)
+
+
+async def soft_delete_forgetting_nodes(
+    end_user_id: str,
+    element_ids: list[str],
+    now: str,
+    *,
+    protection_threshold: int,
+    require_isolated: bool = False,
+    client: Neo4jClient | None = None,
+    outbox_repository: OutboxRepository | None = None,
+) -> list[ForgottenNodeIdentity]:
+    """Soft-delete eligible memory nodes and publish exact DRAFT_DELETE events.
+
+    Node identities are returned by the same Cypher mutation that sets
+    ``delete_at``. An Outbox failure therefore occurs after the primary Neo4j
+    commit and carries those identities for the caller's audit compensation.
+    """
+    if not element_ids:
+        return []
+
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+
+    try:
+        rows = await client.execute_query(
+            FORGET_SOFT_DELETE_WITH_IDENTITIES,
+            end_user_id=end_user_id,
+            element_ids=element_ids,
+            now=now,
+            protection_threshold=protection_threshold,
+            require_isolated=require_isolated,
+            supported_labels=[label.value for label in FORGETTABLE_NODE_TYPES],
+        )
+    finally:
+        if owns_client:
+            await client.close()
+
+    affected_nodes = [
+        ForgottenNodeIdentity(
+            element_id=str(row["element_id"]),
+            node_id=str(row["node_id"]),
+            label=MemoryNodeType(row["label"]),
+        )
+        for row in rows
+    ]
+    unique_element_ids = {node.element_id for node in affected_nodes}
+    unique_node_ids = {(node.label, node.node_id) for node in affected_nodes}
+    if len(unique_element_ids) != len(affected_nodes):
+        raise RuntimeError("Automatic forget returned duplicate element IDs")
+    if len(unique_node_ids) != len(affected_nodes):
+        raise RuntimeError("Automatic forget returned duplicate node identities")
+
+    events = [
+        OutboxEventInput(
+            label=node.label,
+            node_id=node.node_id,
+            operation=OutboxOperation.DRAFT_DELETE,
+        )
+        for node in affected_nodes
+    ]
+    try:
+        await enqueue_events(events, repository=outbox_repository)
+    except OutboxEnqueueError as exc:
+        raise AutomaticForgetOutboxError(exc, affected_nodes) from None
+
+    return affected_nodes

--- a/api/app/core/memory/storage/custom/forget_recovery.py
+++ b/api/app/core/memory/storage/custom/forget_recovery.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.memory.storage.custom.automatic_forgetting import (
+    FORGETTABLE_NODE_TYPES,
+)
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.models import FilterCondition, NodeFilter
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+from app.core.memory.storage.service import MemoryStorageService, get_storage_service
+
+
+FORGET_RECOVERY_TARGET_QUERY = """
+MATCH (n)
+WHERE elementId(n) = $element_id
+  AND n.end_user_id = $end_user_id
+  AND any(label IN labels(n) WHERE label IN $supported_labels)
+  AND n.id IS NOT NULL
+RETURN elementId(n) AS element_id,
+       toString(n.id) AS node_id,
+       labels(n) AS labels,
+       n.delete_at IS NOT NULL AS is_forgotten
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class ForgetRecoveryTarget:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+    recovered_now: bool
+
+
+async def _resolve_forget_recovery_target(
+    client: Neo4jClient,
+    element_id: str,
+    end_user_id: str,
+) -> ForgetRecoveryTarget | None:
+    rows = await client.execute_query(
+        FORGET_RECOVERY_TARGET_QUERY,
+        element_id=element_id,
+        end_user_id=end_user_id,
+        supported_labels=[label.value for label in FORGETTABLE_NODE_TYPES],
+    )
+    if not rows:
+        return None
+    if len(rows) != 1:
+        raise ValueError("elementId resolved to multiple memory nodes")
+
+    row: dict[str, Any] = rows[0]
+    canonical_labels: list[MemoryNodeType] = []
+    for raw_label in row.get("labels", []):
+        try:
+            label = MemoryNodeType(raw_label)
+        except ValueError:
+            continue
+        if label in FORGETTABLE_NODE_TYPES:
+            canonical_labels.append(label)
+    if len(canonical_labels) != 1:
+        raise ValueError(
+            "forgotten node must have exactly one supported storage label"
+        )
+
+    node_id = row.get("node_id")
+    if node_id is None or not str(node_id).strip():
+        raise ValueError("forgotten node is missing its business id")
+
+    return ForgetRecoveryTarget(
+        element_id=str(row.get("element_id") or element_id),
+        node_id=str(node_id),
+        label=canonical_labels[0],
+        recovered_now=bool(row.get("is_forgotten")),
+    )
+
+
+async def resolve_forget_recovery_target(
+    element_id: str,
+    end_user_id: str,
+    *,
+    client: Neo4jClient | None = None,
+) -> ForgetRecoveryTarget | None:
+    """Resolve the authoritative identity and current state of a forget audit."""
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+    try:
+        return await _resolve_forget_recovery_target(
+            client,
+            element_id,
+            end_user_id,
+        )
+    finally:
+        if owns_client:
+            await client.close()
+
+
+async def recover_forgotten_node_by_element_id(
+    element_id: str,
+    end_user_id: str,
+    *,
+    client: Neo4jClient | None = None,
+    storage_service: MemoryStorageService | None = None,
+) -> ForgetRecoveryTarget | None:
+    """Idempotently restore a forgotten node through the storage write router.
+
+    The mutation always clears ``delete_at`` through ``update_node`` so an
+    idempotent retry republishes the UPSERT projection event after a possible
+    prior Outbox failure. ``recovered_now`` still records whether this call
+    observed the node as forgotten before the mutation, allowing PostgreSQL
+    audit reconciliation without refreshing unrelated access fields.
+    """
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+
+    try:
+        target = await _resolve_forget_recovery_target(
+            client,
+            element_id,
+            end_user_id,
+        )
+        if target is None:
+            return None
+
+        service = storage_service or get_storage_service()
+        result = await service.update_node(
+            target.label,
+            {"delete_at": None},
+            NodeFilter.all_of(
+                FilterCondition(field="id", value=target.node_id),
+                FilterCondition(field="end_user_id", value=end_user_id),
+            ),
+        )
+        if result.affected_count == 1 and result.ids == [target.node_id]:
+            return target
+        if result.affected_count != 0:
+            raise RuntimeError(
+                "Forgotten node recovery returned an unexpected identity"
+            )
+
+        # Another recovery may have won between resolution and mutation. Read
+        # Neo4j again so that an idempotent retry can still reconcile the audit.
+        current = await _resolve_forget_recovery_target(
+            client,
+            element_id,
+            end_user_id,
+        )
+        if current is None:
+            return None
+        if (
+            current.node_id != target.node_id
+            or current.label != target.label
+        ):
+            raise RuntimeError("Forgotten node identity changed during recovery")
+        if current.recovered_now:
+            raise RuntimeError("Forgotten node recovery did not update the node")
+        return current
+    finally:
+        if owns_client:
+            await client.close()

--- a/api/app/core/memory/storage/custom/manual_node_delete.py
+++ b/api/app/core/memory/storage/custom/manual_node_delete.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.memory.models.service_models import ForgetLog
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.models import FilterCondition, NodeFilter
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+from app.core.memory.storage.service import MemoryStorageService, get_storage_service
+from app.core.utils.datetime_utils import utcnow
+from app.db import get_db_context
+from app.models.memory_forget_model import ForgetTrigger
+from app.repositories.forget_log_repository import ForgetLogRepository
+
+logger = logging.getLogger(__name__)
+
+
+MANUAL_DELETE_TARGET_QUERY = """
+MATCH (n)
+WHERE elementId(n) = $element_id
+  AND n.end_user_id = $end_user_id
+  AND any(label IN labels(n) WHERE label IN $supported_labels)
+RETURN elementId(n) AS element_id,
+       n.id AS node_id,
+       labels(n) AS labels,
+       n.content AS content,
+       n.statement AS statement,
+       n.text AS text,
+       n.name AS name
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class ManualDeleteTarget:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+    content: str
+
+
+async def resolve_manual_delete_target(
+    element_id: str,
+    end_user_id: str,
+    *,
+    client: Neo4jClient | None = None,
+) -> ManualDeleteTarget | None:
+    """Resolve a Neo4j element ID without mutating the node."""
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+
+    try:
+        rows = await client.execute_query(
+            MANUAL_DELETE_TARGET_QUERY,
+            element_id=element_id,
+            end_user_id=end_user_id,
+            supported_labels=[label.value for label in MemoryNodeType],
+        )
+    finally:
+        if owns_client:
+            await client.close()
+
+    if not rows:
+        return None
+    if len(rows) != 1:
+        raise ValueError("elementId resolved to multiple memory nodes")
+
+    row: dict[str, Any] = rows[0]
+    canonical_labels: list[MemoryNodeType] = []
+    for raw_label in row.get("labels", []):
+        try:
+            canonical_labels.append(MemoryNodeType(raw_label))
+        except ValueError:
+            continue
+    if len(canonical_labels) != 1:
+        raise ValueError("memory node must have exactly one supported storage label")
+
+    node_id = row.get("node_id")
+    if node_id is None or not str(node_id).strip():
+        raise ValueError("memory node is missing its business id")
+
+    content = (
+        row.get("content")
+        or row.get("statement")
+        or row.get("text")
+        or row.get("name")
+        or ""
+    )
+    return ManualDeleteTarget(
+        element_id=str(row.get("element_id") or element_id),
+        node_id=str(node_id),
+        label=canonical_labels[0],
+        content=str(content),
+    )
+
+
+def _write_manual_delete_audit(
+    target: ManualDeleteTarget,
+    end_user_id: str,
+    operator: uuid.UUID,
+) -> None:
+    log = ForgetLog(
+        node_id=target.element_id,
+        end_user_id=uuid.UUID(end_user_id),
+        node_type=target.label.value,
+        content=target.content,
+        trigger=ForgetTrigger.Manual.value,
+        reason="manual",
+        recoverable=False,
+        operator=operator,
+        delete_at=utcnow(),
+        is_recovered=False,
+    )
+    with get_db_context() as db:
+        ForgetLogRepository.sync_logs(db, [log])
+        db.commit()
+
+
+async def delete_manual_node_by_element_id(
+    element_id: str,
+    end_user_id: str,
+    operator: uuid.UUID,
+    *,
+    client: Neo4jClient | None = None,
+    storage_service: MemoryStorageService | None = None,
+) -> bool:
+    """Resolve, physically delete, enqueue DELETE, and persist the audit.
+
+    Resolution is read-only. The mutation is constrained again by business ID
+    and ``end_user_id`` and routed through ``MemoryStorageService`` so that
+    ``WriteRouter`` publishes the DELETE event from the mutation's returned ID.
+    """
+    target = await resolve_manual_delete_target(
+        element_id,
+        end_user_id,
+        client=client,
+    )
+    if target is None:
+        return False
+
+    node_filter = NodeFilter.all_of(
+        FilterCondition(field="id", value=target.node_id),
+        FilterCondition(field="end_user_id", value=end_user_id),
+    )
+    service = storage_service or get_storage_service()
+    try:
+        result = await service.delete_node(
+            target.label,
+            node_filter,
+            draft=False,
+        )
+    except OutboxEnqueueError:
+        # WriteRouter enqueues only after Neo4j commits. Preserve the business
+        # audit for the committed deletion, then retain the original failure.
+        try:
+            _write_manual_delete_audit(target, end_user_id, operator)
+        except Exception:
+            logger.exception(
+                "Failed to persist manual-delete audit after Outbox failure: "
+                "element_id=%s end_user_id=%s",
+                element_id,
+                end_user_id,
+            )
+        raise
+
+    if result.affected_count == 0:
+        # The node changed or disappeared after resolution. The ownership-
+        # constrained mutation did nothing, so no Outbox event or audit exists.
+        return False
+    if result.affected_count != 1 or result.ids != [target.node_id]:
+        raise RuntimeError(
+            "Manual node delete returned an unexpected affected identity"
+        )
+
+    _write_manual_delete_audit(target, end_user_id, operator)
+    return True

--- a/api/app/core/memory/storage/custom/node_queries.py
+++ b/api/app/core/memory/storage/custom/node_queries.py
@@ -151,3 +151,31 @@ async def search_entities_by_name(
         pre_limit=limit,
     )
     return [item.data for item in result.items]
+
+
+async def update_user_entity_aliases(
+        end_user_id: str,
+        aliases: list[str],
+) -> int:
+    """Update aliases on the user entity for an end user.
+
+    The write is routed through ``MemoryStorageService`` so the graph write and
+    its projection outbox event follow the standard storage abstraction.
+
+    Returns:
+        Number of user entity nodes updated.
+    """
+    service = get_storage_service()
+    result = await service.update_node(
+        MemoryNodeType.EXTRACTED_ENTITY,
+        {"aliases": aliases},
+        NodeFilter.all_of(
+            FilterCondition(field="end_user_id", value=end_user_id),
+            FilterCondition(
+                field="name",
+                operator=FilterOperator.IN,
+                value=["用户", "我", "User", "I"],
+            ),
+        ),
+    )
+    return result.affected_count

--- a/api/app/core/memory/storage/custom/topology_score.py
+++ b/api/app/core/memory/storage/custom/topology_score.py
@@ -1,0 +1,170 @@
+"""Custom storage query for Neo4j GDS topology-score computation."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+from app.repositories.neo4j.cypher_queries import CLEAR_GRAPH, G_SCORE
+
+logger = logging.getLogger(__name__)
+
+GDS_GRAPH_BUILD_WITH_AFFECTED_NODES = """
+MATCH (source)
+WHERE source.end_user_id = $end_user_id
+  AND source.delete_at IS NULL
+  AND source.id IS NOT NULL
+  AND any(label IN labels(source) WHERE label IN [
+      'Statement', 'MemorySummary', 'Chunk', 'ExtractedEntity', 'Perceptual'
+  ])
+  AND (source.name IS NULL OR source.name <> '用户')
+OPTIONAL MATCH (source)-[r]-(target)
+WHERE target.end_user_id = $end_user_id
+  AND target.delete_at IS NULL
+  AND target.id IS NOT NULL
+  AND source <> target
+  AND any(label IN labels(target) WHERE label IN [
+      'Statement', 'MemorySummary', 'Chunk', 'ExtractedEntity', 'Perceptual'
+  ])
+  AND (target.name IS NULL OR target.name <> '用户')
+WITH source, target, count(r) AS parallel_count
+WITH
+    gds.graph.project(
+        $end_user_id,
+        source,
+        target,
+        {relationshipProperties: {weight: toFloat(parallel_count)}}
+    ) AS graph,
+    collect(DISTINCT {
+        label: head([
+            label IN [
+                'Statement', 'MemorySummary', 'Chunk',
+                'ExtractedEntity', 'Perceptual'
+            ]
+            WHERE label IN labels(source)
+        ]),
+        node_id: toString(source.id)
+    }) AS affectedNodes
+RETURN graph.graphName AS graphName,
+       graph.nodeCount AS nodeCount,
+       graph.relationshipCount AS relationshipCount,
+       graph.projectMillis AS projectMillis,
+       affectedNodes
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class _AffectedNode:
+    label: MemoryNodeType
+    node_id: str
+
+
+async def compute_topology_score(
+    end_user_id: str,
+    *,
+    neo4j_client: Neo4jClient | None = None,
+    outbox_repository: OutboxRepository | None = None,
+) -> Dict[str, Any]:
+    """Compute topology scores and enqueue the exact projected node snapshot.
+
+    The affected identities are collected by the same Cypher aggregation that
+    builds the GDS graph, so they cannot drift due to a later database query.
+    Neo4j still commits the GDS result before PostgreSQL commits the Outbox
+    events. An enqueue failure therefore has ``primary_committed=True``.
+    """
+    owns_client = neo4j_client is None
+    client = neo4j_client or await Neo4jClient.create()
+    summary: dict[str, Any] | None = None
+    affected_nodes: list[_AffectedNode] = []
+
+    try:
+        projection_rows = await client.execute_query(
+            GDS_GRAPH_BUILD_WITH_AFFECTED_NODES,
+            end_user_id=end_user_id,
+        )
+        affected_rows = (
+            projection_rows[0].get("affectedNodes", [])
+            if projection_rows
+            else []
+        )
+        affected_nodes = [
+            _AffectedNode(
+                label=MemoryNodeType(row["label"]),
+                node_id=str(row["node_id"]),
+            )
+            for row in affected_rows
+        ]
+
+        try:
+            score_rows = await client.execute_query(
+                G_SCORE,
+                end_user_id=end_user_id,
+            )
+        except Exception as exc:
+            # 活跃用户可能尚无记忆节点，投影得到空图，eigenvector 对空图会报错。
+            # 这种情况记 skipped（非失败），避免每次 scan 都产生一条 FAILURE 任务。
+            logger.warning(
+                "GDS eigenvector.write 失败（可能为空图） user=%s: %s",
+                end_user_id,
+                exc,
+            )
+            return {
+                "status": "skipped",
+                "reason": "eigenvector_failed",
+                "error": str(exc),
+            }
+
+        summary = score_rows[0] if score_rows else {}
+        unique_nodes = {(node.label, node.node_id) for node in affected_nodes}
+        if len(unique_nodes) != len(affected_nodes):
+            raise RuntimeError("GDS projection returned duplicate node identities")
+
+        written = int(summary.get("nodePropertiesWritten", 0) or 0)
+        if written != len(affected_nodes):
+            raise RuntimeError(
+                "GDS write count does not match projected nodes: "
+                f"written={written} affected={len(affected_nodes)}"
+            )
+    finally:
+        # 无论成败都释放内存图，避免残留投影图占用 Neo4j 内存。
+        try:
+            await client.execute_query(
+                CLEAR_GRAPH,
+                end_user_id=end_user_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "GDS graph.drop 失败 user=%s: %s",
+                end_user_id,
+                exc,
+            )
+        if owns_client:
+            await client.close()
+
+    events = [
+        OutboxEventInput(
+            label=node.label,
+            node_id=node.node_id,
+            operation=OutboxOperation.UPSERT,
+        )
+        for node in affected_nodes
+    ]
+    event_ids = await enqueue_events(
+        events,
+        repository=outbox_repository,
+    )
+
+    assert summary is not None
+    return {
+        "status": "success",
+        "node_properties_written": summary.get("nodePropertiesWritten", 0),
+        "did_converge": summary.get("didConverge"),
+        "ran_iterations": summary.get("ranIterations"),
+        "outbox_events": len(event_ids),
+    }

--- a/api/app/core/memory/storage/outbox/consumer.py
+++ b/api/app/core/memory/storage/outbox/consumer.py
@@ -6,13 +6,13 @@ from contextlib import AsyncExitStack, suppress
 
 from app.core.memory.storage.outbox.clients import ProjectionClients
 from app.core.memory.storage.outbox.exceptions import ClaimLostError, safe_error
-from app.core.memory.storage.outbox.repository import create_repository
-from app.core.memory.storage.outbox.types import MAX_ATTEMPTS
+from app.core.memory.storage.outbox.repository import create_repository, OutboxRepository
+from app.core.memory.storage.outbox.types import MAX_ATTEMPTS, ClaimedEvent
 
 logger = logging.getLogger(__name__)
 
 
-async def _consume_claim(event, repo, projector) -> str:
+async def _consume_claim(event: ClaimedEvent, repo: OutboxRepository, projector) -> str:
     lost = asyncio.Event()
 
     async def check_claim():

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -80,6 +80,22 @@ class Neo4jClient(BaseClient):
         if self.client:
             await self.client.close()
 
+    async def execute_query(
+            self,
+            cypher: str,
+            **parameters: Any,
+    ) -> list[dict[str, Any]]:
+        """Execute provider-specific Cypher for storage custom queries."""
+        if self.client is None:
+            raise RuntimeError("Neo4jClient is not initialized")
+        async with self.client.session() as session:
+            statement = await session.run(cypher, **parameters)
+            records = await statement.data()
+        return [
+            {key: _to_native(value) for key, value in record.items()}
+            for record in records
+        ]
+
     async def save_node(
             self,
             label: MemoryNodeLabel,

--- a/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
+++ b/api/app/core/memory/storage_services/forgetting_engine/forget_service.py
@@ -6,6 +6,11 @@ from typing import Any
 
 from app.core.memory.enums import Neo4jNodeType
 from app.core.memory.models.service_models import ForgetLog, MemoryContext
+from app.core.memory.storage.custom.automatic_forgetting import (
+    AutomaticForgetOutboxError,
+    soft_delete_forgetting_nodes,
+)
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
 from app.core.memory.storage_services.forgetting_engine.constants import (
     DIALOGUE_AUDIT_CONTENT_MAX_LENGTH,
     FORGET_CORE_BATCH_SIZE,
@@ -19,7 +24,6 @@ from app.repositories.neo4j.graph_search import (
     forget_count_auxiliary_active_nodes,
     forget_get_auxiliary_candidates,
     forget_get_core_candidates,
-    forget_soft_delete_by_element_ids,
 )
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.utils.redis_cache import invalidate_cache
@@ -64,6 +68,7 @@ class ForgetService:
         self.target_count = max(int(memory_limit * self.target_ratio), 50)
 
         self._connector: Neo4jConnector | None = None
+        self._storage_client: Neo4jClient | None = None
         self._scanned_count = 0
         self._released_count = 0
         self._node_type_counts: defaultdict[str, int] = defaultdict(int)
@@ -75,12 +80,22 @@ class ForgetService:
         self._auxiliary_node_type_counts: defaultdict[str, int] = defaultdict(int)
 
     async def run(self) -> dict[str, Any]:
+        """Execute one automatic forgetting cycle and release storage clients."""
+        self._reset_run_state()
+        try:
+            return await self._run_cycle()
+        finally:
+            storage_client = self._storage_client
+            self._storage_client = None
+            if storage_client is not None:
+                await storage_client.close()
+
+    async def _run_cycle(self) -> dict[str, Any]:
         """执行离散优先、辅助驱动、时间价值兜底的遗忘。
 
         核心池未超过配额时直接返回。超过配额时，核心池实际软删除数
         始终受剩余预算约束，避免越过目标水位。
         """
-        self._reset_run_state()
         async with Neo4jConnector() as connector:
             self._connector = connector
             active_count = await forget_count_active_nodes(
@@ -245,6 +260,47 @@ class ForgetService:
             "release_ratio": 0.0,
         }
 
+    async def _get_storage_client(self) -> Neo4jClient:
+        if self._storage_client is None:
+            self._storage_client = await Neo4jClient.create()
+        return self._storage_client
+
+    async def _soft_delete_candidates(
+        self,
+        candidates: list[dict[str, Any]],
+        now: datetime,
+        *,
+        require_isolated: bool,
+    ) -> list[str]:
+        """Soft-delete through storage custom and preserve committed audits."""
+        try:
+            affected_nodes = await soft_delete_forgetting_nodes(
+                self.ctx.end_user_id,
+                [row["element_id"] for row in candidates],
+                to_iso_z(now),
+                protection_threshold=self.ENTITY_PROTECTION_THRESHOLD,
+                require_isolated=require_isolated,
+                client=await self._get_storage_client(),
+            )
+        except AutomaticForgetOutboxError as exc:
+            committed_ids = {node.element_id for node in exc.affected_nodes}
+            committed_rows = [
+                row for row in candidates if row["element_id"] in committed_ids
+            ]
+            try:
+                self._sync_audit([
+                    self._build_audit(row, now) for row in committed_rows
+                ])
+            except Exception:
+                logger.exception(
+                    "Failed to persist automatic-forget audit after Outbox "
+                    "failure: end_user_id=%s committed=%d",
+                    self.ctx.end_user_id,
+                    len(committed_rows),
+                )
+            raise
+        return [node.element_id for node in affected_nodes]
+
     async def _core_clean(
         self,
         budget: int,
@@ -287,12 +343,9 @@ class ForgetService:
             now = utcnow()
             self._scanned_count += len(candidates)
 
-            deleted_element_ids = await forget_soft_delete_by_element_ids(
-                connector,
-                self.ctx.end_user_id,
-                element_ids,
-                to_iso_z(now),
-                protection_threshold=self.ENTITY_PROTECTION_THRESHOLD,
+            deleted_element_ids = await self._soft_delete_candidates(
+                candidates,
+                now,
                 require_isolated=isolated_only,
             )
             deleted_id_set = set(deleted_element_ids)
@@ -376,12 +429,9 @@ class ForgetService:
 
         element_ids = [row["element_id"] for row in candidates]
         now = utcnow()
-        deleted_element_ids = await forget_soft_delete_by_element_ids(
-            connector,
-            self.ctx.end_user_id,
-            element_ids,
-            to_iso_z(now),
-            protection_threshold=self.ENTITY_PROTECTION_THRESHOLD,
+        deleted_element_ids = await self._soft_delete_candidates(
+            candidates,
+            now,
             require_isolated=False,
         )
         deleted_id_set = set(deleted_element_ids)

--- a/api/app/repositories/forget_log_repository.py
+++ b/api/app/repositories/forget_log_repository.py
@@ -9,8 +9,6 @@ from app.core.logging_config import get_db_logger
 from app.core.memory.models.service_models import ForgetLog
 from app.models.memory_forget_model import ForgetAuditModel, ForgetTrigger
 from app.models.user_model import User
-from app.repositories.neo4j.graph_search import forget_recover_by_element_id
-from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 
 logger = get_db_logger()
 
@@ -116,12 +114,14 @@ class ForgetLogRepository:
             )
             return
 
-        async with Neo4jConnector() as connector:
-            recovered = await forget_recover_by_element_id(
-                connector,
-                element_id,
-                end_user_id=str(end_user_id),
-            )
+        from app.core.memory.storage.custom.forget_recovery import (
+            recover_forgotten_node_by_element_id,
+        )
+
+        recovered = await recover_forgotten_node_by_element_id(
+            element_id,
+            end_user_id=str(end_user_id),
+        )
 
         if recovered is None:
             raise BusinessException(
@@ -140,7 +140,7 @@ class ForgetLogRepository:
             "Memory recovery persisted: element_id=%s operator=%s recovered_now=%s",
             element_id,
             operator,
-            bool(recovered.get("recovered_now")),
+            bool(recovered.recovered_now),
         )
 
     @staticmethod

--- a/api/app/repositories/neo4j/cypher_queries.py
+++ b/api/app/repositories/neo4j/cypher_queries.py
@@ -3171,16 +3171,6 @@ FORGET_SOFT_DELETE_BY_ELEMENT_IDS = """
     RETURN collect(elementId(n)) AS deleted_element_ids
 """
 
-FORGET_RECOVER_IDEMPOTENT_BY_ELEMENT_ID = """
-    MATCH (n)
-    WHERE elementId(n) = $element_id
-      AND n.end_user_id = $end_user_id
-      AND (n:Statement OR n:Chunk OR n:ExtractedEntity OR n:MemorySummary OR n:Dialogue)
-    WITH n, n.delete_at IS NOT NULL AS recovered_now
-    SET n.delete_at = CASE WHEN recovered_now THEN NULL ELSE n.delete_at END
-    RETURN elementId(n) AS node_id, labels(n) AS labels, recovered_now
-"""
-
 FORGET_CORE_CANDIDATES = f"""
 CALL () {{
     MATCH (c:Chunk {{end_user_id: $end_user_id}})
@@ -3407,40 +3397,48 @@ SET n.end_user_id = $new_id
 """
 
 GDS_GRAPH_BUILD = """
-CALL gds.graph.project.cypher(
+MATCH (source)
+WHERE source.end_user_id = $end_user_id
+  AND source.delete_at IS NULL
+  AND source.id IS NOT NULL
+  AND any(label IN labels(source) WHERE label IN [
+      'Statement', 'MemorySummary', 'Chunk', 'ExtractedEntity', 'Perceptual'
+  ])
+  AND (source.name IS NULL OR source.name <> '用户')
+OPTIONAL MATCH (source)-[r]-(target)
+WHERE target.end_user_id = $end_user_id
+  AND target.delete_at IS NULL
+  AND target.id IS NOT NULL
+  AND source <> target
+  AND any(label IN labels(target) WHERE label IN [
+      'Statement', 'MemorySummary', 'Chunk', 'ExtractedEntity', 'Perceptual'
+  ])
+  AND (target.name IS NULL OR target.name <> '用户')
+WITH source, target, count(r) AS parallel_count
+WITH gds.graph.project(
     $end_user_id,
-    'MATCH (n)
-    WHERE n.end_user_id = $endUserId
-     AND n.delete_at IS NULL
-     AND n.id IS NOT NULL
-     AND any(l IN labels(n) WHERE l IN ["Statement","MemorySummary","Chunk","ExtractedEntity","Perceptual"])
-     AND (n.name IS NULL OR n.name <> "用户")
-    RETURN id(n) AS id',
-    'MATCH (a)-[r]-(b)
-    WHERE a.end_user_id = $endUserId AND b.end_user_id = $endUserId
-     AND a.delete_at IS NULL AND b.delete_at IS NULL
-     AND a <> b AND a.id IS NOT NULL AND b.id IS NOT NULL
-     AND any(l IN labels(a) WHERE l IN ["Statement","MemorySummary","Chunk","ExtractedEntity","Perceptual"])
-     AND any(l IN labels(b) WHERE l IN ["Statement","MemorySummary","Chunk","ExtractedEntity","Perceptual"])
-     AND (a.name IS NULL OR a.name <> "用户") AND (b.name IS NULL OR b.name <> "用户")
-    WITH a, b, count(r) AS parallel_count
-    WITH a, b, parallel_count,
-        [[id(a), id(b)], [id(b), id(a)]] AS directed_pairs
-    UNWIND directed_pairs AS pair
-    RETURN pair[0] AS source, pair[1] AS target, toFloat(parallel_count) AS weight',
-    {
-        parameters: {endUserId: $end_user_id }
-    }
-);"""
+    source,
+    target,
+    {relationshipProperties: {weight: toFloat(parallel_count)}}
+) AS graph
+RETURN graph.graphName AS graphName,
+       graph.nodeCount AS nodeCount,
+       graph.relationshipCount AS relationshipCount,
+       graph.projectMillis AS projectMillis
+"""
 
 G_SCORE = """
 CALL gds.eigenvector.write($end_user_id, {
       relationshipWeightProperty: 'weight',
       scaler: 'Max',
       writeProperty: 'topology_score',
-      maxIterations: 50,
-      tolerance: 0.000005
+      maxIterations: 200,
+      tolerance: 0.00001
   })
 """
 
-CLEAR_GRAPH = f"CALL gds.graph.drop($end_user_id, false);"
+CLEAR_GRAPH = """
+CALL gds.graph.drop($end_user_id, false)
+YIELD graphName
+RETURN graphName
+"""

--- a/api/app/repositories/neo4j/graph_search.py
+++ b/api/app/repositories/neo4j/graph_search.py
@@ -1227,28 +1227,3 @@ async def forget_soft_delete_by_element_ids(
     if not result:
         return []
     return [str(element_id) for element_id in result[0]["deleted_element_ids"]]
-
-
-async def forget_recover_by_element_id(
-        connector: Neo4jConnector,
-        element_id: str,
-        end_user_id: str,
-) -> dict | None:
-    """幂等恢复节点，并返回本次是否实际清除了软删除标记。
-
-    查询按审计记录中的终端用户和支持的记忆类型限定节点。节点已处于可见状态时
-    仍返回结果，供调用方补齐 PostgreSQL 审计状态，但不会再次刷新访问时间。
-
-    Returns:
-        包含 ``node_id``、``labels`` 和 ``recovered_now`` 的结果；节点不存在时
-        返回 ``None``。
-    """
-    from app.repositories.neo4j.cypher_queries import (
-        FORGET_RECOVER_IDEMPOTENT_BY_ELEMENT_ID,
-    )
-    result = await connector.execute_query(
-        FORGET_RECOVER_IDEMPOTENT_BY_ELEMENT_ID,
-        element_id=element_id,
-        end_user_id=end_user_id,
-    )
-    return result[0] if result else None

--- a/api/app/services/user_memory_service.py
+++ b/api/app/services/user_memory_service.py
@@ -564,15 +564,14 @@ class UserMemoryService:
             db.commit()
             db.refresh(end_user_info_record)
             
-            # 如果 aliases 被更新，同步到 Neo4j
+            # 如果 aliases 被更新，通过 memory_storage 抽象层同步
             if aliases_updated:
                 try:
-                    import asyncio
-                    asyncio.run(self._sync_aliases_to_neo4j(end_user_id, update_data['aliases']))
-                    logger.info(f"已触发 aliases 同步到 Neo4j: end_user_id={end_user_id}, aliases={update_data['aliases']}")
+                    asyncio.run(self._sync_aliases_to_memory_storage(end_user_id, update_data['aliases']))
+                    logger.info(f"已触发 aliases 同步到 memory_storage: end_user_id={end_user_id}, aliases={update_data['aliases']}")
                 except Exception as sync_error:
-                    logger.error(f"触发同步 aliases 到 Neo4j 失败: {sync_error}", exc_info=True)
-                    # 不影响主流程，只记录错误
+                    logger.error(f"触发同步 aliases 到 memory_storage 失败: {sync_error}", exc_info=True)
+                    # PG 已提交；同步失败不影响主流程，只记录错误
             
             # 构建响应数据（转换时间为毫秒时间戳）
             response_data = {
@@ -669,11 +668,11 @@ class UserMemoryService:
             if aliases_updated:
                 neo4j_sync_status = "success"
                 try:
-                    await self._sync_aliases_to_neo4j(end_user_id, update_data['aliases'])
-                    logger.info(f"已触发 aliases 同步到 Neo4j: end_user_id={end_user_id}, aliases={update_data['aliases']}")
+                    await self._sync_aliases_to_memory_storage(end_user_id, update_data['aliases'])
+                    logger.info(f"已触发 aliases 同步到 memory_storage: end_user_id={end_user_id}, aliases={update_data['aliases']}")
                 except Exception as sync_error:
                     neo4j_sync_status = "failed"
-                    logger.error(f"触发同步 aliases 到 Neo4j 失败: {sync_error}", exc_info=True)
+                    logger.error(f"触发同步 aliases 到 memory_storage 失败: {sync_error}", exc_info=True)
             else:
                 neo4j_sync_status = "skipped"
             
@@ -712,41 +711,18 @@ class UserMemoryService:
                 "error": str(e)
             }
     
-    async def _sync_aliases_to_neo4j(self, end_user_id: str, aliases: List[str]) -> None:
-        """
-        将 aliases 同步到 Neo4j 中的用户实体
-        
-        Args:
-            end_user_id: 终端用户ID
-            aliases: 别名列表
-        """
-        from app.repositories.neo4j.neo4j_connector import Neo4jConnector
-        
-        # Cypher 查询：更新用户实体的 aliases
-        cypher_query = """
-        MATCH (e:ExtractedEntity)
-        WHERE e.end_user_id = $end_user_id 
-          AND e.name IN ['用户', '我', 'User', 'I']
-        SET e.aliases = $aliases
-        RETURN e.id AS entity_id, e.name AS entity_name, e.aliases AS updated_aliases
-        """
-        
-        connector = Neo4jConnector()
-        try:
-            result = await connector.execute_query(
-                cypher_query,
-                end_user_id=end_user_id,
-                aliases=aliases
+    async def _sync_aliases_to_memory_storage(self, end_user_id: str, aliases: List[str]) -> None:
+        """通过 memory_storage custom 层更新用户实体 aliases。"""
+        from app.core.memory.storage.custom import update_user_entity_aliases
+
+        affected_count = await update_user_entity_aliases(end_user_id, aliases)
+        if affected_count:
+            logger.info(
+                f"成功同步 aliases 到 memory_storage: end_user_id={end_user_id}, "
+                f"更新了 {affected_count} 个实体节点"
             )
-            
-            if result:
-                logger.info(f"成功同步 aliases 到 Neo4j: end_user_id={end_user_id}, 更新了 {len(result)} 个实体节点")
-            else:
-                logger.warning(f"未找到需要更新的用户实体节点: end_user_id={end_user_id}")
-                
-        except Exception as e:
-            logger.error(f"同步 aliases 到 Neo4j 失败: {e}", exc_info=True)
-            raise
+        else:
+            logger.warning(f"未找到需要更新的用户实体节点: end_user_id={end_user_id}")
 
     async def validate_neo4j_cache_workspace(
         self,

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -3794,7 +3794,7 @@ def do_gds_topology_score(self, end_user_id: str, inflight_token: Optional[str] 
         return {"status": "skipped_stale_inflight", "end_user_id": end_user_id}
 
     async def _run() -> Dict[str, Any]:
-        from app.repositories.neo4j.gds_topology_repository import compute_topology_score
+        from app.core.memory.storage.custom import compute_topology_score
 
         write_lock = RedisFairLock(
             key=f"memory_write:{end_user_id}",


### PR DESCRIPTION
- Extract automatic forgetting, node recovery, manual delete, and topology score logic into dedicated custom storage modules
- Route soft delete and recovery through the new storage client instead of direct Neo4jConnector calls
- Replace GDS graph projection Cypher with an equivalent MATCH-based projection
- Add execute_query helper to Neo4jClient for provider-specific Cypher

## Sourcery 摘要

通过自定义存储层集中处理记忆遗忘、恢复、删除、拓扑评分及相关更新。

Bug 修复：
- 当 Neo4j 更改已提交但 outbox 发布失败时，保留遗忘和手动删除的审计记录。
- 使已遗忘节点的恢复操作具备幂等性，并通过存储层协调审计状态。
- 将空图拓扑评分失败视为跳过的运行，并确保清理临时投影。

增强功能：
- 将自动遗忘、手动删除、恢复、拓扑评分和实体别名更新移至专用的自定义存储操作中。
- 通过存储服务和 outbox 抽象处理记忆变更及投影事件，而不是直接调用 Neo4j 连接器。
- 为 Neo4j 存储客户端添加特定于提供商的 Cypher 执行支持。
- 在图投影期间收集受拓扑评分影响的身份，并验证评分写入覆盖范围。

杂项：
- 将反射间隔设置明确设为整数类型。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在自定义存储层中集中处理记忆遗忘、恢复、删除、拓扑评分及相关更新。

Bug 修复：
- 当 Neo4j 提交成功但 outbox 发布失败时，保留遗忘和手动删除的审计记录。
- 使已遗忘节点的恢复具备幂等性，并通过存储层协调恢复状态。
- 将空图上的拓扑评分失败视为跳过的运行，并确保清理临时投影。

增强功能：
- 将自动遗忘、手动删除、恢复、拓扑评分和用户实体别名更新移至专用的自定义存储操作中。
- 通过存储服务和 outbox 抽象路由记忆变更和投影事件。
- 为 Neo4j 存储客户端添加特定于提供商的 Cypher 执行支持。
- 使用基于 MATCH 的投影替换 GDS Cypher 图投影，并验证拓扑评分覆盖范围。

杂项：
- 将反射间隔设置明确设为整数类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize memory forgetting, recovery, deletion, topology scoring, and related updates in the custom storage layer.

Bug Fixes:
- Preserve forgetting and manual-deletion audit records when Neo4j commits but outbox publication fails.
- Make forgotten-node recovery idempotent and coordinate recovery state through the storage layer.
- Treat topology scoring failures on empty graphs as skipped runs and ensure temporary projections are cleaned up.

Enhancements:
- Move automatic forgetting, manual deletion, recovery, topology scoring, and user-entity alias updates into dedicated custom storage operations.
- Route memory mutations and projection events through the storage service and outbox abstractions.
- Add provider-specific Cypher execution support to the Neo4j storage client.
- Replace the GDS Cypher graph projection with a MATCH-based projection and validate topology-score coverage.

Chores:
- Make the reflection interval setting explicitly integer-typed.

</details>

</details>