### PR TITLE
feat(web): kb image recall

### DIFF
--- a/web/src/api/knowledgeBase.ts
+++ b/web/src/api/knowledgeBase.ts
@@ -14,6 +14,8 @@ import type {
   KnowledgeBaseDocumentData,
   KnowledgeBaseListResponse,
   KnowledgeBaseShareListResponse,
+  RecallTestParams,
+  RetrievalPolicy,
 } from "@/views/KnowledgeBase/types";
 
 //获取知识库类型 (返回字符串数组，每个字符串是 KnowledgeBase 的 type 值)
@@ -253,13 +255,13 @@ export const getDocumentChunkList = async (query: PathQuery) => {
   return response as any;
 };
 // 回归测试
-export const reChunks = async (data: any) => {
+export const reChunks = async (data: RecallTestParams) => {
   const response = await request.post(`/chunks/retrieval`, data);
   return response as any;
 };
 // 获取检索策略
-export const retrievalPolicyApi = (data: { kb_ids: string[] }) => {
-  return request.get('/chunks/retrieval-policy', data)
+export const retrievalPolicyApi = (data: { kb_ids: string[] }): Promise<RetrievalPolicy> => {
+  return request.post('/chunks/retrieval-policy', data);
 }
 // 知识库授权 分享空间列表
 export const getWorkspaceAuthorizationList = async (kb_id: string) => {

--- a/web/src/components/CustomSelect/index.tsx
+++ b/web/src/components/CustomSelect/index.tsx
@@ -13,7 +13,7 @@
  * @component
  */
 
-import { useEffect, useState, useMemo, type FC } from 'react';
+import { isValidElement, useEffect, useState, useMemo, type FC, type ReactNode } from 'react';
 import { Select } from 'antd';
 import type { SelectProps, DefaultOptionType } from 'antd/es/select';
 import { useTranslation } from 'react-i18next';
@@ -55,11 +55,28 @@ interface CustomSelectProps extends Omit<SelectProps, 'filterOption'> {
   filterOption?: (inputValue: string, option?: DefaultOptionType) => boolean;
 }
 
-// Default filter function for search - performs case-insensitive substring matching
+// Extract searchable text from plain values and nested React elements
+const getTextContent = (content: ReactNode): string => {
+  if (typeof content === 'string' || typeof content === 'number') {
+    return String(content);
+  }
+  if (Array.isArray(content)) {
+    return content.map(getTextContent).join(' ');
+  }
+  if (isValidElement<{ children?: ReactNode }>(content)) {
+    return getTextContent(content.props.children);
+  }
+  return '';
+};
+
+// Default filter function for search - matches label and value case-insensitively
 const defaultFilterOption = (inputValue: string, option?: DefaultOptionType): boolean => {
-  if (!option || !inputValue) return true;
-  const label = String(option.children || option.label || '');
-  return label.toLowerCase().includes(inputValue.toLowerCase());
+  const keyword = inputValue.trim().toLowerCase();
+  if (!keyword || !option) return true;
+
+  const label = getTextContent(option.label) || getTextContent(option.children);
+  const value = String(option.value ?? '');
+  return label.toLowerCase().includes(keyword) || value.toLowerCase().includes(keyword);
 };
 
 const CustomSelect: FC<CustomSelectProps> = ({

--- a/web/src/components/SiderMenu/SwitchSpaceModal.tsx
+++ b/web/src/components/SiderMenu/SwitchSpaceModal.tsx
@@ -100,6 +100,7 @@ const SwitchSpaceModal = forwardRef<SwitchSpaceModalRef>((_props, ref) => {
           <CustomSelect
             url={getWorkspacesUrl}
             hasAll={false}
+            showSearch={true}
             format={(list) => list.map(item => ({
               value: item.id,
               label: <Space>{item.name}<Tag color={item.storage_type === 'rag' ? 'processing' : 'warning'}>{t(`space.${item.storage_type || 'neo4j'}`)}</Tag></Space>

--- a/web/src/components/Upload/UploadImages.tsx
+++ b/web/src/components/Upload/UploadImages.tsx
@@ -18,19 +18,18 @@
  * @component
  */
 
-import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Upload, Image, App } from 'antd';
 import type { GetProp, UploadFile, UploadProps } from 'antd';
 import type { UploadProps as RcUploadProps } from 'antd/es/upload/interface';
 import { useTranslation } from 'react-i18next';
 
-import PlusIcon from '@/assets/images/plus.svg'
 import { cookieUtils } from '@/utils/request'
 import { fileUploadUrl } from '@/api/fileStorage'
 import styles from './index.module.less'
 
 /** Props interface for UploadImages component */
-interface UploadImagesProps extends Omit<UploadProps, 'onChange' | 'fileList'> {
+export interface UploadImagesProps extends Omit<UploadProps, 'onChange' | 'fileList'> {
   /** Upload API URL */
   action?: string;
   /** Support multiple file selection */
@@ -66,7 +65,7 @@ const ALL_FILE_TYPE: {
 }
 
 /** Ref methods exposed to parent component */
-interface UploadImagesRef {
+export interface UploadImagesRef {
   fileList: UploadFile[];
   clearFiles: () => void;
 }
@@ -101,6 +100,7 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
 }, ref) => {
   const { t } = useTranslation();
   const { message, modal } = App.useApp()
+  const readRequestIdRef = useRef(0);
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [accept, setAccept] = useState<string | undefined>();
   // const [loading, setLoading] = useState(false);
@@ -112,6 +112,10 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
       setFileList([propFileList]);
     }
   }, [propFileList])
+
+  useEffect(() => () => {
+    readRequestIdRef.current += 1;
+  }, []);
 
   /** Update value based on maxCount (single or multiple) */
   const updateValue = (list: UploadFile[]) => {
@@ -139,7 +143,7 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
   };
 
   /** Validate file type and size before upload */
-  const beforeUpload: RcUploadProps['beforeUpload'] = async (file: UploadFile) => {
+  const beforeUpload: RcUploadProps['beforeUpload'] = async (file) => {
     // Validate file size
     if (fileSize && file.size) {
       const isLtMaxSize = (file.size / 1024 / 1024) < fileSize;
@@ -149,25 +153,39 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
       }
     }
     // Validate file type
-    if (accept && accept.length > 0 && file.type) {
-      const isAccept = accept.includes(file.type);
-      if (!isAccept) {
-        message.error(`${t('common.fileAcceptTip')}${file.type}`);
-        return Upload.LIST_IGNORE;
-      }
+    const acceptedTypes = accept?.split(',').filter(Boolean) ?? [];
+    if (acceptedTypes.length > 0 && !acceptedTypes.includes(file.type)) {
+      message.error(`${t('common.fileAcceptTip')}${file.type || file.name}`);
+      return Upload.LIST_IGNORE;
     }
 
     if (!isAutoUpload) {
-      if (!file.url && !file.preview) {
-        file.url = await getBase64(file.originFileObj as FileType);
+      const readRequestId = readRequestIdRef.current + 1;
+      readRequestIdRef.current = readRequestId;
+      const dataUrl = await getBase64(file as FileType);
+      if (readRequestId !== readRequestIdRef.current) {
+        return Upload.LIST_IGNORE;
       }
-      const newFileList = [...fileList, file];
+
+      const manualFile: UploadFile = {
+        uid: file.uid,
+        name: file.name,
+        status: 'done',
+        type: file.type,
+        size: file.size,
+        originFileObj: file,
+        url: dataUrl,
+        thumbUrl: dataUrl,
+      };
+      const newFileList = maxCount === 1
+        ? [manualFile]
+        : [...fileList, manualFile].slice(-maxCount);
       setFileList(newFileList);
       updateValue(newFileList);
       return Upload.LIST_IGNORE; // Prevent auto upload
     }
 
-    return isAutoUpload;
+    return true;
   };
 
   /** Handle upload status change */
@@ -178,7 +196,10 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
 
   /** Clear all uploaded files */
   const clearFiles = () => {
+    readRequestIdRef.current += 1;
     setFileList([]);
+    setPreviewOpen(false);
+    setPreviewImage('');
     updateValue([]);
   }
 
@@ -204,13 +225,13 @@ const UploadImages = forwardRef<UploadImagesRef, UploadImagesProps>(({
 
   /** Generate upload component configuration */
   const uploadProps: UploadProps = {
-    action,
+    action: isAutoUpload ? action : undefined,
     multiple: multiple && maxCount > 1,
     fileList,
     beforeUpload,
-    headers: {
-      authorization: `Bearer ${cookieUtils.get('authToken') }`,
-    },
+    headers: isAutoUpload
+      ? { authorization: `Bearer ${cookieUtils.get('authToken') }` }
+      : undefined,
     onPreview: handlePreview,
     onRemove: handleRemove,
     onChange: handleChange,

--- a/web/src/views/KnowledgeBase/[knowledgeBaseId]/Share.tsx
+++ b/web/src/views/KnowledgeBase/[knowledgeBaseId]/Share.tsx
@@ -192,16 +192,16 @@ const Share: FC = () => {
           >{t('knowledgeBase.viewBasicInfo')}</span>
         </Popover>
       </Flex>
-      <Flex align="center" gap={8} className="rb:w-full rb:mb-5!">
+      <Flex align="center" gap={8} className="rb:w-full rb:mb-3!">
         <img src={shareUserIcon} className='rb:size-4 rb:ml-2' />
           <span className='rb:text-gray-500 rb:text-xs'>{knowledgeBase.created_by}</span>
           <img src={timestampIcon} className='rb:size-4 rb:ml-2' />
           <span className='rb:text-gray-500 rb:text-xs'>{formatDateTime(knowledgeBase.created_at)}</span>
       </Flex>
       <Flex gap={16} className="rb:flex-1 rb:min-h-0">
-        <Flex vertical className="rb:flex-1 rb:p-4! rb:border rb:border-[#DFE4ED] rb:bg-white rb:rounded-xl rb:overflow-hidden">
-          <Flex vertical gap={8} className='rb:txt-left rb:mb-5! rb:shrink-0'>
-            <h1 className="rb:text-lg rb:font-bold">{t('knowledgeBase.knowledgeBase')} {t('knowledgeBase.recallTest')}</h1>
+        <Flex vertical className="rb:flex-1 rb:p-4! rb-border rb:bg-white rb:rounded-xl rb:overflow-hidden">
+          <Flex vertical gap={8} className='rb:txt-left rb:mb-3! rb:shrink-0'>
+            <h1 className="rb:text-[16px] rb:font-bold">{t('knowledgeBase.knowledgeBase')} {t('knowledgeBase.recallTest')}</h1>
             <span className='rb:text-gray-500 rb:text-xs'>{t('knowledgeBase.recallTestDescription')}</span>
           </Flex>
           <div className='rb:flex-1 rb:min-h-0'>

--- a/web/src/views/KnowledgeBase/components/RecallImageUpload.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallImageUpload.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import type { UploadFile } from 'antd';
+
+import UploadImages, { type UploadImagesRef } from '@/components/Upload/UploadImages';
+
+interface RecallImageUploadProps {
+  value?: string;
+  onChange?: (value?: string) => void;
+  disabled?: boolean;
+}
+
+const RecallImageUpload = ({ value, onChange, disabled = false }: RecallImageUploadProps) => {
+  const uploadRef = useRef<UploadImagesRef>(null);
+
+  useEffect(() => {
+    if (!value) {
+      uploadRef.current?.clearFiles();
+    }
+  }, [value]);
+
+  const handleChange = (fileValue?: UploadFile | UploadFile[]) => {
+    const file = Array.isArray(fileValue) ? fileValue[0] : fileValue;
+    const dataUrl = file?.url || (file?.preview as string | undefined);
+    onChange?.(dataUrl);
+  };
+
+  return (
+    <UploadImages
+      ref={uploadRef}
+      disabled={disabled}
+      fileType={['jpg', 'jpeg', 'png', 'webp', 'bmp']}
+      isAutoUpload={false}
+      maxCount={1}
+      fileSize={10}
+      multiple={false}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default RecallImageUpload;

--- a/web/src/views/KnowledgeBase/components/RecallTest.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTest.tsx
@@ -1,306 +1,456 @@
-
-import { forwardRef, useImperativeHandle, useState, useEffect } from 'react';
-import { Form, Input,  Select, Button, InputNumber, Flex, Switch, Row, Col } from 'antd';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useMemo,
+} from 'react';
+import { Button, Flex, Form, Input, InputNumber, Select, Switch } from 'antd';
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
 
-import type { RecallTestDrawerRef, RecallTestData, RecallTestParams } from '@/views/KnowledgeBase/types';
-import RecallTestResult from './RecallTestResult';
-import { reChunks, retrievalPolicyApi, getRetrievalModeType  } from '@/api/knowledgeBase';
-import RadioGroupButton from '@/components/RadioGroupButton';
+import type {
+  RecallTestData,
+  RecallTestDrawerRef,
+  RecallTestParams,
+  RetrievalPolicy,
+} from '@/views/KnowledgeBase/types';
+import { getRetrievalModeType, reChunks, retrievalPolicyApi } from '@/api/knowledgeBase';
 import ModelSelect from '@/components/ModelSelect';
 import WeightBalanceSlider from '@/components/Knowledge/WeightBalanceSlider';
+import RecallImageUpload from './RecallImageUpload';
+import RecallTestResult from './RecallTestResult';
 
 const { TextArea } = Input;
 
 interface RetrievalModeOption {
-    label: string;
-    value: boolean;
+  label: string;
+  value: string;
 }
 
-const RecallTest = forwardRef<RecallTestDrawerRef>(({},ref) => {
-    const [form] = Form.useForm();
-    const { t } = useTranslation();
-    const [data, setData] = useState<RecallTestData[]>([]);
-    const [knowledgeBaseId, setKnowledgeBaseId] = useState<string>('');
-    const [loading, setLoading] = useState(false);
-    const [retrieveType, setRetrieveType] = useState<string>('hybrid');
-    const [retrievalModeOptions, setRetrievalModeOptions] = useState<RetrievalModeOption[]>([
-        { label: t('knowledgeBase.hybrid'), value: true },
-        { label: t('knowledgeBase.vector'), value: false },
-    ]);
+const RecallTest = forwardRef<RecallTestDrawerRef>((props, ref) => {
+  void props;
+  const [form] = Form.useForm();
+  const { t } = useTranslation();
+  const [data, setData] = useState<RecallTestData[]>([]);
+  const [knowledgeBaseId, setKnowledgeBaseId] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const layoutContainerRef = useRef<HTMLDivElement>(null);
+  const [isWideLayout, setIsWideLayout] = useState(false);
+  const [retrievalModeOptions, setRetrievalModeOptions] = useState<RetrievalModeOption[]>([
+    { label: t('knowledgeBase.hybrid'), value: 'hybrid' },
+    { label: t('knowledgeBase.vector'), value: 'semantic' },
+  ]);
 
-    const formValues = Form.useWatch([], form);
+  const formValues = Form.useWatch([], form) || {};
 
-    console.log('RecallTest - knowledgeBaseId:', knowledgeBaseId);
-    // Get retrieval mode options
-    useEffect(() => {
-        fetchRetrievalModeOptions();
-    }, []);
+  useLayoutEffect(() => {
+    const container = layoutContainerRef.current;
+    if (!container) return;
 
+    const updateLayout = (width: number) => {
+      const nextIsWideLayout = width > 900;
+      setIsWideLayout((current) =>
+        current === nextIsWideLayout ? current : nextIsWideLayout,
+      );
+    };
+
+    updateLayout(container.getBoundingClientRect().width);
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      updateLayout(entry.contentRect.width);
+    });
+    resizeObserver.observe(container);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  console.log('RecallTest - knowledgeBaseId:', knowledgeBaseId);
+  // Get retrieval mode options
+  useEffect(() => {
     const fetchRetrievalModeOptions = async () => {
-        try {
-            const response = await getRetrievalModeType();
-            if (response && Array.isArray(response)) {
-                // Convert API response to option format
-                const options = response.map((item: any) => {
-                    // Support multiple data formats
-                    let label = t(`knowledgeBase.${item}`) + ' ' + t(`knowledgeBase.retrieve`);
-                    let value = item;
-                    
-                    return { label, value };
-                });
-                
-                if (options.length > 0) {
-                    setRetrievalModeOptions(options);
-                }
-            }
-        } catch (error) {
-            console.error('Failed to fetch retrieval mode options:', error);
-            // Keep default options
-        }
-    };
+      try {
+        const response = await getRetrievalModeType();
+        if (response && Array.isArray(response)) {
+          // Convert API response to option format
+          const options = response.map((item: any) => {
+            // Support multiple data formats
+            const label = t(`knowledgeBase.${item}`) + ' ' + t('knowledgeBase.retrieve');
+            const value = item;
 
-    const handleOpen = (kbId?: string) => {
-        console.log('RecallTest - handleOpen called with kbId:', kbId);
-        setKnowledgeBaseId(kbId || '');
-        form.resetFields();
-        setData([]);
-        setRetrieveType('hybrid'); // Reset to default value
-        // Ensure form field is also set to default value
-        form.setFieldsValue({ retrieve_type: 'hybrid', rerank_mode: 'reranking_model' });
-        // getRetrievalPolicy();
-    }
-
-    /*
-    const [retrievalPolicy, setRetrievalPolicy] = useState<Record<string, string[]>>({});
-    const getRetrievalPolicy = () => {
-        retrievalPolicyApi({ kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [] })
-        .then((res) => {
-            setRetrievalPolicy(res as Record<string, string[]>);
-        })
-    }
-    */
-    const fetchData = (params: RecallTestParams) => {
-        if (loading) return;
-        setLoading(true);
-        reChunks(params)
-          .then((res) => {
-            const response = res as  RecallTestData[] ;
-            setData(response || [])
-          })
-          .finally(() => {
-            setLoading(false);
+            return { label, value };
           });
-    }
-    const handleStartTest = () => {
-        form.validateFields().then(({rerank_mode, ...values}) => {
-            const params: RecallTestParams = {
-                query: values.query || '',
-                kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [],
-                similarity_threshold: retrieveType === 'participle' ? undefined :values.similarity_threshold || 0.2,
-                vector_similarity_weight: values.vector_similarity_weight || 0.3,
-                top_k: values.top_k || 100,
-                // hybrid: values.retrieve_type !== hybrid ? true : false,
-                retrieve_type: retrieveType,
-                enable_graph_retrieval: retrieveType === 'hybrid' ? values.enable_graph_retrieval: undefined,
-                ...(retrieveType === 'hybrid' && rerank_mode ? {
-                    rerank_mode: rerank_mode,
-                    ...(rerank_mode === 'reranking_model' ? {
-                        reranker_id: values.reranker_id,
-                    } : {
-                        rerank_weights: values.rerank_weights,
-                    }),
-                } : {}),
-            };
-            console.log('RecallTest - params:', params);
-            fetchData(params);
-        }).catch((error) => {
-            console.error('Form validation failed:', error);
-        });
-    }
-    // Expose methods to parent component
-    useImperativeHandle(ref, () => ({
-        handleOpen,
-    }));
 
-    const handleChangeRerankMode = (value: string | null | undefined) => {
-        if (value === 'reranking_model') {
-            form.setFieldsValue({ rerank_weights: undefined });
-        } else if (value === 'weighted_score') {
-            form.setFieldsValue({
-                reranker_id: undefined,
-                rerank_weights: { semantic_weight: 0.5, participle_weight: 0.5 },
-            });
+          if (options.length > 0) {
+            setRetrievalModeOptions(options);
+          }
         }
+      } catch (error) {
+        console.error('Failed to fetch retrieval mode options:', error);
+        // Keep default options
+      }
     };
+
+    void fetchRetrievalModeOptions();
+  }, [t]);
+
+  const [retrievalPolicy, setRetrievalPolicy] = useState<RetrievalPolicy>({});
+  const retrievalPolicyRequestIdRef = useRef(0);
+
+  const supportsImage = useMemo(() => {
+    const { retrieve_type, rerank_mode, enable_graph_retrieval } = formValues || {};
+    return retrievalPolicy[retrieve_type]?.includes('image')
+    && !(retrieve_type === 'hybrid' && rerank_mode === 'weighted_score')
+    && !(retrieve_type === 'hybrid' && enable_graph_retrieval);
+  }, [retrievalPolicy, formValues])
+
+  useEffect(() => {
+    if (!supportsImage) {
+      form.setFieldValue('image', undefined);
+    }
+  }, [form, supportsImage]);
+
+  const getRetrievalPolicy = (kbId: string) => {
+    const requestId = retrievalPolicyRequestIdRef.current + 1;
+    retrievalPolicyRequestIdRef.current = requestId;
+
+    retrievalPolicyApi({ kb_ids: kbId ? [kbId] : [] })
+      .then((policy) => {
+        if (requestId === retrievalPolicyRequestIdRef.current) {
+          setRetrievalPolicy(policy);
+        }
+      })
+      .catch(() => {
+        if (requestId === retrievalPolicyRequestIdRef.current) {
+          setRetrievalPolicy({});
+        }
+      });
+  };
+
+  const handleOpen = (kbId?: string) => {
+    const nextKnowledgeBaseId = kbId || '';
+    setKnowledgeBaseId(nextKnowledgeBaseId);
+    setRetrievalPolicy({});
+    form.resetFields();
+    setData([]);
+    // Ensure form field is also set to default value
+    form.setFieldsValue({ retrieve_type: 'hybrid', rerank_mode: 'reranking_model' });
+    getRetrievalPolicy(nextKnowledgeBaseId);
+  };
+
+  const fetchData = (params: RecallTestParams) => {
+    if (loading) return;
+    setLoading(true);
+    reChunks(params)
+      .then((res) => {
+        const response = res as RecallTestData[];
+        setData(response || []);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  const handleStartTest = () => {
+    form
+      .validateFields()
+      .then(({
+        image,
+        query,
+        rerank_mode,
+        retrieve_type,
+        similarity_threshold,
+        vector_similarity_weight,
+        top_k,
+        enable_graph_retrieval,
+        reranker_id,
+        rerank_weights,
+      }) => {
+        image = supportsImage ? image : undefined;
+        const params: RecallTestParams = {
+          query: image
+            ? { modality: 'image', content: image }
+            : { modality: 'text', content: query || '' },
+          kb_ids: knowledgeBaseId ? [knowledgeBaseId] : [],
+          similarity_threshold:
+            retrieve_type === 'participle' ? undefined : similarity_threshold || 0.2,
+          vector_similarity_weight: vector_similarity_weight || 0.3,
+          top_k: top_k || 100,
+          // hybrid: values.retrieve_type !== hybrid ? true : false,
+          retrieve_type,
+          enable_graph_retrieval:
+            retrieve_type === 'hybrid' ? enable_graph_retrieval : undefined,
+          ...(retrieve_type === 'hybrid' && rerank_mode
+            ? {
+                rerank_mode,
+                ...(rerank_mode === 'reranking_model'
+                  ? { reranker_id }
+                  : { rerank_weights  }
+                ),
+              }
+            : {}),
+        };
+        console.log('RecallTest - params:', params);
+        fetchData(params);
+      })
+      .catch((error) => {
+        console.error('Form validation failed:', error);
+      });
+  };
+
+  // Expose methods to parent component
+  useImperativeHandle(ref, () => ({
+    handleOpen,
+  }));
+
+  const handleChangeRerankMode = (value: string | null | undefined) => {
+    if (value === 'reranking_model') {
+      form.setFieldsValue({ rerank_weights: undefined, enable_graph_retrieval: 0 });
+    } else if (value === 'weighted_score') {
+      form.setFieldsValue({
+        reranker_id: undefined,
+        rerank_weights: { semantic_weight: 0.5, participle_weight: 0.5 },
+        enable_graph_retrieval: 0,
+      });
+    }
+  };
+
   return (
-    <Flex vertical className='rb:w-full rb:h-full rb:overflow-hidden'>
-      <div className='rb:shrink-0 rb:max-h-[50%]! rb:overflow-y-auto'>
-        <Flex align="center" justify="space-between" className='rb:mb-2!'>
-          <span className='rb:font-medium'>{ t('knowledgeBase.testQuestion')}</span>
-          {/* <Flex align="center" justify="end">
-              <img src={refreshIcon} alt="refresh" className='rb:w-4 rb:h-4 rb:mr-2' />
-              <span className='rb:text-[#155eef]'>{ t('knowledgeBase.loadSampleQuestions')}</span>
-          </Flex> */}
-        </Flex>
+    <div
+      ref={layoutContainerRef}
+      className={clsx(
+        'rb:flex rb:w-full rb:h-full rb:min-w-0 rb:min-h-0 rb:overflow-hidden',
+        isWideLayout ? 'rb:flex-row rb:gap-4' : 'rb:flex-col',
+      )}
+    >
+      <div
+        className={clsx(
+          'rb:min-w-0 rb:min-h-0 rb:overflow-y-auto',
+          isWideLayout ? 'rb:flex-1 rb:basis-1/2 rb:max-h-none! rb-border rb:rounded-xl rb:p-3' : 'rb:shrink-0 rb:max-h-[50%]!',
+        )}
+      >
         <Form form={form} layout="vertical">
-          <Form.Item name="query">
-              <TextArea rows={4} placeholder={t('knowledgeBase.testQuestionPlaceholder')}/>
-          </Form.Item>
-          <div className="rb:grid rb:grid-cols-4 rb:gap-x-4 rb:gap-y-1">
+          <div
+            className={clsx(
+              'rb:grid rb:gap-x-4 rb:gap-y-1 rb:mb-3',
+              isWideLayout ? 'rb:grid-cols-2' : 'rb:grid-cols-3',
+            )}
+          >
             <div>
-              <Form.Item 
-                  name="retrieve_type" 
-                  label={t('knowledgeBase.retrieveMode')}
-                  initialValue="hybrid"
-              > 
-                  <Select
-                      options={retrievalModeOptions}
-                      placeholder={t('knowledgeBase.retrieveMode')}
-                      onChange={(value) => setRetrieveType(value)}
-                  />
-              </Form.Item>
-            </div>
-              
-            <div>
-              <Form.Item name="top_k" label={t('knowledgeBase.recallQuantity')}>
-                  <InputNumber 
-                      placeholder='1 ~ 100'
-                      min={1}
-                      max={100}
-                      className="rb:w-full!"
-                  />
+              <Form.Item
+                name="retrieve_type"
+                label={t('knowledgeBase.retrieveMode')}
+                initialValue="hybrid"
+                className="rb:col-span-full rb:mb-0!"
+              >
+                <Select
+                  options={retrievalModeOptions}
+                  placeholder={t('knowledgeBase.retrieveMode')}
+                  onChange={(value) => {
+                    if (retrievalPolicy[value]?.includes('image') !== true) {
+                      form.setFieldValue('image', undefined);
+                    }
+                  }}
+                />
               </Form.Item>
             </div>
 
-              {/* Show when retrieve_type = semantic or hybrid */}
-              {(retrieveType === 'hybrid') && (
-                <>
+            <div>
+              <Form.Item
+                name="top_k"
+                label={t('knowledgeBase.recallQuantity')}
+                className="rb:col-span-full rb:mb-0!"
+              >
+                <InputNumber
+                  placeholder="1 ~ 100"
+                  min={1}
+                  max={100}
+                  className="rb:w-full!"
+                />
+              </Form.Item>
+            </div>
+
+            {/* Show when retrieve_type = semantic or hybrid */}
+            {formValues.retrieve_type === 'hybrid' && (
+              <>
+                <div>
+                  <Form.Item
+                    name="rerank_mode"
+                    label={t('application.rerank_mode')}
+                    className="rb:col-span-full rb:mb-0!"
+                  >
+                    <Select
+                      options={[
+                        {
+                          label: t('application.reranking_model'),
+                          value: 'reranking_model',
+                        },
+                        {
+                          label: t('application.weighted_score'),
+                          value: 'weighted_score',
+                        },
+                      ]}
+                      placeholder={t('common.pleaseSelect')}
+                      onChange={(value) => handleChangeRerankMode(value)}
+                    />
+                  </Form.Item>
+                </div>
+                <div className={formValues.rerank_mode !== 'reranking_model' ? 'rb:hidden' : ''}>
+                  <Form.Item
+                    name="reranker_id"
+                    label={t('application.rearrangementModel')}
+                    className="rb:col-span-full rb:mb-0!"
+                    hidden={formValues.rerank_mode !== 'reranking_model'}
+                  >
+                    <ModelSelect params={{ type: 'rerank', pagesize: 100 }} />
+                  </Form.Item>
+                </div>
+
+                {formValues.rerank_mode === 'weighted_score' && (
                   <div>
                     <Form.Item
-                      name="rerank_mode"
-                      label={t('application.rerank_mode')}
-                      className="rb:col-span-full rb:mb-0!"
-                    >
-                      <Select
-                        options={[
-                          { label: t('application.reranking_model'), value: 'reranking_model' },
-                          { label: t('application.weighted_score'), value: 'weighted_score' },
-                        ]}
-                        onChange={(value) => handleChangeRerankMode(value)}
-                      />
-                    </Form.Item>
-                  </div>
-                  <div className={formValues?.rerank_mode !== 'reranking_model' ? 'rb:hidden' : ''}>
-                    <Form.Item
-                      name="reranker_id"
-                      label={t('application.rearrangementModel')}
-                      className="rb:col-span-full rb:mb-0!"
-                      hidden={formValues?.rerank_mode !== 'reranking_model'}
-                    >
-                      <ModelSelect
-                        params={{ type: 'rerank', pagesize: 100 }}
-                      />
-                    </Form.Item>
-                  </div>
-
-                  {formValues?.rerank_mode === 'weighted_score' && (
-                    <div>
-                      <Form.Item
                       label={t('application.weight_balance')}
                       className="rb:col-span-full rb:mb-0!"
                       required
-                      >
+                    >
                       <WeightBalanceSlider
-                          semanticWeight={formValues?.rerank_weights?.semantic_weight}
-                          participleWeight={formValues?.rerank_weights?.participle_weight}
-                          onChange={(semanticWeight, participleWeight) => {
+                        semanticWeight={formValues.rerank_weights?.semantic_weight}
+                        participleWeight={formValues.rerank_weights?.participle_weight}
+                        onChange={(semanticWeight, participleWeight) => {
                           form.setFieldsValue({
-                              rerank_weights: {
+                            rerank_weights: {
                               semantic_weight: semanticWeight,
                               participle_weight: participleWeight,
-                              },
+                            },
                           });
-                          }}
+                        }}
                       />
+                    </Form.Item>
+                    <Form.Item name="rerank_weights" hidden />
+                  </div>
+                )}
+
+                {formValues.retrieve_type === 'hybrid' &&
+                  formValues.rerank_mode === 'reranking_model' && (
+                    <div>
+                      <Form.Item
+                        name="similarity_threshold"
+                        label={t('knowledgeBase.similarityThreshold')}
+                        className="rb:col-span-full rb:mb-0!"
+                      >
+                        <Select
+                          options={[
+                            { label: '0.1', value: 0.1 },
+                            { label: '0.2', value: 0.2 },
+                            { label: '0.3', value: 0.3 },
+                            { label: '0.4', value: 0.4 },
+                            { label: '0.5', value: 0.5 },
+                            { label: '0.6', value: 0.6 },
+                            { label: '0.7', value: 0.7 },
+                            { label: '0.8', value: 0.8 },
+                            { label: '0.9', value: 0.9 },
+                            { label: '1.0', value: 1.0 },
+                          ]}
+                          placeholder={t('knowledgeBase.similarityThreshold')}
+                        />
                       </Form.Item>
-                      <Form.Item name="rerank_weights" hidden />
                     </div>
                   )}
+              </>
+            )}
 
-                  {(retrieveType === 'hybrid' && formValues?.rerank_mode === 'reranking_model') &&
-                    <div>
-                      <Form.Item name="similarity_threshold" label={t('knowledgeBase.similarityThreshold')} className="rb:col-span-full rb:mb-0!">
-                          <Select
-                              options={[
-                                  { label: '0.1', value: 0.1 },
-                                  { label: '0.2', value: 0.2 },
-                                  { label: '0.3', value: 0.3 },
-                                  { label: '0.4', value: 0.4 },
-                                  { label: '0.5', value: 0.5 },
-                                  { label: '0.6', value: 0.6 },
-                                  { label: '0.7', value: 0.7 },
-                                  { label: '0.8', value: 0.8 },
-                                  { label: '0.9', value: 0.9 },
-                                  { label: '1.0', value: 1.0 },
-                              ]}
-                              placeholder={t('knowledgeBase.similarityThreshold')}
-                          />
-                      </Form.Item>
-                    </div>
-                  }
-                </>
-              )}
+            {/* Show when retrieve_type = participle or hybrid */}
+            {(formValues.retrieve_type === 'semantic' ||
+              (formValues.retrieve_type === 'hybrid' &&
+                formValues.rerank_mode === 'reranking_model')) && (
+              <div>
+                <Form.Item
+                  name="vector_similarity_weight"
+                  label={t('knowledgeBase.semanticSimilarity')}
+                  className="rb:col-span-full rb:mb-0!"
+                >
+                  <Select
+                    options={[
+                      { label: '0.1', value: 0.1 },
+                      { label: '0.2', value: 0.2 },
+                      { label: '0.3', value: 0.3 },
+                      { label: '0.4', value: 0.4 },
+                      { label: '0.5', value: 0.5 },
+                      { label: '0.6', value: 0.6 },
+                      { label: '0.7', value: 0.7 },
+                      { label: '0.8', value: 0.8 },
+                      { label: '0.9', value: 0.9 },
+                      { label: '1.0', value: 1.0 },
+                    ]}
+                    placeholder={t('knowledgeBase.semanticSimilarity')}
+                  />
+                </Form.Item>
+              </div>
+            )}
 
-              {/* Show when retrieve_type = participle or hybrid */}
-              {(retrieveType === 'semantic' || (retrieveType === 'hybrid' && formValues?.rerank_mode === 'reranking_model')) && (
-                  <div>
-                    <Form.Item name="vector_similarity_weight" label={t('knowledgeBase.semanticSimilarity')}className="rb:col-span-full rb:mb-0!">
-                        <Select
-                            options={[
-                                { label: '0.1', value: 0.1 },
-                                { label: '0.2', value: 0.2 },
-                                { label: '0.3', value: 0.3 },
-                                { label: '0.4', value: 0.4 },
-                                { label: '0.5', value: 0.5 },
-                                { label: '0.6', value: 0.6 },
-                                { label: '0.7', value: 0.7 },
-                                { label: '0.8', value: 0.8 },
-                                { label: '0.9', value: 0.9 },
-                                { label: '1.0', value: 1.0 },
-                            ]}
-                            placeholder={t('knowledgeBase.semanticSimilarity')}
-                        />
-                    </Form.Item>
-                  </div>
-              )}  
-
-              {(retrieveType === 'hybrid') &&
+            {formValues.retrieve_type === 'hybrid' &&
+              formValues.rerank_mode === 'reranking_model' && (
                 <div>
                   <Form.Item
-                      name="enable_graph_retrieval"
-                      getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
-                      getValueFromEvent={(checked: boolean) => checked ? 1 : 0}
-                      initialValue={0}
-                      valuePropName="checked"
-                      label={t('knowledgeBase.hybridIsHasGraph')}
-                      className="rb:col-span-full rb:mb-0!"
+                    name="enable_graph_retrieval"
+                    getValueProps={(value: 0 | 1 | undefined) => ({ checked: value === 1 })}
+                    getValueFromEvent={(checked: boolean) => (checked ? 1 : 0)}
+                    initialValue={0}
+                    valuePropName="checked"
+                    label={t('knowledgeBase.hybridIsHasGraph')}
+                    className="rb:col-span-full rb:mb-0!"
                   >
-                      <Switch checkedChildren={t('knowledgeBase.yes')} unCheckedChildren={t('knowledgeBase.no')} />
+                    <Switch
+                      checkedChildren={t('knowledgeBase.yes')}
+                      unCheckedChildren={t('knowledgeBase.no')}
+                    />
                   </Form.Item>
                 </div>
-              }
-              <Flex align="end" className="rb:h-full!">
-                <Button type="primary" onClick={handleStartTest} loading={loading}>{ t('knowledgeBase.startTesting')}</Button>
-              </Flex>
+              )}
+          </div>
+          <Flex align="center" justify="space-between" className="rb:mb-2!">
+            <span className="rb:font-medium">{t('knowledgeBase.testQuestion')}</span>
+            {/* <Flex align="center" justify="end">
+              <img src={refreshIcon} alt="refresh" className="rb:w-4 rb:h-4 rb:mr-2" />
+              <span className="rb:text-[#155eef]">{t('knowledgeBase.loadSampleQuestions')}</span>
+            </Flex> */}
+            <Button type="primary" onClick={handleStartTest} loading={loading}>
+              {t('knowledgeBase.startTesting')}
+            </Button>
+          </Flex>
+          <div className="rb:flex rb:flex-col rb:gap-4 rb:sm:flex-row">
+            <Form.Item name="query" className="rb:flex-1 rb:mb-0!">
+              <TextArea
+                rows={4}
+                placeholder={t('knowledgeBase.testQuestionPlaceholder')}
+                onChange={() => form.setFieldValue('image', undefined)}
+              />
+            </Form.Item>
+            {supportsImage && (
+              <Form.Item name="image" className="rb:shrink-0 rb:mb-0!" preserve={false}>
+                <RecallImageUpload
+                  disabled={loading}
+                  onChange={(value) => {
+                    if (value) {
+                      form.setFieldValue('query', '');
+                    }
+                  }}
+                />
+              </Form.Item>
+            )}
           </div>
         </Form>
       </div>
-      <div className='rb:flex-1 rb:overflow-y-auto rb:min-h-0'>
-          <RecallTestResult data={data} showEmpty={true} />
+      <div
+        className={clsx(
+          'rb:flex-1 rb:min-w-0 rb:min-h-0 rb:overflow-y-auto',
+          isWideLayout && 'rb:basis-1/2 rb-border rb:rounded-xl rb:p-3',
+        )}
+      >
+        <RecallTestResult data={data} showEmpty={true} />
       </div>
-      
-    </Flex>
+    </div>
   );
 });
 

--- a/web/src/views/KnowledgeBase/components/RecallTestDrawer.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestDrawer.tsx
@@ -4,7 +4,7 @@ import RbDrawer from '@/components/RbDrawer';
 import type { RecallTestDrawerRef } from '@/views/KnowledgeBase/types';
 import RecallTest from './RecallTest';
 
-const RecallTestDrawer = forwardRef<RecallTestDrawerRef>(({},ref) => {
+const RecallTestDrawer = forwardRef<RecallTestDrawerRef>((_props,ref) => {
     const { t } = useTranslation();
     const [open, setOpen] = useState(false);
     const recallTestRef = useRef<any>(null);

--- a/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
+++ b/web/src/views/KnowledgeBase/components/RecallTestResult.tsx
@@ -209,6 +209,7 @@ const RecallTestResult = ({
       <NoData
         title={t('knowledgeBase.recallTestUnStart')}
         subTitle={t('knowledgeBase.recallTestUnStartSubTitle')}
+        className="rb:h-full!"
       />
     );
   }

--- a/web/src/views/KnowledgeBase/components/noData.tsx
+++ b/web/src/views/KnowledgeBase/components/noData.tsx
@@ -5,14 +5,16 @@ interface NoDataProps {
     title?: string;
     subTitle?: string;
     image?: string;
+    className?: string;
 }
-export const NoData = ({ title = 'No data', subTitle }: NoDataProps) => {
+export const NoData = ({ title = 'No data', subTitle, className }: NoDataProps) => {
     return (
         <Empty
             size={200}
             url={blankImage}
             title={title}
             subTitle={subTitle}
+            className={className}
         />
     )
 };

--- a/web/src/views/KnowledgeBase/types.ts
+++ b/web/src/views/KnowledgeBase/types.ts
@@ -64,8 +64,17 @@ export interface RecallTestData {
   children: null | RecallTestData[];
 }
 
+export type RetrievalModality = 'text' | 'image';
+
+export type RetrievalPolicy = Partial<Record<string, RetrievalModality[]>>;
+
+export interface RecallTestQuery {
+  modality: RetrievalModality;
+  content: string;
+}
+
 export interface RecallTestParams {
-  query?: string; // 查询问题
+  query: RecallTestQuery; // 多模态查询内容
   kb_ids?: string[]; // 知识库ID
   similarity_threshold?: number; // 相似度阈值
   vector_similarity_weight?: number; //语义相似度权重


### PR DESCRIPTION
## Sourcery 总结

通过响应式控件、支持策略的检索选项以及更稳健的图片上传处理，启用多模态知识库召回测试。

新功能：
- 添加基于图片的召回测试，支持知识库特定的模态以及图片上传。
- 更新检索测试请求，以提交结构化文本或图片查询，并从 API 获取策略。

Bug 修复：
- 防止过时的图片读取和上传操作更新已清除或替换的文件状态。
- 改进针对已配置文件类型的上传验证，包括没有 MIME 类型的文件。

增强功能：
- 使召回测试能够适应窄屏和宽屏布局，并提供支持策略的控件。
- 改进可搜索选择器对嵌套标签和选项值的筛选。
- 支持在空间切换器中搜索工作区。

日常维护：
- 暴露上传组件的 prop 和 ref 类型，以便召回图片上传功能复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable multimodal knowledge-base recall testing with responsive controls, policy-aware retrieval options, and more robust image upload handling.

New Features:
- Add image-based recall testing with knowledge-base-specific modality support and image uploads.
- Update retrieval test requests to submit structured text or image queries and retrieve policies from the API.

Bug Fixes:
- Prevent stale image reads and uploads from updating cleared or replaced file state.
- Improve upload validation for configured file types, including files without MIME types.

Enhancements:
- Make recall testing responsive across narrow and wide layouts with policy-aware controls.
- Improve searchable select filtering for nested labels and option values.
- Enable workspace searching in the space switcher.

Chores:
- Expose upload component prop and ref types for reuse by recall image uploads.

</details>