### PR TITLE
fix(memory): dispatch same-seq duplicate rows to avoid dialogue collisions

### DIFF
--- a/api/app/core/memory/agent/utils/get_dialogs.py
+++ b/api/app/core/memory/agent/utils/get_dialogs.py
@@ -18,6 +18,7 @@ async def get_chunked_dialogs(
         conversation_id: str = "",
         message_seq: int = 0,
         source: str = "",
+        dialogue_id_suffix: str = "",  # 同 seq 撞号消歧后缀（行级）；空串=规范 id
 ) -> List[DialogData]:
     """Generate chunks from structured messages using the specified chunker strategy.
 
@@ -83,7 +84,12 @@ async def get_chunked_dialogs(
     # 及所有引用 dialog_data.id 的子节点（Chunk/Assistant*/MemorySummary 的 dialog_id）天然一致，
     # 由正写覆盖升级快写占位节点。缺少分组信息（如试运行）时省略 id，回退模型默认的随机 uuid。
     if conversation_id or source:
-        dialog_kwargs["id"] = build_dialogue_id(conversation_id, message_seq, source, end_user_id)
+        _dialog_id = build_dialogue_id(conversation_id, message_seq, source, end_user_id)
+        if dialogue_id_suffix:
+            # 同 seq 撞号且非首条时附加行级后缀，避免与首条共用同一 Dialogue id
+            # 而在下游被覆盖/去重吞掉。
+            _dialog_id = f"{_dialog_id}#{dialogue_id_suffix}"
+        dialog_kwargs["id"] = _dialog_id
     dialog_data = DialogData(**dialog_kwargs)
 
 # step3： 分块

--- a/api/app/core/memory/pipelines/dispatcher.py
+++ b/api/app/core/memory/pipelines/dispatcher.py
@@ -766,27 +766,40 @@ async def dispatch_flush_conversation(conversation_id: str) -> int:
             return 0
         config_id = str(config_id_resolved)
 
-        # Step 3: 逐条处理
+        # Step 3: 按 seq 分组逐组处理。
+        # 每组只 claim 一次 cursor；组内 role=user + should_memorize=TRUE 的行
+        # 逐行派发（同 seq 撞号时后续行附加行级 dialogue 后缀，不被下游覆盖），
+        # 其余角色/标记行仅推进游标，保证“入库即被处理”。
         dispatched = 0
         skipped_non_user = 0  # 因角色不是 user 或 should_memorize=False 被跳过（只推进游标）
-        for msg in pending_messages:
-            target_seq = msg["message_seq"]
+        group_start = 0
+        n_rows = len(pending_messages)
+        while group_start < n_rows:
+            target_seq = pending_messages[group_start]["message_seq"]
 
-            if msg["role"] != "user" or not msg["should_memorize"]:
+            group_end = group_start + 1
+            while group_end < n_rows and pending_messages[group_end]["message_seq"] == target_seq:
+                group_end += 1
+            group_msgs = pending_messages[group_start:group_end]
+            group_start = group_end
+
+            has_target = any(
+                m["role"] == "user" and m["should_memorize"] for m in group_msgs
+            )
+            if not has_target:
                 with get_db_context() as db:
                     MemoryMessageRepository(db).advance_write_cursor(conversation_id, target_seq)
                     db.commit()
-                skipped_non_user += 1
+                skipped_non_user += len(group_msgs)
                 continue
 
-            if await dispatch_single_message(
+            dispatched += await dispatch_single_message(
                 conversation_id=conversation_id,
                 target_seq=target_seq,
                 end_user_id=end_user_id,
                 config_id=config_id,
                 workspace_id=workspace_id,
-            ):
-                dispatched += 1
+            )
 
         # Step 4: 清理 pending_conversations Set（先删后校验，避免并发误删）
         safe_unmark_conversation_pending(conversation_id)
@@ -855,6 +868,23 @@ async def check_sliding_window_and_dispatch(
             )
             return
 
+        # 该 seq 若存在撞号多行（历史脏数据），按“整组逐行派发”处理：
+        # 组内 claim cursor 一次、首条用规范 id、后续 user 行带行级后缀，
+        # 避免后续行被 cursor 跳过后永远不被处理。无撞号时走下方原有单条路径。
+        with get_db_context() as db:
+            repo = MemoryMessageRepository(db)
+            seq_rows = repo.get_seq_group(conversation_id, target_seq)
+        if len(seq_rows) > 1:
+            await dispatch_single_message(
+                conversation_id=conversation_id,
+                target_seq=target_seq,
+                end_user_id=end_user_id,
+                config_id=config_id,
+                workspace_id=workspace_id,
+                language=language,
+            )
+            return
+
         # 先推进 cursor，确保同一条消息不会被后续调用（flush 或下次 ingest）重复派发。
         # advance_write_cursor 使用 WHERE write_cursor < seq，具有原子性保护。
         with get_db_context() as db:
@@ -900,45 +930,92 @@ async def dispatch_single_message(
     end_user_id: str,
     config_id: str,
     workspace_id: str,
-) -> bool:
-    """为单条 user 消息构建上下文并派发写入任务（Flush 路径使用）。"""
+    language: str = "zh",
+) -> int:
+    """整组派发同一个 message_seq（Flush 路径使用）。
+
+    正常无撞号时 1 组 1 条 user，行为与原单条派发一致。历史脏数据同 seq 多行时：
+      - claim cursor 一次，组内逐行派发，保证“入库即被处理”、后续行不被 cursor 吞掉；
+      - 组内首条 user 行使用规范 dialogue_id（Dialog_{conv}_{seq}），保持与快写/既有
+        覆盖语义一致；同组后续 user 行附加行级后缀（源自 memory_messages.id），使其
+        成为独立 Dialogue 节点，不被下游同 id 覆盖/去重；
+      - 上下文按“本组更早入库的行”前插，保持 1、2、3… 的先后顺序。
+
+    Returns:
+        派发的 user 任务数；0 表示无 user 目标，或 cursor 已被其他路径推进。
+    """
     from app.repositories.memory_message_repository import message_to_dict
 
     with get_db_context() as db:
         repo = MemoryMessageRepository(db)
-        target_orm = repo.get_by_seq(conversation_id, target_seq)
-        if target_orm is None:
-            return False
-        msg_dict = message_to_dict(target_orm)
-        context_before = [message_to_dict(m) for m in repo.build_context_before(conversation_id, target_seq)]
-        context_after = [message_to_dict(m) for m in repo.build_context_after(conversation_id, target_seq)]
+        group_rows = repo.get_seq_group(conversation_id, target_seq)
 
-    # 先推进 cursor，防止并发 flush 重复派发同一条消息
+    if not group_rows:
+        return 0
+
+    if len(group_rows) > 1:
+        logger.warning(
+            "[WriteDispatcher] 检测到同 seq 撞号多行，将整组逐行派发: "
+            "conv=%s, seq=%s, rows=%d",
+            conversation_id, target_seq, len(group_rows),
+        )
+
+    eligible = [r for r in group_rows if r.role == "user" and r.should_memorize]
+    if not eligible:
+        # 组内无 user 目标（例如纯 assistant 消息），由调用方负责推进游标。
+        return 0
+
+    # 先 claim 该 seq（WHERE write_cursor < seq 原子保护），
+    # 防止并发 flush / 滑动窗口重复派发整组。
     with get_db_context() as db:
-        repo = MemoryMessageRepository(db)
-        acquired = repo.advance_write_cursor(conversation_id, target_seq)
+        acquired = MemoryMessageRepository(db).advance_write_cursor(conversation_id, target_seq)
         db.commit()
 
     if not acquired:
         logger.info(
-            f"[WriteDispatcher] cursor 已被推进，跳过重复派发: "
+            f"[WriteDispatcher] cursor 已被推进，跳过整组重复派发: "
             f"conv={conversation_id}, seq={target_seq}"
         )
-        return False
+        return 0
 
-    await push_write_task(
-        end_user_id=end_user_id,
-        target_message=msg_dict,
-        context_before=context_before,
-        context_after=context_after,
-        config_id=config_id,
-        workspace_id=workspace_id,
-        conversation_id=conversation_id,
-        message_seq=target_seq,
-        source=MemoryMessageSource.AGENT.value,
-    )
+    # 基于 seq 的滑动窗口上下文（不含本组自身；组内更早的行下方前插补齐）
+    with get_db_context() as db:
+        repo = MemoryMessageRepository(db)
+        context_before_base = [
+            message_to_dict(m) for m in repo.build_context_before(conversation_id, target_seq)
+        ]
+        context_after = [
+            message_to_dict(m) for m in repo.build_context_after(conversation_id, target_seq)
+        ]
 
-    return True
+    group_dicts = [message_to_dict(r) for r in group_rows]
+    row_pos_by_id = {r.id: i for i, r in enumerate(group_rows)}
+    dispatched = 0
+    for k, row in enumerate(eligible):
+        row_pos = row_pos_by_id[row.id]
+        earlier_rows = group_dicts[:row_pos]
+        context_before = context_before_base + earlier_rows
+
+        target_dict = dict(group_dicts[row_pos])
+        # 组内第 1 个 user 行用规范 id；同 seq 撞号的后续 user 行加行级后缀。
+        if k > 0:
+            target_dict["_dialogue_suffix"] = f"m{str(row.id).replace('-', '')[:16]}"
+
+        await push_write_task(
+            end_user_id=end_user_id,
+            target_message=target_dict,
+            context_before=context_before,
+            context_after=context_after,
+            config_id=config_id,
+            workspace_id=workspace_id,
+            conversation_id=conversation_id,
+            message_seq=target_seq,
+            language=language,
+            source=MemoryMessageSource.AGENT.value,
+        )
+        dispatched += 1
+
+    return dispatched
 
 
 # ──────────────────────────────────────────────

--- a/api/app/core/memory/pipelines/write_pipeline.py
+++ b/api/app/core/memory/pipelines/write_pipeline.py
@@ -467,6 +467,9 @@ class WritePipeline:
                         conversation_id=conversation_id,
                         message_seq=message_seq,
                         source=source,
+                        # 同 seq 撞号时 dispatcher 会在 target_message 里附带该后缀，
+                        # 透传给 dialogue id 生成，避免后续行与首条共用同一节点 id。
+                        dialogue_id_suffix=target_message.get("_dialogue_suffix", ""),
                     )
                     # 注入剪枝记录到 dialog_data.metadata
                     if pruning_records:

--- a/api/app/repositories/memory_message_repository.py
+++ b/api/app/repositories/memory_message_repository.py
@@ -59,7 +59,9 @@ class MemoryMessageRepository:
         不同分组之间互不阻塞。详见设计文档 §3.3。
         """
         if conversation_id is not None:
-            lock_key = f"mm_seq:conv:{conversation_id}"
+            # 用 uuid.UUID() 归一化（大小写/连字符），与 _next_seq 的分组键对齐，
+            # 避免同一 conversation 因字符串格式不一致拿到不同锁导致并发撞号。
+            lock_key = f"mm_seq:conv:{uuid.UUID(conversation_id)}"
         else:
             lock_key = f"mm_seq:{end_user_id}:{source.value}"
         self.db.execute(
@@ -203,6 +205,30 @@ class MemoryMessageRepository:
                 MemoryMessage.message_seq == message_seq,
             )
         ).scalar_one_or_none()
+
+    def get_seq_group(
+        self,
+        conversation_id: str,
+        message_seq: int,
+    ) -> List[MemoryMessage]:
+        """返回同一 (conversation_id, message_seq) 的全部行，按入库时间升序。
+
+        正常状态每组仅 1 行；历史脏数据可能同 seq 多行。按 (created_at, id)
+        升序保证确定性，供“撞号整组逐行派发”使用：先入库的排前面（1、2、3…）。
+        """
+        return list(
+            self.db.scalars(
+                select(MemoryMessage)
+                .where(
+                    MemoryMessage.conversation_id == conversation_id,
+                    MemoryMessage.message_seq == message_seq,
+                )
+                .order_by(
+                    MemoryMessage.created_at.asc(),
+                    MemoryMessage.id.asc(),
+                )
+            ).all()
+        )
 
     def get_pending_messages(
         self,
@@ -465,7 +491,11 @@ class MemoryMessageRepository:
                     MemoryMessage.message_seq >= upper_bound,
                     MemoryMessage.message_seq < target_seq,
                 )
-                .order_by(MemoryMessage.message_seq.asc())
+                .order_by(
+                    MemoryMessage.message_seq.asc(),
+                    MemoryMessage.created_at.asc(),
+                    MemoryMessage.id.asc(),
+                )
             ).scalars().all()
         )
 
@@ -502,7 +532,11 @@ class MemoryMessageRepository:
                         MemoryMessage.conversation_id == conversation_id,
                         MemoryMessage.message_seq > target_seq,
                     )
-                    .order_by(MemoryMessage.message_seq.asc())
+                    .order_by(
+                        MemoryMessage.message_seq.asc(),
+                        MemoryMessage.created_at.asc(),
+                        MemoryMessage.id.asc(),
+                    )
                 ).scalars().all()
             )
 
@@ -516,7 +550,11 @@ class MemoryMessageRepository:
                     MemoryMessage.message_seq > target_seq,
                     MemoryMessage.message_seq <= lower_bound,
                 )
-                .order_by(MemoryMessage.message_seq.asc())
+                .order_by(
+                    MemoryMessage.message_seq.asc(),
+                    MemoryMessage.created_at.asc(),
+                    MemoryMessage.id.asc(),
+                )
             ).scalars().all()
         )
 


### PR DESCRIPTION
## Sourcery 摘要

通过分发每个符合条件的行并分配不同的对话标识，安全地处理重复的消息序列。

错误修复：
- 确保共享序列号的所有符合条件的用户消息都能被分发，而不会丢失或被覆盖。
- 为重复序列行中的后续行分配唯一 ID，防止对话 ID 冲突。
- 获取序列锁时规范化对话标识符，避免并发导致的序列冲突。

增强功能：
- 保持重复序列消息的确定性顺序和上下文，包括来自同一序列组的较早行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle duplicate message sequences safely by dispatching each eligible row and assigning distinct dialogue identities.

Bug Fixes:
- Ensure all eligible user messages sharing a sequence number are dispatched instead of being lost or overwritten.
- Prevent dialogue ID collisions for duplicate-sequence rows by assigning unique IDs to subsequent rows.
- Normalize conversation identifiers when acquiring sequence locks to avoid concurrency-related sequence collisions.

Enhancements:
- Preserve deterministic ordering and context for duplicate-sequence messages, including earlier rows from the same sequence group.

</details>