### PR TITLE
feat(web): provider's api key support update is_active

### DIFF
--- a/web/src/api/models.ts
+++ b/web/src/api/models.ts
@@ -48,6 +48,10 @@ export const getProviderApiKeys = (data: { provider: Provider; is_active?: boole
 export const createProviderApiKeys = (data: KeyConfigModalForm, signal?: AbortSignal) => {
   return request.post('/models/provider/apikeys', data, { signal })
 }
+// Update API keys for all matching models by provider
+export const updateProviderApiKeys = (api_key_id: string, data: { is_active: boolean; }) => {
+  return request.put(`/models/provider/apikeys/${api_key_id}`, data)
+}
 // Delete API keys for all matching models by provider
 export const deleteProviderApiKeys = (api_key_id: string) => {
   return request.delete(`/models/provider/apikeys/${api_key_id}`)

--- a/web/src/views/ModelManagement/components/MultiKeyConfigModal.tsx
+++ b/web/src/views/ModelManagement/components/MultiKeyConfigModal.tsx
@@ -5,7 +5,7 @@
  */
 
 import { forwardRef, useImperativeHandle, useState } from 'react';
-import { Form, Input, App, Button, Flex } from 'antd';
+import { Form, Input, App, Button, Flex, Switch, Space } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import type { ModelListItem, ProviderModelItem, MultiKeyForm, MultiKeyConfigModalRef, MultiKeyConfigModalProps, Provider } from '../types';
@@ -13,6 +13,7 @@ import RbModal from '@/components/RbModal'
 import {
   getModelApiKeys, addModelApiKey, deleteModelApiKey, getModelProviderList,
   getProviderApiKeys, createProviderApiKeys, deleteProviderApiKeys,
+  updateProviderApiKeys,
 } from '@/api/models'
 
 type Model = ModelListItem | ProviderModelItem
@@ -140,6 +141,15 @@ const MultiKeyConfigModal = forwardRef<MultiKeyConfigModalRef, MultiKeyConfigMod
         getApiKeys((model as ModelListItem).id, currentProvider)
       })
   }
+  const handleChangeStatus = (checked: boolean, api_key_id: string) => {
+    if (source !== 'provider' || !api_key_id) return
+
+    updateProviderApiKeys(api_key_id, { is_active: checked })
+    .then(() => {
+      message.success(t('common.operateSuccess'))
+      getApiKeys((model as ModelListItem).id, currentProvider)
+    })
+  }
 
   /** Expose methods to parent component */
   useImperativeHandle(ref, () => ({
@@ -162,7 +172,11 @@ const MultiKeyConfigModal = forwardRef<MultiKeyConfigModalRef, MultiKeyConfigMod
                 <div className="rb:text-[14px] rb:font-medium rb:break-all">{key.credential_masked}</div>
                 <div className="rb:text-gray-600 rb:text-[12px] rb:mt-1">{key.api_base}</div>
               </div>
-              <Button type="primary" danger ghost onClick={() => handleDelete(key.id)}>{t('common.remove')}</Button>
+
+              <Space size={12}>
+                {source === 'provider' && <Switch checked={key.is_active} onChange={(checked) => handleChangeStatus(checked, key.id)} />}
+                <Button type="primary" danger ghost onClick={() => handleDelete(key.id)}>{t('common.remove')}</Button>
+              </Space>
             </Flex>
           ))}
         </div>


### PR DESCRIPTION
## Sourcery 总结

新增支持查看和更新提供商 API 密钥的启用状态。

新功能：
- 在模型管理界面中添加提供商 API 密钥的启用控制项。

增强功能：
- 支持更新提供商 API 密钥的启用状态，并在更改后刷新状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for viewing and updating the active status of provider API keys.

New Features:
- Add provider API key activation controls in the model management interface.

Enhancements:
- Allow the active status of provider API keys to be updated and refreshed after changes.

</details>