### PR TITLE
fix(rag): serialize document and metadata responses before session cleanup

### DIFF
--- a/mem-knowledge/src/api/routes/document.py
+++ b/mem-knowledge/src/api/routes/document.py
@@ -97,9 +97,10 @@ async def create_document(
 ) -> SuccessEnvelope[dict[str, Any]]:
     async with runtime.database.async_session() as db:
         document = await document_service.create_document(db, create_data, principal)
+        data = document_service.document_to_data(document)
     return _success(
         request,
-        document_service.document_to_data(document),
+        data,
         "Document creation successful",
     )
 

--- a/mem-knowledge/src/api/routes/knowledge_metadata.py
+++ b/mem-knowledge/src/api/routes/knowledge_metadata.py
@@ -139,9 +139,10 @@ async def create_metadata_field(
             principal.tenant_id,
             principal.actor_id,
         )
+        response = KnowledgeMetadataResponse.model_validate(field).model_dump(mode="json")
     return _success(
         request,
-        KnowledgeMetadataResponse.model_validate(field).model_dump(mode="json"),
+        response,
         "字段创建成功",
     )
 
@@ -167,9 +168,10 @@ async def update_metadata_field(
             data.name,
             principal.actor_id,
         )
+        response = KnowledgeMetadataResponse.model_validate(field).model_dump(mode="json")
     return _success(
         request,
-        KnowledgeMetadataResponse.model_validate(field).model_dump(mode="json"),
+        response,
         "字段更新成功",
     )
 


### PR DESCRIPTION
## Summary

Creating a document or creating/updating a knowledge metadata field could persist the write and then fail while building the response with `DetachedInstanceError`. Document creation raised 20 attribute validation errors; metadata writes raised five. Repository refresh starts a new transaction, and session cleanup rolls it back and expires ORM attributes before response serialization outside the session.

Build response dictionaries inside the existing database sessions for document creation and metadata field creation/update. Return those plain dictionaries after session cleanup.

## Scope and risk

- Changes only `mem-knowledge/src/api/routes/document.py` and `mem-knowledge/src/api/routes/knowledge_metadata.py` (6 additions, 3 deletions).
- Low risk: persistence, transaction cleanup, authentication, tenant/workspace and file access checks, response fields, and millisecond timestamp serialization remain unchanged. No migration or dependency change.
- External API Key impact: no new endpoints or expanded permissions; existing response contracts are preserved.

## Validation

- Before each fix, reproduced the corresponding original `DetachedInstanceError` through the real HTTP route, service, repository, and session manager.
- Ran from `mem-knowledge`: `PYTHONPATH="$PWD" uv run --no-sync --with aiosqlite python -m pytest ../tests/mem_knowledge/documents/test_document_response_lifecycle.py ../tests/mem_knowledge/metadata/test_metadata_response_lifecycle.py -q --tb=short` — 8 passed.
- Document coverage: ordinary and parent-child documents, authenticated creator attribution, committed records, response fields, and millisecond timestamps.
- Metadata coverage: create string/number/time fields; update renamed/unchanged/null names; verify committed database values and response serialization.
- `ruff check` for both routes and regression tests, and `git diff --check` — passed.
- Tests use an in-memory SQLite database with unrelated knowledge/file access lookups and principal dependencies replaced. Production PostgreSQL and gateway authentication were not exercised. Regression tests remain local under `tests/` per repository policy.

## Sourcery 摘要

错误修复：
- 通过在数据库会话仍处于活动状态时序列化响应数据，防止文档和知识元数据创建/更新路由在会话清理后失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent document and knowledge metadata creation/update routes from failing after session cleanup by serializing response data while the database session is still active.

</details>