### PR TITLE
fix(rag): cap multimodal rerank views within modality budgets

### DIFF
--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from enum import Enum
 from functools import partial
+from itertools import islice, zip_longest
 from typing import Any
 
 from langchain_core.documents import Document as LangChainDocument
@@ -77,6 +78,35 @@ from .multimodal_image import resolve_storage_images_async, validate_image_data_
 logger = logging.getLogger(__name__)
 _SOURCE_INDEX = "_retrieval_source_index"
 _MAX_RETRIEVAL_WORKERS = 3
+_MAX_MULTIMODAL_RERANK_TEXT_VIEWS = 100
+_MAX_MULTIMODAL_RERANK_IMAGE_VIEWS = 40
+
+
+def _select_multimodal_rerank_views(
+    views: Sequence[RerankCandidateView],
+) -> list[RerankCandidateView]:
+    """Keep text in candidate order and distribute image slots across chunks."""
+    text_indices: list[int] = []
+    image_indices_by_chunk: dict[int, list[int]] = {}
+    for index, view in enumerate(views):
+        if view.kind == "text":
+            if len(text_indices) < _MAX_MULTIMODAL_RERANK_TEXT_VIEWS:
+                text_indices.append(index)
+        else:
+            image_indices_by_chunk.setdefault(view.chunk_index, []).append(index)
+
+    round_robin_image_indices = (
+        index
+        for layer in zip_longest(*image_indices_by_chunk.values())
+        for index in layer
+        if index is not None
+    )
+    selected_indices = set(text_indices)
+    selected_indices.update(
+        islice(round_robin_image_indices, _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS)
+    )
+    # Preserve the original payload order and each view's source-chunk mapping.
+    return [view for index, view in enumerate(views) if index in selected_indices]
 
 
 def _record_elapsed(
@@ -1084,10 +1114,20 @@ class KnowledgeRetrievalService:
                     )
                     chunk_image_index += 1
                     image_view_count += 1
-        if text_view_count > 100 or image_view_count > 40:
-            raise KnowledgeError.from_code(
-                "KB_MULTIMODAL_INPUT_LIMIT",
-                "Rerank candidate view count exceeds the model limit",
+        if (
+            text_view_count > _MAX_MULTIMODAL_RERANK_TEXT_VIEWS
+            or image_view_count > _MAX_MULTIMODAL_RERANK_IMAGE_VIEWS
+        ):
+            views = _select_multimodal_rerank_views(views)
+            retained_text_count = sum(view.kind == "text" for view in views)
+            logger.warning(
+                "event=kb_multimodal_rerank_views_trimmed "
+                "text_views_before=%s text_views_after=%s "
+                "image_views_before=%s image_views_after=%s",
+                text_view_count,
+                retained_text_count,
+                image_view_count,
+                len(views) - retained_text_count,
             )
         if not views:
             return ModelRerankResult(chunks=(), used_fallback=False)


### PR DESCRIPTION
## Business Background
Image-query retrieval can expand a small set of chunks into more than 40 image views. The existing view-count guard rejects the entire rerank request even when a useful subset can fit the provider limits.

## Summary
- Keep at most 100 text views in the existing candidate order.
- Allocate at most 40 image views round-robin across chunks.
- Preserve retained payload order, source-chunk mapping, and maximum-score aggregation.
- Replace the candidate-count error with a warning containing counts only.
- Keep the original top_n and top_k behavior; no 15-candidate cap is included.

## Changes
```text
mem-knowledge/src/services/knowledge_retrieval.py | 48 +++++++++++++++++++++--
1 file changed, 44 insertions(+), 4 deletions(-)
```

## Risk and Compatibility
- When the view budget is exceeded, omitted views can affect ranking. Chunks without any retained view do not participate in that rerank stage.
- The same selection runs at local and global image-query rerank stages. Existing candidate ordering is preserved.
- This caps view counts, not token usage. Single-item/token limits and provider failures remain errors; no silent semantic fallback is introduced.
- Images are still resolved before selection; this does not introduce a new storage-loading or memory budget.
- Text-query behavior, request/response schemas, authentication, tenant/workspace handling, and frontend code are unchanged.
- External API Key impact: existing authorized image-query requests use the same bounded view selection instead of failing on candidate count; no new endpoints or access scopes are exposed.

## Test Plan
- [x] After rebase onto current origin/develop, 105 local tests passed: retrieval parameter compatibility, text/image count boundaries, round-robin fairness, cross-KB candidates, retained-view score mapping, count-only logging, and strict provider/token errors, plus existing multimodal retrieval/policy/model regressions.
- [x] `ruff check src/services/knowledge_retrieval.py ../tests/mem_knowledge/retrieval/test_image_query_top_n.py ../tests/mem_knowledge/retrieval/test_multimodal_view_selection.py` passed.
- [x] `python scripts/check_import_boundaries.py` passed.
- [x] `git diff --check origin/develop..HEAD` passed.
- [ ] Live provider/deployment verification has not been performed for this change.

Local pytest invocation from mem-knowledge:
```bash
PYTHONPATH=.:../packages/redbear-model/src:../packages/storage-core/src:../packages/auth-sdk/src .venv/bin/python -m pytest ../tests/mem_knowledge/retrieval /private/tmp/memorybear-multimodal-query-tests/{retrieval,rerank,policy,model} -q --tb=short -p no:cacheprovider
```

Tests are local-only under repository instructions and are not included in this PR. The two new local regression files therefore cannot be handed off through the committed-PR-test copy step; that test handoff remains incomplete. No local configuration or unrelated dirty files are included.

## Sourcery 总结

在文本和图像视图预算范围内限制多模态重排序候选项，同时保留有用且分布均衡的候选项。

错误修复：
- 当文本或图像视图数量超过提供商限制时，通过保留有界子集来避免多模态重排序请求失败。

改进：
- 在各区块之间公平分配保留的图像视图时，保留候选项顺序和来源映射。
- 裁剪多模态候选项时，输出包含裁剪前后视图数量的警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bound multimodal rerank candidates within text and image view budgets while preserving useful, fairly distributed candidates.

Bug Fixes:
- Prevent multimodal rerank requests from failing when text or image view counts exceed provider limits by retaining a bounded subset instead.

Enhancements:
- Preserve candidate order and source mappings while distributing retained image views fairly across chunks.
- Warn with before-and-after view counts when multimodal candidates are trimmed.

</details>