### PR TITLE
feat(memory): Add end-user merge and delete with graph mutations

### DIFF
--- a/api/app/controllers/memory_storage_controller.py
+++ b/api/app/controllers/memory_storage_controller.py
@@ -1,9 +1,11 @@
+import asyncio
 from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header
 from fastapi.responses import StreamingResponse
 
+from app.aioRedis import get_thread_safe_sync_redis
 from app.core.error_codes import BizCode
 from app.core.language_utils import get_language_from_header
 from app.core.logging_config import get_api_logger
@@ -32,6 +34,7 @@ from app.services.memory_storage_service import (
 )
 
 from app.utils.config_utils import resolve_config_id, resolve_config_id_async
+from app.utils.redis_lock import RedisFairLock
 
 # Get API logger
 api_logger = get_api_logger()
@@ -395,37 +398,135 @@ async def delete_end_user(
 
     try:
         from app.repositories.end_user_repository import EndUserRepository
-
-        async with get_async_db_context() as db:
-            end_user = await EndUserRepository(db).get_end_user_by_id_async(end_user_id)
-            if not end_user:
-                api_logger.warning(f"终端用户不存在或已删除: end_user_id={end_user_id_str}")
-                return fail(BizCode.NOT_FOUND, "终端用户不存在或已删除", f"end_user_id={end_user_id_str}")
-            if str(end_user.workspace_id) != str(workspace_id):
-                api_logger.warning(
-                    f"用户 {current_user.username} 尝试删除不属于工作空间 {workspace_id} 的终端用户 {end_user_id_str}"
-                )
-                return fail(BizCode.PERMISSION_DENIED, "该终端用户不属于当前工作空间", "end_user workspace mismatch")
-
         from app.core.memory.memory_service import MemoryService
 
-        total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(end_user_id_str)
-
-        try:
+        while True:
+            resolved_snapshot: tuple[UUID, str] | None = None
             async with get_async_db_context() as db:
-                repo = EndUserRepository(db)
-                await repo.update_memory_count_async(end_user_id, 0)
-                await repo.soft_delete_by_end_user_id_async(end_user_id)
-        except Exception as sync_err:
-            api_logger.warning(f"同步 end_user 失败（不影响 Neo4j 删除结果）: {sync_err}")
+                end_user = await EndUserRepository(db).get_end_user_by_id_async(
+                    end_user_id
+                )
+                if end_user is not None:
+                    resolved_snapshot = (
+                        UUID(str(end_user.id)),
+                        str(end_user.workspace_id),
+                    )
+            if resolved_snapshot is None:
+                api_logger.warning(
+                    f"终端用户不存在或已删除: end_user_id={end_user_id_str}"
+                )
+                return fail(
+                    BizCode.NOT_FOUND,
+                    "终端用户不存在或已删除",
+                    f"end_user_id={end_user_id_str}",
+                )
 
-        api_logger.info(
-            f"终端用户删除完成: end_user_id={end_user_id_str}, total_deleted={total_deleted}"
-        )
-        return success(
-            data={"deleted": True, "end_user_id": end_user_id_str, "total_deleted": total_deleted},
-            msg=f"删除用户{end_user_id_str}记忆库成功"
-        )
+            resolved_end_user_id, resolved_workspace_id = resolved_snapshot
+            if resolved_workspace_id != str(workspace_id):
+                api_logger.warning(
+                    f"用户 {current_user.username} 尝试删除不属于工作空间 "
+                    f"{workspace_id} 的终端用户 {end_user_id_str}"
+                )
+                return fail(
+                    BizCode.PERMISSION_DENIED,
+                    "该终端用户不属于当前工作空间",
+                    "end_user workspace mismatch",
+                )
+
+            if resolved_end_user_id != end_user_id:
+                api_logger.warning(
+                    "拒绝通过已合并源用户删除目标用户记忆: requested_id=%s, "
+                    "resolved_id=%s",
+                    end_user_id_str,
+                    resolved_end_user_id,
+                )
+                return fail(
+                    BizCode.NOT_FOUND,
+                    "终端用户不存在或已删除",
+                    f"end_user_id={end_user_id_str}",
+                )
+
+            effective_end_user_id = resolved_end_user_id
+            effective_end_user_id_str = str(effective_end_user_id)
+            write_lock = RedisFairLock(
+                key=f"memory_write:{effective_end_user_id_str}",
+                redis_client=get_thread_safe_sync_redis(),
+                expire=1200,
+                timeout=60,
+                auto_renewal=True,
+            )
+            if not await asyncio.to_thread(write_lock.acquire):
+                raise RuntimeError("memory write lock acquisition timed out")
+            try:
+                # The requested active user may be merged between the first
+                # lookup and lock acquisition. Re-resolve under its old lock;
+                # retry preflight so the merged source is rejected before any
+                # target lock or destructive operation.
+                confirmed_snapshot: tuple[UUID, str] | None = None
+                async with get_async_db_context() as db:
+                    confirmed = await EndUserRepository(
+                        db
+                    ).get_end_user_by_id_async(end_user_id)
+                    if confirmed is not None:
+                        confirmed_snapshot = (
+                            UUID(str(confirmed.id)),
+                            str(confirmed.workspace_id),
+                        )
+                if confirmed_snapshot is None:
+                    return fail(
+                        BizCode.NOT_FOUND,
+                        "终端用户不存在或已删除",
+                        f"end_user_id={end_user_id_str}",
+                    )
+
+                confirmed_id, confirmed_workspace_id = confirmed_snapshot
+                if confirmed_workspace_id != str(workspace_id):
+                    return fail(
+                        BizCode.PERMISSION_DENIED,
+                        "该终端用户不属于当前工作空间",
+                        "end_user workspace mismatch",
+                    )
+
+                if confirmed_id != effective_end_user_id:
+                    api_logger.info(
+                        "删除终端用户时 merge owner 已变化，释放旧锁并重跑预检: "
+                        "%s -> %s",
+                        effective_end_user_id,
+                        confirmed_id,
+                    )
+                    continue
+
+                total_deleted = await MemoryService.delete_all_nodes_by_end_user_id(
+                    effective_end_user_id_str
+                )
+
+                async with get_async_db_context() as db:
+                    finalized = await EndUserRepository(
+                        db
+                    ).finalize_memory_delete_async(effective_end_user_id)
+                    if not finalized:
+                        raise RuntimeError(
+                            "effective end user disappeared during memory deletion"
+                        )
+
+                api_logger.info(
+                    "终端用户删除完成: requested_id=%s, effective_id=%s, "
+                    "total_deleted=%s",
+                    end_user_id_str,
+                    effective_end_user_id_str,
+                    total_deleted,
+                )
+                return success(
+                    data={
+                        "deleted": True,
+                        "end_user_id": end_user_id_str,
+                        "effective_end_user_id": effective_end_user_id_str,
+                        "total_deleted": total_deleted,
+                    },
+                    msg=f"删除用户{end_user_id_str}记忆库成功",
+                )
+            finally:
+                await asyncio.to_thread(write_lock.release)
 
     except Exception as e:
         api_logger.error(f"删除终端用户失败: end_user_id={end_user_id_str}, error={str(e)}")

--- a/api/app/controllers/service/memory_api_controller.py
+++ b/api/app/controllers/service/memory_api_controller.py
@@ -223,11 +223,13 @@ async def merge_memory(
     if payload.target in payload.end_user_ids:
         payload.end_user_ids.remove(payload.target)
     all_users = payload.end_user_ids | {payload.target}
-    activate_end_users = await EndUserRepository(db).filter_existing_ids_async(
+    existing_end_users = await EndUserRepository(
+        db
+    ).filter_existing_ids_any_status_async(
         all_users,
-        workspace_id=auth.workspace_id
+        workspace_id=auth.workspace_id,
     )
-    not_found = all_users - activate_end_users
+    not_found = all_users - existing_end_users
     if not_found:
         return fail(code=BizCode.USER_NOT_FOUND, msg=f"Not found users - {not_found}.")
 

--- a/api/app/core/memory/pipelines/forgetting_pipeline.py
+++ b/api/app/core/memory/pipelines/forgetting_pipeline.py
@@ -2,6 +2,9 @@ import logging
 import uuid
 
 from app.core.memory.pipelines.base_pipeline import BasePipeline
+from app.core.memory.storage.custom.end_user_delete import (
+    delete_end_user_memory_nodes,
+)
 from app.core.memory.storage.custom.manual_node_delete import (
     delete_manual_node_by_element_id as delete_manual_node,
 )
@@ -62,11 +65,5 @@ class ForgettingPipeline(BasePipeline):
 
     @staticmethod
     async def delete_all_nodes_by_end_user_id(end_user_id: str) -> int:
-        """删除指定用户的所有 Neo4j 记忆节点和边。
-
-        Returns:
-            删除的节点总数
-        """
-
-        async with Neo4jConnector() as connector:
-            return await connector.delete_group(end_user_id)
+        """Delete all memory nodes through the shared storage custom operation."""
+        return await delete_end_user_memory_nodes(end_user_id)

--- a/api/app/core/memory/storage/custom/__init__.py
+++ b/api/app/core/memory/storage/custom/__init__.py
@@ -28,6 +28,24 @@ from app.core.memory.storage.custom.manual_node_delete import (
     delete_manual_node_by_element_id,
     resolve_manual_delete_target,
 )
+from app.core.memory.storage.custom.end_user_delete import (
+    DeletedEndUserNodeIdentity,
+    EndUserDeleteOutboxError,
+    delete_end_user_memory_nodes,
+)
+from app.core.memory.storage.custom.end_user_merge import (
+    EndUserMergeNodeIdentity,
+    EndUserMergeOutboxError,
+    EndUserMergePrimaryError,
+    EndUserMergeStats,
+    merge_end_user_memory_nodes,
+)
+from app.core.memory.storage.custom.community_mutations import (
+    CommunityMutationOutboxError,
+    CommunityMutationWriter,
+    CommunityNodeIdentity,
+    CommunityReconcileStats,
+)
 from app.core.memory.storage.custom.topology_score import compute_topology_score
 from app.core.memory.storage.custom.forget_recovery import (
     ForgetRecoveryTarget,
@@ -37,10 +55,21 @@ from app.core.memory.storage.custom.forget_recovery import (
 
 __all__ = [
     "AutomaticForgetOutboxError",
+    "CommunityMutationOutboxError",
+    "CommunityMutationWriter",
+    "CommunityNodeIdentity",
+    "CommunityReconcileStats",
+    "DeletedEndUserNodeIdentity",
+    "EndUserDeleteOutboxError",
+    "EndUserMergeNodeIdentity",
+    "EndUserMergeOutboxError",
+    "EndUserMergePrimaryError",
+    "EndUserMergeStats",
     "ForgottenNodeIdentity",
     "ForgetRecoveryTarget",
     "ManualDeleteTarget",
     "compute_topology_score",
+    "delete_end_user_memory_nodes",
     "delete_manual_node_by_element_id",
     "resolve_manual_delete_target",
     "recover_forgotten_node_by_element_id",
@@ -51,6 +80,7 @@ __all__ = [
     "get_user_entity_id",
     "get_user_metadata",
     "get_user_sources_for_entities",
+    "merge_end_user_memory_nodes",
     "search_entities_by_name",
     "search_related_entities",
     "soft_delete_forgetting_nodes",

--- a/api/app/core/memory/storage/custom/community_mutations.py
+++ b/api/app/core/memory/storage/custom/community_mutations.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from neo4j.exceptions import Neo4jError
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+COMMUNITY_ASSIGN_CHUNK_SIZE = 500
+_DEADLOCK_MAX_RETRY = 3
+
+COMMUNITY_UPSERT_WITH_IDENTITY = """
+MERGE (c:Community {community_id: $community_id})
+ON CREATE SET c.id = $community_id
+SET c.end_user_id = $end_user_id,
+    c.member_count = $member_count,
+    c.updated_at = datetime()
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+"""
+
+COMMUNITY_ASSIGN_ENTITIES_WITH_IDENTITIES = """
+UNWIND $assignments AS row
+MATCH (e:ExtractedEntity {id: row.entity_id, end_user_id: $end_user_id})
+WHERE e.delete_at IS NULL
+MATCH (c:Community {
+    community_id: row.community_id,
+    end_user_id: $end_user_id
+})
+OPTIONAL MATCH (e)-[old_r:BELONGS_TO_COMMUNITY]->(:Community)
+DELETE old_r
+WITH DISTINCT e, c
+MERGE (e)-[:BELONGS_TO_COMMUNITY]->(c)
+WITH DISTINCT c
+SET c.updated_at = datetime()
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+ORDER BY community_id
+"""
+
+COMMUNITY_REFRESH_MEMBER_COUNTS_WITH_IDENTITIES = """
+UNWIND $community_ids AS community_id
+MATCH (c:Community {
+    community_id: community_id,
+    end_user_id: $end_user_id
+})
+OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+      -[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
+WITH c, count(e) AS member_count
+SET c.member_count = member_count
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+ORDER BY community_id
+"""
+
+COMMUNITY_UPDATE_METADATA_WITH_IDENTITIES = """
+UNWIND $communities AS row
+MATCH (c:Community {
+    community_id: row.community_id,
+    end_user_id: row.end_user_id
+})
+SET c.id                = coalesce(c.id, row.community_id),
+    c.name              = row.name,
+    c.summary           = row.summary,
+    c.core_entities     = row.core_entities,
+    c.summary_embedding = row.summary_embedding,
+    c.updated_at        = datetime()
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+ORDER BY community_id
+"""
+
+COMMUNITY_DELETE_EMPTY_WITH_IDENTITIES = """
+MATCH (c:Community {end_user_id: $end_user_id})
+WHERE NOT EXISTS {
+    MATCH (:ExtractedEntity {end_user_id: $end_user_id})
+          -[:BELONGS_TO_COMMUNITY]->(c)
+}
+WITH c,
+     elementId(c) AS element_id,
+     toString(c.community_id) AS community_id
+ORDER BY community_id
+DETACH DELETE c
+RETURN element_id, community_id
+ORDER BY community_id
+"""
+
+COMMUNITY_REFRESH_ALL_WITH_IDENTITIES = """
+MATCH (c:Community {end_user_id: $end_user_id})
+OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+      -[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
+WITH c, count(e) AS member_count
+SET c.member_count = member_count
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+ORDER BY community_id
+"""
+
+COMMUNITY_REFRESH_SCOPED_WITH_IDENTITIES = """
+MATCH (c:Community {end_user_id: $end_user_id})
+WHERE c.community_id IN $community_ids
+OPTIONAL MATCH (e:ExtractedEntity {end_user_id: $end_user_id})
+      -[:BELONGS_TO_COMMUNITY]->(c)
+WHERE e.delete_at IS NULL
+WITH c, count(e) AS member_count
+SET c.member_count = member_count
+RETURN elementId(c) AS element_id,
+       toString(c.community_id) AS community_id
+ORDER BY community_id
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityNodeIdentity:
+    element_id: str
+    community_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityReconcileStats:
+    deleted: int
+    refreshed: int
+
+
+class CommunityMutationOutboxError(OutboxEnqueueError):
+    """Outbox failed after Community nodes were committed in Neo4j."""
+
+    def __init__(
+        self,
+        cause: OutboxEnqueueError,
+        affected_nodes: Sequence[CommunityNodeIdentity],
+        operations: Sequence[OutboxOperation],
+    ) -> None:
+        super().__init__(list(cause.event_ids), cause.reason)
+        self.affected_nodes = tuple(affected_nodes)
+        self.operations = tuple(operations)
+
+
+def _nonblank(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must not be blank")
+    return value
+
+
+def _unique_nonblank(values: Iterable[str], field: str) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = _nonblank(value, field)
+        if normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
+    return result
+
+
+def _parse_identities(
+    rows: list[dict[str, Any]],
+    *,
+    allowed_ids: set[str] | None = None,
+    exact_ids: set[str] | None = None,
+) -> list[CommunityNodeIdentity]:
+    identities: list[CommunityNodeIdentity] = []
+    element_ids: set[str] = set()
+    community_ids: set[str] = set()
+    for row in rows:
+        element_id = str(row.get("element_id") or "")
+        community_id = str(row.get("community_id") or "")
+        if not element_id or not community_id:
+            raise RuntimeError("Community mutation returned a blank node identity")
+        if element_id in element_ids:
+            raise RuntimeError("Community mutation returned duplicate element IDs")
+        if community_id in community_ids:
+            raise RuntimeError("Community mutation returned duplicate business IDs")
+        if allowed_ids is not None and community_id not in allowed_ids:
+            raise RuntimeError("Community mutation returned an unexpected business ID")
+        element_ids.add(element_id)
+        community_ids.add(community_id)
+        identities.append(
+            CommunityNodeIdentity(
+                element_id=element_id,
+                community_id=community_id,
+            )
+        )
+
+    if exact_ids is not None and community_ids != exact_ids:
+        raise RuntimeError("Community mutation did not return the expected identities")
+    return identities
+
+
+async def _tx_rows(tx: Any, query: str, **parameters: Any) -> list[dict[str, Any]]:
+    statement = await tx.run(query, **parameters)
+    return [dict(record) for record in await statement.data()]
+
+
+class CommunityMutationWriter:
+    """Storage custom writer for Community nodes and membership side effects.
+
+    Every node mutation returns and validates ``community_id`` plus Neo4j
+    ``elementId`` inside the managed transaction. Outbox events are enqueued
+    only after Neo4j commit. Membership relationships do not emit events, but
+    assignment updates ``Community.updated_at`` and therefore emits UPSERT for
+    each actually affected Community node.
+    """
+
+    def __init__(
+        self,
+        client: Neo4jClient,
+        *,
+        outbox_repository: OutboxRepository | None = None,
+    ) -> None:
+        self.client = client
+        self.outbox_repository = outbox_repository
+
+    async def _publish(
+        self,
+        identities: Sequence[CommunityNodeIdentity],
+        operation: OutboxOperation,
+    ) -> None:
+        if not identities:
+            return
+        events = [
+            OutboxEventInput(
+                label=MemoryNodeType.COMMUNITY,
+                node_id=identity.community_id,
+                operation=operation,
+            )
+            for identity in identities
+        ]
+        try:
+            await enqueue_events(events, repository=self.outbox_repository)
+        except OutboxEnqueueError as exc:
+            raise CommunityMutationOutboxError(
+                exc,
+                identities,
+                [operation] * len(identities),
+            ) from None
+
+    async def _publish_reconcile(
+        self,
+        deleted: Sequence[CommunityNodeIdentity],
+        refreshed: Sequence[CommunityNodeIdentity],
+    ) -> None:
+        events = [
+            *[
+                OutboxEventInput(
+                    label=MemoryNodeType.COMMUNITY,
+                    node_id=node.community_id,
+                    operation=OutboxOperation.DELETE,
+                )
+                for node in deleted
+            ],
+            *[
+                OutboxEventInput(
+                    label=MemoryNodeType.COMMUNITY,
+                    node_id=node.community_id,
+                    operation=OutboxOperation.UPSERT,
+                )
+                for node in refreshed
+            ],
+        ]
+        if not events:
+            return
+        identities = [*deleted, *refreshed]
+        operations = [
+            *([OutboxOperation.DELETE] * len(deleted)),
+            *([OutboxOperation.UPSERT] * len(refreshed)),
+        ]
+        try:
+            await enqueue_events(events, repository=self.outbox_repository)
+        except OutboxEnqueueError as exc:
+            raise CommunityMutationOutboxError(
+                exc,
+                identities,
+                operations,
+            ) from None
+
+    async def upsert_community(
+        self,
+        community_id: str,
+        end_user_id: str,
+        member_count: int = 0,
+    ) -> CommunityNodeIdentity:
+        community_id = _nonblank(community_id, "community_id")
+        end_user_id = _nonblank(end_user_id, "end_user_id")
+        if not isinstance(member_count, int) or isinstance(member_count, bool) or member_count < 0:
+            raise ValueError("member_count must be a non-negative integer")
+
+        identities = await self.client.execute_validated_write_query(
+            COMMUNITY_UPSERT_WITH_IDENTITY,
+            lambda rows: _parse_identities(rows, exact_ids={community_id}),
+            community_id=community_id,
+            end_user_id=end_user_id,
+            member_count=member_count,
+        )
+        await self._publish(identities, OutboxOperation.UPSERT)
+        return identities[0]
+
+    async def assign_entities_to_communities(
+        self,
+        assignments: Sequence[dict[str, str]],
+        end_user_id: str,
+        *,
+        chunk_size: int = COMMUNITY_ASSIGN_CHUNK_SIZE,
+    ) -> list[CommunityNodeIdentity]:
+        end_user_id = _nonblank(end_user_id, "end_user_id")
+        if not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size <= 0:
+            raise ValueError("chunk_size must be a positive integer")
+        normalized: list[dict[str, str]] = []
+        target_by_entity: dict[str, str] = {}
+        for assignment in assignments:
+            entity_id = _nonblank(assignment.get("entity_id"), "entity_id")
+            community_id = _nonblank(
+                assignment.get("community_id"), "community_id"
+            )
+            previous_target = target_by_entity.get(entity_id)
+            if previous_target is not None:
+                if previous_target != community_id:
+                    raise ValueError(
+                        "one entity cannot be assigned to multiple communities"
+                    )
+                continue
+            target_by_entity[entity_id] = community_id
+            normalized.append(
+                {
+                    "entity_id": entity_id,
+                    "community_id": community_id,
+                }
+            )
+        if not normalized:
+            return []
+
+        return await self._assign_normalized(
+            normalized,
+            end_user_id,
+            chunk_size=chunk_size,
+        )
+
+    async def _assign_normalized(
+        self,
+        normalized: list[dict[str, str]],
+        end_user_id: str,
+        *,
+        chunk_size: int,
+    ) -> list[CommunityNodeIdentity]:
+        affected: list[CommunityNodeIdentity] = []
+        for start in range(0, len(normalized), chunk_size):
+            chunk = normalized[start:start + chunk_size]
+            allowed_ids = {item["community_id"] for item in chunk}
+            for attempt in range(1, _DEADLOCK_MAX_RETRY + 1):
+                try:
+                    identities = await self.client.execute_validated_write_query(
+                        COMMUNITY_ASSIGN_ENTITIES_WITH_IDENTITIES,
+                        lambda rows, allowed=allowed_ids: _parse_identities(
+                            rows,
+                            allowed_ids=allowed,
+                        ),
+                        assignments=chunk,
+                        end_user_id=end_user_id,
+                    )
+                    break
+                except Neo4jError as exc:
+                    if (
+                        exc.code == "Neo.TransientError.Transaction.DeadlockDetected"
+                        and attempt < _DEADLOCK_MAX_RETRY
+                    ):
+                        await asyncio.sleep(0.2 * attempt)
+                        continue
+                    raise
+            await self._publish(identities, OutboxOperation.UPSERT)
+            affected.extend(identities)
+        return affected
+
+    async def assign_entity_to_community(
+        self,
+        entity_id: str,
+        community_id: str,
+        end_user_id: str,
+    ) -> bool:
+        affected = await self.assign_entities_to_communities(
+            [{"entity_id": entity_id, "community_id": community_id}],
+            end_user_id,
+        )
+        return bool(affected)
+
+    async def refresh_member_counts(
+        self,
+        community_ids: Iterable[str],
+        end_user_id: str,
+    ) -> list[CommunityNodeIdentity]:
+        end_user_id = _nonblank(end_user_id, "end_user_id")
+        unique_ids = _unique_nonblank(community_ids, "community_id")
+        if not unique_ids:
+            return []
+        allowed_ids = set(unique_ids)
+        identities = await self.client.execute_validated_write_query(
+            COMMUNITY_REFRESH_MEMBER_COUNTS_WITH_IDENTITIES,
+            lambda rows: _parse_identities(rows, allowed_ids=allowed_ids),
+            community_ids=unique_ids,
+            end_user_id=end_user_id,
+        )
+        await self._publish(identities, OutboxOperation.UPSERT)
+        return identities
+
+    async def refresh_member_count(
+        self,
+        community_id: str,
+        end_user_id: str,
+    ) -> int:
+        identities = await self.refresh_member_counts([community_id], end_user_id)
+        return len(identities)
+
+    async def update_community_metadata(
+        self,
+        communities: Sequence[dict[str, Any]],
+    ) -> list[CommunityNodeIdentity]:
+        if not communities:
+            return []
+        normalized: list[dict[str, Any]] = []
+        allowed_ids: set[str] = set()
+        for community in communities:
+            community_id = _nonblank(community.get("community_id"), "community_id")
+            end_user_id = _nonblank(community.get("end_user_id"), "end_user_id")
+            if community_id in allowed_ids:
+                raise ValueError("communities contains duplicate community_id values")
+            allowed_ids.add(community_id)
+            normalized.append(
+                {
+                    "community_id": community_id,
+                    "end_user_id": end_user_id,
+                    "name": community.get("name"),
+                    "summary": community.get("summary"),
+                    "core_entities": community.get("core_entities"),
+                    "summary_embedding": community.get("summary_embedding"),
+                }
+            )
+
+        identities = await self.client.execute_validated_write_query(
+            COMMUNITY_UPDATE_METADATA_WITH_IDENTITIES,
+            lambda rows: _parse_identities(rows, allowed_ids=allowed_ids),
+            communities=normalized,
+        )
+        await self._publish(identities, OutboxOperation.UPSERT)
+        return identities
+
+    async def reconcile_after_clustering(
+        self,
+        end_user_id: str,
+        refresh_community_ids: Sequence[str] | None = None,
+    ) -> CommunityReconcileStats:
+        end_user_id = _nonblank(end_user_id, "end_user_id")
+        scoped_ids = (
+            None
+            if refresh_community_ids is None
+            else _unique_nonblank(refresh_community_ids, "community_id")
+        )
+
+        async def _operation(tx: Any) -> tuple[
+            list[CommunityNodeIdentity],
+            list[CommunityNodeIdentity],
+        ]:
+            deleted = _parse_identities(
+                await _tx_rows(
+                    tx,
+                    COMMUNITY_DELETE_EMPTY_WITH_IDENTITIES,
+                    end_user_id=end_user_id,
+                )
+            )
+            if scoped_ids is None:
+                refresh_query = COMMUNITY_REFRESH_ALL_WITH_IDENTITIES
+                refresh_parameters: dict[str, Any] = {"end_user_id": end_user_id}
+            elif scoped_ids:
+                refresh_query = COMMUNITY_REFRESH_SCOPED_WITH_IDENTITIES
+                refresh_parameters = {
+                    "end_user_id": end_user_id,
+                    "community_ids": scoped_ids,
+                }
+            else:
+                return deleted, []
+
+            refreshed = _parse_identities(
+                await _tx_rows(tx, refresh_query, **refresh_parameters),
+                allowed_ids=set(scoped_ids) if scoped_ids is not None else None,
+            )
+            if {node.community_id for node in deleted} & {
+                node.community_id for node in refreshed
+            }:
+                raise RuntimeError(
+                    "Community reconcile returned a deleted node as refreshed"
+                )
+            return deleted, refreshed
+
+        deleted, refreshed = await self.client.execute_write_transaction(_operation)
+        await self._publish_reconcile(deleted, refreshed)
+        return CommunityReconcileStats(
+            deleted=len(deleted),
+            refreshed=len(refreshed),
+        )

--- a/api/app/core/memory/storage/custom/end_user_delete.py
+++ b/api/app/core/memory/storage/custom/end_user_delete.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DELETE_BATCH_SIZE = 1000
+
+END_USER_DELETE_BATCH_WITH_IDENTITIES = """
+MATCH (n {end_user_id: $end_user_id})
+WITH n, [
+    label IN $supported_labels
+    WHERE label IN labels(n)
+] AS memory_labels,
+     elementId(n) AS element_id
+ORDER BY element_id
+LIMIT $batch_size
+WITH n,
+     element_id,
+     CASE
+         WHEN size(memory_labels) = 1
+              AND n.id IS NOT NULL
+              AND trim(toString(n.id)) <> ''
+         THEN toString(n.id)
+         ELSE null
+     END AS node_id,
+     CASE
+         WHEN size(memory_labels) = 1
+              AND n.id IS NOT NULL
+              AND trim(toString(n.id)) <> ''
+         THEN head(memory_labels)
+         ELSE null
+     END AS label,
+     size(memory_labels) = 1
+         AND n.id IS NOT NULL
+         AND trim(toString(n.id)) <> '' AS projectable
+DETACH DELETE n
+RETURN element_id, node_id, label, projectable
+ORDER BY element_id
+"""
+
+END_USER_DELETE_REMAINING_COUNT = """
+MATCH (n {end_user_id: $end_user_id})
+RETURN count(n) AS remaining_nodes
+"""
+
+DELETE_END_USER_DANGLING_RELATIONSHIPS = """
+MATCH ()-[r]->()
+WHERE r.end_user_id = $end_user_id
+DELETE r
+RETURN count(r) AS deleted_relationships
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class DeletedEndUserNodeIdentity:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+
+
+@dataclass(frozen=True, slots=True)
+class _DeletedEndUserBatch:
+    deleted_count: int
+    affected_nodes: tuple[DeletedEndUserNodeIdentity, ...]
+    element_ids: frozenset[str]
+    identities: frozenset[tuple[MemoryNodeType, str]]
+
+
+class EndUserDeleteOutboxError(OutboxEnqueueError):
+    """Outbox failed after one end-user deletion batch committed in Neo4j."""
+
+    def __init__(
+        self,
+        cause: OutboxEnqueueError,
+        affected_nodes: list[DeletedEndUserNodeIdentity],
+        *,
+        deleted_count: int,
+        published_count: int,
+    ) -> None:
+        super().__init__(list(cause.event_ids), cause.reason)
+        self.affected_nodes = tuple(affected_nodes)
+        self.deleted_count = deleted_count
+        self.published_count = published_count
+
+
+def _parse_deleted_batch(
+    rows: list[dict],
+    *,
+    batch_size: int,
+    seen_element_ids: set[str] | frozenset[str],
+    seen_identities: set[tuple[MemoryNodeType, str]] | frozenset[tuple[MemoryNodeType, str]],
+) -> _DeletedEndUserBatch:
+    """Validate all deleted rows and project only supported node identities."""
+    if len(rows) > batch_size:
+        raise RuntimeError("End-user delete returned more nodes than its batch size")
+
+    affected: list[DeletedEndUserNodeIdentity] = []
+    element_ids: set[str] = set()
+    identities: set[tuple[MemoryNodeType, str]] = set()
+    for row in rows:
+        element_id = str(row.get("element_id") or "")
+        if not element_id:
+            raise RuntimeError("End-user delete returned a blank element ID")
+        if element_id in element_ids or element_id in seen_element_ids:
+            raise RuntimeError("End-user delete returned duplicate element IDs")
+        element_ids.add(element_id)
+
+        projectable = row.get("projectable")
+        if not isinstance(projectable, bool):
+            raise RuntimeError("End-user delete returned an invalid projection marker")
+        if not projectable:
+            if row.get("node_id") is not None or row.get("label") is not None:
+                raise RuntimeError(
+                    "End-user delete returned identity fields for an unprojectable node"
+                )
+            continue
+
+        node_id = str(row.get("node_id") or "")
+        if not node_id:
+            raise RuntimeError("End-user delete returned a blank business ID")
+        try:
+            label = MemoryNodeType(row.get("label"))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "End-user delete returned an unsupported node label"
+            ) from exc
+
+        identity = (label, node_id)
+        if identity in identities or identity in seen_identities:
+            raise RuntimeError("End-user delete returned duplicate node identities")
+        identities.add(identity)
+        affected.append(
+            DeletedEndUserNodeIdentity(
+                element_id=element_id,
+                node_id=node_id,
+                label=label,
+            )
+        )
+
+    return _DeletedEndUserBatch(
+        deleted_count=len(rows),
+        affected_nodes=tuple(affected),
+        element_ids=frozenset(element_ids),
+        identities=frozenset(identities),
+    )
+
+
+async def delete_end_user_memory_nodes(
+    end_user_id: str,
+    *,
+    batch_size: int = DEFAULT_DELETE_BATCH_SIZE,
+    client: Neo4jClient | None = None,
+    outbox_repository: OutboxRepository | None = None,
+) -> int:
+    """Delete every node owned by one end user and publish exact DELETE events.
+
+    The legacy operation unconditionally removed every ``end_user_id`` node.
+    Preserve that behavior: nodes without exactly one supported memory label or
+    a business ``id`` are still deleted, but cannot produce projection events.
+    Each batch validates all returned element IDs and any projectable identity
+    inside the managed write transaction before commit.
+    """
+    if not isinstance(end_user_id, str) or not end_user_id.strip():
+        raise ValueError("end_user_id must not be blank")
+    if not isinstance(batch_size, int) or isinstance(batch_size, bool) or batch_size <= 0:
+        raise ValueError("batch_size must be a positive integer")
+
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+
+    deleted_count = 0
+    published_count = 0
+    seen_element_ids: set[str] = set()
+    seen_identities: set[tuple[MemoryNodeType, str]] = set()
+    supported_labels = [label.value for label in MemoryNodeType]
+    try:
+        while True:
+            seen_element_snapshot = frozenset(seen_element_ids)
+            seen_identity_snapshot = frozenset(seen_identities)
+            batch = await client.execute_validated_write_query(
+                END_USER_DELETE_BATCH_WITH_IDENTITIES,
+                lambda rows: _parse_deleted_batch(
+                    rows,
+                    batch_size=batch_size,
+                    seen_element_ids=seen_element_snapshot,
+                    seen_identities=seen_identity_snapshot,
+                ),
+                end_user_id=end_user_id,
+                batch_size=batch_size,
+                supported_labels=supported_labels,
+            )
+            seen_element_ids.update(batch.element_ids)
+            seen_identities.update(batch.identities)
+            if batch.deleted_count == 0:
+                break
+
+            deleted_count += batch.deleted_count
+            affected = list(batch.affected_nodes)
+            if not affected:
+                continue
+
+            events = [
+                OutboxEventInput(
+                    label=node.label,
+                    node_id=node.node_id,
+                    operation=OutboxOperation.DELETE,
+                )
+                for node in affected
+            ]
+            try:
+                await enqueue_events(events, repository=outbox_repository)
+            except OutboxEnqueueError as exc:
+                raise EndUserDeleteOutboxError(
+                    exc,
+                    affected,
+                    deleted_count=deleted_count,
+                    published_count=published_count,
+                ) from None
+            published_count += len(affected)
+
+        remaining_rows = await client.execute_query(
+            END_USER_DELETE_REMAINING_COUNT,
+            end_user_id=end_user_id,
+        )
+        remaining = (
+            int(remaining_rows[0].get("remaining_nodes", 0) or 0)
+            if remaining_rows
+            else 0
+        )
+        if remaining != 0:
+            raise RuntimeError(
+                "End-user graph changed during deletion; memory nodes remain"
+            )
+
+        # DETACH DELETE removes relationships attached to deleted nodes. Keep
+        # legacy cleanup semantics for any relationship carrying this user ID
+        # whose endpoints did not belong to the deleted node set.
+        await client.execute_query(
+            DELETE_END_USER_DANGLING_RELATIONSHIPS,
+            end_user_id=end_user_id,
+        )
+        return deleted_count
+    finally:
+        if owns_client:
+            active_error = sys.exc_info()[0] is not None
+            try:
+                await client.close()
+            except Exception:
+                if not active_error:
+                    raise
+                logger.exception(
+                    "Failed to close Neo4j client after end-user delete failure"
+                )

--- a/api/app/core/memory/storage/custom/end_user_merge.py
+++ b/api/app/core/memory/storage/custom/end_user_merge.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+logger = logging.getLogger(__name__)
+
+END_USER_MERGE_SOURCE_SNAPSHOT = """
+MATCH (n {end_user_id: $source_id})
+RETURN elementId(n) AS element_id,
+       toString(n.id) AS node_id,
+       [label IN $supported_labels WHERE label IN labels(n)] AS memory_labels,
+       properties(n) AS properties
+ORDER BY element_id
+"""
+
+END_USER_MERGE_TARGET_USER_SNAPSHOT = """
+MATCH (n:ExtractedEntity {end_user_id: $target_id})
+WHERE n.name = '用户'
+RETURN elementId(n) AS element_id,
+       toString(n.id) AS node_id,
+       [label IN $supported_labels WHERE label IN labels(n)] AS memory_labels,
+       properties(n) AS properties
+ORDER BY element_id
+"""
+
+END_USER_MERGE_UPDATE_TARGET_USER = """
+MATCH (n:ExtractedEntity)
+WHERE elementId(n) = $element_id
+  AND n.end_user_id = $target_id
+SET n += $merged_properties
+RETURN elementId(n) AS element_id,
+       toString(n.id) AS node_id,
+       'ExtractedEntity' AS label
+"""
+
+END_USER_MERGE_REDIRECT_INCOMING = """
+MATCH (src:ExtractedEntity)
+WHERE elementId(src) = $source_element_id
+MATCH (tgt:ExtractedEntity)
+WHERE elementId(tgt) = $target_element_id
+WITH src, tgt
+MATCH (src)<-[r_in]-(other)
+WHERE other <> tgt
+WITH other, tgt, r_in
+CALL apoc.create.relationship(other, type(r_in), properties(r_in), tgt)
+YIELD rel AS r_new
+SET r_new.end_user_id = $target_id
+DELETE r_in
+RETURN count(r_new) AS redirected
+"""
+
+END_USER_MERGE_REDIRECT_OUTGOING = """
+MATCH (src:ExtractedEntity)
+WHERE elementId(src) = $source_element_id
+MATCH (tgt:ExtractedEntity)
+WHERE elementId(tgt) = $target_element_id
+WITH src, tgt
+MATCH (src)-[r_out]->(other)
+WHERE other <> tgt
+WITH other, tgt, r_out
+CALL apoc.create.relationship(tgt, type(r_out), properties(r_out), other)
+YIELD rel AS r_new
+SET r_new.end_user_id = $target_id
+DELETE r_out
+RETURN count(r_new) AS redirected
+"""
+
+END_USER_MERGE_DELETE_SOURCE_USER = """
+MATCH (n:ExtractedEntity)
+WHERE elementId(n) = $element_id
+  AND n.end_user_id = $source_id
+WITH n, elementId(n) AS element_id, toString(n.id) AS node_id
+DETACH DELETE n
+RETURN element_id, node_id, 'ExtractedEntity' AS label
+"""
+
+END_USER_MERGE_REASSIGN_NODES_WITH_IDENTITIES = """
+MATCH (n {end_user_id: $source_id})
+WITH n,
+     elementId(n) AS element_id,
+     toString(n.id) AS node_id,
+     head([
+         label IN $supported_labels
+         WHERE label IN labels(n)
+     ]) AS label
+SET n.end_user_id = $target_id
+RETURN element_id, node_id, label
+ORDER BY element_id
+"""
+
+END_USER_MERGE_REASSIGN_RELATIONSHIPS = """
+MATCH ()-[r]->()
+WHERE r.end_user_id = $source_id
+SET r.end_user_id = $target_id
+RETURN count(r) AS updated_edges
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class EndUserMergeNodeIdentity:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+    operation: OutboxOperation
+
+
+@dataclass(frozen=True, slots=True)
+class EndUserMergeStats:
+    sources_merged: int = 0
+    reassigned_nodes: int = 0
+    reassigned_edges: int = 0
+    outbox_events: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _SnapshotNode:
+    element_id: str
+    node_id: str
+    label: MemoryNodeType
+    properties: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _SourceMergeResult:
+    affected_nodes: tuple[EndUserMergeNodeIdentity, ...]
+    reassigned_nodes: int
+    reassigned_edges: int
+
+
+class EndUserMergePrimaryError(RuntimeError):
+    """A source transaction failed after zero or more prior sources completed."""
+
+    def __init__(
+        self,
+        *,
+        source_id: str,
+        completed_sources: tuple[str, ...],
+    ) -> None:
+        self.source_id = source_id
+        self.completed_sources = completed_sources
+        self.primary_committed = bool(completed_sources)
+        super().__init__(f"End-user Neo4j merge failed for source {source_id}")
+
+
+class EndUserMergeOutboxError(OutboxEnqueueError):
+    """Outbox failed after one source merge committed in Neo4j."""
+
+    def __init__(
+        self,
+        cause: OutboxEnqueueError,
+        *,
+        source_id: str,
+        affected_nodes: tuple[EndUserMergeNodeIdentity, ...],
+        completed_sources: tuple[str, ...],
+    ) -> None:
+        super().__init__(list(cause.event_ids), cause.reason)
+        self.source_id = source_id
+        self.affected_nodes = affected_nodes
+        self.completed_sources = completed_sources
+
+
+def _dedup_list(items: list[Any]) -> list[Any]:
+    seen: set[Any] = set()
+    result: list[Any] = []
+    for item in items:
+        if isinstance(item, (dict, list)):
+            key: Any = json.dumps(item, sort_keys=True, ensure_ascii=False)
+        else:
+            key = item
+        if key not in seen:
+            seen.add(key)
+            result.append(item)
+    return result
+
+
+def _merge_separated_string(target: str, source: str, sep: str = "；") -> str:
+    target_parts = [part.strip() for part in target.split(sep) if part.strip()]
+    source_parts = [part.strip() for part in source.split(sep) if part.strip()]
+    existing = set(target_parts)
+    return sep.join(target_parts + [part for part in source_parts if part not in existing])
+
+
+def _merge_user_properties(
+    source: dict[str, Any],
+    target: dict[str, Any],
+) -> dict[str, Any]:
+    list_fields = (
+        "aliases",
+        "anchors",
+        "beliefs_or_stances",
+        "core_facts",
+        "events",
+        "goals",
+        "interests",
+        "relations",
+        "traits",
+    )
+    merged = {
+        field: _dedup_list(
+            list(target.get(field) or []) + list(source.get(field) or [])
+        )
+        for field in list_fields
+    }
+    merged["description_timeline"] = _merge_separated_string(
+        str(target.get("description_timeline") or ""),
+        str(source.get("description_timeline") or ""),
+    )
+    merged["event_timeline"] = _merge_separated_string(
+        str(target.get("event_timeline") or ""),
+        str(source.get("event_timeline") or ""),
+    )
+
+    source_description = str(source.get("description") or "").strip()
+    target_description = str(target.get("description") or "").strip()
+    merged["description"] = (
+        f"{target_description}；{source_description}"
+        if target_description and source_description
+        else target_description or source_description
+    )
+
+    source_summary = str(source.get("description_summary") or "").strip()
+    target_summary = str(target.get("description_summary") or "").strip()
+    merged["description_summary"] = (
+        f"{target_summary}\n{source_summary}"
+        if target_summary and source_summary
+        else target_summary or source_summary
+    )
+    return merged
+
+
+def _parse_snapshot(
+    rows: list[dict[str, Any]],
+    *,
+    owner: str,
+) -> list[_SnapshotNode]:
+    nodes: list[_SnapshotNode] = []
+    element_ids: set[str] = set()
+    identities: set[tuple[MemoryNodeType, str]] = set()
+    for row in rows:
+        element_id = str(row.get("element_id") or "")
+        node_id = str(row.get("node_id") or "")
+        labels = row.get("memory_labels") or []
+        if not element_id or not node_id or len(labels) != 1:
+            raise ValueError(
+                f"{owner} contains a node without exactly one supported "
+                "memory label and a business id"
+            )
+        try:
+            label = MemoryNodeType(labels[0])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{owner} contains an unsupported memory label") from exc
+        identity = (label, node_id)
+        if element_id in element_ids:
+            raise RuntimeError(f"{owner} snapshot returned duplicate element IDs")
+        if identity in identities:
+            raise RuntimeError(f"{owner} snapshot returned duplicate node identities")
+        element_ids.add(element_id)
+        identities.add(identity)
+        nodes.append(
+            _SnapshotNode(
+                element_id=element_id,
+                node_id=node_id,
+                label=label,
+                properties=dict(row.get("properties") or {}),
+            )
+        )
+    return nodes
+
+
+def _parse_mutation_identity(
+    row: dict[str, Any],
+    operation: OutboxOperation,
+) -> EndUserMergeNodeIdentity:
+    element_id = str(row.get("element_id") or "")
+    node_id = str(row.get("node_id") or "")
+    if not element_id or not node_id:
+        raise RuntimeError("End-user merge mutation returned a node without identity")
+    try:
+        label = MemoryNodeType(row.get("label"))
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "End-user merge mutation returned an unsupported label"
+        ) from exc
+    return EndUserMergeNodeIdentity(
+        element_id=element_id,
+        node_id=node_id,
+        label=label,
+        operation=operation,
+    )
+
+
+async def _query(tx, cypher: str, **parameters: Any) -> list[dict[str, Any]]:
+    result = await tx.run(cypher, **parameters)
+    return await result.data()
+
+
+def _single_count(rows: list[dict[str, Any]], key: str) -> int:
+    return int(rows[0].get(key, 0) or 0) if rows else 0
+
+
+async def _merge_one_source_transaction(
+    tx,
+    *,
+    source_id: str,
+    target_id: str,
+    supported_labels: list[str],
+) -> _SourceMergeResult:
+    source_nodes = _parse_snapshot(
+        await _query(
+            tx,
+            END_USER_MERGE_SOURCE_SNAPSHOT,
+            source_id=source_id,
+            supported_labels=supported_labels,
+        ),
+        owner="source end user",
+    )
+    target_users = _parse_snapshot(
+        await _query(
+            tx,
+            END_USER_MERGE_TARGET_USER_SNAPSHOT,
+            target_id=target_id,
+            supported_labels=supported_labels,
+        ),
+        owner="target user entity",
+    )
+    if len(target_users) > 1:
+        raise ValueError("target end user contains multiple User entities")
+    if target_users and target_users[0].label != MemoryNodeType.EXTRACTED_ENTITY:
+        raise ValueError("target User entity has an invalid memory label")
+
+    source_users = [
+        node
+        for node in source_nodes
+        if node.label == MemoryNodeType.EXTRACTED_ENTITY
+        and node.properties.get("name") == "用户"
+    ]
+    if len(source_users) > 1:
+        raise ValueError("source end user contains multiple User entities")
+
+    source_user = source_users[0] if source_users else None
+    target_user = target_users[0] if target_users else None
+    if source_user and target_user and (
+        source_user.label,
+        source_user.node_id,
+    ) == (target_user.label, target_user.node_id):
+        raise ValueError("source and target User entities share one business identity")
+
+    target_updated: EndUserMergeNodeIdentity | None = None
+    source_deleted: EndUserMergeNodeIdentity | None = None
+    redirected_edges = 0
+    if source_user is not None and target_user is not None:
+        update_rows = await _query(
+            tx,
+            END_USER_MERGE_UPDATE_TARGET_USER,
+            element_id=target_user.element_id,
+            target_id=target_id,
+            merged_properties=_merge_user_properties(
+                source_user.properties,
+                target_user.properties,
+            ),
+        )
+        if len(update_rows) != 1:
+            raise RuntimeError("target User update did not affect exactly one node")
+        target_updated = _parse_mutation_identity(
+            update_rows[0], OutboxOperation.UPSERT
+        )
+        if target_updated.element_id != target_user.element_id:
+            raise RuntimeError("target User identity changed during merge")
+
+        incoming_rows = await _query(
+            tx,
+            END_USER_MERGE_REDIRECT_INCOMING,
+            source_element_id=source_user.element_id,
+            target_element_id=target_user.element_id,
+            target_id=target_id,
+        )
+        outgoing_rows = await _query(
+            tx,
+            END_USER_MERGE_REDIRECT_OUTGOING,
+            source_element_id=source_user.element_id,
+            target_element_id=target_user.element_id,
+            target_id=target_id,
+        )
+        redirected_edges = _single_count(incoming_rows, "redirected") + _single_count(
+            outgoing_rows, "redirected"
+        )
+
+        delete_rows = await _query(
+            tx,
+            END_USER_MERGE_DELETE_SOURCE_USER,
+            element_id=source_user.element_id,
+            source_id=source_id,
+        )
+        if len(delete_rows) != 1:
+            raise RuntimeError("source User delete did not affect exactly one node")
+        source_deleted = _parse_mutation_identity(
+            delete_rows[0], OutboxOperation.DELETE
+        )
+        if source_deleted.element_id != source_user.element_id:
+            raise RuntimeError("source User identity changed during merge")
+
+    moved_rows = await _query(
+        tx,
+        END_USER_MERGE_REASSIGN_NODES_WITH_IDENTITIES,
+        source_id=source_id,
+        target_id=target_id,
+        supported_labels=supported_labels,
+    )
+    moved = [
+        _parse_mutation_identity(row, OutboxOperation.UPSERT)
+        for row in moved_rows
+    ]
+    expected_moved = {
+        node.element_id: node
+        for node in source_nodes
+        if source_deleted is None or node.element_id != source_deleted.element_id
+    }
+    if {node.element_id for node in moved} != set(expected_moved):
+        raise RuntimeError("reassigned node identities do not match source snapshot")
+    for node in moved:
+        expected = expected_moved[node.element_id]
+        if (node.label, node.node_id) != (expected.label, expected.node_id):
+            raise RuntimeError("reassigned node business identity changed during merge")
+
+    relationship_rows = await _query(
+        tx,
+        END_USER_MERGE_REASSIGN_RELATIONSHIPS,
+        source_id=source_id,
+        target_id=target_id,
+    )
+    reassigned_edges = redirected_edges + _single_count(
+        relationship_rows, "updated_edges"
+    )
+
+    affected = list(moved)
+    if target_updated is not None:
+        affected.append(target_updated)
+    if source_deleted is not None:
+        affected.append(source_deleted)
+    unique_identities = {(node.label, node.node_id) for node in affected}
+    if len(unique_identities) != len(affected):
+        raise RuntimeError("End-user merge returned duplicate affected identities")
+
+    return _SourceMergeResult(
+        affected_nodes=tuple(affected),
+        reassigned_nodes=len(moved),
+        reassigned_edges=reassigned_edges,
+    )
+
+
+async def merge_end_user_memory_nodes(
+    source_ids: list[str],
+    target_id: str,
+    *,
+    client: Neo4jClient | None = None,
+    outbox_repository: OutboxRepository | None = None,
+) -> EndUserMergeStats:
+    """Merge each source graph into target and publish exact node events."""
+    if not isinstance(target_id, str) or not target_id.strip():
+        raise ValueError("target_id must not be blank")
+    if any(not isinstance(source_id, str) or not source_id.strip() for source_id in source_ids):
+        raise ValueError("source_ids must not contain blank values")
+    ordered_sources = sorted(set(source_ids))
+    if target_id in ordered_sources:
+        raise ValueError("target_id must not be included in source_ids")
+    if not ordered_sources:
+        return EndUserMergeStats()
+
+    owns_client = client is None
+    if client is None:
+        client = await Neo4jClient.create()
+
+    completed_sources: list[str] = []
+    reassigned_nodes = 0
+    reassigned_edges = 0
+    outbox_events = 0
+    supported_labels = [label.value for label in MemoryNodeType]
+    try:
+        for source_id in ordered_sources:
+            try:
+                result = await client.execute_write_transaction(
+                    lambda tx, source_id=source_id: _merge_one_source_transaction(
+                        tx,
+                        source_id=source_id,
+                        target_id=target_id,
+                        supported_labels=supported_labels,
+                    )
+                )
+            except Exception as exc:
+                raise EndUserMergePrimaryError(
+                    source_id=source_id,
+                    completed_sources=tuple(completed_sources),
+                ) from exc
+            events = [
+                OutboxEventInput(
+                    label=node.label,
+                    node_id=node.node_id,
+                    operation=node.operation,
+                )
+                for node in result.affected_nodes
+            ]
+            try:
+                await enqueue_events(events, repository=outbox_repository)
+            except OutboxEnqueueError as exc:
+                raise EndUserMergeOutboxError(
+                    exc,
+                    source_id=source_id,
+                    affected_nodes=result.affected_nodes,
+                    completed_sources=tuple(completed_sources),
+                ) from None
+
+            completed_sources.append(source_id)
+            reassigned_nodes += result.reassigned_nodes
+            reassigned_edges += result.reassigned_edges
+            outbox_events += len(events)
+
+        return EndUserMergeStats(
+            sources_merged=len(completed_sources),
+            reassigned_nodes=reassigned_nodes,
+            reassigned_edges=reassigned_edges,
+            outbox_events=outbox_events,
+        )
+    finally:
+        if owns_client:
+            try:
+                await client.close()
+            except Exception:
+                logger.exception(
+                    "Failed to close Neo4j client after end-user merge"
+                )

--- a/api/app/core/memory/storage/provider/neo4j/client.py
+++ b/api/app/core/memory/storage/provider/neo4j/client.py
@@ -1,7 +1,7 @@
 import asyncio
 import heapq
 import traceback
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Self, TypeVar
 
 import numpy as np
 from neo4j import AsyncGraphDatabase, AsyncDriver
@@ -45,6 +45,9 @@ from app.core.memory.storage.utils.similarity import compute_cosine_similarity
 
 if TYPE_CHECKING:
     from app.core.memory.models.graph_models import MemorySummaryNode
+
+
+ValidatedWriteResult = TypeVar("ValidatedWriteResult")
 
 
 def _to_native(value: Any) -> Any:
@@ -100,6 +103,43 @@ class Neo4jClient(BaseClient):
             {key: _to_native(value) for key, value in record.items()}
             for record in records
         ]
+
+    async def execute_validated_write_query(
+            self,
+            cypher: str,
+            validator: Callable[[list[dict[str, Any]]], ValidatedWriteResult],
+            **parameters: Any,
+    ) -> ValidatedWriteResult:
+        """Execute a custom mutation and validate its rows before commit.
+
+        ``validator`` runs inside the managed write transaction callback. Any
+        exception it raises propagates through ``execute_write`` and rolls the
+        mutation back instead of exposing an already-committed invalid result.
+        """
+        if self.client is None:
+            raise RuntimeError("Neo4jClient is not initialized")
+
+        async def _execute(tx):
+            statement = await tx.run(cypher, **parameters)
+            records = await statement.data()
+            rows = [
+                {key: _to_native(value) for key, value in record.items()}
+                for record in records
+            ]
+            return validator(rows)
+
+        async with self.client.session() as session:
+            return await session.execute_write(_execute)
+
+    async def execute_write_transaction(
+            self,
+            operation: Callable[[Any], Awaitable[ValidatedWriteResult]],
+    ) -> ValidatedWriteResult:
+        """Run a storage custom callback in one managed write transaction."""
+        if self.client is None:
+            raise RuntimeError("Neo4jClient is not initialized")
+        async with self.client.session() as session:
+            return await session.execute_write(operation)
 
     async def save_memory_graph(
         self,

--- a/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
+++ b/api/app/core/memory/storage_services/clustering_engine/label_propagation.py
@@ -15,6 +15,13 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.core.memory.storage.custom import (
+    CommunityMutationOutboxError,
+    CommunityMutationWriter,
+)
+from app.core.memory.storage.custom.community_mutations import (
+    COMMUNITY_ASSIGN_CHUNK_SIZE,
+)
 from app.repositories.neo4j.community_repository import CommunityRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.schemas.memory_config_schema import MemoryConfig
@@ -92,10 +99,12 @@ class LabelPropagationEngine:
         self,
         connector: Neo4jConnector,
         memory_config: MemoryConfig,
+        community_writer: CommunityMutationWriter,
         language: str = "zh",
     ):
         self.connector = connector
         self.repo = CommunityRepository(connector)
+        self.community_writer = community_writer
         # memory_config 打包了 tenant_id 与各 model_id（同源加载，不会漏传 tenant）。
         # MemoryConfig 是 frozen dataclass（纯值），可安全跨 db 会话/进程边界持有。
         self.memory_config = memory_config
@@ -103,6 +112,35 @@ class LabelPropagationEngine:
         # 缓存客户端实例，避免重复初始化
         self._llm_client = None
         self._embedder_client = None
+
+    async def _compat_write(self, operation, fallback, action: str):
+        try:
+            return await operation
+        except CommunityMutationOutboxError:
+            raise
+        except Exception as error:
+            logger.error(f"{action} failed: {error}", exc_info=True)
+            return fallback
+
+    async def _assign_entities_compat(
+        self,
+        assignments: List[Dict],
+        end_user_id: str,
+    ) -> List:
+        affected = []
+        for start in range(0, len(assignments), COMMUNITY_ASSIGN_CHUNK_SIZE):
+            chunk = assignments[start:start + COMMUNITY_ASSIGN_CHUNK_SIZE]
+            result = await self._compat_write(
+                self.community_writer.assign_entities_to_communities(
+                    chunk,
+                    end_user_id,
+                    chunk_size=COMMUNITY_ASSIGN_CHUNK_SIZE,
+                ),
+                [],
+                "batch_assign_entities_to_communities",
+            )
+            affected.extend(result)
+        return affected
 
 
     # ──────────────────────────────────────────────────────────────────────────
@@ -125,7 +163,13 @@ class LabelPropagationEngine:
             logger.info(f"[Clustering] 用户 {end_user_id} 首次聚类，执行全量初始化")
             await self.full_clustering(end_user_id)
             # 全量聚类后做全量对账（None = 重算全部社区 member_count）
-            await self.repo.reconcile_after_clustering(end_user_id, refresh_community_ids=None)
+            await self._compat_write(
+                self.community_writer.reconcile_after_clustering(
+                    end_user_id, refresh_community_ids=None
+                ),
+                None,
+                "reconcile_after_clustering",
+            )
         else:
             if not new_entity_ids:
                 return
@@ -134,7 +178,13 @@ class LabelPropagationEngine:
             )
             affected = await self.incremental_update(new_entity_ids, end_user_id)
             # 增量后只对本轮触达的社区重算 member_count（删空社区仍全量，覆盖合并解散/并发去重清空）
-            await self.repo.reconcile_after_clustering(end_user_id, refresh_community_ids=affected)
+            await self._compat_write(
+                self.community_writer.reconcile_after_clustering(
+                    end_user_id, refresh_community_ids=affected
+                ),
+                None,
+                "reconcile_after_clustering",
+            )
 
     async def full_clustering(self, end_user_id: str) -> None:
         """
@@ -265,6 +315,8 @@ class LabelPropagationEngine:
                 return_exceptions=True,
             )
             for res in results:
+                if isinstance(res, CommunityMutationOutboxError):
+                    raise res
                 if isinstance(res, Exception):
                     logger.warning(f"[Clustering] _process_single_entity 失败（已忽略）: {res}")
                 elif res:
@@ -305,8 +357,20 @@ class LabelPropagationEngine:
         if not neighbors:
             # 孤立实体：创建单成员社区
             new_cid = self._new_community_id()
-            await self.repo.upsert_community(new_cid, end_user_id, member_count=1)
-            await self.repo.assign_entity_to_community(entity_id, new_cid, end_user_id)
+            await self._compat_write(
+                self.community_writer.upsert_community(
+                    new_cid, end_user_id, member_count=1
+                ),
+                None,
+                "upsert_community",
+            )
+            await self._compat_write(
+                self.community_writer.assign_entity_to_community(
+                    entity_id, new_cid, end_user_id
+                ),
+                False,
+                "assign_entity_to_community",
+            )
             logger.debug(f"[Clustering] 孤立实体 {entity_id} → 新社区 {new_cid}")
             return new_cid
 
@@ -320,21 +384,49 @@ class LabelPropagationEngine:
         if target_cid is None:
             # 邻居都没有社区，连同新实体一起创建新社区
             new_cid = self._new_community_id()
-            await self.repo.upsert_community(new_cid, end_user_id)
-            await self.repo.assign_entity_to_community(entity_id, new_cid, end_user_id)
+            await self._compat_write(
+                self.community_writer.upsert_community(new_cid, end_user_id),
+                None,
+                "upsert_community",
+            )
+            await self._compat_write(
+                self.community_writer.assign_entity_to_community(
+                    entity_id, new_cid, end_user_id
+                ),
+                False,
+                "assign_entity_to_community",
+            )
             for nb in neighbors:
-                await self.repo.assign_entity_to_community(
-                    nb["id"], new_cid, end_user_id
+                await self._compat_write(
+                    self.community_writer.assign_entity_to_community(
+                        nb["id"], new_cid, end_user_id
+                    ),
+                    False,
+                    "assign_entity_to_community",
                 )
-            await self.repo.refresh_member_count(new_cid, end_user_id)
+            await self._compat_write(
+                self.community_writer.refresh_member_count(new_cid, end_user_id),
+                0,
+                "refresh_member_count",
+            )
             logger.debug(
                 f"[Clustering] 新实体 {entity_id} 与 {len(neighbors)} 个无社区邻居 → 新社区 {new_cid}"
             )
             return new_cid
         else:
             # 加入得票最多的社区
-            await self.repo.assign_entity_to_community(entity_id, target_cid, end_user_id)
-            await self.repo.refresh_member_count(target_cid, end_user_id)
+            await self._compat_write(
+                self.community_writer.assign_entity_to_community(
+                    entity_id, target_cid, end_user_id
+                ),
+                False,
+                "assign_entity_to_community",
+            )
+            await self._compat_write(
+                self.community_writer.refresh_member_count(target_cid, end_user_id),
+                0,
+                "refresh_member_count",
+            )
             logger.debug(f"[Clustering] 新实体 {entity_id} → 社区 {target_cid}")
 
             # 若邻居分属多个社区，评估合并
@@ -438,7 +530,7 @@ class LabelPropagationEngine:
             members = await self.repo.get_community_members(dissolve, end_user_id)
             if members:
                 assignments = [{"entity_id": m["id"], "community_id": keep} for m in members]
-                await self.repo.batch_assign_entities_to_communities(assignments, end_user_id)
+                await self._assign_entities_compat(assignments, end_user_id)
 
             # 合并后更新内存中的平均向量（加权平均），供后续对比使用
             keep_emb = community_embeddings.get(keep)
@@ -456,7 +548,11 @@ class LabelPropagationEngine:
 
             community_sizes[keep] = total_size
             community_sizes[dissolve] = 0
-            await self.repo.refresh_member_count(keep, end_user_id)
+            await self._compat_write(
+                self.community_writer.refresh_member_count(keep, end_user_id),
+                0,
+                "refresh_member_count",
+            )
             logger.info(
                 f"[Clustering] 社区合并: {dissolve} → {keep}，"
                 f"相似度={current_sim:.3f}，迁移 {len(members)} 个成员"
@@ -474,21 +570,35 @@ class LabelPropagationEngine:
 
         # 先创建所有唯一社区节点（数量远少于实体，串行可接受）
         for cid in unique_communities:
-            await self.repo.upsert_community(cid, end_user_id)
+            await self._compat_write(
+                self.community_writer.upsert_community(cid, end_user_id),
+                None,
+                "upsert_community",
+            )
 
         # 批量分配实体：一次 UNWIND 替代 N×2 次串行 Cypher
         assignments = [
             {"entity_id": eid, "community_id": cid}
             for eid, cid in labels.items()
         ]
-        await self.repo.batch_assign_entities_to_communities(assignments, end_user_id)
+        await self._assign_entities_compat(assignments, end_user_id)
         logger.info(f"[Clustering] _flush_labels 批量写入完成，实体数={len(assignments)}，社区数={len(unique_communities)}")
 
         # 刷新成员数（并发执行）
-        await asyncio.gather(
-            *[self.repo.refresh_member_count(cid, end_user_id) for cid in unique_communities],
+        refresh_results = await asyncio.gather(
+            *[
+                self._compat_write(
+                    self.community_writer.refresh_member_count(cid, end_user_id),
+                    0,
+                    "refresh_member_count",
+                )
+                for cid in unique_communities
+            ],
             return_exceptions=True,
         )
+        for result in refresh_results:
+            if isinstance(result, CommunityMutationOutboxError):
+                raise result
 
     async def _get_entity_embedding(
         self, entity_id: str, end_user_id: str
@@ -710,24 +820,19 @@ class LabelPropagationEngine:
         for m in metadata_list:
             m.pop("prompt", None)
         
-        if len(metadata_list) == 1:
-            m = metadata_list[0]
-            result = await self.repo.update_community_metadata(
-                community_id=m["community_id"],
-                end_user_id=m["end_user_id"],
-                name=m["name"],
-                summary=m["summary"],
-                core_entities=m["core_entities"],
-                summary_embedding=m["summary_embedding"],
+        affected = await self._compat_write(
+            self.community_writer.update_community_metadata(metadata_list),
+            [],
+            "update_community_metadata",
+        )
+        if len(metadata_list) == 1 and not affected:
+            logger.error(
+                f"[Clustering] 社区 {metadata_list[0]['community_id']} 元数据写入失败"
             )
-            if not result:
-                logger.error(f"[Clustering] 社区 {m['community_id']} 元数据写入失败")
         else:
-            ok = await self.repo.batch_update_community_metadata(metadata_list)
-            if not ok:
-                logger.error(f"[Clustering] 批量写入 {len(metadata_list)} 个社区元数据失败")
-            else:
-                logger.info(f"[Clustering] 批量写入 {len(metadata_list)} 个社区元数据成功")
+            logger.info(
+                f"[Clustering] 批量写入 {len(metadata_list)} 个社区元数据成功"
+            )
     def _get_llm_client(self):
         """获取或创建 LLM 客户端（单例缓存）。
 

--- a/api/app/repositories/end_user_repository.py
+++ b/api/app/repositories/end_user_repository.py
@@ -741,7 +741,11 @@ class EndUserRepository:
         )
 
     async def find_active_by_identity_features(
-        self, workspace_id: uuid.UUID, identity_features: str
+        self,
+        workspace_id: uuid.UUID,
+        identity_features: str,
+        *,
+        for_update: bool = True,
     ) -> Optional["EndUser"]:
         """按 workspace_id + identity_features 查询相同标识的活跃记录（用于跨渠道归并）。
 
@@ -755,7 +759,7 @@ class EndUserRepository:
         获取的 advisory 锁并回滚其 pending 状态，事务边界应由调用方决定。
         """
         try:
-            result = await self.db.execute(
+            stmt = (
                 select(EndUser)
                 .where(
                     EndUser.workspace_id == workspace_id,
@@ -764,8 +768,10 @@ class EndUserRepository:
                 )
                 .order_by(EndUser.created_at.asc())
                 .limit(1)
-                .with_for_update()
             )
+            if for_update:
+                stmt = stmt.with_for_update()
+            result = await self.db.execute(stmt)
             return result.scalars().first()
         except Exception as e:
             db_logger.error(f"按身份标识查询终端用户时出错: {str(e)}")
@@ -808,6 +814,23 @@ class EndUserRepository:
                 f"合并路由: other_id={other_id} → target={target_id}"
             )
         return target_user
+
+    async def get_merge_target_id_async(
+        self,
+        origin_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> uuid.UUID | None:
+        """Return the latest durable merge target for an origin in a workspace."""
+        result = await self.db.execute(
+            select(EndUserMerge.target_id)
+            .where(
+                EndUserMerge.origin_id == origin_id,
+                EndUserMerge.workspace_id == workspace_id,
+            )
+            .order_by(EndUserMerge.id.desc())
+            .limit(1)
+        )
+        return result.scalars().first()
 
     async def resolve_merge_by_origin_id_async(
         self, origin_id: uuid.UUID
@@ -1225,6 +1248,30 @@ class EndUserRepository:
         except Exception as e:
             self.db.rollback()
             db_logger.error(f"批量校验终端用户ID时出错: {str(e)}")
+            raise
+
+    async def filter_existing_ids_any_status_async(
+            self,
+            end_user_ids: set[uuid.UUID],
+            workspace_id: uuid.UUID,
+    ) -> Set[uuid.UUID]:
+        """Return existing end-user IDs in one workspace regardless of status."""
+        if not end_user_ids:
+            return set()
+        try:
+            result = await self.db.execute(
+                select(EndUser.id).where(
+                    EndUser.id.in_(end_user_ids),
+                    EndUser.workspace_id == workspace_id,
+                )
+            )
+            return set(result.scalars().all())
+        except Exception as e:
+            await self.db.rollback()
+            db_logger.error(
+                "批量校验终端用户（含 inactive）异常%s",
+                str(e),
+            )
             raise
 
     async def filter_existing_ids_async(
@@ -2722,6 +2769,30 @@ class EndUserRepository:
         except Exception as e:
             await self.db.rollback()
             db_logger.error(f"更新记忆计数失败(异步): end_user_id={end_user_id}, error={str(e)}")
+            raise
+
+    async def finalize_memory_delete_async(self, end_user_id: uuid.UUID) -> bool:
+        """Idempotently mark an existing graph-deleted user inactive and empty."""
+        try:
+            result = await self.db.execute(
+                update(EndUser)
+                .where(EndUser.id == end_user_id)
+                .values(memory_count=0, is_active=False)
+            )
+            await self.db.commit()
+            if result.rowcount:
+                db_logger.info(
+                    "完成终端用户记忆删除 PG 收尾: end_user_id=%s",
+                    end_user_id,
+                )
+            return bool(result.rowcount)
+        except Exception as e:
+            await self.db.rollback()
+            db_logger.error(
+                "终端用户记忆删除 PG 收尾失败: end_user_id=%s, error=%s",
+                end_user_id,
+                str(e),
+            )
             raise
 
 

--- a/api/app/repositories/neo4j/community_repository.py
+++ b/api/app/repositories/neo4j/community_repository.py
@@ -48,8 +48,19 @@ _DEADLOCK_MAX_RETRY = 3
 
 
 class CommunityRepository:
-    def __init__(self, connector: Neo4jConnector):
+    def __init__(
+        self,
+        connector: Neo4jConnector,
+        *,
+        strict_reads: bool = False,
+    ):
         self.connector = connector
+        self.strict_reads = strict_reads
+
+    def _read_fallback(self, error: Exception, fallback):
+        if self.strict_reads:
+            raise error
+        return fallback
 
     async def upsert_community(
         self, community_id: str, end_user_id: str, member_count: int = 0
@@ -100,7 +111,7 @@ class CommunityRepository:
             )
         except Exception as e:
             logger.error(f"get_entity_neighbors failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def get_all_entities(self, end_user_id: str) -> List[Dict]:
         """拉取某用户下所有实体及其当前社区归属。"""
@@ -111,7 +122,7 @@ class CommunityRepository:
             )
         except Exception as e:
             logger.error(f"get_all_entities failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def get_entity_count(self, end_user_id: str) -> int:
         """仅返回用户实体总数，不加载实体数据。"""
@@ -123,7 +134,7 @@ class CommunityRepository:
             return result[0]["entity_count"] if result else 0
         except Exception as e:
             logger.error(f"get_entity_count failed: {e}")
-            return 0
+            return self._read_fallback(e, 0)
 
     async def get_all_entity_ids(self, end_user_id: str) -> List[str]:
         """仅返回用户所有实体 ID 列表，不加载 embedding 等大字段。"""
@@ -135,7 +146,7 @@ class CommunityRepository:
             return [r["id"] for r in result]
         except Exception as e:
             logger.error(f"get_all_entity_ids failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def get_entities_page(
         self, end_user_id: str, skip: int, limit: int
@@ -150,7 +161,7 @@ class CommunityRepository:
             )
         except Exception as e:
             logger.error(f"get_entities_page failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def get_entity_neighbors_for_ids(
         self, entity_ids: List[str], end_user_id: str
@@ -170,7 +181,7 @@ class CommunityRepository:
             return result
         except Exception as e:
             logger.error(f"get_entity_neighbors_for_ids failed: {e}")
-            return {}
+            return self._read_fallback(e, {})
 
     async def get_community_members(
         self, community_id: str, end_user_id: str
@@ -184,7 +195,7 @@ class CommunityRepository:
             )
         except Exception as e:
             logger.error(f"get_community_members failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def get_community_relationships(
         self, community_id: str, end_user_id: str
@@ -198,7 +209,7 @@ class CommunityRepository:
             )
         except Exception as e:
             logger.error(f"get_community_relationships failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def batch_assign_entities_to_communities(
         self, assignments: List[Dict], end_user_id: str,
@@ -282,7 +293,7 @@ class CommunityRepository:
             return result
         except Exception as e:
             logger.error(f"get_community_avg_embeddings_batch failed: {e}")
-            return {}
+            return self._read_fallback(e, {})
 
     async def has_communities(self, end_user_id: str) -> bool:
         """检查该用户是否已有 Community 节点（用于判断全量 vs 增量）。"""
@@ -294,7 +305,7 @@ class CommunityRepository:
             return result[0]["community_count"] > 0 if result else False
         except Exception as e:
             logger.error(f"has_communities failed: {e}")
-            return False
+            return self._read_fallback(e, False)
 
     async def refresh_member_count(
         self, community_id: str, end_user_id: str
@@ -324,7 +335,7 @@ class CommunityRepository:
             return [row["community_id"] for row in result]
         except Exception as e:
             logger.error(f"get_incomplete_communities failed: {e}")
-            return []
+            return self._read_fallback(e, [])
 
     async def is_community_complete(self, community_id: str, end_user_id: str, check_embedding: bool = False) -> bool:
         """检查单个社区节点的属性是否完整。"""
@@ -334,7 +345,7 @@ class CommunityRepository:
             return result[0]["is_complete"] if result else False
         except Exception as e:
             logger.error(f"is_community_complete failed: {e}")
-            return False
+            return self._read_fallback(e, False)
 
     async def update_community_metadata(
         self,

--- a/api/app/services/conversation_service.py
+++ b/api/app/services/conversation_service.py
@@ -29,6 +29,7 @@ from app.services import workspace_service
 from app.services.memory_config_service import MemoryConfigService
 from app.services.model_service import ModelConfigService, ModelApiKeyService
 from app.services.prompt import prompt_manager
+from app.utils.redis_cache import redis_cache
 
 logger = get_business_logger()
 
@@ -1483,6 +1484,7 @@ class ConversationService:
             "content": target_msg.content,
         }
 
+    @redis_cache(skip_args=['self', 'user'], return_type=ConversationOut)
     async def get_conversation_detail(
             self,
             user: User,

--- a/api/app/services/end_user_service.py
+++ b/api/app/services/end_user_service.py
@@ -1,16 +1,19 @@
+import asyncio
 import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.aioRedis import get_thread_safe_sync_redis
 from app.core.exceptions import BusinessException
 from app.core.logging_config import get_memory_logger
+from app.core.memory.storage.custom import merge_end_user_memory_nodes
 from app.models import EndUserInfo
 from app.models.end_user_model import EndUser
 from app.repositories.end_user_info_repository import EndUserInfoRepository
 from app.repositories.end_user_repository import EndUserRepository
-from app.repositories.neo4j.end_user_merge_repository import EndUserMergeNeo4jRepository
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+from app.utils.redis_lock import RedisFairLock
 
 logger = get_memory_logger()
 
@@ -22,6 +25,63 @@ class EndUserService:
         self.db = db
 
     async def merge_end_users(self, source: set[uuid.UUID], target: uuid.UUID):
+        """Merge end users while holding all graph ownership write locks."""
+        if not source:
+            raise BusinessException(message="No source user provided.")
+        if target in source:
+            raise BusinessException(message="Target user cannot be a source user.")
+
+        locks = await self._acquire_memory_write_locks(source, target)
+        try:
+            return await self._merge_end_users_locked(source, target)
+        finally:
+            await self._release_memory_write_locks(locks)
+
+    @staticmethod
+    async def _acquire_memory_write_locks(
+        source: set[uuid.UUID],
+        target: uuid.UUID,
+    ) -> list[RedisFairLock]:
+        redis_client = get_thread_safe_sync_redis()
+        locks: list[RedisFairLock] = []
+        lock_ids = sorted({str(target), *(str(source_id) for source_id in source)})
+        try:
+            for end_user_id in lock_ids:
+                lock = RedisFairLock(
+                    key=f"memory_write:{end_user_id}",
+                    redis_client=redis_client,
+                    expire=1200,
+                    timeout=60,
+                    auto_renewal=True,
+                )
+                if not await asyncio.to_thread(lock.acquire):
+                    raise BusinessException(
+                        message=f"Memory write lock timed out: {end_user_id}"
+                    )
+                locks.append(lock)
+            return locks
+        except Exception:
+            await EndUserService._release_memory_write_locks(locks)
+            raise
+
+    @staticmethod
+    async def _release_memory_write_locks(
+        locks: list[RedisFairLock],
+    ) -> None:
+        for lock in reversed(locks):
+            try:
+                await asyncio.to_thread(lock.release)
+            except Exception:
+                logger.exception(
+                    "[merge_end_users] 释放 memory_write 锁失败: key=%s",
+                    lock.key,
+                )
+
+    async def _merge_end_users_locked(
+        self,
+        source: set[uuid.UUID],
+        target: uuid.UUID,
+    ):
         """将 source 中的用户合并到 target 用户。
 
         合并操作涵盖（顺序即执行顺序，其中第 2 步是「归并意图先行落库」）：
@@ -64,8 +124,13 @@ class EndUserService:
 
         # ── 1.4 工作空间一致性校验：跨空间归并会串号，须在任何迁移前拦截 ──
         target_user = await self._get_end_user_any_async(target)
-        if not target_user:
-            raise BusinessException(message="Target user not found.")
+        if not target_user or not target_user.is_active:
+            raise BusinessException(message="Target user not found or inactive.")
+        missing_sources = source - set(source_users)
+        if missing_sources:
+            raise BusinessException(
+                message=f"Source users not found: {missing_sources}."
+            )
         mismatched = {
             source_id
             for source_id, source_user in source_users.items()
@@ -75,6 +140,38 @@ class EndUserService:
             raise BusinessException(
                 message=f"Cross-workspace merge is not allowed: {mismatched} not in workspace {target_user.workspace_id}."
             )
+
+        existing_merge_targets: dict[uuid.UUID, uuid.UUID | None] = {}
+        for source_id, source_user in source_users.items():
+            merge_target = await self.user_repo.get_merge_target_id_async(
+                source_id,
+                target_user.workspace_id,
+            )
+            existing_merge_targets[source_id] = merge_target
+            if merge_target is not None and merge_target != target:
+                raise BusinessException(
+                    message=f"Source user {source_id} is already merged to {merge_target}."
+                )
+            if not source_user.is_active and merge_target != target:
+                raise BusinessException(
+                    message=f"Inactive source user {source_id} has no matching merge intent."
+                )
+
+        # Snapshot every ORM value needed after the first commit.  The application
+        # session factory currently uses expire_on_commit=False, but this service
+        # accepts any AsyncSession; callers and tests may use the SQLAlchemy default
+        # (expire_on_commit=True).  Keeping only plain values across the commit also
+        # prevents future rollback/close changes from reintroducing detached access.
+        source_other_ids = {
+            source_id: source_user.other_id
+            for source_id, source_user in source_users.items()
+        }
+        target_aliases_snapshot = list(target_user_info.aliases or [])
+        target_meta_snapshot = dict(target_user_info.meta_data or {})
+        source_info_snapshots = [
+            (list(info.aliases or []), dict(info.meta_data or {}))
+            for info in end_user_infos
+        ]
 
         # ── 1.5 归并意图先行落库：软删 source + 写 end_user_merge 映射，同一次提交 ──
         # 位置刻意放在「所有前置校验之后、任何数据迁移之前」：
@@ -94,11 +191,12 @@ class EndUserService:
         await self.user_repo.soft_delete_many_pending_async(source)
         await self.user_repo.flatten_merge_chain_async(source, target, workspace_id)
         for src_id in source:
-            src_user = source_users.get(src_id)
+            if existing_merge_targets.get(src_id) == target:
+                continue
             # EndUserMerge.origin_other_id 是 NOT NULL，而 EndUser.other_id 允许为空
             # （agent chat 等入口可不传 user_id）。这里必须兜底为 id 字符串，
             # 否则归并会因非空约束直接失败。
-            origin_other_id = (src_user.other_id if src_user else None) or str(src_id)
+            origin_other_id = source_other_ids.get(src_id) or str(src_id)
             self.user_repo.create_merge_record(
                 origin_id=src_id,
                 origin_other_id=origin_other_id,
@@ -112,29 +210,28 @@ class EndUserService:
         )
 
         # ── 2. 合并 aliases 与 meta_data 到 target EndUserInfo ──
-        final_aliases: list[str] = list(target_user_info.aliases or [])
+        final_aliases: list[str] = list(target_aliases_snapshot)
         seen_alias_lower = {a.lower() for a in final_aliases}
 
-        merged_meta: dict = dict(target_user_info.meta_data or {})
+        merged_meta: dict = dict(target_meta_snapshot)
 
-        for info in end_user_infos:
-            for alias in (info.aliases or []):
+        for aliases, meta_data in source_info_snapshots:
+            for alias in aliases:
                 alias = alias.strip()
                 if alias and alias.lower() not in seen_alias_lower:
                     final_aliases.append(alias)
                     seen_alias_lower.add(alias.lower())
 
-            if info.meta_data:
-                for key, values in info.meta_data.items():
-                    if not isinstance(values, list):
-                        continue
-                    existing = list(merged_meta.get(key) or [])
-                    existing_set = {str(v).lower() for v in existing}
-                    for v in values:
-                        if str(v).lower() not in existing_set:
-                            existing.append(v)
-                            existing_set.add(str(v).lower())
-                    merged_meta[key] = existing
+            for key, values in meta_data.items():
+                if not isinstance(values, list):
+                    continue
+                existing = list(merged_meta.get(key) or [])
+                existing_set = {str(v).lower() for v in existing}
+                for v in values:
+                    if str(v).lower() not in existing_set:
+                        existing.append(v)
+                        existing_set.add(str(v).lower())
+                merged_meta[key] = existing
 
         target_user_info.aliases = final_aliases
         target_user_info.meta_data = merged_meta
@@ -146,20 +243,20 @@ class EndUserService:
             f"meta_keys={list(merged_meta.keys())}"
         )
 
-        # ── 3. Neo4j 操作（委托给 EndUserMergeNeo4jRepository） ──
+        # ── 3. Neo4j 操作（storage custom 原子事务 + 逐节点 Outbox） ──
+        source_strs = sorted(str(sid) for sid in source)
+        stats = await merge_end_user_memory_nodes(source_strs, str(target))
+        logger.info(
+            f"[merge_end_users] Neo4j 合并完成: "
+            f"sources={stats.sources_merged}, "
+            f"nodes={stats.reassigned_nodes}, "
+            f"edges={stats.reassigned_edges}, "
+            f"outbox={stats.outbox_events}"
+        )
+
+        # 同步 target 用户的 memory_count（只读 Neo4j 计数）。
         connector = Neo4jConnector(shared_driver=True)
         try:
-            neo4j_repo = EndUserMergeNeo4jRepository(connector)
-            source_strs = [str(sid) for sid in source]
-            stats = await neo4j_repo.reassign_all_to_target(
-                source_strs, str(target)
-            )
-            logger.info(
-                f"[merge_end_users] Neo4j 合并完成: "
-                f"nodes={stats['nodes']}, edges={stats['edges']}"
-            )
-
-            # 同步 target 用户的 memory_count（合并后节点数已变化）
             from app.core.memory.utils.memory_count_utils import (
                 sync_end_user_memory_count_from_neo4j,
             )
@@ -256,23 +353,53 @@ class EndUserService:
             await self.user_repo.acquire_identity_lock_async(
                 workspace_id, clean_features
             )
-            existing = await self.user_repo.find_active_by_identity_features(
-                workspace_id, clean_features
+            candidate = await self.user_repo.find_active_by_identity_features(
+                workspace_id,
+                clean_features,
+                for_update=False,
             )
-            if existing and existing.id != current_end_user.id:
-                # 先落标识再归并：source 行被软删后仍带 identity_features，
-                # 便于事后排查「这条记录当时按哪个标识被并走」。
-                current_end_user.identity_features = clean_features
-                current_end_user.identity_status = identity_status
-                await self.db.flush()
-                await self.merge_end_users(
-                    source={current_end_user.id}, target=existing.id
+            current_end_user_id = uuid.UUID(str(current_end_user.id))
+            candidate_id = uuid.UUID(str(candidate.id)) if candidate else None
+            if candidate_id is not None and candidate_id != current_end_user_id:
+                source_ids = {current_end_user_id}
+                locks = await self._acquire_memory_write_locks(
+                    source_ids,
+                    candidate_id,
                 )
+                try:
+                    existing = await self.user_repo.find_active_by_identity_features(
+                        workspace_id,
+                        clean_features,
+                        for_update=True,
+                    )
+                    existing_id = (
+                        uuid.UUID(str(existing.id)) if existing is not None else None
+                    )
+                    if existing_id is None or existing_id == current_end_user_id:
+                        raise BusinessException(
+                            message="Identity merge target changed during lock acquisition."
+                        )
+                    if existing_id != candidate_id:
+                        raise BusinessException(
+                            message="Identity merge target changed during lock acquisition."
+                        )
+
+                    # 先落标识再归并：source 行被软删后仍带 identity_features，
+                    # 便于事后排查「这条记录当时按哪个标识被并走」。
+                    current_end_user.identity_features = clean_features
+                    current_end_user.identity_status = identity_status
+                    await self.db.flush()
+                    await self._merge_end_users_locked(
+                        source=source_ids,
+                        target=existing_id,
+                    )
+                finally:
+                    await self._release_memory_write_locks(locks)
                 logger.info(
-                    f"[confirm_identity] 跨渠道归并: source={current_end_user.id} "
-                    f"→ target={existing.id}, identity_features={clean_features}"
+                    f"[confirm_identity] 跨渠道归并: source={current_end_user_id} "
+                    f"→ target={existing_id}, identity_features={clean_features}"
                 )
-                return existing.id, "confirmed", True
+                return existing_id, "confirmed", True
 
         current_end_user.identity_features = clean_features
         current_end_user.identity_status = identity_status

--- a/api/app/tasks.py
+++ b/api/app/tasks.py
@@ -24,7 +24,7 @@ from fastapi.encoders import jsonable_encoder
 from redis.exceptions import RedisError
 from sqlalchemy import String, cast, select
 
-from app.aioRedis import get_thread_safe_redis
+from app.aioRedis import get_thread_safe_redis, get_thread_safe_sync_redis
 from app.celery_app import celery_app
 from app.core.config import settings
 from app.core.logging_config import get_logger
@@ -6181,6 +6181,50 @@ def refresh_hot_memory_tags_cache(self) -> Dict[str, Any]:
 
 # =============================================================================
 # 社区聚类补全任务（触发型）
+
+def _resolve_community_clustering_owner_id(end_user_id: str) -> str:
+    """Resolve a possibly merged user to the current active graph owner."""
+    with get_db_context() as db:
+        from app.repositories.end_user_repository import EndUserRepository
+
+        resolved = EndUserRepository(db).resolve_merge_by_origin_id(
+            uuid.UUID(end_user_id)
+        )
+        return str(resolved.id) if resolved else end_user_id
+
+
+def _acquire_community_clustering_lock(
+    original_end_user_id: str,
+    *,
+    redis_client,
+    expire: int,
+) -> tuple[str, RedisFairLock]:
+    """Resolve, lock, and re-resolve until the lock protects current owner."""
+    candidate_id = original_end_user_id
+    while True:
+        effective_id = _resolve_community_clustering_owner_id(candidate_id)
+        write_lock = RedisFairLock(
+            key=f"memory_write:{effective_id}",
+            redis_client=redis_client,
+            expire=expire,
+            timeout=60,
+            auto_renewal=True,
+        )
+        if not write_lock.acquire():
+            raise RuntimeError(
+                f"Get redis lock timeout: memory_write:{effective_id}"
+            )
+        try:
+            confirmed_id = _resolve_community_clustering_owner_id(candidate_id)
+        except Exception:
+            write_lock.release()
+            raise
+        if confirmed_id == effective_id:
+            return effective_id, write_lock
+        write_lock.release()
+        candidate_id = confirmed_id
+
+
 # =============================================================================
 
 @celery_app.task(
@@ -6214,9 +6258,12 @@ def run_incremental_clustering(
         包含任务执行结果的字典
     """
     start_time = time.time()
+    original_end_user_id = end_user_id
 
     async def _run() -> Dict[str, Any]:
         from app.core.logging_config import get_logger
+        from app.core.memory.storage.custom import CommunityMutationWriter
+        from app.core.memory.storage.provider.neo4j.client import Neo4jClient
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
         from app.core.memory.storage_services.clustering_engine.label_propagation import LabelPropagationEngine
 
@@ -6233,10 +6280,13 @@ def run_incremental_clustering(
             memory_config = MemoryConfigService(db).load_memory_config(config_id=config_id)
 
         connector = Neo4jConnector()
+        storage_client = None
         try:
+            storage_client = await Neo4jClient.create()
             engine = LabelPropagationEngine(
                 connector=connector,
                 memory_config=memory_config,
+                community_writer=CommunityMutationWriter(storage_client),
                 language=language,
             )
 
@@ -6254,10 +6304,20 @@ def run_incremental_clustering(
             logger.error(f"[IncrementalClustering] 增量聚类失败: {e}", exc_info=True)
             raise
         finally:
-            await connector.close()
+            try:
+                if storage_client is not None:
+                    await storage_client.close()
+            finally:
+                await connector.close()
 
     loop = set_asyncio_event_loop()
+    write_lock = None
     try:
+        end_user_id, write_lock = _acquire_community_clustering_lock(
+            original_end_user_id,
+            redis_client=get_thread_safe_sync_redis(),
+            expire=1800,
+        )
         result = loop.run_until_complete(_run())
         result["elapsed_time"] = time.time() - start_time
         result["task_id"] = self.request.id
@@ -6270,6 +6330,8 @@ def run_incremental_clustering(
         return result
     # 不再 catch 全局异常，直接冒出 → Celery FAILURE
     finally:
+        if write_lock is not None:
+            write_lock.release()
         _shutdown_loop_gracefully(loop)
 
 
@@ -6301,6 +6363,8 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
     async def _run() -> Dict[str, Any]:
         from app.core.logging_config import get_logger
         from app.repositories.neo4j.community_repository import CommunityRepository
+        from app.core.memory.storage.custom import CommunityMutationWriter
+        from app.core.memory.storage.provider.neo4j.client import Neo4jClient
         from app.repositories.neo4j.neo4j_connector import Neo4jConnector
         from app.core.memory.storage_services.clustering_engine.label_propagation import LabelPropagationEngine
 
@@ -6312,8 +6376,12 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
         failed = 0
 
         connector = Neo4jConnector()
+        storage_client = None
         try:
+            storage_client = await Neo4jClient.create()
             repo = CommunityRepository(connector)
+            community_writer = CommunityMutationWriter(storage_client)
+            redis_client = get_thread_safe_sync_redis()
 
             # 批量预取所有用户的 MemoryConfig（tenant 与 model_id 同源），避免循环内逐个查库。
             # 加载失败的用户不存入 map，循环内检测到缺失时直接 skip。
@@ -6333,13 +6401,40 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
             except Exception as e:
                 logger.error(f"[CommunityCluster] 批量获取配置失败: {e}")
 
-            for end_user_id in end_user_ids:
+            for requested_end_user_id in end_user_ids:
+                write_lock = None
+                end_user_id = requested_end_user_id
                 try:
+                    end_user_id, write_lock = _acquire_community_clustering_lock(
+                        requested_end_user_id,
+                        redis_client=redis_client,
+                        expire=7200,
+                    )
+
                     # 配置加载失败的用户直接跳过
                     memory_config = user_config_map.get(end_user_id)
+                    if not memory_config and end_user_id != requested_end_user_id:
+                        with get_db_context() as db:
+                            from app.services.memory_agent_service import (
+                                get_end_users_connected_configs_batch,
+                            )
+                            from app.services.memory_config_service import MemoryConfigService
+
+                            resolved_configs = get_end_users_connected_configs_batch(
+                                [end_user_id], db
+                            )
+                            config_info = resolved_configs.get(end_user_id) or {}
+                            resolved_config_id = config_info.get("memory_config_id")
+                            if resolved_config_id:
+                                memory_config = MemoryConfigService(db).load_memory_config(
+                                    config_id=resolved_config_id
+                                )
+                                user_config_map[end_user_id] = memory_config
                     if not memory_config:
                         failed += 1
-                        logger.warning(f"[CommunityCluster] 用户 {end_user_id} 无有效配置，跳过聚类")
+                        logger.warning(
+                            f"[CommunityCluster] 用户 {end_user_id} 无有效配置，跳过聚类"
+                        )
                         continue
 
                     # 已有社区节点时，检查是否存在属性不完整的节点
@@ -6358,6 +6453,7 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
                         engine = LabelPropagationEngine(
                             connector=connector,
                             memory_config=memory_config,
+                            community_writer=community_writer,
                         )
                         logger.info(
                             f"[CommunityCluster] 用户 {end_user_id} 发现 {len(incomplete_ids)} 个属性不完整的社区，开始补全"
@@ -6366,7 +6462,9 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
                         patch_fail = 0
                         for cid in incomplete_ids:
                             try:
-                                await engine._generate_community_metadata([cid], end_user_id)
+                                await engine._generate_community_metadata(
+                                    [cid], end_user_id
+                                )
                                 patch_ok += 1
                             except Exception as patch_err:
                                 patch_fail += 1
@@ -6388,6 +6486,7 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
                     engine = LabelPropagationEngine(
                         connector=connector,
                         memory_config=memory_config,
+                        community_writer=community_writer,
                     )
 
                     logger.info(
@@ -6400,9 +6499,16 @@ def init_community_clustering_for_users(self, end_user_ids: List[str], workspace
                 except Exception as e:
                     failed += 1
                     logger.error(f"[CommunityCluster] 用户 {end_user_id} 聚类失败: {e}")
+                finally:
+                    if write_lock is not None:
+                        write_lock.release()
 
         finally:
-            await connector.close()
+            try:
+                if storage_client is not None:
+                    await storage_client.close()
+            finally:
+                await connector.close()
 
         logger.info(
             f"[CommunityCluster] 任务完成: 初始化={initialized}, 跳过={skipped}, 失败={failed}"
@@ -6740,7 +6846,8 @@ def run_workflow_schedule_trigger(app_id: str, release_id: str, trigger_id: str,
 @celery_app.task(name="app.tasks.draft_data_clean", queue="memory_tasks")
 def draft_data_clean():
     import asyncio
-    from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+
+    from app.core.memory.storage.custom import delete_end_user_memory_nodes
 
     with get_db_context() as db:
         stmt = select(EndUser.id).join(
@@ -6750,32 +6857,67 @@ def draft_data_clean():
             EndUser.is_active == True
         )
         result = db.execute(stmt)
-        end_user_ids = [str(eid) for eid in result.scalars()]
+        candidate_ids = list(result.scalars())
 
-        if not end_user_ids:
+        if not candidate_ids:
             logger.info("draft_data_clean: 没有需要清理的终端用户")
             return {"deleted_count": 0}
 
-        updated = (
+        # Preserve the legacy cleanup invariant: deactivate the complete PG
+        # batch first. Graph cleanup is best-effort afterwards, so a Neo4j or
+        # Outbox failure must never leave these users active again.
+        pg_deleted = (
             db.query(EndUser)
-            .filter(EndUser.id.in_(end_user_ids))
-            .update({"is_active": False}, synchronize_session=False)
+            .filter(
+                EndUser.id.in_(candidate_ids),
+                EndUser.is_active == True,
+            )
+            .update(
+                {"is_active": False, "memory_count": 0},
+                synchronize_session=False,
+            )
         )
         db.commit()
-        logger.info(f"draft_data_clean: 软删除 {updated} 个终端用户")
 
-    async def _delete_neo4j_groups():
-        async with Neo4jConnector() as connector:
-            deleted = 0
-            for eid in end_user_ids:
-                try:
-                    await connector.delete_group(eid)
-                    deleted += 1
-                except Exception as e:
-                    logger.error(f"draft_data_clean: Neo4j 删除失败 end_user_id={eid}: {e}")
-        return deleted
+    end_user_ids = [str(end_user_id) for end_user_id in candidate_ids]
+    neo4j_deleted = 0
+    neo4j_deleted_nodes = 0
+    neo4j_failed = 0
+    redis_client = get_thread_safe_sync_redis()
+    for eid in end_user_ids:
+        write_lock = RedisFairLock(
+            key=f"memory_write:{eid}",
+            redis_client=redis_client,
+            expire=1200,
+            timeout=60,
+            auto_renewal=True,
+        )
+        try:
+            with write_lock:
+                deleted_nodes = asyncio.run(
+                    delete_end_user_memory_nodes(eid)
+                )
+            neo4j_deleted += 1
+            neo4j_deleted_nodes += deleted_nodes
+        except Exception:
+            neo4j_failed += 1
+            logger.exception(
+                "draft_data_clean: Neo4j/Outbox 删除失败，继续下一个用户 "
+                "end_user_id=%s",
+                eid,
+            )
+            continue
 
-    neo4j_deleted = asyncio.run(_delete_neo4j_groups())
-    logger.info(f"draft_data_clean: Neo4j 删除 {neo4j_deleted} 组节点")
-
-    return {"pg_deleted": updated, "neo4j_deleted": neo4j_deleted}
+    logger.info(
+        "draft_data_clean: PG 软删除 %s 个用户；Neo4j 成功 %s 组、%s 个节点，失败 %s 组",
+        pg_deleted,
+        neo4j_deleted,
+        neo4j_deleted_nodes,
+        neo4j_failed,
+    )
+    return {
+        "pg_deleted": pg_deleted,
+        "neo4j_deleted": neo4j_deleted,
+        "neo4j_deleted_nodes": neo4j_deleted_nodes,
+        "neo4j_failed": neo4j_failed,
+    }


### PR DESCRIPTION
## Sourcery 摘要

通过图谱变更、所有权锁定和可靠的 outbox 同步，实现终端用户的合并与删除工作流。

新功能：
- 添加终端用户记忆合并和删除操作，修改 Neo4j 图谱并发布节点级 outbox 事件。
- 添加社区变更支持，用于分配、元数据更新、成员数量校准以及清理，并与 outbox 同步。

错误修复：
- 通过在写锁下解析所有权，防止记忆删除和聚类操作基于已合并用户的过时图谱所有者执行。
- 仅在图谱清理成功后完成终端用户删除的数据库状态更新，并拒绝针对已合并源用户的删除请求。
- 改进终端用户合并在非活跃用户、缺少源用户、已有合并映射以及并发身份合并场景下的验证和幂等性。

增强功能：
- 引入经过验证的 Neo4j 写事务，在提交前验证变更身份，并提供结构化的合并、删除和社区变更结果。
- 使用 Redis 所有权锁协调记忆写入、合并、删除和聚类，并采用更安全的重试和故障处理机制。
- 为会话详情检索添加缓存支持，并为社区仓库操作提供可配置的严格读取回退机制。

维护事项：
- 使用共享存储自定义操作和逐节点 outbox 同步，替换旧版 Neo4j 终端用户合并和删除路径。
- 更新清理和聚类任务，以使用新的图谱变更服务并报告图谱清理结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement end-user merge and delete workflows with graph mutations, ownership locking, and reliable outbox synchronization.

New Features:
- Add end-user memory merge and deletion operations that mutate Neo4j graphs and publish node-level outbox events.
- Add community mutation support for assignment, metadata updates, member-count reconciliation, and cleanup with outbox synchronization.

Bug Fixes:
- Prevent memory deletion and clustering from operating on stale merged-user graph owners by resolving ownership under write locks.
- Make end-user deletion finalize database state only after successful graph cleanup and reject deletion requests targeting merged source users.
- Improve end-user merge validation and idempotency for inactive users, missing sources, existing merge mappings, and concurrent identity merges.

Enhancements:
- Introduce validated Neo4j write transactions that validate mutation identities before commit and provide structured merge, delete, and community mutation results.
- Coordinate memory writes, merges, deletions, and clustering with Redis ownership locks and safer retry and failure handling.
- Add cache support for conversation detail retrieval and configurable strict read fallbacks for community repository operations.

Chores:
- Replace legacy Neo4j end-user merge and deletion paths with shared storage custom operations and per-node outbox synchronization.
- Update cleanup and clustering tasks to use the new graph mutation services and report graph cleanup outcomes.

</details>