### PR TITLE
feat(rag): improve multi-knowledge weighted reranking

### DIFF
--- a/mem-knowledge/pyproject.toml
+++ b/mem-knowledge/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "uvicorn[standard]>=0.37,<1",
     "xlrd>=2.0,<3",
     "xxhash>=3.5,<5",
+    "jieba==0.42.1",
 ]
 
 [dependency-groups]

--- a/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
+++ b/mem-knowledge/src/rag/retrieval/async_elasticsearch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from typing import Any, Protocol
@@ -366,8 +367,10 @@ class AsyncChunkStore:
 class AsyncElasticSearchRetrieval:
     """Native asynchronous vector and full-text retrieval."""
 
-    def __init__(self, client: Any):
+    def __init__(self, client: Any, *, track_parent_matches: bool = False):
         self.client = client
+        self._track_parent_matches = track_parent_matches
+        self._parent_matches: dict[tuple[str, str], set[str]] = {}
 
     @staticmethod
     def _raise_on_failed_response(response: Mapping[str, Any], operation: str) -> None:
@@ -434,6 +437,51 @@ class AsyncElasticSearchRetrieval:
             options.indices,
         )
 
+    async def score_candidates_by_vector(
+        self,
+        query_vector: Sequence[float],
+        chunks: Sequence[DocumentChunk],
+        options: RetrievalSearchOptions,
+    ) -> dict[str, float]:
+        """Score authorized candidate IDs, including only actually matched children."""
+        source_ids: dict[str, set[str]] = {}
+        for chunk in chunks:
+            metadata = chunk.metadata or {}
+            doc_id = str(metadata.get("doc_id") or "")
+            if not doc_id:
+                continue
+            source_ids[doc_id] = (
+                self._parent_matches.get((options.indices, doc_id), set())
+                if metadata.get("chunk_type") == "parent"
+                else {doc_id}
+            )
+        ids = sorted({source for sources in source_ids.values() for source in sources})
+        scores = dict.fromkeys(source_ids, 0.0)
+        if not ids or options.document_ids_include == ():
+            return scores
+        filters = build_filter_clauses(
+            options.file_names_filter, options.document_ids_include, require_vector=True
+        )
+        filters.append({"terms": {Field.DOC_ID.value: ids}})
+        response = await self.client.search(
+            index=options.indices,
+            size=len(ids),
+            query=build_vector_script_query(query_vector, filters),
+            source_includes=[Field.DOC_ID.value],
+            allow_partial_search_results=False,
+        )
+        self._raise_on_failed_response(response, "candidate vector scoring")
+        by_id: dict[str, float] = {}
+        for hit in (response.get("hits") or {}).get("hits", []):
+            doc_id = str(((hit.get("_source") or {}).get("metadata") or {}).get("doc_id") or "")
+            score = float(hit["_score"]) / 2
+            if not math.isfinite(score):
+                raise RuntimeError("Elasticsearch candidate vector score is not finite")
+            by_id[doc_id] = max(by_id.get(doc_id, 0.0), min(1.0, max(0.0, score)))
+        for doc_id, sources in source_ids.items():
+            scores[doc_id] = max((by_id.get(source, 0.0) for source in sources), default=0.0)
+        return scores
+
     async def resolve_parent_chunks(
         self,
         chunks: list[DocumentChunk],
@@ -449,6 +497,15 @@ class AsyncElasticSearchRetrieval:
         )
         if not parent_ids:
             return chunks
+        if self._track_parent_matches:
+            for chunk in chunks:
+                metadata = chunk.metadata or {}
+                if metadata.get("chunk_type") == "child" and metadata.get("parent_id"):
+                    child_id = metadata.get("doc_id")
+                    if child_id:
+                        self._parent_matches.setdefault(
+                            (index, str(metadata["parent_id"])), set()
+                        ).add(str(child_id))
         try:
             response = await self.client.search(
                 index=index,

--- a/mem-knowledge/src/rag/retrieval/models.py
+++ b/mem-knowledge/src/rag/retrieval/models.py
@@ -36,6 +36,7 @@ class RerankPlan:
     weights: RerankWeightsSnapshot
     model: ModelRuntimeSnapshot | None
     compatibility_fallback: bool
+    recompute_keywords: bool = False
 
 
 @dataclass(frozen=True)

--- a/mem-knowledge/src/rag/retrieval/rerank.py
+++ b/mem-knowledge/src/rag/retrieval/rerank.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 
 from redbear_model import ImageEmbeddingContent
 
 from ...api.schemas.rerank import RerankMode
-from ..models.chunk import DocumentChunk
+from ..models.chunk import DocumentChunk, chunk_retrieval_content
 from .candidates import candidate_identity, chunk_identity, materialize_candidates
 from .models import ModelRuntimeSnapshot, RerankPlan, RetrievalCandidate
+from .weighted_scoring import keyword_similarities
 
 
 @dataclass(frozen=True)
@@ -40,13 +42,21 @@ class _WeightedScoreAdapter:
         candidates: Sequence[RetrievalCandidate],
         plan: RerankPlan,
     ) -> list[RetrievalCandidate]:
-        del query
+        keyword_scores = [candidate.participle_score or 0.0 for candidate in candidates]
+        if plan.recompute_keywords and plan.weights.participle_weight > 0:
+            if not isinstance(query, str):
+                raise ValueError("Weighted keyword scoring requires a text query")
+            keyword_scores = await asyncio.to_thread(
+                keyword_similarities,
+                query,
+                [chunk_retrieval_content(candidate.chunk) for candidate in candidates],
+            )
         ranked = [
             candidate.with_final_score(
                 plan.weights.semantic_weight * (candidate.semantic_score or 0.0)
-                + plan.weights.participle_weight * (candidate.participle_score or 0.0)
+                + plan.weights.participle_weight * keyword_score
             )
-            for candidate in candidates
+            for candidate, keyword_score in zip(candidates, keyword_scores, strict=True)
         ]
         return sorted(
             ranked,

--- a/mem-knowledge/src/rag/retrieval/weighted_scoring.py
+++ b/mem-knowledge/src/rag/retrieval/weighted_scoring.py
@@ -1,0 +1,58 @@
+"""Candidate-corpus keyword cosine scoring, following Dify's weighted rerank."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Sequence
+from threading import Lock
+from typing import TYPE_CHECKING
+
+from jieba import Tokenizer
+
+if TYPE_CHECKING:
+    from jieba.analyse import TFIDF
+
+_extractor: TFIDF | None = None
+_extractor_lock = Lock()
+
+
+def _keywords(text: str) -> list[str]:
+    global _extractor
+    # Initialize once inside the scoring worker, then share read-only dictionaries.
+    # Do not mutate Jieba's defaults or retain one full dictionary per pool thread.
+    if _extractor is None:
+        with _extractor_lock:
+            if _extractor is None:
+                from jieba.analyse import TFIDF
+
+                tokenizer = Tokenizer()
+                tokenizer.initialize()
+                extractor = TFIDF()
+                extractor.tokenizer = tokenizer
+                _extractor = extractor
+    return _extractor.extract_tags(text, topK=None)
+
+
+def keyword_similarities(query: str, texts: Sequence[str]) -> list[float]:
+    """Return TF-IDF cosine scores in input order, using one candidate corpus."""
+    if not texts:
+        return []
+    query_terms = Counter(_keywords(query))
+    documents = [Counter(_keywords(text)) for text in texts]
+    frequencies: Counter[str] = Counter()
+    for terms in documents:
+        frequencies.update(terms.keys())
+    idf = {
+        term: math.log((1 + len(documents)) / (1 + count)) + 1
+        for term, count in frequencies.items()
+    }
+    query_vector = {term: count * idf.get(term, 0.0) for term, count in query_terms.items()}
+    query_norm = math.sqrt(sum(value * value for value in query_vector.values()))
+    scores: list[float] = []
+    for terms in documents:
+        vector = {term: count * idf[term] for term, count in terms.items()}
+        norm = math.sqrt(sum(value * value for value in vector.values()))
+        numerator = sum(value * query_vector.get(term, 0.0) for term, value in vector.items())
+        scores.append(min(1.0, numerator / (norm * query_norm)) if norm and query_norm else 0.0)
+    return scores

--- a/mem-knowledge/src/services/knowledge_retrieval.py
+++ b/mem-knowledge/src/services/knowledge_retrieval.py
@@ -123,9 +123,15 @@ def _record_elapsed(
 class _TimedElasticSearchRetrieval(AsyncElasticSearchRetrieval):
     """Record oracle-compatible phases without owning another ES client."""
 
-    def __init__(self, client: Any, timings: RetrievalTimings | None) -> None:
+    def __init__(
+        self,
+        client: Any,
+        timings: RetrievalTimings | None,
+        *,
+        track_parent_matches: bool = False,
+    ) -> None:
         self._timings = timings
-        super().__init__(client)
+        super().__init__(client, track_parent_matches=track_parent_matches)
 
     async def search_by_vector(
         self,
@@ -279,7 +285,13 @@ class KnowledgeRetrievalService:
             )
 
         client = await runtime.elasticsearch.client()
-        store = _TimedElasticSearchRetrieval(client, timings)
+        store = _TimedElasticSearchRetrieval(
+            client,
+            timings,
+            track_parent_matches=bool(
+                preparation.global_rerank and preparation.global_rerank.recompute_keywords
+            ),
+        )
         retrieval_result = await cls._retrieve_prepared(
             runtime,
             client,
@@ -374,6 +386,7 @@ class KnowledgeRetrievalService:
                         and target.params.retrieve_type is RetrieveType.HYBRID
                     ),
                     request_reranker=preparation.request_reranker,
+                    global_rerank=preparation.global_rerank,
                     image_query=image_query,
                     timings=timings,
                     log_id=log_id,
@@ -459,6 +472,7 @@ class KnowledgeRetrievalService:
         graph_target: GraphTargetSnapshot | None,
         use_request_reranker: bool = False,
         request_reranker: ModelRuntimeSnapshot | None = None,
+        global_rerank: RerankPlan | None = None,
         image_query: ImageEmbeddingContent | None = None,
         timings: RetrievalTimings | None = None,
         log_id: str | None = None,
@@ -602,6 +616,12 @@ class KnowledgeRetrievalService:
                 )
             )
 
+        weighted_semantics = bool(
+            global_rerank
+            and global_rerank.recompute_keywords
+            and global_rerank.weights.semantic_weight > 0
+        )
+        query_vector: list[float] | None = None
         if image_query is not None:
             query_vector = await cls._embed_image_query(
                 embedding,
@@ -621,9 +641,18 @@ class KnowledgeRetrievalService:
                     "KB_VALIDATION_ERROR",
                     "Text query content is unavailable",
                 )
-            vector_task = asyncio.create_task(
-                store.search_by_vector(embedding, text_query, vector_options)
-            )
+            async def search_vector() -> list[DocumentChunk]:
+                nonlocal query_vector
+                if not weighted_semantics:
+                    return await store.search_by_vector(embedding, text_query, vector_options)
+                embedding_started_at = time.perf_counter()
+                try:
+                    query_vector = normalize_vector(await embedding.aembed_query(text_query))
+                finally:
+                    cls._record_timing(timings, "embedding_ms", embedding_started_at)
+                return await store.search_by_query_vector(query_vector, vector_options)
+
+            vector_task = asyncio.create_task(search_vector())
             text_task = asyncio.create_task(
                 store.search_by_full_text(text_query, full_text_options)
             )
@@ -718,6 +747,27 @@ class KnowledgeRetrievalService:
             )
         finally:
             cls._record_timing(timings, "local_rerank_ms", local_rerank_started_at)
+        if weighted_semantics and query_vector is not None:
+            missing = [candidate for candidate in ranked if candidate.semantic_score is None]
+            if missing:
+                scoring_started_at = time.perf_counter()
+                try:
+                    scores = await store.score_candidates_by_vector(
+                        query_vector, [candidate.chunk for candidate in missing], vector_options
+                    )
+                finally:
+                    cls._record_timing(timings, "es_vector_ms", scoring_started_at)
+                ranked = [
+                    replace(
+                        candidate,
+                        semantic_score=scores.get(
+                            str((candidate.chunk.metadata or {}).get("doc_id") or ""), 0.0
+                        ),
+                    )
+                    if candidate.semantic_score is None
+                    else candidate
+                    for candidate in ranked
+                ]
         cls._log_target_done(
             target,
             len(vector_chunks),

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -332,6 +332,9 @@ class KnowledgeRetrievalPreparation:
                 if mode is RerankMode.RERANKING_MODEL
                 else None,
                 compatibility_fallback=mode is RerankMode.RERANKING_MODEL,
+                recompute_keywords=(
+                    target_count > 1 and mode is RerankMode.WEIGHTED_SCORE
+                ),
             )
         return RetrievalPreparation(
             targets=tuple(targets),
@@ -680,6 +683,8 @@ class KnowledgeRetrievalPreparation:
         if config is not None and config.rerank_mode is not None:
             return config.rerank_mode, cls._resolve_weights(config.rerank_weights), True
         if target_count == 1 and request.rerank_mode is not None:
+            return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
+        if target_count > 1 and request.rerank_mode is RerankMode.WEIGHTED_SCORE:
             return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
         return RerankMode.RERANKING_MODEL, cls._resolve_weights(None), False
 

--- a/mem-knowledge/src/services/knowledge_retrieval_preparation.py
+++ b/mem-knowledge/src/services/knowledge_retrieval_preparation.py
@@ -684,8 +684,6 @@ class KnowledgeRetrievalPreparation:
             return config.rerank_mode, cls._resolve_weights(config.rerank_weights), True
         if target_count == 1 and request.rerank_mode is not None:
             return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
-        if target_count > 1 and request.rerank_mode is RerankMode.WEIGHTED_SCORE:
-            return request.rerank_mode, cls._resolve_weights(request.rerank_weights), True
         return RerankMode.RERANKING_MODEL, cls._resolve_weights(None), False
 
     @classmethod

--- a/mem-knowledge/uv.lock
+++ b/mem-knowledge/uv.lock
@@ -719,6 +719,12 @@ wheels = [
 ]
 
 [[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2", size = 19214172, upload-time = "2020-01-20T14:27:23.5Z" }
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1083,6 +1089,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "html5lib" },
     { name = "httpx" },
+    { name = "jieba" },
     { name = "jinja2" },
     { name = "json-repair" },
     { name = "kombu" },
@@ -1130,6 +1137,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.119,<1" },
     { name = "html5lib", specifier = "==1.1" },
     { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "jieba", specifier = "==0.42.1" },
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "json-repair", specifier = "==0.53.0" },
     { name = "kombu", specifier = "==5.5.4" },


### PR DESCRIPTION
## Summary
Explicit multi-knowledge-base `weighted_score` requests currently fuse keyword scores normalized independently within each knowledge base and treat candidates absent from the vector recall results as having zero semantic relevance. This change computes keyword TF-IDF cosine similarity across the combined candidate corpus and fills missing semantic scores from stored vectors for the authorized recalled candidates, following Dify's weighted-rerank approach.

- Reuse each target's query vector and the existing asynchronous Elasticsearch client for batched semantic scoring after local reranking. Parent candidates use only actually matched children.
- Run keyword scoring outside the event loop with one lazily initialized, read-only tokenizer dictionary shared by scoring threads.
- Preserve local candidate limits, score thresholds, response formats and existing model-rerank fallback behavior.

## Compatibility and scope
- Unspecified per-knowledge-base reranking still defaults to **model rerank**; global weighted mode does not override that default.
- Unspecified global reranking still defaults to **the first resolved knowledge base's model reranker**, unless the request explicitly selects a rerank model as before.
- Weighted fusion remains explicitly opt-in. Single-knowledge-base behavior and explicit local strategy selection are unchanged.
- Existing hybrid/text and matching-embedding-space restrictions remain. No frontend, legacy API business logic, database migration, route, authentication or permission changes.
- External API Key consumers gain no endpoints or permissions. Existing consumers explicitly selecting multi-KB weighted mode receive the revised scores/order through the unchanged request and response contracts.

## Risks
Explicit multi-KB weighted scores, ordering and threshold filtering may change. Missing-score lookups add bounded ES work for locally selected candidates; tokenizer initialization and corpus scoring add memory/CPU cost. Authorization filters, enabled chunk status and matched-child provenance apply to the supplemental lookup. ES failures are surfaced instead of silently interpreted as absent vectors.

## Validation
- [x] After rebasing onto develop: `uv run --locked pytest -c pyproject.toml ../tests/mem_knowledge/retrieval/test_multikb_weighted_rerank.py -q --tb=short` — 35 passed. Includes first-KB model selection with reversed KB order, omitted/null global mode, local default model execution, explicit local weighted mode, score recovery, keyword scoring, concurrency and contract compatibility.
- [x] Before rebase: 2 integration tests passed against a disposable local Elasticsearch 8.19.3 container, verifying vector scores, document/file/status filters and matched-child-only parent scoring. The container was removed afterward.
- [x] Targeted Ruff checks, `scripts/check_import_boundaries.py` and `git diff --check origin/develop..HEAD` passed after rebase.
- [x] Independent review identified and verified the fix for per-thread tokenizer dictionary duplication.
- Local `tests/**` files are intentionally not committed under repository policy. The existing uncommitted broader suite was compared against the original base before rebase: both had the same 35 failures and 28 passes; this PR does not claim a clean full-suite run.
- No production deployment or live model-provider quality evaluation was performed.

## Sourcery 总结

通过在完整的授权候选集上结合关键词相关性和恢复的语义相关性，改进显式多知识加权重排序。

新功能：
- 为显式多知识加权重排序添加基于合并语料库 TF-IDF 的关键词相似度。
- 使用存储的向量恢复授权候选项缺失的语义分数，同时保留仅对匹配子项进行父项评分的行为。

错误修复：
- 确保多知识加权排序不再将未出现在向量召回结果中的候选项视为具有零语义相关性。

增强：
- 在提高加权分数准确性的同时，保留现有的重排序默认值、候选项数量限制、阈值、响应契约以及模型重排序回退行为。

构建：
- 添加 Jieba 作为关键词评分的运行时依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve explicit multi-knowledge weighted reranking by combining keyword and recovered semantic relevance across the complete authorized candidate set.

New Features:
- Add combined-corpus TF-IDF keyword similarity for explicit multi-knowledge weighted reranking.
- Recover missing semantic scores for authorized candidates using stored vectors while preserving matched-child-only parent scoring.

Bug Fixes:
- Ensure multi-knowledge weighted ranking no longer treats candidates absent from vector recall as having zero semantic relevance.

Enhancements:
- Preserve existing reranking defaults, candidate limits, thresholds, response contracts, and model-rerank fallback behavior while improving weighted score accuracy.

Build:
- Add Jieba as a runtime dependency for keyword scoring.

</details>