### PR TITLE
fix(rag): normalize parser layouts and image query candidate limits

### DIFF
--- a/mem-knowledge/src/api/schemas/chunk.py
+++ b/mem-knowledge/src/api/schemas/chunk.py
@@ -10,6 +10,8 @@ from ...rag.models.chunk import QAChunk
 from .knowledge_metadata import FilterGroup, MetadataFilterMode
 from .rerank import RerankMode, RerankWeights
 
+IMAGE_QUERY_TOP_N = 20
+
 
 class RetrieveType(StrEnum):
     PARTICIPLE = "participle"
@@ -204,7 +206,9 @@ class ChunkRetrieve(BaseModel):
         if not self.kb_ids and not self.ex_ids and not self.knowledge_bases:
             raise ValueError("kb_ids, ex_ids and knowledge_bases cannot all be empty")
         top_k = self.top_k or 20
-        if self.top_n is None or "top_n" not in self.model_fields_set:
+        if isinstance(self.normalized_query, ImageRetrievalQuery):
+            self.top_n = IMAGE_QUERY_TOP_N
+        elif self.top_n is None or "top_n" not in self.model_fields_set:
             self.top_n = max(top_k, 20)
         elif self.top_n < top_k:
             raise ValueError("top_n must be greater than or equal to top_k")

--- a/mem-knowledge/src/api/schemas/knowledge_retrieval.py
+++ b/mem-knowledge/src/api/schemas/knowledge_retrieval.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from ...rag.models.chunk import DocumentChunk
 from .chunk import (
+    IMAGE_QUERY_TOP_N,
     ImageRetrievalQuery,
     KnowledgeBaseConfig,
     KnowledgeRetrievalSource,
@@ -82,7 +83,9 @@ class KnowledgeRetrievalRequest(BaseModel):
     def validate_knowledge_ids(self) -> "KnowledgeRetrievalRequest":
         if not self.kb_ids and not self.ex_ids and not self.knowledge_bases:
             raise ValueError("kb_ids, ex_ids and knowledge_bases cannot all be empty")
-        if self.top_n is None or "top_n" not in self.model_fields_set:
+        if isinstance(self.normalized_query, ImageRetrievalQuery):
+            self.top_n = IMAGE_QUERY_TOP_N
+        elif self.top_n is None or "top_n" not in self.model_fields_set:
             self.top_n = max(self.top_k, 20)
         elif self.top_n < self.top_k:
             raise ValueError("top_n must be greater than or equal to top_k")

--- a/mem-knowledge/src/rag/parser_config.py
+++ b/mem-knowledge/src/rag/parser_config.py
@@ -27,11 +27,12 @@ def _default_graph_config() -> dict[str, Any]:
 def resolve_layout_recognize(
     parser_config: Mapping[str, Any] | None,
 ) -> Literal["plain", "mineru", "textln"]:
+    """Default missing layouts to Plain and unsupported explicit values to MinerU."""
     if parser_config is None or "layout_recognize" not in parser_config:
         return "plain"
     raw_value = parser_config["layout_recognize"]
     if not isinstance(raw_value, str):
-        raise GraphPipelineConfigError(f"unsupported layout_recognize: {raw_value!r}")
+        return "mineru"
     normalized = raw_value.strip().lower()
     aliases = {
         "plain": "plain",
@@ -40,10 +41,7 @@ def resolve_layout_recognize(
         "mineru": "mineru",
         "textln": "textln",
     }
-    try:
-        return aliases[normalized]
-    except KeyError:
-        raise GraphPipelineConfigError(f"unsupported layout_recognize: {raw_value}") from None
+    return aliases.get(normalized, "mineru")
 
 
 def build_default_knowledge_parser_config() -> dict[str, Any]:

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -18,6 +18,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..api.dependencies import Principal
 from ..api.schemas.chunk import (
+    IMAGE_QUERY_TOP_N,
+    ImageRetrievalQuery,
     KnowledgeBaseConfig,
     RetrievalPolicy,
     RetrievalPolicyRequest,
@@ -640,11 +642,16 @@ class KnowledgeRetrievalPreparation:
         if rerank_threshold is None:
             rerank_threshold = vector_weight if vector_weight is not None else 0.1
         top_k = int(value("top_k", request.top_k))
+        top_n = (
+            IMAGE_QUERY_TOP_N
+            if isinstance(request.normalized_query, ImageRetrievalQuery)
+            else max(top_k, int(request.top_n or 20))
+        )
         return RetrievalParams(
             similarity_threshold=float(value("similarity_threshold", request.similarity_threshold)),
             vector_similarity_weight=vector_weight,
             top_k=top_k,
-            top_n=max(top_k, int(request.top_n or 20)),
+            top_n=top_n,
             retrieve_type=value("retrieve_type", request.retrieve_type),
             rerank_score_threshold=float(rerank_threshold),
             enable_graph_retrieval=(


### PR DESCRIPTION
## Business Background
Unsupported parser layout values currently fail document configuration validation. Image queries can also retain a large rerank candidate count because retrieval preparation raises `top_n` to `top_k`.

## Summary
- Silently resolve unsupported explicit `layout_recognize` values to `mineru`; preserve the missing-field `plain` default and supported aliases.
- Normalize image-query `top_n` to 20 in both request schemas and retrieval preparation, so a larger `top_k` cannot raise it again.
- Preserve text-query validation and candidate counts, along with the caller's `top_k` return limit.

## Scope
Four files in `mem-knowledge`: parser configuration, two retrieval request schemas, and retrieval preparation. Two focused commits; 20 insertions and 8 deletions.

## Risk and Compatibility
- Previously rejected parser values now select MinerU and require its existing runtime configuration when parsing runs. No stored-configuration migration or automatic reparse is included.
- Image hybrid retrieval uses 20 initial candidates per target. Image views can still expand per chunk, and multi-target/global reranking retains its existing behavior; this is not a guarantee against all provider token limits.
- Authentication, permissions, tenant/workspace checks, response schemas, text-query behavior, and `top_k` remain unchanged. Existing top_n field type/range validation still applies.
- External API Key impact: existing requests reaching mem-knowledge receive the same normalization; no endpoints or permissions are added. The legacy API implementation and its pre-proxy validation remain unchanged.

## Test Plan
- [x] Combined-head Python verification: 96 assertions passed across parser fallback/defaults, image-query schemas and effective retrieval parameters, text compatibility, and top_k preservation.
- [x] Earlier focused verification: 189 parser assertions and 195 image top_n assertions passed.
- [x] `cd mem-knowledge && .venv/bin/ruff check src/rag/parser_config.py src/api/schemas/chunk.py src/api/schemas/knowledge_retrieval.py src/services/knowledge_retrieval_preparation.py`
- [x] Schema/parser formatting and the changed retrieval-preparation region passed. Unrelated whole-file formatting differences already exist in the base and were left unchanged.
- [x] `git diff --check origin/develop..HEAD`
- [ ] Live MinerU parsing and provider reranking were not run.

## Sourcery 总结

使用 MinerU 作为回退方案统一解析器布局设置，并为图像查询强制采用标准检索限制。

错误修复：
- 对基于图像的查询，在分块检索、知识检索和检索参数准备过程中统一设置固定的 20 条检索限制。
- 将不受支持的布局识别值或非字符串布局识别值默认设置为 MinerU，而不是拒绝解析器配置。

增强功能：
- 保留现有的 Plain 默认值以及受支持的布局名称和别名，同时以一致的方式规范化解析器配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize parser layout settings with a MinerU fallback and enforce the standard retrieval limit for image queries.

Bug Fixes:
- Set a fixed retrieval limit of 20 for image-based queries across chunk retrieval, knowledge retrieval, and retrieval parameter preparation.
- Default unsupported or non-string layout recognition values to MinerU instead of rejecting parser configuration.

Enhancements:
- Preserve the existing Plain default and supported layout names and aliases while normalizing parser configuration consistently.

</details>