### PR TITLE
fix(rag): refresh graph writes before cleanup

### DIFF
--- a/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
+++ b/mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
@@ -141,7 +141,10 @@ class GraphElasticsearchStore:
         )
 
     async def refresh_graph(self, graph_index_name: str) -> None:
-        await self._client.indices.refresh(index=graph_index_name, ignore_unavailable=True)
+        result = await self._client.indices.refresh(
+            index=graph_index_name, ignore_unavailable=True
+        )
+        raise_on_shard_failures(result, "graph refresh")
 
     async def _collect_search_after_hits(
         self,
@@ -1456,6 +1459,9 @@ class GraphElasticsearchStore:
         context: str,
         ensure_valid: Callable[[], None] | None,
     ) -> None:
+        self._ensure_valid(ensure_valid)
+        # delete_by_query refreshes after deletion, not before taking its search snapshot.
+        await self.refresh_graph(index_name)
         self._ensure_valid(ensure_valid)
         result = await self._client.delete_by_query(
             index=index_name,

--- a/mem-knowledge/src/rag/knowledge_graph/index_pipeline.py
+++ b/mem-knowledge/src/rag/knowledge_graph/index_pipeline.py
@@ -627,6 +627,10 @@ class KnowledgeGraphIndexPipeline:
             pageranks,
             ensure_valid=self._lock_guard.ensure_valid,
         )
+        # Publish the final writes before the next task acquires the knowledge lock.
+        self._lock_guard.ensure_valid()
+        await self._store.refresh_graph(runtime.graph_index_name)
+        self._lock_guard.ensure_valid()
 
     async def _embed_projections(
         self,


### PR DESCRIPTION
## Business Background
Evidence Graph cleanup can hit an Elasticsearch version conflict immediately after a serialized rebuild. The final PageRank bulk updates were not refreshed before releasing the knowledge lock, so delete_by_query could use stale searchable versions even without a concurrent writer.

## Summary
- Refresh final PageRank writes before returning, with lock validity checks around the refresh.
- Refresh under the knowledge lock before delete_by_query and recheck ownership before deletion.
- Reject partial shard refresh failures using the existing validation helper.

## Changes
- mem-knowledge/src/rag/knowledge_graph/elasticsearch_store.py
- mem-knowledge/src/rag/knowledge_graph/index_pipeline.py
- 2 files changed, 11 insertions, 1 deletion.

## Risk and Compatibility
- Adds index-level refresh work at task boundaries, potentially increasing graph processing latency in a shared workspace index.
- Preserves conflicts=abort, wait_for_completion=True, ignore_unavailable=True, KB/type filters and existing task retries.
- No API schema, authentication, tenant/workspace permission, task routing, database, or dependency changes.
- External API Key interfaces and access scope are unchanged.
- This does not repair an unrelated distributed-lock failure or uncontrolled external writer.

## Test Plan
- [x] Before the fix, new local unit regression tests produced 9 expected failures.
- [x] Real isolated Elasticsearch 8.19.3 reproduced the old cleanup 409 without concurrent writes and stale PageRank search visibility.
- [x] After rebasing onto develop: PYTHONPATH=mem-knowledge python -m pytest tests/mem_knowledge/knowledge_graph tests/mem_knowledge/model_registry tests/mem_knowledge/tasks -q: 26 passed, including 4 opt-in real ES tests using GRAPH_REFRESH_TEST_ES_URL.
- [x] Verified cleanup preserves another KB and unrelated document types; missing-index cleanup remains idempotent.
- [x] Ruff for both changed business files, import-boundary check, and git diff --check passed.
- Local verification tests remain untracked as required by repository policy and are not included in this PR.
- Before rebase, the wider local knowledge suite had 8 document/metadata session lifecycle failures also reproduced against the unmodified baseline; these are outside this fix.
- No target-environment deployment or post-deployment verification performed.

## Sourcery 总结

确保在清理之前刷新图写入并维护锁的有效性，以避免 Elasticsearch 搜索快照过时。

错误修复：
- 通过在释放锁之前使序列化的 PageRank 写入可搜索，并在删除查询之前刷新索引，防止图清理版本冲突。

增强功能：
- 验证分片刷新结果，并在刷新和清理操作前后重新检查知识锁的所有权。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure graph writes are refreshed and lock validity is maintained before cleanup to avoid stale Elasticsearch search snapshots.

Bug Fixes:
- Prevent graph cleanup version conflicts by making serialized PageRank writes searchable before lock release and refreshing the index before deletion queries.

Enhancements:
- Validate shard refresh results and recheck knowledge-lock ownership around refresh and cleanup operations.

</details>