### PR TITLE
feat(web): kb recall rerank config

### DIFF
--- a/web/src/api/knowledgeBase.ts
+++ b/web/src/api/knowledgeBase.ts
@@ -257,6 +257,10 @@ export const reChunks = async (data: any) => {
   const response = await request.post(`/chunks/retrieval`, data);
   return response as any;
 };
+// 获取检索策略
+export const retrievalPolicyApi = (data: { kb_ids: string[] }) => {
+  return request.get('/chunks/retrieval-policy', data)
+}
 // 知识库授权 分享空间列表
 export const getWorkspaceAuthorizationList = async (kb_id: string) => {
   const response = await request.get(`/knowledgeshares/${kb_id}/knowledgeshares`);

--- a/web/src/components/Knowledge/KnowledgeConfigModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeConfigModal.tsx
@@ -11,6 +11,9 @@ import type { KnowledgeConfigModalRef, KnowledgeBase, KnowledgeConfigForm, Retri
 import RbModal from '@/components/RbModal'
 import RbSlider from '@/components/RbSlider'
 import { formatDateTime } from '@/utils/format';
+import ModelSelect from '@/components/ModelSelect'
+import RadioGroupButton from '@/components/RadioGroupButton'
+import WeightBalanceSlider from './WeightBalanceSlider'
 
 const FormItem = Form.Item;
 
@@ -61,6 +64,19 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
         console.log('err', err)
       });
   }
+  const handleChangeMode = (value?: string | null) => {
+    if (value === 'reranking_model') {
+      form.setFieldValue('rerank_weights', null)
+    } else if (value === 'weighted_score') {
+      form.setFieldsValue({
+        reranker_id: null,
+        rerank_weights: {
+          semantic_weight: 1,
+          participle_weight: 0,
+        }
+      })
+    }
+  }
 
   useImperativeHandle(ref, () => ({
     handleOpen,
@@ -101,9 +117,15 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
               label: t(`application.${key}`),
               value: key,
             }))}
+            placeholder={t('common.pleaseSelect')}
+            onChange={(value) => {
+              if (value === 'hybrid') {
+                form.setFieldValue('rerank_mode', 'reranking_model')
+              }
+            }}
           />
         </FormItem>
-        {(values?.retrieve_type === 'hybrid') &&
+        {(values?.retrieve_type === 'hybrid') && <>
           <Form.Item
             name="enable_graph_retrieval"
             getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
@@ -114,7 +136,58 @@ const KnowledgeConfigModal = forwardRef<KnowledgeConfigModalRef, KnowledgeConfig
           >
             <Switch checkedChildren={t('knowledgeBase.yes')} unCheckedChildren={t('knowledgeBase.no')} />
           </Form.Item>
-        }
+
+          <Form.Item name="rerank_mode"
+            label={t('application.rerank_mode')}
+            rules={[{ required: true, message: t('common.pleaseSelect') }]}
+          >
+            <RadioGroupButton
+              circle={false}
+              size="default"
+              variant="outlined"
+              block={true}
+              options={[
+                { label: t('application.reranking_model'), value: 'reranking_model' },
+                { label: t('application.weighted_score'), value: 'weighted_score' },
+              ]}
+              onChange={(value) => handleChangeMode(value)}
+            />
+          </Form.Item>
+
+          <FormItem
+            name="reranker_id"
+            label={t('application.rearrangementModel')}
+            rules={[{ required: values?.rerank_mode === 'reranking_model', message: t('common.pleaseSelect') }]}
+            extra={t('application.rearrangementModelDesc')}
+            hidden={values?.rerank_mode !== 'reranking_model'}
+          >
+            <ModelSelect
+              params={{ type: 'rerank' }}
+              className="rb:w-full!"
+            />
+          </FormItem>
+
+          {values?.rerank_mode === 'weighted_score' && <>
+            <Form.Item
+              required
+              label={t('application.weight_balance')}
+            >
+              <WeightBalanceSlider
+                semanticWeight={values?.rerank_weights?.semantic_weight}
+                participleWeight={values?.rerank_weights?.participle_weight}
+                onChange={(semanticWeight, participleWeight) => {
+                  form.setFieldsValue({
+                    rerank_weights: {
+                      semantic_weight: semanticWeight,
+                      participle_weight: participleWeight,
+                    },
+                  });
+                }}
+              />
+            </Form.Item>
+          </>}
+          <Form.Item name="rerank_weights" hidden />
+        </>}
         <FormItem
           name="top_k"
           label={t('application.top_k')}

--- a/web/src/components/Knowledge/KnowledgeGlobalConfigModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeGlobalConfigModal.tsx
@@ -3,13 +3,15 @@
  * Configures global reranker settings for all knowledge bases
  */
 
-import { forwardRef, useImperativeHandle, useState, useEffect } from 'react';
-import { Form, InputNumber, Switch, Flex } from 'antd';
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Form, InputNumber } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { RerankerConfig, KnowledgeGlobalConfigModalRef } from './types'
 import RbModal from '@/components/RbModal'
 import ModelSelect from '@/components/ModelSelect'
+import RadioGroupCard from '@/components/RadioGroupCard'
+import WeightBalanceSlider from './WeightBalanceSlider'
 
 const FormItem = Form.Item;
 
@@ -33,7 +35,7 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
   };
 
   const handleOpen = () => {
-    form.setFieldsValue({ ...data, rerank_model: !!data?.reranker_id })
+    form.setFieldsValue({ ...data, rerank_mode: data.rerank_mode || 'reranking_model' })
     setVisible(true);
   };
 
@@ -49,14 +51,19 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
       });
   }
 
-  useEffect(() => {
-    if (values?.rerank_model) {
-      const { rerank_model, ...rest } = data;
-      form.setFieldsValue({ ...rest })
-    } else {
-      form.setFieldsValue({ reranker_id: undefined, reranker_top_k: undefined })
+  const handleChangeMode = (value?: string | null) => {
+    if (value === 'reranking_model') {
+      form.setFieldValue('rerank_weights', null)
+    } else if (value === 'weighted_score') {
+      form.setFieldsValue({
+        reranker_id: null,
+        rerank_weights: {
+          semantic_weight: 1,
+          participle_weight: 0,
+        }
+      })
     }
-  }, [values?.rerank_model])
+  }
 
   useImperativeHandle(ref, () => ({
     handleOpen,
@@ -74,50 +81,69 @@ const KnowledgeGlobalConfigModal = forwardRef<KnowledgeGlobalConfigModalRef, Kno
         form={form}
         layout="vertical"
         size="middle"
+        initialValues={{
+          rerank_mode: 'reranking_model',
+        }}
       >
         <div className="rb:text-[#5B6167] rb:mb-6">{t('application.globalConfigDesc')}</div>
 
-        <Flex align="center" justify="space-between" className="rb:my-6!">
-          <div className="rb:text-[14px] rb:font-medium rb:leading-5">
-            {t('application.rerankModel')}
-            <div className="rb:mt-1 rb:text-[12px] rb:text-[#5B6167] rb:font-regular rb:leading-4">{t('application.rerankModelDesc')}</div>
-          </div>
-          <FormItem
-            name="rerank_model"
-            valuePropName="checked"
-            className="rb:mb-0!"
-          >
-            <Switch />
-          </FormItem>
-        </Flex>
+        <Form.Item name="rerank_mode">
+          <RadioGroupCard
+            options={[
+              { label: t('application.reranking_model'), value: 'reranking_model' },
+              { label: t('application.weighted_score'), value: 'weighted_score' },
+            ]}
+            onChange={value => handleChangeMode(value)}
+          />
+        </Form.Item>
 
-        {values?.rerank_model && <>
-          <FormItem
-            name="reranker_id"
-            label={t('application.rearrangementModel')}
-            rules={[{ required: true, message: t('common.pleaseSelect') }]}
-            extra={t('application.rearrangementModelDesc')}
+        <FormItem
+          name="reranker_id"
+          label={t('application.rearrangementModel')}
+          rules={[{ required: values?.rerank_mode === 'reranking_model', message: t('common.pleaseSelect') }]}
+          extra={t('application.rearrangementModelDesc')}
+          hidden={values?.rerank_mode !== 'reranking_model'}
+        >
+          <ModelSelect
+            params={{ type: 'rerank' }}
+            className="rb:w-full!"
+          />
+        </FormItem>
+
+        {values?.rerank_mode === 'weighted_score' && <>
+          <Form.Item
+            required
+            label={t('application.weight_balance')}
           >
-            <ModelSelect
-              params={{ type: 'rerank' }}
-              className="rb:w-full!"
+            <WeightBalanceSlider
+              semanticWeight={values?.rerank_weights?.semantic_weight}
+              participleWeight={values?.rerank_weights?.participle_weight}
+              onChange={(semanticWeight, participleWeight) => {
+                form.setFieldsValue({
+                  rerank_weights: {
+                    semantic_weight: semanticWeight,
+                    participle_weight: participleWeight,
+                  },
+                });
+              }}
             />
-          </FormItem>
-          <FormItem
-            name="reranker_top_k"
-            label={t('application.reranker_top_k')}
-            rules={[{ required: true, message: t('common.pleaseEnter') }]}
-            extra={t('application.reranker_top_k_desc')}
-          >
-            <InputNumber
-              className="rb:w-full!"
-              placeholder={t('common.pleaseEnter')}
-              min={1}
-              max={20}
-              onChange={(value) => form.setFieldValue('reranker_top_k', value)}
-            />
-          </FormItem>
+          </Form.Item>
         </>}
+        <Form.Item name="rerank_weights" hidden />
+        <FormItem
+          name="reranker_top_k"
+          label={t('application.reranker_top_k')}
+          rules={[{ required: true, message: t('common.pleaseEnter') }]}
+          extra={t('application.reranker_top_k_desc')}
+        >
+          <InputNumber
+            className="rb:w-full!"
+            placeholder={t('common.pleaseEnter')}
+            min={1}
+            max={20}
+            onChange={(value) => form.setFieldValue('reranker_top_k', value)}
+          />
+        </FormItem>
       </Form>
     </RbModal>
   );

--- a/web/src/components/Knowledge/KnowledgeListModal.tsx
+++ b/web/src/components/Knowledge/KnowledgeListModal.tsx
@@ -179,6 +179,7 @@ const KnowledgeListModal = forwardRef<KnowledgeModalRef, KnowledgeModalProps>(({
         top_k: 3,
         weight: 1,
         enable_graph_retrieval: 0,
+        rerank_mode: 'reranking_model',
       }
     })), 'knowledge')
     setVisible(false);

--- a/web/src/components/Knowledge/WeightBalanceSlider.tsx
+++ b/web/src/components/Knowledge/WeightBalanceSlider.tsx
@@ -1,0 +1,82 @@
+/**
+ * WeightBalanceSlider Component
+ * 
+ * A balance slider that distributes weight between two dimensions (semantic / keyword).
+ * semantic_weight + participle_weight = 1.0
+ */
+
+import { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { Slider, Flex } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+interface WeightBalanceSliderProps {
+  semanticWeight?: number;
+  participleWeight?: number;
+  onChange: (semanticWeight: number, participleWeight: number) => void;
+  step?: number;
+}
+
+const WeightBalanceSlider: FC<WeightBalanceSliderProps> = ({
+  semanticWeight,
+  participleWeight,
+  onChange,
+  step = 0.1,
+}) => {
+  const { t } = useTranslation();
+  const [value, setValue] = useState<number>(0.5);
+
+  // Sync with external values (semantic_weight is the source of truth)
+  useEffect(() => {
+    if (semanticWeight !== undefined && semanticWeight !== null) {
+      setValue(semanticWeight);
+    } else if (participleWeight !== undefined && participleWeight !== null) {
+      setValue(1 - participleWeight);
+    }
+  }, [semanticWeight, participleWeight]);
+
+  const handleChange = (newValue: number) => {
+    setValue(newValue);
+    onChange(Math.round(newValue * 100) / 100, Math.round((1 - newValue) * 100) / 100);
+  };
+
+  const formattedValue = Number(value.toFixed(1));
+  const formattedOpposite = Number((1 - value).toFixed(1));
+
+  return (
+    <div className="rb:w-full rb:px-2">
+      <Slider
+        min={0}
+        max={1}
+        step={step}
+        value={value}
+        onChange={handleChange}
+        className="rb:my-0!"
+        classNames={{
+          rail: 'rb:h-[6px]!',
+          track: 'rb:h-[6px]!',
+        }}
+        styles={{
+          rail: {
+            background: '#369F21',
+          },
+          track: {
+            background: '#155EEF',
+          },
+        }}
+      />
+      <Flex align="center" justify="space-between" className="rb:px-1! rb:text-[12px]">
+        <Flex gap={4} className="rb:text-blue-500">
+          <span>{t('application.semantic_label')}</span>
+          <span className="rb:font-semibold">{formattedValue}</span>
+        </Flex>
+        <Flex gap={4} className="rb:text-green-600">
+          <span className="rb:font-semibold">{formattedOpposite}</span>
+          <span>{t('application.keyword_label')}</span>
+        </Flex>
+      </Flex>
+    </div>
+  );
+};
+
+export default WeightBalanceSlider;

--- a/web/src/components/Knowledge/index.tsx
+++ b/web/src/components/Knowledge/index.tsx
@@ -132,8 +132,6 @@ const Knowledge: FC<KnowledgeProps> = ({
       onChange && onChange({
         ...editConfig,
         ...rerankerValues,
-        reranker_id: rerankerValues.rerank_model ? rerankerValues.reranker_id : undefined,
-        reranker_top_k: rerankerValues.rerank_model ? rerankerValues.reranker_top_k : undefined,
       })
     }
   }

--- a/web/src/components/Knowledge/types.ts
+++ b/web/src/components/Knowledge/types.ts
@@ -14,9 +14,14 @@ import type { KnowledgeBaseListItem } from '@/views/KnowledgeBase/types'
  * Reranker configuration for knowledge retrieval
  */
 export interface RerankerConfig {
-  rerank_model?: boolean | undefined;
-  reranker_id?: string | undefined;
-  reranker_top_k?: number | undefined;
+  rerank_model?: boolean | null;
+  reranker_id?: string | null;
+  reranker_top_k?: number | null;
+  rerank_mode?: 'reranking_model' | 'weighted_score';
+  rerank_weights?: {
+    semantic_weight: number,
+    participle_weight: number
+  } | null;
 }
 
 /**
@@ -37,12 +42,19 @@ export interface KnowledgeConfigForm {
   enable_graph_retrieval?: 0 | 1;
   weight?: number;
   config?: KnowledgeConfigForm;
+
+  rerank_mode?: 'reranking_model' | 'weighted_score';
+  reranker_id?: string | null;
+  rerank_weights?: {
+    semantic_weight: number,
+    participle_weight: number
+  } | null;
 }
 
 /**
  * Knowledge base with configuration
  */
-export interface KnowledgeBase extends Omit<KnowledgeBaseListItem, 'id'>, KnowledgeConfigForm {
+export interface KnowledgeBase extends Omit<KnowledgeBaseListItem, 'id' | 'reranker_id'>, KnowledgeConfigForm {
   id: string;
   config?: KnowledgeConfigForm
 }

--- a/web/src/components/RadioGroupButton/index.tsx
+++ b/web/src/components/RadioGroupButton/index.tsx
@@ -1,8 +1,8 @@
 /*
  * @Author: ZhaoYing 
  * @Date: 2026-03-16 14:53:33 
- * @Last Modified by:   ZhaoYing 
- * @Last Modified time: 2026-03-16 14:53:33 
+ * @Last Modified by: ZhaoYing
+ * @Last Modified time: 2026-09-03 14:00:39
  */
 /**
  * RadioGroupButton Component
@@ -21,7 +21,7 @@
  */
 
 import { type FC, type Key, type ReactNode, useEffect } from 'react';
-import { type RadioGroupProps, Space } from 'antd';
+import { type RadioGroupProps, Flex } from 'antd';
 import clsx from 'clsx'
 
 /** Describes a single selectable option within the radio group. */
@@ -35,7 +35,7 @@ interface RadioCardOption {
 }
 
 /** Props for the RadioGroupButton component. */
-interface RadioCardProps extends Omit<RadioGroupProps, 'onChange'> {
+interface RadioCardProps extends Omit<RadioGroupProps, 'onChange' | 'size'> {
   /** List of selectable options to render as pill tags. */
   options: RadioCardOption[];
   /** Side-effect callback invoked whenever the value changes (including on mount). */
@@ -44,6 +44,10 @@ interface RadioCardProps extends Omit<RadioGroupProps, 'onChange'> {
   onChange?: (value: string | null | undefined, option?: RadioCardOption) => void;
   /** If true, clicking the already-selected option will deselect it (set value to null). */
   allowClear?: boolean;
+  circle?: boolean;
+  size?: 'small' | 'default';
+  variant?: 'filled' | 'outlined';
+  block?: boolean;
 }
 
 /** Renders a horizontal row of pill-shaped radio options. */
@@ -53,6 +57,10 @@ const RadioGroupButton: FC<RadioCardProps> = ({
   onValueChange,
   onChange,
   allowClear = false,
+  circle = true,
+  size = 'small',
+  variant = 'filled',
+  block = false,
 }) => {
   /* Notify parent of value changes (useful for side-effects like analytics). */
   useEffect(() => {
@@ -76,20 +84,30 @@ const RadioGroupButton: FC<RadioCardProps> = ({
   }
   
   return (
-    <Space size={12}>
+    <Flex gap={12} className={clsx({
+      'rb:grid rb:w-full!': block,
+      [`rb:grid-cols-${options.length}`]: block
+    })}
+    >
       {options.map(option => (
         <div
           key={String(option.value)}
-          className={clsx('rb:rounded-[14px] rb:py-1 rb:px-2 rb:text-[12px] rb:leading-4.5 rb:cursor-pointer', {
-            'rb:bg-[#171719] rb:font-medium rb:text-white': value === option.value,
-            'rb:bg-[#F6F6F6]': value !== option.value,
+          className={clsx('rb:px-2 rb:leading-4.5 rb:cursor-pointer', {
+            'rb:rounded-full': circle,
+            'rb:rounded-[8px]': !circle,
+            'rb:bg-[#171719] rb:font-medium rb:text-white': value === option.value && variant === 'filled',
+            'rb:bg-[#F6F6F6]': value !== option.value && variant === 'filled',
+            'rb:border rb:border-[#171719] rb:font-medium': value === option.value && variant === 'outlined',
+            'rb-border rb:text-[#171719]': value !== option.value && variant === 'outlined',
+            'rb:py-1 rb:text-[12px]': size === 'small',
+            'rb:py-2 rb:text-[14px]': size === 'default',
           })}
           onClick={() => handleChange(option)}
         >
           {option.label}
         </div>
       ))}
-    </Space>
+    </Flex>
   );
 };
 

--- a/web/src/components/RadioGroupCard/index.tsx
+++ b/web/src/components/RadioGroupCard/index.tsx
@@ -2,7 +2,7 @@
  * @Author: ZhaoYing 
  * @Date: 2026-02-02 15:19:30 
  * @Last Modified by: ZhaoYing
- * @Last Modified time: 2026-07-02 16:30:15
+ * @Last Modified time: 2026-09-03 14:20:12
  */
 /**
  * RadioGroupCard Component
@@ -45,9 +45,9 @@ interface RadioCardProps extends Omit<RadioGroupProps, 'onChange'> {
   /** Array of radio card options */
   options: RadioCardOption[];
   /** Callback fired when value changes (for side effects) */
-  onValueChange?: (value: string | null | undefined, option?: RadioCardOption) => void;
+  onValueChange?: (value?: string | null, option?: RadioCardOption) => void;
   /** Callback fired when selection changes */
-  onChange?: (value: string | null | undefined, option?: RadioCardOption) => void;
+  onChange?: (value?: string | null, option?: RadioCardOption) => void;
   /** Custom render function for each option */
   itemRender?: (option: RadioCardOption) => ReactNode;
   /** Whether clicking selected option clears selection */

--- a/web/src/i18n/en/applicationPart2.ts
+++ b/web/src/i18n/en/applicationPart2.ts
@@ -41,4 +41,12 @@ export const applicationPart2 = {
       moderation_input_output_required: 'Review Input and Output Content Required',
       moderation_input_output_required_desc: 'At least one of review input and review output must be enabled',
       execution_id: 'Execution ID',
+      rerank_mode: 'Rerank Mode',
+      reranking_model: 'Model Rerank',
+      weighted_score: 'Weighted Score Rerank',
+      semantic_weight: 'Semantic Weight',
+      participle_weight: 'Keyword Weight',
+      weight_balance: 'Weight Balance',
+      semantic_label: 'Semantic',
+      keyword_label: 'Keyword',
 }

--- a/web/src/i18n/zh/applicationPart2.ts
+++ b/web/src/i18n/zh/applicationPart2.ts
@@ -39,4 +39,12 @@ export const applicationPart2 = {
       moderation_input_output_required: '审查输入输出内容必填',
       moderation_input_output_required_desc: '审查输入内容和审查输出内容至少启用一项',
       execution_id: '执行ID',
+      rerank_mode: '重排模式',
+      reranking_model: '模型重排',
+      weighted_score: '加权重排',
+      semantic_weight: '语义权重',
+      participle_weight: '词元权重',
+      weight_balance: '权重分配',
+      semantic_label: '语义',
+      keyword_label: '关键词',
 }

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -1,11 +1,14 @@
 
 import { forwardRef, useImperativeHandle, useState, useEffect } from 'react';
-import { Form, Input,  Select, Button, InputNumber, Flex, Switch } from 'antd';
+import { Form, Input,  Select, Button, InputNumber, Flex, Switch, Row, Col } from 'antd';
 import { useTranslation } from 'react-i18next';
+
 import type { RecallTestDrawerRef, RecallTestData, RecallTestParams } from '@/views/KnowledgeBase/types';
-// import refreshIcon from '@/assets/images/knowledgeBase/refresh-blue.png';
 import RecallTestResult from './RecallTestResult';
-import { reChunks, getRetrievalModeType } from '@/api/knowledgeBase';
+import { reChunks, retrievalPolicyApi, getRetrievalModeType  } from '@/api/knowledgeBase';
+import RadioGroupButton from '@/components/RadioGroupButton';
+import ModelSelect from '@/components/ModelSelect';
+import WeightBalanceSlider from '@/components/Knowledge/WeightBalanceSlider';
 
 const { TextArea } = Input;
 
@@ -25,6 +28,8 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
         { label: t('knowledgeBase.hybrid'), value: true },
         { label: t('knowledgeBase.vector'), value: false },
     ]);
+
+    const formValues = Form.useWatch([], form);
 
     console.log('RecallTest - knowledgeBaseId:', knowledgeBaseId);
     // Get retrieval mode options
@@ -62,8 +67,19 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
         setData([]);
         setRetrieveType('hybrid'); // Reset to default value
         // Ensure form field is also set to default value
-        form.setFieldsValue({ retrieve_type: 'hybrid' });
+        form.setFieldsValue({ retrieve_type: 'hybrid', rerank_mode: 'reranking_model' });
+        // getRetrievalPolicy();
     }
+
+    /*
+    const [retrievalPolicy, setRetrievalPolicy] = useState<Record<string, string[]>>({});
+    const getRetrievalPolicy = () => {
+        retrievalPolicyApi({ kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [] })
+        .then((res) => {
+            setRetrievalPolicy(res as Record<string, string[]>);
+        })
+    }
+    */
     const fetchData = (params: RecallTestParams) => {
         if (loading) return;
         setLoading(true);
@@ -77,7 +93,7 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
           });
     }
     const handleStartTest = () => {
-        form.validateFields().then((values) => {
+        form.validateFields().then(({rerank_mode, ...values}) => {
             const params: RecallTestParams = {
                 query: values.query || '',
                 kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [],
@@ -87,6 +103,14 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                 // hybrid: values.retrieve_type !== hybrid ? true : false,
                 retrieve_type: retrieveType,
                 enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval: undefined,
+                ...(retrieveType === 'hybrid' && rerank_mode ? {
+                    rerank_mode: rerank_mode,
+                    ...(rerank_mode === 'reranking_model' ? {
+                        reranker_id: values.reranker_id,
+                    } : {
+                        rerank_weights: values.rerank_weights,
+                    }),
+                } : {}),
             };
             console.log('RecallTest - params:', params);
             fetchData(params);
@@ -98,9 +122,20 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
     useImperativeHandle(ref, () => ({
         handleOpen,
     }));
+
+    const handleChangeRerankMode = (value: string | null | undefined) => {
+        if (value === 'reranking_model') {
+            form.setFieldsValue({ rerank_weights: undefined });
+        } else if (value === 'weighted_score') {
+            form.setFieldsValue({
+                reranker_id: undefined,
+                rerank_weights: { semantic_weight: 0.5, participle_weight: 0.5 },
+            });
+        }
+    };
   return (
     <Flex vertical className='rb:w-full rb:h-full rb:overflow-hidden'>
-      <div className='rb:shrink-0'>
+      <div className='rb:shrink-0 rb:max-h-[50%]! rb:overflow-y-auto'>
         <Flex align="center" justify="space-between" className='rb:mb-2!'>
           <span className='rb:font-medium'>{ t('knowledgeBase.testQuestion')}</span>
           {/* <Flex align="center" justify="end">
@@ -112,7 +147,8 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
           <Form.Item name="query">
               <TextArea rows={4} placeholder={t('knowledgeBase.testQuestionPlaceholder')}/>
           </Form.Item>
-          <div className='rb:grid rb:grid-cols-6 rb:gap-x-4'>
+          <div className="rb:grid rb:grid-cols-4 rb:gap-x-4 rb:gap-y-1">
+            <div>
               <Form.Item 
                   name="retrieve_type" 
                   label={t('knowledgeBase.retrieveMode')}
@@ -124,7 +160,9 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                       onChange={(value) => setRetrieveType(value)}
                   />
               </Form.Item>
+            </div>
               
+            <div>
               <Form.Item name="top_k" label={t('knowledgeBase.recallQuantity')}>
                   <InputNumber 
                       placeholder='1 ~ 100'
@@ -133,66 +171,128 @@ const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
                       className="rb:w-full!"
                   />
               </Form.Item>
+            </div>
 
               {/* Show when retrieve_type = semantic or hybrid */}
               {(retrieveType === 'hybrid') && (
                 <>
-                  <Form.Item name="similarity_threshold" label={t('knowledgeBase.similarityThreshold')}>
+                  <div>
+                    <Form.Item
+                      name="rerank_mode"
+                      label={t('application.rerank_mode')}
+                      className="rb:col-span-full rb:mb-0!"
+                    >
                       <Select
-                          options={[
-                              { label: '0.1', value: 0.1 },
-                              { label: '0.2', value: 0.2 },
-                              { label: '0.3', value: 0.3 },
-                              { label: '0.4', value: 0.4 },
-                              { label: '0.5', value: 0.5 },
-                              { label: '0.6', value: 0.6 },
-                              { label: '0.7', value: 0.7 },
-                              { label: '0.8', value: 0.8 },
-                              { label: '0.9', value: 0.9 },
-                              { label: '1.0', value: 1.0 },
-                          ]}
-                          placeholder={t('knowledgeBase.similarityThreshold')}
+                        options={[
+                          { label: t('application.reranking_model'), value: 'reranking_model' },
+                          { label: t('application.weighted_score'), value: 'weighted_score' },
+                        ]}
+                        onChange={(value) => handleChangeRerankMode(value)}
                       />
-                  </Form.Item>
+                    </Form.Item>
+                  </div>
+                  <div className={formValues?.rerank_mode !== 'reranking_model' ? 'rb:hidden' : ''}>
+                    <Form.Item
+                      name="reranker_id"
+                      label={t('application.rearrangementModel')}
+                      className="rb:col-span-full rb:mb-0!"
+                      hidden={formValues?.rerank_mode !== 'reranking_model'}
+                    >
+                      <ModelSelect
+                        params={{ type: 'rerank', pagesize: 100 }}
+                      />
+                    </Form.Item>
+                  </div>
+
+                  {formValues?.rerank_mode === 'weighted_score' && (
+                    <div>
+                      <Form.Item
+                      label={t('application.weight_balance')}
+                      className="rb:col-span-full rb:mb-0!"
+                      required
+                      >
+                      <WeightBalanceSlider
+                          semanticWeight={formValues?.rerank_weights?.semantic_weight}
+                          participleWeight={formValues?.rerank_weights?.participle_weight}
+                          onChange={(semanticWeight, participleWeight) => {
+                          form.setFieldsValue({
+                              rerank_weights: {
+                              semantic_weight: semanticWeight,
+                              participle_weight: participleWeight,
+                              },
+                          });
+                          }}
+                      />
+                      </Form.Item>
+                      <Form.Item name="rerank_weights" hidden />
+                    </div>
+                  )}
+
+                  {(retrieveType === 'hybrid' && formValues?.rerank_mode === 'reranking_model') &&
+                    <div>
+                      <Form.Item name="similarity_threshold" label={t('knowledgeBase.similarityThreshold')} className="rb:col-span-full rb:mb-0!">
+                          <Select
+                              options={[
+                                  { label: '0.1', value: 0.1 },
+                                  { label: '0.2', value: 0.2 },
+                                  { label: '0.3', value: 0.3 },
+                                  { label: '0.4', value: 0.4 },
+                                  { label: '0.5', value: 0.5 },
+                                  { label: '0.6', value: 0.6 },
+                                  { label: '0.7', value: 0.7 },
+                                  { label: '0.8', value: 0.8 },
+                                  { label: '0.9', value: 0.9 },
+                                  { label: '1.0', value: 1.0 },
+                              ]}
+                              placeholder={t('knowledgeBase.similarityThreshold')}
+                          />
+                      </Form.Item>
+                    </div>
+                  }
                 </>
               )}
 
               {/* Show when retrieve_type = participle or hybrid */}
-              {(retrieveType === 'semantic' || retrieveType === 'hybrid') && (
-                  <Form.Item name="vector_similarity_weight" label={t('knowledgeBase.semanticSimilarity')}>
-                      <Select
-                          options={[
-                              { label: '0.1', value: 0.1 },
-                              { label: '0.2', value: 0.2 },
-                              { label: '0.3', value: 0.3 },
-                              { label: '0.4', value: 0.4 },
-                              { label: '0.5', value: 0.5 },
-                              { label: '0.6', value: 0.6 },
-                              { label: '0.7', value: 0.7 },
-                              { label: '0.8', value: 0.8 },
-                              { label: '0.9', value: 0.9 },
-                              { label: '1.0', value: 1.0 },
-                          ]}
-                          placeholder={t('knowledgeBase.semanticSimilarity')}
-                      />
-                  </Form.Item>
+              {(retrieveType === 'semantic' || (retrieveType === 'hybrid' && formValues?.rerank_mode === 'reranking_model')) && (
+                  <div>
+                    <Form.Item name="vector_similarity_weight" label={t('knowledgeBase.semanticSimilarity')}className="rb:col-span-full rb:mb-0!">
+                        <Select
+                            options={[
+                                { label: '0.1', value: 0.1 },
+                                { label: '0.2', value: 0.2 },
+                                { label: '0.3', value: 0.3 },
+                                { label: '0.4', value: 0.4 },
+                                { label: '0.5', value: 0.5 },
+                                { label: '0.6', value: 0.6 },
+                                { label: '0.7', value: 0.7 },
+                                { label: '0.8', value: 0.8 },
+                                { label: '0.9', value: 0.9 },
+                                { label: '1.0', value: 1.0 },
+                            ]}
+                            placeholder={t('knowledgeBase.semanticSimilarity')}
+                        />
+                    </Form.Item>
+                  </div>
               )}  
 
               {(retrieveType === 'hybrid') &&
-                <Form.Item
-                    name="enable_graph_retrieval"
-                    getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
-                    getValueFromEvent={(checked: boolean) => checked ? 1 : 0}
-                    initialValue={0}
-                    valuePropName="checked"
-                    label={t('knowledgeBase.hybridIsHasGraph')}
-                >
-                    <Switch checkedChildren={t('knowledgeBase.yes')} unCheckedChildren={t('knowledgeBase.no')} />
-                </Form.Item>
+                <div>
+                  <Form.Item
+                      name="enable_graph_retrieval"
+                      getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
+                      getValueFromEvent={(checked: boolean) => checked ? 1 : 0}
+                      initialValue={0}
+                      valuePropName="checked"
+                      label={t('knowledgeBase.hybridIsHasGraph')}
+                      className="rb:col-span-full rb:mb-0!"
+                  >
+                      <Switch checkedChildren={t('knowledgeBase.yes')} unCheckedChildren={t('knowledgeBase.no')} />
+                  </Form.Item>
+                </div>
               }
-              <Form.Item className="rb:flex rb:items-end rb:justify-end">
-                  <Button type="primary" onClick={handleStartTest} loading={loading}>{ t('knowledgeBase.startTesting')}</Button>
-              </Form.Item> 
+              <Flex align="end" className="rb:h-full!">
+                <Button type="primary" onClick={handleStartTest} loading={loading}>{ t('knowledgeBase.startTesting')}</Button>
+              </Flex>
           </div>
         </Form>
       </div>

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -74,6 +74,9 @@ export interface RecallTestParams {
   hybrid_weight?: string;
   retrieve_type?: string; // 检索类型
   enable_graph_retrieval?: number; // 是否启用图谱检索
+  rerank_mode?: 'reranking_model' | 'weighted_score'; // 重排模式
+  reranker_id?: string; // 重排模型ID
+  rerank_weights?: { semantic_weight: number; participle_weight: number }; // 重排权重
 }
 // 文件夹 
 export interface FolderFormData {


### PR DESCRIPTION
## Sourcery 摘要

在知识库检索设置和召回测试中启用基于模型和加权评分的重排配置。

新功能：
- 为知识检索添加可配置的重排模式，支持重排模型以及语义/关键词加权评分。
- 在知识库设置、全局设置和召回测试中提供重排配置。
- 添加可复用的权重平衡滑块和检索策略 API 集成点。

增强功能：
- 更新检索配置类型和召回测试请求参数，以支持重排模式和权重。
- 扩展单选组控件，支持可配置的展示方式、尺寸和全宽布局。
- 为重排选项和权重控件添加英文和中文翻译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable model-based and weighted-score reranking configuration across knowledge-base retrieval settings and recall testing.

New Features:
- Add configurable reranking modes for knowledge retrieval, supporting reranking models and weighted semantic/keyword scoring.
- Expose reranking configuration in knowledge-base settings, global settings, and recall testing.
- Add a reusable weight-balance slider and retrieval-policy API integration point.

Enhancements:
- Update retrieval configuration types and recall-test request parameters to support reranking modes and weights.
- Extend radio-group controls for configurable presentation, sizing, and full-width layouts.
- Add English and Chinese translations for reranking options and weight controls.

</details>