### PR TITLE
fix(rag): restore graph extraction output constraints

### DIFF
--- a/mem-knowledge/src/rag/knowledge_graph/prompts.py
+++ b/mem-knowledge/src/rag/knowledge_graph/prompts.py
@@ -12,6 +12,42 @@ the user, build communities, summarize a whole graph, or infer missing facts.
 Return a valid JSON object only. The JSON object must contain "entities" and
 "relations" arrays. Use empty arrays when no direct evidence is present. Do not
 return markdown, code fences, comments, or explanatory text.
+Use exactly the field names below; never substitute alternatives such as
+"type", "source", or "target".
+Each entity: "ref" (string, unique within this response, e.g. "e1"), "name"
+(string), "entity_type" (string, one of the allowed types), "description"
+(string, one or two sentences grounded in the source). Optional: "aliases"
+(string array), "confidence" (number 0-1).
+Each relation: "from_ref" (string entity ref), "to_ref" (string entity ref),
+"predicate" (string, short verb phrase), "description" (string, one sentence
+grounded in the source). Optional: "keywords" (string array), "directed"
+(boolean), "confidence" (number 0-1).
+Example:
+{
+  "entities": [
+    {
+      "ref": "e1",
+      "name": "Acme Corp",
+      "entity_type": "organization",
+      "description": "Semiconductor company headquartered in Hsinchu."
+    },
+    {
+      "ref": "e2",
+      "name": "Zeta",
+      "entity_type": "product",
+      "description": "AI accelerator chip launched by Acme Corp in 2025."
+    }
+  ],
+  "relations": [
+    {
+      "from_ref": "e1",
+      "to_ref": "e2",
+      "predicate": "launched",
+      "description": "Acme Corp launched the Zeta chip in 2025.",
+      "keywords": ["product launch"]
+    }
+  ]
+}
 """.strip()
 
 EXTRACTION_PROMPT_VERSION = "2026-07-27-v1"


### PR DESCRIPTION
Model output using `type`, `source`, or `target` fails the Evidence Graph extraction schema. Native structured-output failures also fall back to plain text without explicit field instructions, so retries can repeat the same validation error.

Restore the required entity/relation field descriptions and complete JSON example previously added to the legacy API but omitted during migration to `mem-knowledge`. Both native and text-fallback calls now receive the same explicit output contract. This changes one production file (+36 lines).

## Risk and compatibility
- Keeps strict validation, task parameters, retry behavior, schema and extraction-cache version unchanged.
- Adds prompt input tokens and may improve extraction output; supplier behavior still needs validation after deployment.
- No external API Key endpoint, authentication, permission or response-contract changes.

## Validation
- Focused extraction tests: 5 passed after rebasing onto develop. Covers native output, unsupported/invalid native output falling back to text, strict rejection of malformed output, empty extraction, and source binding.
- Ruff check and git diff --check passed.
- Local regression tests remain uncommitted under the repository's test policy.
- No deployment or live model reprocessing performed.

## Sourcery 摘要

恢复图提取的显式 JSON 输出指导，以防止无效字段名称并提升重试兼容性。

错误修复：
- 恢复 Evidence Graph 实体和关系字段的显式约束及示例，使模型输出符合提取架构。

增强功能：
- 对原生结构化输出和纯文本回退提取请求应用相同的输出契约。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore explicit JSON output guidance for graph extraction to prevent invalid field names and improve retry compatibility.

Bug Fixes:
- Restore explicit Evidence Graph entity and relation field constraints and examples so model outputs conform to the extraction schema.

Enhancements:
- Apply the same output contract to native structured-output and plain-text fallback extraction requests.

</details>