### PR TITLE
feat(rag): copy knowledge configurations with optional names

### DIFF
--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -6,7 +6,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Request
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.background import BackgroundTask
@@ -436,6 +436,23 @@ async def create_knowledge(
     except Exception as e:
         api_logger.error(f"The creation of the knowledge base failed: {create_data.name} - {str(e)}")
         raise
+
+
+@router.post("/{knowledge_id}/copy", response_model=ApiResponse)
+@cur_workspace_access_guard_async()
+@check_knowledge_capacity_quota
+@route_through_knowledge_service(source=KnowledgeRetrievalSource.MANAGER_API)
+async def copy_knowledge(
+        knowledge_id: uuid.UUID,
+        db: AsyncSession = Depends(get_async_db),  # noqa: B008
+        current_user: User = Depends(get_current_user_async),  # noqa: B008
+        request: Request = None,
+):
+    message = "Knowledge configuration copy requires the knowledge service"
+    return JSONResponse(
+        status_code=503,
+        content=fail(503, msg=message, error=message),
+    )
 
 
 @router.get("/{knowledge_id}", response_model=ApiResponse)

--- a/api/app/controllers/knowledge_controller.py
+++ b/api/app/controllers/knowledge_controller.py
@@ -4,7 +4,7 @@ import json
 from typing import Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, status, Query, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy import or_, select
@@ -447,6 +447,7 @@ async def copy_knowledge(
         db: AsyncSession = Depends(get_async_db),  # noqa: B008
         current_user: User = Depends(get_current_user_async),  # noqa: B008
         request: Request = None,
+        name: Optional[str] = Body(default=None, embed=True),  # noqa: B008
 ):
     message = "Knowledge configuration copy requires the knowledge service"
     return JSONResponse(

--- a/mem-knowledge/src/api/dependencies.py
+++ b/mem-knowledge/src/api/dependencies.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import Header, Request
+from fastapi import Header, HTTPException, Request
 from pydantic import BaseModel, ValidationError
 
 from ..errors import KnowledgeError
@@ -60,7 +60,7 @@ async def get_principal(request: Request) -> Principal:
 
 
 async def get_optional_principal(request: Request) -> Principal | None:
-    """Return middleware-populated request.state.principal before falling back to trusted identity headers."""
+    """Return the middleware principal or trusted identity-header fallback."""
 
     principal = getattr(request.state, "principal", None)
     if isinstance(principal, Principal):
@@ -74,6 +74,18 @@ async def get_optional_principal(request: Request) -> Principal | None:
     if all(value is None for value in values):
         return None
     return _principal_from_headers(request)
+
+
+async def require_knowledge_copy_principal(request: Request) -> Principal:
+    """Require the legacy manager proxy trust boundary for configuration copy."""
+
+    if getattr(request.state, "kb_legacy_proxy_authenticated", False) is not True:
+        raise HTTPException(status_code=403, detail="Knowledge copy source is not trusted")
+    if request.headers.get("X-KB-Source") != KnowledgeRetrievalSource.MANAGER_API.value:
+        raise HTTPException(status_code=403, detail="Knowledge copy source is not trusted")
+    if "authorization" in request.headers or "x-api-key" in request.headers:
+        raise HTTPException(status_code=403, detail="Knowledge copy credentials are not allowed")
+    return await get_principal(request)
 
 
 async def get_source(
@@ -96,4 +108,5 @@ __all__ = [
     "get_principal",
     "get_runtime",
     "get_source",
+    "require_knowledge_copy_principal",
 ]

--- a/mem-knowledge/src/api/routes/knowledge.py
+++ b/mem-knowledge/src/api/routes/knowledge.py
@@ -318,12 +318,16 @@ async def copy_knowledge(
     knowledge_id: uuid.UUID,
     principal: Annotated[Principal, Depends(require_knowledge_copy_principal)],
     runtime: Annotated[ProcessRuntime, Depends(get_runtime)],
+    name: Annotated[
+        str | None, Body(embed=True, description="Optional copied knowledge name")
+    ] = None,
 ) -> SuccessEnvelope[dict[str, Any]]:
     async with runtime.database.async_session() as db:
         data = await knowledge_copy_service.copy_knowledge_configuration(
             db,
             knowledge_id,
             principal,
+            name=name,
         )
     return _success(
         request,

--- a/mem-knowledge/src/api/routes/knowledge.py
+++ b/mem-knowledge/src/api/routes/knowledge.py
@@ -34,6 +34,7 @@ from ...runtime import ProcessRuntime
 from ...services import file as file_service
 from ...services import graph as graph_service
 from ...services import knowledge as knowledge_service
+from ...services import knowledge_copy as knowledge_copy_service
 from ...services.knowledge_commands import (
     dispatch_graph_transition,
     dispatch_reparse_snapshots,
@@ -53,7 +54,13 @@ from ...tasks.state import (
     claim_or_get_rebuild_job_async,
     release_rebuild_job_async,
 )
-from ..dependencies import Principal, get_principal, get_runtime, get_source
+from ..dependencies import (
+    Principal,
+    get_principal,
+    get_runtime,
+    get_source,
+    require_knowledge_copy_principal,
+)
 from ..schemas.chunk import KnowledgeRetrievalSource
 from ..schemas.common import SuccessEnvelope, fail, success
 from ..schemas.file import KBBatchDownloadRequest
@@ -302,6 +309,26 @@ async def create_knowledge(
         request,
         data,
         "The knowledge base has been successfully created",
+    )
+
+
+@router.post("/{knowledge_id}/copy", response_model=SuccessEnvelope[dict[str, Any]])
+async def copy_knowledge(
+    request: Request,
+    knowledge_id: uuid.UUID,
+    principal: Annotated[Principal, Depends(require_knowledge_copy_principal)],
+    runtime: Annotated[ProcessRuntime, Depends(get_runtime)],
+) -> SuccessEnvelope[dict[str, Any]]:
+    async with runtime.database.async_session() as db:
+        data = await knowledge_copy_service.copy_knowledge_configuration(
+            db,
+            knowledge_id,
+            principal,
+        )
+    return _success(
+        request,
+        data,
+        "The knowledge base configuration has been successfully copied",
     )
 
 

--- a/mem-knowledge/src/auth.py
+++ b/mem-knowledge/src/auth.py
@@ -104,6 +104,7 @@ class KbAuthMiddleware(BaseHTTPMiddleware):
         self._gateway = _load_gateway_auth(kb_auth) if kb_auth.auth_mode == "gateway" else None
 
     async def dispatch(self, request: Request, call_next):
+        request.state.kb_legacy_proxy_authenticated = False
         # 应急开关：文件存在即恢复无鉴权状态（仅灰度窗口期，评审稿 6.2）
         if self._kill_switch_active():
             logger.warning("kb auth kill switch ACTIVE — bypassing auth")
@@ -177,6 +178,7 @@ class KbAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(status_code=401, content={"detail": "invalid token"})
         if ctx is None:
             # 通道 2：老单体直连豁免（过渡态，NetworkPolicy 兜底受信来源）
+            request.state.kb_legacy_proxy_authenticated = True
             return await call_next(request)
         try:
             request.state.principal = Principal(

--- a/mem-knowledge/src/repositories/knowledge.py
+++ b/mem-knowledge/src/repositories/knowledge.py
@@ -6,17 +6,133 @@ import logging
 import uuid
 from typing import Any
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, null, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..api.schemas.knowledge import KnowledgeCreate
-from ..models.owned import Document, Knowledge, PermissionType
+from ..models.owned import Document, Knowledge, KnowledgeMetadata, PermissionType
 from ..rag.parser_config import (
     build_default_knowledge_parser_config,
     normalize_new_knowledge_parser_config,
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def lock_knowledge_copy_names_async(
+    db: AsyncSession,
+    workspace_id: uuid.UUID,
+) -> None:
+    """Serialize copy-name allocation within one workspace transaction."""
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))"),
+        {"key": f"knowledge:copy:name:{workspace_id}"},
+    )
+
+
+async def get_knowledge_copy_snapshot_async(
+    db: AsyncSession,
+    knowledge_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """Load the source configuration and metadata fields in one SQL statement."""
+    result = await db.execute(
+        select(
+            Knowledge.id.label("source_id"),
+            Knowledge.workspace_id.label("source_workspace_id"),
+            Knowledge.parent_id.label("source_parent_id"),
+            Knowledge.name.label("source_name"),
+            Knowledge.description.label("source_description"),
+            Knowledge.avatar.label("source_avatar"),
+            Knowledge.type.label("source_type"),
+            Knowledge.permission_id.label("source_permission_id"),
+            Knowledge.embedding_id.label("source_embedding_id"),
+            Knowledge.reranker_id.label("source_reranker_id"),
+            Knowledge.llm_id.label("source_llm_id"),
+            Knowledge.image2text_id.label("source_image2text_id"),
+            Knowledge.parser_id.label("source_parser_id"),
+            Knowledge.parser_config.label("source_parser_config"),
+            Knowledge.status.label("source_status"),
+            Knowledge.builtin_metadata_enabled.label(
+                "source_builtin_metadata_enabled"
+            ),
+            KnowledgeMetadata.tenant_id.label("metadata_tenant_id"),
+            KnowledgeMetadata.name.label("metadata_name"),
+            KnowledgeMetadata.type.label("metadata_type"),
+        )
+        .select_from(Knowledge)
+        .outerjoin(
+            KnowledgeMetadata,
+            KnowledgeMetadata.knowledge_id == Knowledge.id,
+        )
+        .where(
+            Knowledge.id == knowledge_id,
+            Knowledge.workspace_id == workspace_id,
+        )
+    )
+    rows = result.mappings().all()
+    if not rows:
+        return None
+
+    first = rows[0]
+    source = {
+        "id": first["source_id"],
+        "workspace_id": first["source_workspace_id"],
+        "parent_id": first["source_parent_id"],
+        "name": first["source_name"],
+        "description": first["source_description"],
+        "avatar": first["source_avatar"],
+        "type": first["source_type"],
+        "permission_id": first["source_permission_id"],
+        "embedding_id": first["source_embedding_id"],
+        "reranker_id": first["source_reranker_id"],
+        "llm_id": first["source_llm_id"],
+        "image2text_id": first["source_image2text_id"],
+        "parser_id": first["source_parser_id"],
+        "parser_config": first["source_parser_config"],
+        "status": first["source_status"],
+        "builtin_metadata_enabled": first["source_builtin_metadata_enabled"],
+    }
+    metadata_fields = [
+        {
+            "tenant_id": row["metadata_tenant_id"],
+            "name": row["metadata_name"],
+            "type": row["metadata_type"],
+        }
+        for row in rows
+        if row["metadata_name"] is not None
+    ]
+    return source, metadata_fields
+
+
+async def get_knowledge_copy_names_async(
+    db: AsyncSession,
+    workspace_id: uuid.UUID,
+    source_name: str,
+) -> set[str]:
+    """Return active names sharing the escaped copy-name prefix."""
+    prefix = f"{source_name}_副本"
+    result = await db.execute(
+        select(Knowledge.name).where(
+            Knowledge.workspace_id == workspace_id,
+            Knowledge.status == 1,
+            Knowledge.name.startswith(prefix, autoescape=True),
+        )
+    )
+    return set(result.scalars().all())
+
+
+def stage_knowledge_copy(
+    db: AsyncSession,
+    values: dict[str, Any],
+) -> Knowledge:
+    """Add a copied knowledge row to the current transaction without I/O."""
+    copy_values = dict(values)
+    if copy_values.get("parser_id") is None:
+        copy_values["parser_id"] = null()
+    knowledge = Knowledge(**copy_values)
+    db.add(knowledge)
+    return knowledge
 
 
 def _knowledge_values(

--- a/mem-knowledge/src/repositories/knowledge_metadata.py
+++ b/mem-knowledge/src/repositories/knowledge_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,6 +12,14 @@ from ..models.owned import Document, KnowledgeMetadata, KnowledgeMetadataBinding
 
 
 class KnowledgeMetadataRepository:
+    @staticmethod
+    def stage_copy_fields(
+        db: AsyncSession,
+        values: list[dict[str, Any]],
+    ) -> None:
+        """Add copied metadata fields without flushing or committing."""
+        db.add_all([KnowledgeMetadata(**value) for value in values])
+
     @staticmethod
     async def create_async(
         db: AsyncSession,

--- a/mem-knowledge/src/services/knowledge_copy.py
+++ b/mem-knowledge/src/services/knowledge_copy.py
@@ -251,6 +251,8 @@ async def copy_knowledge_configuration(
     db: AsyncSession,
     knowledge_id: uuid.UUID,
     principal: Principal,
+    *,
+    name: str | None = None,
 ) -> dict[str, Any]:
     """Copy one ordinary knowledge configuration in a single transaction."""
     try:
@@ -281,12 +283,21 @@ async def copy_knowledge_configuration(
         except ValueError as exc:
             raise _validation(str(exc)) from exc
 
-        occupied_names = await knowledge_repository.get_knowledge_copy_names_async(
-            db,
-            principal.workspace_id,
-            source["name"],
-        )
-        copy_name = choose_copy_name(source["name"], occupied_names)
+        copy_name = (name or "").strip()
+        if copy_name:
+            if await knowledge_repository.get_knowledge_by_name_async(
+                db, copy_name, principal.workspace_id
+            ):
+                raise knowledge_service._conflict(
+                    f"The knowledge base name already exists: {copy_name}"
+                )
+        else:
+            occupied_names = await knowledge_repository.get_knowledge_copy_names_async(
+                db,
+                principal.workspace_id,
+                source["name"],
+            )
+            copy_name = choose_copy_name(source["name"], occupied_names)
         copied_id = uuid.uuid4()
         now = utcnow_naive()
         values = _build_knowledge_values(

--- a/mem-knowledge/src/services/knowledge_copy.py
+++ b/mem-knowledge/src/services/knowledge_copy.py
@@ -1,0 +1,328 @@
+"""Atomic configuration copying for ordinary private knowledge bases."""
+
+from __future__ import annotations
+
+import uuid
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+from pydantic import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..api.dependencies import Principal
+from ..api.schemas.common import SuccessEnvelope
+from ..api.schemas.knowledge_metadata import KnowledgeMetadataCreate
+from ..errors import KnowledgeError
+from ..models.owned import Knowledge, KnowledgeType, PermissionType
+from ..models.references import ModelConfig
+from ..rag.knowledge_graph import (
+    GraphPipeline,
+    require_graph_mapping,
+    resolve_graph_pipeline,
+)
+from ..repositories import knowledge as knowledge_repository
+from ..repositories.knowledge_metadata import KnowledgeMetadataRepository
+from ..repositories.reference import ReferenceRepository
+from ..utils.datetime_utils import utcnow_naive
+from . import knowledge as knowledge_service
+from .knowledge_metadata import KnowledgeMetadataService
+
+_MODEL_REFERENCE_FIELDS = (
+    "embedding_id",
+    "reranker_id",
+    "llm_id",
+    "image2text_id",
+)
+
+
+def choose_copy_name(source_name: str, occupied_names: set[str]) -> str:
+    """Return the first available numbered copy name."""
+    base = f"{source_name}_副本"
+    if base not in occupied_names:
+        return base
+
+    suffix = 2
+    while f"{base}{suffix}" in occupied_names:
+        suffix += 1
+    return f"{base}{suffix}"
+
+
+def copy_parser_config(source_config: dict[str, Any]) -> dict[str, Any]:
+    """Deep-copy parser settings while selecting the current graph pipeline."""
+    if not isinstance(source_config, dict):
+        raise ValueError("Source parser_config must be an object")
+
+    resolve_graph_pipeline(source_config)
+    result = deepcopy(source_config)
+    graph = dict(require_graph_mapping(result))
+    graph["pipeline"] = GraphPipeline.EVIDENCE.value
+    result["graphrag"] = graph
+    return result
+
+
+def _validation(message: str) -> KnowledgeError:
+    return KnowledgeError.from_code("KB_VALIDATION_ERROR", message)
+
+
+def _resource_not_found() -> KnowledgeError:
+    return KnowledgeError.from_code(
+        "KB_RESOURCE_NOT_FOUND",
+        "Knowledge resource not found",
+    )
+
+
+def _principal_invalid(message: str) -> KnowledgeError:
+    return KnowledgeError.from_code("KB_PRINCIPAL_INVALID", message)
+
+
+def _model_unavailable(field_name: str) -> KnowledgeError:
+    return KnowledgeError.from_code(
+        "KB_MODEL_UNAVAILABLE",
+        f"Source model reference is unavailable: {field_name}",
+    )
+
+
+async def _validate_principal_references(
+    db: AsyncSession,
+    principal: Principal,
+) -> None:
+    workspace = await ReferenceRepository.get_workspace(db, principal.workspace_id)
+    if (
+        workspace is None
+        or workspace.is_active is not True
+        or workspace.tenant_id != principal.tenant_id
+    ):
+        raise _principal_invalid("Invalid knowledge workspace principal")
+
+    user = await ReferenceRepository.get_user(db, principal.actor_id)
+    if (
+        user is None
+        or user.is_active is not True
+        or user.tenant_id != principal.tenant_id
+    ):
+        raise _principal_invalid("Invalid knowledge actor principal")
+
+
+def _validate_source(source: dict[str, Any]) -> None:
+    if source["status"] not in (0, 1):
+        raise _resource_not_found()
+    if source["type"] != KnowledgeType.General:
+        raise _validation("Only general knowledge bases can be copied")
+    if source["permission_id"] != PermissionType.Private:
+        raise _validation("Only private knowledge bases can be copied")
+    if source["builtin_metadata_enabled"] not in (0, 1):
+        raise _validation("Source builtin metadata setting is invalid")
+
+
+async def _resolve_copy_parent_id(
+    db: AsyncSession,
+    source: dict[str, Any],
+    workspace_id: uuid.UUID,
+) -> uuid.UUID:
+    parent_id = source["parent_id"]
+    if parent_id is None or parent_id == workspace_id:
+        return workspace_id
+
+    parent = await knowledge_repository.get_knowledge_by_id_in_workspace_async(
+        db,
+        parent_id,
+        workspace_id,
+    )
+    if (
+        parent is None
+        or parent.type != KnowledgeType.FOLDER
+        or parent.status != 1
+    ):
+        raise _validation("Source parent folder is invalid")
+    return parent.id
+
+
+def _validate_metadata_fields(
+    metadata_fields: list[dict[str, Any]],
+    tenant_id: uuid.UUID,
+) -> None:
+    for field in metadata_fields:
+        if field["tenant_id"] != tenant_id:
+            raise _validation("Source metadata field tenant is invalid")
+        name = field["name"]
+        if name in KnowledgeMetadataService.BUILTIN_FIELD_NAMES:
+            raise _validation(f"Source metadata field conflicts with builtin field: {name}")
+        try:
+            KnowledgeMetadataCreate.model_validate(
+                {"name": name, "type": field["type"]}
+            )
+        except ValidationError as exc:
+            raise _validation(f"Source metadata field is invalid: {name}") from exc
+
+
+def _is_model_visible(model: ModelConfig, tenant_id: uuid.UUID) -> bool:
+    return model.tenant_id == tenant_id or model.is_public is True
+
+
+async def _validate_model_references(
+    db: AsyncSession,
+    source: dict[str, Any],
+    tenant_id: uuid.UUID,
+) -> None:
+    model_ids = list(
+        dict.fromkeys(
+            source[field_name]
+            for field_name in _MODEL_REFERENCE_FIELDS
+            if source[field_name] is not None
+        )
+    )
+    models = await ReferenceRepository.get_model_configs(db, model_ids)
+    models_by_id = {model.id: model for model in models}
+    for field_name in _MODEL_REFERENCE_FIELDS:
+        model_id = source[field_name]
+        if model_id is None:
+            continue
+        model = models_by_id.get(model_id)
+        if (
+            model is None
+            or model.is_active is not True
+            or not _is_model_visible(model, tenant_id)
+        ):
+            raise _model_unavailable(field_name)
+
+
+def _build_knowledge_values(
+    source: dict[str, Any],
+    principal: Principal,
+    *,
+    knowledge_id: uuid.UUID,
+    name: str,
+    parent_id: uuid.UUID,
+    parser_config: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "id": knowledge_id,
+        "external_id": None,
+        "workspace_id": principal.workspace_id,
+        "created_by": principal.actor_id,
+        "parent_id": parent_id,
+        "name": name,
+        "description": source["description"],
+        "avatar": source["avatar"],
+        "type": KnowledgeType.General.value,
+        "permission_id": PermissionType.Private.value,
+        "embedding_id": source["embedding_id"],
+        "reranker_id": source["reranker_id"],
+        "llm_id": source["llm_id"],
+        "image2text_id": source["image2text_id"],
+        "doc_num": 0,
+        "chunk_num": 0,
+        "parser_id": source["parser_id"],
+        "parser_config": parser_config,
+        "status": 1,
+        "builtin_metadata_enabled": source["builtin_metadata_enabled"],
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _build_metadata_values(
+    metadata_fields: list[dict[str, Any]],
+    principal: Principal,
+    *,
+    knowledge_id: uuid.UUID,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": uuid.uuid4(),
+            "tenant_id": principal.tenant_id,
+            "knowledge_id": knowledge_id,
+            "name": field["name"],
+            "type": field["type"],
+            "created_by": principal.actor_id,
+            "updated_by": principal.actor_id,
+            "created_at": now,
+            "updated_at": now,
+        }
+        for field in metadata_fields
+    ]
+
+
+async def copy_knowledge_configuration(
+    db: AsyncSession,
+    knowledge_id: uuid.UUID,
+    principal: Principal,
+) -> dict[str, Any]:
+    """Copy one ordinary knowledge configuration in a single transaction."""
+    try:
+        await _validate_principal_references(db, principal)
+        await knowledge_repository.lock_knowledge_copy_names_async(
+            db,
+            principal.workspace_id,
+        )
+        snapshot = await knowledge_repository.get_knowledge_copy_snapshot_async(
+            db,
+            knowledge_id,
+            principal.workspace_id,
+        )
+        if snapshot is None:
+            raise _resource_not_found()
+        source, metadata_fields = snapshot
+
+        _validate_source(source)
+        parent_id = await _resolve_copy_parent_id(
+            db,
+            source,
+            principal.workspace_id,
+        )
+        _validate_metadata_fields(metadata_fields, principal.tenant_id)
+        await _validate_model_references(db, source, principal.tenant_id)
+        try:
+            parser_config = copy_parser_config(source["parser_config"])
+        except ValueError as exc:
+            raise _validation(str(exc)) from exc
+
+        occupied_names = await knowledge_repository.get_knowledge_copy_names_async(
+            db,
+            principal.workspace_id,
+            source["name"],
+        )
+        copy_name = choose_copy_name(source["name"], occupied_names)
+        copied_id = uuid.uuid4()
+        now = utcnow_naive()
+        values = _build_knowledge_values(
+            source,
+            principal,
+            knowledge_id=copied_id,
+            name=copy_name,
+            parent_id=parent_id,
+            parser_config=parser_config,
+            now=now,
+        )
+        metadata_values = _build_metadata_values(
+            metadata_fields,
+            principal,
+            knowledge_id=copied_id,
+            now=now,
+        )
+
+        copied: Knowledge = knowledge_repository.stage_knowledge_copy(db, values)
+        KnowledgeMetadataRepository.stage_copy_fields(db, metadata_values)
+        await db.flush()
+        if source["parser_id"] is None:
+            await db.refresh(copied, attribute_names=["parser_id"])
+        response_data = await knowledge_service.knowledge_to_data(db, copied)
+        SuccessEnvelope[dict[str, Any]](data=response_data).model_dump_json()
+        await db.commit()
+        return response_data
+    except KnowledgeError:
+        await db.rollback()
+        raise
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        raise KnowledgeError.from_code(
+            "KB_DATABASE_UNAVAILABLE",
+            "Knowledge database operation failed",
+        ) from exc
+    except BaseException:
+        await db.rollback()
+        raise


### PR DESCRIPTION
## Business Background
Users need to reuse an existing knowledge base configuration for a new collection of documents. This adds configuration-only copying for General/Private knowledge bases in the same workspace and folder.

## Summary
- Support an optional JSON `name` for the copy. Omitted bodies, null, empty, and whitespace-only names retain automatic naming; nonempty names are trimmed, and active workspace name collisions return the existing conflict response.
- Add `POST /api/knowledges/{knowledge_id}/copy` through the existing manager authentication, workspace access, capacity quota, and remote proxy path.
- Create the new knowledge base and custom metadata definitions atomically, retaining model references and nullable parser settings while resetting identity, timestamps, counters, and external ID.
- Preserve parser business settings and use the current Evidence graph pipeline for the empty copy. Serialize the response before committing.
- Accept only the existing trusted manager proxy channel for the new internal operation. Existing creation, sharing, and authentication behavior stays unchanged.

## Scope and Risk
- Seven backend files only; no frontend, database migration, worker, shared model, or dependency changes.
- No external `/v1` or API Key endpoint is added. Direct JWT/API Key and gateway-token calls to the new internal copy endpoint are rejected; the supported entry is the manager API proxy.
- Deployment must route the new management operation through the manager API and preserve the existing service-network isolation for legacy identity headers. Deployment routing and network isolation have not been verified in a target environment.
- Copies contain no documents, files, vectors, graph data, metadata bindings, sharing grants, or background jobs. Model configuration records and avatar references remain shared references.
- Naming is serialized among copy requests in a workspace; this does not introduce global name uniqueness or persistent request idempotency. Requests should not be blindly retried after an uncertain response.
- Tests are local verification material and intentionally excluded from Git under this repository's project instructions. The pre-existing `api/uv.lock` change is excluded.

## Validation on the Latest Head
- `PYTHONPATH='../packages/redbear-model/src:../packages/storage-core/src:../packages/auth-sdk/src:.' ../api/.venv/bin/python -m pytest ../tests/mem_knowledge/knowledge_copy -q` from `mem-knowledge`: **45 passed**, using an isolated local PostgreSQL container. Covers transactions, rollback, concurrency, authentication, HTTP readback, and OpenAPI compatibility.
- `.venv/bin/python -m pytest tests/knowledge_copy -q` from `api`: **9 passed**, with four existing dependency deprecation warnings. Uses the actual extracted manager endpoint, real decorators, and HTTP MockTransport without booting unrelated legacy integrations.
- `ruff check --config pyproject.toml src ../tests/mem_knowledge/knowledge_copy`: passed.
- `python scripts/check_import_boundaries.py`: passed.
- `git diff --check origin/develop..HEAD`: passed; the initial feature commit was rebased without a patch change; the optional-name follow-up only modifies three existing backend files.

## API Documentation
Apifox project 7257691: internal endpoint 513309484 and positive test cases 412573500 (automatic naming, eight assertion groups) and 412775093 (custom naming, nine assertion groups). The positive case definition and success example were verified by readback; it has not been executed against a deployed environment.

## Sourcery 摘要

通过受信任的管理器 API 路径，支持对符合条件的知识库配置进行原子复制。

新功能：
- 添加一个由内部管理器代理的端点，用于在同一工作区和文件夹内原子复制符合条件的私有 General 知识库配置。

错误修复：
- 拒绝未通过受信任的管理器代理通道，或使用直接身份验证凭据的复制请求。

增强功能：
- 保留已验证的模型、解析器和元数据配置，同时重置复制后知识库的标识、计数器、时间戳、外部 ID 以及与内容相关的状态。
- 在工作区内串行化复制命名，并将知识库和元数据定义作为一个事务一并提交。

测试：
- 验证知识库配置复制的事务性、回滚、并发、身份验证、HTTP 读取结果以及 API 兼容性。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

允许受信任的 manager-proxy 客户端从符合条件的现有配置中以原子方式创建空知识库。

新功能：
- 添加一个内部 manager-proxy 端点，用于在同一工作区和文件夹内，以原子方式复制符合条件的私有 General 知识库配置。

错误修复：
- 拒绝绕过受信任 manager proxy 通道或提供直接身份验证凭据的复制请求。

改进：
- 在重置内容状态、身份信息、计数器、时间戳和外部标识符的同时，保留已验证的模型、解析器和自定义元数据设置。
- 按工作区串行分配复制名称，并以事务方式提交知识库和元数据定义。

测试：
- 增加对事务性、回滚、并发、身份验证、HTTP 读回和 API 兼容性的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable trusted manager-proxy clients to atomically create empty knowledge bases from eligible existing configurations.

New Features:
- Add an internal manager-proxy endpoint to atomically copy eligible private General knowledge base configurations within the same workspace and folder.

Bug Fixes:
- Reject copy requests that bypass the trusted manager proxy channel or provide direct authentication credentials.

Enhancements:
- Preserve validated model, parser, and custom metadata settings while resetting content state, identity, counters, timestamps, and external identifiers.
- Serialize copy-name allocation per workspace and commit the knowledge base and metadata definitions transactionally.

Tests:
- Add coverage for transactionality, rollback, concurrency, authentication, HTTP readback, and API compatibility.

</details>

</details>