### PR TITLE
refactor(reflection): migrate reflection pipeline to storage abstract layer

### DIFF
--- a/api/app/core/memory/pipelines/reflection_pipeline.py
+++ b/api/app/core/memory/pipelines/reflection_pipeline.py
@@ -148,6 +148,9 @@ class ReflectionPipeline:
                 language=self.language,
             )
         finally:
+            # inspector 内部自建的 storage service 与这里的 Neo4jConnector
+            # 各自持有独立的 Neo4j driver，两者都要释放。
+            await inspector.close_storage_service()
             await connector.close()
 
         await self._save_reflection_display_event(result, "layer2_frequent")
@@ -185,6 +188,7 @@ class ReflectionPipeline:
         try:
             result = await inspector.run_dedup_full_scan(self.end_user_id, baseline=baseline)
         finally:
+            await inspector.close_storage_service()
             await connector.close()
 
         await self._save_reflection_display_event(result, "dedup_full_scan")

--- a/api/app/core/memory/storage/custom/__init__.py
+++ b/api/app/core/memory/storage/custom/__init__.py
@@ -52,6 +52,24 @@ from app.core.memory.storage.custom.forget_recovery import (
     recover_forgotten_node_by_element_id,
     resolve_forget_recovery_target,
 )
+from app.core.memory.storage.custom.reflection_entity_updates import (
+    merge_entity_description,
+    rename_entity,
+    update_entity_name_embedding,
+)
+from app.core.memory.storage.custom.reflection_mutations import (
+    append_user_info,
+    create_unresolved_entity,
+    create_unresolved_relationship,
+    create_unresolved_statement_entity_edge,
+    delete_alias_nodes,
+    drop_alias_belongs_edges,
+    merge_alias_properties,
+    merge_entities,
+    patch_entity_metadata,
+    redirect_alias_edges,
+    resolve_statement,
+)
 
 __all__ = [
     "AutomaticForgetOutboxError",
@@ -68,9 +86,15 @@ __all__ = [
     "ForgottenNodeIdentity",
     "ForgetRecoveryTarget",
     "ManualDeleteTarget",
+    "append_user_info",
     "compute_topology_score",
+    "create_unresolved_entity",
+    "create_unresolved_relationship",
+    "create_unresolved_statement_entity_edge",
+    "delete_alias_nodes",
     "delete_end_user_memory_nodes",
     "delete_manual_node_by_element_id",
+    "drop_alias_belongs_edges",
     "resolve_manual_delete_target",
     "recover_forgotten_node_by_element_id",
     "resolve_forget_recovery_target",
@@ -80,9 +104,17 @@ __all__ = [
     "get_user_entity_id",
     "get_user_metadata",
     "get_user_sources_for_entities",
+    "merge_alias_properties",
     "merge_end_user_memory_nodes",
+    "merge_entities",
+    "merge_entity_description",
+    "patch_entity_metadata",
+    "redirect_alias_edges",
+    "rename_entity",
+    "resolve_statement",
     "search_entities_by_name",
     "search_related_entities",
     "soft_delete_forgetting_nodes",
+    "update_entity_name_embedding",
     "update_user_entity_aliases",
 ]

--- a/api/app/core/memory/storage/custom/reflection_entity_updates.py
+++ b/api/app/core/memory/storage/custom/reflection_entity_updates.py
@@ -1,0 +1,184 @@
+"""Layer2 反思 · 实体更新写链（模式 A：经 storage 抽象层）。
+
+三条写链：
+- ``merge_entity_description``：写入描述摘要、历史碎片与事件时间线，清空 description。
+- ``rename_entity``：改写实体名称。
+- ``update_entity_name_embedding``：更新实体名称向量。
+
+三者都是单实体属性赋值、无拓扑变化，因此走模式 A 的标准 CRUD：
+经 ``MemoryStorageService.update_node`` 写 Neo4j，由 ``WriteRouter`` 向 PostgreSQL
+Outbox 发布该实体的 ``UPSERT`` 投影事件，投影 worker 再同步到 Elasticsearch。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.models import (
+    FilterCondition,
+    FilterOperator,
+    NodeFilter,
+)
+from app.core.memory.storage.outbox.exceptions import OutboxEnqueueError
+from app.core.memory.storage.service import MemoryStorageService, get_storage_service
+
+logger = logging.getLogger(__name__)
+
+
+async def _update_entity_fields(
+    entity_id: str,
+    data: dict,
+    storage_service: MemoryStorageService | None,
+    *,
+    operation: str,
+) -> bool:
+    """按业务 id 更新单个存活实体，并校验命中身份。
+
+    过滤条件为 ``id`` + ``delete_at IS NULL``。``ExtractedEntity.id`` 有全局唯一约束
+    （``repositories/neo4j/create_indexes.py`` 的 ``entity_id_unique``，由 ``main.py``
+    启动流程建立），单 id 最多命中一个节点，因此不需要再按 ``end_user_id`` 收窄。
+
+    Args:
+        entity_id: 待更新 ``ExtractedEntity`` 的业务 ``id``。
+        data: 待写入的字段字典。
+        storage_service: 测试注入点，缺省时使用全局或上下文单例。
+        operation: 出现在日志与异常消息里的操作名，便于定位是哪条写链出的问题。
+
+    Returns:
+        ``True`` 表示已更新；``False`` 表示未命中任何节点（实体已被软删）。
+
+    Raises:
+        RuntimeError: mutation 命中了本不该被它改到的节点身份（多条匹配或 id 不符）。
+            ``WriteRouter`` 用命中结果推导 Outbox 事件身份，放行会把脏数据扩散到 ES。
+    """
+    service = storage_service or get_storage_service()
+    try:
+        result = await service.update_node(
+            MemoryNodeType.EXTRACTED_ENTITY,
+            data,
+            NodeFilter.all_of(
+                FilterCondition(field="id", value=entity_id),
+                FilterCondition(
+                    field="delete_at",
+                    operator=FilterOperator.EXISTS,
+                    value=False,
+                ),
+            ),
+        )
+    except OutboxEnqueueError as exc:
+        # 事件溯源主键是 (label, node_id)，日志带 entity_id 与 event_ids 即可定位
+        logger.error(
+            f"{operation} Neo4j 已提交但 Outbox 入队失败 "
+            f"entity_id={entity_id} "
+            f"event_ids={[str(i) for i in exc.event_ids]} reason={exc.reason}",
+            exc_info=True,
+        )
+        return True
+
+    # 业务 id 唯一，命中多个说明数据已脏，放行会让 WriteRouter 为每个命中节点各发一条 UPSERT 扩散脏数据
+    if result.affected_count > 1:
+        raise RuntimeError(
+            f"{operation} matched multiple entities for one business id"
+        )
+    if result.affected_count == 1 and result.ids != [entity_id]:
+        raise RuntimeError(f"{operation} updated an unexpected entity id")
+    return result.affected_count == 1
+
+
+async def merge_entity_description(
+    entity_id: str,
+    *,
+    description_summary: str,
+    description_timeline: str,
+    event_timeline: str,
+    storage_service: MemoryStorageService | None = None,
+) -> bool:
+    """把实体的 description 碎片替换为合并后的摘要。
+
+    ``description`` 被清空，因为调用方已经把原始碎片并入了
+    ``description_timeline``；清空它才能让下一轮反思不再重复合并同一批碎片。
+
+    Args:
+        entity_id: 待更新 ``ExtractedEntity`` 的业务 ``id``。
+        description_summary: 合并后的摘要，替代原碎片。
+        description_timeline: 碎片历史，包含被清空的正文。
+        event_timeline: 序列化后的事件时间线。
+        storage_service: 测试注入点。
+
+    Returns:
+        ``True`` 表示实体已更新；``False`` 表示未命中（实体已被软删）。
+    """
+    return await _update_entity_fields(
+        entity_id,
+        {
+            "description": "",
+            "description_summary": description_summary,
+            "description_timeline": description_timeline,
+            "event_timeline": event_timeline,
+        },
+        storage_service,
+        operation="描述合并",
+    )
+
+
+async def rename_entity(
+    entity_id: str,
+    *,
+    new_name: str,
+    storage_service: MemoryStorageService | None = None,
+) -> bool:
+    """改写实体名称。
+
+    冲突检查（``REFLECTION_RENAME_CHECK_CONFLICT``）是只读查询，留在调用方，
+    本函数只负责写入。空名字由 ``Layer2Inspector._try_rename_entity`` 的两层判空拦掉
+    （``should_rename_entity`` 与 ``not suggested_name.strip() -> "skipped:empty"``）。
+
+    Args:
+        entity_id: 待更名 ``ExtractedEntity`` 的业务 ``id``。
+        new_name: 新名称，调用方已 strip。
+        storage_service: 测试注入点。
+
+    Returns:
+        ``True`` 表示已更名；``False`` 表示未命中（实体已被软删）。
+
+    Raises:
+        RuntimeError: mutation 命中了本不该被它改到的节点身份。
+    """
+    return await _update_entity_fields(
+        entity_id,
+        {"name": new_name},
+        storage_service,
+        operation="Entity rename",
+    )
+
+
+async def update_entity_name_embedding(
+    entity_id: str,
+    *,
+    name_embedding: list[float],
+    storage_service: MemoryStorageService | None = None,
+) -> bool:
+    """写入实体名称向量。
+
+    更名后、去重合并后、未识别实体回填后都会重算 name_embedding，三处共用本函数：
+    写入语义相同，发出的都是同一个实体的 UPSERT 事件。更名与向量更新分两次调用，
+    避免向量计算超时或失败影响名称本身的落库。
+
+    Args:
+        entity_id: 目标 ``ExtractedEntity`` 的业务 ``id``。
+        name_embedding: 新名称的向量，三个调用点各自用 ``if <向量>:`` 拦掉空值。
+        storage_service: 测试注入点。
+
+    Returns:
+        ``True`` 表示已写入；``False`` 表示未命中（实体已被软删）。
+
+    Raises:
+        RuntimeError: mutation 命中了本不该被它改到的节点身份。
+    """
+    return await _update_entity_fields(
+        entity_id,
+        {"name_embedding": name_embedding},
+        storage_service,
+        operation="Entity name embedding update",
+    )

--- a/api/app/core/memory/storage/custom/reflection_mutations.py
+++ b/api/app/core/memory/storage/custom/reflection_mutations.py
@@ -1,0 +1,629 @@
+"""Layer2 反思的 custom 写链：显式事务 + 精确的 Outbox 事件身份。
+
+每个 mutation 提交一次 Cypher 事务，只为该事务实际改动的节点发布投影事件；
+事件身份内联在查询的 ``RETURN`` 里（``affected_count`` + ``affected_nodes``），
+在 commit 之前校验，物理删除的节点也能拿到正确的 DELETE 身份。
+
+纯关系写走 ``_relationship_write``，提交但不发事件。
+
+别名归并的三步（属性合并 / 边重定向 / 删别名节点）各自一个独立事务，
+失败隔离由 ``deterministic/alias_merger.py`` 负责。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.memory.storage.enums import MemoryNodeType
+from app.core.memory.storage.outbox.producer import enqueue_events
+from app.core.memory.storage.outbox.repository import OutboxRepository
+from app.core.memory.storage.outbox.types import OutboxEventInput, OutboxOperation
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+logger = logging.getLogger(__name__)
+
+
+def _events_from_rows(rows: list[dict[str, Any]]) -> list[OutboxEventInput]:
+    affected = [node for row in rows for node in row["affected_nodes"]]
+    count = sum(row["affected_count"] for row in rows)
+    identities = {(node["label"], node["node_id"]) for node in affected}
+    if count != len(affected) or count != len(identities):
+        raise RuntimeError("Reflection mutation affected identity count mismatch")
+    if any(not isinstance(node["node_id"], str) or not node["node_id"].strip() for node in affected):
+        raise RuntimeError("Reflection mutation returned a missing node id")
+    # Stable ordering includes batches whose Cypher aggregation has no row order.
+    affected.sort(key=lambda node: (node["operation"] != "UPSERT", node["label"], node["node_id"]))
+    return [OutboxEventInput(
+        label=MemoryNodeType(node["label"]),
+        node_id=node["node_id"],
+        operation=OutboxOperation[node["operation"]],
+    ) for node in affected]
+
+
+async def _write(
+    query: str,
+    parameters: dict[str, Any],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+    outbox_repository: OutboxRepository | None = None,
+) -> list[dict[str, Any]]:
+    # 参数由 Layer2Inspector 从任务入参透传，此处不判空：租户参数为空时
+    # {end_user_id: $end_user_id} 匹配不到任何节点，退化为 no-op。
+    client = neo4j_client or await Neo4jClient.create()
+    try:
+        if client.client is None:
+            raise RuntimeError("Neo4jClient is not initialized")
+        # Validate while rollback is still possible. Never re-MATCH after commit.
+        async with client.client.session() as session, await session.begin_transaction() as transaction:
+            result = await transaction.run(query, **parameters)
+            rows = await result.data()
+            events = _events_from_rows(rows)
+            await transaction.commit()
+        # Publish before closing an owned client, so close failures cannot lose events.
+        try:
+            await enqueue_events(events, repository=outbox_repository)
+        except Exception as exc:
+            logger.error(
+                f"反思写链 Neo4j 已提交但 Outbox 入队失败 "
+                f"user={parameters.get('end_user_id', '(查询未按用户过滤，见 affected_nodes)')} "
+                f"affected_nodes={[(e.label.value, e.node_id, e.operation.name) for e in events]} "
+                f"reason={exc}",
+                exc_info=True,
+            )
+        return rows
+    finally:
+        if neo4j_client is None:
+            try:
+                await client.close()
+            except Exception:
+                logger.warning("Closing reflection storage client failed", exc_info=True)
+
+
+async def patch_entity_metadata(parameters: dict[str, Any], **dependencies) -> list[dict[str, Any]]:
+    """原子 patch 八个 metadata 列表字段，按业务 ``entity_id`` 定位。
+
+    ``parameters`` 由 ``extract_metadata_service._build_patch_params`` 构造，含
+    ``entity_id`` 与每个字段的 ``_add`` / ``_delete`` / ``_update`` 三组操作。
+    全部操作为空时直接返回，不建连接、不发无变化的 UPSERT 事件。
+    """
+    if not any(value for key, value in parameters.items() if key.endswith(("_add", "_delete", "_update"))):
+        return []
+    return await _write(PATCH_METADATA, parameters, **dependencies)
+
+
+async def merge_entities(end_user_id: str, keeper_id: str, loser_id: str,
+                         merged_name: str, merged_aliases: list[str], **dependencies) -> bool:
+    """一个事务内合并 keeper 与 loser 的属性、迁移 loser 的边、物理删除 loser。
+
+    返回 keeper 的 UPSERT 与 loser 的 DELETE 两条事件。
+
+    自合并（``keeper_id == loser_id``）由三条配对来源各自排除：高频的
+    ``DEDUP_CANDIDATES_BY_NAME`` / ``_BY_EMBED`` 带 ``elementId(e1) < elementId(e2)``，
+    低频 LLM 判定与同名直合在 ``Layer2Inspector`` 内 ``continue`` 掉。真走到这里也是
+    安全的——两条事件身份重复，``_events_from_rows`` 会在 commit 前抛错并回滚。
+    """
+    rows = await _write(MERGE_ENTITIES, {"end_user_id": end_user_id, "keeper_id": keeper_id,
+                        "loser_id": loser_id, "merged_name": merged_name, "merged_aliases": merged_aliases}, **dependencies)
+    return bool(rows)
+
+
+async def create_unresolved_entity(parameters: dict[str, Any], **dependencies) -> list[dict[str, Any]]:
+    return await _write(CREATE_UNRESOLVED_ENTITY, parameters, **dependencies)
+
+
+async def append_user_info(end_user_id: str, description: str, **dependencies) -> list[dict[str, Any]]:
+    if not description:
+        return []
+    return await _write(APPEND_USER_INFO, {"end_user_id": end_user_id, "description": description}, **dependencies)
+
+
+async def resolve_statement(statement_id: str, **dependencies) -> bool:
+    """把 Statement 的 ``has_unsolved_reference`` 置为 false，按业务 ``statement_id`` 定位。"""
+    rows = await _write(RESOLVE_STATEMENT, {"statement_id": statement_id}, **dependencies)
+    return bool(rows)
+
+
+async def merge_alias_properties(end_user_id: str, alias_ids: list[str], **dependencies) -> int:
+    """别名归并第 1 步：source.name → target.aliases、source.description → target.description。
+
+    三步（本步、边重定向、删别名节点）各自一个事务，单步失败由
+    ``alias_merger.merge_alias_belongs_to`` 隔离，不回滚其它步骤。发 target 的 UPSERT 事件。
+
+    Returns:
+        受影响的 target 数量。
+    """
+    if not alias_ids:
+        return 0
+    rows = await _write(
+        MERGE_ALIAS_PROPERTIES,
+        {"end_user_id": end_user_id, "alias_ids": sorted(set(alias_ids))},
+        **dependencies,
+    )
+    return int(rows[0]["alias_merged"]) if rows else 0
+
+
+async def delete_alias_nodes(end_user_id: str, alias_ids: list[str], **dependencies) -> int:
+    """别名归并第 3 步：DETACH DELETE 别名节点。发 alias 的 DELETE 事件。
+
+    事件身份在 ``DETACH DELETE`` 之前构造：节点删除后 ``a.id`` 已不可读。
+
+    Returns:
+        被删除的别名节点数量。
+    """
+    if not alias_ids:
+        return 0
+    rows = await _write(
+        DELETE_ALIAS_NODES,
+        {"end_user_id": end_user_id, "alias_ids": sorted(set(alias_ids))},
+        **dependencies,
+    )
+    return int(rows[0]["alias_nodes_deleted"]) if rows else 0
+
+
+async def _relationship_write(
+    query: str,
+    parameters: dict[str, Any],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+) -> list[dict[str, Any]]:
+    """Commit a relationship-only reflection mutation through storage Neo4j.
+
+    Relationship writes do not create projection events by themselves; the two
+    endpoint nodes are projected by their own UPSERT events. The caller still uses
+    the storage-owned client so that no reflection mutation bypasses the storage
+    boundary. Parameters are passed through as-is.
+    """
+    client = neo4j_client or await Neo4jClient.create()
+    try:
+        if client.client is None:
+            raise RuntimeError("Neo4jClient is not initialized")
+        async with client.client.session() as session:
+            transaction = await session.begin_transaction()
+            try:
+                result = await transaction.run(query, **parameters)
+                rows = await result.data()
+                await transaction.commit()
+                return rows
+            except BaseException:
+                await transaction.rollback()
+                raise
+    finally:
+        if neo4j_client is None:
+            await client.close()
+
+
+async def create_unresolved_relationship(
+    parameters: dict[str, Any],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+) -> list[dict[str, Any]]:
+    return await _relationship_write(
+        CREATE_UNRESOLVED_RELATIONSHIP,
+        parameters,
+        neo4j_client=neo4j_client,
+    )
+
+
+async def create_unresolved_statement_entity_edge(
+    parameters: dict[str, Any],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+) -> list[dict[str, Any]]:
+    return await _relationship_write(
+        CREATE_UNRESOLVED_STATEMENT_ENTITY_EDGE,
+        parameters,
+        neo4j_client=neo4j_client,
+    )
+
+
+async def redirect_alias_edges(
+    end_user_id: str,
+    alias_ids: list[str],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+) -> int:
+    """别名归并第 2 步：别名节点上「别名属于」以外的边重定向到 target。
+
+    纯关系写，不发节点事件；被重定向的两端节点属性未变，其状态由第 1、3 步的
+    节点事件覆盖。四段各自一个 ``CALL () {}`` 子查询，空输入时不会让后续段被跳过。
+
+    Returns:
+        重定向的边总数（入边 + 出边 + Statement 边）。
+    """
+    if not alias_ids:
+        return 0
+    rows = await _relationship_write(
+        REDIRECT_ALIAS_EDGES,
+        {"end_user_id": end_user_id, "alias_ids": sorted(set(alias_ids))},
+        neo4j_client=neo4j_client,
+    )
+    if not rows:
+        return 0
+    row = rows[0]
+    return (
+        int(row.get("redirected_incoming") or 0)
+        + int(row.get("redirected_outgoing") or 0)
+        + int(row.get("redirected_stmt") or 0)
+    )
+
+
+async def drop_alias_belongs_edges(
+    end_user_id: str,
+    drop_alias_ids: list[str],
+    *,
+    neo4j_client: Neo4jClient | None = None,
+) -> int:
+    if not drop_alias_ids:
+        return 0
+    rows = await _relationship_write(
+        DROP_ALIAS_BELONGS_EDGES,
+        {"end_user_id": end_user_id, "drop_alias_ids": sorted(set(drop_alias_ids))},
+        neo4j_client=neo4j_client,
+    )
+    return int(rows[0].get("dropped_count", 0) or 0) if rows else 0
+
+
+DROP_ALIAS_BELONGS_EDGES = """
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})
+      -[r:EXTRACTED_RELATIONSHIP {predicate: '别名属于'}]->
+      (target:ExtractedEntity {end_user_id: $end_user_id})
+WHERE alias.id IN $drop_alias_ids
+  AND alias.delete_at IS NULL
+  AND target.delete_at IS NULL
+DELETE r
+RETURN count(r) AS dropped_count
+"""
+
+PATCH_METADATA = """
+MATCH (e:ExtractedEntity {id: $entity_id})
+WHERE e.delete_at IS NULL
+// ── core_facts ──
+WITH e,
+     [x IN coalesce(e.core_facts, []) WHERE NOT x IN $core_facts_delete] AS cf0
+WITH e, reduce(acc = cf0, pair IN $core_facts_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS cf1
+WITH e, reduce(acc = cf1, item IN $core_facts_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS cf2
+SET e.core_facts = cf2
+// ── traits ──
+WITH e,
+     [x IN coalesce(e.traits, []) WHERE NOT x IN $traits_delete] AS tr0
+WITH e, reduce(acc = tr0, pair IN $traits_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS tr1
+WITH e, reduce(acc = tr1, item IN $traits_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS tr2
+SET e.traits = tr2
+// ── relations ──
+WITH e,
+     [x IN coalesce(e.relations, []) WHERE NOT x IN $relations_delete] AS re0
+WITH e, reduce(acc = re0, pair IN $relations_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS re1
+WITH e, reduce(acc = re1, item IN $relations_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS re2
+SET e.relations = re2
+// ── goals ──
+WITH e,
+     [x IN coalesce(e.goals, []) WHERE NOT x IN $goals_delete] AS go0
+WITH e, reduce(acc = go0, pair IN $goals_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS go1
+WITH e, reduce(acc = go1, item IN $goals_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS go2
+SET e.goals = go2
+// ── interests ──
+WITH e,
+     [x IN coalesce(e.interests, []) WHERE NOT x IN $interests_delete] AS in0
+WITH e, reduce(acc = in0, pair IN $interests_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS in1
+WITH e, reduce(acc = in1, item IN $interests_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS in2
+SET e.interests = in2
+// ── beliefs_or_stances ──
+WITH e,
+     [x IN coalesce(e.beliefs_or_stances, []) WHERE NOT x IN $beliefs_or_stances_delete] AS be0
+WITH e, reduce(acc = be0, pair IN $beliefs_or_stances_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS be1
+WITH e, reduce(acc = be1, item IN $beliefs_or_stances_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS be2
+SET e.beliefs_or_stances = be2
+// ── anchors ──
+WITH e,
+     [x IN coalesce(e.anchors, []) WHERE NOT x IN $anchors_delete] AS an0
+WITH e, reduce(acc = an0, pair IN $anchors_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS an1
+WITH e, reduce(acc = an1, item IN $anchors_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS an2
+SET e.anchors = an2
+// ── events ──
+WITH e,
+     [x IN coalesce(e.events, []) WHERE NOT x IN $events_delete] AS ev0
+WITH e, reduce(acc = ev0, pair IN $events_update |
+        [x IN acc | CASE WHEN x = pair.old THEN pair.new ELSE x END]) AS ev1
+WITH e, reduce(acc = ev1, item IN $events_add |
+        CASE WHEN item IN acc THEN acc ELSE acc + item END) AS ev2
+SET e.events = ev2
+RETURN 1 AS affected_count,
+       [{label: 'ExtractedEntity', node_id: e.id, operation: 'UPSERT'}] AS affected_nodes,
+       e.id AS uuid,
+       e.core_facts AS core_facts,
+       e.traits AS traits,
+       e.relations AS relations,
+       e.goals AS goals,
+       e.interests AS interests,
+       e.beliefs_or_stances AS beliefs_or_stances,
+       e.anchors AS anchors,
+       e.events AS events
+"""
+
+MERGE_ENTITIES = """
+MATCH (keeper:ExtractedEntity {id: $keeper_id, end_user_id: $end_user_id})
+WHERE keeper.delete_at IS NULL
+MATCH (loser:ExtractedEntity {id: $loser_id, end_user_id: $end_user_id})
+WHERE loser.delete_at IS NULL
+SET keeper.name = $merged_name,
+    keeper.aliases = $merged_aliases,
+    keeper.description = CASE
+      WHEN coalesce(keeper.description, '') = '' THEN coalesce(loser.description, '')
+      WHEN coalesce(loser.description, '') = '' THEN coalesce(keeper.description, '')
+      ELSE keeper.description + '；' + loser.description
+    END,
+    keeper.connect_strength = CASE
+      WHEN keeper.connect_strength = 'both' OR loser.connect_strength = 'both' THEN 'both'
+      WHEN keeper.connect_strength <> loser.connect_strength THEN 'both'
+      ELSE coalesce(keeper.connect_strength, loser.connect_strength, 'weak')
+    END,
+    keeper.importance_score = CASE
+      WHEN coalesce(loser.importance_score, 0) > coalesce(keeper.importance_score, 0)
+      THEN loser.importance_score ELSE keeper.importance_score END,
+    keeper.access_count = coalesce(keeper.access_count, 0) + coalesce(loser.access_count, 0),
+    keeper.extraction_count = coalesce(keeper.extraction_count, 1) + coalesce(loser.extraction_count, 1),
+    keeper.created_at = CASE
+      WHEN keeper.created_at IS NULL THEN loser.created_at
+      WHEN loser.created_at IS NULL THEN keeper.created_at
+      WHEN loser.created_at > keeper.created_at THEN loser.created_at
+      ELSE keeper.created_at END,
+    keeper.core_facts = apoc.coll.toSet(coalesce(keeper.core_facts,[]) + coalesce(loser.core_facts,[])),
+    keeper.traits = apoc.coll.toSet(coalesce(keeper.traits,[]) + coalesce(loser.traits,[])),
+    keeper.relations = apoc.coll.toSet(coalesce(keeper.relations,[]) + coalesce(loser.relations,[])),
+    keeper.goals = apoc.coll.toSet(coalesce(keeper.goals,[]) + coalesce(loser.goals,[])),
+    keeper.interests = apoc.coll.toSet(coalesce(keeper.interests,[]) + coalesce(loser.interests,[])),
+    keeper.beliefs_or_stances = apoc.coll.toSet(coalesce(keeper.beliefs_or_stances,[]) + coalesce(loser.beliefs_or_stances,[])),
+    keeper.anchors = apoc.coll.toSet(coalesce(keeper.anchors,[]) + coalesce(loser.anchors,[])),
+    keeper.events = apoc.coll.toSet(coalesce(keeper.events,[]) + coalesce(loser.events,[]))
+WITH keeper, loser
+OPTIONAL MATCH (s:Statement)-[r:REFERENCES_ENTITY]->(loser)
+WHERE s.delete_at IS NULL AND NOT (s)-[:REFERENCES_ENTITY]->(keeper)
+FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
+  CREATE (s)-[:REFERENCES_ENTITY]->(keeper)
+)
+WITH DISTINCT keeper, loser
+OPTIONAL MATCH (loser)-[r:EXTRACTED_RELATIONSHIP]->(target)
+WHERE target <> keeper
+FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
+  MERGE (keeper)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(target)
+  SET nr += properties(r)
+)
+WITH DISTINCT keeper, loser
+OPTIONAL MATCH (source)-[r:EXTRACTED_RELATIONSHIP]->(loser)
+WHERE source <> keeper
+FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
+  MERGE (source)-[nr:EXTRACTED_RELATIONSHIP {predicate: r.predicate}]->(keeper)
+  SET nr += properties(r)
+)
+WITH DISTINCT keeper, loser,
+     [{label: 'ExtractedEntity', node_id: keeper.id, operation: 'UPSERT'},
+      {label: 'ExtractedEntity', node_id: loser.id, operation: 'DELETE'}] AS affected_nodes
+DETACH DELETE loser
+RETURN keeper.id AS merged_id, 2 AS affected_count, affected_nodes
+"""
+
+CREATE_UNRESOLVED_ENTITY = """
+MERGE (e:ExtractedEntity {
+  end_user_id: $end_user_id,
+  name: $name,
+  entity_type: $entity_type
+})
+ON CREATE SET
+  e.delete_at = null,
+  e.id = randomUUID(),
+  e.description = $description,
+  e.example = "",
+  e.statement_id = $statement_id,
+  e.aliases = [],
+  e.connect_strength = "weak",
+  e.source = "reflection_unresolved",
+  e.run_id = $run_id,
+  e.type_id = $type_id,
+  e.type_description = $type_description,
+  e.entity_idx = $entity_idx,
+  e.importance_score = 0.5,
+  e.activation_value = null,
+  e.access_history = [],
+  e.access_count = 0,
+  e.last_access_time = null,
+  e.is_explicit_memory = $is_explicit_memory,
+  e.created_at = $created_at,
+  e.extraction_count = 1
+ON MATCH SET
+  e.delete_at = null,
+  e.description = CASE
+    WHEN e.description IS NULL OR e.description = "" THEN $description
+    ELSE e.description + '；' + $description
+  END,
+  e.extraction_count = coalesce(e.extraction_count, 1) + 1,
+  e.created_at = CASE
+    WHEN e.created_at IS NULL THEN $created_at
+    WHEN $created_at IS NULL THEN e.created_at
+    WHEN $created_at > e.created_at THEN $created_at
+    ELSE e.created_at END
+RETURN e.id AS entity_id, e.name AS name, 1 AS affected_count,
+       [{label: 'ExtractedEntity', node_id: e.id, operation: 'UPSERT'}] AS affected_nodes
+"""
+
+APPEND_USER_INFO = """
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id, entity_type: '用户'})
+WHERE e.delete_at IS NULL
+SET e.description = CASE
+    WHEN $description IS NULL OR $description = '' THEN e.description
+    WHEN e.description IS NULL OR e.description = '' THEN $description
+    ELSE e.description + '；' + $description
+END
+RETURN e.id AS entity_id, 1 AS affected_count,
+       [{label: 'ExtractedEntity', node_id: e.id, operation: 'UPSERT'}] AS affected_nodes
+"""
+
+RESOLVE_STATEMENT = """
+MATCH (s:Statement {id: $statement_id})
+WHERE s.delete_at IS NULL
+SET s.has_unsolved_reference = false
+RETURN s.id AS statement_id, 1 AS affected_count,
+       [{label: 'Statement', node_id: s.id, operation: 'UPSERT'}] AS affected_nodes
+"""
+
+CREATE_UNRESOLVED_RELATIONSHIP = """
+MATCH (subj:ExtractedEntity {end_user_id: $end_user_id, name: $subject_name})
+WHERE subj.delete_at IS NULL
+MATCH (obj:ExtractedEntity {end_user_id: $end_user_id, name: $object_name})
+WHERE obj.delete_at IS NULL
+CREATE (subj)-[r:EXTRACTED_RELATIONSHIP {
+  predicate: $predicate,
+  predicate_id: $predicate_id,
+  predicate_surface: $predicate_surface,
+  predicate_description: $predicate_description,
+  statement_id: $statement_id,
+  valid_at: $valid_at,
+  invalid_at: $invalid_at,
+  end_user_id: $end_user_id,
+  run_id: $run_id,
+  connect_strength: "weak",
+  source: "reflection_unresolved",
+  created_at: $created_at
+}]->(obj)
+RETURN count(r) AS relationship_count
+"""
+
+CREATE_UNRESOLVED_STATEMENT_ENTITY_EDGE = """
+MATCH (s:Statement {id: $statement_id})
+WHERE s.delete_at IS NULL
+MATCH (e:ExtractedEntity {end_user_id: $end_user_id, name: $entity_name})
+WHERE e.delete_at IS NULL
+MERGE (s)-[r:REFERENCES_ENTITY]->(e)
+SET r.end_user_id = $end_user_id,
+    r.run_id = $run_id,
+    r.created_at = $created_at,
+    r.connect_strength = "weak"
+RETURN count(r) AS relationship_count
+"""
+
+# 别名归并第 1 步：source.name 进 target.aliases、source.description 拼入 target.description。
+# 与第 2、3 步分属三个独立事务，单步失败不影响其余两步。
+MERGE_ALIAS_PROPERTIES = """
+// 先按 target 分组，将所有 source.name 和 source.description 聚合，
+// 再一次性 SET，避免多条 别名属于 边对同一 target 反复覆盖。
+MATCH (source:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(target:ExtractedEntity {end_user_id: $end_user_id})
+WHERE r.predicate = '别名属于' AND source.id IN $alias_ids
+  AND source.delete_at IS NULL
+  AND target.delete_at IS NULL
+WITH target,
+     coalesce(target.aliases, []) AS existing_aliases,
+     coalesce(target.description, '') AS tgt_desc,
+     collect(DISTINCT source.name) AS source_names,
+     collect(DISTINCT coalesce(source.description, '')) AS source_descs
+
+// 1. 合并 aliases：将所有 source.name 追加到 target.aliases（去重，忽略空值与大小写）
+WITH target, tgt_desc, source_names, source_descs, existing_aliases,
+     existing_aliases + [n IN source_names WHERE n IS NOT NULL AND n <> '' AND NOT toLower(n) IN [x IN existing_aliases WHERE x IS NOT NULL | toLower(x)]] AS new_aliases
+
+// 2. 合并 description：将所有 source.description 逐一追加（去重，分号分隔）
+WITH target, new_aliases, existing_aliases, source_descs,
+     reduce(desc = tgt_desc, src IN source_descs |
+         CASE
+             WHEN src <> '' AND NOT desc CONTAINS src
+             THEN CASE WHEN desc = '' THEN src ELSE desc + '；' + src END
+             ELSE desc
+         END
+     ) AS new_description
+
+SET target.aliases = new_aliases,
+    target.description = new_description
+
+// 无分组键聚合：0 命中时也返回一行（affected_nodes=[]、alias_merged=0），不发假事件
+WITH collect({label: 'ExtractedEntity', node_id: target.id, operation: 'UPSERT'}) AS affected_nodes,
+     count(target) AS alias_merged
+RETURN alias_merged, size(affected_nodes) AS affected_count, affected_nodes
+"""
+
+# 别名归并第 2 步：别名节点上「别名属于」以外的边重定向到 target。
+# 纯关系写，不返回 affected_nodes，经 _relationship_write 提交、不登记 Outbox。
+# 各段独立 CALL () {} 子查询，避免空输入时分组聚合丢行导致后续段被跳过。
+#
+# 四段分别覆盖：入边 EXTRACTED_RELATIONSHIP、出边 EXTRACTED_RELATIONSHIP、
+# 陈述句的 STATEMENT_ENTITY（legacy 边类型）、陈述句的 REFERENCES_ENTITY
+# （当前主写链 graph_write_queries.STATEMENT_ENTITY_EDGE_SAVE 建的类型）。
+# 两种陈述句边都要处理：漏掉任一种，该边会在第 3 步 DETACH DELETE 时被连带删除，
+# 导致陈述句丢失对实体的引用。
+# 第 4 段用 WHERE NOT (stmt)-[:REFERENCES_ENTITY]->(user4) 跳过 target 已有同名边的
+# 情况，不覆盖既有边属性；未被重定向的别名边由第 3 步的 DETACH DELETE 清理。
+REDIRECT_ALIAS_EDGES = """
+// 1. 入边：其他实体 → 别名节点，重定向到 target
+CALL () {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user.delete_at IS NULL
+  WITH DISTINCT alias, user
+  MATCH (other)-[r:EXTRACTED_RELATIONSHIP]->(alias)
+  WHERE r.predicate <> '别名属于' AND other.id <> user.id
+  CREATE (other)-[nr:EXTRACTED_RELATIONSHIP]->(user)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_incoming
+}
+// 2. 出边：别名节点 → 其他实体，重定向到 target
+CALL () {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar2:EXTRACTED_RELATIONSHIP]->(user2:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar2.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user2.delete_at IS NULL
+  WITH DISTINCT alias, user2
+  MATCH (alias)-[r:EXTRACTED_RELATIONSHIP]->(other)
+  WHERE r.predicate <> '别名属于' AND other.id <> user2.id
+  CREATE (user2)-[nr:EXTRACTED_RELATIONSHIP]->(other)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_outgoing
+}
+// 3. 陈述句 → 别名节点，重定向到 target（legacy STATEMENT_ENTITY）
+CALL () {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar3:EXTRACTED_RELATIONSHIP]->(user3:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar3.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user3.delete_at IS NULL
+  WITH DISTINCT alias, user3
+  MATCH (stmt)-[r:STATEMENT_ENTITY]->(alias)
+  CREATE (stmt)-[nr:STATEMENT_ENTITY]->(user3)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_legacy_stmt
+}
+// 4. 陈述句 → 别名节点，重定向到 target（当前 REFERENCES_ENTITY，缺陷修复）
+CALL () {
+  MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[ar4:EXTRACTED_RELATIONSHIP]->(user4:ExtractedEntity {end_user_id: $end_user_id})
+  WHERE ar4.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user4.delete_at IS NULL
+  WITH DISTINCT alias, user4
+  MATCH (stmt)-[r:REFERENCES_ENTITY]->(alias)
+  WHERE NOT (stmt)-[:REFERENCES_ENTITY]->(user4)
+  CREATE (stmt)-[nr:REFERENCES_ENTITY]->(user4)
+  SET nr = properties(r)
+  DELETE r
+  RETURN count(*) AS redirected_reference_stmt
+}
+RETURN redirected_incoming, redirected_outgoing,
+       redirected_legacy_stmt + redirected_reference_stmt AS redirected_stmt
+"""
+
+# 别名归并第 3 步：删除别名节点。调用前第 2 步已把其它边重定向完毕，
+# 剩下的边只有 (alias)-[:EXTRACTED_RELATIONSHIP {predicate:'别名属于'}]->(target)，
+# DETACH DELETE 一并删除节点和该边。
+# 事件身份必须在 DETACH DELETE 之前构造：节点删掉后 a.id 已不可读。
+DELETE_ALIAS_NODES = """
+MATCH (alias:ExtractedEntity {end_user_id: $end_user_id})-[r:EXTRACTED_RELATIONSHIP]->(user:ExtractedEntity {end_user_id: $end_user_id})
+WHERE r.predicate = '别名属于' AND alias.id IN $alias_ids AND alias.delete_at IS NULL AND user.delete_at IS NULL
+WITH collect(DISTINCT alias) AS aliases
+WITH aliases, [a IN aliases | {label: 'ExtractedEntity', node_id: a.id, operation: 'DELETE'}] AS affected_nodes
+FOREACH (a IN aliases | DETACH DELETE a)
+RETURN size(aliases) AS alias_nodes_deleted, size(affected_nodes) AS affected_count, affected_nodes
+"""

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/alias_merger.py
@@ -13,13 +13,17 @@ from typing import Any, Dict, List
 
 from app.repositories.neo4j.neo4j_connector import Neo4jConnector
 from app.repositories.neo4j.cypher_queries import (
-    MERGE_ALIAS_BELONGS_TO,
-    REDIRECT_ALIAS_EDGES,
-    DELETE_ALIAS_NODES,
     GET_USER_ENTITY_ALIASES,
     GET_ALIAS_BELONGS_CANDIDATES,
-    DROP_ALIAS_BELONGS_EDGES,
 )
+
+from app.core.memory.storage.custom.reflection_mutations import (
+    delete_alias_nodes,
+    drop_alias_belongs_edges,
+    merge_alias_properties,
+    redirect_alias_edges,
+)
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
 
 logger = logging.getLogger(__name__)
 
@@ -40,29 +44,36 @@ async def drop_alias_edges(
     connector: Neo4jConnector,
     end_user_id: str,
     drop_alias_ids: List[str],
+    *,
+    neo4j_client: Neo4jClient | None = None,
 ) -> int:
     """删除被判 drop 的 "别名属于" 边（只删边，不删节点）。返回删除条数。"""
     if not drop_alias_ids:
         return 0
-    records = await connector.execute_query(
-        DROP_ALIAS_BELONGS_EDGES,
-        end_user_id=end_user_id,
-        drop_alias_ids=drop_alias_ids,
+    return await drop_alias_belongs_edges(
+        end_user_id,
+        drop_alias_ids,
+        neo4j_client=neo4j_client,
     )
-    return records[0].get("dropped_count", 0) if records else 0
 
 
 async def merge_alias_belongs_to(
     connector: Neo4jConnector,
     end_user_id: str,
     alias_ids: List[str],
+    *,
+    neo4j_client: Neo4jClient | None = None,
 ) -> Dict[str, Any]:
     """按 end_user_id 全量处理 "别名属于" 关系。
 
-    顺序执行三步，每步独立异常隔离：
+    顺序执行三步，每步一个独立的 storage 事务、独立的异常隔离：
       1. 别名归并：source.name → target.aliases，source.description → target.description
       2. 边重定向：别名节点其它边 → 规范实体
       3. 删除别名节点：DETACH DELETE
+
+    某步失败只记 warning 并写入 ``errors``，不回滚其它步骤、不跳过后续步骤，
+    第 4 步 PG 同步照常执行。第 1、3 步各自登记节点 Outbox 事件，
+    第 2 步是纯关系写、不发事件。
 
     归并完成后，再将用户实体的最新 aliases 同步回 PostgreSQL end_user_info
     （aliases 增量合并、other_name 为空时取 aliases[0]、同步 end_user.other_name）。
@@ -70,6 +81,8 @@ async def merge_alias_belongs_to(
     Args:
         connector: Neo4j 连接器
         end_user_id: 终端用户 ID
+        alias_ids: 判定通过、需要归并的别名节点业务 ID
+        neo4j_client: 本轮复用的 storage Neo4j client；缺省时下层自建并即用即关
 
     Returns:
         统计字典：alias_merged / edges_redirected / alias_nodes_deleted / pg_synced / errors
@@ -88,12 +101,9 @@ async def merge_alias_belongs_to(
     else:
         # ── 1. 别名归并（name 进 aliases，description 拼接） ──
         try:
-            records = await connector.execute_query(
-                MERGE_ALIAS_BELONGS_TO,
-                end_user_id=end_user_id,
-                alias_ids=alias_ids,
+            result["alias_merged"] = await merge_alias_properties(
+                end_user_id, alias_ids, neo4j_client=neo4j_client
             )
-            result["alias_merged"] = len(records) if records else 0
             logger.info(
                 f"[AliasMerge] 别名归并完成 end_user_id={end_user_id}, "
                 f"影响 target={result['alias_merged']}"
@@ -104,18 +114,9 @@ async def merge_alias_belongs_to(
 
         # ── 2. 边重定向（别名节点其它边 → 规范实体） ──
         try:
-            redirect_records = await connector.execute_query(
-                REDIRECT_ALIAS_EDGES,
-                end_user_id=end_user_id,
-                alias_ids=alias_ids,
+            result["edges_redirected"] = await redirect_alias_edges(
+                end_user_id, alias_ids, neo4j_client=neo4j_client
             )
-            if redirect_records:
-                row = redirect_records[0]
-                result["edges_redirected"] = (
-                    (row.get("redirected_incoming") or 0)
-                    + (row.get("redirected_outgoing") or 0)
-                    + (row.get("redirected_stmt") or 0)
-                )
             logger.info(
                 f"[AliasMerge] 边重定向完成 end_user_id={end_user_id}, "
                 f"汇总={result['edges_redirected']}"
@@ -126,13 +127,8 @@ async def merge_alias_belongs_to(
 
         # ── 3. 删除别名节点（DETACH DELETE） ──
         try:
-            delete_records = await connector.execute_query(
-                DELETE_ALIAS_NODES,
-                end_user_id=end_user_id,
-                alias_ids=alias_ids,
-            )
-            result["alias_nodes_deleted"] = (
-                delete_records[0].get("deleted_count", 0) if delete_records else 0
+            result["alias_nodes_deleted"] = await delete_alias_nodes(
+                end_user_id, alias_ids, neo4j_client=neo4j_client
             )
             logger.info(
                 f"[AliasMerge] 别名节点删除完成 end_user_id={end_user_id}, "

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/cypher_merger.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/cypher_merger.py
@@ -2,7 +2,10 @@
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from app.repositories.neo4j.neo4j_connector import Neo4jConnector
+# NOTE: 下方被注释掉的 fetch_degrees / fetch_degrees_batch 依赖 Neo4jConnector，
+# 恢复它们时需要一并恢复 `from app.repositories.neo4j.neo4j_connector import Neo4jConnector`。
+from app.core.memory.storage.custom.reflection_mutations import merge_entities
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +86,6 @@ def choose_keeper(
 
 
 async def execute_merge(
-    connector: Neo4jConnector,
     end_user_id: str,
     keeper_id: str,
     loser_id: str,
@@ -91,6 +93,8 @@ async def execute_merge(
     merged_aliases: List[str],
     loser_degree: int = 0,
     merge_max_degree: int = 1000,
+    *,
+    neo4j_client: Neo4jClient | None = None,
 ) -> str:
     """执行合并事务（属性合并 + 边迁移 + 删除 loser）
 
@@ -101,7 +105,6 @@ async def execute_merge(
     NOTE: 当前版本暂时关闭超级节点保护（loser_degree / merge_max_degree 参数仍保留，
     用于度数优先的 keeper 选择 / 调用方签名兼容）。下个版本恢复时把下方 if 块取消注释即可。
     """
-    from app.repositories.neo4j.cypher_queries import DEDUP_MERGE_ENTITIES
 
     # === 超级节点保护（暂时关闭，下版打开）===
     # if loser_degree > merge_max_degree:
@@ -113,8 +116,8 @@ async def execute_merge(
     # ========================================
 
     try:
-        result = await connector.execute_query(
-            DEDUP_MERGE_ENTITIES,
+        result = await merge_entities(
+            neo4j_client=neo4j_client,
             end_user_id=end_user_id,
             keeper_id=keeper_id,
             loser_id=loser_id,

--- a/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
+++ b/api/app/core/memory/storage_services/reflection_engine/deterministic/extract_metadata_service.py
@@ -20,6 +20,8 @@ from app.core.memory.storage_services.reflection_engine.errors import (
     ReflectionFailureReason,
     ReflectionModelType,
 )
+from app.core.memory.storage.custom.reflection_mutations import patch_entity_metadata
+from app.core.memory.storage.provider.neo4j.client import Neo4jClient
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +186,7 @@ async def extract_metadata_for_user(
     min_fragments: int = 5,
     max_list_len_per_field: int = 200,
     collect_trace: bool = False,
+    neo4j_client: Neo4jClient | None = None,
 ) -> Dict[str, Any]:
     """对指定用户的 User 实体执行元数据提取 + Neo4j 回写 + PostgreSQL 同步。
 
@@ -203,7 +206,6 @@ async def extract_metadata_for_user(
     """
     from app.core.memory.models.metadata_models import ALLOWED_METADATA_FIELDS
     from app.repositories.neo4j.cypher_queries import (
-        ENTITY_METADATA_PATCH,
         ENTITY_METADATA_QUERY,
         USER_ENTITY_FOR_METADATA,
     )
@@ -274,7 +276,7 @@ async def extract_metadata_for_user(
                 descriptions=entity_dict.get("descriptions", []),
                 allowed_fields=ALLOWED_METADATA_FIELDS,
                 metadata_query=ENTITY_METADATA_QUERY,
-                metadata_patch=ENTITY_METADATA_PATCH,
+                neo4j_client=neo4j_client,
                 max_list_len_per_field=max_list_len_per_field,
                 collect_trace=collect_trace,
             )
@@ -414,14 +416,16 @@ async def _extract_single_entity(
     descriptions: List[str],
     allowed_fields: Tuple[str, ...],
     metadata_query: str,
-    metadata_patch: str,
     max_list_len_per_field: int,
     collect_trace: bool = False,
+    neo4j_client: Neo4jClient | None = None,
 ) -> Dict[str, Any] | None:
     """对单个 User 实体执行：读取已有元数据 → LLM 提取 → patch 回写。
 
     Returns:
-        成功时返回 {"post_state": {...}}，跳过或无变更时返回 None。
+        成功时返回 {"post_state": {...}}，跳过时返回 None。
+        LLM 有输出但 patch 未命中任何节点（实体已被软删）时 ``post_state`` 为空 dict，
+        调用方仍把该实体计入 ``extracted``。
         collect_trace=True 时额外带 "_trace"（input/llm_raw/changes 片段）。
     """
     from app.core.memory.storage_services.extraction_engine.steps.schema import (
@@ -471,13 +475,13 @@ async def _extract_single_entity(
     # 构建详细变更列表（在 patch 前记录，因为 patch 后 operations 仍然有效）
     operations_detail = _build_operations_detail(result)
 
-    patch_records = await connector.execute_query(
-        metadata_patch,
-        **_build_patch_params(
+    patch_records = await patch_entity_metadata(
+        _build_patch_params(
             result, entity_id, existing, entity_name,
             allowed_fields, max_list_len_per_field,
             truncated_sink=truncated_recs if collect_trace else None,
         ),
+        neo4j_client=neo4j_client,
     )
     counts = result.counts()
     logger.info(

--- a/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
+++ b/api/app/core/memory/storage_services/reflection_engine/layer2_inspector.py
@@ -41,18 +41,16 @@ from app.core.memory.utils.debug.reflection_snapshot_recorder import (
     ReflectionSnapshotRecorder,
     change,
 )
-from app.repositories.neo4j.cypher_queries import (
-    REFLECTION_DESC_UPDATE,
-    REFLECTION_RENAME_CHECK_CONFLICT,
-    REFLECTION_RENAME_ENTITY,
-    REFLECTION_UPDATE_NAME_EMBEDDING,
-    UNRESOLVED_CREATE_ENTITY,
-    UNRESOLVED_UPDATE_NAME_EMBEDDING,
-    UNRESOLVED_APPEND_USER_INFO,
-    UNRESOLVED_CREATE_RELATIONSHIP,
-    UNRESOLVED_CREATE_STATEMENT_ENTITY_EDGE,
-    UNRESOLVED_UPDATE_STATEMENT_FLAG,
+from app.core.memory.storage.custom.reflection_entity_updates import (
+    merge_entity_description,
+    rename_entity,
+    update_entity_name_embedding,
 )
+from app.core.memory.storage.custom.reflection_mutations import (
+    append_user_info, create_unresolved_entity, create_unresolved_relationship,
+    create_unresolved_statement_entity_edge, resolve_statement,
+)
+from app.repositories.neo4j.cypher_queries import REFLECTION_RENAME_CHECK_CONFLICT
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +191,60 @@ class Layer2Inspector:
         self._recorder: Optional[ReflectionSnapshotRecorder] = None
         # 实体合并后 name_embedding 重算失败记录（不中断合并，由步骤聚合进告警）
         self._embedding_errors: List[str] = []
+        # 本轮巡检独占的 write-only storage service，供模式 A 使用，见 _get_storage_service
+        self._storage_service = None
+        self._storage_service_lock = asyncio.Lock()
+        # 本轮巡检独占的 storage Neo4j client，供模式 B 的 custom 事务使用，见 _get_reflection_client
+        self._reflection_client = None
+        self._reflection_client_lock = asyncio.Lock()
+
+    async def _get_storage_service(self):
+        """返回本轮巡检独占的 write-only storage service，供模式 A 的节点 CRUD 使用。
+
+        反思跑在 celery worker 进程，不经过 FastAPI lifespan，
+        ``get_storage_service()`` 的进程级单例在这里恒为 None。因此自建
+        独占实例，只含 Neo4j write client，由 ``close_storage_service`` 释放。
+        """
+        if self._storage_service is None:
+            from app.core.memory.storage.service import MemoryStorageService
+
+            async with self._storage_service_lock:
+                if self._storage_service is None:
+                    self._storage_service = await MemoryStorageService.create_graph_write_only()
+        return self._storage_service
+
+    async def _get_reflection_client(self):
+        """返回本轮巡检独占的 storage Neo4j client，供模式 B 的 custom 事务使用。
+
+        模式 B 的写入要自己开显式事务、在 commit 前校验 affected identities，因此需要
+        裸 client 而不是 ``MemoryStorageService``——后者的公开方法一律经 Router 并登记
+        Outbox，不提供绕过投影的出口。这里自建并整轮复用，由
+        ``close_storage_service`` 与模式 A 的 service 一并释放。
+        """
+        if self._reflection_client is None:
+            from app.core.memory.storage.provider.neo4j.client import Neo4jClient
+
+            async with self._reflection_client_lock:
+                if self._reflection_client is None:
+                    self._reflection_client = await Neo4jClient.create()
+        return self._reflection_client
+
+    async def close_storage_service(self) -> None:
+        """释放本轮独占的 storage 资源。由 pipeline 在 finally 中调用。
+
+        模式 A 的 write-only service 与模式 B 的 custom 事务 client 各持一个独立
+        Neo4j driver，两者都要释放，且前者关闭失败不能影响后者。
+        """
+        service, self._storage_service = self._storage_service, None
+        client, self._reflection_client = self._reflection_client, None
+        for name, resource in (("storage service", service),
+                               ("custom 事务 client", client)):
+            if resource is None:
+                continue
+            try:
+                await resource.close()
+            except Exception as e:
+                logger.warning(f"[Layer2] 关闭 {name} 失败: {e}")
 
     def _snap(self, subproblem: str, stage: str, data) -> None:
         """安全落普通阶段文件；recorder 为 None / 关闭 / 异常时只告警，不影响主流程。"""
@@ -458,9 +510,15 @@ class Layer2Inspector:
             llm_ms = int((time.perf_counter() - llm_t0) * 1000)
 
             # S2 drop（只删边）
-            await drop_alias_edges(self.connector, end_user_id, drop_ids)
+            await drop_alias_edges(
+                self.connector,
+                end_user_id,
+                drop_ids,
+                neo4j_client=await self._get_reflection_client(),
+            )
             # S3-5 merge（按 merge 集合）+ S6 PG 同步
-            result = await merge_alias_belongs_to(self.connector, end_user_id, alias_ids=merge_ids)
+            result = await merge_alias_belongs_to(self.connector, end_user_id, alias_ids=merge_ids,
+                                                 neo4j_client=await self._get_reflection_client())
 
             # 写日志（含 LLM 判定与重复短路命中的候选；仅 skip 不写）
             timing = {"recall_ms": recall_ms, "llm_ms": llm_ms}
@@ -564,6 +622,7 @@ class Layer2Inspector:
                 end_user_id=end_user_id,
                 language=language,
                 min_fragments=self.desc_config.min_fragments,
+                neo4j_client=await self._get_reflection_client(),
                 collect_trace=want_trace,
             )
 
@@ -974,11 +1033,12 @@ class Layer2Inspector:
 
                 t1 = time.perf_counter()
                 merge_status = await execute_merge(
-                    self.connector, end_user_id,
+                    end_user_id,
                     keeper["entity_id"], loser["entity_id"],
                     merged_name, merged_aliases,
                     loser_degree=loser_degree,
                     merge_max_degree=config.merge_max_degree,
+                    neo4j_client=await self._get_reflection_client(),
                 )
                 write_ms = int((time.perf_counter() - t1) * 1000)
 
@@ -1361,11 +1421,12 @@ class Layer2Inspector:
         # Step 5: 写入
         tracker.start_step("写入", "write")
         merge_status = await execute_merge(
-            self.connector, end_user_id,
+            end_user_id,
             keeper["entity_id"], loser["entity_id"],
             merged_name, merged_aliases,
             loser_degree=loser_degree,
             merge_max_degree=self.dedup_config.merge_max_degree,
+            neo4j_client=await self._get_reflection_client(),
         )
         if merge_status == "skipped_super_node":
             # 当前版本超级节点保护已关闭，理论上不会进此分支；保留兜底。
@@ -1407,6 +1468,9 @@ class Layer2Inspector:
 
         Embedding 重算失败不中断合并，但记入 ``_embedding_errors`` 供步骤聚合为
         MODEL_CALL_FAILED + Embedding，让告警能区分是 Embedding 模型出问题。
+
+        写入经 storage custom，会发布 keeper 的 UPSERT 投影事件。写入失败同样只告警：
+        合并本身已经成功提交，不该因为向量没写上就把整次合并判为失败。
         """
         old_name = keeper.get("name") or ""
         if not merged_name or merged_name == old_name:
@@ -1422,10 +1486,10 @@ class Layer2Inspector:
 
         if emb:
             try:
-                await self.connector.execute_query(
-                    REFLECTION_UPDATE_NAME_EMBEDDING,
-                    entity_id=keeper.get("entity_id") or keeper.get("id"),
+                await update_entity_name_embedding(
+                    keeper.get("entity_id") or keeper.get("id"),
                     name_embedding=emb,
+                    storage_service=await self._get_storage_service(),
                 )
             except Exception as e:
                 logger.warning(f"合并后写入 name_embedding 失败 name={merged_name}: {e}")
@@ -1480,11 +1544,12 @@ class Layer2Inspector:
         merged_aliases = build_merged_aliases(keeper, loser, merged_name)  # 不传 new_aliases
 
         merge_status = await execute_merge(
-            self.connector, end_user_id,
+            end_user_id,
             keeper["entity_id"], loser["entity_id"],
             merged_name, merged_aliases,
             loser_degree=loser_degree,
             merge_max_degree=self.dedup_config.merge_max_degree,
+            neo4j_client=await self._get_reflection_client(),
         )
         if merge_status != "success":
             return False, None, None, None, None
@@ -1594,11 +1659,12 @@ class Layer2Inspector:
                 loser_degree = degrees.get(loser["entity_id"], 0)
 
                 merge_status = await execute_merge(
-                    self.connector, end_user_id,
+                    end_user_id,
                     keeper_id, loser["entity_id"],
                     merged_name, merged_aliases,
                     loser_degree=loser_degree,
                     merge_max_degree=self.dedup_config.merge_max_degree,
+                    neo4j_client=await self._get_reflection_client(),
                 )
                 if merge_status != "success":
                     continue
@@ -1828,29 +1894,30 @@ class Layer2Inspector:
             if entity.name.strip() == "用户":
                 if entity.description:
                     try:
-                        await self.connector.execute_query(
-                            UNRESOLVED_APPEND_USER_INFO,
-                            end_user_id=end_user_id,
-                            description=entity.description,
+                        await append_user_info(
+                            end_user_id, entity.description,
+                            neo4j_client=await self._get_reflection_client(),
                         )
                     except Exception as user_err:
                         logger.warning(
                             f"追加用户实体描述失败 end_user={end_user_id}: {user_err}"
                         )
                 continue
-            entity_result = await self.connector.execute_query(
-                UNRESOLVED_CREATE_ENTITY,
-                end_user_id=end_user_id,
-                name=entity.name,
-                entity_type=entity.type,
-                description=entity.description,
-                run_id=fallback_run_id,
-                type_id=entity.type_id,
-                type_description=entity.type_description,
-                entity_idx=entity.entity_idx,
-                is_explicit_memory=entity.is_explicit_memory,
-                statement_id=stmt["statement_id"],
-                created_at=entity_last_seen,
+            entity_result = await create_unresolved_entity(
+                dict(
+                    end_user_id=end_user_id,
+                    name=entity.name,
+                    entity_type=entity.type,
+                    description=entity.description,
+                    run_id=fallback_run_id,
+                    type_id=entity.type_id,
+                    type_description=entity.type_description,
+                    entity_idx=entity.entity_idx,
+                    is_explicit_memory=entity.is_explicit_memory,
+                    statement_id=stmt["statement_id"],
+                    created_at=entity_last_seen,
+                ),
+                neo4j_client=await self._get_reflection_client(),
             )
             if entity_result:
                 entity_id = entity_result[0].get("entity_id", "")
@@ -1861,10 +1928,10 @@ class Layer2Inspector:
                         name_embedding = self.embedding_client.embed_query(entity.name)
                         if name_embedding:
                             snap_name_embeddings[entity.name] = name_embedding
-                            await self.connector.execute_query(
-                                UNRESOLVED_UPDATE_NAME_EMBEDDING,
-                                entity_id=entity_id,
+                            await update_entity_name_embedding(
+                                entity_id,
                                 name_embedding=name_embedding,
+                                storage_service=await self._get_storage_service(),
                             )
                     except Exception as emb_err:
                         logger.warning(f"补 name_embedding 失败 entity={entity.name}: {emb_err}")
@@ -1872,39 +1939,43 @@ class Layer2Inspector:
         # 4.2 创建关系边
         for triplet in validated.triplets:
             try:
-                await self.connector.execute_query(
-                    UNRESOLVED_CREATE_RELATIONSHIP,
-                    end_user_id=end_user_id,
-                    subject_name=triplet.subject_name,
-                    object_name=triplet.object_name,
-                    predicate=triplet.predicate,
-                    predicate_id=triplet.predicate_id,
-                    predicate_surface=triplet.predicate_surface,
-                    predicate_description=triplet.predicate_description,
-                    statement_id=stmt["statement_id"],
-                    valid_at=triplet.valid_at,
-                    invalid_at=triplet.invalid_at,
-                    run_id=fallback_run_id,
-                    created_at=utcnow_naive(),
+                await create_unresolved_relationship(
+                    {
+                        "end_user_id": end_user_id,
+                        "subject_name": triplet.subject_name,
+                        "object_name": triplet.object_name,
+                        "predicate": triplet.predicate,
+                        "predicate_id": triplet.predicate_id,
+                        "predicate_surface": triplet.predicate_surface,
+                        "predicate_description": triplet.predicate_description,
+                        "statement_id": stmt["statement_id"],
+                        "valid_at": triplet.valid_at,
+                        "invalid_at": triplet.invalid_at,
+                        "run_id": fallback_run_id,
+                        "created_at": utcnow_naive(),
+                    },
+                    neo4j_client=await self._get_reflection_client(),
                 )
             except Exception as rel_err:
                 logger.warning(f"创建关系边失败: {rel_err}")
 
         # 4.3 创建 REFERENCES_ENTITY 边
         for entity in validated.entities:
-            await self.connector.execute_query(
-                UNRESOLVED_CREATE_STATEMENT_ENTITY_EDGE,
-                statement_id=stmt["statement_id"],
-                end_user_id=end_user_id,
-                entity_name=entity.name,
-                run_id=fallback_run_id,
-                created_at=utcnow_naive(),
+            await create_unresolved_statement_entity_edge(
+                {
+                    "statement_id": stmt["statement_id"],
+                    "end_user_id": end_user_id,
+                    "entity_name": entity.name,
+                    "run_id": fallback_run_id,
+                    "created_at": utcnow_naive(),
+                },
+                neo4j_client=await self._get_reflection_client(),
             )
 
         # 4.4 更新 Statement 标记
-        await self.connector.execute_query(
-            UNRESOLVED_UPDATE_STATEMENT_FLAG,
-            statement_id=stmt["statement_id"],
+        await resolve_statement(
+            stmt["statement_id"],
+            neo4j_client=await self._get_reflection_client(),
         )
         tracker.end_step(
             f"创建 {len(validated.entities)} 实体, "
@@ -2171,15 +2242,24 @@ class Layer2Inspector:
             event_timeline = existing_event_timeline
 
         # Step 5: 写入 Neo4j（summary + timeline + event_timeline + 清空 description）
+        # 经 storage custom → MemoryStorageService，写入后发布 UPSERT 投影事件，
+        # 让 Elasticsearch 拿到新的 description_summary。
         tracker.start_step("写入", "write")
         merged_text = result.description_summary
-        await self.connector.execute_query(
-            REFLECTION_DESC_UPDATE,
-            entity_id=entity["entity_id"],
-            summary=merged_text,
-            timeline=timeline,
+        updated = await merge_entity_description(
+            entity["entity_id"],
+            description_summary=merged_text,
+            description_timeline=timeline,
             event_timeline=event_timeline,
+            storage_service=await self._get_storage_service(),
         )
+        if not updated:
+            # 未命中说明候选扫描之后实体被软删或改了归属。不中断本方法：
+            # 后续的更名判断、ReflectionLog 与快照照常执行，这里只留一行日志便于排查。
+            logger.info(
+                f"描述合并未命中实体（已软删或改归属）entity_id={entity['entity_id']}, "
+                f"end_user_id={end_user_id}"
+            )
         tracker.end_step("写入完成")
 
         # Step 6: 更名判断
@@ -2290,23 +2370,29 @@ class Layer2Inspector:
             )
             return "rejected:conflict"
 
-        # 执行更名
-        await self.connector.execute_query(
-            REFLECTION_RENAME_ENTITY,
-            entity_id=entity["entity_id"],
+        # 执行更名（经 storage custom，写入后发布 UPSERT 投影事件）
+        renamed = await rename_entity(
+            entity["entity_id"],
             new_name=suggested_name.strip(),
-            old_name=old_name,
+            storage_service=await self._get_storage_service(),
         )
+        if not renamed:
+            # 未命中说明候选扫描之后实体被软删或改了归属。不中断流程，
+            # 后续的 name_embedding 重算与日志照常执行，这里只留一行日志便于排查。
+            logger.info(
+                f"更名未命中实体（已软删或改归属）entity_id={entity['entity_id']}, "
+                f"end_user_id={end_user_id}"
+            )
 
         # 重新生成 name_embedding（同步方法）
         if self.embedding_client:
             try:
                 name_embedding = self.embedding_client.embed_query(suggested_name.strip())
                 if name_embedding:
-                    await self.connector.execute_query(
-                        REFLECTION_UPDATE_NAME_EMBEDDING,
-                        entity_id=entity["entity_id"],
+                    await update_entity_name_embedding(
+                        entity["entity_id"],
                         name_embedding=name_embedding,
+                        storage_service=await self._get_storage_service(),
                     )
             except Exception as emb_err:
                 logger.warning(f"更名后补 name_embedding 失败: {emb_err}")


### PR DESCRIPTION
## Sourcery 摘要

将反射管道的变更路径迁移至存储抽象层，同时保持事务一致性、投影同步和资源清理。

Bug 修复：
- 重定向别名边时，确保别名合并能够保留当前的语句到实体引用。

增强功能：
- 将反射写入操作从直接执行 Neo4j 连接器查询迁移至存储层自定义变更和实体更新，并支持事务处理及投影事件发布。
- 在第 2 层处理期间复用反射作用域内的存储资源，并显式关闭这些资源。
- 集中管理用于元数据更新、实体合并、未解析实体解析、关系变更和别名合并的反射变更 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the reflection pipeline’s mutation paths to the storage abstraction while preserving transactional consistency, projection synchronization, and resource cleanup.

Bug Fixes:
- Ensure alias consolidation preserves current statement-to-entity references when redirecting alias edges.

Enhancements:
- Migrate reflection writes from direct Neo4j connector queries to storage-layer custom mutations and entity updates with transactional handling and projection event publication.
- Reuse and explicitly close reflection-scoped storage resources across Layer 2 processing.
- Centralize reflection mutation APIs for metadata updates, entity merging, unresolved entity resolution, relationship changes, and alias consolidation.

</details>