### PR TITLE
feat(gateway-service): support route configuration via file, env, and built-in default

### DIFF
--- a/gateway-service/.env.example
+++ b/gateway-service/.env.example
@@ -28,9 +28,14 @@ INTERNAL_TOKEN_LEEWAY=30
 # direct（缺省）= 社区版透传凭据给下游自验；gateway = 企业插件终结凭据签发内部 token
 # （AUTH_STRATEGY=gateway 而 enterprise-extensions 未装 → 启动即 RuntimeError，响亮暴露）
 AUTH_STRATEGY=direct
-# 转发路由表（无默认；缺省/为空则任何请求都无转发目标）：JSON 完整示例见
-# docker-compose.enterprise.yml 的 TARGET_ROUTES（K8s 部署拆入 configmap.yaml）
-TARGET_ROUTES={"routes":[{"path_prefix":"/api/knowledges","service":"kb","base_url":"http://kb:8080","aud":"kb"}]}
+# 转发路由表（本仓库 routes.json 为镜像内置默认，Dockerfile COPY → 容器
+# /etc/gateway/routes.json，裸部署开箱即用；compose bind-mount / K8s ConfigMap
+# 挂载同一路径覆盖镜像默认。新增服务只改该文件）。优先级：
+#   TARGET_ROUTES_FILE（显式指向，缺失/非法 JSON → 启动 RuntimeError 响亮失败）
+#   > TARGET_ROUTES env（旧行为兜底）> 镜像内置 /etc/gateway/routes.json > 空路由
+TARGET_ROUTES_FILE=/etc/gateway/routes.json
+# env 兜底（未配 TARGET_ROUTES_FILE 时生效；缺省/为空 = 空路由，任何请求无转发目标）
+TARGET_ROUTES=
 # 用户路径固定窗口限流（60s 窗口；企业 gateway 策略消费，Redis 故障旁路放行）
 USER_RATE_LIMIT_PER_MINUTE=600
 

--- a/gateway-service/Dockerfile
+++ b/gateway-service/Dockerfile
@@ -22,6 +22,9 @@ RUN if [ "$NEED_MIRROR" == "1" ]; then \
 COPY core/packages/auth-sdk /app/packages/auth-sdk
 COPY core/gateway-service/pyproject.toml /app/gateway-service/
 COPY core/gateway-service/src /app/gateway-service/src
+# 路由表默认文件内置进镜像（固定路径 /etc/gateway/routes.json）：裸部署开箱即用；
+# compose/k8s 以 bind-mount / ConfigMap 挂载同一路径覆盖镜像默认
+COPY core/gateway-service/routes.json /etc/gateway/routes.json
 WORKDIR /app/gateway-service
 RUN pip install --no-cache-dir -e /app/packages/auth-sdk && pip install --no-cache-dir .
 

--- a/gateway-service/routes.json
+++ b/gateway-service/routes.json
@@ -1,0 +1,13 @@
+{
+  "routes": [
+    {"path_prefix": "/api/knowledges", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/v1/knowledges", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/api/chunks", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/v1/chunks", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/api/documents", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/v1/documents", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/api/files", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/v1/files", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"},
+    {"path_prefix": "/api/knowledgeshares", "service": "kb", "base_url": "http://mem-knowledge:8080", "aud": "kb"}
+  ]
+}

--- a/gateway-service/src/config.py
+++ b/gateway-service/src/config.py
@@ -12,6 +12,32 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# 镜像内置默认路由文件（Dockerfile COPY 的固定路径）：裸部署未显式配置时兜底；
+# compose/k8s 以 bind-mount / ConfigMap 挂载同一路径覆盖镜像默认
+_DEFAULT_ROUTES_FILE = "/etc/gateway/routes.json"
+
+
+def _read_routes_file(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"TARGET_ROUTES_FILE unreadable/invalid: {path}: {exc}") from exc
+
+
+def _target_routes_raw() -> dict:
+    path = os.getenv("TARGET_ROUTES_FILE")
+    if path:
+        # 显式配置：文件缺失/非法 = misconfiguration → 启动失败（fail-fast）
+        return _read_routes_file(path)
+    env = os.getenv("TARGET_ROUTES")
+    if env:
+        return json.loads(env)
+    if os.path.exists(_DEFAULT_ROUTES_FILE):
+        return _read_routes_file(_DEFAULT_ROUTES_FILE)
+    return {}
+
 
 class Settings:
     # ---- Redis（用户快照 + 审计队列）----
@@ -58,11 +84,16 @@ class Settings:
     def user_rate_limit_per_minute(self) -> int:
         return int(os.getenv("USER_RATE_LIMIT_PER_MINUTE", "600"))
 
-    # ---- 转发目标路由（TARGET_ROUTES JSON，惰性读）----
+    # ---- 转发目标路由（文件/env 三层，惰性读）----
+    # 优先级：TARGET_ROUTES_FILE（部署显式指向，缺失/非法 = misconfiguration →
+    # RuntimeError 启动失败）> TARGET_ROUTES env（旧行为）> 镜像内置默认
+    # /etc/gateway/routes.json（Dockerfile COPY，裸部署开箱即用；存在即读）> 空路由。
+    # 路由表是静态配置，compose bind-mount / K8s ConfigMap 挂载同路径覆盖镜像默认；
+    # 新增服务只改路由文件不动代码。target_routes 仅 lifespan 消费一次。
     @property
     def target_routes(self) -> list:
         from src.forward import TargetRoute  # 延迟导入避免循环
-        raw = json.loads(os.getenv("TARGET_ROUTES", "{}")) if os.getenv("TARGET_ROUTES") else {}
+        raw = _target_routes_raw()
         return [TargetRoute(**item) for item in raw.get("routes", [])]
 
 

--- a/gateway-service/src/config.py
+++ b/gateway-service/src/config.py
@@ -21,7 +21,7 @@ def _read_routes_file(path: str) -> dict:
     try:
         with open(path, encoding="utf-8") as fh:
             return json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise RuntimeError(
             f"TARGET_ROUTES_FILE unreadable/invalid: {path}: {exc}") from exc
 

--- a/gateway-service/src/forward.py
+++ b/gateway-service/src/forward.py
@@ -38,7 +38,7 @@ _DROP_HEADERS = ("content-length", "transfer-encoding", "connection")
 class TargetRoute(BaseModel):
     path_prefix: str
     service: str
-    base_url: str      # K8s Service DNS 名，如 http://kb-service:8080
+    base_url: str      # K8s Service DNS 名，如 http://mem-knowledge:8080
     aud: str           # 内部 token 受众 = 目标服务名
 
 


### PR DESCRIPTION
Add support for loading gateway forwarding routes from three sources in priority order: TARGET_ROUTES_FILE (fail-fast on error), TARGET_ROUTES environment variable (legacy fallback), and built-in /etc/gateway/routes.json (Dockerfile-copied default for bare deployment). Introduce routes.json with initial KB service routes, update Dockerfile to copy it, enhance config.py routing logic, document the new behavior in .env.example, and extend verify_target_routes.py to accept --target-routes-file. Also update base_url comment to reflect actual service name.

## Sourcery 摘要

支持可配置的网关转发路由，并支持基于文件的部署方式和内置默认配置。

新功能：
- 支持按优先级从显式配置的文件、旧版环境变量或内置镜像默认配置中加载网关转发路由。

增强功能：
- 当显式配置的路由文件缺失或无效时，快速失败。
- 将默认 KB 服务路由包含在容器镜像中，并允许部署通过挂载进行覆盖。
- 更新路由服务名称示例，使其与实际服务名称一致。

构建：
- 将内置路由配置复制到 gateway-service 镜像中的 /etc/gateway/routes.json。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为独立部署和挂载部署启用灵活的网关路由配置。

新功能：
- 支持按优先级顺序从显式配置的文件、旧版环境变量或内置镜像默认配置中加载网关转发路由。

错误修复：
- 当显式配置的路由文件缺失或无效时立即失败。

增强：
- 将初始知识库服务路由作为可替换的默认配置，并更新服务名称示例。

构建：
- 将默认路由配置复制到 gateway-service 镜像中的 `/etc/gateway/routes.json`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable flexible gateway route configuration for standalone and mounted deployments.

New Features:
- Support loading gateway forwarding routes from an explicitly configured file, the legacy environment variable, or a built-in image default in priority order.

Bug Fixes:
- Fail fast when an explicitly configured route file is missing or invalid.

Enhancements:
- Include initial knowledge-base service routes as a replaceable default configuration and update the service-name example.

Build:
- Copy the default route configuration into the gateway-service image at /etc/gateway/routes.json.

</details>

</details>