### PR TITLE
feat(memory): add multi-query search and cache user snapshots

### DIFF
--- a/api/app/core/api_key_utils.py
+++ b/api/app/core/api_key_utils.py
@@ -15,6 +15,8 @@ from app.core.utils.datetime_utils import parse_timestamp_to_utc_naive, to_times
 from app.models.api_key_model import ApiKeyType
 from app.models.end_user_model import EndUser as _EndUser
 from app.repositories.end_user_repository import EndUserRepository as _EndUserRepository
+from app.schemas.user_schema import UserSnap
+from app.utils.redis_cache import redis_cache
 
 
 def generate_api_key(key_type: ApiKeyType) -> str:
@@ -91,9 +93,9 @@ def get_current_user_from_api_key(db: _Session, api_key_auth):
 
 
 def validate_end_user_in_workspace(
-    db: _Session,
-    end_user_id: str,
-    workspace_id,
+        db: _Session,
+        end_user_id: str,
+        workspace_id,
 ) -> _EndUser:
     """校验 end_user 是否存在且属于指定 workspace。
 
@@ -137,9 +139,9 @@ def validate_end_user_in_workspace(
 
 
 async def validate_end_user_in_workspace_async(
-    db: AsyncSession,
-    end_user_id: str,
-    workspace_id,
+        db: AsyncSession,
+        end_user_id: str,
+        workspace_id,
 ) -> _EndUser:
     try:
         end_user_id = _uuid.UUID(end_user_id)
@@ -167,9 +169,41 @@ async def validate_end_user_in_workspace_async(
     return end_user
 
 
+@redis_cache(prefix="end_user", skip_args=["db"], id_arg="end_user_id", return_type=UserSnap)
+async def validate_end_user_snap_in_workspace_async(
+        db: AsyncSession,
+        end_user_id: str,
+        workspace_id,
+) -> UserSnap:
+    try:
+        end_user_id = _uuid.UUID(end_user_id)
+    except (ValueError, AttributeError):
+        raise _BusinessException(
+            f"Invalid end_user_id format: {end_user_id}",
+            _BizCode.INVALID_PARAMETER,
+        )
+
+    end_user_repo = _EndUserRepository(db)
+    end_user = await end_user_repo.get_end_user_by_id_async(end_user_id)
+
+    if end_user is None:
+        raise _BusinessException(
+            "End user not found",
+            _BizCode.USER_NOT_FOUND,
+        )
+
+    if str(end_user.workspace_id) != str(workspace_id):
+        raise _BusinessException(
+            "End user does not belong to this workspace",
+            _BizCode.PERMISSION_DENIED,
+        )
+
+    return UserSnap(id=end_user.id)
+
+
 async def get_current_user_snapshot_from_api_key_async(
-    db: AsyncSession,
-    api_key_auth,
+        db: AsyncSession,
+        api_key_auth,
 ) -> "CurrentUserSnapshot":
     """通过 API Key 异步构造 CurrentUserSnapshot（detach-safe）。
 

--- a/api/app/core/memory/pipelines/memory_read.py
+++ b/api/app/core/memory/pipelines/memory_read.py
@@ -747,7 +747,7 @@ class ReadPipeLine(ModelClientMixin, BasePipeline):
             includes=None,
             enable_rerank: bool = False
     ) -> MemorySearchResult:
-        meta_task = asyncio.ensure_future(self._user_meta())
+        meta_task = asyncio.create_task(self._user_meta())
         search_service = await self._get_search_service(
             includes,
             need_llm=False,

--- a/api/app/core/memory/read_services/search_engine/content_search.py
+++ b/api/app/core/memory/read_services/search_engine/content_search.py
@@ -29,11 +29,11 @@ from app.core.memory.models.service_models import MemoryContext
 from app.core.memory.prompt import prompt_manager
 from app.core.memory.read_services.search_engine.result_builder import MetadataBuilder
 from app.core.memory.read_services.search_engine.result_builder import data_builder_factory
-from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
-    make_user_source_lookup_tool
 from app.core.memory.read_services.search_engine.search_policy import (
     build_content_search_filters,
 )
+from app.core.memory.read_services.search_engine.tools import make_entity_search_tool, make_relation_search_tool, \
+    make_user_source_lookup_tool
 from app.core.memory.retrieval_trace.models import (
     RetrievalExecutionTrace,
     build_score_trace,
@@ -59,6 +59,7 @@ from app.db import get_async_db_context
 from app.models import Conversation, MemoryMessage
 from app.repositories import knowledge_repository
 from app.schemas.app_schema import FileInput, FileType, TransferMethod
+from app.utils.redis_cache import redis_cache
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,10 @@ class Neo4jSearchService:
             )
         return sidecar
 
+    @redis_cache(prefix="embeddings", skip_args=["self"], id_arg="model_name")
+    async def get_embed(self, model_name, query):
+        return await self.embedder.aembed_query(query)
+
     async def _keyword_search(
             self,
             query: str,
@@ -165,7 +170,8 @@ class Neo4jSearchService:
             query: str,
             limit: int
     ) -> StorageReadResult:
-        query_embed = await self.embedder.aembed_query(query)
+        query_embed = await self.get_embed(self.embedder._config.model_name, query)
+        # query_embed = await self.embedder.aembed_query(query)
         return await self.service.search_by_embedding(
             node_filters=build_content_search_filters(
                 self.includes,

--- a/api/app/core/memory/storage/models/__init__.py
+++ b/api/app/core/memory/storage/models/__init__.py
@@ -20,6 +20,7 @@ from app.core.memory.storage.models.projection import (
     RelationshipProjectionField,
 )
 from app.core.memory.storage.models.pattern import RelationshipPattern
+from app.core.memory.storage.models.search import NodeSearchSpec
 from app.core.memory.storage.models.sort import (
     NodeSort,
     RelationshipSort,
@@ -47,6 +48,7 @@ __all__ = [
     "RelationshipProjection",
     "RelationshipProjectionField",
     "RelationshipPattern",
+    "NodeSearchSpec",
 
     "NodeSort",
     "RelationshipSort",

--- a/api/app/core/memory/storage/models/search.py
+++ b/api/app/core/memory/storage/models/search.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from app.core.memory.storage.enums import MemoryNodeLabel
+from app.core.memory.storage.models.filter import NodeFilter
+from app.core.memory.storage.models.projection import NodeProjection
+
+
+@dataclass(frozen=True, slots=True)
+class NodeSearchSpec:
+    """One label-specific search in a provider batch request."""
+
+    label: MemoryNodeLabel
+    node_filter: NodeFilter
+    projection: NodeProjection | None = None

--- a/api/app/core/memory/storage/provider/base.py
+++ b/api/app/core/memory/storage/provider/base.py
@@ -1,11 +1,12 @@
 from abc import ABC, abstractmethod
-
+import asyncio
 from typing import Self
 
 from app.core.memory.storage.enums import MemoryNodeLabel, MemoryRelationshipType
 from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
+    NodeSearchSpec,
     NodeSort,
     RelationshipFilter,
     RelationshipPattern,
@@ -106,6 +107,42 @@ class BaseClient(ABC):
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
         pass
+
+    async def search_many_by_fulltext(
+            self,
+            specs: list[NodeSearchSpec],
+            text: str,
+            limit: int,
+    ) -> list[StorageReadResult]:
+        """Search multiple labels, falling back to one request per label."""
+        return list(await asyncio.gather(*(
+            self.search_by_fulltext(
+                spec.label,
+                spec.node_filter,
+                text,
+                limit,
+                spec.projection,
+            )
+            for spec in specs
+        )))
+
+    async def search_many_by_embedding(
+            self,
+            specs: list[NodeSearchSpec],
+            embed: list,
+            limit: int,
+    ) -> list[StorageReadResult]:
+        """Search multiple labels, falling back to one request per label."""
+        return list(await asyncio.gather(*(
+            self.search_by_embedding(
+                spec.label,
+                spec.node_filter,
+                embed,
+                limit,
+                spec.projection,
+            )
+            for spec in specs
+        )))
 
     async def save_relationship(
         self,

--- a/api/app/core/memory/storage/provider/elasticsearch/client.py
+++ b/api/app/core/memory/storage/provider/elasticsearch/client.py
@@ -13,6 +13,7 @@ from app.core.memory.storage.models import (
     FilterOperator,
     NodeFilter,
     NodeProjection,
+    NodeSearchSpec,
     NodeSort,
     ProjectionField,
     StorageReadResult,
@@ -143,6 +144,20 @@ def _compile_search_source_options(
     return {"source": False}, False
 
 
+def _compile_msearch_source_options(
+        projection: NodeProjection | None,
+) -> tuple[dict[str, Any], bool]:
+    source_fields = compile_elasticsearch_projection(
+        projection,
+        virtual_fields={VIRTUAL_SCORE_FIELD},
+    )
+    if source_fields is None:
+        return {}, True
+    if source_fields:
+        return {"_source": source_fields}, True
+    return {"_source": False}, False
+
+
 def _parse_search_hits(
         result: ObjectApiResponse[Any],
         projection: NodeProjection | None,
@@ -201,6 +216,39 @@ def _parse_search_hits(
             )
         )
     return nodes
+
+
+def _parse_msearch_responses(
+        result: Mapping[str, Any],
+        specs: list[NodeSearchSpec],
+        operation: str,
+) -> list[Mapping[str, Any]]:
+    responses = result.get("responses")
+    if not isinstance(responses, (list, tuple)):
+        raise RuntimeError(
+            f"Elasticsearch {operation} returned invalid responses"
+        )
+    if len(responses) != len(specs):
+        raise RuntimeError(
+            f"Elasticsearch {operation} response count mismatch: "
+            f"expected {len(specs)}, got {len(responses)}"
+        )
+
+    parsed: list[Mapping[str, Any]] = []
+    for index, (spec, response) in enumerate(zip(specs, responses)):
+        if not isinstance(response, Mapping):
+            raise RuntimeError(
+                f"Elasticsearch {operation} returned invalid response "
+                f"at index {index}"
+            )
+        error = response.get("error")
+        if error is not None:
+            raise RuntimeError(
+                f"Elasticsearch {operation} failed for "
+                f"{spec.label.value}: {error!r}"
+            )
+        parsed.append(response)
+    return parsed
 
 
 class ElasticClient(BaseClient):
@@ -417,6 +465,198 @@ class ElasticClient(BaseClient):
         finally:
             await client.close_point_in_time(id=pit_id)
         return StorageReadResult.from_items(nodes, label=label, backend=self.name)
+
+    async def search_many_by_embedding(
+            self,
+            specs: list[NodeSearchSpec],
+            embed: list,
+            limit: int,
+    ) -> list[StorageReadResult]:
+        if not specs:
+            return []
+
+        embedding_fields: list[str] = []
+        for spec in specs:
+            self.verify_label(spec.label)
+            embedding_field = EMBEDDING_FIELDS.get(spec.label)
+            if embedding_field is None:
+                raise UnsupportedQueryError(
+                    self.name,
+                    spec.label,
+                    "embedding",
+                )
+            embedding_fields.append(embedding_field)
+
+        _validate_search_limit(limit)
+        query_vector = _normalize_query_vector(embed)
+        vector_norm = math.hypot(*query_vector)
+        if not math.isfinite(vector_norm):
+            raise ValueError("embedding query vector norm must be finite")
+        if vector_norm == 0:
+            return [
+                StorageReadResult(backend=self.name)
+                for _ in specs
+            ]
+
+        num_candidates = min(
+            MAX_SEARCH_LIMIT,
+            max(
+                MIN_KNN_CANDIDATES,
+                limit,
+                limit * KNN_CANDIDATE_MULTIPLIER,
+            ),
+        )
+        searches: list[dict[str, Any]] = []
+        source_required: list[bool] = []
+        for spec, embedding_field in zip(specs, embedding_fields):
+            source_options, requires_source = _compile_msearch_source_options(
+                spec.projection
+            )
+            source_required.append(requires_source)
+            searches.extend(
+                [
+                    {
+                        "index": get_index_name(spec.label),
+                        "allow_partial_search_results": False,
+                    },
+                    {
+                        "knn": {
+                            "field": embedding_field,
+                            "query_vector": query_vector,
+                            "k": limit,
+                            "num_candidates": num_candidates,
+                            "filter": compile_elasticsearch_filter(
+                                spec.node_filter
+                            ),
+                        },
+                        "size": limit,
+                        **source_options,
+                    },
+                ]
+            )
+
+        result = await self._require_client().msearch(
+            searches=searches,
+            max_concurrent_searches=len(specs),
+        )
+        responses = _parse_msearch_responses(
+            result,
+            specs,
+            "embedding msearch",
+        )
+        return [
+            StorageReadResult.from_items(
+                _parse_search_hits(
+                    response,
+                    spec.projection,
+                    f"embedding msearch for {spec.label.value}",
+                    source_required=requires_source,
+                    score_transform=lambda score: (2.0 * score) - 1.0,
+                ),
+                label=spec.label,
+                backend=self.name,
+            )
+            for spec, response, requires_source in zip(
+                specs,
+                responses,
+                source_required,
+            )
+        ]
+
+    async def search_many_by_fulltext(
+            self,
+            specs: list[NodeSearchSpec],
+            text: str,
+            limit: int,
+    ) -> list[StorageReadResult]:
+        if not specs:
+            return []
+
+        fulltext_fields: list[tuple[str, ...]] = []
+        for spec in specs:
+            self.verify_label(spec.label)
+            fields = FULLTEXT_FIELDS.get(spec.label)
+            if fields is None:
+                raise UnsupportedQueryError(
+                    self.name,
+                    spec.label,
+                    "fulltext",
+                )
+            fulltext_fields.append(fields)
+
+        _validate_search_limit(limit)
+        if not isinstance(text, str):
+            raise ValueError("fulltext query must be a string")
+        normalized_text = text.strip()
+        if not normalized_text:
+            return [
+                StorageReadResult(backend=self.name)
+                for _ in specs
+            ]
+
+        searches: list[dict[str, Any]] = []
+        source_required: list[bool] = []
+        for spec, fields in zip(specs, fulltext_fields):
+            source_options, requires_source = _compile_msearch_source_options(
+                spec.projection
+            )
+            source_required.append(requires_source)
+            searches.extend(
+                [
+                    {
+                        "index": get_index_name(spec.label),
+                        "allow_partial_search_results": False,
+                    },
+                    {
+                        "query": {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "multi_match": {
+                                            "query": normalized_text,
+                                            "fields": list(fields),
+                                        }
+                                    }
+                                ],
+                                "filter": [
+                                    compile_elasticsearch_filter(
+                                        spec.node_filter
+                                    )
+                                ],
+                            }
+                        },
+                        "size": limit,
+                        **source_options,
+                    },
+                ]
+            )
+
+        result = await self._require_client().msearch(
+            searches=searches,
+            max_concurrent_searches=len(specs),
+        )
+        responses = _parse_msearch_responses(
+            result,
+            specs,
+            "fulltext msearch",
+        )
+        return [
+            StorageReadResult.from_items(
+                _parse_search_hits(
+                    response,
+                    spec.projection,
+                    f"fulltext msearch for {spec.label.value}",
+                    source_required=requires_source,
+                ),
+                label=spec.label,
+                backend=self.name,
+            )
+            for spec, response, requires_source in zip(
+                specs,
+                responses,
+                source_required,
+            )
+        ]
 
     async def search_by_embedding(
             self,

--- a/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
+++ b/api/app/core/memory/storage/provider/neo4j/compiler/filter_compiler.py
@@ -9,6 +9,11 @@ from app.core.memory.storage.models import (
 )
 
 
+def _escape_identifier(identifier: str) -> str:
+    """Escape a Cypher identifier while keeping it static for index planning."""
+    return identifier.replace("`", "``")
+
+
 def compile_neo4j_filter(
     node_filter: NodeFilter,
     variable: str = "n",
@@ -80,10 +85,10 @@ def _compile_group(
             condition_prefix = (
                 f"{parameter_prefix}_" + "_".join(map(str, expression_path))
             )
-            field_parameter = f"{condition_prefix}_field"
             value_parameter = f"{condition_prefix}_value"
-            property_expression = f"{variable}[${field_parameter}]"
-            parameters[field_parameter] = expression.field
+            property_expression = (
+                f"{variable}.`{_escape_identifier(expression.field)}`"
+            )
             predicate = _compile_condition(
                 expression,
                 property_expression=property_expression,

--- a/api/app/core/memory/storage/router/read_router.py
+++ b/api/app/core/memory/storage/router/read_router.py
@@ -1,6 +1,7 @@
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 
+from app.core.logging_config import get_logger
 from app.core.memory.storage.enums import (
     MemoryNodeLabel,
     StorageBackendType,
@@ -8,6 +9,7 @@ from app.core.memory.storage.enums import (
 from app.core.memory.storage.models import (
     NodeFilter,
     NodeProjection,
+    NodeSearchSpec,
     NodeSort,
     RelationshipFilter,
     RelationshipPattern,
@@ -16,7 +18,10 @@ from app.core.memory.storage.models import (
     StorageReadResult,
 )
 from app.core.memory.storage.models.projection import DEFAULT_PROJECTION
+from app.core.memory.storage.provider.base import BaseClient
 from app.core.memory.storage.provider.factory import BackendFactory
+
+logger = get_logger()
 
 
 def _merge_read_results(
@@ -35,6 +40,39 @@ def _merge_read_results(
         items=items,
         total=sum(result.total for result in results),
     )
+
+
+async def _run_grouped_search(
+        resolved: list[tuple[BaseClient, NodeSearchSpec]],
+        invoke: Callable[
+            [BaseClient, list[NodeSearchSpec]],
+            Awaitable[list[StorageReadResult]],
+        ],
+) -> list[StorageReadResult]:
+    groups: list[
+        tuple[BaseClient, list[tuple[int, NodeSearchSpec]]]
+    ] = []
+    for index, (client, spec) in enumerate(resolved):
+        for grouped_client, indexed_specs in groups:
+            if grouped_client is client:
+                indexed_specs.append((index, spec))
+                break
+        else:
+            groups.append((client, [(index, spec)]))
+
+    batches = await asyncio.gather(*(
+        invoke(client, [spec for _, spec in indexed_specs])
+        for client, indexed_specs in groups
+    ))
+    ordered: dict[int, StorageReadResult] = {}
+    for (_, indexed_specs), batch in zip(groups, batches):
+        if len(batch) != len(indexed_specs):
+            raise RuntimeError(
+                "storage batch search returned an unexpected result count"
+            )
+        for (index, _), result in zip(indexed_specs, batch):
+            ordered[index] = result
+    return [ordered[index] for index in range(len(resolved))]
 
 
 class ReadRouter:
@@ -61,20 +99,28 @@ class ReadRouter:
             pre_limit: int,
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
-        tasks = [
-            self.backend_factory.get_read_client(
-                label,
-                StorageBackendType.VECTOR_MAIN_READ,
-            ).search_by_embedding(
-                label,
-                node_filter,
-                embed,
-                pre_limit,
-                projection or DEFAULT_PROJECTION[label],
+        resolved = [
+            (
+                self.backend_factory.get_read_client(
+                    label,
+                    StorageBackendType.VECTOR_MAIN_READ,
+                ),
+                NodeSearchSpec(
+                    label=label,
+                    node_filter=node_filter,
+                    projection=projection or DEFAULT_PROJECTION[label],
+                ),
             )
             for label, node_filter in node_filters.items()
         ]
-        results: list[StorageReadResult] = list(await asyncio.gather(*tasks))
+        results = await _run_grouped_search(
+            resolved,
+            lambda client, specs: client.search_many_by_embedding(
+                specs,
+                embed,
+                pre_limit,
+            ),
+        )
         return _merge_read_results(results)
 
     async def search_by_fulltext(
@@ -84,20 +130,28 @@ class ReadRouter:
             pre_limit: int,
             projection: NodeProjection | None = None,
     ) -> StorageReadResult:
-        tasks = [
-            self.backend_factory.get_read_client(
-                label,
-                StorageBackendType.TEXT_MAIN_READ,
-            ).search_by_fulltext(
-                label,
-                node_filter,
-                text,
-                pre_limit,
-                projection or DEFAULT_PROJECTION[label],
+        resolved = [
+            (
+                self.backend_factory.get_read_client(
+                    label,
+                    StorageBackendType.TEXT_MAIN_READ,
+                ),
+                NodeSearchSpec(
+                    label=label,
+                    node_filter=node_filter,
+                    projection=projection or DEFAULT_PROJECTION[label],
+                ),
             )
             for label, node_filter in node_filters.items()
         ]
-        results: list[StorageReadResult] = list(await asyncio.gather(*tasks))
+        results = await _run_grouped_search(
+            resolved,
+            lambda client, specs: client.search_many_by_fulltext(
+                specs,
+                text,
+                pre_limit,
+            ),
+        )
         return _merge_read_results(results)
 
     async def search_relationships_by_graph(

--- a/api/app/core/memory/storage/tests/test_elasticsearch_client.py
+++ b/api/app/core/memory/storage/tests/test_elasticsearch_client.py
@@ -8,7 +8,13 @@ from elasticsearch import AsyncElasticsearch
 
 from app.core.config import settings
 from app.core.memory.storage.enums import BackendType, MemoryNodeType
-from app.core.memory.storage.models import NodeFilter, NodeProjection, NodeSort
+from app.core.memory.storage.models import (
+    NodeFilter,
+    NodeProjection,
+    NodeSearchSpec,
+    NodeSort,
+    StorageReadResult,
+)
 from app.core.memory.storage.models.dto import StorageItem
 from app.core.memory.storage.provider.elasticsearch import index as elasticsearch_index
 from app.core.memory.storage.provider.elasticsearch.client import (
@@ -250,6 +256,7 @@ class _FakeElasticsearch:
         self.index_calls: list[dict[str, Any]] = []
         self.open_point_in_time_calls: list[dict[str, Any]] = []
         self.search_calls: list[dict[str, Any]] = []
+        self.msearch_calls: list[dict[str, Any]] = []
         self.close_point_in_time_calls: list[dict[str, Any]] = []
         self.update_by_query_calls: list[dict[str, Any]] = []
         self.delete_by_query_calls: list[dict[str, Any]] = []
@@ -262,6 +269,7 @@ class _FakeElasticsearch:
         self.open_point_in_time_result: dict[str, Any] = {"id": "pit-1"}
         self.search_result: dict[str, Any] = {"hits": {"hits": []}}
         self.search_results: list[dict[str, Any]] = []
+        self.msearch_result: dict[str, Any] = {"responses": []}
         self.index_result: dict[str, Any] = {"result": "created"}
         self.update_result: dict[str, Any] | None = None
         self.delete_result: dict[str, Any] | None = None
@@ -289,6 +297,10 @@ class _FakeElasticsearch:
 
             return self.search_results.pop(0)
         return self.search_result
+
+    async def msearch(self, **kwargs: Any) -> dict[str, Any]:
+        self.msearch_calls.append(kwargs)
+        return self.msearch_result
 
     async def close_point_in_time(self, **kwargs: Any) -> dict[str, bool]:
         self.close_point_in_time_calls.append(kwargs)
@@ -1775,6 +1787,269 @@ async def test_elastic_client_fulltext_search_uses_multi_match_filter_and_score(
             data={"id": "entity-1", "score": 3.25},
         ),
     ]
+
+
+async def test_elastic_client_fulltext_msearch_preserves_spec_order() -> None:
+    fake = _FakeElasticsearch()
+    fake.msearch_result = {
+        "responses": [
+            {
+                "hits": {
+                    "hits": [
+                        {"_source": {"id": "statement-1"}, "_score": 2.5},
+                    ]
+                }
+            },
+            {
+                "hits": {
+                    "hits": [
+                        {"_source": {"id": "chunk-1"}, "_score": 1.5},
+                    ]
+                }
+            },
+        ]
+    }
+    client = ElasticClient()
+    client.client = _as_elasticsearch(fake)
+    specs = [
+        NodeSearchSpec(
+            MemoryNodeType.STATEMENT,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id", "score"),
+        ),
+        NodeSearchSpec(
+            MemoryNodeType.CHUNK,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id"),
+        ),
+    ]
+
+    results = await client.search_many_by_fulltext(specs, "  memory  ", 3)
+
+    assert fake.msearch_calls == [
+        {
+            "searches": [
+                {
+                    "index": get_index_name(MemoryNodeType.STATEMENT),
+                    "allow_partial_search_results": False,
+                },
+                {
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "multi_match": {
+                                        "query": "memory",
+                                        "fields": ["statement"],
+                                    }
+                                }
+                            ],
+                            "filter": [
+                                {
+                                    "bool": {
+                                        "filter": [
+                                            {
+                                                "term": {
+                                                    "end_user_id": "user-1"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                        }
+                    },
+                    "size": 3,
+                    "_source": ["id"],
+                },
+                {
+                    "index": get_index_name(MemoryNodeType.CHUNK),
+                    "allow_partial_search_results": False,
+                },
+                {
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "multi_match": {
+                                        "query": "memory",
+                                        "fields": ["content"],
+                                    }
+                                }
+                            ],
+                            "filter": [
+                                {
+                                    "bool": {
+                                        "filter": [
+                                            {
+                                                "term": {
+                                                    "end_user_id": "user-1"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                        }
+                    },
+                    "size": 3,
+                    "_source": ["id"],
+                },
+            ],
+            "max_concurrent_searches": 2,
+        }
+    ]
+    assert results == [
+        StorageReadResult.from_items(
+            [{"id": "statement-1", "score": 2.5}],
+            label=MemoryNodeType.STATEMENT,
+            backend=BackendType.ELASTIC,
+        ),
+        StorageReadResult.from_items(
+            [{"id": "chunk-1"}],
+            label=MemoryNodeType.CHUNK,
+            backend=BackendType.ELASTIC,
+        ),
+    ]
+
+
+async def test_elastic_client_embedding_msearch_uses_knn_and_transforms_score() -> None:
+    fake = _FakeElasticsearch()
+    fake.msearch_result = {
+        "responses": [
+            {
+                "hits": {
+                    "hits": [
+                        {"_source": {"id": "statement-1"}, "_score": 0.9},
+                    ]
+                }
+            },
+            {
+                "hits": {
+                    "hits": [
+                        {"_source": {"id": "chunk-1"}, "_score": 0.75},
+                    ]
+                }
+            },
+        ]
+    }
+    client = ElasticClient()
+    client.client = _as_elasticsearch(fake)
+    specs = [
+        NodeSearchSpec(
+            MemoryNodeType.STATEMENT,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id", "score"),
+        ),
+        NodeSearchSpec(
+            MemoryNodeType.CHUNK,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id", "score"),
+        ),
+    ]
+
+    results = await client.search_many_by_embedding(
+        specs,
+        [0.1, 0.2],
+        2,
+    )
+
+    searches = fake.msearch_calls[0]["searches"]
+    assert fake.msearch_calls[0]["max_concurrent_searches"] == 2
+    assert searches[0] == {
+        "index": get_index_name(MemoryNodeType.STATEMENT),
+        "allow_partial_search_results": False,
+    }
+    assert searches[1] == {
+        "knn": {
+            "field": "statement_embedding",
+            "query_vector": [0.1, 0.2],
+            "k": 2,
+            "num_candidates": 100,
+            "filter": {
+                "bool": {
+                    "filter": [{"term": {"end_user_id": "user-1"}}]
+                }
+            },
+        },
+        "size": 2,
+        "_source": ["id"],
+    }
+    assert searches[2]["index"] == get_index_name(MemoryNodeType.CHUNK)
+    assert searches[3]["knn"]["field"] == "chunk_embedding"
+    assert results[0].items[0].data == {
+        "id": "statement-1",
+        "score": pytest.approx(0.8),
+    }
+    assert results[1].items[0].data == {
+        "id": "chunk-1",
+        "score": pytest.approx(0.5),
+    }
+
+
+@pytest.mark.parametrize(
+    ("msearch_result", "error_pattern"),
+    [
+        ({}, "invalid responses"),
+        ({"responses": []}, "response count mismatch"),
+        (
+            {
+                "responses": [
+                    {
+                        "error": {
+                            "type": "search_phase_execution_exception",
+                            "reason": "boom",
+                        },
+                        "status": 500,
+                    }
+                ]
+            },
+            "failed for Statement",
+        ),
+    ],
+)
+async def test_elastic_client_msearch_rejects_invalid_or_failed_response(
+        msearch_result: dict[str, Any],
+        error_pattern: str,
+) -> None:
+    fake = _FakeElasticsearch()
+    fake.msearch_result = msearch_result
+    client = ElasticClient()
+    client.client = _as_elasticsearch(fake)
+    specs = [
+        NodeSearchSpec(
+            MemoryNodeType.STATEMENT,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id"),
+        )
+    ]
+
+    with pytest.raises(RuntimeError, match=error_pattern):
+        await client.search_many_by_fulltext(specs, "memory", 2)
+
+
+async def test_elastic_client_msearch_skips_blank_text_and_zero_vector() -> None:
+    fake = _FakeElasticsearch()
+    client = ElasticClient()
+    client.client = _as_elasticsearch(fake)
+    specs = [
+        NodeSearchSpec(
+            MemoryNodeType.STATEMENT,
+            NodeFilter.eq("end_user_id", "user-1"),
+            NodeProjection.of("id"),
+        )
+    ]
+
+    fulltext = await client.search_many_by_fulltext(specs, "   ", 2)
+    embedding = await client.search_many_by_embedding(
+        specs,
+        [0.0, 0.0],
+        2,
+    )
+
+    assert fulltext == [StorageReadResult(backend=BackendType.ELASTIC)]
+    assert embedding == [StorageReadResult(backend=BackendType.ELASTIC)]
+    assert fake.msearch_calls == []
 
 
 async def test_elastic_client_search_supports_score_only_projection() -> None:

--- a/api/app/core/memory/storage/tests/test_filters.py
+++ b/api/app/core/memory/storage/tests/test_filters.py
@@ -63,7 +63,7 @@ def test_filter_condition_rejects_non_portable_values(
         FilterCondition(field="status", operator=operator, value=value)
 
 
-def test_neo4j_filter_is_fully_parameterized() -> None:
+def test_neo4j_filter_escapes_identifiers_and_parameterizes_values() -> None:
     unsafe_field = "status`) MATCH (x) //"
     node_filter = NodeFilter(
         conditions=(
@@ -75,14 +75,12 @@ def test_neo4j_filter_is_fully_parameterized() -> None:
     predicate, parameters = compile_neo4j_filter(node_filter)
 
     assert predicate == (
-        "(n[$filter_0_field] = $filter_0_value) AND "
-        "(n[$filter_1_field] >= $filter_1_value)"
+        "(n.`status``) MATCH (x) //` = $filter_0_value) AND "
+        "(n.`score` >= $filter_1_value)"
     )
     assert unsafe_field not in predicate
     assert parameters == {
-        "filter_0_field": unsafe_field,
         "filter_0_value": "active",
-        "filter_1_field": "score",
         "filter_1_value": 10,
     }
 
@@ -108,7 +106,7 @@ def test_neo4j_filter_supports_or_in_and_missing_checks() -> None:
 
     assert " OR " in predicate
     assert " IN $filter_0_value" in predicate
-    assert "n[$filter_1_field] IS NULL" in predicate
+    assert "n.`deleted_at` IS NULL" in predicate
     assert set(parameters["filter_0_value"]) == {"active", "pending"}
 
 
@@ -333,14 +331,12 @@ async def test_neo4j_delete_relationship_uses_scoped_filter() -> None:
 
     query, parameters = driver.calls[0]
     assert "[r:`RELATES_TO`]" in query
-    assert "r[$relationship_filter_relationship_0_field]" in query
-    assert "source[$relationship_filter_source_0_field]" in query
+    assert "r.`id`" in query
+    assert "source.`tenant_id`" in query
     assert "DELETE r" in query
     assert "RETURN relationship_id, properties" in query
     assert parameters == {
-        "relationship_filter_relationship_0_field": "id",
         "relationship_filter_relationship_0_value": "edge-1",
-        "relationship_filter_source_0_field": "tenant_id",
         "relationship_filter_source_0_value": "tenant-1",
     }
     assert result.backend == BackendType.NEO4J
@@ -425,11 +421,10 @@ async def test_neo4j_update_node_uses_custom_filter_without_data_id() -> None:
 
     query, parameters = driver.calls[0]
     assert "MATCH (n:Test)" in query
-    assert "WHERE (n[$filter_0_field] = $filter_0_value)" in query
+    assert "WHERE (n.`external_id` = $filter_0_value)" in query
     assert "MERGE" not in query
     assert parameters == {
         "properties": {"change": True},
-        "filter_0_field": "external_id",
         "filter_0_value": "node-1",
     }
     assert result.backend == BackendType.NEO4J
@@ -455,16 +450,13 @@ def test_neo4j_filter_supports_nested_boolean_groups() -> None:
     predicate, parameters = compile_neo4j_filter(node_filter)
 
     assert predicate == (
-        "(n[$filter_0_field] = $filter_0_value) AND "
-        "((n[$filter_1_0_field] = $filter_1_0_value) OR "
-        "(n[$filter_1_1_field] IN $filter_1_1_value))"
+        "(n.`tenant_id` = $filter_0_value) AND "
+        "((n.`status` = $filter_1_0_value) OR "
+        "(n.`priority` IN $filter_1_1_value))"
     )
     assert parameters == {
-        "filter_0_field": "tenant_id",
         "filter_0_value": "tenant-1",
-        "filter_1_0_field": "status",
         "filter_1_0_value": "pending",
-        "filter_1_1_field": "priority",
         "filter_1_1_value": ["high", "urgent"],
     }
 
@@ -509,9 +501,8 @@ def test_neo4j_filter_uses_cypher_not_in_syntax() -> None:
 
     predicate, parameters = compile_neo4j_filter(node_filter)
 
-    assert predicate == "(NOT n[$filter_0_field] IN $filter_0_value)"
+    assert predicate == "(NOT n.`status` IN $filter_0_value)"
     assert parameters == {
-        "filter_0_field": "status",
         "filter_0_value": ["deleted", "ignored"],
     }
 
@@ -556,10 +547,9 @@ async def test_neo4j_get_node_uses_selected_field_projection() -> None:
     )
 
     query, parameters = driver.calls[0]
-    assert "WHERE (n[$filter_0_field] = $filter_0_value)" in query
+    assert "WHERE (n.`id` = $filter_0_value)" in query
     assert "RETURN n { .`id`, .`name` } AS n" in query
     assert parameters == {
-        "filter_0_field": "id",
         "filter_0_value": 1,
     }
 
@@ -711,7 +701,6 @@ async def test_neo4j_get_node_sorts_before_projecting_fields() -> None:
     assert "RETURN n { .`id` } AS n" in query
     assert query.index("ORDER BY") < query.index("RETURN")
     assert parameters == {
-        "filter_0_field": "category",
         "filter_0_value": "sort-test",
         "sort_0_field": "score",
         "sort_1_field": "id",
@@ -769,17 +758,15 @@ async def test_neo4j_delete_node_uses_parameterized_filter_and_returns_ids() -> 
     query, parameters = driver.calls[0]
     assert "MATCH (n:Test)" in query
     assert (
-        "WHERE (n[$filter_0_field] = $filter_0_value) AND "
-        "(n[$filter_1_field] = $filter_1_value)"
+        "WHERE (n.`external_id``) DETACH DELETE all //` = $filter_0_value) AND "
+        "(n.`tenant_id` = $filter_1_value)"
     ) in query
     assert "WITH n, n.id AS id" in query
     assert "DETACH DELETE n" in query
     assert "RETURN id" in query
     assert unsafe_field not in query
     assert parameters == {
-        "filter_0_field": unsafe_field,
         "filter_0_value": "node-1",
-        "filter_1_field": "tenant_id",
         "filter_1_value": "tenant-1",
     }
     assert result.backend == BackendType.NEO4J
@@ -805,17 +792,15 @@ async def test_neo4j_delete_node_draft_sets_delete_at_without_detaching() -> Non
     query, parameters = driver.calls[0]
     assert "MATCH (n:Test)" in query
     assert (
-        "WHERE ((n[$filter_0_field] = $filter_0_value) OR "
-        "(n[$filter_1_field] = $filter_1_value)) "
+        "WHERE ((n.`external_id` = $filter_0_value) OR "
+        "(n.`external_id` = $filter_1_value)) "
         "AND n.delete_at IS NULL"
     ) in query
     assert "SET n.delete_at = datetime()" in query
     assert "DETACH DELETE" not in query
     assert "RETURN n.id AS id" in query
     assert parameters == {
-        "filter_0_field": "external_id",
         "filter_0_value": "node-1",
-        "filter_1_field": "external_id",
         "filter_1_value": "node-2",
     }
     assert result.backend == BackendType.NEO4J
@@ -1045,7 +1030,6 @@ async def test_neo4j_get_node_passes_coalesce_default_as_parameter() -> None:
         "coalesce(n.`nickname`, n.`name`, $projection_0_default) } AS n"
     ) in query
     assert parameters == {
-        "filter_0_field": "id",
         "filter_0_value": 1,
         "projection_0_default": "Unknown",
     }
@@ -1105,7 +1089,6 @@ async def test_neo4j_get_relationship_uses_pattern() -> None:
     )
     assert "ORDER BY target[$sort_0_field] DESC" in cypher
     assert parameters == {
-        "relationship_filter_source_0_field": "id",
         "relationship_filter_source_0_value": "source-1",
         "sort_0_field": "created_at",
     }
@@ -1181,7 +1164,6 @@ async def test_neo4j_relationship_projection_and_sort_keep_all_variables() -> No
     assert cypher.index("WITH source, r, target") < cypher.index("ORDER BY")
     assert cypher.index("ORDER BY") < cypher.index("RETURN")
     assert parameters == {
-        "relationship_filter_source_0_field": "id",
         "relationship_filter_source_0_value": "source-1",
         "sort_0_field": "created_at",
         "sort_1_field": "weight",

--- a/api/app/schemas/user_schema.py
+++ b/api/app/schemas/user_schema.py
@@ -114,3 +114,6 @@ class User(UserBase):
             return int(v)
         return v
 
+
+class UserSnap(BaseModel):
+    id: uuid.UUID

--- a/api/app/services/memory_config_service.py
+++ b/api/app/services/memory_config_service.py
@@ -1044,6 +1044,7 @@ class MemoryConfigService:
         config_id = self.get_workspace_active_config_id(end_user.workspace_id)
         return config_id
 
+    @redis_cache(prefix="memory_config", skip_args=["self"], id_arg="end_user_id", return_type=uuid.UUID)
     async def get_config_id_by_end_user_async(
             self,
             end_user_id: uuid.UUID | str,


### PR DESCRIPTION
## Sourcery 摘要

通过批量多查询搜索和针对性缓存提高记忆检索效率，同时加强 Neo4j 查询安全性。

新功能：
- 支持跨多个记忆节点类型的批量全文搜索和向量搜索，包括 Elasticsearch 多重搜索支持。
- 缓存经过验证的最终用户快照、记忆配置查询结果和嵌入生成结果。

错误修复：
- 安全转义 Neo4j 过滤器字段标识符，同时继续对过滤值使用参数化处理。

改进：
- 按后端对存储搜索进行分组，同时保留结果顺序；对于不支持原生批处理的提供商，提供并发回退支持。

测试：
- 增加对 Elasticsearch 批量搜索构建、结果排序、分数处理、空查询行为和响应验证的测试覆盖。
- 更新 Neo4j 过滤器测试，覆盖已转义的标识符和参数化值。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过批量搜索和针对性缓存，提升记忆检索性能与查询安全性。

新功能：
- 支持跨多种记忆节点类型的批量全文搜索和向量搜索，包括 Elasticsearch 多重搜索支持。
- 缓存经过验证的终端用户快照、记忆配置查找结果和生成的嵌入向量。

错误修复：
- 对 Neo4j 过滤器字段标识符进行转义，同时保留参数化的过滤器值，以防止查询注入。

增强功能：
- 按后端对存储搜索进行分组，同时保留结果顺序；对于不支持原生批量搜索的提供商，提供并发回退批处理。

测试：
- 扩展 Elasticsearch 批量搜索测试范围，涵盖查询构建、排序、分数转换、空输入和响应验证。
- 更新 Neo4j 过滤器测试，覆盖已转义的标识符和参数化值。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过批量搜索和针对性缓存，提升内存检索性能并增强查询安全性。

新功能：
- 支持跨多种内存节点类型的批量全文搜索和向量搜索，包括原生 Elasticsearch 多重搜索支持。
- 缓存经过验证的最终用户快照、内存配置查询结果和生成的嵌入向量。

错误修复：
- 对 Neo4j 过滤器字段标识符进行转义，同时保留参数化过滤器值，以防止查询注入。

改进：
- 按后端对存储搜索进行分组，同时保留结果顺序；对于不支持原生批量搜索的提供商，使用并发回退批处理。

测试：
- 扩展 Elasticsearch 批量搜索测试覆盖范围，包括查询构造、排序、分数转换、空输入和响应验证。
- 更新 Neo4j 过滤器测试，覆盖转义后的标识符和参数化值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve memory retrieval performance and query safety with batched searches and targeted caching.

New Features:
- Add batched full-text and vector search across multiple memory node types, including native Elasticsearch multi-search support.
- Cache validated end-user snapshots, memory configuration lookups, and generated embeddings.

Bug Fixes:
- Escape Neo4j filter field identifiers while retaining parameterized filter values to prevent query injection.

Enhancements:
- Group storage searches by backend while preserving result order, with concurrent fallback batching for providers without native support.

Tests:
- Expand Elasticsearch batch-search coverage for query construction, ordering, score conversion, empty inputs, and response validation.
- Update Neo4j filter tests for escaped identifiers and parameterized values.

</details>

</details>

</details>