### PR TITLE
fix(rag): handle legacy null knowledge parser config

### DIFF
--- a/mem-knowledge/src/models/owned/knowledge.py
+++ b/mem-knowledge/src/models/owned/knowledge.py
@@ -126,6 +126,10 @@ class Knowledge(KnowledgeBase):
     def chunk_mode(self) -> int:
         """Return the legacy knowledge chunk policy state."""
 
+        # Legacy null configurations have no recorded chunk policy.
+        if self.parser_config is None:
+            return 0
+
         if (
             "auto_questions" not in self.parser_config
             and "parent_chunk_mode" not in self.parser_config


### PR DESCRIPTION
## Summary
Legacy knowledge rows can contain JSON null in `parser_config`. Reading their chunk policy or saving document parser settings raises `TypeError` because `Knowledge.chunk_mode` tests membership in None.

Treat None as the existing unrecorded policy (0), matching an empty configuration. This restores policy reads and lets the first document configuration be saved through the existing persistence flow. Non-null policy behavior remains unchanged.

## Scope and risk
- One model property, four added lines.
- No database migration, bulk backfill, or re-parsing is required for this compatibility fix.
- Do not inject full defaults: their `auto_questions` field would incorrectly select normal mode.
- External API Key impact: no new routes, permission changes, or response schema changes; existing callers benefit from the same null compatibility.

## Validation
- `PYTHONPATH=mem-knowledge mem-knowledge/.venv/bin/python -m pytest tests/mem_knowledge/knowledges/test_null_parser_config.py -q`: 9 passed after rebase. Covers persisted JSON null through the policy endpoint, first normal/parent-child configuration persistence, and mode locking afterward. Before the fix, four cases reproduced the original TypeError.
- Ruff and `git diff --check`: passed.
- Local regression tests are intentionally untracked per repository policy.
- Broader check: the two existing `test_document_response_lifecycle.py` cases fail with DetachedInstanceError. Both also fail with the original develop getter restored in memory; this pre-existing response lifecycle issue is outside this patch.
- Not yet deployed or verified against the live environment.

## Sourcery 总结

使旧版的 null 解析器配置与现有的知识分块策略处理兼容。

错误修复：
- 处理解析器配置为 null 的旧版知识记录，将其视为没有记录分块策略。
- 恢复对旧版 null 配置的分块策略读取，以及首次文档解析器设置的持久化，同时不改变非 null 配置的行为。

测试：
- 增加针对 null 解析器配置的回归测试，覆盖策略读取、初始配置持久化以及后续模式锁定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make legacy null parser configurations compatible with existing knowledge chunk-policy handling.

Bug Fixes:
- Handle legacy knowledge records with null parser configurations by treating them as having no recorded chunk policy.
- Restore chunk-policy reads and first document parser-setting persistence for legacy null configurations without changing non-null behavior.

Tests:
- Add regression coverage for null parser configurations across policy reads, initial configuration persistence, and subsequent mode locking.

</details>