### PR TITLE
fix(rag): make api shared model runtime optional

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ ARG NEED_MIRROR=1
 
 WORKDIR /code
 
-# Build from the repository root so local workspace packages are available.
+# Build from the repository root; application files use the api/ prefix.
 
 # 1. Download dependencies through download_deps.py: python download_deps.py --china-mirrors
 # 2. Copy models
@@ -65,7 +65,6 @@ ENV PATH=/root/.local/bin:$PATH
 
 
 # 5. install dependencies from uv.lock file
-COPY packages/redbear-model /packages/redbear-model
 COPY api/pyproject.toml /code/pyproject.toml
 COPY api/uv.lock /code/uv.lock
 COPY api/app /code/app
@@ -84,5 +83,4 @@ RUN --mount=type=cache,id=mem_uv,target=/root/.cache/uv,sharing=locked \
     uv sync --locked --no-dev
 
 ENV PATH=/code/.venv/bin:$PATH
-
 

--- a/api/app/services/model_service.py
+++ b/api/app/services/model_service.py
@@ -3,31 +3,13 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
-from typing import List, Optional, Dict, Any
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 import uuid
 import math
 import time
 import asyncio
 
 from pydantic import SecretStr
-from redbear_model import (
-    EmbeddingPurpose,
-    EmbeddingRequest,
-    ImageEmbeddingContent,
-    ModelCapability as SharedModelCapability,
-    ModelProvider as SharedModelProvider,
-    ModelRuntimeOptions,
-    ModelType as SharedModelType,
-    RerankCandidateView,
-    ResolvedModelConfig,
-    TextEmbeddingContent,
-    is_qwen3_vl_embedding,
-    is_qwen3_vl_reranker,
-)
-from redbear_model.runtime import (
-    RedBearEmbeddings as SharedRedBearEmbeddings,
-    RedBearRerank as SharedRedBearRerank,
-)
 
 from app.models.models_model import ModelConfig, ModelApiKey, ModelType, LoadBalanceStrategy, ModelProvider
 from app.repositories.model_repository import ModelConfigRepository, ModelApiKeyRepository, ModelBaseRepository
@@ -44,6 +26,9 @@ from app.core.error_codes import BizCode
 from app.core.utils.datetime_utils import utcnow_naive
 from app.utils.redis_cache import (invalidate_workspace_model_options, get_json_async, set_json_async,
                                    CACHE_MISS, invalidate_runtime_model_info, invalidate_runtime_model_info_async)
+
+if TYPE_CHECKING:
+    from redbear_model import ImageEmbeddingContent, ResolvedModelConfig
 
 logger = get_business_logger()
 
@@ -71,7 +56,21 @@ def _shared_validation_config(
     api_base: str | None,
     model_type: str,
     capability: list | None,
-) -> ResolvedModelConfig:
+) -> "ResolvedModelConfig":
+    from redbear_model import (
+        ModelCapability as SharedModelCapability,
+    )
+    from redbear_model import (
+        ModelProvider as SharedModelProvider,
+    )
+    from redbear_model import (
+        ModelRuntimeOptions,
+        ResolvedModelConfig,
+    )
+    from redbear_model import (
+        ModelType as SharedModelType,
+    )
+
     return ResolvedModelConfig(
         model_config_id=_MODEL_VALIDATION_CONFIG_ID,
         key_id=_MODEL_VALIDATION_KEY_ID,
@@ -88,7 +87,9 @@ def _shared_validation_config(
     )
 
 
-def _validation_image() -> ImageEmbeddingContent:
+def _validation_image() -> "ImageEmbeddingContent":
+    from redbear_model import ImageEmbeddingContent
+
     return ImageEmbeddingContent(
         media_type="image/png",
         data_uri=_MODEL_VALIDATION_IMAGE_DATA_URI,
@@ -97,10 +98,13 @@ def _validation_image() -> ImageEmbeddingContent:
 
 
 async def _validate_qwen3_vl_embedding(
-    config: ResolvedModelConfig,
+    config: "ResolvedModelConfig",
     test_message: str,
     started_at: float,
 ) -> dict[str, Any]:
+    from redbear_model import EmbeddingPurpose, EmbeddingRequest, TextEmbeddingContent
+    from redbear_model.runtime import RedBearEmbeddings as SharedRedBearEmbeddings
+
     embedding = SharedRedBearEmbeddings(config)
     try:
         result = await embedding.aembed_contents(
@@ -124,9 +128,12 @@ async def _validate_qwen3_vl_embedding(
 
 
 async def _validate_qwen3_vl_rerank(
-    config: ResolvedModelConfig,
+    config: "ResolvedModelConfig",
     started_at: float,
 ) -> dict[str, Any]:
+    from redbear_model import RerankCandidateView
+    from redbear_model.runtime import RedBearRerank as SharedRedBearRerank
+
     rerank = SharedRedBearRerank(config)
     views = (
         RerankCandidateView(chunk_index=0, kind="text", content="测试文本候选"),
@@ -354,6 +361,23 @@ class ModelConfigService:
             start_time = time.time()
 
             if is_qwen3_vl_request:
+                try:
+                    from redbear_model import (
+                        is_qwen3_vl_embedding,
+                        is_qwen3_vl_reranker,
+                    )
+                except ModuleNotFoundError as exc:
+                    if exc.name != "redbear_model":
+                        raise
+                    return {
+                        "valid": False,
+                        "message": "当前 API 暂不支持 Qwen3-VL 模型配置验证",
+                        "response": None,
+                        "elapsed_time": time.time() - start_time,
+                        "usage": None,
+                        "error": "API 未安装可选的 redbear-model 包，暂无法验证 Qwen3-VL 模型",
+                        "error_type": "ModelRuntimeUnavailable",
+                    }
                 validation_capability = list(capability or [])
                 if "vision" not in {
                     _enum_value(item) for item in validation_capability

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -72,7 +72,6 @@ dependencies = [
     "langchain-openai>=1.0.2",
     "langchain-community>=0.3.31",
     "dashscope>=1.25.0",
-    "redbear-model[runtime,dashscope]",
     "neo4j>=6.0.3",
     "chonkie>=1.1.2",
     "pandas>=2.3.3",
@@ -153,9 +152,6 @@ dependencies = [
     "langid>=1.1.6",
     "asyncpg==0.31.0"
 ]
-
-[tool.uv.sources]
-redbear-model = { path = "../packages/redbear-model" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -3209,7 +3209,6 @@ dependencies = [
     { name = "python-pptx" },
     { name = "pyyaml" },
     { name = "rdflib" },
-    { name = "redbear-model", extra = ["dashscope", "runtime"] },
     { name = "redis" },
     { name = "requests" },
     { name = "roman-numbers" },
@@ -3353,7 +3352,6 @@ requires-dist = [
     { name = "python-pptx", specifier = "==1.0.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "rdflib", specifier = ">=7.0.0" },
-    { name = "redbear-model", extras = ["runtime", "dashscope"], directory = "../packages/redbear-model" },
     { name = "redis", specifier = "==6.4.0" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "roman-numbers", specifier = "==1.0.2" },
@@ -3390,52 +3388,6 @@ requires-dist = [
     { name = "xpinyin", specifier = "==0.7.7" },
     { name = "xxhash", specifier = "==3.6.0" },
 ]
-
-[[package]]
-name = "redbear-model"
-version = "0.1.0"
-source = { directory = "../packages/redbear-model" }
-dependencies = [
-    { name = "pydantic" },
-]
-
-[package.optional-dependencies]
-dashscope = [
-    { name = "dashscope" },
-]
-runtime = [
-    { name = "httpx" },
-    { name = "json-repair" },
-    { name = "langchain-community" },
-    { name = "langchain-core" },
-    { name = "langchain-openai" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "dashscope", marker = "extra == 'all'", specifier = ">=1.25,<2" },
-    { name = "dashscope", marker = "extra == 'dashscope'", specifier = ">=1.25,<2" },
-    { name = "httpx", marker = "extra == 'all'", specifier = ">=0.28,<1" },
-    { name = "httpx", marker = "extra == 'runtime'", specifier = ">=0.28,<1" },
-    { name = "httpx", extras = ["socks"], marker = "extra == 'all'", specifier = ">=0.28,<1" },
-    { name = "httpx", extras = ["socks"], marker = "extra == 'ollama'", specifier = ">=0.28,<1" },
-    { name = "json-repair", marker = "extra == 'all'", specifier = ">=0.53,<1" },
-    { name = "json-repair", marker = "extra == 'runtime'", specifier = ">=0.53,<1" },
-    { name = "langchain-aws", marker = "extra == 'all'", specifier = ">=1.0.0a1,<2" },
-    { name = "langchain-aws", marker = "extra == 'bedrock'", specifier = ">=1.0.0a1,<2" },
-    { name = "langchain-community", marker = "extra == 'all'", specifier = ">=0.3,<1" },
-    { name = "langchain-community", marker = "extra == 'runtime'", specifier = ">=0.3,<1" },
-    { name = "langchain-core", marker = "extra == 'all'", specifier = ">=1.0,<2" },
-    { name = "langchain-core", marker = "extra == 'runtime'", specifier = ">=1.0,<2" },
-    { name = "langchain-ollama", marker = "extra == 'all'", specifier = ">=1.0,<2" },
-    { name = "langchain-ollama", marker = "extra == 'ollama'", specifier = ">=1.0,<2" },
-    { name = "langchain-openai", marker = "extra == 'all'", specifier = ">=1.0,<2" },
-    { name = "langchain-openai", marker = "extra == 'runtime'", specifier = ">=1.0,<2" },
-    { name = "pydantic", specifier = ">=2.12,<3" },
-    { name = "volcengine-python-sdk", extras = ["ark"], marker = "extra == 'all'", specifier = ">=5.0.19,<6" },
-    { name = "volcengine-python-sdk", extras = ["ark"], marker = "extra == 'generation'", specifier = ">=5.0.19,<6" },
-]
-provides-extras = ["runtime", "ollama", "bedrock", "dashscope", "generation", "all"]
 
 [[package]]
 name = "redis"


### PR DESCRIPTION
## Business Background
The API fails during startup when the deployed Python environment does not include the local redbear-model package. This is a temporary decoupling to restore service startup.

## Summary
- Remove redbear-model from the API dependency manifest and lockfile.
- Stop copying the shared package into the API image; retain the current repository-root build context.
- Load the shared model runtime only for Qwen3-VL configuration validation.
- Return an explicit validation-unavailable result when the optional package is absent.

## Scope
Four API files only. No frontend, mem-knowledge, local configuration, or test files are included. Unrelated local lockfile changes remain uncommitted.

## Risk
Qwen3-VL configuration validation is unavailable in API environments without redbear-model. Existing text-model validation and knowledge-service forwarding retain their behavior. Rebuilding and restarting the deployed API is required.

## External API Key Impact
No route, authentication, request, response, or knowledge retrieval proxy contract changes.

## Validation
- 29 focused API regression tests passed before submission, including missing-runtime imports, unavailable Qwen validation, existing text validation, and retrieval proxy contracts.
- Python compilation and diff checks passed; no new Ruff findings.
- Isolated dependency resolution followed the Dockerfile uv lock step without shared package sources.
- Full Docker image build was not verified because the local daemon was unavailable.
- The user explicitly requested expedited submission and merge without additional validation or review waiting.

## Sourcery 摘要

使 API 的共享模型运行时成为可选项，同时保留现有的验证和检索行为。

错误修复：
- 在未安装可选的 redbear-model 软件包时，允许 API 启动并运行。
- 当缺少共享运行时时无法执行 Qwen3-VL 模型配置验证时，返回明确的不可用结果。

增强功能：
- 仅在请求 Qwen3-VL 验证时加载共享模型运行时，同时保留现有的文本模型验证和检索代理行为。

构建：
- 从 API 依赖清单和锁定文件中移除 redbear-model，并停止将本地共享软件包复制到 API 镜像中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the API's shared model runtime optional while preserving existing validation and retrieval behavior.

Bug Fixes:
- Allow the API to start and operate when the optional redbear-model package is not installed.
- Return an explicit unavailable result when Qwen3-VL model configuration validation cannot run without the shared runtime.

Enhancements:
- Load the shared model runtime only when Qwen3-VL validation is requested, preserving existing text-model validation and retrieval proxy behavior.

Build:
- Remove redbear-model from the API dependency manifest and lockfile, and stop copying the local shared package into the API image.

</details>