### PR TITLE
refactor(liteskill): make admin client async with shared httpx client

### DIFF
--- a/api/app/services/liteskill_admin_client.py
+++ b/api/app/services/liteskill_admin_client.py
@@ -6,10 +6,26 @@
 等写入接口。携带服务凭证 ``X-Internal-Token`` 以证明"请求来自 Enterprise"，
 并透传 admin_id / request_id 用于链路追踪。参照 ``speedbear_gateway_client``
 的错误映射范式。
+
+实现约束：
+- 全部方法为 ``async``：适配层端点为 ``async def``，若在此处做同步阻塞的
+  HTTP 调用会卡死事件循环（LiteSkill 变慢/挂起时每次最长阻塞
+  ``LITESKILL_TIMEOUT`` 秒），因此底层统一使用 ``httpx.AsyncClient``。
+- 客户端实例按请求创建，但底层 ``httpx.AsyncClient`` 在模块级共享复用，
+  避免每次请求新建 TCP/TLS 连接；共享实例绑定创建它的运行事件循环，
+  loop 变化时自动重建（覆盖 uvicorn reload / 测试多 loop 场景）。
+  进程退出前由应用 lifespan 调用 :func:`aclose_shared_client` 释放。
+- 异常统一抛 :class:`LiteSkillAdminError`，按失败类别标记 ``category``，
+  供适配层 ``_gateway_error`` 做对外状态码映射：
+    ``upstream``  — 上游返回了 HTTP 状态（4xx/5xx/3xx），携带原始状态码
+    ``transport`` — 网络错误 / 超时（未获得 HTTP 响应）
+    ``config``    — 本端配置问题（未配置 token / 响应非 JSON，疑似 URL 配错）
+    ``business``  — 上游 HTTP 2xx 但信封 ``code != OK``（业务拒绝）
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -17,14 +33,82 @@ import httpx
 from app.core.config import settings
 
 
-class LiteSkillAdminError(Exception):
-    """LiteSkill 内部接口调用异常。"""
+class LiteSkillAdminErrorCategory:
+    """LiteSkill 内部接口调用失败的类别（供适配层做对外映射）。"""
 
-    def __init__(self, message: str, *, status_code: int | None = None, payload: Any = None):
+    #: 上游返回了 HTTP 状态码（4xx / 5xx / 3xx）
+    UPSTREAM = "upstream"
+    #: 网络错误 / 超时，未获得 HTTP 响应
+    TRANSPORT = "transport"
+    #: 本端配置问题（未配置 token / 响应非 JSON，疑似 LITESKILL_BASE_URL 配错）
+    CONFIG = "config"
+    #: 上游 HTTP 2xx 但信封 code != OK（业务拒绝）
+    BUSINESS = "business"
+
+
+class LiteSkillAdminError(Exception):
+    """LiteSkill 内部接口调用异常。
+
+    Attributes:
+        message: 人读提示
+        category: 失败类别，见 :class:`LiteSkillAdminErrorCategory`
+        status_code: 上游 HTTP 状态码；``category == UPSTREAM`` 时有值，
+            其余类别通常为 ``None``
+        payload: 上游响应体（若可解析为 JSON）
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        category: str = LiteSkillAdminErrorCategory.UPSTREAM,
+        payload: Any = None,
+    ):
         super().__init__(message)
         self.message = message
         self.status_code = status_code
+        self.category = category
         self.payload = payload
+
+
+#: 模块级共享 AsyncClient（懒创建、绑定当前运行事件循环）
+_shared_client: httpx.AsyncClient | None = None
+_shared_client_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_shared_client(timeout: float) -> httpx.AsyncClient:
+    """取共享 AsyncClient；绑定创建时的运行 loop，loop 变化则重建。
+
+    重建时旧实例直接丢给 GC——旧实例通常绑定已结束的 loop（uvicorn reload /
+    测试切换 loop），无需也不能在其上发起关闭。
+    """
+    global _shared_client, _shared_client_loop
+    loop = asyncio.get_running_loop()
+    if _shared_client is None or _shared_client_loop is not loop:
+        _shared_client = httpx.AsyncClient(timeout=timeout, follow_redirects=False)
+        _shared_client_loop = loop
+    return _shared_client
+
+
+async def aclose_shared_client() -> None:
+    """关闭共享 AsyncClient（应用 shutdown 时调用；未创建则 no-op）。
+
+    仅在当前运行 loop 与创建时一致时才执行真正的 ``aclose``；loop 已切换
+    （如 uvicorn reload 后旧进程退出）则直接丢弃引用，交由解释器回收。
+    """
+    global _shared_client, _shared_client_loop
+    if _shared_client is None:
+        return
+    client = _shared_client
+    bound_loop = _shared_client_loop
+    _shared_client = None
+    _shared_client_loop = None
+    try:
+        if asyncio.get_running_loop() is bound_loop:
+            await client.aclose()
+    except RuntimeError:
+        pass  # 无运行 loop（进程退出中），交由解释器回收
 
 
 class LiteSkillAdminClient:
@@ -36,10 +120,10 @@ class LiteSkillAdminClient:
         self.timeout = settings.LITESKILL_TIMEOUT
 
     # ── 业务便捷方法 ──────────────────────────────────────────────
-    def overview(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
-        return self._get("/internal/admin/memory-lite/overview", lang=lang, admin_id=admin_id, request_id=request_id)
+    async def overview(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return await self._get("/internal/admin/memory-lite/overview", lang=lang, admin_id=admin_id, request_id=request_id)
 
-    def users(
+    async def users(
         self,
         *,
         page: int = 1,
@@ -55,7 +139,7 @@ class LiteSkillAdminClient:
             params["keyword"] = keyword
         if status:
             params["status"] = status
-        return self._get(
+        return await self._get(
             "/internal/admin/memory-lite/users",
             params=params,
             lang=lang,
@@ -63,18 +147,18 @@ class LiteSkillAdminClient:
             request_id=request_id,
         )
 
-    def user_detail(self, account_id: str, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
-        return self._get(
+    async def user_detail(self, account_id: str, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return await self._get(
             f"/internal/admin/memory-lite/users/{account_id}",
             lang=lang,
             admin_id=admin_id,
             request_id=request_id,
         )
 
-    def products(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
-        return self._get("/internal/admin/memory-lite/products", lang=lang, admin_id=admin_id, request_id=request_id)
+    async def products(self, *, lang: str | None = None, admin_id: str = "", request_id: str = "") -> Any:
+        return await self._get("/internal/admin/memory-lite/products", lang=lang, admin_id=admin_id, request_id=request_id)
 
-    def update_product(
+    async def update_product(
         self,
         body: dict[str, Any],
         *,
@@ -83,7 +167,7 @@ class LiteSkillAdminClient:
         request_id: str = "",
     ) -> Any:
         """修改预设包（POST，目标 id 在 body 内）。"""
-        return self._request(
+        return await self._request(
             "POST",
             "/internal/admin/memory-lite/products/update",
             json=body,
@@ -92,7 +176,7 @@ class LiteSkillAdminClient:
             request_id=request_id,
         )
 
-    def create_product(
+    async def create_product(
         self,
         body: dict[str, Any],
         *,
@@ -100,7 +184,7 @@ class LiteSkillAdminClient:
         admin_id: str = "",
         request_id: str = "",
     ) -> Any:
-        return self._request(
+        return await self._request(
             "POST",
             "/internal/admin/memory-lite/products/create",
             json=body,
@@ -109,7 +193,7 @@ class LiteSkillAdminClient:
             request_id=request_id,
         )
 
-    def recharge_write_quota(
+    async def recharge_write_quota(
         self,
         body: dict[str, Any],
         *,
@@ -118,7 +202,7 @@ class LiteSkillAdminClient:
         request_id: str = "",
     ) -> Any:
         """给指定端用户加写入次数（POST，end_user_id + count 在 body 内）。"""
-        return self._request(
+        return await self._request(
             "POST",
             "/internal/admin/memory-lite/write-quota/recharge",
             json=body,
@@ -128,7 +212,7 @@ class LiteSkillAdminClient:
         )
 
     # ── 底层请求 ──────────────────────────────────────────────────
-    def _get(
+    async def _get(
         self,
         path: str,
         *,
@@ -137,11 +221,11 @@ class LiteSkillAdminClient:
         admin_id: str = "",
         request_id: str = "",
     ) -> Any:
-        return self._request(
+        return await self._request(
             "GET", path, params=params, lang=lang, admin_id=admin_id, request_id=request_id
         )
 
-    def _request(
+    async def _request(
         self,
         method: str,
         path: str,
@@ -161,15 +245,19 @@ class LiteSkillAdminClient:
         try:
             # 禁止自动跟随重定向：内部管理接口本不应发生重定向，
             # 若跟随跨域重定向会把 X-Internal-Token 内部服务凭证泄露给重定向目标主机。
-            with httpx.Client(timeout=self.timeout, follow_redirects=False) as client:
-                response = client.request(
-                    method.upper(), url, headers=headers, params=request_params, json=json
-                )
+            client = _get_shared_client(self.timeout)
+            response = await client.request(
+                method.upper(), url, headers=headers, params=request_params, json=json
+            )
             if response.is_redirect:
+                # 先消费响应体再抛错：未读完的 body 会让 httpx 关闭该连接，
+                # 无法归还 keep-alive 池复用；3xx 响应体通常为空，读取开销可忽略。
+                await response.aread()
                 raise LiteSkillAdminError(
                     f"LiteSkill 接口返回意外重定向: {response.status_code} -> "
                     f"{response.headers.get('location', '')}",
                     status_code=response.status_code,
+                    category=LiteSkillAdminErrorCategory.UPSTREAM,
                 )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -177,17 +265,24 @@ class LiteSkillAdminClient:
             raise LiteSkillAdminError(
                 self._extract_msg(payload) or f"LiteSkill 接口请求失败: {exc.response.status_code}",
                 status_code=exc.response.status_code,
+                category=LiteSkillAdminErrorCategory.UPSTREAM,
                 payload=payload,
             ) from exc
         except httpx.HTTPError as exc:
-            raise LiteSkillAdminError(f"LiteSkill 网络请求失败: {exc}") from exc
+            raise LiteSkillAdminError(
+                f"LiteSkill 网络请求失败: {exc}",
+                category=LiteSkillAdminErrorCategory.TRANSPORT,
+            ) from exc
 
         payload = self._safe_json(response)
         return self._unwrap(payload)
 
     def _build_headers(self, *, admin_id: str, request_id: str, lang: str | None) -> dict[str, str]:
         if not self.token:
-            raise LiteSkillAdminError("未配置 LITESKILL_INTERNAL_TOKEN")
+            raise LiteSkillAdminError(
+                "未配置 LITESKILL_INTERNAL_TOKEN，请检查环境变量",
+                category=LiteSkillAdminErrorCategory.CONFIG,
+            )
         headers = {"X-Internal-Token": self.token}
         if admin_id:
             headers["X-Admin-Id"] = admin_id
@@ -216,8 +311,9 @@ class LiteSkillAdminClient:
 
         HTTP 2xx 不代表业务成功：LiteSkill 可能在成功状态码下返回
         ``code != "OK"`` 的业务错误信封。此处先校验 ``code``，非 OK 时
-        以信封中的 ``msg`` 抛出 :class:`LiteSkillAdminError`，避免调用方把
-        错误数据当成功结果消费。
+        以信封中的 ``msg`` 抛出 :class:`LiteSkillAdminError`
+        （category=BUSINESS，不代表服务不可用），避免调用方把错误数据
+        当成功结果消费。
         """
         if isinstance(payload, dict) and "code" in payload:
             code = payload.get("code")
@@ -226,6 +322,7 @@ class LiteSkillAdminClient:
                     LiteSkillAdminClient._extract_msg(payload)
                     or f"LiteSkill 接口返回业务错误: {code}",
                     payload=payload,
+                    category=LiteSkillAdminErrorCategory.BUSINESS,
                 )
         if isinstance(payload, dict) and "data" in payload:
             return payload["data"]

--- a/api/app/services/liteskill_admin_client.py
+++ b/api/app/services/liteskill_admin_client.py
@@ -249,12 +249,12 @@ class LiteSkillAdminClient:
             response = await client.request(
                 method.upper(), url, headers=headers, params=request_params, json=json
             )
-            if response.is_redirect:
-                # 先消费响应体再抛错：未读完的 body 会让 httpx 关闭该连接，
-                # 无法归还 keep-alive 池复用；3xx 响应体通常为空，读取开销可忽略。
+            if 300 <= response.status_code < 400:
+                # 拒绝全部 3xx：内部接口不应出现任何重定向/未修改等响应。
+                # 先消费响应体再抛错，保证连接归还 keep-alive 池。
                 await response.aread()
                 raise LiteSkillAdminError(
-                    f"LiteSkill 接口返回意外重定向: {response.status_code} -> "
+                    f"LiteSkill 接口返回意外 3xx 状态: {response.status_code} -> "
                     f"{response.headers.get('location', '')}",
                     status_code=response.status_code,
                     category=LiteSkillAdminErrorCategory.UPSTREAM,


### PR DESCRIPTION
Convert LiteSkillAdminClient methods to async, reusing a module-level httpx.AsyncClient bound to the running event loop. Classify failures (upstream/transport/config/business) for adapter status mapping and consume redirect bodies before raising.

## Sourcery 摘要

使 LiteSkill 管理客户端支持异步操作，并复用共享的 HTTP 连接，同时对错误进行分类处理。

错误修复：
- 确保在引发错误前读取重定向响应正文，以便复用共享连接。

功能增强：
- 使用与事件循环关联的共享 HTTP 客户端，将 LiteSkill 管理操作转换为异步调用。
- 将 LiteSkill 故障分类为上游错误、传输错误、配置错误或业务错误，以便统一映射适配器状态。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 LiteSkill 管理客户端改为异步，并复用共享的 HTTP 连接，同时对失败进行结构化分类。

错误修复：
- 确保在引发错误前读取重定向响应正文，以便复用共享连接。

增强功能：
- 使用与共享事件循环绑定的 HTTP 客户端，将 LiteSkill 管理操作转换为异步调用。
- 将 LiteSkill 失败分类为上游错误、传输错误、配置错误或业务错误，以便适配器统一映射状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the LiteSkill admin client asynchronous with shared HTTP connection reuse and structured failure classification.

Bug Fixes:
- Ensure redirect response bodies are consumed before raising errors so shared connections can be reused.

Enhancements:
- Convert LiteSkill admin operations to asynchronous calls using a shared event-loop-bound HTTP client.
- Classify LiteSkill failures as upstream, transport, configuration, or business errors for consistent adapter status mapping.

</details>

</details>