### PR TITLE
refactor(memory-dashboard): drop foreign key on display projection workspace_id

### DIFF
--- a/api/app/models/memory_display_record_model.py
+++ b/api/app/models/memory_display_record_model.py
@@ -44,8 +44,6 @@ class MemoryDisplayRecord(Base):
         nullable=False,
     )
     # 冗余列：终端用户所属工作空间，支撑空间级倒序分页查询。
-    # 不建外键：本表为展示投影（best effort 写入），空间归属可经
-    # end_user_id -> end_users.workspace_id 间接保证，避免外键校验破坏写入容错语义。
     # nullable=True 兼容存量数据回填期与展示写入的容错语义（写入失败不影响主流程）。
     workspace_id = Column(
         UUID(as_uuid=True),

--- a/api/app/models/memory_display_record_model.py
+++ b/api/app/models/memory_display_record_model.py
@@ -44,10 +44,11 @@ class MemoryDisplayRecord(Base):
         nullable=False,
     )
     # 冗余列：终端用户所属工作空间，支撑空间级倒序分页查询。
+    # 不建外键：本表为展示投影（best effort 写入），空间归属可经
+    # end_user_id -> end_users.workspace_id 间接保证，避免外键校验破坏写入容错语义。
     # nullable=True 兼容存量数据回填期与展示写入的容错语义（写入失败不影响主流程）。
     workspace_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("workspaces.id"),
         nullable=True,
     )
     operation_id = Column(UUID(as_uuid=True), nullable=False)

--- a/api/app/models/memory_engine_display_event_model.py
+++ b/api/app/models/memory_engine_display_event_model.py
@@ -39,8 +39,6 @@ class MemoryEngineDisplayEvent(Base):
         nullable=False,
     )
     # 冗余列：终端用户所属工作空间，支撑空间级聚合查询（免 JOIN end_users）。
-    # 不建外键：本表为展示投影（best effort 写入），空间归属可经
-    # end_user_id -> end_users.workspace_id 间接保证，避免外键校验破坏写入容错语义。
     # nullable=True 兼容存量回填期与展示写入的容错语义（写入失败不影响主流程）。
     workspace_id = Column(
         UUID(as_uuid=True),

--- a/api/app/models/memory_engine_display_event_model.py
+++ b/api/app/models/memory_engine_display_event_model.py
@@ -39,10 +39,11 @@ class MemoryEngineDisplayEvent(Base):
         nullable=False,
     )
     # 冗余列：终端用户所属工作空间，支撑空间级聚合查询（免 JOIN end_users）。
+    # 不建外键：本表为展示投影（best effort 写入），空间归属可经
+    # end_user_id -> end_users.workspace_id 间接保证，避免外键校验破坏写入容错语义。
     # nullable=True 兼容存量回填期与展示写入的容错语义（写入失败不影响主流程）。
     workspace_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("workspaces.id"),
         nullable=True,
     )
     operation_id = Column(UUID(as_uuid=True), nullable=False)


### PR DESCRIPTION
## Sourcery 摘要

增强功能：
- 移除内存显示投影记录和引擎显示事件中工作区标识符的外键约束，以允许可为空且具备容错能力的投影数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove foreign key constraints from workspace identifiers in memory display projection records and engine display events to allow nullable, fault-tolerant projection data.

</details>