### PR TITLE
fix(rag): ignore global rerank for single non-hybrid retrieval

### DIFF
--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -882,24 +882,7 @@ class KnowledgeRetrievalService:
             return []
 
         targets = preparation.targets
-        single_hybrid_uses_request_rerank = (
-            request.rerank_id is not None
-            and len(targets) == 1
-            and targets[0].params.retrieve_type is RetrieveType.HYBRID
-        )
-        single_evidence_graph_target = (
-            preparation.graph is not None
-            and preparation.graph.pipeline is GraphPipeline.EVIDENCE
-            and len(targets) == 1
-            and targets[0].params.retrieve_type is RetrieveType.Graph
-        )
-        needs_global_rerank = not single_evidence_graph_target and (
-            len(targets) > 1
-            or (
-                request.rerank_id is not None
-                and not single_hybrid_uses_request_rerank
-            )
-        )
+        needs_global_rerank = len(targets) > 1
         if needs_global_rerank:
             global_rerank_started_at = time.perf_counter()
             try:
@@ -946,7 +929,13 @@ class KnowledgeRetrievalService:
                 key=cls._candidate_score,
                 reverse=True,
             )
-        result_candidates = ranked[: request.top_k]
+        # A single non-hybrid target is governed by its own retrieval limit.
+        top_k = (
+            targets[0].params.top_k
+            if len(targets) == 1 and targets[0].params.retrieve_type is not RetrieveType.HYBRID
+            else request.top_k
+        )
+        result_candidates = ranked[:top_k]
         result = materialize_candidates(result_candidates)
         cls._log_finalize(
             log_id,

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -104,7 +104,7 @@ def build_retrieval_policy(
         request_reranker=request_reranker,
         fallback_reranker=targets[0].reranker,
     )
-    semantic_requires_reranker = len(targets) > 1 or request_has_rerank_id
+    semantic_requires_reranker = len(targets) > 1
     semantic_supports_image = embeddings_support_image and (
         not semantic_requires_reranker
         or _supports_qwen3_vl_rerank(global_reranker)
@@ -679,7 +679,11 @@ class KnowledgeRetrievalPreparation:
     ) -> tuple[RerankMode, RerankWeightsSnapshot, bool]:
         if config is not None and config.rerank_mode is not None:
             return config.rerank_mode, cls._resolve_weights(config.rerank_weights), True
-        if target_count == 1 and request.rerank_mode is not None:
+        if (
+            target_count == 1
+            and cls._resolve_retrieve_type(request, config) is RetrieveType.HYBRID
+            and request.rerank_mode is not None
+        ):
             return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
         return RerankMode.RERANKING_MODEL, cls._resolve_weights(None), False
 
@@ -690,9 +694,7 @@ class KnowledgeRetrievalPreparation:
         target_count: int,
         single_retrieve_type: RetrieveType | None,
     ) -> tuple[RerankMode, RerankWeightsSnapshot, bool] | None:
-        if target_count == 1 and single_retrieve_type is RetrieveType.HYBRID:
-            return None
-        if target_count == 1 and request.rerank_id is None:
+        if target_count == 1:
             return None
         mode = request.rerank_mode or RerankMode.RERANKING_MODEL
         return mode, cls._resolve_weights(request.rerank_weights), request.rerank_mode is not None


### PR DESCRIPTION
## Summary
Single non-hybrid retrieval now ignores request-level rerank configuration. A semantic or full-text request carrying a global rerank model no longer loads or invokes it, and global weighted settings no longer force that single target to use hybrid retrieval.

- Limit request-level rerank inheritance to single hybrid targets and global reranking to multiple resolved targets.
- Use the effective single non-hybrid target top_k at finalization so an agent global reranker_top_k cannot further truncate it; direct requests without a per-KB limit still inherit request top_k.
- Align single semantic image capability reporting with the absence of global reranking. Hybrid capability checks remain unchanged.

## Scope and compatibility
Only two mem-knowledge service files change. Single hybrid retains its one local rerank and request-selected model; multi-target model/weighted reranking and explicit local configuration validation remain unchanged. Public schemas, authentication, tenant/workspace boundaries, response envelopes and API Key endpoint scope are unchanged. API Key callers using this service receive the same corrected single non-hybrid behavior. The legacy api retrieval backend is not modified.

## Risk
Callers that relied on global reranking for a single non-hybrid target will receive the original retrieval scores/order and effective local limit instead of globally reranked/filtered results. This is the requested behavior change. Existing schema validation still rejects malformed model IDs or invalid weights. The capability endpoint still resolves a supplied model for its hybrid capability/error contract.

## Validation
- 30 local regression cases passed using real service/schema classes with database, search and model boundaries mocked. Coverage includes semantic/full-text retrieval, model loading/call counts, weighted validation, local limits, graph finalization, image preparation/policy, mode precedence, single hybrid one-call behavior, and multi-target model/weighted finalization.
- Command (from mem-knowledge): `PYTHONPATH=.:../packages/redbear-model/src:../packages/storage-core/src:../packages/auth-sdk/src .venv/bin/python -m pytest -c pyproject.toml ../tests/mem_knowledge/retrieval/test_single_non_hybrid_global_rerank.py -q`
- `.venv/bin/ruff check src/services/knowledge_retrieval.py src/services/knowledge_retrieval_preparation.py` passed.
- `git diff --check origin/release/v0.4.5..HEAD` passed.
- Tests remain local under tests/mem_knowledge/retrieval per repository policy; no test, documentation, agent configuration or frontend files are included in the PR. No live deployment or external model verification was performed.

## Sourcery 摘要

确保单一非混合检索使用自身的排序和结果限制，而无需加载或应用全局重新排序配置。

错误修复：
- 防止全局重新排序配置影响单一语义检索或全文检索目标。
- 保留单一非混合目标的有效检索限制，避免使用代理级重新排序限制截断结果。

增强功能：
- 将请求级重新排序继承限制为单一混合检索，同时保留多目标检索的全局重新排序功能。
- 使单一语义图像能力报告与更新后的全局重新排序行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure single non-hybrid retrieval uses its own ranking and result limit without loading or applying global reranking configuration.

Bug Fixes:
- Prevent global reranking configuration from affecting single semantic or full-text retrieval targets.
- Preserve the effective retrieval limit for single non-hybrid targets instead of truncating results with the agent-level reranker limit.

Enhancements:
- Restrict request-level rerank inheritance to single hybrid retrieval while retaining global reranking for multi-target retrieval.
- Align single semantic image capability reporting with the updated global reranking behavior.

</details>