### PR TITLE
feat(api): add liteskill admin client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ MINIO_REGION=us-east-1
 # Shared model runtime
 SPEEDBEAR_BASE_URL=https://testspeedbear.redbearai.com
 SPEEDBEAR_AUTH_KEY=
+# LiteSkill (MemorySkills) 内部管理接口（运营查看后台调用）
+LITESKILL_BASE_URL=http://liteskill:8010
+# 必须与 LiteSkill 侧 INTERNAL_ADMIN_TOKEN 一致
+LITESKILL_INTERNAL_TOKEN=
+LITESKILL_TIMEOUT=10
 LLM_TIMEOUT=120
 LLM_MAX_RETRIES=2
 EMBEDDING_BATCH_SIZE=10

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -40,6 +40,12 @@ class Settings:
     SPEEDBEAR_SYSTEM_TENANT_ID: str = os.getenv(
         "SPEEDBEAR_SYSTEM_TENANT_ID", "00000000-0000-0000-0000-000000000000"
     )
+
+    # LiteSkill (MemorySkills) 内部管理接口配置（运营查看后台调用）
+    LITESKILL_BASE_URL: str = os.getenv("LITESKILL_BASE_URL", "http://liteskill:8010")
+    # 服务间凭证；必须与 LiteSkill 侧 INTERNAL_ADMIN_TOKEN 一致
+    LITESKILL_INTERNAL_TOKEN: str = os.getenv("LITESKILL_INTERNAL_TOKEN", "")
+    LITESKILL_TIMEOUT: float = float(os.getenv("LITESKILL_TIMEOUT", "10"))
     # SSO 新租户绑定 SpeedBear 失败时的策略（轮询重试后仍失败时生效）：
     #   true  = 严格模式：物理回滚本次新建的租户及其临时数据，本次登录失败
     #   false = 宽松模式：保留租户，返回「未绑定成功，请联系管理员」提示

--- a/api/app/services/liteskill_admin_client.py
+++ b/api/app/services/liteskill_admin_client.py
@@ -1,0 +1,208 @@
+"""LiteSkill（MemorySkills）内部管理接口客户端。
+
+供运营后台 ``/sys/memory-lite/*`` 适配层调用 LiteSkill 的
+``/internal/admin/memory-lite/*`` 只读接口。携带服务凭证
+``X-Internal-Token`` 以证明"请求来自 Enterprise"，并透传 admin_id / request_id
+用于链路追踪。参照 ``speedbear_gateway_client`` 的错误映射范式。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+
+class LiteSkillAdminError(Exception):
+    """LiteSkill 内部接口调用异常。"""
+
+    def __init__(self, message: str, *, status_code: int | None = None, payload: Any = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.payload = payload
+
+
+class LiteSkillAdminClient:
+    """调用 LiteSkill 内部只读管理接口。"""
+
+    def __init__(self) -> None:
+        self.base_url = settings.LITESKILL_BASE_URL.rstrip("/")
+        self.token = settings.LITESKILL_INTERNAL_TOKEN
+        self.timeout = settings.LITESKILL_TIMEOUT
+
+    # ── 业务便捷方法 ──────────────────────────────────────────────
+    def overview(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return self._get("/internal/admin/memory-lite/overview", lang=lang, admin_id=admin_id, request_id=request_id)
+
+    def users(
+        self,
+        *,
+        page: int = 1,
+        pagesize: int = 20,
+        keyword: str | None = None,
+        status: str | None = None,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        params: dict[str, Any] = {"page": page, "pagesize": pagesize}
+        if keyword:
+            params["keyword"] = keyword
+        if status:
+            params["status"] = status
+        return self._get(
+            "/internal/admin/memory-lite/users",
+            params=params,
+            lang=lang,
+            admin_id=admin_id,
+            request_id=request_id,
+        )
+
+    def user_detail(self, account_id: str, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return self._get(
+            f"/internal/admin/memory-lite/users/{account_id}",
+            lang=lang,
+            admin_id=admin_id,
+            request_id=request_id,
+        )
+
+    def products(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return self._get("/internal/admin/memory-lite/products", lang=lang, admin_id=admin_id, request_id=request_id)
+
+    def update_product(
+        self,
+        body: dict[str, Any],
+        *,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        """修改预设包（POST，目标 id 在 body 内）。"""
+        return self._request(
+            "POST",
+            "/internal/admin/memory-lite/products/update",
+            json=body,
+            lang=lang,
+            admin_id=admin_id,
+            request_id=request_id,
+        )
+
+    def create_product(
+        self,
+        body: dict[str, Any],
+        *,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        return self._request(
+            "POST",
+            "/internal/admin/memory-lite/products/create",
+            json=body,
+            lang=lang,
+            admin_id=admin_id,
+            request_id=request_id,
+        )
+
+    def recharge_write_quota(
+        self,
+        body: dict[str, Any],
+        *,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        """给指定端用户加写入次数（POST，end_user_id + count 在 body 内）。"""
+        return self._request(
+            "POST",
+            "/internal/admin/memory-lite/write-quota/recharge",
+            json=body,
+            lang=lang,
+            admin_id=admin_id,
+            request_id=request_id,
+        )
+
+    # ── 底层请求 ──────────────────────────────────────────────────
+    def _get(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        return self._request(
+            "GET", path, params=params, lang=lang, admin_id=admin_id, request_id=request_id
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        lang: str | None = None,
+        admin_id: str = "",
+        request_id: str = "",
+    ) -> Any:
+        headers = self._build_headers(admin_id=admin_id, request_id=request_id, lang=lang)
+        request_params = dict(params or {})
+        if lang:
+            request_params.setdefault("lang", lang)
+
+        url = f"{self.base_url}{path}"
+        try:
+            with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+                response = client.request(
+                    method.upper(), url, headers=headers, params=request_params, json=json
+                )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            payload = self._safe_json(exc.response)
+            raise LiteSkillAdminError(
+                self._extract_msg(payload) or f"LiteSkill 接口请求失败: {exc.response.status_code}",
+                status_code=exc.response.status_code,
+                payload=payload,
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise LiteSkillAdminError(f"LiteSkill 网络请求失败: {exc}") from exc
+
+        payload = self._safe_json(response)
+        return self._unwrap(payload)
+
+    def _build_headers(self, *, admin_id: str, request_id: str, lang: str | None) -> dict[str, str]:
+        if not self.token:
+            raise LiteSkillAdminError("未配置 LITESKILL_INTERNAL_TOKEN")
+        headers = {"X-Internal-Token": self.token}
+        if admin_id:
+            headers["X-Admin-Id"] = admin_id
+        if request_id:
+            headers["X-Request-Id"] = request_id
+        if lang:
+            headers["Accept-Language"] = lang
+        return headers
+
+    @staticmethod
+    def _safe_json(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return {"raw_text": response.text}
+
+    @staticmethod
+    def _extract_msg(payload: Any) -> str | None:
+        if isinstance(payload, dict):
+            return payload.get("msg") or payload.get("message")
+        return None
+
+    @staticmethod
+    def _unwrap(payload: Any) -> Any:
+        """解包 LiteSkill 统一信封 ``{code:"OK", msg, data}`` 取 data。"""
+        if isinstance(payload, dict) and "data" in payload:
+            return payload["data"]
+        return payload

--- a/api/app/services/liteskill_admin_client.py
+++ b/api/app/services/liteskill_admin_client.py
@@ -1,9 +1,11 @@
 """LiteSkill（MemorySkills）内部管理接口客户端。
 
 供运营后台 ``/sys/memory-lite/*`` 适配层调用 LiteSkill 的
-``/internal/admin/memory-lite/*`` 只读接口。携带服务凭证
-``X-Internal-Token`` 以证明"请求来自 Enterprise"，并透传 admin_id / request_id
-用于链路追踪。参照 ``speedbear_gateway_client`` 的错误映射范式。
+``/internal/admin/memory-lite/*`` 管理接口，既包含 overview / users / products
+等只读查询接口，也包含 update_product / create_product / recharge_write_quota
+等写入接口。携带服务凭证 ``X-Internal-Token`` 以证明"请求来自 Enterprise"，
+并透传 admin_id / request_id 用于链路追踪。参照 ``speedbear_gateway_client``
+的错误映射范式。
 """
 
 from __future__ import annotations
@@ -26,7 +28,7 @@ class LiteSkillAdminError(Exception):
 
 
 class LiteSkillAdminClient:
-    """调用 LiteSkill 内部只读管理接口。"""
+    """调用 LiteSkill 内部管理接口（含只读查询与写入操作）。"""
 
     def __init__(self) -> None:
         self.base_url = settings.LITESKILL_BASE_URL.rstrip("/")
@@ -157,9 +159,17 @@ class LiteSkillAdminClient:
 
         url = f"{self.base_url}{path}"
         try:
-            with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+            # 禁止自动跟随重定向：内部管理接口本不应发生重定向，
+            # 若跟随跨域重定向会把 X-Internal-Token 内部服务凭证泄露给重定向目标主机。
+            with httpx.Client(timeout=self.timeout, follow_redirects=False) as client:
                 response = client.request(
                     method.upper(), url, headers=headers, params=request_params, json=json
+                )
+            if response.is_redirect:
+                raise LiteSkillAdminError(
+                    f"LiteSkill 接口返回意外重定向: {response.status_code} -> "
+                    f"{response.headers.get('location', '')}",
+                    status_code=response.status_code,
                 )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -202,7 +212,21 @@ class LiteSkillAdminClient:
 
     @staticmethod
     def _unwrap(payload: Any) -> Any:
-        """解包 LiteSkill 统一信封 ``{code:"OK", msg, data}`` 取 data。"""
+        """解包 LiteSkill 统一信封 ``{code:"OK", msg, data}`` 取 data。
+
+        HTTP 2xx 不代表业务成功：LiteSkill 可能在成功状态码下返回
+        ``code != "OK"`` 的业务错误信封。此处先校验 ``code``，非 OK 时
+        以信封中的 ``msg`` 抛出 :class:`LiteSkillAdminError`，避免调用方把
+        错误数据当成功结果消费。
+        """
+        if isinstance(payload, dict) and "code" in payload:
+            code = payload.get("code")
+            if code != "OK":
+                raise LiteSkillAdminError(
+                    LiteSkillAdminClient._extract_msg(payload)
+                    or f"LiteSkill 接口返回业务错误: {code}",
+                    payload=payload,
+                )
         if isinstance(payload, dict) and "data" in payload:
             return payload["data"]
         return payload


### PR DESCRIPTION
## Sourcery 摘要

启用 API 与 LiteSkill 的内部管理端点通信，以支持 Memory-Lite 操作。

新功能：
- 添加 LiteSkill 管理客户端，用于获取 Memory-Lite 概览、用户、用户详细信息和产品，并支持创建或更新产品以及为写入配额充值。

增强功能：
- 集中处理经过身份验证的 LiteSkill 请求，包括服务令牌验证、请求追踪、本地化、响应解包以及一致的错误转换。

构建：
- 添加可配置的 LiteSkill 基础 URL、内部令牌和请求超时设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持 API 服务与 LiteSkill 的内部 Memory-Lite 管理端点进行安全通信。

新功能：
- 添加 LiteSkill 管理客户端，用于查询 Memory-Lite 概览、用户、用户详情和产品，以及管理产品和补充写入配额。

增强：
- 集中处理经过身份验证的 LiteSkill 请求，包括请求追踪、本地化、响应封装处理、重定向保护，以及统一转换网络、HTTP 和业务错误。

构建：
- 添加可配置的 LiteSkill 基础 URL、内部服务令牌和请求超时设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable API services to securely communicate with LiteSkill’s internal Memory-Lite administration endpoints.

New Features:
- Add a LiteSkill administration client for querying Memory-Lite overviews, users, user details, and products, as well as managing products and replenishing write quotas.

Enhancements:
- Centralize authenticated LiteSkill requests with request tracing, localization, response envelope handling, redirect protection, and consistent network, HTTP, and business error conversion.

Build:
- Add configurable LiteSkill base URL, internal service token, and request timeout settings.

</details>

</details>