### PR TITLE
fix(memory): add server defaults for scene config fields

### DIFF
--- a/api/app/models/memory_config_model.py
+++ b/api/app/models/memory_config_model.py
@@ -84,12 +84,12 @@ class MemoryConfig(Base):
     min_days_since_access = Column(Integer, default=30, comment="最小未访问天数，默认30")
     
     # SceneSummary 场景边界配置
-    scene_threshold = Column(Float, nullable=False, default=0.8, comment="Scene 连续性阈值")
-    scene_history_window_size = Column(Integer, nullable=False, default=4, comment="BERT 历史 user 窗口")
-    scene_min_turns = Column(Integer, nullable=False, default=2, comment="Scene 最小保护轮次")
-    scene_max_turns = Column(Integer, nullable=False, default=10, comment="Scene 最大轮次")
-    scene_idle_timeout_seconds = Column(Integer, nullable=False, default=86400, comment="Scene 静默超时秒数")
-    scene_min_chars_to_summary = Column(Integer, nullable=False, default=0, comment="SceneSummary 最小有效字符数")
+    scene_threshold = Column(Float, nullable=False, default=0.8, server_default="0.8", comment="Scene 连续性阈值")
+    scene_history_window_size = Column(Integer, nullable=False, default=4, server_default="4", comment="BERT 历史 user 窗口")
+    scene_min_turns = Column(Integer, nullable=False, default=2, server_default="2", comment="Scene 最小保护轮次")
+    scene_max_turns = Column(Integer, nullable=False, default=10, server_default="10", comment="Scene 最大轮次")
+    scene_idle_timeout_seconds = Column(Integer, nullable=False, default=86400, server_default="86400", comment="Scene 静默超时秒数")
+    scene_min_chars_to_summary = Column(Integer, nullable=False, default=0, server_default="0", comment="SceneSummary 最小有效字符数")
     time_decay_penalty = Column(Float, nullable=False, default=0.1, server_default="0.1",comment="时间衰减惩罚（0-0.2），仅存储，暂不参与计算",)
 
     # 情绪引擎配置


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 确保在插入记录时未显式指定值的场景配置字段在数据库层级获得其默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure scene configuration fields receive their default values at the database level when records are inserted without explicit values.

</details>