### PR TITLE
fix(rag): prefer knowledge error details over generic messages

### DIFF
--- a/api/app/integrations/knowledge/client.py
+++ b/api/app/integrations/knowledge/client.py
@@ -247,7 +247,7 @@ class KnowledgeServiceClient:
             if not isinstance(code, int):
                 raise KnowledgeProtocolError("Knowledge service envelope code must be an integer")
             if not 200 <= upstream.status_code < 300 or code != 0:
-                message = str(envelope.get("msg") or envelope.get("error") or "Knowledge error")
+                message = str(envelope.get("error") or envelope.get("msg") or "Knowledge error")
                 raise KnowledgeServiceError(upstream.status_code, code, message, trace_id)
             data = envelope.get("data")
             try:


### PR DESCRIPTION
Knowledge retrieval failures currently show a generic `msg` even when the service returns a specific `error`. Prefer non-empty `error`, then `msg`, then the existing default when constructing KnowledgeServiceError.

Scope: one expression in the API knowledge service client.

Validation: Python AST syntax validation and four cases covering specific error, empty error, missing error, and empty messages passed; git diff --check passed.

Risk: callers will see the existing service error detail instead of the generic message. Retrieval behavior and success handling are unchanged. External API Key routes, authentication, response schemas, and access scope are unchanged.

## Sourcery 总结

错误修复：
- 构建检索失败信息时，优先使用知识服务返回的具体且非空的错误详情，而不是通用消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prefer specific non-empty knowledge service error details over generic messages when constructing retrieval failures.

</details>